### PR TITLE
issue #10: handle closed change channel

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
+github.com/d3vi1/helianthus-ebusgo v0.0.0-20260201200950-6fa99f8750e2 h1:5htyCCOyGQkri38j9M5o4frFnhhy0hF9YZeAkAihw6c=
 github.com/d3vi1/helianthus-ebusgo v0.0.0-20260201200950-6fa99f8750e2/go.mod h1:WVYXygxQrRS/FMsQm9h04pQbJp6zoVyY4scq1ps3OS8=
+github.com/d3vi1/helianthus-ebusreg v0.0.0-20260201212610-32c2b7eeec50 h1:y0fv+QOfxFZhgmSiNbr8U2WvFyVHn5L/bqBLRNqRrFQ=
 github.com/d3vi1/helianthus-ebusreg v0.0.0-20260201212610-32c2b7eeec50/go.mod h1:W9ZtSpWXmA60YD5PeGKmL9CO93Eqj48iugtgslAFkf0=
 github.com/graphql-go/graphql v0.8.1 h1:p7/Ou/WpmulocJeEx7wjQy611rtXGQaAcXGqanuMMgc=
 github.com/graphql-go/graphql v0.8.1/go.mod h1:nKiHzRM0qopJEwCITUuIsxk9PlVlwIiiI8pnJEhordQ=

--- a/graphql/builder.go
+++ b/graphql/builder.go
@@ -38,7 +38,10 @@ func (b *Builder) Start(ctx context.Context) error {
 			select {
 			case <-ctx.Done():
 				return
-			case <-b.changes:
+			case _, ok := <-b.changes:
+				if !ok {
+					return
+				}
 				_ = b.Rebuild()
 			}
 		}

--- a/graphql/builder_test.go
+++ b/graphql/builder_test.go
@@ -168,6 +168,28 @@ func TestBuilder_RebuildsOnChange(t *testing.T) {
 	}
 }
 
+func TestBuilder_StopsOnClosedChannel(t *testing.T) {
+	reg := mockRegistry{}
+	changes := make(chan struct{})
+
+	builder := NewBuilder(reg, changes)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := builder.Start(ctx); err != nil {
+		t.Fatalf("Start error = %v", err)
+	}
+
+	rev := builder.Revision()
+	close(changes)
+
+	time.Sleep(50 * time.Millisecond)
+
+	if got := builder.Revision(); got != rev {
+		t.Fatalf("Revision advanced after close: %d -> %d", rev, got)
+	}
+}
+
 func waitForRevision(t *testing.T, builder *Builder, last uint64) {
 	t.Helper()
 


### PR DESCRIPTION
Fixes #10.

- Stop schema builder loop when changes channel is closed.
- Adds regression test for closed channel behavior.

Tests: 