### PR TITLE
smoke: configurable source address and scan targets

### DIFF
--- a/smoke.go
+++ b/smoke.go
@@ -90,7 +90,11 @@ func RunSmoke(ctx context.Context, cfg smokeConfig, opts SmokeOptions) error {
 
 	source := opts.SourceAddress
 	if source == 0 {
-		source = defaultSmokeSource
+		if cfg.Smoke.SourceAddress.Byte() != 0 {
+			source = cfg.Smoke.SourceAddress.Byte()
+		} else {
+			source = defaultSmokeSource
+		}
 	}
 
 	scanBus := &timeoutBus{
@@ -98,7 +102,8 @@ func RunSmoke(ctx context.Context, cfg smokeConfig, opts SmokeOptions) error {
 		timeout: time.Duration(cfg.Smoke.ScanTimeoutSec) * time.Second,
 	}
 
-	entries, err := registry.Scan(ctx, scanBus, gateway.Registry, source, nil)
+	targets := scanTargetsFromExpectedDevices(cfg.ExpectedDevices)
+	entries, err := registry.Scan(ctx, scanBus, gateway.Registry, source, targets)
 	if err != nil {
 		return err
 	}
@@ -507,4 +512,21 @@ func decodeDeviceInfoPayload(payload []byte) (map[string]string, error) {
 		"sw_version":   fmt.Sprintf("%02X%02X", payload[4], payload[5]),
 		"hw_version":   fmt.Sprintf("%02X%02X", payload[6], payload[7]),
 	}, nil
+}
+
+func scanTargetsFromExpectedDevices(expected []expectedDevice) []byte {
+	if len(expected) == 0 {
+		return nil
+	}
+	seen := make(map[byte]struct{}, len(expected))
+	out := make([]byte, 0, len(expected))
+	for _, item := range expected {
+		addr := item.Address.Byte()
+		if _, ok := seen[addr]; ok {
+			continue
+		}
+		seen[addr] = struct{}{}
+		out = append(out, addr)
+	}
+	return out
 }

--- a/smoke_config.go
+++ b/smoke_config.go
@@ -37,6 +37,7 @@ type smokeBehavior struct {
 	VerboseFrames    bool `yaml:"verbose_frames"`
 	ScanTimeoutSec   int  `yaml:"scan_timeout_sec"`
 	MethodTimeoutSec int  `yaml:"method_timeout_sec"`
+	SourceAddress    hexByte `yaml:"source_address"`
 }
 
 type expectedDevice struct {

--- a/smoke_config_test.go
+++ b/smoke_config_test.go
@@ -25,7 +25,7 @@ smoke:
 func TestLoadSmokeConfigFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "AGENT-local.md")
-	content := "```yaml\nenh:\n  type: tcp\n  host: \"127.0.0.1\"\n  port: 7624\n  timeout_sec: 3\nexpected_devices:\n  - address: 0x08\n    description: \"Boiler\"\nsmoke:\n  verbose_frames: true\n  scan_timeout_sec: 4\n  method_timeout_sec: 6\n```\n"
+	content := "```yaml\nenh:\n  type: tcp\n  host: \"127.0.0.1\"\n  port: 7624\n  timeout_sec: 3\nexpected_devices:\n  - address: 0x08\n    description: \"Boiler\"\nsmoke:\n  source_address: 0xf0\n  verbose_frames: true\n  scan_timeout_sec: 4\n  method_timeout_sec: 6\n```\n"
 	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatalf("WriteFile error = %v", err)
 	}
@@ -39,6 +39,9 @@ func TestLoadSmokeConfigFile(t *testing.T) {
 	}
 	if cfg.ENH.TimeoutSec != 3 {
 		t.Fatalf("timeout = %d; want 3", cfg.ENH.TimeoutSec)
+	}
+	if cfg.Smoke.SourceAddress.Byte() != 0xF0 {
+		t.Fatalf("source address = 0x%02x; want 0xf0", cfg.Smoke.SourceAddress.Byte())
 	}
 	if !cfg.Smoke.VerboseFrames || cfg.Smoke.ScanTimeoutSec != 4 || cfg.Smoke.MethodTimeoutSec != 6 {
 		t.Fatalf("unexpected smoke config: %+v", cfg.Smoke)

--- a/smoke_test.go
+++ b/smoke_test.go
@@ -1,6 +1,7 @@
 package ebusgateway
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/d3vi1/helianthus-ebusgo/protocol"
@@ -124,5 +125,19 @@ func TestDecodeDeviceInfoPayload(t *testing.T) {
 	}
 	if _, err := decodeDeviceInfoPayload([]byte{0x01}); err == nil {
 		t.Fatalf("expected error on short payload")
+	}
+}
+
+func TestScanTargetsFromExpectedDevices(t *testing.T) {
+	expected := []expectedDevice{
+		{Address: hexByte(0x08), Description: "Boiler"},
+		{Address: hexByte(0x10), Description: "Controller"},
+		{Address: hexByte(0x08), Description: "Duplicate"},
+	}
+
+	got := scanTargetsFromExpectedDevices(expected)
+	want := []byte{0x08, 0x10}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("scan targets = %v; want %v", got, want)
 	}
 }


### PR DESCRIPTION
Fixes #15.

- Add `smoke.source_address` to smoke config (AGENT-local.md YAML).
- When `expected_devices` is non-empty, use its addresses as scan targets instead of scanning the full range.
- Add unit tests for config parsing and scan target selection.

Tests: `go test ./...`