### PR TITLE
gateway: init ENH transports on connect

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -95,6 +95,9 @@ func (g *Gateway) AddRouterPlane(plane router.Plane) {
 
 func resolveTransport(ctx context.Context, cfg Config) (transport.RawTransport, func() error, error) {
 	if cfg.Transport != nil {
+		if err := initTransportIfSupported(cfg.Transport); err != nil {
+			return nil, nil, err
+		}
 		return cfg.Transport, cfg.Transport.Close, nil
 	}
 
@@ -125,6 +128,10 @@ func resolveTransport(ctx context.Context, cfg Config) (transport.RawTransport, 
 		_ = conn.Close()
 		return nil, nil, err
 	}
+	if err := initTransportIfSupported(transportLayer); err != nil {
+		_ = conn.Close()
+		return nil, nil, err
+	}
 
 	return transportLayer, conn.Close, nil
 }
@@ -139,6 +146,22 @@ func transportFromConn(protocolName TransportProtocol, conn net.Conn, readTimeou
 	default:
 		return nil, fmt.Errorf("gateway transport unsupported protocol %q: %w", protocolName, ebuserrors.ErrInvalidPayload)
 	}
+}
+
+type initTransport interface {
+	Init(features byte) error
+}
+
+func initTransportIfSupported(tr transport.RawTransport) error {
+	initializer, ok := tr.(initTransport)
+	if !ok {
+		return nil
+	}
+	const defaultInitFeatures = byte(0x00)
+	if err := initializer.Init(defaultInitFeatures); err != nil {
+		return fmt.Errorf("gateway transport init failed: %w", err)
+	}
+	return nil
 }
 
 func dialContext(ctx context.Context, network, address string, timeout time.Duration) (net.Conn, error) {

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -2,6 +2,7 @@ package ebusgateway
 
 import (
 	"context"
+	"io"
 	"net"
 	"testing"
 	"time"
@@ -51,6 +52,17 @@ func TestNewGateway_DialsWithENH(t *testing.T) {
 		gotAddress = address
 		client, server := net.Pipe()
 		serverClose = func() { _ = server.Close() }
+
+		go func() {
+			buf := make([]byte, 2)
+			if _, err := io.ReadFull(server, buf); err != nil {
+				_ = server.Close()
+				return
+			}
+			resp := transport.EncodeENH(transport.ENHResResetted, 0x00)
+			_, _ = server.Write(resp[:])
+		}()
+
 		return client, nil
 	}
 
@@ -61,6 +73,7 @@ func TestNewGateway_DialsWithENH(t *testing.T) {
 			Address:     "/tmp/ebusd.sock",
 			DialTimeout: time.Second,
 			Dial:        dialer,
+			ReadTimeout: 200 * time.Millisecond,
 		},
 	}
 
@@ -84,6 +97,53 @@ func TestNewGateway_DialsWithENH(t *testing.T) {
 	if err := gateway.Close(); err != nil {
 		t.Fatalf("Close() error = %v", err)
 	}
+}
+
+type mockInitTransport struct {
+	called   bool
+	features []byte
+}
+
+func (m *mockInitTransport) Init(features byte) error {
+	m.called = true
+	m.features = append(m.features, features)
+	return nil
+}
+
+func (m *mockInitTransport) ReadByte() (byte, error) { return 0, nil }
+func (m *mockInitTransport) Write([]byte) (int, error) {
+	return 0, nil
+}
+func (m *mockInitTransport) Close() error { return nil }
+
+type mockRawTransport struct{}
+
+func (mockRawTransport) ReadByte() (byte, error) { return 0, nil }
+func (mockRawTransport) Write([]byte) (int, error) {
+	return 0, nil
+}
+func (mockRawTransport) Close() error { return nil }
+
+func TestInitTransportIfSupported(t *testing.T) {
+	t.Run("calls Init when supported", func(t *testing.T) {
+		tr := &mockInitTransport{}
+		if err := initTransportIfSupported(tr); err != nil {
+			t.Fatalf("initTransportIfSupported error = %v", err)
+		}
+		if !tr.called {
+			t.Fatalf("Init was not called")
+		}
+		if len(tr.features) != 1 || tr.features[0] != 0x00 {
+			t.Fatalf("Init features = %v; want [0]", tr.features)
+		}
+	})
+
+	t.Run("no-op when unsupported", func(t *testing.T) {
+		tr := mockRawTransport{}
+		if err := initTransportIfSupported(tr); err != nil {
+			t.Fatalf("initTransportIfSupported error = %v", err)
+		}
+	})
 }
 
 func TestGateway_RefreshRouterPlanes(t *testing.T) {


### PR DESCRIPTION
Fixes #17.

- Call `Init(0x00)` when the configured transport supports it (ENH).
- Add unit tests covering init wiring and ENH dial path.

Tests: `go test ./...`