### PR TITLE
graphql: stop schema rebuild loop when changes closes

### DIFF
--- a/graphql/builder.go
+++ b/graphql/builder.go
@@ -28,26 +28,31 @@ func (b *Builder) Start(ctx context.Context) error {
 	if b.changes == nil {
 		return nil
 	}
+
+	// Goroutine exits when ctx.Done() closes or when changes closes.
+	go b.watchChanges(ctx)
+
+	return nil
+}
+
+func (b *Builder) watchChanges(ctx context.Context) {
+	if b == nil || b.changes == nil {
+		return
+	}
 	if ctx == nil {
 		ctx = context.Background()
 	}
-
-	// Goroutine exits when ctx.Done() closes.
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case _, ok := <-b.changes:
+			if !ok {
 				return
-			case _, ok := <-b.changes:
-				if !ok {
-					return
-				}
-				_ = b.Rebuild()
 			}
+			_ = b.Rebuild()
 		}
-	}()
-
-	return nil
+	}
 }
 
 func (b *Builder) Rebuild() error {

--- a/graphql/builder_test.go
+++ b/graphql/builder_test.go
@@ -173,20 +173,27 @@ func TestBuilder_StopsOnClosedChannel(t *testing.T) {
 	changes := make(chan struct{})
 
 	builder := NewBuilder(reg, changes)
+	close(changes)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := builder.Start(ctx); err != nil {
-		t.Fatalf("Start error = %v", err)
-	}
+	done := make(chan struct{})
+	go func() {
+		builder.watchChanges(ctx)
+		close(done)
+	}()
 
-	rev := builder.Revision()
-	close(changes)
-
-	time.Sleep(50 * time.Millisecond)
-
-	if got := builder.Revision(); got != rev {
-		t.Fatalf("Revision advanced after close: %d -> %d", rev, got)
+	select {
+	case <-done:
+		return
+	case <-time.After(200 * time.Millisecond):
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(200 * time.Millisecond):
+		}
+		t.Fatalf("watchChanges did not exit after changes closed")
 	}
 }
 


### PR DESCRIPTION
Fixes #21

- Extract builder change-watcher into `watchChanges` for testability.
- Add a unit test that asserts the watcher goroutine exits when the `changes` channel is closed.