### PR TITLE
Fix smoke identify decode parsing

### DIFF
--- a/smoke.go
+++ b/smoke.go
@@ -503,14 +503,20 @@ func (identifyTemplate) Primary() byte   { return 0x07 }
 func (identifyTemplate) Secondary() byte { return 0x04 }
 
 func decodeDeviceInfoPayload(payload []byte) (map[string]string, error) {
-	if len(payload) < 8 {
+	if len(payload) < 10 {
 		return nil, fmt.Errorf("identify short payload: %w", ebuserrors.ErrInvalidPayload)
 	}
+
+	manufacturer := fmt.Sprintf("0x%02X", payload[0])
+	if payload[0] == 0xB5 {
+		manufacturer = "Vaillant"
+	}
+
 	return map[string]string{
-		"manufacturer": fmt.Sprintf("%02X%02X", payload[0], payload[1]),
-		"device_id":    fmt.Sprintf("%02X%02X", payload[2], payload[3]),
-		"sw_version":   fmt.Sprintf("%02X%02X", payload[4], payload[5]),
-		"hw_version":   fmt.Sprintf("%02X%02X", payload[6], payload[7]),
+		"manufacturer": manufacturer,
+		"device_id":    strings.Trim(string(payload[1:6]), " \x00"),
+		"sw_version":   fmt.Sprintf("%02X%02X", payload[6], payload[7]),
+		"hw_version":   fmt.Sprintf("%02X%02X", payload[8], payload[9]),
 	}, nil
 }
 

--- a/smoke_test.go
+++ b/smoke_test.go
@@ -115,12 +115,12 @@ func TestSmokePlaneBuildRequestAndDecode(t *testing.T) {
 }
 
 func TestDecodeDeviceInfoPayload(t *testing.T) {
-	payload := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	payload := []byte{0xB5, ' ', 'A', 'B', ' ', 0x00, 0x01, 0x02, 0x76, 0x03}
 	info, err := decodeDeviceInfoPayload(payload)
 	if err != nil {
 		t.Fatalf("decodeDeviceInfoPayload error = %v", err)
 	}
-	if info["manufacturer"] != "0102" || info["device_id"] != "0304" || info["sw_version"] != "0506" || info["hw_version"] != "0708" {
+	if info["manufacturer"] != "Vaillant" || info["device_id"] != "AB" || info["sw_version"] != "0102" || info["hw_version"] != "7603" {
 		t.Fatalf("unexpected decoded info: %+v", info)
 	}
 	if _, err := decodeDeviceInfoPayload([]byte{0x01}); err == nil {


### PR DESCRIPTION
Fixes #23

- Update `decodeDeviceInfoPayload` to parse MF(1) + ID(5 ASCII) + SW(2) + HW(2), including Vaillant manufacturer mapping.
- Update `TestDecodeDeviceInfoPayload` to use a 10-byte fixture.

Tests: `go test ./...`