### PR TITLE
Smoke: invoke router planes directly

### DIFF
--- a/smoke.go
+++ b/smoke.go
@@ -131,22 +131,48 @@ func RunSmoke(ctx context.Context, cfg smokeConfig, opts SmokeOptions) error {
 			continue
 		}
 		for _, plane := range planes {
-			method, ok := firstReadOnlyMethod(plane.Methods())
-			if !ok {
-				logger.Printf("device 0x%02x plane %s has no read-only methods", entry.Address(), plane.Name())
-				continue
-			}
+			invokePlane, direct := smokeInvocationPlane(entry, plane, source)
 
-			smokePlane := newSmokePlane(entry, plane, source)
-			methodTimeout := time.Duration(cfg.Smoke.MethodTimeoutSec) * time.Second
-			ctxMethod, cancelMethod := context.WithTimeout(ctx, methodTimeout)
-			result, err := gateway.Router.Invoke(ctxMethod, smokePlane, method.Name(), map[string]any{})
-			cancelMethod()
-			if err != nil {
-				invokeErrors = append(invokeErrors, fmt.Sprintf("device 0x%02x plane %s method %s: %v", entry.Address(), plane.Name(), method.Name(), err))
+			hasReadOnly := false
+			invoked := false
+			for _, method := range invokePlane.Methods() {
+				if method == nil || !method.ReadOnly() {
+					continue
+				}
+				hasReadOnly = true
+
+				params, ok := smokeParams(entry, invokePlane.Name(), method.Name(), source)
+				if !ok {
+					if smokeMethodNeedsParams(method) {
+						logger.Printf("device 0x%02x plane %s method %s skipped: cannot determine params", entry.Address(), invokePlane.Name(), method.Name())
+						continue
+					}
+					params = map[string]any{}
+					if direct {
+						params["source"] = source
+					}
+				}
+
+				methodTimeout := time.Duration(cfg.Smoke.MethodTimeoutSec) * time.Second
+				ctxMethod, cancelMethod := context.WithTimeout(ctx, methodTimeout)
+				result, err := gateway.Router.Invoke(ctxMethod, invokePlane, method.Name(), params)
+				cancelMethod()
+				invoked = true
+				if err != nil {
+					invokeErrors = append(invokeErrors, fmt.Sprintf("device 0x%02x plane %s method %s: %v", entry.Address(), invokePlane.Name(), method.Name(), err))
+					break
+				}
+				logger.Printf("device 0x%02x plane %s method %s ok: %+v", entry.Address(), invokePlane.Name(), method.Name(), result)
+				break
+			}
+			if !hasReadOnly {
+				logger.Printf("device 0x%02x plane %s has no read-only methods", entry.Address(), invokePlane.Name())
 				continue
 			}
-			logger.Printf("device 0x%02x plane %s method %s ok: %+v", entry.Address(), plane.Name(), method.Name(), result)
+			if !invoked {
+				logger.Printf("device 0x%02x plane %s has no invokable read-only methods", entry.Address(), invokePlane.Name())
+				continue
+			}
 		}
 	}
 
@@ -260,6 +286,53 @@ func firstReadOnlyMethod(methods []registry.Method) (registry.Method, bool) {
 		}
 	}
 	return nil, false
+}
+
+func smokeInvocationPlane(entry registry.DeviceEntry, plane registry.Plane, source byte) (router.Plane, bool) {
+	if plane == nil {
+		return newSmokePlane(entry, plane, source), false
+	}
+	if typed, ok := plane.(router.Plane); ok {
+		return typed, true
+	}
+	return newSmokePlane(entry, plane, source), false
+}
+
+func smokeParams(entry registry.DeviceEntry, planeName, methodName string, source byte) (map[string]any, bool) {
+	if entry == nil {
+		return nil, false
+	}
+	if strings.TrimSpace(entry.DeviceID()) != "BAI00" {
+		return nil, false
+	}
+	if planeName != "system" || methodName != "get_operational_data" {
+		return nil, false
+	}
+
+	return map[string]any{
+		"source": source,
+		"op":     byte(0x00),
+	}, true
+}
+
+func smokeMethodNeedsParams(method registry.Method) bool {
+	if method == nil {
+		return false
+	}
+	template := method.Template()
+	if template == nil {
+		return false
+	}
+
+	if schemaProvider, ok := template.(interface{ ParamSchema() schema.Schema }); ok {
+		return len(schemaProvider.ParamSchema().Fields) > 0
+	}
+	if _, ok := template.(interface {
+		Build(params map[string]any) ([]byte, error)
+	}); ok {
+		return true
+	}
+	return false
 }
 
 func newGatewayWithTransport(ctx context.Context, cfg Config, wrap func(transport.RawTransport) transport.RawTransport) (*Gateway, error) {

--- a/smoke_test.go
+++ b/smoke_test.go
@@ -1,13 +1,17 @@
 package ebusgateway
 
 import (
+	"bytes"
+	"context"
 	"reflect"
 	"testing"
 
 	"github.com/d3vi1/helianthus-ebusgo/protocol"
 	"github.com/d3vi1/helianthus-ebusgo/types"
 	"github.com/d3vi1/helianthus-ebusreg/registry"
+	"github.com/d3vi1/helianthus-ebusreg/router"
 	"github.com/d3vi1/helianthus-ebusreg/schema"
+	"github.com/d3vi1/helianthus-ebusreg/vaillant/system"
 )
 
 type testMethod struct {
@@ -139,5 +143,101 @@ func TestScanTargetsFromExpectedDevices(t *testing.T) {
 	want := []byte{0x08, 0x10}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("scan targets = %v; want %v", got, want)
+	}
+}
+
+type smokeMockBus struct {
+	lastRequest protocol.Frame
+	response    *protocol.Frame
+	err         error
+}
+
+func (bus *smokeMockBus) Send(ctx context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+	bus.lastRequest = frame
+	return bus.response, bus.err
+}
+
+func TestSmokeInvoke_UsesDirectRouterPlaneAndDefaultsParams(t *testing.T) {
+	t.Parallel()
+
+	planes := system.NewProvider().CreatePlanes(registry.DeviceInfo{
+		Manufacturer: "Vaillant",
+		Address:      0x08,
+	})
+	if len(planes) != 1 {
+		t.Fatalf("expected 1 plane, got %d", len(planes))
+	}
+	plane := planes[0]
+
+	entry := testEntry{
+		info: registry.DeviceInfo{
+			Manufacturer: "Vaillant",
+			DeviceID:     "BAI00",
+			Address:      0x08,
+		},
+		planes: []registry.Plane{plane},
+	}
+
+	invokePlane, direct := smokeInvocationPlane(entry, plane, 0x10)
+	if !direct {
+		t.Fatalf("expected plane to be invoked directly")
+	}
+	if typed, ok := plane.(router.Plane); !ok || invokePlane != typed {
+		t.Fatalf("expected returned plane to match the original router.Plane")
+	}
+
+	params, ok := smokeParams(entry, invokePlane.Name(), "get_operational_data", 0x10)
+	if !ok {
+		t.Fatalf("expected smoke params for get_operational_data")
+	}
+
+	payload := []byte{
+		0x01,       // dcfstate
+		0x12,       // hour (BCD 12)
+		0x34,       // minute (BCD 34)
+		0x03,       // day (BCD 03)
+		0x02,       // month (BCD 02)
+		0x26,       // year (BCD 26)
+		0x80, 0x14, // temp (DATA2b 20.5)
+	}
+
+	bus := &smokeMockBus{
+		response: &protocol.Frame{
+			Source:    0x08,
+			Target:    0x10,
+			Primary:   0xB5,
+			Secondary: 0x04,
+			Data:      payload,
+		},
+	}
+	eventRouter := router.NewBusEventRouter(bus)
+
+	result, err := eventRouter.Invoke(context.Background(), invokePlane, "get_operational_data", params)
+	if err != nil {
+		t.Fatalf("Invoke error = %v", err)
+	}
+
+	if bus.lastRequest.Source != 0x10 || bus.lastRequest.Target != 0x08 {
+		t.Fatalf("unexpected request addresses: %+v", bus.lastRequest)
+	}
+	if bus.lastRequest.Primary != 0xB5 || bus.lastRequest.Secondary != 0x04 {
+		t.Fatalf("unexpected request type: %+v", bus.lastRequest)
+	}
+	if !bytes.Equal(bus.lastRequest.Data, []byte{0x00}) {
+		t.Fatalf("unexpected request data %v", bus.lastRequest.Data)
+	}
+
+	values, ok := result.(map[string]types.Value)
+	if !ok {
+		t.Fatalf("expected map[string]types.Value, got %T", result)
+	}
+	if op := values["op"]; !op.Valid || op.Value != byte(0x00) {
+		t.Fatalf("op = %+v; want 0x00 valid", op)
+	}
+	if got := values["payload"]; !got.Valid || !bytes.Equal(got.Value.([]byte), payload) {
+		t.Fatalf("payload = %+v; want %v", got, payload)
+	}
+	if got := values["dcfstate"]; !got.Valid || got.Value != uint8(0x01) {
+		t.Fatalf("dcfstate = %+v; want 1 valid", got)
 	}
 }


### PR DESCRIPTION
## What
- When a registry plane implements `router.Plane`, smoke now invokes it directly (no schema-only wrapper).
- Adds default params for Vaillant system `get_operational_data` (BAI00 only); skips read-only methods when params can't be determined.

## Testing
- `go test ./...`
- Smoke test: not run (requires ENH socket / real bus)

Fixes #24