### PR TITLE
smoke: test B5/24 on BASV2

### DIFF
--- a/smoke.go
+++ b/smoke.go
@@ -301,17 +301,24 @@ func smokeParams(entry registry.DeviceEntry, planeName, methodName string, sourc
 	if entry == nil {
 		return nil, false
 	}
-	if strings.TrimSpace(entry.DeviceID()) != "BAI00" {
-		return nil, false
-	}
-	if planeName != "system" || methodName != "get_operational_data" {
-		return nil, false
-	}
 
-	return map[string]any{
-		"source": source,
-		"op":     byte(0x00),
-	}, true
+	deviceID := strings.TrimSpace(entry.DeviceID())
+	switch {
+	case deviceID == "BAI00" && planeName == "system" && methodName == "get_operational_data":
+		return map[string]any{
+			"source": source,
+			"op":     byte(0x00),
+		}, true
+	case deviceID == "BASV2" && planeName == "system" && methodName == "get_ext_register":
+		return map[string]any{
+			"source":   source,
+			"group":    byte(0x00),
+			"instance": byte(0x00),
+			"addr":     uint16(0x5C00),
+		}, true
+	default:
+		return nil, false
+	}
 }
 
 func smokeMethodNeedsParams(method registry.Method) bool {

--- a/smoke_test.go
+++ b/smoke_test.go
@@ -284,3 +284,36 @@ func TestSmokeInvoke_UsesDirectRouterPlaneAndDefaultsParams(t *testing.T) {
 		t.Fatalf("dcfstate = %+v; want 1 valid", got)
 	}
 }
+
+func TestSmokeParams_SelectsBASV2ExtRegister(t *testing.T) {
+	t.Parallel()
+
+	entry := testEntry{
+		info: registry.DeviceInfo{
+			Manufacturer: "Vaillant",
+			DeviceID:     "BASV2",
+			Address:      0x15,
+		},
+	}
+
+	params, ok := smokeParams(entry, "system", "get_ext_register", 0x10)
+	if !ok {
+		t.Fatalf("expected smoke params for BASV2 get_ext_register")
+	}
+
+	if len(params) != 4 {
+		t.Fatalf("params keys=%d; want 4", len(params))
+	}
+	if got, ok := params["source"].(byte); !ok || got != 0x10 {
+		t.Fatalf("source=%v (%T); want 0x10 byte", params["source"], params["source"])
+	}
+	if got, ok := params["group"].(byte); !ok || got != 0x00 {
+		t.Fatalf("group=%v (%T); want 0x00 byte", params["group"], params["group"])
+	}
+	if got, ok := params["instance"].(byte); !ok || got != 0x00 {
+		t.Fatalf("instance=%v (%T); want 0x00 byte", params["instance"], params["instance"])
+	}
+	if got, ok := params["addr"].(uint16); !ok || got != 0x5C00 {
+		t.Fatalf("addr=%v (%T); want 0x5C00 uint16", params["addr"], params["addr"])
+	}
+}


### PR DESCRIPTION
Closes #29.

- Extend `smokeParams` to invoke Vaillant `system.get_ext_register` on devices with `DeviceID == "BASV2"` using `group=0x00`, `instance=0x00`, `addr=0x5C00`.
- Add unit test covering the new param selection.

Tests:
- `go test ./...`
- `EBUS_SMOKE=1 go run ./cmd/smoke`
