### PR TITLE
GraphQL: add daemon/adapter status

### DIFF
--- a/graphql/builder.go
+++ b/graphql/builder.go
@@ -8,6 +8,7 @@ import (
 type Builder struct {
 	registry Registry
 	changes  <-chan struct{}
+	status   StatusProvider
 
 	mu       sync.RWMutex
 	schema   Schema
@@ -18,6 +19,7 @@ func NewBuilder(reg Registry, changes <-chan struct{}) *Builder {
 	return &Builder{
 		registry: reg,
 		changes:  changes,
+		status:   staticStatusProvider{},
 	}
 }
 
@@ -89,4 +91,26 @@ func (b *Builder) Revision() uint64 {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 	return b.revision
+}
+
+func (b *Builder) SetStatusProvider(provider StatusProvider) {
+	if b == nil || provider == nil {
+		return
+	}
+	b.mu.Lock()
+	b.status = provider
+	b.mu.Unlock()
+}
+
+func (b *Builder) statusProvider() StatusProvider {
+	if b == nil {
+		return staticStatusProvider{}
+	}
+	b.mu.RLock()
+	provider := b.status
+	b.mu.RUnlock()
+	if provider == nil {
+		return staticStatusProvider{}
+	}
+	return provider
 }

--- a/graphql/queries.go
+++ b/graphql/queries.go
@@ -16,9 +16,46 @@ type graphqlSchemaTypes struct {
 	planeType     *graphqlgo.Object
 	deviceType    *graphqlgo.Object
 	broadcastType *graphqlgo.Object
+	statusType    *graphqlgo.Object
 }
 
 func buildSchemaTypes() graphqlSchemaTypes {
+	statusType := graphqlgo.NewObject(graphqlgo.ObjectConfig{
+		Name: "ServiceStatus",
+		Fields: graphqlgo.Fields{
+			"status": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.String),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					status, ok := params.Source.(ServiceStatus)
+					if !ok {
+						return nil, nil
+					}
+					return status.Status, nil
+				},
+			},
+			"firmwareVersion": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					status, ok := params.Source.(ServiceStatus)
+					if !ok {
+						return nil, nil
+					}
+					return status.FirmwareVersion, nil
+				},
+			},
+			"updatesAvailable": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Boolean),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					status, ok := params.Source.(ServiceStatus)
+					if !ok {
+						return nil, nil
+					}
+					return status.UpdatesAvailable, nil
+				},
+			},
+		},
+	})
+
 	fieldType := graphqlgo.NewObject(graphqlgo.ObjectConfig{
 		Name: "Field",
 		Fields: graphqlgo.Fields{
@@ -246,6 +283,7 @@ func buildSchemaTypes() graphqlSchemaTypes {
 		planeType:     planeType,
 		deviceType:    deviceType,
 		broadcastType: buildBroadcastType(),
+		statusType:    statusType,
 	}
 }
 
@@ -253,6 +291,18 @@ func buildQueryType(builder *Builder, types graphqlSchemaTypes) *graphqlgo.Objec
 	return graphqlgo.NewObject(graphqlgo.ObjectConfig{
 		Name: "Query",
 		Fields: graphqlgo.Fields{
+			"daemonStatus": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(types.statusType),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					return builder.statusProvider().DaemonStatus(), nil
+				},
+			},
+			"adapterStatus": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(types.statusType),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					return builder.statusProvider().AdapterStatus(), nil
+				},
+			},
 			"devices": &graphqlgo.Field{
 				Type: graphqlgo.NewNonNull(graphqlgo.NewList(graphqlgo.NewNonNull(types.deviceType))),
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {

--- a/graphql/queries_test.go
+++ b/graphql/queries_test.go
@@ -164,6 +164,47 @@ func TestQueryResolvers_Integration(t *testing.T) {
 		}
 	})
 
+	t.Run("service_status", func(t *testing.T) {
+		request := graphqlclient.NewRequest(`
+			query {
+				daemonStatus {
+					status
+					firmwareVersion
+					updatesAvailable
+				}
+				adapterStatus {
+					status
+					firmwareVersion
+					updatesAvailable
+				}
+			}
+		`)
+
+		var response struct {
+			DaemonStatus struct {
+				Status           string `json:"status"`
+				FirmwareVersion  string `json:"firmwareVersion"`
+				UpdatesAvailable bool   `json:"updatesAvailable"`
+			} `json:"daemonStatus"`
+			AdapterStatus struct {
+				Status           string `json:"status"`
+				FirmwareVersion  string `json:"firmwareVersion"`
+				UpdatesAvailable bool   `json:"updatesAvailable"`
+			} `json:"adapterStatus"`
+		}
+
+		if err := client.Run(context.Background(), request, &response); err != nil {
+			t.Fatalf("status query error = %v", err)
+		}
+
+		if response.DaemonStatus.Status == "" {
+			t.Fatalf("daemon status empty")
+		}
+		if response.AdapterStatus.Status == "" {
+			t.Fatalf("adapter status empty")
+		}
+	})
+
 	t.Run("planes", func(t *testing.T) {
 		request := graphqlclient.NewRequest(`
 			query($address: Int!) {

--- a/graphql/status.go
+++ b/graphql/status.go
@@ -1,0 +1,30 @@
+package graphql
+
+type ServiceStatus struct {
+	Status           string
+	FirmwareVersion  string
+	UpdatesAvailable bool
+}
+
+type StatusProvider interface {
+	DaemonStatus() ServiceStatus
+	AdapterStatus() ServiceStatus
+}
+
+type staticStatusProvider struct{}
+
+func (staticStatusProvider) DaemonStatus() ServiceStatus {
+	return ServiceStatus{
+		Status:           "running",
+		FirmwareVersion:  "",
+		UpdatesAvailable: false,
+	}
+}
+
+func (staticStatusProvider) AdapterStatus() ServiceStatus {
+	return ServiceStatus{
+		Status:           "unknown",
+		FirmwareVersion:  "",
+		UpdatesAvailable: false,
+	}
+}


### PR DESCRIPTION
Fixes #32.

- Add ServiceStatus GraphQL type
- Expose daemonStatus and adapterStatus queries
- Add status provider hook with static defaults
- Add query test