### PR TITLE
GraphQL: semantic subscriptions

### DIFF
--- a/graphql/subscription_schema.go
+++ b/graphql/subscription_schema.go
@@ -112,6 +112,54 @@ func buildSubscriptionType(hub *BroadcastHub, types graphqlSchemaTypes) *graphql
 					return params.Source, nil
 				},
 			},
+			"zoneUpdate": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(types.zoneType),
+				Subscribe: func(params graphqlgo.ResolveParams) (any, error) {
+					ctx := params.Context
+					if ctx == nil {
+						ctx = context.Background()
+					}
+					return hub.SubscribeZones(ctx)
+				},
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					if params.Source == nil {
+						return nil, fmt.Errorf("graphql subscription missing zone payload: %w", ebuserrors.ErrInvalidPayload)
+					}
+					return params.Source, nil
+				},
+			},
+			"dhwUpdate": &graphqlgo.Field{
+				Type: types.dhwType,
+				Subscribe: func(params graphqlgo.ResolveParams) (any, error) {
+					ctx := params.Context
+					if ctx == nil {
+						ctx = context.Background()
+					}
+					return hub.SubscribeDHW(ctx)
+				},
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					if params.Source == nil {
+						return nil, fmt.Errorf("graphql subscription missing dhw payload: %w", ebuserrors.ErrInvalidPayload)
+					}
+					return params.Source, nil
+				},
+			},
+			"energyUpdate": &graphqlgo.Field{
+				Type: types.energyTotals,
+				Subscribe: func(params graphqlgo.ResolveParams) (any, error) {
+					ctx := params.Context
+					if ctx == nil {
+						ctx = context.Background()
+					}
+					return hub.SubscribeEnergy(ctx)
+				},
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					if params.Source == nil {
+						return nil, fmt.Errorf("graphql subscription missing energy payload: %w", ebuserrors.ErrInvalidPayload)
+					}
+					return params.Source, nil
+				},
+			},
 		},
 	})
 }

--- a/graphql/subscriptions.go
+++ b/graphql/subscriptions.go
@@ -42,6 +42,9 @@ type BroadcastHub struct {
 
 	mu          sync.RWMutex
 	subscribers map[broadcastKey]map[uint64]*broadcastSubscriber
+	zoneSubs    map[uint64]*broadcastSubscriber
+	dhwSubs     map[uint64]*broadcastSubscriber
+	energySubs  map[uint64]*broadcastSubscriber
 	nextID      uint64
 	onChange    func()
 }
@@ -50,6 +53,9 @@ func NewBroadcastHub(onChange func()) *BroadcastHub {
 	return &BroadcastHub{
 		name:        "graphql_broadcasts",
 		subscribers: make(map[broadcastKey]map[uint64]*broadcastSubscriber),
+		zoneSubs:    make(map[uint64]*broadcastSubscriber),
+		dhwSubs:     make(map[uint64]*broadcastSubscriber),
+		energySubs:  make(map[uint64]*broadcastSubscriber),
 		onChange:    onChange,
 	}
 }
@@ -163,6 +169,97 @@ func (hub *BroadcastHub) Subscribe(ctx context.Context, primary, secondary byte)
 	}(id)
 
 	return sub.ch, nil
+}
+
+func (hub *BroadcastHub) SubscribeZones(ctx context.Context) (chan interface{}, error) {
+	return hub.subscribeSemantic(ctx, hub.zoneSubs)
+}
+
+func (hub *BroadcastHub) SubscribeDHW(ctx context.Context) (chan interface{}, error) {
+	return hub.subscribeSemantic(ctx, hub.dhwSubs)
+}
+
+func (hub *BroadcastHub) SubscribeEnergy(ctx context.Context) (chan interface{}, error) {
+	return hub.subscribeSemantic(ctx, hub.energySubs)
+}
+
+func (hub *BroadcastHub) PublishZoneUpdate(zone Zone) {
+	hub.publishSemantic(hub.zoneSubs, zone)
+}
+
+func (hub *BroadcastHub) PublishDHWUpdate(status *DhwStatus) {
+	if status == nil {
+		return
+	}
+	hub.publishSemantic(hub.dhwSubs, status)
+}
+
+func (hub *BroadcastHub) PublishEnergyUpdate(totals *EnergyTotals) {
+	if totals == nil {
+		return
+	}
+	hub.publishSemantic(hub.energySubs, totals)
+}
+
+func (hub *BroadcastHub) subscribeSemantic(ctx context.Context, subscribers map[uint64]*broadcastSubscriber) (chan interface{}, error) {
+	if hub == nil {
+		return nil, fmt.Errorf("broadcast hub missing: %w", ebuserrors.ErrInvalidPayload)
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	sub := &broadcastSubscriber{
+		ch: make(chan interface{}, broadcastBufferSize),
+	}
+
+	hub.mu.Lock()
+	hub.nextID++
+	sub.id = hub.nextID
+	subscribers[sub.id] = sub
+	id := sub.id
+	hub.mu.Unlock()
+
+	go func(id uint64) {
+		<-ctx.Done()
+		hub.removeSemanticSubscriber(subscribers, id)
+	}(id)
+
+	return sub.ch, nil
+}
+
+func (hub *BroadcastHub) removeSemanticSubscriber(subscribers map[uint64]*broadcastSubscriber, id uint64) {
+	if hub == nil {
+		return
+	}
+	hub.mu.Lock()
+	sub := subscribers[id]
+	delete(subscribers, id)
+	hub.mu.Unlock()
+
+	if sub != nil {
+		sub.close()
+	}
+}
+
+func (hub *BroadcastHub) publishSemantic(subscribers map[uint64]*broadcastSubscriber, payload any) {
+	if hub == nil {
+		return
+	}
+
+	hub.mu.RLock()
+	list := make([]*broadcastSubscriber, 0, len(subscribers))
+	for _, sub := range subscribers {
+		list = append(list, sub)
+	}
+	hub.mu.RUnlock()
+
+	for _, sub := range list {
+		select {
+		case sub.ch <- payload:
+		default:
+		}
+	}
 }
 
 func (hub *BroadcastHub) notifyChange() {

--- a/graphql/subscriptions_test.go
+++ b/graphql/subscriptions_test.go
@@ -86,3 +86,57 @@ func TestBroadcastHub_SubscriptionsUpdated(t *testing.T) {
 		t.Fatal("timeout waiting for subscription channel close")
 	}
 }
+
+func TestBroadcastHub_SemanticUpdates(t *testing.T) {
+	hub := NewBroadcastHub(nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	zoneCh, err := hub.SubscribeZones(ctx)
+	if err != nil {
+		t.Fatalf("SubscribeZones error = %v", err)
+	}
+
+	dhwCh, err := hub.SubscribeDHW(ctx)
+	if err != nil {
+		t.Fatalf("SubscribeDHW error = %v", err)
+	}
+
+	energyCh, err := hub.SubscribeEnergy(ctx)
+	if err != nil {
+		t.Fatalf("SubscribeEnergy error = %v", err)
+	}
+
+	hub.PublishZoneUpdate(Zone{ID: "zone-1", Name: "Zone 1"})
+	hub.PublishDHWUpdate(&DhwStatus{OperatingMode: "auto"})
+	hub.PublishEnergyUpdate(&EnergyTotals{})
+
+	select {
+	case value := <-zoneCh:
+		zone, ok := value.(Zone)
+		if !ok || zone.ID != "zone-1" {
+			t.Fatalf("zone = %#v; want zone-1", value)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for zone update")
+	}
+
+	select {
+	case value := <-dhwCh:
+		status, ok := value.(*DhwStatus)
+		if !ok || status.OperatingMode != "auto" {
+			t.Fatalf("dhw = %#v; want operatingMode=auto", value)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for dhw update")
+	}
+
+	select {
+	case value := <-energyCh:
+		if _, ok := value.(*EnergyTotals); !ok {
+			t.Fatalf("energy = %#v; want EnergyTotals", value)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for energy update")
+	}
+}


### PR DESCRIPTION
Fixes #37.

- Add semantic subscription channels for zones/DHW/energy
- Extend subscription schema with zoneUpdate/dhwUpdate/energyUpdate
- Add hub tests