### PR TITLE
Allow smoke to invoke op-coded methods without params

### DIFF
--- a/smoke.go
+++ b/smoke.go
@@ -357,6 +357,12 @@ func smokeMethodNeedsParams(method registry.Method) bool {
 	if _, ok := template.(interface {
 		Build(params map[string]any) ([]byte, error)
 	}); ok {
+		builder := template.(interface {
+			Build(params map[string]any) ([]byte, error)
+		})
+		if _, err := builder.Build(map[string]any{}); err == nil {
+			return false
+		}
 		return true
 	}
 	return false


### PR DESCRIPTION
Fixes #48.

## Summary
- Smoke now probes Build() with empty params; if it succeeds, params are treated as optional.

## Testing
- go test ./...