### PR TITLE
GraphQL: stabilize projection IDs

### DIFF
--- a/graphql/builder_test.go
+++ b/graphql/builder_test.go
@@ -171,6 +171,92 @@ func TestBuildSchema_ReflectsRegistry(t *testing.T) {
 	}
 }
 
+func TestBuildSchema_ProjectionCanonicalIDs(t *testing.T) {
+	canonicalRoot := registry.ProjectionPath{
+		Plane: registry.ServicePlane,
+		Segments: []registry.PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+		},
+	}
+	canonicalChild := registry.ProjectionPath{
+		Plane: registry.ServicePlane,
+		Segments: []registry.PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+			{Name: "status"},
+		},
+	}
+	pathRoot := registry.ProjectionPath{
+		Plane: "Observability",
+		Segments: []registry.PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+		},
+	}
+	pathChild := registry.ProjectionPath{
+		Plane: "Observability",
+		Segments: []registry.PathSegment{
+			{Name: "devices"},
+			{Name: "boiler"},
+			{Name: "status"},
+		},
+	}
+	root := registry.Node{
+		ID:            registry.NodeID("obs-root"),
+		Path:          pathRoot,
+		CanonicalPath: canonicalRoot,
+	}
+	child := registry.Node{
+		ID:            registry.NodeID("obs-child"),
+		Path:          pathChild,
+		CanonicalPath: canonicalChild,
+	}
+	edge := registry.Edge{
+		ID:   registry.EdgeID("edge-custom"),
+		From: root.ID,
+		To:   child.ID,
+	}
+	projection, err := registry.NewProjection("Observability", []registry.Node{root, child}, []registry.Edge{edge})
+	if err != nil {
+		t.Fatalf("NewProjection error = %v", err)
+	}
+
+	entry := mockEntry{
+		info: registry.DeviceInfo{
+			Address:         0x10,
+			Manufacturer:    "vaillant",
+			DeviceID:        "device-a",
+			SoftwareVersion: "1.0",
+			HardwareVersion: "7603",
+		},
+		projections: []registry.Projection{projection},
+	}
+
+	reg := mockRegistry{entries: []registry.DeviceEntry{entry}}
+	got, err := BuildSchema(reg)
+	if err != nil {
+		t.Fatalf("BuildSchema error = %v", err)
+	}
+	if len(got.Devices) != 1 || len(got.Devices[0].Projections) != 1 {
+		t.Fatalf("Projections = %d; want 1", len(got.Devices[0].Projections))
+	}
+	gotProjection := got.Devices[0].Projections[0]
+	if gotProjection.Nodes[0].ID != canonicalRoot.String() || gotProjection.Nodes[0].CanonicalPath != canonicalRoot.String() {
+		t.Fatalf("Root node = %+v; want id=%s canonical=%s", gotProjection.Nodes[0], canonicalRoot.String(), canonicalRoot.String())
+	}
+	if gotProjection.Nodes[1].ID != canonicalChild.String() || gotProjection.Nodes[1].CanonicalPath != canonicalChild.String() {
+		t.Fatalf("Child node = %+v; want id=%s canonical=%s", gotProjection.Nodes[1], canonicalChild.String(), canonicalChild.String())
+	}
+	expectedEdgeID, err := registry.StableEdgeID("Observability", registry.NodeID(canonicalRoot.String()), registry.NodeID(canonicalChild.String()))
+	if err != nil {
+		t.Fatalf("StableEdgeID error = %v", err)
+	}
+	if gotProjection.Edges[0].ID != string(expectedEdgeID) || gotProjection.Edges[0].From != canonicalRoot.String() || gotProjection.Edges[0].To != canonicalChild.String() {
+		t.Fatalf("Edge = %+v; want id=%s from=%s to=%s", gotProjection.Edges[0], expectedEdgeID, canonicalRoot.String(), canonicalChild.String())
+	}
+}
+
 func TestBuilder_RebuildsOnChange(t *testing.T) {
 	entryA := mockEntry{
 		info: registry.DeviceInfo{

--- a/graphql/schema.go
+++ b/graphql/schema.go
@@ -129,19 +129,37 @@ func BuildSchema(reg Registry) (Schema, error) {
 				return false
 			}
 			nodes := make([]ProjectionNode, len(projection.Nodes))
+			canonicalByID := make(map[registry.NodeID]string, len(projection.Nodes))
 			for index, node := range projection.Nodes {
+				canonicalPath := node.CanonicalPath.String()
+				canonicalByID[node.ID] = canonicalPath
 				nodes[index] = ProjectionNode{
-					ID:            string(node.ID),
+					ID:            canonicalPath,
 					Path:          node.Path.String(),
-					CanonicalPath: node.CanonicalPath.String(),
+					CanonicalPath: canonicalPath,
 				}
 			}
 			edges := make([]ProjectionEdge, len(projection.Edges))
 			for index, edge := range projection.Edges {
+				from := canonicalByID[edge.From]
+				to := canonicalByID[edge.To]
+				if from == "" {
+					from = string(edge.From)
+				}
+				if to == "" {
+					to = string(edge.To)
+				}
+				edgeID := edge.ID
+				if from != "" && to != "" {
+					stableID, err := registry.StableEdgeID(projection.Plane, registry.NodeID(from), registry.NodeID(to))
+					if err == nil {
+						edgeID = stableID
+					}
+				}
 				edges[index] = ProjectionEdge{
-					ID:   string(edge.ID),
-					From: string(edge.From),
-					To:   string(edge.To),
+					ID:   string(edgeID),
+					From: from,
+					To:   to,
 				}
 			}
 			device.Projections = append(device.Projections, Projection{


### PR DESCRIPTION
## Summary
- expose projection node IDs as canonical Service paths in GraphQL schema
- normalize projection edges to canonical node IDs with stable edge IDs
- add coverage for canonical ID mapping

## Testing
- go test ./...

## Smoke test
- not required (per issue)

Closes #72