### PR TITLE
M6: Device Dump Pipeline (structured register dump artifacts)

### DIFF
--- a/register_dump.go
+++ b/register_dump.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math"
@@ -31,6 +32,27 @@ type registerDumpEntry struct {
 	Line     int
 }
 
+type registerDumpJSON struct {
+	Metadata registerDumpJSONMetadata `json:"metadata"`
+	Entries  []registerDumpJSONEntry  `json:"entries"`
+}
+
+type registerDumpJSONMetadata struct {
+	Timestamp  string `json:"timestamp"`
+	Target     string `json:"target"`
+	TSPSource  string `json:"tsp_source"`
+	EntryCount int    `json:"entry_count"`
+}
+
+type registerDumpJSONEntry struct {
+	Method   string `json:"method"`
+	Group    string `json:"group"`
+	Instance string `json:"instance"`
+	Address  string `json:"address"`
+	Raw      string `json:"raw"`
+	Decoded  string `json:"decoded"`
+}
+
 type registerField struct {
 	Name   string
 	Type   string
@@ -52,6 +74,11 @@ type baseContext struct {
 	Instance  byte
 	AddrLo    byte
 	HasAddrLo bool
+}
+
+type registerDumpRetryEntry struct {
+	Index int
+	Entry registerDumpEntry
 }
 
 func runRegisterDump(ctx context.Context, cfg smokeConfig, gateway *Gateway, entries []registry.DeviceEntry, source byte, logger *wireLogger, logOutput io.Writer) error {
@@ -94,14 +121,8 @@ func runRegisterDump(ctx context.Context, cfg smokeConfig, gateway *Gateway, ent
 		return fmt.Errorf("register dump target 0x%02x missing system plane", target)
 	}
 
-	dumpPath := cfg.Smoke.RegisterDumpOutput
-	if strings.TrimSpace(dumpPath) == "" {
-		if strings.TrimSpace(cfg.Smoke.WireLogPath) != "" {
-			dumpPath = cfg.Smoke.WireLogPath + ".dump.log"
-		} else {
-			dumpPath = filepath.Join(".", "register_dump.log")
-		}
-	}
+	dumpPath := resolveRegisterDumpLogPath(cfg)
+	jsonPath := resolveRegisterDumpJSONPath(cfg, dumpPath)
 
 	writer := logOutput
 	if writer == nil {
@@ -138,10 +159,17 @@ func runRegisterDump(ctx context.Context, cfg smokeConfig, gateway *Gateway, ent
 
 	writeDumpLine(writer, "register dump started: target=0x%02x entries=%d tsp=%s", target, len(requests), cfg.Smoke.RegisterDumpTSP)
 
-	var emptyEntries []registerDumpEntry
-	for _, req := range requests {
+	jsonEntries := make([]registerDumpJSONEntry, len(requests))
+	var emptyEntries []registerDumpRetryEntry
+	for idx, req := range requests {
 		if ctx != nil && ctx.Err() != nil {
 			return ctx.Err()
+		}
+		jsonEntries[idx] = registerDumpJSONEntry{
+			Method:   req.Method,
+			Group:    formatHexByte(req.Group),
+			Instance: formatHexByte(req.Instance),
+			Address:  formatHexWord(req.Addr),
 		}
 		params := map[string]any{
 			"source": source,
@@ -163,10 +191,12 @@ func runRegisterDump(ctx context.Context, cfg smokeConfig, gateway *Gateway, ent
 
 		payload := extractDumpPayload(result)
 		fields := decodeRegisterFields(req, payload, models)
+		jsonEntries[idx].Raw = payload
+		jsonEntries[idx].Decoded = fields
 		writeDumpLine(writer, "target=0x%02x group=0x%02x instance=0x%02x addr=0x%04x method=%s model=%s line=%d payload=%s fields=%s",
 			target, req.Group, req.Instance, req.Addr, req.Method, req.Model, req.Line, payload, fields)
 		if payload == "" {
-			emptyEntries = append(emptyEntries, req)
+			emptyEntries = append(emptyEntries, registerDumpRetryEntry{Index: idx, Entry: req})
 		}
 	}
 
@@ -177,7 +207,8 @@ func runRegisterDump(ctx context.Context, cfg smokeConfig, gateway *Gateway, ent
 		}
 		writeDumpLine(writer, "register dump retry: empty=%d delay_ms=%d", len(emptyEntries), int(delay/time.Millisecond))
 		time.Sleep(delay)
-		for _, req := range emptyEntries {
+		for _, retry := range emptyEntries {
+			req := retry.Entry
 			if ctx != nil && ctx.Err() != nil {
 				return ctx.Err()
 			}
@@ -201,9 +232,15 @@ func runRegisterDump(ctx context.Context, cfg smokeConfig, gateway *Gateway, ent
 
 			payload := extractDumpPayload(result)
 			fields := decodeRegisterFields(req, payload, models)
+			jsonEntries[retry.Index].Raw = payload
+			jsonEntries[retry.Index].Decoded = fields
 			writeDumpLine(writer, "retry=1 target=0x%02x group=0x%02x instance=0x%02x addr=0x%04x method=%s model=%s line=%d payload=%s fields=%s",
 				target, req.Group, req.Instance, req.Addr, req.Method, req.Model, req.Line, payload, fields)
 		}
+	}
+
+	if err := writeRegisterDumpJSON(jsonPath, buildRegisterDumpJSON(time.Now(), target, cfg.Smoke.RegisterDumpTSP, jsonEntries)); err != nil {
+		return err
 	}
 
 	writeDumpLine(writer, "register dump completed: target=0x%02x entries=%d", target, len(requests))
@@ -1222,4 +1259,69 @@ func writeDumpLine(writer io.Writer, format string, args ...any) {
 	}
 	ts := time.Now().Format(time.RFC3339Nano)
 	fmt.Fprintf(writer, "%s %s\n", ts, fmt.Sprintf(format, args...))
+}
+
+func resolveRegisterDumpLogPath(cfg smokeConfig) string {
+	dumpPath := strings.TrimSpace(cfg.Smoke.RegisterDumpOutput)
+	if dumpPath == "" {
+		if strings.TrimSpace(cfg.Smoke.WireLogPath) != "" {
+			dumpPath = cfg.Smoke.WireLogPath + ".dump.log"
+		} else {
+			dumpPath = filepath.Join(".", "register_dump.log")
+		}
+	}
+	return dumpPath
+}
+
+func resolveRegisterDumpJSONPath(cfg smokeConfig, dumpPath string) string {
+	jsonPath := strings.TrimSpace(cfg.Smoke.RegisterDumpJSONOutput)
+	if jsonPath != "" {
+		return jsonPath
+	}
+	base := dumpPath
+	if strings.HasSuffix(strings.ToLower(base), ".log") {
+		base = strings.TrimSuffix(base, ".log")
+	}
+	if strings.TrimSpace(base) == "" {
+		base = filepath.Join(".", "register_dump")
+	}
+	return base + ".json"
+}
+
+func buildRegisterDumpJSON(ts time.Time, target byte, tspSource string, entries []registerDumpJSONEntry) registerDumpJSON {
+	return registerDumpJSON{
+		Metadata: registerDumpJSONMetadata{
+			Timestamp:  ts.Format(time.RFC3339Nano),
+			Target:     formatHexByte(target),
+			TSPSource:  tspSource,
+			EntryCount: len(entries),
+		},
+		Entries: entries,
+	}
+}
+
+func writeRegisterDumpJSON(path string, payload registerDumpJSON) error {
+	if strings.TrimSpace(path) == "" {
+		return nil
+	}
+	dir := filepath.Dir(path)
+	if dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0o644)
+}
+
+func formatHexByte(value byte) string {
+	return fmt.Sprintf("0x%02x", value)
+}
+
+func formatHexWord(value uint16) string {
+	return fmt.Sprintf("0x%04x", value)
 }

--- a/register_dump_test.go
+++ b/register_dump_test.go
@@ -1,0 +1,78 @@
+package ebusgateway
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestResolveRegisterDumpJSONPath(t *testing.T) {
+	cfg := smokeConfig{}
+	base := filepath.Join(t.TempDir(), "dump.log")
+	got := resolveRegisterDumpJSONPath(cfg, base)
+	want := filepath.Join(filepath.Dir(base), "dump.json")
+	if got != want {
+		t.Fatalf("resolveRegisterDumpJSONPath() = %q; want %q", got, want)
+	}
+
+	cfg.Smoke.RegisterDumpJSONOutput = filepath.Join(t.TempDir(), "custom.json")
+	got = resolveRegisterDumpJSONPath(cfg, base)
+	if got != cfg.Smoke.RegisterDumpJSONOutput {
+		t.Fatalf("resolveRegisterDumpJSONPath() = %q; want %q", got, cfg.Smoke.RegisterDumpJSONOutput)
+	}
+}
+
+func TestWriteRegisterDumpJSON(t *testing.T) {
+	ts := time.Date(2026, 2, 11, 12, 0, 0, 0, time.UTC)
+	payload := buildRegisterDumpJSON(ts, 0x15, "./data/vaillant/15.720.annotated.tsp", []registerDumpJSONEntry{
+		{
+			Method:   "get_ext_register",
+			Group:    "0x01",
+			Instance: "0x02",
+			Address:  "0x0100",
+			Raw:      "010203",
+			Decoded:  "value=7",
+		},
+	})
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "register_dump.json")
+	if err := writeRegisterDumpJSON(path, payload); err != nil {
+		t.Fatalf("writeRegisterDumpJSON error = %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile error = %v", err)
+	}
+
+	var decoded registerDumpJSON
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal error = %v", err)
+	}
+
+	if decoded.Metadata.Timestamp != ts.Format(time.RFC3339Nano) {
+		t.Fatalf("timestamp = %q; want %q", decoded.Metadata.Timestamp, ts.Format(time.RFC3339Nano))
+	}
+	if decoded.Metadata.Target != "0x15" {
+		t.Fatalf("target = %q; want 0x15", decoded.Metadata.Target)
+	}
+	if decoded.Metadata.TSPSource != "./data/vaillant/15.720.annotated.tsp" {
+		t.Fatalf("tsp = %q; want %q", decoded.Metadata.TSPSource, "./data/vaillant/15.720.annotated.tsp")
+	}
+	if decoded.Metadata.EntryCount != 1 {
+		t.Fatalf("entry_count = %d; want 1", decoded.Metadata.EntryCount)
+	}
+	if len(decoded.Entries) != 1 {
+		t.Fatalf("entries len = %d; want 1", len(decoded.Entries))
+	}
+	entry := decoded.Entries[0]
+	if entry.Method != "get_ext_register" || entry.Group != "0x01" || entry.Instance != "0x02" || entry.Address != "0x0100" {
+		t.Fatalf("entry mismatch: %+v", entry)
+	}
+	if entry.Raw != "010203" || entry.Decoded != "value=7" {
+		t.Fatalf("entry payload mismatch: %+v", entry)
+	}
+}

--- a/smoke_config.go
+++ b/smoke_config.go
@@ -42,6 +42,7 @@ type smokeBehavior struct {
 	RegisterDumpTSP               string  `yaml:"register_dump_tsp"`
 	RegisterDumpTarget            hexByte `yaml:"register_dump_target"`
 	RegisterDumpOutput            string  `yaml:"register_dump_output"`
+	RegisterDumpJSONOutput        string  `yaml:"register_dump_json_output"`
 	RegisterDumpTimeoutSec        int     `yaml:"register_dump_timeout_sec"`
 	RegisterDumpLimit             int     `yaml:"register_dump_limit"`
 	IdentifyB50928xx              bool    `yaml:"identify_b509_28xx"`
@@ -164,6 +165,7 @@ func (cfg *smokeConfig) normalize() error {
 	cfg.Smoke.WireLogPath = strings.TrimSpace(cfg.Smoke.WireLogPath)
 	cfg.Smoke.RegisterDumpTSP = strings.TrimSpace(cfg.Smoke.RegisterDumpTSP)
 	cfg.Smoke.RegisterDumpOutput = strings.TrimSpace(cfg.Smoke.RegisterDumpOutput)
+	cfg.Smoke.RegisterDumpJSONOutput = strings.TrimSpace(cfg.Smoke.RegisterDumpJSONOutput)
 
 	if cfg.ENH.Type == "" {
 		return fmt.Errorf("smoke config missing enh.type")


### PR DESCRIPTION
## What
- Emit a structured JSON artifact alongside register dump logs
- Add configurable JSON output path + metadata payload
- Store raw/decoded register entry results and update on retry
- Add tests for JSON output shape and path resolution

## Why
Downstream tooling needs machine-readable artifacts for device dump correlation and analysis.

## Acceptance Criteria
- [x] Register dump output includes a structured JSON artifact with metadata (timestamp, target, TSP source, entry count)
- [x] CLI or smoke config can direct output paths for both log and JSON artifacts
- [x] JSON artifact captures each register entry with method, group/instance, address, raw payload, and decoded fields (when available)
- [x] Unit or integration tests validate JSON output shape using fixtures
- [x] CI green
- [x] Smoke test required: NO

Closes #68.

Smoke test: not required (not run).
