### PR TITLE
Register dump upload flow

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -101,6 +101,7 @@ func bindFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) {
 	fs.StringVar(&cfg.SubscriptionPath, "subscription-path", cfg.SubscriptionPath, "graphql subscriptions path")
 	fs.StringVar(&cfg.MCPPath, "mcp-path", cfg.MCPPath, "mcp endpoint path")
 	fs.StringVar(&cfg.UIPath, "ui-path", cfg.UIPath, "portal ui path")
+	fs.StringVar(&cfg.DumpUploadPath, "dump-upload-path", cfg.DumpUploadPath, "register dump upload endpoint path")
 	fs.BoolVar(&cfg.MDNSAdvertise, "mdns", cfg.MDNSAdvertise, "advertise graphql endpoint via mdns")
 	fs.StringVar(&cfg.MDNSInstance, "mdns-instance", cfg.MDNSInstance, "mdns instance name")
 	fs.StringVar(&cfg.DumpOutputDir, "dump-output-dir", cfg.DumpOutputDir, "unknown device dump output dir")
@@ -153,6 +154,13 @@ func startHTTPServer(ctx context.Context, cfg ebusgateway.Config, gateway *ebusg
 	mux.Handle(cfg.SnapshotPath, snapshotHandler)
 	mux.Handle(cfg.SubscriptionPath, subscriptionHandler)
 	mux.Handle(cfg.MCPPath, mcpServer.Handler())
+	if cfg.DumpUploadPath != "" {
+		uploadPath := cfg.DumpUploadPath
+		if !strings.HasPrefix(uploadPath, "/") {
+			uploadPath = "/" + uploadPath
+		}
+		mux.Handle(uploadPath, ebusgateway.NewRegisterDumpUploadHandler(cfg.DumpOutputDir))
+	}
 	if cfg.UIPath != "" {
 		uiPath := cfg.UIPath
 		if !strings.HasPrefix(uiPath, "/") {

--- a/config.go
+++ b/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	MDNSAdvertise    bool
 	MDNSInstance     string
 	DumpOutputDir    string
+	DumpUploadPath   string
 	DumpUploadURL    string
 	DumpIncludePII   bool
 }
@@ -65,6 +66,7 @@ func DefaultConfig() Config {
 		SubscriptionPath: "/graphql/subscriptions",
 		MCPPath:          "/mcp",
 		UIPath:           "/ui",
+		DumpUploadPath:   "/dump/upload",
 		MDNSAdvertise:    true,
 		MDNSInstance:     "helianthus",
 		DumpOutputDir:    "./dumps",
@@ -112,6 +114,9 @@ func applyDefaults(cfg Config) Config {
 	}
 	if cfg.UIPath == "" {
 		cfg.UIPath = "/ui"
+	}
+	if cfg.DumpUploadPath == "" {
+		cfg.DumpUploadPath = "/dump/upload"
 	}
 	if cfg.MDNSInstance == "" {
 		cfg.MDNSInstance = "helianthus"

--- a/register_dump.go
+++ b/register_dump.go
@@ -242,6 +242,11 @@ func runRegisterDump(ctx context.Context, cfg smokeConfig, gateway *Gateway, ent
 	if err := writeRegisterDumpJSON(jsonPath, buildRegisterDumpJSON(time.Now(), target, cfg.Smoke.RegisterDumpTSP, jsonEntries)); err != nil {
 		return err
 	}
+	if uploadURL := strings.TrimSpace(cfg.Smoke.RegisterDumpUploadURL); uploadURL != "" {
+		if err := uploadRegisterDumpJSON(ctx, uploadURL, jsonPath); err != nil {
+			return err
+		}
+	}
 
 	writeDumpLine(writer, "register dump completed: target=0x%02x entries=%d", target, len(requests))
 

--- a/register_dump_upload.go
+++ b/register_dump_upload.go
@@ -1,0 +1,115 @@
+package ebusgateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const registerDumpUploadMaxBytes = 10 << 20
+
+type registerDumpUploadResponse struct {
+	Path string `json:"path"`
+	Size int64  `json:"size"`
+}
+
+func NewRegisterDumpUploadHandler(outputDir string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		body := http.MaxBytesReader(w, r.Body, registerDumpUploadMaxBytes)
+		defer body.Close()
+
+		var payload registerDumpJSON
+		if err := json.NewDecoder(body).Decode(&payload); err != nil {
+			http.Error(w, "invalid json payload", http.StatusBadRequest)
+			return
+		}
+		if strings.TrimSpace(payload.Metadata.Timestamp) == "" || strings.TrimSpace(payload.Metadata.Target) == "" {
+			http.Error(w, "missing metadata", http.StatusBadRequest)
+			return
+		}
+		if payload.Metadata.EntryCount == 0 {
+			payload.Metadata.EntryCount = len(payload.Entries)
+		}
+		if payload.Metadata.EntryCount != len(payload.Entries) {
+			http.Error(w, "entry count mismatch", http.StatusBadRequest)
+			return
+		}
+
+		dir := filepath.Join(outputDir, "register_dumps")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			http.Error(w, "cannot create output directory", http.StatusInternalServerError)
+			return
+		}
+
+		filename := registerDumpFilename(payload.Metadata)
+		path := filepath.Join(dir, filename)
+		data, err := json.MarshalIndent(payload, "", "  ")
+		if err != nil {
+			http.Error(w, "cannot encode payload", http.StatusInternalServerError)
+			return
+		}
+		if err := os.WriteFile(path, data, 0o644); err != nil {
+			http.Error(w, "cannot write output file", http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(registerDumpUploadResponse{
+			Path: path,
+			Size: int64(len(data)),
+		})
+	})
+}
+
+func uploadRegisterDumpJSON(ctx context.Context, uploadURL string, jsonPath string) error {
+	data, err := os.ReadFile(jsonPath)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, uploadURL, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("register dump upload status %s", resp.Status)
+	}
+	return nil
+}
+
+func registerDumpFilename(meta registerDumpJSONMetadata) string {
+	timestamp := strings.TrimSpace(meta.Timestamp)
+	if timestamp != "" {
+		if parsed, err := time.Parse(time.RFC3339Nano, timestamp); err == nil {
+			timestamp = parsed.UTC().Format("20060102T150405.000000000Z")
+		}
+	}
+	timestamp = strings.ReplaceAll(timestamp, ":", "")
+	timestamp = strings.ReplaceAll(timestamp, "/", "")
+	target := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(meta.Target)), "0x")
+	if target == "" {
+		target = "unknown"
+	}
+	if timestamp == "" {
+		timestamp = "unknown"
+	}
+	return fmt.Sprintf("register_dump_%s_%s.json", target, timestamp)
+}

--- a/register_dump_upload_test.go
+++ b/register_dump_upload_test.go
@@ -1,0 +1,87 @@
+package ebusgateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRegisterDumpUploadHandler_WritesFile(t *testing.T) {
+	dir := t.TempDir()
+	handler := NewRegisterDumpUploadHandler(dir)
+	payload := registerDumpJSON{
+		Metadata: registerDumpJSONMetadata{
+			Timestamp:  "2026-02-11T05:30:00Z",
+			Target:     "0x08",
+			TSPSource:  "test.tsp",
+			EntryCount: 1,
+		},
+		Entries: []registerDumpJSONEntry{
+			{
+				Method:   "get_register",
+				Group:    "0x00",
+				Instance: "0x00",
+				Address:  "0x0001",
+				Raw:      "0102",
+				Decoded:  "ok",
+			},
+		},
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/dump/upload", bytes.NewReader(data))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d; want %d", rec.Code, http.StatusCreated)
+	}
+
+	var resp registerDumpUploadResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Path == "" {
+		t.Fatalf("response path empty")
+	}
+	if _, err := os.Stat(resp.Path); err != nil {
+		t.Fatalf("stat uploaded file: %v", err)
+	}
+}
+
+func TestUploadRegisterDumpJSON_PostsPayload(t *testing.T) {
+	dir := t.TempDir()
+	handler := NewRegisterDumpUploadHandler(dir)
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	path := filepath.Join(dir, "dump.json")
+	payload := registerDumpJSON{
+		Metadata: registerDumpJSONMetadata{
+			Timestamp:  "2026-02-11T05:30:00Z",
+			Target:     "0x10",
+			TSPSource:  "test.tsp",
+			EntryCount: 0,
+		},
+		Entries: []registerDumpJSONEntry{},
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write temp json: %v", err)
+	}
+
+	if err := uploadRegisterDumpJSON(context.Background(), server.URL, path); err != nil {
+		t.Fatalf("uploadRegisterDumpJSON error: %v", err)
+	}
+}

--- a/smoke_config.go
+++ b/smoke_config.go
@@ -43,6 +43,7 @@ type smokeBehavior struct {
 	RegisterDumpTarget            hexByte `yaml:"register_dump_target"`
 	RegisterDumpOutput            string  `yaml:"register_dump_output"`
 	RegisterDumpJSONOutput        string  `yaml:"register_dump_json_output"`
+	RegisterDumpUploadURL         string  `yaml:"register_dump_upload_url"`
 	RegisterDumpTimeoutSec        int     `yaml:"register_dump_timeout_sec"`
 	RegisterDumpLimit             int     `yaml:"register_dump_limit"`
 	IdentifyB50928xx              bool    `yaml:"identify_b509_28xx"`


### PR DESCRIPTION
Fixes #70.

- add register dump upload endpoint and storage handler
- add post-dump upload option via register_dump_upload_url
- add tests for upload handler and client
- add dump-upload-path config flag

Tests: go test ./...