### PR TITLE
Harden register dump upload defaults

### DIFF
--- a/config.go
+++ b/config.go
@@ -66,7 +66,6 @@ func DefaultConfig() Config {
 		SubscriptionPath: "/graphql/subscriptions",
 		MCPPath:          "/mcp",
 		UIPath:           "/ui",
-		DumpUploadPath:   "/dump/upload",
 		MDNSAdvertise:    true,
 		MDNSInstance:     "helianthus",
 		DumpOutputDir:    "./dumps",
@@ -114,9 +113,6 @@ func applyDefaults(cfg Config) Config {
 	}
 	if cfg.UIPath == "" {
 		cfg.UIPath = "/ui"
-	}
-	if cfg.DumpUploadPath == "" {
-		cfg.DumpUploadPath = "/dump/upload"
 	}
 	if cfg.MDNSInstance == "" {
 		cfg.MDNSInstance = "helianthus"

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,17 @@
+package ebusgateway
+
+import "testing"
+
+func TestDefaultConfig_DisablesDumpUploadPath(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.DumpUploadPath != "" {
+		t.Fatalf("expected DumpUploadPath empty by default, got %q", cfg.DumpUploadPath)
+	}
+}
+
+func TestApplyDefaults_DoesNotEnableDumpUploadPath(t *testing.T) {
+	cfg := applyDefaults(Config{})
+	if cfg.DumpUploadPath != "" {
+		t.Fatalf("expected DumpUploadPath empty after defaults, got %q", cfg.DumpUploadPath)
+	}
+}

--- a/register_dump_upload.go
+++ b/register_dump_upload.go
@@ -15,6 +15,8 @@ import (
 
 const registerDumpUploadMaxBytes = 10 << 20
 
+var registerDumpUploadTimeout = 20 * time.Second
+
 type registerDumpUploadResponse struct {
 	Path string `json:"path"`
 	Size int64  `json:"size"`
@@ -83,7 +85,8 @@ func uploadRegisterDumpJSON(ctx context.Context, uploadURL string, jsonPath stri
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := http.DefaultClient.Do(req)
+	client := &http.Client{Timeout: registerDumpUploadTimeout}
+	resp, err := client.Do(req)
 	if err != nil {
 		return err
 	}

--- a/register_dump_upload_test.go
+++ b/register_dump_upload_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestRegisterDumpUploadHandler_WritesFile(t *testing.T) {
@@ -83,5 +84,26 @@ func TestUploadRegisterDumpJSON_PostsPayload(t *testing.T) {
 
 	if err := uploadRegisterDumpJSON(context.Background(), server.URL, path); err != nil {
 		t.Fatalf("uploadRegisterDumpJSON error: %v", err)
+	}
+}
+
+func TestUploadRegisterDumpJSON_TimesOut(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dump.json")
+	if err := os.WriteFile(path, []byte(`{"metadata":{},"entries":[]}`), 0o644); err != nil {
+		t.Fatalf("write temp json: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+	}))
+	defer server.Close()
+
+	originalTimeout := registerDumpUploadTimeout
+	registerDumpUploadTimeout = 50 * time.Millisecond
+	defer func() { registerDumpUploadTimeout = originalTimeout }()
+
+	if err := uploadRegisterDumpJSON(context.Background(), server.URL, path); err == nil {
+		t.Fatalf("expected timeout error, got nil")
 	}
 }


### PR DESCRIPTION
Fixes #79.

- Disable register dump upload endpoint by default (no implicit /dump/upload)
- Add bounded upload timeout via registerDumpUploadTimeout
- Add tests for default config and upload timeout

Tests: go test ./...