### PR TITLE
Add initiator/target terminology guard in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,16 @@ on:
   pull_request:
 
 jobs:
+  terminology:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          if git grep -nIwiE 'm[a]ster|s[l]ave'; then
+            echo "Found legacy terminology."
+            exit 1
+          fi
+
   build:
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
## Summary
- verify tracked files contain no whole-word legacy role terms
- add a CI terminology gate that fails on whole-word legacy terms
- keep runtime behavior unchanged

## Validation
- go test ./...
- go vet ./...
- git grep -nIwE '(master|slave)'

Closes #83

@codex review