### PR TITLE
Add adapter-proxy direct transport profile (ENH/ENS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ go run ./cmd/gateway \
   -http-addr :8080
 ```
 
+Adapter-proxy direct endpoint profile examples (profile inferred from endpoint URI):
+
+```bash
+go run ./cmd/gateway -address enh://127.0.0.1:19001 -http-addr :8080
+go run ./cmd/gateway -address ens://127.0.0.1:19002 -http-addr :8080
+```
+
 Basic GraphQL probe:
 
 ```bash
@@ -141,7 +148,7 @@ This keeps optional surfaces disabled by default while preserving GraphQL/MCP AP
 | --- | --- | --- |
 | `-transport` | `enh` | `enh`, `ens`, or `ebusd-tcp` |
 | `-network` | `unix` | Transport dial network (`unix` or `tcp`) |
-| `-address` | `/var/run/ebusd/ebusd.socket` | Transport socket path or `host:port` |
+| `-address` | `/var/run/ebusd/ebusd.socket` | Transport socket path, `host:port`, or endpoint URI (`enh://`, `ens://`, `ebusd-tcp://`) |
 | `-read-timeout` | `5s` | Transport read timeout |
 | `-write-timeout` | `5s` | Transport write timeout |
 | `-dial-timeout` | `5s` | Transport dial timeout |
@@ -249,10 +256,20 @@ Smoke coverage is intentionally opt-in and hardware-backed:
 
 - Command: `EBUS_SMOKE=1 go run ./cmd/smoke`
 - Loads repo-root `AGENT-local.md` YAML blocks (`enh`, `expected_devices`, `smoke`)
-- Supports smoke profiles: `enh` and `ebusd-tcp`
+- Supports smoke profiles: `enh`, `ens`, and `ebusd-tcp`
 - Runs read-only GraphQL/MCP checks as part of the smoke flow
 - Writes JSON report to `artifacts/smoke-report.json` by default (`smoke.report_json_output` overrides)
 - Supports register probe-only mode with `smoke.register_dump_probe_only=true` (requires `smoke.register_dump_target`)
+
+Dual-topology smoke notes (`helianthus-ebus-adapter-proxy` issue #15):
+
+- Run smoke once per proxy endpoint profile (`smoke.profile: enh` then `smoke.profile: ens`) against the matching endpoint.
+- Keep the same read-only smoke flow; only endpoint/profile wiring changes between runs.
+- Suggested command:
+
+```bash
+EBUS_SMOKE=1 go run ./cmd/smoke
+```
 
 Important limits:
 

--- a/gateway.go
+++ b/gateway.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -106,6 +107,10 @@ func resolveTransport(ctx context.Context, cfg Config) (transport.RawTransport, 
 	}
 
 	config := cfg.TransportConfig
+	config, err := normalizeTransportConfig(config)
+	if err != nil {
+		return nil, nil, err
+	}
 	if config.Network == "" {
 		return nil, nil, fmt.Errorf("gateway transport missing network: %w", ebuserrors.ErrInvalidPayload)
 	}
@@ -134,6 +139,78 @@ func resolveTransport(ctx context.Context, cfg Config) (transport.RawTransport, 
 	}
 
 	return transportLayer, conn.Close, nil
+}
+
+func normalizeTransportConfig(config TransportConfig) (TransportConfig, error) {
+	config.Protocol = TransportProtocol(strings.ToLower(strings.TrimSpace(string(config.Protocol))))
+	config.Network = strings.ToLower(strings.TrimSpace(config.Network))
+	config.Address = strings.TrimSpace(config.Address)
+
+	if !strings.Contains(config.Address, "://") {
+		if config.Protocol == "" {
+			config.Protocol = TransportENH
+		}
+		return config, nil
+	}
+
+	protocol, network, address, err := parseTransportEndpoint(config.Address, config.Protocol)
+	if err != nil {
+		return TransportConfig{}, err
+	}
+	config.Protocol = protocol
+	config.Network = network
+	config.Address = address
+	return config, nil
+}
+
+func parseTransportEndpoint(endpoint string, fallbackProtocol TransportProtocol) (TransportProtocol, string, string, error) {
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return "", "", "", fmt.Errorf("gateway transport endpoint parse failed %q: %w", endpoint, err)
+	}
+
+	scheme := strings.ToLower(strings.TrimSpace(parsed.Scheme))
+	if scheme == "" {
+		return "", "", "", fmt.Errorf("gateway transport endpoint missing scheme %q", endpoint)
+	}
+
+	protocol := fallbackProtocol
+	switch scheme {
+	case "enh":
+		protocol = TransportENH
+	case "ens":
+		protocol = TransportENS
+	case "ebusd", "ebusd-tcp":
+		protocol = TransportEbusdTCP
+	case "tcp", "unix":
+	default:
+		return "", "", "", fmt.Errorf("gateway transport endpoint unsupported scheme %q", scheme)
+	}
+
+	network := ""
+	address := ""
+	switch {
+	case parsed.Host != "":
+		network = "tcp"
+		address = strings.TrimSpace(parsed.Host)
+	case parsed.Path != "" && parsed.Path != "/":
+		network = "unix"
+		address = strings.TrimSpace(parsed.Path)
+	default:
+		return "", "", "", fmt.Errorf("gateway transport endpoint %q missing host or unix path", endpoint)
+	}
+
+	if scheme == "tcp" && network != "tcp" {
+		return "", "", "", fmt.Errorf("gateway transport endpoint %q missing tcp host", endpoint)
+	}
+	if scheme == "unix" && network != "unix" {
+		return "", "", "", fmt.Errorf("gateway transport endpoint %q missing unix path", endpoint)
+	}
+	if protocol == "" {
+		protocol = TransportENH
+	}
+
+	return protocol, network, address, nil
 }
 
 func transportFromConn(protocolName TransportProtocol, conn net.Conn, readTimeout, writeTimeout time.Duration) (transport.RawTransport, error) {

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -148,6 +148,139 @@ func TestNewGateway_DialsWithEbusdTCP(t *testing.T) {
 	}
 }
 
+func TestNewGateway_DialsWithENHEndpointProfile(t *testing.T) {
+	var (
+		dialed      bool
+		gotNetwork  string
+		gotAddress  string
+		serverClose func()
+	)
+
+	dialer := func(ctx context.Context, network, address string, timeout time.Duration) (net.Conn, error) {
+		dialed = true
+		gotNetwork = network
+		gotAddress = address
+		client, server := net.Pipe()
+		serverClose = func() { _ = server.Close() }
+
+		go func() {
+			buf := make([]byte, 2)
+			if _, err := io.ReadFull(server, buf); err != nil {
+				_ = server.Close()
+				return
+			}
+			resp := transport.EncodeENH(transport.ENHResResetted, 0x00)
+			_, _ = server.Write(resp[:])
+		}()
+
+		return client, nil
+	}
+
+	cfg := Config{
+		TransportConfig: TransportConfig{
+			Address:     "enh://127.0.0.1:9999",
+			DialTimeout: time.Second,
+			Dial:        dialer,
+			ReadTimeout: 200 * time.Millisecond,
+		},
+	}
+
+	gateway, err := New(context.Background(), cfg)
+	if serverClose != nil {
+		defer serverClose()
+	}
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if !dialed {
+		t.Fatalf("dialer was not invoked")
+	}
+	if gotNetwork != "tcp" || gotAddress != "127.0.0.1:9999" {
+		t.Fatalf("dialer args = %s %s; want tcp 127.0.0.1:9999", gotNetwork, gotAddress)
+	}
+	if _, ok := gateway.Transport.(*transport.ENHTransport); !ok {
+		t.Fatalf("gateway.Transport = %T; want *transport.ENHTransport", gateway.Transport)
+	}
+
+	if err := gateway.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+}
+
+func TestNewGateway_DialsWithENSEndpointProfile(t *testing.T) {
+	var (
+		dialed      bool
+		gotNetwork  string
+		gotAddress  string
+		serverClose func()
+	)
+
+	dialer := func(ctx context.Context, network, address string, timeout time.Duration) (net.Conn, error) {
+		dialed = true
+		gotNetwork = network
+		gotAddress = address
+		client, server := net.Pipe()
+		serverClose = func() { _ = server.Close() }
+		return client, nil
+	}
+
+	cfg := Config{
+		TransportConfig: TransportConfig{
+			Address:     "ens://127.0.0.1:10000",
+			DialTimeout: time.Second,
+			Dial:        dialer,
+		},
+	}
+
+	gateway, err := New(context.Background(), cfg)
+	if serverClose != nil {
+		defer serverClose()
+	}
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if !dialed {
+		t.Fatalf("dialer was not invoked")
+	}
+	if gotNetwork != "tcp" || gotAddress != "127.0.0.1:10000" {
+		t.Fatalf("dialer args = %s %s; want tcp 127.0.0.1:10000", gotNetwork, gotAddress)
+	}
+	if _, ok := gateway.Transport.(*transport.ENSTransport); !ok {
+		t.Fatalf("gateway.Transport = %T; want *transport.ENSTransport", gateway.Transport)
+	}
+
+	if err := gateway.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+}
+
+func TestNormalizeTransportConfigRejectsUnsupportedEndpointScheme(t *testing.T) {
+	_, err := normalizeTransportConfig(TransportConfig{
+		Address: "unsupported://127.0.0.1:9999",
+	})
+	if err == nil {
+		t.Fatalf("expected error for unsupported endpoint scheme")
+	}
+}
+
+func TestNormalizeTransportConfigENHUnixEndpoint(t *testing.T) {
+	cfg, err := normalizeTransportConfig(TransportConfig{
+		Address: "enh:///var/run/ebusd/ebusd.socket",
+	})
+	if err != nil {
+		t.Fatalf("normalizeTransportConfig error = %v", err)
+	}
+	if cfg.Protocol != TransportENH {
+		t.Fatalf("protocol = %q; want %q", cfg.Protocol, TransportENH)
+	}
+	if cfg.Network != "unix" {
+		t.Fatalf("network = %q; want unix", cfg.Network)
+	}
+	if cfg.Address != "/var/run/ebusd/ebusd.socket" {
+		t.Fatalf("address = %q; want /var/run/ebusd/ebusd.socket", cfg.Address)
+	}
+}
+
 type mockInitTransport struct {
 	called   bool
 	features []byte

--- a/smoke.go
+++ b/smoke.go
@@ -427,6 +427,8 @@ func transportConfigFromSmoke(smokeCfg smokeConfig) (TransportConfig, error) {
 	switch profile {
 	case string(TransportENH):
 		cfg.Protocol = TransportENH
+	case string(TransportENS):
+		cfg.Protocol = TransportENS
 	case string(TransportEbusdTCP):
 		cfg.Protocol = TransportEbusdTCP
 	default:

--- a/smoke_config.go
+++ b/smoke_config.go
@@ -176,7 +176,7 @@ func (cfg *smokeConfig) normalize() error {
 		cfg.Smoke.Profile = string(TransportENH)
 	}
 	switch cfg.Smoke.Profile {
-	case string(TransportENH), string(TransportEbusdTCP):
+	case string(TransportENH), string(TransportENS), string(TransportEbusdTCP):
 	default:
 		return fmt.Errorf("smoke config unsupported smoke.profile %q", cfg.Smoke.Profile)
 	}

--- a/smoke_config_test.go
+++ b/smoke_config_test.go
@@ -71,6 +71,23 @@ func TestLoadSmokeConfigFileProfileValidValue(t *testing.T) {
 	}
 }
 
+func TestLoadSmokeConfigFileProfileENSValidValue(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "AGENT-local.md")
+	content := "```yaml\nenh:\n  type: tcp\n  host: \"127.0.0.1\"\n  port: 7624\nsmoke:\n  profile: ens\n```\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	cfg, err := loadSmokeConfigFile(path)
+	if err != nil {
+		t.Fatalf("loadSmokeConfigFile error = %v", err)
+	}
+	if cfg.Smoke.Profile != string(TransportENS) {
+		t.Fatalf("profile = %q; want %q", cfg.Smoke.Profile, string(TransportENS))
+	}
+}
+
 func TestLoadSmokeConfigFileProfileInvalidValue(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "AGENT-local.md")

--- a/smoke_runtime_test.go
+++ b/smoke_runtime_test.go
@@ -39,6 +39,36 @@ func TestTransportConfigFromSmokeEbusdTCPProfile(t *testing.T) {
 	}
 }
 
+func TestTransportConfigFromSmokeENSProfile(t *testing.T) {
+	t.Parallel()
+
+	cfg := smokeConfig{
+		ENH: enhConfig{
+			Type:       "tcp",
+			Host:       "127.0.0.1",
+			Port:       9900,
+			TimeoutSec: 3,
+		},
+		Smoke: smokeBehavior{
+			Profile: string(TransportENS),
+		},
+	}
+
+	transportCfg, err := transportConfigFromSmoke(cfg)
+	if err != nil {
+		t.Fatalf("transportConfigFromSmoke error = %v", err)
+	}
+	if transportCfg.Protocol != TransportENS {
+		t.Fatalf("protocol = %q; want %q", transportCfg.Protocol, TransportENS)
+	}
+	if transportCfg.Network != "tcp" {
+		t.Fatalf("network = %q; want tcp", transportCfg.Network)
+	}
+	if transportCfg.Address != "127.0.0.1:9900" {
+		t.Fatalf("address = %q; want 127.0.0.1:9900", transportCfg.Address)
+	}
+}
+
 func TestTransportConfigFromSmokeEbusdTCPRejectsNonTCP(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #91

## Summary
- add endpoint-URI transport inference so gateway transport profile can be selected by endpoint only (`enh://`, `ens://`, `ebusd-tcp://`)
- keep existing `network + address` behavior intact when URI scheme is not used
- add ENS smoke profile support and map it into runtime transport config
- document adapter-proxy direct endpoint usage and dual-topology smoke notes for ENH/ENS paths
- add/extend tests for endpoint profile parsing and smoke profile handling

## Tests run
- `GOWORK=off go test ./... -run 'TestNewGateway_DialsWithENHEndpointProfile|TestNewGateway_DialsWithENSEndpointProfile|TestNormalizeTransportConfigENHUnixEndpoint|TestLoadSmokeConfigFileProfileENSValidValue|TestTransportConfigFromSmokeENSProfile'`
- `if git grep -nIwiE 'm[a]ster|s[l]ave'; then echo 'Found legacy terminology.'; exit 1; fi`
- `GOWORK=off go vet ./...`
- `GOWORK=off go build ./...`
- `GOWORK=off go test -race -count=1 ./...`
