### PR TITLE
README refresh for practical onboarding and operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,14 @@ export GOPROXY=direct
 # Use a GitHub token with read access to private repos.
 export GH_TOKEN='<your_github_token>'
 
-# Align Git URL rewrite with CI so Go can fetch private modules.
-git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
+# CI uses a tokenized Git URL rewrite; keep local onboarding non-persistent.
+export GIT_CONFIG_COUNT=1
+export GIT_CONFIG_KEY_0="url.https://x-access-token:${GH_TOKEN}@github.com/.insteadOf"
+export GIT_CONFIG_VALUE_0="https://github.com/"
 ```
+
+After local checks, clear auth-related shell variables:
+`unset GIT_CONFIG_COUNT GIT_CONFIG_KEY_0 GIT_CONFIG_VALUE_0 GH_TOKEN`
 
 ### 1) Clone and baseline validation
 


### PR DESCRIPTION
Fixes #93

## Summary
- refresh README around explicit purpose/scope boundaries for gateway runtime responsibilities
- add status/maturity note and clear Helianthus dependency-chain placement
- add copy-paste quickstart, smoke configuration example, and endpoint examples
- add focused validation matrix, docs link map, and issue workflow conventions

## Local validation
- if git grep -nIwiE 'm[a]ster|s[l]ave'; then echo "Found legacy terminology."; exit 1; fi
- go test ./...
- go vet ./...
- go build ./...
- go test -race -count=1 ./...
- go run ./cmd/gateway -h
- EBUS_SMOKE=0 go run ./cmd/smoke
- go run ./cmd/ebusdscan -h
