### PR TITLE
gateway: scan bus on start

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -11,12 +11,15 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/d3vi1/helianthus-ebusgateway"
 	"github.com/d3vi1/helianthus-ebusgateway/graphql"
 	"github.com/d3vi1/helianthus-ebusgateway/mcp"
 	"github.com/d3vi1/helianthus-ebusgateway/mdns"
 	"github.com/d3vi1/helianthus-ebusgateway/ui"
+	"github.com/d3vi1/helianthus-ebusgo/protocol"
+	"github.com/d3vi1/helianthus-ebusreg/registry"
 )
 
 func main() {
@@ -132,6 +135,8 @@ func startHTTPServer(ctx context.Context, cfg ebusgateway.Config, gateway *ebusg
 		return nil, nil, err
 	}
 
+	startStartupScan(ctx, cfg, gateway, builder)
+
 	queryHandler, err := graphql.NewInvokeHandler(builder, gateway.Registry, gateway.Router)
 	if err != nil {
 		return nil, nil, err
@@ -213,4 +218,69 @@ func startHTTPServer(ctx context.Context, cfg ebusgateway.Config, gateway *ebusg
 	}()
 
 	return server, advertiser, nil
+}
+
+type timeoutBus struct {
+	bus     registry.ScanBus
+	timeout time.Duration
+}
+
+func (b *timeoutBus) Send(ctx context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+	if b == nil || b.bus == nil {
+		return nil, fmt.Errorf("scan timeout bus missing")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if b.timeout <= 0 {
+		return b.bus.Send(ctx, frame)
+	}
+	if deadline, ok := ctx.Deadline(); ok {
+		if time.Until(deadline) <= b.timeout {
+			return b.bus.Send(ctx, frame)
+		}
+	}
+	ctxTimeout, cancel := context.WithTimeout(ctx, b.timeout)
+	defer cancel()
+	return b.bus.Send(ctxTimeout, frame)
+}
+
+func startStartupScan(ctx context.Context, cfg ebusgateway.Config, gateway *ebusgateway.Gateway, builder *graphql.Builder) {
+	if !cfg.ScanOnStart {
+		return
+	}
+	if gateway == nil || gateway.Bus == nil || gateway.Registry == nil {
+		return
+	}
+	if builder == nil {
+		return
+	}
+
+	go func() {
+		scanCtx := ctx
+		var cancel context.CancelFunc = func() {}
+		if cfg.ScanTimeout > 0 {
+			scanCtx, cancel = context.WithTimeout(ctx, cfg.ScanTimeout)
+		}
+		defer cancel()
+
+		gateway.Start(ctx)
+
+		scanBus := &timeoutBus{bus: gateway.Bus, timeout: cfg.ScanRequestTimeout}
+		entries, err := registry.Scan(scanCtx, scanBus, gateway.Registry, cfg.ScanSource, nil)
+		if err != nil {
+			log.Printf("startup scan failed: %v", err)
+			return
+		}
+		if len(entries) == 0 {
+			log.Printf("startup scan: no devices found")
+			return
+		}
+
+		_ = gateway.RefreshRouterPlanes()
+		if err := builder.Rebuild(); err != nil {
+			log.Printf("startup scan: graphql rebuild failed: %v", err)
+		}
+		log.Printf("startup scan completed: devices=%d", len(entries))
+	}()
 }

--- a/config.go
+++ b/config.go
@@ -7,14 +7,15 @@ import (
 
 	"github.com/d3vi1/helianthus-ebusgo/protocol"
 	"github.com/d3vi1/helianthus-ebusgo/transport"
+	vaillantproviders "github.com/d3vi1/helianthus-ebusreg/providers/vaillant"
 	"github.com/d3vi1/helianthus-ebusreg/registry"
 )
 
 type TransportProtocol string
 
 const (
-	TransportENH TransportProtocol = "enh"
-	TransportENS TransportProtocol = "ens"
+	TransportENH      TransportProtocol = "enh"
+	TransportENS      TransportProtocol = "ens"
 	TransportEbusdTCP TransportProtocol = "ebusd-tcp"
 )
 
@@ -29,24 +30,28 @@ type TransportConfig struct {
 }
 
 type Config struct {
-	Transport        transport.RawTransport
-	TransportConfig  TransportConfig
-	BusConfig        protocol.BusConfig
-	QueueCapacity    int
-	Providers        []registry.PlaneProvider
-	BroadcastListen  bool
-	HTTPAddr         string
-	GraphQLPath      string
-	SnapshotPath     string
-	SubscriptionPath string
-	MCPPath          string
-	UIPath           string
-	MDNSAdvertise    bool
-	MDNSInstance     string
-	DumpOutputDir    string
-	DumpUploadPath   string
-	DumpUploadURL    string
-	DumpIncludePII   bool
+	Transport          transport.RawTransport
+	TransportConfig    TransportConfig
+	BusConfig          protocol.BusConfig
+	QueueCapacity      int
+	Providers          []registry.PlaneProvider
+	ScanOnStart        bool
+	ScanSource         byte
+	ScanTimeout        time.Duration
+	ScanRequestTimeout time.Duration
+	BroadcastListen    bool
+	HTTPAddr           string
+	GraphQLPath        string
+	SnapshotPath       string
+	SubscriptionPath   string
+	MCPPath            string
+	UIPath             string
+	MDNSAdvertise      bool
+	MDNSInstance       string
+	DumpOutputDir      string
+	DumpUploadPath     string
+	DumpUploadURL      string
+	DumpIncludePII     bool
 }
 
 func DefaultConfig() Config {
@@ -59,22 +64,39 @@ func DefaultConfig() Config {
 			WriteTimeout: 5 * time.Second,
 			DialTimeout:  5 * time.Second,
 		},
-		BusConfig:        protocol.DefaultBusConfig(),
-		HTTPAddr:         ":8080",
-		GraphQLPath:      "/graphql",
-		SnapshotPath:     "/snapshot",
-		SubscriptionPath: "/graphql/subscriptions",
-		MCPPath:          "/mcp",
-		UIPath:           "/ui",
-		MDNSAdvertise:    true,
-		MDNSInstance:     "helianthus",
-		DumpOutputDir:    "./dumps",
+		BusConfig:          protocol.DefaultBusConfig(),
+		Providers:          vaillantproviders.Default(),
+		ScanOnStart:        true,
+		ScanSource:         0x30,
+		ScanTimeout:        90 * time.Second,
+		ScanRequestTimeout: 500 * time.Millisecond,
+		HTTPAddr:           ":8080",
+		GraphQLPath:        "/graphql",
+		SnapshotPath:       "/snapshot",
+		SubscriptionPath:   "/graphql/subscriptions",
+		MCPPath:            "/mcp",
+		UIPath:             "/ui",
+		MDNSAdvertise:      true,
+		MDNSInstance:       "helianthus",
+		DumpOutputDir:      "./dumps",
 	}
 }
 
 func applyDefaults(cfg Config) Config {
 	if cfg.BusConfig == (protocol.BusConfig{}) {
 		cfg.BusConfig = protocol.DefaultBusConfig()
+	}
+	if cfg.Providers == nil {
+		cfg.Providers = vaillantproviders.Default()
+	}
+	if cfg.ScanSource == 0 {
+		cfg.ScanSource = 0x30
+	}
+	if cfg.ScanTimeout == 0 {
+		cfg.ScanTimeout = 90 * time.Second
+	}
+	if cfg.ScanRequestTimeout == 0 {
+		cfg.ScanRequestTimeout = 500 * time.Millisecond
 	}
 	if cfg.Transport == nil {
 		if cfg.TransportConfig.Protocol == "" {


### PR DESCRIPTION
Config defaults now include Vaillant plane providers, and the gateway runs an identification scan on startup (with per-request timeout) to populate the registry. After the scan, router planes are refreshed and the GraphQL schema is rebuilt.

Fixes #99.