### PR TITLE
chore: bump ebusgo (response telegram parsing)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/d3vi1/helianthus-ebusgateway
 go 1.22
 
 require (
-	github.com/d3vi1/helianthus-ebusgo v0.0.0-20260210004527-3804889d9d46
+	github.com/d3vi1/helianthus-ebusgo v0.0.0-20260215165413-aaea4f97cc62
 	github.com/d3vi1/helianthus-ebusreg v0.0.0-20260209221620-d0e67ae21997
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/d3vi1/helianthus-ebusgo v0.0.0-20260202235800-1f4cf9472862 h1:g6CTfK8
 github.com/d3vi1/helianthus-ebusgo v0.0.0-20260202235800-1f4cf9472862/go.mod h1:WVYXygxQrRS/FMsQm9h04pQbJp6zoVyY4scq1ps3OS8=
 github.com/d3vi1/helianthus-ebusgo v0.0.0-20260210004527-3804889d9d46 h1:ML3wpCtIT+G/W1w7ObZrXsC6+exuDTqYSQ3FbZc+lzg=
 github.com/d3vi1/helianthus-ebusgo v0.0.0-20260210004527-3804889d9d46/go.mod h1:WVYXygxQrRS/FMsQm9h04pQbJp6zoVyY4scq1ps3OS8=
+github.com/d3vi1/helianthus-ebusgo v0.0.0-20260215165413-aaea4f97cc62 h1:KDJxUYKgXOiHxMmuQ1CYzr2qqD+WlAbdCfF9z36pteU=
+github.com/d3vi1/helianthus-ebusgo v0.0.0-20260215165413-aaea4f97cc62/go.mod h1:WVYXygxQrRS/FMsQm9h04pQbJp6zoVyY4scq1ps3OS8=
 github.com/d3vi1/helianthus-ebusreg v0.0.0-20260201212610-32c2b7eeec50 h1:y0fv+QOfxFZhgmSiNbr8U2WvFyVHn5L/bqBLRNqRrFQ=
 github.com/d3vi1/helianthus-ebusreg v0.0.0-20260201212610-32c2b7eeec50/go.mod h1:W9ZtSpWXmA60YD5PeGKmL9CO93Eqj48iugtgslAFkf0=
 github.com/d3vi1/helianthus-ebusreg v0.0.0-20260203005630-ac8899888940 h1:pLBlbZGk1VlebRo9gqiascPO0uLQ3dBdmmeE6Lqev/I=

--- a/graphql/mutations_integration_test.go
+++ b/graphql/mutations_integration_test.go
@@ -197,15 +197,20 @@ func TestInvokeMutation_Integration(t *testing.T) {
 		t.Fatalf("responseSchema.Encode error = %v", err)
 	}
 
-	length := byte(len(responsePayload))
-	crc := protocol.CRC(append([]byte{length}, responsePayload...))
+	responseSegment := append([]byte{
+		plane.target,
+		plane.source,
+		method.Template().Primary(),
+		method.Template().Secondary(),
+		byte(len(responsePayload)),
+	}, responsePayload...)
+	crc := protocol.CRC(responseSegment)
 	transport := &scriptedTransport{
 		reads: []readEvent{
 			{value: protocol.SymbolAck},
-			{value: length},
 		},
 	}
-	for _, b := range responsePayload {
+	for _, b := range responseSegment {
 		transport.reads = append(transport.reads, readEvent{value: b})
 	}
 	transport.reads = append(transport.reads, readEvent{value: crc})
@@ -296,12 +301,12 @@ func TestInvokeMutation_Integration(t *testing.T) {
 	}, payload...)
 	expectedWrite = append(expectedWrite, protocol.CRC(expectedWrite))
 
-		if got := transport.allWrites(); len(got) < len(expectedWrite) {
-			t.Fatalf("transport write missing")
-		} else if !equalBytes(got[:len(expectedWrite)], expectedWrite) {
-			t.Fatalf("transport write prefix = %v; want %v", got[:len(expectedWrite)], expectedWrite)
-		}
+	if got := transport.allWrites(); len(got) < len(expectedWrite) {
+		t.Fatalf("transport write missing")
+	} else if !equalBytes(got[:len(expectedWrite)], expectedWrite) {
+		t.Fatalf("transport write prefix = %v; want %v", got[:len(expectedWrite)], expectedWrite)
 	}
+}
 
 func equalBytes(a, b []byte) bool {
 	if len(a) != len(b) {


### PR DESCRIPTION
Bump `helianthus-ebusgo` to pick up the initiator-target response parsing fix (full response telegram + CRC).

Also updates the GraphQL invoke integration test fixture to reflect the real response wire format (`SRC DST PB SB LEN DATA CRC`).

Fixes #105.
