### PR TITLE
gateway: configurable scan-request-timeout

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -120,6 +120,7 @@ func bindFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) {
 	fs.IntVar(&cfg.QueueCapacity, "queue-capacity", cfg.QueueCapacity, "bus queue capacity (0 uses protocol default)")
 	fs.BoolVar(&cfg.ScanOnStart, "scan", cfg.ScanOnStart, "scan bus on startup")
 	fs.DurationVar(&cfg.ScanTimeout, "scan-timeout", cfg.ScanTimeout, "startup scan timeout")
+	fs.DurationVar(&cfg.ScanRequestTimeout, "scan-request-timeout", cfg.ScanRequestTimeout, "startup scan per-request timeout")
 	fs.DurationVar(&cfg.ScanInterval, "scan-interval", cfg.ScanInterval, "startup scan retry interval (when scan finds 0 devices)")
 	fs.DurationVar(&cfg.SemanticInterval, "semantic-interval", cfg.SemanticInterval, "semantic polling interval")
 	fs.BoolVar(&cfg.BroadcastListen, "broadcast", cfg.BroadcastListen, "enable broadcast listener (separate connection)")

--- a/config.go
+++ b/config.go
@@ -71,7 +71,9 @@ func DefaultConfig() Config {
 		ScanOnStart:        true,
 		ScanSource:         0x30,
 		ScanTimeout:        3 * time.Minute,
-		ScanRequestTimeout: 150 * time.Millisecond,
+		// Per-request scan timeout must accommodate bus/transport latency.
+		// 150ms is too aggressive for real-world ENH over TCP setups.
+		ScanRequestTimeout: 400 * time.Millisecond,
 		ScanInterval:       30 * time.Second,
 		SemanticInterval:   10 * time.Second,
 		HTTPAddr:           ":8080",


### PR DESCRIPTION
- Bump default startup scan per-request timeout to 400ms (150ms was too aggressive on real ENH-over-TCP).
- Add `-scan-request-timeout` flag so add-ons can tune without code changes.

Motivation: ebusd ident scan round-trips observed around ~200ms; 150ms caused Helianthus startup scan to time out every target and register 0 devices.