### PR TITLE
gateway: semantic read scheduler + discovery/config/state polling

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/d3vi1/helianthus-ebusgateway"
 	"github.com/d3vi1/helianthus-ebusgateway/graphql"
@@ -122,7 +123,19 @@ func bindFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) {
 	fs.DurationVar(&cfg.ScanTimeout, "scan-timeout", cfg.ScanTimeout, "startup scan timeout")
 	fs.DurationVar(&cfg.ScanRequestTimeout, "scan-request-timeout", cfg.ScanRequestTimeout, "startup scan per-request timeout")
 	fs.DurationVar(&cfg.ScanInterval, "scan-interval", cfg.ScanInterval, "startup scan retry interval (when scan finds 0 devices)")
-	fs.DurationVar(&cfg.SemanticInterval, "semantic-interval", cfg.SemanticInterval, "semantic polling interval")
+	fs.DurationVar(&cfg.SemanticDiscoveryInterval, "semantic-discovery-interval", cfg.SemanticDiscoveryInterval, "semantic discovery polling interval")
+	fs.DurationVar(&cfg.SemanticConfigInterval, "semantic-config-interval", cfg.SemanticConfigInterval, "semantic config polling interval")
+	fs.DurationVar(&cfg.SemanticStateInterval, "semantic-state-interval", cfg.SemanticStateInterval, "semantic state polling interval")
+	fs.DurationVar(&cfg.SemanticRequestTimeout, "semantic-request-timeout", cfg.SemanticRequestTimeout, "semantic per-request timeout")
+	fs.Func("semantic-interval", "DEPRECATED: semantic state polling interval", func(value string) error {
+		duration, err := time.ParseDuration(value)
+		if err != nil {
+			return fmt.Errorf("invalid semantic-interval %q", value)
+		}
+		cfg.SemanticInterval = duration
+		cfg.SemanticStateInterval = duration
+		return nil
+	})
 	fs.BoolVar(&cfg.BroadcastListen, "broadcast", cfg.BroadcastListen, "enable broadcast listener (separate connection)")
 	fs.StringVar(&cfg.HTTPAddr, "http-addr", cfg.HTTPAddr, "http listen address (empty disables)")
 	fs.StringVar(&cfg.GraphQLPath, "graphql-path", cfg.GraphQLPath, "graphql endpoint path")

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/d3vi1/helianthus-ebusgateway"
@@ -34,86 +36,273 @@ func startVaillantSemanticPolling(ctx context.Context, cfg ebusgateway.Config, g
 		return
 	}
 
-	interval := cfg.SemanticInterval
-	if interval <= 0 {
-		interval = 10 * time.Second
-	}
-
-	go func() {
-		pollCtx := ctx
-		if pollCtx == nil {
-			pollCtx = context.Background()
-		}
-
-		// First poll quickly so HA can create entities on initial coordinator refresh.
-		pollVaillantZonesOnce(pollCtx, cfg.ScanSource, gateway.Registry, gateway.Bus, provider, hub)
-
-		ticker := time.NewTicker(interval)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-pollCtx.Done():
-				return
-			case <-ticker.C:
-				pollVaillantZonesOnce(pollCtx, cfg.ScanSource, gateway.Registry, gateway.Bus, provider, hub)
-			}
-		}
-	}()
+	poller := newVaillantSemanticPoller(cfg, gateway, provider, hub)
+	poller.Start(ctx)
 }
 
-func pollVaillantZonesOnce(ctx context.Context, source byte, reg *registry.DeviceRegistry, bus *protocol.Bus, provider *graphql.LiveSemanticProvider, hub *graphql.BroadcastHub) {
-	if bus == nil || provider == nil {
+type vaillantSemanticPoller struct {
+	scheduler *ebusgateway.SemanticReadScheduler
+
+	reg      *registry.DeviceRegistry
+	bus      *protocol.Bus
+	provider *graphql.LiveSemanticProvider
+	hub      *graphql.BroadcastHub
+
+	source           byte
+	requestTimeout   time.Duration
+	discoveryInterval time.Duration
+	configInterval    time.Duration
+	stateInterval     time.Duration
+
+	mu         sync.Mutex
+	controller byte
+	zones      map[byte]*vaillantZoneSnapshot
+}
+
+type vaillantZoneSnapshot struct {
+	Instance byte
+	Present  bool
+
+	Name string
+
+	CurrentTempC *float64
+	TargetTempC  *float64
+}
+
+func newVaillantSemanticPoller(cfg ebusgateway.Config, gateway *ebusgateway.Gateway, provider *graphql.LiveSemanticProvider, hub *graphql.BroadcastHub) *vaillantSemanticPoller {
+	return &vaillantSemanticPoller{
+		scheduler: ebusgateway.NewSemanticReadScheduler(),
+		reg:       gateway.Registry,
+		bus:       gateway.Bus,
+		provider:  provider,
+		hub:       hub,
+		source:    cfg.ScanSource,
+
+		requestTimeout:    cfg.SemanticRequestTimeout,
+		discoveryInterval: cfg.SemanticDiscoveryInterval,
+		configInterval:    cfg.SemanticConfigInterval,
+		stateInterval:     cfg.SemanticStateInterval,
+
+		zones: make(map[byte]*vaillantZoneSnapshot),
+	}
+}
+
+func (p *vaillantSemanticPoller) Start(ctx context.Context) {
+	if p == nil {
 		return
 	}
 	if ctx == nil {
 		ctx = context.Background()
 	}
 
-	controller, ok := findDeviceAddressByPrefix(reg, "BASV")
+	// Prime quickly so HA can create entities on first coordinator refresh.
+	go func() {
+		p.refreshDiscovery(ctx)
+		p.refreshConfig(ctx)
+		p.refreshState(ctx)
+	}()
+
+	go p.runLoop(ctx, p.discoveryInterval, p.refreshDiscovery)
+	go p.runLoop(ctx, p.configInterval, p.refreshConfig)
+	go p.runLoop(ctx, p.stateInterval, p.refreshState)
+}
+
+func (p *vaillantSemanticPoller) runLoop(ctx context.Context, interval time.Duration, fn func(context.Context)) {
+	if interval <= 0 {
+		return
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			fn(ctx)
+		}
+	}
+}
+
+func (p *vaillantSemanticPoller) refreshDiscovery(ctx context.Context) {
+	controller, ok := findDeviceAddressByPrefix(p.reg, "BASV")
 	if !ok {
+		p.mu.Lock()
+		p.controller = 0
+		p.zones = make(map[byte]*vaillantZoneSnapshot)
+		p.mu.Unlock()
+		p.publishZones()
 		return
 	}
 
-	zones := make([]graphql.Zone, 0, 3)
+	p.mu.Lock()
+	p.controller = controller
+	p.mu.Unlock()
+
+	present := make(map[byte]bool, 4)
 	for instance := byte(0x00); instance <= 0x0A; instance++ {
-		indexBytes, ok := readB524Value(ctx, bus, source, controller, vaillantB524OpcodeLocal, vaillantGroupZones, instance, zoneRegIndex)
+		indexBytes, ok := p.readB524Value(ctx, vaillantB524OpcodeLocal, vaillantGroupZones, instance, zoneRegIndex)
 		if !ok || len(indexBytes) < 1 || indexBytes[0] == 0xFF {
 			continue
 		}
+		present[instance] = true
+	}
 
-		name := fmt.Sprintf("Zone %d", instance+1)
-		if rawName, ok := readB524CString(ctx, bus, source, controller, vaillantB524OpcodeLocal, vaillantGroupZones, instance, zoneRegName); ok {
+	p.mu.Lock()
+	for instance := range present {
+		entry := p.zones[instance]
+		if entry == nil {
+			entry = &vaillantZoneSnapshot{Instance: instance}
+			p.zones[instance] = entry
+		}
+		entry.Present = true
+	}
+	for instance := range p.zones {
+		if !present[instance] {
+			delete(p.zones, instance)
+		}
+	}
+	p.mu.Unlock()
+
+	p.publishZones()
+}
+
+func (p *vaillantSemanticPoller) refreshConfig(ctx context.Context) {
+	controller, zones := p.snapshotZones()
+	if controller == 0 || len(zones) == 0 {
+		return
+	}
+
+	for _, instance := range zones {
+		if rawName, ok := p.readB524CString(ctx, vaillantB524OpcodeLocal, vaillantGroupZones, instance, zoneRegName); ok {
 			if trimmed := strings.TrimSpace(rawName); trimmed != "" {
-				name = trimmed
+				p.mu.Lock()
+				if entry := p.zones[instance]; entry != nil {
+					entry.Name = trimmed
+				}
+				p.mu.Unlock()
 			}
 		}
+	}
 
+	p.publishZones()
+}
+
+func (p *vaillantSemanticPoller) refreshState(ctx context.Context) {
+	controller, zones := p.snapshotZones()
+	if controller == 0 || len(zones) == 0 {
+		return
+	}
+
+	for _, instance := range zones {
 		var currentPtr *float64
-		if value, ok := readB524Float32LE(ctx, bus, source, controller, vaillantB524OpcodeLocal, vaillantGroupZones, instance, zoneRegCurrentTemp); ok {
-			currentPtr = &value
+		if value, ok := p.readB524Float32LE(ctx, vaillantB524OpcodeLocal, vaillantGroupZones, instance, zoneRegCurrentTemp); ok {
+			current := value
+			currentPtr = &current
 		}
 
 		var targetPtr *float64
-		if value, ok := readB524Float32LE(ctx, bus, source, controller, vaillantB524OpcodeLocal, vaillantGroupZones, instance, zoneRegTargetTemp); ok {
-			targetPtr = &value
+		if value, ok := p.readB524Float32LE(ctx, vaillantB524OpcodeLocal, vaillantGroupZones, instance, zoneRegTargetTemp); ok {
+			target := value
+			targetPtr = &target
+		}
+
+		p.mu.Lock()
+		if entry := p.zones[instance]; entry != nil {
+			entry.CurrentTempC = currentPtr
+			entry.TargetTempC = targetPtr
+		}
+		p.mu.Unlock()
+	}
+
+	p.publishZones()
+}
+
+func (p *vaillantSemanticPoller) snapshotZones() (byte, []byte) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	controller := p.controller
+	if controller == 0 || len(p.zones) == 0 {
+		return controller, nil
+	}
+	instances := make([]byte, 0, len(p.zones))
+	for instance := range p.zones {
+		instances = append(instances, instance)
+	}
+	slices.Sort(instances)
+	return controller, instances
+}
+
+func (p *vaillantSemanticPoller) publishZones() {
+	if p.provider == nil {
+		return
+	}
+
+	p.mu.Lock()
+	instances := make([]byte, 0, len(p.zones))
+	for instance := range p.zones {
+		instances = append(instances, instance)
+	}
+	slices.Sort(instances)
+	zones := make([]graphql.Zone, 0, len(instances))
+	for _, instance := range instances {
+		entry := p.zones[instance]
+		if entry == nil {
+			continue
+		}
+
+		name := entry.Name
+		if strings.TrimSpace(name) == "" {
+			name = fmt.Sprintf("Zone %d", instance+1)
 		}
 
 		zone := graphql.Zone{
 			ID:           fmt.Sprintf("zone-%d", instance+1),
 			Name:         name,
-			CurrentTempC: currentPtr,
-			TargetTempC:  targetPtr,
+			CurrentTempC: entry.CurrentTempC,
+			TargetTempC:  entry.TargetTempC,
 		}
 		zones = append(zones, zone)
 	}
+	p.mu.Unlock()
 
-	provider.SetZones(zones)
-	if hub != nil {
+	previous := p.provider.Zones()
+	p.provider.SetZones(zones)
+
+	if p.hub != nil {
+		prevByID := make(map[string]graphql.Zone, len(previous))
+		for _, z := range previous {
+			prevByID[z.ID] = z
+		}
 		for _, zone := range zones {
-			hub.PublishZoneUpdate(zone)
+			if !zoneEquals(prevByID[zone.ID], zone) {
+				p.hub.PublishZoneUpdate(zone)
+			}
 		}
 	}
+}
+
+func zoneEquals(a, b graphql.Zone) bool {
+	if a.ID != b.ID || a.Name != b.Name {
+		return false
+	}
+	if !floatPtrEquals(a.CurrentTempC, b.CurrentTempC) {
+		return false
+	}
+	if !floatPtrEquals(a.TargetTempC, b.TargetTempC) {
+		return false
+	}
+	return true
+}
+
+func floatPtrEquals(a, b *float64) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
 }
 
 func findDeviceAddressByPrefix(reg *registry.DeviceRegistry, wantedPrefix string) (byte, bool) {
@@ -149,27 +338,56 @@ func normalizeDeviceID(value string) string {
 	return normalized
 }
 
-func readB524Value(ctx context.Context, bus *protocol.Bus, source, target, opcode, group, instance byte, addr uint16) ([]byte, bool) {
-	if bus == nil {
+func (p *vaillantSemanticPoller) readB524Value(ctx context.Context, opcode, group, instance byte, addr uint16) ([]byte, bool) {
+	if p == nil || p.bus == nil {
 		return nil, false
 	}
 	if ctx == nil {
 		ctx = context.Background()
 	}
 
-	request := protocol.Frame{
-		Source:    source,
-		Target:    target,
-		Primary:   vaillantExtRegisterPrimary,
-		Secondary: vaillantExtRegisterSecondary,
-		Data:      []byte{opcode, vaillantB524OpRead, group, instance, byte(addr), byte(addr >> 8)},
-	}
+	p.mu.Lock()
+	source := p.source
+	target := p.controller
+	timeout := p.requestTimeout
+	p.mu.Unlock()
 
-	response, err := bus.Send(ctx, request)
-	if err != nil || response == nil {
+	if target == 0 {
 		return nil, false
 	}
-	return parseB524ReadPayload(response.Data, opcode, group, instance, addr)
+	if timeout <= 0 {
+		timeout = 2 * time.Second
+	}
+
+	key := fmt.Sprintf("b524:%02x:%02x:%02x:%02x:%04x", target, opcode, group, instance, addr)
+	value, err := p.scheduler.Get(ctx, key, 500*time.Millisecond, func(ctx context.Context) ([]byte, error) {
+		reqCtx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+
+		request := protocol.Frame{
+			Source:    source,
+			Target:    target,
+			Primary:   vaillantExtRegisterPrimary,
+			Secondary: vaillantExtRegisterSecondary,
+			Data:      []byte{opcode, vaillantB524OpRead, group, instance, byte(addr), byte(addr >> 8)},
+		}
+		response, err := p.bus.Send(reqCtx, request)
+		if err != nil {
+			return nil, err
+		}
+		if response == nil {
+			return nil, fmt.Errorf("b524 read returned nil response")
+		}
+		payload, ok := parseB524ReadPayload(response.Data, opcode, group, instance, addr)
+		if !ok {
+			return nil, fmt.Errorf("b524 read failed: opcode=0x%02x group=0x%02x instance=0x%02x addr=0x%04x", opcode, group, instance, addr)
+		}
+		return payload, nil
+	})
+	if err != nil {
+		return nil, false
+	}
+	return value, true
 }
 
 func parseB524ReadPayload(payload []byte, opcode, group, instance byte, addr uint16) ([]byte, bool) {
@@ -207,8 +425,8 @@ func parseB524ReadPayload(payload []byte, opcode, group, instance byte, addr uin
 	return payload[4:], true
 }
 
-func readB524Float32LE(ctx context.Context, bus *protocol.Bus, source, target, opcode, group, instance byte, addr uint16) (float64, bool) {
-	raw, ok := readB524Value(ctx, bus, source, target, opcode, group, instance, addr)
+func (p *vaillantSemanticPoller) readB524Float32LE(ctx context.Context, opcode, group, instance byte, addr uint16) (float64, bool) {
+	raw, ok := p.readB524Value(ctx, opcode, group, instance, addr)
 	if !ok || len(raw) < 4 {
 		return 0, false
 	}
@@ -220,8 +438,8 @@ func readB524Float32LE(ctx context.Context, bus *protocol.Bus, source, target, o
 	return value, true
 }
 
-func readB524CString(ctx context.Context, bus *protocol.Bus, source, target, opcode, group, instance byte, addr uint16) (string, bool) {
-	raw, ok := readB524Value(ctx, bus, source, target, opcode, group, instance, addr)
+func (p *vaillantSemanticPoller) readB524CString(ctx context.Context, opcode, group, instance byte, addr uint16) (string, bool) {
+	raw, ok := p.readB524Value(ctx, opcode, group, instance, addr)
 	if !ok || len(raw) == 0 {
 		return "", false
 	}

--- a/config.go
+++ b/config.go
@@ -40,7 +40,13 @@ type Config struct {
 	ScanTimeout        time.Duration
 	ScanRequestTimeout time.Duration
 	ScanInterval       time.Duration
-	SemanticInterval   time.Duration
+	// SemanticInterval is a legacy single-interval semantic polling configuration.
+	// Prefer SemanticDiscoveryInterval / SemanticConfigInterval / SemanticStateInterval.
+	SemanticInterval          time.Duration
+	SemanticDiscoveryInterval time.Duration
+	SemanticConfigInterval    time.Duration
+	SemanticStateInterval     time.Duration
+	SemanticRequestTimeout    time.Duration
 	BroadcastListen    bool
 	HTTPAddr           string
 	GraphQLPath        string
@@ -73,13 +79,17 @@ func DefaultConfig() Config {
 		ScanTimeout:        3 * time.Minute,
 		// Per-request scan timeout must accommodate bus/transport latency.
 		// 150ms is too aggressive for real-world ENH over TCP setups.
-		ScanRequestTimeout: 400 * time.Millisecond,
-		ScanInterval:       30 * time.Second,
-		SemanticInterval:   10 * time.Second,
-		HTTPAddr:           ":8080",
-		GraphQLPath:        "/graphql",
-		SnapshotPath:       "/snapshot",
-		SubscriptionPath:   "/graphql/subscriptions",
+			ScanRequestTimeout: 400 * time.Millisecond,
+			ScanInterval:       30 * time.Second,
+			SemanticInterval:          1 * time.Minute,
+			SemanticDiscoveryInterval: 10 * time.Minute,
+			SemanticConfigInterval:    5 * time.Minute,
+			SemanticStateInterval:     1 * time.Minute,
+			SemanticRequestTimeout:    2 * time.Second,
+			HTTPAddr:           ":8080",
+			GraphQLPath:        "/graphql",
+			SnapshotPath:       "/snapshot",
+			SubscriptionPath:   "/graphql/subscriptions",
 		MCPPath:            "/mcp",
 		UIPath:             "/ui",
 		MDNSAdvertise:      true,
@@ -108,7 +118,19 @@ func applyDefaults(cfg Config) Config {
 		cfg.ScanInterval = 30 * time.Second
 	}
 	if cfg.SemanticInterval == 0 {
-		cfg.SemanticInterval = 10 * time.Second
+		cfg.SemanticInterval = 1 * time.Minute
+	}
+	if cfg.SemanticStateInterval == 0 {
+		cfg.SemanticStateInterval = cfg.SemanticInterval
+	}
+	if cfg.SemanticConfigInterval == 0 {
+		cfg.SemanticConfigInterval = 5 * time.Minute
+	}
+	if cfg.SemanticDiscoveryInterval == 0 {
+		cfg.SemanticDiscoveryInterval = 10 * time.Minute
+	}
+	if cfg.SemanticRequestTimeout == 0 {
+		cfg.SemanticRequestTimeout = 2 * time.Second
 	}
 	if cfg.Transport == nil {
 		if cfg.TransportConfig.Protocol == "" {

--- a/semantic_read_scheduler.go
+++ b/semantic_read_scheduler.go
@@ -1,0 +1,106 @@
+package ebusgateway
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// SemanticReadScheduler coalesces identical semantic reads and provides a small
+// in-memory cache to avoid multiplying eBUS traffic under multiple consumers.
+//
+// It is intentionally generic: callers choose the key and the maxAge policy.
+type SemanticReadScheduler struct {
+	mu      sync.Mutex
+	entries map[string]*semanticReadEntry
+	now     func() time.Time
+}
+
+type semanticReadEntry struct {
+	running bool
+	done    chan struct{}
+
+	lastOKAt time.Time
+	lastOK   []byte
+	lastErr  error
+}
+
+func NewSemanticReadScheduler() *SemanticReadScheduler {
+	return &SemanticReadScheduler{
+		entries: make(map[string]*semanticReadEntry),
+		now:     time.Now,
+	}
+}
+
+// Get returns a cached value when it is fresh, otherwise it performs fetch once
+// and shares the result with concurrent callers.
+//
+// If fetch fails, the last successful value (if any) remains cached.
+func (s *SemanticReadScheduler) Get(ctx context.Context, key string, maxAge time.Duration, fetch func(context.Context) ([]byte, error)) ([]byte, error) {
+	if s == nil {
+		return fetch(ctx)
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if key == "" {
+		return fetch(ctx)
+	}
+	if fetch == nil {
+		return nil, context.Canceled
+	}
+
+	for {
+		s.mu.Lock()
+		entry := s.entries[key]
+		if entry == nil {
+			entry = &semanticReadEntry{}
+			s.entries[key] = entry
+		}
+
+		if !entry.running && len(entry.lastOK) > 0 && maxAge > 0 {
+			age := s.now().Sub(entry.lastOKAt)
+			if age >= 0 && age <= maxAge {
+				value := append([]byte(nil), entry.lastOK...)
+				s.mu.Unlock()
+				return value, nil
+			}
+		}
+
+		if entry.running {
+			done := entry.done
+			s.mu.Unlock()
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-done:
+				continue
+			}
+		}
+
+		entry.running = true
+		entry.done = make(chan struct{})
+		done := entry.done
+		s.mu.Unlock()
+
+		value, err := fetch(ctx)
+
+		s.mu.Lock()
+		entry.running = false
+		if err == nil {
+			entry.lastOKAt = s.now()
+			entry.lastOK = append(entry.lastOK[:0], value...)
+			entry.lastErr = nil
+		} else {
+			entry.lastErr = err
+		}
+		close(done)
+		s.mu.Unlock()
+
+		if err != nil {
+			return nil, err
+		}
+		return append([]byte(nil), value...), nil
+	}
+}
+

--- a/semantic_read_scheduler_test.go
+++ b/semantic_read_scheduler_test.go
@@ -1,0 +1,116 @@
+package ebusgateway
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestSemanticReadScheduler_CoalescesConcurrentGets(t *testing.T) {
+	scheduler := NewSemanticReadScheduler()
+	scheduler.now = func() time.Time { return time.Unix(0, 0) }
+
+	var calls int32
+	fetch := func(ctx context.Context) ([]byte, error) {
+		atomic.AddInt32(&calls, 1)
+		time.Sleep(25 * time.Millisecond)
+		return []byte{0x01, 0x02}, nil
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	results := make([][]byte, 2)
+	errs := make([]error, 2)
+
+	for i := 0; i < 2; i++ {
+		go func(i int) {
+			defer wg.Done()
+			value, err := scheduler.Get(context.Background(), "k", time.Second, fetch)
+			results[i] = value
+			errs[i] = err
+		}(i)
+	}
+
+	wg.Wait()
+
+	if atomic.LoadInt32(&calls) != 1 {
+		t.Fatalf("expected 1 fetch call, got %d", calls)
+	}
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("result %d: unexpected error: %v", i, err)
+		}
+		if got := results[i]; len(got) != 2 || got[0] != 0x01 || got[1] != 0x02 {
+			t.Fatalf("result %d: unexpected value: %v", i, got)
+		}
+	}
+}
+
+func TestSemanticReadScheduler_UsesCacheWithinMaxAge(t *testing.T) {
+	now := time.Unix(0, 0)
+	scheduler := NewSemanticReadScheduler()
+	scheduler.now = func() time.Time { return now }
+
+	var calls int32
+	fetch := func(ctx context.Context) ([]byte, error) {
+		atomic.AddInt32(&calls, 1)
+		return []byte{0xAA}, nil
+	}
+
+	value1, err := scheduler.Get(context.Background(), "k", time.Second, fetch)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(value1) != 1 || value1[0] != 0xAA {
+		t.Fatalf("unexpected value1: %v", value1)
+	}
+
+	value2, err := scheduler.Get(context.Background(), "k", time.Second, fetch)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(value2) != 1 || value2[0] != 0xAA {
+		t.Fatalf("unexpected value2: %v", value2)
+	}
+
+	if atomic.LoadInt32(&calls) != 1 {
+		t.Fatalf("expected 1 fetch call, got %d", calls)
+	}
+}
+
+func TestSemanticReadScheduler_RefreshesAfterMaxAge(t *testing.T) {
+	now := time.Unix(0, 0)
+	scheduler := NewSemanticReadScheduler()
+	scheduler.now = func() time.Time { return now }
+
+	var calls int32
+	fetch := func(ctx context.Context) ([]byte, error) {
+		call := atomic.AddInt32(&calls, 1)
+		return []byte{byte(call)}, nil
+	}
+
+	value1, err := scheduler.Get(context.Background(), "k", 10*time.Millisecond, fetch)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(value1) != 1 || value1[0] != 0x01 {
+		t.Fatalf("unexpected value1: %v", value1)
+	}
+
+	now = now.Add(25 * time.Millisecond)
+
+	value2, err := scheduler.Get(context.Background(), "k", 10*time.Millisecond, fetch)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(value2) != 1 || value2[0] != 0x02 {
+		t.Fatalf("unexpected value2: %v", value2)
+	}
+
+	if atomic.LoadInt32(&calls) != 2 {
+		t.Fatalf("expected 2 fetch calls, got %d", calls)
+	}
+}


### PR DESCRIPTION
Closes #110.

- Add `SemanticReadScheduler` to coalesce identical semantic reads by key and share in-flight results.
- Split Vaillant semantic polling into 3 loops: discovery (10m), config (5m), state (1m).
- Add config fields + CLI flags for semantic intervals and per-request timeout (`--semantic-*-interval`, `--semantic-request-timeout`).
- Publish zone updates only when values change.

Local CI: `go test ./...`
