### PR TITLE
META-02: gateway udp-plain endpoints + ENS alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,14 +137,15 @@ Protocol can be inferred from endpoint URI in `-address`:
 go run ./cmd/gateway -address enh://127.0.0.1:19001 -http-addr :8080
 go run ./cmd/gateway -address ens://127.0.0.1:19002 -http-addr :8080
 go run ./cmd/gateway -address ebusd-tcp://127.0.0.1:9999 -http-addr :8080
+go run ./cmd/gateway -address udp-plain://203.0.113.10:9999 -http-addr :8080
 ```
 
 ## Gateway Flag Cheat Sheet
 
 | Flag | Default | Notes |
 |---|---|---|
-| `-transport` | `enh` | `enh`, `ens`, `ebusd-tcp` |
-| `-network` | `unix` | `unix` or `tcp` |
+| `-transport` | `enh` | `enh`, `ens`, `ebusd-tcp`, `udp-plain` |
+| `-network` | `unix` | `unix`, `tcp`, or `udp` |
 | `-address` | `/var/run/ebusd/ebusd.socket` | socket path, `host:port`, or endpoint URI |
 | `-http-addr` | `:8080` | empty disables HTTP server |
 | `-graphql-path` | `/graphql` | query/mutation endpoint |

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -116,8 +116,8 @@ func bindFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) {
 		return
 	}
 
-	fs.StringVar((*string)(&cfg.TransportConfig.Protocol), "transport", string(cfg.TransportConfig.Protocol), "transport protocol: enh, ens, or ebusd-tcp")
-	fs.StringVar(&cfg.TransportConfig.Network, "network", cfg.TransportConfig.Network, "transport network: unix or tcp")
+	fs.StringVar((*string)(&cfg.TransportConfig.Protocol), "transport", string(cfg.TransportConfig.Protocol), "transport protocol: enh, ens, udp-plain, or ebusd-tcp")
+	fs.StringVar(&cfg.TransportConfig.Network, "network", cfg.TransportConfig.Network, "transport network: unix, tcp, or udp")
 	fs.StringVar(&cfg.TransportConfig.Address, "address", cfg.TransportConfig.Address, "transport address (unix socket path or host:port)")
 	fs.DurationVar(&cfg.TransportConfig.ReadTimeout, "read-timeout", cfg.TransportConfig.ReadTimeout, "transport read timeout")
 	fs.DurationVar(&cfg.TransportConfig.WriteTimeout, "write-timeout", cfg.TransportConfig.WriteTimeout, "transport write timeout")

--- a/config.go
+++ b/config.go
@@ -16,6 +16,7 @@ type TransportProtocol string
 const (
 	TransportENH      TransportProtocol = "enh"
 	TransportENS      TransportProtocol = "ens"
+	TransportUDPPlain TransportProtocol = "udp-plain"
 	TransportEbusdTCP TransportProtocol = "ebusd-tcp"
 )
 

--- a/gateway.go
+++ b/gateway.go
@@ -195,7 +195,11 @@ func parseTransportEndpoint(endpoint string, fallbackProtocol TransportProtocol)
 	case "enh":
 		protocol = TransportENH
 	case "ens":
-		protocol = TransportENS
+		// ebusd semantics: ENS is an ENH variant (serial speed selector).
+		// For TCP/UDP endpoints, ENS behaves as ENH.
+		protocol = TransportENH
+	case "udp-plain":
+		protocol = TransportUDPPlain
 	case "ebusd", "ebusd-tcp":
 		protocol = TransportEbusdTCP
 	case "tcp", "unix":
@@ -208,6 +212,9 @@ func parseTransportEndpoint(endpoint string, fallbackProtocol TransportProtocol)
 	switch {
 	case parsed.Host != "":
 		network = "tcp"
+		if scheme == "udp-plain" {
+			network = "udp"
+		}
 		address = strings.TrimSpace(parsed.Host)
 	case parsed.Path != "" && parsed.Path != "/":
 		network = "unix"
@@ -218,6 +225,9 @@ func parseTransportEndpoint(endpoint string, fallbackProtocol TransportProtocol)
 
 	if scheme == "tcp" && network != "tcp" {
 		return "", "", "", fmt.Errorf("gateway transport endpoint %q missing tcp host", endpoint)
+	}
+	if scheme == "udp-plain" && network != "udp" {
+		return "", "", "", fmt.Errorf("gateway transport endpoint %q missing udp host", endpoint)
 	}
 	if scheme == "unix" && network != "unix" {
 		return "", "", "", fmt.Errorf("gateway transport endpoint %q missing unix path", endpoint)
@@ -232,10 +242,14 @@ func parseTransportEndpoint(endpoint string, fallbackProtocol TransportProtocol)
 func transportFromConn(protocolName TransportProtocol, conn net.Conn, readTimeout, writeTimeout time.Duration) (transport.RawTransport, error) {
 	normalized := strings.ToLower(string(protocolName))
 	switch TransportProtocol(normalized) {
-	case TransportENH, "":
+	case TransportENH, TransportENS, "":
 		return transport.NewENHTransport(conn, readTimeout, writeTimeout), nil
-	case TransportENS:
-		return transport.NewENSTransport(conn, readTimeout, writeTimeout), nil
+	case TransportUDPPlain:
+		udpConn, ok := conn.(*net.UDPConn)
+		if !ok {
+			return nil, fmt.Errorf("gateway transport %q requires udp connection: %w", protocolName, ebuserrors.ErrInvalidPayload)
+		}
+		return transport.NewUDPPlainTransport(udpConn, readTimeout, writeTimeout), nil
 	case TransportEbusdTCP, TransportProtocol("ebusd"):
 		return transport.NewEbusdTCPTransport(conn, readTimeout, writeTimeout), nil
 	default:

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -221,6 +221,16 @@ func TestNewGateway_DialsWithENSEndpointProfile(t *testing.T) {
 		gotAddress = address
 		client, server := net.Pipe()
 		serverClose = func() { _ = server.Close() }
+
+		go func() {
+			buf := make([]byte, 2)
+			if _, err := io.ReadFull(server, buf); err != nil {
+				_ = server.Close()
+				return
+			}
+			resp := transport.EncodeENH(transport.ENHResResetted, 0x00)
+			_, _ = server.Write(resp[:])
+		}()
 		return client, nil
 	}
 
@@ -229,6 +239,7 @@ func TestNewGateway_DialsWithENSEndpointProfile(t *testing.T) {
 			Address:     "ens://127.0.0.1:10000",
 			DialTimeout: time.Second,
 			Dial:        dialer,
+			ReadTimeout: 200 * time.Millisecond,
 		},
 	}
 
@@ -245,8 +256,8 @@ func TestNewGateway_DialsWithENSEndpointProfile(t *testing.T) {
 	if gotNetwork != "tcp" || gotAddress != "127.0.0.1:10000" {
 		t.Fatalf("dialer args = %s %s; want tcp 127.0.0.1:10000", gotNetwork, gotAddress)
 	}
-	if _, ok := gateway.Transport.(*transport.ENSTransport); !ok {
-		t.Fatalf("gateway.Transport = %T; want *transport.ENSTransport", gateway.Transport)
+	if _, ok := gateway.Transport.(*transport.ENHTransport); !ok {
+		t.Fatalf("gateway.Transport = %T; want *transport.ENHTransport", gateway.Transport)
 	}
 
 	if err := gateway.Close(); err != nil {
@@ -279,6 +290,60 @@ func TestNormalizeTransportConfigENHUnixEndpoint(t *testing.T) {
 	if cfg.Address != "/var/run/ebusd/ebusd.socket" {
 		t.Fatalf("address = %q; want /var/run/ebusd/ebusd.socket", cfg.Address)
 	}
+}
+
+func TestNormalizeTransportConfigUDPPlainEndpoint(t *testing.T) {
+	cfg, err := normalizeTransportConfig(TransportConfig{
+		Address: "udp-plain://127.0.0.1:9999",
+	})
+	if err != nil {
+		t.Fatalf("normalizeTransportConfig error = %v", err)
+	}
+	if cfg.Protocol != TransportUDPPlain {
+		t.Fatalf("protocol = %q; want %q", cfg.Protocol, TransportUDPPlain)
+	}
+	if cfg.Network != "udp" {
+		t.Fatalf("network = %q; want udp", cfg.Network)
+	}
+	if cfg.Address != "127.0.0.1:9999" {
+		t.Fatalf("address = %q; want 127.0.0.1:9999", cfg.Address)
+	}
+}
+
+func TestTransportFromConn_UDPPlain(t *testing.T) {
+	t.Run("requires udp conn", func(t *testing.T) {
+		client, server := net.Pipe()
+		defer func() { _ = client.Close() }()
+		defer func() { _ = server.Close() }()
+
+		_, err := transportFromConn(TransportUDPPlain, client, 200*time.Millisecond, 200*time.Millisecond)
+		if err == nil {
+			t.Fatalf("expected error for non-udp conn")
+		}
+	})
+
+	t.Run("returns UDPPlainTransport", func(t *testing.T) {
+		server, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+		if err != nil {
+			t.Fatalf("ListenUDP error = %v", err)
+		}
+		t.Cleanup(func() { _ = server.Close() })
+
+		clientConn, err := net.DialUDP("udp", nil, server.LocalAddr().(*net.UDPAddr))
+		if err != nil {
+			t.Fatalf("DialUDP error = %v", err)
+		}
+		t.Cleanup(func() { _ = clientConn.Close() })
+
+		raw, err := transportFromConn(TransportUDPPlain, clientConn, 200*time.Millisecond, 200*time.Millisecond)
+		if err != nil {
+			t.Fatalf("transportFromConn error = %v", err)
+		}
+		if _, ok := raw.(*transport.UDPPlainTransport); !ok {
+			t.Fatalf("transport = %T; want *transport.UDPPlainTransport", raw)
+		}
+		_ = raw.Close()
+	})
 }
 
 type mockInitTransport struct {


### PR DESCRIPTION
Fixes #114.

- Accept `udp-plain://host:port` in `-address` parsing.
- Dial UDP and instantiate `UDPPlainTransport`.
- Treat `ens://` endpoints as ENH (ebusd semantics; no ESC/SYN transport).
- Update README + CLI flag descriptions.

Local CI:

```bash
./scripts/ci_local.sh
```
