### PR TITLE
META-05.2: harden ebusd-tcp smoke/runtime profile handling

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -111,22 +111,7 @@ func resolveTransport(ctx context.Context, cfg Config) (transport.RawTransport, 
 	if err != nil {
 		return nil, nil, err
 	}
-	// ebusd command port responses include the bus roundtrip, so short socket
-	// deadlines can desync the stream (late "ERR:" lines from a previous command
-	// appear as the next command's response). Clamp to at least the per-request
-	// scan timeout to keep scans stable under the default add-on config.
-	if config.Protocol == TransportEbusdTCP {
-		minTimeout := cfg.ScanRequestTimeout
-		if minTimeout <= 0 {
-			minTimeout = 400 * time.Millisecond
-		}
-		if config.ReadTimeout > 0 && config.ReadTimeout < minTimeout {
-			config.ReadTimeout = minTimeout
-		}
-		if config.WriteTimeout > 0 && config.WriteTimeout < minTimeout {
-			config.WriteTimeout = minTimeout
-		}
-	}
+	config = clampEbusdTCPTimeouts(config, cfg.ScanRequestTimeout)
 	if config.Network == "" {
 		return nil, nil, fmt.Errorf("gateway transport missing network: %w", ebuserrors.ErrInvalidPayload)
 	}
@@ -155,6 +140,27 @@ func resolveTransport(ctx context.Context, cfg Config) (transport.RawTransport, 
 	}
 
 	return transportLayer, conn.Close, nil
+}
+
+func clampEbusdTCPTimeouts(config TransportConfig, scanRequestTimeout time.Duration) TransportConfig {
+	if config.Protocol != TransportEbusdTCP {
+		return config
+	}
+	// ebusd command port responses include the full bus roundtrip, so too-short
+	// socket deadlines can desync the stream (late `ERR:` lines from the previous
+	// command can be consumed by the next command). Keep read/write timeouts at
+	// least at per-request scan timeout (or a conservative floor when unset).
+	minTimeout := scanRequestTimeout
+	if minTimeout <= 0 {
+		minTimeout = 400 * time.Millisecond
+	}
+	if config.ReadTimeout <= 0 || config.ReadTimeout < minTimeout {
+		config.ReadTimeout = minTimeout
+	}
+	if config.WriteTimeout <= 0 || config.WriteTimeout < minTimeout {
+		config.WriteTimeout = minTimeout
+	}
+	return config
 }
 
 func normalizeTransportConfig(config TransportConfig) (TransportConfig, error) {

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -346,6 +346,56 @@ func TestTransportFromConn_UDPPlain(t *testing.T) {
 	})
 }
 
+func TestClampEbusdTCPTimeouts_UsesMinimumForShortOrUnset(t *testing.T) {
+	t.Parallel()
+
+	cfg := TransportConfig{
+		Protocol:     TransportEbusdTCP,
+		ReadTimeout:  0,
+		WriteTimeout: 150 * time.Millisecond,
+	}
+
+	got := clampEbusdTCPTimeouts(cfg, 2*time.Second)
+	if got.ReadTimeout != 2*time.Second {
+		t.Fatalf("ReadTimeout = %s; want 2s", got.ReadTimeout)
+	}
+	if got.WriteTimeout != 2*time.Second {
+		t.Fatalf("WriteTimeout = %s; want 2s", got.WriteTimeout)
+	}
+}
+
+func TestClampEbusdTCPTimeouts_LeavesLargerTimeoutsUntouched(t *testing.T) {
+	t.Parallel()
+
+	cfg := TransportConfig{
+		Protocol:     TransportEbusdTCP,
+		ReadTimeout:  4 * time.Second,
+		WriteTimeout: 3 * time.Second,
+	}
+
+	got := clampEbusdTCPTimeouts(cfg, 2*time.Second)
+	if got.ReadTimeout != 4*time.Second {
+		t.Fatalf("ReadTimeout = %s; want 4s", got.ReadTimeout)
+	}
+	if got.WriteTimeout != 3*time.Second {
+		t.Fatalf("WriteTimeout = %s; want 3s", got.WriteTimeout)
+	}
+}
+
+func TestClampEbusdTCPTimeouts_NonEbusdUnchanged(t *testing.T) {
+	t.Parallel()
+
+	cfg := TransportConfig{
+		Protocol:     TransportENH,
+		ReadTimeout:  100 * time.Millisecond,
+		WriteTimeout: 120 * time.Millisecond,
+	}
+	got := clampEbusdTCPTimeouts(cfg, 2*time.Second)
+	if got.ReadTimeout != cfg.ReadTimeout || got.WriteTimeout != cfg.WriteTimeout {
+		t.Fatalf("timeouts changed for non-ebusd: got read=%s write=%s", got.ReadTimeout, got.WriteTimeout)
+	}
+}
+
 type mockInitTransport struct {
 	called   bool
 	features []byte

--- a/smoke.go
+++ b/smoke.go
@@ -429,10 +429,10 @@ func transportConfigFromSmoke(smokeCfg smokeConfig) (TransportConfig, error) {
 		cfg.Protocol = TransportENH
 	case string(TransportENS):
 		cfg.Protocol = TransportENS
-	case string(TransportEbusdTCP):
+	case string(TransportEbusdTCP), "ebusd":
 		cfg.Protocol = TransportEbusdTCP
 	default:
-		return TransportConfig{}, fmt.Errorf("smoke config unsupported smoke.profile %q", profile)
+		return TransportConfig{}, fmt.Errorf("smoke config unsupported smoke.profile %q (allowed: enh, ens, ebusd-tcp)", profile)
 	}
 
 	enh := smokeCfg.ENH
@@ -455,6 +455,7 @@ func transportConfigFromSmoke(smokeCfg smokeConfig) (TransportConfig, error) {
 		cfg.WriteTimeout = timeout
 		cfg.DialTimeout = timeout
 	}
+	cfg = clampEbusdTCPTimeouts(cfg, DefaultConfig().ScanRequestTimeout)
 	return cfg, nil
 }
 

--- a/smoke_config.go
+++ b/smoke_config.go
@@ -177,8 +177,10 @@ func (cfg *smokeConfig) normalize() error {
 	}
 	switch cfg.Smoke.Profile {
 	case string(TransportENH), string(TransportENS), string(TransportEbusdTCP):
+	case "ebusd":
+		cfg.Smoke.Profile = string(TransportEbusdTCP)
 	default:
-		return fmt.Errorf("smoke config unsupported smoke.profile %q", cfg.Smoke.Profile)
+		return fmt.Errorf("smoke config unsupported smoke.profile %q (allowed: enh, ens, ebusd-tcp)", cfg.Smoke.Profile)
 	}
 
 	if cfg.ENH.Type == "" {

--- a/smoke_config_test.go
+++ b/smoke_config_test.go
@@ -71,6 +71,23 @@ func TestLoadSmokeConfigFileProfileValidValue(t *testing.T) {
 	}
 }
 
+func TestLoadSmokeConfigFileProfileEbusdAlias(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "AGENT-local.md")
+	content := "```yaml\nenh:\n  type: tcp\n  host: \"127.0.0.1\"\n  port: 7624\nsmoke:\n  profile: ebusd\n```\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	cfg, err := loadSmokeConfigFile(path)
+	if err != nil {
+		t.Fatalf("loadSmokeConfigFile error = %v", err)
+	}
+	if cfg.Smoke.Profile != string(TransportEbusdTCP) {
+		t.Fatalf("profile = %q; want %q", cfg.Smoke.Profile, string(TransportEbusdTCP))
+	}
+}
+
 func TestLoadSmokeConfigFileProfileENSValidValue(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "AGENT-local.md")

--- a/smoke_runtime_test.go
+++ b/smoke_runtime_test.go
@@ -39,6 +39,30 @@ func TestTransportConfigFromSmokeEbusdTCPProfile(t *testing.T) {
 	}
 }
 
+func TestTransportConfigFromSmokeEbusdAliasProfile(t *testing.T) {
+	t.Parallel()
+
+	cfg := smokeConfig{
+		ENH: enhConfig{
+			Type:       "tcp",
+			Host:       "127.0.0.1",
+			Port:       9999,
+			TimeoutSec: 3,
+		},
+		Smoke: smokeBehavior{
+			Profile: "ebusd",
+		},
+	}
+
+	transportCfg, err := transportConfigFromSmoke(cfg)
+	if err != nil {
+		t.Fatalf("transportConfigFromSmoke error = %v", err)
+	}
+	if transportCfg.Protocol != TransportEbusdTCP {
+		t.Fatalf("protocol = %q; want %q", transportCfg.Protocol, TransportEbusdTCP)
+	}
+}
+
 func TestTransportConfigFromSmokeENSProfile(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #115

## Summary
- centralize ebusd-tcp timeout clamping in `clampEbusdTCPTimeouts` and apply it in runtime transport resolution
- accept `smoke.profile: ebusd` as an alias to `ebusd-tcp` for safer config interoperability
- improve unsupported profile error message to include allowed values
- add regression tests for timeout clamp logic and ebusd alias handling in smoke config/runtime

## Validation
- `./scripts/ci_local.sh` (pass)
