### PR TITLE
matrix: implement 42-topology runner (META-08.1)

### DIFF
--- a/cmd/matrix-runner/main.go
+++ b/cmd/matrix-runner/main.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/d3vi1/helianthus-ebusgateway/internal/matrix"
+)
+
+func main() {
+	var (
+		outputDir    = flag.String("output-dir", "results", "matrix output directory")
+		target       = flag.String("target", "local", "execution target: local|ha-addon")
+		includeIDs   = flag.String("cases", "", "comma-separated case IDs (default: all T01..T42)")
+		execute      = flag.Bool("execute", false, "execute commands instead of dry-run planning")
+		settleDelay  = flag.Duration("settle-delay", 3*time.Second, "delay after service startup")
+		caseTimeout  = flag.Duration("case-timeout", 2*time.Minute, "per-case timeout (0 disables timeout)")
+		startGateway = flag.String("start-gateway", "", "shell command to start gateway service")
+		stopGateway  = flag.String("stop-gateway", "", "shell command to stop gateway service")
+		startProxy   = flag.String("start-proxy", "", "shell command to start proxy service")
+		stopProxy    = flag.String("stop-proxy", "", "shell command to stop proxy service")
+		startEbusd   = flag.String("start-ebusd", "", "shell command to start ebusd service")
+		stopEbusd    = flag.String("stop-ebusd", "", "shell command to stop ebusd service")
+		smokeCommand = flag.String("smoke-command", "", "shell command that executes smoke validation")
+	)
+	flag.Parse()
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	runner, err := matrix.NewRunner(matrix.RunnerOptions{
+		OutputDir:    *outputDir,
+		Target:       *target,
+		IncludeIDs:   splitCSV(*includeIDs),
+		Execute:      *execute,
+		SettleDelay:  *settleDelay,
+		CaseTimeout:  *caseTimeout,
+		StartGateway: *startGateway,
+		StopGateway:  *stopGateway,
+		StartProxy:   *startProxy,
+		StopProxy:    *stopProxy,
+		StartEbusd:   *startEbusd,
+		StopEbusd:    *stopEbusd,
+		SmokeCommand: *smokeCommand,
+	})
+	if err != nil {
+		log.Fatalf("matrix runner options: %v", err)
+	}
+
+	verdicts, err := runner.Run(ctx)
+	if err != nil {
+		log.Fatalf("matrix run failed after %d case(s): %v", len(verdicts), err)
+	}
+
+	passed, failed, planned := 0, 0, 0
+	for _, verdict := range verdicts {
+		switch verdict.Status {
+		case "passed":
+			passed++
+		case "failed":
+			failed++
+		default:
+			planned++
+		}
+	}
+
+	fmt.Printf(
+		"matrix complete: total=%d passed=%d failed=%d planned=%d output=%s\n",
+		len(verdicts),
+		passed,
+		failed,
+		planned,
+		*outputDir,
+	)
+}
+
+func splitCSV(value string) []string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil
+	}
+	parts := strings.Split(trimmed, ",")
+	filtered := make([]string, 0, len(parts))
+	for _, part := range parts {
+		item := strings.TrimSpace(part)
+		if item == "" {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	return filtered
+}

--- a/internal/matrix/runner.go
+++ b/internal/matrix/runner.go
@@ -1,0 +1,445 @@
+package matrix
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type RunnerOptions struct {
+	OutputDir    string
+	Target       string
+	IncludeIDs   []string
+	Execute      bool
+	SettleDelay  time.Duration
+	CaseTimeout  time.Duration
+	StartGateway string
+	StopGateway  string
+	StartProxy   string
+	StopProxy    string
+	StartEbusd   string
+	StopEbusd    string
+	SmokeCommand string
+}
+
+type commandResult struct {
+	Name      string `json:"name"`
+	Command   string `json:"command"`
+	LogFile   string `json:"log_file"`
+	Status    string `json:"status"`
+	ExitCode  int    `json:"exit_code,omitempty"`
+	Error     string `json:"error,omitempty"`
+	StartedAt string `json:"started_at,omitempty"`
+	EndedAt   string `json:"ended_at,omitempty"`
+}
+
+type CaseVerdict struct {
+	CaseID      string          `json:"case_id"`
+	Kind        TopologyKind    `json:"kind"`
+	Target      string          `json:"target"`
+	Status      string          `json:"status"`
+	Error       string          `json:"error,omitempty"`
+	StartedAt   string          `json:"started_at"`
+	EndedAt     string          `json:"ended_at"`
+	ConfigFiles []string        `json:"config_files"`
+	LogFiles    []string        `json:"log_files"`
+	Commands    []commandResult `json:"commands"`
+}
+
+type Runner struct {
+	options RunnerOptions
+	nowUTC  func() time.Time
+}
+
+func NewRunner(options RunnerOptions) (*Runner, error) {
+	if strings.TrimSpace(options.OutputDir) == "" {
+		options.OutputDir = "results"
+	}
+	options.Target = strings.TrimSpace(strings.ToLower(options.Target))
+	if options.Target == "" {
+		options.Target = "local"
+	}
+	if options.Target != "local" && options.Target != "ha-addon" {
+		return nil, fmt.Errorf("unsupported target %q (allowed: local, ha-addon)", options.Target)
+	}
+	if options.SettleDelay < 0 {
+		return nil, fmt.Errorf("settle delay must be >= 0")
+	}
+	if options.CaseTimeout < 0 {
+		return nil, fmt.Errorf("case timeout must be >= 0")
+	}
+	return &Runner{
+		options: options,
+		nowUTC: func() time.Time {
+			return time.Now().UTC()
+		},
+	}, nil
+}
+
+func (runner *Runner) Run(ctx context.Context) ([]CaseVerdict, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	cases := FilterCases(GenerateTopologyCases(), runner.options.IncludeIDs)
+	if len(cases) == 0 {
+		return nil, fmt.Errorf("no topology cases selected")
+	}
+
+	if err := os.MkdirAll(runner.options.OutputDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create output dir: %w", err)
+	}
+
+	verdicts := make([]CaseVerdict, 0, len(cases))
+	for _, testCase := range cases {
+		select {
+		case <-ctx.Done():
+			return verdicts, ctx.Err()
+		default:
+		}
+
+		verdict, runErr := runner.runCase(ctx, testCase)
+		verdicts = append(verdicts, verdict)
+		if runErr != nil {
+			return verdicts, runErr
+		}
+	}
+
+	indexPath := filepath.Join(runner.options.OutputDir, "index.json")
+	if err := writeJSON(indexPath, map[string]any{
+		"generated_at": runner.nowUTC().Format(time.RFC3339),
+		"target":       runner.options.Target,
+		"cases":        verdicts,
+	}); err != nil {
+		return verdicts, fmt.Errorf("write matrix index: %w", err)
+	}
+
+	return verdicts, nil
+}
+
+func (runner *Runner) runCase(ctx context.Context, testCase TopologyCase) (CaseVerdict, error) {
+	startedAt := runner.nowUTC()
+	caseDir := filepath.Join(runner.options.OutputDir, testCase.ID)
+	configDir := filepath.Join(caseDir, "configs")
+	logDir := filepath.Join(caseDir, "logs")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		return CaseVerdict{}, fmt.Errorf("create config dir: %w", err)
+	}
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		return CaseVerdict{}, fmt.Errorf("create log dir: %w", err)
+	}
+
+	configFiles, err := runner.writeCaseConfigs(testCase, configDir)
+	if err != nil {
+		return CaseVerdict{}, err
+	}
+
+	commandLogPath := filepath.Join(logDir, "runner.log")
+	logFiles := []string{filepath.ToSlash(commandLogPath)}
+	commands := make([]commandResult, 0, 8)
+	status := "planned"
+	var firstError string
+
+	if !runner.options.Execute {
+		planned := []string{
+			runner.options.StartGateway,
+			runner.options.StartProxy,
+			runner.options.StartEbusd,
+			runner.options.SmokeCommand,
+			runner.options.StopEbusd,
+			runner.options.StopProxy,
+			runner.options.StopGateway,
+		}
+		lines := make([]string, 0, len(planned)+2)
+		lines = append(lines, "dry-run mode: no command executed")
+		for _, value := range planned {
+			trimmed := strings.TrimSpace(value)
+			if trimmed == "" {
+				continue
+			}
+			lines = append(lines, trimmed)
+		}
+		if err := os.WriteFile(commandLogPath, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+			return CaseVerdict{}, fmt.Errorf("write dry-run log: %w", err)
+		}
+	} else {
+		caseCtx := ctx
+		var cancel context.CancelFunc
+		if runner.options.CaseTimeout > 0 {
+			caseCtx, cancel = context.WithTimeout(ctx, runner.options.CaseTimeout)
+		}
+		if cancel != nil {
+			defer cancel()
+		}
+
+		env := buildCaseEnv(testCase, runner.options.Target, caseDir, configDir, logDir)
+		appendResult := func(result commandResult) {
+			commands = append(commands, result)
+			logFiles = append(logFiles, filepath.ToSlash(result.LogFile))
+			if result.Status == "failed" && firstError == "" {
+				firstError = result.Error
+				status = "failed"
+			}
+		}
+
+		startPlan := []struct {
+			name    string
+			command string
+			enabled bool
+		}{
+			{name: "gateway-start", command: runner.options.StartGateway, enabled: true},
+			{name: "proxy-start", command: runner.options.StartProxy, enabled: testCase.UsesProxy},
+			{name: "ebusd-start", command: runner.options.StartEbusd, enabled: testCase.UsesEbusd},
+		}
+		stopPlan := []struct {
+			name    string
+			command string
+			enabled bool
+		}{
+			{name: "ebusd-stop", command: runner.options.StopEbusd, enabled: testCase.UsesEbusd},
+			{name: "proxy-stop", command: runner.options.StopProxy, enabled: testCase.UsesProxy},
+			{name: "gateway-stop", command: runner.options.StopGateway, enabled: true},
+		}
+
+		for _, step := range startPlan {
+			result := runner.runPlannedCommand(caseCtx, commandLogPath, step.name, step.command, step.enabled, env)
+			appendResult(result)
+			if result.Status == "failed" {
+				break
+			}
+		}
+
+		if firstError == "" && runner.options.SettleDelay > 0 {
+			time.Sleep(runner.options.SettleDelay)
+		}
+
+		if firstError == "" {
+			smokeResult := runner.runPlannedCommand(
+				caseCtx,
+				commandLogPath,
+				"smoke",
+				runner.options.SmokeCommand,
+				strings.TrimSpace(runner.options.SmokeCommand) != "",
+				env,
+			)
+			appendResult(smokeResult)
+		}
+
+		for _, step := range stopPlan {
+			result := runner.runPlannedCommand(caseCtx, commandLogPath, step.name, step.command, step.enabled, env)
+			appendResult(result)
+		}
+
+		if firstError == "" {
+			status = "passed"
+		}
+	}
+
+	verdict := CaseVerdict{
+		CaseID:      testCase.ID,
+		Kind:        testCase.Kind,
+		Target:      runner.options.Target,
+		Status:      status,
+		Error:       firstError,
+		StartedAt:   startedAt.Format(time.RFC3339),
+		EndedAt:     runner.nowUTC().Format(time.RFC3339),
+		ConfigFiles: configFiles,
+		LogFiles:    uniqueStrings(logFiles),
+		Commands:    commands,
+	}
+
+	verdictPath := filepath.Join(caseDir, "verdict.json")
+	if err := writeJSON(verdictPath, verdict); err != nil {
+		return CaseVerdict{}, fmt.Errorf("write verdict: %w", err)
+	}
+	return verdict, nil
+}
+
+func (runner *Runner) writeCaseConfigs(testCase TopologyCase, configDir string) ([]string, error) {
+	configFiles := make([]string, 0, 3)
+
+	helianthusConfig := map[string]any{
+		"case_id":            testCase.ID,
+		"kind":               testCase.Kind,
+		"target":             runner.options.Target,
+		"gateway_transport":  testCase.GatewayTransport,
+		"uses_proxy":         testCase.UsesProxy,
+		"uses_ebusd":         testCase.UsesEbusd,
+		"ebusd_via_proxy":    testCase.EbusdViaProxy,
+		"adapter_addr_env":   "MATRIX_ADAPTER_ADDR",
+		"proxy_addr_env":     "MATRIX_PROXY_ADDR",
+		"ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+	}
+	helianthusPath := filepath.Join(configDir, "helianthus.json")
+	if err := writeJSON(helianthusPath, helianthusConfig); err != nil {
+		return nil, fmt.Errorf("write helianthus config: %w", err)
+	}
+	configFiles = append(configFiles, filepath.ToSlash(helianthusPath))
+
+	if testCase.UsesProxy {
+		proxyConfig := map[string]any{
+			"case_id":               testCase.ID,
+			"target":                runner.options.Target,
+			"southbound_transport":  testCase.ProxyTransport,
+			"southbound_addr_env":   "MATRIX_ADAPTER_ADDR",
+			"northbound_enh_env":    "MATRIX_PROXY_ENH_ADDR",
+			"northbound_ens_env":    "MATRIX_PROXY_ENS_ADDR",
+			"northbound_udp_env":    "MATRIX_PROXY_UDP_ADDR",
+			"max_parallel_sessions": 2,
+		}
+		proxyPath := filepath.Join(configDir, "proxy.json")
+		if err := writeJSON(proxyPath, proxyConfig); err != nil {
+			return nil, fmt.Errorf("write proxy config: %w", err)
+		}
+		configFiles = append(configFiles, filepath.ToSlash(proxyPath))
+	}
+
+	if testCase.UsesEbusd {
+		target := "adapter"
+		deviceEnv := "MATRIX_ADAPTER_ADDR"
+		if testCase.EbusdViaProxy {
+			target = "proxy"
+			deviceEnv = "MATRIX_PROXY_ENS_ADDR"
+		}
+		ebusdConfig := map[string]any{
+			"case_id":          testCase.ID,
+			"target":           runner.options.Target,
+			"transport":        testCase.EbusdTransport,
+			"upstream":         target,
+			"network_device":   deviceEnv,
+			"config_path_env":  "MATRIX_EBUSD_CONFIG_PATH",
+			"mqtt_host_env":    "MATRIX_MQTT_HOST",
+			"mqtt_port_env":    "MATRIX_MQTT_PORT",
+			"http_port_env":    "MATRIX_EBUSD_HTTP_PORT",
+			"scanconfig":       true,
+			"commandline_opts": "--enablehex",
+		}
+		ebusdPath := filepath.Join(configDir, "ebusd.json")
+		if err := writeJSON(ebusdPath, ebusdConfig); err != nil {
+			return nil, fmt.Errorf("write ebusd config: %w", err)
+		}
+		configFiles = append(configFiles, filepath.ToSlash(ebusdPath))
+	}
+
+	return configFiles, nil
+}
+
+func (runner *Runner) runPlannedCommand(
+	ctx context.Context,
+	logFilePath string,
+	name string,
+	command string,
+	enabled bool,
+	env []string,
+) commandResult {
+	result := commandResult{
+		Name:    name,
+		Command: strings.TrimSpace(command),
+		LogFile: filepath.ToSlash(logFilePath),
+		Status:  "skipped",
+	}
+
+	if !enabled {
+		return result
+	}
+	if result.Command == "" {
+		result.Status = "failed"
+		result.Error = fmt.Sprintf("%s command is empty", name)
+		return result
+	}
+
+	logFile, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		result.Status = "failed"
+		result.Error = err.Error()
+		return result
+	}
+	defer func() {
+		_ = logFile.Close()
+	}()
+
+	start := runner.nowUTC()
+	result.StartedAt = start.Format(time.RFC3339)
+	_, _ = fmt.Fprintf(logFile, "\n[%s] %s\n", name, result.Command)
+
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-lc", result.Command)
+	cmd.Env = append(os.Environ(), env...)
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	runErr := cmd.Run()
+
+	end := runner.nowUTC()
+	result.EndedAt = end.Format(time.RFC3339)
+	if runErr == nil {
+		result.Status = "passed"
+		return result
+	}
+
+	result.Status = "failed"
+	result.Error = runErr.Error()
+	if exitErr, ok := runErr.(*exec.ExitError); ok {
+		result.ExitCode = exitErr.ExitCode()
+	}
+	return result
+}
+
+func buildCaseEnv(
+	testCase TopologyCase,
+	target string,
+	caseDir string,
+	configDir string,
+	logDir string,
+) []string {
+	return []string{
+		"MATRIX_CASE_ID=" + testCase.ID,
+		"MATRIX_CASE_KIND=" + string(testCase.Kind),
+		"MATRIX_TARGET=" + target,
+		"MATRIX_CASE_DIR=" + caseDir,
+		"MATRIX_CONFIG_DIR=" + configDir,
+		"MATRIX_LOG_DIR=" + logDir,
+		"MATRIX_GATEWAY_TRANSPORT=" + string(testCase.GatewayTransport),
+		"MATRIX_PROXY_TRANSPORT=" + string(testCase.ProxyTransport),
+		"MATRIX_EBUSD_TRANSPORT=" + string(testCase.EbusdTransport),
+		"MATRIX_USES_PROXY=" + boolString(testCase.UsesProxy),
+		"MATRIX_USES_EBUSD=" + boolString(testCase.UsesEbusd),
+		"MATRIX_EBUSD_VIA_PROXY=" + boolString(testCase.EbusdViaProxy),
+	}
+}
+
+func boolString(value bool) string {
+	if value {
+		return "1"
+	}
+	return "0"
+}
+
+func writeJSON(path string, value any) error {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0o644)
+}
+
+func uniqueStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	filtered := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		filtered = append(filtered, trimmed)
+	}
+	return filtered
+}

--- a/internal/matrix/runner_test.go
+++ b/internal/matrix/runner_test.go
@@ -1,0 +1,112 @@
+package matrix
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunnerDryRunWritesMatrixArtifacts(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	runner, err := NewRunner(RunnerOptions{
+		OutputDir: filepath.Join(tempDir, "results"),
+		Target:    "local",
+		Execute:   false,
+	})
+	if err != nil {
+		t.Fatalf("NewRunner error = %v", err)
+	}
+
+	verdicts, err := runner.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if len(verdicts) != 42 {
+		t.Fatalf("len(verdicts) = %d; want 42", len(verdicts))
+	}
+
+	checkPath := filepath.Join(tempDir, "results", "T01", "configs", "helianthus.json")
+	if _, err := os.Stat(checkPath); err != nil {
+		t.Fatalf("stat %s: %v", checkPath, err)
+	}
+	checkPath = filepath.Join(tempDir, "results", "T07", "configs", "proxy.json")
+	if _, err := os.Stat(checkPath); err != nil {
+		t.Fatalf("stat %s: %v", checkPath, err)
+	}
+	checkPath = filepath.Join(tempDir, "results", "T04", "configs", "ebusd.json")
+	if _, err := os.Stat(checkPath); err != nil {
+		t.Fatalf("stat %s: %v", checkPath, err)
+	}
+	checkPath = filepath.Join(tempDir, "results", "T42", "verdict.json")
+	data, err := os.ReadFile(checkPath)
+	if err != nil {
+		t.Fatalf("read verdict %s: %v", checkPath, err)
+	}
+
+	var verdict CaseVerdict
+	if err := json.Unmarshal(data, &verdict); err != nil {
+		t.Fatalf("decode verdict: %v", err)
+	}
+	if verdict.Status != "planned" {
+		t.Fatalf("verdict status = %q; want planned", verdict.Status)
+	}
+}
+
+func TestRunnerExecuteCapturesFailure(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	runner, err := NewRunner(RunnerOptions{
+		OutputDir:    filepath.Join(tempDir, "results"),
+		Target:       "local",
+		IncludeIDs:   []string{"T01"},
+		Execute:      true,
+		StartGateway: "echo gateway-start",
+		StopGateway:  "echo gateway-stop",
+		SmokeCommand: "exit 7",
+	})
+	if err != nil {
+		t.Fatalf("NewRunner error = %v", err)
+	}
+
+	verdicts, err := runner.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if len(verdicts) != 1 {
+		t.Fatalf("len(verdicts) = %d; want 1", len(verdicts))
+	}
+
+	verdict := verdicts[0]
+	if verdict.Status != "failed" {
+		t.Fatalf("verdict status = %q; want failed", verdict.Status)
+	}
+	if verdict.Error == "" {
+		t.Fatalf("verdict error empty")
+	}
+
+	smokeLogged := false
+	for _, command := range verdict.Commands {
+		if command.Name == "smoke" {
+			smokeLogged = true
+			if command.Status != "failed" {
+				t.Fatalf("smoke status = %q; want failed", command.Status)
+			}
+			if command.ExitCode != 7 {
+				t.Fatalf("smoke exit code = %d; want 7", command.ExitCode)
+			}
+		}
+	}
+	if !smokeLogged {
+		t.Fatalf("smoke command result missing")
+	}
+
+	logPath := filepath.Join(tempDir, "results", "T01", "logs", "runner.log")
+	if _, err := os.Stat(logPath); err != nil {
+		t.Fatalf("expected runner.log, stat error: %v", err)
+	}
+}

--- a/internal/matrix/topology.go
+++ b/internal/matrix/topology.go
@@ -1,0 +1,115 @@
+package matrix
+
+import "fmt"
+
+type Transport string
+
+const (
+	TransportENS      Transport = "ens"
+	TransportENH      Transport = "enh"
+	TransportUDPPlain Transport = "udp"
+	TransportEbusdTCP Transport = "ebusd-tcp"
+)
+
+var StandardTransports = []Transport{
+	TransportENS,
+	TransportENH,
+	TransportUDPPlain,
+}
+
+type TopologyKind string
+
+const (
+	TopologyDirectAdapter TopologyKind = "direct-adapter"
+	TopologyViaEbusdTCP   TopologyKind = "via-ebusd-tcp"
+	TopologyProxySingle   TopologyKind = "proxy-single-client"
+	TopologyProxyDual     TopologyKind = "proxy-dual-client"
+)
+
+type TopologyCase struct {
+	ID               string       `json:"id"`
+	Kind             TopologyKind `json:"kind"`
+	GatewayTransport Transport    `json:"gateway_transport"`
+	ProxyTransport   Transport    `json:"proxy_transport,omitempty"`
+	EbusdTransport   Transport    `json:"ebusd_transport,omitempty"`
+	UsesProxy        bool         `json:"uses_proxy"`
+	UsesEbusd        bool         `json:"uses_ebusd"`
+	EbusdViaProxy    bool         `json:"ebusd_via_proxy"`
+}
+
+func GenerateTopologyCases() []TopologyCase {
+	nextID := 1
+	buildID := func() string {
+		value := fmt.Sprintf("T%02d", nextID)
+		nextID++
+		return value
+	}
+
+	cases := make([]TopologyCase, 0, 42)
+
+	for _, transport := range StandardTransports {
+		cases = append(cases, TopologyCase{
+			ID:               buildID(),
+			Kind:             TopologyDirectAdapter,
+			GatewayTransport: transport,
+		})
+	}
+
+	for _, transport := range StandardTransports {
+		cases = append(cases, TopologyCase{
+			ID:               buildID(),
+			Kind:             TopologyViaEbusdTCP,
+			GatewayTransport: TransportEbusdTCP,
+			EbusdTransport:   transport,
+			UsesEbusd:        true,
+		})
+	}
+
+	for _, gatewayTransport := range StandardTransports {
+		for _, proxyTransport := range StandardTransports {
+			cases = append(cases, TopologyCase{
+				ID:               buildID(),
+				Kind:             TopologyProxySingle,
+				GatewayTransport: gatewayTransport,
+				ProxyTransport:   proxyTransport,
+				UsesProxy:        true,
+			})
+		}
+	}
+
+	for _, gatewayTransport := range StandardTransports {
+		for _, proxyTransport := range StandardTransports {
+			for _, ebusdTransport := range StandardTransports {
+				cases = append(cases, TopologyCase{
+					ID:               buildID(),
+					Kind:             TopologyProxyDual,
+					GatewayTransport: gatewayTransport,
+					ProxyTransport:   proxyTransport,
+					EbusdTransport:   ebusdTransport,
+					UsesProxy:        true,
+					UsesEbusd:        true,
+					EbusdViaProxy:    true,
+				})
+			}
+		}
+	}
+
+	return cases
+}
+
+func FilterCases(cases []TopologyCase, includeIDs []string) []TopologyCase {
+	if len(includeIDs) == 0 {
+		return append([]TopologyCase(nil), cases...)
+	}
+	allowed := make(map[string]struct{}, len(includeIDs))
+	for _, id := range includeIDs {
+		allowed[id] = struct{}{}
+	}
+	filtered := make([]TopologyCase, 0, len(cases))
+	for _, candidate := range cases {
+		if _, ok := allowed[candidate.ID]; ok {
+			filtered = append(filtered, candidate)
+		}
+	}
+	return filtered
+}

--- a/internal/matrix/topology_test.go
+++ b/internal/matrix/topology_test.go
@@ -1,0 +1,67 @@
+package matrix
+
+import "testing"
+
+func TestGenerateTopologyCasesMatrixCounts(t *testing.T) {
+	t.Parallel()
+
+	cases := GenerateTopologyCases()
+	if len(cases) != 42 {
+		t.Fatalf("len(cases) = %d; want 42", len(cases))
+	}
+
+	if cases[0].ID != "T01" {
+		t.Fatalf("first case id = %q; want T01", cases[0].ID)
+	}
+	if cases[len(cases)-1].ID != "T42" {
+		t.Fatalf("last case id = %q; want T42", cases[len(cases)-1].ID)
+	}
+
+	seen := make(map[string]struct{}, len(cases))
+	countByKind := make(map[TopologyKind]int)
+	for _, candidate := range cases {
+		if _, duplicate := seen[candidate.ID]; duplicate {
+			t.Fatalf("duplicate id %q", candidate.ID)
+		}
+		seen[candidate.ID] = struct{}{}
+		countByKind[candidate.Kind]++
+	}
+
+	if countByKind[TopologyDirectAdapter] != 3 {
+		t.Fatalf(
+			"direct count = %d; want 3",
+			countByKind[TopologyDirectAdapter],
+		)
+	}
+	if countByKind[TopologyViaEbusdTCP] != 3 {
+		t.Fatalf(
+			"ebusd count = %d; want 3",
+			countByKind[TopologyViaEbusdTCP],
+		)
+	}
+	if countByKind[TopologyProxySingle] != 9 {
+		t.Fatalf(
+			"proxy-single count = %d; want 9",
+			countByKind[TopologyProxySingle],
+		)
+	}
+	if countByKind[TopologyProxyDual] != 27 {
+		t.Fatalf(
+			"proxy-dual count = %d; want 27",
+			countByKind[TopologyProxyDual],
+		)
+	}
+}
+
+func TestFilterCases(t *testing.T) {
+	t.Parallel()
+
+	cases := GenerateTopologyCases()
+	filtered := FilterCases(cases, []string{"T02", "T09", "T42"})
+	if len(filtered) != 3 {
+		t.Fatalf("len(filtered) = %d; want 3", len(filtered))
+	}
+	if filtered[0].ID != "T02" || filtered[1].ID != "T09" || filtered[2].ID != "T42" {
+		t.Fatalf("filtered ids = %#v", filtered)
+	}
+}


### PR DESCRIPTION
## Summary
- add a 42-case topology model (`T01..T42`) covering direct, ebusd-tcp, proxy-single and proxy-dual paths
- add `cmd/matrix-runner` to generate per-case artifacts under `results/Txx/{configs,logs,verdict.json}`
- add execution hooks for local/HA-addon command flows and machine-readable case verdicts
- add tests for matrix cardinality, filtering, dry-run artifact generation, and execute-mode failure capture

## Validation
- ./scripts/ci_local.sh

Closes #116
