### PR TITLE
Add daemon initiatorAddress to GraphQL service status

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -61,6 +61,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 	gateway.Start(ctx)
 
 	builder := graphql.NewBuilder(gateway.Registry, nil)
+	builder.SetStatusProvider(newRuntimeStatusProvider(cfg))
 	hub := graphql.NewBroadcastHub(nil)
 	gateway.AddRouterPlane(hub)
 	gateway.RefreshRouterPlanes()

--- a/cmd/gateway/status_provider.go
+++ b/cmd/gateway/status_provider.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/d3vi1/helianthus-ebusgateway"
+	"github.com/d3vi1/helianthus-ebusgateway/graphql"
+)
+
+type runtimeStatusProvider struct {
+	daemon  graphql.ServiceStatus
+	adapter graphql.ServiceStatus
+}
+
+func (p runtimeStatusProvider) DaemonStatus() graphql.ServiceStatus {
+	return p.daemon
+}
+
+func (p runtimeStatusProvider) AdapterStatus() graphql.ServiceStatus {
+	return p.adapter
+}
+
+func newRuntimeStatusProvider(cfg ebusgateway.Config) graphql.StatusProvider {
+	return runtimeStatusProvider{
+		daemon: graphql.ServiceStatus{
+			Status:           "running",
+			FirmwareVersion:  "",
+			UpdatesAvailable: false,
+			InitiatorAddress: formatConfiguredInitiator(cfg.ScanSource, cfg.ScanSourceAuto),
+		},
+		adapter: graphql.ServiceStatus{
+			Status:           "unknown",
+			FirmwareVersion:  "",
+			UpdatesAvailable: false,
+		},
+	}
+}
+
+func formatConfiguredInitiator(source byte, auto bool) string {
+	if auto && source == 0x00 {
+		return "auto"
+	}
+	return fmt.Sprintf("0x%02X", source)
+}

--- a/cmd/gateway/status_provider_test.go
+++ b/cmd/gateway/status_provider_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/d3vi1/helianthus-ebusgateway"
+)
+
+func TestFormatConfiguredInitiator(t *testing.T) {
+	tests := []struct {
+		name   string
+		source byte
+		auto   bool
+		want   string
+	}{
+		{name: "explicit_source", source: 0xF0, auto: false, want: "0xF0"},
+		{name: "auto_unresolved", source: 0x00, auto: true, want: "auto"},
+		{name: "auto_policy_ebusd", source: 0x31, auto: true, want: "0x31"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := formatConfiguredInitiator(test.source, test.auto)
+			if got != test.want {
+				t.Fatalf("formatConfiguredInitiator(0x%02x, auto=%v) = %q; want %q", test.source, test.auto, got, test.want)
+			}
+		})
+	}
+}
+
+func TestRuntimeStatusProviderIncludesInitiatorAddress(t *testing.T) {
+	cfg := ebusgateway.DefaultConfig()
+	cfg.ScanSource = 0xF7
+	cfg.ScanSourceAuto = false
+
+	provider := newRuntimeStatusProvider(cfg)
+	daemon := provider.DaemonStatus()
+	adapter := provider.AdapterStatus()
+	if daemon.InitiatorAddress != "0xF7" {
+		t.Fatalf("daemon initiatorAddress = %q; want 0xF7", daemon.InitiatorAddress)
+	}
+	if adapter.InitiatorAddress != "" {
+		t.Fatalf("adapter initiatorAddress = %q; want empty", adapter.InitiatorAddress)
+	}
+}

--- a/graphql/queries.go
+++ b/graphql/queries.go
@@ -309,6 +309,16 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return status.UpdatesAvailable, nil
 				},
 			},
+			"initiatorAddress": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					status, ok := params.Source.(ServiceStatus)
+					if !ok {
+						return nil, nil
+					}
+					return status.InitiatorAddress, nil
+				},
+			},
 		},
 	})
 

--- a/graphql/queries_test.go
+++ b/graphql/queries_test.go
@@ -218,16 +218,17 @@ func TestQueryResolvers_Integration(t *testing.T) {
 
 	t.Run("service_status", func(t *testing.T) {
 		request := graphqlclient.NewRequest(`
-			query {
-				daemonStatus {
-					status
-					firmwareVersion
-					updatesAvailable
-				}
-				adapterStatus {
-					status
-					firmwareVersion
-					updatesAvailable
+				query {
+					daemonStatus {
+						status
+						firmwareVersion
+						updatesAvailable
+						initiatorAddress
+					}
+					adapterStatus {
+						status
+						firmwareVersion
+						updatesAvailable
 				}
 			}
 		`)
@@ -237,6 +238,7 @@ func TestQueryResolvers_Integration(t *testing.T) {
 				Status           string `json:"status"`
 				FirmwareVersion  string `json:"firmwareVersion"`
 				UpdatesAvailable bool   `json:"updatesAvailable"`
+				InitiatorAddress string `json:"initiatorAddress"`
 			} `json:"daemonStatus"`
 			AdapterStatus struct {
 				Status           string `json:"status"`
@@ -251,6 +253,9 @@ func TestQueryResolvers_Integration(t *testing.T) {
 
 		if response.DaemonStatus.Status == "" {
 			t.Fatalf("daemon status empty")
+		}
+		if response.DaemonStatus.InitiatorAddress != "" {
+			t.Fatalf("daemon initiatorAddress = %q; want empty for static provider", response.DaemonStatus.InitiatorAddress)
 		}
 		if response.AdapterStatus.Status == "" {
 			t.Fatalf("adapter status empty")

--- a/graphql/status.go
+++ b/graphql/status.go
@@ -4,6 +4,7 @@ type ServiceStatus struct {
 	Status           string
 	FirmwareVersion  string
 	UpdatesAvailable bool
+	InitiatorAddress string
 }
 
 type StatusProvider interface {
@@ -18,6 +19,7 @@ func (staticStatusProvider) DaemonStatus() ServiceStatus {
 		Status:           "running",
 		FirmwareVersion:  "",
 		UpdatesAvailable: false,
+		InitiatorAddress: "",
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `initiatorAddress` to GraphQL `ServiceStatus` and expose it on `daemonStatus`
- wire a runtime status provider in `cmd/gateway` so daemon status returns configured initiator address (`0x..` or `auto`)
- add unit tests for formatter/provider behavior and extend GraphQL status query test coverage

## Validation
- `go test ./graphql ./cmd/gateway`
- `TRANSPORT_GATE_OWNER_OVERRIDE=OVERRIDE_TRANSPORT_GATE_BY_OWNER TRANSPORT_GATE_OWNER_REASON='non-transport GraphQL status field change' ./scripts/ci_local.sh`

## Notes
- This PR changes GraphQL surface only; no transport/protocol logic changed.
- Doc-gate tracked in d3vi1/helianthus-docs-ebus#115.

Closes #126
