### PR TITLE
GraphQL: expose canonical + alias addresses for devices (#128)

### DIFF
--- a/graphql/builder_test.go
+++ b/graphql/builder_test.go
@@ -67,6 +67,7 @@ func TestBuildSchema_ReflectsRegistry(t *testing.T) {
 			SoftwareVersion: "1.0",
 			HardwareVersion: "7603",
 		},
+		addresses: []byte{0x10, 0x11},
 		planes: []registry.Plane{
 			mockPlane{
 				name: "heating",
@@ -124,6 +125,15 @@ func TestBuildSchema_ReflectsRegistry(t *testing.T) {
 	}
 	if len(got.Devices) != 2 {
 		t.Fatalf("Devices = %d; want 2", len(got.Devices))
+	}
+	if got.Devices[0].Address != 0x10 {
+		t.Fatalf("DeviceA address = 0x%02x; want 0x10", got.Devices[0].Address)
+	}
+	if len(got.Devices[0].Addresses) != 2 || got.Devices[0].Addresses[0] != 0x10 || got.Devices[0].Addresses[1] != 0x11 {
+		t.Fatalf("DeviceA addresses = %v; want [16 17]", got.Devices[0].Addresses)
+	}
+	if len(got.Devices[1].Addresses) != 1 || got.Devices[1].Addresses[0] != 0x08 {
+		t.Fatalf("DeviceB addresses = %v; want [8]", got.Devices[1].Addresses)
 	}
 
 	methodA := got.Devices[0].Planes[0].Methods[0]
@@ -408,12 +418,22 @@ func (reg *mutableRegistry) SetEntries(entries []registry.DeviceEntry) {
 
 type mockEntry struct {
 	info        registry.DeviceInfo
+	addresses   []byte
 	planes      []registry.Plane
 	projections []registry.Projection
 }
 
 func (entry mockEntry) Address() byte {
 	return entry.info.Address
+}
+
+func (entry mockEntry) Addresses() []byte {
+	if len(entry.addresses) == 0 {
+		return []byte{entry.info.Address}
+	}
+	out := make([]byte, len(entry.addresses))
+	copy(out, entry.addresses)
+	return out
 }
 
 func (entry mockEntry) Manufacturer() string {

--- a/graphql/queries.go
+++ b/graphql/queries.go
@@ -577,6 +577,21 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return int(device.Address), nil
 				},
 			},
+			"addresses": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.NewList(graphqlgo.NewNonNull(graphqlgo.Int))),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					device, ok := deviceFromSource(params)
+					if !ok {
+						return nil, nil
+					}
+					addresses := normalizeDeviceAddresses(device.Address, device.Addresses)
+					values := make([]int, len(addresses))
+					for index, address := range addresses {
+						values[index] = int(address)
+					}
+					return values, nil
+				},
+			},
 			"manufacturer": &graphqlgo.Field{
 				Type: graphqlgo.NewNonNull(graphqlgo.String),
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
@@ -893,11 +908,20 @@ func toAddress(value int) (byte, error) {
 
 func findDevice(devices []Device, address byte) (Device, bool) {
 	for _, device := range devices {
-		if device.Address == address {
+		if deviceHasAddress(device, address) {
 			return device, true
 		}
 	}
 	return Device{}, false
+}
+
+func deviceHasAddress(device Device, address byte) bool {
+	for _, candidate := range normalizeDeviceAddresses(device.Address, device.Addresses) {
+		if candidate == address {
+			return true
+		}
+	}
+	return false
 }
 
 func findPlane(planes []Plane, name string) (Plane, bool) {

--- a/graphql/queries_test.go
+++ b/graphql/queries_test.go
@@ -48,6 +48,15 @@ func TestQueryResolvers_Integration(t *testing.T) {
 		Address:         0x10,
 		Manufacturer:    "vaillant",
 		DeviceID:        "device-a",
+		SerialNumber:    "serial-a",
+		SoftwareVersion: "1.0",
+		HardwareVersion: "7603",
+	})
+	gateway.Registry.Register(registry.DeviceInfo{
+		Address:         0x11,
+		Manufacturer:    "vaillant",
+		DeviceID:        "device-a",
+		SerialNumber:    "serial-a",
 		SoftwareVersion: "1.0",
 		HardwareVersion: "7603",
 	})
@@ -72,6 +81,7 @@ func TestQueryResolvers_Integration(t *testing.T) {
 			query {
 				devices {
 					address
+					addresses
 					manufacturer
 					deviceId
 					planes {
@@ -110,6 +120,7 @@ func TestQueryResolvers_Integration(t *testing.T) {
 		var response struct {
 			Devices []struct {
 				Address      int    `json:"address"`
+				Addresses    []int  `json:"addresses"`
 				Manufacturer string `json:"manufacturer"`
 				DeviceID     string `json:"deviceId"`
 				Planes       []struct {
@@ -153,6 +164,9 @@ func TestQueryResolvers_Integration(t *testing.T) {
 		if response.Devices[0].Address != 16 || response.Devices[0].DeviceID != "device-a" {
 			t.Fatalf("device payload = %+v; want address=16 deviceId=device-a", response.Devices[0])
 		}
+		if len(response.Devices[0].Addresses) != 2 || response.Devices[0].Addresses[0] != 16 || response.Devices[0].Addresses[1] != 17 {
+			t.Fatalf("addresses = %+v; want [16 17]", response.Devices[0].Addresses)
+		}
 		if len(response.Devices[0].Planes) != 1 {
 			t.Fatalf("planes = %d; want 1", len(response.Devices[0].Planes))
 		}
@@ -191,28 +205,35 @@ func TestQueryResolvers_Integration(t *testing.T) {
 	})
 
 	t.Run("device", func(t *testing.T) {
-		request := graphqlclient.NewRequest(`
-			query($address: Int!) {
-				device(address: $address) {
-					address
-					deviceId
+		for _, address := range []int{16, 17} {
+			request := graphqlclient.NewRequest(`
+				query($address: Int!) {
+					device(address: $address) {
+						address
+						addresses
+						deviceId
+					}
 				}
+			`)
+			request.Var("address", address)
+
+			var response struct {
+				Device struct {
+					Address   int    `json:"address"`
+					Addresses []int  `json:"addresses"`
+					DeviceID  string `json:"deviceId"`
+				} `json:"device"`
 			}
-		`)
-		request.Var("address", 16)
 
-		var response struct {
-			Device struct {
-				Address  int    `json:"address"`
-				DeviceID string `json:"deviceId"`
-			} `json:"device"`
-		}
-
-		if err := client.Run(context.Background(), request, &response); err != nil {
-			t.Fatalf("device query error = %v", err)
-		}
-		if response.Device.Address != 16 || response.Device.DeviceID != "device-a" {
-			t.Fatalf("device = %+v; want address=16 deviceId=device-a", response.Device)
+			if err := client.Run(context.Background(), request, &response); err != nil {
+				t.Fatalf("device query error = %v", err)
+			}
+			if response.Device.Address != 16 || response.Device.DeviceID != "device-a" {
+				t.Fatalf("address %d device = %+v; want address=16 deviceId=device-a", address, response.Device)
+			}
+			if len(response.Device.Addresses) != 2 || response.Device.Addresses[0] != 16 || response.Device.Addresses[1] != 17 {
+				t.Fatalf("address %d addresses = %+v; want [16 17]", address, response.Device.Addresses)
+			}
 		}
 	})
 
@@ -369,51 +390,55 @@ func TestQueryResolvers_Integration(t *testing.T) {
 	})
 
 	t.Run("planes", func(t *testing.T) {
-		request := graphqlclient.NewRequest(`
-			query($address: Int!) {
-				planes(address: $address) {
-					name
+		for _, address := range []int{16, 17} {
+			request := graphqlclient.NewRequest(`
+				query($address: Int!) {
+					planes(address: $address) {
+						name
+					}
 				}
+			`)
+			request.Var("address", address)
+
+			var response struct {
+				Planes []struct {
+					Name string `json:"name"`
+				} `json:"planes"`
 			}
-		`)
-		request.Var("address", 16)
 
-		var response struct {
-			Planes []struct {
-				Name string `json:"name"`
-			} `json:"planes"`
-		}
-
-		if err := client.Run(context.Background(), request, &response); err != nil {
-			t.Fatalf("planes query error = %v", err)
-		}
-		if len(response.Planes) != 1 || response.Planes[0].Name != "heating" {
-			t.Fatalf("planes = %+v; want [heating]", response.Planes)
+			if err := client.Run(context.Background(), request, &response); err != nil {
+				t.Fatalf("planes query error = %v", err)
+			}
+			if len(response.Planes) != 1 || response.Planes[0].Name != "heating" {
+				t.Fatalf("address %d planes = %+v; want [heating]", address, response.Planes)
+			}
 		}
 	})
 
 	t.Run("methods", func(t *testing.T) {
-		request := graphqlclient.NewRequest(`
-			query($address: Int!, $plane: String!) {
-				methods(address: $address, plane: $plane) {
-					name
+		for _, address := range []int{16, 17} {
+			request := graphqlclient.NewRequest(`
+				query($address: Int!, $plane: String!) {
+					methods(address: $address, plane: $plane) {
+						name
+					}
 				}
+			`)
+			request.Var("address", address)
+			request.Var("plane", "heating")
+
+			var response struct {
+				Methods []struct {
+					Name string `json:"name"`
+				} `json:"methods"`
 			}
-		`)
-		request.Var("address", 16)
-		request.Var("plane", "heating")
 
-		var response struct {
-			Methods []struct {
-				Name string `json:"name"`
-			} `json:"methods"`
-		}
-
-		if err := client.Run(context.Background(), request, &response); err != nil {
-			t.Fatalf("methods query error = %v", err)
-		}
-		if len(response.Methods) != 1 || response.Methods[0].Name != "get_status" {
-			t.Fatalf("methods = %+v; want [get_status]", response.Methods)
+			if err := client.Run(context.Background(), request, &response); err != nil {
+				t.Fatalf("methods query error = %v", err)
+			}
+			if len(response.Methods) != 1 || response.Methods[0].Name != "get_status" {
+				t.Fatalf("address %d methods = %+v; want [get_status]", address, response.Methods)
+			}
 		}
 	})
 }

--- a/graphql/schema.go
+++ b/graphql/schema.go
@@ -17,6 +17,7 @@ type Schema struct {
 
 type Device struct {
 	Address         byte
+	Addresses       []byte
 	Manufacturer    string
 	DeviceID        string
 	SerialNumber    string
@@ -101,6 +102,7 @@ func BuildSchema(reg Registry) (Schema, error) {
 
 		device := Device{
 			Address:         entry.Address(),
+			Addresses:       normalizeDeviceAddresses(entry.Address(), entry.Addresses()),
 			Manufacturer:    entry.Manufacturer(),
 			DeviceID:        entry.DeviceID(),
 			SerialNumber:    entry.SerialNumber(),
@@ -273,6 +275,25 @@ func looksLikeVaillantFunctionalModule(prefix string) bool {
 	return true
 }
 
+func normalizeDeviceAddresses(primary byte, aliases []byte) []byte {
+	out := make([]byte, 0, len(aliases)+1)
+	appendUniqueAddress := func(address byte) {
+		for _, existing := range out {
+			if existing == address {
+				return
+			}
+		}
+		out = append(out, address)
+	}
+
+	appendUniqueAddress(primary)
+	for _, address := range aliases {
+		appendUniqueAddress(address)
+	}
+
+	return out
+}
+
 func isDigits(value string) bool {
 	if value == "" {
 		return false
@@ -369,6 +390,7 @@ func cloneSchema(schema Schema) Schema {
 		}
 		devices[i] = Device{
 			Address:         device.Address,
+			Addresses:       append([]byte(nil), device.Addresses...),
 			Manufacturer:    device.Manufacturer,
 			DeviceID:        device.DeviceID,
 			SerialNumber:    device.SerialNumber,

--- a/graphql/schema_metadata_test.go
+++ b/graphql/schema_metadata_test.go
@@ -49,6 +49,7 @@ func TestCloneSchema_PreservesDeviceMetadataFields(t *testing.T) {
 		Devices: []Device{
 			{
 				Address:       0x08,
+				Addresses:     []byte{0x08, 0x09},
 				Manufacturer:  "Vaillant",
 				DeviceID:      "dev-a",
 				DisplayName:   "FM5 Control Centre",
@@ -73,5 +74,8 @@ func TestCloneSchema_PreservesDeviceMetadataFields(t *testing.T) {
 		got.PartNumber != "0020184848" ||
 		got.Role != "controller" {
 		t.Fatalf("metadata clone mismatch: %+v", got)
+	}
+	if len(got.Addresses) != 2 || got.Addresses[0] != 0x08 || got.Addresses[1] != 0x09 {
+		t.Fatalf("addresses clone mismatch: %v", got.Addresses)
 	}
 }

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -42,6 +42,7 @@ type testEntry struct {
 }
 
 func (e testEntry) Address() byte            { return e.info.Address }
+func (e testEntry) Addresses() []byte        { return []byte{e.info.Address} }
 func (e testEntry) Manufacturer() string     { return e.info.Manufacturer }
 func (e testEntry) DeviceID() string         { return e.info.DeviceID }
 func (e testEntry) SerialNumber() string     { return e.info.SerialNumber }

--- a/smoke_test.go
+++ b/smoke_test.go
@@ -47,6 +47,7 @@ type testEntry struct {
 }
 
 func (e testEntry) Address() byte            { return e.info.Address }
+func (e testEntry) Addresses() []byte        { return []byte{e.info.Address} }
 func (e testEntry) Manufacturer() string     { return e.info.Manufacturer }
 func (e testEntry) DeviceID() string         { return e.info.DeviceID }
 func (e testEntry) SerialNumber() string     { return e.info.SerialNumber }

--- a/unknown_device_dump_test.go
+++ b/unknown_device_dump_test.go
@@ -24,6 +24,7 @@ type testDumpEntry struct {
 }
 
 func (e testDumpEntry) Address() byte        { return e.info.Address }
+func (e testDumpEntry) Addresses() []byte    { return []byte{e.info.Address} }
 func (e testDumpEntry) Manufacturer() string { return e.info.Manufacturer }
 func (e testDumpEntry) DeviceID() string     { return e.info.DeviceID }
 func (e testDumpEntry) SerialNumber() string { return e.info.SerialNumber }


### PR DESCRIPTION
## Summary
- extend GraphQL `Device` with `addresses` (canonical + aliases)
- keep `address` as canonical primary address
- make `device(address:)`, `planes(address:)`, and `methods(address:, ...)` resolve by canonical or alias address
- add tests for alias-aware lookups and schema cloning

## Validation
- `./scripts/ci_local.sh`

Closes #128