### PR TITLE
MCP-10-000: ADR baseline + MCP-first governance policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,3 +10,46 @@ These instructions apply to the entire repository.
 4. React (emoji) to every review comment and reply with status when actioned.
 5. If a change modifies externally visible behavior (transport options, GraphQL/MCP surface, smoke behavior), open/update the corresponding docs in `helianthus-docs-ebus` and merge docs alongside code (doc-gate).
 6. Transport/protocol changes require a full 88-case runtime matrix pass (`TRANSPORT_MATRIX_REPORT=<index.json>`), unless explicitly overridden by owner approval (`TRANSPORT_GATE_OWNER_OVERRIDE=OVERRIDE_TRANSPORT_GATE_BY_OWNER` with a reason).
+
+## MCP-first Policy
+
+### Scope and ordering
+- MCP is the primary prototyping/exploration interface.
+- GraphQL is second and may reach parity only after MCP tools are deterministic and contract-solid.
+- Home Assistant and other consumers are enabled only after GraphQL parity and stability gates are met.
+
+### Tool taxonomy and naming
+- Core stable tools use versioned names: `ebus.v<MAJOR>.<domain>.<subdomain>.<verb>`.
+- Experimental tools live under `ebus.experimental.*` and are never used by external consumers.
+- Prefer composable tools over monolithic endpoints.
+
+### Contract envelope (required for ebus.v1.*)
+Each `ebus.v1.*` tool returns:
+- `meta` with `contract`, `consistency`, `data_timestamp`, `data_hash`
+- `data`
+- `error` (null or structured error)
+
+### Determinism requirements
+- List ordering must be stable.
+- Snapshot mode must produce stable `data_hash` for identical snapshot + request.
+- Tool schemas and outputs must have golden snapshots.
+
+### Invoke safety
+`ebus.v1.rpc.invoke` requires:
+- explicit `intent` (`READ_ONLY` or `MUTATE`)
+- `allow_dangerous=true` for mutating or unknown methods
+- `idempotency_key` for mutating intent
+
+### Graduation gates (MCP -> GraphQL)
+A capability may graduate to GraphQL only if:
+1. it exists as core stable MCP (`ebus.v1.*`)
+2. it passes determinism + contract + golden tests
+3. parity tests MCP <-> GraphQL are green
+
+### End-of-cycle cleanup
+At cycle end, each `ebus.experimental.*` tool must be promoted, deleted, or moved to internal-only with written justification.
+No temporary/junk tool may remain in the showroom surface.
+
+### CI gates
+- Breaking changes in `ebus.v1.*` require a new major namespace.
+- Parity drift MCP vs GraphQL fails CI.

--- a/docs/adr/ADR-0001-mcp-first-governance.md
+++ b/docs/adr/ADR-0001-mcp-first-governance.md
@@ -1,0 +1,13 @@
+# ADR-0001: MCP-first Governance
+
+## Status
+Accepted
+
+## Context
+Helianthus needs a deterministic, contract-solid MCP surface before GraphQL parity and consumer rollout.
+
+## Decision
+Adopt MCP-first delivery order: MCP prototype/stabilize -> GraphQL parity -> consumer rollout.
+
+## Consequences
+Enables structured prototyping and reduces consumer-facing drift.

--- a/docs/adr/ADR-0002-mcp-v1-contract-envelope.md
+++ b/docs/adr/ADR-0002-mcp-v1-contract-envelope.md
@@ -1,0 +1,13 @@
+# ADR-0002: MCP v1 Contract Envelope
+
+## Status
+Accepted
+
+## Context
+Current MCP responses are inconsistent across tools.
+
+## Decision
+Standardize `ebus.v1.*` responses as `meta/data/error`, including deterministic `data_hash`.
+
+## Consequences
+Improves determinism, testing, and parity verification with GraphQL.

--- a/docs/adr/ADR-0003-parity-gates-and-cleanup.md
+++ b/docs/adr/ADR-0003-parity-gates-and-cleanup.md
@@ -1,0 +1,13 @@
+# ADR-0003: Parity Gates and Cleanup
+
+## Status
+Accepted
+
+## Context
+MCP and GraphQL can drift without explicit gates.
+
+## Decision
+Require determinism/contract/parity gates before GraphQL graduation and enforce end-of-cycle cleanup for experimental tools.
+
+## Consequences
+Reduces long-term surface sprawl and protects consumer quality.

--- a/docs/adr/ADR-0004-invoke-safety-idempotency.md
+++ b/docs/adr/ADR-0004-invoke-safety-idempotency.md
@@ -1,0 +1,13 @@
+# ADR-0004: Invoke Safety and Idempotency
+
+## Status
+Accepted
+
+## Context
+Mutating operations need explicit safety controls.
+
+## Decision
+`ebus.v1.rpc.invoke` must require intent, dangerous override for mutating/unknown methods, and idempotency key for mutate intent.
+
+## Consequences
+Makes side-effectful calls explicit and auditable.


### PR DESCRIPTION
## Summary
- add ADR baseline under docs/adr
- add MCP-first governance policy block in agent instructions
- establish deterministic/parity/cleanup policy guardrails for META-10

## Issue
Closes #138

## Validation
- CI fails on existing mainline build breakages (undefined transport.NewTCPPlainTransport, registry.DeviceEntry.Addresses); this PR is docs/policy only
