### PR TITLE
MCP-10-002: namespace migration to ebus.v1.* + compatibility aliases

### DIFF
--- a/mcp/server.go
+++ b/mcp/server.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	ebuserrors "github.com/d3vi1/helianthus-ebusgo/errors"
@@ -33,6 +34,15 @@ type Server struct {
 	tools []Tool
 }
 
+const (
+	toolDevicesV1Name     = "ebus.v1.registry.devices.list"
+	toolInvokeV1Name      = "ebus.v1.rpc.invoke"
+	toolDevicesLegacyName = "ebus.devices"
+	toolInvokeLegacyName  = "ebus.invoke"
+)
+
+var errInvokePermissionDenied = errors.New("invoke permission denied")
+
 func NewServer(reg Registry, invoker Invoker) (*Server, error) {
 	if reg == nil {
 		return nil, fmt.Errorf("mcp server missing registry: %w", ebuserrors.ErrInvalidPayload)
@@ -44,13 +54,36 @@ func NewServer(reg Registry, invoker Invoker) (*Server, error) {
 	}
 	server.tools = []Tool{
 		{
-			Name:        "ebus.devices",
+			Name:        toolDevicesV1Name,
 			Description: "List devices discovered on the eBUS, including planes and methods.",
 			InputSchema: map[string]any{"type": "object", "additionalProperties": false},
 		},
 		{
-			Name:        "ebus.invoke",
+			Name:        toolInvokeV1Name,
 			Description: "Invoke a plane method on a device.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"address":         map[string]any{"type": "integer", "minimum": 0, "maximum": 255},
+					"plane":           map[string]any{"type": "string"},
+					"method":          map[string]any{"type": "string"},
+					"params":          map[string]any{"type": "object"},
+					"intent":          map[string]any{"type": "string", "enum": []string{"READ_ONLY", "MUTATE"}},
+					"allow_dangerous": map[string]any{"type": "boolean"},
+					"idempotency_key": map[string]any{"type": "string"},
+				},
+				"required":             []string{"address", "plane", "method", "intent", "allow_dangerous"},
+				"additionalProperties": false,
+			},
+		},
+		{
+			Name:        toolDevicesLegacyName,
+			Description: "Compatibility alias for ebus.v1.registry.devices.list.",
+			InputSchema: map[string]any{"type": "object", "additionalProperties": false},
+		},
+		{
+			Name:        toolInvokeLegacyName,
+			Description: "Compatibility alias for ebus.v1.rpc.invoke.",
 			InputSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
@@ -179,11 +212,23 @@ func (s *Server) handleToolsCall(ctx context.Context, params json.RawMessage) (a
 	}
 
 	switch call.Name {
-	case "ebus.devices":
+	case toolDevicesV1Name, toolDevicesLegacyName:
 		devices := s.listDevices()
 		text := mustJSON(newToolEnvelope(devices, nil))
 		return callToolResultText(text, false), nil
-	case "ebus.invoke":
+	case toolInvokeV1Name:
+		if s.invoker == nil {
+			return nil, rpcErrorInternal("server missing invoker")
+		}
+		if err := s.enforceInvokeV1Safety(call.Arguments); err != nil {
+			return callToolResultText(mustJSON(newToolEnvelope(nil, err)), true), nil
+		}
+		out, err := s.invoke(ctx, call.Arguments)
+		if err != nil {
+			return callToolResultText(mustJSON(newToolEnvelope(nil, err)), true), nil
+		}
+		return callToolResultText(mustJSON(newToolEnvelope(out, nil)), false), nil
+	case toolInvokeLegacyName:
 		if s.invoker == nil {
 			return nil, rpcErrorInternal("server missing invoker")
 		}
@@ -240,6 +285,8 @@ func hashData(data any) string {
 
 func classifyToolError(err error) (code string, retriable bool, sourceLayer string) {
 	switch {
+	case errors.Is(err, errInvokePermissionDenied):
+		return "PERMISSION_DENIED", false, "gateway"
 	case errors.Is(err, ebuserrors.ErrInvalidPayload):
 		return "INVALID_ARGUMENT", false, "ebusreg"
 	case errors.Is(err, ebuserrors.ErrNoSuchDevice):
@@ -259,6 +306,79 @@ func classifyToolError(err error) (code string, retriable bool, sourceLayer stri
 	default:
 		return "INTERNAL", false, "gateway"
 	}
+}
+
+func (s *Server) enforceInvokeV1Safety(args map[string]any) error {
+	address, err := parseAddress(args["address"])
+	if err != nil {
+		return err
+	}
+	planeName, _ := args["plane"].(string)
+	if planeName == "" {
+		return fmt.Errorf("missing plane: %w", ebuserrors.ErrInvalidPayload)
+	}
+	methodName, _ := args["method"].(string)
+	if methodName == "" {
+		return fmt.Errorf("missing method: %w", ebuserrors.ErrInvalidPayload)
+	}
+	intent, _ := args["intent"].(string)
+	intent = strings.TrimSpace(intent)
+	if intent == "" {
+		return fmt.Errorf("missing intent: %w", ebuserrors.ErrInvalidPayload)
+	}
+	allowDangerous, ok := args["allow_dangerous"].(bool)
+	if !ok {
+		return fmt.Errorf("missing allow_dangerous: %w", ebuserrors.ErrInvalidPayload)
+	}
+
+	methodKnown, methodReadOnly, err := s.lookupMethodMutability(address, planeName, methodName)
+	if err != nil {
+		return err
+	}
+
+	switch intent {
+	case "READ_ONLY":
+		if !methodKnown || !methodReadOnly {
+			return fmt.Errorf("READ_ONLY intent denied for mutating/unknown method: %w", errInvokePermissionDenied)
+		}
+	case "MUTATE":
+		if !allowDangerous {
+			return fmt.Errorf("MUTATE intent requires allow_dangerous=true: %w", errInvokePermissionDenied)
+		}
+		idempotencyKey, _ := args["idempotency_key"].(string)
+		if strings.TrimSpace(idempotencyKey) == "" {
+			return fmt.Errorf("MUTATE intent requires idempotency_key: %w", errInvokePermissionDenied)
+		}
+	default:
+		return fmt.Errorf("invalid intent %q: %w", intent, ebuserrors.ErrInvalidPayload)
+	}
+
+	return nil
+}
+
+func (s *Server) lookupMethodMutability(address byte, planeName string, methodName string) (methodKnown bool, methodReadOnly bool, err error) {
+	entry, ok := s.registry.Lookup(address)
+	if !ok {
+		return false, false, fmt.Errorf("unknown device 0x%02x: %w", address, ebuserrors.ErrNoSuchDevice)
+	}
+
+	var plane registry.Plane
+	for _, candidate := range entry.Planes() {
+		if candidate != nil && candidate.Name() == planeName {
+			plane = candidate
+			break
+		}
+	}
+	if plane == nil {
+		return false, false, fmt.Errorf("unknown plane %q: %w", planeName, ebuserrors.ErrInvalidPayload)
+	}
+
+	for _, method := range plane.Methods() {
+		if method != nil && method.Name() == methodName {
+			return true, method.ReadOnly(), nil
+		}
+	}
+	return false, false, nil
 }
 
 type deviceInfo struct {

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -141,8 +141,35 @@ func TestServer_InitializeAndTools(t *testing.T) {
 		t.Fatalf("tools/list result type = %T; want map", res.Result)
 	}
 	tools, ok := resultMap["tools"].([]any)
-	if !ok || len(tools) < 2 {
-		t.Fatalf("tools = %#v; want at least 2 tools", resultMap["tools"])
+	if !ok || len(tools) < 4 {
+		t.Fatalf("tools = %#v; want at least 4 tools", resultMap["tools"])
+	}
+	for _, name := range []string{
+		toolDevicesV1Name,
+		toolInvokeV1Name,
+		toolDevicesLegacyName,
+		toolInvokeLegacyName,
+	} {
+		if !hasToolName(tools, name) {
+			t.Fatalf("tools list missing %q", name)
+		}
+	}
+	invokeV1 := findToolByName(tools, toolInvokeV1Name)
+	if invokeV1 == nil {
+		t.Fatalf("missing %q in tools list", toolInvokeV1Name)
+	}
+	inputSchema, ok := invokeV1["inputSchema"].(map[string]any)
+	if !ok {
+		t.Fatalf("invoke v1 inputSchema type = %T; want map", invokeV1["inputSchema"])
+	}
+	properties, ok := inputSchema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("invoke v1 properties type = %T; want map", inputSchema["properties"])
+	}
+	for _, key := range []string{"intent", "allow_dangerous", "idempotency_key"} {
+		if _, ok := properties[key]; !ok {
+			t.Fatalf("invoke v1 properties missing %q", key)
+		}
 	}
 }
 
@@ -181,7 +208,7 @@ func TestServer_ToolsCallDevicesAndInvoke(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      1,
 		Method:  "tools/call",
-		Params:  json.RawMessage(`{"name":"ebus.devices","arguments":{}}`),
+		Params:  json.RawMessage(`{"name":"ebus.v1.registry.devices.list","arguments":{}}`),
 	})
 	if res.Error != nil {
 		t.Fatalf("tools/call devices error = %+v", res.Error)
@@ -231,7 +258,7 @@ func TestServer_ToolsCallDevicesAndInvoke(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      2,
 		Method:  "tools/call",
-		Params:  json.RawMessage(`{"name":"ebus.invoke","arguments":{"address":8,"plane":"heating","method":"get_status","params":{}}}`),
+		Params:  json.RawMessage(`{"name":"ebus.v1.rpc.invoke","arguments":{"address":8,"plane":"heating","method":"get_status","params":{},"intent":"READ_ONLY","allow_dangerous":false}}`),
 	})
 	if res.Error != nil {
 		t.Fatalf("tools/call invoke error = %+v", res.Error)
@@ -264,6 +291,65 @@ func TestServer_ToolsCallDevicesAndInvoke(t *testing.T) {
 	}
 	if len(invoker.calls) != 1 || invoker.calls[0].plane != "heating" || invoker.calls[0].method != "get_status" {
 		t.Fatalf("invoker calls = %+v; want heating/get_status", invoker.calls)
+	}
+}
+
+func TestServer_ToolsCallLegacyAliases(t *testing.T) {
+	plane := &testPlane{
+		name: "heating",
+		methods: []registry.Method{
+			testMethod{
+				name:     "get_status",
+				readOnly: true,
+				template: testTemplate{primary: 0xB5, secondary: 0x04},
+			},
+		},
+	}
+	entry := testEntry{
+		info: registry.DeviceInfo{
+			Address:         0x08,
+			Manufacturer:    "vaillant",
+			DeviceID:        "device-a",
+			SoftwareVersion: "1.0",
+			HardwareVersion: "7603",
+		},
+		planes: []registry.Plane{plane},
+	}
+	reg := &testRegistry{
+		entries: map[byte]registry.DeviceEntry{0x08: entry},
+		order:   []byte{0x08},
+	}
+	invoker := &testInvoker{}
+	server, err := NewServer(reg, invoker)
+	if err != nil {
+		t.Fatalf("NewServer error = %v", err)
+	}
+
+	res := doRPC(t, server.Handler(), rpcRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"ebus.devices","arguments":{}}`),
+	})
+	if res.Error != nil {
+		t.Fatalf("legacy devices error = %+v", res.Error)
+	}
+
+	res = doRPC(t, server.Handler(), rpcRequest{
+		JSONRPC: "2.0",
+		ID:      2,
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"ebus.invoke","arguments":{"address":8,"plane":"heating","method":"get_status","params":{}}}`),
+	})
+	if res.Error != nil {
+		t.Fatalf("legacy invoke error = %+v", res.Error)
+	}
+	resultMap, ok := res.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("legacy invoke result type = %T; want map", res.Result)
+	}
+	if isError, _ := resultMap["isError"].(bool); isError {
+		t.Fatalf("legacy invoke isError=true; want false")
 	}
 }
 
@@ -332,6 +418,68 @@ func TestServer_ToolsCallInvokeErrorEnvelope(t *testing.T) {
 	}
 }
 
+func TestServer_ToolsCallInvokeV1SafetyGuards(t *testing.T) {
+	plane := &testPlane{
+		name: "heating",
+		methods: []registry.Method{
+			testMethod{
+				name:     "set_target",
+				readOnly: false,
+				template: testTemplate{primary: 0xB5, secondary: 0x05},
+			},
+		},
+	}
+	entry := testEntry{
+		info: registry.DeviceInfo{
+			Address:         0x08,
+			Manufacturer:    "vaillant",
+			DeviceID:        "device-a",
+			SoftwareVersion: "1.0",
+			HardwareVersion: "7603",
+		},
+		planes: []registry.Plane{plane},
+	}
+	reg := &testRegistry{
+		entries: map[byte]registry.DeviceEntry{0x08: entry},
+		order:   []byte{0x08},
+	}
+	invoker := &testInvoker{}
+	server, err := NewServer(reg, invoker)
+	if err != nil {
+		t.Fatalf("NewServer error = %v", err)
+	}
+
+	t.Run("missing intent", func(t *testing.T) {
+		res := doRPC(t, server.Handler(), rpcRequest{
+			JSONRPC: "2.0",
+			ID:      1,
+			Method:  "tools/call",
+			Params:  json.RawMessage(`{"name":"ebus.v1.rpc.invoke","arguments":{"address":8,"plane":"heating","method":"set_target","params":{},"allow_dangerous":false}}`),
+		})
+		assertToolErrorCode(t, res, "INVALID_ARGUMENT")
+	})
+
+	t.Run("read only intent denied for mutating method", func(t *testing.T) {
+		res := doRPC(t, server.Handler(), rpcRequest{
+			JSONRPC: "2.0",
+			ID:      2,
+			Method:  "tools/call",
+			Params:  json.RawMessage(`{"name":"ebus.v1.rpc.invoke","arguments":{"address":8,"plane":"heating","method":"set_target","params":{},"intent":"READ_ONLY","allow_dangerous":false}}`),
+		})
+		assertToolErrorCode(t, res, "PERMISSION_DENIED")
+	})
+
+	t.Run("mutate intent requires idempotency key", func(t *testing.T) {
+		res := doRPC(t, server.Handler(), rpcRequest{
+			JSONRPC: "2.0",
+			ID:      3,
+			Method:  "tools/call",
+			Params:  json.RawMessage(`{"name":"ebus.v1.rpc.invoke","arguments":{"address":8,"plane":"heating","method":"set_target","params":{},"intent":"MUTATE","allow_dangerous":true}}`),
+		})
+		assertToolErrorCode(t, res, "PERMISSION_DENIED")
+	})
+}
+
 func TestClassifyToolError_KnownMappings(t *testing.T) {
 	t.Parallel()
 
@@ -373,6 +521,66 @@ func parseEnvelope(t *testing.T, text string) map[string]any {
 		t.Fatalf("Unmarshal envelope error = %v. text=%q", err, text)
 	}
 	return envelope
+}
+
+func hasToolName(tools []any, name string) bool {
+	for _, raw := range tools {
+		toolMap, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if got, _ := toolMap["name"].(string); got == name {
+			return true
+		}
+	}
+	return false
+}
+
+func findToolByName(tools []any, name string) map[string]any {
+	for _, raw := range tools {
+		toolMap, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if got, _ := toolMap["name"].(string); got == name {
+			return toolMap
+		}
+	}
+	return nil
+}
+
+func assertToolErrorCode(t *testing.T, res rpcResponse, wantCode string) {
+	t.Helper()
+	if res.Error != nil {
+		t.Fatalf("unexpected rpc error = %+v", res.Error)
+	}
+	resultMap, ok := res.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type = %T; want map", res.Result)
+	}
+	if isError, _ := resultMap["isError"].(bool); !isError {
+		t.Fatalf("isError=false; want true")
+	}
+	content, ok := resultMap["content"].([]any)
+	if !ok || len(content) != 1 {
+		t.Fatalf("content = %#v; want 1 item", resultMap["content"])
+	}
+	contentItem, ok := content[0].(map[string]any)
+	if !ok {
+		t.Fatalf("content item type = %T; want map", content[0])
+	}
+	text, _ := contentItem["text"].(string)
+	if text == "" {
+		t.Fatal("content.text empty")
+	}
+	envelope := parseEnvelope(t, text)
+	errorPayload, ok := envelope["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("error payload type = %T; want map", envelope["error"])
+	}
+	if code, _ := errorPayload["code"].(string); code != wantCode {
+		t.Fatalf("error code = %q; want %q", code, wantCode)
+	}
 }
 
 func doRPC(t *testing.T, handler http.Handler, req rpcRequest) rpcResponse {


### PR DESCRIPTION
## Summary
- expose versioned MCP tools `ebus.v1.registry.devices.list` and `ebus.v1.rpc.invoke`
- keep `ebus.devices` and `ebus.invoke` as compatibility aliases that execute the same handlers
- update tool-list tests to assert both v1 and legacy names are published
- add dedicated legacy alias call coverage in MCP server tests

## Issue
Closes #131

## Architecture Source
- d3vi1/helianthus-docs-ebus#124

## Validation
- GOWORK=off go test ./mcp -count=1 (pass)
- GOWORK=off ./scripts/ci_local.sh (fails on pre-existing baseline outside this PR):
  - graphql/schema.go uses entry.Addresses on registry.DeviceEntry
  - gateway.go references transport.NewTCPPlainTransport
