### PR TITLE
portal: add observability baseline and ETag caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,19 @@ Portal static assets are built from canonical sources under `portal/web/src` and
 
 Production runtime does not require Node. Node is only needed at build time when regenerating portal assets.
 
+## Portal Observability (M0 Baseline)
+
+Portal requests emit structured log lines with:
+- `method`
+- `path`
+- `route`
+- `status`
+- `duration_ms`
+
+Portal also exports `expvar` counters/maps:
+- `portal_requests_total`
+- `portal_route_duration_ms_total`
+
 ## Link Map
 
 ### Repositories and docs

--- a/portal/handler.go
+++ b/portal/handler.go
@@ -3,9 +3,13 @@ package portal
 import (
 	"embed"
 	"encoding/json"
+	"expvar"
+	"fmt"
 	"html/template"
 	"io/fs"
+	"log"
 	"net/http"
+	"path"
 	"strings"
 	"time"
 )
@@ -22,6 +26,20 @@ var staticFS = func() fs.FS {
 }()
 
 var indexTemplate = template.Must(template.ParseFS(assets, "static/index.html"))
+
+type assetHashEntry struct {
+	SHA256 string `json:"sha256"`
+}
+
+type assetManifest struct {
+	Assets map[string]assetHashEntry `json:"assets"`
+}
+
+var (
+	portalRequestCount      = expvar.NewMap("portal_requests_total")
+	portalRouteDurationMS   = expvar.NewMap("portal_route_duration_ms_total")
+	portalAssetETagByTarget = loadAssetETags()
+)
 
 type Options struct {
 	GraphQLPath      string
@@ -75,24 +93,38 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if path == "" {
 		path = "/"
 	}
+	route := classifyRoute(path)
+	startedAt := time.Now()
+	recorder := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+	defer func() {
+		duration := time.Since(startedAt).Milliseconds()
+		portalRequestCount.Add(fmt.Sprintf("%s|%s|%d", r.Method, route, recorder.status), 1)
+		portalRouteDurationMS.Add(route, duration)
+		log.Printf("portal request method=%s path=%q route=%s status=%d duration_ms=%d", r.Method, path, route, recorder.status, duration)
+	}()
+
 	if strings.HasPrefix(path, "/api/v1/") {
-		h.handleAPI(w, r, strings.TrimPrefix(path, "/api/v1/"))
+		h.handleAPI(recorder, r, strings.TrimPrefix(path, "/api/v1/"))
 		return
 	}
 	if path == "/" || strings.EqualFold(path, "/index.html") {
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		_ = indexTemplate.Execute(w, map[string]any{
+		recorder.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_ = indexTemplate.Execute(recorder, map[string]any{
 			"GraphQLPath": h.opts.GraphQLPath,
 		})
 		return
 	}
 	if strings.HasPrefix(path, "/assets/") {
-		w.Header().Set("Cache-Control", "public, max-age=3600")
+		recorder.Header().Set("Cache-Control", "public, max-age=3600")
+		if applyAssetETag(recorder, r, path) {
+			return
+		}
 	}
-	h.files.ServeHTTP(w, r)
+	h.files.ServeHTTP(recorder, r)
 }
 
 func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string) {
+	w.Header().Set("Cache-Control", "no-store")
 	if r.Method != http.MethodGet {
 		w.Header().Set("Allow", http.MethodGet)
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -136,4 +168,73 @@ func writeJSON(w http.ResponseWriter, statusCode int, payload any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
 	_ = json.NewEncoder(w).Encode(payload)
+}
+
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (rec *statusRecorder) WriteHeader(code int) {
+	rec.status = code
+	rec.ResponseWriter.WriteHeader(code)
+}
+
+func (rec *statusRecorder) Write(payload []byte) (int, error) {
+	if rec.status == 0 {
+		rec.status = http.StatusOK
+	}
+	return rec.ResponseWriter.Write(payload)
+}
+
+func classifyRoute(path string) string {
+	switch {
+	case strings.HasPrefix(path, "/api/v1/health"):
+		return "api.health"
+	case strings.HasPrefix(path, "/api/v1/bootstrap"):
+		return "api.bootstrap"
+	case strings.HasPrefix(path, "/assets/"):
+		return "assets"
+	case path == "/" || strings.EqualFold(path, "/index.html"):
+		return "index"
+	default:
+		return "static"
+	}
+}
+
+func loadAssetETags() map[string]string {
+	raw, err := assets.ReadFile("static/assets/manifest.json")
+	if err != nil {
+		return nil
+	}
+	var manifest assetManifest
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		return nil
+	}
+	etags := make(map[string]string, len(manifest.Assets))
+	for name, entry := range manifest.Assets {
+		hash := strings.TrimSpace(entry.SHA256)
+		if hash == "" {
+			continue
+		}
+		etags[name] = fmt.Sprintf("\"sha256-%s\"", hash)
+	}
+	return etags
+}
+
+func applyAssetETag(w http.ResponseWriter, r *http.Request, assetPath string) bool {
+	if len(portalAssetETagByTarget) == 0 || r == nil {
+		return false
+	}
+	name := path.Base(assetPath)
+	etag, ok := portalAssetETagByTarget[name]
+	if !ok {
+		return false
+	}
+	w.Header().Set("ETag", etag)
+	if strings.TrimSpace(r.Header.Get("If-None-Match")) == etag {
+		w.WriteHeader(http.StatusNotModified)
+		return true
+	}
+	return false
 }

--- a/portal/handler_test.go
+++ b/portal/handler_test.go
@@ -44,6 +44,32 @@ func TestHandlerAssets(t *testing.T) {
 	if got := rec.Header().Get("Cache-Control"); got == "" {
 		t.Fatalf("cache-control missing")
 	}
+	if got := rec.Header().Get("ETag"); got == "" {
+		t.Fatalf("etag missing")
+	}
+}
+
+func TestHandlerAssetsNotModified(t *testing.T) {
+	h := NewHandler(Options{})
+
+	firstReq := httptest.NewRequest(http.MethodGet, "/assets/app.js", nil)
+	firstRec := httptest.NewRecorder()
+	h.ServeHTTP(firstRec, firstReq)
+	if firstRec.Code != http.StatusOK {
+		t.Fatalf("first status = %d; want %d", firstRec.Code, http.StatusOK)
+	}
+	etag := firstRec.Header().Get("ETag")
+	if etag == "" {
+		t.Fatalf("etag missing on initial response")
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/assets/app.js", nil)
+	req.Header.Set("If-None-Match", etag)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotModified {
+		t.Fatalf("status = %d; want %d", rec.Code, http.StatusNotModified)
+	}
 }
 
 func TestHealthEndpoint(t *testing.T) {
@@ -71,6 +97,9 @@ func TestHealthEndpoint(t *testing.T) {
 	}
 	if _, err := time.Parse(time.RFC3339, payload["time_utc"].(string)); err != nil {
 		t.Fatalf("time_utc not RFC3339: %v", err)
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("Cache-Control=%q; want no-store", got)
 	}
 }
 


### PR DESCRIPTION
## What
Implements ISSUE-007 (`#147`) for portal observability and cache behavior.

### Added
- Portal request observability in `portal/handler.go`:
  - structured log line per request (`method`, `path`, `route`, `status`, `duration_ms`)
  - `expvar` maps:
    - `portal_requests_total`
    - `portal_route_duration_ms_total`
- Asset caching improvements:
  - existing `Cache-Control` kept for `/assets/*`
  - ETag lookup from embedded `portal/static/assets/manifest.json`
  - conditional requests return `304 Not Modified` when `If-None-Match` matches
- API cache policy:
  - `Cache-Control: no-store` on `/portal/api/v1/*`

### Tests
- `TestHandlerAssets` now validates ETag header
- `TestHandlerAssetsNotModified` validates 304 flow
- `TestHealthEndpoint` validates `Cache-Control: no-store`

## Validation (local)
- `./scripts/check_portal_assets.sh`
- `GOWORK=off go test ./portal ./ui`

## Notes
- GitHub runners remain unavailable due billing limits; validated locally.

Closes #147
Refs #148
