### PR TITLE
portal: add registry browse API and preview list

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ curl -fsS http://127.0.0.1:8080/graphql \
 curl -fsS http://127.0.0.1:8080/mcp \
   -H 'content-type: application/json' \
   --data '{"jsonrpc":"2.0","id":"ready","method":"ping","params":{}}'
+
+# Portal registry browse preview
+curl -fsS 'http://127.0.0.1:8080/portal/api/v1/registry/devices?limit=5'
 ```
 
 ## Local Smoke-Test Configuration Example

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/d3vi1/helianthus-ebusgateway/portal"
 	"github.com/d3vi1/helianthus-ebusgateway/ui"
 	vaillantproviders "github.com/d3vi1/helianthus-ebusreg/providers/vaillant"
+	"github.com/d3vi1/helianthus-ebusreg/registry"
 )
 
 var (
@@ -265,6 +266,44 @@ func startHTTPServer(ctx context.Context, cfg ebusgateway.Config, gateway *ebusg
 			MCPPath:          cfg.MCPPath,
 			GatewayVersion:   buildVersion,
 			BuildID:          buildID,
+			ListRegistry: func() []portal.RegistryDevice {
+				items := make([]portal.RegistryDevice, 0)
+				gateway.Registry.Iterate(func(entry registry.DeviceEntry) bool {
+					if entry == nil {
+						return true
+					}
+					device := portal.RegistryDevice{
+						Address:      entry.Address(),
+						Addresses:    append([]byte(nil), entry.Addresses()...),
+						Manufacturer: entry.Manufacturer(),
+						DeviceID:     entry.DeviceID(),
+						SerialNumber: entry.SerialNumber(),
+						Software:     entry.SoftwareVersion(),
+						Hardware:     entry.HardwareVersion(),
+						Planes:       make([]portal.RegistryPlane, 0),
+					}
+					for _, plane := range entry.Planes() {
+						if plane == nil {
+							continue
+						}
+						methods := plane.Methods()
+						methodNames := make([]string, 0, len(methods))
+						for _, method := range methods {
+							if method == nil {
+								continue
+							}
+							methodNames = append(methodNames, method.Name())
+						}
+						device.Planes = append(device.Planes, portal.RegistryPlane{
+							Name:    plane.Name(),
+							Methods: methodNames,
+						})
+					}
+					items = append(items, device)
+					return true
+				})
+				return items
+			},
 		})
 		mux.Handle(portalPath+"/", http.StripPrefix(portalPath, portalHandler))
 		mux.HandleFunc(portalPath, func(w http.ResponseWriter, r *http.Request) {

--- a/portal/handler.go
+++ b/portal/handler.go
@@ -1,6 +1,7 @@
 package portal
 
 import (
+	"cmp"
 	"embed"
 	"encoding/json"
 	"expvar"
@@ -10,6 +11,8 @@ import (
 	"log"
 	"net/http"
 	"path"
+	"slices"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -48,11 +51,28 @@ type Options struct {
 	MCPPath          string
 	GatewayVersion   string
 	BuildID          string
+	ListRegistry     func() []RegistryDevice
 }
 
 type handler struct {
 	opts  Options
 	files http.Handler
+}
+
+type RegistryDevice struct {
+	Address      byte            `json:"address"`
+	Addresses    []byte          `json:"addresses,omitempty"`
+	Manufacturer string          `json:"manufacturer"`
+	DeviceID     string          `json:"device_id"`
+	SerialNumber string          `json:"serial_number,omitempty"`
+	Software     string          `json:"software_version"`
+	Hardware     string          `json:"hardware_version"`
+	Planes       []RegistryPlane `json:"planes,omitempty"`
+}
+
+type RegistryPlane struct {
+	Name    string   `json:"name"`
+	Methods []string `json:"methods,omitempty"`
 }
 
 func NewHandler(opts Options) http.Handler {
@@ -142,7 +162,7 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 	case "bootstrap":
 		writeJSON(w, http.StatusOK, map[string]any{
 			"capabilities": map[string]bool{
-				"registry":   true,
+				"registry":   h.opts.ListRegistry != nil,
 				"semantic":   true,
 				"projection": true,
 				"stream":     false,
@@ -159,6 +179,8 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 			},
 			"ui_version": "m0",
 		})
+	case "registry/devices":
+		h.handleRegistryDevices(w, r)
 	default:
 		http.NotFound(w, r)
 	}
@@ -193,6 +215,8 @@ func classifyRoute(path string) string {
 		return "api.health"
 	case strings.HasPrefix(path, "/api/v1/bootstrap"):
 		return "api.bootstrap"
+	case strings.HasPrefix(path, "/api/v1/registry/devices"):
+		return "api.registry.devices"
 	case strings.HasPrefix(path, "/assets/"):
 		return "assets"
 	case path == "/" || strings.EqualFold(path, "/index.html"):
@@ -235,6 +259,90 @@ func applyAssetETag(w http.ResponseWriter, r *http.Request, assetPath string) bo
 	if strings.TrimSpace(r.Header.Get("If-None-Match")) == etag {
 		w.WriteHeader(http.StatusNotModified)
 		return true
+	}
+	return false
+}
+
+func (h *handler) handleRegistryDevices(w http.ResponseWriter, r *http.Request) {
+	if h.opts.ListRegistry == nil {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"count": 0,
+			"items": []RegistryDevice{},
+		})
+		return
+	}
+
+	devices := h.opts.ListRegistry()
+	needle := strings.TrimSpace(strings.ToLower(r.URL.Query().Get("q")))
+	limit := parseQueryLimit(r.URL.Query().Get("limit"), 200)
+	if limit < 0 {
+		limit = 0
+	}
+
+	filtered := make([]RegistryDevice, 0, len(devices))
+	for _, device := range devices {
+		if needle != "" && !matchesDeviceFilter(device, needle) {
+			continue
+		}
+		filtered = append(filtered, device)
+	}
+
+	slices.SortFunc(filtered, func(a, b RegistryDevice) int {
+		return cmp.Compare(int(a.Address), int(b.Address))
+	})
+
+	total := len(filtered)
+	if limit > 0 && len(filtered) > limit {
+		filtered = filtered[:limit]
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"count": total,
+		"items": filtered,
+	})
+}
+
+func parseQueryLimit(raw string, fallback int) int {
+	if strings.TrimSpace(raw) == "" {
+		return fallback
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil {
+		return fallback
+	}
+	switch {
+	case value <= 0:
+		return 0
+	case value > 1000:
+		return 1000
+	default:
+		return value
+	}
+}
+
+func matchesDeviceFilter(device RegistryDevice, needle string) bool {
+	if needle == "" {
+		return true
+	}
+	candidate := strings.ToLower(strings.Join([]string{
+		device.Manufacturer,
+		device.DeviceID,
+		device.SerialNumber,
+		device.Software,
+		device.Hardware,
+	}, " "))
+	if strings.Contains(candidate, needle) {
+		return true
+	}
+	for _, plane := range device.Planes {
+		if strings.Contains(strings.ToLower(plane.Name), needle) {
+			return true
+		}
+		for _, method := range plane.Methods {
+			if strings.Contains(strings.ToLower(method), needle) {
+				return true
+			}
+		}
 	}
 	return false
 }

--- a/portal/handler_test.go
+++ b/portal/handler_test.go
@@ -109,6 +109,9 @@ func TestBootstrapEndpoint(t *testing.T) {
 		SnapshotPath:     "/snapshot",
 		SubscriptionPath: "/graphql/subscriptions",
 		MCPPath:          "/mcp",
+		ListRegistry: func() []RegistryDevice {
+			return []RegistryDevice{{Address: 0x10, Manufacturer: "Vaillant", DeviceID: "VRC720"}}
+		},
 	})
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/bootstrap", nil)
 	rec := httptest.NewRecorder()
@@ -128,6 +131,10 @@ func TestBootstrapEndpoint(t *testing.T) {
 	endpoints := payload["endpoints"].(map[string]any)
 	if endpoints["graphql"] != "/graphql" {
 		t.Fatalf("graphql endpoint=%v; want /graphql", endpoints["graphql"])
+	}
+	capabilities := payload["capabilities"].(map[string]any)
+	if capabilities["registry"] != true {
+		t.Fatalf("capabilities.registry=%v; want true", capabilities["registry"])
 	}
 }
 
@@ -177,5 +184,82 @@ func TestMountedPortalEndpoints(t *testing.T) {
 	}
 	if bootstrap["ui_version"] != "m0" {
 		t.Fatalf("ui_version=%v; want m0", bootstrap["ui_version"])
+	}
+}
+
+func TestRegistryDevicesEndpoint(t *testing.T) {
+	h := NewHandler(Options{
+		ListRegistry: func() []RegistryDevice {
+			return []RegistryDevice{
+				{
+					Address:      0x10,
+					Manufacturer: "Vaillant",
+					DeviceID:     "VRC720",
+					Planes: []RegistryPlane{
+						{Name: "system", Methods: []string{"get_status"}},
+					},
+				},
+				{
+					Address:      0x08,
+					Manufacturer: "Vaillant",
+					DeviceID:     "BAI",
+					Planes: []RegistryPlane{
+						{Name: "heating", Methods: []string{"get_operational_data"}},
+					},
+				},
+			}
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/registry/devices?limit=1", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; want %d", rec.Code, http.StatusOK)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if int(payload["count"].(float64)) != 2 {
+		t.Fatalf("count=%v; want 2", payload["count"])
+	}
+	items := payload["items"].([]any)
+	if len(items) != 1 {
+		t.Fatalf("len(items)=%d; want 1 due to limit", len(items))
+	}
+	first := items[0].(map[string]any)
+	if int(first["address"].(float64)) != 0x08 {
+		t.Fatalf("first.address=%v; want 8 sorted asc", first["address"])
+	}
+}
+
+func TestRegistryDevicesEndpoint_Filter(t *testing.T) {
+	h := NewHandler(Options{
+		ListRegistry: func() []RegistryDevice {
+			return []RegistryDevice{
+				{Address: 0x10, Manufacturer: "Vaillant", DeviceID: "VRC720", Planes: []RegistryPlane{{Name: "system", Methods: []string{"get_status"}}}},
+				{Address: 0x08, Manufacturer: "Vaillant", DeviceID: "BAI", Planes: []RegistryPlane{{Name: "heating", Methods: []string{"get_operational_data"}}}},
+			}
+		},
+	})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/registry/devices?q=operational", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if int(payload["count"].(float64)) != 1 {
+		t.Fatalf("count=%v; want 1", payload["count"])
+	}
+	items := payload["items"].([]any)
+	if len(items) != 1 {
+		t.Fatalf("len(items)=%d; want 1", len(items))
+	}
+	if int(items[0].(map[string]any)["address"].(float64)) != 0x08 {
+		t.Fatalf("address=%v; want 8", items[0].(map[string]any)["address"])
 	}
 }

--- a/portal/static/assets/app.css
+++ b/portal/static/assets/app.css
@@ -175,6 +175,25 @@ body {
   color: var(--muted);
 }
 
+.registry-preview {
+  margin-top: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 0.8rem;
+  background: color-mix(in srgb, var(--panel-soft) 90%, transparent);
+}
+
+.registry-preview h2 {
+  margin: 0 0 0.55rem;
+  font-size: 0.95rem;
+}
+
+.registry-preview ul {
+  margin: 0;
+  padding-left: 1rem;
+  color: var(--muted);
+}
+
 @media (max-width: 900px) {
   .topbar {
     grid-template-columns: 1fr;

--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -35,6 +35,7 @@ class PortalShell extends HTMLElement {
   async loadStatus() {
     const statusEl = this.querySelector('[data-role="status"]');
     const metaEl = this.querySelector('[data-role="meta"]');
+    const listEl = this.querySelector('[data-role="registry-list"]');
     try {
       const [healthRes, bootstrapRes] = await Promise.all([
         fetch("api/v1/health"),
@@ -50,6 +51,9 @@ class PortalShell extends HTMLElement {
         metaEl.textContent =
           `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, stream=${caps.stream}`;
       }
+      if (bootstrap.capabilities?.registry && listEl) {
+        await this.loadRegistryPreview(listEl);
+      }
     } catch (err) {
       if (statusEl) {
         statusEl.textContent = "Gateway unavailable";
@@ -58,6 +62,29 @@ class PortalShell extends HTMLElement {
         metaEl.textContent = "Bootstrap fetch failed";
       }
       console.error("portal bootstrap failed", err);
+    }
+  }
+
+  async loadRegistryPreview(listEl) {
+    try {
+      const response = await fetch("api/v1/registry/devices?limit=8");
+      const payload = await response.json();
+      const items = Array.isArray(payload.items) ? payload.items : [];
+      if (items.length === 0) {
+        listEl.innerHTML = "<li>No devices discovered yet.</li>";
+        return;
+      }
+      listEl.innerHTML = items
+        .map((item) => {
+          const addr = Number(item.address).toString(16).padStart(2, "0");
+          const model = item.device_id || "unknown";
+          const vendor = item.manufacturer || "unknown";
+          return `<li><strong>0x${addr}</strong> ${vendor} ${model}</li>`;
+        })
+        .join("");
+    } catch (err) {
+      listEl.innerHTML = "<li>Registry preview unavailable.</li>";
+      console.error("registry preview failed", err);
     }
   }
 
@@ -93,6 +120,12 @@ class PortalShell extends HTMLElement {
               <article class="card"><h3>Timeline</h3><span class="badge">Coming Soon</span></article>
               <article class="card"><h3>Snapshots</h3><span class="badge">Coming Soon</span></article>
               <article class="card"><h3>Issue Builder</h3><span class="badge">Coming Soon</span></article>
+            </section>
+            <section class="registry-preview">
+              <h2>Registry Preview</h2>
+              <ul data-role="registry-list">
+                <li>Loading discovered devices...</li>
+              </ul>
             </section>
             <div class="meta" data-role="meta">Waiting for bootstrap...</div>
           </main>

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,12 +2,12 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 3950,
-      "sha256": "1ef6451c89cbf0ca1a8adda71f2037ce2f5f620a3554a4a8ffddf841bd6404ab"
+      "bytes": 5216,
+      "sha256": "6e56c9a88aa493a2d71c0e16468315ec827ccc408589bc32edc21e8cacd98fb7"
     },
     "app.css": {
-      "bytes": 3365,
-      "sha256": "d6d7d2cb80ab60a9a213b74cc2e140129d3109a25841449afd1b46d285862559"
+      "bytes": 3710,
+      "sha256": "59206873cc08e96fd7124ed997ebe08df2a666d9da5c11a56e59914dd926b65d"
     }
   }
 }

--- a/portal/web/src/app.css
+++ b/portal/web/src/app.css
@@ -174,6 +174,25 @@ body {
   color: var(--muted);
 }
 
+.registry-preview {
+  margin-top: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 0.8rem;
+  background: color-mix(in srgb, var(--panel-soft) 90%, transparent);
+}
+
+.registry-preview h2 {
+  margin: 0 0 0.55rem;
+  font-size: 0.95rem;
+}
+
+.registry-preview ul {
+  margin: 0;
+  padding-left: 1rem;
+  color: var(--muted);
+}
+
 @media (max-width: 900px) {
   .topbar {
     grid-template-columns: 1fr;

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -34,6 +34,7 @@ class PortalShell extends HTMLElement {
   async loadStatus() {
     const statusEl = this.querySelector('[data-role="status"]');
     const metaEl = this.querySelector('[data-role="meta"]');
+    const listEl = this.querySelector('[data-role="registry-list"]');
     try {
       const [healthRes, bootstrapRes] = await Promise.all([
         fetch("api/v1/health"),
@@ -49,6 +50,9 @@ class PortalShell extends HTMLElement {
         metaEl.textContent =
           `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, stream=${caps.stream}`;
       }
+      if (bootstrap.capabilities?.registry && listEl) {
+        await this.loadRegistryPreview(listEl);
+      }
     } catch (err) {
       if (statusEl) {
         statusEl.textContent = "Gateway unavailable";
@@ -57,6 +61,29 @@ class PortalShell extends HTMLElement {
         metaEl.textContent = "Bootstrap fetch failed";
       }
       console.error("portal bootstrap failed", err);
+    }
+  }
+
+  async loadRegistryPreview(listEl) {
+    try {
+      const response = await fetch("api/v1/registry/devices?limit=8");
+      const payload = await response.json();
+      const items = Array.isArray(payload.items) ? payload.items : [];
+      if (items.length === 0) {
+        listEl.innerHTML = "<li>No devices discovered yet.</li>";
+        return;
+      }
+      listEl.innerHTML = items
+        .map((item) => {
+          const addr = Number(item.address).toString(16).padStart(2, "0");
+          const model = item.device_id || "unknown";
+          const vendor = item.manufacturer || "unknown";
+          return `<li><strong>0x${addr}</strong> ${vendor} ${model}</li>`;
+        })
+        .join("");
+    } catch (err) {
+      listEl.innerHTML = "<li>Registry preview unavailable.</li>";
+      console.error("registry preview failed", err);
     }
   }
 
@@ -92,6 +119,12 @@ class PortalShell extends HTMLElement {
               <article class="card"><h3>Timeline</h3><span class="badge">Coming Soon</span></article>
               <article class="card"><h3>Snapshots</h3><span class="badge">Coming Soon</span></article>
               <article class="card"><h3>Issue Builder</h3><span class="badge">Coming Soon</span></article>
+            </section>
+            <section class="registry-preview">
+              <h2>Registry Preview</h2>
+              <ul data-role="registry-list">
+                <li>Loading discovered devices...</li>
+              </ul>
             </section>
             <div class="meta" data-role="meta">Waiting for bootstrap...</div>
           </main>


### PR DESCRIPTION
## What
Implements ISSUE-009 (`#149`) by adding portal registry browse API and a registry preview list in the portal UI.

### API
- Added `GET /portal/api/v1/registry/devices`
  - optional query params: `q`, `limit`
  - returns sorted, filterable registry snapshot from gateway registry
- Bootstrap capability `registry` now reflects availability of registry listing callback.

### Gateway wiring
- `cmd/gateway/main.go` now injects a registry snapshot callback into portal handler options.

### UI
- Portal shell now loads a registry preview list (`limit=8`) after bootstrap.

### Tests
- Added endpoint tests for:
  - registry list + limit behavior
  - query filter behavior
  - mounted `/portal` endpoint behavior remains covered

### Docs
- Doc update merged: d3vi1/helianthus-docs-ebus#128

## Validation (local)
- `./scripts/check_portal_assets.sh`
- `GOWORK=off go test ./portal ./ui`

## Notes
- GitHub runners remain unavailable due billing limits; validated locally.

Closes #149
Refs #152
