### PR TITLE
portal: add semantic snapshot API and preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ curl -fsS http://127.0.0.1:8080/mcp \
 
 # Portal registry browse preview
 curl -fsS 'http://127.0.0.1:8080/portal/api/v1/registry/devices?limit=5'
+
+# Portal semantic browse preview
+curl -fsS 'http://127.0.0.1:8080/portal/api/v1/semantic/snapshot'
 ```
 
 ## Local Smoke-Test Configuration Example

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -83,7 +83,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 
 	startDiscoveryScanLoop(ctx, cfg, gateway, builder)
 
-	server, advertiser, err := startHTTPServer(ctx, cfg, gateway, builder, hub)
+	server, advertiser, err := startHTTPServer(ctx, cfg, gateway, builder, hub, semanticRuntime.Provider())
 	if err != nil {
 		return err
 	}
@@ -203,7 +203,7 @@ func bindFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) {
 	})
 }
 
-func startHTTPServer(ctx context.Context, cfg ebusgateway.Config, gateway *ebusgateway.Gateway, builder *graphql.Builder, hub *graphql.BroadcastHub) (*http.Server, mdns.Advertiser, error) {
+func startHTTPServer(ctx context.Context, cfg ebusgateway.Config, gateway *ebusgateway.Gateway, builder *graphql.Builder, hub *graphql.BroadcastHub, semantic graphql.SemanticProvider) (*http.Server, mdns.Advertiser, error) {
 	if cfg.HTTPAddr == "" {
 		return nil, nil, nil
 	}
@@ -303,6 +303,60 @@ func startHTTPServer(ctx context.Context, cfg ebusgateway.Config, gateway *ebusg
 					return true
 				})
 				return items
+			},
+			ListSemantic: func() portal.SemanticSnapshot {
+				if semantic == nil {
+					return portal.SemanticSnapshot{}
+				}
+				zones := semantic.Zones()
+				zoneItems := make([]portal.SemanticZone, 0, len(zones))
+				for _, zone := range zones {
+					zoneItems = append(zoneItems, portal.SemanticZone{
+						ID:            zone.ID,
+						Name:          zone.Name,
+						OperatingMode: zone.OperatingMode,
+						Preset:        zone.Preset,
+						CurrentTempC:  zone.CurrentTempC,
+						TargetTempC:   zone.TargetTempC,
+						HeatingDemand: zone.HeatingDemand,
+					})
+				}
+
+				var dhw *portal.SemanticDHW
+				if value := semantic.DHW(); value != nil {
+					dhw = &portal.SemanticDHW{
+						OperatingMode: value.OperatingMode,
+						Preset:        value.Preset,
+						CurrentTempC:  value.CurrentTempC,
+						TargetTempC:   value.TargetTempC,
+						HeatingDemand: value.HeatingDemand,
+					}
+				}
+
+				var energy *portal.SemanticEnergyTotals
+				if value := semantic.EnergyTotals(); value != nil {
+					energy = &portal.SemanticEnergyTotals{
+						Gas: portal.SemanticEnergyChannel{
+							DHW:     portal.SemanticEnergySeries{Today: value.Gas.DHW.Today, Yearly: append([]float64(nil), value.Gas.DHW.Yearly...)},
+							Climate: portal.SemanticEnergySeries{Today: value.Gas.Climate.Today, Yearly: append([]float64(nil), value.Gas.Climate.Yearly...)},
+						},
+						Electric: portal.SemanticEnergyChannel{
+							DHW:     portal.SemanticEnergySeries{Today: value.Electric.DHW.Today, Yearly: append([]float64(nil), value.Electric.DHW.Yearly...)},
+							Climate: portal.SemanticEnergySeries{Today: value.Electric.Climate.Today, Yearly: append([]float64(nil), value.Electric.Climate.Yearly...)},
+						},
+						Solar: portal.SemanticEnergyChannel{
+							DHW:     portal.SemanticEnergySeries{Today: value.Solar.DHW.Today, Yearly: append([]float64(nil), value.Solar.DHW.Yearly...)},
+							Climate: portal.SemanticEnergySeries{Today: value.Solar.Climate.Today, Yearly: append([]float64(nil), value.Solar.Climate.Yearly...)},
+						},
+					}
+				}
+
+				return portal.SemanticSnapshot{
+					Zones:       zoneItems,
+					DHW:         dhw,
+					Energy:      energy,
+					CapturedUTC: time.Now().UTC().Format(time.RFC3339),
+				}
 			},
 		})
 		mux.Handle(portalPath+"/", http.StripPrefix(portalPath, portalHandler))

--- a/portal/handler.go
+++ b/portal/handler.go
@@ -52,6 +52,7 @@ type Options struct {
 	GatewayVersion   string
 	BuildID          string
 	ListRegistry     func() []RegistryDevice
+	ListSemantic     func() SemanticSnapshot
 }
 
 type handler struct {
@@ -73,6 +74,47 @@ type RegistryDevice struct {
 type RegistryPlane struct {
 	Name    string   `json:"name"`
 	Methods []string `json:"methods,omitempty"`
+}
+
+type SemanticSnapshot struct {
+	Zones       []SemanticZone        `json:"zones"`
+	DHW         *SemanticDHW          `json:"dhw,omitempty"`
+	Energy      *SemanticEnergyTotals `json:"energy_totals,omitempty"`
+	CapturedUTC string                `json:"captured_utc"`
+}
+
+type SemanticZone struct {
+	ID            string   `json:"id"`
+	Name          string   `json:"name"`
+	OperatingMode string   `json:"operating_mode,omitempty"`
+	Preset        string   `json:"preset,omitempty"`
+	CurrentTempC  *float64 `json:"current_temp_c,omitempty"`
+	TargetTempC   *float64 `json:"target_temp_c,omitempty"`
+	HeatingDemand *float64 `json:"heating_demand,omitempty"`
+}
+
+type SemanticDHW struct {
+	OperatingMode string   `json:"operating_mode,omitempty"`
+	Preset        string   `json:"preset,omitempty"`
+	CurrentTempC  *float64 `json:"current_temp_c,omitempty"`
+	TargetTempC   *float64 `json:"target_temp_c,omitempty"`
+	HeatingDemand *float64 `json:"heating_demand,omitempty"`
+}
+
+type SemanticEnergyTotals struct {
+	Gas      SemanticEnergyChannel `json:"gas"`
+	Electric SemanticEnergyChannel `json:"electric"`
+	Solar    SemanticEnergyChannel `json:"solar"`
+}
+
+type SemanticEnergyChannel struct {
+	DHW     SemanticEnergySeries `json:"dhw"`
+	Climate SemanticEnergySeries `json:"climate"`
+}
+
+type SemanticEnergySeries struct {
+	Today  float64   `json:"today"`
+	Yearly []float64 `json:"yearly,omitempty"`
 }
 
 func NewHandler(opts Options) http.Handler {
@@ -163,7 +205,7 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 		writeJSON(w, http.StatusOK, map[string]any{
 			"capabilities": map[string]bool{
 				"registry":   h.opts.ListRegistry != nil,
-				"semantic":   true,
+				"semantic":   h.opts.ListSemantic != nil,
 				"projection": true,
 				"stream":     false,
 			},
@@ -181,6 +223,8 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 		})
 	case "registry/devices":
 		h.handleRegistryDevices(w, r)
+	case "semantic/snapshot":
+		h.handleSemanticSnapshot(w)
 	default:
 		http.NotFound(w, r)
 	}
@@ -217,6 +261,8 @@ func classifyRoute(path string) string {
 		return "api.bootstrap"
 	case strings.HasPrefix(path, "/api/v1/registry/devices"):
 		return "api.registry.devices"
+	case strings.HasPrefix(path, "/api/v1/semantic/snapshot"):
+		return "api.semantic.snapshot"
 	case strings.HasPrefix(path, "/assets/"):
 		return "assets"
 	case path == "/" || strings.EqualFold(path, "/index.html"):
@@ -345,4 +391,22 @@ func matchesDeviceFilter(device RegistryDevice, needle string) bool {
 		}
 	}
 	return false
+}
+
+func (h *handler) handleSemanticSnapshot(w http.ResponseWriter) {
+	if h.opts.ListSemantic == nil {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"zones":        []SemanticZone{},
+			"captured_utc": time.Now().UTC().Format(time.RFC3339),
+		})
+		return
+	}
+	snapshot := h.opts.ListSemantic()
+	if strings.TrimSpace(snapshot.CapturedUTC) == "" {
+		snapshot.CapturedUTC = time.Now().UTC().Format(time.RFC3339)
+	}
+	if snapshot.Zones == nil {
+		snapshot.Zones = []SemanticZone{}
+	}
+	writeJSON(w, http.StatusOK, snapshot)
 }

--- a/portal/handler_test.go
+++ b/portal/handler_test.go
@@ -112,6 +112,9 @@ func TestBootstrapEndpoint(t *testing.T) {
 		ListRegistry: func() []RegistryDevice {
 			return []RegistryDevice{{Address: 0x10, Manufacturer: "Vaillant", DeviceID: "VRC720"}}
 		},
+		ListSemantic: func() SemanticSnapshot {
+			return SemanticSnapshot{Zones: []SemanticZone{{ID: "z1", Name: "Zone 1"}}}
+		},
 	})
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/bootstrap", nil)
 	rec := httptest.NewRecorder()
@@ -135,6 +138,9 @@ func TestBootstrapEndpoint(t *testing.T) {
 	capabilities := payload["capabilities"].(map[string]any)
 	if capabilities["registry"] != true {
 		t.Fatalf("capabilities.registry=%v; want true", capabilities["registry"])
+	}
+	if capabilities["semantic"] != true {
+		t.Fatalf("capabilities.semantic=%v; want true", capabilities["semantic"])
 	}
 }
 
@@ -261,5 +267,58 @@ func TestRegistryDevicesEndpoint_Filter(t *testing.T) {
 	}
 	if int(items[0].(map[string]any)["address"].(float64)) != 0x08 {
 		t.Fatalf("address=%v; want 8", items[0].(map[string]any)["address"])
+	}
+}
+
+func TestSemanticSnapshotEndpoint(t *testing.T) {
+	current := 43.5
+	h := NewHandler(Options{
+		ListSemantic: func() SemanticSnapshot {
+			return SemanticSnapshot{
+				Zones: []SemanticZone{
+					{ID: "zone_1", Name: "Living", CurrentTempC: &current},
+				},
+				DHW: &SemanticDHW{
+					OperatingMode: "auto",
+				},
+				CapturedUTC: "2026-02-23T22:00:00Z",
+			}
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/semantic/snapshot", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d; want %d", rec.Code, http.StatusOK)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if payload["captured_utc"] != "2026-02-23T22:00:00Z" {
+		t.Fatalf("captured_utc=%v", payload["captured_utc"])
+	}
+	zones := payload["zones"].([]any)
+	if len(zones) != 1 {
+		t.Fatalf("zones=%d; want 1", len(zones))
+	}
+}
+
+func TestSemanticSnapshotEndpoint_DefaultWhenMissingProvider(t *testing.T) {
+	h := NewHandler(Options{})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/semantic/snapshot", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d; want %d", rec.Code, http.StatusOK)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	zones := payload["zones"].([]any)
+	if len(zones) != 0 {
+		t.Fatalf("zones=%d; want 0", len(zones))
 	}
 }

--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -36,6 +36,7 @@ class PortalShell extends HTMLElement {
     const statusEl = this.querySelector('[data-role="status"]');
     const metaEl = this.querySelector('[data-role="meta"]');
     const listEl = this.querySelector('[data-role="registry-list"]');
+    const semanticEl = this.querySelector('[data-role="semantic-list"]');
     try {
       const [healthRes, bootstrapRes] = await Promise.all([
         fetch("api/v1/health"),
@@ -53,6 +54,9 @@ class PortalShell extends HTMLElement {
       }
       if (bootstrap.capabilities?.registry && listEl) {
         await this.loadRegistryPreview(listEl);
+      }
+      if (bootstrap.capabilities?.semantic && semanticEl) {
+        await this.loadSemanticPreview(semanticEl);
       }
     } catch (err) {
       if (statusEl) {
@@ -85,6 +89,27 @@ class PortalShell extends HTMLElement {
     } catch (err) {
       listEl.innerHTML = "<li>Registry preview unavailable.</li>";
       console.error("registry preview failed", err);
+    }
+  }
+
+  async loadSemanticPreview(listEl) {
+    try {
+      const response = await fetch("api/v1/semantic/snapshot");
+      const payload = await response.json();
+      const zones = Array.isArray(payload.zones) ? payload.zones : [];
+      const dhw = payload.dhw;
+      const rows = [];
+      rows.push(`<li>Zones: ${zones.length}</li>`);
+      if (zones[0]) {
+        rows.push(`<li>Zone #1: ${zones[0].name || zones[0].id || "unknown"}</li>`);
+      }
+      if (dhw) {
+        rows.push(`<li>DHW mode: ${dhw.operating_mode || "unknown"}</li>`);
+      }
+      listEl.innerHTML = rows.join("");
+    } catch (err) {
+      listEl.innerHTML = "<li>Semantic preview unavailable.</li>";
+      console.error("semantic preview failed", err);
     }
   }
 
@@ -125,6 +150,12 @@ class PortalShell extends HTMLElement {
               <h2>Registry Preview</h2>
               <ul data-role="registry-list">
                 <li>Loading discovered devices...</li>
+              </ul>
+            </section>
+            <section class="registry-preview">
+              <h2>Semantic Preview</h2>
+              <ul data-role="semantic-list">
+                <li>Loading semantic snapshot...</li>
               </ul>
             </section>
             <div class="meta" data-role="meta">Waiting for bootstrap...</div>

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,8 +2,8 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 5216,
-      "sha256": "6e56c9a88aa493a2d71c0e16468315ec827ccc408589bc32edc21e8cacd98fb7"
+      "bytes": 6380,
+      "sha256": "a4e2fed37147adb14ec7d5b49ad687dcd846ab6627d005e0aaacca92da3d832a"
     },
     "app.css": {
       "bytes": 3710,

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -35,6 +35,7 @@ class PortalShell extends HTMLElement {
     const statusEl = this.querySelector('[data-role="status"]');
     const metaEl = this.querySelector('[data-role="meta"]');
     const listEl = this.querySelector('[data-role="registry-list"]');
+    const semanticEl = this.querySelector('[data-role="semantic-list"]');
     try {
       const [healthRes, bootstrapRes] = await Promise.all([
         fetch("api/v1/health"),
@@ -52,6 +53,9 @@ class PortalShell extends HTMLElement {
       }
       if (bootstrap.capabilities?.registry && listEl) {
         await this.loadRegistryPreview(listEl);
+      }
+      if (bootstrap.capabilities?.semantic && semanticEl) {
+        await this.loadSemanticPreview(semanticEl);
       }
     } catch (err) {
       if (statusEl) {
@@ -84,6 +88,27 @@ class PortalShell extends HTMLElement {
     } catch (err) {
       listEl.innerHTML = "<li>Registry preview unavailable.</li>";
       console.error("registry preview failed", err);
+    }
+  }
+
+  async loadSemanticPreview(listEl) {
+    try {
+      const response = await fetch("api/v1/semantic/snapshot");
+      const payload = await response.json();
+      const zones = Array.isArray(payload.zones) ? payload.zones : [];
+      const dhw = payload.dhw;
+      const rows = [];
+      rows.push(`<li>Zones: ${zones.length}</li>`);
+      if (zones[0]) {
+        rows.push(`<li>Zone #1: ${zones[0].name || zones[0].id || "unknown"}</li>`);
+      }
+      if (dhw) {
+        rows.push(`<li>DHW mode: ${dhw.operating_mode || "unknown"}</li>`);
+      }
+      listEl.innerHTML = rows.join("");
+    } catch (err) {
+      listEl.innerHTML = "<li>Semantic preview unavailable.</li>";
+      console.error("semantic preview failed", err);
     }
   }
 
@@ -124,6 +149,12 @@ class PortalShell extends HTMLElement {
               <h2>Registry Preview</h2>
               <ul data-role="registry-list">
                 <li>Loading discovered devices...</li>
+              </ul>
+            </section>
+            <section class="registry-preview">
+              <h2>Semantic Preview</h2>
+              <ul data-role="semantic-list">
+                <li>Loading semantic snapshot...</li>
               </ul>
             </section>
             <div class="meta" data-role="meta">Waiting for bootstrap...</div>


### PR DESCRIPTION
## What
Implements ISSUE-010 (`#150`) by adding semantic browse API and semantic list preview in portal UI.

### API
- Added `GET /portal/api/v1/semantic/snapshot`
- Bootstrap capability `semantic` now reflects provider availability.

### Gateway wiring
- `startHTTPServer` now receives semantic provider and maps semantic runtime data into portal snapshot payloads.

### UI
- Added semantic preview list section sourced from `/portal/api/v1/semantic/snapshot`.

### Tests
- Added semantic endpoint tests (provider + fallback behavior)
- Bootstrap capability assertions updated

### Docs
- Doc update merged: d3vi1/helianthus-docs-ebus#129

## Validation (local)
- `./scripts/check_portal_assets.sh`
- `GOWORK=off go test ./portal ./ui`

## Notes
- GitHub runners unavailable due billing limits; validated locally.

Closes #150
Refs #152
