### PR TITLE
feat(portal): add projection browse endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ curl -fsS 'http://127.0.0.1:8080/portal/api/v1/registry/devices?limit=5'
 
 # Portal semantic browse preview
 curl -fsS 'http://127.0.0.1:8080/portal/api/v1/semantic/snapshot'
+
+# Portal projection browse preview
+curl -fsS 'http://127.0.0.1:8080/portal/api/v1/projection/devices?limit=5'
 ```
 
 ## Local Smoke-Test Configuration Example

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -358,6 +358,64 @@ func startHTTPServer(ctx context.Context, cfg ebusgateway.Config, gateway *ebusg
 					CapturedUTC: time.Now().UTC().Format(time.RFC3339),
 				}
 			},
+			ListProjections: func() []portal.ProjectionDevice {
+				snapshot := builder.Schema()
+				items := make([]portal.ProjectionDevice, 0, len(snapshot.Devices))
+				for _, device := range snapshot.Devices {
+					summaries := make([]portal.ProjectionSummary, 0, len(device.Projections))
+					for _, projection := range device.Projections {
+						summaries = append(summaries, portal.ProjectionSummary{
+							Plane:     projection.Plane,
+							NodeCount: len(projection.Nodes),
+							EdgeCount: len(projection.Edges),
+						})
+					}
+					items = append(items, portal.ProjectionDevice{
+						Address:      device.Address,
+						DeviceID:     device.DeviceID,
+						DisplayName:  device.DisplayName,
+						Manufacturer: device.Manufacturer,
+						Projections:  summaries,
+					})
+				}
+				return items
+			},
+			GetProjection: func(address byte, plane string) (portal.ProjectionGraph, bool) {
+				snapshot := builder.Schema()
+				for _, device := range snapshot.Devices {
+					if device.Address != address {
+						continue
+					}
+					for _, projection := range device.Projections {
+						if !strings.EqualFold(projection.Plane, plane) {
+							continue
+						}
+						nodes := make([]portal.ProjectionNode, 0, len(projection.Nodes))
+						for _, node := range projection.Nodes {
+							nodes = append(nodes, portal.ProjectionNode{
+								ID:            node.ID,
+								Path:          node.Path,
+								CanonicalPath: node.CanonicalPath,
+							})
+						}
+						edges := make([]portal.ProjectionEdge, 0, len(projection.Edges))
+						for _, edge := range projection.Edges {
+							edges = append(edges, portal.ProjectionEdge{
+								ID:   edge.ID,
+								From: edge.From,
+								To:   edge.To,
+							})
+						}
+						return portal.ProjectionGraph{
+							Address: address,
+							Plane:   projection.Plane,
+							Nodes:   nodes,
+							Edges:   edges,
+						}, true
+					}
+				}
+				return portal.ProjectionGraph{}, false
+			},
 		})
 		mux.Handle(portalPath+"/", http.StripPrefix(portalPath, portalHandler))
 		mux.HandleFunc(portalPath, func(w http.ResponseWriter, r *http.Request) {

--- a/portal/handler.go
+++ b/portal/handler.go
@@ -53,6 +53,8 @@ type Options struct {
 	BuildID          string
 	ListRegistry     func() []RegistryDevice
 	ListSemantic     func() SemanticSnapshot
+	ListProjections  func() []ProjectionDevice
+	GetProjection    func(address byte, plane string) (ProjectionGraph, bool)
 }
 
 type handler struct {
@@ -115,6 +117,39 @@ type SemanticEnergyChannel struct {
 type SemanticEnergySeries struct {
 	Today  float64   `json:"today"`
 	Yearly []float64 `json:"yearly,omitempty"`
+}
+
+type ProjectionDevice struct {
+	Address      byte                `json:"address"`
+	DeviceID     string              `json:"device_id,omitempty"`
+	DisplayName  string              `json:"display_name,omitempty"`
+	Manufacturer string              `json:"manufacturer,omitempty"`
+	Projections  []ProjectionSummary `json:"projections"`
+}
+
+type ProjectionSummary struct {
+	Plane     string `json:"plane"`
+	NodeCount int    `json:"node_count"`
+	EdgeCount int    `json:"edge_count"`
+}
+
+type ProjectionGraph struct {
+	Address byte             `json:"address"`
+	Plane   string           `json:"plane"`
+	Nodes   []ProjectionNode `json:"nodes"`
+	Edges   []ProjectionEdge `json:"edges"`
+}
+
+type ProjectionNode struct {
+	ID            string `json:"id"`
+	Path          string `json:"path"`
+	CanonicalPath string `json:"canonical_path"`
+}
+
+type ProjectionEdge struct {
+	ID   string `json:"id"`
+	From string `json:"from"`
+	To   string `json:"to"`
 }
 
 func NewHandler(opts Options) http.Handler {
@@ -206,7 +241,7 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 			"capabilities": map[string]bool{
 				"registry":   h.opts.ListRegistry != nil,
 				"semantic":   h.opts.ListSemantic != nil,
-				"projection": true,
+				"projection": h.opts.ListProjections != nil && h.opts.GetProjection != nil,
 				"stream":     false,
 			},
 			"endpoints": map[string]string{
@@ -225,6 +260,10 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 		h.handleRegistryDevices(w, r)
 	case "semantic/snapshot":
 		h.handleSemanticSnapshot(w)
+	case "projection/devices":
+		h.handleProjectionDevices(w, r)
+	case "projection/graph":
+		h.handleProjectionGraph(w, r)
 	default:
 		http.NotFound(w, r)
 	}
@@ -263,6 +302,10 @@ func classifyRoute(path string) string {
 		return "api.registry.devices"
 	case strings.HasPrefix(path, "/api/v1/semantic/snapshot"):
 		return "api.semantic.snapshot"
+	case strings.HasPrefix(path, "/api/v1/projection/devices"):
+		return "api.projection.devices"
+	case strings.HasPrefix(path, "/api/v1/projection/graph"):
+		return "api.projection.graph"
 	case strings.HasPrefix(path, "/assets/"):
 		return "assets"
 	case path == "/" || strings.EqualFold(path, "/index.html"):
@@ -409,4 +452,85 @@ func (h *handler) handleSemanticSnapshot(w http.ResponseWriter) {
 		snapshot.Zones = []SemanticZone{}
 	}
 	writeJSON(w, http.StatusOK, snapshot)
+}
+
+func (h *handler) handleProjectionDevices(w http.ResponseWriter, r *http.Request) {
+	if h.opts.ListProjections == nil {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"count": 0,
+			"items": []ProjectionDevice{},
+		})
+		return
+	}
+	items := h.opts.ListProjections()
+	needle := strings.TrimSpace(strings.ToLower(r.URL.Query().Get("q")))
+	limit := parseQueryLimit(r.URL.Query().Get("limit"), 200)
+
+	filtered := make([]ProjectionDevice, 0, len(items))
+	for _, item := range items {
+		if needle != "" && !matchesProjectionFilter(item, needle) {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	slices.SortFunc(filtered, func(a, b ProjectionDevice) int {
+		return cmp.Compare(int(a.Address), int(b.Address))
+	})
+
+	total := len(filtered)
+	if limit > 0 && len(filtered) > limit {
+		filtered = filtered[:limit]
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"count": total,
+		"items": filtered,
+	})
+}
+
+func (h *handler) handleProjectionGraph(w http.ResponseWriter, r *http.Request) {
+	if h.opts.GetProjection == nil {
+		http.NotFound(w, r)
+		return
+	}
+	address, err := parseQueryAddress(r.URL.Query().Get("address"))
+	if err != nil {
+		http.Error(w, "invalid address", http.StatusBadRequest)
+		return
+	}
+	plane := strings.TrimSpace(r.URL.Query().Get("plane"))
+	if plane == "" {
+		http.Error(w, "missing plane", http.StatusBadRequest)
+		return
+	}
+	graph, ok := h.opts.GetProjection(address, plane)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	writeJSON(w, http.StatusOK, graph)
+}
+
+func parseQueryAddress(raw string) (byte, error) {
+	parsed, err := strconv.ParseUint(strings.TrimSpace(raw), 0, 8)
+	if err != nil {
+		return 0, err
+	}
+	return byte(parsed), nil
+}
+
+func matchesProjectionFilter(item ProjectionDevice, needle string) bool {
+	text := strings.ToLower(strings.Join([]string{
+		item.DeviceID,
+		item.DisplayName,
+		item.Manufacturer,
+	}, " "))
+	if strings.Contains(text, needle) {
+		return true
+	}
+	for _, projection := range item.Projections {
+		if strings.Contains(strings.ToLower(projection.Plane), needle) {
+			return true
+		}
+	}
+	return false
 }

--- a/portal/handler_test.go
+++ b/portal/handler_test.go
@@ -115,6 +115,12 @@ func TestBootstrapEndpoint(t *testing.T) {
 		ListSemantic: func() SemanticSnapshot {
 			return SemanticSnapshot{Zones: []SemanticZone{{ID: "z1", Name: "Zone 1"}}}
 		},
+		ListProjections: func() []ProjectionDevice {
+			return []ProjectionDevice{{Address: 0x10, Projections: []ProjectionSummary{{Plane: "Service"}}}}
+		},
+		GetProjection: func(address byte, plane string) (ProjectionGraph, bool) {
+			return ProjectionGraph{}, true
+		},
 	})
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/bootstrap", nil)
 	rec := httptest.NewRecorder()
@@ -141,6 +147,9 @@ func TestBootstrapEndpoint(t *testing.T) {
 	}
 	if capabilities["semantic"] != true {
 		t.Fatalf("capabilities.semantic=%v; want true", capabilities["semantic"])
+	}
+	if capabilities["projection"] != true {
+		t.Fatalf("capabilities.projection=%v; want true", capabilities["projection"])
 	}
 }
 
@@ -320,5 +329,85 @@ func TestSemanticSnapshotEndpoint_DefaultWhenMissingProvider(t *testing.T) {
 	zones := payload["zones"].([]any)
 	if len(zones) != 0 {
 		t.Fatalf("zones=%d; want 0", len(zones))
+	}
+}
+
+func TestProjectionDevicesEndpoint(t *testing.T) {
+	h := NewHandler(Options{
+		ListProjections: func() []ProjectionDevice {
+			return []ProjectionDevice{
+				{
+					Address:      0x10,
+					DeviceID:     "VRC720",
+					Manufacturer: "Vaillant",
+					Projections: []ProjectionSummary{
+						{Plane: "Service", NodeCount: 12, EdgeCount: 10},
+					},
+				},
+				{
+					Address:      0x08,
+					DeviceID:     "BAI",
+					Manufacturer: "Vaillant",
+					Projections: []ProjectionSummary{
+						{Plane: "Observability", NodeCount: 5, EdgeCount: 4},
+					},
+				},
+			}
+		},
+	})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projection/devices?limit=1", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d; want %d", rec.Code, http.StatusOK)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if int(payload["count"].(float64)) != 2 {
+		t.Fatalf("count=%v; want 2", payload["count"])
+	}
+	items := payload["items"].([]any)
+	if len(items) != 1 {
+		t.Fatalf("len(items)=%d; want 1 due limit", len(items))
+	}
+	if int(items[0].(map[string]any)["address"].(float64)) != 0x08 {
+		t.Fatalf("address=%v; want 8 sorted asc", items[0].(map[string]any)["address"])
+	}
+}
+
+func TestProjectionGraphEndpoint(t *testing.T) {
+	h := NewHandler(Options{
+		GetProjection: func(address byte, plane string) (ProjectionGraph, bool) {
+			if address != 0x10 || !strings.EqualFold(plane, "Service") {
+				return ProjectionGraph{}, false
+			}
+			return ProjectionGraph{
+				Address: 0x10,
+				Plane:   "Service",
+				Nodes: []ProjectionNode{
+					{ID: "n1", Path: "Service:/n1", CanonicalPath: "Service:/n1"},
+				},
+				Edges: []ProjectionEdge{
+					{ID: "e1", From: "n1", To: "n1"},
+				},
+			}, true
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projection/graph?address=0x10&plane=Service", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d; want %d", rec.Code, http.StatusOK)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/projection/graph?address=0x10", nil)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("missing plane status=%d; want %d", rec.Code, http.StatusBadRequest)
 	}
 }

--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -37,6 +37,7 @@ class PortalShell extends HTMLElement {
     const metaEl = this.querySelector('[data-role="meta"]');
     const listEl = this.querySelector('[data-role="registry-list"]');
     const semanticEl = this.querySelector('[data-role="semantic-list"]');
+    const projectionEl = this.querySelector('[data-role="projection-list"]');
     try {
       const [healthRes, bootstrapRes] = await Promise.all([
         fetch("api/v1/health"),
@@ -57,6 +58,9 @@ class PortalShell extends HTMLElement {
       }
       if (bootstrap.capabilities?.semantic && semanticEl) {
         await this.loadSemanticPreview(semanticEl);
+      }
+      if (bootstrap.capabilities?.projection && projectionEl) {
+        await this.loadProjectionPreview(projectionEl);
       }
     } catch (err) {
       if (statusEl) {
@@ -113,6 +117,28 @@ class PortalShell extends HTMLElement {
     }
   }
 
+  async loadProjectionPreview(listEl) {
+    try {
+      const response = await fetch("api/v1/projection/devices?limit=5");
+      const payload = await response.json();
+      const items = Array.isArray(payload.items) ? payload.items : [];
+      if (items.length === 0) {
+        listEl.innerHTML = "<li>No projection graphs available.</li>";
+        return;
+      }
+      listEl.innerHTML = items
+        .map((item) => {
+          const projectionCount = Array.isArray(item.projections) ? item.projections.length : 0;
+          const label = item.display_name || item.device_id || `0x${Number(item.address).toString(16)}`;
+          return `<li><strong>${label}</strong> projections=${projectionCount}</li>`;
+        })
+        .join("");
+    } catch (err) {
+      listEl.innerHTML = "<li>Projection preview unavailable.</li>";
+      console.error("projection preview failed", err);
+    }
+  }
+
   render() {
     this.innerHTML = `
       <div class="shell">
@@ -156,6 +182,12 @@ class PortalShell extends HTMLElement {
               <h2>Semantic Preview</h2>
               <ul data-role="semantic-list">
                 <li>Loading semantic snapshot...</li>
+              </ul>
+            </section>
+            <section class="registry-preview">
+              <h2>Projection Preview</h2>
+              <ul data-role="projection-list">
+                <li>Loading projection summary...</li>
               </ul>
             </section>
             <div class="meta" data-role="meta">Waiting for bootstrap...</div>

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,8 +2,8 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 6380,
-      "sha256": "a4e2fed37147adb14ec7d5b49ad687dcd846ab6627d005e0aaacca92da3d832a"
+      "bytes": 7715,
+      "sha256": "1dcda4f8a2a748d19e331a4616ec281889aaf7bb0ae6addacadcca0d41e37bf2"
     },
     "app.css": {
       "bytes": 3710,

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -36,6 +36,7 @@ class PortalShell extends HTMLElement {
     const metaEl = this.querySelector('[data-role="meta"]');
     const listEl = this.querySelector('[data-role="registry-list"]');
     const semanticEl = this.querySelector('[data-role="semantic-list"]');
+    const projectionEl = this.querySelector('[data-role="projection-list"]');
     try {
       const [healthRes, bootstrapRes] = await Promise.all([
         fetch("api/v1/health"),
@@ -56,6 +57,9 @@ class PortalShell extends HTMLElement {
       }
       if (bootstrap.capabilities?.semantic && semanticEl) {
         await this.loadSemanticPreview(semanticEl);
+      }
+      if (bootstrap.capabilities?.projection && projectionEl) {
+        await this.loadProjectionPreview(projectionEl);
       }
     } catch (err) {
       if (statusEl) {
@@ -112,6 +116,28 @@ class PortalShell extends HTMLElement {
     }
   }
 
+  async loadProjectionPreview(listEl) {
+    try {
+      const response = await fetch("api/v1/projection/devices?limit=5");
+      const payload = await response.json();
+      const items = Array.isArray(payload.items) ? payload.items : [];
+      if (items.length === 0) {
+        listEl.innerHTML = "<li>No projection graphs available.</li>";
+        return;
+      }
+      listEl.innerHTML = items
+        .map((item) => {
+          const projectionCount = Array.isArray(item.projections) ? item.projections.length : 0;
+          const label = item.display_name || item.device_id || `0x${Number(item.address).toString(16)}`;
+          return `<li><strong>${label}</strong> projections=${projectionCount}</li>`;
+        })
+        .join("");
+    } catch (err) {
+      listEl.innerHTML = "<li>Projection preview unavailable.</li>";
+      console.error("projection preview failed", err);
+    }
+  }
+
   render() {
     this.innerHTML = `
       <div class="shell">
@@ -155,6 +181,12 @@ class PortalShell extends HTMLElement {
               <h2>Semantic Preview</h2>
               <ul data-role="semantic-list">
                 <li>Loading semantic snapshot...</li>
+              </ul>
+            </section>
+            <section class="registry-preview">
+              <h2>Projection Preview</h2>
+              <ul data-role="projection-list">
+                <li>Loading projection summary...</li>
               </ul>
             </section>
             <div class="meta" data-role="meta">Waiting for bootstrap...</div>


### PR DESCRIPTION
## Summary
- add portal projection browse read endpoints:
  - `GET /portal/api/v1/projection/devices`
  - `GET /portal/api/v1/projection/graph`
- wire projection data providers from schema builder into portal handler options
- show projection preview list in the M0 portal UI shell
- add handler tests for bootstrap capability and projection endpoints
- add README curl example for projection browse

## Testing
- `./scripts/check_portal_assets.sh`
- `GOWORK=off go test ./portal ./ui`

## Links
- Docs: d3vi1/helianthus-docs-ebus#130
- Closes #151
