### PR TITLE
feat(portal): add unified cross-layer search

### DIFF
--- a/portal/handler.go
+++ b/portal/handler.go
@@ -152,6 +152,15 @@ type ProjectionEdge struct {
 	To   string `json:"to"`
 }
 
+type SearchResult struct {
+	Layer    string `json:"layer"`
+	Kind     string `json:"kind"`
+	ID       string `json:"id"`
+	Title    string `json:"title"`
+	Subtitle string `json:"subtitle,omitempty"`
+	Address  *byte  `json:"address,omitempty"`
+}
+
 func NewHandler(opts Options) http.Handler {
 	if opts.GraphQLPath == "" {
 		opts.GraphQLPath = "/graphql"
@@ -242,6 +251,7 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 				"registry":   h.opts.ListRegistry != nil,
 				"semantic":   h.opts.ListSemantic != nil,
 				"projection": h.opts.ListProjections != nil && h.opts.GetProjection != nil,
+				"search":     h.opts.ListRegistry != nil || h.opts.ListSemantic != nil || h.opts.ListProjections != nil,
 				"stream":     false,
 			},
 			"endpoints": map[string]string{
@@ -249,6 +259,7 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 				"snapshot":      h.opts.SnapshotPath,
 				"subscriptions": h.opts.SubscriptionPath,
 				"mcp":           h.opts.MCPPath,
+				"search":        "/portal/api/v1/search",
 			},
 			"limits": map[string]any{
 				"max_events_per_second": 200,
@@ -264,6 +275,8 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 		h.handleProjectionDevices(w, r)
 	case "projection/graph":
 		h.handleProjectionGraph(w, r)
+	case "search":
+		h.handleSearch(w, r)
 	default:
 		http.NotFound(w, r)
 	}
@@ -306,6 +319,8 @@ func classifyRoute(path string) string {
 		return "api.projection.devices"
 	case strings.HasPrefix(path, "/api/v1/projection/graph"):
 		return "api.projection.graph"
+	case strings.HasPrefix(path, "/api/v1/search"):
+		return "api.search"
 	case strings.HasPrefix(path, "/assets/"):
 		return "assets"
 	case path == "/" || strings.EqualFold(path, "/index.html"):
@@ -533,4 +548,161 @@ func matchesProjectionFilter(item ProjectionDevice, needle string) bool {
 		}
 	}
 	return false
+}
+
+func (h *handler) handleSearch(w http.ResponseWriter, r *http.Request) {
+	needle := strings.TrimSpace(strings.ToLower(r.URL.Query().Get("q")))
+	limit := parseQueryLimit(r.URL.Query().Get("limit"), 25)
+	if needle == "" {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"query": needle,
+			"count": 0,
+			"items": []SearchResult{},
+		})
+		return
+	}
+
+	results := make([]SearchResult, 0, limit)
+	appendResult := func(item SearchResult) {
+		if limit > 0 && len(results) >= limit {
+			return
+		}
+		results = append(results, item)
+	}
+
+	if h.opts.ListRegistry != nil {
+		devices := h.opts.ListRegistry()
+		slices.SortFunc(devices, func(a, b RegistryDevice) int {
+			return cmp.Compare(int(a.Address), int(b.Address))
+		})
+		for _, device := range devices {
+			label := strings.TrimSpace(strings.Join([]string{device.Manufacturer, device.DeviceID}, " "))
+			if strings.Contains(strings.ToLower(strings.Join([]string{
+				device.Manufacturer,
+				device.DeviceID,
+				device.SerialNumber,
+				device.Software,
+				device.Hardware,
+			}, " ")), needle) {
+				address := device.Address
+				appendResult(SearchResult{
+					Layer:    "registry",
+					Kind:     "device",
+					ID:       fmt.Sprintf("reg:%02x", device.Address),
+					Title:    strings.TrimSpace(label),
+					Subtitle: fmt.Sprintf("addr=0x%02x", device.Address),
+					Address:  &address,
+				})
+			}
+			for _, plane := range device.Planes {
+				if strings.Contains(strings.ToLower(plane.Name), needle) {
+					address := device.Address
+					appendResult(SearchResult{
+						Layer:    "registry",
+						Kind:     "plane",
+						ID:       fmt.Sprintf("reg:%02x:%s", device.Address, strings.ToLower(plane.Name)),
+						Title:    fmt.Sprintf("%s plane", plane.Name),
+						Subtitle: fmt.Sprintf("addr=0x%02x", device.Address),
+						Address:  &address,
+					})
+				}
+				for _, method := range plane.Methods {
+					if strings.Contains(strings.ToLower(method), needle) {
+						address := device.Address
+						appendResult(SearchResult{
+							Layer:    "registry",
+							Kind:     "method",
+							ID:       fmt.Sprintf("reg:%02x:%s:%s", device.Address, strings.ToLower(plane.Name), strings.ToLower(method)),
+							Title:    method,
+							Subtitle: fmt.Sprintf("%s plane addr=0x%02x", plane.Name, device.Address),
+							Address:  &address,
+						})
+					}
+				}
+			}
+		}
+	}
+
+	if h.opts.ListSemantic != nil {
+		snapshot := h.opts.ListSemantic()
+		for _, zone := range snapshot.Zones {
+			if strings.Contains(strings.ToLower(strings.Join([]string{
+				zone.ID,
+				zone.Name,
+				zone.OperatingMode,
+				zone.Preset,
+			}, " ")), needle) {
+				appendResult(SearchResult{
+					Layer:    "semantic",
+					Kind:     "zone",
+					ID:       zone.ID,
+					Title:    zone.Name,
+					Subtitle: strings.TrimSpace(strings.Join([]string{zone.OperatingMode, zone.Preset}, " / ")),
+				})
+			}
+		}
+		if snapshot.DHW != nil && strings.Contains(strings.ToLower(strings.Join([]string{
+			"dhw",
+			snapshot.DHW.OperatingMode,
+			snapshot.DHW.Preset,
+		}, " ")), needle) {
+			appendResult(SearchResult{
+				Layer:    "semantic",
+				Kind:     "dhw",
+				ID:       "dhw",
+				Title:    "Domestic Hot Water",
+				Subtitle: strings.TrimSpace(strings.Join([]string{snapshot.DHW.OperatingMode, snapshot.DHW.Preset}, " / ")),
+			})
+		}
+	}
+
+	if h.opts.ListProjections != nil {
+		items := h.opts.ListProjections()
+		slices.SortFunc(items, func(a, b ProjectionDevice) int {
+			return cmp.Compare(int(a.Address), int(b.Address))
+		})
+		for _, item := range items {
+			if strings.Contains(strings.ToLower(strings.Join([]string{
+				item.DeviceID,
+				item.DisplayName,
+				item.Manufacturer,
+			}, " ")), needle) {
+				address := item.Address
+				title := strings.TrimSpace(item.DisplayName)
+				if title == "" {
+					title = strings.TrimSpace(item.DeviceID)
+				}
+				if title == "" {
+					title = fmt.Sprintf("Projection Device 0x%02x", item.Address)
+				}
+				appendResult(SearchResult{
+					Layer:    "projection",
+					Kind:     "device",
+					ID:       fmt.Sprintf("proj:%02x", item.Address),
+					Title:    title,
+					Subtitle: fmt.Sprintf("addr=0x%02x", item.Address),
+					Address:  &address,
+				})
+			}
+			for _, projection := range item.Projections {
+				if strings.Contains(strings.ToLower(projection.Plane), needle) {
+					address := item.Address
+					appendResult(SearchResult{
+						Layer:    "projection",
+						Kind:     "plane",
+						ID:       fmt.Sprintf("proj:%02x:%s", item.Address, strings.ToLower(projection.Plane)),
+						Title:    projection.Plane,
+						Subtitle: fmt.Sprintf("addr=0x%02x nodes=%d edges=%d", item.Address, projection.NodeCount, projection.EdgeCount),
+						Address:  &address,
+					})
+				}
+			}
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"query": needle,
+		"count": len(results),
+		"items": results,
+	})
 }

--- a/portal/handler_test.go
+++ b/portal/handler_test.go
@@ -141,6 +141,9 @@ func TestBootstrapEndpoint(t *testing.T) {
 	if endpoints["graphql"] != "/graphql" {
 		t.Fatalf("graphql endpoint=%v; want /graphql", endpoints["graphql"])
 	}
+	if endpoints["search"] != "/portal/api/v1/search" {
+		t.Fatalf("search endpoint=%v; want /portal/api/v1/search", endpoints["search"])
+	}
 	capabilities := payload["capabilities"].(map[string]any)
 	if capabilities["registry"] != true {
 		t.Fatalf("capabilities.registry=%v; want true", capabilities["registry"])
@@ -150,6 +153,9 @@ func TestBootstrapEndpoint(t *testing.T) {
 	}
 	if capabilities["projection"] != true {
 		t.Fatalf("capabilities.projection=%v; want true", capabilities["projection"])
+	}
+	if capabilities["search"] != true {
+		t.Fatalf("capabilities.search=%v; want true", capabilities["search"])
 	}
 }
 
@@ -409,5 +415,87 @@ func TestProjectionGraphEndpoint(t *testing.T) {
 	h.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("missing plane status=%d; want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestSearchEndpoint(t *testing.T) {
+	current := 21.7
+	h := NewHandler(Options{
+		ListRegistry: func() []RegistryDevice {
+			return []RegistryDevice{
+				{
+					Address:      0x10,
+					Manufacturer: "Vaillant",
+					DeviceID:     "VRC720",
+					Planes: []RegistryPlane{
+						{Name: "system", Methods: []string{"get_status"}},
+					},
+				},
+			}
+		},
+		ListSemantic: func() SemanticSnapshot {
+			return SemanticSnapshot{
+				Zones: []SemanticZone{
+					{ID: "zone_1", Name: "Living", OperatingMode: "auto", CurrentTempC: &current},
+				},
+				DHW: &SemanticDHW{OperatingMode: "auto"},
+			}
+		},
+		ListProjections: func() []ProjectionDevice {
+			return []ProjectionDevice{
+				{
+					Address:      0x10,
+					DeviceID:     "VRC720",
+					DisplayName:  "sensoCOMFORT",
+					Manufacturer: "Vaillant",
+					Projections: []ProjectionSummary{
+						{Plane: "Service", NodeCount: 1, EdgeCount: 1},
+					},
+				},
+			}
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/search?q=service&limit=10", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d; want %d", rec.Code, http.StatusOK)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if payload["query"] != "service" {
+		t.Fatalf("query=%v; want service", payload["query"])
+	}
+	items := payload["items"].([]any)
+	if len(items) == 0 {
+		t.Fatalf("expected at least one search result")
+	}
+	first := items[0].(map[string]any)
+	if first["layer"] == "" {
+		t.Fatalf("layer missing on first result")
+	}
+	if first["title"] == "" {
+		t.Fatalf("title missing on first result")
+	}
+}
+
+func TestSearchEndpoint_EmptyQuery(t *testing.T) {
+	h := NewHandler(Options{})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/search?q=&limit=10", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d; want %d", rec.Code, http.StatusOK)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if int(payload["count"].(float64)) != 0 {
+		t.Fatalf("count=%v; want 0", payload["count"])
 	}
 }

--- a/portal/static/assets/app.css
+++ b/portal/static/assets/app.css
@@ -194,6 +194,21 @@ body {
   color: var(--muted);
 }
 
+.pill {
+  display: inline-block;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.08rem 0.45rem;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.muted-inline {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
 @media (max-width: 900px) {
   .topbar {
     grid-template-columns: 1fr;

--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -14,6 +14,15 @@ function setTheme(theme) {
   localStorage.setItem(THEME_KEY, theme);
 }
 
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
 class PortalShell extends HTMLElement {
   connectedCallback() {
     this.render();
@@ -24,10 +33,16 @@ class PortalShell extends HTMLElement {
 
   bindEvents() {
     const toggle = this.querySelector('[data-role="theme-toggle"]');
+    const search = this.querySelector('[data-role="search-input"]');
     if (toggle) {
       toggle.addEventListener("click", () => {
         const current = loadTheme();
         setTheme(current === "dark" ? "light" : "dark");
+      });
+    }
+    if (search) {
+      search.addEventListener("input", () => {
+        this.scheduleSearch(search.value);
       });
     }
   }
@@ -38,6 +53,8 @@ class PortalShell extends HTMLElement {
     const listEl = this.querySelector('[data-role="registry-list"]');
     const semanticEl = this.querySelector('[data-role="semantic-list"]');
     const projectionEl = this.querySelector('[data-role="projection-list"]');
+    const searchInput = this.querySelector('[data-role="search-input"]');
+    const searchList = this.querySelector('[data-role="search-list"]');
     try {
       const [healthRes, bootstrapRes] = await Promise.all([
         fetch("api/v1/health"),
@@ -51,7 +68,11 @@ class PortalShell extends HTMLElement {
       if (metaEl) {
         const caps = bootstrap.capabilities || {};
         metaEl.textContent =
-          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, stream=${caps.stream}`;
+          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, search=${caps.search}, stream=${caps.stream}`;
+      }
+      if (searchInput) {
+        searchInput.disabled = !bootstrap.capabilities?.search;
+        searchInput.title = bootstrap.capabilities?.search ? "" : "Search is unavailable (no data providers)";
       }
       if (bootstrap.capabilities?.registry && listEl) {
         await this.loadRegistryPreview(listEl);
@@ -62,6 +83,11 @@ class PortalShell extends HTMLElement {
       if (bootstrap.capabilities?.projection && projectionEl) {
         await this.loadProjectionPreview(projectionEl);
       }
+      if (searchList) {
+        searchList.innerHTML = bootstrap.capabilities?.search
+          ? "<li>Type at least 2 characters to search across registry, semantic and projection layers.</li>"
+          : "<li>Search unavailable: no readable layers enabled.</li>";
+      }
     } catch (err) {
       if (statusEl) {
         statusEl.textContent = "Gateway unavailable";
@@ -70,6 +96,47 @@ class PortalShell extends HTMLElement {
         metaEl.textContent = "Bootstrap fetch failed";
       }
       console.error("portal bootstrap failed", err);
+    }
+  }
+
+  scheduleSearch(rawQuery) {
+    if (this.searchTimer) {
+      clearTimeout(this.searchTimer);
+    }
+    this.searchTimer = setTimeout(() => {
+      this.runSearch(rawQuery);
+    }, 220);
+  }
+
+  async runSearch(rawQuery) {
+    const listEl = this.querySelector('[data-role="search-list"]');
+    if (!listEl) {
+      return;
+    }
+    const query = String(rawQuery || "").trim();
+    if (query.length < 2) {
+      listEl.innerHTML = "<li>Type at least 2 characters.</li>";
+      return;
+    }
+    try {
+      const response = await fetch(`api/v1/search?q=${encodeURIComponent(query)}&limit=20`);
+      const payload = await response.json();
+      const items = Array.isArray(payload.items) ? payload.items : [];
+      if (items.length === 0) {
+        listEl.innerHTML = "<li>No matches.</li>";
+        return;
+      }
+      listEl.innerHTML = items
+        .map((item) => {
+          const layer = escapeHtml(item.layer || "unknown");
+          const title = escapeHtml(item.title || item.id || "item");
+          const subtitle = item.subtitle ? ` <span class="muted-inline">${escapeHtml(item.subtitle)}</span>` : "";
+          return `<li><span class="pill">${layer}</span> <strong>${title}</strong>${subtitle}</li>`;
+        })
+        .join("");
+    } catch (err) {
+      listEl.innerHTML = "<li>Search request failed.</li>";
+      console.error("search failed", err);
     }
   }
 
@@ -148,7 +215,7 @@ class PortalShell extends HTMLElement {
           <select class="select" aria-label="Controller selector">
             <option>Controller (M1)</option>
           </select>
-          <input class="search" type="search" disabled title="Available in M1" aria-label="Search" placeholder="Search (M1)" />
+          <input class="search" type="search" data-role="search-input" aria-label="Search" placeholder="Search across layers" />
           <button class="button" data-role="theme-toggle" aria-label="Toggle theme">Theme</button>
         </header>
         <div class="content">
@@ -188,6 +255,12 @@ class PortalShell extends HTMLElement {
               <h2>Projection Preview</h2>
               <ul data-role="projection-list">
                 <li>Loading projection summary...</li>
+              </ul>
+            </section>
+            <section class="registry-preview">
+              <h2>Search Results</h2>
+              <ul data-role="search-list">
+                <li>Loading search capability...</li>
               </ul>
             </section>
             <div class="meta" data-role="meta">Waiting for bootstrap...</div>

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,12 +2,12 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 7715,
-      "sha256": "1dcda4f8a2a748d19e331a4616ec281889aaf7bb0ae6addacadcca0d41e37bf2"
+      "bytes": 10375,
+      "sha256": "3fbc9b7f50c1b784dd27b7872c04aa31675c7246a72df4ab6694abfa06338cc5"
     },
     "app.css": {
-      "bytes": 3710,
-      "sha256": "59206873cc08e96fd7124ed997ebe08df2a666d9da5c11a56e59914dd926b65d"
+      "bytes": 3974,
+      "sha256": "ecbad65354a652d693375ffb961e6bbc52e4ef36a6eef632d334f578529d0901"
     }
   }
 }

--- a/portal/web/src/app.css
+++ b/portal/web/src/app.css
@@ -193,6 +193,21 @@ body {
   color: var(--muted);
 }
 
+.pill {
+  display: inline-block;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.08rem 0.45rem;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.muted-inline {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
 @media (max-width: 900px) {
   .topbar {
     grid-template-columns: 1fr;

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -13,6 +13,15 @@ function setTheme(theme) {
   localStorage.setItem(THEME_KEY, theme);
 }
 
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
 class PortalShell extends HTMLElement {
   connectedCallback() {
     this.render();
@@ -23,10 +32,16 @@ class PortalShell extends HTMLElement {
 
   bindEvents() {
     const toggle = this.querySelector('[data-role="theme-toggle"]');
+    const search = this.querySelector('[data-role="search-input"]');
     if (toggle) {
       toggle.addEventListener("click", () => {
         const current = loadTheme();
         setTheme(current === "dark" ? "light" : "dark");
+      });
+    }
+    if (search) {
+      search.addEventListener("input", () => {
+        this.scheduleSearch(search.value);
       });
     }
   }
@@ -37,6 +52,8 @@ class PortalShell extends HTMLElement {
     const listEl = this.querySelector('[data-role="registry-list"]');
     const semanticEl = this.querySelector('[data-role="semantic-list"]');
     const projectionEl = this.querySelector('[data-role="projection-list"]');
+    const searchInput = this.querySelector('[data-role="search-input"]');
+    const searchList = this.querySelector('[data-role="search-list"]');
     try {
       const [healthRes, bootstrapRes] = await Promise.all([
         fetch("api/v1/health"),
@@ -50,7 +67,11 @@ class PortalShell extends HTMLElement {
       if (metaEl) {
         const caps = bootstrap.capabilities || {};
         metaEl.textContent =
-          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, stream=${caps.stream}`;
+          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, search=${caps.search}, stream=${caps.stream}`;
+      }
+      if (searchInput) {
+        searchInput.disabled = !bootstrap.capabilities?.search;
+        searchInput.title = bootstrap.capabilities?.search ? "" : "Search is unavailable (no data providers)";
       }
       if (bootstrap.capabilities?.registry && listEl) {
         await this.loadRegistryPreview(listEl);
@@ -61,6 +82,11 @@ class PortalShell extends HTMLElement {
       if (bootstrap.capabilities?.projection && projectionEl) {
         await this.loadProjectionPreview(projectionEl);
       }
+      if (searchList) {
+        searchList.innerHTML = bootstrap.capabilities?.search
+          ? "<li>Type at least 2 characters to search across registry, semantic and projection layers.</li>"
+          : "<li>Search unavailable: no readable layers enabled.</li>";
+      }
     } catch (err) {
       if (statusEl) {
         statusEl.textContent = "Gateway unavailable";
@@ -69,6 +95,47 @@ class PortalShell extends HTMLElement {
         metaEl.textContent = "Bootstrap fetch failed";
       }
       console.error("portal bootstrap failed", err);
+    }
+  }
+
+  scheduleSearch(rawQuery) {
+    if (this.searchTimer) {
+      clearTimeout(this.searchTimer);
+    }
+    this.searchTimer = setTimeout(() => {
+      this.runSearch(rawQuery);
+    }, 220);
+  }
+
+  async runSearch(rawQuery) {
+    const listEl = this.querySelector('[data-role="search-list"]');
+    if (!listEl) {
+      return;
+    }
+    const query = String(rawQuery || "").trim();
+    if (query.length < 2) {
+      listEl.innerHTML = "<li>Type at least 2 characters.</li>";
+      return;
+    }
+    try {
+      const response = await fetch(`api/v1/search?q=${encodeURIComponent(query)}&limit=20`);
+      const payload = await response.json();
+      const items = Array.isArray(payload.items) ? payload.items : [];
+      if (items.length === 0) {
+        listEl.innerHTML = "<li>No matches.</li>";
+        return;
+      }
+      listEl.innerHTML = items
+        .map((item) => {
+          const layer = escapeHtml(item.layer || "unknown");
+          const title = escapeHtml(item.title || item.id || "item");
+          const subtitle = item.subtitle ? ` <span class="muted-inline">${escapeHtml(item.subtitle)}</span>` : "";
+          return `<li><span class="pill">${layer}</span> <strong>${title}</strong>${subtitle}</li>`;
+        })
+        .join("");
+    } catch (err) {
+      listEl.innerHTML = "<li>Search request failed.</li>";
+      console.error("search failed", err);
     }
   }
 
@@ -147,7 +214,7 @@ class PortalShell extends HTMLElement {
           <select class="select" aria-label="Controller selector">
             <option>Controller (M1)</option>
           </select>
-          <input class="search" type="search" disabled title="Available in M1" aria-label="Search" placeholder="Search (M1)" />
+          <input class="search" type="search" data-role="search-input" aria-label="Search" placeholder="Search across layers" />
           <button class="button" data-role="theme-toggle" aria-label="Toggle theme">Theme</button>
         </header>
         <div class="content">
@@ -187,6 +254,12 @@ class PortalShell extends HTMLElement {
               <h2>Projection Preview</h2>
               <ul data-role="projection-list">
                 <li>Loading projection summary...</li>
+              </ul>
+            </section>
+            <section class="registry-preview">
+              <h2>Search Results</h2>
+              <ul data-role="search-list">
+                <li>Loading search capability...</li>
               </ul>
             </section>
             <div class="meta" data-role="meta">Waiting for bootstrap...</div>


### PR DESCRIPTION
## Summary
- add unified portal search endpoint: `GET /portal/api/v1/search`
- aggregate read-only matches across registry, semantic snapshot, and projection summaries
- expose bootstrap search capability + endpoint metadata
- enable portal topbar search input with debounced query + results list
- add handler tests for bootstrap search flags and search endpoint behavior

## Testing
- `GOWORK=off go test ./portal ./ui`
- `./scripts/check_portal_assets.sh`

## Docs
- d3vi1/helianthus-docs-ebus#132

Closes #152
