### PR TITLE
MCP-10-003: runtime+registry read parity tools

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -235,6 +235,7 @@ func startHTTPServer(ctx context.Context, cfg ebusgateway.Config, gateway *ebusg
 	if err != nil {
 		return nil, nil, err
 	}
+	mcpServer.SetStatusProvider(newMCPRuntimeStatusProvider(cfg))
 
 	mux := http.NewServeMux()
 	mux.Handle(cfg.GraphQLPath, queryHandler)

--- a/cmd/gateway/status_provider.go
+++ b/cmd/gateway/status_provider.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/d3vi1/helianthus-ebusgateway"
 	"github.com/d3vi1/helianthus-ebusgateway/graphql"
+	"github.com/d3vi1/helianthus-ebusgateway/mcp"
 )
 
 type runtimeStatusProvider struct {
@@ -29,6 +30,35 @@ func newRuntimeStatusProvider(cfg ebusgateway.Config) graphql.StatusProvider {
 			InitiatorAddress: formatConfiguredInitiator(cfg.ScanSource, cfg.ScanSourceAuto),
 		},
 		adapter: graphql.ServiceStatus{
+			Status:           "unknown",
+			FirmwareVersion:  "",
+			UpdatesAvailable: false,
+		},
+	}
+}
+
+type runtimeMCPStatusProvider struct {
+	daemon  mcp.ServiceStatus
+	adapter mcp.ServiceStatus
+}
+
+func (p runtimeMCPStatusProvider) DaemonStatus() mcp.ServiceStatus {
+	return p.daemon
+}
+
+func (p runtimeMCPStatusProvider) AdapterStatus() mcp.ServiceStatus {
+	return p.adapter
+}
+
+func newMCPRuntimeStatusProvider(cfg ebusgateway.Config) mcp.StatusProvider {
+	return runtimeMCPStatusProvider{
+		daemon: mcp.ServiceStatus{
+			Status:           "running",
+			FirmwareVersion:  "",
+			UpdatesAvailable: false,
+			InitiatorAddress: formatConfiguredInitiator(cfg.ScanSource, cfg.ScanSourceAuto),
+		},
+		adapter: mcp.ServiceStatus{
 			Status:           "unknown",
 			FirmwareVersion:  "",
 			UpdatesAvailable: false,

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"reflect"
+	"sort"
 	"strings"
 	"time"
 
@@ -27,21 +29,63 @@ type Invoker interface {
 	Invoke(ctx context.Context, plane router.Plane, methodName string, params map[string]any) (any, error)
 }
 
+type ServiceStatus struct {
+	Status           string `json:"status"`
+	FirmwareVersion  string `json:"firmware_version"`
+	UpdatesAvailable bool   `json:"updates_available"`
+	InitiatorAddress string `json:"initiator_address,omitempty"`
+}
+
+type StatusProvider interface {
+	DaemonStatus() ServiceStatus
+	AdapterStatus() ServiceStatus
+}
+
 type Server struct {
-	registry Registry
-	invoker  Invoker
+	registry       Registry
+	invoker        Invoker
+	statusProvider StatusProvider
 
 	tools []Tool
 }
 
 const (
-	toolDevicesV1Name     = "ebus.v1.registry.devices.list"
-	toolInvokeV1Name      = "ebus.v1.rpc.invoke"
-	toolDevicesLegacyName = "ebus.devices"
-	toolInvokeLegacyName  = "ebus.invoke"
+	toolRuntimeStatusGetName = "ebus.v1.runtime.status.get"
+	toolDevicesV1Name        = "ebus.v1.registry.devices.list"
+	toolDeviceGetV1Name      = "ebus.v1.registry.devices.get"
+	toolPlanesListV1Name     = "ebus.v1.registry.planes.list"
+	toolMethodsListV1Name    = "ebus.v1.registry.methods.list"
+	toolInvokeV1Name         = "ebus.v1.rpc.invoke"
+	toolDevicesLegacyName    = "ebus.devices"
+	toolInvokeLegacyName     = "ebus.invoke"
+	methodMutabilityUnknown  = "unknown"
+	methodMutabilityReadOnly = "read_only"
+	methodMutabilityMutating = "mutating"
+	methodDangerUnknown      = "unknown"
+	methodDangerSafe         = "safe"
+	methodDangerDangerous    = "dangerous"
 )
 
 var errInvokePermissionDenied = errors.New("invoke permission denied")
+
+type staticStatusProvider struct{}
+
+func (staticStatusProvider) DaemonStatus() ServiceStatus {
+	return ServiceStatus{
+		Status:           "running",
+		FirmwareVersion:  "",
+		UpdatesAvailable: false,
+		InitiatorAddress: "",
+	}
+}
+
+func (staticStatusProvider) AdapterStatus() ServiceStatus {
+	return ServiceStatus{
+		Status:           "unknown",
+		FirmwareVersion:  "",
+		UpdatesAvailable: false,
+	}
+}
 
 func NewServer(reg Registry, invoker Invoker) (*Server, error) {
 	if reg == nil {
@@ -49,14 +93,57 @@ func NewServer(reg Registry, invoker Invoker) (*Server, error) {
 	}
 
 	server := &Server{
-		registry: reg,
-		invoker:  invoker,
+		registry:       reg,
+		invoker:        invoker,
+		statusProvider: staticStatusProvider{},
 	}
 	server.tools = []Tool{
+		{
+			Name:        toolRuntimeStatusGetName,
+			Description: "Get runtime daemon and adapter status.",
+			InputSchema: map[string]any{"type": "object", "additionalProperties": false},
+		},
 		{
 			Name:        toolDevicesV1Name,
 			Description: "List devices discovered on the eBUS, including planes and methods.",
 			InputSchema: map[string]any{"type": "object", "additionalProperties": false},
+		},
+		{
+			Name:        toolDeviceGetV1Name,
+			Description: "Get one device by address.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"address": map[string]any{"type": "integer", "minimum": 0, "maximum": 255},
+				},
+				"required":             []string{"address"},
+				"additionalProperties": false,
+			},
+		},
+		{
+			Name:        toolPlanesListV1Name,
+			Description: "List registry planes for one device address.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"address": map[string]any{"type": "integer", "minimum": 0, "maximum": 255},
+				},
+				"required":             []string{"address"},
+				"additionalProperties": false,
+			},
+		},
+		{
+			Name:        toolMethodsListV1Name,
+			Description: "List registry methods for a device address and plane.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"address": map[string]any{"type": "integer", "minimum": 0, "maximum": 255},
+					"plane":   map[string]any{"type": "string"},
+				},
+				"required":             []string{"address", "plane"},
+				"additionalProperties": false,
+			},
 		},
 		{
 			Name:        toolInvokeV1Name,
@@ -99,6 +186,13 @@ func NewServer(reg Registry, invoker Invoker) (*Server, error) {
 	}
 
 	return server, nil
+}
+
+func (s *Server) SetStatusProvider(provider StatusProvider) {
+	if s == nil || provider == nil {
+		return
+	}
+	s.statusProvider = provider
 }
 
 func (s *Server) Handler() http.Handler {
@@ -212,10 +306,34 @@ func (s *Server) handleToolsCall(ctx context.Context, params json.RawMessage) (a
 	}
 
 	switch call.Name {
+	case toolRuntimeStatusGetName:
+		status := map[string]any{
+			"daemon_status":  s.statusProvider.DaemonStatus(),
+			"adapter_status": s.statusProvider.AdapterStatus(),
+		}
+		return callToolResultText(mustJSON(newToolEnvelope(status, nil)), false), nil
 	case toolDevicesV1Name, toolDevicesLegacyName:
 		devices := s.listDevices()
 		text := mustJSON(newToolEnvelope(devices, nil))
 		return callToolResultText(text, false), nil
+	case toolDeviceGetV1Name:
+		device, err := s.getDevice(call.Arguments)
+		if err != nil {
+			return callToolResultText(mustJSON(newToolEnvelope(nil, err)), true), nil
+		}
+		return callToolResultText(mustJSON(newToolEnvelope(device, nil)), false), nil
+	case toolPlanesListV1Name:
+		planes, err := s.listPlanes(call.Arguments)
+		if err != nil {
+			return callToolResultText(mustJSON(newToolEnvelope(nil, err)), true), nil
+		}
+		return callToolResultText(mustJSON(newToolEnvelope(planes, nil)), false), nil
+	case toolMethodsListV1Name:
+		methods, err := s.listMethods(call.Arguments)
+		if err != nil {
+			return callToolResultText(mustJSON(newToolEnvelope(nil, err)), true), nil
+		}
+		return callToolResultText(mustJSON(newToolEnvelope(methods, nil)), false), nil
 	case toolInvokeV1Name:
 		if s.invoker == nil {
 			return nil, rpcErrorInternal("server missing invoker")
@@ -391,56 +509,251 @@ type deviceInfo struct {
 }
 
 type planeInfo struct {
-	Name    string       `json:"name"`
-	Methods []methodInfo `json:"methods"`
+	Name     string       `json:"name"`
+	Routable bool         `json:"routable"`
+	Methods  []methodInfo `json:"methods"`
 }
 
 type methodInfo struct {
-	Name      string `json:"name"`
-	ReadOnly  bool   `json:"read_only"`
-	Primary   int    `json:"primary"`
-	Secondary int    `json:"secondary"`
+	Name       string `json:"name"`
+	ReadOnly   bool   `json:"read_only"`
+	Primary    int    `json:"primary"`
+	Secondary  int    `json:"secondary"`
+	Mutability string `json:"mutability"`
+	Danger     string `json:"danger_level"`
+	Routable   bool   `json:"routable"`
 }
 
 func (s *Server) listDevices() []deviceInfo {
 	out := make([]deviceInfo, 0)
 	s.registry.Iterate(func(entry registry.DeviceEntry) bool {
-		device := deviceInfo{
-			Address:         int(entry.Address()),
-			Manufacturer:    entry.Manufacturer(),
-			DeviceID:        entry.DeviceID(),
-			SoftwareVersion: entry.SoftwareVersion(),
-			HardwareVersion: entry.HardwareVersion(),
-			Planes:          make([]planeInfo, 0),
-		}
-
-		for _, plane := range entry.Planes() {
-			pi := planeInfo{
-				Name:    plane.Name(),
-				Methods: make([]methodInfo, 0, len(plane.Methods())),
-			}
-			for _, method := range plane.Methods() {
-				template := method.Template()
-				primary := 0
-				secondary := 0
-				if template != nil {
-					primary = int(template.Primary())
-					secondary = int(template.Secondary())
-				}
-				pi.Methods = append(pi.Methods, methodInfo{
-					Name:      method.Name(),
-					ReadOnly:  method.ReadOnly(),
-					Primary:   primary,
-					Secondary: secondary,
-				})
-			}
-			device.Planes = append(device.Planes, pi)
-		}
-
-		out = append(out, device)
+		out = append(out, buildDeviceInfo(entry))
 		return true
 	})
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Address != out[j].Address {
+			return out[i].Address < out[j].Address
+		}
+		if out[i].Manufacturer != out[j].Manufacturer {
+			return out[i].Manufacturer < out[j].Manufacturer
+		}
+		return out[i].DeviceID < out[j].DeviceID
+	})
 	return out
+}
+
+func (s *Server) getDevice(args map[string]any) (deviceInfo, error) {
+	address, err := parseAddress(args["address"])
+	if err != nil {
+		return deviceInfo{}, err
+	}
+	entry, ok := s.registry.Lookup(address)
+	if !ok {
+		return deviceInfo{}, fmt.Errorf("unknown device 0x%02x: %w", address, ebuserrors.ErrNoSuchDevice)
+	}
+	return buildDeviceInfo(entry), nil
+}
+
+func (s *Server) listPlanes(args map[string]any) ([]planeInfo, error) {
+	address, err := parseAddress(args["address"])
+	if err != nil {
+		return nil, err
+	}
+	entry, ok := s.registry.Lookup(address)
+	if !ok {
+		return nil, fmt.Errorf("unknown device 0x%02x: %w", address, ebuserrors.ErrNoSuchDevice)
+	}
+	return buildPlaneInfoList(entry.Planes()), nil
+}
+
+func (s *Server) listMethods(args map[string]any) ([]methodInfo, error) {
+	address, err := parseAddress(args["address"])
+	if err != nil {
+		return nil, err
+	}
+	planeName, _ := args["plane"].(string)
+	planeName = strings.TrimSpace(planeName)
+	if planeName == "" {
+		return nil, fmt.Errorf("missing plane: %w", ebuserrors.ErrInvalidPayload)
+	}
+
+	entry, ok := s.registry.Lookup(address)
+	if !ok {
+		return nil, fmt.Errorf("unknown device 0x%02x: %w", address, ebuserrors.ErrNoSuchDevice)
+	}
+	plane, found := findPlane(entry.Planes(), planeName)
+	if !found {
+		return nil, fmt.Errorf("unknown plane %q: %w", planeName, ebuserrors.ErrInvalidPayload)
+	}
+
+	return buildMethodInfoList(plane), nil
+}
+
+func buildDeviceInfo(entry registry.DeviceEntry) deviceInfo {
+	return deviceInfo{
+		Address:         int(entry.Address()),
+		Manufacturer:    entry.Manufacturer(),
+		DeviceID:        entry.DeviceID(),
+		SoftwareVersion: entry.SoftwareVersion(),
+		HardwareVersion: entry.HardwareVersion(),
+		Planes:          buildPlaneInfoList(entry.Planes()),
+	}
+}
+
+func buildPlaneInfoList(planes []registry.Plane) []planeInfo {
+	out := make([]planeInfo, 0, len(planes))
+	for _, plane := range planes {
+		if plane == nil {
+			continue
+		}
+		_, routable := plane.(router.Plane)
+		out = append(out, planeInfo{
+			Name:     plane.Name(),
+			Routable: routable,
+			Methods:  buildMethodInfoList(plane),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+func buildMethodInfoList(plane registry.Plane) []methodInfo {
+	if plane == nil {
+		return nil
+	}
+	methods := plane.Methods()
+	out := make([]methodInfo, 0, len(methods))
+	for _, method := range methods {
+		if method == nil {
+			continue
+		}
+		template := method.Template()
+		primary := 0
+		secondary := 0
+		if template != nil {
+			primary = int(template.Primary())
+			secondary = int(template.Secondary())
+		}
+		mutability, danger, routable := extractMethodMetadata(method, plane)
+		out = append(out, methodInfo{
+			Name:       method.Name(),
+			ReadOnly:   method.ReadOnly(),
+			Primary:    primary,
+			Secondary:  secondary,
+			Mutability: mutability,
+			Danger:     danger,
+			Routable:   routable,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		if out[i].Primary != out[j].Primary {
+			return out[i].Primary < out[j].Primary
+		}
+		return out[i].Secondary < out[j].Secondary
+	})
+	return out
+}
+
+func extractMethodMetadata(method registry.Method, plane registry.Plane) (mutability string, danger string, routable bool) {
+	if method == nil {
+		return methodMutabilityUnknown, methodDangerUnknown, false
+	}
+
+	if method.ReadOnly() {
+		mutability = methodMutabilityReadOnly
+	} else {
+		mutability = methodMutabilityMutating
+	}
+	if value, ok := invokeStringNoArg(method, "Mutability"); ok {
+		if normalized, valid := normalizeMethodMutability(value); valid {
+			mutability = normalized
+		}
+	}
+
+	if mutability == methodMutabilityReadOnly {
+		danger = methodDangerSafe
+	} else {
+		danger = methodDangerDangerous
+	}
+	if value, ok := invokeStringNoArg(method, "Danger"); ok {
+		if normalized, valid := normalizeMethodDanger(value); valid {
+			danger = normalized
+		}
+	}
+
+	_, routable = plane.(router.Plane)
+	if value, ok := invokeBoolNoArg(method, "Routable"); ok {
+		routable = value
+	}
+
+	return mutability, danger, routable
+}
+
+func normalizeMethodMutability(raw string) (string, bool) {
+	value := strings.ToLower(strings.TrimSpace(raw))
+	value = strings.ReplaceAll(value, "-", "_")
+	switch value {
+	case methodMutabilityUnknown, methodMutabilityReadOnly, methodMutabilityMutating:
+		return value, true
+	default:
+		return "", false
+	}
+}
+
+func normalizeMethodDanger(raw string) (string, bool) {
+	value := strings.ToLower(strings.TrimSpace(raw))
+	switch value {
+	case methodDangerUnknown, methodDangerSafe, methodDangerDangerous:
+		return value, true
+	default:
+		return "", false
+	}
+}
+
+func invokeStringNoArg(target any, methodName string) (string, bool) {
+	if target == nil {
+		return "", false
+	}
+	value := reflect.ValueOf(target)
+	method := value.MethodByName(methodName)
+	if !method.IsValid() || method.Type().NumIn() != 0 || method.Type().NumOut() != 1 {
+		return "", false
+	}
+	out := method.Call(nil)
+	if len(out) != 1 {
+		return "", false
+	}
+	return fmt.Sprint(out[0].Interface()), true
+}
+
+func invokeBoolNoArg(target any, methodName string) (bool, bool) {
+	if target == nil {
+		return false, false
+	}
+	value := reflect.ValueOf(target)
+	method := value.MethodByName(methodName)
+	if !method.IsValid() || method.Type().NumIn() != 0 || method.Type().NumOut() != 1 || method.Type().Out(0).Kind() != reflect.Bool {
+		return false, false
+	}
+	out := method.Call(nil)
+	if len(out) != 1 {
+		return false, false
+	}
+	return out[0].Bool(), true
+}
+
+func findPlane(planes []registry.Plane, planeName string) (registry.Plane, bool) {
+	for _, plane := range planes {
+		if plane != nil && plane.Name() == planeName {
+			return plane, true
+		}
+	}
+	return nil, false
 }
 
 func (s *Server) invoke(ctx context.Context, args map[string]any) (any, error) {

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -76,6 +76,17 @@ func (m testMethod) ResponseSchema() schema.SchemaSelector {
 	return schema.SchemaSelector{}
 }
 
+type testMetadataMethod struct {
+	testMethod
+	mutability string
+	danger     string
+	routable   bool
+}
+
+func (m testMetadataMethod) Mutability() string { return m.mutability }
+func (m testMetadataMethod) Danger() string     { return m.danger }
+func (m testMetadataMethod) Routable() bool     { return m.routable }
+
 type testPlane struct {
 	name      string
 	methods   []registry.Method
@@ -96,6 +107,14 @@ func (p *testPlane) DecodeResponse(registry.Method, protocol.Frame, map[string]a
 	return map[string]any{"ok": true}, nil
 }
 
+type testPlainPlane struct {
+	name    string
+	methods []registry.Method
+}
+
+func (p testPlainPlane) Name() string               { return p.name }
+func (p testPlainPlane) Methods() []registry.Method { return p.methods }
+
 type testInvoker struct {
 	calls []invokeCall
 }
@@ -108,6 +127,19 @@ type invokeCall struct {
 func (i *testInvoker) Invoke(ctx context.Context, plane router.Plane, methodName string, params map[string]any) (any, error) {
 	i.calls = append(i.calls, invokeCall{plane: plane.Name(), method: methodName})
 	return map[string]any{"ok": true}, nil
+}
+
+type testStatusProvider struct {
+	daemon  ServiceStatus
+	adapter ServiceStatus
+}
+
+func (p testStatusProvider) DaemonStatus() ServiceStatus {
+	return p.daemon
+}
+
+func (p testStatusProvider) AdapterStatus() ServiceStatus {
+	return p.adapter
 }
 
 func TestServer_InitializeAndTools(t *testing.T) {
@@ -141,11 +173,15 @@ func TestServer_InitializeAndTools(t *testing.T) {
 		t.Fatalf("tools/list result type = %T; want map", res.Result)
 	}
 	tools, ok := resultMap["tools"].([]any)
-	if !ok || len(tools) < 4 {
-		t.Fatalf("tools = %#v; want at least 4 tools", resultMap["tools"])
+	if !ok || len(tools) < 8 {
+		t.Fatalf("tools = %#v; want at least 8 tools", resultMap["tools"])
 	}
 	for _, name := range []string{
+		toolRuntimeStatusGetName,
 		toolDevicesV1Name,
+		toolDeviceGetV1Name,
+		toolPlanesListV1Name,
+		toolMethodsListV1Name,
 		toolInvokeV1Name,
 		toolDevicesLegacyName,
 		toolInvokeLegacyName,
@@ -292,6 +328,227 @@ func TestServer_ToolsCallDevicesAndInvoke(t *testing.T) {
 	if len(invoker.calls) != 1 || invoker.calls[0].plane != "heating" || invoker.calls[0].method != "get_status" {
 		t.Fatalf("invoker calls = %+v; want heating/get_status", invoker.calls)
 	}
+}
+
+func TestServer_ToolsCallRuntimeStatus(t *testing.T) {
+	reg := &testRegistry{entries: make(map[byte]registry.DeviceEntry)}
+	server, err := NewServer(reg, &testInvoker{})
+	if err != nil {
+		t.Fatalf("NewServer error = %v", err)
+	}
+	server.SetStatusProvider(testStatusProvider{
+		daemon: ServiceStatus{
+			Status:           "running",
+			FirmwareVersion:  "1.2.3",
+			UpdatesAvailable: false,
+			InitiatorAddress: "0x15",
+		},
+		adapter: ServiceStatus{
+			Status:           "connected",
+			FirmwareVersion:  "2.0.0",
+			UpdatesAvailable: true,
+		},
+	})
+
+	res := doRPC(t, server.Handler(), rpcRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"ebus.v1.runtime.status.get","arguments":{}}`),
+	})
+	if res.Error != nil {
+		t.Fatalf("tools/call runtime status error = %+v", res.Error)
+	}
+	resultMap, ok := res.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("runtime status result type = %T; want map", res.Result)
+	}
+	content, ok := resultMap["content"].([]any)
+	if !ok || len(content) != 1 {
+		t.Fatalf("runtime status content = %#v; want 1 item", resultMap["content"])
+	}
+	contentItem, ok := content[0].(map[string]any)
+	if !ok {
+		t.Fatalf("runtime status content item type = %T; want map", content[0])
+	}
+	text, _ := contentItem["text"].(string)
+	envelope := parseEnvelope(t, text)
+	data, ok := envelope["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("runtime status data type = %T; want map", envelope["data"])
+	}
+	daemon, ok := data["daemon_status"].(map[string]any)
+	if !ok {
+		t.Fatalf("daemon_status type = %T; want map", data["daemon_status"])
+	}
+	if got, _ := daemon["initiator_address"].(string); got != "0x15" {
+		t.Fatalf("daemon initiator_address = %q; want 0x15", got)
+	}
+	adapter, ok := data["adapter_status"].(map[string]any)
+	if !ok {
+		t.Fatalf("adapter_status type = %T; want map", data["adapter_status"])
+	}
+	if got, _ := adapter["status"].(string); got != "connected" {
+		t.Fatalf("adapter status = %q; want connected", got)
+	}
+}
+
+func TestServer_RegistryReadToolsOrderingAndMetadata(t *testing.T) {
+	heatingPlane := &testPlane{
+		name: "heating",
+		methods: []registry.Method{
+			testMethod{
+				name:     "zeta",
+				readOnly: true,
+				template: testTemplate{primary: 0xB5, secondary: 0x0A},
+			},
+			testMetadataMethod{
+				testMethod: testMethod{
+					name:     "alpha",
+					readOnly: true,
+					template: testTemplate{primary: 0xB5, secondary: 0x04},
+				},
+				mutability: "unknown",
+				danger:     "dangerous",
+				routable:   false,
+			},
+		},
+	}
+	plainPlane := testPlainPlane{
+		name: "alpha",
+		methods: []registry.Method{
+			testMethod{
+				name:     "noop",
+				readOnly: true,
+				template: testTemplate{primary: 0xB5, secondary: 0x01},
+			},
+		},
+	}
+
+	reg := &testRegistry{
+		entries: map[byte]registry.DeviceEntry{
+			0x10: testEntry{
+				info: registry.DeviceInfo{
+					Address:         0x10,
+					Manufacturer:    "vaillant",
+					DeviceID:        "device-b",
+					SoftwareVersion: "1.0",
+					HardwareVersion: "7603",
+				},
+				planes: []registry.Plane{heatingPlane, plainPlane},
+			},
+			0x08: testEntry{
+				info: registry.DeviceInfo{
+					Address:         0x08,
+					Manufacturer:    "vaillant",
+					DeviceID:        "device-a",
+					SoftwareVersion: "1.0",
+					HardwareVersion: "7603",
+				},
+				planes: []registry.Plane{plainPlane},
+			},
+		},
+		order: []byte{0x10, 0x08},
+	}
+
+	server, err := NewServer(reg, &testInvoker{})
+	if err != nil {
+		t.Fatalf("NewServer error = %v", err)
+	}
+
+	t.Run("devices list sorted by address", func(t *testing.T) {
+		res := doRPC(t, server.Handler(), rpcRequest{
+			JSONRPC: "2.0",
+			ID:      1,
+			Method:  "tools/call",
+			Params:  json.RawMessage(`{"name":"ebus.v1.registry.devices.list","arguments":{}}`),
+		})
+		envelope := envelopeFromResult(t, res)
+		data, ok := envelope["data"].([]any)
+		if !ok || len(data) != 2 {
+			t.Fatalf("devices data = %#v; want 2 entries", envelope["data"])
+		}
+		first, _ := data[0].(map[string]any)
+		if address, _ := first["address"].(float64); int(address) != 0x08 {
+			t.Fatalf("first device address = %v; want 8", first["address"])
+		}
+	})
+
+	t.Run("device get by address", func(t *testing.T) {
+		res := doRPC(t, server.Handler(), rpcRequest{
+			JSONRPC: "2.0",
+			ID:      2,
+			Method:  "tools/call",
+			Params:  json.RawMessage(`{"name":"ebus.v1.registry.devices.get","arguments":{"address":16}}`),
+		})
+		envelope := envelopeFromResult(t, res)
+		data, ok := envelope["data"].(map[string]any)
+		if !ok {
+			t.Fatalf("device get data type = %T; want map", envelope["data"])
+		}
+		if address, _ := data["address"].(float64); int(address) != 0x10 {
+			t.Fatalf("device get address = %v; want 16", data["address"])
+		}
+	})
+
+	t.Run("planes list sorted and routable", func(t *testing.T) {
+		res := doRPC(t, server.Handler(), rpcRequest{
+			JSONRPC: "2.0",
+			ID:      3,
+			Method:  "tools/call",
+			Params:  json.RawMessage(`{"name":"ebus.v1.registry.planes.list","arguments":{"address":16}}`),
+		})
+		envelope := envelopeFromResult(t, res)
+		data, ok := envelope["data"].([]any)
+		if !ok || len(data) != 2 {
+			t.Fatalf("planes data = %#v; want 2 entries", envelope["data"])
+		}
+		first, _ := data[0].(map[string]any)
+		second, _ := data[1].(map[string]any)
+		if name, _ := first["name"].(string); name != "alpha" {
+			t.Fatalf("first plane name = %q; want alpha", name)
+		}
+		if name, _ := second["name"].(string); name != "heating" {
+			t.Fatalf("second plane name = %q; want heating", name)
+		}
+		if routable, _ := first["routable"].(bool); routable {
+			t.Fatalf("alpha routable = true; want false")
+		}
+		if routable, _ := second["routable"].(bool); !routable {
+			t.Fatalf("heating routable = false; want true")
+		}
+	})
+
+	t.Run("methods list sorted with metadata", func(t *testing.T) {
+		res := doRPC(t, server.Handler(), rpcRequest{
+			JSONRPC: "2.0",
+			ID:      4,
+			Method:  "tools/call",
+			Params:  json.RawMessage(`{"name":"ebus.v1.registry.methods.list","arguments":{"address":16,"plane":"heating"}}`),
+		})
+		envelope := envelopeFromResult(t, res)
+		data, ok := envelope["data"].([]any)
+		if !ok || len(data) != 2 {
+			t.Fatalf("methods data = %#v; want 2 entries", envelope["data"])
+		}
+		first, _ := data[0].(map[string]any)
+		second, _ := data[1].(map[string]any)
+		if name, _ := first["name"].(string); name != "alpha" {
+			t.Fatalf("first method name = %q; want alpha", name)
+		}
+		if name, _ := second["name"].(string); name != "zeta" {
+			t.Fatalf("second method name = %q; want zeta", name)
+		}
+		if mutability, _ := first["mutability"].(string); mutability != methodMutabilityUnknown {
+			t.Fatalf("alpha mutability = %q; want %q", mutability, methodMutabilityUnknown)
+		}
+		if danger, _ := first["danger_level"].(string); danger != methodDangerDangerous {
+			t.Fatalf("alpha danger = %q; want %q", danger, methodDangerDangerous)
+		}
+		if routable, _ := first["routable"].(bool); routable {
+			t.Fatalf("alpha routable = true; want false (explicit override)")
+		}
+	})
 }
 
 func TestServer_ToolsCallLegacyAliases(t *testing.T) {
@@ -521,6 +778,30 @@ func parseEnvelope(t *testing.T, text string) map[string]any {
 		t.Fatalf("Unmarshal envelope error = %v. text=%q", err, text)
 	}
 	return envelope
+}
+
+func envelopeFromResult(t *testing.T, res rpcResponse) map[string]any {
+	t.Helper()
+	if res.Error != nil {
+		t.Fatalf("unexpected rpc error = %+v", res.Error)
+	}
+	resultMap, ok := res.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type = %T; want map", res.Result)
+	}
+	content, ok := resultMap["content"].([]any)
+	if !ok || len(content) != 1 {
+		t.Fatalf("content = %#v; want 1 item", resultMap["content"])
+	}
+	contentItem, ok := content[0].(map[string]any)
+	if !ok {
+		t.Fatalf("content item type = %T; want map", content[0])
+	}
+	text, _ := contentItem["text"].(string)
+	if text == "" {
+		t.Fatal("content.text empty")
+	}
+	return parseEnvelope(t, text)
 }
 
 func hasToolName(tools []any, name string) bool {


### PR DESCRIPTION
## Summary
- add MCP read tools: ebus.v1.runtime.status.get, ebus.v1.registry.devices.get, ebus.v1.registry.planes.list, ebus.v1.registry.methods.list
- keep ebus.v1.registry.devices.list and legacy aliases; route all read tools through unified envelope path
- add deterministic ordering for devices, planes, and methods list outputs
- expose method metadata path (mutability, danger_level, routable) with safe defaults and optional provider overrides
- wire MCP runtime status provider from gateway startup config

## Issue
Closes #132

## Base Branch
- mcpfirst-cruise-control

## Architecture Source
- d3vi1/helianthus-docs-ebus#124

## Validation
- GOWORK=off go test ./mcp -count=1 (pass)
- GOWORK=off ./scripts/ci_local.sh (fails on pre-existing baseline outside this PR):
  - graphql/schema.go uses entry.Addresses on registry.DeviceEntry
  - gateway.go references transport.NewTCPPlainTransport
