### PR TITLE
feat(portal): add SSE stream endpoint with throttling

### DIFF
--- a/portal/handler.go
+++ b/portal/handler.go
@@ -42,6 +42,8 @@ var (
 	portalRequestCount      = expvar.NewMap("portal_requests_total")
 	portalRouteDurationMS   = expvar.NewMap("portal_route_duration_ms_total")
 	portalAssetETagByTarget = loadAssetETags()
+	portalStreamEventsTotal = expvar.NewMap("portal_stream_events_total")
+	portalStreamDropped     = expvar.NewMap("portal_stream_dropped_total")
 )
 
 type Options struct {
@@ -161,6 +163,21 @@ type SearchResult struct {
 	Address  *byte  `json:"address,omitempty"`
 }
 
+type StreamEventEnvelope struct {
+	At            string         `json:"at"`
+	Type          string         `json:"type"`
+	Layer         string         `json:"layer"`
+	CorrelationID string         `json:"correlation_id"`
+	Payload       map[string]any `json:"payload"`
+	Provenance    StreamSource   `json:"provenance"`
+}
+
+type StreamSource struct {
+	Source   string `json:"source"`
+	Dropped  int    `json:"dropped"`
+	Interval int    `json:"interval_ms"`
+}
+
 func NewHandler(opts Options) http.Handler {
 	if opts.GraphQLPath == "" {
 		opts.GraphQLPath = "/graphql"
@@ -246,13 +263,14 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 			"time_utc":        time.Now().UTC().Format(time.RFC3339),
 		})
 	case "bootstrap":
+		streamEnabled := h.opts.ListRegistry != nil || h.opts.ListSemantic != nil || h.opts.ListProjections != nil
 		writeJSON(w, http.StatusOK, map[string]any{
 			"capabilities": map[string]bool{
 				"registry":   h.opts.ListRegistry != nil,
 				"semantic":   h.opts.ListSemantic != nil,
 				"projection": h.opts.ListProjections != nil && h.opts.GetProjection != nil,
 				"search":     h.opts.ListRegistry != nil || h.opts.ListSemantic != nil || h.opts.ListProjections != nil,
-				"stream":     false,
+				"stream":     streamEnabled,
 			},
 			"endpoints": map[string]string{
 				"graphql":       h.opts.GraphQLPath,
@@ -260,6 +278,7 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 				"subscriptions": h.opts.SubscriptionPath,
 				"mcp":           h.opts.MCPPath,
 				"search":        "/portal/api/v1/search",
+				"stream":        "/portal/api/v1/stream",
 			},
 			"limits": map[string]any{
 				"max_events_per_second": 200,
@@ -277,6 +296,8 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 		h.handleProjectionGraph(w, r)
 	case "search":
 		h.handleSearch(w, r)
+	case "stream":
+		h.handleStream(w, r)
 	default:
 		http.NotFound(w, r)
 	}
@@ -305,6 +326,12 @@ func (rec *statusRecorder) Write(payload []byte) (int, error) {
 	return rec.ResponseWriter.Write(payload)
 }
 
+func (rec *statusRecorder) Flush() {
+	if flusher, ok := rec.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
 func classifyRoute(path string) string {
 	switch {
 	case strings.HasPrefix(path, "/api/v1/health"):
@@ -321,6 +348,8 @@ func classifyRoute(path string) string {
 		return "api.projection.graph"
 	case strings.HasPrefix(path, "/api/v1/search"):
 		return "api.search"
+	case strings.HasPrefix(path, "/api/v1/stream"):
+		return "api.stream"
 	case strings.HasPrefix(path, "/assets/"):
 		return "assets"
 	case path == "/" || strings.EqualFold(path, "/index.html"):
@@ -705,4 +734,187 @@ func (h *handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 		"count": len(results),
 		"items": results,
 	})
+}
+
+func (h *handler) handleStream(w http.ResponseWriter, r *http.Request) {
+	if h.opts.ListRegistry == nil && h.opts.ListSemantic == nil && h.opts.ListProjections == nil {
+		http.Error(w, "stream unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	intervalMS := parseIntBounded(r.URL.Query().Get("interval_ms"), 1000, 200, 5000)
+	maxEventsPerSecond := parseIntBounded(r.URL.Query().Get("max_events_per_second"), 3, 1, 30)
+	maxEvents := parseIntBounded(r.URL.Query().Get("max_events"), 0, 0, 200)
+
+	selectedLayers := parseLayerSelection(r.URL.Query().Get("layers"))
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Connection", "keep-alive")
+
+	produceTicker := time.NewTicker(time.Duration(intervalMS) * time.Millisecond)
+	defer produceTicker.Stop()
+	flushTicker := time.NewTicker(time.Second / time.Duration(maxEventsPerSecond))
+	defer flushTicker.Stop()
+	heartbeatTicker := time.NewTicker(15 * time.Second)
+	defer heartbeatTicker.Stop()
+
+	var (
+		pending    *StreamEventEnvelope
+		dropped    int
+		sentEvents int
+	)
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-produceTicker.C:
+			for _, event := range h.snapshotStreamEvents(selectedLayers, intervalMS) {
+				if pending != nil {
+					dropped++
+				}
+				event.Provenance.Dropped = dropped
+				pending = &event
+			}
+		case <-flushTicker.C:
+			if pending == nil {
+				continue
+			}
+			payload, err := json.Marshal(pending)
+			if err != nil {
+				continue
+			}
+			if _, err := fmt.Fprintf(w, "event: update\ndata: %s\n\n", payload); err != nil {
+				return
+			}
+			flusher.Flush()
+			portalStreamEventsTotal.Add(pending.Layer, 1)
+			if dropped > 0 {
+				portalStreamDropped.Add(pending.Layer, int64(dropped))
+			}
+			dropped = 0
+			pending = nil
+			sentEvents++
+			if maxEvents > 0 && sentEvents >= maxEvents {
+				return
+			}
+		case <-heartbeatTicker.C:
+			if _, err := fmt.Fprint(w, ": keep-alive\n\n"); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}
+
+func parseIntBounded(raw string, fallback, min, max int) int {
+	value := fallback
+	if strings.TrimSpace(raw) != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err == nil {
+			value = parsed
+		}
+	}
+	if value < min {
+		return min
+	}
+	if value > max {
+		return max
+	}
+	return value
+}
+
+func parseLayerSelection(raw string) map[string]bool {
+	layers := map[string]bool{
+		"registry":   true,
+		"semantic":   true,
+		"projection": true,
+	}
+	if strings.TrimSpace(raw) == "" {
+		return layers
+	}
+	selected := map[string]bool{
+		"registry":   false,
+		"semantic":   false,
+		"projection": false,
+	}
+	for _, token := range strings.Split(strings.ToLower(raw), ",") {
+		key := strings.TrimSpace(token)
+		if _, ok := selected[key]; ok {
+			selected[key] = true
+		}
+	}
+	return selected
+}
+
+func (h *handler) snapshotStreamEvents(layers map[string]bool, intervalMS int) []StreamEventEnvelope {
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	events := make([]StreamEventEnvelope, 0, 3)
+
+	if layers["registry"] && h.opts.ListRegistry != nil {
+		devices := h.opts.ListRegistry()
+		events = append(events, StreamEventEnvelope{
+			At:            now,
+			Type:          "snapshot",
+			Layer:         "registry",
+			CorrelationID: fmt.Sprintf("reg-%d", time.Now().UnixNano()),
+			Payload: map[string]any{
+				"device_count": len(devices),
+			},
+			Provenance: StreamSource{
+				Source:   "poll:registry",
+				Interval: intervalMS,
+			},
+		})
+	}
+
+	if layers["semantic"] && h.opts.ListSemantic != nil {
+		snapshot := h.opts.ListSemantic()
+		events = append(events, StreamEventEnvelope{
+			At:            now,
+			Type:          "snapshot",
+			Layer:         "semantic",
+			CorrelationID: fmt.Sprintf("sem-%d", time.Now().UnixNano()),
+			Payload: map[string]any{
+				"zones_count":   len(snapshot.Zones),
+				"has_dhw":       snapshot.DHW != nil,
+				"captured_utc":  snapshot.CapturedUTC,
+				"has_energy":    snapshot.Energy != nil,
+				"energy_series": snapshot.Energy != nil,
+			},
+			Provenance: StreamSource{
+				Source:   "poll:semantic",
+				Interval: intervalMS,
+			},
+		})
+	}
+
+	if layers["projection"] && h.opts.ListProjections != nil {
+		items := h.opts.ListProjections()
+		projectionCount := 0
+		for _, item := range items {
+			projectionCount += len(item.Projections)
+		}
+		events = append(events, StreamEventEnvelope{
+			At:            now,
+			Type:          "snapshot",
+			Layer:         "projection",
+			CorrelationID: fmt.Sprintf("proj-%d", time.Now().UnixNano()),
+			Payload: map[string]any{
+				"device_count":     len(items),
+				"projection_count": projectionCount,
+			},
+			Provenance: StreamSource{
+				Source:   "poll:projection",
+				Interval: intervalMS,
+			},
+		})
+	}
+
+	return events
 }

--- a/portal/handler_test.go
+++ b/portal/handler_test.go
@@ -1,6 +1,7 @@
 package portal
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -156,6 +157,9 @@ func TestBootstrapEndpoint(t *testing.T) {
 	}
 	if capabilities["search"] != true {
 		t.Fatalf("capabilities.search=%v; want true", capabilities["search"])
+	}
+	if capabilities["stream"] != true {
+		t.Fatalf("capabilities.stream=%v; want true", capabilities["stream"])
 	}
 }
 
@@ -497,5 +501,44 @@ func TestSearchEndpoint_EmptyQuery(t *testing.T) {
 	}
 	if int(payload["count"].(float64)) != 0 {
 		t.Fatalf("count=%v; want 0", payload["count"])
+	}
+}
+
+func TestStreamEndpoint(t *testing.T) {
+	h := NewHandler(Options{
+		ListRegistry: func() []RegistryDevice {
+			return []RegistryDevice{
+				{Address: 0x10, Manufacturer: "Vaillant", DeviceID: "VRC720"},
+			}
+		},
+	})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stream?layers=registry&interval_ms=10&max_events_per_second=10&max_events=1", nil)
+	ctx, cancel := context.WithTimeout(req.Context(), time.Second)
+	defer cancel()
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d; want %d", rec.Code, http.StatusOK)
+	}
+	if got := rec.Header().Get("Content-Type"); !strings.HasPrefix(got, "text/event-stream") {
+		t.Fatalf("Content-Type=%q; want text/event-stream", got)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "event: update") {
+		t.Fatalf("stream body missing update event: %q", body)
+	}
+	if !strings.Contains(body, "\"layer\":\"registry\"") {
+		t.Fatalf("stream payload missing registry layer: %q", body)
+	}
+}
+
+func TestStreamEndpoint_UnavailableWithoutProviders(t *testing.T) {
+	h := NewHandler(Options{})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stream", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d; want %d", rec.Code, http.StatusServiceUnavailable)
 	}
 }

--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -31,6 +31,13 @@ class PortalShell extends HTMLElement {
     this.loadStatus();
   }
 
+  disconnectedCallback() {
+    if (this.streamSource) {
+      this.streamSource.close();
+      this.streamSource = undefined;
+    }
+  }
+
   bindEvents() {
     const toggle = this.querySelector('[data-role="theme-toggle"]');
     const search = this.querySelector('[data-role="search-input"]');
@@ -88,6 +95,9 @@ class PortalShell extends HTMLElement {
           ? "<li>Type at least 2 characters to search across registry, semantic and projection layers.</li>"
           : "<li>Search unavailable: no readable layers enabled.</li>";
       }
+      if (bootstrap.capabilities?.stream) {
+        this.startStream();
+      }
     } catch (err) {
       if (statusEl) {
         statusEl.textContent = "Gateway unavailable";
@@ -97,6 +107,34 @@ class PortalShell extends HTMLElement {
       }
       console.error("portal bootstrap failed", err);
     }
+  }
+
+  startStream() {
+    const streamStatus = this.querySelector('[data-role="stream-status"]');
+    if (this.streamSource) {
+      this.streamSource.close();
+      this.streamSource = undefined;
+    }
+    const source = new EventSource("api/v1/stream?max_events_per_second=2&interval_ms=1000");
+    this.streamSource = source;
+    source.addEventListener("update", (event) => {
+      if (!streamStatus) {
+        return;
+      }
+      try {
+        const payload = JSON.parse(event.data);
+        const layer = payload.layer || "unknown";
+        const at = payload.at || "n/a";
+        streamStatus.textContent = `Stream live: layer=${layer} at=${at}`;
+      } catch (err) {
+        streamStatus.textContent = "Stream payload parse error";
+      }
+    });
+    source.onerror = () => {
+      if (streamStatus) {
+        streamStatus.textContent = "Stream disconnected";
+      }
+    };
   }
 
   scheduleSearch(rawQuery) {
@@ -263,6 +301,7 @@ class PortalShell extends HTMLElement {
                 <li>Loading search capability...</li>
               </ul>
             </section>
+            <div class="meta" data-role="stream-status">Stream idle</div>
             <div class="meta" data-role="meta">Waiting for bootstrap...</div>
           </main>
         </div>

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,8 +2,8 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 10375,
-      "sha256": "3fbc9b7f50c1b784dd27b7872c04aa31675c7246a72df4ab6694abfa06338cc5"
+      "bytes": 11554,
+      "sha256": "d96c37a20ab8b27db0f51399a6f87912bc00fd9a949a3fcee5aa004cdcbc9f56"
     },
     "app.css": {
       "bytes": 3974,

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -30,6 +30,13 @@ class PortalShell extends HTMLElement {
     this.loadStatus();
   }
 
+  disconnectedCallback() {
+    if (this.streamSource) {
+      this.streamSource.close();
+      this.streamSource = undefined;
+    }
+  }
+
   bindEvents() {
     const toggle = this.querySelector('[data-role="theme-toggle"]');
     const search = this.querySelector('[data-role="search-input"]');
@@ -87,6 +94,9 @@ class PortalShell extends HTMLElement {
           ? "<li>Type at least 2 characters to search across registry, semantic and projection layers.</li>"
           : "<li>Search unavailable: no readable layers enabled.</li>";
       }
+      if (bootstrap.capabilities?.stream) {
+        this.startStream();
+      }
     } catch (err) {
       if (statusEl) {
         statusEl.textContent = "Gateway unavailable";
@@ -96,6 +106,34 @@ class PortalShell extends HTMLElement {
       }
       console.error("portal bootstrap failed", err);
     }
+  }
+
+  startStream() {
+    const streamStatus = this.querySelector('[data-role="stream-status"]');
+    if (this.streamSource) {
+      this.streamSource.close();
+      this.streamSource = undefined;
+    }
+    const source = new EventSource("api/v1/stream?max_events_per_second=2&interval_ms=1000");
+    this.streamSource = source;
+    source.addEventListener("update", (event) => {
+      if (!streamStatus) {
+        return;
+      }
+      try {
+        const payload = JSON.parse(event.data);
+        const layer = payload.layer || "unknown";
+        const at = payload.at || "n/a";
+        streamStatus.textContent = `Stream live: layer=${layer} at=${at}`;
+      } catch (err) {
+        streamStatus.textContent = "Stream payload parse error";
+      }
+    });
+    source.onerror = () => {
+      if (streamStatus) {
+        streamStatus.textContent = "Stream disconnected";
+      }
+    };
   }
 
   scheduleSearch(rawQuery) {
@@ -262,6 +300,7 @@ class PortalShell extends HTMLElement {
                 <li>Loading search capability...</li>
               </ul>
             </section>
+            <div class="meta" data-role="stream-status">Stream idle</div>
             <div class="meta" data-role="meta">Waiting for bootstrap...</div>
           </main>
         </div>


### PR DESCRIPTION
## Summary
- add `GET /portal/api/v1/stream` SSE endpoint with standard envelope (`at,type,layer,correlation_id,payload,provenance`)
- implement stream throttling/coalescing controls (`interval_ms`, `max_events_per_second`, `layers`) and dropped event accounting
- add stream expvar metrics: `portal_stream_events_total`, `portal_stream_dropped_total`
- expose stream capability/endpoint in portal bootstrap response
- wire portal UI to open SSE stream and show live stream status
- add handler tests for stream happy-path + unavailable case

## Testing
- `GOWORK=off go test ./portal ./ui`
- `./scripts/check_portal_assets.sh`

## Docs
- d3vi1/helianthus-docs-ebus#133

Closes #153
