### PR TITLE
MCP-10-004: semantic parity tools (zones/dhw/energy_totals)

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -82,7 +82,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 
 	startDiscoveryScanLoop(ctx, cfg, gateway, builder)
 
-	server, advertiser, err := startHTTPServer(ctx, cfg, gateway, builder, hub)
+	server, advertiser, err := startHTTPServer(ctx, cfg, gateway, builder, semanticRuntime.Provider(), hub)
 	if err != nil {
 		return err
 	}
@@ -202,7 +202,7 @@ func bindFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) {
 	})
 }
 
-func startHTTPServer(ctx context.Context, cfg ebusgateway.Config, gateway *ebusgateway.Gateway, builder *graphql.Builder, hub *graphql.BroadcastHub) (*http.Server, mdns.Advertiser, error) {
+func startHTTPServer(ctx context.Context, cfg ebusgateway.Config, gateway *ebusgateway.Gateway, builder *graphql.Builder, semanticProvider graphql.SemanticProvider, hub *graphql.BroadcastHub) (*http.Server, mdns.Advertiser, error) {
 	if cfg.HTTPAddr == "" {
 		return nil, nil, nil
 	}
@@ -236,6 +236,7 @@ func startHTTPServer(ctx context.Context, cfg ebusgateway.Config, gateway *ebusg
 		return nil, nil, err
 	}
 	mcpServer.SetStatusProvider(newMCPRuntimeStatusProvider(cfg))
+	mcpServer.SetSemanticProvider(newMCPSemanticProvider(semanticProvider))
 
 	mux := http.NewServeMux()
 	mux.Handle(cfg.GraphQLPath, queryHandler)

--- a/cmd/gateway/semantic_provider.go
+++ b/cmd/gateway/semantic_provider.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"github.com/d3vi1/helianthus-ebusgateway/graphql"
+	"github.com/d3vi1/helianthus-ebusgateway/mcp"
+)
+
+type mcpSemanticProviderAdapter struct {
+	provider graphql.SemanticProvider
+}
+
+func newMCPSemanticProvider(provider graphql.SemanticProvider) mcp.SemanticProvider {
+	return mcpSemanticProviderAdapter{provider: provider}
+}
+
+func (adapter mcpSemanticProviderAdapter) Zones() []mcp.Zone {
+	if adapter.provider == nil {
+		return nil
+	}
+	zones := adapter.provider.Zones()
+	if len(zones) == 0 {
+		return nil
+	}
+	out := make([]mcp.Zone, len(zones))
+	for i, zone := range zones {
+		out[i] = mcp.Zone{
+			ID:            zone.ID,
+			Name:          zone.Name,
+			OperatingMode: zone.OperatingMode,
+			Preset:        zone.Preset,
+			CurrentTempC:  cloneFloatPtr(zone.CurrentTempC),
+			TargetTempC:   cloneFloatPtr(zone.TargetTempC),
+			HeatingDemand: cloneFloatPtr(zone.HeatingDemand),
+		}
+	}
+	return out
+}
+
+func (adapter mcpSemanticProviderAdapter) DHW() *mcp.DhwStatus {
+	if adapter.provider == nil {
+		return nil
+	}
+	status := adapter.provider.DHW()
+	if status == nil {
+		return nil
+	}
+	return &mcp.DhwStatus{
+		OperatingMode: status.OperatingMode,
+		Preset:        status.Preset,
+		CurrentTempC:  cloneFloatPtr(status.CurrentTempC),
+		TargetTempC:   cloneFloatPtr(status.TargetTempC),
+		HeatingDemand: cloneFloatPtr(status.HeatingDemand),
+	}
+}
+
+func (adapter mcpSemanticProviderAdapter) EnergyTotals() *mcp.EnergyTotals {
+	if adapter.provider == nil {
+		return nil
+	}
+	totals := adapter.provider.EnergyTotals()
+	if totals == nil {
+		return nil
+	}
+	return &mcp.EnergyTotals{
+		Gas:      mapEnergyChannel(totals.Gas),
+		Electric: mapEnergyChannel(totals.Electric),
+		Solar:    mapEnergyChannel(totals.Solar),
+	}
+}
+
+func mapEnergyChannel(channel graphql.EnergyChannel) mcp.EnergyChannel {
+	return mcp.EnergyChannel{
+		DHW:     mapEnergySeries(channel.DHW),
+		Climate: mapEnergySeries(channel.Climate),
+	}
+}
+
+func mapEnergySeries(series graphql.EnergySeries) mcp.EnergySeries {
+	out := mcp.EnergySeries{Today: series.Today}
+	if len(series.Yearly) > 0 {
+		out.Yearly = make([]float64, len(series.Yearly))
+		copy(out.Yearly, series.Yearly)
+	}
+	return out
+}
+
+func cloneFloatPtr(value *float64) *float64 {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -41,34 +41,79 @@ type StatusProvider interface {
 	AdapterStatus() ServiceStatus
 }
 
+type Zone struct {
+	ID            string   `json:"id"`
+	Name          string   `json:"name"`
+	OperatingMode string   `json:"operating_mode"`
+	Preset        string   `json:"preset"`
+	CurrentTempC  *float64 `json:"current_temp_c,omitempty"`
+	TargetTempC   *float64 `json:"target_temp_c,omitempty"`
+	HeatingDemand *float64 `json:"heating_demand,omitempty"`
+}
+
+type DhwStatus struct {
+	OperatingMode string   `json:"operating_mode"`
+	Preset        string   `json:"preset"`
+	CurrentTempC  *float64 `json:"current_temp_c,omitempty"`
+	TargetTempC   *float64 `json:"target_temp_c,omitempty"`
+	HeatingDemand *float64 `json:"heating_demand,omitempty"`
+}
+
+type EnergySeries struct {
+	Today  float64   `json:"today"`
+	Yearly []float64 `json:"yearly"`
+}
+
+type EnergyChannel struct {
+	DHW     EnergySeries `json:"dhw"`
+	Climate EnergySeries `json:"climate"`
+}
+
+type EnergyTotals struct {
+	Gas      EnergyChannel `json:"gas"`
+	Electric EnergyChannel `json:"electric"`
+	Solar    EnergyChannel `json:"solar"`
+}
+
+type SemanticProvider interface {
+	Zones() []Zone
+	DHW() *DhwStatus
+	EnergyTotals() *EnergyTotals
+}
+
 type Server struct {
 	registry       Registry
 	invoker        Invoker
 	statusProvider StatusProvider
+	semantic       SemanticProvider
 
 	tools []Tool
 }
 
 const (
-	toolRuntimeStatusGetName = "ebus.v1.runtime.status.get"
-	toolDevicesV1Name        = "ebus.v1.registry.devices.list"
-	toolDeviceGetV1Name      = "ebus.v1.registry.devices.get"
-	toolPlanesListV1Name     = "ebus.v1.registry.planes.list"
-	toolMethodsListV1Name    = "ebus.v1.registry.methods.list"
-	toolInvokeV1Name         = "ebus.v1.rpc.invoke"
-	toolDevicesLegacyName    = "ebus.devices"
-	toolInvokeLegacyName     = "ebus.invoke"
-	methodMutabilityUnknown  = "unknown"
-	methodMutabilityReadOnly = "read_only"
-	methodMutabilityMutating = "mutating"
-	methodDangerUnknown      = "unknown"
-	methodDangerSafe         = "safe"
-	methodDangerDangerous    = "dangerous"
+	toolRuntimeStatusGetName  = "ebus.v1.runtime.status.get"
+	toolSemanticZonesGetName  = "ebus.v1.semantic.zones.get"
+	toolSemanticDHWGetName    = "ebus.v1.semantic.dhw.get"
+	toolSemanticEnergyGetName = "ebus.v1.semantic.energy_totals.get"
+	toolDevicesV1Name         = "ebus.v1.registry.devices.list"
+	toolDeviceGetV1Name       = "ebus.v1.registry.devices.get"
+	toolPlanesListV1Name      = "ebus.v1.registry.planes.list"
+	toolMethodsListV1Name     = "ebus.v1.registry.methods.list"
+	toolInvokeV1Name          = "ebus.v1.rpc.invoke"
+	toolDevicesLegacyName     = "ebus.devices"
+	toolInvokeLegacyName      = "ebus.invoke"
+	methodMutabilityUnknown   = "unknown"
+	methodMutabilityReadOnly  = "read_only"
+	methodMutabilityMutating  = "mutating"
+	methodDangerUnknown       = "unknown"
+	methodDangerSafe          = "safe"
+	methodDangerDangerous     = "dangerous"
 )
 
 var errInvokePermissionDenied = errors.New("invoke permission denied")
 
 type staticStatusProvider struct{}
+type staticSemanticProvider struct{}
 
 func (staticStatusProvider) DaemonStatus() ServiceStatus {
 	return ServiceStatus{
@@ -87,6 +132,18 @@ func (staticStatusProvider) AdapterStatus() ServiceStatus {
 	}
 }
 
+func (staticSemanticProvider) Zones() []Zone {
+	return nil
+}
+
+func (staticSemanticProvider) DHW() *DhwStatus {
+	return nil
+}
+
+func (staticSemanticProvider) EnergyTotals() *EnergyTotals {
+	return nil
+}
+
 func NewServer(reg Registry, invoker Invoker) (*Server, error) {
 	if reg == nil {
 		return nil, fmt.Errorf("mcp server missing registry: %w", ebuserrors.ErrInvalidPayload)
@@ -96,11 +153,27 @@ func NewServer(reg Registry, invoker Invoker) (*Server, error) {
 		registry:       reg,
 		invoker:        invoker,
 		statusProvider: staticStatusProvider{},
+		semantic:       staticSemanticProvider{},
 	}
 	server.tools = []Tool{
 		{
 			Name:        toolRuntimeStatusGetName,
 			Description: "Get runtime daemon and adapter status.",
+			InputSchema: map[string]any{"type": "object", "additionalProperties": false},
+		},
+		{
+			Name:        toolSemanticZonesGetName,
+			Description: "Get semantic zones snapshot.",
+			InputSchema: map[string]any{"type": "object", "additionalProperties": false},
+		},
+		{
+			Name:        toolSemanticDHWGetName,
+			Description: "Get semantic domestic hot water snapshot.",
+			InputSchema: map[string]any{"type": "object", "additionalProperties": false},
+		},
+		{
+			Name:        toolSemanticEnergyGetName,
+			Description: "Get semantic energy totals snapshot.",
 			InputSchema: map[string]any{"type": "object", "additionalProperties": false},
 		},
 		{
@@ -193,6 +266,13 @@ func (s *Server) SetStatusProvider(provider StatusProvider) {
 		return
 	}
 	s.statusProvider = provider
+}
+
+func (s *Server) SetSemanticProvider(provider SemanticProvider) {
+	if s == nil || provider == nil {
+		return
+	}
+	s.semantic = provider
 }
 
 func (s *Server) Handler() http.Handler {
@@ -312,6 +392,13 @@ func (s *Server) handleToolsCall(ctx context.Context, params json.RawMessage) (a
 			"adapter_status": s.statusProvider.AdapterStatus(),
 		}
 		return callToolResultText(mustJSON(newToolEnvelope(status, nil)), false), nil
+	case toolSemanticZonesGetName:
+		zones := s.snapshotZones()
+		return callToolResultText(mustJSON(newToolEnvelope(zones, nil)), false), nil
+	case toolSemanticDHWGetName:
+		return callToolResultText(mustJSON(newToolEnvelope(s.snapshotDHW(), nil)), false), nil
+	case toolSemanticEnergyGetName:
+		return callToolResultText(mustJSON(newToolEnvelope(s.snapshotEnergyTotals(), nil)), false), nil
 	case toolDevicesV1Name, toolDevicesLegacyName:
 		devices := s.listDevices()
 		text := mustJSON(newToolEnvelope(devices, nil))
@@ -587,6 +674,70 @@ func (s *Server) listMethods(args map[string]any) ([]methodInfo, error) {
 	}
 
 	return buildMethodInfoList(plane), nil
+}
+
+func (s *Server) snapshotZones() []Zone {
+	if s == nil || s.semantic == nil {
+		return nil
+	}
+	zones := s.semantic.Zones()
+	if len(zones) == 0 {
+		return nil
+	}
+	out := make([]Zone, len(zones))
+	copy(out, zones)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].ID != out[j].ID {
+			return out[i].ID < out[j].ID
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+func (s *Server) snapshotDHW() *DhwStatus {
+	if s == nil || s.semantic == nil {
+		return nil
+	}
+	source := s.semantic.DHW()
+	if source == nil {
+		return nil
+	}
+	copy := *source
+	return &copy
+}
+
+func (s *Server) snapshotEnergyTotals() *EnergyTotals {
+	if s == nil || s.semantic == nil {
+		return nil
+	}
+	source := s.semantic.EnergyTotals()
+	if source == nil {
+		return nil
+	}
+	copy := *source
+	copy.Gas = cloneEnergyChannel(copy.Gas)
+	copy.Electric = cloneEnergyChannel(copy.Electric)
+	copy.Solar = cloneEnergyChannel(copy.Solar)
+	return &copy
+}
+
+func cloneEnergyChannel(channel EnergyChannel) EnergyChannel {
+	channel.DHW = cloneEnergySeries(channel.DHW)
+	channel.Climate = cloneEnergySeries(channel.Climate)
+	return channel
+}
+
+func cloneEnergySeries(series EnergySeries) EnergySeries {
+	if len(series.Yearly) == 0 {
+		return EnergySeries{Today: series.Today}
+	}
+	values := make([]float64, len(series.Yearly))
+	copy(values, series.Yearly)
+	return EnergySeries{
+		Today:  series.Today,
+		Yearly: values,
+	}
 }
 
 func buildDeviceInfo(entry registry.DeviceEntry) deviceInfo {

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -142,6 +142,40 @@ func (p testStatusProvider) AdapterStatus() ServiceStatus {
 	return p.adapter
 }
 
+type testSemanticProvider struct {
+	zones  []Zone
+	dhw    *DhwStatus
+	energy *EnergyTotals
+}
+
+func (p testSemanticProvider) Zones() []Zone {
+	if len(p.zones) == 0 {
+		return nil
+	}
+	out := make([]Zone, len(p.zones))
+	copy(out, p.zones)
+	return out
+}
+
+func (p testSemanticProvider) DHW() *DhwStatus {
+	if p.dhw == nil {
+		return nil
+	}
+	copy := *p.dhw
+	return &copy
+}
+
+func (p testSemanticProvider) EnergyTotals() *EnergyTotals {
+	if p.energy == nil {
+		return nil
+	}
+	copy := *p.energy
+	copy.Gas = cloneEnergyChannel(copy.Gas)
+	copy.Electric = cloneEnergyChannel(copy.Electric)
+	copy.Solar = cloneEnergyChannel(copy.Solar)
+	return &copy
+}
+
 func TestServer_InitializeAndTools(t *testing.T) {
 	reg := &testRegistry{entries: make(map[byte]registry.DeviceEntry)}
 	server, err := NewServer(reg, &testInvoker{})
@@ -173,11 +207,14 @@ func TestServer_InitializeAndTools(t *testing.T) {
 		t.Fatalf("tools/list result type = %T; want map", res.Result)
 	}
 	tools, ok := resultMap["tools"].([]any)
-	if !ok || len(tools) < 8 {
-		t.Fatalf("tools = %#v; want at least 8 tools", resultMap["tools"])
+	if !ok || len(tools) < 11 {
+		t.Fatalf("tools = %#v; want at least 11 tools", resultMap["tools"])
 	}
 	for _, name := range []string{
 		toolRuntimeStatusGetName,
+		toolSemanticZonesGetName,
+		toolSemanticDHWGetName,
+		toolSemanticEnergyGetName,
 		toolDevicesV1Name,
 		toolDeviceGetV1Name,
 		toolPlanesListV1Name,
@@ -391,6 +428,94 @@ func TestServer_ToolsCallRuntimeStatus(t *testing.T) {
 	if got, _ := adapter["status"].(string); got != "connected" {
 		t.Fatalf("adapter status = %q; want connected", got)
 	}
+}
+
+func TestServer_ToolsCallSemanticSnapshots(t *testing.T) {
+	reg := &testRegistry{entries: make(map[byte]registry.DeviceEntry)}
+	server, err := NewServer(reg, &testInvoker{})
+	if err != nil {
+		t.Fatalf("NewServer error = %v", err)
+	}
+	server.SetSemanticProvider(testSemanticProvider{
+		zones: []Zone{
+			{ID: "zone-b", Name: "Bedroom", OperatingMode: "AUTO", Preset: "COMFORT"},
+			{ID: "zone-a", Name: "Living", OperatingMode: "AUTO", Preset: "COMFORT"},
+		},
+		dhw: &DhwStatus{
+			OperatingMode: "AUTO",
+			Preset:        "ECO",
+		},
+		energy: &EnergyTotals{
+			Gas: EnergyChannel{
+				DHW:     EnergySeries{Today: 1.25, Yearly: []float64{10, 20}},
+				Climate: EnergySeries{Today: 2.5, Yearly: []float64{30, 40}},
+			},
+		},
+	})
+
+	t.Run("zones sorted", func(t *testing.T) {
+		res := doRPC(t, server.Handler(), rpcRequest{
+			JSONRPC: "2.0",
+			ID:      1,
+			Method:  "tools/call",
+			Params:  json.RawMessage(`{"name":"ebus.v1.semantic.zones.get","arguments":{}}`),
+		})
+		envelope := envelopeFromResult(t, res)
+		data, ok := envelope["data"].([]any)
+		if !ok || len(data) != 2 {
+			t.Fatalf("zones data = %#v; want 2 entries", envelope["data"])
+		}
+		first, _ := data[0].(map[string]any)
+		second, _ := data[1].(map[string]any)
+		if id, _ := first["id"].(string); id != "zone-a" {
+			t.Fatalf("first zone id = %q; want zone-a", id)
+		}
+		if id, _ := second["id"].(string); id != "zone-b" {
+			t.Fatalf("second zone id = %q; want zone-b", id)
+		}
+	})
+
+	t.Run("dhw payload", func(t *testing.T) {
+		res := doRPC(t, server.Handler(), rpcRequest{
+			JSONRPC: "2.0",
+			ID:      2,
+			Method:  "tools/call",
+			Params:  json.RawMessage(`{"name":"ebus.v1.semantic.dhw.get","arguments":{}}`),
+		})
+		envelope := envelopeFromResult(t, res)
+		data, ok := envelope["data"].(map[string]any)
+		if !ok {
+			t.Fatalf("dhw data type = %T; want map", envelope["data"])
+		}
+		if preset, _ := data["preset"].(string); preset != "ECO" {
+			t.Fatalf("dhw preset = %q; want ECO", preset)
+		}
+	})
+
+	t.Run("energy totals payload", func(t *testing.T) {
+		res := doRPC(t, server.Handler(), rpcRequest{
+			JSONRPC: "2.0",
+			ID:      3,
+			Method:  "tools/call",
+			Params:  json.RawMessage(`{"name":"ebus.v1.semantic.energy_totals.get","arguments":{}}`),
+		})
+		envelope := envelopeFromResult(t, res)
+		data, ok := envelope["data"].(map[string]any)
+		if !ok {
+			t.Fatalf("energy data type = %T; want map", envelope["data"])
+		}
+		gas, ok := data["gas"].(map[string]any)
+		if !ok {
+			t.Fatalf("energy gas type = %T; want map", data["gas"])
+		}
+		dhw, ok := gas["dhw"].(map[string]any)
+		if !ok {
+			t.Fatalf("energy gas.dhw type = %T; want map", gas["dhw"])
+		}
+		if today, _ := dhw["today"].(float64); today != 1.25 {
+			t.Fatalf("energy gas.dhw.today = %v; want 1.25", dhw["today"])
+		}
+	})
 }
 
 func TestServer_RegistryReadToolsOrderingAndMetadata(t *testing.T) {


### PR DESCRIPTION
## Summary
- add MCP semantic tools: ebus.v1.semantic.zones.get, ebus.v1.semantic.dhw.get, ebus.v1.semantic.energy_totals.get
- add MCP semantic provider contract and static defaults in MCP server
- wire MCP semantic provider from gateway runtime via adapter over GraphQL semantic provider
- enforce deterministic ordering for zones snapshots
- extend MCP server tests for semantic tool surface and payload shape

## Issue
Closes #133

## Base Branch
- mcpfirst-cruise-control

## Architecture Source
- d3vi1/helianthus-docs-ebus#124

## Validation
- GOWORK=off go test ./mcp -count=1 (pass)
- GOWORK=off ./scripts/ci_local.sh (fails on pre-existing baseline outside this PR):
  - graphql/schema.go uses entry.Addresses on registry.DeviceEntry
  - gateway.go references transport.NewTCPPlainTransport
