### PR TITLE
feat(portal): add timeline query and correlation filter

### DIFF
--- a/portal/handler.go
+++ b/portal/handler.go
@@ -14,6 +14,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -60,8 +61,9 @@ type Options struct {
 }
 
 type handler struct {
-	opts  Options
-	files http.Handler
+	opts     Options
+	files    http.Handler
+	timeline *timelineBuffer
 }
 
 type RegistryDevice struct {
@@ -178,6 +180,12 @@ type StreamSource struct {
 	Interval int    `json:"interval_ms"`
 }
 
+type timelineBuffer struct {
+	mu      sync.Mutex
+	cap     int
+	entries []StreamEventEnvelope
+}
+
 func NewHandler(opts Options) http.Handler {
 	if opts.GraphQLPath == "" {
 		opts.GraphQLPath = "/graphql"
@@ -198,9 +206,85 @@ func NewHandler(opts Options) http.Handler {
 		opts.BuildID = "unknown"
 	}
 	return &handler{
-		opts:  opts,
-		files: http.FileServer(http.FS(staticFS)),
+		opts:     opts,
+		files:    http.FileServer(http.FS(staticFS)),
+		timeline: newTimelineBuffer(1000),
 	}
+}
+
+func newTimelineBuffer(capacity int) *timelineBuffer {
+	if capacity <= 0 {
+		capacity = 100
+	}
+	return &timelineBuffer{
+		cap:     capacity,
+		entries: make([]StreamEventEnvelope, 0, capacity),
+	}
+}
+
+func (tb *timelineBuffer) add(event StreamEventEnvelope) {
+	if tb == nil {
+		return
+	}
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+	if len(tb.entries) >= tb.cap {
+		copy(tb.entries, tb.entries[1:])
+		tb.entries[len(tb.entries)-1] = cloneStreamEvent(event)
+		return
+	}
+	tb.entries = append(tb.entries, cloneStreamEvent(event))
+}
+
+func (tb *timelineBuffer) query(limit int, layer, correlationID string, since time.Time) []StreamEventEnvelope {
+	if tb == nil {
+		return []StreamEventEnvelope{}
+	}
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+
+	items := make([]StreamEventEnvelope, 0, limit)
+	wantsLayer := strings.TrimSpace(strings.ToLower(layer)) != ""
+	wantsCorrelation := strings.TrimSpace(strings.ToLower(correlationID)) != ""
+	sinceActive := !since.IsZero()
+
+	for i := len(tb.entries) - 1; i >= 0; i-- {
+		item := tb.entries[i]
+		if wantsLayer && !strings.EqualFold(item.Layer, layer) {
+			continue
+		}
+		if wantsCorrelation && !strings.Contains(strings.ToLower(item.CorrelationID), strings.ToLower(correlationID)) {
+			continue
+		}
+		if sinceActive {
+			at, err := time.Parse(time.RFC3339Nano, item.At)
+			if err != nil {
+				at, err = time.Parse(time.RFC3339, item.At)
+			}
+			if err == nil && at.Before(since) {
+				continue
+			}
+		}
+		items = append(items, cloneStreamEvent(item))
+		if limit > 0 && len(items) >= limit {
+			break
+		}
+	}
+
+	return items
+}
+
+func cloneStreamEvent(event StreamEventEnvelope) StreamEventEnvelope {
+	cloned := event
+	if event.Payload == nil {
+		return cloned
+	}
+	clonedPayload := make(map[string]any, len(event.Payload))
+	for key, value := range event.Payload {
+		clonedPayload[key] = value
+	}
+	cloned.Payload = clonedPayload
+	return cloned
 }
 
 func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -271,6 +355,7 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 				"projection": h.opts.ListProjections != nil && h.opts.GetProjection != nil,
 				"search":     h.opts.ListRegistry != nil || h.opts.ListSemantic != nil || h.opts.ListProjections != nil,
 				"stream":     streamEnabled,
+				"timeline":   streamEnabled,
 			},
 			"endpoints": map[string]string{
 				"graphql":       h.opts.GraphQLPath,
@@ -279,6 +364,7 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 				"mcp":           h.opts.MCPPath,
 				"search":        "/portal/api/v1/search",
 				"stream":        "/portal/api/v1/stream",
+				"timeline":      "/portal/api/v1/timeline/events",
 			},
 			"limits": map[string]any{
 				"max_events_per_second": 200,
@@ -298,6 +384,8 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 		h.handleSearch(w, r)
 	case "stream":
 		h.handleStream(w, r)
+	case "timeline/events":
+		h.handleTimelineEvents(w, r)
 	default:
 		http.NotFound(w, r)
 	}
@@ -350,6 +438,8 @@ func classifyRoute(path string) string {
 		return "api.search"
 	case strings.HasPrefix(path, "/api/v1/stream"):
 		return "api.stream"
+	case strings.HasPrefix(path, "/api/v1/timeline/events"):
+		return "api.timeline.events"
 	case strings.HasPrefix(path, "/assets/"):
 		return "assets"
 	case path == "/" || strings.EqualFold(path, "/index.html"):
@@ -736,6 +826,39 @@ func (h *handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func (h *handler) handleTimelineEvents(w http.ResponseWriter, r *http.Request) {
+	if h.timeline == nil {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"count": 0,
+			"items": []StreamEventEnvelope{},
+		})
+		return
+	}
+
+	limit := parseQueryLimit(r.URL.Query().Get("limit"), 100)
+	layer := strings.TrimSpace(r.URL.Query().Get("layer"))
+	correlationID := strings.TrimSpace(r.URL.Query().Get("correlation_id"))
+	sinceRaw := strings.TrimSpace(r.URL.Query().Get("since"))
+	var since time.Time
+	if sinceRaw != "" {
+		parsed, err := time.Parse(time.RFC3339, sinceRaw)
+		if err != nil {
+			parsed, err = time.Parse(time.RFC3339Nano, sinceRaw)
+		}
+		if err != nil {
+			http.Error(w, "invalid since timestamp", http.StatusBadRequest)
+			return
+		}
+		since = parsed
+	}
+
+	items := h.timeline.query(limit, layer, correlationID, since)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"count": len(items),
+		"items": items,
+	})
+}
+
 func (h *handler) handleStream(w http.ResponseWriter, r *http.Request) {
 	if h.opts.ListRegistry == nil && h.opts.ListSemantic == nil && h.opts.ListProjections == nil {
 		http.Error(w, "stream unavailable", http.StatusServiceUnavailable)
@@ -797,6 +920,7 @@ func (h *handler) handleStream(w http.ResponseWriter, r *http.Request) {
 			if dropped > 0 {
 				portalStreamDropped.Add(pending.Layer, int64(dropped))
 			}
+			h.timeline.add(*pending)
 			dropped = 0
 			pending = nil
 			sentEvents++

--- a/portal/handler_test.go
+++ b/portal/handler_test.go
@@ -145,6 +145,9 @@ func TestBootstrapEndpoint(t *testing.T) {
 	if endpoints["search"] != "/portal/api/v1/search" {
 		t.Fatalf("search endpoint=%v; want /portal/api/v1/search", endpoints["search"])
 	}
+	if endpoints["timeline"] != "/portal/api/v1/timeline/events" {
+		t.Fatalf("timeline endpoint=%v; want /portal/api/v1/timeline/events", endpoints["timeline"])
+	}
 	capabilities := payload["capabilities"].(map[string]any)
 	if capabilities["registry"] != true {
 		t.Fatalf("capabilities.registry=%v; want true", capabilities["registry"])
@@ -160,6 +163,9 @@ func TestBootstrapEndpoint(t *testing.T) {
 	}
 	if capabilities["stream"] != true {
 		t.Fatalf("capabilities.stream=%v; want true", capabilities["stream"])
+	}
+	if capabilities["timeline"] != true {
+		t.Fatalf("capabilities.timeline=%v; want true", capabilities["timeline"])
 	}
 }
 
@@ -540,5 +546,69 @@ func TestStreamEndpoint_UnavailableWithoutProviders(t *testing.T) {
 	h.ServeHTTP(rec, req)
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status=%d; want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+}
+
+func TestTimelineEventsEndpoint(t *testing.T) {
+	h := NewHandler(Options{
+		ListRegistry: func() []RegistryDevice {
+			return []RegistryDevice{{Address: 0x10, Manufacturer: "Vaillant", DeviceID: "VRC720"}}
+		},
+	})
+
+	streamReq := httptest.NewRequest(http.MethodGet, "/api/v1/stream?layers=registry&interval_ms=10&max_events_per_second=10&max_events=1", nil)
+	ctx, cancel := context.WithTimeout(streamReq.Context(), time.Second)
+	defer cancel()
+	streamReq = streamReq.WithContext(ctx)
+	streamRec := httptest.NewRecorder()
+	h.ServeHTTP(streamRec, streamReq)
+	if streamRec.Code != http.StatusOK {
+		t.Fatalf("stream status=%d; want %d", streamRec.Code, http.StatusOK)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/timeline/events?limit=10&layer=registry", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d; want %d", rec.Code, http.StatusOK)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if int(payload["count"].(float64)) < 1 {
+		t.Fatalf("count=%v; want >=1", payload["count"])
+	}
+	items := payload["items"].([]any)
+	first := items[0].(map[string]any)
+	if first["layer"] != "registry" {
+		t.Fatalf("layer=%v; want registry", first["layer"])
+	}
+
+	correlation := first["correlation_id"].(string)
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/timeline/events?correlation_id="+correlation, nil)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("correlation status=%d; want %d", rec.Code, http.StatusOK)
+	}
+	var filtered map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &filtered); err != nil {
+		t.Fatalf("filtered unmarshal: %v", err)
+	}
+	if int(filtered["count"].(float64)) < 1 {
+		t.Fatalf("filtered count=%v; want >=1", filtered["count"])
+	}
+}
+
+func TestTimelineEventsEndpoint_InvalidSince(t *testing.T) {
+	h := NewHandler(Options{
+		ListRegistry: func() []RegistryDevice { return []RegistryDevice{} },
+	})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/timeline/events?since=invalid", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d; want %d", rec.Code, http.StatusBadRequest)
 	}
 }

--- a/portal/static/assets/app.css
+++ b/portal/static/assets/app.css
@@ -194,6 +194,11 @@ body {
   color: var(--muted);
 }
 
+.timeline-filter {
+  width: 100%;
+  margin: 0 0 0.6rem;
+}
+
 .pill {
   display: inline-block;
   border: 1px solid var(--border);

--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -36,11 +36,20 @@ class PortalShell extends HTMLElement {
       this.streamSource.close();
       this.streamSource = undefined;
     }
+    if (this.timelineInterval) {
+      clearInterval(this.timelineInterval);
+      this.timelineInterval = undefined;
+    }
+    if (this.timelineTimer) {
+      clearTimeout(this.timelineTimer);
+      this.timelineTimer = undefined;
+    }
   }
 
   bindEvents() {
     const toggle = this.querySelector('[data-role="theme-toggle"]');
     const search = this.querySelector('[data-role="search-input"]');
+    const correlation = this.querySelector('[data-role="timeline-correlation"]');
     if (toggle) {
       toggle.addEventListener("click", () => {
         const current = loadTheme();
@@ -50,6 +59,11 @@ class PortalShell extends HTMLElement {
     if (search) {
       search.addEventListener("input", () => {
         this.scheduleSearch(search.value);
+      });
+    }
+    if (correlation) {
+      correlation.addEventListener("input", () => {
+        this.scheduleTimelineRefresh();
       });
     }
   }
@@ -62,6 +76,7 @@ class PortalShell extends HTMLElement {
     const projectionEl = this.querySelector('[data-role="projection-list"]');
     const searchInput = this.querySelector('[data-role="search-input"]');
     const searchList = this.querySelector('[data-role="search-list"]');
+    const timelineList = this.querySelector('[data-role="timeline-list"]');
     try {
       const [healthRes, bootstrapRes] = await Promise.all([
         fetch("api/v1/health"),
@@ -75,7 +90,7 @@ class PortalShell extends HTMLElement {
       if (metaEl) {
         const caps = bootstrap.capabilities || {};
         metaEl.textContent =
-          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, search=${caps.search}, stream=${caps.stream}`;
+          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, search=${caps.search}, stream=${caps.stream}, timeline=${caps.timeline}`;
       }
       if (searchInput) {
         searchInput.disabled = !bootstrap.capabilities?.search;
@@ -97,6 +112,20 @@ class PortalShell extends HTMLElement {
       }
       if (bootstrap.capabilities?.stream) {
         this.startStream();
+      }
+      if (timelineList) {
+        timelineList.innerHTML = bootstrap.capabilities?.timeline
+          ? "<li>Loading timeline events...</li>"
+          : "<li>Timeline unavailable: stream capability disabled.</li>";
+      }
+      if (bootstrap.capabilities?.timeline) {
+        await this.refreshTimeline();
+        if (this.timelineInterval) {
+          clearInterval(this.timelineInterval);
+        }
+        this.timelineInterval = setInterval(() => {
+          this.refreshTimeline();
+        }, 3000);
       }
     } catch (err) {
       if (statusEl) {
@@ -126,6 +155,7 @@ class PortalShell extends HTMLElement {
         const layer = payload.layer || "unknown";
         const at = payload.at || "n/a";
         streamStatus.textContent = `Stream live: layer=${layer} at=${at}`;
+        this.scheduleTimelineRefresh();
       } catch (err) {
         streamStatus.textContent = "Stream payload parse error";
       }
@@ -135,6 +165,49 @@ class PortalShell extends HTMLElement {
         streamStatus.textContent = "Stream disconnected";
       }
     };
+  }
+
+  scheduleTimelineRefresh() {
+    if (this.timelineTimer) {
+      clearTimeout(this.timelineTimer);
+    }
+    this.timelineTimer = setTimeout(() => {
+      this.refreshTimeline();
+    }, 220);
+  }
+
+  async refreshTimeline() {
+    const timelineList = this.querySelector('[data-role="timeline-list"]');
+    const correlationInput = this.querySelector('[data-role="timeline-correlation"]');
+    if (!timelineList) {
+      return;
+    }
+    try {
+      const correlation = correlationInput ? String(correlationInput.value || "").trim() : "";
+      const query = new URLSearchParams();
+      query.set("limit", "8");
+      if (correlation.length > 0) {
+        query.set("correlation_id", correlation);
+      }
+      const response = await fetch(`api/v1/timeline/events?${query.toString()}`);
+      const payload = await response.json();
+      const items = Array.isArray(payload.items) ? payload.items : [];
+      if (items.length === 0) {
+        timelineList.innerHTML = "<li>No timeline events yet.</li>";
+        return;
+      }
+      timelineList.innerHTML = items
+        .map((item) => {
+          const layer = escapeHtml(item.layer || "unknown");
+          const corr = escapeHtml(item.correlation_id || "n/a");
+          const at = escapeHtml(item.at || "n/a");
+          return `<li><span class="pill">${layer}</span> <strong>${corr}</strong> <span class="muted-inline">${at}</span></li>`;
+        })
+        .join("");
+    } catch (err) {
+      timelineList.innerHTML = "<li>Timeline query failed.</li>";
+      console.error("timeline query failed", err);
+    }
   }
 
   scheduleSearch(rawQuery) {
@@ -299,6 +372,13 @@ class PortalShell extends HTMLElement {
               <h2>Search Results</h2>
               <ul data-role="search-list">
                 <li>Loading search capability...</li>
+              </ul>
+            </section>
+            <section class="registry-preview">
+              <h2>Timeline</h2>
+              <input class="search timeline-filter" data-role="timeline-correlation" type="search" placeholder="Filter by correlation id" aria-label="Filter timeline by correlation id" />
+              <ul data-role="timeline-list">
+                <li>Loading timeline capability...</li>
               </ul>
             </section>
             <div class="meta" data-role="stream-status">Stream idle</div>

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,12 +2,12 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 11554,
-      "sha256": "d96c37a20ab8b27db0f51399a6f87912bc00fd9a949a3fcee5aa004cdcbc9f56"
+      "bytes": 14650,
+      "sha256": "e6a2ff8e1f0a4d64831a2c27297281abfdb054f36435c23ad4964e8d72d39979"
     },
     "app.css": {
-      "bytes": 3974,
-      "sha256": "ecbad65354a652d693375ffb961e6bbc52e4ef36a6eef632d334f578529d0901"
+      "bytes": 4033,
+      "sha256": "5a2df98bff2ccd8a35c2dccc2b00e18be52b698bc69da5f97ba95af1a1abc50c"
     }
   }
 }

--- a/portal/web/src/app.css
+++ b/portal/web/src/app.css
@@ -193,6 +193,11 @@ body {
   color: var(--muted);
 }
 
+.timeline-filter {
+  width: 100%;
+  margin: 0 0 0.6rem;
+}
+
 .pill {
   display: inline-block;
   border: 1px solid var(--border);

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -35,11 +35,20 @@ class PortalShell extends HTMLElement {
       this.streamSource.close();
       this.streamSource = undefined;
     }
+    if (this.timelineInterval) {
+      clearInterval(this.timelineInterval);
+      this.timelineInterval = undefined;
+    }
+    if (this.timelineTimer) {
+      clearTimeout(this.timelineTimer);
+      this.timelineTimer = undefined;
+    }
   }
 
   bindEvents() {
     const toggle = this.querySelector('[data-role="theme-toggle"]');
     const search = this.querySelector('[data-role="search-input"]');
+    const correlation = this.querySelector('[data-role="timeline-correlation"]');
     if (toggle) {
       toggle.addEventListener("click", () => {
         const current = loadTheme();
@@ -49,6 +58,11 @@ class PortalShell extends HTMLElement {
     if (search) {
       search.addEventListener("input", () => {
         this.scheduleSearch(search.value);
+      });
+    }
+    if (correlation) {
+      correlation.addEventListener("input", () => {
+        this.scheduleTimelineRefresh();
       });
     }
   }
@@ -61,6 +75,7 @@ class PortalShell extends HTMLElement {
     const projectionEl = this.querySelector('[data-role="projection-list"]');
     const searchInput = this.querySelector('[data-role="search-input"]');
     const searchList = this.querySelector('[data-role="search-list"]');
+    const timelineList = this.querySelector('[data-role="timeline-list"]');
     try {
       const [healthRes, bootstrapRes] = await Promise.all([
         fetch("api/v1/health"),
@@ -74,7 +89,7 @@ class PortalShell extends HTMLElement {
       if (metaEl) {
         const caps = bootstrap.capabilities || {};
         metaEl.textContent =
-          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, search=${caps.search}, stream=${caps.stream}`;
+          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, search=${caps.search}, stream=${caps.stream}, timeline=${caps.timeline}`;
       }
       if (searchInput) {
         searchInput.disabled = !bootstrap.capabilities?.search;
@@ -96,6 +111,20 @@ class PortalShell extends HTMLElement {
       }
       if (bootstrap.capabilities?.stream) {
         this.startStream();
+      }
+      if (timelineList) {
+        timelineList.innerHTML = bootstrap.capabilities?.timeline
+          ? "<li>Loading timeline events...</li>"
+          : "<li>Timeline unavailable: stream capability disabled.</li>";
+      }
+      if (bootstrap.capabilities?.timeline) {
+        await this.refreshTimeline();
+        if (this.timelineInterval) {
+          clearInterval(this.timelineInterval);
+        }
+        this.timelineInterval = setInterval(() => {
+          this.refreshTimeline();
+        }, 3000);
       }
     } catch (err) {
       if (statusEl) {
@@ -125,6 +154,7 @@ class PortalShell extends HTMLElement {
         const layer = payload.layer || "unknown";
         const at = payload.at || "n/a";
         streamStatus.textContent = `Stream live: layer=${layer} at=${at}`;
+        this.scheduleTimelineRefresh();
       } catch (err) {
         streamStatus.textContent = "Stream payload parse error";
       }
@@ -134,6 +164,49 @@ class PortalShell extends HTMLElement {
         streamStatus.textContent = "Stream disconnected";
       }
     };
+  }
+
+  scheduleTimelineRefresh() {
+    if (this.timelineTimer) {
+      clearTimeout(this.timelineTimer);
+    }
+    this.timelineTimer = setTimeout(() => {
+      this.refreshTimeline();
+    }, 220);
+  }
+
+  async refreshTimeline() {
+    const timelineList = this.querySelector('[data-role="timeline-list"]');
+    const correlationInput = this.querySelector('[data-role="timeline-correlation"]');
+    if (!timelineList) {
+      return;
+    }
+    try {
+      const correlation = correlationInput ? String(correlationInput.value || "").trim() : "";
+      const query = new URLSearchParams();
+      query.set("limit", "8");
+      if (correlation.length > 0) {
+        query.set("correlation_id", correlation);
+      }
+      const response = await fetch(`api/v1/timeline/events?${query.toString()}`);
+      const payload = await response.json();
+      const items = Array.isArray(payload.items) ? payload.items : [];
+      if (items.length === 0) {
+        timelineList.innerHTML = "<li>No timeline events yet.</li>";
+        return;
+      }
+      timelineList.innerHTML = items
+        .map((item) => {
+          const layer = escapeHtml(item.layer || "unknown");
+          const corr = escapeHtml(item.correlation_id || "n/a");
+          const at = escapeHtml(item.at || "n/a");
+          return `<li><span class="pill">${layer}</span> <strong>${corr}</strong> <span class="muted-inline">${at}</span></li>`;
+        })
+        .join("");
+    } catch (err) {
+      timelineList.innerHTML = "<li>Timeline query failed.</li>";
+      console.error("timeline query failed", err);
+    }
   }
 
   scheduleSearch(rawQuery) {
@@ -298,6 +371,13 @@ class PortalShell extends HTMLElement {
               <h2>Search Results</h2>
               <ul data-role="search-list">
                 <li>Loading search capability...</li>
+              </ul>
+            </section>
+            <section class="registry-preview">
+              <h2>Timeline</h2>
+              <input class="search timeline-filter" data-role="timeline-correlation" type="search" placeholder="Filter by correlation id" aria-label="Filter timeline by correlation id" />
+              <ul data-role="timeline-list">
+                <li>Loading timeline capability...</li>
               </ul>
             </section>
             <div class="meta" data-role="stream-status">Stream idle</div>


### PR DESCRIPTION
## Summary
- add timeline store in portal handler (in-memory ring buffer) populated from emitted stream events
- add timeline query endpoint: `GET /portal/api/v1/timeline/events`
- add timeline capability + endpoint metadata to bootstrap payload
- support timeline filtering via `limit`, `layer`, `correlation_id`, and `since`
- extend portal UI with timeline preview and correlation-id filter
- add tests for timeline endpoint behavior and bootstrap flags

## Testing
- `GOWORK=off go test ./portal ./ui`
- `./scripts/check_portal_assets.sh`

## Docs
- docs updated directly on main: d3vi1/helianthus-docs-ebus@bc3d19c

Closes #154
