### PR TITLE
MCP-10-005: invoke safety rails + idempotency

### DIFF
--- a/mcp/server.go
+++ b/mcp/server.go
@@ -13,6 +13,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	ebuserrors "github.com/d3vi1/helianthus-ebusgo/errors"
@@ -86,6 +87,8 @@ type Server struct {
 	invoker        Invoker
 	statusProvider StatusProvider
 	semantic       SemanticProvider
+	idempotencyMu  sync.Mutex
+	idempotency    map[string]idempotencyEntry
 
 	tools []Tool
 }
@@ -108,9 +111,12 @@ const (
 	methodDangerUnknown       = "unknown"
 	methodDangerSafe          = "safe"
 	methodDangerDangerous     = "dangerous"
+	defaultInvokeTimeout      = 3 * time.Second
+	defaultIdempotencyTTL     = 30 * time.Second
 )
 
 var errInvokePermissionDenied = errors.New("invoke permission denied")
+var errInvokeIdempotencyConflict = errors.New("invoke idempotency conflict")
 
 type staticStatusProvider struct{}
 type staticSemanticProvider struct{}
@@ -144,6 +150,18 @@ func (staticSemanticProvider) EnergyTotals() *EnergyTotals {
 	return nil
 }
 
+type idempotencyEntry struct {
+	signature string
+	result    any
+	expiresAt time.Time
+}
+
+type invokeV1Policy struct {
+	intent         string
+	idempotencyKey string
+	timeout        time.Duration
+}
+
 func NewServer(reg Registry, invoker Invoker) (*Server, error) {
 	if reg == nil {
 		return nil, fmt.Errorf("mcp server missing registry: %w", ebuserrors.ErrInvalidPayload)
@@ -154,6 +172,7 @@ func NewServer(reg Registry, invoker Invoker) (*Server, error) {
 		invoker:        invoker,
 		statusProvider: staticStatusProvider{},
 		semantic:       staticSemanticProvider{},
+		idempotency:    make(map[string]idempotencyEntry),
 	}
 	server.tools = []Tool{
 		{
@@ -231,6 +250,7 @@ func NewServer(reg Registry, invoker Invoker) (*Server, error) {
 					"intent":          map[string]any{"type": "string", "enum": []string{"READ_ONLY", "MUTATE"}},
 					"allow_dangerous": map[string]any{"type": "boolean"},
 					"idempotency_key": map[string]any{"type": "string"},
+					"timeout_ms":      map[string]any{"type": "integer", "minimum": 1},
 				},
 				"required":             []string{"address", "plane", "method", "intent", "allow_dangerous"},
 				"additionalProperties": false,
@@ -425,12 +445,36 @@ func (s *Server) handleToolsCall(ctx context.Context, params json.RawMessage) (a
 		if s.invoker == nil {
 			return nil, rpcErrorInternal("server missing invoker")
 		}
-		if err := s.enforceInvokeV1Safety(call.Arguments); err != nil {
-			return callToolResultText(mustJSON(newToolEnvelope(nil, err)), true), nil
-		}
-		out, err := s.invoke(ctx, call.Arguments)
+		policy, err := s.enforceInvokeV1Safety(call.Arguments)
 		if err != nil {
 			return callToolResultText(mustJSON(newToolEnvelope(nil, err)), true), nil
+		}
+		signature := ""
+		if policy.intent == "MUTATE" {
+			signature, err = buildInvokeIdempotencySignature(call.Arguments)
+			if err != nil {
+				return callToolResultText(mustJSON(newToolEnvelope(nil, err)), true), nil
+			}
+			if cached, ok, err := s.lookupIdempotency(policy.idempotencyKey, signature); err != nil {
+				return callToolResultText(mustJSON(newToolEnvelope(nil, err)), true), nil
+			} else if ok {
+				return callToolResultText(mustJSON(newToolEnvelope(cached, nil)), false), nil
+			}
+		}
+
+		invokeCtx := ctx
+		cancel := func() {}
+		if policy.timeout > 0 {
+			invokeCtx, cancel = context.WithTimeout(ctx, policy.timeout)
+		}
+		defer cancel()
+
+		out, err := s.invoke(invokeCtx, call.Arguments)
+		if err != nil {
+			return callToolResultText(mustJSON(newToolEnvelope(nil, err)), true), nil
+		}
+		if policy.intent == "MUTATE" {
+			s.storeIdempotency(policy.idempotencyKey, signature, out)
 		}
 		return callToolResultText(mustJSON(newToolEnvelope(out, nil)), false), nil
 	case toolInvokeLegacyName:
@@ -490,8 +534,12 @@ func hashData(data any) string {
 
 func classifyToolError(err error) (code string, retriable bool, sourceLayer string) {
 	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		return "TIMEOUT", true, "gateway"
 	case errors.Is(err, errInvokePermissionDenied):
 		return "PERMISSION_DENIED", false, "gateway"
+	case errors.Is(err, errInvokeIdempotencyConflict):
+		return "CONFLICT", false, "gateway"
 	case errors.Is(err, ebuserrors.ErrInvalidPayload):
 		return "INVALID_ARGUMENT", false, "ebusreg"
 	case errors.Is(err, ebuserrors.ErrNoSuchDevice):
@@ -513,52 +561,63 @@ func classifyToolError(err error) (code string, retriable bool, sourceLayer stri
 	}
 }
 
-func (s *Server) enforceInvokeV1Safety(args map[string]any) error {
+func (s *Server) enforceInvokeV1Safety(args map[string]any) (invokeV1Policy, error) {
+	policy := invokeV1Policy{
+		timeout: defaultInvokeTimeout,
+	}
+
 	address, err := parseAddress(args["address"])
 	if err != nil {
-		return err
+		return invokeV1Policy{}, err
 	}
 	planeName, _ := args["plane"].(string)
 	if planeName == "" {
-		return fmt.Errorf("missing plane: %w", ebuserrors.ErrInvalidPayload)
+		return invokeV1Policy{}, fmt.Errorf("missing plane: %w", ebuserrors.ErrInvalidPayload)
 	}
 	methodName, _ := args["method"].(string)
 	if methodName == "" {
-		return fmt.Errorf("missing method: %w", ebuserrors.ErrInvalidPayload)
+		return invokeV1Policy{}, fmt.Errorf("missing method: %w", ebuserrors.ErrInvalidPayload)
 	}
 	intent, _ := args["intent"].(string)
 	intent = strings.TrimSpace(intent)
 	if intent == "" {
-		return fmt.Errorf("missing intent: %w", ebuserrors.ErrInvalidPayload)
+		return invokeV1Policy{}, fmt.Errorf("missing intent: %w", ebuserrors.ErrInvalidPayload)
 	}
+	policy.intent = intent
 	allowDangerous, ok := args["allow_dangerous"].(bool)
 	if !ok {
-		return fmt.Errorf("missing allow_dangerous: %w", ebuserrors.ErrInvalidPayload)
+		return invokeV1Policy{}, fmt.Errorf("missing allow_dangerous: %w", ebuserrors.ErrInvalidPayload)
+	}
+	if timeout, err := parseInvokeTimeout(args["timeout_ms"]); err != nil {
+		return invokeV1Policy{}, err
+	} else if timeout > 0 {
+		policy.timeout = timeout
 	}
 
 	methodKnown, methodReadOnly, err := s.lookupMethodMutability(address, planeName, methodName)
 	if err != nil {
-		return err
+		return invokeV1Policy{}, err
 	}
 
 	switch intent {
 	case "READ_ONLY":
 		if !methodKnown || !methodReadOnly {
-			return fmt.Errorf("READ_ONLY intent denied for mutating/unknown method: %w", errInvokePermissionDenied)
+			return invokeV1Policy{}, fmt.Errorf("READ_ONLY intent denied for mutating/unknown method: %w", errInvokePermissionDenied)
 		}
 	case "MUTATE":
 		if !allowDangerous {
-			return fmt.Errorf("MUTATE intent requires allow_dangerous=true: %w", errInvokePermissionDenied)
+			return invokeV1Policy{}, fmt.Errorf("MUTATE intent requires allow_dangerous=true: %w", errInvokePermissionDenied)
 		}
 		idempotencyKey, _ := args["idempotency_key"].(string)
 		if strings.TrimSpace(idempotencyKey) == "" {
-			return fmt.Errorf("MUTATE intent requires idempotency_key: %w", errInvokePermissionDenied)
+			return invokeV1Policy{}, fmt.Errorf("MUTATE intent requires idempotency_key: %w", errInvokePermissionDenied)
 		}
+		policy.idempotencyKey = strings.TrimSpace(idempotencyKey)
 	default:
-		return fmt.Errorf("invalid intent %q: %w", intent, ebuserrors.ErrInvalidPayload)
+		return invokeV1Policy{}, fmt.Errorf("invalid intent %q: %w", intent, ebuserrors.ErrInvalidPayload)
 	}
 
-	return nil
+	return policy, nil
 }
 
 func (s *Server) lookupMethodMutability(address byte, planeName string, methodName string) (methodKnown bool, methodReadOnly bool, err error) {
@@ -584,6 +643,94 @@ func (s *Server) lookupMethodMutability(address byte, planeName string, methodNa
 		}
 	}
 	return false, false, nil
+}
+
+func parseInvokeTimeout(raw any) (time.Duration, error) {
+	if raw == nil {
+		return defaultInvokeTimeout, nil
+	}
+
+	switch value := raw.(type) {
+	case int:
+		if value <= 0 {
+			return 0, fmt.Errorf("invalid timeout_ms: %w", ebuserrors.ErrInvalidPayload)
+		}
+		return time.Duration(value) * time.Millisecond, nil
+	case int64:
+		if value <= 0 {
+			return 0, fmt.Errorf("invalid timeout_ms: %w", ebuserrors.ErrInvalidPayload)
+		}
+		return time.Duration(value) * time.Millisecond, nil
+	case float64:
+		if value <= 0 || value != float64(int(value)) {
+			return 0, fmt.Errorf("invalid timeout_ms: %w", ebuserrors.ErrInvalidPayload)
+		}
+		return time.Duration(int(value)) * time.Millisecond, nil
+	default:
+		return 0, fmt.Errorf("invalid timeout_ms: %w", ebuserrors.ErrInvalidPayload)
+	}
+}
+
+func buildInvokeIdempotencySignature(args map[string]any) (string, error) {
+	payload := map[string]any{
+		"address": args["address"],
+		"plane":   args["plane"],
+		"method":  args["method"],
+		"params":  args["params"],
+		"intent":  args["intent"],
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("failed to canonicalize idempotency payload: %w", ebuserrors.ErrInvalidPayload)
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func (s *Server) lookupIdempotency(key string, signature string) (any, bool, error) {
+	now := time.Now()
+	s.idempotencyMu.Lock()
+	defer s.idempotencyMu.Unlock()
+
+	for candidate, entry := range s.idempotency {
+		if now.After(entry.expiresAt) {
+			delete(s.idempotency, candidate)
+		}
+	}
+
+	entry, ok := s.idempotency[key]
+	if !ok {
+		return nil, false, nil
+	}
+	if entry.signature != signature {
+		return nil, false, fmt.Errorf("idempotency key reused with different payload: %w", errInvokeIdempotencyConflict)
+	}
+	return cloneJSONValue(entry.result), true, nil
+}
+
+func (s *Server) storeIdempotency(key string, signature string, result any) {
+	if strings.TrimSpace(key) == "" {
+		return
+	}
+	s.idempotencyMu.Lock()
+	s.idempotency[key] = idempotencyEntry{
+		signature: signature,
+		result:    cloneJSONValue(result),
+		expiresAt: time.Now().Add(defaultIdempotencyTTL),
+	}
+	s.idempotencyMu.Unlock()
+}
+
+func cloneJSONValue(value any) any {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return value
+	}
+	var out any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return value
+	}
+	return out
 }
 
 type deviceInfo struct {

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	ebuserrors "github.com/d3vi1/helianthus-ebusgo/errors"
 	"github.com/d3vi1/helianthus-ebusgo/protocol"
@@ -129,6 +130,21 @@ func (i *testInvoker) Invoke(ctx context.Context, plane router.Plane, methodName
 	return map[string]any{"ok": true}, nil
 }
 
+type slowInvoker struct {
+	delay time.Duration
+	calls int
+}
+
+func (i *slowInvoker) Invoke(ctx context.Context, plane router.Plane, methodName string, params map[string]any) (any, error) {
+	i.calls++
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-time.After(i.delay):
+		return map[string]any{"ok": true}, nil
+	}
+}
+
 type testStatusProvider struct {
 	daemon  ServiceStatus
 	adapter ServiceStatus
@@ -239,7 +255,7 @@ func TestServer_InitializeAndTools(t *testing.T) {
 	if !ok {
 		t.Fatalf("invoke v1 properties type = %T; want map", inputSchema["properties"])
 	}
-	for _, key := range []string{"intent", "allow_dangerous", "idempotency_key"} {
+	for _, key := range []string{"intent", "allow_dangerous", "idempotency_key", "timeout_ms"} {
 		if _, ok := properties[key]; !ok {
 			t.Fatalf("invoke v1 properties missing %q", key)
 		}
@@ -862,6 +878,109 @@ func TestServer_ToolsCallInvokeV1SafetyGuards(t *testing.T) {
 	})
 }
 
+func TestServer_ToolsCallInvokeV1Idempotency(t *testing.T) {
+	plane := &testPlane{
+		name: "heating",
+		methods: []registry.Method{
+			testMethod{
+				name:     "set_target",
+				readOnly: false,
+				template: testTemplate{primary: 0xB5, secondary: 0x05},
+			},
+		},
+	}
+	entry := testEntry{
+		info: registry.DeviceInfo{
+			Address:         0x08,
+			Manufacturer:    "vaillant",
+			DeviceID:        "device-a",
+			SoftwareVersion: "1.0",
+			HardwareVersion: "7603",
+		},
+		planes: []registry.Plane{plane},
+	}
+	reg := &testRegistry{
+		entries: map[byte]registry.DeviceEntry{0x08: entry},
+		order:   []byte{0x08},
+	}
+	invoker := &testInvoker{}
+	server, err := NewServer(reg, invoker)
+	if err != nil {
+		t.Fatalf("NewServer error = %v", err)
+	}
+
+	first := doRPC(t, server.Handler(), rpcRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"ebus.v1.rpc.invoke","arguments":{"address":8,"plane":"heating","method":"set_target","params":{"target_c":21.5},"intent":"MUTATE","allow_dangerous":true,"idempotency_key":"abc123"}}`),
+	})
+	if first.Error != nil {
+		t.Fatalf("first invoke rpc error = %+v", first.Error)
+	}
+
+	second := doRPC(t, server.Handler(), rpcRequest{
+		JSONRPC: "2.0",
+		ID:      2,
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"ebus.v1.rpc.invoke","arguments":{"address":8,"plane":"heating","method":"set_target","params":{"target_c":21.5},"intent":"MUTATE","allow_dangerous":true,"idempotency_key":"abc123"}}`),
+	})
+	if second.Error != nil {
+		t.Fatalf("second invoke rpc error = %+v", second.Error)
+	}
+	if len(invoker.calls) != 1 {
+		t.Fatalf("invoker calls = %d; want 1 (deduped)", len(invoker.calls))
+	}
+
+	conflict := doRPC(t, server.Handler(), rpcRequest{
+		JSONRPC: "2.0",
+		ID:      3,
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"ebus.v1.rpc.invoke","arguments":{"address":8,"plane":"heating","method":"set_target","params":{"target_c":22.0},"intent":"MUTATE","allow_dangerous":true,"idempotency_key":"abc123"}}`),
+	})
+	assertToolErrorCode(t, conflict, "CONFLICT")
+}
+
+func TestServer_ToolsCallInvokeV1Timeout(t *testing.T) {
+	plane := &testPlane{
+		name: "heating",
+		methods: []registry.Method{
+			testMethod{
+				name:     "get_status",
+				readOnly: true,
+				template: testTemplate{primary: 0xB5, secondary: 0x04},
+			},
+		},
+	}
+	entry := testEntry{
+		info: registry.DeviceInfo{
+			Address:         0x08,
+			Manufacturer:    "vaillant",
+			DeviceID:        "device-a",
+			SoftwareVersion: "1.0",
+			HardwareVersion: "7603",
+		},
+		planes: []registry.Plane{plane},
+	}
+	reg := &testRegistry{
+		entries: map[byte]registry.DeviceEntry{0x08: entry},
+		order:   []byte{0x08},
+	}
+	invoker := &slowInvoker{delay: 50 * time.Millisecond}
+	server, err := NewServer(reg, invoker)
+	if err != nil {
+		t.Fatalf("NewServer error = %v", err)
+	}
+
+	res := doRPC(t, server.Handler(), rpcRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"ebus.v1.rpc.invoke","arguments":{"address":8,"plane":"heating","method":"get_status","params":{},"intent":"READ_ONLY","allow_dangerous":false,"timeout_ms":1}}`),
+	})
+	assertToolErrorCode(t, res, "TIMEOUT")
+}
+
 func TestClassifyToolError_KnownMappings(t *testing.T) {
 	t.Parallel()
 
@@ -880,6 +999,8 @@ func TestClassifyToolError_KnownMappings(t *testing.T) {
 		{name: "transport closed", err: ebuserrors.ErrTransportClosed, code: "BUS_UNAVAILABLE", retriable: false, sourceLayer: "ebusgo"},
 		{name: "bus collision", err: ebuserrors.ErrBusCollision, code: "BUS_UNAVAILABLE", retriable: true, sourceLayer: "ebusgo"},
 		{name: "retry exhausted", err: ebuserrors.ErrRetryExhausted, code: "BUS_UNAVAILABLE", retriable: true, sourceLayer: "ebusgo"},
+		{name: "deadline exceeded", err: context.DeadlineExceeded, code: "TIMEOUT", retriable: true, sourceLayer: "gateway"},
+		{name: "idempotency conflict", err: errInvokeIdempotencyConflict, code: "CONFLICT", retriable: false, sourceLayer: "gateway"},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary
- extend ebus.v1.rpc.invoke with deterministic timeout_ms policy (default 3000ms)
- add in-memory idempotency dedupe for MUTATE calls with key+payload signature window
- reject idempotency key reuse with different payload using stable CONFLICT error mapping
- map context deadline to TIMEOUT and keep stable taxonomy for invoke failures
- expand MCP tests for timeout, dedupe replay, and conflict behavior

## Issue
Closes #134

## Base Branch
- mcpfirst-cruise-control

## Architecture Source
- d3vi1/helianthus-docs-ebus#124

## Validation
- GOWORK=off go test ./mcp -count=1 (pass)
- GOWORK=off ./scripts/ci_local.sh (fails on pre-existing baseline outside this PR):
  - graphql/schema.go uses entry.Addresses on registry.DeviceEntry
  - gateway.go references transport.NewTCPPlainTransport
