### PR TITLE
feat(portal): add provenance inspector endpoint and UI

### DIFF
--- a/portal/handler.go
+++ b/portal/handler.go
@@ -180,6 +180,18 @@ type StreamSource struct {
 	Interval int    `json:"interval_ms"`
 }
 
+type ProvenanceRecord struct {
+	CorrelationID string   `json:"correlation_id"`
+	Layer         string   `json:"layer"`
+	At            string   `json:"at"`
+	Source        string   `json:"source"`
+	Dropped       int      `json:"dropped"`
+	IntervalMS    int      `json:"interval_ms"`
+	DecodePath    []string `json:"decode_path"`
+	PayloadKeys   []string `json:"payload_keys"`
+	Confidence    float64  `json:"confidence"`
+}
+
 type timelineBuffer struct {
 	mu      sync.Mutex
 	cap     int
@@ -356,6 +368,7 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 				"search":     h.opts.ListRegistry != nil || h.opts.ListSemantic != nil || h.opts.ListProjections != nil,
 				"stream":     streamEnabled,
 				"timeline":   streamEnabled,
+				"provenance": streamEnabled,
 			},
 			"endpoints": map[string]string{
 				"graphql":       h.opts.GraphQLPath,
@@ -365,6 +378,7 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 				"search":        "/portal/api/v1/search",
 				"stream":        "/portal/api/v1/stream",
 				"timeline":      "/portal/api/v1/timeline/events",
+				"provenance":    "/portal/api/v1/provenance/events",
 			},
 			"limits": map[string]any{
 				"max_events_per_second": 200,
@@ -386,6 +400,8 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 		h.handleStream(w, r)
 	case "timeline/events":
 		h.handleTimelineEvents(w, r)
+	case "provenance/events":
+		h.handleProvenanceEvents(w, r)
 	default:
 		http.NotFound(w, r)
 	}
@@ -440,6 +456,8 @@ func classifyRoute(path string) string {
 		return "api.stream"
 	case strings.HasPrefix(path, "/api/v1/timeline/events"):
 		return "api.timeline.events"
+	case strings.HasPrefix(path, "/api/v1/provenance/events"):
+		return "api.provenance.events"
 	case strings.HasPrefix(path, "/assets/"):
 		return "assets"
 	case path == "/" || strings.EqualFold(path, "/index.html"):
@@ -857,6 +875,53 @@ func (h *handler) handleTimelineEvents(w http.ResponseWriter, r *http.Request) {
 		"count": len(items),
 		"items": items,
 	})
+}
+
+func (h *handler) handleProvenanceEvents(w http.ResponseWriter, r *http.Request) {
+	if h.timeline == nil {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"count": 0,
+			"items": []ProvenanceRecord{},
+		})
+		return
+	}
+	limit := parseQueryLimit(r.URL.Query().Get("limit"), 50)
+	layer := strings.TrimSpace(r.URL.Query().Get("layer"))
+	correlationID := strings.TrimSpace(r.URL.Query().Get("correlation_id"))
+	items := h.timeline.query(limit, layer, correlationID, time.Time{})
+
+	records := make([]ProvenanceRecord, 0, len(items))
+	for _, item := range items {
+		records = append(records, toProvenanceRecord(item))
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"count": len(records),
+		"items": records,
+	})
+}
+
+func toProvenanceRecord(event StreamEventEnvelope) ProvenanceRecord {
+	keys := make([]string, 0, len(event.Payload))
+	for key := range event.Payload {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return ProvenanceRecord{
+		CorrelationID: event.CorrelationID,
+		Layer:         event.Layer,
+		At:            event.At,
+		Source:        event.Provenance.Source,
+		Dropped:       event.Provenance.Dropped,
+		IntervalMS:    event.Provenance.Interval,
+		DecodePath: []string{
+			fmt.Sprintf("source:%s", event.Provenance.Source),
+			fmt.Sprintf("layer:%s", event.Layer),
+			"gateway.portal.stream",
+			"gateway.portal.timeline",
+		},
+		PayloadKeys: keys,
+		Confidence:  0.7,
+	}
 }
 
 func (h *handler) handleStream(w http.ResponseWriter, r *http.Request) {

--- a/portal/handler_test.go
+++ b/portal/handler_test.go
@@ -148,6 +148,9 @@ func TestBootstrapEndpoint(t *testing.T) {
 	if endpoints["timeline"] != "/portal/api/v1/timeline/events" {
 		t.Fatalf("timeline endpoint=%v; want /portal/api/v1/timeline/events", endpoints["timeline"])
 	}
+	if endpoints["provenance"] != "/portal/api/v1/provenance/events" {
+		t.Fatalf("provenance endpoint=%v; want /portal/api/v1/provenance/events", endpoints["provenance"])
+	}
 	capabilities := payload["capabilities"].(map[string]any)
 	if capabilities["registry"] != true {
 		t.Fatalf("capabilities.registry=%v; want true", capabilities["registry"])
@@ -166,6 +169,9 @@ func TestBootstrapEndpoint(t *testing.T) {
 	}
 	if capabilities["timeline"] != true {
 		t.Fatalf("capabilities.timeline=%v; want true", capabilities["timeline"])
+	}
+	if capabilities["provenance"] != true {
+		t.Fatalf("capabilities.provenance=%v; want true", capabilities["provenance"])
 	}
 }
 
@@ -610,5 +616,48 @@ func TestTimelineEventsEndpoint_InvalidSince(t *testing.T) {
 	h.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status=%d; want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestProvenanceEventsEndpoint(t *testing.T) {
+	h := NewHandler(Options{
+		ListRegistry: func() []RegistryDevice {
+			return []RegistryDevice{{Address: 0x10, Manufacturer: "Vaillant", DeviceID: "VRC720"}}
+		},
+	})
+
+	streamReq := httptest.NewRequest(http.MethodGet, "/api/v1/stream?layers=registry&interval_ms=10&max_events_per_second=10&max_events=1", nil)
+	ctx, cancel := context.WithTimeout(streamReq.Context(), time.Second)
+	defer cancel()
+	streamReq = streamReq.WithContext(ctx)
+	streamRec := httptest.NewRecorder()
+	h.ServeHTTP(streamRec, streamReq)
+	if streamRec.Code != http.StatusOK {
+		t.Fatalf("stream status=%d; want %d", streamRec.Code, http.StatusOK)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/provenance/events?limit=5&layer=registry", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d; want %d", rec.Code, http.StatusOK)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if int(payload["count"].(float64)) < 1 {
+		t.Fatalf("count=%v; want >=1", payload["count"])
+	}
+	items := payload["items"].([]any)
+	first := items[0].(map[string]any)
+	if first["layer"] != "registry" {
+		t.Fatalf("layer=%v; want registry", first["layer"])
+	}
+	if first["source"] == "" {
+		t.Fatalf("source missing")
+	}
+	if first["confidence"] == nil {
+		t.Fatalf("confidence missing")
 	}
 }

--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -44,12 +44,21 @@ class PortalShell extends HTMLElement {
       clearTimeout(this.timelineTimer);
       this.timelineTimer = undefined;
     }
+    if (this.provenanceInterval) {
+      clearInterval(this.provenanceInterval);
+      this.provenanceInterval = undefined;
+    }
+    if (this.provenanceTimer) {
+      clearTimeout(this.provenanceTimer);
+      this.provenanceTimer = undefined;
+    }
   }
 
   bindEvents() {
     const toggle = this.querySelector('[data-role="theme-toggle"]');
     const search = this.querySelector('[data-role="search-input"]');
     const correlation = this.querySelector('[data-role="timeline-correlation"]');
+    const provenanceCorrelation = this.querySelector('[data-role="provenance-correlation"]');
     if (toggle) {
       toggle.addEventListener("click", () => {
         const current = loadTheme();
@@ -66,6 +75,11 @@ class PortalShell extends HTMLElement {
         this.scheduleTimelineRefresh();
       });
     }
+    if (provenanceCorrelation) {
+      provenanceCorrelation.addEventListener("input", () => {
+        this.scheduleProvenanceRefresh();
+      });
+    }
   }
 
   async loadStatus() {
@@ -77,6 +91,7 @@ class PortalShell extends HTMLElement {
     const searchInput = this.querySelector('[data-role="search-input"]');
     const searchList = this.querySelector('[data-role="search-list"]');
     const timelineList = this.querySelector('[data-role="timeline-list"]');
+    const provenanceList = this.querySelector('[data-role="provenance-list"]');
     try {
       const [healthRes, bootstrapRes] = await Promise.all([
         fetch("api/v1/health"),
@@ -90,7 +105,7 @@ class PortalShell extends HTMLElement {
       if (metaEl) {
         const caps = bootstrap.capabilities || {};
         metaEl.textContent =
-          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, search=${caps.search}, stream=${caps.stream}, timeline=${caps.timeline}`;
+          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, search=${caps.search}, stream=${caps.stream}, timeline=${caps.timeline}, provenance=${caps.provenance}`;
       }
       if (searchInput) {
         searchInput.disabled = !bootstrap.capabilities?.search;
@@ -127,6 +142,20 @@ class PortalShell extends HTMLElement {
           this.refreshTimeline();
         }, 3000);
       }
+      if (provenanceList) {
+        provenanceList.innerHTML = bootstrap.capabilities?.provenance
+          ? "<li>Loading provenance records...</li>"
+          : "<li>Provenance unavailable: stream capability disabled.</li>";
+      }
+      if (bootstrap.capabilities?.provenance) {
+        await this.refreshProvenance();
+        if (this.provenanceInterval) {
+          clearInterval(this.provenanceInterval);
+        }
+        this.provenanceInterval = setInterval(() => {
+          this.refreshProvenance();
+        }, 4000);
+      }
     } catch (err) {
       if (statusEl) {
         statusEl.textContent = "Gateway unavailable";
@@ -156,6 +185,7 @@ class PortalShell extends HTMLElement {
         const at = payload.at || "n/a";
         streamStatus.textContent = `Stream live: layer=${layer} at=${at}`;
         this.scheduleTimelineRefresh();
+        this.scheduleProvenanceRefresh();
       } catch (err) {
         streamStatus.textContent = "Stream payload parse error";
       }
@@ -207,6 +237,50 @@ class PortalShell extends HTMLElement {
     } catch (err) {
       timelineList.innerHTML = "<li>Timeline query failed.</li>";
       console.error("timeline query failed", err);
+    }
+  }
+
+  scheduleProvenanceRefresh() {
+    if (this.provenanceTimer) {
+      clearTimeout(this.provenanceTimer);
+    }
+    this.provenanceTimer = setTimeout(() => {
+      this.refreshProvenance();
+    }, 220);
+  }
+
+  async refreshProvenance() {
+    const provenanceList = this.querySelector('[data-role="provenance-list"]');
+    const provenanceCorrelation = this.querySelector('[data-role="provenance-correlation"]');
+    if (!provenanceList) {
+      return;
+    }
+    try {
+      const correlation = provenanceCorrelation ? String(provenanceCorrelation.value || "").trim() : "";
+      const query = new URLSearchParams();
+      query.set("limit", "8");
+      if (correlation.length > 0) {
+        query.set("correlation_id", correlation);
+      }
+      const response = await fetch(`api/v1/provenance/events?${query.toString()}`);
+      const payload = await response.json();
+      const items = Array.isArray(payload.items) ? payload.items : [];
+      if (items.length === 0) {
+        provenanceList.innerHTML = "<li>No provenance records yet.</li>";
+        return;
+      }
+      provenanceList.innerHTML = items
+        .map((item) => {
+          const source = escapeHtml(item.source || "unknown");
+          const corr = escapeHtml(item.correlation_id || "n/a");
+          const keys = Array.isArray(item.payload_keys) ? item.payload_keys.join(",") : "";
+          const confidence = Number(item.confidence || 0).toFixed(2);
+          return `<li><span class="pill">prov</span> <strong>${corr}</strong> <span class="muted-inline">${source} keys=${escapeHtml(keys)} conf=${confidence}</span></li>`;
+        })
+        .join("");
+    } catch (err) {
+      provenanceList.innerHTML = "<li>Provenance query failed.</li>";
+      console.error("provenance query failed", err);
     }
   }
 
@@ -379,6 +453,13 @@ class PortalShell extends HTMLElement {
               <input class="search timeline-filter" data-role="timeline-correlation" type="search" placeholder="Filter by correlation id" aria-label="Filter timeline by correlation id" />
               <ul data-role="timeline-list">
                 <li>Loading timeline capability...</li>
+              </ul>
+            </section>
+            <section class="registry-preview">
+              <h2>Provenance Inspector</h2>
+              <input class="search timeline-filter" data-role="provenance-correlation" type="search" placeholder="Filter provenance by correlation id" aria-label="Filter provenance by correlation id" />
+              <ul data-role="provenance-list">
+                <li>Loading provenance capability...</li>
               </ul>
             </section>
             <div class="meta" data-role="stream-status">Stream idle</div>

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,8 +2,8 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 14650,
-      "sha256": "e6a2ff8e1f0a4d64831a2c27297281abfdb054f36435c23ad4964e8d72d39979"
+      "bytes": 18063,
+      "sha256": "4a1f0c5e190ef6b3a46c2b84ecd811f331323fa8eef656da4c7bc292bdf8ea97"
     },
     "app.css": {
       "bytes": 4033,

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -43,12 +43,21 @@ class PortalShell extends HTMLElement {
       clearTimeout(this.timelineTimer);
       this.timelineTimer = undefined;
     }
+    if (this.provenanceInterval) {
+      clearInterval(this.provenanceInterval);
+      this.provenanceInterval = undefined;
+    }
+    if (this.provenanceTimer) {
+      clearTimeout(this.provenanceTimer);
+      this.provenanceTimer = undefined;
+    }
   }
 
   bindEvents() {
     const toggle = this.querySelector('[data-role="theme-toggle"]');
     const search = this.querySelector('[data-role="search-input"]');
     const correlation = this.querySelector('[data-role="timeline-correlation"]');
+    const provenanceCorrelation = this.querySelector('[data-role="provenance-correlation"]');
     if (toggle) {
       toggle.addEventListener("click", () => {
         const current = loadTheme();
@@ -65,6 +74,11 @@ class PortalShell extends HTMLElement {
         this.scheduleTimelineRefresh();
       });
     }
+    if (provenanceCorrelation) {
+      provenanceCorrelation.addEventListener("input", () => {
+        this.scheduleProvenanceRefresh();
+      });
+    }
   }
 
   async loadStatus() {
@@ -76,6 +90,7 @@ class PortalShell extends HTMLElement {
     const searchInput = this.querySelector('[data-role="search-input"]');
     const searchList = this.querySelector('[data-role="search-list"]');
     const timelineList = this.querySelector('[data-role="timeline-list"]');
+    const provenanceList = this.querySelector('[data-role="provenance-list"]');
     try {
       const [healthRes, bootstrapRes] = await Promise.all([
         fetch("api/v1/health"),
@@ -89,7 +104,7 @@ class PortalShell extends HTMLElement {
       if (metaEl) {
         const caps = bootstrap.capabilities || {};
         metaEl.textContent =
-          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, search=${caps.search}, stream=${caps.stream}, timeline=${caps.timeline}`;
+          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, search=${caps.search}, stream=${caps.stream}, timeline=${caps.timeline}, provenance=${caps.provenance}`;
       }
       if (searchInput) {
         searchInput.disabled = !bootstrap.capabilities?.search;
@@ -126,6 +141,20 @@ class PortalShell extends HTMLElement {
           this.refreshTimeline();
         }, 3000);
       }
+      if (provenanceList) {
+        provenanceList.innerHTML = bootstrap.capabilities?.provenance
+          ? "<li>Loading provenance records...</li>"
+          : "<li>Provenance unavailable: stream capability disabled.</li>";
+      }
+      if (bootstrap.capabilities?.provenance) {
+        await this.refreshProvenance();
+        if (this.provenanceInterval) {
+          clearInterval(this.provenanceInterval);
+        }
+        this.provenanceInterval = setInterval(() => {
+          this.refreshProvenance();
+        }, 4000);
+      }
     } catch (err) {
       if (statusEl) {
         statusEl.textContent = "Gateway unavailable";
@@ -155,6 +184,7 @@ class PortalShell extends HTMLElement {
         const at = payload.at || "n/a";
         streamStatus.textContent = `Stream live: layer=${layer} at=${at}`;
         this.scheduleTimelineRefresh();
+        this.scheduleProvenanceRefresh();
       } catch (err) {
         streamStatus.textContent = "Stream payload parse error";
       }
@@ -206,6 +236,50 @@ class PortalShell extends HTMLElement {
     } catch (err) {
       timelineList.innerHTML = "<li>Timeline query failed.</li>";
       console.error("timeline query failed", err);
+    }
+  }
+
+  scheduleProvenanceRefresh() {
+    if (this.provenanceTimer) {
+      clearTimeout(this.provenanceTimer);
+    }
+    this.provenanceTimer = setTimeout(() => {
+      this.refreshProvenance();
+    }, 220);
+  }
+
+  async refreshProvenance() {
+    const provenanceList = this.querySelector('[data-role="provenance-list"]');
+    const provenanceCorrelation = this.querySelector('[data-role="provenance-correlation"]');
+    if (!provenanceList) {
+      return;
+    }
+    try {
+      const correlation = provenanceCorrelation ? String(provenanceCorrelation.value || "").trim() : "";
+      const query = new URLSearchParams();
+      query.set("limit", "8");
+      if (correlation.length > 0) {
+        query.set("correlation_id", correlation);
+      }
+      const response = await fetch(`api/v1/provenance/events?${query.toString()}`);
+      const payload = await response.json();
+      const items = Array.isArray(payload.items) ? payload.items : [];
+      if (items.length === 0) {
+        provenanceList.innerHTML = "<li>No provenance records yet.</li>";
+        return;
+      }
+      provenanceList.innerHTML = items
+        .map((item) => {
+          const source = escapeHtml(item.source || "unknown");
+          const corr = escapeHtml(item.correlation_id || "n/a");
+          const keys = Array.isArray(item.payload_keys) ? item.payload_keys.join(",") : "";
+          const confidence = Number(item.confidence || 0).toFixed(2);
+          return `<li><span class="pill">prov</span> <strong>${corr}</strong> <span class="muted-inline">${source} keys=${escapeHtml(keys)} conf=${confidence}</span></li>`;
+        })
+        .join("");
+    } catch (err) {
+      provenanceList.innerHTML = "<li>Provenance query failed.</li>";
+      console.error("provenance query failed", err);
     }
   }
 
@@ -378,6 +452,13 @@ class PortalShell extends HTMLElement {
               <input class="search timeline-filter" data-role="timeline-correlation" type="search" placeholder="Filter by correlation id" aria-label="Filter timeline by correlation id" />
               <ul data-role="timeline-list">
                 <li>Loading timeline capability...</li>
+              </ul>
+            </section>
+            <section class="registry-preview">
+              <h2>Provenance Inspector</h2>
+              <input class="search timeline-filter" data-role="provenance-correlation" type="search" placeholder="Filter provenance by correlation id" aria-label="Filter provenance by correlation id" />
+              <ul data-role="provenance-list">
+                <li>Loading provenance capability...</li>
               </ul>
             </section>
             <div class="meta" data-role="stream-status">Stream idle</div>


### PR DESCRIPTION
## Summary
- add provenance record data model derived from timeline stream envelopes
- add provenance API endpoint: `GET /portal/api/v1/provenance/events`
- expose provenance capability and endpoint in bootstrap payload
- extend portal UI with provenance inspector list + correlation-id filter
- add tests for bootstrap provenance flags and provenance endpoint behavior

## Testing
- `GOWORK=off go test ./portal ./ui`
- `./scripts/check_portal_assets.sh`

## Docs
- docs updated directly on main: d3vi1/helianthus-docs-ebus@55642ff

Closes #155
