### PR TITLE
feat(portal): add snapshot capture and retention controls

### DIFF
--- a/portal/handler.go
+++ b/portal/handler.go
@@ -61,9 +61,10 @@ type Options struct {
 }
 
 type handler struct {
-	opts     Options
-	files    http.Handler
-	timeline *timelineBuffer
+	opts      Options
+	files     http.Handler
+	timeline  *timelineBuffer
+	snapshots *snapshotStore
 }
 
 type RegistryDevice struct {
@@ -198,6 +199,20 @@ type timelineBuffer struct {
 	entries []StreamEventEnvelope
 }
 
+type SnapshotEnvelope struct {
+	ID         string         `json:"id"`
+	Label      string         `json:"label,omitempty"`
+	CapturedAt string         `json:"captured_at"`
+	Payload    map[string]any `json:"payload"`
+}
+
+type snapshotStore struct {
+	mu           sync.Mutex
+	maxSnapshots int
+	seq          uint64
+	items        []SnapshotEnvelope
+}
+
 func NewHandler(opts Options) http.Handler {
 	if opts.GraphQLPath == "" {
 		opts.GraphQLPath = "/graphql"
@@ -218,9 +233,10 @@ func NewHandler(opts Options) http.Handler {
 		opts.BuildID = "unknown"
 	}
 	return &handler{
-		opts:     opts,
-		files:    http.FileServer(http.FS(staticFS)),
-		timeline: newTimelineBuffer(1000),
+		opts:      opts,
+		files:     http.FileServer(http.FS(staticFS)),
+		timeline:  newTimelineBuffer(1000),
+		snapshots: newSnapshotStore(50),
 	}
 }
 
@@ -299,6 +315,99 @@ func cloneStreamEvent(event StreamEventEnvelope) StreamEventEnvelope {
 	return cloned
 }
 
+func newSnapshotStore(maxSnapshots int) *snapshotStore {
+	if maxSnapshots <= 0 {
+		maxSnapshots = 50
+	}
+	return &snapshotStore{
+		maxSnapshots: maxSnapshots,
+		items:        make([]SnapshotEnvelope, 0, maxSnapshots),
+	}
+}
+
+func (ss *snapshotStore) capture(label string, payload map[string]any) SnapshotEnvelope {
+	if ss == nil {
+		return SnapshotEnvelope{}
+	}
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+	ss.seq++
+	snapshot := SnapshotEnvelope{
+		ID:         fmt.Sprintf("snap-%d", ss.seq),
+		Label:      strings.TrimSpace(label),
+		CapturedAt: time.Now().UTC().Format(time.RFC3339Nano),
+		Payload:    cloneMap(payload),
+	}
+	if len(ss.items) >= ss.maxSnapshots {
+		copy(ss.items, ss.items[1:])
+		ss.items[len(ss.items)-1] = snapshot
+	} else {
+		ss.items = append(ss.items, snapshot)
+	}
+	return snapshot
+}
+
+func (ss *snapshotStore) list(limit int) []SnapshotEnvelope {
+	if ss == nil {
+		return []SnapshotEnvelope{}
+	}
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+
+	items := make([]SnapshotEnvelope, 0, limit)
+	for i := len(ss.items) - 1; i >= 0; i-- {
+		items = append(items, SnapshotEnvelope{
+			ID:         ss.items[i].ID,
+			Label:      ss.items[i].Label,
+			CapturedAt: ss.items[i].CapturedAt,
+			Payload:    cloneMap(ss.items[i].Payload),
+		})
+		if limit > 0 && len(items) >= limit {
+			break
+		}
+	}
+	return items
+}
+
+func (ss *snapshotStore) setMaxSnapshots(maxSnapshots int) int {
+	if ss == nil {
+		return 0
+	}
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+	if maxSnapshots < 1 {
+		maxSnapshots = 1
+	}
+	if maxSnapshots > 500 {
+		maxSnapshots = 500
+	}
+	ss.maxSnapshots = maxSnapshots
+	for len(ss.items) > ss.maxSnapshots {
+		ss.items = ss.items[1:]
+	}
+	return ss.maxSnapshots
+}
+
+func (ss *snapshotStore) config() (maxSnapshots int, count int) {
+	if ss == nil {
+		return 0, 0
+	}
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+	return ss.maxSnapshots, len(ss.items)
+}
+
+func cloneMap(payload map[string]any) map[string]any {
+	if payload == nil {
+		return nil
+	}
+	cloned := make(map[string]any, len(payload))
+	for key, value := range payload {
+		cloned[key] = value
+	}
+	return cloned
+}
+
 func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r == nil {
 		http.Error(w, "request missing", http.StatusBadRequest)
@@ -369,6 +478,7 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 				"stream":     streamEnabled,
 				"timeline":   streamEnabled,
 				"provenance": streamEnabled,
+				"snapshots":  streamEnabled,
 			},
 			"endpoints": map[string]string{
 				"graphql":       h.opts.GraphQLPath,
@@ -379,6 +489,9 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 				"stream":        "/portal/api/v1/stream",
 				"timeline":      "/portal/api/v1/timeline/events",
 				"provenance":    "/portal/api/v1/provenance/events",
+				"snapshots":     "/portal/api/v1/snapshots",
+				"capture":       "/portal/api/v1/snapshots/capture",
+				"retention":     "/portal/api/v1/snapshots/retention",
 			},
 			"limits": map[string]any{
 				"max_events_per_second": 200,
@@ -402,6 +515,12 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 		h.handleTimelineEvents(w, r)
 	case "provenance/events":
 		h.handleProvenanceEvents(w, r)
+	case "snapshots":
+		h.handleSnapshotsList(w, r)
+	case "snapshots/capture":
+		h.handleSnapshotsCapture(w, r)
+	case "snapshots/retention":
+		h.handleSnapshotsRetention(w, r)
 	default:
 		http.NotFound(w, r)
 	}
@@ -458,6 +577,12 @@ func classifyRoute(path string) string {
 		return "api.timeline.events"
 	case strings.HasPrefix(path, "/api/v1/provenance/events"):
 		return "api.provenance.events"
+	case strings.HasPrefix(path, "/api/v1/snapshots/capture"):
+		return "api.snapshots.capture"
+	case strings.HasPrefix(path, "/api/v1/snapshots/retention"):
+		return "api.snapshots.retention"
+	case strings.HasPrefix(path, "/api/v1/snapshots"):
+		return "api.snapshots.list"
 	case strings.HasPrefix(path, "/assets/"):
 		return "assets"
 	case path == "/" || strings.EqualFold(path, "/index.html"):
@@ -898,6 +1023,104 @@ func (h *handler) handleProvenanceEvents(w http.ResponseWriter, r *http.Request)
 		"count": len(records),
 		"items": records,
 	})
+}
+
+func (h *handler) handleSnapshotsList(w http.ResponseWriter, r *http.Request) {
+	if h.snapshots == nil {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"count": 0,
+			"items": []SnapshotEnvelope{},
+		})
+		return
+	}
+	limit := parseQueryLimit(r.URL.Query().Get("limit"), 20)
+	items := h.snapshots.list(limit)
+	maxSnapshots, count := h.snapshots.config()
+	writeJSON(w, http.StatusOK, map[string]any{
+		"count":         len(items),
+		"stored_count":  count,
+		"max_snapshots": maxSnapshots,
+		"items":         items,
+	})
+}
+
+func (h *handler) handleSnapshotsCapture(w http.ResponseWriter, r *http.Request) {
+	if h.snapshots == nil {
+		http.Error(w, "snapshot store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	if h.opts.ListRegistry == nil && h.opts.ListSemantic == nil && h.opts.ListProjections == nil {
+		http.Error(w, "snapshot capture unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	label := strings.TrimSpace(r.URL.Query().Get("label"))
+	snapshot := h.snapshots.capture(label, h.buildSnapshotPayload())
+	maxSnapshots, count := h.snapshots.config()
+	writeJSON(w, http.StatusOK, map[string]any{
+		"snapshot":      snapshot,
+		"stored_count":  count,
+		"max_snapshots": maxSnapshots,
+	})
+}
+
+func (h *handler) handleSnapshotsRetention(w http.ResponseWriter, r *http.Request) {
+	if h.snapshots == nil {
+		http.Error(w, "snapshot store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	if raw := strings.TrimSpace(r.URL.Query().Get("max_snapshots")); raw != "" {
+		value, err := strconv.Atoi(raw)
+		if err != nil {
+			http.Error(w, "invalid max_snapshots", http.StatusBadRequest)
+			return
+		}
+		h.snapshots.setMaxSnapshots(value)
+	}
+	maxSnapshots, count := h.snapshots.config()
+	writeJSON(w, http.StatusOK, map[string]any{
+		"max_snapshots": maxSnapshots,
+		"stored_count":  count,
+	})
+}
+
+func (h *handler) buildSnapshotPayload() map[string]any {
+	payload := map[string]any{
+		"captured_at": time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	if h.opts.ListRegistry != nil {
+		devices := h.opts.ListRegistry()
+		payload["registry"] = map[string]any{
+			"count": len(devices),
+			"items": devices,
+		}
+	}
+	if h.opts.ListSemantic != nil {
+		semantic := h.opts.ListSemantic()
+		payload["semantic"] = semantic
+	}
+	if h.opts.ListProjections != nil {
+		projections := h.opts.ListProjections()
+		payload["projection"] = map[string]any{
+			"count": len(projections),
+			"items": projections,
+		}
+	}
+	if h.timeline != nil {
+		events := h.timeline.query(20, "", "", time.Time{})
+		provenance := make([]ProvenanceRecord, 0, len(events))
+		for _, event := range events {
+			provenance = append(provenance, toProvenanceRecord(event))
+		}
+		payload["timeline"] = map[string]any{
+			"count": len(events),
+			"items": events,
+		}
+		payload["provenance"] = map[string]any{
+			"count": len(provenance),
+			"items": provenance,
+		}
+	}
+	return payload
 }
 
 func toProvenanceRecord(event StreamEventEnvelope) ProvenanceRecord {

--- a/portal/handler_test.go
+++ b/portal/handler_test.go
@@ -151,6 +151,15 @@ func TestBootstrapEndpoint(t *testing.T) {
 	if endpoints["provenance"] != "/portal/api/v1/provenance/events" {
 		t.Fatalf("provenance endpoint=%v; want /portal/api/v1/provenance/events", endpoints["provenance"])
 	}
+	if endpoints["snapshots"] != "/portal/api/v1/snapshots" {
+		t.Fatalf("snapshots endpoint=%v; want /portal/api/v1/snapshots", endpoints["snapshots"])
+	}
+	if endpoints["capture"] != "/portal/api/v1/snapshots/capture" {
+		t.Fatalf("capture endpoint=%v; want /portal/api/v1/snapshots/capture", endpoints["capture"])
+	}
+	if endpoints["retention"] != "/portal/api/v1/snapshots/retention" {
+		t.Fatalf("retention endpoint=%v; want /portal/api/v1/snapshots/retention", endpoints["retention"])
+	}
 	capabilities := payload["capabilities"].(map[string]any)
 	if capabilities["registry"] != true {
 		t.Fatalf("capabilities.registry=%v; want true", capabilities["registry"])
@@ -172,6 +181,9 @@ func TestBootstrapEndpoint(t *testing.T) {
 	}
 	if capabilities["provenance"] != true {
 		t.Fatalf("capabilities.provenance=%v; want true", capabilities["provenance"])
+	}
+	if capabilities["snapshots"] != true {
+		t.Fatalf("capabilities.snapshots=%v; want true", capabilities["snapshots"])
 	}
 }
 
@@ -659,5 +671,61 @@ func TestProvenanceEventsEndpoint(t *testing.T) {
 	}
 	if first["confidence"] == nil {
 		t.Fatalf("confidence missing")
+	}
+}
+
+func TestSnapshotsCaptureAndRetention(t *testing.T) {
+	h := NewHandler(Options{
+		ListRegistry: func() []RegistryDevice {
+			return []RegistryDevice{{Address: 0x10, Manufacturer: "Vaillant", DeviceID: "VRC720"}}
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/snapshots/retention?max_snapshots=2", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("retention status=%d; want %d", rec.Code, http.StatusOK)
+	}
+
+	for _, label := range []string{"a", "b", "c"} {
+		req = httptest.NewRequest(http.MethodGet, "/api/v1/snapshots/capture?label="+label, nil)
+		rec = httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("capture status=%d; want %d", rec.Code, http.StatusOK)
+		}
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/snapshots?limit=10", nil)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list status=%d; want %d", rec.Code, http.StatusOK)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if int(payload["stored_count"].(float64)) != 2 {
+		t.Fatalf("stored_count=%v; want 2", payload["stored_count"])
+	}
+	items := payload["items"].([]any)
+	if len(items) != 2 {
+		t.Fatalf("len(items)=%d; want 2", len(items))
+	}
+	first := items[0].(map[string]any)
+	if first["label"] != "c" {
+		t.Fatalf("first.label=%v; want c newest first", first["label"])
+	}
+}
+
+func TestSnapshotsCaptureUnavailableWithoutProviders(t *testing.T) {
+	h := NewHandler(Options{})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/snapshots/capture", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d; want %d", rec.Code, http.StatusServiceUnavailable)
 	}
 }

--- a/portal/static/assets/app.css
+++ b/portal/static/assets/app.css
@@ -199,6 +199,17 @@ body {
   margin: 0 0 0.6rem;
 }
 
+.snapshot-controls {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.45rem;
+  margin-bottom: 0.65rem;
+}
+
+.snapshot-retention {
+  margin-bottom: 0;
+}
+
 .pill {
   display: inline-block;
   border: 1px solid var(--border);

--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -52,6 +52,10 @@ class PortalShell extends HTMLElement {
       clearTimeout(this.provenanceTimer);
       this.provenanceTimer = undefined;
     }
+    if (this.snapshotInterval) {
+      clearInterval(this.snapshotInterval);
+      this.snapshotInterval = undefined;
+    }
   }
 
   bindEvents() {
@@ -59,6 +63,8 @@ class PortalShell extends HTMLElement {
     const search = this.querySelector('[data-role="search-input"]');
     const correlation = this.querySelector('[data-role="timeline-correlation"]');
     const provenanceCorrelation = this.querySelector('[data-role="provenance-correlation"]');
+    const captureButton = this.querySelector('[data-role="snapshot-capture"]');
+    const retentionButton = this.querySelector('[data-role="snapshot-retention-apply"]');
     if (toggle) {
       toggle.addEventListener("click", () => {
         const current = loadTheme();
@@ -80,6 +86,16 @@ class PortalShell extends HTMLElement {
         this.scheduleProvenanceRefresh();
       });
     }
+    if (captureButton) {
+      captureButton.addEventListener("click", () => {
+        this.captureSnapshot();
+      });
+    }
+    if (retentionButton) {
+      retentionButton.addEventListener("click", () => {
+        this.updateSnapshotRetention();
+      });
+    }
   }
 
   async loadStatus() {
@@ -92,6 +108,8 @@ class PortalShell extends HTMLElement {
     const searchList = this.querySelector('[data-role="search-list"]');
     const timelineList = this.querySelector('[data-role="timeline-list"]');
     const provenanceList = this.querySelector('[data-role="provenance-list"]');
+    const snapshotsList = this.querySelector('[data-role="snapshots-list"]');
+    const retentionInput = this.querySelector('[data-role="snapshot-retention"]');
     try {
       const [healthRes, bootstrapRes] = await Promise.all([
         fetch("api/v1/health"),
@@ -105,7 +123,7 @@ class PortalShell extends HTMLElement {
       if (metaEl) {
         const caps = bootstrap.capabilities || {};
         metaEl.textContent =
-          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, search=${caps.search}, stream=${caps.stream}, timeline=${caps.timeline}, provenance=${caps.provenance}`;
+          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, search=${caps.search}, stream=${caps.stream}, timeline=${caps.timeline}, provenance=${caps.provenance}, snapshots=${caps.snapshots}`;
       }
       if (searchInput) {
         searchInput.disabled = !bootstrap.capabilities?.search;
@@ -156,6 +174,24 @@ class PortalShell extends HTMLElement {
           this.refreshProvenance();
         }, 4000);
       }
+      if (snapshotsList) {
+        snapshotsList.innerHTML = bootstrap.capabilities?.snapshots
+          ? "<li>Loading snapshot store...</li>"
+          : "<li>Snapshots unavailable: stream capability disabled.</li>";
+      }
+      if (bootstrap.capabilities?.snapshots) {
+        await this.refreshSnapshots();
+        const retention = await this.fetchSnapshotRetention();
+        if (retentionInput && retention > 0) {
+          retentionInput.value = String(retention);
+        }
+        if (this.snapshotInterval) {
+          clearInterval(this.snapshotInterval);
+        }
+        this.snapshotInterval = setInterval(() => {
+          this.refreshSnapshots();
+        }, 5000);
+      }
     } catch (err) {
       if (statusEl) {
         statusEl.textContent = "Gateway unavailable";
@@ -186,6 +222,7 @@ class PortalShell extends HTMLElement {
         streamStatus.textContent = `Stream live: layer=${layer} at=${at}`;
         this.scheduleTimelineRefresh();
         this.scheduleProvenanceRefresh();
+        this.refreshSnapshots();
       } catch (err) {
         streamStatus.textContent = "Stream payload parse error";
       }
@@ -281,6 +318,87 @@ class PortalShell extends HTMLElement {
     } catch (err) {
       provenanceList.innerHTML = "<li>Provenance query failed.</li>";
       console.error("provenance query failed", err);
+    }
+  }
+
+  async fetchSnapshotRetention() {
+    try {
+      const response = await fetch("api/v1/snapshots/retention");
+      const payload = await response.json();
+      return Number(payload.max_snapshots || 0);
+    } catch (err) {
+      return 0;
+    }
+  }
+
+  async refreshSnapshots() {
+    const list = this.querySelector('[data-role="snapshots-list"]');
+    if (!list) {
+      return;
+    }
+    try {
+      const response = await fetch("api/v1/snapshots?limit=6");
+      const payload = await response.json();
+      const items = Array.isArray(payload.items) ? payload.items : [];
+      if (items.length === 0) {
+        list.innerHTML = "<li>No snapshots captured yet.</li>";
+        return;
+      }
+      list.innerHTML = items
+        .map((item) => {
+          const id = escapeHtml(item.id || "n/a");
+          const label = escapeHtml(item.label || "snapshot");
+          const at = escapeHtml(item.captured_at || "n/a");
+          return `<li><span class="pill">snap</span> <strong>${id}</strong> <span class="muted-inline">${label} ${at}</span></li>`;
+        })
+        .join("");
+    } catch (err) {
+      list.innerHTML = "<li>Snapshot list query failed.</li>";
+      console.error("snapshot query failed", err);
+    }
+  }
+
+  async captureSnapshot() {
+    const labelInput = this.querySelector('[data-role="snapshot-label"]');
+    const streamStatus = this.querySelector('[data-role="stream-status"]');
+    const label = labelInput ? String(labelInput.value || "").trim() : "";
+    try {
+      const query = new URLSearchParams();
+      if (label.length > 0) {
+        query.set("label", label);
+      }
+      const response = await fetch(`api/v1/snapshots/capture?${query.toString()}`);
+      const payload = await response.json();
+      if (streamStatus) {
+        const snapID = payload.snapshot?.id || "unknown";
+        streamStatus.textContent = `Snapshot captured: ${snapID}`;
+      }
+      await this.refreshSnapshots();
+    } catch (err) {
+      if (streamStatus) {
+        streamStatus.textContent = "Snapshot capture failed";
+      }
+    }
+  }
+
+  async updateSnapshotRetention() {
+    const retentionInput = this.querySelector('[data-role="snapshot-retention"]');
+    const streamStatus = this.querySelector('[data-role="stream-status"]');
+    if (!retentionInput) {
+      return;
+    }
+    const value = String(retentionInput.value || "").trim();
+    try {
+      const response = await fetch(`api/v1/snapshots/retention?max_snapshots=${encodeURIComponent(value)}`);
+      const payload = await response.json();
+      if (streamStatus) {
+        streamStatus.textContent = `Snapshot retention=${payload.max_snapshots}`;
+      }
+      await this.refreshSnapshots();
+    } catch (err) {
+      if (streamStatus) {
+        streamStatus.textContent = "Snapshot retention update failed";
+      }
     }
   }
 
@@ -460,6 +578,18 @@ class PortalShell extends HTMLElement {
               <input class="search timeline-filter" data-role="provenance-correlation" type="search" placeholder="Filter provenance by correlation id" aria-label="Filter provenance by correlation id" />
               <ul data-role="provenance-list">
                 <li>Loading provenance capability...</li>
+              </ul>
+            </section>
+            <section class="registry-preview">
+              <h2>Snapshots</h2>
+              <div class="snapshot-controls">
+                <input class="search timeline-filter" data-role="snapshot-label" type="search" placeholder="Snapshot label (optional)" aria-label="Snapshot label" />
+                <button class="button" data-role="snapshot-capture" type="button">Capture</button>
+                <input class="search timeline-filter snapshot-retention" data-role="snapshot-retention" type="number" min="1" max="500" placeholder="Retention max" aria-label="Snapshot retention max" />
+                <button class="button" data-role="snapshot-retention-apply" type="button">Apply Retention</button>
+              </div>
+              <ul data-role="snapshots-list">
+                <li>Loading snapshots capability...</li>
               </ul>
             </section>
             <div class="meta" data-role="stream-status">Stream idle</div>

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,12 +2,12 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 18063,
-      "sha256": "4a1f0c5e190ef6b3a46c2b84ecd811f331323fa8eef656da4c7bc292bdf8ea97"
+      "bytes": 23234,
+      "sha256": "b4750369be04aa26e7976f1ec6981f7cc70d948cc771a839a54926b711207cfc"
     },
     "app.css": {
-      "bytes": 4033,
-      "sha256": "5a2df98bff2ccd8a35c2dccc2b00e18be52b698bc69da5f97ba95af1a1abc50c"
+      "bytes": 4196,
+      "sha256": "2d5d985ad84c2dcb133db5a6aaa881e19144afa87f064468a927dfdce2942ec8"
     }
   }
 }

--- a/portal/web/src/app.css
+++ b/portal/web/src/app.css
@@ -198,6 +198,17 @@ body {
   margin: 0 0 0.6rem;
 }
 
+.snapshot-controls {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.45rem;
+  margin-bottom: 0.65rem;
+}
+
+.snapshot-retention {
+  margin-bottom: 0;
+}
+
 .pill {
   display: inline-block;
   border: 1px solid var(--border);

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -51,6 +51,10 @@ class PortalShell extends HTMLElement {
       clearTimeout(this.provenanceTimer);
       this.provenanceTimer = undefined;
     }
+    if (this.snapshotInterval) {
+      clearInterval(this.snapshotInterval);
+      this.snapshotInterval = undefined;
+    }
   }
 
   bindEvents() {
@@ -58,6 +62,8 @@ class PortalShell extends HTMLElement {
     const search = this.querySelector('[data-role="search-input"]');
     const correlation = this.querySelector('[data-role="timeline-correlation"]');
     const provenanceCorrelation = this.querySelector('[data-role="provenance-correlation"]');
+    const captureButton = this.querySelector('[data-role="snapshot-capture"]');
+    const retentionButton = this.querySelector('[data-role="snapshot-retention-apply"]');
     if (toggle) {
       toggle.addEventListener("click", () => {
         const current = loadTheme();
@@ -79,6 +85,16 @@ class PortalShell extends HTMLElement {
         this.scheduleProvenanceRefresh();
       });
     }
+    if (captureButton) {
+      captureButton.addEventListener("click", () => {
+        this.captureSnapshot();
+      });
+    }
+    if (retentionButton) {
+      retentionButton.addEventListener("click", () => {
+        this.updateSnapshotRetention();
+      });
+    }
   }
 
   async loadStatus() {
@@ -91,6 +107,8 @@ class PortalShell extends HTMLElement {
     const searchList = this.querySelector('[data-role="search-list"]');
     const timelineList = this.querySelector('[data-role="timeline-list"]');
     const provenanceList = this.querySelector('[data-role="provenance-list"]');
+    const snapshotsList = this.querySelector('[data-role="snapshots-list"]');
+    const retentionInput = this.querySelector('[data-role="snapshot-retention"]');
     try {
       const [healthRes, bootstrapRes] = await Promise.all([
         fetch("api/v1/health"),
@@ -104,7 +122,7 @@ class PortalShell extends HTMLElement {
       if (metaEl) {
         const caps = bootstrap.capabilities || {};
         metaEl.textContent =
-          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, search=${caps.search}, stream=${caps.stream}, timeline=${caps.timeline}, provenance=${caps.provenance}`;
+          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, search=${caps.search}, stream=${caps.stream}, timeline=${caps.timeline}, provenance=${caps.provenance}, snapshots=${caps.snapshots}`;
       }
       if (searchInput) {
         searchInput.disabled = !bootstrap.capabilities?.search;
@@ -155,6 +173,24 @@ class PortalShell extends HTMLElement {
           this.refreshProvenance();
         }, 4000);
       }
+      if (snapshotsList) {
+        snapshotsList.innerHTML = bootstrap.capabilities?.snapshots
+          ? "<li>Loading snapshot store...</li>"
+          : "<li>Snapshots unavailable: stream capability disabled.</li>";
+      }
+      if (bootstrap.capabilities?.snapshots) {
+        await this.refreshSnapshots();
+        const retention = await this.fetchSnapshotRetention();
+        if (retentionInput && retention > 0) {
+          retentionInput.value = String(retention);
+        }
+        if (this.snapshotInterval) {
+          clearInterval(this.snapshotInterval);
+        }
+        this.snapshotInterval = setInterval(() => {
+          this.refreshSnapshots();
+        }, 5000);
+      }
     } catch (err) {
       if (statusEl) {
         statusEl.textContent = "Gateway unavailable";
@@ -185,6 +221,7 @@ class PortalShell extends HTMLElement {
         streamStatus.textContent = `Stream live: layer=${layer} at=${at}`;
         this.scheduleTimelineRefresh();
         this.scheduleProvenanceRefresh();
+        this.refreshSnapshots();
       } catch (err) {
         streamStatus.textContent = "Stream payload parse error";
       }
@@ -280,6 +317,87 @@ class PortalShell extends HTMLElement {
     } catch (err) {
       provenanceList.innerHTML = "<li>Provenance query failed.</li>";
       console.error("provenance query failed", err);
+    }
+  }
+
+  async fetchSnapshotRetention() {
+    try {
+      const response = await fetch("api/v1/snapshots/retention");
+      const payload = await response.json();
+      return Number(payload.max_snapshots || 0);
+    } catch (err) {
+      return 0;
+    }
+  }
+
+  async refreshSnapshots() {
+    const list = this.querySelector('[data-role="snapshots-list"]');
+    if (!list) {
+      return;
+    }
+    try {
+      const response = await fetch("api/v1/snapshots?limit=6");
+      const payload = await response.json();
+      const items = Array.isArray(payload.items) ? payload.items : [];
+      if (items.length === 0) {
+        list.innerHTML = "<li>No snapshots captured yet.</li>";
+        return;
+      }
+      list.innerHTML = items
+        .map((item) => {
+          const id = escapeHtml(item.id || "n/a");
+          const label = escapeHtml(item.label || "snapshot");
+          const at = escapeHtml(item.captured_at || "n/a");
+          return `<li><span class="pill">snap</span> <strong>${id}</strong> <span class="muted-inline">${label} ${at}</span></li>`;
+        })
+        .join("");
+    } catch (err) {
+      list.innerHTML = "<li>Snapshot list query failed.</li>";
+      console.error("snapshot query failed", err);
+    }
+  }
+
+  async captureSnapshot() {
+    const labelInput = this.querySelector('[data-role="snapshot-label"]');
+    const streamStatus = this.querySelector('[data-role="stream-status"]');
+    const label = labelInput ? String(labelInput.value || "").trim() : "";
+    try {
+      const query = new URLSearchParams();
+      if (label.length > 0) {
+        query.set("label", label);
+      }
+      const response = await fetch(`api/v1/snapshots/capture?${query.toString()}`);
+      const payload = await response.json();
+      if (streamStatus) {
+        const snapID = payload.snapshot?.id || "unknown";
+        streamStatus.textContent = `Snapshot captured: ${snapID}`;
+      }
+      await this.refreshSnapshots();
+    } catch (err) {
+      if (streamStatus) {
+        streamStatus.textContent = "Snapshot capture failed";
+      }
+    }
+  }
+
+  async updateSnapshotRetention() {
+    const retentionInput = this.querySelector('[data-role="snapshot-retention"]');
+    const streamStatus = this.querySelector('[data-role="stream-status"]');
+    if (!retentionInput) {
+      return;
+    }
+    const value = String(retentionInput.value || "").trim();
+    try {
+      const response = await fetch(`api/v1/snapshots/retention?max_snapshots=${encodeURIComponent(value)}`);
+      const payload = await response.json();
+      if (streamStatus) {
+        streamStatus.textContent = `Snapshot retention=${payload.max_snapshots}`;
+      }
+      await this.refreshSnapshots();
+    } catch (err) {
+      if (streamStatus) {
+        streamStatus.textContent = "Snapshot retention update failed";
+      }
     }
   }
 
@@ -459,6 +577,18 @@ class PortalShell extends HTMLElement {
               <input class="search timeline-filter" data-role="provenance-correlation" type="search" placeholder="Filter provenance by correlation id" aria-label="Filter provenance by correlation id" />
               <ul data-role="provenance-list">
                 <li>Loading provenance capability...</li>
+              </ul>
+            </section>
+            <section class="registry-preview">
+              <h2>Snapshots</h2>
+              <div class="snapshot-controls">
+                <input class="search timeline-filter" data-role="snapshot-label" type="search" placeholder="Snapshot label (optional)" aria-label="Snapshot label" />
+                <button class="button" data-role="snapshot-capture" type="button">Capture</button>
+                <input class="search timeline-filter snapshot-retention" data-role="snapshot-retention" type="number" min="1" max="500" placeholder="Retention max" aria-label="Snapshot retention max" />
+                <button class="button" data-role="snapshot-retention-apply" type="button">Apply Retention</button>
+              </div>
+              <ul data-role="snapshots-list">
+                <li>Loading snapshots capability...</li>
               </ul>
             </section>
             <div class="meta" data-role="stream-status">Stream idle</div>


### PR DESCRIPTION
## Summary
- add in-memory snapshot store with bounded retention controls
- add snapshots endpoints:
  - `GET /portal/api/v1/snapshots`
  - `GET /portal/api/v1/snapshots/capture`
  - `GET /portal/api/v1/snapshots/retention`
- include snapshots metadata in bootstrap capabilities/endpoints
- extend portal UI with snapshot capture, retention controls, and snapshots list
- add tests for snapshots capture/list/retention behavior

## Testing
- `GOWORK=off go test ./portal ./ui`
- `./scripts/check_portal_assets.sh`

## Docs
- docs updated directly on main: d3vi1/helianthus-docs-ebus@2ac7dc4

Closes #156
