### PR TITLE
feat(portal): add snapshot diff API and UI

### DIFF
--- a/portal/handler.go
+++ b/portal/handler.go
@@ -206,6 +206,13 @@ type SnapshotEnvelope struct {
 	Payload    map[string]any `json:"payload"`
 }
 
+type SnapshotDiffEntry struct {
+	Path   string `json:"path"`
+	Change string `json:"change"`
+	From   string `json:"from,omitempty"`
+	To     string `json:"to,omitempty"`
+}
+
 type snapshotStore struct {
 	mu           sync.Mutex
 	maxSnapshots int
@@ -397,6 +404,49 @@ func (ss *snapshotStore) config() (maxSnapshots int, count int) {
 	return ss.maxSnapshots, len(ss.items)
 }
 
+func (ss *snapshotStore) getByID(id string) (SnapshotEnvelope, bool) {
+	if ss == nil {
+		return SnapshotEnvelope{}, false
+	}
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+	for i := len(ss.items) - 1; i >= 0; i-- {
+		if ss.items[i].ID == id {
+			return SnapshotEnvelope{
+				ID:         ss.items[i].ID,
+				Label:      ss.items[i].Label,
+				CapturedAt: ss.items[i].CapturedAt,
+				Payload:    cloneMap(ss.items[i].Payload),
+			}, true
+		}
+	}
+	return SnapshotEnvelope{}, false
+}
+
+func (ss *snapshotStore) latestTwo() (SnapshotEnvelope, SnapshotEnvelope, bool) {
+	if ss == nil {
+		return SnapshotEnvelope{}, SnapshotEnvelope{}, false
+	}
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+	if len(ss.items) < 2 {
+		return SnapshotEnvelope{}, SnapshotEnvelope{}, false
+	}
+	from := ss.items[len(ss.items)-2]
+	to := ss.items[len(ss.items)-1]
+	return SnapshotEnvelope{
+			ID:         from.ID,
+			Label:      from.Label,
+			CapturedAt: from.CapturedAt,
+			Payload:    cloneMap(from.Payload),
+		}, SnapshotEnvelope{
+			ID:         to.ID,
+			Label:      to.Label,
+			CapturedAt: to.CapturedAt,
+			Payload:    cloneMap(to.Payload),
+		}, true
+}
+
 func cloneMap(payload map[string]any) map[string]any {
 	if payload == nil {
 		return nil
@@ -471,14 +521,15 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 		streamEnabled := h.opts.ListRegistry != nil || h.opts.ListSemantic != nil || h.opts.ListProjections != nil
 		writeJSON(w, http.StatusOK, map[string]any{
 			"capabilities": map[string]bool{
-				"registry":   h.opts.ListRegistry != nil,
-				"semantic":   h.opts.ListSemantic != nil,
-				"projection": h.opts.ListProjections != nil && h.opts.GetProjection != nil,
-				"search":     h.opts.ListRegistry != nil || h.opts.ListSemantic != nil || h.opts.ListProjections != nil,
-				"stream":     streamEnabled,
-				"timeline":   streamEnabled,
-				"provenance": streamEnabled,
-				"snapshots":  streamEnabled,
+				"registry":      h.opts.ListRegistry != nil,
+				"semantic":      h.opts.ListSemantic != nil,
+				"projection":    h.opts.ListProjections != nil && h.opts.GetProjection != nil,
+				"search":        h.opts.ListRegistry != nil || h.opts.ListSemantic != nil || h.opts.ListProjections != nil,
+				"stream":        streamEnabled,
+				"timeline":      streamEnabled,
+				"provenance":    streamEnabled,
+				"snapshots":     streamEnabled,
+				"snapshot_diff": streamEnabled,
 			},
 			"endpoints": map[string]string{
 				"graphql":       h.opts.GraphQLPath,
@@ -492,6 +543,7 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 				"snapshots":     "/portal/api/v1/snapshots",
 				"capture":       "/portal/api/v1/snapshots/capture",
 				"retention":     "/portal/api/v1/snapshots/retention",
+				"snapshot_diff": "/portal/api/v1/snapshots/diff",
 			},
 			"limits": map[string]any{
 				"max_events_per_second": 200,
@@ -521,6 +573,8 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 		h.handleSnapshotsCapture(w, r)
 	case "snapshots/retention":
 		h.handleSnapshotsRetention(w, r)
+	case "snapshots/diff":
+		h.handleSnapshotsDiff(w, r)
 	default:
 		http.NotFound(w, r)
 	}
@@ -581,6 +635,8 @@ func classifyRoute(path string) string {
 		return "api.snapshots.capture"
 	case strings.HasPrefix(path, "/api/v1/snapshots/retention"):
 		return "api.snapshots.retention"
+	case strings.HasPrefix(path, "/api/v1/snapshots/diff"):
+		return "api.snapshots.diff"
 	case strings.HasPrefix(path, "/api/v1/snapshots"):
 		return "api.snapshots.list"
 	case strings.HasPrefix(path, "/assets/"):
@@ -1081,6 +1137,166 @@ func (h *handler) handleSnapshotsRetention(w http.ResponseWriter, r *http.Reques
 		"max_snapshots": maxSnapshots,
 		"stored_count":  count,
 	})
+}
+
+func (h *handler) handleSnapshotsDiff(w http.ResponseWriter, r *http.Request) {
+	if h.snapshots == nil {
+		http.Error(w, "snapshot store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	fromID := strings.TrimSpace(r.URL.Query().Get("from_id"))
+	toID := strings.TrimSpace(r.URL.Query().Get("to_id"))
+
+	var (
+		from SnapshotEnvelope
+		to   SnapshotEnvelope
+		ok   bool
+	)
+	switch {
+	case fromID == "" && toID == "":
+		from, to, ok = h.snapshots.latestTwo()
+		if !ok {
+			http.Error(w, "need at least two snapshots", http.StatusNotFound)
+			return
+		}
+	case fromID == "" || toID == "":
+		http.Error(w, "both from_id and to_id are required", http.StatusBadRequest)
+		return
+	default:
+		from, ok = h.snapshots.getByID(fromID)
+		if !ok {
+			http.Error(w, "from snapshot not found", http.StatusNotFound)
+			return
+		}
+		to, ok = h.snapshots.getByID(toID)
+		if !ok {
+			http.Error(w, "to snapshot not found", http.StatusNotFound)
+			return
+		}
+	}
+
+	limit := parseQueryLimit(r.URL.Query().Get("limit"), 200)
+	diffEntries := buildSnapshotDiffEntries(from.Payload, to.Payload)
+	totalChanges := len(diffEntries)
+	if limit > 0 && len(diffEntries) > limit {
+		diffEntries = diffEntries[:limit]
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"from_snapshot": map[string]any{
+			"id":          from.ID,
+			"label":       from.Label,
+			"captured_at": from.CapturedAt,
+		},
+		"to_snapshot": map[string]any{
+			"id":          to.ID,
+			"label":       to.Label,
+			"captured_at": to.CapturedAt,
+		},
+		"change_count": totalChanges,
+		"count":        len(diffEntries),
+		"items":        diffEntries,
+	})
+}
+
+func buildSnapshotDiffEntries(fromPayload map[string]any, toPayload map[string]any) []SnapshotDiffEntry {
+	fromFlat := flattenSnapshotPayload(fromPayload)
+	toFlat := flattenSnapshotPayload(toPayload)
+
+	pathsMap := make(map[string]struct{}, len(fromFlat)+len(toFlat))
+	for path := range fromFlat {
+		pathsMap[path] = struct{}{}
+	}
+	for path := range toFlat {
+		pathsMap[path] = struct{}{}
+	}
+	paths := make([]string, 0, len(pathsMap))
+	for path := range pathsMap {
+		paths = append(paths, path)
+	}
+	slices.Sort(paths)
+
+	entries := make([]SnapshotDiffEntry, 0, len(paths))
+	for _, path := range paths {
+		fromValue, fromOK := fromFlat[path]
+		toValue, toOK := toFlat[path]
+		switch {
+		case !fromOK && toOK:
+			entries = append(entries, SnapshotDiffEntry{
+				Path:   path,
+				Change: "added",
+				To:     toValue,
+			})
+		case fromOK && !toOK:
+			entries = append(entries, SnapshotDiffEntry{
+				Path:   path,
+				Change: "removed",
+				From:   fromValue,
+			})
+		case fromOK && toOK && fromValue != toValue:
+			entries = append(entries, SnapshotDiffEntry{
+				Path:   path,
+				Change: "changed",
+				From:   fromValue,
+				To:     toValue,
+			})
+		}
+	}
+	return entries
+}
+
+func flattenSnapshotPayload(payload map[string]any) map[string]string {
+	normalized := normalizePayload(payload)
+	out := make(map[string]string)
+	flattenValue("$", normalized, out)
+	return out
+}
+
+func normalizePayload(payload map[string]any) map[string]any {
+	if payload == nil {
+		return map[string]any{}
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return cloneMap(payload)
+	}
+	var normalized map[string]any
+	if err := json.Unmarshal(raw, &normalized); err != nil {
+		return cloneMap(payload)
+	}
+	return normalized
+}
+
+func flattenValue(path string, value any, out map[string]string) {
+	switch typed := value.(type) {
+	case map[string]any:
+		if len(typed) == 0 {
+			out[path] = "{}"
+			return
+		}
+		keys := make([]string, 0, len(typed))
+		for key := range typed {
+			keys = append(keys, key)
+		}
+		slices.Sort(keys)
+		for _, key := range keys {
+			flattenValue(path+"."+key, typed[key], out)
+		}
+	case []any:
+		if len(typed) == 0 {
+			out[path] = "[]"
+			return
+		}
+		for idx, item := range typed {
+			flattenValue(fmt.Sprintf("%s[%d]", path, idx), item, out)
+		}
+	default:
+		encoded, err := json.Marshal(typed)
+		if err != nil {
+			out[path] = fmt.Sprintf("%v", typed)
+			return
+		}
+		out[path] = string(encoded)
+	}
 }
 
 func (h *handler) buildSnapshotPayload() map[string]any {

--- a/portal/handler_test.go
+++ b/portal/handler_test.go
@@ -160,6 +160,9 @@ func TestBootstrapEndpoint(t *testing.T) {
 	if endpoints["retention"] != "/portal/api/v1/snapshots/retention" {
 		t.Fatalf("retention endpoint=%v; want /portal/api/v1/snapshots/retention", endpoints["retention"])
 	}
+	if endpoints["snapshot_diff"] != "/portal/api/v1/snapshots/diff" {
+		t.Fatalf("snapshot_diff endpoint=%v; want /portal/api/v1/snapshots/diff", endpoints["snapshot_diff"])
+	}
 	capabilities := payload["capabilities"].(map[string]any)
 	if capabilities["registry"] != true {
 		t.Fatalf("capabilities.registry=%v; want true", capabilities["registry"])
@@ -184,6 +187,9 @@ func TestBootstrapEndpoint(t *testing.T) {
 	}
 	if capabilities["snapshots"] != true {
 		t.Fatalf("capabilities.snapshots=%v; want true", capabilities["snapshots"])
+	}
+	if capabilities["snapshot_diff"] != true {
+		t.Fatalf("capabilities.snapshot_diff=%v; want true", capabilities["snapshot_diff"])
 	}
 }
 
@@ -727,5 +733,107 @@ func TestSnapshotsCaptureUnavailableWithoutProviders(t *testing.T) {
 	h.ServeHTTP(rec, req)
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status=%d; want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+}
+
+func TestSnapshotsDiff_DefaultLatestPair(t *testing.T) {
+	h := NewHandler(Options{
+		ListRegistry: func() []RegistryDevice {
+			return []RegistryDevice{{Address: 0x10, Manufacturer: "Vaillant", DeviceID: "VRC720"}}
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/snapshots/capture?label=first", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first capture status=%d; want %d", rec.Code, http.StatusOK)
+	}
+
+	// Change upstream payload to ensure a detectable diff.
+	h.(*handler).opts.ListRegistry = func() []RegistryDevice {
+		return []RegistryDevice{{Address: 0x10, Manufacturer: "Vaillant", DeviceID: "VRC720B"}}
+	}
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/snapshots/capture?label=second", nil)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("second capture status=%d; want %d", rec.Code, http.StatusOK)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/snapshots/diff", nil)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("diff status=%d; want %d", rec.Code, http.StatusOK)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if int(payload["change_count"].(float64)) < 1 {
+		t.Fatalf("change_count=%v; want >=1", payload["change_count"])
+	}
+	items := payload["items"].([]any)
+	if len(items) < 1 {
+		t.Fatalf("len(items)=%d; want >=1", len(items))
+	}
+}
+
+func TestSnapshotsDiff_WithExplicitIDs(t *testing.T) {
+	h := NewHandler(Options{
+		ListRegistry: func() []RegistryDevice {
+			return []RegistryDevice{{Address: 0x10, Manufacturer: "Vaillant", DeviceID: "VRC720"}}
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/snapshots/capture?label=a", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	var aPayload map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &aPayload)
+	aID := aPayload["snapshot"].(map[string]any)["id"].(string)
+
+	h.(*handler).opts.ListRegistry = func() []RegistryDevice {
+		return []RegistryDevice{{Address: 0x10, Manufacturer: "Vaillant", DeviceID: "VRC720X"}}
+	}
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/snapshots/capture?label=b", nil)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	var bPayload map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &bPayload)
+	bID := bPayload["snapshot"].(map[string]any)["id"].(string)
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/snapshots/diff?from_id="+aID+"&to_id="+bID+"&limit=5", nil)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d; want %d", rec.Code, http.StatusOK)
+	}
+}
+
+func TestSnapshotsDiff_ValidationErrors(t *testing.T) {
+	h := NewHandler(Options{
+		ListRegistry: func() []RegistryDevice {
+			return []RegistryDevice{{Address: 0x10, Manufacturer: "Vaillant", DeviceID: "VRC720"}}
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/snapshots/diff", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status=%d; want %d when snapshots missing", rec.Code, http.StatusNotFound)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/snapshots/capture?label=only-one", nil)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/snapshots/diff?from_id=snap-1", nil)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d; want %d for partial id params", rec.Code, http.StatusBadRequest)
 	}
 }

--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -65,6 +65,7 @@ class PortalShell extends HTMLElement {
     const provenanceCorrelation = this.querySelector('[data-role="provenance-correlation"]');
     const captureButton = this.querySelector('[data-role="snapshot-capture"]');
     const retentionButton = this.querySelector('[data-role="snapshot-retention-apply"]');
+    const diffButton = this.querySelector('[data-role="snapshot-diff-run"]');
     if (toggle) {
       toggle.addEventListener("click", () => {
         const current = loadTheme();
@@ -96,6 +97,11 @@ class PortalShell extends HTMLElement {
         this.updateSnapshotRetention();
       });
     }
+    if (diffButton) {
+      diffButton.addEventListener("click", () => {
+        this.runSnapshotDiff();
+      });
+    }
   }
 
   async loadStatus() {
@@ -110,6 +116,7 @@ class PortalShell extends HTMLElement {
     const provenanceList = this.querySelector('[data-role="provenance-list"]');
     const snapshotsList = this.querySelector('[data-role="snapshots-list"]');
     const retentionInput = this.querySelector('[data-role="snapshot-retention"]');
+    const diffList = this.querySelector('[data-role="snapshot-diff-list"]');
     try {
       const [healthRes, bootstrapRes] = await Promise.all([
         fetch("api/v1/health"),
@@ -123,7 +130,7 @@ class PortalShell extends HTMLElement {
       if (metaEl) {
         const caps = bootstrap.capabilities || {};
         metaEl.textContent =
-          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, search=${caps.search}, stream=${caps.stream}, timeline=${caps.timeline}, provenance=${caps.provenance}, snapshots=${caps.snapshots}`;
+          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, search=${caps.search}, stream=${caps.stream}, timeline=${caps.timeline}, provenance=${caps.provenance}, snapshots=${caps.snapshots}, snapshot_diff=${caps.snapshot_diff}`;
       }
       if (searchInput) {
         searchInput.disabled = !bootstrap.capabilities?.search;
@@ -192,6 +199,11 @@ class PortalShell extends HTMLElement {
           this.refreshSnapshots();
         }, 5000);
       }
+      if (diffList) {
+        diffList.innerHTML = bootstrap.capabilities?.snapshot_diff
+          ? "<li>Select snapshot IDs and run diff.</li>"
+          : "<li>Snapshot diff unavailable.</li>";
+      }
     } catch (err) {
       if (statusEl) {
         statusEl.textContent = "Gateway unavailable";
@@ -223,6 +235,7 @@ class PortalShell extends HTMLElement {
         this.scheduleTimelineRefresh();
         this.scheduleProvenanceRefresh();
         this.refreshSnapshots();
+        this.runSnapshotDiff();
       } catch (err) {
         streamStatus.textContent = "Stream payload parse error";
       }
@@ -352,6 +365,15 @@ class PortalShell extends HTMLElement {
           return `<li><span class="pill">snap</span> <strong>${id}</strong> <span class="muted-inline">${label} ${at}</span></li>`;
         })
         .join("");
+
+      const fromInput = this.querySelector('[data-role="snapshot-diff-from"]');
+      const toInput = this.querySelector('[data-role="snapshot-diff-to"]');
+      if (toInput && !String(toInput.value || "").trim() && items[0]?.id) {
+        toInput.value = String(items[0].id);
+      }
+      if (fromInput && !String(fromInput.value || "").trim() && items[1]?.id) {
+        fromInput.value = String(items[1].id);
+      }
     } catch (err) {
       list.innerHTML = "<li>Snapshot list query failed.</li>";
       console.error("snapshot query failed", err);
@@ -399,6 +421,50 @@ class PortalShell extends HTMLElement {
       if (streamStatus) {
         streamStatus.textContent = "Snapshot retention update failed";
       }
+    }
+  }
+
+  async runSnapshotDiff() {
+    const list = this.querySelector('[data-role="snapshot-diff-list"]');
+    const fromInput = this.querySelector('[data-role="snapshot-diff-from"]');
+    const toInput = this.querySelector('[data-role="snapshot-diff-to"]');
+    if (!list) {
+      return;
+    }
+    try {
+      const query = new URLSearchParams();
+      query.set("limit", "12");
+      const from = fromInput ? String(fromInput.value || "").trim() : "";
+      const to = toInput ? String(toInput.value || "").trim() : "";
+      if (from.length > 0) {
+        query.set("from_id", from);
+      }
+      if (to.length > 0) {
+        query.set("to_id", to);
+      }
+      const response = await fetch(`api/v1/snapshots/diff?${query.toString()}`);
+      if (!response.ok) {
+        list.innerHTML = `<li>Snapshot diff unavailable (${response.status}).</li>`;
+        return;
+      }
+      const payload = await response.json();
+      const items = Array.isArray(payload.items) ? payload.items : [];
+      if (items.length === 0) {
+        list.innerHTML = "<li>No diff changes detected.</li>";
+        return;
+      }
+      list.innerHTML = items
+        .map((item) => {
+          const path = escapeHtml(item.path || "");
+          const change = escapeHtml(item.change || "changed");
+          const fromVal = escapeHtml(item.from || "");
+          const toVal = escapeHtml(item.to || "");
+          return `<li><span class="pill">${change}</span> <strong>${path}</strong> <span class="muted-inline">${fromVal} -> ${toVal}</span></li>`;
+        })
+        .join("");
+    } catch (err) {
+      list.innerHTML = "<li>Snapshot diff failed.</li>";
+      console.error("snapshot diff failed", err);
     }
   }
 
@@ -590,6 +656,17 @@ class PortalShell extends HTMLElement {
               </div>
               <ul data-role="snapshots-list">
                 <li>Loading snapshots capability...</li>
+              </ul>
+            </section>
+            <section class="registry-preview">
+              <h2>Snapshot Diff</h2>
+              <div class="snapshot-controls">
+                <input class="search timeline-filter" data-role="snapshot-diff-from" type="search" placeholder="from_id (optional)" aria-label="Snapshot diff from id" />
+                <input class="search timeline-filter" data-role="snapshot-diff-to" type="search" placeholder="to_id (optional)" aria-label="Snapshot diff to id" />
+                <button class="button" data-role="snapshot-diff-run" type="button">Run Diff</button>
+              </div>
+              <ul data-role="snapshot-diff-list">
+                <li>Loading snapshot diff capability...</li>
               </ul>
             </section>
             <div class="meta" data-role="stream-status">Stream idle</div>

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,8 +2,8 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 23234,
-      "sha256": "b4750369be04aa26e7976f1ec6981f7cc70d948cc771a839a54926b711207cfc"
+      "bytes": 26643,
+      "sha256": "8430e365f6b1f84d18a2ea16b21766e2d713b4522dc56ea72f2bee9dd67268ca"
     },
     "app.css": {
       "bytes": 4196,

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -64,6 +64,7 @@ class PortalShell extends HTMLElement {
     const provenanceCorrelation = this.querySelector('[data-role="provenance-correlation"]');
     const captureButton = this.querySelector('[data-role="snapshot-capture"]');
     const retentionButton = this.querySelector('[data-role="snapshot-retention-apply"]');
+    const diffButton = this.querySelector('[data-role="snapshot-diff-run"]');
     if (toggle) {
       toggle.addEventListener("click", () => {
         const current = loadTheme();
@@ -95,6 +96,11 @@ class PortalShell extends HTMLElement {
         this.updateSnapshotRetention();
       });
     }
+    if (diffButton) {
+      diffButton.addEventListener("click", () => {
+        this.runSnapshotDiff();
+      });
+    }
   }
 
   async loadStatus() {
@@ -109,6 +115,7 @@ class PortalShell extends HTMLElement {
     const provenanceList = this.querySelector('[data-role="provenance-list"]');
     const snapshotsList = this.querySelector('[data-role="snapshots-list"]');
     const retentionInput = this.querySelector('[data-role="snapshot-retention"]');
+    const diffList = this.querySelector('[data-role="snapshot-diff-list"]');
     try {
       const [healthRes, bootstrapRes] = await Promise.all([
         fetch("api/v1/health"),
@@ -122,7 +129,7 @@ class PortalShell extends HTMLElement {
       if (metaEl) {
         const caps = bootstrap.capabilities || {};
         metaEl.textContent =
-          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, search=${caps.search}, stream=${caps.stream}, timeline=${caps.timeline}, provenance=${caps.provenance}, snapshots=${caps.snapshots}`;
+          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, search=${caps.search}, stream=${caps.stream}, timeline=${caps.timeline}, provenance=${caps.provenance}, snapshots=${caps.snapshots}, snapshot_diff=${caps.snapshot_diff}`;
       }
       if (searchInput) {
         searchInput.disabled = !bootstrap.capabilities?.search;
@@ -191,6 +198,11 @@ class PortalShell extends HTMLElement {
           this.refreshSnapshots();
         }, 5000);
       }
+      if (diffList) {
+        diffList.innerHTML = bootstrap.capabilities?.snapshot_diff
+          ? "<li>Select snapshot IDs and run diff.</li>"
+          : "<li>Snapshot diff unavailable.</li>";
+      }
     } catch (err) {
       if (statusEl) {
         statusEl.textContent = "Gateway unavailable";
@@ -222,6 +234,7 @@ class PortalShell extends HTMLElement {
         this.scheduleTimelineRefresh();
         this.scheduleProvenanceRefresh();
         this.refreshSnapshots();
+        this.runSnapshotDiff();
       } catch (err) {
         streamStatus.textContent = "Stream payload parse error";
       }
@@ -351,6 +364,15 @@ class PortalShell extends HTMLElement {
           return `<li><span class="pill">snap</span> <strong>${id}</strong> <span class="muted-inline">${label} ${at}</span></li>`;
         })
         .join("");
+
+      const fromInput = this.querySelector('[data-role="snapshot-diff-from"]');
+      const toInput = this.querySelector('[data-role="snapshot-diff-to"]');
+      if (toInput && !String(toInput.value || "").trim() && items[0]?.id) {
+        toInput.value = String(items[0].id);
+      }
+      if (fromInput && !String(fromInput.value || "").trim() && items[1]?.id) {
+        fromInput.value = String(items[1].id);
+      }
     } catch (err) {
       list.innerHTML = "<li>Snapshot list query failed.</li>";
       console.error("snapshot query failed", err);
@@ -398,6 +420,50 @@ class PortalShell extends HTMLElement {
       if (streamStatus) {
         streamStatus.textContent = "Snapshot retention update failed";
       }
+    }
+  }
+
+  async runSnapshotDiff() {
+    const list = this.querySelector('[data-role="snapshot-diff-list"]');
+    const fromInput = this.querySelector('[data-role="snapshot-diff-from"]');
+    const toInput = this.querySelector('[data-role="snapshot-diff-to"]');
+    if (!list) {
+      return;
+    }
+    try {
+      const query = new URLSearchParams();
+      query.set("limit", "12");
+      const from = fromInput ? String(fromInput.value || "").trim() : "";
+      const to = toInput ? String(toInput.value || "").trim() : "";
+      if (from.length > 0) {
+        query.set("from_id", from);
+      }
+      if (to.length > 0) {
+        query.set("to_id", to);
+      }
+      const response = await fetch(`api/v1/snapshots/diff?${query.toString()}`);
+      if (!response.ok) {
+        list.innerHTML = `<li>Snapshot diff unavailable (${response.status}).</li>`;
+        return;
+      }
+      const payload = await response.json();
+      const items = Array.isArray(payload.items) ? payload.items : [];
+      if (items.length === 0) {
+        list.innerHTML = "<li>No diff changes detected.</li>";
+        return;
+      }
+      list.innerHTML = items
+        .map((item) => {
+          const path = escapeHtml(item.path || "");
+          const change = escapeHtml(item.change || "changed");
+          const fromVal = escapeHtml(item.from || "");
+          const toVal = escapeHtml(item.to || "");
+          return `<li><span class="pill">${change}</span> <strong>${path}</strong> <span class="muted-inline">${fromVal} -> ${toVal}</span></li>`;
+        })
+        .join("");
+    } catch (err) {
+      list.innerHTML = "<li>Snapshot diff failed.</li>";
+      console.error("snapshot diff failed", err);
     }
   }
 
@@ -589,6 +655,17 @@ class PortalShell extends HTMLElement {
               </div>
               <ul data-role="snapshots-list">
                 <li>Loading snapshots capability...</li>
+              </ul>
+            </section>
+            <section class="registry-preview">
+              <h2>Snapshot Diff</h2>
+              <div class="snapshot-controls">
+                <input class="search timeline-filter" data-role="snapshot-diff-from" type="search" placeholder="from_id (optional)" aria-label="Snapshot diff from id" />
+                <input class="search timeline-filter" data-role="snapshot-diff-to" type="search" placeholder="to_id (optional)" aria-label="Snapshot diff to id" />
+                <button class="button" data-role="snapshot-diff-run" type="button">Run Diff</button>
+              </div>
+              <ul data-role="snapshot-diff-list">
+                <li>Loading snapshot diff capability...</li>
               </ul>
             </section>
             <div class="meta" data-role="stream-status">Stream idle</div>


### PR DESCRIPTION
## Summary
- add snapshot diff API endpoint: `GET /portal/api/v1/snapshots/diff`
- support explicit snapshot IDs (`from_id`, `to_id`) and default latest-pair diff mode
- add structural diff engine over normalized snapshot payload paths
- expose snapshot diff capability/endpoint in bootstrap payload
- extend portal UI with snapshot diff panel and run action
- add tests for default diff mode, explicit-id mode, and validation failures

## Testing
- `GOWORK=off go test ./portal ./ui`
- `./scripts/check_portal_assets.sh`

## Docs
- docs updated directly on main: d3vi1/helianthus-docs-ebus@918f057

Closes #157
