### PR TITLE
feat(portal): add investigation sessions and bookmarks

### DIFF
--- a/portal/handler.go
+++ b/portal/handler.go
@@ -65,6 +65,7 @@ type handler struct {
 	files     http.Handler
 	timeline  *timelineBuffer
 	snapshots *snapshotStore
+	sessions  *sessionStore
 }
 
 type RegistryDevice struct {
@@ -220,6 +221,30 @@ type snapshotStore struct {
 	items        []SnapshotEnvelope
 }
 
+type InvestigationSession struct {
+	ID        string       `json:"id"`
+	Name      string       `json:"name"`
+	CreatedAt string       `json:"created_at"`
+	UpdatedAt string       `json:"updated_at"`
+	State     SessionState `json:"state"`
+}
+
+type SessionState struct {
+	SearchQuery           string `json:"search_query,omitempty"`
+	TimelineCorrelation   string `json:"timeline_correlation,omitempty"`
+	ProvenanceCorrelation string `json:"provenance_correlation,omitempty"`
+	SnapshotFromID        string `json:"snapshot_from_id,omitempty"`
+	SnapshotToID          string `json:"snapshot_to_id,omitempty"`
+	SelectedLayer         string `json:"selected_layer,omitempty"`
+}
+
+type sessionStore struct {
+	mu          sync.Mutex
+	maxSessions int
+	seq         uint64
+	items       []InvestigationSession
+}
+
 func NewHandler(opts Options) http.Handler {
 	if opts.GraphQLPath == "" {
 		opts.GraphQLPath = "/graphql"
@@ -244,6 +269,7 @@ func NewHandler(opts Options) http.Handler {
 		files:     http.FileServer(http.FS(staticFS)),
 		timeline:  newTimelineBuffer(1000),
 		snapshots: newSnapshotStore(50),
+		sessions:  newSessionStore(100),
 	}
 }
 
@@ -458,6 +484,86 @@ func cloneMap(payload map[string]any) map[string]any {
 	return cloned
 }
 
+func newSessionStore(maxSessions int) *sessionStore {
+	if maxSessions <= 0 {
+		maxSessions = 100
+	}
+	return &sessionStore{
+		maxSessions: maxSessions,
+		items:       make([]InvestigationSession, 0, maxSessions),
+	}
+}
+
+func (ss *sessionStore) save(name string, state SessionState) InvestigationSession {
+	if ss == nil {
+		return InvestigationSession{}
+	}
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	trimmedName := strings.TrimSpace(name)
+	if trimmedName == "" {
+		trimmedName = "investigation-session"
+	}
+
+	ss.seq++
+	session := InvestigationSession{
+		ID:        fmt.Sprintf("sess-%d", ss.seq),
+		Name:      trimmedName,
+		CreatedAt: now,
+		UpdatedAt: now,
+		State: SessionState{
+			SearchQuery:           strings.TrimSpace(state.SearchQuery),
+			TimelineCorrelation:   strings.TrimSpace(state.TimelineCorrelation),
+			ProvenanceCorrelation: strings.TrimSpace(state.ProvenanceCorrelation),
+			SnapshotFromID:        strings.TrimSpace(state.SnapshotFromID),
+			SnapshotToID:          strings.TrimSpace(state.SnapshotToID),
+			SelectedLayer:         strings.TrimSpace(state.SelectedLayer),
+		},
+	}
+
+	if len(ss.items) >= ss.maxSessions {
+		copy(ss.items, ss.items[1:])
+		ss.items[len(ss.items)-1] = session
+	} else {
+		ss.items = append(ss.items, session)
+	}
+	return session
+}
+
+func (ss *sessionStore) list(limit int) []InvestigationSession {
+	if ss == nil {
+		return []InvestigationSession{}
+	}
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+
+	out := make([]InvestigationSession, 0, limit)
+	for i := len(ss.items) - 1; i >= 0; i-- {
+		item := ss.items[i]
+		out = append(out, item)
+		if limit > 0 && len(out) >= limit {
+			break
+		}
+	}
+	return out
+}
+
+func (ss *sessionStore) get(id string) (InvestigationSession, bool) {
+	if ss == nil {
+		return InvestigationSession{}, false
+	}
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+	for i := len(ss.items) - 1; i >= 0; i-- {
+		if ss.items[i].ID == id {
+			return ss.items[i], true
+		}
+	}
+	return InvestigationSession{}, false
+}
+
 func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r == nil {
 		http.Error(w, "request missing", http.StatusBadRequest)
@@ -530,6 +636,7 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 				"provenance":    streamEnabled,
 				"snapshots":     streamEnabled,
 				"snapshot_diff": streamEnabled,
+				"sessions":      true,
 			},
 			"endpoints": map[string]string{
 				"graphql":       h.opts.GraphQLPath,
@@ -544,6 +651,9 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 				"capture":       "/portal/api/v1/snapshots/capture",
 				"retention":     "/portal/api/v1/snapshots/retention",
 				"snapshot_diff": "/portal/api/v1/snapshots/diff",
+				"sessions":      "/portal/api/v1/sessions",
+				"session_save":  "/portal/api/v1/sessions/save",
+				"session_load":  "/portal/api/v1/sessions/load",
 			},
 			"limits": map[string]any{
 				"max_events_per_second": 200,
@@ -575,6 +685,12 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 		h.handleSnapshotsRetention(w, r)
 	case "snapshots/diff":
 		h.handleSnapshotsDiff(w, r)
+	case "sessions":
+		h.handleSessionsList(w, r)
+	case "sessions/save":
+		h.handleSessionsSave(w, r)
+	case "sessions/load":
+		h.handleSessionsLoad(w, r)
 	default:
 		http.NotFound(w, r)
 	}
@@ -639,6 +755,12 @@ func classifyRoute(path string) string {
 		return "api.snapshots.diff"
 	case strings.HasPrefix(path, "/api/v1/snapshots"):
 		return "api.snapshots.list"
+	case strings.HasPrefix(path, "/api/v1/sessions/save"):
+		return "api.sessions.save"
+	case strings.HasPrefix(path, "/api/v1/sessions/load"):
+		return "api.sessions.load"
+	case strings.HasPrefix(path, "/api/v1/sessions"):
+		return "api.sessions.list"
 	case strings.HasPrefix(path, "/assets/"):
 		return "assets"
 	case path == "/" || strings.EqualFold(path, "/index.html"):
@@ -1195,6 +1317,61 @@ func (h *handler) handleSnapshotsDiff(w http.ResponseWriter, r *http.Request) {
 		"change_count": totalChanges,
 		"count":        len(diffEntries),
 		"items":        diffEntries,
+	})
+}
+
+func (h *handler) handleSessionsList(w http.ResponseWriter, r *http.Request) {
+	if h.sessions == nil {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"count": 0,
+			"items": []InvestigationSession{},
+		})
+		return
+	}
+	limit := parseQueryLimit(r.URL.Query().Get("limit"), 30)
+	items := h.sessions.list(limit)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"count": len(items),
+		"items": items,
+	})
+}
+
+func (h *handler) handleSessionsSave(w http.ResponseWriter, r *http.Request) {
+	if h.sessions == nil {
+		http.Error(w, "session store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	state := SessionState{
+		SearchQuery:           r.URL.Query().Get("search_query"),
+		TimelineCorrelation:   r.URL.Query().Get("timeline_correlation"),
+		ProvenanceCorrelation: r.URL.Query().Get("provenance_correlation"),
+		SnapshotFromID:        r.URL.Query().Get("snapshot_from_id"),
+		SnapshotToID:          r.URL.Query().Get("snapshot_to_id"),
+		SelectedLayer:         r.URL.Query().Get("selected_layer"),
+	}
+	saved := h.sessions.save(r.URL.Query().Get("name"), state)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"session": saved,
+	})
+}
+
+func (h *handler) handleSessionsLoad(w http.ResponseWriter, r *http.Request) {
+	if h.sessions == nil {
+		http.Error(w, "session store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	id := strings.TrimSpace(r.URL.Query().Get("id"))
+	if id == "" {
+		http.Error(w, "missing id", http.StatusBadRequest)
+		return
+	}
+	session, ok := h.sessions.get(id)
+	if !ok {
+		http.Error(w, "session not found", http.StatusNotFound)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"session": session,
 	})
 }
 

--- a/portal/handler_test.go
+++ b/portal/handler_test.go
@@ -163,6 +163,15 @@ func TestBootstrapEndpoint(t *testing.T) {
 	if endpoints["snapshot_diff"] != "/portal/api/v1/snapshots/diff" {
 		t.Fatalf("snapshot_diff endpoint=%v; want /portal/api/v1/snapshots/diff", endpoints["snapshot_diff"])
 	}
+	if endpoints["sessions"] != "/portal/api/v1/sessions" {
+		t.Fatalf("sessions endpoint=%v; want /portal/api/v1/sessions", endpoints["sessions"])
+	}
+	if endpoints["session_save"] != "/portal/api/v1/sessions/save" {
+		t.Fatalf("session_save endpoint=%v; want /portal/api/v1/sessions/save", endpoints["session_save"])
+	}
+	if endpoints["session_load"] != "/portal/api/v1/sessions/load" {
+		t.Fatalf("session_load endpoint=%v; want /portal/api/v1/sessions/load", endpoints["session_load"])
+	}
 	capabilities := payload["capabilities"].(map[string]any)
 	if capabilities["registry"] != true {
 		t.Fatalf("capabilities.registry=%v; want true", capabilities["registry"])
@@ -190,6 +199,9 @@ func TestBootstrapEndpoint(t *testing.T) {
 	}
 	if capabilities["snapshot_diff"] != true {
 		t.Fatalf("capabilities.snapshot_diff=%v; want true", capabilities["snapshot_diff"])
+	}
+	if capabilities["sessions"] != true {
+		t.Fatalf("capabilities.sessions=%v; want true", capabilities["sessions"])
 	}
 }
 
@@ -835,5 +847,67 @@ func TestSnapshotsDiff_ValidationErrors(t *testing.T) {
 	h.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status=%d; want %d for partial id params", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestSessionsSaveLoadAndList(t *testing.T) {
+	h := NewHandler(Options{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions/save?name=investigation-a&search_query=service&timeline_correlation=reg-1&snapshot_from_id=snap-1&snapshot_to_id=snap-2", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("save status=%d; want %d", rec.Code, http.StatusOK)
+	}
+	var savePayload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &savePayload); err != nil {
+		t.Fatalf("save unmarshal: %v", err)
+	}
+	session := savePayload["session"].(map[string]any)
+	id := session["id"].(string)
+	if id == "" {
+		t.Fatalf("saved session id missing")
+	}
+	if session["name"] != "investigation-a" {
+		t.Fatalf("session.name=%v; want investigation-a", session["name"])
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/sessions?limit=10", nil)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list status=%d; want %d", rec.Code, http.StatusOK)
+	}
+	var listPayload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &listPayload); err != nil {
+		t.Fatalf("list unmarshal: %v", err)
+	}
+	if int(listPayload["count"].(float64)) < 1 {
+		t.Fatalf("list count=%v; want >=1", listPayload["count"])
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/sessions/load?id="+id, nil)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("load status=%d; want %d", rec.Code, http.StatusOK)
+	}
+	var loadPayload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &loadPayload); err != nil {
+		t.Fatalf("load unmarshal: %v", err)
+	}
+	loaded := loadPayload["session"].(map[string]any)
+	if loaded["id"] != id {
+		t.Fatalf("loaded id=%v; want %s", loaded["id"], id)
+	}
+}
+
+func TestSessionsLoadValidation(t *testing.T) {
+	h := NewHandler(Options{})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions/load", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d; want %d", rec.Code, http.StatusBadRequest)
 	}
 }

--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -66,6 +66,8 @@ class PortalShell extends HTMLElement {
     const captureButton = this.querySelector('[data-role="snapshot-capture"]');
     const retentionButton = this.querySelector('[data-role="snapshot-retention-apply"]');
     const diffButton = this.querySelector('[data-role="snapshot-diff-run"]');
+    const sessionSave = this.querySelector('[data-role="session-save"]');
+    const sessionLoad = this.querySelector('[data-role="session-load"]');
     if (toggle) {
       toggle.addEventListener("click", () => {
         const current = loadTheme();
@@ -102,6 +104,16 @@ class PortalShell extends HTMLElement {
         this.runSnapshotDiff();
       });
     }
+    if (sessionSave) {
+      sessionSave.addEventListener("click", () => {
+        this.saveSession();
+      });
+    }
+    if (sessionLoad) {
+      sessionLoad.addEventListener("click", () => {
+        this.loadSession();
+      });
+    }
   }
 
   async loadStatus() {
@@ -117,6 +129,7 @@ class PortalShell extends HTMLElement {
     const snapshotsList = this.querySelector('[data-role="snapshots-list"]');
     const retentionInput = this.querySelector('[data-role="snapshot-retention"]');
     const diffList = this.querySelector('[data-role="snapshot-diff-list"]');
+    const sessionsList = this.querySelector('[data-role="sessions-list"]');
     try {
       const [healthRes, bootstrapRes] = await Promise.all([
         fetch("api/v1/health"),
@@ -130,7 +143,7 @@ class PortalShell extends HTMLElement {
       if (metaEl) {
         const caps = bootstrap.capabilities || {};
         metaEl.textContent =
-          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, search=${caps.search}, stream=${caps.stream}, timeline=${caps.timeline}, provenance=${caps.provenance}, snapshots=${caps.snapshots}, snapshot_diff=${caps.snapshot_diff}`;
+          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, search=${caps.search}, stream=${caps.stream}, timeline=${caps.timeline}, provenance=${caps.provenance}, snapshots=${caps.snapshots}, snapshot_diff=${caps.snapshot_diff}, sessions=${caps.sessions}`;
       }
       if (searchInput) {
         searchInput.disabled = !bootstrap.capabilities?.search;
@@ -203,6 +216,14 @@ class PortalShell extends HTMLElement {
         diffList.innerHTML = bootstrap.capabilities?.snapshot_diff
           ? "<li>Select snapshot IDs and run diff.</li>"
           : "<li>Snapshot diff unavailable.</li>";
+      }
+      if (sessionsList) {
+        sessionsList.innerHTML = bootstrap.capabilities?.sessions
+          ? "<li>Loading sessions...</li>"
+          : "<li>Sessions unavailable.</li>";
+      }
+      if (bootstrap.capabilities?.sessions) {
+        await this.refreshSessions();
       }
     } catch (err) {
       if (statusEl) {
@@ -468,6 +489,115 @@ class PortalShell extends HTMLElement {
     }
   }
 
+  async refreshSessions() {
+    const sessionsList = this.querySelector('[data-role="sessions-list"]');
+    if (!sessionsList) {
+      return;
+    }
+    try {
+      const response = await fetch("api/v1/sessions?limit=8");
+      const payload = await response.json();
+      const items = Array.isArray(payload.items) ? payload.items : [];
+      if (items.length === 0) {
+        sessionsList.innerHTML = "<li>No saved sessions.</li>";
+        return;
+      }
+      sessionsList.innerHTML = items
+        .map((item) => {
+          const id = escapeHtml(item.id || "n/a");
+          const name = escapeHtml(item.name || "session");
+          const updated = escapeHtml(item.updated_at || "");
+          return `<li><span class="pill">sess</span> <strong>${id}</strong> <span class="muted-inline">${name} ${updated}</span></li>`;
+        })
+        .join("");
+    } catch (err) {
+      sessionsList.innerHTML = "<li>Sessions query failed.</li>";
+      console.error("sessions query failed", err);
+    }
+  }
+
+  async saveSession() {
+    const nameInput = this.querySelector('[data-role="session-name"]');
+    const streamStatus = this.querySelector('[data-role="stream-status"]');
+    const searchInput = this.querySelector('[data-role="search-input"]');
+    const timelineInput = this.querySelector('[data-role="timeline-correlation"]');
+    const provenanceInput = this.querySelector('[data-role="provenance-correlation"]');
+    const fromInput = this.querySelector('[data-role="snapshot-diff-from"]');
+    const toInput = this.querySelector('[data-role="snapshot-diff-to"]');
+
+    const query = new URLSearchParams();
+    query.set("name", nameInput ? String(nameInput.value || "").trim() : "");
+    query.set("search_query", searchInput ? String(searchInput.value || "").trim() : "");
+    query.set("timeline_correlation", timelineInput ? String(timelineInput.value || "").trim() : "");
+    query.set("provenance_correlation", provenanceInput ? String(provenanceInput.value || "").trim() : "");
+    query.set("snapshot_from_id", fromInput ? String(fromInput.value || "").trim() : "");
+    query.set("snapshot_to_id", toInput ? String(toInput.value || "").trim() : "");
+
+    try {
+      const response = await fetch(`api/v1/sessions/save?${query.toString()}`);
+      const payload = await response.json();
+      const id = payload.session?.id || "unknown";
+      const loadInput = this.querySelector('[data-role="session-load-id"]');
+      if (loadInput) {
+        loadInput.value = id;
+      }
+      if (streamStatus) {
+        streamStatus.textContent = `Session saved: ${id}`;
+      }
+      await this.refreshSessions();
+    } catch (err) {
+      if (streamStatus) {
+        streamStatus.textContent = "Session save failed";
+      }
+    }
+  }
+
+  async loadSession() {
+    const loadInput = this.querySelector('[data-role="session-load-id"]');
+    const streamStatus = this.querySelector('[data-role="stream-status"]');
+    const sessionID = loadInput ? String(loadInput.value || "").trim() : "";
+    if (!sessionID) {
+      if (streamStatus) {
+        streamStatus.textContent = "Session id missing";
+      }
+      return;
+    }
+    try {
+      const response = await fetch(`api/v1/sessions/load?id=${encodeURIComponent(sessionID)}`);
+      if (!response.ok) {
+        if (streamStatus) {
+          streamStatus.textContent = `Session load failed (${response.status})`;
+        }
+        return;
+      }
+      const payload = await response.json();
+      const state = payload.session?.state || {};
+      const searchInput = this.querySelector('[data-role="search-input"]');
+      const timelineInput = this.querySelector('[data-role="timeline-correlation"]');
+      const provenanceInput = this.querySelector('[data-role="provenance-correlation"]');
+      const fromInput = this.querySelector('[data-role="snapshot-diff-from"]');
+      const toInput = this.querySelector('[data-role="snapshot-diff-to"]');
+      if (searchInput) searchInput.value = state.search_query || "";
+      if (timelineInput) timelineInput.value = state.timeline_correlation || "";
+      if (provenanceInput) provenanceInput.value = state.provenance_correlation || "";
+      if (fromInput) fromInput.value = state.snapshot_from_id || "";
+      if (toInput) toInput.value = state.snapshot_to_id || "";
+
+      this.scheduleSearch(searchInput ? searchInput.value : "");
+      this.scheduleTimelineRefresh();
+      this.scheduleProvenanceRefresh();
+      this.runSnapshotDiff();
+
+      if (streamStatus) {
+        streamStatus.textContent = `Session loaded: ${sessionID}`;
+      }
+    } catch (err) {
+      if (streamStatus) {
+        streamStatus.textContent = "Session load failed";
+      }
+    }
+  }
+
   scheduleSearch(rawQuery) {
     if (this.searchTimer) {
       clearTimeout(this.searchTimer);
@@ -667,6 +797,18 @@ class PortalShell extends HTMLElement {
               </div>
               <ul data-role="snapshot-diff-list">
                 <li>Loading snapshot diff capability...</li>
+              </ul>
+            </section>
+            <section class="registry-preview">
+              <h2>Sessions</h2>
+              <div class="snapshot-controls">
+                <input class="search timeline-filter" data-role="session-name" type="search" placeholder="Session name" aria-label="Session name" />
+                <button class="button" data-role="session-save" type="button">Save Session</button>
+                <input class="search timeline-filter" data-role="session-load-id" type="search" placeholder="Session id" aria-label="Session id" />
+                <button class="button" data-role="session-load" type="button">Load Session</button>
+              </div>
+              <ul data-role="sessions-list">
+                <li>Loading sessions capability...</li>
               </ul>
             </section>
             <div class="meta" data-role="stream-status">Stream idle</div>

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,8 +2,8 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 26643,
-      "sha256": "8430e365f6b1f84d18a2ea16b21766e2d713b4522dc56ea72f2bee9dd67268ca"
+      "bytes": 32877,
+      "sha256": "b3c916f351ecd97cc55c23e0688903c7e197c1b65c137f34f5cec0c086c716a8"
     },
     "app.css": {
       "bytes": 4196,

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -65,6 +65,8 @@ class PortalShell extends HTMLElement {
     const captureButton = this.querySelector('[data-role="snapshot-capture"]');
     const retentionButton = this.querySelector('[data-role="snapshot-retention-apply"]');
     const diffButton = this.querySelector('[data-role="snapshot-diff-run"]');
+    const sessionSave = this.querySelector('[data-role="session-save"]');
+    const sessionLoad = this.querySelector('[data-role="session-load"]');
     if (toggle) {
       toggle.addEventListener("click", () => {
         const current = loadTheme();
@@ -101,6 +103,16 @@ class PortalShell extends HTMLElement {
         this.runSnapshotDiff();
       });
     }
+    if (sessionSave) {
+      sessionSave.addEventListener("click", () => {
+        this.saveSession();
+      });
+    }
+    if (sessionLoad) {
+      sessionLoad.addEventListener("click", () => {
+        this.loadSession();
+      });
+    }
   }
 
   async loadStatus() {
@@ -116,6 +128,7 @@ class PortalShell extends HTMLElement {
     const snapshotsList = this.querySelector('[data-role="snapshots-list"]');
     const retentionInput = this.querySelector('[data-role="snapshot-retention"]');
     const diffList = this.querySelector('[data-role="snapshot-diff-list"]');
+    const sessionsList = this.querySelector('[data-role="sessions-list"]');
     try {
       const [healthRes, bootstrapRes] = await Promise.all([
         fetch("api/v1/health"),
@@ -129,7 +142,7 @@ class PortalShell extends HTMLElement {
       if (metaEl) {
         const caps = bootstrap.capabilities || {};
         metaEl.textContent =
-          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, search=${caps.search}, stream=${caps.stream}, timeline=${caps.timeline}, provenance=${caps.provenance}, snapshots=${caps.snapshots}, snapshot_diff=${caps.snapshot_diff}`;
+          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, search=${caps.search}, stream=${caps.stream}, timeline=${caps.timeline}, provenance=${caps.provenance}, snapshots=${caps.snapshots}, snapshot_diff=${caps.snapshot_diff}, sessions=${caps.sessions}`;
       }
       if (searchInput) {
         searchInput.disabled = !bootstrap.capabilities?.search;
@@ -202,6 +215,14 @@ class PortalShell extends HTMLElement {
         diffList.innerHTML = bootstrap.capabilities?.snapshot_diff
           ? "<li>Select snapshot IDs and run diff.</li>"
           : "<li>Snapshot diff unavailable.</li>";
+      }
+      if (sessionsList) {
+        sessionsList.innerHTML = bootstrap.capabilities?.sessions
+          ? "<li>Loading sessions...</li>"
+          : "<li>Sessions unavailable.</li>";
+      }
+      if (bootstrap.capabilities?.sessions) {
+        await this.refreshSessions();
       }
     } catch (err) {
       if (statusEl) {
@@ -467,6 +488,115 @@ class PortalShell extends HTMLElement {
     }
   }
 
+  async refreshSessions() {
+    const sessionsList = this.querySelector('[data-role="sessions-list"]');
+    if (!sessionsList) {
+      return;
+    }
+    try {
+      const response = await fetch("api/v1/sessions?limit=8");
+      const payload = await response.json();
+      const items = Array.isArray(payload.items) ? payload.items : [];
+      if (items.length === 0) {
+        sessionsList.innerHTML = "<li>No saved sessions.</li>";
+        return;
+      }
+      sessionsList.innerHTML = items
+        .map((item) => {
+          const id = escapeHtml(item.id || "n/a");
+          const name = escapeHtml(item.name || "session");
+          const updated = escapeHtml(item.updated_at || "");
+          return `<li><span class="pill">sess</span> <strong>${id}</strong> <span class="muted-inline">${name} ${updated}</span></li>`;
+        })
+        .join("");
+    } catch (err) {
+      sessionsList.innerHTML = "<li>Sessions query failed.</li>";
+      console.error("sessions query failed", err);
+    }
+  }
+
+  async saveSession() {
+    const nameInput = this.querySelector('[data-role="session-name"]');
+    const streamStatus = this.querySelector('[data-role="stream-status"]');
+    const searchInput = this.querySelector('[data-role="search-input"]');
+    const timelineInput = this.querySelector('[data-role="timeline-correlation"]');
+    const provenanceInput = this.querySelector('[data-role="provenance-correlation"]');
+    const fromInput = this.querySelector('[data-role="snapshot-diff-from"]');
+    const toInput = this.querySelector('[data-role="snapshot-diff-to"]');
+
+    const query = new URLSearchParams();
+    query.set("name", nameInput ? String(nameInput.value || "").trim() : "");
+    query.set("search_query", searchInput ? String(searchInput.value || "").trim() : "");
+    query.set("timeline_correlation", timelineInput ? String(timelineInput.value || "").trim() : "");
+    query.set("provenance_correlation", provenanceInput ? String(provenanceInput.value || "").trim() : "");
+    query.set("snapshot_from_id", fromInput ? String(fromInput.value || "").trim() : "");
+    query.set("snapshot_to_id", toInput ? String(toInput.value || "").trim() : "");
+
+    try {
+      const response = await fetch(`api/v1/sessions/save?${query.toString()}`);
+      const payload = await response.json();
+      const id = payload.session?.id || "unknown";
+      const loadInput = this.querySelector('[data-role="session-load-id"]');
+      if (loadInput) {
+        loadInput.value = id;
+      }
+      if (streamStatus) {
+        streamStatus.textContent = `Session saved: ${id}`;
+      }
+      await this.refreshSessions();
+    } catch (err) {
+      if (streamStatus) {
+        streamStatus.textContent = "Session save failed";
+      }
+    }
+  }
+
+  async loadSession() {
+    const loadInput = this.querySelector('[data-role="session-load-id"]');
+    const streamStatus = this.querySelector('[data-role="stream-status"]');
+    const sessionID = loadInput ? String(loadInput.value || "").trim() : "";
+    if (!sessionID) {
+      if (streamStatus) {
+        streamStatus.textContent = "Session id missing";
+      }
+      return;
+    }
+    try {
+      const response = await fetch(`api/v1/sessions/load?id=${encodeURIComponent(sessionID)}`);
+      if (!response.ok) {
+        if (streamStatus) {
+          streamStatus.textContent = `Session load failed (${response.status})`;
+        }
+        return;
+      }
+      const payload = await response.json();
+      const state = payload.session?.state || {};
+      const searchInput = this.querySelector('[data-role="search-input"]');
+      const timelineInput = this.querySelector('[data-role="timeline-correlation"]');
+      const provenanceInput = this.querySelector('[data-role="provenance-correlation"]');
+      const fromInput = this.querySelector('[data-role="snapshot-diff-from"]');
+      const toInput = this.querySelector('[data-role="snapshot-diff-to"]');
+      if (searchInput) searchInput.value = state.search_query || "";
+      if (timelineInput) timelineInput.value = state.timeline_correlation || "";
+      if (provenanceInput) provenanceInput.value = state.provenance_correlation || "";
+      if (fromInput) fromInput.value = state.snapshot_from_id || "";
+      if (toInput) toInput.value = state.snapshot_to_id || "";
+
+      this.scheduleSearch(searchInput ? searchInput.value : "");
+      this.scheduleTimelineRefresh();
+      this.scheduleProvenanceRefresh();
+      this.runSnapshotDiff();
+
+      if (streamStatus) {
+        streamStatus.textContent = `Session loaded: ${sessionID}`;
+      }
+    } catch (err) {
+      if (streamStatus) {
+        streamStatus.textContent = "Session load failed";
+      }
+    }
+  }
+
   scheduleSearch(rawQuery) {
     if (this.searchTimer) {
       clearTimeout(this.searchTimer);
@@ -666,6 +796,18 @@ class PortalShell extends HTMLElement {
               </div>
               <ul data-role="snapshot-diff-list">
                 <li>Loading snapshot diff capability...</li>
+              </ul>
+            </section>
+            <section class="registry-preview">
+              <h2>Sessions</h2>
+              <div class="snapshot-controls">
+                <input class="search timeline-filter" data-role="session-name" type="search" placeholder="Session name" aria-label="Session name" />
+                <button class="button" data-role="session-save" type="button">Save Session</button>
+                <input class="search timeline-filter" data-role="session-load-id" type="search" placeholder="Session id" aria-label="Session id" />
+                <button class="button" data-role="session-load" type="button">Load Session</button>
+              </div>
+              <ul data-role="sessions-list">
+                <li>Loading sessions capability...</li>
               </ul>
             </section>
             <div class="meta" data-role="stream-status">Stream idle</div>


### PR DESCRIPTION
## Summary
- add in-memory investigation session/bookmark store
- add session endpoints:
  - `GET /portal/api/v1/sessions`
  - `GET /portal/api/v1/sessions/save`
  - `GET /portal/api/v1/sessions/load`
- expose sessions capability/endpoints in bootstrap payload
- extend portal UI with save/load session controls and sessions list
- add handler tests for session save/list/load and validation

## Testing
- `GOWORK=off go test ./portal ./ui`
- `./scripts/check_portal_assets.sh`

## Docs
- docs updated directly on main: d3vi1/helianthus-docs-ebus@95e6eb2

Closes #158
