### PR TITLE
feat(portal): add issue draft and export bundle API

### DIFF
--- a/portal/handler.go
+++ b/portal/handler.go
@@ -245,6 +245,12 @@ type sessionStore struct {
 	items       []InvestigationSession
 }
 
+type IssueDraft struct {
+	Title    string         `json:"title"`
+	Markdown string         `json:"markdown"`
+	Evidence map[string]any `json:"evidence"`
+}
+
 func NewHandler(opts Options) http.Handler {
 	if opts.GraphQLPath == "" {
 		opts.GraphQLPath = "/graphql"
@@ -637,6 +643,7 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 				"snapshots":     streamEnabled,
 				"snapshot_diff": streamEnabled,
 				"sessions":      true,
+				"issue_builder": true,
 			},
 			"endpoints": map[string]string{
 				"graphql":       h.opts.GraphQLPath,
@@ -654,6 +661,8 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 				"sessions":      "/portal/api/v1/sessions",
 				"session_save":  "/portal/api/v1/sessions/save",
 				"session_load":  "/portal/api/v1/sessions/load",
+				"issue_draft":   "/portal/api/v1/issues/draft",
+				"issue_export":  "/portal/api/v1/issues/export",
 			},
 			"limits": map[string]any{
 				"max_events_per_second": 200,
@@ -691,6 +700,10 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 		h.handleSessionsSave(w, r)
 	case "sessions/load":
 		h.handleSessionsLoad(w, r)
+	case "issues/draft":
+		h.handleIssueDraft(w, r)
+	case "issues/export":
+		h.handleIssueExport(w, r)
 	default:
 		http.NotFound(w, r)
 	}
@@ -761,6 +774,10 @@ func classifyRoute(path string) string {
 		return "api.sessions.load"
 	case strings.HasPrefix(path, "/api/v1/sessions"):
 		return "api.sessions.list"
+	case strings.HasPrefix(path, "/api/v1/issues/draft"):
+		return "api.issues.draft"
+	case strings.HasPrefix(path, "/api/v1/issues/export"):
+		return "api.issues.export"
 	case strings.HasPrefix(path, "/assets/"):
 		return "assets"
 	case path == "/" || strings.EqualFold(path, "/index.html"):
@@ -1373,6 +1390,136 @@ func (h *handler) handleSessionsLoad(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{
 		"session": session,
 	})
+}
+
+func (h *handler) handleIssueDraft(w http.ResponseWriter, r *http.Request) {
+	draft := h.buildIssueDraft(r)
+	writeJSON(w, http.StatusOK, draft)
+}
+
+func (h *handler) handleIssueExport(w http.ResponseWriter, r *http.Request) {
+	draft := h.buildIssueDraft(r)
+	bundle := map[string]any{
+		"format_version": "helianthus-issue-bundle/v1",
+		"generated_at":   time.Now().UTC().Format(time.RFC3339Nano),
+		"title":          draft.Title,
+		"markdown":       draft.Markdown,
+		"evidence":       draft.Evidence,
+		"filename_hint":  sanitizeFilename(draft.Title) + ".json",
+	}
+	writeJSON(w, http.StatusOK, bundle)
+}
+
+func (h *handler) buildIssueDraft(r *http.Request) IssueDraft {
+	query := r.URL.Query()
+	title := strings.TrimSpace(query.Get("title"))
+	if title == "" {
+		title = "Vaillant semantic mapping candidate"
+	}
+	observation := defaultText(query.Get("observation"), "Observed behavior requiring semantic mapping.")
+	repro := defaultText(query.Get("reproduction_steps"), "1) Open portal 2) Capture evidence 3) Compare expected vs actual behavior")
+	hypothesis := defaultText(query.Get("hypothesis"), "Potential register/method meaning inferred from correlated evidence.")
+	impact := defaultText(query.Get("impact"), "Incorrect/unknown mapping blocks reliable gateway semantic extension.")
+	proposal := defaultText(query.Get("proposal"), "Implement semantic mapping in gateway provider and expose through GraphQL contract.")
+	ac := defaultText(query.Get("acceptance_criteria"), "1) Deterministic mapping 2) Contract fields populated 3) Tests and docs updated")
+	controller := defaultText(query.Get("controller"), "unknown-controller")
+	device := defaultText(query.Get("device"), "unknown-device")
+
+	evidence := h.collectIssueEvidence()
+	prettyEvidence, _ := json.MarshalIndent(evidence, "", "  ")
+	markdown := strings.Join([]string{
+		"# " + title,
+		"",
+		"## 1) Context",
+		fmt.Sprintf("- gateway_version: `%s`", h.opts.GatewayVersion),
+		fmt.Sprintf("- build_id: `%s`", h.opts.BuildID),
+		fmt.Sprintf("- controller: `%s`", controller),
+		fmt.Sprintf("- device: `%s`", device),
+		"",
+		"## 2) Observation & Goal",
+		observation,
+		"",
+		"## 3) Reproduction Steps",
+		repro,
+		"",
+		"## 4) Evidence",
+		"- snapshots: included in JSON bundle",
+		"- timeline/provenance: included in JSON bundle",
+		"```json",
+		string(prettyEvidence),
+		"```",
+		"",
+		"## 5) Semantic Hypothesis",
+		hypothesis,
+		"",
+		"## 6) Impact",
+		impact,
+		"",
+		"## 7) Proposed Implementation",
+		proposal,
+		"",
+		"## 8) Acceptance Criteria",
+		ac,
+		"",
+	}, "\n")
+
+	return IssueDraft{
+		Title:    title,
+		Markdown: markdown,
+		Evidence: evidence,
+	}
+}
+
+func (h *handler) collectIssueEvidence() map[string]any {
+	evidence := map[string]any{
+		"captured_at": time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	if h.snapshots != nil {
+		evidence["snapshots"] = h.snapshots.list(3)
+	}
+	if h.timeline != nil {
+		events := h.timeline.query(20, "", "", time.Time{})
+		evidence["timeline"] = events
+		provenance := make([]ProvenanceRecord, 0, len(events))
+		for _, event := range events {
+			provenance = append(provenance, toProvenanceRecord(event))
+		}
+		evidence["provenance"] = provenance
+	}
+	if h.opts.ListRegistry != nil {
+		evidence["registry_devices"] = h.opts.ListRegistry()
+	}
+	return evidence
+}
+
+func defaultText(value, fallback string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return fallback
+	}
+	return trimmed
+}
+
+func sanitizeFilename(value string) string {
+	trimmed := strings.TrimSpace(strings.ToLower(value))
+	if trimmed == "" {
+		return "issue-draft"
+	}
+	var builder strings.Builder
+	for _, ch := range trimmed {
+		if (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') {
+			builder.WriteRune(ch)
+			continue
+		}
+		if ch == '-' || ch == '_' || ch == ' ' {
+			builder.WriteByte('-')
+		}
+	}
+	out := strings.Trim(builder.String(), "-")
+	if out == "" {
+		return "issue-draft"
+	}
+	return out
 }
 
 func buildSnapshotDiffEntries(fromPayload map[string]any, toPayload map[string]any) []SnapshotDiffEntry {

--- a/portal/handler_test.go
+++ b/portal/handler_test.go
@@ -172,6 +172,12 @@ func TestBootstrapEndpoint(t *testing.T) {
 	if endpoints["session_load"] != "/portal/api/v1/sessions/load" {
 		t.Fatalf("session_load endpoint=%v; want /portal/api/v1/sessions/load", endpoints["session_load"])
 	}
+	if endpoints["issue_draft"] != "/portal/api/v1/issues/draft" {
+		t.Fatalf("issue_draft endpoint=%v; want /portal/api/v1/issues/draft", endpoints["issue_draft"])
+	}
+	if endpoints["issue_export"] != "/portal/api/v1/issues/export" {
+		t.Fatalf("issue_export endpoint=%v; want /portal/api/v1/issues/export", endpoints["issue_export"])
+	}
 	capabilities := payload["capabilities"].(map[string]any)
 	if capabilities["registry"] != true {
 		t.Fatalf("capabilities.registry=%v; want true", capabilities["registry"])
@@ -202,6 +208,9 @@ func TestBootstrapEndpoint(t *testing.T) {
 	}
 	if capabilities["sessions"] != true {
 		t.Fatalf("capabilities.sessions=%v; want true", capabilities["sessions"])
+	}
+	if capabilities["issue_builder"] != true {
+		t.Fatalf("capabilities.issue_builder=%v; want true", capabilities["issue_builder"])
 	}
 }
 
@@ -909,5 +918,52 @@ func TestSessionsLoadValidation(t *testing.T) {
 	h.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status=%d; want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestIssueDraftAndExportEndpoints(t *testing.T) {
+	h := NewHandler(Options{
+		GatewayVersion: "test-v",
+		BuildID:        "test-b",
+		ListRegistry: func() []RegistryDevice {
+			return []RegistryDevice{{Address: 0x10, Manufacturer: "Vaillant", DeviceID: "VRC720"}}
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/issues/draft?title=Draft+Title&observation=Obs", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("draft status=%d; want %d", rec.Code, http.StatusOK)
+	}
+	var draft map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &draft); err != nil {
+		t.Fatalf("draft unmarshal: %v", err)
+	}
+	if draft["title"] != "Draft Title" {
+		t.Fatalf("title=%v; want Draft Title", draft["title"])
+	}
+	if !strings.Contains(draft["markdown"].(string), "## 1) Context") {
+		t.Fatalf("markdown missing context section")
+	}
+	if _, ok := draft["evidence"].(map[string]any); !ok {
+		t.Fatalf("evidence missing or invalid")
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/issues/export?title=Draft+Title", nil)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("export status=%d; want %d", rec.Code, http.StatusOK)
+	}
+	var bundle map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &bundle); err != nil {
+		t.Fatalf("export unmarshal: %v", err)
+	}
+	if bundle["format_version"] != "helianthus-issue-bundle/v1" {
+		t.Fatalf("format_version=%v", bundle["format_version"])
+	}
+	if bundle["filename_hint"] == "" {
+		t.Fatalf("filename_hint missing")
 	}
 }

--- a/portal/static/assets/app.css
+++ b/portal/static/assets/app.css
@@ -210,6 +210,19 @@ body {
   margin-bottom: 0;
 }
 
+.issue-preview {
+  white-space: pre-wrap;
+  font-family: "IBM Plex Mono", "Fira Code", monospace;
+  font-size: 0.78rem;
+  line-height: 1.35;
+  padding: 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--panel-soft) 90%, transparent);
+  max-height: 260px;
+  overflow: auto;
+}
+
 .pill {
   display: inline-block;
   border: 1px solid var(--border);

--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -68,6 +68,8 @@ class PortalShell extends HTMLElement {
     const diffButton = this.querySelector('[data-role="snapshot-diff-run"]');
     const sessionSave = this.querySelector('[data-role="session-save"]');
     const sessionLoad = this.querySelector('[data-role="session-load"]');
+    const issueDraftButton = this.querySelector('[data-role="issue-draft-run"]');
+    const issueExportButton = this.querySelector('[data-role="issue-export-run"]');
     if (toggle) {
       toggle.addEventListener("click", () => {
         const current = loadTheme();
@@ -114,6 +116,16 @@ class PortalShell extends HTMLElement {
         this.loadSession();
       });
     }
+    if (issueDraftButton) {
+      issueDraftButton.addEventListener("click", () => {
+        this.generateIssueDraft();
+      });
+    }
+    if (issueExportButton) {
+      issueExportButton.addEventListener("click", () => {
+        this.generateIssueExport();
+      });
+    }
   }
 
   async loadStatus() {
@@ -130,6 +142,7 @@ class PortalShell extends HTMLElement {
     const retentionInput = this.querySelector('[data-role="snapshot-retention"]');
     const diffList = this.querySelector('[data-role="snapshot-diff-list"]');
     const sessionsList = this.querySelector('[data-role="sessions-list"]');
+    const issuePreview = this.querySelector('[data-role="issue-preview"]');
     try {
       const [healthRes, bootstrapRes] = await Promise.all([
         fetch("api/v1/health"),
@@ -143,7 +156,7 @@ class PortalShell extends HTMLElement {
       if (metaEl) {
         const caps = bootstrap.capabilities || {};
         metaEl.textContent =
-          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, search=${caps.search}, stream=${caps.stream}, timeline=${caps.timeline}, provenance=${caps.provenance}, snapshots=${caps.snapshots}, snapshot_diff=${caps.snapshot_diff}, sessions=${caps.sessions}`;
+          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, search=${caps.search}, stream=${caps.stream}, timeline=${caps.timeline}, provenance=${caps.provenance}, snapshots=${caps.snapshots}, snapshot_diff=${caps.snapshot_diff}, sessions=${caps.sessions}, issue_builder=${caps.issue_builder}`;
       }
       if (searchInput) {
         searchInput.disabled = !bootstrap.capabilities?.search;
@@ -224,6 +237,11 @@ class PortalShell extends HTMLElement {
       }
       if (bootstrap.capabilities?.sessions) {
         await this.refreshSessions();
+      }
+      if (issuePreview) {
+        issuePreview.textContent = bootstrap.capabilities?.issue_builder
+          ? "Issue builder ready. Fill fields and generate draft."
+          : "Issue builder unavailable.";
       }
     } catch (err) {
       if (statusEl) {
@@ -598,6 +616,46 @@ class PortalShell extends HTMLElement {
     }
   }
 
+  async generateIssueDraft() {
+    const titleInput = this.querySelector('[data-role="issue-title"]');
+    const obsInput = this.querySelector('[data-role="issue-observation"]');
+    const hypoInput = this.querySelector('[data-role="issue-hypothesis"]');
+    const preview = this.querySelector('[data-role="issue-preview"]');
+    try {
+      const query = new URLSearchParams();
+      query.set("title", titleInput ? String(titleInput.value || "").trim() : "");
+      query.set("observation", obsInput ? String(obsInput.value || "").trim() : "");
+      query.set("hypothesis", hypoInput ? String(hypoInput.value || "").trim() : "");
+      const response = await fetch(`api/v1/issues/draft?${query.toString()}`);
+      const payload = await response.json();
+      if (preview) {
+        preview.textContent = payload.markdown || "Draft generation failed";
+      }
+    } catch (err) {
+      if (preview) {
+        preview.textContent = "Draft generation failed";
+      }
+    }
+  }
+
+  async generateIssueExport() {
+    const titleInput = this.querySelector('[data-role="issue-title"]');
+    const preview = this.querySelector('[data-role="issue-preview"]');
+    try {
+      const query = new URLSearchParams();
+      query.set("title", titleInput ? String(titleInput.value || "").trim() : "");
+      const response = await fetch(`api/v1/issues/export?${query.toString()}`);
+      const payload = await response.json();
+      if (preview) {
+        preview.textContent = JSON.stringify(payload, null, 2);
+      }
+    } catch (err) {
+      if (preview) {
+        preview.textContent = "Issue export failed";
+      }
+    }
+  }
+
   scheduleSearch(rawQuery) {
     if (this.searchTimer) {
       clearTimeout(this.searchTimer);
@@ -810,6 +868,17 @@ class PortalShell extends HTMLElement {
               <ul data-role="sessions-list">
                 <li>Loading sessions capability...</li>
               </ul>
+            </section>
+            <section class="registry-preview">
+              <h2>Issue Builder</h2>
+              <div class="snapshot-controls">
+                <input class="search timeline-filter" data-role="issue-title" type="search" placeholder="Issue title" aria-label="Issue title" />
+                <input class="search timeline-filter" data-role="issue-observation" type="search" placeholder="Observation" aria-label="Issue observation" />
+                <input class="search timeline-filter" data-role="issue-hypothesis" type="search" placeholder="Hypothesis" aria-label="Issue hypothesis" />
+                <button class="button" data-role="issue-draft-run" type="button">Draft Markdown</button>
+                <button class="button" data-role="issue-export-run" type="button">Export Bundle</button>
+              </div>
+              <pre class="issue-preview" data-role="issue-preview">Loading issue builder capability...</pre>
             </section>
             <div class="meta" data-role="stream-status">Stream idle</div>
             <div class="meta" data-role="meta">Waiting for bootstrap...</div>

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,12 +2,12 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 32877,
-      "sha256": "b3c916f351ecd97cc55c23e0688903c7e197c1b65c137f34f5cec0c086c716a8"
+      "bytes": 36221,
+      "sha256": "49f26b68977b6182b92cb513f0b83b10f5896e497498f3b77c50f055e4422080"
     },
     "app.css": {
-      "bytes": 4196,
-      "sha256": "2d5d985ad84c2dcb133db5a6aaa881e19144afa87f064468a927dfdce2942ec8"
+      "bytes": 4527,
+      "sha256": "eca67d98a239679499ae42d595e9140719f25eb7640804293db7285f772d7d51"
     }
   }
 }

--- a/portal/web/src/app.css
+++ b/portal/web/src/app.css
@@ -209,6 +209,19 @@ body {
   margin-bottom: 0;
 }
 
+.issue-preview {
+  white-space: pre-wrap;
+  font-family: "IBM Plex Mono", "Fira Code", monospace;
+  font-size: 0.78rem;
+  line-height: 1.35;
+  padding: 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--panel-soft) 90%, transparent);
+  max-height: 260px;
+  overflow: auto;
+}
+
 .pill {
   display: inline-block;
   border: 1px solid var(--border);

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -67,6 +67,8 @@ class PortalShell extends HTMLElement {
     const diffButton = this.querySelector('[data-role="snapshot-diff-run"]');
     const sessionSave = this.querySelector('[data-role="session-save"]');
     const sessionLoad = this.querySelector('[data-role="session-load"]');
+    const issueDraftButton = this.querySelector('[data-role="issue-draft-run"]');
+    const issueExportButton = this.querySelector('[data-role="issue-export-run"]');
     if (toggle) {
       toggle.addEventListener("click", () => {
         const current = loadTheme();
@@ -113,6 +115,16 @@ class PortalShell extends HTMLElement {
         this.loadSession();
       });
     }
+    if (issueDraftButton) {
+      issueDraftButton.addEventListener("click", () => {
+        this.generateIssueDraft();
+      });
+    }
+    if (issueExportButton) {
+      issueExportButton.addEventListener("click", () => {
+        this.generateIssueExport();
+      });
+    }
   }
 
   async loadStatus() {
@@ -129,6 +141,7 @@ class PortalShell extends HTMLElement {
     const retentionInput = this.querySelector('[data-role="snapshot-retention"]');
     const diffList = this.querySelector('[data-role="snapshot-diff-list"]');
     const sessionsList = this.querySelector('[data-role="sessions-list"]');
+    const issuePreview = this.querySelector('[data-role="issue-preview"]');
     try {
       const [healthRes, bootstrapRes] = await Promise.all([
         fetch("api/v1/health"),
@@ -142,7 +155,7 @@ class PortalShell extends HTMLElement {
       if (metaEl) {
         const caps = bootstrap.capabilities || {};
         metaEl.textContent =
-          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, search=${caps.search}, stream=${caps.stream}, timeline=${caps.timeline}, provenance=${caps.provenance}, snapshots=${caps.snapshots}, snapshot_diff=${caps.snapshot_diff}, sessions=${caps.sessions}`;
+          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, search=${caps.search}, stream=${caps.stream}, timeline=${caps.timeline}, provenance=${caps.provenance}, snapshots=${caps.snapshots}, snapshot_diff=${caps.snapshot_diff}, sessions=${caps.sessions}, issue_builder=${caps.issue_builder}`;
       }
       if (searchInput) {
         searchInput.disabled = !bootstrap.capabilities?.search;
@@ -223,6 +236,11 @@ class PortalShell extends HTMLElement {
       }
       if (bootstrap.capabilities?.sessions) {
         await this.refreshSessions();
+      }
+      if (issuePreview) {
+        issuePreview.textContent = bootstrap.capabilities?.issue_builder
+          ? "Issue builder ready. Fill fields and generate draft."
+          : "Issue builder unavailable.";
       }
     } catch (err) {
       if (statusEl) {
@@ -597,6 +615,46 @@ class PortalShell extends HTMLElement {
     }
   }
 
+  async generateIssueDraft() {
+    const titleInput = this.querySelector('[data-role="issue-title"]');
+    const obsInput = this.querySelector('[data-role="issue-observation"]');
+    const hypoInput = this.querySelector('[data-role="issue-hypothesis"]');
+    const preview = this.querySelector('[data-role="issue-preview"]');
+    try {
+      const query = new URLSearchParams();
+      query.set("title", titleInput ? String(titleInput.value || "").trim() : "");
+      query.set("observation", obsInput ? String(obsInput.value || "").trim() : "");
+      query.set("hypothesis", hypoInput ? String(hypoInput.value || "").trim() : "");
+      const response = await fetch(`api/v1/issues/draft?${query.toString()}`);
+      const payload = await response.json();
+      if (preview) {
+        preview.textContent = payload.markdown || "Draft generation failed";
+      }
+    } catch (err) {
+      if (preview) {
+        preview.textContent = "Draft generation failed";
+      }
+    }
+  }
+
+  async generateIssueExport() {
+    const titleInput = this.querySelector('[data-role="issue-title"]');
+    const preview = this.querySelector('[data-role="issue-preview"]');
+    try {
+      const query = new URLSearchParams();
+      query.set("title", titleInput ? String(titleInput.value || "").trim() : "");
+      const response = await fetch(`api/v1/issues/export?${query.toString()}`);
+      const payload = await response.json();
+      if (preview) {
+        preview.textContent = JSON.stringify(payload, null, 2);
+      }
+    } catch (err) {
+      if (preview) {
+        preview.textContent = "Issue export failed";
+      }
+    }
+  }
+
   scheduleSearch(rawQuery) {
     if (this.searchTimer) {
       clearTimeout(this.searchTimer);
@@ -809,6 +867,17 @@ class PortalShell extends HTMLElement {
               <ul data-role="sessions-list">
                 <li>Loading sessions capability...</li>
               </ul>
+            </section>
+            <section class="registry-preview">
+              <h2>Issue Builder</h2>
+              <div class="snapshot-controls">
+                <input class="search timeline-filter" data-role="issue-title" type="search" placeholder="Issue title" aria-label="Issue title" />
+                <input class="search timeline-filter" data-role="issue-observation" type="search" placeholder="Observation" aria-label="Issue observation" />
+                <input class="search timeline-filter" data-role="issue-hypothesis" type="search" placeholder="Hypothesis" aria-label="Issue hypothesis" />
+                <button class="button" data-role="issue-draft-run" type="button">Draft Markdown</button>
+                <button class="button" data-role="issue-export-run" type="button">Export Bundle</button>
+              </div>
+              <pre class="issue-preview" data-role="issue-preview">Loading issue builder capability...</pre>
             </section>
             <div class="meta" data-role="stream-status">Stream idle</div>
             <div class="meta" data-role="meta">Waiting for bootstrap...</div>


### PR DESCRIPTION
## Summary
- add issue builder endpoints:
  - `GET /portal/api/v1/issues/draft`
  - `GET /portal/api/v1/issues/export`
- generate structured markdown template with evidence context sections
- generate JSON export bundle (`helianthus-issue-bundle/v1`) including evidence payload
- expose issue builder capability/endpoints via bootstrap
- extend portal UI with issue builder controls and preview panel
- add handler tests for draft/export routes and bootstrap flags

## Testing
- `GOWORK=off go test ./portal ./ui`
- `./scripts/check_portal_assets.sh`

## Docs
- docs updated directly on main: d3vi1/helianthus-docs-ebus@4454d88

Closes #159
