### PR TITLE
feat(portal): add VRC-Explorer deprecation migration surface

### DIFF
--- a/portal/handler.go
+++ b/portal/handler.go
@@ -644,6 +644,7 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 				"snapshot_diff": streamEnabled,
 				"sessions":      true,
 				"issue_builder": true,
+				"migration":     true,
 			},
 			"endpoints": map[string]string{
 				"graphql":       h.opts.GraphQLPath,
@@ -663,6 +664,7 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 				"session_load":  "/portal/api/v1/sessions/load",
 				"issue_draft":   "/portal/api/v1/issues/draft",
 				"issue_export":  "/portal/api/v1/issues/export",
+				"vrc_migration": "/portal/api/v1/deprecation/vrc-explorer",
 			},
 			"limits": map[string]any{
 				"max_events_per_second": 200,
@@ -704,6 +706,8 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 		h.handleIssueDraft(w, r)
 	case "issues/export":
 		h.handleIssueExport(w, r)
+	case "deprecation/vrc-explorer":
+		h.handleVRCExplorerDeprecation(w, r)
 	default:
 		http.NotFound(w, r)
 	}
@@ -778,6 +782,8 @@ func classifyRoute(path string) string {
 		return "api.issues.draft"
 	case strings.HasPrefix(path, "/api/v1/issues/export"):
 		return "api.issues.export"
+	case strings.HasPrefix(path, "/api/v1/deprecation/vrc-explorer"):
+		return "api.deprecation.vrc_explorer"
 	case strings.HasPrefix(path, "/assets/"):
 		return "assets"
 	case path == "/" || strings.EqualFold(path, "/index.html"):
@@ -1408,6 +1414,31 @@ func (h *handler) handleIssueExport(w http.ResponseWriter, r *http.Request) {
 		"filename_hint":  sanitizeFilename(draft.Title) + ".json",
 	}
 	writeJSON(w, http.StatusOK, bundle)
+}
+
+func (h *handler) handleVRCExplorerDeprecation(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{
+		"component":      "VRC-Explorer",
+		"status":         "deprecated",
+		"effective_from": "2026-02-24",
+		"freeze_mode":    true,
+		"replacement": map[string]any{
+			"name": "Helianthus Portal",
+			"path": "/portal",
+		},
+		"migration_doc": "https://github.com/d3vi1/helianthus-docs-ebus/blob/main/development/vrc-explorer-migration.md",
+		"feature_mapping": []map[string]string{
+			{"vrc_explorer": "live register browsing", "portal": "registry + projection + timeline panels"},
+			{"vrc_explorer": "manual evidence notes", "portal": "sessions + issue draft builder"},
+			{"vrc_explorer": "state snapshots", "portal": "snapshot capture/diff/retention"},
+		},
+		"deprecation_gates": []string{
+			"portal_read_path_stable",
+			"snapshot_diff_available",
+			"issue_export_bundle_available",
+			"migration_guide_published",
+		},
+	})
 }
 
 func (h *handler) buildIssueDraft(r *http.Request) IssueDraft {

--- a/portal/handler_test.go
+++ b/portal/handler_test.go
@@ -178,6 +178,9 @@ func TestBootstrapEndpoint(t *testing.T) {
 	if endpoints["issue_export"] != "/portal/api/v1/issues/export" {
 		t.Fatalf("issue_export endpoint=%v; want /portal/api/v1/issues/export", endpoints["issue_export"])
 	}
+	if endpoints["vrc_migration"] != "/portal/api/v1/deprecation/vrc-explorer" {
+		t.Fatalf("vrc_migration endpoint=%v; want /portal/api/v1/deprecation/vrc-explorer", endpoints["vrc_migration"])
+	}
 	capabilities := payload["capabilities"].(map[string]any)
 	if capabilities["registry"] != true {
 		t.Fatalf("capabilities.registry=%v; want true", capabilities["registry"])
@@ -211,6 +214,9 @@ func TestBootstrapEndpoint(t *testing.T) {
 	}
 	if capabilities["issue_builder"] != true {
 		t.Fatalf("capabilities.issue_builder=%v; want true", capabilities["issue_builder"])
+	}
+	if capabilities["migration"] != true {
+		t.Fatalf("capabilities.migration=%v; want true", capabilities["migration"])
 	}
 }
 
@@ -965,5 +971,25 @@ func TestIssueDraftAndExportEndpoints(t *testing.T) {
 	}
 	if bundle["filename_hint"] == "" {
 		t.Fatalf("filename_hint missing")
+	}
+}
+
+func TestVRCExplorerDeprecationEndpoint(t *testing.T) {
+	h := NewHandler(Options{})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/deprecation/vrc-explorer", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d; want %d", rec.Code, http.StatusOK)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if payload["status"] != "deprecated" {
+		t.Fatalf("status=%v; want deprecated", payload["status"])
+	}
+	if payload["component"] != "VRC-Explorer" {
+		t.Fatalf("component=%v; want VRC-Explorer", payload["component"])
 	}
 }

--- a/portal/static/assets/app.css
+++ b/portal/static/assets/app.css
@@ -140,6 +140,20 @@ body {
   color: var(--muted);
 }
 
+.deprecation-banner {
+  margin: 0 0 0.8rem;
+  padding: 0.75rem 0.9rem;
+  border: 1px solid color-mix(in srgb, var(--warn) 45%, var(--border));
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--warn) 12%, var(--panel-soft));
+  color: var(--text);
+  font-size: 0.88rem;
+}
+
+.deprecation-banner a {
+  color: var(--accent);
+}
+
 .cards {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));

--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -143,6 +143,7 @@ class PortalShell extends HTMLElement {
     const diffList = this.querySelector('[data-role="snapshot-diff-list"]');
     const sessionsList = this.querySelector('[data-role="sessions-list"]');
     const issuePreview = this.querySelector('[data-role="issue-preview"]');
+    const deprecationBanner = this.querySelector('[data-role="deprecation-banner"]');
     try {
       const [healthRes, bootstrapRes] = await Promise.all([
         fetch("api/v1/health"),
@@ -156,7 +157,7 @@ class PortalShell extends HTMLElement {
       if (metaEl) {
         const caps = bootstrap.capabilities || {};
         metaEl.textContent =
-          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, search=${caps.search}, stream=${caps.stream}, timeline=${caps.timeline}, provenance=${caps.provenance}, snapshots=${caps.snapshots}, snapshot_diff=${caps.snapshot_diff}, sessions=${caps.sessions}, issue_builder=${caps.issue_builder}`;
+          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, search=${caps.search}, stream=${caps.stream}, timeline=${caps.timeline}, provenance=${caps.provenance}, snapshots=${caps.snapshots}, snapshot_diff=${caps.snapshot_diff}, sessions=${caps.sessions}, issue_builder=${caps.issue_builder}, migration=${caps.migration}`;
       }
       if (searchInput) {
         searchInput.disabled = !bootstrap.capabilities?.search;
@@ -243,6 +244,13 @@ class PortalShell extends HTMLElement {
           ? "Issue builder ready. Fill fields and generate draft."
           : "Issue builder unavailable.";
       }
+      if (deprecationBanner) {
+        if (bootstrap.capabilities?.migration) {
+          await this.refreshDeprecationBanner(deprecationBanner);
+        } else {
+          deprecationBanner.textContent = "Migration metadata unavailable.";
+        }
+      }
     } catch (err) {
       if (statusEl) {
         statusEl.textContent = "Gateway unavailable";
@@ -251,6 +259,17 @@ class PortalShell extends HTMLElement {
         metaEl.textContent = "Bootstrap fetch failed";
       }
       console.error("portal bootstrap failed", err);
+    }
+  }
+
+  async refreshDeprecationBanner(target) {
+    try {
+      const response = await fetch("api/v1/deprecation/vrc-explorer");
+      const payload = await response.json();
+      const replacement = payload.replacement?.name || "Portal";
+      target.innerHTML = `<strong>${escapeHtml(payload.component || "VRC-Explorer")} is deprecated.</strong> Use ${escapeHtml(replacement)}. <a href="${escapeHtml(payload.migration_doc || "#")}" target="_blank" rel="noreferrer">Migration guide</a>`;
+    } catch (err) {
+      target.textContent = "Deprecation metadata request failed.";
     }
   }
 
@@ -787,6 +806,7 @@ class PortalShell extends HTMLElement {
           </aside>
           <main class="main">
             <h1>Portal Overview</h1>
+            <div class="deprecation-banner" data-role="deprecation-banner">Loading deprecation policy...</div>
             <p class="hero">M0 skeleton online. Discovery and evidence workflows unlock in subsequent milestones.</p>
             <section class="cards" aria-label="Capability cards">
               <article class="card"><h3>Registry</h3><span class="badge">Coming Soon</span></article>

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,12 +2,12 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 36221,
-      "sha256": "49f26b68977b6182b92cb513f0b83b10f5896e497498f3b77c50f055e4422080"
+      "bytes": 37287,
+      "sha256": "61847b3d0a59081d02b5f36e4188436d5165922c8a3ca15425136c99b6dd489c"
     },
     "app.css": {
-      "bytes": 4527,
-      "sha256": "eca67d98a239679499ae42d595e9140719f25eb7640804293db7285f772d7d51"
+      "bytes": 4861,
+      "sha256": "10af55b4d78c1bde1cb61b63ef3d4926c2e851a364eb85660262937497c441b5"
     }
   }
 }

--- a/portal/web/src/app.css
+++ b/portal/web/src/app.css
@@ -139,6 +139,20 @@ body {
   color: var(--muted);
 }
 
+.deprecation-banner {
+  margin: 0 0 0.8rem;
+  padding: 0.75rem 0.9rem;
+  border: 1px solid color-mix(in srgb, var(--warn) 45%, var(--border));
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--warn) 12%, var(--panel-soft));
+  color: var(--text);
+  font-size: 0.88rem;
+}
+
+.deprecation-banner a {
+  color: var(--accent);
+}
+
 .cards {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -142,6 +142,7 @@ class PortalShell extends HTMLElement {
     const diffList = this.querySelector('[data-role="snapshot-diff-list"]');
     const sessionsList = this.querySelector('[data-role="sessions-list"]');
     const issuePreview = this.querySelector('[data-role="issue-preview"]');
+    const deprecationBanner = this.querySelector('[data-role="deprecation-banner"]');
     try {
       const [healthRes, bootstrapRes] = await Promise.all([
         fetch("api/v1/health"),
@@ -155,7 +156,7 @@ class PortalShell extends HTMLElement {
       if (metaEl) {
         const caps = bootstrap.capabilities || {};
         metaEl.textContent =
-          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, search=${caps.search}, stream=${caps.stream}, timeline=${caps.timeline}, provenance=${caps.provenance}, snapshots=${caps.snapshots}, snapshot_diff=${caps.snapshot_diff}, sessions=${caps.sessions}, issue_builder=${caps.issue_builder}`;
+          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, search=${caps.search}, stream=${caps.stream}, timeline=${caps.timeline}, provenance=${caps.provenance}, snapshots=${caps.snapshots}, snapshot_diff=${caps.snapshot_diff}, sessions=${caps.sessions}, issue_builder=${caps.issue_builder}, migration=${caps.migration}`;
       }
       if (searchInput) {
         searchInput.disabled = !bootstrap.capabilities?.search;
@@ -242,6 +243,13 @@ class PortalShell extends HTMLElement {
           ? "Issue builder ready. Fill fields and generate draft."
           : "Issue builder unavailable.";
       }
+      if (deprecationBanner) {
+        if (bootstrap.capabilities?.migration) {
+          await this.refreshDeprecationBanner(deprecationBanner);
+        } else {
+          deprecationBanner.textContent = "Migration metadata unavailable.";
+        }
+      }
     } catch (err) {
       if (statusEl) {
         statusEl.textContent = "Gateway unavailable";
@@ -250,6 +258,17 @@ class PortalShell extends HTMLElement {
         metaEl.textContent = "Bootstrap fetch failed";
       }
       console.error("portal bootstrap failed", err);
+    }
+  }
+
+  async refreshDeprecationBanner(target) {
+    try {
+      const response = await fetch("api/v1/deprecation/vrc-explorer");
+      const payload = await response.json();
+      const replacement = payload.replacement?.name || "Portal";
+      target.innerHTML = `<strong>${escapeHtml(payload.component || "VRC-Explorer")} is deprecated.</strong> Use ${escapeHtml(replacement)}. <a href="${escapeHtml(payload.migration_doc || "#")}" target="_blank" rel="noreferrer">Migration guide</a>`;
+    } catch (err) {
+      target.textContent = "Deprecation metadata request failed.";
     }
   }
 
@@ -786,6 +805,7 @@ class PortalShell extends HTMLElement {
           </aside>
           <main class="main">
             <h1>Portal Overview</h1>
+            <div class="deprecation-banner" data-role="deprecation-banner">Loading deprecation policy...</div>
             <p class="hero">M0 skeleton online. Discovery and evidence workflows unlock in subsequent milestones.</p>
             <section class="cards" aria-label="Capability cards">
               <article class="card"><h3>Registry</h3><span class="badge">Coming Soon</span></article>


### PR DESCRIPTION
## Summary
- add VRC-Explorer deprecation metadata endpoint:
  - `GET /portal/api/v1/deprecation/vrc-explorer`
- expose migration capability/endpoint in bootstrap payload
- add portal UI deprecation banner with migration guide link
- add handler tests for migration endpoint and bootstrap flags

## Testing
- `GOWORK=off go test ./portal ./ui`
- `./scripts/check_portal_assets.sh`

## Docs
- docs updated directly on main: d3vi1/helianthus-docs-ebus@973c0ef
- closed docs issue: d3vi1/helianthus-docs-ebus#126

Closes #160
