### PR TITLE
Portal: replace milestone placeholders with live semantic/projection views

### DIFF
--- a/portal/handler_test.go
+++ b/portal/handler_test.go
@@ -50,6 +50,31 @@ func TestHandlerAssets(t *testing.T) {
 	}
 }
 
+func TestHandlerAssets_NoMilestonePlaceholders(t *testing.T) {
+	h := NewHandler(Options{})
+	req := httptest.NewRequest(http.MethodGet, "/assets/app.js", nil)
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; want %d", rec.Code, http.StatusOK)
+	}
+	body := rec.Body.String()
+	for _, banned := range []string{
+		"Coming Soon",
+		"M0 skeleton",
+		"(M1)",
+		"(M2)",
+		"(M3)",
+		"(M5)",
+	} {
+		if strings.Contains(body, banned) {
+			t.Fatalf("asset app.js still contains banned placeholder text %q", banned)
+		}
+	}
+}
+
 func TestHandlerAssetsNotModified(t *testing.T) {
 	h := NewHandler(Options{})
 

--- a/portal/static/assets/app.css
+++ b/portal/static/assets/app.css
@@ -127,6 +127,17 @@ body {
   padding: 0.52rem 0.6rem;
 }
 
+.sidebar button.enabled {
+  border-style: solid;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.sidebar button.enabled:hover {
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
 .main {
   background: var(--panel);
   border: 1px solid var(--border);
@@ -173,6 +184,13 @@ body {
   font-size: 0.95rem;
 }
 
+.card-meta {
+  margin: 0.5rem 0 0;
+  color: var(--muted);
+  font-size: 0.82rem;
+  line-height: 1.3;
+}
+
 .badge {
   display: inline-block;
   margin-top: 0.45rem;
@@ -180,6 +198,18 @@ body {
   border-radius: 999px;
   padding: 0.2rem 0.5rem;
   font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.badge.available {
+  color: var(--text);
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+  background: color-mix(in srgb, var(--accent) 20%, transparent);
+}
+
+.badge.unavailable {
+  border-color: color-mix(in srgb, #d96f6f 45%, var(--border));
+  background: color-mix(in srgb, #d96f6f 14%, transparent);
   color: var(--muted);
 }
 
@@ -211,6 +241,70 @@ body {
 .timeline-filter {
   width: 100%;
   margin: 0 0 0.6rem;
+}
+
+.projection-controls {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) minmax(160px, 240px) auto;
+  gap: 0.45rem;
+  margin: 0 0 0.65rem;
+}
+
+.projection-controls.disabled {
+  opacity: 0.7;
+}
+
+.projection-graph {
+  margin-top: 0.8rem;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--panel) 84%, transparent);
+  padding: 0.6rem;
+  overflow: auto;
+}
+
+.projection-empty {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.projection-graph-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-bottom: 0.55rem;
+  flex-wrap: wrap;
+}
+
+.projection-svg {
+  width: 100%;
+  min-width: 620px;
+  height: auto;
+}
+
+.projection-edge {
+  fill: none;
+  stroke: color-mix(in srgb, var(--accent) 38%, var(--border));
+  stroke-width: 1.4;
+  opacity: 0.78;
+}
+
+.projection-node rect {
+  fill: color-mix(in srgb, var(--card) 92%, var(--accent) 8%);
+  stroke: color-mix(in srgb, var(--accent) 40%, var(--border));
+  stroke-width: 1;
+}
+
+.projection-node-title {
+  fill: var(--text);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.projection-node-subtitle {
+  fill: var(--muted);
+  font-size: 10px;
 }
 
 .snapshot-controls {
@@ -259,5 +353,13 @@ body {
 
   .content {
     grid-template-columns: 1fr;
+  }
+
+  .projection-controls {
+    grid-template-columns: 1fr;
+  }
+
+  .projection-svg {
+    min-width: 360px;
   }
 }

--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -23,6 +23,38 @@ function escapeHtml(value) {
     .replaceAll("'", "&#39;");
 }
 
+function formatFixed(value, digits = 1) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    return "n/a";
+  }
+  return number.toFixed(digits);
+}
+
+function formatTemperature(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    return "n/a";
+  }
+  return `${number.toFixed(1)}°C`;
+}
+
+function formatPercent(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    return "n/a";
+  }
+  return `${number.toFixed(0)}%`;
+}
+
+function formatAddress(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    return "0x??";
+  }
+  return `0x${number.toString(16).padStart(2, "0")}`;
+}
+
 class PortalShell extends HTMLElement {
   connectedCallback() {
     this.render();
@@ -70,6 +102,9 @@ class PortalShell extends HTMLElement {
     const sessionLoad = this.querySelector('[data-role="session-load"]');
     const issueDraftButton = this.querySelector('[data-role="issue-draft-run"]');
     const issueExportButton = this.querySelector('[data-role="issue-export-run"]');
+    const projectionDeviceSelect = this.querySelector('[data-role="projection-device-select"]');
+    const projectionPlaneSelect = this.querySelector('[data-role="projection-plane-select"]');
+    const projectionLoadButton = this.querySelector('[data-role="projection-load"]');
     if (toggle) {
       toggle.addEventListener("click", () => {
         const current = loadTheme();
@@ -126,6 +161,34 @@ class PortalShell extends HTMLElement {
         this.generateIssueExport();
       });
     }
+    if (projectionDeviceSelect) {
+      projectionDeviceSelect.addEventListener("change", () => {
+        this.refreshProjectionPlaneOptions();
+        this.loadSelectedProjectionGraph();
+      });
+    }
+    if (projectionPlaneSelect) {
+      projectionPlaneSelect.addEventListener("change", () => {
+        this.loadSelectedProjectionGraph();
+      });
+    }
+    if (projectionLoadButton) {
+      projectionLoadButton.addEventListener("click", () => {
+        this.loadSelectedProjectionGraph();
+      });
+    }
+    this.querySelectorAll("[data-nav-target]").forEach((button) => {
+      button.addEventListener("click", () => {
+        const targetID = button.getAttribute("data-nav-target");
+        if (!targetID) {
+          return;
+        }
+        const section = this.querySelector(`#${targetID}`);
+        if (section) {
+          section.scrollIntoView({ behavior: "smooth", block: "start" });
+        }
+      });
+    });
   }
 
   async loadStatus() {
@@ -154,38 +217,41 @@ class PortalShell extends HTMLElement {
       if (statusEl) {
         statusEl.textContent = `Gateway ${health.status}`;
       }
+      const capabilities = bootstrap.capabilities || {};
+      this.applyCapabilityState(capabilities);
       if (metaEl) {
-        const caps = bootstrap.capabilities || {};
+        const caps = capabilities;
+        const enabled = Object.keys(caps).filter((key) => caps[key]).length;
         metaEl.textContent =
-          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, search=${caps.search}, stream=${caps.stream}, timeline=${caps.timeline}, provenance=${caps.provenance}, snapshots=${caps.snapshots}, snapshot_diff=${caps.snapshot_diff}, sessions=${caps.sessions}, issue_builder=${caps.issue_builder}, migration=${caps.migration}`;
+          `Portal capabilities: ${enabled}/${Object.keys(caps).length || 0} enabled. GraphQL=${bootstrap.endpoints?.graphql || "n/a"}`;
       }
       if (searchInput) {
-        searchInput.disabled = !bootstrap.capabilities?.search;
-        searchInput.title = bootstrap.capabilities?.search ? "" : "Search is unavailable (no data providers)";
+        searchInput.disabled = !capabilities.search;
+        searchInput.title = capabilities.search ? "" : "Search is unavailable (no data providers)";
       }
-      if (bootstrap.capabilities?.registry && listEl) {
+      if (capabilities.registry && listEl) {
         await this.loadRegistryPreview(listEl);
       }
-      if (bootstrap.capabilities?.semantic && semanticEl) {
+      if (capabilities.semantic && semanticEl) {
         await this.loadSemanticPreview(semanticEl);
       }
-      if (bootstrap.capabilities?.projection && projectionEl) {
+      if (capabilities.projection && projectionEl) {
         await this.loadProjectionPreview(projectionEl);
       }
       if (searchList) {
-        searchList.innerHTML = bootstrap.capabilities?.search
+        searchList.innerHTML = capabilities.search
           ? "<li>Type at least 2 characters to search across registry, semantic and projection layers.</li>"
           : "<li>Search unavailable: no readable layers enabled.</li>";
       }
-      if (bootstrap.capabilities?.stream) {
+      if (capabilities.stream) {
         this.startStream();
       }
       if (timelineList) {
-        timelineList.innerHTML = bootstrap.capabilities?.timeline
+        timelineList.innerHTML = capabilities.timeline
           ? "<li>Loading timeline events...</li>"
           : "<li>Timeline unavailable: stream capability disabled.</li>";
       }
-      if (bootstrap.capabilities?.timeline) {
+      if (capabilities.timeline) {
         await this.refreshTimeline();
         if (this.timelineInterval) {
           clearInterval(this.timelineInterval);
@@ -195,11 +261,11 @@ class PortalShell extends HTMLElement {
         }, 3000);
       }
       if (provenanceList) {
-        provenanceList.innerHTML = bootstrap.capabilities?.provenance
+        provenanceList.innerHTML = capabilities.provenance
           ? "<li>Loading provenance records...</li>"
           : "<li>Provenance unavailable: stream capability disabled.</li>";
       }
-      if (bootstrap.capabilities?.provenance) {
+      if (capabilities.provenance) {
         await this.refreshProvenance();
         if (this.provenanceInterval) {
           clearInterval(this.provenanceInterval);
@@ -209,11 +275,11 @@ class PortalShell extends HTMLElement {
         }, 4000);
       }
       if (snapshotsList) {
-        snapshotsList.innerHTML = bootstrap.capabilities?.snapshots
+        snapshotsList.innerHTML = capabilities.snapshots
           ? "<li>Loading snapshot store...</li>"
           : "<li>Snapshots unavailable: stream capability disabled.</li>";
       }
-      if (bootstrap.capabilities?.snapshots) {
+      if (capabilities.snapshots) {
         await this.refreshSnapshots();
         const retention = await this.fetchSnapshotRetention();
         if (retentionInput && retention > 0) {
@@ -227,25 +293,25 @@ class PortalShell extends HTMLElement {
         }, 5000);
       }
       if (diffList) {
-        diffList.innerHTML = bootstrap.capabilities?.snapshot_diff
+        diffList.innerHTML = capabilities.snapshot_diff
           ? "<li>Select snapshot IDs and run diff.</li>"
           : "<li>Snapshot diff unavailable.</li>";
       }
       if (sessionsList) {
-        sessionsList.innerHTML = bootstrap.capabilities?.sessions
+        sessionsList.innerHTML = capabilities.sessions
           ? "<li>Loading sessions...</li>"
           : "<li>Sessions unavailable.</li>";
       }
-      if (bootstrap.capabilities?.sessions) {
+      if (capabilities.sessions) {
         await this.refreshSessions();
       }
       if (issuePreview) {
-        issuePreview.textContent = bootstrap.capabilities?.issue_builder
+        issuePreview.textContent = capabilities.issue_builder
           ? "Issue builder ready. Fill fields and generate draft."
           : "Issue builder unavailable.";
       }
       if (deprecationBanner) {
-        if (bootstrap.capabilities?.migration) {
+        if (capabilities.migration) {
           await this.refreshDeprecationBanner(deprecationBanner);
         } else {
           deprecationBanner.textContent = "Migration metadata unavailable.";
@@ -260,6 +326,49 @@ class PortalShell extends HTMLElement {
       }
       console.error("portal bootstrap failed", err);
     }
+  }
+
+  applyCapabilityState(capabilities) {
+    const cap = capabilities || {};
+    this.setCapabilityCard("registry", cap.registry, "Device registry and planes");
+    this.setCapabilityCard("semantic", cap.semantic, "Zones, DHW and energy snapshots");
+    this.setCapabilityCard("projection", cap.projection, "Plane graphs and topology links");
+    this.setCapabilityCard("timeline", cap.timeline, "Live stream timeline events");
+    this.setCapabilityCard("snapshots", cap.snapshots && cap.snapshot_diff, "Capture, retention and diff");
+    this.setCapabilityCard("issue_builder", cap.issue_builder, "Evidence draft and export bundle");
+
+    this.setNavState("registry", cap.registry);
+    this.setNavState("semantic", cap.semantic);
+    this.setNavState("projection", cap.projection);
+    this.setNavState("timeline", cap.timeline || cap.provenance);
+    this.setNavState("snapshots", cap.snapshots || cap.snapshot_diff);
+    this.setNavState("issue-builder", cap.issue_builder);
+  }
+
+  setCapabilityCard(capability, enabled, detail) {
+    const card = this.querySelector(`[data-capability="${capability}"]`);
+    if (!card) {
+      return;
+    }
+    const badge = card.querySelector(".badge");
+    if (badge) {
+      badge.textContent = enabled ? "Available" : "Unavailable";
+      badge.classList.toggle("available", Boolean(enabled));
+      badge.classList.toggle("unavailable", !enabled);
+    }
+    const meta = card.querySelector(".card-meta");
+    if (meta) {
+      meta.textContent = enabled ? detail : `${detail} (not exposed by this gateway)`;
+    }
+  }
+
+  setNavState(name, enabled) {
+    const button = this.querySelector(`[data-role="nav-${name}"]`);
+    if (!button) {
+      return;
+    }
+    button.disabled = !enabled;
+    button.classList.toggle("enabled", Boolean(enabled));
   }
 
   async refreshDeprecationBanner(target) {
@@ -746,12 +855,29 @@ class PortalShell extends HTMLElement {
       const zones = Array.isArray(payload.zones) ? payload.zones : [];
       const dhw = payload.dhw;
       const rows = [];
-      rows.push(`<li>Zones: ${zones.length}</li>`);
-      if (zones[0]) {
-        rows.push(`<li>Zone #1: ${zones[0].name || zones[0].id || "unknown"}</li>`);
+      rows.push(`<li><strong>Zones detected:</strong> ${zones.length}</li>`);
+      if (zones.length === 0) {
+        rows.push("<li>No semantic zones available.</li>");
+      } else {
+        zones.forEach((zone) => {
+          const name = escapeHtml(zone.name || zone.id || "zone");
+          const mode = escapeHtml(zone.operating_mode || "unknown");
+          const preset = escapeHtml(zone.preset || "n/a");
+          const current = formatTemperature(zone.current_temp_c);
+          const target = formatTemperature(zone.target_temp_c);
+          const demand = formatPercent(zone.heating_demand);
+          rows.push(
+            `<li><strong>${name}</strong> <span class="muted-inline">mode=${mode} preset=${preset} current=${escapeHtml(current)} target=${escapeHtml(target)} demand=${escapeHtml(demand)}</span></li>`,
+          );
+        });
       }
       if (dhw) {
-        rows.push(`<li>DHW mode: ${dhw.operating_mode || "unknown"}</li>`);
+        rows.push(`<li><strong>DHW</strong> <span class="muted-inline">mode=${escapeHtml(dhw.operating_mode || "unknown")} current=${escapeHtml(formatTemperature(dhw.current_temp_c))} target=${escapeHtml(formatTemperature(dhw.target_temp_c))}</span></li>`);
+      }
+      if (payload.energy_totals) {
+        rows.push(
+          `<li><strong>Energy today</strong> <span class="muted-inline">gas climate=${escapeHtml(formatFixed(payload.energy_totals?.gas?.climate?.today, 2))} dhw=${escapeHtml(formatFixed(payload.energy_totals?.gas?.dhw?.today, 2))}</span></li>`,
+        );
       }
       listEl.innerHTML = rows.join("");
     } catch (err) {
@@ -761,25 +887,273 @@ class PortalShell extends HTMLElement {
   }
 
   async loadProjectionPreview(listEl) {
+    const graphEl = this.querySelector('[data-role="projection-graph"]');
+    const controls = this.querySelector('[data-role="projection-controls"]');
+    const loadButton = this.querySelector('[data-role="projection-load"]');
     try {
-      const response = await fetch("api/v1/projection/devices?limit=5");
+      const response = await fetch("api/v1/projection/devices?limit=30");
       const payload = await response.json();
       const items = Array.isArray(payload.items) ? payload.items : [];
+      this.projectionDevices = items;
       if (items.length === 0) {
-        listEl.innerHTML = "<li>No projection graphs available.</li>";
+        listEl.innerHTML = "<li>No projection graphs available from current registry snapshot.</li>";
+        if (controls) {
+          controls.classList.add("disabled");
+        }
+        if (loadButton) {
+          loadButton.disabled = true;
+        }
+        this.renderProjectionState(graphEl, "Projection graph unavailable. No device projections published yet.");
         return;
       }
       listEl.innerHTML = items
         .map((item) => {
           const projectionCount = Array.isArray(item.projections) ? item.projections.length : 0;
-          const label = item.display_name || item.device_id || `0x${Number(item.address).toString(16)}`;
-          return `<li><strong>${label}</strong> projections=${projectionCount}</li>`;
+          const label = item.display_name || item.device_id || formatAddress(item.address);
+          const planes = Array.isArray(item.projections)
+            ? item.projections.map((projection) => projection.plane).filter(Boolean).join(", ")
+            : "";
+          return `<li><strong>${escapeHtml(label)}</strong> <span class="muted-inline">addr=${escapeHtml(formatAddress(item.address))} projections=${projectionCount}${planes ? ` planes=${escapeHtml(planes)}` : ""}</span></li>`;
         })
         .join("");
+      this.populateProjectionDeviceOptions();
+      if (controls) {
+        controls.classList.remove("disabled");
+      }
+      if (loadButton) {
+        loadButton.disabled = false;
+      }
+      await this.loadSelectedProjectionGraph();
     } catch (err) {
       listEl.innerHTML = "<li>Projection preview unavailable.</li>";
+      this.renderProjectionState(graphEl, "Projection preview request failed.");
       console.error("projection preview failed", err);
     }
+  }
+
+  populateProjectionDeviceOptions() {
+    const deviceSelect = this.querySelector('[data-role="projection-device-select"]');
+    if (!deviceSelect) {
+      return;
+    }
+    const items = Array.isArray(this.projectionDevices) ? this.projectionDevices : [];
+    if (items.length === 0) {
+      deviceSelect.innerHTML = "<option value=\"\">No devices</option>";
+      deviceSelect.disabled = true;
+      this.refreshProjectionPlaneOptions();
+      return;
+    }
+    deviceSelect.disabled = false;
+    deviceSelect.innerHTML = items
+      .map((item) => {
+        const label = item.display_name || item.device_id || formatAddress(item.address);
+        return `<option value="${escapeHtml(String(item.address))}">${escapeHtml(`${label} (${formatAddress(item.address)})`)}</option>`;
+      })
+      .join("");
+    this.refreshProjectionPlaneOptions();
+  }
+
+  refreshProjectionPlaneOptions() {
+    const deviceSelect = this.querySelector('[data-role="projection-device-select"]');
+    const planeSelect = this.querySelector('[data-role="projection-plane-select"]');
+    if (!deviceSelect || !planeSelect) {
+      return;
+    }
+    const address = Number(deviceSelect.value);
+    const items = Array.isArray(this.projectionDevices) ? this.projectionDevices : [];
+    const current = items.find((item) => Number(item.address) === address) || null;
+    const planes = current && Array.isArray(current.projections)
+      ? current.projections.map((projection) => projection.plane).filter(Boolean)
+      : [];
+    if (planes.length === 0) {
+      planeSelect.innerHTML = "<option value=\"\">No planes</option>";
+      planeSelect.disabled = true;
+      return;
+    }
+    planeSelect.disabled = false;
+    planeSelect.innerHTML = planes
+      .map((plane) => `<option value="${escapeHtml(plane)}">${escapeHtml(plane)}</option>`)
+      .join("");
+  }
+
+  async loadSelectedProjectionGraph() {
+    const graphEl = this.querySelector('[data-role="projection-graph"]');
+    const deviceSelect = this.querySelector('[data-role="projection-device-select"]');
+    const planeSelect = this.querySelector('[data-role="projection-plane-select"]');
+    if (!graphEl || !deviceSelect || !planeSelect) {
+      return;
+    }
+    const addressRaw = String(deviceSelect.value || "").trim();
+    const plane = String(planeSelect.value || "").trim();
+    if (!addressRaw || !plane) {
+      this.renderProjectionState(graphEl, "Pick device and plane to load graph.");
+      return;
+    }
+    const query = new URLSearchParams();
+    query.set("address", addressRaw);
+    query.set("plane", plane);
+    try {
+      const response = await fetch(`api/v1/projection/graph?${query.toString()}`);
+      if (!response.ok) {
+        this.renderProjectionState(graphEl, `Projection graph request failed (${response.status}).`);
+        return;
+      }
+      const payload = await response.json();
+      this.renderProjectionGraph(graphEl, payload);
+    } catch (err) {
+      this.renderProjectionState(graphEl, "Projection graph request failed.");
+      console.error("projection graph failed", err);
+    }
+  }
+
+  renderProjectionState(target, text) {
+    if (!target) {
+      return;
+    }
+    target.innerHTML = `<p class="projection-empty">${escapeHtml(text || "Projection graph unavailable.")}</p>`;
+  }
+
+  renderProjectionGraph(target, payload) {
+    if (!target) {
+      return;
+    }
+    const nodes = Array.isArray(payload?.nodes) ? payload.nodes : [];
+    const edges = Array.isArray(payload?.edges) ? payload.edges : [];
+    if (nodes.length === 0) {
+      this.renderProjectionState(target, "No projection nodes for selected plane.");
+      return;
+    }
+
+    const nodeByID = new Map();
+    nodes.forEach((node) => {
+      const id = String(node.id || "");
+      if (id) {
+        nodeByID.set(id, node);
+      }
+    });
+
+    const validEdges = edges.filter((edge) => nodeByID.has(String(edge.from || "")) && nodeByID.has(String(edge.to || "")));
+    const incoming = new Map();
+    const outgoing = new Map();
+    nodeByID.forEach((_, id) => {
+      incoming.set(id, 0);
+      outgoing.set(id, []);
+    });
+    validEdges.forEach((edge) => {
+      const from = String(edge.from || "");
+      const to = String(edge.to || "");
+      incoming.set(to, (incoming.get(to) || 0) + 1);
+      outgoing.get(from).push(to);
+    });
+
+    const roots = [];
+    incoming.forEach((count, id) => {
+      if (count === 0) {
+        roots.push(id);
+      }
+    });
+    if (roots.length === 0 && nodes[0]?.id) {
+      roots.push(String(nodes[0].id));
+    }
+
+    const depth = new Map();
+    const queue = [...roots];
+    roots.forEach((id) => depth.set(id, 0));
+    while (queue.length > 0) {
+      const current = queue.shift();
+      const nextDepth = (depth.get(current) || 0) + 1;
+      const neighbors = outgoing.get(current) || [];
+      neighbors.forEach((next) => {
+        if (!depth.has(next) || nextDepth < depth.get(next)) {
+          depth.set(next, nextDepth);
+          queue.push(next);
+        }
+      });
+    }
+    let maxDepth = 0;
+    depth.forEach((value) => {
+      if (value > maxDepth) {
+        maxDepth = value;
+      }
+    });
+    nodeByID.forEach((_, id) => {
+      if (!depth.has(id)) {
+        maxDepth += 1;
+        depth.set(id, maxDepth);
+      }
+    });
+
+    const columns = new Map();
+    depth.forEach((value, id) => {
+      if (!columns.has(value)) {
+        columns.set(value, []);
+      }
+      columns.get(value).push(id);
+    });
+    const orderedDepths = [...columns.keys()].sort((a, b) => a - b);
+    orderedDepths.forEach((columnDepth) => {
+      columns.get(columnDepth).sort((left, right) => left.localeCompare(right));
+    });
+
+    const colGap = 220;
+    const rowGap = 84;
+    const paddingX = 70;
+    const paddingY = 60;
+    const maxRows = orderedDepths.reduce((acc, columnDepth) => {
+      return Math.max(acc, columns.get(columnDepth).length);
+    }, 1);
+    const width = paddingX * 2 + Math.max(1, orderedDepths.length - 1) * colGap + 190;
+    const height = paddingY * 2 + Math.max(1, maxRows - 1) * rowGap + 70;
+
+    const positions = new Map();
+    orderedDepths.forEach((columnDepth, columnIndex) => {
+      const ids = columns.get(columnDepth);
+      ids.forEach((id, rowIndex) => {
+        const x = paddingX + columnIndex * colGap;
+        const y = paddingY + rowIndex * rowGap;
+        positions.set(id, { x, y });
+      });
+    });
+
+    const edgeMarkup = validEdges.map((edge) => {
+      const from = positions.get(String(edge.from || ""));
+      const to = positions.get(String(edge.to || ""));
+      if (!from || !to) {
+        return "";
+      }
+      const startX = from.x + 154;
+      const startY = from.y + 20;
+      const endX = to.x;
+      const endY = to.y + 20;
+      const cx1 = startX + 56;
+      const cx2 = endX - 56;
+      return `<path d="M ${startX} ${startY} C ${cx1} ${startY}, ${cx2} ${endY}, ${endX} ${endY}" class="projection-edge" />`;
+    }).join("");
+
+    const nodeMarkup = [...positions.entries()].map(([id, pos]) => {
+      const node = nodeByID.get(id) || {};
+      const pathText = String(node.path || node.canonical_path || id);
+      const segments = pathText.split("/").filter(Boolean);
+      const title = segments.length > 0 ? segments[segments.length - 1] : pathText;
+      const subtitle = pathText.length > 38 ? `${pathText.slice(0, 35)}...` : pathText;
+      return `<g class="projection-node" transform="translate(${pos.x},${pos.y})">
+        <rect width="154" height="40" rx="10" ry="10"></rect>
+        <text x="10" y="16" class="projection-node-title">${escapeHtml(title)}</text>
+        <text x="10" y="31" class="projection-node-subtitle">${escapeHtml(subtitle)}</text>
+      </g>`;
+    }).join("");
+
+    target.innerHTML = `
+      <div class="projection-graph-meta">
+        <span class="pill">nodes ${nodes.length}</span>
+        <span class="pill">edges ${validEdges.length}</span>
+        <span class="muted-inline">plane=${escapeHtml(payload?.plane || "unknown")} address=${escapeHtml(formatAddress(payload?.address))}</span>
+      </div>
+      <svg class="projection-svg" viewBox="0 0 ${width} ${height}" role="img" aria-label="Projection graph">
+        ${edgeMarkup}
+        ${nodeMarkup}
+      </svg>
+    `;
   }
 
   render() {
@@ -788,8 +1162,8 @@ class PortalShell extends HTMLElement {
         <header class="topbar">
           <div class="brand">Helianthus Dynamic Portal</div>
           <div class="status" data-role="status">Gateway checking...</div>
-          <select class="select" aria-label="Controller selector">
-            <option>Controller (M1)</option>
+          <select class="select" aria-label="Controller selector" disabled>
+            <option>Controller</option>
           </select>
           <input class="search" type="search" data-role="search-input" aria-label="Search" placeholder="Search across layers" />
           <button class="button" data-role="theme-toggle" aria-label="Toggle theme">Theme</button>
@@ -797,42 +1171,78 @@ class PortalShell extends HTMLElement {
         <div class="content">
           <aside class="sidebar" aria-label="Portal sections">
             <h2>Views</h2>
-            <button disabled>Registry (M1)</button>
-            <button disabled>Semantic (M1)</button>
-            <button disabled>Projection (M1)</button>
-            <button disabled>Timeline (M2)</button>
-            <button disabled>Snapshots (M3)</button>
-            <button disabled>Issue Builder (M5)</button>
+            <button data-role="nav-registry" data-nav-target="section-registry" disabled>Registry</button>
+            <button data-role="nav-semantic" data-nav-target="section-semantic" disabled>Semantic</button>
+            <button data-role="nav-projection" data-nav-target="section-projection" disabled>Projection</button>
+            <button data-role="nav-timeline" data-nav-target="section-timeline" disabled>Timeline</button>
+            <button data-role="nav-snapshots" data-nav-target="section-snapshots" disabled>Snapshots</button>
+            <button data-role="nav-issue-builder" data-nav-target="section-issue-builder" disabled>Issue Builder</button>
           </aside>
           <main class="main">
             <h1>Portal Overview</h1>
             <div class="deprecation-banner" data-role="deprecation-banner">Loading deprecation policy...</div>
-            <p class="hero">M0 skeleton online. Discovery and evidence workflows unlock in subsequent milestones.</p>
+            <p class="hero">Explore registry, semantic state, projection topology and evidence workflows from one gateway-native surface.</p>
             <section class="cards" aria-label="Capability cards">
-              <article class="card"><h3>Registry</h3><span class="badge">Coming Soon</span></article>
-              <article class="card"><h3>Semantic</h3><span class="badge">Coming Soon</span></article>
-              <article class="card"><h3>Projection</h3><span class="badge">Coming Soon</span></article>
-              <article class="card"><h3>Timeline</h3><span class="badge">Coming Soon</span></article>
-              <article class="card"><h3>Snapshots</h3><span class="badge">Coming Soon</span></article>
-              <article class="card"><h3>Issue Builder</h3><span class="badge">Coming Soon</span></article>
+              <article class="card" data-capability="registry">
+                <h3>Registry</h3>
+                <span class="badge">Checking...</span>
+                <p class="card-meta">Device discovery and callable planes.</p>
+              </article>
+              <article class="card" data-capability="semantic">
+                <h3>Semantic</h3>
+                <span class="badge">Checking...</span>
+                <p class="card-meta">Zones, DHW and energy snapshots.</p>
+              </article>
+              <article class="card" data-capability="projection">
+                <h3>Projection</h3>
+                <span class="badge">Checking...</span>
+                <p class="card-meta">Plane topology and canonical paths.</p>
+              </article>
+              <article class="card" data-capability="timeline">
+                <h3>Timeline</h3>
+                <span class="badge">Checking...</span>
+                <p class="card-meta">Correlated stream events and provenance.</p>
+              </article>
+              <article class="card" data-capability="snapshots">
+                <h3>Snapshots</h3>
+                <span class="badge">Checking...</span>
+                <p class="card-meta">Capture, retention controls and diff.</p>
+              </article>
+              <article class="card" data-capability="issue_builder">
+                <h3>Issue Builder</h3>
+                <span class="badge">Checking...</span>
+                <p class="card-meta">Export evidence-first issue bundles.</p>
+              </article>
             </section>
-            <section class="registry-preview">
+            <section id="section-registry" class="registry-preview">
               <h2>Registry Preview</h2>
               <ul data-role="registry-list">
                 <li>Loading discovered devices...</li>
               </ul>
             </section>
-            <section class="registry-preview">
+            <section id="section-semantic" class="registry-preview">
               <h2>Semantic Preview</h2>
               <ul data-role="semantic-list">
                 <li>Loading semantic snapshot...</li>
               </ul>
             </section>
-            <section class="registry-preview">
+            <section id="section-projection" class="registry-preview">
               <h2>Projection Preview</h2>
+              <div class="projection-controls disabled" data-role="projection-controls">
+                <select class="select" data-role="projection-device-select" aria-label="Projection device" disabled>
+                  <option value="">No projection devices</option>
+                </select>
+                <select class="select" data-role="projection-plane-select" aria-label="Projection plane" disabled>
+                  <option value="">No planes</option>
+                </select>
+                <button class="button" data-role="projection-load" type="button" disabled>Load Graph</button>
+              </div>
               <ul data-role="projection-list">
                 <li>Loading projection summary...</li>
               </ul>
+              <div class="projection-graph" data-role="projection-graph">
+                <p class="projection-empty">Projection graph will appear here.</p>
+              </div>
             </section>
             <section class="registry-preview">
               <h2>Search Results</h2>
@@ -840,7 +1250,7 @@ class PortalShell extends HTMLElement {
                 <li>Loading search capability...</li>
               </ul>
             </section>
-            <section class="registry-preview">
+            <section id="section-timeline" class="registry-preview">
               <h2>Timeline</h2>
               <input class="search timeline-filter" data-role="timeline-correlation" type="search" placeholder="Filter by correlation id" aria-label="Filter timeline by correlation id" />
               <ul data-role="timeline-list">
@@ -854,7 +1264,7 @@ class PortalShell extends HTMLElement {
                 <li>Loading provenance capability...</li>
               </ul>
             </section>
-            <section class="registry-preview">
+            <section id="section-snapshots" class="registry-preview">
               <h2>Snapshots</h2>
               <div class="snapshot-controls">
                 <input class="search timeline-filter" data-role="snapshot-label" type="search" placeholder="Snapshot label (optional)" aria-label="Snapshot label" />
@@ -889,7 +1299,7 @@ class PortalShell extends HTMLElement {
                 <li>Loading sessions capability...</li>
               </ul>
             </section>
-            <section class="registry-preview">
+            <section id="section-issue-builder" class="registry-preview">
               <h2>Issue Builder</h2>
               <div class="snapshot-controls">
                 <input class="search timeline-filter" data-role="issue-title" type="search" placeholder="Issue title" aria-label="Issue title" />

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,12 +2,12 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 37287,
-      "sha256": "61847b3d0a59081d02b5f36e4188436d5165922c8a3ca15425136c99b6dd489c"
+      "bytes": 53508,
+      "sha256": "3af1d6c41302eb4e83384ec797a87ca816955df20c21560836718c3349a975b5"
     },
     "app.css": {
-      "bytes": 4861,
-      "sha256": "10af55b4d78c1bde1cb61b63ef3d4926c2e851a364eb85660262937497c441b5"
+      "bytes": 6850,
+      "sha256": "09d3ede7f3cef3a62c926dc9f9f631985de6b6a4a74a84d1bd982495f2792c3f"
     }
   }
 }

--- a/portal/web/src/app.css
+++ b/portal/web/src/app.css
@@ -126,6 +126,17 @@ body {
   padding: 0.52rem 0.6rem;
 }
 
+.sidebar button.enabled {
+  border-style: solid;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.sidebar button.enabled:hover {
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
 .main {
   background: var(--panel);
   border: 1px solid var(--border);
@@ -172,6 +183,13 @@ body {
   font-size: 0.95rem;
 }
 
+.card-meta {
+  margin: 0.5rem 0 0;
+  color: var(--muted);
+  font-size: 0.82rem;
+  line-height: 1.3;
+}
+
 .badge {
   display: inline-block;
   margin-top: 0.45rem;
@@ -179,6 +197,18 @@ body {
   border-radius: 999px;
   padding: 0.2rem 0.5rem;
   font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.badge.available {
+  color: var(--text);
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+  background: color-mix(in srgb, var(--accent) 20%, transparent);
+}
+
+.badge.unavailable {
+  border-color: color-mix(in srgb, #d96f6f 45%, var(--border));
+  background: color-mix(in srgb, #d96f6f 14%, transparent);
   color: var(--muted);
 }
 
@@ -210,6 +240,70 @@ body {
 .timeline-filter {
   width: 100%;
   margin: 0 0 0.6rem;
+}
+
+.projection-controls {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) minmax(160px, 240px) auto;
+  gap: 0.45rem;
+  margin: 0 0 0.65rem;
+}
+
+.projection-controls.disabled {
+  opacity: 0.7;
+}
+
+.projection-graph {
+  margin-top: 0.8rem;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--panel) 84%, transparent);
+  padding: 0.6rem;
+  overflow: auto;
+}
+
+.projection-empty {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.projection-graph-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-bottom: 0.55rem;
+  flex-wrap: wrap;
+}
+
+.projection-svg {
+  width: 100%;
+  min-width: 620px;
+  height: auto;
+}
+
+.projection-edge {
+  fill: none;
+  stroke: color-mix(in srgb, var(--accent) 38%, var(--border));
+  stroke-width: 1.4;
+  opacity: 0.78;
+}
+
+.projection-node rect {
+  fill: color-mix(in srgb, var(--card) 92%, var(--accent) 8%);
+  stroke: color-mix(in srgb, var(--accent) 40%, var(--border));
+  stroke-width: 1;
+}
+
+.projection-node-title {
+  fill: var(--text);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.projection-node-subtitle {
+  fill: var(--muted);
+  font-size: 10px;
 }
 
 .snapshot-controls {
@@ -258,5 +352,13 @@ body {
 
   .content {
     grid-template-columns: 1fr;
+  }
+
+  .projection-controls {
+    grid-template-columns: 1fr;
+  }
+
+  .projection-svg {
+    min-width: 360px;
   }
 }

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -22,6 +22,38 @@ function escapeHtml(value) {
     .replaceAll("'", "&#39;");
 }
 
+function formatFixed(value, digits = 1) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    return "n/a";
+  }
+  return number.toFixed(digits);
+}
+
+function formatTemperature(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    return "n/a";
+  }
+  return `${number.toFixed(1)}°C`;
+}
+
+function formatPercent(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    return "n/a";
+  }
+  return `${number.toFixed(0)}%`;
+}
+
+function formatAddress(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    return "0x??";
+  }
+  return `0x${number.toString(16).padStart(2, "0")}`;
+}
+
 class PortalShell extends HTMLElement {
   connectedCallback() {
     this.render();
@@ -69,6 +101,9 @@ class PortalShell extends HTMLElement {
     const sessionLoad = this.querySelector('[data-role="session-load"]');
     const issueDraftButton = this.querySelector('[data-role="issue-draft-run"]');
     const issueExportButton = this.querySelector('[data-role="issue-export-run"]');
+    const projectionDeviceSelect = this.querySelector('[data-role="projection-device-select"]');
+    const projectionPlaneSelect = this.querySelector('[data-role="projection-plane-select"]');
+    const projectionLoadButton = this.querySelector('[data-role="projection-load"]');
     if (toggle) {
       toggle.addEventListener("click", () => {
         const current = loadTheme();
@@ -125,6 +160,34 @@ class PortalShell extends HTMLElement {
         this.generateIssueExport();
       });
     }
+    if (projectionDeviceSelect) {
+      projectionDeviceSelect.addEventListener("change", () => {
+        this.refreshProjectionPlaneOptions();
+        this.loadSelectedProjectionGraph();
+      });
+    }
+    if (projectionPlaneSelect) {
+      projectionPlaneSelect.addEventListener("change", () => {
+        this.loadSelectedProjectionGraph();
+      });
+    }
+    if (projectionLoadButton) {
+      projectionLoadButton.addEventListener("click", () => {
+        this.loadSelectedProjectionGraph();
+      });
+    }
+    this.querySelectorAll("[data-nav-target]").forEach((button) => {
+      button.addEventListener("click", () => {
+        const targetID = button.getAttribute("data-nav-target");
+        if (!targetID) {
+          return;
+        }
+        const section = this.querySelector(`#${targetID}`);
+        if (section) {
+          section.scrollIntoView({ behavior: "smooth", block: "start" });
+        }
+      });
+    });
   }
 
   async loadStatus() {
@@ -153,38 +216,41 @@ class PortalShell extends HTMLElement {
       if (statusEl) {
         statusEl.textContent = `Gateway ${health.status}`;
       }
+      const capabilities = bootstrap.capabilities || {};
+      this.applyCapabilityState(capabilities);
       if (metaEl) {
-        const caps = bootstrap.capabilities || {};
+        const caps = capabilities;
+        const enabled = Object.keys(caps).filter((key) => caps[key]).length;
         metaEl.textContent =
-          `Capabilities: registry=${caps.registry}, semantic=${caps.semantic}, projection=${caps.projection}, search=${caps.search}, stream=${caps.stream}, timeline=${caps.timeline}, provenance=${caps.provenance}, snapshots=${caps.snapshots}, snapshot_diff=${caps.snapshot_diff}, sessions=${caps.sessions}, issue_builder=${caps.issue_builder}, migration=${caps.migration}`;
+          `Portal capabilities: ${enabled}/${Object.keys(caps).length || 0} enabled. GraphQL=${bootstrap.endpoints?.graphql || "n/a"}`;
       }
       if (searchInput) {
-        searchInput.disabled = !bootstrap.capabilities?.search;
-        searchInput.title = bootstrap.capabilities?.search ? "" : "Search is unavailable (no data providers)";
+        searchInput.disabled = !capabilities.search;
+        searchInput.title = capabilities.search ? "" : "Search is unavailable (no data providers)";
       }
-      if (bootstrap.capabilities?.registry && listEl) {
+      if (capabilities.registry && listEl) {
         await this.loadRegistryPreview(listEl);
       }
-      if (bootstrap.capabilities?.semantic && semanticEl) {
+      if (capabilities.semantic && semanticEl) {
         await this.loadSemanticPreview(semanticEl);
       }
-      if (bootstrap.capabilities?.projection && projectionEl) {
+      if (capabilities.projection && projectionEl) {
         await this.loadProjectionPreview(projectionEl);
       }
       if (searchList) {
-        searchList.innerHTML = bootstrap.capabilities?.search
+        searchList.innerHTML = capabilities.search
           ? "<li>Type at least 2 characters to search across registry, semantic and projection layers.</li>"
           : "<li>Search unavailable: no readable layers enabled.</li>";
       }
-      if (bootstrap.capabilities?.stream) {
+      if (capabilities.stream) {
         this.startStream();
       }
       if (timelineList) {
-        timelineList.innerHTML = bootstrap.capabilities?.timeline
+        timelineList.innerHTML = capabilities.timeline
           ? "<li>Loading timeline events...</li>"
           : "<li>Timeline unavailable: stream capability disabled.</li>";
       }
-      if (bootstrap.capabilities?.timeline) {
+      if (capabilities.timeline) {
         await this.refreshTimeline();
         if (this.timelineInterval) {
           clearInterval(this.timelineInterval);
@@ -194,11 +260,11 @@ class PortalShell extends HTMLElement {
         }, 3000);
       }
       if (provenanceList) {
-        provenanceList.innerHTML = bootstrap.capabilities?.provenance
+        provenanceList.innerHTML = capabilities.provenance
           ? "<li>Loading provenance records...</li>"
           : "<li>Provenance unavailable: stream capability disabled.</li>";
       }
-      if (bootstrap.capabilities?.provenance) {
+      if (capabilities.provenance) {
         await this.refreshProvenance();
         if (this.provenanceInterval) {
           clearInterval(this.provenanceInterval);
@@ -208,11 +274,11 @@ class PortalShell extends HTMLElement {
         }, 4000);
       }
       if (snapshotsList) {
-        snapshotsList.innerHTML = bootstrap.capabilities?.snapshots
+        snapshotsList.innerHTML = capabilities.snapshots
           ? "<li>Loading snapshot store...</li>"
           : "<li>Snapshots unavailable: stream capability disabled.</li>";
       }
-      if (bootstrap.capabilities?.snapshots) {
+      if (capabilities.snapshots) {
         await this.refreshSnapshots();
         const retention = await this.fetchSnapshotRetention();
         if (retentionInput && retention > 0) {
@@ -226,25 +292,25 @@ class PortalShell extends HTMLElement {
         }, 5000);
       }
       if (diffList) {
-        diffList.innerHTML = bootstrap.capabilities?.snapshot_diff
+        diffList.innerHTML = capabilities.snapshot_diff
           ? "<li>Select snapshot IDs and run diff.</li>"
           : "<li>Snapshot diff unavailable.</li>";
       }
       if (sessionsList) {
-        sessionsList.innerHTML = bootstrap.capabilities?.sessions
+        sessionsList.innerHTML = capabilities.sessions
           ? "<li>Loading sessions...</li>"
           : "<li>Sessions unavailable.</li>";
       }
-      if (bootstrap.capabilities?.sessions) {
+      if (capabilities.sessions) {
         await this.refreshSessions();
       }
       if (issuePreview) {
-        issuePreview.textContent = bootstrap.capabilities?.issue_builder
+        issuePreview.textContent = capabilities.issue_builder
           ? "Issue builder ready. Fill fields and generate draft."
           : "Issue builder unavailable.";
       }
       if (deprecationBanner) {
-        if (bootstrap.capabilities?.migration) {
+        if (capabilities.migration) {
           await this.refreshDeprecationBanner(deprecationBanner);
         } else {
           deprecationBanner.textContent = "Migration metadata unavailable.";
@@ -259,6 +325,49 @@ class PortalShell extends HTMLElement {
       }
       console.error("portal bootstrap failed", err);
     }
+  }
+
+  applyCapabilityState(capabilities) {
+    const cap = capabilities || {};
+    this.setCapabilityCard("registry", cap.registry, "Device registry and planes");
+    this.setCapabilityCard("semantic", cap.semantic, "Zones, DHW and energy snapshots");
+    this.setCapabilityCard("projection", cap.projection, "Plane graphs and topology links");
+    this.setCapabilityCard("timeline", cap.timeline, "Live stream timeline events");
+    this.setCapabilityCard("snapshots", cap.snapshots && cap.snapshot_diff, "Capture, retention and diff");
+    this.setCapabilityCard("issue_builder", cap.issue_builder, "Evidence draft and export bundle");
+
+    this.setNavState("registry", cap.registry);
+    this.setNavState("semantic", cap.semantic);
+    this.setNavState("projection", cap.projection);
+    this.setNavState("timeline", cap.timeline || cap.provenance);
+    this.setNavState("snapshots", cap.snapshots || cap.snapshot_diff);
+    this.setNavState("issue-builder", cap.issue_builder);
+  }
+
+  setCapabilityCard(capability, enabled, detail) {
+    const card = this.querySelector(`[data-capability="${capability}"]`);
+    if (!card) {
+      return;
+    }
+    const badge = card.querySelector(".badge");
+    if (badge) {
+      badge.textContent = enabled ? "Available" : "Unavailable";
+      badge.classList.toggle("available", Boolean(enabled));
+      badge.classList.toggle("unavailable", !enabled);
+    }
+    const meta = card.querySelector(".card-meta");
+    if (meta) {
+      meta.textContent = enabled ? detail : `${detail} (not exposed by this gateway)`;
+    }
+  }
+
+  setNavState(name, enabled) {
+    const button = this.querySelector(`[data-role="nav-${name}"]`);
+    if (!button) {
+      return;
+    }
+    button.disabled = !enabled;
+    button.classList.toggle("enabled", Boolean(enabled));
   }
 
   async refreshDeprecationBanner(target) {
@@ -745,12 +854,29 @@ class PortalShell extends HTMLElement {
       const zones = Array.isArray(payload.zones) ? payload.zones : [];
       const dhw = payload.dhw;
       const rows = [];
-      rows.push(`<li>Zones: ${zones.length}</li>`);
-      if (zones[0]) {
-        rows.push(`<li>Zone #1: ${zones[0].name || zones[0].id || "unknown"}</li>`);
+      rows.push(`<li><strong>Zones detected:</strong> ${zones.length}</li>`);
+      if (zones.length === 0) {
+        rows.push("<li>No semantic zones available.</li>");
+      } else {
+        zones.forEach((zone) => {
+          const name = escapeHtml(zone.name || zone.id || "zone");
+          const mode = escapeHtml(zone.operating_mode || "unknown");
+          const preset = escapeHtml(zone.preset || "n/a");
+          const current = formatTemperature(zone.current_temp_c);
+          const target = formatTemperature(zone.target_temp_c);
+          const demand = formatPercent(zone.heating_demand);
+          rows.push(
+            `<li><strong>${name}</strong> <span class="muted-inline">mode=${mode} preset=${preset} current=${escapeHtml(current)} target=${escapeHtml(target)} demand=${escapeHtml(demand)}</span></li>`,
+          );
+        });
       }
       if (dhw) {
-        rows.push(`<li>DHW mode: ${dhw.operating_mode || "unknown"}</li>`);
+        rows.push(`<li><strong>DHW</strong> <span class="muted-inline">mode=${escapeHtml(dhw.operating_mode || "unknown")} current=${escapeHtml(formatTemperature(dhw.current_temp_c))} target=${escapeHtml(formatTemperature(dhw.target_temp_c))}</span></li>`);
+      }
+      if (payload.energy_totals) {
+        rows.push(
+          `<li><strong>Energy today</strong> <span class="muted-inline">gas climate=${escapeHtml(formatFixed(payload.energy_totals?.gas?.climate?.today, 2))} dhw=${escapeHtml(formatFixed(payload.energy_totals?.gas?.dhw?.today, 2))}</span></li>`,
+        );
       }
       listEl.innerHTML = rows.join("");
     } catch (err) {
@@ -760,25 +886,273 @@ class PortalShell extends HTMLElement {
   }
 
   async loadProjectionPreview(listEl) {
+    const graphEl = this.querySelector('[data-role="projection-graph"]');
+    const controls = this.querySelector('[data-role="projection-controls"]');
+    const loadButton = this.querySelector('[data-role="projection-load"]');
     try {
-      const response = await fetch("api/v1/projection/devices?limit=5");
+      const response = await fetch("api/v1/projection/devices?limit=30");
       const payload = await response.json();
       const items = Array.isArray(payload.items) ? payload.items : [];
+      this.projectionDevices = items;
       if (items.length === 0) {
-        listEl.innerHTML = "<li>No projection graphs available.</li>";
+        listEl.innerHTML = "<li>No projection graphs available from current registry snapshot.</li>";
+        if (controls) {
+          controls.classList.add("disabled");
+        }
+        if (loadButton) {
+          loadButton.disabled = true;
+        }
+        this.renderProjectionState(graphEl, "Projection graph unavailable. No device projections published yet.");
         return;
       }
       listEl.innerHTML = items
         .map((item) => {
           const projectionCount = Array.isArray(item.projections) ? item.projections.length : 0;
-          const label = item.display_name || item.device_id || `0x${Number(item.address).toString(16)}`;
-          return `<li><strong>${label}</strong> projections=${projectionCount}</li>`;
+          const label = item.display_name || item.device_id || formatAddress(item.address);
+          const planes = Array.isArray(item.projections)
+            ? item.projections.map((projection) => projection.plane).filter(Boolean).join(", ")
+            : "";
+          return `<li><strong>${escapeHtml(label)}</strong> <span class="muted-inline">addr=${escapeHtml(formatAddress(item.address))} projections=${projectionCount}${planes ? ` planes=${escapeHtml(planes)}` : ""}</span></li>`;
         })
         .join("");
+      this.populateProjectionDeviceOptions();
+      if (controls) {
+        controls.classList.remove("disabled");
+      }
+      if (loadButton) {
+        loadButton.disabled = false;
+      }
+      await this.loadSelectedProjectionGraph();
     } catch (err) {
       listEl.innerHTML = "<li>Projection preview unavailable.</li>";
+      this.renderProjectionState(graphEl, "Projection preview request failed.");
       console.error("projection preview failed", err);
     }
+  }
+
+  populateProjectionDeviceOptions() {
+    const deviceSelect = this.querySelector('[data-role="projection-device-select"]');
+    if (!deviceSelect) {
+      return;
+    }
+    const items = Array.isArray(this.projectionDevices) ? this.projectionDevices : [];
+    if (items.length === 0) {
+      deviceSelect.innerHTML = "<option value=\"\">No devices</option>";
+      deviceSelect.disabled = true;
+      this.refreshProjectionPlaneOptions();
+      return;
+    }
+    deviceSelect.disabled = false;
+    deviceSelect.innerHTML = items
+      .map((item) => {
+        const label = item.display_name || item.device_id || formatAddress(item.address);
+        return `<option value="${escapeHtml(String(item.address))}">${escapeHtml(`${label} (${formatAddress(item.address)})`)}</option>`;
+      })
+      .join("");
+    this.refreshProjectionPlaneOptions();
+  }
+
+  refreshProjectionPlaneOptions() {
+    const deviceSelect = this.querySelector('[data-role="projection-device-select"]');
+    const planeSelect = this.querySelector('[data-role="projection-plane-select"]');
+    if (!deviceSelect || !planeSelect) {
+      return;
+    }
+    const address = Number(deviceSelect.value);
+    const items = Array.isArray(this.projectionDevices) ? this.projectionDevices : [];
+    const current = items.find((item) => Number(item.address) === address) || null;
+    const planes = current && Array.isArray(current.projections)
+      ? current.projections.map((projection) => projection.plane).filter(Boolean)
+      : [];
+    if (planes.length === 0) {
+      planeSelect.innerHTML = "<option value=\"\">No planes</option>";
+      planeSelect.disabled = true;
+      return;
+    }
+    planeSelect.disabled = false;
+    planeSelect.innerHTML = planes
+      .map((plane) => `<option value="${escapeHtml(plane)}">${escapeHtml(plane)}</option>`)
+      .join("");
+  }
+
+  async loadSelectedProjectionGraph() {
+    const graphEl = this.querySelector('[data-role="projection-graph"]');
+    const deviceSelect = this.querySelector('[data-role="projection-device-select"]');
+    const planeSelect = this.querySelector('[data-role="projection-plane-select"]');
+    if (!graphEl || !deviceSelect || !planeSelect) {
+      return;
+    }
+    const addressRaw = String(deviceSelect.value || "").trim();
+    const plane = String(planeSelect.value || "").trim();
+    if (!addressRaw || !plane) {
+      this.renderProjectionState(graphEl, "Pick device and plane to load graph.");
+      return;
+    }
+    const query = new URLSearchParams();
+    query.set("address", addressRaw);
+    query.set("plane", plane);
+    try {
+      const response = await fetch(`api/v1/projection/graph?${query.toString()}`);
+      if (!response.ok) {
+        this.renderProjectionState(graphEl, `Projection graph request failed (${response.status}).`);
+        return;
+      }
+      const payload = await response.json();
+      this.renderProjectionGraph(graphEl, payload);
+    } catch (err) {
+      this.renderProjectionState(graphEl, "Projection graph request failed.");
+      console.error("projection graph failed", err);
+    }
+  }
+
+  renderProjectionState(target, text) {
+    if (!target) {
+      return;
+    }
+    target.innerHTML = `<p class="projection-empty">${escapeHtml(text || "Projection graph unavailable.")}</p>`;
+  }
+
+  renderProjectionGraph(target, payload) {
+    if (!target) {
+      return;
+    }
+    const nodes = Array.isArray(payload?.nodes) ? payload.nodes : [];
+    const edges = Array.isArray(payload?.edges) ? payload.edges : [];
+    if (nodes.length === 0) {
+      this.renderProjectionState(target, "No projection nodes for selected plane.");
+      return;
+    }
+
+    const nodeByID = new Map();
+    nodes.forEach((node) => {
+      const id = String(node.id || "");
+      if (id) {
+        nodeByID.set(id, node);
+      }
+    });
+
+    const validEdges = edges.filter((edge) => nodeByID.has(String(edge.from || "")) && nodeByID.has(String(edge.to || "")));
+    const incoming = new Map();
+    const outgoing = new Map();
+    nodeByID.forEach((_, id) => {
+      incoming.set(id, 0);
+      outgoing.set(id, []);
+    });
+    validEdges.forEach((edge) => {
+      const from = String(edge.from || "");
+      const to = String(edge.to || "");
+      incoming.set(to, (incoming.get(to) || 0) + 1);
+      outgoing.get(from).push(to);
+    });
+
+    const roots = [];
+    incoming.forEach((count, id) => {
+      if (count === 0) {
+        roots.push(id);
+      }
+    });
+    if (roots.length === 0 && nodes[0]?.id) {
+      roots.push(String(nodes[0].id));
+    }
+
+    const depth = new Map();
+    const queue = [...roots];
+    roots.forEach((id) => depth.set(id, 0));
+    while (queue.length > 0) {
+      const current = queue.shift();
+      const nextDepth = (depth.get(current) || 0) + 1;
+      const neighbors = outgoing.get(current) || [];
+      neighbors.forEach((next) => {
+        if (!depth.has(next) || nextDepth < depth.get(next)) {
+          depth.set(next, nextDepth);
+          queue.push(next);
+        }
+      });
+    }
+    let maxDepth = 0;
+    depth.forEach((value) => {
+      if (value > maxDepth) {
+        maxDepth = value;
+      }
+    });
+    nodeByID.forEach((_, id) => {
+      if (!depth.has(id)) {
+        maxDepth += 1;
+        depth.set(id, maxDepth);
+      }
+    });
+
+    const columns = new Map();
+    depth.forEach((value, id) => {
+      if (!columns.has(value)) {
+        columns.set(value, []);
+      }
+      columns.get(value).push(id);
+    });
+    const orderedDepths = [...columns.keys()].sort((a, b) => a - b);
+    orderedDepths.forEach((columnDepth) => {
+      columns.get(columnDepth).sort((left, right) => left.localeCompare(right));
+    });
+
+    const colGap = 220;
+    const rowGap = 84;
+    const paddingX = 70;
+    const paddingY = 60;
+    const maxRows = orderedDepths.reduce((acc, columnDepth) => {
+      return Math.max(acc, columns.get(columnDepth).length);
+    }, 1);
+    const width = paddingX * 2 + Math.max(1, orderedDepths.length - 1) * colGap + 190;
+    const height = paddingY * 2 + Math.max(1, maxRows - 1) * rowGap + 70;
+
+    const positions = new Map();
+    orderedDepths.forEach((columnDepth, columnIndex) => {
+      const ids = columns.get(columnDepth);
+      ids.forEach((id, rowIndex) => {
+        const x = paddingX + columnIndex * colGap;
+        const y = paddingY + rowIndex * rowGap;
+        positions.set(id, { x, y });
+      });
+    });
+
+    const edgeMarkup = validEdges.map((edge) => {
+      const from = positions.get(String(edge.from || ""));
+      const to = positions.get(String(edge.to || ""));
+      if (!from || !to) {
+        return "";
+      }
+      const startX = from.x + 154;
+      const startY = from.y + 20;
+      const endX = to.x;
+      const endY = to.y + 20;
+      const cx1 = startX + 56;
+      const cx2 = endX - 56;
+      return `<path d="M ${startX} ${startY} C ${cx1} ${startY}, ${cx2} ${endY}, ${endX} ${endY}" class="projection-edge" />`;
+    }).join("");
+
+    const nodeMarkup = [...positions.entries()].map(([id, pos]) => {
+      const node = nodeByID.get(id) || {};
+      const pathText = String(node.path || node.canonical_path || id);
+      const segments = pathText.split("/").filter(Boolean);
+      const title = segments.length > 0 ? segments[segments.length - 1] : pathText;
+      const subtitle = pathText.length > 38 ? `${pathText.slice(0, 35)}...` : pathText;
+      return `<g class="projection-node" transform="translate(${pos.x},${pos.y})">
+        <rect width="154" height="40" rx="10" ry="10"></rect>
+        <text x="10" y="16" class="projection-node-title">${escapeHtml(title)}</text>
+        <text x="10" y="31" class="projection-node-subtitle">${escapeHtml(subtitle)}</text>
+      </g>`;
+    }).join("");
+
+    target.innerHTML = `
+      <div class="projection-graph-meta">
+        <span class="pill">nodes ${nodes.length}</span>
+        <span class="pill">edges ${validEdges.length}</span>
+        <span class="muted-inline">plane=${escapeHtml(payload?.plane || "unknown")} address=${escapeHtml(formatAddress(payload?.address))}</span>
+      </div>
+      <svg class="projection-svg" viewBox="0 0 ${width} ${height}" role="img" aria-label="Projection graph">
+        ${edgeMarkup}
+        ${nodeMarkup}
+      </svg>
+    `;
   }
 
   render() {
@@ -787,8 +1161,8 @@ class PortalShell extends HTMLElement {
         <header class="topbar">
           <div class="brand">Helianthus Dynamic Portal</div>
           <div class="status" data-role="status">Gateway checking...</div>
-          <select class="select" aria-label="Controller selector">
-            <option>Controller (M1)</option>
+          <select class="select" aria-label="Controller selector" disabled>
+            <option>Controller</option>
           </select>
           <input class="search" type="search" data-role="search-input" aria-label="Search" placeholder="Search across layers" />
           <button class="button" data-role="theme-toggle" aria-label="Toggle theme">Theme</button>
@@ -796,42 +1170,78 @@ class PortalShell extends HTMLElement {
         <div class="content">
           <aside class="sidebar" aria-label="Portal sections">
             <h2>Views</h2>
-            <button disabled>Registry (M1)</button>
-            <button disabled>Semantic (M1)</button>
-            <button disabled>Projection (M1)</button>
-            <button disabled>Timeline (M2)</button>
-            <button disabled>Snapshots (M3)</button>
-            <button disabled>Issue Builder (M5)</button>
+            <button data-role="nav-registry" data-nav-target="section-registry" disabled>Registry</button>
+            <button data-role="nav-semantic" data-nav-target="section-semantic" disabled>Semantic</button>
+            <button data-role="nav-projection" data-nav-target="section-projection" disabled>Projection</button>
+            <button data-role="nav-timeline" data-nav-target="section-timeline" disabled>Timeline</button>
+            <button data-role="nav-snapshots" data-nav-target="section-snapshots" disabled>Snapshots</button>
+            <button data-role="nav-issue-builder" data-nav-target="section-issue-builder" disabled>Issue Builder</button>
           </aside>
           <main class="main">
             <h1>Portal Overview</h1>
             <div class="deprecation-banner" data-role="deprecation-banner">Loading deprecation policy...</div>
-            <p class="hero">M0 skeleton online. Discovery and evidence workflows unlock in subsequent milestones.</p>
+            <p class="hero">Explore registry, semantic state, projection topology and evidence workflows from one gateway-native surface.</p>
             <section class="cards" aria-label="Capability cards">
-              <article class="card"><h3>Registry</h3><span class="badge">Coming Soon</span></article>
-              <article class="card"><h3>Semantic</h3><span class="badge">Coming Soon</span></article>
-              <article class="card"><h3>Projection</h3><span class="badge">Coming Soon</span></article>
-              <article class="card"><h3>Timeline</h3><span class="badge">Coming Soon</span></article>
-              <article class="card"><h3>Snapshots</h3><span class="badge">Coming Soon</span></article>
-              <article class="card"><h3>Issue Builder</h3><span class="badge">Coming Soon</span></article>
+              <article class="card" data-capability="registry">
+                <h3>Registry</h3>
+                <span class="badge">Checking...</span>
+                <p class="card-meta">Device discovery and callable planes.</p>
+              </article>
+              <article class="card" data-capability="semantic">
+                <h3>Semantic</h3>
+                <span class="badge">Checking...</span>
+                <p class="card-meta">Zones, DHW and energy snapshots.</p>
+              </article>
+              <article class="card" data-capability="projection">
+                <h3>Projection</h3>
+                <span class="badge">Checking...</span>
+                <p class="card-meta">Plane topology and canonical paths.</p>
+              </article>
+              <article class="card" data-capability="timeline">
+                <h3>Timeline</h3>
+                <span class="badge">Checking...</span>
+                <p class="card-meta">Correlated stream events and provenance.</p>
+              </article>
+              <article class="card" data-capability="snapshots">
+                <h3>Snapshots</h3>
+                <span class="badge">Checking...</span>
+                <p class="card-meta">Capture, retention controls and diff.</p>
+              </article>
+              <article class="card" data-capability="issue_builder">
+                <h3>Issue Builder</h3>
+                <span class="badge">Checking...</span>
+                <p class="card-meta">Export evidence-first issue bundles.</p>
+              </article>
             </section>
-            <section class="registry-preview">
+            <section id="section-registry" class="registry-preview">
               <h2>Registry Preview</h2>
               <ul data-role="registry-list">
                 <li>Loading discovered devices...</li>
               </ul>
             </section>
-            <section class="registry-preview">
+            <section id="section-semantic" class="registry-preview">
               <h2>Semantic Preview</h2>
               <ul data-role="semantic-list">
                 <li>Loading semantic snapshot...</li>
               </ul>
             </section>
-            <section class="registry-preview">
+            <section id="section-projection" class="registry-preview">
               <h2>Projection Preview</h2>
+              <div class="projection-controls disabled" data-role="projection-controls">
+                <select class="select" data-role="projection-device-select" aria-label="Projection device" disabled>
+                  <option value="">No projection devices</option>
+                </select>
+                <select class="select" data-role="projection-plane-select" aria-label="Projection plane" disabled>
+                  <option value="">No planes</option>
+                </select>
+                <button class="button" data-role="projection-load" type="button" disabled>Load Graph</button>
+              </div>
               <ul data-role="projection-list">
                 <li>Loading projection summary...</li>
               </ul>
+              <div class="projection-graph" data-role="projection-graph">
+                <p class="projection-empty">Projection graph will appear here.</p>
+              </div>
             </section>
             <section class="registry-preview">
               <h2>Search Results</h2>
@@ -839,7 +1249,7 @@ class PortalShell extends HTMLElement {
                 <li>Loading search capability...</li>
               </ul>
             </section>
-            <section class="registry-preview">
+            <section id="section-timeline" class="registry-preview">
               <h2>Timeline</h2>
               <input class="search timeline-filter" data-role="timeline-correlation" type="search" placeholder="Filter by correlation id" aria-label="Filter timeline by correlation id" />
               <ul data-role="timeline-list">
@@ -853,7 +1263,7 @@ class PortalShell extends HTMLElement {
                 <li>Loading provenance capability...</li>
               </ul>
             </section>
-            <section class="registry-preview">
+            <section id="section-snapshots" class="registry-preview">
               <h2>Snapshots</h2>
               <div class="snapshot-controls">
                 <input class="search timeline-filter" data-role="snapshot-label" type="search" placeholder="Snapshot label (optional)" aria-label="Snapshot label" />
@@ -888,7 +1298,7 @@ class PortalShell extends HTMLElement {
                 <li>Loading sessions capability...</li>
               </ul>
             </section>
-            <section class="registry-preview">
+            <section id="section-issue-builder" class="registry-preview">
               <h2>Issue Builder</h2>
               <div class="snapshot-controls">
                 <input class="search timeline-filter" data-role="issue-title" type="search" placeholder="Issue title" aria-label="Issue title" />


### PR DESCRIPTION
## Summary\n- remove milestone/"Coming Soon" placeholder text from portal overview UI\n- render full semantic zone list (all detected zones, including key fields), plus DHW/energy summary\n- add live projection explorer flow (device + plane selectors, graph fetch/render)\n- make capability cards/sidebar state dynamic from bootstrap capabilities\n- add regression test blocking milestone placeholder strings in embedded app assets\n\n## Validation\n- node --check portal/web/src/app.js\n- GOWORK=off go test ./portal ./ui\n- ./scripts/build_portal_assets.sh\n\n## Notes\n- static assets regenerated from portal/web/src and embedded in portal/static/assets\n- this PR intentionally focuses on gateway portal runtime + embedded UI only