### PR TITLE
Update AGENTS.md with dual-AI operating model reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,25 @@
 # AGENTS
 
+This repository is part of the **Helianthus Multi-Protocol HVAC Gateway Platform**.
+
+## Dual-AI Operating Model
+
+All development follows the dual-AI orchestrator protocol defined in the workspace-root [`AGENTS.md`](../AGENTS.md):
+
+- **Orchestrator:** Claude Code — orchestration, hard dev (complexity 7–10), angry tester, deep consultant
+- **Co-Pilot:** Codex — adversarial planning, easy dev (complexity 1–6), code review, second opinions
+- Phases: Adversarial Planning → Smart Routing → Dual Code Review
+- Hard rules: one issue/PR per repo, squash+merge only, doc-gate, transport-gate, MCP-first
+
+See the root AGENTS.md for the full protocol, routing tables, system prompts, and invariants.
+
+---
+
+## Repo-Specific Rules
+
 These instructions apply to the entire repository.
 
-## Workflow
+### Workflow
 
 1. Work one issue at a time and keep changes scoped to that issue.
 2. Keep at most one open PR for this repository at any time.
@@ -11,51 +28,51 @@ These instructions apply to the entire repository.
 5. If a change modifies externally visible behavior (transport options, GraphQL/MCP surface, smoke behavior), open/update the corresponding docs in `helianthus-docs-ebus` and merge docs alongside code (doc-gate).
 6. Transport/protocol changes require a full 88-case runtime matrix pass (`TRANSPORT_MATRIX_REPORT=<index.json>`), unless explicitly overridden by owner approval (`TRANSPORT_GATE_OWNER_OVERRIDE=OVERRIDE_TRANSPORT_GATE_BY_OWNER` with a reason).
 
-## MCP-first Policy
+### MCP-first Policy
 
-### Scope and ordering
+#### Scope and ordering
 - MCP is the primary prototyping/exploration interface.
 - GraphQL is second and may reach parity only after MCP tools are deterministic and contract-solid.
 - Home Assistant and other consumers are enabled only after GraphQL parity and stability gates are met.
 
-### Tool taxonomy and naming
+#### Tool taxonomy and naming
 - Core stable tools use versioned names: `ebus.v<MAJOR>.<domain>.<subdomain>.<verb>`.
 - Experimental tools live under `ebus.experimental.*` and are never used by external consumers.
 - Prefer composable tools over monolithic endpoints.
 
-### Contract envelope (required for ebus.v1.*)
+#### Contract envelope (required for ebus.v1.*)
 Each `ebus.v1.*` tool returns:
 - `meta` with `contract`, `consistency`, `data_timestamp`, `data_hash`
 - `data`
 - `error` (null or structured error)
 
-### Determinism requirements
+#### Determinism requirements
 - List ordering must be stable.
 - Snapshot mode must produce stable `data_hash` for identical snapshot + request.
 - Tool schemas and outputs must have golden snapshots.
 
-### Invoke safety
+#### Invoke safety
 `ebus.v1.rpc.invoke` requires:
 - explicit `intent` (`READ_ONLY` or `MUTATE`)
 - `allow_dangerous=true` for mutating or unknown methods
 - `idempotency_key` for mutating intent
 
-### Graduation gates (MCP -> GraphQL)
+#### Graduation gates (MCP -> GraphQL)
 A capability may graduate to GraphQL only if:
 1. it exists as core stable MCP (`ebus.v1.*`)
 2. it passes determinism + contract + golden tests
 3. parity tests MCP <-> GraphQL are green
 
-### End-of-cycle cleanup
+#### End-of-cycle cleanup
 At cycle end, each `ebus.experimental.*` tool must be promoted, deleted, or moved to internal-only with written justification.
 No temporary/junk tool may remain in the showroom surface.
 
-### CI gates
+#### CI gates
 - Breaking changes in `ebus.v1.*` require a new major namespace.
 - Parity drift MCP vs GraphQL fails CI.
 - MCP tool inventory must pass classification enforcement (`go test ./mcp -run TestToolClassificationPolicy`), and any unclassified tool fails the gate.
 
-### Heat-source modeling boundary
+#### Heat-source modeling boundary
 - Treat `scan` as cross-device discovery, not as a class-specific heat-source plane.
 - Keep `HEAT_SOURCE` and `REGULATOR` semantic domains isolated; cross-domain register access must be denied explicitly.
 - Architecture updates for heat-source design must be mirrored in `helianthus-docs-ebus` and be reusable for equivalent VWZ-class implementation.


### PR DESCRIPTION
## Summary
- Add dual-AI orchestrator reference header to AGENTS.md
- Reorganize existing repo-specific rules under dedicated heading
- All existing workflow, MCP-first policy, CI gates, and heat-source boundary rules preserved intact

## Linked
- Closes #208

## Review note
Documentation-only change (AGENTS.md). No code changes, no CI impact.

[codex-dev] — content generated by Codex, integrated by Claude orchestrator.