### PR TITLE
Fix: DHW TTL bypass on controller discovery loss (#207)

### DIFF
--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -717,8 +717,6 @@ func (p *vaillantSemanticPoller) refreshDiscovery(ctx context.Context) {
 		p.controller = 0
 		p.zones = make(map[byte]*vaillantZoneSnapshot)
 		p.presence = make(map[byte]*zonePresenceRecord)
-		p.dhw = nil
-		p.dhwLastUpdateAt = time.Time{}
 		p.mu.Unlock()
 		p.publishZones(semanticSnapshotSourceCache)
 		p.publishDHW(semanticSnapshotSourceCache)

--- a/cmd/gateway/semantic_vaillant_test.go
+++ b/cmd/gateway/semantic_vaillant_test.go
@@ -442,6 +442,151 @@ func TestVaillantSemanticPoller_HydrateFromCacheFallsBackToNowWhenPersistedAtZer
 	}
 }
 
+func TestVaillantSemanticPoller_DiscoveryLossTTLExpiresDHW(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.January, 11, 9, 0, 0, 0, time.UTC)
+	current := 49.1
+
+	provider := graphql.NewLiveSemanticProvider()
+	cacheSpy := &semanticSnapshotCaptureSpy{}
+	poller := &vaillantSemanticPoller{
+		provider:    provider,
+		cache:       cacheSpy,
+		dhwStaleTTL: 10 * time.Minute,
+		dhw: &vaillantDhwSnapshot{
+			OperatingMode: "auto",
+			Preset:        "schedule",
+			CurrentTempC:  &current,
+		},
+	}
+	poller.nowFn = func() time.Time { return now }
+	poller.dhwLastUpdateAt = now
+
+	poller.publishDHW(semanticSnapshotSourceLive)
+
+	now = now.Add(5 * time.Minute)
+	poller.refreshDiscovery(context.Background())
+	if dhw := provider.DHW(); dhw == nil {
+		t.Fatalf("provider.DHW() = nil; want DHW preserved before TTL expiry")
+	}
+
+	now = now.Add(6 * time.Minute)
+	poller.refreshDiscovery(context.Background())
+
+	if dhw := provider.DHW(); dhw != nil {
+		t.Fatalf("provider.DHW() = %#v; want nil after TTL expiry on discovery loss", dhw)
+	}
+	if poller.dhw != nil {
+		t.Fatalf("poller.dhw = %#v; want nil after TTL expiry on discovery loss", poller.dhw)
+	}
+	if cacheSpy.calls < 2 {
+		t.Fatalf("cache Save calls = %d; want at least 2 (live persist + expiry persist)", cacheSpy.calls)
+	}
+	if cacheSpy.last.DHW != nil {
+		t.Fatalf("cache last DHW = %#v; want nil after TTL expiry persist", cacheSpy.last.DHW)
+	}
+}
+
+func TestVaillantSemanticPoller_DiscoveryLossPreservesDHWBeforeTTL(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.January, 11, 10, 0, 0, 0, time.UTC)
+	current := 47.8
+
+	provider := graphql.NewLiveSemanticProvider()
+	cacheSpy := &semanticSnapshotCaptureSpy{}
+	poller := &vaillantSemanticPoller{
+		provider:    provider,
+		cache:       cacheSpy,
+		dhwStaleTTL: 15 * time.Minute,
+		dhw: &vaillantDhwSnapshot{
+			OperatingMode: "auto",
+			Preset:        "schedule",
+			CurrentTempC:  &current,
+		},
+	}
+	poller.nowFn = func() time.Time { return now }
+	poller.dhwLastUpdateAt = now
+
+	poller.publishDHW(semanticSnapshotSourceLive)
+
+	now = now.Add(14 * time.Minute)
+	poller.refreshDiscovery(context.Background())
+
+	dhw := provider.DHW()
+	if dhw == nil {
+		t.Fatalf("provider.DHW() = nil; want DHW preserved before TTL expiry")
+	}
+	if dhw.OperatingMode != "auto" {
+		t.Fatalf("provider.DHW().OperatingMode = %q; want auto", dhw.OperatingMode)
+	}
+	if dhw.CurrentTempC == nil || *dhw.CurrentTempC != 47.8 {
+		t.Fatalf("provider.DHW().CurrentTempC = %v; want 47.8", dhw.CurrentTempC)
+	}
+	if poller.dhw == nil {
+		t.Fatalf("poller.dhw = nil; want preserved snapshot before TTL expiry")
+	}
+	if cacheSpy.last.DHW == nil {
+		t.Fatalf("cache last DHW = nil; want last persisted live DHW snapshot")
+	}
+}
+
+func TestVaillantSemanticPoller_DiscoveryFlapDuringStartup(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.January, 11, 11, 0, 0, 0, time.UTC)
+	current := 46.6
+	cached := &graphql.DhwStatus{
+		OperatingMode: "auto",
+		Preset:        "schedule",
+		CurrentTempC:  &current,
+	}
+
+	provider := graphql.NewLiveSemanticProvider()
+	provider.SetDHWFromCache(cached)
+	if got := provider.StartupPhase(); got != graphql.SemanticStartupPhaseCacheLoadedStale {
+		t.Fatalf("phase after cache load = %s; want %s", got, graphql.SemanticStartupPhaseCacheLoadedStale)
+	}
+
+	poller := &vaillantSemanticPoller{
+		provider:    provider,
+		dhwStaleTTL: 30 * time.Minute,
+	}
+	poller.nowFn = func() time.Time { return now }
+	poller.hydrateFromCache(semanticCacheSnapshot{
+		DHW:         cached,
+		PersistedAt: now.Add(-5 * time.Minute),
+	})
+
+	poller.refreshDiscovery(context.Background())
+	if got := provider.StartupPhase(); got != graphql.SemanticStartupPhaseCacheLoadedStale {
+		t.Fatalf("phase after cache-phase discovery flap = %s; want %s", got, graphql.SemanticStartupPhaseCacheLoadedStale)
+	}
+	if dhw := provider.DHW(); dhw == nil {
+		t.Fatalf("provider.DHW() = nil; want preserved cached DHW during CACHE_LOADED_STALE discovery flap")
+	}
+
+	now = now.Add(1 * time.Minute)
+	poller.publishDHW(semanticSnapshotSourceLive)
+	if got := provider.StartupPhase(); got != graphql.SemanticStartupPhaseLiveWarmup {
+		t.Fatalf("phase after first live DHW publish = %s; want %s", got, graphql.SemanticStartupPhaseLiveWarmup)
+	}
+
+	now = now.Add(1 * time.Minute)
+	poller.refreshDiscovery(context.Background())
+	if got := provider.StartupPhase(); got != graphql.SemanticStartupPhaseLiveWarmup {
+		t.Fatalf("phase after warmup discovery flap = %s; want %s", got, graphql.SemanticStartupPhaseLiveWarmup)
+	}
+	dhw := provider.DHW()
+	if dhw == nil {
+		t.Fatalf("provider.DHW() = nil; want preserved DHW during LIVE_WARMUP discovery flap")
+	}
+	if dhw.CurrentTempC == nil || *dhw.CurrentTempC != 46.6 {
+		t.Fatalf("provider.DHW().CurrentTempC = %v; want 46.6", dhw.CurrentTempC)
+	}
+}
+
 func TestMergeZoneSnapshotFields_PartialLiveUpdatePreservesLastKnownAndFreshness(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Preserve DHW state in `refreshDiscovery` no-controller path instead of zeroing it
- DHW now expires naturally via `expireDHWIfStaleLocked()` based on configured stale TTL
- Zones/presence still cleared immediately (no TTL for zones)

## Linked
- Closes #207
- Follow-up from [🔵 Codex] review blocker #1 on PR #206

## Tests
- `TestVaillantSemanticPoller_DiscoveryLossTTLExpiresDHW` — DHW expires after TTL on discovery loss
- `TestVaillantSemanticPoller_DiscoveryLossPreservesDHWBeforeTTL` — DHW preserved before TTL
- `TestVaillantSemanticPoller_DiscoveryFlapDuringStartup` — DHW preserved during CACHE_LOADED_STALE and LIVE_WARMUP discovery flaps

## CI
Local CI green (all tests pass with `-race`, 0 lint issues).
Transport gate: no transport code path changes.

[codex-dev] — developed by Codex, reviewed by Claude (angry tester).