### PR TITLE
issue-195: deterministic energy merge v2 with truth-table contract

### DIFF
--- a/graphql/energy_merge.go
+++ b/graphql/energy_merge.go
@@ -23,11 +23,23 @@ type energyDataPoint struct {
 }
 
 // energyMergeKey uniquely identifies an energy data point.
+// Usage is canonicalized: "heating" and "cooling" both map to "climate".
 type energyMergeKey struct {
 	Channel  string // "gas", "electricity", "solar"
-	Usage    string // "hot_water", "heating", "cooling"
+	Usage    string // "hot_water", "climate" (canonicalized from heating/cooling)
 	Period   string // "day", "year"
 	YearKind string // "" for day, "previous"/"current" for year
+}
+
+// canonicalizeUsage maps raw usage strings to canonical merge key values.
+// "heating" and "cooling" both target the same Climate series.
+func canonicalizeUsage(usage string) string {
+	switch usage {
+	case "heating", "cooling":
+		return "climate"
+	default:
+		return usage
+	}
 }
 
 // energyMergeStore holds all tracked energy data points, indexed by a composite key.
@@ -44,8 +56,9 @@ type energyMergeKey struct {
 //	| register        | register       | no              | reject (monotonic)                  |
 //	| register        | broadcast      | any             | reject (broadcast never overwrites) |
 type energyMergeStore struct {
-	mu     sync.RWMutex
-	points map[energyMergeKey]energyDataPoint
+	mu       sync.RWMutex
+	points   map[energyMergeKey]energyDataPoint
+	revision uint64
 }
 
 func newEnergyMergeStore() *energyMergeStore {
@@ -56,7 +69,10 @@ func newEnergyMergeStore() *energyMergeStore {
 
 // Apply attempts to merge an incoming energy value into the store.
 // Returns true if the value was accepted according to the merge rules.
+// The key's Usage is canonicalized internally.
 func (s *energyMergeStore) Apply(key energyMergeKey, value float64, source EnergyDataSource, ingestAt time.Time) bool {
+	key.Usage = canonicalizeUsage(key.Usage)
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -64,6 +80,7 @@ func (s *energyMergeStore) Apply(key energyMergeKey, value float64, source Energ
 	if !exists {
 		// No existing point: accept any source.
 		s.points[key] = energyDataPoint{Value: value, Source: source, IngestAt: ingestAt}
+		s.revision++
 		return true
 	}
 
@@ -74,6 +91,7 @@ func (s *energyMergeStore) Apply(key energyMergeKey, value float64, source Energ
 	case existing.Source == EnergySourceBroadcast && source == EnergySourceRegister:
 		// Register always wins over broadcast, regardless of timestamp.
 		s.points[key] = energyDataPoint{Value: value, Source: source, IngestAt: ingestAt}
+		s.revision++
 		return true
 	default:
 		// Same source: enforce monotonic ingest timestamp.
@@ -81,8 +99,16 @@ func (s *energyMergeStore) Apply(key energyMergeKey, value float64, source Energ
 			return false
 		}
 		s.points[key] = energyDataPoint{Value: value, Source: source, IngestAt: ingestAt}
+		s.revision++
 		return true
 	}
+}
+
+// Revision returns the current store revision. Each accepted Apply increments it.
+func (s *energyMergeStore) Revision() uint64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.revision
 }
 
 // Snapshot builds an EnergyTotals from all current points in the store.
@@ -101,7 +127,7 @@ func (s *energyMergeStore) Snapshot() *EnergyTotals {
 		if channel == nil {
 			continue
 		}
-		series := selectUsageSeries(channel, key.Usage)
+		series := mergeSelectUsage(channel, key.Usage)
 		if series == nil {
 			continue
 		}
@@ -123,6 +149,21 @@ func (s *energyMergeStore) Snapshot() *EnergyTotals {
 	}
 
 	return totals
+}
+
+// mergeSelectUsage returns a pointer to the EnergySeries for the canonical usage.
+func mergeSelectUsage(channel *EnergyChannel, usage string) *EnergySeries {
+	if channel == nil {
+		return nil
+	}
+	switch usage {
+	case "hot_water":
+		return &channel.DHW
+	case "climate":
+		return &channel.Climate
+	default:
+		return nil
+	}
 }
 
 // mergeSelectChannel returns a pointer to the EnergyChannel for the given

--- a/graphql/energy_merge_test.go
+++ b/graphql/energy_merge_test.go
@@ -35,8 +35,10 @@ func TestEnergyMerge_RegisterOverwritesBroadcast(t *testing.T) {
 		t.Fatal("register should overwrite broadcast")
 	}
 
+	// Key is canonicalized: "heating" → "climate"
+	canonKey := energyMergeKey{Channel: "gas", Usage: "climate", Period: "day"}
 	store.mu.RLock()
-	point := store.points[key]
+	point := store.points[canonKey]
 	store.mu.RUnlock()
 
 	if point.Value != 2.0 {
@@ -58,8 +60,9 @@ func TestEnergyMerge_BroadcastNeverOverwritesRegister(t *testing.T) {
 		t.Fatal("broadcast should never overwrite register")
 	}
 
+	canonKey := energyMergeKey{Channel: "gas", Usage: "climate", Period: "day"}
 	store.mu.RLock()
-	point := store.points[key]
+	point := store.points[canonKey]
 	store.mu.RUnlock()
 
 	if point.Value != 1.0 {
@@ -88,8 +91,9 @@ func TestEnergyMerge_MonotonicBroadcast(t *testing.T) {
 		t.Fatal("same-timestamp broadcast should be rejected (monotonic: must be strictly newer)")
 	}
 
+	canonKey := energyMergeKey{Channel: "electricity", Usage: "hot_water", Period: "year", YearKind: "current"}
 	store.mu.RLock()
-	point := store.points[key]
+	point := store.points[canonKey]
 	store.mu.RUnlock()
 
 	if point.Value != 20.0 {
@@ -113,8 +117,9 @@ func TestEnergyMerge_MonotonicRegister(t *testing.T) {
 		t.Fatal("older register should be rejected (monotonic)")
 	}
 
+	canonKey := energyMergeKey{Channel: "solar", Usage: "climate", Period: "day"}
 	store.mu.RLock()
-	point := store.points[key]
+	point := store.points[canonKey]
 	store.mu.RUnlock()
 
 	if point.Value != 200.0 {
@@ -134,8 +139,9 @@ func TestEnergyMerge_RegisterOverwritesBroadcastRegardlessOfTime(t *testing.T) {
 		t.Fatal("register should overwrite broadcast even with older timestamp")
 	}
 
+	canonKey := energyMergeKey{Channel: "gas", Usage: "hot_water", Period: "year", YearKind: "previous"}
 	store.mu.RLock()
-	point := store.points[key]
+	point := store.points[canonKey]
 	store.mu.RUnlock()
 
 	if point.Value != 10.0 {
@@ -201,8 +207,10 @@ func TestEnergyMerge_SnapshotReturnsNilWhenEmpty(t *testing.T) {
 }
 
 func TestEnergyMerge_AllChannelUsagePeriodCombinations(t *testing.T) {
+	// Canonical usages after canonicalization: "hot_water", "climate".
+	// 3 channels x 2 canonical usages x 3 periods = 18 canonical keys.
 	channels := []string{"gas", "electricity", "solar"}
-	usages := []string{"hot_water", "heating"}
+	usages := []string{"hot_water", "climate"}
 	type periodSpec struct {
 		period   string
 		yearKind string
@@ -213,7 +221,6 @@ func TestEnergyMerge_AllChannelUsagePeriodCombinations(t *testing.T) {
 		{period: "year", yearKind: "current"},
 	}
 
-	// 3 channels x 2 usages x 3 periods = 18 combinations.
 	store := newEnergyMergeStore()
 	expectedCount := 0
 
@@ -246,13 +253,11 @@ func TestEnergyMerge_AllChannelUsagePeriodCombinations(t *testing.T) {
 		t.Fatalf("store has %d points; want 18", gotCount)
 	}
 
-	// Verify snapshot produces non-nil totals with data in all channels.
 	totals := store.Snapshot()
 	if totals == nil {
 		t.Fatal("Snapshot() = nil after 18 inserts")
 	}
 
-	// Verify each channel has non-zero data.
 	checkChannel := func(name string, ch EnergyChannel) {
 		t.Helper()
 		if ch.DHW.Today == 0 && ch.Climate.Today == 0 &&
@@ -263,4 +268,34 @@ func TestEnergyMerge_AllChannelUsagePeriodCombinations(t *testing.T) {
 	checkChannel("Gas", totals.Gas)
 	checkChannel("Electric", totals.Electric)
 	checkChannel("Solar", totals.Solar)
+}
+
+func TestEnergyMerge_HeatingCoolingCanonicalizedToClimate(t *testing.T) {
+	store := newEnergyMergeStore()
+
+	// "heating" and "cooling" both map to "climate" — they share the same merge slot.
+	keyHeating := energyMergeKey{Channel: "gas", Usage: "heating", Period: "day"}
+	keyCooling := energyMergeKey{Channel: "gas", Usage: "cooling", Period: "day"}
+
+	if !store.Apply(keyHeating, 10.0, EnergySourceBroadcast, t0) {
+		t.Fatal("first heating broadcast should be accepted")
+	}
+
+	// Cooling with a newer timestamp overwrites the same slot (same canonical key).
+	if !store.Apply(keyCooling, 20.0, EnergySourceBroadcast, t1) {
+		t.Fatal("cooling broadcast with newer timestamp should overwrite heating (same canonical key)")
+	}
+
+	canonKey := energyMergeKey{Channel: "gas", Usage: "climate", Period: "day"}
+	store.mu.RLock()
+	point := store.points[canonKey]
+	count := len(store.points)
+	store.mu.RUnlock()
+
+	if count != 1 {
+		t.Fatalf("store has %d points; want 1 (heating and cooling share canonical key)", count)
+	}
+	if point.Value != 20.0 {
+		t.Fatalf("value = %f; want 20.0 (latest write)", point.Value)
+	}
 }

--- a/graphql/semantic_live.go
+++ b/graphql/semantic_live.go
@@ -50,7 +50,8 @@ type LiveSemanticProvider struct {
 	dhw    *DhwStatus
 	energy *EnergyTotals
 
-	energyMerge *energyMergeStore
+	energyMerge    *energyMergeStore
+	energyRevision uint64
 
 	phase              SemanticStartupPhase
 	cacheEpoch         uint64
@@ -376,14 +377,24 @@ func (provider *LiveSemanticProvider) applyEnergy(values map[string]types.Value,
 		return false
 	}
 
+	if provider.energyMerge == nil {
+		return false
+	}
+
 	if !provider.energyMerge.Apply(key, kwh, EnergySourceBroadcast, now) {
 		return false
 	}
 
-	// Rebuild the snapshot from the merge store and update the provider.
+	// Rebuild the snapshot from the merge store and publish atomically.
+	// Only publish if our revision is still the latest (prevents stale overwrites
+	// from concurrent callers).
+	rev := provider.energyMerge.Revision()
 	snapshot := provider.energyMerge.Snapshot()
 	provider.mu.Lock()
-	provider.energy = snapshot
+	if rev >= provider.energyRevision {
+		provider.energy = snapshot
+		provider.energyRevision = rev
+	}
 	provider.mu.Unlock()
 	return true
 }


### PR DESCRIPTION
## Summary
- New `energyMergeStore` with explicit merge rules: register > broadcast confidence, monotonic ingest timestamps
- Truth-table documentation in code comments matching the merge contract
- Integrated into `LiveSemanticProvider.applyEnergy()` — broadcast values now go through the merge store
- 9 test functions covering all merge rules, boundary cases, and 18 channel×usage×period combinations

## Merge Truth Table
| Existing | Incoming | Newer? | Action |
|---|---|---|---|
| none | any | - | accept |
| broadcast | register | any | accept |
| broadcast | broadcast | yes | accept |
| broadcast | broadcast | no | reject |
| register | register | yes | accept |
| register | register | no | reject |
| register | broadcast | any | reject |

## New files
- `graphql/energy_merge.go` — merge types and algorithm
- `graphql/energy_merge_test.go` — truth-table tests

## References
- Issue: #195
- Depends on: #194 (merged)
- Blocks: #196 (register-primary energy)
- Doc-gate: d3vi1/helianthus-docs-ebus#137

## Test plan
- [x] 9 new merge tests pass with `-race`
- [x] All existing energy tests pass (no regression)
- [x] Local CI green (all 13 packages)
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)