### PR TITLE
issue-197: observability minimum pack for runtime FSMs

### DIFF
--- a/cmd/gateway/observability_test.go
+++ b/cmd/gateway/observability_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"context"
+	"expvar"
+	"testing"
+	"time"
+
+	"github.com/d3vi1/helianthus-ebusreg/registry"
+	"github.com/d3vi1/helianthus-ebusreg/vaillant/productids"
+)
+
+func TestObservability_ZonePresenceTransitionIncrementsCounter(t *testing.T) {
+	instance := byte(0x01)
+	poller := &vaillantSemanticPoller{
+		zones:             make(map[byte]*vaillantZoneSnapshot),
+		presence:          make(map[byte]*zonePresenceRecord),
+		zoneMissThreshold: 3,
+		zoneHitThreshold:  2,
+	}
+
+	key := "ABSENT->SUSPECT_RESURRECT"
+	before := expvarMapInt64(semanticZonePresenceTransitionsTotal, key)
+
+	poller.applyZonePresenceProbes(
+		map[byte]bool{instance: true},
+		map[byte]bool{instance: true},
+	)
+
+	after := expvarMapInt64(semanticZonePresenceTransitionsTotal, key)
+	if after != before+1 {
+		t.Fatalf("semanticZonePresenceTransitionsTotal[%q] = %d; want %d", key, after, before+1)
+	}
+}
+
+func TestObservability_RegulatorTransitionIncrementsCounter(t *testing.T) {
+	catalog, err := productids.LoadCatalog()
+	if err != nil {
+		t.Fatalf("LoadCatalog() error: %v", err)
+	}
+
+	now := time.Date(2026, time.February, 26, 12, 0, 0, 0, time.UTC)
+	poller := &vaillantSemanticPoller{
+		reg: newTestRegistry(
+			registry.DeviceInfo{Address: 0x15, Manufacturer: "Vaillant", DeviceID: "BASV", SerialNumber: "21-22-09-0010002460-0082-005409-N4"},
+			registry.DeviceInfo{Address: 0x60, Manufacturer: "Vaillant", DeviceID: "VRC430", SerialNumber: "21-22-09-0020028521-0082-005409-N4"},
+		),
+		catalog:               catalog,
+		regAbsenceState:       regulatorPresent,
+		regulatorCapability:   productids.ControllerPresent,
+		registryDeviceCount:   2,
+		regulatorAbsenceGrace: 5 * time.Minute,
+		zones:                 make(map[byte]*vaillantZoneSnapshot),
+		presence:              make(map[byte]*zonePresenceRecord),
+		nowFn:                 func() time.Time { return now },
+	}
+
+	key := "PRESENT->ABSENCE_GRACE"
+	before := expvarMapInt64(semanticRegulatorTransitionsTotal, key)
+
+	poller.reg = newTestRegistry(
+		registry.DeviceInfo{Address: 0x15, Manufacturer: "Vaillant", DeviceID: "BASV", SerialNumber: "21-22-09-0010002460-0082-005409-N4"},
+	)
+	poller.refreshRegulatorCapability(context.Background())
+
+	after := expvarMapInt64(semanticRegulatorTransitionsTotal, key)
+	if after != before+1 {
+		t.Fatalf("semanticRegulatorTransitionsTotal[%q] = %d; want %d", key, after, before+1)
+	}
+	if got := semanticRegulatorState.Value(); got != string(regulatorAbsenceGrace) {
+		t.Fatalf("semanticRegulatorState = %q; want %q", got, regulatorAbsenceGrace)
+	}
+}
+
+func TestObservability_DHWExpiry_IncrementsCounter(t *testing.T) {
+	now := time.Date(2026, time.February, 26, 12, 0, 0, 0, time.UTC)
+	poller := &vaillantSemanticPoller{
+		dhw:             &vaillantDhwSnapshot{OperatingMode: "auto"},
+		dhwStaleTTL:     10 * time.Minute,
+		dhwLastUpdateAt: now.Add(-11 * time.Minute),
+		nowFn:           func() time.Time { return now },
+	}
+
+	before := semanticDHWStaleExpiryTotal.Value()
+	expired := poller.expireDHWIfStaleLocked(semanticSnapshotSourceCache)
+	if !expired {
+		t.Fatal("expireDHWIfStaleLocked() = false; want true")
+	}
+	after := semanticDHWStaleExpiryTotal.Value()
+	if after != before+1 {
+		t.Fatalf("semanticDHWStaleExpiryTotal = %d; want %d", after, before+1)
+	}
+}
+
+func expvarMapInt64(m *expvar.Map, key string) int64 {
+	if m == nil {
+		return 0
+	}
+	variable := m.Get(key)
+	if variable == nil {
+		return 0
+	}
+	counter, ok := variable.(*expvar.Int)
+	if !ok {
+		return 0
+	}
+	return counter.Value()
+}

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -64,8 +64,14 @@ const (
 )
 
 var (
-	semanticReadBreakerTransitionsTotal = expvar.NewMap("semantic_read_breaker_transitions_total")
-	semanticReadBreakerSuppressedTotal  = expvar.NewMap("semantic_read_breaker_suppressed_total")
+	semanticReadBreakerTransitionsTotal  = expvar.NewMap("semantic_read_breaker_transitions_total")
+	semanticReadBreakerSuppressedTotal   = expvar.NewMap("semantic_read_breaker_suppressed_total")
+	semanticZonePresenceTransitionsTotal = expvar.NewMap("semantic_zone_presence_transitions_total")
+	semanticZoneCount                    = expvar.NewInt("semantic_zone_count")
+	semanticDHWStaleExpiryTotal          = expvar.NewInt("semantic_dhw_stale_expiry_total")
+	semanticDHWUpdatesTotal              = expvar.NewInt("semantic_dhw_updates_total")
+	semanticRegulatorState               = expvar.NewString("semantic_regulator_state")
+	semanticRegulatorTransitionsTotal    = expvar.NewMap("semantic_regulator_transitions_total")
 )
 
 func startVaillantSemanticPolling(ctx context.Context, cfg ebusgateway.Config, gateway *ebusgateway.Gateway, provider *graphql.LiveSemanticProvider, hub *graphql.BroadcastHub) {
@@ -327,6 +333,8 @@ func newVaillantSemanticPoller(cfg ebusgateway.Config, gateway *ebusgateway.Gate
 	if poller.regulatorAbsenceGrace <= 0 {
 		poller.regulatorAbsenceGrace = ebusgateway.DefaultSemanticRegulatorAbsenceGrace
 	}
+	semanticZoneCount.Set(0)
+	semanticRegulatorState.Set(string(poller.regAbsenceState))
 	poller.scheduler.SetCircuitBreaker(ebusgateway.SemanticReadCircuitBreakerOptions{
 		FailureBudget:      cfg.SemanticReadBreakerFailureBudget,
 		OpenCooldown:       cfg.SemanticReadBreakerOpenCooldown,
@@ -412,6 +420,7 @@ func (p *vaillantSemanticPoller) hydrateFromCache(snapshot semanticCacheSnapshot
 			p.markDHWUpdatedNowLocked()
 		}
 	}
+	semanticZoneCount.Set(int64(len(p.zones)))
 }
 
 func zoneInstanceFromSemanticID(id string, fallbackIndex int) byte {
@@ -785,6 +794,7 @@ func (p *vaillantSemanticPoller) refreshRegulatorCapability(_ context.Context) {
 	}
 	newAbsence := p.regAbsenceState
 	p.mu.Unlock()
+	semanticRegulatorState.Set(string(newAbsence))
 
 	// Log capability changes.
 	if regCap != prevCap {
@@ -793,6 +803,8 @@ func (p *vaillantSemanticPoller) refreshRegulatorCapability(_ context.Context) {
 
 	// Log absence state transitions.
 	if newAbsence != prevAbsence {
+		semanticRegulatorTransitionsTotal.Add(fmt.Sprintf("%s->%s", prevAbsence, newAbsence), 1)
+		log.Printf("semantic_regulator_transition from=%s to=%s capability=%s", prevAbsence, newAbsence, regCap.String())
 		log.Printf("semantic_regulator_absence state=%s capability=%s", newAbsence, regCap.String())
 	}
 
@@ -815,6 +827,7 @@ func (p *vaillantSemanticPoller) refreshDiscovery(ctx context.Context) {
 		p.regulatorCapability = regCap
 		p.zones = make(map[byte]*vaillantZoneSnapshot)
 		p.presence = make(map[byte]*zonePresenceRecord)
+		semanticZoneCount.Set(0)
 		p.mu.Unlock()
 		if regCap != prev {
 			log.Printf("semantic_regulator_capability capability=%s", regCap.String())
@@ -925,6 +938,7 @@ func (p *vaillantSemanticPoller) applyZonePresenceMissesOnly(checked, present ma
 
 func (p *vaillantSemanticPoller) markZonePresentLocked(instance byte) {
 	record := p.ensureZonePresenceRecordLocked(instance)
+	previousState := record.State
 	record.MissStreak = 0
 	hitThreshold := p.zoneHitThresholdValue()
 
@@ -945,10 +959,13 @@ func (p *vaillantSemanticPoller) markZonePresentLocked(instance byte) {
 			record.State = zonePresenceSuspectResurrect
 		}
 	}
+	p.recordZonePresenceTransitionLocked(instance, previousState, record.State, record.HitStreak, record.MissStreak)
+	semanticZoneCount.Set(int64(len(p.zones)))
 }
 
 func (p *vaillantSemanticPoller) markZoneMissingLocked(instance byte) {
 	record := p.ensureZonePresenceRecordLocked(instance)
+	previousState := record.State
 	record.HitStreak = 0
 	missThreshold := p.zoneMissThresholdValue()
 
@@ -959,6 +976,8 @@ func (p *vaillantSemanticPoller) markZoneMissingLocked(instance byte) {
 			record.MissStreak = missThreshold
 			record.State = zonePresenceAbsent
 			delete(p.zones, instance)
+			p.recordZonePresenceTransitionLocked(instance, previousState, record.State, record.HitStreak, record.MissStreak)
+			semanticZoneCount.Set(int64(len(p.zones)))
 			return
 		}
 		record.State = zonePresenceSuspectMissing
@@ -967,6 +986,8 @@ func (p *vaillantSemanticPoller) markZoneMissingLocked(instance byte) {
 		record.State = zonePresenceAbsent
 		delete(p.zones, instance)
 	}
+	p.recordZonePresenceTransitionLocked(instance, previousState, record.State, record.HitStreak, record.MissStreak)
+	semanticZoneCount.Set(int64(len(p.zones)))
 }
 
 func (p *vaillantSemanticPoller) ensureZonePresenceRecordLocked(instance byte) *zonePresenceRecord {
@@ -1016,6 +1037,8 @@ func (p *vaillantSemanticPoller) markDHWUpdatedNowLocked() {
 		return
 	}
 	p.dhwLastUpdateAt = p.now()
+	semanticDHWUpdatesTotal.Add(1)
+	log.Printf("semantic_dhw_update last_update_utc=%s", p.dhwLastUpdateAt.UTC().Format(time.RFC3339))
 }
 
 func (p *vaillantSemanticPoller) tryRefreshFromEbusdGrab(ctx context.Context) bool {
@@ -1516,6 +1539,7 @@ func (p *vaillantSemanticPoller) expireDHWIfStaleLocked(source semanticSnapshotS
 	if age < p.dhwStaleTTL {
 		return false
 	}
+	semanticDHWStaleExpiryTotal.Add(1)
 	log.Printf(
 		"semantic_dhw_expired ttl=%s age=%s last_update_utc=%s",
 		p.dhwStaleTTL.Round(time.Second),
@@ -1525,6 +1549,22 @@ func (p *vaillantSemanticPoller) expireDHWIfStaleLocked(source semanticSnapshotS
 	p.dhw = nil
 	p.dhwLastUpdateAt = time.Time{}
 	return true
+}
+
+func (p *vaillantSemanticPoller) recordZonePresenceTransitionLocked(instance byte, previous, next zonePresenceState, hitStreak, missStreak int) {
+	if previous == next {
+		return
+	}
+	semanticZonePresenceTransitionsTotal.Add(fmt.Sprintf("%s->%s", previous, next), 1)
+	log.Printf(
+		"semantic_zone_presence_transition instance=%d from=%s to=%s hit_streak=%d miss_streak=%d zone_count=%d",
+		instance,
+		previous,
+		next,
+		hitStreak,
+		missStreak,
+		len(p.zones),
+	)
 }
 
 func (p *vaillantSemanticPoller) publishDHW(source semanticSnapshotSource) {

--- a/cmd/gateway/startup_scan.go
+++ b/cmd/gateway/startup_scan.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"errors"
+	"expvar"
 	"fmt"
 	"log"
 	"net"
@@ -66,6 +67,10 @@ type statsBus struct {
 	stats scanStats
 }
 
+var (
+	semanticBusCollisionsTotal = expvar.NewInt("semantic_bus_collisions_total")
+)
+
 func (b *statsBus) Send(ctx context.Context, frame protocol.Frame) (*protocol.Frame, error) {
 	if b == nil || b.bus == nil {
 		return nil, fmt.Errorf("scan stats bus missing")
@@ -81,6 +86,8 @@ func (b *statsBus) Send(ctx context.Context, frame protocol.Frame) (*protocol.Fr
 		b.stats.timeouts++
 	case errors.Is(err, ebuserrors.ErrBusCollision):
 		b.stats.collisions++
+		semanticBusCollisionsTotal.Add(1)
+		log.Printf("semantic_bus_collision total=%d", semanticBusCollisionsTotal.Value())
 	case errors.Is(err, ebuserrors.ErrNACK):
 		b.stats.nacks++
 	case errors.Is(err, ebuserrors.ErrCRCMismatch):

--- a/graphql/energy_merge.go
+++ b/graphql/energy_merge.go
@@ -1,6 +1,8 @@
 package graphql
 
 import (
+	"expvar"
+	"log"
 	"sync"
 	"time"
 )
@@ -13,6 +15,11 @@ const (
 	EnergySourceBroadcast EnergyDataSource = iota
 	// EnergySourceRegister is a high-confidence source from direct register reads.
 	EnergySourceRegister
+)
+
+var (
+	semanticEnergyMergesTotal     = expvar.NewMap("semantic_energy_merges_total")
+	semanticEnergyRejectionsTotal = expvar.NewMap("semantic_energy_rejections_total")
 )
 
 // energyDataPoint tracks a single energy value with its source and ingest time.
@@ -75,6 +82,7 @@ func newEnergyMergeStore() *energyMergeStore {
 // The key's Usage is canonicalized internally.
 func (s *energyMergeStore) Apply(key energyMergeKey, value float64, source EnergyDataSource, ingestAt time.Time) bool {
 	key.Usage = canonicalizeUsage(key.Usage)
+	sourceLabel := energySourceLabel(source)
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -84,26 +92,45 @@ func (s *energyMergeStore) Apply(key energyMergeKey, value float64, source Energ
 		// No existing point: accept any source.
 		s.points[key] = energyDataPoint{Value: value, Source: source, IngestAt: ingestAt}
 		s.revision++
+		semanticEnergyMergesTotal.Add(sourceLabel, 1)
+		log.Printf("semantic_energy_merge_accept source=%s", sourceLabel)
 		return true
 	}
 
 	switch {
 	case existing.Source == EnergySourceRegister && source == EnergySourceBroadcast:
 		// Broadcast never overwrites register.
+		semanticEnergyRejectionsTotal.Add("source_downgrade", 1)
+		log.Printf("semantic_energy_merge_reject reason=source_downgrade source=%s existing_source=%s", sourceLabel, energySourceLabel(existing.Source))
 		return false
 	case existing.Source == EnergySourceBroadcast && source == EnergySourceRegister:
 		// Register always wins over broadcast, regardless of timestamp.
 		s.points[key] = energyDataPoint{Value: value, Source: source, IngestAt: ingestAt}
 		s.revision++
+		semanticEnergyMergesTotal.Add(sourceLabel, 1)
+		log.Printf("semantic_energy_merge_accept source=%s", sourceLabel)
 		return true
 	default:
 		// Same source: enforce monotonic ingest timestamp.
 		if !ingestAt.After(existing.IngestAt) {
+			semanticEnergyRejectionsTotal.Add("monotonic", 1)
+			log.Printf("semantic_energy_merge_reject reason=monotonic source=%s", sourceLabel)
 			return false
 		}
 		s.points[key] = energyDataPoint{Value: value, Source: source, IngestAt: ingestAt}
 		s.revision++
+		semanticEnergyMergesTotal.Add(sourceLabel, 1)
+		log.Printf("semantic_energy_merge_accept source=%s", sourceLabel)
 		return true
+	}
+}
+
+func energySourceLabel(source EnergyDataSource) string {
+	switch source {
+	case EnergySourceRegister:
+		return "register"
+	default:
+		return "broadcast"
 	}
 }
 

--- a/graphql/observability_test.go
+++ b/graphql/observability_test.go
@@ -1,0 +1,81 @@
+package graphql
+
+import (
+	"expvar"
+	"testing"
+	"time"
+)
+
+func TestObservability_StartupPhaseTransitionIncrementsCounter(t *testing.T) {
+	provider := NewLiveSemanticProvider()
+
+	key := "BOOT_INIT->CACHE_LOADED_STALE"
+	before := expvarMapInt64Value(semanticStartupPhaseTransitionsTotal, key)
+
+	provider.SetZonesFromCache([]Zone{{ID: "zone-1", Name: "Zone 1"}})
+
+	after := expvarMapInt64Value(semanticStartupPhaseTransitionsTotal, key)
+	if after != before+1 {
+		t.Fatalf("semanticStartupPhaseTransitionsTotal[%q] = %d; want %d", key, after, before+1)
+	}
+	if got := semanticStartupCurrentPhase.Value(); got != string(SemanticStartupPhaseCacheLoadedStale) {
+		t.Fatalf("semanticStartupCurrentPhase = %q; want %q", got, SemanticStartupPhaseCacheLoadedStale)
+	}
+}
+
+func TestObservability_EnergyMergeCounters(t *testing.T) {
+	store := newEnergyMergeStore()
+	now := time.Date(2026, time.February, 26, 12, 0, 0, 0, time.UTC)
+	key := energyMergeKey{Channel: "gas", Usage: "heating", Period: "day"}
+
+	beforeBroadcastAccept := expvarMapInt64Value(semanticEnergyMergesTotal, "broadcast")
+	beforeRegisterAccept := expvarMapInt64Value(semanticEnergyMergesTotal, "register")
+	beforeMonotonicReject := expvarMapInt64Value(semanticEnergyRejectionsTotal, "monotonic")
+	beforeSourceDowngradeReject := expvarMapInt64Value(semanticEnergyRejectionsTotal, "source_downgrade")
+
+	if !store.Apply(key, 1.0, EnergySourceBroadcast, now) {
+		t.Fatal("first broadcast apply rejected; want accepted")
+	}
+	if store.Apply(key, 2.0, EnergySourceBroadcast, now) {
+		t.Fatal("same-timestamp broadcast apply accepted; want monotonic reject")
+	}
+	if !store.Apply(key, 3.0, EnergySourceRegister, now) {
+		t.Fatal("register apply over broadcast rejected; want accepted")
+	}
+	if store.Apply(key, 4.0, EnergySourceBroadcast, now.Add(1*time.Second)) {
+		t.Fatal("broadcast apply over register accepted; want source_downgrade reject")
+	}
+
+	afterBroadcastAccept := expvarMapInt64Value(semanticEnergyMergesTotal, "broadcast")
+	afterRegisterAccept := expvarMapInt64Value(semanticEnergyMergesTotal, "register")
+	afterMonotonicReject := expvarMapInt64Value(semanticEnergyRejectionsTotal, "monotonic")
+	afterSourceDowngradeReject := expvarMapInt64Value(semanticEnergyRejectionsTotal, "source_downgrade")
+
+	if afterBroadcastAccept != beforeBroadcastAccept+1 {
+		t.Fatalf("semanticEnergyMergesTotal[broadcast] = %d; want %d", afterBroadcastAccept, beforeBroadcastAccept+1)
+	}
+	if afterRegisterAccept != beforeRegisterAccept+1 {
+		t.Fatalf("semanticEnergyMergesTotal[register] = %d; want %d", afterRegisterAccept, beforeRegisterAccept+1)
+	}
+	if afterMonotonicReject != beforeMonotonicReject+1 {
+		t.Fatalf("semanticEnergyRejectionsTotal[monotonic] = %d; want %d", afterMonotonicReject, beforeMonotonicReject+1)
+	}
+	if afterSourceDowngradeReject != beforeSourceDowngradeReject+1 {
+		t.Fatalf("semanticEnergyRejectionsTotal[source_downgrade] = %d; want %d", afterSourceDowngradeReject, beforeSourceDowngradeReject+1)
+	}
+}
+
+func expvarMapInt64Value(m *expvar.Map, key string) int64 {
+	if m == nil {
+		return 0
+	}
+	variable := m.Get(key)
+	if variable == nil {
+		return 0
+	}
+	counter, ok := variable.(*expvar.Int)
+	if !ok {
+		return 0
+	}
+	return counter.Value()
+}

--- a/graphql/semantic_live.go
+++ b/graphql/semantic_live.go
@@ -2,6 +2,7 @@ package graphql
 
 import (
 	"context"
+	"expvar"
 	"fmt"
 	"log"
 	"sync"
@@ -43,6 +44,13 @@ type phaseTransitionLog struct {
 	liveEpoch  uint64
 }
 
+var (
+	semanticStartupPhaseTransitionsTotal = expvar.NewMap("semantic_startup_phase_transitions_total")
+	semanticStartupCurrentPhase          = expvar.NewString("semantic_startup_current_phase")
+	semanticCacheEpoch                   = expvar.NewInt("semantic_cache_epoch")
+	semanticLiveEpoch                    = expvar.NewInt("semantic_live_epoch")
+)
+
 // LiveSemanticProvider maintains semantic snapshots derived from bus data.
 type LiveSemanticProvider struct {
 	mu     sync.RWMutex
@@ -65,6 +73,10 @@ type LiveSemanticProvider struct {
 }
 
 func NewLiveSemanticProvider() *LiveSemanticProvider {
+	semanticStartupCurrentPhase.Set(string(SemanticStartupPhaseBootInit))
+	semanticCacheEpoch.Set(0)
+	semanticLiveEpoch.Set(0)
+
 	return &LiveSemanticProvider{
 		phase:       SemanticStartupPhaseBootInit,
 		energyMerge: newEnergyMergeStore(),
@@ -239,6 +251,7 @@ func (provider *LiveSemanticProvider) recordEpochUpdateLocked(source semanticDat
 	switch source {
 	case semanticDataSourceCache:
 		provider.cacheEpoch++
+		semanticCacheEpoch.Set(int64(provider.cacheEpoch))
 		if provider.liveEpoch == 0 && provider.phase != SemanticStartupPhaseDegraded {
 			return provider.transitionPhaseLocked(SemanticStartupPhaseCacheLoadedStale, reason)
 		}
@@ -250,6 +263,7 @@ func (provider *LiveSemanticProvider) recordEpochUpdateLocked(source semanticDat
 			provider.dhwLiveSeen = true
 		}
 		provider.liveEpoch++
+		semanticLiveEpoch.Set(int64(provider.liveEpoch))
 		if provider.liveEpoch == 1 {
 			return provider.transitionPhaseLocked(SemanticStartupPhaseLiveWarmup, reason)
 		}
@@ -276,6 +290,8 @@ func (provider *LiveSemanticProvider) transitionPhaseLocked(next SemanticStartup
 	}
 	previous := provider.phase
 	provider.phase = next
+	semanticStartupPhaseTransitionsTotal.Add(fmt.Sprintf("%s->%s", previous, next), 1)
+	semanticStartupCurrentPhase.Set(string(next))
 	return &phaseTransitionLog{
 		previous:   previous,
 		next:       next,


### PR DESCRIPTION
## Summary
13 new expvar metrics covering all critical runtime FSMs:

| Area | Metrics |
|---|---|
| Startup FSM | `semantic_startup_phase_transitions_total`, `semantic_startup_current_phase` |
| Cache lifecycle | `semantic_cache_epoch`, `semantic_live_epoch` |
| Zone presence | `semantic_zone_presence_transitions_total`, `semantic_zone_count` |
| DHW lifecycle | `semantic_dhw_stale_expiry_total`, `semantic_dhw_updates_total` |
| Energy merge | `semantic_energy_merges_total`, `semantic_energy_rejections_total` |
| Regulator state | `semantic_regulator_state`, `semantic_regulator_transitions_total` |
| Bus health | `semantic_bus_collisions_total` |

## Implementation
- Pure instrumentation: no behavioral changes
- Structured log markers for FSM transitions
- 5 new test functions verifying counter increments on key transitions

## Transport gate
Observability-only changes. Owner override justified.

## References
- Issue: #197
- Doc-gate: d3vi1/helianthus-docs-ebus#138

🤖 Generated with [Claude Code](https://claude.com/claude-code)