### PR TITLE
fix(gateway): remove duplicate opcode in B524 read selector

### DIFF
--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -1954,7 +1954,6 @@ func semanticReadBreakerKey(target, opcode, group, instance byte, addr uint16) s
 
 func buildB524ReadSelector(opcode, group, instance byte, addr uint16) []byte {
 	return []byte{
-		vaillantB524OpcodeRead,
 		opcode,
 		vaillantB524OpRead,
 		group,

--- a/cmd/gateway/semantic_vaillant_test.go
+++ b/cmd/gateway/semantic_vaillant_test.go
@@ -28,7 +28,7 @@ func TestBuildB524ReadSelector(t *testing.T) {
 	t.Parallel()
 
 	got := buildB524ReadSelector(0x02, 0x03, 0x01, 0x001C)
-	want := []byte{0x06, 0x02, 0x00, 0x03, 0x01, 0x1C, 0x00}
+	want := []byte{0x02, 0x00, 0x03, 0x01, 0x1C, 0x00}
 	if len(got) != len(want) {
 		t.Fatalf("len(got)=%d; want %d", len(got), len(want))
 	}


### PR DESCRIPTION
## Summary

- Remove duplicate `vaillantB524OpcodeRead` byte from `buildB524ReadSelector()`
- Selector now produces correct 6-byte output instead of 7-byte with spurious 0x06 prefix
- Test updated to match correct selector format

## Root Cause

The function prepended `vaillantB524OpcodeRead` (0x06) before the `opcode` parameter, but the opcode was already the correct value. This produced a malformed B524 read selector with an extra byte.

## Test Evidence

```
go test -race ./cmd/gateway/...
ok  github.com/d3vi1/helianthus-ebusgateway/cmd/gateway  1.067s
```

## Transport-gate

Non-transport change (semantic layer only). No transport matrix impact.

Fixes #217