### PR TITLE
fix(gateway): normalize transport config in broadcast listener

### DIFF
--- a/broadcast_listener.go
+++ b/broadcast_listener.go
@@ -52,7 +52,10 @@ func resolveBroadcastTransport(ctx context.Context, cfg Config) (transport.RawTr
 		ctx = context.Background()
 	}
 
-	config := cfg.TransportConfig
+	config, err := normalizeTransportConfig(cfg.TransportConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("broadcast transport config: %w", err)
+	}
 	if config.Network == "" {
 		return nil, nil, fmt.Errorf("broadcast transport missing network: %w", ebuserrors.ErrInvalidPayload)
 	}


### PR DESCRIPTION
## Summary

- Call normalizeTransportConfig() in resolveBroadcastTransport()
- Invalid transport configs now rejected early with descriptive error

## Root Cause

The broadcast listener used raw cfg.TransportConfig without the normalizeTransportConfig() validation that the main gateway path performs. This could allow malformed endpoint schemes through to the dial layer.

## Test Evidence

```
go test -race ./cmd/gateway/...
ok  github.com/d3vi1/helianthus-ebusgateway/cmd/gateway  1.067s
```

Note: graphql/TestInvokeMutation_Integration failure is pre-existing on main (unrelated timeout in mock bus).

## Follow-up

broadcast_listener_test.go coverage planned per adversarial planning agreement.

Fixes #219