### PR TITLE
Fix B5.16 energy register: correct payload, values, and decode

### DIFF
--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -1892,6 +1892,15 @@ func (p *vaillantSemanticPoller) readB516Value(ctx context.Context, data []byte)
 		return 0, false
 	}
 
+	return decodeB516ResponseKWh(payload)
+}
+
+// decodeB516ResponseKWh extracts the energy value from a B5.16 response payload.
+// The last 4 bytes are IEEE 754 float32 LE representing Wh; the result is kWh.
+func decodeB516ResponseKWh(payload []byte) (float64, bool) {
+	if len(payload) < 4 {
+		return 0, false
+	}
 	raw := payload[len(payload)-4:]
 	bits := uint32(raw[0]) | uint32(raw[1])<<8 | uint32(raw[2])<<16 | uint32(raw[3])<<24
 	value := float64(math.Float32frombits(bits))

--- a/cmd/gateway/semantic_vaillant_test.go
+++ b/cmd/gateway/semantic_vaillant_test.go
@@ -1808,13 +1808,13 @@ func TestBuildB516DayPayload(t *testing.T) {
 func TestReadB516Value_Float32Decode(t *testing.T) {
 	t.Parallel()
 
-	// Test the float32 LE decode logic that readB516Value uses internally.
-	// We test decodeFloat32LE (same pattern) since readB516Value requires a
-	// real protocol.Bus which is not easily mockable.
+	// Test the production decode path used by readB516Value:
+	// decodeB516ResponseKWh extracts last 4 bytes as float32 LE (Wh) → kWh.
 
 	tests := []struct {
 		name    string
 		whValue float32 // input in Wh (what the device returns)
+		prefix  []byte  // optional prefix bytes before the float32 (simulates full response)
 		wantKwh float64 // expected output in kWh
 		wantOk  bool
 	}{
@@ -1836,22 +1836,29 @@ func TestReadB516Value_Float32Decode(t *testing.T) {
 			wantKwh: 9876.543,
 			wantOk:  true,
 		},
+		{
+			name:    "with_prefix_bytes",
+			whValue: 5000.0,
+			prefix:  []byte{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x11},
+			wantKwh: 5.0,
+			wantOk:  true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Encode the float32 value as 4 bytes LE (simulating device response).
 			raw := make([]byte, 4)
 			binary.LittleEndian.PutUint32(raw, math.Float32bits(tt.whValue))
+			// Prepend prefix bytes to simulate a full response payload.
+			payload := append(tt.prefix, raw...)
 
-			value, ok := decodeFloat32LE(raw)
-			if !ok {
-				t.Fatalf("decodeFloat32LE(%x) returned ok=false; want ok=true", raw)
+			kwh, ok := decodeB516ResponseKWh(payload)
+			if ok != tt.wantOk {
+				t.Fatalf("decodeB516ResponseKWh(%x) ok=%v; want %v", payload, ok, tt.wantOk)
 			}
-			kwh := value / 1000.0
-			if math.Abs(kwh-tt.wantKwh) > 0.01 {
-				t.Fatalf("decodeFloat32LE(%x)/1000 = %f; want %f", raw, kwh, tt.wantKwh)
+			if ok && math.Abs(kwh-tt.wantKwh) > 0.01 {
+				t.Fatalf("decodeB516ResponseKWh(%x) = %f kWh; want %f", payload, kwh, tt.wantKwh)
 			}
-			_ = ok == tt.wantOk
 		})
 	}
 
@@ -1859,9 +1866,9 @@ func TestReadB516Value_Float32Decode(t *testing.T) {
 	t.Run("nan", func(t *testing.T) {
 		raw := make([]byte, 4)
 		binary.LittleEndian.PutUint32(raw, math.Float32bits(float32(math.NaN())))
-		_, ok := decodeFloat32LE(raw)
+		_, ok := decodeB516ResponseKWh(raw)
 		if ok {
-			t.Fatal("decodeFloat32LE(NaN) returned ok=true; want ok=false")
+			t.Fatal("decodeB516ResponseKWh(NaN) returned ok=true; want ok=false")
 		}
 	})
 
@@ -1869,17 +1876,17 @@ func TestReadB516Value_Float32Decode(t *testing.T) {
 	t.Run("inf", func(t *testing.T) {
 		raw := make([]byte, 4)
 		binary.LittleEndian.PutUint32(raw, math.Float32bits(float32(math.Inf(1))))
-		_, ok := decodeFloat32LE(raw)
+		_, ok := decodeB516ResponseKWh(raw)
 		if ok {
-			t.Fatal("decodeFloat32LE(+Inf) returned ok=true; want ok=false")
+			t.Fatal("decodeB516ResponseKWh(+Inf) returned ok=true; want ok=false")
 		}
 	})
 
 	// Short payload must be rejected.
 	t.Run("short_payload", func(t *testing.T) {
-		_, ok := decodeFloat32LE([]byte{0x01, 0x02})
+		_, ok := decodeB516ResponseKWh([]byte{0x01, 0x02})
 		if ok {
-			t.Fatal("decodeFloat32LE(2 bytes) returned ok=true; want ok=false")
+			t.Fatal("decodeB516ResponseKWh(2 bytes) returned ok=true; want ok=false")
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- Rewrites B5.16 energy register protocol implementation that was completely non-functional (3 bugs: wrong payload format, wrong enum values, wrong response decode)
- Adds payload builder functions for year and day queries with correct 8-byte protocol encoding
- Replaces `readB516Value` signature from `(period, source, usage byte) → uint16` to `(payload []byte) → float64` (kWh)
- Decodes response as IEEE 754 float32 LE (Wh) instead of uint16, with NaN/Inf rejection
- Replaces triple nested loop in `refreshEnergy` with query table (`b516Queries`) iterating correct source/usage/period combinations
- Removes `b516EnergyMergeKey` (keys now built inline)

## Protocol Reference

B5.16 request: `[0x10, 0x0X, 0xFF, 0xFF, 0x0Y, 0x0Z, (W<<4)|V, 0x30|Q]`
- X=period (3=year, 1=day), Y=source (1=solar, 3=electrical, 4=gas), Z=usage (3=heating, 4=hotwater)
- Response: last 4 bytes = float32 LE in Wh

## Test Plan

- [x] `TestBuildB516YearPayload` — byte-for-byte payload verification (4 cases)
- [x] `TestBuildB516DayPayload` — day encoding verification (3 cases: jan/aug/dec boundary)
- [x] `TestReadB516Value_Float32Decode` — float32 decode, NaN/Inf rejection, short payload (6 cases)
- [x] `TestB516Queries_Coverage` — all 6 source/usage combinations present
- [x] Existing `TestRefreshEnergy_NilController` and `TestRefreshEnergy_NoRegulator` pass
- [x] Local CI green (pre-existing `TestInvokeMutation_Integration` failure unrelated)
- [ ] Deploy to HA: energy dashboard shows non-zero values
- [ ] Logs: `semantic_energy_merge_accept source=register` entries

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)