### PR TITLE
Fix TestInvokeMutation_Integration mock transport (#251)

### DIFF
--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -1600,9 +1600,6 @@ const (
 
 	// system_flow_temperature — float32 LE (°C)
 	regulatorRegSystemFlowTemp = uint16(0x004B)
-	// system_water_pressure — float32 LE (bar)
-	regulatorRegSystemWaterPressure = uint16(0x0039)
-
 	// Heating circuit registers (group 0x02)
 	circuitRegFlowTemp    = uint16(0x0008) // heating_circuit_flow_temperature — float32 LE (°C)
 	circuitRegPumpStatus  = uint16(0x001E) // pump_status — uint16 LE (0=off, !0=on)

--- a/graphql/mutations_integration_test.go
+++ b/graphql/mutations_integration_test.go
@@ -203,11 +203,11 @@ func TestInvokeMutation_Integration(t *testing.T) {
 		t.Fatalf("responseSchema.Encode error = %v", err)
 	}
 
-	// eBUS slave response on the wire is NN DATA... CRC (no QQ/ZZ/PB/SB header).
-	slaveResponse := append([]byte{byte(len(responsePayload))}, responsePayload...)
-	crc := protocol.CRC(slaveResponse)
+	// eBUS target response on the wire is NN DATA... CRC (no QQ/ZZ/PB/SB header).
+	targetResponse := append([]byte{byte(len(responsePayload))}, responsePayload...)
+	crc := protocol.CRC(targetResponse)
 	inbound := []readEvent{{value: protocol.SymbolAck}}
-	for _, b := range slaveResponse {
+	for _, b := range targetResponse {
 		inbound = append(inbound, readEvent{value: b})
 	}
 	inbound = append(inbound, readEvent{value: crc})

--- a/portal/explorer_test.go
+++ b/portal/explorer_test.go
@@ -36,12 +36,6 @@ func (m *mockExplorerBus) Send(ctx context.Context, frame protocol.Frame) (*prot
 	return nil, fmt.Errorf("no handler configured")
 }
 
-func (m *mockExplorerBus) requestCount() int {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return len(m.requests)
-}
-
 // --- Helpers ---
 
 func explorerHandler(bus ExplorerBus) http.Handler {


### PR DESCRIPTION
## Summary

- **Split-queue transport**: Replace single `reads` queue with separate `echo` and `inbound` queues. `Write()` populates `echo`; `ReadByte()` drains `echo` first, then `inbound`. Matches the proven pattern in `ebusgo/protocol/bus_test.go`.
- **Correct slave response format**: The test provided a full frame header (QQ/ZZ/PB/SB/NN/DATA) but the eBUS slave response only sends NN/DATA/CRC. The bus misread the target address as NN=8 and ran out of bytes.

## Test plan

- [x] `TestInvokeMutation_Integration` passes locally (`go test -race -count=1 -run TestInvokeMutation_Integration ./graphql/`)
- [x] Full test suite passes (`go test -race -count=1 ./...`)
- [ ] CI passes (build + test + lint + terminology)

Fixes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)