### PR TITLE
fix(portal): explorer device list reads wrong JSON field

### DIFF
--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -1504,7 +1504,7 @@ class PortalShell extends HTMLElement {
     try {
       const res = await fetch("api/v1/registry/devices");
       const payload = await res.json();
-      const devices = Array.isArray(payload.devices) ? payload.devices : [];
+      const devices = Array.isArray(payload.items) ? payload.items : [];
       deviceSelect.innerHTML = '<option value="">Select device...</option>' +
         devices.map((d) => {
           const addr = formatAddress(d.address);

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,8 +2,8 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 81407,
-      "sha256": "a35351e9ef1bd831a23bf927191554a355b9f010d348345cf846865dc8d66ffa"
+      "bytes": 81403,
+      "sha256": "daa224b9ec6cd8f6c72a2c30cd2e300d9ebafe78a95c756ef21c99b64558f4ea"
     },
     "app.css": {
       "bytes": 7389,

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -1503,7 +1503,7 @@ class PortalShell extends HTMLElement {
     try {
       const res = await fetch("api/v1/registry/devices");
       const payload = await res.json();
-      const devices = Array.isArray(payload.devices) ? payload.devices : [];
+      const devices = Array.isArray(payload.items) ? payload.items : [];
       deviceSelect.innerHTML = '<option value="">Select device...</option>' +
         devices.map((d) => {
           const addr = formatAddress(d.address);


### PR DESCRIPTION
## Summary
- Fix `initExplorer()` reading `payload.devices` instead of `payload.items` from the registry devices API response
- Device dropdown was always empty, making the Explorer feature completely unusable
- Found by Playwright adversarial testing of the live portal

Fixes #253

## Test plan
- [x] Playwright adversarial test: device dropdown populates with 4 devices
- [x] Playwright adversarial test: scan works after device selection
- [x] Playwright adversarial test: Quick Read works after device selection
- [x] Deployed and verified on live system (192.168.100.4:8080)

🤖 Generated with [Claude Code](https://claude.com/claude-code)