### PR TITLE
fix(portal): use no-cache for static assets to prevent stale JS

### DIFF
--- a/portal/handler.go
+++ b/portal/handler.go
@@ -614,7 +614,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if strings.HasPrefix(path, "/assets/") {
-		recorder.Header().Set("Cache-Control", "public, max-age=3600")
+		recorder.Header().Set("Cache-Control", "no-cache")
 		if applyAssetETag(recorder, r, path) {
 			return
 		}


### PR DESCRIPTION
## Summary

- Change `Cache-Control` for `/assets/` from `public, max-age=3600` to `no-cache`
- Ensures browsers always revalidate via ETag, preventing stale JS after redeployment
- ETag mechanism (`applyAssetETag` with SHA256 from manifest.json) provides efficient 304 responses for unchanged assets

## Context

After merging #256 (snapshot diff fix), browsers continued serving old JavaScript from disk cache for up to 1 hour. The `max-age=3600` header bypassed ETag revalidation entirely. Since asset filenames aren't content-hashed (`app.js`, not `app.abc123.js`), the same URL serves different content after redeployment.

## Test plan

- [ ] `go test ./portal/...` passes (existing Cache-Control test checks non-empty, not specific value)
- [ ] Deployed and verified: `Cache-Control: no-cache` header on `/assets/app.js`
- [ ] Fresh page load picks up new JS immediately without cache-busting

Fixes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)