### PR TITLE
Explorer ScanID: partial results and status byte on chunk failure

### DIFF
--- a/portal/explorer.go
+++ b/portal/explorer.go
@@ -737,6 +737,7 @@ func (es *explorerStore) readScanID(ctx context.Context, target, source byte) Ex
 	}
 
 	raw := make([]byte, 0, 32)
+	var errs []string
 	for qq := byte(0x24); qq <= byte(0x27); qq++ {
 		frame := protocol.Frame{
 			Source:    source,
@@ -747,16 +748,35 @@ func (es *explorerStore) readScanID(ctx context.Context, target, source byte) Ex
 		}
 		resp, err := explorerSendWithRetry(ctx, es.bus, frame)
 		if err != nil {
-			result.Error = fmt.Sprintf("chunk 0x%02x: %v", qq, err)
-			return result
+			errs = append(errs, fmt.Sprintf("chunk 0x%02x: %v", qq, err))
+			result.Chunks = append(result.Chunks, "")
+			raw = append(raw, make([]byte, 8)...)
+			continue
 		}
-		if len(resp.Data) != 9 || resp.Data[0] != 0x00 {
-			result.Error = fmt.Sprintf("chunk 0x%02x: unexpected response (%d bytes)", qq, len(resp.Data))
-			return result
+		if len(resp.Data) < 1 {
+			errs = append(errs, fmt.Sprintf("chunk 0x%02x: empty response", qq))
+			result.Chunks = append(result.Chunks, "")
+			raw = append(raw, make([]byte, 8)...)
+			continue
+		}
+		if resp.Data[0] != 0x00 {
+			errs = append(errs, fmt.Sprintf("chunk 0x%02x: status=0x%02x (%d bytes)", qq, resp.Data[0], len(resp.Data)))
+			result.Chunks = append(result.Chunks, hex.EncodeToString(resp.Data))
+			raw = append(raw, make([]byte, 8)...)
+			continue
+		}
+		if len(resp.Data) != 9 {
+			errs = append(errs, fmt.Sprintf("chunk 0x%02x: expected 9 bytes, got %d", qq, len(resp.Data)))
+			result.Chunks = append(result.Chunks, hex.EncodeToString(resp.Data))
+			raw = append(raw, make([]byte, 8)...)
+			continue
 		}
 		chunk := resp.Data[1:]
 		result.Chunks = append(result.Chunks, hex.EncodeToString(chunk))
 		raw = append(raw, chunk...)
+	}
+	if len(errs) > 0 {
+		result.Error = strings.Join(errs, "; ")
 	}
 
 	// Trim trailing NUL/space/0xFF padding.


### PR DESCRIPTION
## Summary
- Continue reading all 4 ScanID chunks even when individual chunks fail (don't abort early)
- Show actual status byte value in errors (e.g. `status=0x03` instead of generic "unexpected response")
- Preserve raw response data for failed chunks in the chunks array
- Join multiple chunk errors with "; " separator

Fixes #261. Follow-up to #260.

## Test plan
- [x] All existing ScanID tests pass (including BusError which now gets 4 errors instead of 1)
- [x] Full `go test ./portal/...` passes
- [ ] Deploy to HA and verify partial ScanID results shown for BASV2

🤖 Generated with [Claude Code](https://claude.com/claude-code)