### PR TITLE
Explorer ScanID: dual interpretation for BAI/BASV2 formats

### DIFF
--- a/portal/explorer.go
+++ b/portal/explorer.go
@@ -726,6 +726,12 @@ func (es *explorerStore) singleB509Read(ctx context.Context, target, source byte
 
 // readScanID reads the device serial via B5.09 ScanID frames (QQ=0x24..0x27).
 // Mirrors readVaillantScanID from ebusreg/registry/scan.go but uses explorerSendWithRetry.
+//
+// Some devices (e.g. BAI boiler) return 9 bytes where Data[0] is a 0x00 status
+// byte and Data[1:9] holds 8 serial bytes.  Other devices (e.g. BASV2 controller)
+// return 9 bytes of raw serial data with no status prefix.  We try the status-byte
+// interpretation first; if it doesn't yield a formatted serial we fall back to
+// the full-9-byte interpretation.
 func (es *explorerStore) readScanID(ctx context.Context, target, source byte) ExplorerScanIDResult {
 	if source == 0 {
 		source = es.source
@@ -736,7 +742,12 @@ func (es *explorerStore) readScanID(ctx context.Context, target, source byte) Ex
 		Chunks: make([]string, 0, 4),
 	}
 
-	raw := make([]byte, 0, 32)
+	// Collect raw 9-byte responses for each chunk.
+	type chunkResp struct {
+		data []byte
+		err  string
+	}
+	chunks := make([]chunkResp, 0, 4)
 	var errs []string
 	for qq := byte(0x24); qq <= byte(0x27); qq++ {
 		frame := protocol.Frame{
@@ -748,50 +759,82 @@ func (es *explorerStore) readScanID(ctx context.Context, target, source byte) Ex
 		}
 		resp, err := explorerSendWithRetry(ctx, es.bus, frame)
 		if err != nil {
-			errs = append(errs, fmt.Sprintf("chunk 0x%02x: %v", qq, err))
+			msg := fmt.Sprintf("chunk 0x%02x: %v", qq, err)
+			errs = append(errs, msg)
+			chunks = append(chunks, chunkResp{err: msg})
 			result.Chunks = append(result.Chunks, "")
-			raw = append(raw, make([]byte, 8)...)
 			continue
 		}
-		if len(resp.Data) < 1 {
-			errs = append(errs, fmt.Sprintf("chunk 0x%02x: empty response", qq))
+		if len(resp.Data) == 0 {
+			msg := fmt.Sprintf("chunk 0x%02x: empty response", qq)
+			errs = append(errs, msg)
+			chunks = append(chunks, chunkResp{err: msg})
 			result.Chunks = append(result.Chunks, "")
-			raw = append(raw, make([]byte, 8)...)
 			continue
 		}
-		if resp.Data[0] != 0x00 {
-			errs = append(errs, fmt.Sprintf("chunk 0x%02x: status=0x%02x (%d bytes)", qq, resp.Data[0], len(resp.Data)))
-			result.Chunks = append(result.Chunks, hex.EncodeToString(resp.Data))
-			raw = append(raw, make([]byte, 8)...)
+		result.Chunks = append(result.Chunks, hex.EncodeToString(resp.Data))
+		chunks = append(chunks, chunkResp{data: resp.Data})
+	}
+
+	// Try status-byte interpretation: Data[0]==0x00 → Data[1:9] are serial bytes.
+	statusRaw := make([]byte, 0, 32)
+	statusOK := true
+	for _, c := range chunks {
+		if c.err != "" || len(c.data) != 9 || c.data[0] != 0x00 {
+			statusOK = false
+			break
+		}
+		statusRaw = append(statusRaw, c.data[1:]...)
+	}
+	if statusOK {
+		serial := formatScanIDSerial(string(trimScanIDPadding(statusRaw)))
+		if serial != "" {
+			result.Serial = serial
+			return result
+		}
+	}
+
+	// Fallback: no status byte — all 9 bytes per chunk are serial data.
+	fullRaw := make([]byte, 0, 36)
+	for _, c := range chunks {
+		if c.err != "" {
+			fullRaw = append(fullRaw, make([]byte, 9)...)
 			continue
 		}
-		if len(resp.Data) != 9 {
-			errs = append(errs, fmt.Sprintf("chunk 0x%02x: expected 9 bytes, got %d", qq, len(resp.Data)))
-			result.Chunks = append(result.Chunks, hex.EncodeToString(resp.Data))
-			raw = append(raw, make([]byte, 8)...)
-			continue
-		}
-		chunk := resp.Data[1:]
-		result.Chunks = append(result.Chunks, hex.EncodeToString(chunk))
-		raw = append(raw, chunk...)
+		fullRaw = append(fullRaw, c.data...)
+	}
+	trimmed := trimScanIDPadding(fullRaw)
+	serial := formatScanIDSerial(string(trimmed))
+	if serial != "" {
+		result.Serial = serial
 	}
 	if len(errs) > 0 {
 		result.Error = strings.Join(errs, "; ")
 	}
+	return result
+}
 
-	// Trim trailing NUL/space/0xFF padding.
-	end := len(raw)
-	for end > 0 {
-		last := raw[end-1]
-		if last == 0x00 || last == 0x20 || last == 0xFF {
+// trimScanIDPadding strips leading and trailing NUL/space/0xFF bytes.
+func trimScanIDPadding(data []byte) []byte {
+	start := 0
+	for start < len(data) {
+		b := data[start]
+		if b == 0x00 || b == 0x20 || b == 0xFF {
+			start++
+			continue
+		}
+		break
+	}
+	end := len(data)
+	for end > start {
+		b := data[end-1]
+		if b == 0x00 || b == 0x20 || b == 0xFF {
 			end--
 			continue
 		}
 		break
 	}
-	trimmed := string(raw[:end])
-	result.Serial = formatScanIDSerial(trimmed)
-	return result
+	return data[start:end]
 }
 
 // formatScanIDSerial formats a raw Vaillant serial string.

--- a/portal/explorer_test.go
+++ b/portal/explorer_test.go
@@ -973,6 +973,49 @@ func TestExplorerScanID_Formatted(t *testing.T) {
 	}
 }
 
+func TestExplorerScanID_NoStatusByte(t *testing.T) {
+	// Simulate BASV2-style response: all 9 bytes are serial data (no status prefix).
+	// Chunk 0x24 first byte happens to be 0x00 (NUL padding), rest are ASCII.
+	// Full serial across 36 bytes: NUL + "21213400202621480082014267N7" + 0xFF padding.
+	chunkData := [][]byte{
+		{0x00, '2', '1', '2', '1', '3', '4', '0', '0'}, // 0x24: NUL + "21213400"
+		{'2', '0', '2', '6', '2', '1', '4', '8', '0'},   // 0x25: "202621480"
+		{'0', '8', '2', '0', '1', '4', '2', '6', '7'},   // 0x26: "082014267"
+		{'N', '7', 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}, // 0x27: "N7" + padding
+	}
+
+	bus := &mockExplorerBus{
+		handler: func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+			idx := int(frame.Data[0]) - 0x24
+			return &protocol.Frame{
+				Source:    frame.Target,
+				Target:    frame.Source,
+				Primary:   0xB5,
+				Secondary: 0x09,
+				Data:      chunkData[idx],
+			}, nil
+		},
+	}
+	h := explorerHandler(bus)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/explorer/read/scanid?target=15", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	payload := explorerJSON(t, rec)
+	serialResult, _ := payload["serial"].(string)
+	// Chunk 0x24 has Data[0]==0x00 but chunks 0x25-0x27 don't, so status-byte path
+	// fails.  Fallback concatenates all 36 bytes, trims NUL/0xFF → "21213400202621480082014267N7".
+	expected := "21-21-34-0020262148-0082-014267-N7"
+	if serialResult != expected {
+		t.Fatalf("serial = %q; want %q", serialResult, expected)
+	}
+	// Error field should be empty (all chunks returned valid data).
+	errMsg, _ := payload["error"].(string)
+	if errMsg != "" {
+		t.Fatalf("unexpected error: %q", errMsg)
+	}
+}
+
 func TestExplorerScanID_BusError(t *testing.T) {
 	bus := &mockExplorerBus{
 		handler: func(_ context.Context, _ protocol.Frame) (*protocol.Frame, error) {


### PR DESCRIPTION
## Summary
- BAI boilers: Data[0]=0x00 status prefix + 8 serial bytes per chunk (existing behavior)
- BASV2 controllers: all 9 bytes are serial data, no status prefix
- Try status-byte interpretation first; fall back to full-9-byte with padding stripped
- Add `trimScanIDPadding` helper (strips leading AND trailing NUL/space/0xFF)
- Add `TestExplorerScanID_NoStatusByte` test covering the BASV2 pattern

Tested on live BASV2 (0x15): returns `21-21-34-0020262148-0082-014267-N7`.

Fixes #261. Follow-up to #262.

## Test plan
- [x] All ScanID tests pass (Success, Formatted, NoStatusByte, BusError, MissingTarget)
- [x] Full `go test ./portal/...` passes
- [ ] Deploy to HA and verify serial displayed for BASV2

🤖 Generated with [Claude Code](https://claude.com/claude-code)