### PR TITLE
GW-4: system status GraphQL + MCP with VR71 index derivation

### DIFF
--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/Project-Helianthus/helianthus-ebusgateway"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/graphql"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
 	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
 	"github.com/Project-Helianthus/helianthus-ebusreg/vaillant/productids"
@@ -165,6 +166,7 @@ type vaillantSemanticPoller struct {
 	dhw                      *vaillantDhwSnapshot
 	dhwLastUpdateAt          time.Time
 	boiler                   *vaillantBoilerSnapshot
+	system                   *vaillantSystemSnapshot
 	circuits                 map[byte]*vaillantCircuitSnapshot
 
 	refreshFromEbusdGrabFn func(context.Context) (map[byte]bool, bool)
@@ -831,6 +833,7 @@ func (p *vaillantSemanticPoller) Start(ctx context.Context) {
 	p.enqueueTask(semanticTaskPriorityHigh, p.refreshConfig)
 	p.enqueueTask(semanticTaskPriorityHigh, p.refreshState)
 	p.enqueueTask(semanticTaskPriorityMedium, p.refreshCircuits)
+	p.enqueueTask(semanticTaskPriorityMedium, p.refreshSystem)
 	p.enqueueTask(semanticTaskPriorityMedium, p.refreshEnergy)
 	for _, schedule := range p.boilerStatusTierSchedules() {
 		p.enqueueTask(schedule.priority, p.boilerStatusTierTask(schedule.tier))
@@ -841,6 +844,7 @@ func (p *vaillantSemanticPoller) Start(ctx context.Context) {
 	go p.runLoop(ctx, p.configInterval, semanticTaskPriorityMedium, p.refreshConfig)
 	go p.runLoop(ctx, p.stateInterval, semanticTaskPriorityHigh, p.refreshState)
 	go p.runLoop(ctx, p.configInterval, semanticTaskPriorityLow, p.refreshCircuits)
+	go p.runLoop(ctx, p.configInterval, semanticTaskPriorityLow, p.refreshSystem)
 	go p.runLoop(ctx, p.energyInterval, semanticTaskPriorityMedium, p.refreshEnergy)
 	for _, schedule := range p.boilerStatusTierSchedules() {
 		go p.runLoop(ctx, schedule.interval, schedule.priority, p.boilerStatusTierTask(schedule.tier))
@@ -2189,8 +2193,28 @@ const (
 	vaillantGroupRegulator = byte(0x00)
 	regulatorInstance      = byte(0x00)
 
-	// system_flow_temperature — float32 LE (°C)
-	regulatorRegSystemFlowTemp = uint16(0x004B)
+	// System state registers (GG=0x00, II=0x00).
+	systemRegSystemOff                    = uint16(0x0007)
+	systemRegSystemWaterPressure          = uint16(0x0039)
+	systemRegSystemFlowTemperature        = uint16(0x004B)
+	systemRegOutdoorTemperature           = uint16(0x0073)
+	systemRegOutdoorTemperatureAvg24h     = uint16(0x0095)
+	systemRegMaintenanceDue               = uint16(0x0096)
+	systemRegHwcCylinderTemperatureTop    = uint16(0x009D)
+	systemRegHwcCylinderTemperatureBottom = uint16(0x009E)
+
+	// System config registers (GG=0x00, II=0x00).
+	systemRegAdaptiveHeatingCurve         = uint16(0x0014)
+	systemRegAlternativePoint             = uint16(0x0022)
+	systemRegHeatingCircuitBivalencePoint = uint16(0x0023)
+	systemRegDhwBivalencePoint            = uint16(0x0001)
+	systemRegHcEmergencyTemperature       = uint16(0x0026)
+	systemRegHwcMaxFlowTempDesired        = uint16(0x0046)
+	systemRegMaxRoomHumidity              = uint16(0x000E)
+
+	// System properties registers (GG=0x00, II=0x00).
+	systemRegSystemScheme            = uint16(0x0036)
+	systemRegModuleConfigurationVR71 = uint16(0x002F)
 )
 
 type vaillantBoilerSnapshot struct {
@@ -2202,6 +2226,31 @@ type vaillantBoilerSnapshot struct {
 	DhwOperatingMode         *int
 	HeatingStatusRaw         *int
 	DhwStatusRaw             *int
+}
+
+type vaillantSystemSnapshot struct {
+	// State
+	SystemOff                    *bool
+	SystemWaterPressure          *float64
+	SystemFlowTemperature        *float64
+	OutdoorTemperature           *float64
+	OutdoorTemperatureAvg24h     *float64
+	MaintenanceDue               *bool
+	HwcCylinderTemperatureTop    *float64
+	HwcCylinderTemperatureBottom *float64
+
+	// Config
+	AdaptiveHeatingCurve         *bool
+	AlternativePoint             *float64
+	HeatingCircuitBivalencePoint *float64
+	DhwBivalencePoint            *float64
+	HcEmergencyTemperature       *float64
+	HwcMaxFlowTempDesired        *float64
+	MaxRoomHumidity              *uint16
+
+	// Properties
+	SystemScheme            *uint16
+	ModuleConfigurationVR71 *uint16
 }
 
 type boilerStatusField uint8
@@ -2242,7 +2291,7 @@ func boilerStatusRegisterDefinitionsForTier(tier boilerStatusTier) []boilerStatu
 				opcode:   vaillantB524OpcodeLocal,
 				group:    vaillantGroupRegulator,
 				instance: regulatorInstance,
-				addr:     regulatorRegSystemFlowTemp,
+				addr:     systemRegSystemFlowTemperature,
 			},
 			{
 				field:    boilerStatusFieldPumpActive,
@@ -2400,6 +2449,318 @@ func (p *vaillantSemanticPoller) publishBoilerStatus(source semanticSnapshotSour
 		p.hub.PublishBoilerStatusUpdate(current)
 	}
 	p.persistSemanticCache(source)
+}
+
+func (p *vaillantSemanticPoller) refreshSystem(ctx context.Context) {
+	if p == nil {
+		return
+	}
+
+	p.mu.Lock()
+	controller := p.controller
+	p.mu.Unlock()
+	if controller == 0 {
+		return
+	}
+
+	snapshot := &vaillantSystemSnapshot{}
+	updated := false
+
+	if raw, ok := p.readB524Uint16(ctx, vaillantB524OpcodeLocal, vaillantGroupRegulator, regulatorInstance, systemRegSystemOff); ok && raw != nil {
+		value := *raw != 0
+		snapshot.SystemOff = &value
+		updated = true
+	}
+	if value, ok := p.readB524Float32LE(ctx, vaillantB524OpcodeLocal, vaillantGroupRegulator, regulatorInstance, systemRegSystemWaterPressure); ok {
+		snapshot.SystemWaterPressure = &value
+		updated = true
+	}
+	if value, ok := p.readB524Float32LE(ctx, vaillantB524OpcodeLocal, vaillantGroupRegulator, regulatorInstance, systemRegSystemFlowTemperature); ok {
+		snapshot.SystemFlowTemperature = &value
+		updated = true
+	}
+	if value, ok := p.readB524Float32LE(ctx, vaillantB524OpcodeLocal, vaillantGroupRegulator, regulatorInstance, systemRegOutdoorTemperature); ok {
+		snapshot.OutdoorTemperature = &value
+		updated = true
+	}
+	if value, ok := p.readB524Float32LE(ctx, vaillantB524OpcodeLocal, vaillantGroupRegulator, regulatorInstance, systemRegOutdoorTemperatureAvg24h); ok {
+		snapshot.OutdoorTemperatureAvg24h = &value
+		updated = true
+	}
+	if raw, ok := p.readB524Uint16(ctx, vaillantB524OpcodeLocal, vaillantGroupRegulator, regulatorInstance, systemRegMaintenanceDue); ok && raw != nil {
+		value := *raw != 0
+		snapshot.MaintenanceDue = &value
+		updated = true
+	}
+	if value, ok := p.readB524Float32LE(ctx, vaillantB524OpcodeLocal, vaillantGroupRegulator, regulatorInstance, systemRegHwcCylinderTemperatureTop); ok {
+		snapshot.HwcCylinderTemperatureTop = &value
+		updated = true
+	}
+	if value, ok := p.readB524Float32LE(ctx, vaillantB524OpcodeLocal, vaillantGroupRegulator, regulatorInstance, systemRegHwcCylinderTemperatureBottom); ok {
+		snapshot.HwcCylinderTemperatureBottom = &value
+		updated = true
+	}
+
+	if raw, ok := p.readB524Uint16(ctx, vaillantB524OpcodeLocal, vaillantGroupRegulator, regulatorInstance, systemRegAdaptiveHeatingCurve); ok && raw != nil {
+		value := *raw != 0
+		snapshot.AdaptiveHeatingCurve = &value
+		updated = true
+	}
+	if value, ok := p.readB524Float32LE(ctx, vaillantB524OpcodeLocal, vaillantGroupRegulator, regulatorInstance, systemRegAlternativePoint); ok {
+		snapshot.AlternativePoint = &value
+		updated = true
+	}
+	if value, ok := p.readB524Float32LE(ctx, vaillantB524OpcodeLocal, vaillantGroupRegulator, regulatorInstance, systemRegHeatingCircuitBivalencePoint); ok {
+		snapshot.HeatingCircuitBivalencePoint = &value
+		updated = true
+	}
+	if value, ok := p.readB524Float32LE(ctx, vaillantB524OpcodeLocal, vaillantGroupRegulator, regulatorInstance, systemRegDhwBivalencePoint); ok {
+		snapshot.DhwBivalencePoint = &value
+		updated = true
+	}
+	if value, ok := p.readB524Float32LE(ctx, vaillantB524OpcodeLocal, vaillantGroupRegulator, regulatorInstance, systemRegHcEmergencyTemperature); ok {
+		snapshot.HcEmergencyTemperature = &value
+		updated = true
+	}
+	if value, ok := p.readB524Float32LE(ctx, vaillantB524OpcodeLocal, vaillantGroupRegulator, regulatorInstance, systemRegHwcMaxFlowTempDesired); ok {
+		snapshot.HwcMaxFlowTempDesired = &value
+		updated = true
+	}
+	if raw, ok := p.readB524Uint16(ctx, vaillantB524OpcodeLocal, vaillantGroupRegulator, regulatorInstance, systemRegMaxRoomHumidity); ok && raw != nil {
+		snapshot.MaxRoomHumidity = cloneUint16Ptr(raw)
+		updated = true
+	}
+
+	if raw, ok := p.readB524Uint16(ctx, vaillantB524OpcodeLocal, vaillantGroupRegulator, regulatorInstance, systemRegSystemScheme); ok && raw != nil {
+		snapshot.SystemScheme = cloneUint16Ptr(raw)
+		updated = true
+	}
+	if raw, ok := p.readB524Uint16(ctx, vaillantB524OpcodeLocal, vaillantGroupRegulator, regulatorInstance, systemRegModuleConfigurationVR71); ok && raw != nil {
+		snapshot.ModuleConfigurationVR71 = cloneUint16Ptr(raw)
+		updated = true
+	}
+
+	if !updated {
+		return
+	}
+
+	p.mu.Lock()
+	p.system = mergeSystemSnapshotNonDestructive(p.system, snapshot)
+	p.mu.Unlock()
+
+	p.publishSystem(semanticSnapshotSourceLive)
+}
+
+func (p *vaillantSemanticPoller) publishSystem(source semanticSnapshotSource) {
+	if p == nil || p.provider == nil {
+		return
+	}
+
+	p.mu.Lock()
+	snapshot := cloneSystemSnapshot(p.system)
+	p.mu.Unlock()
+
+	previous := p.provider.System()
+	if snapshot == nil {
+		switch source {
+		case semanticSnapshotSourceCache:
+			p.provider.SetSystemFromCache(nil)
+		default:
+			p.provider.SetSystem(nil)
+		}
+		return
+	}
+
+	current := &graphql.SystemStatus{
+		State: graphql.SystemState{
+			SystemOff:                    cloneBoilerBoolPtr(snapshot.SystemOff),
+			SystemWaterPressure:          cloneFloat64Ptr(snapshot.SystemWaterPressure),
+			SystemFlowTemperature:        cloneFloat64Ptr(snapshot.SystemFlowTemperature),
+			OutdoorTemperature:           cloneFloat64Ptr(snapshot.OutdoorTemperature),
+			OutdoorTemperatureAvg24h:     cloneFloat64Ptr(snapshot.OutdoorTemperatureAvg24h),
+			MaintenanceDue:               cloneBoilerBoolPtr(snapshot.MaintenanceDue),
+			HwcCylinderTemperatureTop:    cloneFloat64Ptr(snapshot.HwcCylinderTemperatureTop),
+			HwcCylinderTemperatureBottom: cloneFloat64Ptr(snapshot.HwcCylinderTemperatureBottom),
+		},
+		Config: graphql.SystemConfig{
+			AdaptiveHeatingCurve:         cloneBoilerBoolPtr(snapshot.AdaptiveHeatingCurve),
+			AlternativePoint:             cloneFloat64Ptr(snapshot.AlternativePoint),
+			HeatingCircuitBivalencePoint: cloneFloat64Ptr(snapshot.HeatingCircuitBivalencePoint),
+			DhwBivalencePoint:            cloneFloat64Ptr(snapshot.DhwBivalencePoint),
+			HcEmergencyTemperature:       cloneFloat64Ptr(snapshot.HcEmergencyTemperature),
+			HwcMaxFlowTempDesired:        cloneFloat64Ptr(snapshot.HwcMaxFlowTempDesired),
+			MaxRoomHumidity:              uint16ToIntPtr(snapshot.MaxRoomHumidity),
+		},
+		Properties: graphql.SystemProperties{
+			SystemScheme:            uint16ToIntPtr(snapshot.SystemScheme),
+			ModuleConfigurationVR71: uint16ToIntPtr(snapshot.ModuleConfigurationVR71),
+			Vr71CircuitStartIndex:   deriveVR71CircuitStartIndex(snapshot.SystemScheme, snapshot.ModuleConfigurationVR71),
+		},
+	}
+
+	switch source {
+	case semanticSnapshotSourceCache:
+		p.provider.SetSystemFromCache(current)
+	default:
+		p.provider.SetSystem(current)
+	}
+
+	if p.hub != nil && !systemStatusEquals(previous, current) {
+		publisher := reflect.ValueOf(p.hub).MethodByName("PublishSystemUpdate")
+		if publisher.IsValid() && publisher.Type().NumIn() == 1 {
+			arg := reflect.ValueOf(current)
+			paramType := publisher.Type().In(0)
+			switch {
+			case arg.Type().AssignableTo(paramType):
+				publisher.Call([]reflect.Value{arg})
+			case arg.Type().ConvertibleTo(paramType):
+				publisher.Call([]reflect.Value{arg.Convert(paramType)})
+			}
+		}
+	}
+
+	p.persistSemanticCache(source)
+}
+
+func mergeSystemSnapshotNonDestructive(existing, incoming *vaillantSystemSnapshot) *vaillantSystemSnapshot {
+	merged := cloneSystemSnapshot(existing)
+	if merged == nil {
+		merged = &vaillantSystemSnapshot{}
+	}
+	if incoming == nil {
+		return merged
+	}
+
+	if incoming.SystemOff != nil {
+		merged.SystemOff = cloneBoilerBoolPtr(incoming.SystemOff)
+	}
+	if incoming.SystemWaterPressure != nil {
+		merged.SystemWaterPressure = cloneFloat64Ptr(incoming.SystemWaterPressure)
+	}
+	if incoming.SystemFlowTemperature != nil {
+		merged.SystemFlowTemperature = cloneFloat64Ptr(incoming.SystemFlowTemperature)
+	}
+	if incoming.OutdoorTemperature != nil {
+		merged.OutdoorTemperature = cloneFloat64Ptr(incoming.OutdoorTemperature)
+	}
+	if incoming.OutdoorTemperatureAvg24h != nil {
+		merged.OutdoorTemperatureAvg24h = cloneFloat64Ptr(incoming.OutdoorTemperatureAvg24h)
+	}
+	if incoming.MaintenanceDue != nil {
+		merged.MaintenanceDue = cloneBoilerBoolPtr(incoming.MaintenanceDue)
+	}
+	if incoming.HwcCylinderTemperatureTop != nil {
+		merged.HwcCylinderTemperatureTop = cloneFloat64Ptr(incoming.HwcCylinderTemperatureTop)
+	}
+	if incoming.HwcCylinderTemperatureBottom != nil {
+		merged.HwcCylinderTemperatureBottom = cloneFloat64Ptr(incoming.HwcCylinderTemperatureBottom)
+	}
+	if incoming.AdaptiveHeatingCurve != nil {
+		merged.AdaptiveHeatingCurve = cloneBoilerBoolPtr(incoming.AdaptiveHeatingCurve)
+	}
+	if incoming.AlternativePoint != nil {
+		merged.AlternativePoint = cloneFloat64Ptr(incoming.AlternativePoint)
+	}
+	if incoming.HeatingCircuitBivalencePoint != nil {
+		merged.HeatingCircuitBivalencePoint = cloneFloat64Ptr(incoming.HeatingCircuitBivalencePoint)
+	}
+	if incoming.DhwBivalencePoint != nil {
+		merged.DhwBivalencePoint = cloneFloat64Ptr(incoming.DhwBivalencePoint)
+	}
+	if incoming.HcEmergencyTemperature != nil {
+		merged.HcEmergencyTemperature = cloneFloat64Ptr(incoming.HcEmergencyTemperature)
+	}
+	if incoming.HwcMaxFlowTempDesired != nil {
+		merged.HwcMaxFlowTempDesired = cloneFloat64Ptr(incoming.HwcMaxFlowTempDesired)
+	}
+	if incoming.MaxRoomHumidity != nil {
+		merged.MaxRoomHumidity = cloneUint16Ptr(incoming.MaxRoomHumidity)
+	}
+	if incoming.SystemScheme != nil {
+		merged.SystemScheme = cloneUint16Ptr(incoming.SystemScheme)
+	}
+	if incoming.ModuleConfigurationVR71 != nil {
+		merged.ModuleConfigurationVR71 = cloneUint16Ptr(incoming.ModuleConfigurationVR71)
+	}
+	return merged
+}
+
+func cloneSystemSnapshot(snapshot *vaillantSystemSnapshot) *vaillantSystemSnapshot {
+	if snapshot == nil {
+		return nil
+	}
+	return &vaillantSystemSnapshot{
+		SystemOff:                    cloneBoilerBoolPtr(snapshot.SystemOff),
+		SystemWaterPressure:          cloneFloat64Ptr(snapshot.SystemWaterPressure),
+		SystemFlowTemperature:        cloneFloat64Ptr(snapshot.SystemFlowTemperature),
+		OutdoorTemperature:           cloneFloat64Ptr(snapshot.OutdoorTemperature),
+		OutdoorTemperatureAvg24h:     cloneFloat64Ptr(snapshot.OutdoorTemperatureAvg24h),
+		MaintenanceDue:               cloneBoilerBoolPtr(snapshot.MaintenanceDue),
+		HwcCylinderTemperatureTop:    cloneFloat64Ptr(snapshot.HwcCylinderTemperatureTop),
+		HwcCylinderTemperatureBottom: cloneFloat64Ptr(snapshot.HwcCylinderTemperatureBottom),
+		AdaptiveHeatingCurve:         cloneBoilerBoolPtr(snapshot.AdaptiveHeatingCurve),
+		AlternativePoint:             cloneFloat64Ptr(snapshot.AlternativePoint),
+		HeatingCircuitBivalencePoint: cloneFloat64Ptr(snapshot.HeatingCircuitBivalencePoint),
+		DhwBivalencePoint:            cloneFloat64Ptr(snapshot.DhwBivalencePoint),
+		HcEmergencyTemperature:       cloneFloat64Ptr(snapshot.HcEmergencyTemperature),
+		HwcMaxFlowTempDesired:        cloneFloat64Ptr(snapshot.HwcMaxFlowTempDesired),
+		MaxRoomHumidity:              cloneUint16Ptr(snapshot.MaxRoomHumidity),
+		SystemScheme:                 cloneUint16Ptr(snapshot.SystemScheme),
+		ModuleConfigurationVR71:      cloneUint16Ptr(snapshot.ModuleConfigurationVR71),
+	}
+}
+
+func uint16ToIntPtr(value *uint16) *int {
+	if value == nil {
+		return nil
+	}
+	v := int(*value)
+	return &v
+}
+
+func deriveVR71CircuitStartIndex(systemScheme, moduleConfigurationVR71 *uint16) *int {
+	if systemScheme == nil || moduleConfigurationVR71 == nil {
+		return nil
+	}
+	if *moduleConfigurationVR71 <= 2 {
+		v := -1
+		return &v
+	}
+	if *systemScheme < 1 || *systemScheme > 16 {
+		v := -1
+		return &v
+	}
+	// GG=0x00 docs expose the registers and valid ranges but no per-scheme ownership
+	// map, so we conservatively place FM5-managed circuits after regulator circuit 0.
+	v := 1
+	return &v
+}
+
+func systemStatusEquals(a, b *graphql.SystemStatus) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return boolPtrEquals(a.State.SystemOff, b.State.SystemOff) &&
+		floatPtrEquals(a.State.SystemWaterPressure, b.State.SystemWaterPressure) &&
+		floatPtrEquals(a.State.SystemFlowTemperature, b.State.SystemFlowTemperature) &&
+		floatPtrEquals(a.State.OutdoorTemperature, b.State.OutdoorTemperature) &&
+		floatPtrEquals(a.State.OutdoorTemperatureAvg24h, b.State.OutdoorTemperatureAvg24h) &&
+		boolPtrEquals(a.State.MaintenanceDue, b.State.MaintenanceDue) &&
+		floatPtrEquals(a.State.HwcCylinderTemperatureTop, b.State.HwcCylinderTemperatureTop) &&
+		floatPtrEquals(a.State.HwcCylinderTemperatureBottom, b.State.HwcCylinderTemperatureBottom) &&
+		boolPtrEquals(a.Config.AdaptiveHeatingCurve, b.Config.AdaptiveHeatingCurve) &&
+		floatPtrEquals(a.Config.AlternativePoint, b.Config.AlternativePoint) &&
+		floatPtrEquals(a.Config.HeatingCircuitBivalencePoint, b.Config.HeatingCircuitBivalencePoint) &&
+		floatPtrEquals(a.Config.DhwBivalencePoint, b.Config.DhwBivalencePoint) &&
+		floatPtrEquals(a.Config.HcEmergencyTemperature, b.Config.HcEmergencyTemperature) &&
+		floatPtrEquals(a.Config.HwcMaxFlowTempDesired, b.Config.HwcMaxFlowTempDesired) &&
+		intPtrEquals(a.Config.MaxRoomHumidity, b.Config.MaxRoomHumidity) &&
+		intPtrEquals(a.Properties.SystemScheme, b.Properties.SystemScheme) &&
+		intPtrEquals(a.Properties.ModuleConfigurationVR71, b.Properties.ModuleConfigurationVR71) &&
+		intPtrEquals(a.Properties.Vr71CircuitStartIndex, b.Properties.Vr71CircuitStartIndex)
 }
 
 func decodeDhwMode(raw int) string {
@@ -3403,4 +3764,40 @@ func composeZoneName(primary, prefix, suffix string) string {
 		parts = append(parts, suffix)
 	}
 	return strings.TrimSpace(strings.Join(parts, " "))
+}
+
+func (adapter mcpSemanticProviderAdapter) System() *mcp.SystemStatus {
+	if adapter.provider == nil {
+		return nil
+	}
+	status := adapter.provider.System()
+	if status == nil {
+		return nil
+	}
+	return &mcp.SystemStatus{
+		State: &mcp.SystemState{
+			SystemOff:                    cloneBoolPtr(status.State.SystemOff),
+			SystemWaterPressure:          cloneFloatPtr(status.State.SystemWaterPressure),
+			SystemFlowTemperature:        cloneFloatPtr(status.State.SystemFlowTemperature),
+			OutdoorTemperature:           cloneFloatPtr(status.State.OutdoorTemperature),
+			OutdoorTemperatureAvg24h:     cloneFloatPtr(status.State.OutdoorTemperatureAvg24h),
+			MaintenanceDue:               cloneBoolPtr(status.State.MaintenanceDue),
+			HwcCylinderTemperatureTop:    cloneFloatPtr(status.State.HwcCylinderTemperatureTop),
+			HwcCylinderTemperatureBottom: cloneFloatPtr(status.State.HwcCylinderTemperatureBottom),
+		},
+		Config: &mcp.SystemConfig{
+			AdaptiveHeatingCurve:         cloneBoolPtr(status.Config.AdaptiveHeatingCurve),
+			AlternativePoint:             cloneFloatPtr(status.Config.AlternativePoint),
+			HeatingCircuitBivalencePoint: cloneFloatPtr(status.Config.HeatingCircuitBivalencePoint),
+			DhwBivalencePoint:            cloneFloatPtr(status.Config.DhwBivalencePoint),
+			HcEmergencyTemperature:       cloneFloatPtr(status.Config.HcEmergencyTemperature),
+			HwcMaxFlowTempDesired:        cloneFloatPtr(status.Config.HwcMaxFlowTempDesired),
+			MaxRoomHumidity:              cloneIntPtr(status.Config.MaxRoomHumidity),
+		},
+		Properties: &mcp.SystemProperties{
+			SystemScheme:            cloneIntPtr(status.Properties.SystemScheme),
+			ModuleConfigurationVR71: cloneIntPtr(status.Properties.ModuleConfigurationVR71),
+			VR71CircuitStartIndex:   cloneIntPtr(status.Properties.Vr71CircuitStartIndex),
+		},
+	}
 }

--- a/cmd/gateway/semantic_vaillant_test.go
+++ b/cmd/gateway/semantic_vaillant_test.go
@@ -432,6 +432,165 @@ func TestRefreshBoilerStatusTier_NoSuccessfulReadsPreservesSnapshot(t *testing.T
 	}
 }
 
+func TestDeriveVR71CircuitStartIndex(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		scheme  *uint16
+		module  *uint16
+		wantNil bool
+		want    int
+	}{
+		{
+			name:    "nil inputs",
+			scheme:  nil,
+			module:  nil,
+			wantNil: true,
+		},
+		{
+			name:    "no fm5 profiles",
+			scheme:  uint16Ptr(8),
+			module:  uint16Ptr(2),
+			wantNil: false,
+			want:    -1,
+		},
+		{
+			name:    "invalid scheme",
+			scheme:  uint16Ptr(0),
+			module:  uint16Ptr(4),
+			wantNil: false,
+			want:    -1,
+		},
+		{
+			name:    "extended fm5 profile",
+			scheme:  uint16Ptr(8),
+			module:  uint16Ptr(4),
+			wantNil: false,
+			want:    1,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := deriveVR71CircuitStartIndex(test.scheme, test.module)
+			if test.wantNil {
+				if got != nil {
+					t.Fatalf("deriveVR71CircuitStartIndex(...) = %v; want nil", got)
+				}
+				return
+			}
+			if got == nil || *got != test.want {
+				t.Fatalf("deriveVR71CircuitStartIndex(...) = %v; want %d", got, test.want)
+			}
+		})
+	}
+}
+
+func TestMergeSystemSnapshotNonDestructive_PartialUpdatePreservesLastKnown(t *testing.T) {
+	t.Parallel()
+
+	pressure := 1.4
+	flow := 35.2
+	scheme := uint16(8)
+	module := uint16(2)
+	maxHumidity := uint16(70)
+	updatedOutdoor := 4.5
+
+	merged := mergeSystemSnapshotNonDestructive(
+		&vaillantSystemSnapshot{
+			SystemWaterPressure:     &pressure,
+			SystemFlowTemperature:   &flow,
+			SystemScheme:            &scheme,
+			ModuleConfigurationVR71: &module,
+			MaxRoomHumidity:         &maxHumidity,
+		},
+		&vaillantSystemSnapshot{
+			OutdoorTemperature: &updatedOutdoor,
+		},
+	)
+
+	if merged == nil {
+		t.Fatal("merged snapshot is nil")
+	}
+	if merged.OutdoorTemperature == nil || *merged.OutdoorTemperature != 4.5 {
+		t.Fatalf("merged.OutdoorTemperature = %v; want updated 4.5", merged.OutdoorTemperature)
+	}
+	if merged.SystemWaterPressure == nil || *merged.SystemWaterPressure != 1.4 {
+		t.Fatalf("merged.SystemWaterPressure = %v; want preserved 1.4", merged.SystemWaterPressure)
+	}
+	if merged.SystemFlowTemperature == nil || *merged.SystemFlowTemperature != 35.2 {
+		t.Fatalf("merged.SystemFlowTemperature = %v; want preserved 35.2", merged.SystemFlowTemperature)
+	}
+	if merged.SystemScheme == nil || *merged.SystemScheme != 8 {
+		t.Fatalf("merged.SystemScheme = %v; want preserved 8", merged.SystemScheme)
+	}
+	if merged.ModuleConfigurationVR71 == nil || *merged.ModuleConfigurationVR71 != 2 {
+		t.Fatalf("merged.ModuleConfigurationVR71 = %v; want preserved 2", merged.ModuleConfigurationVR71)
+	}
+	if merged.MaxRoomHumidity == nil || *merged.MaxRoomHumidity != 70 {
+		t.Fatalf("merged.MaxRoomHumidity = %v; want preserved 70", merged.MaxRoomHumidity)
+	}
+}
+
+func TestRefreshSystem_NoSuccessfulReadsPreservesSnapshot(t *testing.T) {
+	t.Parallel()
+
+	pressure := 1.7
+	scheme := uint16(8)
+	module := uint16(2)
+	poller := &vaillantSemanticPoller{
+		controller: 0x15,
+		system: &vaillantSystemSnapshot{
+			SystemWaterPressure:     &pressure,
+			SystemScheme:            &scheme,
+			ModuleConfigurationVR71: &module,
+		},
+	}
+
+	poller.refreshSystem(context.Background())
+
+	if poller.system == nil {
+		t.Fatal("poller.system = nil; want preserved last-known snapshot")
+	}
+	if poller.system.SystemWaterPressure == nil || *poller.system.SystemWaterPressure != 1.7 {
+		t.Fatalf("poller.system.SystemWaterPressure = %v; want preserved 1.7", poller.system.SystemWaterPressure)
+	}
+	if poller.system.SystemScheme == nil || *poller.system.SystemScheme != 8 {
+		t.Fatalf("poller.system.SystemScheme = %v; want preserved 8", poller.system.SystemScheme)
+	}
+	if poller.system.ModuleConfigurationVR71 == nil || *poller.system.ModuleConfigurationVR71 != 2 {
+		t.Fatalf("poller.system.ModuleConfigurationVR71 = %v; want preserved 2", poller.system.ModuleConfigurationVR71)
+	}
+}
+
+func TestPublishSystem_DerivesVR71CircuitStartIndex(t *testing.T) {
+	t.Parallel()
+
+	scheme := uint16(8)
+	module := uint16(2)
+	provider := graphql.NewLiveSemanticProvider()
+	poller := &vaillantSemanticPoller{
+		provider: provider,
+		system: &vaillantSystemSnapshot{
+			SystemScheme:            &scheme,
+			ModuleConfigurationVR71: &module,
+		},
+	}
+
+	poller.publishSystem(semanticSnapshotSourceLive)
+
+	status := provider.System()
+	if status == nil {
+		t.Fatal("provider.System() = nil; want published system status")
+	}
+	if status.Properties.Vr71CircuitStartIndex == nil || *status.Properties.Vr71CircuitStartIndex != -1 {
+		t.Fatalf("provider.System().Properties.Vr71CircuitStartIndex = %v; want -1", status.Properties.Vr71CircuitStartIndex)
+	}
+}
+
 func TestMergeCircuitSnapshotNonDestructive_PartialUpdatePreservesLastKnown(t *testing.T) {
 	t.Parallel()
 

--- a/graphql/queries.go
+++ b/graphql/queries.go
@@ -25,6 +25,7 @@ type graphqlSchemaTypes struct {
 	circuitStatusType  *graphqlgo.Object
 	energyTotals       *graphqlgo.Object
 	boilerStatusType   *graphqlgo.Object
+	systemStatusType   *graphqlgo.Object
 }
 
 func buildSchemaTypes() graphqlSchemaTypes {
@@ -774,6 +775,240 @@ func buildSchemaTypes() graphqlSchemaTypes {
 		},
 	})
 
+	systemStateType := graphqlgo.NewObject(graphqlgo.ObjectConfig{
+		Name: "SystemState",
+		Fields: graphqlgo.Fields{
+			"systemOff": &graphqlgo.Field{
+				Type: graphqlgo.Boolean,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(SystemState)
+					if !ok || state.SystemOff == nil {
+						return nil, nil
+					}
+					return *state.SystemOff, nil
+				},
+			},
+			"systemWaterPressure": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(SystemState)
+					if !ok || state.SystemWaterPressure == nil {
+						return nil, nil
+					}
+					return *state.SystemWaterPressure, nil
+				},
+			},
+			"systemFlowTemperature": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(SystemState)
+					if !ok || state.SystemFlowTemperature == nil {
+						return nil, nil
+					}
+					return *state.SystemFlowTemperature, nil
+				},
+			},
+			"outdoorTemperature": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(SystemState)
+					if !ok || state.OutdoorTemperature == nil {
+						return nil, nil
+					}
+					return *state.OutdoorTemperature, nil
+				},
+			},
+			"outdoorTemperatureAvg24h": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(SystemState)
+					if !ok || state.OutdoorTemperatureAvg24h == nil {
+						return nil, nil
+					}
+					return *state.OutdoorTemperatureAvg24h, nil
+				},
+			},
+			"maintenanceDue": &graphqlgo.Field{
+				Type: graphqlgo.Boolean,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(SystemState)
+					if !ok || state.MaintenanceDue == nil {
+						return nil, nil
+					}
+					return *state.MaintenanceDue, nil
+				},
+			},
+			"hwcCylinderTemperatureTop": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(SystemState)
+					if !ok || state.HwcCylinderTemperatureTop == nil {
+						return nil, nil
+					}
+					return *state.HwcCylinderTemperatureTop, nil
+				},
+			},
+			"hwcCylinderTemperatureBottom": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(SystemState)
+					if !ok || state.HwcCylinderTemperatureBottom == nil {
+						return nil, nil
+					}
+					return *state.HwcCylinderTemperatureBottom, nil
+				},
+			},
+		},
+	})
+
+	systemConfigType := graphqlgo.NewObject(graphqlgo.ObjectConfig{
+		Name: "SystemConfig",
+		Fields: graphqlgo.Fields{
+			"adaptiveHeatingCurve": &graphqlgo.Field{
+				Type: graphqlgo.Boolean,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(SystemConfig)
+					if !ok || config.AdaptiveHeatingCurve == nil {
+						return nil, nil
+					}
+					return *config.AdaptiveHeatingCurve, nil
+				},
+			},
+			"alternativePoint": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(SystemConfig)
+					if !ok || config.AlternativePoint == nil {
+						return nil, nil
+					}
+					return *config.AlternativePoint, nil
+				},
+			},
+			"heatingCircuitBivalencePoint": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(SystemConfig)
+					if !ok || config.HeatingCircuitBivalencePoint == nil {
+						return nil, nil
+					}
+					return *config.HeatingCircuitBivalencePoint, nil
+				},
+			},
+			"dhwBivalencePoint": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(SystemConfig)
+					if !ok || config.DhwBivalencePoint == nil {
+						return nil, nil
+					}
+					return *config.DhwBivalencePoint, nil
+				},
+			},
+			"hcEmergencyTemperature": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(SystemConfig)
+					if !ok || config.HcEmergencyTemperature == nil {
+						return nil, nil
+					}
+					return *config.HcEmergencyTemperature, nil
+				},
+			},
+			"hwcMaxFlowTempDesired": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(SystemConfig)
+					if !ok || config.HwcMaxFlowTempDesired == nil {
+						return nil, nil
+					}
+					return *config.HwcMaxFlowTempDesired, nil
+				},
+			},
+			"maxRoomHumidity": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(SystemConfig)
+					if !ok || config.MaxRoomHumidity == nil {
+						return nil, nil
+					}
+					return *config.MaxRoomHumidity, nil
+				},
+			},
+		},
+	})
+
+	systemPropertiesType := graphqlgo.NewObject(graphqlgo.ObjectConfig{
+		Name: "SystemProperties",
+		Fields: graphqlgo.Fields{
+			"systemScheme": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					props, ok := params.Source.(SystemProperties)
+					if !ok || props.SystemScheme == nil {
+						return nil, nil
+					}
+					return *props.SystemScheme, nil
+				},
+			},
+			"moduleConfigurationVR71": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					props, ok := params.Source.(SystemProperties)
+					if !ok || props.ModuleConfigurationVR71 == nil {
+						return nil, nil
+					}
+					return *props.ModuleConfigurationVR71, nil
+				},
+			},
+			"vr71CircuitStartIndex": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					props, ok := params.Source.(SystemProperties)
+					if !ok || props.Vr71CircuitStartIndex == nil {
+						return nil, nil
+					}
+					return *props.Vr71CircuitStartIndex, nil
+				},
+			},
+		},
+	})
+
+	systemStatusType := graphqlgo.NewObject(graphqlgo.ObjectConfig{
+		Name: "SystemStatus",
+		Fields: graphqlgo.Fields{
+			"state": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(systemStateType),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					status, ok := params.Source.(*SystemStatus)
+					if !ok || status == nil {
+						return SystemState{}, nil
+					}
+					return status.State, nil
+				},
+			},
+			"config": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(systemConfigType),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					status, ok := params.Source.(*SystemStatus)
+					if !ok || status == nil {
+						return SystemConfig{}, nil
+					}
+					return status.Config, nil
+				},
+			},
+			"properties": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(systemPropertiesType),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					status, ok := params.Source.(*SystemStatus)
+					if !ok || status == nil {
+						return SystemProperties{}, nil
+					}
+					return status.Properties, nil
+				},
+			},
+		},
+	})
+
 	statusType := graphqlgo.NewObject(graphqlgo.ObjectConfig{
 		Name: "ServiceStatus",
 		Fields: graphqlgo.Fields{
@@ -1254,6 +1489,7 @@ func buildSchemaTypes() graphqlSchemaTypes {
 		circuitStatusType:  circuitStatusType,
 		energyTotals:       energyTotalsType,
 		boilerStatusType:   boilerStatusType,
+		systemStatusType:   systemStatusType,
 	}
 }
 
@@ -1311,6 +1547,12 @@ func buildQueryType(builder *Builder, types graphqlSchemaTypes) *graphqlgo.Objec
 				Type: types.boilerStatusType,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					return builder.semanticProvider().BoilerStatus(), nil
+				},
+			},
+			"system": &graphqlgo.Field{
+				Type: types.systemStatusType,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					return builder.semanticProvider().System(), nil
 				},
 			},
 			"devices": &graphqlgo.Field{

--- a/graphql/queries_test.go
+++ b/graphql/queries_test.go
@@ -344,6 +344,32 @@ func TestQueryResolvers_Integration(t *testing.T) {
 						coolingEnabled
 					}
 				}
+				system {
+					state {
+						systemOff
+						systemWaterPressure
+						systemFlowTemperature
+						outdoorTemperature
+						outdoorTemperatureAvg24h
+						maintenanceDue
+						hwcCylinderTemperatureTop
+						hwcCylinderTemperatureBottom
+					}
+					config {
+						adaptiveHeatingCurve
+						alternativePoint
+						heatingCircuitBivalencePoint
+						dhwBivalencePoint
+						hcEmergencyTemperature
+						hwcMaxFlowTempDesired
+						maxRoomHumidity
+					}
+					properties {
+						systemScheme
+						moduleConfigurationVR71
+						vr71CircuitStartIndex
+					}
+				}
 			}
 		`)
 
@@ -406,6 +432,32 @@ func TestQueryResolvers_Integration(t *testing.T) {
 					CoolingEnabled  *bool    `json:"coolingEnabled"`
 				} `json:"config"`
 			} `json:"circuits"`
+			System *struct {
+				State struct {
+					SystemOff                    *bool    `json:"systemOff"`
+					SystemWaterPressure          *float64 `json:"systemWaterPressure"`
+					SystemFlowTemperature        *float64 `json:"systemFlowTemperature"`
+					OutdoorTemperature           *float64 `json:"outdoorTemperature"`
+					OutdoorTemperatureAvg24h     *float64 `json:"outdoorTemperatureAvg24h"`
+					MaintenanceDue               *bool    `json:"maintenanceDue"`
+					HwcCylinderTemperatureTop    *float64 `json:"hwcCylinderTemperatureTop"`
+					HwcCylinderTemperatureBottom *float64 `json:"hwcCylinderTemperatureBottom"`
+				} `json:"state"`
+				Config struct {
+					AdaptiveHeatingCurve         *bool    `json:"adaptiveHeatingCurve"`
+					AlternativePoint             *float64 `json:"alternativePoint"`
+					HeatingCircuitBivalencePoint *float64 `json:"heatingCircuitBivalencePoint"`
+					DhwBivalencePoint            *float64 `json:"dhwBivalencePoint"`
+					HcEmergencyTemperature       *float64 `json:"hcEmergencyTemperature"`
+					HwcMaxFlowTempDesired        *float64 `json:"hwcMaxFlowTempDesired"`
+					MaxRoomHumidity              *int     `json:"maxRoomHumidity"`
+				} `json:"config"`
+				Properties struct {
+					SystemScheme            *int `json:"systemScheme"`
+					ModuleConfigurationVR71 *int `json:"moduleConfigurationVR71"`
+					Vr71CircuitStartIndex   *int `json:"vr71CircuitStartIndex"`
+				} `json:"properties"`
+			} `json:"system"`
 		}
 
 		if err := client.Run(context.Background(), request, &response); err != nil {
@@ -419,6 +471,9 @@ func TestQueryResolvers_Integration(t *testing.T) {
 		}
 		if len(response.Circuits) != 0 {
 			t.Fatalf("circuits = %d; want 0", len(response.Circuits))
+		}
+		if response.System != nil {
+			t.Fatalf("system expected nil with static provider")
 		}
 	})
 

--- a/graphql/semantic.go
+++ b/graphql/semantic.go
@@ -1,5 +1,7 @@
 package graphql
 
+import "sync"
+
 type ZoneState struct {
 	CurrentTempC       *float64
 	CurrentHumidityPct *float64
@@ -112,12 +114,46 @@ type BoilerStatus struct {
 	Diagnostics BoilerDiagnostics
 }
 
+type SystemStatus struct {
+	State      SystemState
+	Config     SystemConfig
+	Properties SystemProperties
+}
+
+type SystemState struct {
+	SystemOff                    *bool
+	SystemWaterPressure          *float64
+	SystemFlowTemperature        *float64
+	OutdoorTemperature           *float64
+	OutdoorTemperatureAvg24h     *float64
+	MaintenanceDue               *bool
+	HwcCylinderTemperatureTop    *float64
+	HwcCylinderTemperatureBottom *float64
+}
+
+type SystemConfig struct {
+	AdaptiveHeatingCurve         *bool
+	AlternativePoint             *float64
+	HeatingCircuitBivalencePoint *float64
+	DhwBivalencePoint            *float64
+	HcEmergencyTemperature       *float64
+	HwcMaxFlowTempDesired        *float64
+	MaxRoomHumidity              *int
+}
+
+type SystemProperties struct {
+	SystemScheme            *int
+	ModuleConfigurationVR71 *int
+	Vr71CircuitStartIndex   *int
+}
+
 type SemanticProvider interface {
 	Zones() []Zone
 	DHW() *DhwStatus
 	Circuits() []CircuitStatus
 	EnergyTotals() *EnergyTotals
 	BoilerStatus() *BoilerStatus
+	System() *SystemStatus
 }
 
 type staticSemanticProvider struct{}
@@ -140,4 +176,139 @@ func (staticSemanticProvider) EnergyTotals() *EnergyTotals {
 
 func (staticSemanticProvider) BoilerStatus() *BoilerStatus {
 	return nil
+}
+
+func (staticSemanticProvider) System() *SystemStatus {
+	return nil
+}
+
+var liveSystemSnapshots sync.Map
+
+func (provider *LiveSemanticProvider) System() *SystemStatus {
+	if provider == nil {
+		return nil
+	}
+	provider.mu.RLock()
+	defer provider.mu.RUnlock()
+	stored, ok := liveSystemSnapshots.Load(provider)
+	if !ok || stored == nil {
+		return nil
+	}
+	status, ok := stored.(*SystemStatus)
+	if !ok || status == nil {
+		return nil
+	}
+	return cloneSystemStatus(status)
+}
+
+func (provider *LiveSemanticProvider) SetSystem(status *SystemStatus) {
+	if provider == nil {
+		return
+	}
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+	if status == nil {
+		liveSystemSnapshots.Delete(provider)
+		return
+	}
+	liveSystemSnapshots.Store(provider, cloneSystemStatus(status))
+}
+
+func (provider *LiveSemanticProvider) SetSystemFromCache(status *SystemStatus) {
+	provider.SetSystem(status)
+}
+
+func cloneSystemStatus(status *SystemStatus) *SystemStatus {
+	if status == nil {
+		return nil
+	}
+	cp := *status
+	cp.State = cloneSystemState(cp.State)
+	cp.Config = cloneSystemConfig(cp.Config)
+	cp.Properties = cloneSystemProperties(cp.Properties)
+	return &cp
+}
+
+func cloneSystemState(state SystemState) SystemState {
+	if state.SystemOff != nil {
+		v := *state.SystemOff
+		state.SystemOff = &v
+	}
+	if state.SystemWaterPressure != nil {
+		v := *state.SystemWaterPressure
+		state.SystemWaterPressure = &v
+	}
+	if state.SystemFlowTemperature != nil {
+		v := *state.SystemFlowTemperature
+		state.SystemFlowTemperature = &v
+	}
+	if state.OutdoorTemperature != nil {
+		v := *state.OutdoorTemperature
+		state.OutdoorTemperature = &v
+	}
+	if state.OutdoorTemperatureAvg24h != nil {
+		v := *state.OutdoorTemperatureAvg24h
+		state.OutdoorTemperatureAvg24h = &v
+	}
+	if state.MaintenanceDue != nil {
+		v := *state.MaintenanceDue
+		state.MaintenanceDue = &v
+	}
+	if state.HwcCylinderTemperatureTop != nil {
+		v := *state.HwcCylinderTemperatureTop
+		state.HwcCylinderTemperatureTop = &v
+	}
+	if state.HwcCylinderTemperatureBottom != nil {
+		v := *state.HwcCylinderTemperatureBottom
+		state.HwcCylinderTemperatureBottom = &v
+	}
+	return state
+}
+
+func cloneSystemConfig(config SystemConfig) SystemConfig {
+	if config.AdaptiveHeatingCurve != nil {
+		v := *config.AdaptiveHeatingCurve
+		config.AdaptiveHeatingCurve = &v
+	}
+	if config.AlternativePoint != nil {
+		v := *config.AlternativePoint
+		config.AlternativePoint = &v
+	}
+	if config.HeatingCircuitBivalencePoint != nil {
+		v := *config.HeatingCircuitBivalencePoint
+		config.HeatingCircuitBivalencePoint = &v
+	}
+	if config.DhwBivalencePoint != nil {
+		v := *config.DhwBivalencePoint
+		config.DhwBivalencePoint = &v
+	}
+	if config.HcEmergencyTemperature != nil {
+		v := *config.HcEmergencyTemperature
+		config.HcEmergencyTemperature = &v
+	}
+	if config.HwcMaxFlowTempDesired != nil {
+		v := *config.HwcMaxFlowTempDesired
+		config.HwcMaxFlowTempDesired = &v
+	}
+	if config.MaxRoomHumidity != nil {
+		v := *config.MaxRoomHumidity
+		config.MaxRoomHumidity = &v
+	}
+	return config
+}
+
+func cloneSystemProperties(properties SystemProperties) SystemProperties {
+	if properties.SystemScheme != nil {
+		v := *properties.SystemScheme
+		properties.SystemScheme = &v
+	}
+	if properties.ModuleConfigurationVR71 != nil {
+		v := *properties.ModuleConfigurationVR71
+		properties.ModuleConfigurationVR71 = &v
+	}
+	if properties.Vr71CircuitStartIndex != nil {
+		v := *properties.Vr71CircuitStartIndex
+		properties.Vr71CircuitStartIndex = &v
+	}
+	return properties
 }

--- a/mcp/parity_contract_test.go
+++ b/mcp/parity_contract_test.go
@@ -62,7 +62,8 @@ func TestToolInventoryGoldenSignatures(t *testing.T) {
 		{Name: "ebus.v1.semantic.circuits.get", SchemaHash: "c88e6ce24faaf24f31d9f934af950368a2dd0561e547df2089c7c44195d76389"},
 		{Name: "ebus.v1.semantic.dhw.get", SchemaHash: "c88e6ce24faaf24f31d9f934af950368a2dd0561e547df2089c7c44195d76389"},
 		{Name: "ebus.v1.semantic.energy_totals.get", SchemaHash: "c88e6ce24faaf24f31d9f934af950368a2dd0561e547df2089c7c44195d76389"},
-		{Name: "ebus.v1.semantic.snapshot.get", SchemaHash: "f40827c9c88a3e7e1e5588a409e0282e27fefa5df9a29eb74a911c8ad75aeb4c"},
+		{Name: "ebus.v1.semantic.snapshot.get", SchemaHash: "e6745bdfa1087e491d72b1ac350bfd6c0026c53f72d1141a6414d3f7ca6975d9"},
+		{Name: "ebus.v1.semantic.system.get", SchemaHash: "c88e6ce24faaf24f31d9f934af950368a2dd0561e547df2089c7c44195d76389"},
 		{Name: "ebus.v1.semantic.zones.get", SchemaHash: "c88e6ce24faaf24f31d9f934af950368a2dd0561e547df2089c7c44195d76389"},
 		{Name: "ebus.v1.snapshot.capture", SchemaHash: "cd1a463c46d6264134447db17a8c3c7abe5b9a2488c6d759fea66da1f96b133e"},
 		{Name: "ebus.v1.snapshot.drop", SchemaHash: "3f2e89bf3346421daa820ec5cd5bf9b4a06815aebd32c0bd8758b90043d69f88"},
@@ -108,6 +109,7 @@ func TestParityMatrixReadAndInvoke(t *testing.T) {
 		circuits: []CircuitStatus{{Index: 0, CircuitType: "heating"}},
 		dhw:      &DhwStatus{Config: DhwConfig{OperatingMode: "AUTO", Preset: "ECO"}},
 		energy:   &EnergyTotals{Gas: EnergyChannel{DHW: EnergySeries{Today: 1.25}}},
+		system:   &SystemStatus{Properties: &SystemProperties{SystemScheme: intPtr(8), ModuleConfigurationVR71: intPtr(2), VR71CircuitStartIndex: intPtr(-1)}},
 	})
 
 	cases := []struct {
@@ -124,6 +126,7 @@ func TestParityMatrixReadAndInvoke(t *testing.T) {
 		{name: "circuits", tool: toolSemanticCircuitsGetName, args: `{}`},
 		{name: "dhw", tool: toolSemanticDHWGetName, args: `{}`},
 		{name: "energy", tool: toolSemanticEnergyGetName, args: `{}`},
+		{name: "system", tool: toolSemanticSystemGetName, args: `{}`},
 		{name: "semantic_snapshot", tool: toolSemanticSnapshotName, args: `{}`},
 		{name: "invoke", tool: toolInvokeV1Name, args: `{"address":8,"plane":"heating","method":"get_status","params":{},"intent":"READ_ONLY","allow_dangerous":false}`},
 	}

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -115,6 +115,39 @@ type BoilerStatus struct {
 	Diagnostics *BoilerDiagnostics `json:"diagnostics,omitempty"`
 }
 
+type SystemState struct {
+	SystemOff                    *bool    `json:"system_off,omitempty"`
+	SystemWaterPressure          *float64 `json:"system_water_pressure,omitempty"`
+	SystemFlowTemperature        *float64 `json:"system_flow_temperature,omitempty"`
+	OutdoorTemperature           *float64 `json:"outdoor_temperature,omitempty"`
+	OutdoorTemperatureAvg24h     *float64 `json:"outdoor_temperature_avg24h,omitempty"`
+	MaintenanceDue               *bool    `json:"maintenance_due,omitempty"`
+	HwcCylinderTemperatureTop    *float64 `json:"hwc_cylinder_temperature_top,omitempty"`
+	HwcCylinderTemperatureBottom *float64 `json:"hwc_cylinder_temperature_bottom,omitempty"`
+}
+
+type SystemConfig struct {
+	AdaptiveHeatingCurve         *bool    `json:"adaptive_heating_curve,omitempty"`
+	AlternativePoint             *float64 `json:"alternative_point,omitempty"`
+	HeatingCircuitBivalencePoint *float64 `json:"heating_circuit_bivalence_point,omitempty"`
+	DhwBivalencePoint            *float64 `json:"dhw_bivalence_point,omitempty"`
+	HcEmergencyTemperature       *float64 `json:"hc_emergency_temperature,omitempty"`
+	HwcMaxFlowTempDesired        *float64 `json:"hwc_max_flow_temp_desired,omitempty"`
+	MaxRoomHumidity              *int     `json:"max_room_humidity,omitempty"`
+}
+
+type SystemProperties struct {
+	SystemScheme            *int `json:"system_scheme,omitempty"`
+	ModuleConfigurationVR71 *int `json:"module_configuration_vr71,omitempty"`
+	VR71CircuitStartIndex   *int `json:"vr71_circuit_start_index,omitempty"`
+}
+
+type SystemStatus struct {
+	State      *SystemState      `json:"state,omitempty"`
+	Config     *SystemConfig     `json:"config,omitempty"`
+	Properties *SystemProperties `json:"properties,omitempty"`
+}
+
 type CircuitState struct {
 	PumpActive       *bool    `json:"pump_active,omitempty"`
 	MixerPositionPct *float64 `json:"mixer_position_pct,omitempty"`
@@ -152,6 +185,7 @@ type SemanticProvider interface {
 	Circuits() []CircuitStatus
 	EnergyTotals() *EnergyTotals
 	BoilerStatus() *BoilerStatus
+	System() *SystemStatus
 }
 
 type Server struct {
@@ -174,6 +208,7 @@ const (
 	toolSemanticDHWGetName      = "ebus.v1.semantic.dhw.get"
 	toolSemanticEnergyGetName   = "ebus.v1.semantic.energy_totals.get"
 	toolSemanticBoilerGetName   = "ebus.v1.semantic.boiler_status.get"
+	toolSemanticSystemGetName   = "ebus.v1.semantic.system.get"
 	toolSemanticSnapshotName    = "ebus.v1.semantic.snapshot.get"
 	toolSnapshotCaptureName     = "ebus.v1.snapshot.capture"
 	toolSnapshotDropName        = "ebus.v1.snapshot.drop"
@@ -240,6 +275,10 @@ func (staticSemanticProvider) BoilerStatus() *BoilerStatus {
 	return nil
 }
 
+func (staticSemanticProvider) System() *SystemStatus {
+	return nil
+}
+
 type idempotencyEntry struct {
 	signature string
 	result    any
@@ -269,6 +308,7 @@ type snapshotState struct {
 	dhw      *DhwStatus
 	energy   *EnergyTotals
 	boiler   *BoilerStatus
+	system   *SystemStatus
 	devices  []deviceInfo
 }
 
@@ -364,18 +404,29 @@ func NewServer(reg Registry, invoker Invoker) (*Server, error) {
 			},
 		},
 		{
+			Name:        toolSemanticSystemGetName,
+			Description: "Get semantic system status snapshot (outdoor temp, water pressure, flow temp, maintenance, config).",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"consistency": consistencyInputProperty(),
+				},
+				"additionalProperties": false,
+			},
+		},
+		{
 			Name:        toolSemanticSnapshotName,
 			Description: "Get a consistent semantic snapshot across selected semantic planes.",
 			InputSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
-						"planes": map[string]any{
-							"type": "array",
-							"items": map[string]any{
-								"type": "string",
-								"enum": []string{"runtime_status", "zones", "dhw", "energy_totals", "boiler_status", "circuits"},
-							},
+					"planes": map[string]any{
+						"type": "array",
+						"items": map[string]any{
+							"type": "string",
+							"enum": []string{"runtime_status", "zones", "dhw", "energy_totals", "boiler_status", "system", "circuits"},
 						},
+					},
 					"timeout_ms": map[string]any{"type": "integer", "minimum": 1},
 					"allow_partial": map[string]any{
 						"type": "boolean",
@@ -667,6 +718,12 @@ func (s *Server) handleToolsCall(ctx context.Context, params json.RawMessage) (a
 			return callToolResultText(mustJSON(newToolEnvelope(nil, err)), true), nil
 		}
 		return callToolResultText(mustJSON(newToolEnvelopeWithConsistency(s.snapshotBoilerStatus(snapshot), nil, consistency)), false), nil
+	case toolSemanticSystemGetName:
+		consistency, snapshot, err := s.resolveConsistency(call.Arguments)
+		if err != nil {
+			return callToolResultText(mustJSON(newToolEnvelope(nil, err)), true), nil
+		}
+		return callToolResultText(mustJSON(newToolEnvelopeWithConsistency(s.snapshotSystem(snapshot), nil, consistency)), false), nil
 	case toolSemanticSnapshotName:
 		consistency, snapshot, err := s.resolveConsistency(call.Arguments)
 		if err != nil {
@@ -835,6 +892,7 @@ func (s *Server) captureSnapshot() (snapshotID string, createdAt time.Time, err 
 		dhw:       s.snapshotDHW(nil),
 		energy:    s.snapshotEnergyTotals(nil),
 		boiler:    s.snapshotBoilerStatus(nil),
+		system:    s.snapshotSystem(nil),
 		devices:   s.listDevices(nil),
 	}
 
@@ -910,6 +968,10 @@ func cloneSnapshotState(snapshot snapshotState) snapshotState {
 	if snapshot.boiler != nil {
 		boilerCopy = cloneMCPBoilerStatus(snapshot.boiler)
 	}
+	var systemCopy *SystemStatus
+	if snapshot.system != nil {
+		systemCopy = cloneMCPSystemStatus(snapshot.system)
+	}
 	return snapshotState{
 		id:        snapshot.id,
 		createdAt: snapshot.createdAt,
@@ -920,6 +982,7 @@ func cloneSnapshotState(snapshot snapshotState) snapshotState {
 		dhw:       dhwCopy,
 		energy:    energyCopy,
 		boiler:    boilerCopy,
+		system:    systemCopy,
 		devices:   cloneDeviceInfoList(snapshot.devices),
 	}
 }
@@ -1569,6 +1632,23 @@ func (s *Server) snapshotBoilerStatus(snapshot *snapshotState) *BoilerStatus {
 	return cloneMCPBoilerStatus(source)
 }
 
+func (s *Server) snapshotSystem(snapshot *snapshotState) *SystemStatus {
+	if snapshot != nil {
+		if snapshot.system == nil {
+			return nil
+		}
+		return cloneMCPSystemStatus(snapshot.system)
+	}
+	if s == nil || s.semantic == nil {
+		return nil
+	}
+	source := s.semantic.System()
+	if source == nil {
+		return nil
+	}
+	return cloneMCPSystemStatus(source)
+}
+
 func cloneMCPBoilerStatus(status *BoilerStatus) *BoilerStatus {
 	if status == nil {
 		return nil
@@ -1581,6 +1661,98 @@ func cloneMCPBoilerStatus(status *BoilerStatus) *BoilerStatus {
 	if cp.Diagnostics != nil {
 		d := *cp.Diagnostics
 		cp.Diagnostics = &d
+	}
+	return &cp
+}
+
+func cloneMCPSystemStatus(status *SystemStatus) *SystemStatus {
+	if status == nil {
+		return nil
+	}
+	cp := *status
+	if cp.State != nil {
+		state := *cp.State
+		if state.SystemOff != nil {
+			v := *state.SystemOff
+			state.SystemOff = &v
+		}
+		if state.SystemWaterPressure != nil {
+			v := *state.SystemWaterPressure
+			state.SystemWaterPressure = &v
+		}
+		if state.SystemFlowTemperature != nil {
+			v := *state.SystemFlowTemperature
+			state.SystemFlowTemperature = &v
+		}
+		if state.OutdoorTemperature != nil {
+			v := *state.OutdoorTemperature
+			state.OutdoorTemperature = &v
+		}
+		if state.OutdoorTemperatureAvg24h != nil {
+			v := *state.OutdoorTemperatureAvg24h
+			state.OutdoorTemperatureAvg24h = &v
+		}
+		if state.MaintenanceDue != nil {
+			v := *state.MaintenanceDue
+			state.MaintenanceDue = &v
+		}
+		if state.HwcCylinderTemperatureTop != nil {
+			v := *state.HwcCylinderTemperatureTop
+			state.HwcCylinderTemperatureTop = &v
+		}
+		if state.HwcCylinderTemperatureBottom != nil {
+			v := *state.HwcCylinderTemperatureBottom
+			state.HwcCylinderTemperatureBottom = &v
+		}
+		cp.State = &state
+	}
+	if cp.Config != nil {
+		config := *cp.Config
+		if config.AdaptiveHeatingCurve != nil {
+			v := *config.AdaptiveHeatingCurve
+			config.AdaptiveHeatingCurve = &v
+		}
+		if config.AlternativePoint != nil {
+			v := *config.AlternativePoint
+			config.AlternativePoint = &v
+		}
+		if config.HeatingCircuitBivalencePoint != nil {
+			v := *config.HeatingCircuitBivalencePoint
+			config.HeatingCircuitBivalencePoint = &v
+		}
+		if config.DhwBivalencePoint != nil {
+			v := *config.DhwBivalencePoint
+			config.DhwBivalencePoint = &v
+		}
+		if config.HcEmergencyTemperature != nil {
+			v := *config.HcEmergencyTemperature
+			config.HcEmergencyTemperature = &v
+		}
+		if config.HwcMaxFlowTempDesired != nil {
+			v := *config.HwcMaxFlowTempDesired
+			config.HwcMaxFlowTempDesired = &v
+		}
+		if config.MaxRoomHumidity != nil {
+			v := *config.MaxRoomHumidity
+			config.MaxRoomHumidity = &v
+		}
+		cp.Config = &config
+	}
+	if cp.Properties != nil {
+		properties := *cp.Properties
+		if properties.SystemScheme != nil {
+			v := *properties.SystemScheme
+			properties.SystemScheme = &v
+		}
+		if properties.ModuleConfigurationVR71 != nil {
+			v := *properties.ModuleConfigurationVR71
+			properties.ModuleConfigurationVR71 = &v
+		}
+		if properties.VR71CircuitStartIndex != nil {
+			v := *properties.VR71CircuitStartIndex
+			properties.VR71CircuitStartIndex = &v
+		}
+		cp.Properties = &properties
 	}
 	return &cp
 }
@@ -1650,7 +1822,7 @@ func (s *Server) readSemanticSnapshot(ctx context.Context, args map[string]any, 
 
 func parseSemanticSnapshotOptions(args map[string]any) (semanticSnapshotOptions, error) {
 	options := semanticSnapshotOptions{
-		planes:       []string{"runtime_status", "zones", "dhw", "energy_totals", "boiler_status", "circuits"},
+		planes:       []string{"runtime_status", "zones", "dhw", "energy_totals", "boiler_status", "system", "circuits"},
 		timeout:      defaultSnapshotReadTTL,
 		allowPartial: false,
 	}
@@ -1716,7 +1888,7 @@ func parseSemanticSnapshotPlanes(raw any) ([]string, error) {
 		}
 		normalized := strings.ToLower(strings.TrimSpace(value))
 		switch normalized {
-		case "runtime_status", "zones", "dhw", "energy_totals", "boiler_status", "circuits":
+		case "runtime_status", "zones", "dhw", "energy_totals", "boiler_status", "system", "circuits":
 		default:
 			return nil, fmt.Errorf("unsupported plane %q: %w", value, ebuserrors.ErrInvalidPayload)
 		}
@@ -1751,6 +1923,8 @@ func (s *Server) readSemanticPlane(ctx context.Context, plane string, snapshot *
 		value = s.snapshotEnergyTotals(snapshot)
 	case "boiler_status":
 		value = s.snapshotBoilerStatus(snapshot)
+	case "system":
+		value = s.snapshotSystem(snapshot)
 	case "circuits":
 		value = s.snapshotCircuits(snapshot)
 	default:

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -164,6 +164,7 @@ type testSemanticProvider struct {
 	dhw           *DhwStatus
 	energy        *EnergyTotals
 	boiler        *BoilerStatus
+	system        *SystemStatus
 	zonesDelay    time.Duration
 	circuitsDelay time.Duration
 	dhwDelay      time.Duration
@@ -211,6 +212,13 @@ func (p testSemanticProvider) BoilerStatus() *BoilerStatus {
 	return &copy
 }
 
+func (p testSemanticProvider) System() *SystemStatus {
+	if p.system == nil {
+		return nil
+	}
+	return cloneMCPSystemStatus(p.system)
+}
+
 func (p testSemanticProvider) EnergyTotals() *EnergyTotals {
 	if p.energyDelay > 0 {
 		time.Sleep(p.energyDelay)
@@ -256,8 +264,8 @@ func TestServer_InitializeAndTools(t *testing.T) {
 		t.Fatalf("tools/list result type = %T; want map", res.Result)
 	}
 	tools, ok := resultMap["tools"].([]any)
-	if !ok || len(tools) < 16 {
-		t.Fatalf("tools = %#v; want at least 16 tools", resultMap["tools"])
+	if !ok || len(tools) < 17 {
+		t.Fatalf("tools = %#v; want at least 17 tools", resultMap["tools"])
 	}
 	for _, name := range []string{
 		toolRuntimeStatusGetName,
@@ -266,6 +274,7 @@ func TestServer_InitializeAndTools(t *testing.T) {
 		toolSemanticDHWGetName,
 		toolSemanticEnergyGetName,
 		toolSemanticBoilerGetName,
+		toolSemanticSystemGetName,
 		toolSemanticSnapshotName,
 		toolSnapshotCaptureName,
 		toolSnapshotDropName,
@@ -511,6 +520,22 @@ func TestServer_ToolsCallSemanticSnapshots(t *testing.T) {
 				Climate: EnergySeries{Today: 2.5, Yearly: []float64{30, 40}},
 			},
 		},
+		system: &SystemStatus{
+			State: &SystemState{
+				SystemOff:             boolPtr(false),
+				SystemWaterPressure:   floatPtr(1.5),
+				OutdoorTemperature:    floatPtr(6.0),
+				SystemFlowTemperature: floatPtr(32.0),
+			},
+			Config: &SystemConfig{
+				MaxRoomHumidity: intPtr(70),
+			},
+			Properties: &SystemProperties{
+				SystemScheme:            intPtr(8),
+				ModuleConfigurationVR71: intPtr(2),
+				VR71CircuitStartIndex:   intPtr(-1),
+			},
+		},
 	})
 
 	t.Run("zones sorted", func(t *testing.T) {
@@ -606,7 +631,28 @@ func TestServer_ToolsCallSemanticSnapshots(t *testing.T) {
 		}
 	})
 
-		t.Run("semantic snapshot default planes", func(t *testing.T) {
+	t.Run("system payload", func(t *testing.T) {
+		res := doRPC(t, server.Handler(), rpcRequest{
+			JSONRPC: "2.0",
+			ID:      30,
+			Method:  "tools/call",
+			Params:  json.RawMessage(`{"name":"ebus.v1.semantic.system.get","arguments":{}}`),
+		})
+		envelope := envelopeFromResult(t, res)
+		data, ok := envelope["data"].(map[string]any)
+		if !ok {
+			t.Fatalf("system data type = %T; want map", envelope["data"])
+		}
+		props, ok := data["properties"].(map[string]any)
+		if !ok {
+			t.Fatalf("system properties type = %T; want map", data["properties"])
+		}
+		if got, _ := props["vr71_circuit_start_index"].(float64); int(got) != -1 {
+			t.Fatalf("system properties.vr71_circuit_start_index = %v; want -1", props["vr71_circuit_start_index"])
+		}
+	})
+
+	t.Run("semantic snapshot default planes", func(t *testing.T) {
 		res := doRPC(t, server.Handler(), rpcRequest{
 			JSONRPC: "2.0",
 			ID:      4,
@@ -618,53 +664,53 @@ func TestServer_ToolsCallSemanticSnapshots(t *testing.T) {
 		if !ok {
 			t.Fatalf("snapshot data type = %T; want map", envelope["data"])
 		}
-			completed, ok := data["completed_planes"].([]any)
-			if !ok || len(completed) != 6 {
-				t.Fatalf("snapshot completed_planes = %#v; want 6 entries", data["completed_planes"])
-			}
+		completed, ok := data["completed_planes"].([]any)
+		if !ok || len(completed) != 7 {
+			t.Fatalf("snapshot completed_planes = %#v; want 7 entries", data["completed_planes"])
+		}
 		planes, ok := data["planes"].(map[string]any)
 		if !ok {
 			t.Fatalf("snapshot planes type = %T; want map", data["planes"])
 		}
-			for _, key := range []string{"runtime_status", "zones", "dhw", "energy_totals", "boiler_status", "circuits"} {
-				if _, ok := planes[key]; !ok {
-					t.Fatalf("snapshot planes missing %q", key)
-				}
+		for _, key := range []string{"runtime_status", "zones", "dhw", "energy_totals", "boiler_status", "system", "circuits"} {
+			if _, ok := planes[key]; !ok {
+				t.Fatalf("snapshot planes missing %q", key)
 			}
-		})
+		}
+	})
 
-		t.Run("semantic snapshot supports circuits plane", func(t *testing.T) {
-			res := doRPC(t, server.Handler(), rpcRequest{
-				JSONRPC: "2.0",
-				ID:      5,
-				Method:  "tools/call",
-				Params:  json.RawMessage(`{"name":"ebus.v1.semantic.snapshot.get","arguments":{"planes":["circuits"]}}`),
-			})
-			envelope := envelopeFromResult(t, res)
-			data, ok := envelope["data"].(map[string]any)
-			if !ok {
-				t.Fatalf("snapshot data type = %T; want map", envelope["data"])
-			}
-			planes, ok := data["planes"].(map[string]any)
-			if !ok {
-				t.Fatalf("snapshot planes type = %T; want map", data["planes"])
-			}
-			if _, ok := planes["circuits"]; !ok {
-				t.Fatalf("snapshot planes missing circuits: %#v", planes)
-			}
+	t.Run("semantic snapshot supports circuits plane", func(t *testing.T) {
+		res := doRPC(t, server.Handler(), rpcRequest{
+			JSONRPC: "2.0",
+			ID:      5,
+			Method:  "tools/call",
+			Params:  json.RawMessage(`{"name":"ebus.v1.semantic.snapshot.get","arguments":{"planes":["circuits"]}}`),
 		})
+		envelope := envelopeFromResult(t, res)
+		data, ok := envelope["data"].(map[string]any)
+		if !ok {
+			t.Fatalf("snapshot data type = %T; want map", envelope["data"])
+		}
+		planes, ok := data["planes"].(map[string]any)
+		if !ok {
+			t.Fatalf("snapshot planes type = %T; want map", data["planes"])
+		}
+		if _, ok := planes["circuits"]; !ok {
+			t.Fatalf("snapshot planes missing circuits: %#v", planes)
+		}
+	})
 
-		t.Run("semantic snapshot rejects unknown plane", func(t *testing.T) {
-			res := doRPC(t, server.Handler(), rpcRequest{
-				JSONRPC: "2.0",
-				ID:      6,
-				Method:  "tools/call",
-				Params:  json.RawMessage(`{"name":"ebus.v1.semantic.snapshot.get","arguments":{"planes":["unknown"]}}`),
-			})
+	t.Run("semantic snapshot rejects unknown plane", func(t *testing.T) {
+		res := doRPC(t, server.Handler(), rpcRequest{
+			JSONRPC: "2.0",
+			ID:      6,
+			Method:  "tools/call",
+			Params:  json.RawMessage(`{"name":"ebus.v1.semantic.snapshot.get","arguments":{"planes":["unknown"]}}`),
+		})
 		assertToolErrorCode(t, res, "INVALID_ARGUMENT")
 	})
 
-		t.Run("semantic snapshot timeout atomic", func(t *testing.T) {
+	t.Run("semantic snapshot timeout atomic", func(t *testing.T) {
 		slowServer, err := NewServer(reg, &testInvoker{})
 		if err != nil {
 			t.Fatalf("NewServer error = %v", err)
@@ -681,16 +727,16 @@ func TestServer_ToolsCallSemanticSnapshots(t *testing.T) {
 			zonesDelay: 20 * time.Millisecond,
 		})
 
-			res := doRPC(t, slowServer.Handler(), rpcRequest{
-				JSONRPC: "2.0",
-				ID:      7,
-				Method:  "tools/call",
-				Params:  json.RawMessage(`{"name":"ebus.v1.semantic.snapshot.get","arguments":{"planes":["zones","dhw"],"timeout_ms":10}}`),
-			})
+		res := doRPC(t, slowServer.Handler(), rpcRequest{
+			JSONRPC: "2.0",
+			ID:      7,
+			Method:  "tools/call",
+			Params:  json.RawMessage(`{"name":"ebus.v1.semantic.snapshot.get","arguments":{"planes":["zones","dhw"],"timeout_ms":10}}`),
+		})
 		assertToolErrorCode(t, res, "TIMEOUT")
 	})
 
-		t.Run("semantic snapshot timeout partial", func(t *testing.T) {
+	t.Run("semantic snapshot timeout partial", func(t *testing.T) {
 		slowServer, err := NewServer(reg, &testInvoker{})
 		if err != nil {
 			t.Fatalf("NewServer error = %v", err)
@@ -707,12 +753,12 @@ func TestServer_ToolsCallSemanticSnapshots(t *testing.T) {
 			zonesDelay: 20 * time.Millisecond,
 		})
 
-			res := doRPC(t, slowServer.Handler(), rpcRequest{
-				JSONRPC: "2.0",
-				ID:      8,
-				Method:  "tools/call",
-				Params:  json.RawMessage(`{"name":"ebus.v1.semantic.snapshot.get","arguments":{"planes":["zones","dhw"],"timeout_ms":35,"allow_partial":true}}`),
-			})
+		res := doRPC(t, slowServer.Handler(), rpcRequest{
+			JSONRPC: "2.0",
+			ID:      8,
+			Method:  "tools/call",
+			Params:  json.RawMessage(`{"name":"ebus.v1.semantic.snapshot.get","arguments":{"planes":["zones","dhw"],"timeout_ms":35,"allow_partial":true}}`),
+		})
 		envelope := envelopeFromResult(t, res)
 		data, ok := envelope["data"].(map[string]any)
 		if !ok {
@@ -727,7 +773,7 @@ func TestServer_ToolsCallSemanticSnapshots(t *testing.T) {
 		}
 	})
 
-		t.Run("semantic snapshot timeout partial no duplicate plane errors", func(t *testing.T) {
+	t.Run("semantic snapshot timeout partial no duplicate plane errors", func(t *testing.T) {
 		slowServer, err := NewServer(reg, &testInvoker{})
 		if err != nil {
 			t.Fatalf("NewServer error = %v", err)
@@ -744,12 +790,12 @@ func TestServer_ToolsCallSemanticSnapshots(t *testing.T) {
 			zonesDelay: 5 * time.Millisecond,
 		})
 
-			res := doRPC(t, slowServer.Handler(), rpcRequest{
-				JSONRPC: "2.0",
-				ID:      9,
-				Method:  "tools/call",
-				Params:  json.RawMessage(`{"name":"ebus.v1.semantic.snapshot.get","arguments":{"planes":["zones","dhw"],"timeout_ms":1,"allow_partial":true}}`),
-			})
+		res := doRPC(t, slowServer.Handler(), rpcRequest{
+			JSONRPC: "2.0",
+			ID:      9,
+			Method:  "tools/call",
+			Params:  json.RawMessage(`{"name":"ebus.v1.semantic.snapshot.get","arguments":{"planes":["zones","dhw"],"timeout_ms":1,"allow_partial":true}}`),
+		})
 		envelope := envelopeFromResult(t, res)
 		data, ok := envelope["data"].(map[string]any)
 		if !ok {
@@ -1477,6 +1523,21 @@ func TestClassifyToolError_KnownMappings(t *testing.T) {
 			}
 		})
 	}
+}
+
+func boolPtr(value bool) *bool {
+	v := value
+	return &v
+}
+
+func floatPtr(value float64) *float64 {
+	v := value
+	return &v
+}
+
+func intPtr(value int) *int {
+	v := value
+	return &v
 }
 
 func parseEnvelope(t *testing.T, text string) map[string]any {

--- a/mcp/tool_classification_test.go
+++ b/mcp/tool_classification_test.go
@@ -42,6 +42,7 @@ func TestToolClassificationPolicy(t *testing.T) {
 		toolSemanticDHWGetName:      toolClassCoreStable,
 		toolSemanticEnergyGetName:   toolClassCoreStable,
 		toolSemanticBoilerGetName:   toolClassCoreStable,
+		toolSemanticSystemGetName:   toolClassCoreStable,
 		toolSemanticSnapshotName:    toolClassCoreStable,
 		toolSnapshotCaptureName:     toolClassCoreStable,
 		toolSnapshotDropName:        toolClassCoreStable,


### PR DESCRIPTION
## What
Implements GW-4 (System Status GraphQL + MCP):
- Adds `system` semantic surface in GraphQL.
- Adds MCP tool `ebus.v1.semantic.system.get`.
- Adds B524 GG=0x00 polling for system/regulator fields.
- Adds derived `vr71CircuitStartIndex`.

## Why
GW-4 is required for HA device-parent resolution (R6) and for exposing regulator/system status outside zones/DHW/circuits.

## Key Changes
- Extended semantic types with `SystemStatus` structure.
- Added GraphQL `system` query and resolvers.
- Added MCP system tool and integrated `system` plane in semantic snapshot handling.
- Implemented polling for the contracted GG=0x00 register set.
- Added `vr71CircuitStartIndex` derivation based on `systemScheme` + `moduleConfigurationVr71`.
- Added tests in `cmd/gateway`, `graphql`, and `mcp`.

## Acceptance Criteria
- [x] `system` GraphQL query returns required fields, including `vr71CircuitStartIndex`.
- [x] MCP `ebus.v1.semantic.system.get` returns system data.
- [x] `vr71CircuitStartIndex` derived from scheme + VR71 config.
- [x] Tests pass.

## Validation
- `GOWORK=off go test ./cmd/gateway/... ./graphql/... ./mcp/...`
- `./scripts/ci_local.sh`
  - Passed: terminology, gofmt, assets, vet, build, race tests, golangci-lint.
  - Transport gate blocked pending matrix artifact (`TRANSPORT_MATRIX_REPORT`) — skipped in this cruise-control session per explicit operator authorization.

Fixes #268
