### PR TITLE
GW-6: add circuit/system config mutations with write confirm

### DIFF
--- a/graphql/mutations.go
+++ b/graphql/mutations.go
@@ -73,7 +73,7 @@ type configFieldSpec struct {
 
 const (
 	mutationControllerFallbackAddr = byte(0x15)
-	mutationSourceAddr             = byte(0x10)
+	mutationSourceAddr             = byte(0x31)
 	mutationB524OpcodeLocal        = byte(0x02)
 	mutationSystemPlane            = "system"
 	mutationSetExtRegisterMethod   = "set_ext_register"
@@ -410,6 +410,9 @@ func applyConfigMutation(ctx context.Context, registry InvokeRegistry, invoker I
 	if err := confirmDecodableReadback(spec, readValue); err != nil {
 		return configMutationError(fmt.Errorf("write confirm failed: %w", err))
 	}
+	if !configReadbackMatchesWrite(spec, data, readValue) {
+		return configMutationError(fmt.Errorf("write confirm failed: read-back mismatch: %w", ebuserrors.ErrInvalidPayload))
+	}
 
 	return ConfigMutationResult{Success: true}
 }
@@ -458,7 +461,7 @@ func encodeConfigValue(spec configFieldSpec, raw string) ([]byte, error) {
 		binary.LittleEndian.PutUint32(payload, math.Float32bits(float32(value)))
 		return payload, nil
 	case configValueUint16:
-		value, err := strconv.Atoi(strings.TrimSpace(raw))
+		value, err := parseIntegerString(strings.TrimSpace(raw))
 		if err != nil {
 			return nil, fmt.Errorf("invalid integer value %q: %w", raw, ebuserrors.ErrInvalidPayload)
 		}
@@ -503,6 +506,23 @@ func parseBoolString(raw string) (bool, bool) {
 	default:
 		return false, false
 	}
+}
+
+func parseIntegerString(raw string) (int, error) {
+	if raw == "" {
+		return 0, fmt.Errorf("empty integer")
+	}
+	if strings.ContainsAny(raw, ".eE") {
+		value, err := strconv.ParseFloat(raw, 64)
+		if err != nil {
+			return 0, err
+		}
+		if math.IsNaN(value) || math.IsInf(value, 0) || math.Trunc(value) != value {
+			return 0, fmt.Errorf("not an integer")
+		}
+		return int(value), nil
+	}
+	return strconv.Atoi(raw)
 }
 
 func sortedEnumKeys(values map[string]uint16) []string {
@@ -702,6 +722,24 @@ func confirmDecodableReadback(spec configFieldSpec, payload []byte) error {
 		return fmt.Errorf("enum payload unknown value %d: %w", value, ebuserrors.ErrInvalidPayload)
 	default:
 		return fmt.Errorf("unsupported readback decode: %w", ebuserrors.ErrInvalidPayload)
+	}
+}
+
+func configReadbackMatchesWrite(spec configFieldSpec, written, readback []byte) bool {
+	switch spec.valueType {
+	case configValueFloat32:
+		if len(written) < 4 || len(readback) < 4 {
+			return false
+		}
+		return binary.LittleEndian.Uint32(readback[:4]) == binary.LittleEndian.Uint32(written[:4])
+	case configValueUint16, configValueEnumU16:
+		want, okWant := decodePayloadUint16(written)
+		got, okGot := decodePayloadUint16(readback)
+		return okWant && okGot && want == got
+	case configValueBoolU8:
+		return len(written) > 0 && len(readback) > 0 && (readback[0] == 0 || readback[0] == 1) && readback[0] == written[0]
+	default:
+		return false
 	}
 }
 

--- a/graphql/mutations_unit_test.go
+++ b/graphql/mutations_unit_test.go
@@ -292,8 +292,8 @@ func TestSetCircuitConfigMutation_Success(t *testing.T) {
 	if got := first.Params["opcode"]; got != byte(0x02) {
 		t.Fatalf("first call opcode = %#v; want 0x02", got)
 	}
-	if got := first.Params["source"]; got != byte(0x10) {
-		t.Fatalf("first call source = %#v; want 0x10", got)
+	if got := first.Params["source"]; got != byte(0x31) {
+		t.Fatalf("first call source = %#v; want 0x31", got)
 	}
 	dataBytes, ok := first.Params["data"].([]byte)
 	if !ok || !bytes.Equal(dataBytes, []byte{0x00, 0x00, 0xC0, 0x3F}) {
@@ -359,6 +359,50 @@ func TestSetSystemConfigMutation_Success(t *testing.T) {
 	dataBytes, ok := first.Params["data"].([]byte)
 	if !ok || !bytes.Equal(dataBytes, []byte{0x01}) {
 		t.Fatalf("first call data = %v; want [01]", first.Params["data"])
+	}
+}
+
+func TestSetSystemConfigMutation_IntegerLikeFloatString(t *testing.T) {
+	registry := mutationTestRegistry{
+		entries: map[byte]registry.DeviceEntry{
+			0x15: testControllerEntryWithMethods(mutationSetExtRegisterMethod, mutationGetExtRegisterMethod),
+		},
+		order: []byte{0x15},
+	}
+	invoker := &mutationTestInvoker{
+		responses: []any{
+			map[string]types.Value{},
+			map[string]types.Value{
+				"value": {Value: []byte{0x37, 0x00}, Valid: true}, // 55
+			},
+		},
+	}
+
+	data := executeMutation(t, buildMutationSchema(t, registry, invoker), `mutation {
+		setSystemConfig(field: "maxRoomHumidityPct", value: "55.0") {
+			success
+			error
+		}
+	}`)
+
+	payload, ok := data["setSystemConfig"].(map[string]any)
+	if !ok {
+		t.Fatalf("setSystemConfig payload type = %T; want map", data["setSystemConfig"])
+	}
+	if got, _ := payload["success"].(bool); !got {
+		t.Fatalf("setSystemConfig success = %v; want true", got)
+	}
+
+	if len(invoker.calls) != 2 {
+		t.Fatalf("invoker calls = %d; want 2", len(invoker.calls))
+	}
+	first := invoker.calls[0]
+	if got := first.Params["addr"]; got != uint16(0x000E) {
+		t.Fatalf("first call addr = %#v; want 0x000E", got)
+	}
+	dataBytes, ok := first.Params["data"].([]byte)
+	if !ok || !bytes.Equal(dataBytes, []byte{0x37, 0x00}) {
+		t.Fatalf("first call data = %v; want [37 00]", first.Params["data"])
 	}
 }
 
@@ -494,19 +538,19 @@ func TestSetCircuitConfigMutation_ReadbackConfirmFailure(t *testing.T) {
 		responses: []any{
 			map[string]types.Value{},
 			map[string]types.Value{
-				"value": {Value: []byte{}, Valid: true},
+				"value": {Value: []byte{0x00, 0x00, 0x40, 0x40}, Valid: true}, // 3.0 (mismatch)
 			},
 		},
 	}
 	data := executeMutation(t, buildMutationSchema(t, registry, invoker), `mutation {
-		setCircuitConfig(index: 2, field: "flowTempMaxC", value: "55") { success error }
+		setCircuitConfig(index: 2, field: "heatingCurve", value: "1.5") { success error }
 	}`)
 	payload, _ := data["setCircuitConfig"].(map[string]any)
 	if got, _ := payload["success"].(bool); got {
 		t.Fatalf("setCircuitConfig success = %v; want false", got)
 	}
-	if errMessage, _ := payload["error"].(string); !strings.Contains(errMessage, "write confirm failed") {
-		t.Fatalf("setCircuitConfig error = %q; want write confirm failed", errMessage)
+	if errMessage, _ := payload["error"].(string); !strings.Contains(errMessage, "read-back mismatch") {
+		t.Fatalf("setCircuitConfig error = %q; want read-back mismatch", errMessage)
 	}
 	if len(invoker.calls) != 2 {
 		t.Fatalf("invoker calls = %d; want 2", len(invoker.calls))


### PR DESCRIPTION
## Summary
- add GraphQL mutation `setCircuitConfig(index, field, value)` with strict allowlist/range/enum validation
- add GraphQL mutation `setSystemConfig(field, value)` with strict allowlist/range/bool validation
- keep reduced-profile `setBoilerConfig` behavior unchanged
- implement B524 write path through `system.set_ext_register` followed by `system.get_ext_register` read-back confirmation
- return mutation-level `{success,error}` results for validation/missing-controller/invocation/readback failures without GraphQL execution errors
- add comprehensive unit tests for success paths, validation failures, missing prerequisites, and read-back mismatch detection

## Testing
- `go test ./graphql/...`
- `go test ./...`

Fixes #269
