### PR TITLE
[HVAC-Blueprint] GW-Recovery: expose room temperature zone mapping for deterministic R8 parentage

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -360,12 +360,13 @@ func startHTTPServer(ctx context.Context, cfg ebusgateway.Config, gateway *ebusg
 							ValvePositionPct:   zone.State.ValvePositionPct,
 						},
 						Config: portal.SemanticZoneConfig{
-							OperatingMode:     zone.Config.OperatingMode,
-							Preset:            zone.Config.Preset,
-							TargetTempC:       zone.Config.TargetTempC,
-							AllowedModes:      zone.Config.AllowedModes,
-							CircuitType:       zone.Config.CircuitType,
-							AssociatedCircuit: zone.Config.AssociatedCircuit,
+							OperatingMode:              zone.Config.OperatingMode,
+							Preset:                     zone.Config.Preset,
+							TargetTempC:                zone.Config.TargetTempC,
+							AllowedModes:               zone.Config.AllowedModes,
+							CircuitType:                zone.Config.CircuitType,
+							AssociatedCircuit:          zone.Config.AssociatedCircuit,
+							RoomTemperatureZoneMapping: zone.Config.RoomTemperatureZoneMapping,
 						},
 					})
 				}

--- a/cmd/gateway/semantic_cache.go
+++ b/cmd/gateway/semantic_cache.go
@@ -71,12 +71,13 @@ type semanticCacheZoneState struct {
 }
 
 type semanticCacheZoneConfig struct {
-	OperatingMode     string   `json:"operating_mode,omitempty"`
-	Preset            string   `json:"preset,omitempty"`
-	TargetTempC       *float64 `json:"target_temp_c,omitempty"`
-	AllowedModes      []string `json:"allowed_modes,omitempty"`
-	CircuitType       string   `json:"circuit_type,omitempty"`
-	AssociatedCircuit *int     `json:"associated_circuit,omitempty"`
+	OperatingMode              string   `json:"operating_mode,omitempty"`
+	Preset                     string   `json:"preset,omitempty"`
+	TargetTempC                *float64 `json:"target_temp_c,omitempty"`
+	AllowedModes               []string `json:"allowed_modes,omitempty"`
+	CircuitType                string   `json:"circuit_type,omitempty"`
+	AssociatedCircuit          *int     `json:"associated_circuit,omitempty"`
+	RoomTemperatureZoneMapping *int     `json:"room_temperature_zone_mapping,omitempty"`
 }
 
 type semanticCacheDHWV3 struct {
@@ -214,12 +215,13 @@ func semanticCacheV3ToSnapshot(cacheV3 semanticCacheV3) semanticCacheSnapshot {
 				ValvePositionPct:   cloneFloatPtr(zone.State.ValvePositionPct),
 			},
 			Config: graphql.ZoneConfig{
-				OperatingMode:     zone.Config.OperatingMode,
-				Preset:            zone.Config.Preset,
-				TargetTempC:       cloneFloatPtr(zone.Config.TargetTempC),
-				AllowedModes:      append([]string(nil), zone.Config.AllowedModes...),
-				CircuitType:       zone.Config.CircuitType,
-				AssociatedCircuit: cloneIntPtr(zone.Config.AssociatedCircuit),
+				OperatingMode:              zone.Config.OperatingMode,
+				Preset:                     zone.Config.Preset,
+				TargetTempC:                cloneFloatPtr(zone.Config.TargetTempC),
+				AllowedModes:               append([]string(nil), zone.Config.AllowedModes...),
+				CircuitType:                zone.Config.CircuitType,
+				AssociatedCircuit:          cloneIntPtr(zone.Config.AssociatedCircuit),
+				RoomTemperatureZoneMapping: cloneIntPtr(zone.Config.RoomTemperatureZoneMapping),
 			},
 		})
 	}
@@ -265,12 +267,13 @@ func semanticCacheSnapshotToV3(snapshot semanticCacheSnapshot, persistedAt time.
 				ValvePositionPct:   cloneFloatPtr(zone.State.ValvePositionPct),
 			},
 			Config: semanticCacheZoneConfig{
-				OperatingMode:     zone.Config.OperatingMode,
-				Preset:            zone.Config.Preset,
-				TargetTempC:       cloneFloatPtr(zone.Config.TargetTempC),
-				AllowedModes:      append([]string(nil), zone.Config.AllowedModes...),
-				CircuitType:       zone.Config.CircuitType,
-				AssociatedCircuit: cloneIntPtr(zone.Config.AssociatedCircuit),
+				OperatingMode:              zone.Config.OperatingMode,
+				Preset:                     zone.Config.Preset,
+				TargetTempC:                cloneFloatPtr(zone.Config.TargetTempC),
+				AllowedModes:               append([]string(nil), zone.Config.AllowedModes...),
+				CircuitType:                zone.Config.CircuitType,
+				AssociatedCircuit:          cloneIntPtr(zone.Config.AssociatedCircuit),
+				RoomTemperatureZoneMapping: cloneIntPtr(zone.Config.RoomTemperatureZoneMapping),
 			},
 		})
 	}
@@ -310,12 +313,13 @@ func normalizeSemanticCacheSnapshot(snapshot semanticCacheSnapshot) semanticCach
 			ValvePositionPct:   cloneFloatPtr(zone.State.ValvePositionPct),
 		}
 		zoneCopy.Config = graphql.ZoneConfig{
-			OperatingMode:     zone.Config.OperatingMode,
-			Preset:            zone.Config.Preset,
-			TargetTempC:       cloneFloatPtr(zone.Config.TargetTempC),
-			AllowedModes:      append([]string(nil), zone.Config.AllowedModes...),
-			CircuitType:       zone.Config.CircuitType,
-			AssociatedCircuit: cloneIntPtr(zone.Config.AssociatedCircuit),
+			OperatingMode:              zone.Config.OperatingMode,
+			Preset:                     zone.Config.Preset,
+			TargetTempC:                cloneFloatPtr(zone.Config.TargetTempC),
+			AllowedModes:               append([]string(nil), zone.Config.AllowedModes...),
+			CircuitType:                zone.Config.CircuitType,
+			AssociatedCircuit:          cloneIntPtr(zone.Config.AssociatedCircuit),
+			RoomTemperatureZoneMapping: cloneIntPtr(zone.Config.RoomTemperatureZoneMapping),
 		}
 		slices.Sort(zoneCopy.Config.AllowedModes)
 		out.Zones = append(out.Zones, zoneCopy)
@@ -356,6 +360,7 @@ func normalizeSemanticCacheZonesV3(zones []semanticCacheZoneV3) []semanticCacheZ
 		zoneCopy.Config.AllowedModes = append([]string(nil), zone.Config.AllowedModes...)
 		slices.Sort(zoneCopy.Config.AllowedModes)
 		zoneCopy.Config.AssociatedCircuit = cloneIntPtr(zone.Config.AssociatedCircuit)
+		zoneCopy.Config.RoomTemperatureZoneMapping = cloneIntPtr(zone.Config.RoomTemperatureZoneMapping)
 		out = append(out, zoneCopy)
 	}
 	slices.SortFunc(out, func(a, b semanticCacheZoneV3) int {

--- a/cmd/gateway/semantic_cache_test.go
+++ b/cmd/gateway/semantic_cache_test.go
@@ -338,7 +338,8 @@ func TestVaillantSemanticPoller_HydrateFromCache_SeedsInternalState(t *testing.T
 	target := 22.0
 	dhwCurrent := 48.2
 	dhwTarget := 50.0
-	assocCircuit := 2
+	assocCircuit := 1
+	roomTemperatureZoneMapping := 2
 	snapshot := semanticCacheSnapshot{
 		Zones: []graphql.Zone{
 			{
@@ -348,12 +349,13 @@ func TestVaillantSemanticPoller_HydrateFromCache_SeedsInternalState(t *testing.T
 					CurrentTempC: &current,
 				},
 				Config: graphql.ZoneConfig{
-					OperatingMode:     "heat",
-					Preset:            "manual",
-					AllowedModes:      []string{"off", "auto", "heat"},
-					TargetTempC:       &target,
-					CircuitType:       "underfloor",
-					AssociatedCircuit: &assocCircuit,
+					OperatingMode:              "heat",
+					Preset:                     "manual",
+					AllowedModes:               []string{"off", "auto", "heat"},
+					TargetTempC:                &target,
+					CircuitType:                "underfloor",
+					AssociatedCircuit:          &assocCircuit,
+					RoomTemperatureZoneMapping: &roomTemperatureZoneMapping,
 				},
 			},
 		},
@@ -381,8 +383,11 @@ func TestVaillantSemanticPoller_HydrateFromCache_SeedsInternalState(t *testing.T
 	if zone.Name != "Etaj" || zone.OperatingMode != "heat" || zone.Preset != "manual" {
 		t.Fatalf("hydrated zone = %#v; unexpected core fields", zone)
 	}
-	if zone.ConfigurationAssociatedCircuitRaw == nil || *zone.ConfigurationAssociatedCircuitRaw != 2 {
-		t.Fatalf("hydrated zone circuit index = %#v; want 2", zone.ConfigurationAssociatedCircuitRaw)
+	if zone.ConfigurationAssociatedCircuitRaw == nil || *zone.ConfigurationAssociatedCircuitRaw != 1 {
+		t.Fatalf("hydrated zone circuit index = %#v; want 1", zone.ConfigurationAssociatedCircuitRaw)
+	}
+	if zone.ConfigurationRoomTemperatureZoneMappingRaw == nil || *zone.ConfigurationRoomTemperatureZoneMappingRaw != 2 {
+		t.Fatalf("hydrated zone room mapping = %#v; want 2", zone.ConfigurationRoomTemperatureZoneMappingRaw)
 	}
 	if poller.dhw == nil || poller.dhw.OperatingMode != "auto" || poller.dhw.Preset != "schedule" {
 		t.Fatalf("poller.dhw = %#v; want hydrated dhw state", poller.dhw)

--- a/cmd/gateway/semantic_provider.go
+++ b/cmd/gateway/semantic_provider.go
@@ -35,12 +35,13 @@ func (adapter mcpSemanticProviderAdapter) Zones() []mcp.Zone {
 				ValvePositionPct:   cloneFloatPtr(zone.State.ValvePositionPct),
 			},
 			Config: mcp.ZoneConfig{
-				OperatingMode:     zone.Config.OperatingMode,
-				Preset:            zone.Config.Preset,
-				TargetTempC:       cloneFloatPtr(zone.Config.TargetTempC),
-				AllowedModes:      append([]string(nil), zone.Config.AllowedModes...),
-				CircuitType:       zone.Config.CircuitType,
-				AssociatedCircuit: cloneIntPtr(zone.Config.AssociatedCircuit),
+				OperatingMode:              zone.Config.OperatingMode,
+				Preset:                     zone.Config.Preset,
+				TargetTempC:                cloneFloatPtr(zone.Config.TargetTempC),
+				AllowedModes:               append([]string(nil), zone.Config.AllowedModes...),
+				CircuitType:                zone.Config.CircuitType,
+				AssociatedCircuit:          cloneIntPtr(zone.Config.AssociatedCircuit),
+				RoomTemperatureZoneMapping: cloneIntPtr(zone.Config.RoomTemperatureZoneMapping),
 			},
 		}
 	}

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -43,18 +43,18 @@ const (
 	vaillantGroupRadio10   = byte(0x0A)
 	vaillantGroupRadio0C   = byte(0x0C)
 
-	zoneRegName                 = uint16(0x0016)
-	zoneRegNamePrefix           = uint16(0x0017)
-	zoneRegNameSuffix           = uint16(0x0018)
-	zoneRegIndex                = uint16(0x001C)
-	zoneRegHeatingOpMode        = uint16(0x0006) // configuration.heating.operation_mode
-	zoneRegCurrentTemp          = uint16(0x000F) // state.current_room_temperature
-	zoneRegTargetTemp           = uint16(0x0022) // configuration.heating.desired_setpoint
-	zoneRegFallbackManualTemp   = uint16(0x0014) // configuration.heating.manual_mode_setpoint
-	zoneRegSpecialFunction      = uint16(0x000E) // state.current_special_function
-	zoneRegValveStatus          = uint16(0x0012) // state.valve_status
-	zoneRegAssociatedCircuitRaw = uint16(0x0013) // configuration.associated_circuit_index
-	zoneRegCurrentHumidity      = uint16(0x0028) // state.current_room_humidity
+	zoneRegName                          = uint16(0x0016)
+	zoneRegNamePrefix                    = uint16(0x0017)
+	zoneRegNameSuffix                    = uint16(0x0018)
+	zoneRegIndex                         = uint16(0x001C)
+	zoneRegHeatingOpMode                 = uint16(0x0006) // configuration.heating.operation_mode
+	zoneRegCurrentTemp                   = uint16(0x000F) // state.current_room_temperature
+	zoneRegTargetTemp                    = uint16(0x0022) // configuration.heating.desired_setpoint
+	zoneRegFallbackManualTemp            = uint16(0x0014) // configuration.heating.manual_mode_setpoint
+	zoneRegSpecialFunction               = uint16(0x000E) // state.current_special_function
+	zoneRegValveStatus                   = uint16(0x0012) // state.valve_status
+	zoneRegRoomTemperatureZoneMappingRaw = uint16(0x0013) // configuration.room_temperature_zone_mapping
+	zoneRegCurrentHumidity               = uint16(0x0028) // state.current_room_humidity
 
 	circuitRegType            = uint16(0x0002) // configuration.heating_circuit_type / mixer_circuit_type_external
 	circuitRegCoolingEnabled  = uint16(0x0006) // cooling_enabled
@@ -238,11 +238,12 @@ type vaillantZoneSnapshot struct {
 	TargetTempC  *float64
 	HumidityPct  *float64
 
-	ConfigurationHeatingOperationMode string
-	StateSpecialFunction              string
-	ConfigurationAssociatedCircuitRaw *uint16
-	ConfigurationCircuitTypeRaw       *uint16
-	StateValveStatusRaw               *uint16
+	ConfigurationHeatingOperationMode          string
+	StateSpecialFunction                       string
+	ConfigurationRoomTemperatureZoneMappingRaw *uint16
+	ConfigurationAssociatedCircuitRaw          *uint16
+	ConfigurationCircuitTypeRaw                *uint16
+	StateValveStatusRaw                        *uint16
 
 	FieldFreshness map[semanticFieldKey]semanticFieldFreshness
 }
@@ -334,25 +335,26 @@ const (
 type semanticFieldKey string
 
 const (
-	zoneFieldName                 semanticFieldKey = "zone.name"
-	zoneFieldOperatingMode        semanticFieldKey = "zone.operating_mode"
-	zoneFieldPreset               semanticFieldKey = "zone.preset"
-	zoneFieldHvacAction           semanticFieldKey = "zone.hvac_action"
-	zoneFieldAllowedModes         semanticFieldKey = "zone.allowed_modes"
-	zoneFieldCurrentTempC         semanticFieldKey = "zone.current_temp_c"
-	zoneFieldTargetTempC          semanticFieldKey = "zone.target_temp_c"
-	zoneFieldCurrentHumidityPct   semanticFieldKey = "zone.current_humidity_pct"
-	zoneFieldSpecialFunctionRaw   semanticFieldKey = "zone.special_function_raw"
-	zoneFieldZoneOperationModeRaw semanticFieldKey = "zone.operation_mode_raw"
-	zoneFieldZoneCircuitIndexRaw  semanticFieldKey = "zone.circuit_index_raw"
-	zoneFieldCircuitTypeRaw       semanticFieldKey = "zone.circuit_type_raw"
-	zoneFieldZoneValveStatusRaw   semanticFieldKey = "zone.valve_status_raw"
-	dhwFieldOperatingMode         semanticFieldKey = "dhw.operating_mode"
-	dhwFieldPreset                semanticFieldKey = "dhw.preset"
-	dhwFieldCurrentTempC          semanticFieldKey = "dhw.current_temp_c"
-	dhwFieldTargetTempC           semanticFieldKey = "dhw.target_temp_c"
-	dhwFieldSpecialFunctionRaw    semanticFieldKey = "dhw.special_function_raw"
-	dhwFieldDhwOperationModeRaw   semanticFieldKey = "dhw.operation_mode_raw"
+	zoneFieldName                          semanticFieldKey = "zone.name"
+	zoneFieldOperatingMode                 semanticFieldKey = "zone.operating_mode"
+	zoneFieldPreset                        semanticFieldKey = "zone.preset"
+	zoneFieldHvacAction                    semanticFieldKey = "zone.hvac_action"
+	zoneFieldAllowedModes                  semanticFieldKey = "zone.allowed_modes"
+	zoneFieldCurrentTempC                  semanticFieldKey = "zone.current_temp_c"
+	zoneFieldTargetTempC                   semanticFieldKey = "zone.target_temp_c"
+	zoneFieldCurrentHumidityPct            semanticFieldKey = "zone.current_humidity_pct"
+	zoneFieldSpecialFunctionRaw            semanticFieldKey = "zone.special_function_raw"
+	zoneFieldZoneOperationModeRaw          semanticFieldKey = "zone.operation_mode_raw"
+	zoneFieldRoomTemperatureZoneMappingRaw semanticFieldKey = "zone.room_temperature_zone_mapping_raw"
+	zoneFieldZoneCircuitIndexRaw           semanticFieldKey = "zone.circuit_index_raw"
+	zoneFieldCircuitTypeRaw                semanticFieldKey = "zone.circuit_type_raw"
+	zoneFieldZoneValveStatusRaw            semanticFieldKey = "zone.valve_status_raw"
+	dhwFieldOperatingMode                  semanticFieldKey = "dhw.operating_mode"
+	dhwFieldPreset                         semanticFieldKey = "dhw.preset"
+	dhwFieldCurrentTempC                   semanticFieldKey = "dhw.current_temp_c"
+	dhwFieldTargetTempC                    semanticFieldKey = "dhw.target_temp_c"
+	dhwFieldSpecialFunctionRaw             semanticFieldKey = "dhw.special_function_raw"
+	dhwFieldDhwOperationModeRaw            semanticFieldKey = "dhw.operation_mode_raw"
 )
 
 type semanticFieldFreshness struct {
@@ -406,6 +408,7 @@ var (
 		zoneFieldCurrentHumidityPct,
 		zoneFieldZoneOperationModeRaw,
 		zoneFieldSpecialFunctionRaw,
+		zoneFieldRoomTemperatureZoneMappingRaw,
 		zoneFieldZoneCircuitIndexRaw,
 		zoneFieldZoneValveStatusRaw,
 		zoneFieldCircuitTypeRaw,
@@ -421,6 +424,7 @@ var (
 		zoneFieldCurrentHumidityPct,
 		zoneFieldZoneOperationModeRaw,
 		zoneFieldSpecialFunctionRaw,
+		zoneFieldRoomTemperatureZoneMappingRaw,
 		zoneFieldZoneCircuitIndexRaw,
 		zoneFieldZoneValveStatusRaw,
 		zoneFieldCircuitTypeRaw,
@@ -624,6 +628,10 @@ func zoneSnapshotFromSemanticZone(instance byte, zone graphql.Zone) *vaillantZon
 		v := uint16(*zone.Config.AssociatedCircuit)
 		snapshot.ConfigurationAssociatedCircuitRaw = &v
 	}
+	if zone.Config.RoomTemperatureZoneMapping != nil {
+		v := uint16(*zone.Config.RoomTemperatureZoneMapping)
+		snapshot.ConfigurationRoomTemperatureZoneMappingRaw = &v
+	}
 	if zone.Config.CircuitType != "" {
 		v := encodeCircuitTypeRaw(zone.Config.CircuitType)
 		snapshot.ConfigurationCircuitTypeRaw = &v
@@ -793,6 +801,7 @@ func mergeZoneSnapshotFields(entry *vaillantZoneSnapshot, incoming *vaillantZone
 	mergeFloatField(&entry.HumidityPct, incoming.HumidityPct, attempted.has(zoneFieldCurrentHumidityPct), fields, zoneFieldCurrentHumidityPct, source)
 	mergeStringField(&entry.ConfigurationHeatingOperationMode, incoming.ConfigurationHeatingOperationMode, attempted.has(zoneFieldZoneOperationModeRaw), fields, zoneFieldZoneOperationModeRaw, source)
 	mergeStringField(&entry.StateSpecialFunction, incoming.StateSpecialFunction, attempted.has(zoneFieldSpecialFunctionRaw), fields, zoneFieldSpecialFunctionRaw, source)
+	mergeUint16Field(&entry.ConfigurationRoomTemperatureZoneMappingRaw, incoming.ConfigurationRoomTemperatureZoneMappingRaw, attempted.has(zoneFieldRoomTemperatureZoneMappingRaw), fields, zoneFieldRoomTemperatureZoneMappingRaw, source)
 	mergeUint16Field(&entry.ConfigurationAssociatedCircuitRaw, incoming.ConfigurationAssociatedCircuitRaw, attempted.has(zoneFieldZoneCircuitIndexRaw), fields, zoneFieldZoneCircuitIndexRaw, source)
 	mergeUint16Field(&entry.ConfigurationCircuitTypeRaw, incoming.ConfigurationCircuitTypeRaw, attempted.has(zoneFieldCircuitTypeRaw), fields, zoneFieldCircuitTypeRaw, source)
 	mergeUint16Field(&entry.StateValveStatusRaw, incoming.StateValveStatusRaw, attempted.has(zoneFieldZoneValveStatusRaw), fields, zoneFieldZoneValveStatusRaw, source)
@@ -846,6 +855,9 @@ func seedZoneFreshness(snapshot *vaillantZoneSnapshot, source semanticSnapshotSo
 	}
 	if strings.TrimSpace(snapshot.StateSpecialFunction) != "" {
 		setFieldFreshness(fields, zoneFieldSpecialFunctionRaw, source, stale)
+	}
+	if snapshot.ConfigurationRoomTemperatureZoneMappingRaw != nil {
+		setFieldFreshness(fields, zoneFieldRoomTemperatureZoneMappingRaw, source, stale)
 	}
 	if snapshot.ConfigurationAssociatedCircuitRaw != nil {
 		setFieldFreshness(fields, zoneFieldZoneCircuitIndexRaw, source, stale)
@@ -1400,29 +1412,35 @@ func (p *vaillantSemanticPoller) refreshState(ctx context.Context) {
 		zoneOpMode, zoneOpModeOK := p.readB524Uint16(ctx, vaillantB524OpcodeLocal, vaillantGroupZones, instance, zoneRegHeatingOpMode)
 		zoneSF, zoneSFOK := p.readB524Uint16(ctx, vaillantB524OpcodeLocal, vaillantGroupZones, instance, zoneRegSpecialFunction)
 		zoneValve, zoneValveOK := p.readB524Uint16(ctx, vaillantB524OpcodeLocal, vaillantGroupZones, instance, zoneRegValveStatus)
-		zoneCircuitRaw, zoneCircuitRawOK := p.readB524Uint16(ctx, vaillantB524OpcodeLocal, vaillantGroupZones, instance, zoneRegAssociatedCircuitRaw)
-		if zoneOpModeOK || zoneSFOK || zoneValveOK || zoneCircuitRawOK {
+		zoneRoomTemperatureZoneMappingRaw, zoneRoomTemperatureZoneMappingRawOK := p.readB524Uint16(ctx, vaillantB524OpcodeLocal, vaillantGroupZones, instance, zoneRegRoomTemperatureZoneMappingRaw)
+		if zoneOpModeOK || zoneSFOK || zoneValveOK || zoneRoomTemperatureZoneMappingRawOK {
 			liveReadSuccess = true
 		}
-		circuitInstance := resolveCircuitInstance(zoneCircuitRaw, instance)
+		circuitInstance := resolveAssociatedCircuitInstance(zoneRoomTemperatureZoneMappingRaw, instance)
 		circuitType, hasCircuitType := p.readB524Uint16(ctx, vaillantB524OpcodeLocal, vaillantGroupCircuits, circuitInstance, circuitRegType)
 		if hasCircuitType {
 			liveReadSuccess = true
+		}
+		var associatedCircuitRaw *uint16
+		if zoneRoomTemperatureZoneMappingRaw != nil {
+			value := uint16(circuitInstance)
+			associatedCircuitRaw = &value
 		}
 
 		operatingMode, preset, allowedModes := deriveZoneModeAndPreset(zoneOpMode, zoneSF, circuitType, hasCircuitType)
 		hvacAction := deriveZoneHvacAction(zoneValve, circuitType, hasCircuitType)
 		incoming := &vaillantZoneSnapshot{
-			OperatingMode:                     operatingMode,
-			Preset:                            preset,
-			HvacAction:                        hvacAction,
-			AllowedModes:                      allowedModes,
-			CurrentTempC:                      currentPtr,
-			TargetTempC:                       targetPtr,
-			HumidityPct:                       humidity,
-			ConfigurationAssociatedCircuitRaw: zoneCircuitRaw,
-			ConfigurationCircuitTypeRaw:       circuitType,
-			StateValveStatusRaw:               zoneValve,
+			OperatingMode: operatingMode,
+			Preset:        preset,
+			HvacAction:    hvacAction,
+			AllowedModes:  allowedModes,
+			CurrentTempC:  currentPtr,
+			TargetTempC:   targetPtr,
+			HumidityPct:   humidity,
+			ConfigurationRoomTemperatureZoneMappingRaw: zoneRoomTemperatureZoneMappingRaw,
+			ConfigurationAssociatedCircuitRaw:          associatedCircuitRaw,
+			ConfigurationCircuitTypeRaw:                circuitType,
+			StateValveStatusRaw:                        zoneValve,
 		}
 		if zoneOpMode != nil {
 			incoming.ConfigurationHeatingOperationMode = formatUintToken(*zoneOpMode)
@@ -1500,12 +1518,13 @@ func (p *vaillantSemanticPoller) publishZones(source semanticSnapshotSource) {
 				ValvePositionPct:   decodeValvePositionPct(entry.StateValveStatusRaw),
 			},
 			Config: graphql.ZoneConfig{
-				OperatingMode:     entry.OperatingMode,
-				Preset:            entry.Preset,
-				TargetTempC:       entry.TargetTempC,
-				AllowedModes:      append([]string(nil), entry.AllowedModes...),
-				CircuitType:       decodeCircuitType(entry.ConfigurationCircuitTypeRaw),
-				AssociatedCircuit: decodeAssociatedCircuit(entry.ConfigurationAssociatedCircuitRaw),
+				OperatingMode:              entry.OperatingMode,
+				Preset:                     entry.Preset,
+				TargetTempC:                entry.TargetTempC,
+				AllowedModes:               append([]string(nil), entry.AllowedModes...),
+				CircuitType:                decodeCircuitType(entry.ConfigurationCircuitTypeRaw),
+				AssociatedCircuit:          decodeAssociatedCircuit(entry.ConfigurationAssociatedCircuitRaw),
+				RoomTemperatureZoneMapping: decodeRoomTemperatureZoneMapping(entry.ConfigurationRoomTemperatureZoneMappingRaw),
 			},
 		}
 		zones = append(zones, zone)
@@ -1571,6 +1590,9 @@ func zoneEquals(a, b graphql.Zone) bool {
 		return false
 	}
 	if !intPtrEquals(a.Config.AssociatedCircuit, b.Config.AssociatedCircuit) {
+		return false
+	}
+	if !intPtrEquals(a.Config.RoomTemperatureZoneMapping, b.Config.RoomTemperatureZoneMapping) {
 		return false
 	}
 	return true
@@ -3706,6 +3728,20 @@ func decodeAssociatedCircuit(raw *uint16) *int {
 	if raw == nil {
 		return nil
 	}
+	if *raw == 0xFF || *raw == 0xFFFF {
+		return nil
+	}
+	v := int(*raw)
+	return &v
+}
+
+func decodeRoomTemperatureZoneMapping(raw *uint16) *int {
+	if raw == nil {
+		return nil
+	}
+	if *raw == 0xFF || *raw == 0xFFFF {
+		return nil
+	}
 	v := int(*raw)
 	return &v
 }
@@ -4367,17 +4403,17 @@ func (p *vaillantSemanticPoller) readB524Uint32LE(ctx context.Context, opcode, g
 	return v, true
 }
 
-func resolveCircuitInstance(associatedCircuit *uint16, zoneInstance byte) byte {
-	if associatedCircuit == nil {
+func resolveAssociatedCircuitInstance(roomTemperatureZoneMapping *uint16, zoneInstance byte) byte {
+	if roomTemperatureZoneMapping == nil {
 		return zoneInstance
 	}
-	value := *associatedCircuit
+	value := *roomTemperatureZoneMapping
 	switch value {
-	case 0xFF, 0xFFFF:
+	case 0xFF, 0xFFFF, 0:
 		return zoneInstance
 	default:
-		if value <= 0x1F {
-			return byte(value)
+		if value >= 1 && value <= 0x20 {
+			return byte(value - 1)
 		}
 		return zoneInstance
 	}

--- a/cmd/gateway/semantic_vaillant_ebusd_grab.go
+++ b/cmd/gateway/semantic_vaillant_ebusd_grab.go
@@ -193,14 +193,14 @@ func parseB524ZonesFromGrab(lines []string, controller byte) map[byte]*vaillantZ
 		suffix  string
 	}
 	type zoneState struct {
-		snapshot                   *vaillantZoneSnapshot
-		nameParts                  zoneNameParts
-		hasIndex                   bool
-		indexPresent               bool
-		configurationOperationMode *uint16
-		stateSpecialFunction       *uint16
-		stateValveStatus           *uint16
-		configurationCircuitRaw    *uint16
+		snapshot                      *vaillantZoneSnapshot
+		nameParts                     zoneNameParts
+		hasIndex                      bool
+		indexPresent                  bool
+		configurationOperationMode    *uint16
+		stateSpecialFunction          *uint16
+		stateValveStatus              *uint16
+		roomTemperatureZoneMappingRaw *uint16
 	}
 
 	states := make(map[byte]*zoneState)
@@ -269,11 +269,11 @@ func parseB524ZonesFromGrab(lines []string, controller byte) map[byte]*vaillantZ
 				state.stateValveStatus = &typed
 				snapshot.StateValveStatusRaw = &typed
 			}
-		case zoneRegAssociatedCircuitRaw:
+		case zoneRegRoomTemperatureZoneMappingRaw:
 			if value, ok := decodeB524Uint16(payload); ok {
 				typed := value
-				state.configurationCircuitRaw = &typed
-				snapshot.ConfigurationAssociatedCircuitRaw = &typed
+				state.roomTemperatureZoneMappingRaw = &typed
+				snapshot.ConfigurationRoomTemperatureZoneMappingRaw = &typed
 			}
 		case zoneRegCurrentTemp:
 			if value, ok := decodeFloat32LE(payload); ok {
@@ -304,7 +304,11 @@ func parseB524ZonesFromGrab(lines []string, controller byte) map[byte]*vaillantZ
 		if state == nil || state.snapshot == nil {
 			continue
 		}
-		circuitInstance := resolveCircuitInstance(state.configurationCircuitRaw, instance)
+		circuitInstance := resolveAssociatedCircuitInstance(state.roomTemperatureZoneMappingRaw, instance)
+		if state.roomTemperatureZoneMappingRaw != nil {
+			typed := uint16(circuitInstance)
+			state.snapshot.ConfigurationAssociatedCircuitRaw = &typed
+		}
 		circuitType, hasCircuitType := circuitTypeByInstance[circuitInstance]
 		if hasCircuitType && circuitType != nil {
 			state.snapshot.ConfigurationCircuitTypeRaw = circuitType

--- a/cmd/gateway/semantic_vaillant_test.go
+++ b/cmd/gateway/semantic_vaillant_test.go
@@ -1233,6 +1233,7 @@ func TestMergeZoneSnapshotFields_PartialLiveUpdatePreservesLastKnownAndFreshness
 	current := 21.0
 	target := 22.5
 	humidity := 44.0
+	roomTemperatureZoneMapping := uint16(2)
 	circuitIndex := uint16(2)
 	circuitType := uint16(1)
 	valve := uint16(1)
@@ -1247,9 +1248,10 @@ func TestMergeZoneSnapshotFields_PartialLiveUpdatePreservesLastKnownAndFreshness
 		HumidityPct:                       &humidity,
 		ConfigurationHeatingOperationMode: "1",
 		StateSpecialFunction:              "0",
-		ConfigurationAssociatedCircuitRaw: &circuitIndex,
-		ConfigurationCircuitTypeRaw:       &circuitType,
-		StateValveStatusRaw:               &valve,
+		ConfigurationRoomTemperatureZoneMappingRaw: &roomTemperatureZoneMapping,
+		ConfigurationAssociatedCircuitRaw:          &circuitIndex,
+		ConfigurationCircuitTypeRaw:                &circuitType,
+		StateValveStatusRaw:                        &valve,
 	}
 	seedZoneFreshness(entry, semanticSnapshotSourceCache, true)
 
@@ -1269,6 +1271,9 @@ func TestMergeZoneSnapshotFields_PartialLiveUpdatePreservesLastKnownAndFreshness
 	if entry.ConfigurationAssociatedCircuitRaw == nil || *entry.ConfigurationAssociatedCircuitRaw != 2 {
 		t.Fatalf("entry.ConfigurationAssociatedCircuitRaw = %v; want preserved 2", entry.ConfigurationAssociatedCircuitRaw)
 	}
+	if entry.ConfigurationRoomTemperatureZoneMappingRaw == nil || *entry.ConfigurationRoomTemperatureZoneMappingRaw != 2 {
+		t.Fatalf("entry.ConfigurationRoomTemperatureZoneMappingRaw = %v; want preserved 2", entry.ConfigurationRoomTemperatureZoneMappingRaw)
+	}
 	if entry.ConfigurationHeatingOperationMode != "2" {
 		t.Fatalf("entry.ConfigurationHeatingOperationMode = %q; want 2", entry.ConfigurationHeatingOperationMode)
 	}
@@ -1284,6 +1289,47 @@ func TestMergeZoneSnapshotFields_PartialLiveUpdatePreservesLastKnownAndFreshness
 	opModeFreshness, ok := entry.FieldFreshness[zoneFieldZoneOperationModeRaw]
 	if !ok || opModeFreshness.Source != semanticSnapshotSourceLive || opModeFreshness.Stale {
 		t.Fatalf("operation_mode_raw freshness = %+v (ok=%v); want source=live stale=false", opModeFreshness, ok)
+	}
+	roomMappingFreshness, ok := entry.FieldFreshness[zoneFieldRoomTemperatureZoneMappingRaw]
+	if !ok || roomMappingFreshness.Source != semanticSnapshotSourceCache || !roomMappingFreshness.Stale {
+		t.Fatalf("room_temperature_zone_mapping_raw freshness = %+v (ok=%v); want source=cache stale=true", roomMappingFreshness, ok)
+	}
+}
+
+func TestVaillantSemanticPoller_PublishZones_SeparatesRoomTemperatureZoneMappingFromAssociatedCircuit(t *testing.T) {
+	t.Parallel()
+
+	provider := graphql.NewLiveSemanticProvider()
+	roomTemperatureZoneMapping := uint16(2)
+	associatedCircuit := uint16(resolveAssociatedCircuitInstance(&roomTemperatureZoneMapping, 1))
+
+	poller := &vaillantSemanticPoller{
+		provider: provider,
+		zones: map[byte]*vaillantZoneSnapshot{
+			0x01: {
+				Instance:      0x01,
+				Present:       true,
+				Name:          "Etaj",
+				OperatingMode: "heat",
+				Preset:        "manual",
+				AllowedModes:  []string{"off", "auto", "heat"},
+				ConfigurationRoomTemperatureZoneMappingRaw: &roomTemperatureZoneMapping,
+				ConfigurationAssociatedCircuitRaw:          &associatedCircuit,
+			},
+		},
+	}
+
+	poller.publishZones(semanticSnapshotSourceLive)
+
+	zones := provider.Zones()
+	if len(zones) != 1 {
+		t.Fatalf("len(provider.Zones()) = %d; want 1", len(zones))
+	}
+	if zones[0].Config.RoomTemperatureZoneMapping == nil || *zones[0].Config.RoomTemperatureZoneMapping != 2 {
+		t.Fatalf("roomTemperatureZoneMapping = %#v; want 2", zones[0].Config.RoomTemperatureZoneMapping)
+	}
+	if zones[0].Config.AssociatedCircuit == nil || *zones[0].Config.AssociatedCircuit != 1 {
+		t.Fatalf("associatedCircuit = %#v; want 1", zones[0].Config.AssociatedCircuit)
 	}
 }
 

--- a/graphql/queries.go
+++ b/graphql/queries.go
@@ -198,6 +198,19 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *config.AssociatedCircuit, nil
 				},
 			},
+			"roomTemperatureZoneMapping": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(ZoneConfig)
+					if !ok {
+						return nil, nil
+					}
+					if config.RoomTemperatureZoneMapping == nil {
+						return nil, nil
+					}
+					return *config.RoomTemperatureZoneMapping, nil
+				},
+			},
 		},
 	})
 

--- a/graphql/queries_test.go
+++ b/graphql/queries_test.go
@@ -75,6 +75,8 @@ func TestQueryResolvers_Integration(t *testing.T) {
 	defer server.Close()
 
 	client := graphqlclient.NewClient(server.URL)
+	semantic := NewLiveSemanticProvider()
+	builder.SetSemanticProvider(semantic)
 
 	t.Run("devices", func(t *testing.T) {
 		request := graphqlclient.NewRequest(`
@@ -284,6 +286,23 @@ func TestQueryResolvers_Integration(t *testing.T) {
 	})
 
 	t.Run("zones_dhw", func(t *testing.T) {
+		associatedCircuit := 1
+		roomTemperatureZoneMapping := 2
+		semantic.SetZones([]Zone{
+			{
+				ID:   "zone-2",
+				Name: "Etaj",
+				Config: ZoneConfig{
+					OperatingMode:              "heat",
+					Preset:                     "manual",
+					AllowedModes:               []string{"off", "auto", "heat"},
+					CircuitType:                "underfloor",
+					AssociatedCircuit:          &associatedCircuit,
+					RoomTemperatureZoneMapping: &roomTemperatureZoneMapping,
+				},
+			},
+		})
+
 		request := graphqlclient.NewRequest(`
 			query {
 				zones {
@@ -304,6 +323,7 @@ func TestQueryResolvers_Integration(t *testing.T) {
 						allowedModes
 						circuitType
 						associatedCircuit
+						roomTemperatureZoneMapping
 					}
 				}
 				dhw {
@@ -419,12 +439,13 @@ func TestQueryResolvers_Integration(t *testing.T) {
 					ValvePositionPct   *float64 `json:"valvePositionPct"`
 				} `json:"state"`
 				Config struct {
-					OperatingMode     *string  `json:"operatingMode"`
-					Preset            *string  `json:"preset"`
-					TargetTempC       *float64 `json:"targetTempC"`
-					AllowedModes      []string `json:"allowedModes"`
-					CircuitType       *string  `json:"circuitType"`
-					AssociatedCircuit *int     `json:"associatedCircuit"`
+					OperatingMode              *string  `json:"operatingMode"`
+					Preset                     *string  `json:"preset"`
+					TargetTempC                *float64 `json:"targetTempC"`
+					AllowedModes               []string `json:"allowedModes"`
+					CircuitType                *string  `json:"circuitType"`
+					AssociatedCircuit          *int     `json:"associatedCircuit"`
+					RoomTemperatureZoneMapping *int     `json:"roomTemperatureZoneMapping"`
 				} `json:"config"`
 			} `json:"zones"`
 			DHW *struct {
@@ -529,8 +550,14 @@ func TestQueryResolvers_Integration(t *testing.T) {
 		if err := client.Run(context.Background(), request, &response); err != nil {
 			t.Fatalf("zones/dhw query error = %v", err)
 		}
-		if len(response.Zones) != 0 {
-			t.Fatalf("zones = %d; want 0", len(response.Zones))
+		if len(response.Zones) != 1 {
+			t.Fatalf("zones = %d; want 1", len(response.Zones))
+		}
+		if response.Zones[0].Config.AssociatedCircuit == nil || *response.Zones[0].Config.AssociatedCircuit != 1 {
+			t.Fatalf("associatedCircuit = %#v; want 1", response.Zones[0].Config.AssociatedCircuit)
+		}
+		if response.Zones[0].Config.RoomTemperatureZoneMapping == nil || *response.Zones[0].Config.RoomTemperatureZoneMapping != 2 {
+			t.Fatalf("roomTemperatureZoneMapping = %#v; want 2", response.Zones[0].Config.RoomTemperatureZoneMapping)
 		}
 		if response.DHW != nil {
 			t.Fatalf("dhw expected nil with static provider")

--- a/graphql/semantic.go
+++ b/graphql/semantic.go
@@ -12,12 +12,13 @@ type ZoneState struct {
 }
 
 type ZoneConfig struct {
-	OperatingMode     string
-	Preset            string
-	TargetTempC       *float64
-	AllowedModes      []string
-	CircuitType       string
-	AssociatedCircuit *int
+	OperatingMode              string
+	Preset                     string
+	TargetTempC                *float64
+	AllowedModes               []string
+	CircuitType                string
+	AssociatedCircuit          *int
+	RoomTemperatureZoneMapping *int
 }
 
 type Zone struct {

--- a/graphql/semantic_live.go
+++ b/graphql/semantic_live.go
@@ -890,6 +890,10 @@ func cloneZoneConfig(c ZoneConfig) ZoneConfig {
 		v := *c.AssociatedCircuit
 		out.AssociatedCircuit = &v
 	}
+	if c.RoomTemperatureZoneMapping != nil {
+		v := *c.RoomTemperatureZoneMapping
+		out.RoomTemperatureZoneMapping = &v
+	}
 	return out
 }
 

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -52,12 +52,13 @@ type ZoneState struct {
 }
 
 type ZoneConfig struct {
-	OperatingMode     string   `json:"operating_mode"`
-	Preset            string   `json:"preset"`
-	TargetTempC       *float64 `json:"target_temp_c,omitempty"`
-	AllowedModes      []string `json:"allowed_modes,omitempty"`
-	CircuitType       string   `json:"circuit_type,omitempty"`
-	AssociatedCircuit *int     `json:"associated_circuit,omitempty"`
+	OperatingMode              string   `json:"operating_mode"`
+	Preset                     string   `json:"preset"`
+	TargetTempC                *float64 `json:"target_temp_c,omitempty"`
+	AllowedModes               []string `json:"allowed_modes,omitempty"`
+	CircuitType                string   `json:"circuit_type,omitempty"`
+	AssociatedCircuit          *int     `json:"associated_circuit,omitempty"`
+	RoomTemperatureZoneMapping *int     `json:"room_temperature_zone_mapping,omitempty"`
 }
 
 type Zone struct {

--- a/portal/handler.go
+++ b/portal/handler.go
@@ -106,12 +106,13 @@ type SemanticZoneState struct {
 }
 
 type SemanticZoneConfig struct {
-	OperatingMode     string   `json:"operating_mode,omitempty"`
-	Preset            string   `json:"preset,omitempty"`
-	TargetTempC       *float64 `json:"target_temp_c,omitempty"`
-	AllowedModes      []string `json:"allowed_modes,omitempty"`
-	CircuitType       string   `json:"circuit_type,omitempty"`
-	AssociatedCircuit *int     `json:"associated_circuit,omitempty"`
+	OperatingMode              string   `json:"operating_mode,omitempty"`
+	Preset                     string   `json:"preset,omitempty"`
+	TargetTempC                *float64 `json:"target_temp_c,omitempty"`
+	AllowedModes               []string `json:"allowed_modes,omitempty"`
+	CircuitType                string   `json:"circuit_type,omitempty"`
+	AssociatedCircuit          *int     `json:"associated_circuit,omitempty"`
+	RoomTemperatureZoneMapping *int     `json:"room_temperature_zone_mapping,omitempty"`
 }
 
 type SemanticZone struct {


### PR DESCRIPTION
## What
Expose `zones[].config.roomTemperatureZoneMapping` from B524 `GG=0x03 RR=0x0013` and keep `associatedCircuit` as a separate resolved circuit index.

## Why
HA-8 / HA-11 need the authoritative room-temperature mapping to parent zones deterministically under `VRC720` vs `VR92` according to R8. The current gateway contract omitted this field from GraphQL and conflated `RR=0x0013` with `associatedCircuit`.

## Changes
- add `roomTemperatureZoneMapping` to the semantic zone model, GraphQL, MCP, portal, and semantic cache
- resolve `associatedCircuit` separately as a 0-based circuit index instead of aliasing the raw mapping register
- update live polling and ebusd-grab hydration for the separated fields
- add tests covering semantic publication, cache hydration, and GraphQL query shape

## Validation
- `GOWORK=off go test ./graphql ./cmd/gateway ./mcp ./portal`
- `GOWORK=off TRANSPORT_GATE_OWNER_OVERRIDE=OVERRIDE_TRANSPORT_GATE_BY_OWNER TRANSPORT_GATE_OWNER_REASON="semantic-only GraphQL/cache zone mapping recovery; no transport or protocol path behavior changed" ./scripts/ci_local.sh`

Closes #286