### PR TITLE
Gateway parity: expose energyTotals at GraphQL query root

### DIFF
--- a/graphql/queries.go
+++ b/graphql/queries.go
@@ -2204,6 +2204,12 @@ func buildQueryType(builder *Builder, types graphqlSchemaTypes) *graphqlgo.Objec
 					return builder.semanticProvider().DHW(), nil
 				},
 			},
+			"energyTotals": &graphqlgo.Field{
+				Type: types.energyTotals,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					return builder.semanticProvider().EnergyTotals(), nil
+				},
+			},
 			"circuits": &graphqlgo.Field{
 				Type: graphqlgo.NewNonNull(graphqlgo.NewList(graphqlgo.NewNonNull(types.circuitStatusType))),
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {

--- a/graphql/queries_test.go
+++ b/graphql/queries_test.go
@@ -285,6 +285,56 @@ func TestQueryResolvers_Integration(t *testing.T) {
 		}
 	})
 
+	t.Run("query_root_inventory", func(t *testing.T) {
+		request := graphqlclient.NewRequest(`
+			query {
+				__schema {
+					queryType {
+						fields {
+							name
+						}
+					}
+				}
+			}
+		`)
+
+		var response struct {
+			Schema struct {
+				QueryType struct {
+					Fields []struct {
+						Name string `json:"name"`
+					} `json:"fields"`
+				} `json:"queryType"`
+			} `json:"__schema"`
+		}
+
+		if err := client.Run(context.Background(), request, &response); err != nil {
+			t.Fatalf("query root introspection error = %v", err)
+		}
+
+		got := make(map[string]bool, len(response.Schema.QueryType.Fields))
+		for _, field := range response.Schema.QueryType.Fields {
+			got[field.Name] = true
+		}
+
+		for _, name := range []string{
+			"zones",
+			"dhw",
+			"energyTotals",
+			"circuits",
+			"radioDevices",
+			"fm5SemanticMode",
+			"solar",
+			"cylinders",
+			"boilerStatus",
+			"system",
+		} {
+			if !got[name] {
+				t.Fatalf("query root missing %q in introspection: %#v", name, got)
+			}
+		}
+	})
+
 	t.Run("zones_dhw", func(t *testing.T) {
 		associatedCircuit := 1
 		roomTemperatureZoneMapping := 2
@@ -579,6 +629,100 @@ func TestQueryResolvers_Integration(t *testing.T) {
 		}
 		if response.System != nil {
 			t.Fatalf("system expected nil with static provider")
+		}
+	})
+
+	t.Run("energy_totals_root", func(t *testing.T) {
+		semantic.ApplyEnergyFromRegister(EnergyMergeKey{
+			Channel: "gas",
+			Usage:   "hot_water",
+			Period:  "day",
+		}, 3.5)
+		semantic.ApplyEnergyFromRegister(EnergyMergeKey{
+			Channel:  "gas",
+			Usage:    "hot_water",
+			Period:   "year",
+			YearKind: "previous",
+		}, 120.0)
+		semantic.ApplyEnergyFromRegister(EnergyMergeKey{
+			Channel:  "gas",
+			Usage:    "hot_water",
+			Period:   "year",
+			YearKind: "current",
+		}, 240.0)
+		semantic.ApplyEnergyFromRegister(EnergyMergeKey{
+			Channel: "electricity",
+			Usage:   "heating",
+			Period:  "day",
+		}, 1.25)
+		semantic.ApplyEnergyFromRegister(EnergyMergeKey{
+			Channel: "solar",
+			Usage:   "cooling",
+			Period:  "day",
+		}, 2.75)
+
+		request := graphqlclient.NewRequest(`
+			query {
+				energyTotals {
+					gas { dhw { today yearly } climate { today yearly } }
+					electric { dhw { today yearly } climate { today yearly } }
+					solar { dhw { today yearly } climate { today yearly } }
+				}
+			}
+		`)
+
+		var response struct {
+			EnergyTotals *struct {
+				Gas struct {
+					DHW struct {
+						Today  float64   `json:"today"`
+						Yearly []float64 `json:"yearly"`
+					} `json:"dhw"`
+					Climate struct {
+						Today  float64   `json:"today"`
+						Yearly []float64 `json:"yearly"`
+					} `json:"climate"`
+				} `json:"gas"`
+				Electric struct {
+					DHW struct {
+						Today  float64   `json:"today"`
+						Yearly []float64 `json:"yearly"`
+					} `json:"dhw"`
+					Climate struct {
+						Today  float64   `json:"today"`
+						Yearly []float64 `json:"yearly"`
+					} `json:"climate"`
+				} `json:"electric"`
+				Solar struct {
+					DHW struct {
+						Today  float64   `json:"today"`
+						Yearly []float64 `json:"yearly"`
+					} `json:"dhw"`
+					Climate struct {
+						Today  float64   `json:"today"`
+						Yearly []float64 `json:"yearly"`
+					} `json:"climate"`
+				} `json:"solar"`
+			} `json:"energyTotals"`
+		}
+
+		if err := client.Run(context.Background(), request, &response); err != nil {
+			t.Fatalf("energyTotals root query error = %v", err)
+		}
+		if response.EnergyTotals == nil {
+			t.Fatal("energyTotals = nil; want non-nil")
+		}
+		if response.EnergyTotals.Gas.DHW.Today != 3.5 {
+			t.Fatalf("gas.dhw.today = %v; want 3.5", response.EnergyTotals.Gas.DHW.Today)
+		}
+		if len(response.EnergyTotals.Gas.DHW.Yearly) != 2 || response.EnergyTotals.Gas.DHW.Yearly[0] != 120.0 || response.EnergyTotals.Gas.DHW.Yearly[1] != 240.0 {
+			t.Fatalf("gas.dhw.yearly = %#v; want [120 240]", response.EnergyTotals.Gas.DHW.Yearly)
+		}
+		if response.EnergyTotals.Electric.Climate.Today != 1.25 {
+			t.Fatalf("electric.climate.today = %v; want 1.25", response.EnergyTotals.Electric.Climate.Today)
+		}
+		if response.EnergyTotals.Solar.Climate.Today != 2.75 {
+			t.Fatalf("solar.climate.today = %v; want 2.75", response.EnergyTotals.Solar.Climate.Today)
 		}
 	})
 


### PR DESCRIPTION
## What
Adds the missing `energyTotals` root field to the GraphQL query surface.

## Why
`EnergyTotals` already exists in the canonical semantic model, MCP, and docs intent, but runtime GraphQL on `main` did not expose it at the query root. This PR closes that root-surface parity gap and adds tests that guard the query inventory.

## Changes
- adds `energyTotals` to `Query`
- adds query-root introspection coverage for the canonical semantic families published at GraphQL root
- adds a live `energyTotals` query test using the existing semantic energy merge path

## Validation
- `GOWORK=off go test -count=1 ./graphql -run TestQueryResolvers_Integration`
- `GOWORK=off go test -count=1 ./graphql ./mcp ./portal`

## Merge Gate
- blocked on companion docs PR `Project-Helianthus/helianthus-docs-ebus#176`

Closes #292
