### PR TITLE
Gateway parity: expose core families in Portal semantic snapshot

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -348,71 +348,14 @@ func startHTTPServer(ctx context.Context, cfg ebusgateway.Config, gateway *ebusg
 				if semanticProvider == nil {
 					return portal.SemanticSnapshot{}
 				}
-				zones := semanticProvider.Zones()
-				zoneItems := make([]portal.SemanticZone, 0, len(zones))
-				for _, zone := range zones {
-					zoneItems = append(zoneItems, portal.SemanticZone{
-						ID:   zone.ID,
-						Name: zone.Name,
-						State: portal.SemanticZoneState{
-							CurrentTempC:       zone.State.CurrentTempC,
-							CurrentHumidityPct: zone.State.CurrentHumidityPct,
-							HvacAction:         zone.State.HvacAction,
-							SpecialFunction:    zone.State.SpecialFunction,
-							HeatingDemandPct:   zone.State.HeatingDemandPct,
-							ValvePositionPct:   zone.State.ValvePositionPct,
-						},
-						Config: portal.SemanticZoneConfig{
-							OperatingMode:              zone.Config.OperatingMode,
-							Preset:                     zone.Config.Preset,
-							TargetTempC:                zone.Config.TargetTempC,
-							AllowedModes:               zone.Config.AllowedModes,
-							CircuitType:                zone.Config.CircuitType,
-							AssociatedCircuit:          zone.Config.AssociatedCircuit,
-							RoomTemperatureZoneMapping: zone.Config.RoomTemperatureZoneMapping,
-						},
-					})
-				}
-
-				var dhw *portal.SemanticDHW
-				if value := semanticProvider.DHW(); value != nil {
-					dhw = &portal.SemanticDHW{
-						State: portal.SemanticDhwState{
-							CurrentTempC:     value.State.CurrentTempC,
-							SpecialFunction:  value.State.SpecialFunction,
-							HeatingDemandPct: value.State.HeatingDemandPct,
-						},
-						Config: portal.SemanticDhwConfig{
-							OperatingMode: value.Config.OperatingMode,
-							Preset:        value.Config.Preset,
-							TargetTempC:   value.Config.TargetTempC,
-						},
-					}
-				}
-
-				var energy *portal.SemanticEnergyTotals
-				if value := semanticProvider.EnergyTotals(); value != nil {
-					energy = &portal.SemanticEnergyTotals{
-						Gas: portal.SemanticEnergyChannel{
-							DHW:     portal.SemanticEnergySeries{Today: value.Gas.DHW.Today, Yearly: append([]float64(nil), value.Gas.DHW.Yearly...)},
-							Climate: portal.SemanticEnergySeries{Today: value.Gas.Climate.Today, Yearly: append([]float64(nil), value.Gas.Climate.Yearly...)},
-						},
-						Electric: portal.SemanticEnergyChannel{
-							DHW:     portal.SemanticEnergySeries{Today: value.Electric.DHW.Today, Yearly: append([]float64(nil), value.Electric.DHW.Yearly...)},
-							Climate: portal.SemanticEnergySeries{Today: value.Electric.Climate.Today, Yearly: append([]float64(nil), value.Electric.Climate.Yearly...)},
-						},
-						Solar: portal.SemanticEnergyChannel{
-							DHW:     portal.SemanticEnergySeries{Today: value.Solar.DHW.Today, Yearly: append([]float64(nil), value.Solar.DHW.Yearly...)},
-							Climate: portal.SemanticEnergySeries{Today: value.Solar.Climate.Today, Yearly: append([]float64(nil), value.Solar.Climate.Yearly...)},
-						},
-					}
-				}
-
 				return portal.SemanticSnapshot{
-					Zones:       zoneItems,
-					DHW:         dhw,
-					Energy:      energy,
-					CapturedUTC: time.Now().UTC().Format(time.RFC3339),
+					Zones:        mapPortalZones(semanticProvider.Zones()),
+					DHW:          mapPortalDHW(semanticProvider.DHW()),
+					Energy:       mapPortalEnergyTotals(semanticProvider.EnergyTotals()),
+					BoilerStatus: mapPortalBoilerStatus(semanticProvider.BoilerStatus()),
+					System:       mapPortalSystemStatus(semanticProvider.System()),
+					Circuits:     mapPortalCircuits(semanticProvider.Circuits()),
+					CapturedUTC:  time.Now().UTC().Format(time.RFC3339),
 				}
 			},
 			ListProjections: func() []portal.ProjectionDevice {
@@ -539,4 +482,199 @@ func normalizeMountPath(path string, fallback string) string {
 		return fallback
 	}
 	return normalized
+}
+
+func mapPortalZones(zones []graphql.Zone) []portal.SemanticZone {
+	if len(zones) == 0 {
+		return nil
+	}
+	items := make([]portal.SemanticZone, 0, len(zones))
+	for _, zone := range zones {
+		items = append(items, portal.SemanticZone{
+			ID:   zone.ID,
+			Name: zone.Name,
+			State: portal.SemanticZoneState{
+				CurrentTempC:       cloneFloatPtr(zone.State.CurrentTempC),
+				CurrentHumidityPct: cloneFloatPtr(zone.State.CurrentHumidityPct),
+				HvacAction:         zone.State.HvacAction,
+				SpecialFunction:    zone.State.SpecialFunction,
+				HeatingDemandPct:   cloneFloatPtr(zone.State.HeatingDemandPct),
+				ValvePositionPct:   cloneFloatPtr(zone.State.ValvePositionPct),
+			},
+			Config: portal.SemanticZoneConfig{
+				OperatingMode:              zone.Config.OperatingMode,
+				Preset:                     zone.Config.Preset,
+				TargetTempC:                cloneFloatPtr(zone.Config.TargetTempC),
+				AllowedModes:               append([]string(nil), zone.Config.AllowedModes...),
+				CircuitType:                zone.Config.CircuitType,
+				AssociatedCircuit:          cloneIntPtr(zone.Config.AssociatedCircuit),
+				RoomTemperatureZoneMapping: cloneIntPtr(zone.Config.RoomTemperatureZoneMapping),
+			},
+		})
+	}
+	return items
+}
+
+func mapPortalDHW(status *graphql.DhwStatus) *portal.SemanticDHW {
+	if status == nil {
+		return nil
+	}
+	return &portal.SemanticDHW{
+		State: portal.SemanticDhwState{
+			CurrentTempC:     cloneFloatPtr(status.State.CurrentTempC),
+			SpecialFunction:  status.State.SpecialFunction,
+			HeatingDemandPct: cloneFloatPtr(status.State.HeatingDemandPct),
+		},
+		Config: portal.SemanticDhwConfig{
+			OperatingMode: status.Config.OperatingMode,
+			Preset:        status.Config.Preset,
+			TargetTempC:   cloneFloatPtr(status.Config.TargetTempC),
+		},
+	}
+}
+
+func mapPortalEnergyTotals(value *graphql.EnergyTotals) *portal.SemanticEnergyTotals {
+	if value == nil {
+		return nil
+	}
+	return &portal.SemanticEnergyTotals{
+		Gas:      mapPortalEnergyChannel(value.Gas),
+		Electric: mapPortalEnergyChannel(value.Electric),
+		Solar:    mapPortalEnergyChannel(value.Solar),
+	}
+}
+
+func mapPortalEnergyChannel(channel graphql.EnergyChannel) portal.SemanticEnergyChannel {
+	return portal.SemanticEnergyChannel{
+		DHW:     mapPortalEnergySeries(channel.DHW),
+		Climate: mapPortalEnergySeries(channel.Climate),
+	}
+}
+
+func mapPortalEnergySeries(series graphql.EnergySeries) portal.SemanticEnergySeries {
+	out := portal.SemanticEnergySeries{Today: series.Today}
+	if len(series.Yearly) > 0 {
+		out.Yearly = append([]float64(nil), series.Yearly...)
+	}
+	return out
+}
+
+func mapPortalBoilerStatus(status *graphql.BoilerStatus) *portal.SemanticBoilerStatus {
+	if status == nil {
+		return nil
+	}
+	return &portal.SemanticBoilerStatus{
+		State: portal.SemanticBoilerState{
+			FlowTemperatureC:         cloneFloatPtr(status.State.FlowTemperatureC),
+			ReturnTemperatureC:       cloneFloatPtr(status.State.ReturnTemperatureC),
+			CentralHeatingPumpActive: cloneBoolPtr(status.State.CentralHeatingPumpActive),
+			WaterPressureBar:         cloneFloatPtr(status.State.WaterPressureBar),
+			ExternalPumpActive:       cloneBoolPtr(status.State.ExternalPumpActive),
+			CirculationPumpActive:    cloneBoolPtr(status.State.CirculationPumpActive),
+			GasValveActive:           cloneBoolPtr(status.State.GasValveActive),
+			FlameActive:              cloneBoolPtr(status.State.FlameActive),
+			DiverterValvePositionPct: cloneFloatPtr(status.State.DiverterValvePositionPct),
+			FanSpeedRpm:              cloneIntPtr(status.State.FanSpeedRpm),
+			TargetFanSpeedRpm:        cloneIntPtr(status.State.TargetFanSpeedRpm),
+			IonisationVoltageUa:      cloneFloatPtr(status.State.IonisationVoltageUa),
+			DhwWaterFlowLpm:          cloneFloatPtr(status.State.DhwWaterFlowLpm),
+			DhwDemandActive:          cloneBoolPtr(status.State.DhwDemandActive),
+			HeatingSwitchActive:      cloneBoolPtr(status.State.HeatingSwitchActive),
+			StorageLoadPumpPct:       cloneFloatPtr(status.State.StorageLoadPumpPct),
+			ModulationPct:            cloneFloatPtr(status.State.ModulationPct),
+			PrimaryCircuitFlowLpm:    cloneFloatPtr(status.State.PrimaryCircuitFlowLpm),
+			FlowTempDesiredC:         cloneFloatPtr(status.State.FlowTempDesiredC),
+			DhwTempDesiredC:          cloneFloatPtr(status.State.DhwTempDesiredC),
+			StateNumber:              cloneIntPtr(status.State.StateNumber),
+			DhwTemperatureC:          cloneFloatPtr(status.State.DhwTemperatureC),
+			DhwTargetTemperatureC:    cloneFloatPtr(status.State.DhwTargetTemperatureC),
+		},
+		Config: portal.SemanticBoilerConfig{
+			DhwOperatingMode: cloneStringPtr(status.Config.DhwOperatingMode),
+			FlowsetHcMaxC:    cloneFloatPtr(status.Config.FlowsetHcMaxC),
+			FlowsetHwcMaxC:   cloneFloatPtr(status.Config.FlowsetHwcMaxC),
+			PartloadHcKW:     cloneFloatPtr(status.Config.PartloadHcKW),
+			PartloadHwcKW:    cloneFloatPtr(status.Config.PartloadHwcKW),
+		},
+		Diagnostics: portal.SemanticBoilerDiagnostics{
+			HeatingStatusRaw:         cloneIntPtr(status.Diagnostics.HeatingStatusRaw),
+			DhwStatusRaw:             cloneIntPtr(status.Diagnostics.DhwStatusRaw),
+			CentralHeatingHours:      cloneFloatPtr(status.Diagnostics.CentralHeatingHours),
+			DhwHours:                 cloneFloatPtr(status.Diagnostics.DhwHours),
+			CentralHeatingStarts:     cloneIntPtr(status.Diagnostics.CentralHeatingStarts),
+			DhwStarts:                cloneIntPtr(status.Diagnostics.DhwStarts),
+			PumpHours:                cloneFloatPtr(status.Diagnostics.PumpHours),
+			FanHours:                 cloneFloatPtr(status.Diagnostics.FanHours),
+			DeactivationsIFC:         cloneIntPtr(status.Diagnostics.DeactivationsIFC),
+			DeactivationsTemplimiter: cloneIntPtr(status.Diagnostics.DeactivationsTemplimiter),
+		},
+	}
+}
+
+func mapPortalSystemStatus(status *graphql.SystemStatus) *portal.SemanticSystemStatus {
+	if status == nil {
+		return nil
+	}
+	return &portal.SemanticSystemStatus{
+		State: portal.SemanticSystemState{
+			SystemOff:                    cloneBoolPtr(status.State.SystemOff),
+			SystemWaterPressure:          cloneFloatPtr(status.State.SystemWaterPressure),
+			SystemFlowTemperature:        cloneFloatPtr(status.State.SystemFlowTemperature),
+			OutdoorTemperature:           cloneFloatPtr(status.State.OutdoorTemperature),
+			OutdoorTemperatureAvg24h:     cloneFloatPtr(status.State.OutdoorTemperatureAvg24h),
+			MaintenanceDue:               cloneBoolPtr(status.State.MaintenanceDue),
+			HwcCylinderTemperatureTop:    cloneFloatPtr(status.State.HwcCylinderTemperatureTop),
+			HwcCylinderTemperatureBottom: cloneFloatPtr(status.State.HwcCylinderTemperatureBottom),
+		},
+		Config: portal.SemanticSystemConfig{
+			AdaptiveHeatingCurve:         cloneBoolPtr(status.Config.AdaptiveHeatingCurve),
+			AlternativePoint:             cloneFloatPtr(status.Config.AlternativePoint),
+			HeatingCircuitBivalencePoint: cloneFloatPtr(status.Config.HeatingCircuitBivalencePoint),
+			DhwBivalencePoint:            cloneFloatPtr(status.Config.DhwBivalencePoint),
+			HcEmergencyTemperature:       cloneFloatPtr(status.Config.HcEmergencyTemperature),
+			HwcMaxFlowTempDesired:        cloneFloatPtr(status.Config.HwcMaxFlowTempDesired),
+			MaxRoomHumidity:              cloneIntPtr(status.Config.MaxRoomHumidity),
+		},
+		Properties: portal.SemanticSystemProperties{
+			SystemScheme:            cloneIntPtr(status.Properties.SystemScheme),
+			ModuleConfigurationVR71: cloneIntPtr(status.Properties.ModuleConfigurationVR71),
+			Vr71CircuitStartIndex:   cloneIntPtr(status.Properties.Vr71CircuitStartIndex),
+		},
+	}
+}
+
+func mapPortalCircuits(circuits []graphql.CircuitStatus) []portal.SemanticCircuit {
+	if len(circuits) == 0 {
+		return nil
+	}
+	items := make([]portal.SemanticCircuit, 0, len(circuits))
+	for _, circuit := range circuits {
+		items = append(items, portal.SemanticCircuit{
+			Index:       circuit.Index,
+			CircuitType: circuit.CircuitType,
+			HasMixer:    circuit.HasMixer,
+			State: portal.SemanticCircuitState{
+				PumpActive:       cloneBoolPtr(circuit.State.PumpActive),
+				MixerPositionPct: cloneFloatPtr(circuit.State.MixerPositionPct),
+				FlowTemperatureC: cloneFloatPtr(circuit.State.FlowTemperatureC),
+				FlowSetpointC:    cloneFloatPtr(circuit.State.FlowSetpointC),
+				CalcFlowTempC:    cloneFloatPtr(circuit.State.CalcFlowTempC),
+				CircuitState:     circuit.State.CircuitState,
+				Humidity:         cloneFloatPtr(circuit.State.Humidity),
+				DewPoint:         cloneFloatPtr(circuit.State.DewPoint),
+				PumpHours:        cloneFloatPtr(circuit.State.PumpHours),
+				PumpStarts:       cloneIntPtr(circuit.State.PumpStarts),
+			},
+			Config: portal.SemanticCircuitConfig{
+				HeatingCurve:    cloneFloatPtr(circuit.Config.HeatingCurve),
+				FlowTempMaxC:    cloneFloatPtr(circuit.Config.FlowTempMaxC),
+				FlowTempMinC:    cloneFloatPtr(circuit.Config.FlowTempMinC),
+				SummerLimitC:    cloneFloatPtr(circuit.Config.SummerLimitC),
+				FrostProtC:      cloneFloatPtr(circuit.Config.FrostProtC),
+				RoomTempControl: circuit.Config.RoomTempControl,
+				CoolingEnabled:  cloneBoolPtr(circuit.Config.CoolingEnabled),
+			},
+		})
+	}
+	return items
 }

--- a/portal/handler.go
+++ b/portal/handler.go
@@ -90,10 +90,13 @@ type RegistryPlane struct {
 }
 
 type SemanticSnapshot struct {
-	Zones       []SemanticZone        `json:"zones"`
-	DHW         *SemanticDHW          `json:"dhw,omitempty"`
-	Energy      *SemanticEnergyTotals `json:"energy_totals,omitempty"`
-	CapturedUTC string                `json:"captured_utc"`
+	Zones        []SemanticZone        `json:"zones"`
+	DHW          *SemanticDHW          `json:"dhw,omitempty"`
+	Energy       *SemanticEnergyTotals `json:"energy_totals,omitempty"`
+	BoilerStatus *SemanticBoilerStatus `json:"boiler_status,omitempty"`
+	System       *SemanticSystemStatus `json:"system,omitempty"`
+	Circuits     []SemanticCircuit     `json:"circuits,omitempty"`
+	CapturedUTC  string                `json:"captured_utc"`
 }
 
 type SemanticZoneState struct {
@@ -153,6 +156,123 @@ type SemanticEnergyChannel struct {
 type SemanticEnergySeries struct {
 	Today  float64   `json:"today"`
 	Yearly []float64 `json:"yearly,omitempty"`
+}
+
+type SemanticBoilerState struct {
+	FlowTemperatureC         *float64 `json:"flow_temperature_c,omitempty"`
+	ReturnTemperatureC       *float64 `json:"return_temperature_c,omitempty"`
+	CentralHeatingPumpActive *bool    `json:"central_heating_pump_active,omitempty"`
+	WaterPressureBar         *float64 `json:"water_pressure_bar,omitempty"`
+	ExternalPumpActive       *bool    `json:"external_pump_active,omitempty"`
+	CirculationPumpActive    *bool    `json:"circulation_pump_active,omitempty"`
+	GasValveActive           *bool    `json:"gas_valve_active,omitempty"`
+	FlameActive              *bool    `json:"flame_active,omitempty"`
+	DiverterValvePositionPct *float64 `json:"diverter_valve_position_pct,omitempty"`
+	FanSpeedRpm              *int     `json:"fan_speed_rpm,omitempty"`
+	TargetFanSpeedRpm        *int     `json:"target_fan_speed_rpm,omitempty"`
+	IonisationVoltageUa      *float64 `json:"ionisation_voltage_ua,omitempty"`
+	DhwWaterFlowLpm          *float64 `json:"dhw_water_flow_lpm,omitempty"`
+	DhwDemandActive          *bool    `json:"dhw_demand_active,omitempty"`
+	HeatingSwitchActive      *bool    `json:"heating_switch_active,omitempty"`
+	StorageLoadPumpPct       *float64 `json:"storage_load_pump_pct,omitempty"`
+	ModulationPct            *float64 `json:"modulation_pct,omitempty"`
+	PrimaryCircuitFlowLpm    *float64 `json:"primary_circuit_flow_lpm,omitempty"`
+	FlowTempDesiredC         *float64 `json:"flow_temp_desired_c,omitempty"`
+	DhwTempDesiredC          *float64 `json:"dhw_temp_desired_c,omitempty"`
+	StateNumber              *int     `json:"state_number,omitempty"`
+	DhwTemperatureC          *float64 `json:"dhw_temperature_c,omitempty"`
+	DhwTargetTemperatureC    *float64 `json:"dhw_target_temperature_c,omitempty"`
+}
+
+type SemanticBoilerConfig struct {
+	DhwOperatingMode *string  `json:"dhw_operating_mode,omitempty"`
+	FlowsetHcMaxC    *float64 `json:"flowset_hc_max_c,omitempty"`
+	FlowsetHwcMaxC   *float64 `json:"flowset_hwc_max_c,omitempty"`
+	PartloadHcKW     *float64 `json:"partload_hc_kw,omitempty"`
+	PartloadHwcKW    *float64 `json:"partload_hwc_kw,omitempty"`
+}
+
+type SemanticBoilerDiagnostics struct {
+	HeatingStatusRaw         *int     `json:"heating_status_raw,omitempty"`
+	DhwStatusRaw             *int     `json:"dhw_status_raw,omitempty"`
+	CentralHeatingHours      *float64 `json:"central_heating_hours,omitempty"`
+	DhwHours                 *float64 `json:"dhw_hours,omitempty"`
+	CentralHeatingStarts     *int     `json:"central_heating_starts,omitempty"`
+	DhwStarts                *int     `json:"dhw_starts,omitempty"`
+	PumpHours                *float64 `json:"pump_hours,omitempty"`
+	FanHours                 *float64 `json:"fan_hours,omitempty"`
+	DeactivationsIFC         *int     `json:"deactivations_ifc,omitempty"`
+	DeactivationsTemplimiter *int     `json:"deactivations_templimiter,omitempty"`
+}
+
+type SemanticBoilerStatus struct {
+	State       SemanticBoilerState       `json:"state"`
+	Config      SemanticBoilerConfig      `json:"config"`
+	Diagnostics SemanticBoilerDiagnostics `json:"diagnostics"`
+}
+
+type SemanticSystemState struct {
+	SystemOff                    *bool    `json:"system_off,omitempty"`
+	SystemWaterPressure          *float64 `json:"system_water_pressure,omitempty"`
+	SystemFlowTemperature        *float64 `json:"system_flow_temperature,omitempty"`
+	OutdoorTemperature           *float64 `json:"outdoor_temperature,omitempty"`
+	OutdoorTemperatureAvg24h     *float64 `json:"outdoor_temperature_avg24h,omitempty"`
+	MaintenanceDue               *bool    `json:"maintenance_due,omitempty"`
+	HwcCylinderTemperatureTop    *float64 `json:"hwc_cylinder_temperature_top,omitempty"`
+	HwcCylinderTemperatureBottom *float64 `json:"hwc_cylinder_temperature_bottom,omitempty"`
+}
+
+type SemanticSystemConfig struct {
+	AdaptiveHeatingCurve         *bool    `json:"adaptive_heating_curve,omitempty"`
+	AlternativePoint             *float64 `json:"alternative_point,omitempty"`
+	HeatingCircuitBivalencePoint *float64 `json:"heating_circuit_bivalence_point,omitempty"`
+	DhwBivalencePoint            *float64 `json:"dhw_bivalence_point,omitempty"`
+	HcEmergencyTemperature       *float64 `json:"hc_emergency_temperature,omitempty"`
+	HwcMaxFlowTempDesired        *float64 `json:"hwc_max_flow_temp_desired,omitempty"`
+	MaxRoomHumidity              *int     `json:"max_room_humidity,omitempty"`
+}
+
+type SemanticSystemProperties struct {
+	SystemScheme            *int `json:"system_scheme,omitempty"`
+	ModuleConfigurationVR71 *int `json:"module_configuration_vr71,omitempty"`
+	Vr71CircuitStartIndex   *int `json:"vr71_circuit_start_index,omitempty"`
+}
+
+type SemanticSystemStatus struct {
+	State      SemanticSystemState      `json:"state"`
+	Config     SemanticSystemConfig     `json:"config"`
+	Properties SemanticSystemProperties `json:"properties"`
+}
+
+type SemanticCircuitState struct {
+	PumpActive       *bool    `json:"pump_active,omitempty"`
+	MixerPositionPct *float64 `json:"mixer_position_pct,omitempty"`
+	FlowTemperatureC *float64 `json:"flow_temperature_c,omitempty"`
+	FlowSetpointC    *float64 `json:"flow_setpoint_c,omitempty"`
+	CalcFlowTempC    *float64 `json:"calc_flow_temp_c,omitempty"`
+	CircuitState     string   `json:"circuit_state,omitempty"`
+	Humidity         *float64 `json:"humidity,omitempty"`
+	DewPoint         *float64 `json:"dew_point,omitempty"`
+	PumpHours        *float64 `json:"pump_hours,omitempty"`
+	PumpStarts       *int     `json:"pump_starts,omitempty"`
+}
+
+type SemanticCircuitConfig struct {
+	HeatingCurve    *float64 `json:"heating_curve,omitempty"`
+	FlowTempMaxC    *float64 `json:"flow_temp_max_c,omitempty"`
+	FlowTempMinC    *float64 `json:"flow_temp_min_c,omitempty"`
+	SummerLimitC    *float64 `json:"summer_limit_c,omitempty"`
+	FrostProtC      *float64 `json:"frost_prot_c,omitempty"`
+	RoomTempControl string   `json:"room_temp_control,omitempty"`
+	CoolingEnabled  *bool    `json:"cooling_enabled,omitempty"`
+}
+
+type SemanticCircuit struct {
+	Index       int                   `json:"index"`
+	CircuitType string                `json:"circuit_type,omitempty"`
+	HasMixer    bool                  `json:"has_mixer"`
+	State       SemanticCircuitState  `json:"state"`
+	Config      SemanticCircuitConfig `json:"config"`
 }
 
 type ProjectionDevice struct {

--- a/portal/handler_test.go
+++ b/portal/handler_test.go
@@ -370,14 +370,68 @@ func TestRegistryDevicesEndpoint_Filter(t *testing.T) {
 
 func TestSemanticSnapshotEndpoint(t *testing.T) {
 	current := 43.5
+	target := 45.0
+	flowTemperature := 54.2
+	dhwOperatingMode := "auto"
+	systemFlowTemperature := 31.4
+	adaptiveHeatingCurve := true
+	systemScheme := 8
+	pumpActive := true
+	flowSetpoint := 35.0
+	heatingCurve := 0.8
 	h := NewHandler(Options{
 		ListSemantic: func() SemanticSnapshot {
 			return SemanticSnapshot{
 				Zones: []SemanticZone{
-					{ID: "zone_1", Name: "Living", State: SemanticZoneState{CurrentTempC: &current}},
+					{
+						ID:   "zone_1",
+						Name: "Living",
+						State: SemanticZoneState{
+							CurrentTempC: &current,
+						},
+						Config: SemanticZoneConfig{
+							TargetTempC: &target,
+						},
+					},
 				},
 				DHW: &SemanticDHW{
+					State: SemanticDhwState{
+						CurrentTempC: &current,
+					},
 					Config: SemanticDhwConfig{OperatingMode: "auto"},
+				},
+				BoilerStatus: &SemanticBoilerStatus{
+					State: SemanticBoilerState{
+						FlowTemperatureC: &flowTemperature,
+					},
+					Config: SemanticBoilerConfig{
+						DhwOperatingMode: &dhwOperatingMode,
+					},
+				},
+				System: &SemanticSystemStatus{
+					State: SemanticSystemState{
+						SystemFlowTemperature: &systemFlowTemperature,
+					},
+					Config: SemanticSystemConfig{
+						AdaptiveHeatingCurve: &adaptiveHeatingCurve,
+					},
+					Properties: SemanticSystemProperties{
+						SystemScheme: &systemScheme,
+					},
+				},
+				Circuits: []SemanticCircuit{
+					{
+						Index:       1,
+						CircuitType: "DIRECT",
+						HasMixer:    false,
+						State: SemanticCircuitState{
+							PumpActive:    &pumpActive,
+							FlowSetpointC: &flowSetpoint,
+						},
+						Config: SemanticCircuitConfig{
+							HeatingCurve: &heatingCurve,
+						},
+					},
 				},
 				CapturedUTC: "2026-02-23T22:00:00Z",
 			}
@@ -400,6 +454,74 @@ func TestSemanticSnapshotEndpoint(t *testing.T) {
 	zones := payload["zones"].([]any)
 	if len(zones) != 1 {
 		t.Fatalf("zones=%d; want 1", len(zones))
+	}
+	zone := zones[0].(map[string]any)
+	if zone["name"] != "Living" {
+		t.Fatalf("zone.name=%v; want Living", zone["name"])
+	}
+	zoneState := zone["state"].(map[string]any)
+	if zoneState["current_temp_c"] != current {
+		t.Fatalf("zone.state.current_temp_c=%v; want %v", zoneState["current_temp_c"], current)
+	}
+	zoneConfig := zone["config"].(map[string]any)
+	if zoneConfig["target_temp_c"] != target {
+		t.Fatalf("zone.config.target_temp_c=%v; want %v", zoneConfig["target_temp_c"], target)
+	}
+	dhw := payload["dhw"].(map[string]any)
+	dhwState := dhw["state"].(map[string]any)
+	if dhwState["current_temp_c"] != current {
+		t.Fatalf("dhw.state.current_temp_c=%v; want %v", dhwState["current_temp_c"], current)
+	}
+	dhwConfig := dhw["config"].(map[string]any)
+	if dhwConfig["operating_mode"] != "auto" {
+		t.Fatalf("dhw.config.operating_mode=%v; want auto", dhwConfig["operating_mode"])
+	}
+	boiler := payload["boiler_status"].(map[string]any)
+	boilerState := boiler["state"].(map[string]any)
+	if boilerState["flow_temperature_c"] != flowTemperature {
+		t.Fatalf("boiler.state.flow_temperature_c=%v; want %v", boilerState["flow_temperature_c"], flowTemperature)
+	}
+	boilerConfig := boiler["config"].(map[string]any)
+	if boilerConfig["dhw_operating_mode"] != dhwOperatingMode {
+		t.Fatalf("boiler.config.dhw_operating_mode=%v; want %v", boilerConfig["dhw_operating_mode"], dhwOperatingMode)
+	}
+	system := payload["system"].(map[string]any)
+	systemState := system["state"].(map[string]any)
+	if systemState["system_flow_temperature"] != systemFlowTemperature {
+		t.Fatalf("system.state.system_flow_temperature=%v; want %v", systemState["system_flow_temperature"], systemFlowTemperature)
+	}
+	systemConfig := system["config"].(map[string]any)
+	if systemConfig["adaptive_heating_curve"] != adaptiveHeatingCurve {
+		t.Fatalf("system.config.adaptive_heating_curve=%v; want %v", systemConfig["adaptive_heating_curve"], adaptiveHeatingCurve)
+	}
+	systemProperties := system["properties"].(map[string]any)
+	if int(systemProperties["system_scheme"].(float64)) != systemScheme {
+		t.Fatalf("system.properties.system_scheme=%v; want %d", systemProperties["system_scheme"], systemScheme)
+	}
+	circuits := payload["circuits"].([]any)
+	if len(circuits) != 1 {
+		t.Fatalf("circuits=%d; want 1", len(circuits))
+	}
+	circuit := circuits[0].(map[string]any)
+	if int(circuit["index"].(float64)) != 1 {
+		t.Fatalf("circuit.index=%v; want 1", circuit["index"])
+	}
+	if circuit["circuit_type"] != "DIRECT" {
+		t.Fatalf("circuit.circuit_type=%v; want DIRECT", circuit["circuit_type"])
+	}
+	if circuit["has_mixer"] != false {
+		t.Fatalf("circuit.has_mixer=%v; want false", circuit["has_mixer"])
+	}
+	circuitState := circuit["state"].(map[string]any)
+	if circuitState["pump_active"] != pumpActive {
+		t.Fatalf("circuit.state.pump_active=%v; want %v", circuitState["pump_active"], pumpActive)
+	}
+	if circuitState["flow_setpoint_c"] != flowSetpoint {
+		t.Fatalf("circuit.state.flow_setpoint_c=%v; want %v", circuitState["flow_setpoint_c"], flowSetpoint)
+	}
+	circuitConfig := circuit["config"].(map[string]any)
+	if circuitConfig["heating_curve"] != heatingCurve {
+		t.Fatalf("circuit.config.heating_curve=%v; want %v", circuitConfig["heating_curve"], heatingCurve)
 	}
 }
 


### PR DESCRIPTION
## Summary
- extend `/portal/api/v1/semantic/snapshot` with `boiler_status`, `system`, and `circuits`
- keep Portal snapshot aligned with the canonical nested semantic contract
- add endpoint coverage for the new nested JSON shape in portal handler tests

## Testing
- `GOWORK=off go test -count=1 ./portal -run 'TestSemanticSnapshotEndpoint|TestSemanticSnapshotEndpoint_DefaultWhenMissingProvider'`
- `GOWORK=off go test -count=1 ./graphql ./mcp ./portal`

## Docs
- companion docs PR: Project-Helianthus/helianthus-docs-ebus#178

Closes #282
