### PR TITLE
Gateway parity: expose extension families in Portal semantic snapshot

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -355,6 +355,10 @@ func startHTTPServer(ctx context.Context, cfg ebusgateway.Config, gateway *ebusg
 					BoilerStatus: mapPortalBoilerStatus(semanticProvider.BoilerStatus()),
 					System:       mapPortalSystemStatus(semanticProvider.System()),
 					Circuits:     mapPortalCircuits(semanticProvider.Circuits()),
+					RadioDevices: mapPortalRadioDevices(semanticProvider.RadioDevices()),
+					FM5Mode:      string(semanticProvider.FM5SemanticMode()),
+					Solar:        mapPortalSolarStatus(semanticProvider.Solar()),
+					Cylinders:    mapPortalCylinders(semanticProvider.Cylinders()),
 					CapturedUTC:  time.Now().UTC().Format(time.RFC3339),
 				}
 			},
@@ -674,6 +678,64 @@ func mapPortalCircuits(circuits []graphql.CircuitStatus) []portal.SemanticCircui
 				RoomTempControl: circuit.Config.RoomTempControl,
 				CoolingEnabled:  cloneBoolPtr(circuit.Config.CoolingEnabled),
 			},
+		})
+	}
+	return items
+}
+
+func mapPortalRadioDevices(devices []graphql.RadioDevice) []portal.SemanticRadioDevice {
+	if len(devices) == 0 {
+		return nil
+	}
+	items := make([]portal.SemanticRadioDevice, 0, len(devices))
+	for _, device := range devices {
+		items = append(items, portal.SemanticRadioDevice{
+			Group:                device.Group,
+			Instance:             device.Instance,
+			SlotMode:             device.SlotMode,
+			DeviceConnected:      cloneBoolPtr(device.DeviceConnected),
+			DeviceClassAddress:   cloneIntPtr(device.DeviceClassAddress),
+			DeviceModel:          device.DeviceModel,
+			FirmwareVersion:      cloneStringPtr(device.FirmwareVersion),
+			HardwareIdentifier:   cloneIntPtr(device.HardwareIdentifier),
+			RemoteControlAddress: cloneIntPtr(device.RemoteControlAddress),
+			DevicePaired:         cloneBoolPtr(device.DevicePaired),
+			ReceptionStrength:    cloneIntPtr(device.ReceptionStrength),
+			ZoneAssignment:       cloneIntPtr(device.ZoneAssignment),
+			RoomTemperatureC:     cloneFloatPtr(device.RoomTemperatureC),
+			RoomHumidityPct:      cloneFloatPtr(device.RoomHumidityPct),
+		})
+	}
+	return items
+}
+
+func mapPortalSolarStatus(status *graphql.SolarStatus) *portal.SemanticSolarStatus {
+	if status == nil {
+		return nil
+	}
+	return &portal.SemanticSolarStatus{
+		CollectorTemperatureC: cloneFloatPtr(status.CollectorTemperatureC),
+		ReturnTemperatureC:    cloneFloatPtr(status.ReturnTemperatureC),
+		PumpActive:            cloneBoolPtr(status.PumpActive),
+		CurrentYield:          cloneFloatPtr(status.CurrentYield),
+		PumpHours:             cloneFloatPtr(status.PumpHours),
+		SolarEnabled:          cloneBoolPtr(status.SolarEnabled),
+		FunctionMode:          cloneBoolPtr(status.FunctionMode),
+	}
+}
+
+func mapPortalCylinders(cylinders []graphql.CylinderStatus) []portal.SemanticCylinder {
+	if len(cylinders) == 0 {
+		return nil
+	}
+	items := make([]portal.SemanticCylinder, 0, len(cylinders))
+	for _, cylinder := range cylinders {
+		items = append(items, portal.SemanticCylinder{
+			Index:             cylinder.Index,
+			TemperatureC:      cloneFloatPtr(cylinder.TemperatureC),
+			MaxSetpointC:      cloneFloatPtr(cylinder.MaxSetpointC),
+			ChargeHysteresisC: cloneFloatPtr(cylinder.ChargeHysteresisC),
+			ChargeOffsetC:     cloneFloatPtr(cylinder.ChargeOffsetC),
 		})
 	}
 	return items

--- a/portal/handler.go
+++ b/portal/handler.go
@@ -96,6 +96,10 @@ type SemanticSnapshot struct {
 	BoilerStatus *SemanticBoilerStatus `json:"boiler_status,omitempty"`
 	System       *SemanticSystemStatus `json:"system,omitempty"`
 	Circuits     []SemanticCircuit     `json:"circuits,omitempty"`
+	RadioDevices []SemanticRadioDevice `json:"radio_devices,omitempty"`
+	FM5Mode      string                `json:"fm5_semantic_mode,omitempty"`
+	Solar        *SemanticSolarStatus  `json:"solar,omitempty"`
+	Cylinders    []SemanticCylinder    `json:"cylinders,omitempty"`
 	CapturedUTC  string                `json:"captured_utc"`
 }
 
@@ -273,6 +277,41 @@ type SemanticCircuit struct {
 	HasMixer    bool                  `json:"has_mixer"`
 	State       SemanticCircuitState  `json:"state"`
 	Config      SemanticCircuitConfig `json:"config"`
+}
+
+type SemanticRadioDevice struct {
+	Group                int      `json:"group"`
+	Instance             int      `json:"instance"`
+	SlotMode             string   `json:"slot_mode,omitempty"`
+	DeviceConnected      *bool    `json:"device_connected,omitempty"`
+	DeviceClassAddress   *int     `json:"device_class_address,omitempty"`
+	DeviceModel          string   `json:"device_model,omitempty"`
+	FirmwareVersion      *string  `json:"firmware_version,omitempty"`
+	HardwareIdentifier   *int     `json:"hardware_identifier,omitempty"`
+	RemoteControlAddress *int     `json:"remote_control_address,omitempty"`
+	DevicePaired         *bool    `json:"device_paired,omitempty"`
+	ReceptionStrength    *int     `json:"reception_strength,omitempty"`
+	ZoneAssignment       *int     `json:"zone_assignment,omitempty"`
+	RoomTemperatureC     *float64 `json:"room_temperature_c,omitempty"`
+	RoomHumidityPct      *float64 `json:"room_humidity_pct,omitempty"`
+}
+
+type SemanticSolarStatus struct {
+	CollectorTemperatureC *float64 `json:"collector_temperature_c,omitempty"`
+	ReturnTemperatureC    *float64 `json:"return_temperature_c,omitempty"`
+	PumpActive            *bool    `json:"pump_active,omitempty"`
+	CurrentYield          *float64 `json:"current_yield,omitempty"`
+	PumpHours             *float64 `json:"pump_hours,omitempty"`
+	SolarEnabled          *bool    `json:"solar_enabled,omitempty"`
+	FunctionMode          *bool    `json:"function_mode,omitempty"`
+}
+
+type SemanticCylinder struct {
+	Index             int      `json:"index"`
+	TemperatureC      *float64 `json:"temperature_c,omitempty"`
+	MaxSetpointC      *float64 `json:"max_setpoint_c,omitempty"`
+	ChargeHysteresisC *float64 `json:"charge_hysteresis_c,omitempty"`
+	ChargeOffsetC     *float64 `json:"charge_offset_c,omitempty"`
 }
 
 type ProjectionDevice struct {

--- a/portal/handler_test.go
+++ b/portal/handler_test.go
@@ -543,6 +543,121 @@ func TestSemanticSnapshotEndpoint_DefaultWhenMissingProvider(t *testing.T) {
 	}
 }
 
+func TestSemanticSnapshotEndpoint_ExtensionFamilies(t *testing.T) {
+	deviceConnected := true
+	devicePaired := true
+	deviceClassAddress := 0x15
+	firmwareVersion := "09.03"
+	hardwareIdentifier := 4711
+	remoteControlAddress := 0x01
+	receptionStrength := 88
+	zoneAssignment := 2
+	roomTemperature := 22.5
+	roomHumidity := 44.0
+	solarCollectorTemperature := 62.5
+	solarReturnTemperature := 45.1
+	solarPumpActive := true
+	solarYield := 3.4
+	solarPumpHours := 104.0
+	solarEnabled := true
+	solarFunctionMode := false
+	cylinderTemperature := 49.5
+	cylinderMaxSetpoint := 59.0
+	cylinderChargeHysteresis := 5.0
+	cylinderChargeOffset := 2.0
+
+	h := NewHandler(Options{
+		ListSemantic: func() SemanticSnapshot {
+			return SemanticSnapshot{
+				RadioDevices: []SemanticRadioDevice{
+					{
+						Group:                0,
+						Instance:             1,
+						SlotMode:             "THERMOSTAT",
+						DeviceConnected:      &deviceConnected,
+						DeviceClassAddress:   &deviceClassAddress,
+						DeviceModel:          "VR92",
+						FirmwareVersion:      &firmwareVersion,
+						HardwareIdentifier:   &hardwareIdentifier,
+						RemoteControlAddress: &remoteControlAddress,
+						DevicePaired:         &devicePaired,
+						ReceptionStrength:    &receptionStrength,
+						ZoneAssignment:       &zoneAssignment,
+						RoomTemperatureC:     &roomTemperature,
+						RoomHumidityPct:      &roomHumidity,
+					},
+				},
+				FM5Mode: "INTERPRETED",
+				Solar: &SemanticSolarStatus{
+					CollectorTemperatureC: &solarCollectorTemperature,
+					ReturnTemperatureC:    &solarReturnTemperature,
+					PumpActive:            &solarPumpActive,
+					CurrentYield:          &solarYield,
+					PumpHours:             &solarPumpHours,
+					SolarEnabled:          &solarEnabled,
+					FunctionMode:          &solarFunctionMode,
+				},
+				Cylinders: []SemanticCylinder{
+					{
+						Index:             1,
+						TemperatureC:      &cylinderTemperature,
+						MaxSetpointC:      &cylinderMaxSetpoint,
+						ChargeHysteresisC: &cylinderChargeHysteresis,
+						ChargeOffsetC:     &cylinderChargeOffset,
+					},
+				},
+				CapturedUTC: "2026-02-23T22:05:00Z",
+			}
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/semantic/snapshot", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d; want %d", rec.Code, http.StatusOK)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if payload["fm5_semantic_mode"] != "INTERPRETED" {
+		t.Fatalf("fm5_semantic_mode=%v; want INTERPRETED", payload["fm5_semantic_mode"])
+	}
+	radioDevices := payload["radio_devices"].([]any)
+	if len(radioDevices) != 1 {
+		t.Fatalf("radio_devices=%d; want 1", len(radioDevices))
+	}
+	radio := radioDevices[0].(map[string]any)
+	if radio["device_model"] != "VR92" {
+		t.Fatalf("radio.device_model=%v; want VR92", radio["device_model"])
+	}
+	if radio["slot_mode"] != "THERMOSTAT" {
+		t.Fatalf("radio.slot_mode=%v; want THERMOSTAT", radio["slot_mode"])
+	}
+	if int(radio["zone_assignment"].(float64)) != zoneAssignment {
+		t.Fatalf("radio.zone_assignment=%v; want %d", radio["zone_assignment"], zoneAssignment)
+	}
+	solar := payload["solar"].(map[string]any)
+	if solar["collector_temperature_c"] != solarCollectorTemperature {
+		t.Fatalf("solar.collector_temperature_c=%v; want %v", solar["collector_temperature_c"], solarCollectorTemperature)
+	}
+	if solar["pump_active"] != solarPumpActive {
+		t.Fatalf("solar.pump_active=%v; want %v", solar["pump_active"], solarPumpActive)
+	}
+	cylinders := payload["cylinders"].([]any)
+	if len(cylinders) != 1 {
+		t.Fatalf("cylinders=%d; want 1", len(cylinders))
+	}
+	cylinder := cylinders[0].(map[string]any)
+	if int(cylinder["index"].(float64)) != 1 {
+		t.Fatalf("cylinder.index=%v; want 1", cylinder["index"])
+	}
+	if cylinder["temperature_c"] != cylinderTemperature {
+		t.Fatalf("cylinder.temperature_c=%v; want %v", cylinder["temperature_c"], cylinderTemperature)
+	}
+}
+
 func TestProjectionDevicesEndpoint(t *testing.T) {
 	h := NewHandler(Options{
 		ListProjections: func() []ProjectionDevice {


### PR DESCRIPTION
## Summary
- extend `/portal/api/v1/semantic/snapshot` with `radio_devices`, `fm5_semantic_mode`, `solar`, and `cylinders`
- keep Portal snapshot aligned with the remaining extension families already exposed by GraphQL and MCP
- add handler coverage for the extension-family JSON shape

## Testing
- `GOWORK=off go test -count=1 ./portal -run 'TestSemanticSnapshotEndpoint|TestSemanticSnapshotEndpoint_DefaultWhenMissingProvider|TestSemanticSnapshotEndpoint_ExtensionFamilies'`
- `GOWORK=off go test -count=1 ./graphql ./mcp ./portal`

## Docs
- companion docs PR: Project-Helianthus/helianthus-docs-ebus#180

Closes #291
