### PR TITLE
Gateway parity: extend Portal semantic search and energy history

### DIFF
--- a/portal/handler.go
+++ b/portal/handler.go
@@ -1319,6 +1319,7 @@ func (h *handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 		}
 		if snapshot.DHW != nil && strings.Contains(strings.ToLower(strings.Join([]string{
 			"dhw",
+			"domestic hot water",
 			snapshot.DHW.Config.OperatingMode,
 			snapshot.DHW.Config.Preset,
 		}, " ")), needle) {
@@ -1328,6 +1329,100 @@ func (h *handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 				ID:       "dhw",
 				Title:    "Domestic Hot Water",
 				Subtitle: strings.TrimSpace(strings.Join([]string{snapshot.DHW.Config.OperatingMode, snapshot.DHW.Config.Preset}, " / ")),
+			})
+		}
+		if snapshot.Energy != nil && semanticSearchMatch(needle, "energy", "gas", "electric", "solar", "dhw", "climate") {
+			appendResult(SearchResult{
+				Layer:    "semantic",
+				Kind:     "energy",
+				ID:       "energy",
+				Title:    "Energy Totals",
+				Subtitle: "gas / electric / solar",
+			})
+		}
+		if snapshot.BoilerStatus != nil && semanticSearchMatch(needle, "boiler", derefString(snapshot.BoilerStatus.Config.DhwOperatingMode)) {
+			appendResult(SearchResult{
+				Layer:    "semantic",
+				Kind:     "boiler",
+				ID:       "boiler",
+				Title:    "Boiler",
+				Subtitle: strings.TrimSpace(strings.Join([]string{"dhw_mode=" + defaultText(derefString(snapshot.BoilerStatus.Config.DhwOperatingMode), "n/a")}, "")),
+			})
+		}
+		if snapshot.System != nil && semanticSearchMatch(needle, "system", semanticIntString(snapshot.System.Properties.SystemScheme), semanticIntString(snapshot.System.Properties.ModuleConfigurationVR71)) {
+			appendResult(SearchResult{
+				Layer:    "semantic",
+				Kind:     "system",
+				ID:       "system",
+				Title:    "System",
+				Subtitle: fmt.Sprintf("scheme=%s", defaultText(semanticIntString(snapshot.System.Properties.SystemScheme), "n/a")),
+			})
+		}
+		for _, circuit := range snapshot.Circuits {
+			if !semanticSearchMatch(needle, "circuit", semanticInt(circuit.Index), circuit.CircuitType, circuit.State.CircuitState, circuit.Config.RoomTempControl) {
+				continue
+			}
+			appendResult(SearchResult{
+				Layer:    "semantic",
+				Kind:     "circuit",
+				ID:       fmt.Sprintf("circuit:%d", circuit.Index),
+				Title:    fmt.Sprintf("Circuit %d", circuit.Index),
+				Subtitle: strings.TrimSpace(strings.Join([]string{circuit.CircuitType, circuit.State.CircuitState}, " / ")),
+			})
+		}
+		for _, device := range snapshot.RadioDevices {
+			fields := []string{
+				"radio",
+				device.DeviceModel,
+				device.SlotMode,
+				semanticIntString(device.ZoneAssignment),
+				derefString(device.FirmwareVersion),
+			}
+			if !semanticSearchMatch(needle, fields...) {
+				continue
+			}
+			title := strings.TrimSpace(device.DeviceModel)
+			if title == "" {
+				title = fmt.Sprintf("Radio %d/%d", device.Group, device.Instance)
+			} else {
+				title = "Radio " + title
+			}
+			appendResult(SearchResult{
+				Layer:    "semantic",
+				Kind:     "radio",
+				ID:       fmt.Sprintf("radio:%d:%d", device.Group, device.Instance),
+				Title:    title,
+				Subtitle: fmt.Sprintf("slot=%s zone=%s", defaultText(device.SlotMode, "n/a"), defaultText(semanticIntString(device.ZoneAssignment), "n/a")),
+			})
+		}
+		if semanticSearchMatch(needle, "fm5", snapshot.FM5Mode) {
+			appendResult(SearchResult{
+				Layer:    "semantic",
+				Kind:     "fm5",
+				ID:       "fm5",
+				Title:    "FM5",
+				Subtitle: defaultText(snapshot.FM5Mode, "n/a"),
+			})
+		}
+		if snapshot.Solar != nil && semanticSearchMatch(needle, "solar", semanticBoolString(snapshot.Solar.SolarEnabled), semanticBoolString(snapshot.Solar.PumpActive)) {
+			appendResult(SearchResult{
+				Layer:    "semantic",
+				Kind:     "solar",
+				ID:       "solar",
+				Title:    "Solar",
+				Subtitle: fmt.Sprintf("collector=%s", defaultText(semanticFloatString(snapshot.Solar.CollectorTemperatureC, 1), "n/a")),
+			})
+		}
+		for _, cylinder := range snapshot.Cylinders {
+			if !semanticSearchMatch(needle, "cylinder", semanticInt(cylinder.Index)) {
+				continue
+			}
+			appendResult(SearchResult{
+				Layer:    "semantic",
+				Kind:     "cylinder",
+				ID:       fmt.Sprintf("cylinder:%d", cylinder.Index),
+				Title:    fmt.Sprintf("Cylinder %d", cylinder.Index),
+				Subtitle: fmt.Sprintf("temp=%s", defaultText(semanticFloatString(cylinder.TemperatureC, 1), "n/a")),
 			})
 		}
 	}
@@ -1381,6 +1476,48 @@ func (h *handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 		"count": len(results),
 		"items": results,
 	})
+}
+
+func semanticSearchMatch(needle string, fields ...string) bool {
+	if needle == "" {
+		return false
+	}
+	return strings.Contains(strings.ToLower(strings.Join(fields, " ")), needle)
+}
+
+func semanticInt(value int) string {
+	return strconv.Itoa(value)
+}
+
+func semanticIntString(value *int) string {
+	if value == nil {
+		return ""
+	}
+	return strconv.Itoa(*value)
+}
+
+func semanticFloatString(value *float64, digits int) string {
+	if value == nil {
+		return ""
+	}
+	return strconv.FormatFloat(*value, 'f', digits, 64)
+}
+
+func semanticBoolString(value *bool) string {
+	if value == nil {
+		return ""
+	}
+	if *value {
+		return "true"
+	}
+	return "false"
+}
+
+func derefString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
 }
 
 func (h *handler) handleTimelineEvents(w http.ResponseWriter, r *http.Request) {

--- a/portal/handler_test.go
+++ b/portal/handler_test.go
@@ -820,6 +820,95 @@ func TestSearchEndpoint_EmptyQuery(t *testing.T) {
 	}
 }
 
+func TestSearchEndpoint_SemanticFamilyCoverage(t *testing.T) {
+	dhwOperatingMode := "AUTO"
+	systemScheme := 1
+	zoneAssignment := 2
+	firmwareVersion := "09.03"
+	solarEnabled := false
+	solarCollector := 138.7
+	cylinderTemperature := 58.1
+
+	h := NewHandler(Options{
+		ListSemantic: func() SemanticSnapshot {
+			return SemanticSnapshot{
+				Energy: &SemanticEnergyTotals{},
+				BoilerStatus: &SemanticBoilerStatus{
+					Config: SemanticBoilerConfig{
+						DhwOperatingMode: &dhwOperatingMode,
+					},
+				},
+				System: &SemanticSystemStatus{
+					Properties: SemanticSystemProperties{
+						SystemScheme: &systemScheme,
+					},
+				},
+				Circuits: []SemanticCircuit{
+					{Index: 1, CircuitType: "heating", State: SemanticCircuitState{CircuitState: "active"}, Config: SemanticCircuitConfig{RoomTempControl: "thermostat"}},
+				},
+				RadioDevices: []SemanticRadioDevice{
+					{Group: 0, Instance: 1, DeviceModel: "VR92", SlotMode: "THERMOSTAT", ZoneAssignment: &zoneAssignment, FirmwareVersion: &firmwareVersion},
+				},
+				FM5Mode: "INTERPRETED",
+				Solar: &SemanticSolarStatus{
+					CollectorTemperatureC: &solarCollector,
+					SolarEnabled:          &solarEnabled,
+				},
+				Cylinders: []SemanticCylinder{
+					{Index: 0, TemperatureC: &cylinderTemperature},
+				},
+			}
+		},
+	})
+
+	testCases := []struct {
+		query     string
+		wantKind  string
+		wantTitle string
+	}{
+		{query: "boiler", wantKind: "boiler", wantTitle: "Boiler"},
+		{query: "system", wantKind: "system", wantTitle: "System"},
+		{query: "solar", wantKind: "solar", wantTitle: "Solar"},
+		{query: "energy", wantKind: "energy", wantTitle: "Energy Totals"},
+		{query: "circuit", wantKind: "circuit", wantTitle: "Circuit 1"},
+		{query: "vr92", wantKind: "radio", wantTitle: "Radio VR92"},
+		{query: "fm5", wantKind: "fm5", wantTitle: "FM5"},
+		{query: "cylinder", wantKind: "cylinder", wantTitle: "Cylinder 0"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.query, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/search?q="+tc.query+"&limit=20", nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status=%d; want %d", rec.Code, http.StatusOK)
+			}
+
+			var payload map[string]any
+			if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			items := payload["items"].([]any)
+			if len(items) == 0 {
+				t.Fatalf("expected at least one search result for %q", tc.query)
+			}
+
+			found := false
+			for _, item := range items {
+				entry := item.(map[string]any)
+				if entry["layer"] == "semantic" && entry["kind"] == tc.wantKind && entry["title"] == tc.wantTitle {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("missing semantic result kind=%q title=%q in %v", tc.wantKind, tc.wantTitle, items)
+			}
+		})
+	}
+}
+
 func TestStreamEndpoint(t *testing.T) {
 	h := NewHandler(Options{
 		ListRegistry: func() []RegistryDevice {

--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -75,6 +75,13 @@ function formatInteger(value) {
   return String(Math.round(number));
 }
 
+function formatSeriesYearly(values, digits = 2) {
+  if (!Array.isArray(values) || values.length === 0) {
+    return "n/a";
+  }
+  return values.map((value) => formatFixed(value, digits)).join(", ");
+}
+
 function formatAddress(value) {
   const number = Number(value);
   if (!Number.isFinite(number)) {
@@ -1032,13 +1039,13 @@ class PortalShell extends HTMLElement {
       if (payload.energy_totals) {
         const et = payload.energy_totals;
         rows.push(
-          `<li><strong>Energy today (gas)</strong> <span class="muted-inline">climate=${escapeHtml(formatFixed(et.gas?.climate?.today, 2))} dhw=${escapeHtml(formatFixed(et.gas?.dhw?.today, 2))}</span></li>`,
+          `<li><strong>Energy (gas)</strong> <span class="muted-inline">today climate=${escapeHtml(formatFixed(et.gas?.climate?.today, 2))} dhw=${escapeHtml(formatFixed(et.gas?.dhw?.today, 2))} yearly climate=[${escapeHtml(formatSeriesYearly(et.gas?.climate?.yearly))}] dhw=[${escapeHtml(formatSeriesYearly(et.gas?.dhw?.yearly))}]</span></li>`,
         );
         rows.push(
-          `<li><strong>Energy today (electric)</strong> <span class="muted-inline">climate=${escapeHtml(formatFixed(et.electric?.climate?.today, 2))} dhw=${escapeHtml(formatFixed(et.electric?.dhw?.today, 2))}</span></li>`,
+          `<li><strong>Energy (electric)</strong> <span class="muted-inline">today climate=${escapeHtml(formatFixed(et.electric?.climate?.today, 2))} dhw=${escapeHtml(formatFixed(et.electric?.dhw?.today, 2))} yearly climate=[${escapeHtml(formatSeriesYearly(et.electric?.climate?.yearly))}] dhw=[${escapeHtml(formatSeriesYearly(et.electric?.dhw?.yearly))}]</span></li>`,
         );
         rows.push(
-          `<li><strong>Energy today (solar)</strong> <span class="muted-inline">climate=${escapeHtml(formatFixed(et.solar?.climate?.today, 2))} dhw=${escapeHtml(formatFixed(et.solar?.dhw?.today, 2))}</span></li>`,
+          `<li><strong>Energy (solar)</strong> <span class="muted-inline">today climate=${escapeHtml(formatFixed(et.solar?.climate?.today, 2))} dhw=${escapeHtml(formatFixed(et.solar?.dhw?.today, 2))} yearly climate=[${escapeHtml(formatSeriesYearly(et.solar?.climate?.yearly))}] dhw=[${escapeHtml(formatSeriesYearly(et.solar?.dhw?.yearly))}]</span></li>`,
         );
       }
       if (circuits.length > 0) {

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,8 +2,8 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 77728,
-      "sha256": "234518ca56a1629367eb99dc5f23be3d19d1d4988401f8f0d1dabcdfa16f3817"
+      "bytes": 78354,
+      "sha256": "9ed73d08370cef056abf4ceada78ddd8c977d3ef096431ddd42ca47ce3f631ba"
     },
     "app.css": {
       "bytes": 7370,

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -74,6 +74,13 @@ function formatInteger(value) {
   return String(Math.round(number));
 }
 
+function formatSeriesYearly(values, digits = 2) {
+  if (!Array.isArray(values) || values.length === 0) {
+    return "n/a";
+  }
+  return values.map((value) => formatFixed(value, digits)).join(", ");
+}
+
 function formatAddress(value) {
   const number = Number(value);
   if (!Number.isFinite(number)) {
@@ -1031,13 +1038,13 @@ class PortalShell extends HTMLElement {
       if (payload.energy_totals) {
         const et = payload.energy_totals;
         rows.push(
-          `<li><strong>Energy today (gas)</strong> <span class="muted-inline">climate=${escapeHtml(formatFixed(et.gas?.climate?.today, 2))} dhw=${escapeHtml(formatFixed(et.gas?.dhw?.today, 2))}</span></li>`,
+          `<li><strong>Energy (gas)</strong> <span class="muted-inline">today climate=${escapeHtml(formatFixed(et.gas?.climate?.today, 2))} dhw=${escapeHtml(formatFixed(et.gas?.dhw?.today, 2))} yearly climate=[${escapeHtml(formatSeriesYearly(et.gas?.climate?.yearly))}] dhw=[${escapeHtml(formatSeriesYearly(et.gas?.dhw?.yearly))}]</span></li>`,
         );
         rows.push(
-          `<li><strong>Energy today (electric)</strong> <span class="muted-inline">climate=${escapeHtml(formatFixed(et.electric?.climate?.today, 2))} dhw=${escapeHtml(formatFixed(et.electric?.dhw?.today, 2))}</span></li>`,
+          `<li><strong>Energy (electric)</strong> <span class="muted-inline">today climate=${escapeHtml(formatFixed(et.electric?.climate?.today, 2))} dhw=${escapeHtml(formatFixed(et.electric?.dhw?.today, 2))} yearly climate=[${escapeHtml(formatSeriesYearly(et.electric?.climate?.yearly))}] dhw=[${escapeHtml(formatSeriesYearly(et.electric?.dhw?.yearly))}]</span></li>`,
         );
         rows.push(
-          `<li><strong>Energy today (solar)</strong> <span class="muted-inline">climate=${escapeHtml(formatFixed(et.solar?.climate?.today, 2))} dhw=${escapeHtml(formatFixed(et.solar?.dhw?.today, 2))}</span></li>`,
+          `<li><strong>Energy (solar)</strong> <span class="muted-inline">today climate=${escapeHtml(formatFixed(et.solar?.climate?.today, 2))} dhw=${escapeHtml(formatFixed(et.solar?.dhw?.today, 2))} yearly climate=[${escapeHtml(formatSeriesYearly(et.solar?.climate?.yearly))}] dhw=[${escapeHtml(formatSeriesYearly(et.solar?.dhw?.yearly))}]</span></li>`,
         );
       }
       if (circuits.length > 0) {


### PR DESCRIPTION
## Summary
- extend Portal semantic search coverage to boiler, system, circuits, radio, fm5, solar, cylinders, and energy
- add handler coverage for semantic search family discovery
- render yearly energy history in the Portal semantic preview and regenerate embedded assets

## Testing
- `gofmt -w portal/handler.go portal/handler_test.go`
- `./scripts/build_portal_assets.sh`
- `GOWORK=off go test -count=1 ./portal`
- `GOWORK=off go test -count=1 ./graphql ./mcp ./portal`

Closes #284
