### PR TITLE
Gateway parity: enforce cross-surface semantic family inventory

### DIFF
--- a/graphql/queries_test.go
+++ b/graphql/queries_test.go
@@ -14,6 +14,19 @@ import (
 	graphqlclient "github.com/machinebox/graphql"
 )
 
+var canonicalSemanticRootFields = []string{
+	"zones",
+	"dhw",
+	"energyTotals",
+	"circuits",
+	"radioDevices",
+	"fm5SemanticMode",
+	"solar",
+	"cylinders",
+	"boilerStatus",
+	"system",
+}
+
 func TestQueryResolvers_Integration(t *testing.T) {
 	provider := mockProvider{
 		planes: []registry.Plane{
@@ -317,18 +330,7 @@ func TestQueryResolvers_Integration(t *testing.T) {
 			got[field.Name] = true
 		}
 
-		for _, name := range []string{
-			"zones",
-			"dhw",
-			"energyTotals",
-			"circuits",
-			"radioDevices",
-			"fm5SemanticMode",
-			"solar",
-			"cylinders",
-			"boilerStatus",
-			"system",
-		} {
+		for _, name := range canonicalSemanticRootFields {
 			if !got[name] {
 				t.Fatalf("query root missing %q in introspection: %#v", name, got)
 			}

--- a/mcp/parity_contract_test.go
+++ b/mcp/parity_contract_test.go
@@ -14,6 +14,20 @@ type toolSchemaSignature struct {
 	SchemaHash string `json:"schema_hash"`
 }
 
+var canonicalSemanticSnapshotPlanes = []string{
+	"runtime_status",
+	"zones",
+	"dhw",
+	"energy_totals",
+	"boiler_status",
+	"system",
+	"circuits",
+	"radio_devices",
+	"fm5_mode",
+	"solar",
+	"cylinders",
+}
+
 func TestToolInventoryGoldenSignatures(t *testing.T) {
 	reg := &testRegistry{entries: make(map[byte]registry.DeviceEntry)}
 	server, err := NewServer(reg, &testInvoker{})
@@ -85,6 +99,7 @@ func TestToolInventoryGoldenSignatures(t *testing.T) {
 }
 
 func TestParityMatrixReadAndInvoke(t *testing.T) {
+	boilerMode := "AUTO"
 	plane := &testPlane{
 		name: "heating",
 		methods: []registry.Method{
@@ -119,6 +134,7 @@ func TestParityMatrixReadAndInvoke(t *testing.T) {
 		},
 		dhw:    &DhwStatus{Config: DhwConfig{OperatingMode: "AUTO", Preset: "ECO"}},
 		energy: &EnergyTotals{Gas: EnergyChannel{DHW: EnergySeries{Today: 1.25}}},
+		boiler: &BoilerStatus{Config: &BoilerConfig{DhwOperatingMode: &boilerMode}},
 		system: &SystemStatus{Properties: &SystemProperties{SystemScheme: intPtr(8), ModuleConfigurationVR71: intPtr(2), VR71CircuitStartIndex: intPtr(-1)}},
 	})
 
@@ -140,6 +156,7 @@ func TestParityMatrixReadAndInvoke(t *testing.T) {
 		{name: "cylinders", tool: toolSemanticCylindersGetName, args: `{}`},
 		{name: "dhw", tool: toolSemanticDHWGetName, args: `{}`},
 		{name: "energy", tool: toolSemanticEnergyGetName, args: `{}`},
+		{name: "boiler", tool: toolSemanticBoilerGetName, args: `{}`},
 		{name: "system", tool: toolSemanticSystemGetName, args: `{}`},
 		{name: "semantic_snapshot", tool: toolSemanticSnapshotName, args: `{}`},
 		{name: "invoke", tool: toolInvokeV1Name, args: `{"address":8,"plane":"heating","method":"get_status","params":{},"intent":"READ_ONLY","allow_dangerous":false}`},
@@ -166,6 +183,21 @@ func TestParityMatrixReadAndInvoke(t *testing.T) {
 			}
 			if hash, _ := meta["data_hash"].(string); hash == "" {
 				t.Fatalf("tool %s data_hash empty", tc.tool)
+			}
+			if tc.tool == toolSemanticSnapshotName {
+				data, ok := envelope["data"].(map[string]any)
+				if !ok {
+					t.Fatalf("semantic snapshot data type = %T; want map", envelope["data"])
+				}
+				planes, ok := data["planes"].(map[string]any)
+				if !ok {
+					t.Fatalf("semantic snapshot planes type = %T; want map", data["planes"])
+				}
+				for _, plane := range canonicalSemanticSnapshotPlanes {
+					if _, ok := planes[plane]; !ok {
+						t.Fatalf("semantic snapshot missing plane %q: %#v", plane, planes)
+					}
+				}
 			}
 		})
 	}

--- a/portal/handler_test.go
+++ b/portal/handler_test.go
@@ -10,6 +10,20 @@ import (
 	"time"
 )
 
+var canonicalPortalSemanticKeys = []string{
+	"zones",
+	"dhw",
+	"energy_totals",
+	"boiler_status",
+	"system",
+	"circuits",
+	"radio_devices",
+	"fm5_semantic_mode",
+	"solar",
+	"cylinders",
+	"captured_utc",
+}
+
 func TestHandlerIndex(t *testing.T) {
 	h := NewHandler(Options{GraphQLPath: "/graphql"})
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -655,6 +669,64 @@ func TestSemanticSnapshotEndpoint_ExtensionFamilies(t *testing.T) {
 	}
 	if cylinder["temperature_c"] != cylinderTemperature {
 		t.Fatalf("cylinder.temperature_c=%v; want %v", cylinder["temperature_c"], cylinderTemperature)
+	}
+}
+
+func TestSemanticSnapshotEndpoint_CanonicalFamilyInventory(t *testing.T) {
+	dhwMode := "AUTO"
+	systemScheme := 1
+	zoneAssignment := 2
+	solarEnabled := false
+	solarCollector := 120.5
+	cylinderTemperature := 58.1
+
+	h := NewHandler(Options{
+		ListSemantic: func() SemanticSnapshot {
+			return SemanticSnapshot{
+				Zones:  []SemanticZone{{ID: "zone-1", Name: "Parter"}},
+				DHW:    &SemanticDHW{Config: SemanticDhwConfig{OperatingMode: "heat"}},
+				Energy: &SemanticEnergyTotals{},
+				BoilerStatus: &SemanticBoilerStatus{
+					Config: SemanticBoilerConfig{DhwOperatingMode: &dhwMode},
+				},
+				System: &SemanticSystemStatus{
+					Properties: SemanticSystemProperties{SystemScheme: &systemScheme},
+				},
+				Circuits: []SemanticCircuit{
+					{Index: 0, CircuitType: "heating"},
+				},
+				RadioDevices: []SemanticRadioDevice{
+					{Group: 0, Instance: 1, DeviceModel: "VR92", ZoneAssignment: &zoneAssignment},
+				},
+				FM5Mode: "INTERPRETED",
+				Solar: &SemanticSolarStatus{
+					CollectorTemperatureC: &solarCollector,
+					SolarEnabled:          &solarEnabled,
+				},
+				Cylinders: []SemanticCylinder{
+					{Index: 0, TemperatureC: &cylinderTemperature},
+				},
+				CapturedUTC: "2026-02-23T23:00:00Z",
+			}
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/semantic/snapshot", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d; want %d", rec.Code, http.StatusOK)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	for _, key := range canonicalPortalSemanticKeys {
+		if _, ok := payload[key]; !ok {
+			t.Fatalf("semantic snapshot missing key %q: %#v", key, payload)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- centralize the canonical semantic family inventory used by GraphQL root introspection coverage
- extend MCP parity tests to cover boiler and assert the complete semantic snapshot plane inventory
- add a Portal semantic snapshot inventory test that fails when any canonical family key is missing

## Testing
- `gofmt -w graphql/queries_test.go mcp/parity_contract_test.go portal/handler_test.go`
- `GOWORK=off go test -count=1 ./graphql ./mcp ./portal`

Closes #285
