### PR TITLE
GW-301: fix ebusreg pin for addon Docker rebuilds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.0.0-20260228114515-463da768cb9f
-	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260228115527-d292c2f9dc68
+	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260305074420-fd5cc098a003
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Project-Helianthus/helianthus-ebusgo v0.0.0-20260228114515-463da768cb9f h1:mBTY1wIlBqiS43yvPKfj8bH0klxtv1g2NFeza7gTPWs=
 github.com/Project-Helianthus/helianthus-ebusgo v0.0.0-20260228114515-463da768cb9f/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260228115527-d292c2f9dc68 h1:yBAszn7n6Iajb9Dq7JrC0lFcqnid5Hj7EhSfM8t6iOE=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260228115527-d292c2f9dc68/go.mod h1:FrDhh/Q0KQhP+11jGrQFJLur/kLjAA2mQ7UjJYthOlE=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260305074420-fd5cc098a003 h1:UuiYg6oGpbz2HDuw2lGsmPPKVyBL5rLKi0H1j+u+Qq8=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260305074420-fd5cc098a003/go.mod h1:FrDhh/Q0KQhP+11jGrQFJLur/kLjAA2mQ7UjJYthOlE=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=


### PR DESCRIPTION
## What
Fix the `helianthus-ebusreg` pin in `go.mod` so Docker addon builds can resolve gateway dependencies outside `go.work`.

## Why
`helianthus-ha-addon` builds the gateway with `go install @<version>` inside Docker. Docker ignores the local `go.work`, so the stale `ebusreg` pseudo-version on `main` broke rebuilds with `invalid version: unknown revision d292c2f9dc68`. This restores the standard addon rebuild path and unblocks removal of the temporary binary override.

## Acceptance Criteria
- [x] `go.mod` / `go.sum` pin `helianthus-ebusreg` to a resolvable revision
- [x] `GOWORK=off go build ./cmd/gateway` succeeds locally
- [x] `GOWORK=off go test ./cmd/gateway ./graphql ./mcp ./portal` succeeds locally
- [x] HA-host Docker build succeeds with `--build-arg EBUSGATEWAY_VERSION=7ed3c6d`
- [x] No semantic/runtime code paths change

## Evidence
- Local validation:
  - `GOWORK=off GOPRIVATE=github.com/Project-Helianthus/* GONOSUMCHECK=github.com/Project-Helianthus/* go build ./cmd/gateway`
  - `GOWORK=off GOPRIVATE=github.com/Project-Helianthus/* GONOSUMCHECK=github.com/Project-Helianthus/* go test ./cmd/gateway ./graphql ./mcp ./portal`
- HA host validation:
  - `docker build --no-cache --build-arg BUILD_FROM=ghcr.io/home-assistant/aarch64-base:3.20 --build-arg EBUSGATEWAY_VERSION=7ed3c6d --secret id=github_token,src=/mnt/data/addon-build/github_token -t ghcr.io/project-helianthus/helianthus-ha-addon:301-test .`
  - Build completed successfully on `192.168.100.4`

## Dependencies
- Depends on issue #301
