### PR TITLE
Add monthly energy counters from B524 registers

### DIFF
--- a/cmd/gateway/semantic_provider.go
+++ b/cmd/gateway/semantic_provider.go
@@ -309,6 +309,10 @@ func mapEnergySeries(series graphql.EnergySeries) mcp.EnergySeries {
 		out.Yearly = make([]float64, len(series.Yearly))
 		copy(out.Yearly, series.Yearly)
 	}
+	if len(series.Monthly) > 0 {
+		out.Monthly = make([]float64, len(series.Monthly))
+		copy(out.Monthly, series.Monthly)
+	}
 	return out
 }
 

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -119,8 +119,18 @@ const (
 	energyRegEnergySumHc  = uint16(0x0057) // PrEnergySumHc: total electricity consumption heating
 	energyRegEnergySumHwc = uint16(0x0058) // PrEnergySumHwc: total electricity consumption hot water
 	energyRegFuelSumHwc   = uint16(0x0059) // PrFuelSumHwc: total gas consumption hot water
-	energyGroup           = byte(0x00)
-	energyInstance        = byte(0x00)
+
+	energyRegFuelSumHcThisMonth    = uint16(0x004E) // PrFuelSumHcThisMonth: gas heating this month
+	energyRegEnergySumHcThisMonth  = uint16(0x004F) // PrEnergySumHcThisMonth: electricity heating this month
+	energyRegEnergySumHwcThisMonth = uint16(0x0050) // PrEnergySumHwcThisMonth: electricity hot water this month
+	energyRegFuelSumHwcThisMonth   = uint16(0x0051) // PrFuelSumHwcThisMonth: gas hot water this month
+	energyRegFuelSumHcLastMonth    = uint16(0x0052) // PrFuelSumHcLastMonth: gas heating last month
+	energyRegEnergySumHcLastMonth  = uint16(0x0053) // PrEnergySumHcLastMonth: electricity heating last month
+	energyRegEnergySumHwcLastMonth = uint16(0x0054) // PrEnergySumHwcLastMonth: electricity hot water last month
+	energyRegFuelSumHwcLastMonth   = uint16(0x0055) // PrFuelSumHwcLastMonth: gas hot water last month
+
+	energyGroup    = byte(0x00)
+	energyInstance = byte(0x00)
 )
 
 type regulatorAbsenceState string
@@ -1677,16 +1687,29 @@ func zoneEquals(a, b graphql.Zone) bool {
 }
 
 type b524EnergyQuery struct {
-	addr    uint16 // B5.24 register address
-	channel string // EnergyMergeKey.Channel
-	usage   string // EnergyMergeKey.Usage
+	addr     uint16 // B5.24 register address
+	channel  string // EnergyMergeKey.Channel
+	usage    string // EnergyMergeKey.Usage
+	period   string // EnergyMergeKey.Period ("year", "month")
+	yearKind string // EnergyMergeKey.YearKind ("current", "previous")
 }
 
 var b524EnergyQueries = []b524EnergyQuery{
-	{energyRegFuelSumHc, "gas", "climate"},
-	{energyRegFuelSumHwc, "gas", "hot_water"},
-	{energyRegEnergySumHc, "electricity", "climate"},
-	{energyRegEnergySumHwc, "electricity", "hot_water"},
+	// All-time totals (mapped as year/current).
+	{energyRegFuelSumHc, "gas", "climate", "year", "current"},
+	{energyRegFuelSumHwc, "gas", "hot_water", "year", "current"},
+	{energyRegEnergySumHc, "electricity", "climate", "year", "current"},
+	{energyRegEnergySumHwc, "electricity", "hot_water", "year", "current"},
+	// Monthly: this month (month/current).
+	{energyRegFuelSumHcThisMonth, "gas", "climate", "month", "current"},
+	{energyRegFuelSumHwcThisMonth, "gas", "hot_water", "month", "current"},
+	{energyRegEnergySumHcThisMonth, "electricity", "climate", "month", "current"},
+	{energyRegEnergySumHwcThisMonth, "electricity", "hot_water", "month", "current"},
+	// Monthly: last month (month/previous).
+	{energyRegFuelSumHcLastMonth, "gas", "climate", "month", "previous"},
+	{energyRegFuelSumHwcLastMonth, "gas", "hot_water", "month", "previous"},
+	{energyRegEnergySumHcLastMonth, "electricity", "climate", "month", "previous"},
+	{energyRegEnergySumHwcLastMonth, "electricity", "hot_water", "month", "previous"},
 }
 
 func (p *vaillantSemanticPoller) refreshEnergy(ctx context.Context) {
@@ -1711,20 +1734,21 @@ func (p *vaillantSemanticPoller) refreshEnergy(ctx context.Context) {
 		}
 		kwh := float64(val)
 
-		// Write all-time total as year/current.
 		if p.provider.ApplyEnergyFromRegister(graphql.EnergyMergeKey{
-			Channel: q.channel, Usage: q.usage, Period: "year", YearKind: "current",
+			Channel: q.channel, Usage: q.usage, Period: q.period, YearKind: q.yearKind,
 		}, kwh) {
 			accepted++
 		}
-		// Lock day and year/previous with register-priority 0 to prevent
-		// broadcast double-counting (all-time total already includes them).
-		p.provider.ApplyEnergyFromRegister(graphql.EnergyMergeKey{
-			Channel: q.channel, Usage: q.usage, Period: "year", YearKind: "previous",
-		}, 0)
-		p.provider.ApplyEnergyFromRegister(graphql.EnergyMergeKey{
-			Channel: q.channel, Usage: q.usage, Period: "day", YearKind: "",
-		}, 0)
+		// For all-time totals, lock day and year/previous with register-priority 0
+		// to prevent broadcast double-counting (all-time total already includes them).
+		if q.period == "year" && q.yearKind == "current" {
+			p.provider.ApplyEnergyFromRegister(graphql.EnergyMergeKey{
+				Channel: q.channel, Usage: q.usage, Period: "year", YearKind: "previous",
+			}, 0)
+			p.provider.ApplyEnergyFromRegister(graphql.EnergyMergeKey{
+				Channel: q.channel, Usage: q.usage, Period: "day", YearKind: "",
+			}, 0)
+		}
 	}
 	if accepted > 0 || failed > 0 {
 		log.Printf("semantic energy b524: accepted=%d failed=%d", accepted, failed)

--- a/cmd/gateway/semantic_vaillant_test.go
+++ b/cmd/gateway/semantic_vaillant_test.go
@@ -3026,30 +3026,43 @@ func TestRefreshRegulatorCapability_NoChangeNoLog(t *testing.T) {
 func TestB524EnergyQueries_Coverage(t *testing.T) {
 	t.Parallel()
 
-	type pair struct {
-		channel string
-		usage   string
+	type tuple struct {
+		channel  string
+		usage    string
+		period   string
+		yearKind string
 	}
-	expected := map[pair]bool{
-		{"gas", "climate"}:           false,
-		{"gas", "hot_water"}:         false,
-		{"electricity", "climate"}:   false,
-		{"electricity", "hot_water"}: false,
+	expected := map[tuple]bool{
+		// All-time totals.
+		{"gas", "climate", "year", "current"}:           false,
+		{"gas", "hot_water", "year", "current"}:         false,
+		{"electricity", "climate", "year", "current"}:   false,
+		{"electricity", "hot_water", "year", "current"}: false,
+		// Monthly: this month.
+		{"gas", "climate", "month", "current"}:           false,
+		{"gas", "hot_water", "month", "current"}:         false,
+		{"electricity", "climate", "month", "current"}:   false,
+		{"electricity", "hot_water", "month", "current"}: false,
+		// Monthly: last month.
+		{"gas", "climate", "month", "previous"}:           false,
+		{"gas", "hot_water", "month", "previous"}:         false,
+		{"electricity", "climate", "month", "previous"}:   false,
+		{"electricity", "hot_water", "month", "previous"}: false,
 	}
 	for _, q := range b524EnergyQueries {
-		p := pair{q.channel, q.usage}
-		if _, ok := expected[p]; !ok {
-			t.Fatalf("unexpected query in b524EnergyQueries: channel=%q usage=%q", q.channel, q.usage)
+		tup := tuple{q.channel, q.usage, q.period, q.yearKind}
+		if _, ok := expected[tup]; !ok {
+			t.Fatalf("unexpected query in b524EnergyQueries: %+v", tup)
 		}
-		expected[p] = true
+		expected[tup] = true
 	}
-	for p, seen := range expected {
+	for tup, seen := range expected {
 		if !seen {
-			t.Fatalf("missing query in b524EnergyQueries: channel=%q usage=%q", p.channel, p.usage)
+			t.Fatalf("missing query in b524EnergyQueries: %+v", tup)
 		}
 	}
-	if len(b524EnergyQueries) != 4 {
-		t.Fatalf("len(b524EnergyQueries) = %d; want 4", len(b524EnergyQueries))
+	if len(b524EnergyQueries) != 12 {
+		t.Fatalf("len(b524EnergyQueries) = %d; want 12", len(b524EnergyQueries))
 	}
 }
 

--- a/graphql/energy_merge.go
+++ b/graphql/energy_merge.go
@@ -34,8 +34,8 @@ type energyDataPoint struct {
 type energyMergeKey struct {
 	Channel  string // "gas", "electricity", "solar"
 	Usage    string // "hot_water", "climate" (canonicalized from heating/cooling)
-	Period   string // "day", "year"
-	YearKind string // "" for day, "previous"/"current" for year
+	Period   string // "day", "year", "month"
+	YearKind string // "" for day, "previous"/"current" for year/month
 }
 
 // EnergyMergeKey is the external key contract for register/broadcast energy merge inputs.
@@ -174,6 +174,16 @@ func (s *energyMergeStore) Snapshot() *EnergyTotals {
 				series.Yearly[0] = point.Value
 			case "current":
 				series.Yearly[1] = point.Value
+			}
+		case "month":
+			if len(series.Monthly) < 2 {
+				series.Monthly = make([]float64, 2)
+			}
+			switch key.YearKind {
+			case "previous":
+				series.Monthly[0] = point.Value
+			case "current":
+				series.Monthly[1] = point.Value
 			}
 		}
 	}

--- a/graphql/energy_merge_test.go
+++ b/graphql/energy_merge_test.go
@@ -202,6 +202,43 @@ func TestEnergyMerge_SnapshotBuildsCorrectTotals(t *testing.T) {
 	}
 }
 
+func TestEnergyMerge_SnapshotBuildsMonthlySeries(t *testing.T) {
+	store := newEnergyMergeStore()
+
+	// Gas climate: this month = 284, last month = 266.
+	store.Apply(energyMergeKey{Channel: "gas", Usage: "climate", Period: "month", YearKind: "current"}, 284.0, EnergySourceRegister, t0)
+	store.Apply(energyMergeKey{Channel: "gas", Usage: "climate", Period: "month", YearKind: "previous"}, 266.0, EnergySourceRegister, t0)
+
+	// Electricity hot_water: this month = 5, last month = 3.
+	store.Apply(energyMergeKey{Channel: "electricity", Usage: "hot_water", Period: "month", YearKind: "current"}, 5.0, EnergySourceRegister, t0)
+	store.Apply(energyMergeKey{Channel: "electricity", Usage: "hot_water", Period: "month", YearKind: "previous"}, 3.0, EnergySourceRegister, t0)
+
+	totals := store.Snapshot()
+	if totals == nil {
+		t.Fatal("Snapshot() = nil; want non-nil")
+	}
+
+	if len(totals.Gas.Climate.Monthly) < 2 {
+		t.Fatalf("Gas.Climate.Monthly len = %d; want >= 2", len(totals.Gas.Climate.Monthly))
+	}
+	if totals.Gas.Climate.Monthly[0] != 266.0 {
+		t.Fatalf("Gas.Climate.Monthly[0] = %f; want 266.0 (previous)", totals.Gas.Climate.Monthly[0])
+	}
+	if totals.Gas.Climate.Monthly[1] != 284.0 {
+		t.Fatalf("Gas.Climate.Monthly[1] = %f; want 284.0 (current)", totals.Gas.Climate.Monthly[1])
+	}
+
+	if len(totals.Electric.DHW.Monthly) < 2 {
+		t.Fatalf("Electric.DHW.Monthly len = %d; want >= 2", len(totals.Electric.DHW.Monthly))
+	}
+	if totals.Electric.DHW.Monthly[0] != 3.0 {
+		t.Fatalf("Electric.DHW.Monthly[0] = %f; want 3.0 (previous)", totals.Electric.DHW.Monthly[0])
+	}
+	if totals.Electric.DHW.Monthly[1] != 5.0 {
+		t.Fatalf("Electric.DHW.Monthly[1] = %f; want 5.0 (current)", totals.Electric.DHW.Monthly[1])
+	}
+}
+
 func TestEnergyMerge_SnapshotReturnsNilWhenEmpty(t *testing.T) {
 	store := newEnergyMergeStore()
 	if snap := store.Snapshot(); snap != nil {
@@ -211,7 +248,7 @@ func TestEnergyMerge_SnapshotReturnsNilWhenEmpty(t *testing.T) {
 
 func TestEnergyMerge_AllChannelUsagePeriodCombinations(t *testing.T) {
 	// Canonical usages after canonicalization: "hot_water", "climate".
-	// 3 channels x 2 canonical usages x 3 periods = 18 canonical keys.
+	// 3 channels x 2 canonical usages x 5 period variants = 30 canonical keys.
 	channels := []string{"gas", "electricity", "solar"}
 	usages := []string{"hot_water", "climate"}
 	type periodSpec struct {
@@ -222,6 +259,8 @@ func TestEnergyMerge_AllChannelUsagePeriodCombinations(t *testing.T) {
 		{period: "day", yearKind: ""},
 		{period: "year", yearKind: "previous"},
 		{period: "year", yearKind: "current"},
+		{period: "month", yearKind: "current"},
+		{period: "month", yearKind: "previous"},
 	}
 
 	store := newEnergyMergeStore()
@@ -244,21 +283,21 @@ func TestEnergyMerge_AllChannelUsagePeriodCombinations(t *testing.T) {
 		}
 	}
 
-	if expectedCount != 18 {
-		t.Fatalf("expected 18 combinations; got %d", expectedCount)
+	if expectedCount != 30 {
+		t.Fatalf("expected 30 combinations; got %d", expectedCount)
 	}
 
 	store.mu.RLock()
 	gotCount := len(store.points)
 	store.mu.RUnlock()
 
-	if gotCount != 18 {
-		t.Fatalf("store has %d points; want 18", gotCount)
+	if gotCount != 30 {
+		t.Fatalf("store has %d points; want 30", gotCount)
 	}
 
 	totals := store.Snapshot()
 	if totals == nil {
-		t.Fatal("Snapshot() = nil after 18 inserts")
+		t.Fatal("Snapshot() = nil after 30 inserts")
 	}
 
 	checkChannel := func(name string, ch EnergyChannel) {
@@ -266,6 +305,12 @@ func TestEnergyMerge_AllChannelUsagePeriodCombinations(t *testing.T) {
 		if ch.DHW.Today == 0 && ch.Climate.Today == 0 &&
 			len(ch.DHW.Yearly) == 0 && len(ch.Climate.Yearly) == 0 {
 			t.Fatalf("channel %s has no data in snapshot", name)
+		}
+		if len(ch.DHW.Monthly) < 2 {
+			t.Fatalf("channel %s DHW.Monthly len = %d; want >= 2", name, len(ch.DHW.Monthly))
+		}
+		if len(ch.Climate.Monthly) < 2 {
+			t.Fatalf("channel %s Climate.Monthly len = %d; want >= 2", name, len(ch.Climate.Monthly))
 		}
 	}
 	checkChannel("Gas", totals.Gas)

--- a/graphql/semantic.go
+++ b/graphql/semantic.go
@@ -135,8 +135,9 @@ type CylinderStatus struct {
 }
 
 type EnergySeries struct {
-	Today  float64
-	Yearly []float64
+	Today   float64
+	Yearly  []float64
+	Monthly []float64
 }
 
 type EnergyChannel struct {

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -86,8 +86,9 @@ type DhwStatus struct {
 }
 
 type EnergySeries struct {
-	Today  float64   `json:"today"`
-	Yearly []float64 `json:"yearly"`
+	Today   float64   `json:"today"`
+	Yearly  []float64 `json:"yearly"`
+	Monthly []float64 `json:"monthly"`
 }
 
 type EnergyChannel struct {


### PR DESCRIPTION
## Summary
- Poll monthly gas/electricity registers 0x004E-0x0055 (this_month + last_month)
- Extend `EnergySeries` with `Monthly []float64` (index 0=previous, 1=current)
- Surface monthly data via `energy_totals.{gas,electric}.{climate,dhw}.monthly[]` in MCP

## Test plan
- [x] `TestB524EnergyQueries_Coverage` updated for 12 queries
- [x] `TestEnergyMerge_SnapshotBuildsMonthlySeries` — new test
- [x] `TestEnergyMerge_AllChannelUsagePeriodCombinations` extended for month periods
- [x] `TestRefreshEnergy_*` — all pass (lock semantics preserved)
- [x] Full test suite: all 14 packages green
- [x] `golangci-lint run ./...`: 0 issues

Closes #312
Doc-gate: Project-Helianthus/helianthus-docs-ebus#198

🤖 Generated with [Claude Code](https://claude.com/claude-code)