### PR TITLE
GraphQL: expose monthly field in EnergySeries

### DIFF
--- a/graphql/queries.go
+++ b/graphql/queries.go
@@ -283,6 +283,16 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return series.Yearly, nil
 				},
 			},
+			"monthly": &graphqlgo.Field{
+				Type: graphqlgo.NewList(graphqlgo.NewNonNull(graphqlgo.Float)),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					series, ok := params.Source.(EnergySeries)
+					if !ok {
+						return nil, nil
+					}
+					return series.Monthly, nil
+				},
+			},
 		},
 	})
 


### PR DESCRIPTION
## Summary
- Add `monthly` field resolver to GraphQL `EnergySeries` type
- The `Monthly` slice was already populated by the semantic provider and available via MCP but not exposed in GraphQL
- Nullable list (unlike `yearly` which is non-null) since monthly data may not be available

## Test plan
- [x] `go test ./...` passes
- [x] Existing energy merge tests cover Monthly population

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)