### PR TITLE
Bump ebusreg pin for B524 timer/raw opcode methods

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.0.0-20260228114515-463da768cb9f
-	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260308024753-a0eb51c7c727
+	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260308133434-a4dd8f3e0af1
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/Project-Helianthus/helianthus-ebusgo v0.0.0-20260228114515-463da768cb
 github.com/Project-Helianthus/helianthus-ebusgo v0.0.0-20260228114515-463da768cb9f/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260308024753-a0eb51c7c727 h1:OMtWNGq/TWjo/6fgzxFYPBZVYCCdOXMjb0SDHA+I2qk=
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260308024753-a0eb51c7c727/go.mod h1:FrDhh/Q0KQhP+11jGrQFJLur/kLjAA2mQ7UjJYthOlE=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260308133434-a4dd8f3e0af1 h1:+UIwSdvIUVnZJEV4oSvNlTtHw9s4V/NgZg57/kC99yI=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260308133434-a4dd8f3e0af1/go.mod h1:FrDhh/Q0KQhP+11jGrQFJLur/kLjAA2mQ7UjJYthOlE=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=


### PR DESCRIPTION
## Summary
- Bumps `helianthus-ebusreg` go.mod pin to pick up PR #108 (B524 timer read + raw opcode RPC methods)
- No gateway code changes — MCP server dynamically discovers new plane methods

## Detail
The new methods are now available via `ebus.v1.rpc.invoke`:
- `read_timer` — B524 opcode 0x03 for per-day weekly schedule reads
- `read_raw` — raw opcode passthrough for investigation (e.g. 0x0B array transport)

## Test plan
- [x] `go build ./...` — passes
- [x] `go test ./...` — all 14 packages pass
- [x] New methods discoverable via MCP after deployment

Closes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)