### PR TITLE
Add B555 schedule semantic reader and MCP tool

### DIFF
--- a/cmd/gateway/semantic_provider.go
+++ b/cmd/gateway/semantic_provider.go
@@ -316,6 +316,63 @@ func mapEnergySeries(series graphql.EnergySeries) mcp.EnergySeries {
 	return out
 }
 
+func (adapter mcpSemanticProviderAdapter) Schedules() *mcp.ScheduleStatus {
+	if adapter.provider == nil {
+		return nil
+	}
+	status := adapter.provider.Schedules()
+	if status == nil {
+		return nil
+	}
+	out := &mcp.ScheduleStatus{}
+	if len(status.Programs) > 0 {
+		out.Programs = make([]mcp.ScheduleProgram, len(status.Programs))
+		for i, prog := range status.Programs {
+			mp := mcp.ScheduleProgram{
+				Zone: prog.Zone,
+				HC:   prog.HC,
+			}
+			if prog.Config != nil {
+				mp.Config = &mcp.ScheduleConfig{
+					MaxSlots:       prog.Config.MaxSlots,
+					TimeResolution: prog.Config.TimeResolution,
+					MinDuration:    prog.Config.MinDuration,
+					HasTemperature: prog.Config.HasTemperature,
+					TempSlots:      prog.Config.TempSlots,
+					MinTempC:       cloneFloatPtr(prog.Config.MinTempC),
+					MaxTempC:       cloneFloatPtr(prog.Config.MaxTempC),
+				}
+			}
+			if len(prog.SlotsUsed) > 0 {
+				mp.SlotsUsed = make([]int, len(prog.SlotsUsed))
+				copy(mp.SlotsUsed, prog.SlotsUsed)
+			}
+			if len(prog.Days) > 0 {
+				mp.Days = make([]mcp.ScheduleDayProgram, len(prog.Days))
+				for j, day := range prog.Days {
+					md := mcp.ScheduleDayProgram{Weekday: day.Weekday}
+					if len(day.Slots) > 0 {
+						md.Slots = make([]mcp.ScheduleTimerSlot, len(day.Slots))
+						for k, slot := range day.Slots {
+							md.Slots[k] = mcp.ScheduleTimerSlot{
+								StartHour:      slot.StartHour,
+								StartMinute:    slot.StartMinute,
+								EndHour:        slot.EndHour,
+								EndMinute:      slot.EndMinute,
+								TemperatureC:   cloneFloatPtr(slot.TemperatureC),
+								TemperatureRaw: cloneIntPtr(slot.TemperatureRaw),
+							}
+						}
+					}
+					mp.Days[j] = md
+				}
+			}
+			out.Programs[i] = mp
+		}
+	}
+	return out
+}
+
 func cloneFloatPtr(value *float64) *float64 {
 	if value == nil {
 		return nil

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -112,6 +112,33 @@ const (
 	cylinderRegTemperature      = uint16(0x0004)
 )
 
+// B5.55 timer/schedule protocol constants.
+const (
+	vaillantB555Primary   = byte(0xB5)
+	vaillantB555Secondary = byte(0x55)
+
+	b555OpcodeConfigRead = byte(0xA3)
+	b555OpcodeSlotsRead  = byte(0xA4)
+	b555OpcodeTimerRead  = byte(0xA5)
+
+	b555HCHeating  = byte(0x00)
+	b555HCCooling  = byte(0x01)
+	b555HCDHW      = byte(0x02)
+	b555HCCC       = byte(0x03)
+	b555HCSilent   = byte(0x04)
+	b555ZoneDHW    = byte(0xFF) // zone-agnostic selector for DHW/CC/Silent
+)
+
+var b555WeekdayNames = [7]string{"monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"}
+
+var b555HCNames = map[byte]string{
+	b555HCHeating: "heating",
+	b555HCCooling: "cooling",
+	b555HCDHW:     "dhw",
+	b555HCCC:      "circulation",
+	b555HCSilent:  "silent",
+}
+
 // B5.24 energy registers (VRC 720f TSP 15.720, group=0, instance=0).
 // energy4 type = ULG (unsigned 32-bit LE) in kWh.
 const (
@@ -185,6 +212,7 @@ type vaillantSemanticPoller struct {
 	configInterval       time.Duration
 	stateInterval        time.Duration
 	energyInterval       time.Duration
+	scheduleInterval     time.Duration
 	boilerFastInterval   time.Duration
 	boilerMediumInterval time.Duration
 	boilerSlowInterval   time.Duration
@@ -492,6 +520,7 @@ func newVaillantSemanticPoller(cfg ebusgateway.Config, gateway *ebusgateway.Gate
 		configInterval:       cfg.SemanticConfigInterval,
 		stateInterval:        cfg.SemanticStateInterval,
 		energyInterval:       cfg.SemanticEnergyInterval,
+		scheduleInterval:     10 * time.Minute,
 		boilerFastInterval:   30 * time.Second,
 		boilerMediumInterval: 5 * time.Minute,
 		boilerSlowInterval:   10 * time.Minute,
@@ -1013,6 +1042,7 @@ func (p *vaillantSemanticPoller) Start(ctx context.Context) {
 	go p.runLoop(ctx, p.configInterval, semanticTaskPriorityLow, p.refreshSystem)
 	go p.runLoop(ctx, p.configInterval, semanticTaskPriorityLow, p.refreshRadioDevices)
 	go p.runLoop(ctx, p.energyInterval, semanticTaskPriorityMedium, p.refreshEnergy)
+	go p.runLoop(ctx, p.scheduleInterval, semanticTaskPriorityLow, p.refreshSchedules)
 	for _, schedule := range p.boilerStatusTierSchedules() {
 		go p.runLoop(ctx, schedule.interval, schedule.priority, p.boilerStatusTierTask(schedule.tier))
 	}
@@ -5566,6 +5596,235 @@ func composeZoneName(primary, prefix, suffix string) string {
 		parts = append(parts, suffix)
 	}
 	return strings.TrimSpace(strings.Join(parts, " "))
+}
+
+// readB555Frame sends a B555 frame and returns the responder payload.
+func (p *vaillantSemanticPoller) readB555Frame(ctx context.Context, data []byte) ([]byte, bool) {
+	if p == nil || p.bus == nil {
+		return nil, false
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	p.mu.Lock()
+	source := p.source
+	target := p.controller
+	timeout := p.requestTimeout
+	p.mu.Unlock()
+
+	if target == 0 {
+		return nil, false
+	}
+	if timeout <= 0 {
+		timeout = 2 * time.Second
+	}
+
+	p.readMu.Lock()
+	reqCtx, cancel := context.WithTimeout(ctx, timeout)
+	request := protocol.Frame{
+		Source:    source,
+		Target:    target,
+		Primary:   vaillantB555Primary,
+		Secondary: vaillantB555Secondary,
+		Data:      data,
+	}
+	response, err := p.bus.Send(reqCtx, request)
+	cancel()
+	p.readMu.Unlock()
+
+	if err != nil || response == nil {
+		return nil, false
+	}
+	return response.Data, true
+}
+
+// readB555Config reads a B555 A3 config response for a zone+HC.
+func (p *vaillantSemanticPoller) readB555Config(ctx context.Context, zone, hc byte) *graphql.ScheduleConfig {
+	data, ok := p.readB555Frame(ctx, []byte{b555OpcodeConfigRead, zone, hc})
+	if !ok || len(data) < 9 {
+		return nil
+	}
+	status := data[0]
+	if status != 0x00 {
+		return nil
+	}
+	cfg := &graphql.ScheduleConfig{
+		MaxSlots:       int(data[1]),
+		TimeResolution: int(data[2]),
+		MinDuration:    int(data[3]),
+		HasTemperature: data[4] != 0,
+		TempSlots:      int(data[5]),
+	}
+	// A3 layout: status(1)+max_slots(1)+time_res(1)+min_dur(1)+has_temp(1)+temp_slots(1)+min_temp(1)+max_temp(1)+pad(1) = 9 bytes
+	// min_temp and max_temp are UCH (whole °C), sentinel 0xFF = unavailable.
+	if data[6] != 0xFF {
+		v := float64(data[6])
+		cfg.MinTempC = &v
+	}
+	if data[7] != 0xFF {
+		v := float64(data[7])
+		cfg.MaxTempC = &v
+	}
+	return cfg
+}
+
+// readB555Slots reads B555 A4 slots-per-day response for a zone+HC.
+func (p *vaillantSemanticPoller) readB555Slots(ctx context.Context, zone, hc byte) ([]int, bool) {
+	data, ok := p.readB555Frame(ctx, []byte{b555OpcodeSlotsRead, zone, hc})
+	if !ok || len(data) < 9 {
+		return nil, false
+	}
+	status := data[0]
+	if status != 0x00 {
+		return nil, false
+	}
+	// A4 layout: status(1)+Mon(1)+Tue(1)+Wed(1)+Thu(1)+Fri(1)+Sat(1)+Sun(1)+pad(1) = 9 bytes
+	slots := make([]int, 7)
+	for i := 0; i < 7 && i+1 < len(data); i++ {
+		slots[i] = int(data[i+1])
+	}
+	return slots, true
+}
+
+// readB555Timer reads a single timer slot from B555 A5.
+func (p *vaillantSemanticPoller) readB555Timer(ctx context.Context, zone, hc, weekday, slotIdx byte) *graphql.ScheduleTimerSlot {
+	data, ok := p.readB555Frame(ctx, []byte{b555OpcodeTimerRead, zone, hc, weekday, slotIdx})
+	if !ok || len(data) < 7 {
+		return nil
+	}
+	status := data[0]
+	if status != 0x00 {
+		return nil
+	}
+	slot := &graphql.ScheduleTimerSlot{
+		StartHour:   int(data[1]),
+		StartMinute: int(data[2]),
+		EndHour:     int(data[3]),
+		EndMinute:   int(data[4]),
+	}
+	tempRaw := uint16(data[5]) | uint16(data[6])<<8
+	if tempRaw != 0xFFFF {
+		v := float64(tempRaw) / 10.0
+		slot.TemperatureC = &v
+		rawInt := int(tempRaw)
+		slot.TemperatureRaw = &rawInt
+	}
+	return slot
+}
+
+// b555ProgramSpec defines a (zone, hc) combination to poll.
+type b555ProgramSpec struct {
+	zone byte
+	hc   byte
+}
+
+// refreshSchedules polls B555 timer schedules and publishes to the semantic provider.
+func (p *vaillantSemanticPoller) refreshSchedules(ctx context.Context) {
+	if p == nil || p.bus == nil || p.provider == nil {
+		return
+	}
+
+	p.mu.Lock()
+	controller := p.controller
+	p.mu.Unlock()
+	if controller == 0 {
+		return
+	}
+
+	// Define which (zone, HC) combinations to poll.
+	// Per-zone programs: zone 0-2 × heating/cooling
+	// Zone-agnostic programs: 0xFF × DHW/CC/Silent
+	specs := []b555ProgramSpec{
+		{zone: 0x00, hc: b555HCHeating},
+		{zone: 0x01, hc: b555HCHeating},
+		{zone: 0x02, hc: b555HCHeating},
+		{zone: 0x00, hc: b555HCCooling},
+		{zone: 0x01, hc: b555HCCooling},
+		{zone: 0x02, hc: b555HCCooling},
+		{zone: b555ZoneDHW, hc: b555HCDHW},
+		{zone: b555ZoneDHW, hc: b555HCCC},
+		{zone: b555ZoneDHW, hc: b555HCSilent},
+	}
+
+	var programs []graphql.ScheduleProgram
+
+	for _, spec := range specs {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		// Step 1: Read config (A3)
+		cfg := p.readB555Config(ctx, spec.zone, spec.hc)
+		if cfg == nil {
+			continue
+		}
+
+		hcName := b555HCNames[spec.hc]
+		if hcName == "" {
+			hcName = fmt.Sprintf("unknown_%d", spec.hc)
+		}
+		zoneIdx := int(spec.zone)
+		if spec.zone == b555ZoneDHW {
+			zoneIdx = 255
+		}
+
+		prog := graphql.ScheduleProgram{
+			Zone:   zoneIdx,
+			HC:     hcName,
+			Config: cfg,
+		}
+
+		// Step 2: Read slots per day (A4)
+		slotsPerDay, ok := p.readB555Slots(ctx, spec.zone, spec.hc)
+		if ok {
+			prog.SlotsUsed = slotsPerDay
+		}
+
+		// Step 3: Read timer entries (A5) for each day/slot
+		maxSlots := cfg.MaxSlots
+		if maxSlots <= 0 {
+			maxSlots = 3
+		}
+
+		days := make([]graphql.ScheduleDayProgram, 7)
+		for dd := byte(0); dd < 7; dd++ {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			day := graphql.ScheduleDayProgram{
+				Weekday: b555WeekdayNames[dd],
+			}
+
+			slotCount := maxSlots
+			if ok && int(dd) < len(slotsPerDay) && slotsPerDay[dd] < slotCount {
+				slotCount = slotsPerDay[dd]
+			}
+
+			for ss := 0; ss < slotCount; ss++ {
+				slot := p.readB555Timer(ctx, spec.zone, spec.hc, dd, byte(ss))
+				if slot == nil {
+					break
+				}
+				day.Slots = append(day.Slots, *slot)
+			}
+			days[dd] = day
+		}
+		prog.Days = days
+
+		programs = append(programs, prog)
+	}
+
+	if len(programs) > 0 {
+		p.provider.SetSchedules(&graphql.ScheduleStatus{
+			Programs: programs,
+		})
+	}
 }
 
 func (adapter mcpSemanticProviderAdapter) System() *mcp.SystemStatus {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.0.0-20260228114515-463da768cb9f
-	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260308133434-a4dd8f3e0af1
+	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260308222957-ffe0bbc91386
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,7 @@
 github.com/Project-Helianthus/helianthus-ebusgo v0.0.0-20260228114515-463da768cb9f h1:mBTY1wIlBqiS43yvPKfj8bH0klxtv1g2NFeza7gTPWs=
 github.com/Project-Helianthus/helianthus-ebusgo v0.0.0-20260228114515-463da768cb9f/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260308024753-a0eb51c7c727 h1:OMtWNGq/TWjo/6fgzxFYPBZVYCCdOXMjb0SDHA+I2qk=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260308024753-a0eb51c7c727/go.mod h1:FrDhh/Q0KQhP+11jGrQFJLur/kLjAA2mQ7UjJYthOlE=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260308133434-a4dd8f3e0af1 h1:+UIwSdvIUVnZJEV4oSvNlTtHw9s4V/NgZg57/kC99yI=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260308133434-a4dd8f3e0af1/go.mod h1:FrDhh/Q0KQhP+11jGrQFJLur/kLjAA2mQ7UjJYthOlE=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260308222957-ffe0bbc91386 h1:LB2qsODNxkORRsnKJ5HrTAwJ2UmEIlN9+Rlr6SHx06c=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260308222957-ffe0bbc91386/go.mod h1:FrDhh/Q0KQhP+11jGrQFJLur/kLjAA2mQ7UjJYthOlE=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=

--- a/graphql/semantic.go
+++ b/graphql/semantic.go
@@ -236,6 +236,42 @@ type SystemProperties struct {
 	ModuleConfigurationVR71 *int
 }
 
+type ScheduleTimerSlot struct {
+	StartHour      int
+	StartMinute    int
+	EndHour        int
+	EndMinute      int
+	TemperatureC   *float64
+	TemperatureRaw *int
+}
+
+type ScheduleDayProgram struct {
+	Weekday string
+	Slots   []ScheduleTimerSlot
+}
+
+type ScheduleConfig struct {
+	MaxSlots       int
+	TimeResolution int
+	MinDuration    int
+	HasTemperature bool
+	TempSlots      int
+	MinTempC       *float64
+	MaxTempC       *float64
+}
+
+type ScheduleProgram struct {
+	Zone      int
+	HC        string
+	Config    *ScheduleConfig
+	SlotsUsed []int
+	Days      []ScheduleDayProgram
+}
+
+type ScheduleStatus struct {
+	Programs []ScheduleProgram
+}
+
 type SemanticProvider interface {
 	Zones() []Zone
 	DHW() *DhwStatus
@@ -247,6 +283,7 @@ type SemanticProvider interface {
 	EnergyTotals() *EnergyTotals
 	BoilerStatus() *BoilerStatus
 	System() *SystemStatus
+	Schedules() *ScheduleStatus
 }
 
 type staticSemanticProvider struct{}
@@ -291,6 +328,10 @@ func (staticSemanticProvider) System() *SystemStatus {
 	return nil
 }
 
+func (staticSemanticProvider) Schedules() *ScheduleStatus {
+	return nil
+}
+
 var liveSystemSnapshots sync.Map
 
 func (provider *LiveSemanticProvider) System() *SystemStatus {
@@ -325,6 +366,38 @@ func (provider *LiveSemanticProvider) SetSystem(status *SystemStatus) {
 
 func (provider *LiveSemanticProvider) SetSystemFromCache(status *SystemStatus) {
 	provider.SetSystem(status)
+}
+
+var liveScheduleSnapshots sync.Map
+
+func (provider *LiveSemanticProvider) Schedules() *ScheduleStatus {
+	if provider == nil {
+		return nil
+	}
+	provider.mu.RLock()
+	defer provider.mu.RUnlock()
+	stored, ok := liveScheduleSnapshots.Load(provider)
+	if !ok || stored == nil {
+		return nil
+	}
+	status, ok := stored.(*ScheduleStatus)
+	if !ok || status == nil {
+		return nil
+	}
+	return cloneScheduleStatus(status)
+}
+
+func (provider *LiveSemanticProvider) SetSchedules(status *ScheduleStatus) {
+	if provider == nil {
+		return
+	}
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+	if status == nil {
+		liveScheduleSnapshots.Delete(provider)
+		return
+	}
+	liveScheduleSnapshots.Store(provider, cloneScheduleStatus(status))
 }
 
 func cloneSystemStatus(status *SystemStatus) *SystemStatus {
@@ -404,6 +477,71 @@ func cloneSystemConfig(config SystemConfig) SystemConfig {
 		config.MaxRoomHumidity = &v
 	}
 	return config
+}
+
+func cloneScheduleStatus(status *ScheduleStatus) *ScheduleStatus {
+	if status == nil {
+		return nil
+	}
+	cp := ScheduleStatus{}
+	if len(status.Programs) > 0 {
+		cp.Programs = make([]ScheduleProgram, len(status.Programs))
+		for i, prog := range status.Programs {
+			cp.Programs[i] = cloneScheduleProgram(prog)
+		}
+	}
+	return &cp
+}
+
+func cloneScheduleProgram(prog ScheduleProgram) ScheduleProgram {
+	out := prog
+	if prog.Config != nil {
+		cfgCopy := *prog.Config
+		if prog.Config.MinTempC != nil {
+			v := *prog.Config.MinTempC
+			cfgCopy.MinTempC = &v
+		}
+		if prog.Config.MaxTempC != nil {
+			v := *prog.Config.MaxTempC
+			cfgCopy.MaxTempC = &v
+		}
+		out.Config = &cfgCopy
+	}
+	if len(prog.SlotsUsed) > 0 {
+		out.SlotsUsed = make([]int, len(prog.SlotsUsed))
+		copy(out.SlotsUsed, prog.SlotsUsed)
+	}
+	if len(prog.Days) > 0 {
+		out.Days = make([]ScheduleDayProgram, len(prog.Days))
+		for i, day := range prog.Days {
+			out.Days[i] = cloneScheduleDayProgram(day)
+		}
+	}
+	return out
+}
+
+func cloneScheduleDayProgram(day ScheduleDayProgram) ScheduleDayProgram {
+	out := day
+	if len(day.Slots) > 0 {
+		out.Slots = make([]ScheduleTimerSlot, len(day.Slots))
+		for i, slot := range day.Slots {
+			out.Slots[i] = cloneScheduleTimerSlot(slot)
+		}
+	}
+	return out
+}
+
+func cloneScheduleTimerSlot(slot ScheduleTimerSlot) ScheduleTimerSlot {
+	out := slot
+	if slot.TemperatureC != nil {
+		v := *slot.TemperatureC
+		out.TemperatureC = &v
+	}
+	if slot.TemperatureRaw != nil {
+		v := *slot.TemperatureRaw
+		out.TemperatureRaw = &v
+	}
+	return out
 }
 
 func cloneSystemProperties(properties SystemProperties) SystemProperties {

--- a/mcp/parity_contract_test.go
+++ b/mcp/parity_contract_test.go
@@ -26,6 +26,7 @@ var canonicalSemanticSnapshotPlanes = []string{
 	"fm5_mode",
 	"solar",
 	"cylinders",
+	"schedules",
 }
 
 func TestToolInventoryGoldenSignatures(t *testing.T) {
@@ -79,7 +80,8 @@ func TestToolInventoryGoldenSignatures(t *testing.T) {
 		{Name: "ebus.v1.semantic.energy_totals.get", SchemaHash: "c88e6ce24faaf24f31d9f934af950368a2dd0561e547df2089c7c44195d76389"},
 		{Name: "ebus.v1.semantic.fm5_mode.get", SchemaHash: "c88e6ce24faaf24f31d9f934af950368a2dd0561e547df2089c7c44195d76389"},
 		{Name: "ebus.v1.semantic.radio_devices.get", SchemaHash: "c88e6ce24faaf24f31d9f934af950368a2dd0561e547df2089c7c44195d76389"},
-		{Name: "ebus.v1.semantic.snapshot.get", SchemaHash: "6e43bdd1f23f2ad7fe0eb914d3c8304ed0ddb2d6bb6723e35c5ace4120982e83"},
+		{Name: "ebus.v1.semantic.schedules.get", SchemaHash: "c88e6ce24faaf24f31d9f934af950368a2dd0561e547df2089c7c44195d76389"},
+		{Name: "ebus.v1.semantic.snapshot.get", SchemaHash: "b393a16a2de0a0dd8eb8a3daa78992285d24771ed3005023a801b48fcf55aa13"},
 		{Name: "ebus.v1.semantic.solar.get", SchemaHash: "c88e6ce24faaf24f31d9f934af950368a2dd0561e547df2089c7c44195d76389"},
 		{Name: "ebus.v1.semantic.system.get", SchemaHash: "c88e6ce24faaf24f31d9f934af950368a2dd0561e547df2089c7c44195d76389"},
 		{Name: "ebus.v1.semantic.zones.get", SchemaHash: "c88e6ce24faaf24f31d9f934af950368a2dd0561e547df2089c7c44195d76389"},

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -268,6 +268,42 @@ type CylinderStatus struct {
 	ChargeOffsetC     *float64 `json:"charge_offset_c,omitempty"`
 }
 
+type ScheduleTimerSlot struct {
+	StartHour      int      `json:"start_hour"`
+	StartMinute    int      `json:"start_minute"`
+	EndHour        int      `json:"end_hour"`
+	EndMinute      int      `json:"end_minute"`
+	TemperatureC   *float64 `json:"temperature_c,omitempty"`
+	TemperatureRaw *int     `json:"temperature_raw,omitempty"`
+}
+
+type ScheduleDayProgram struct {
+	Weekday string              `json:"weekday"`
+	Slots   []ScheduleTimerSlot `json:"slots"`
+}
+
+type ScheduleConfig struct {
+	MaxSlots       int      `json:"max_slots"`
+	TimeResolution int      `json:"time_resolution"`
+	MinDuration    int      `json:"min_duration"`
+	HasTemperature bool     `json:"has_temperature"`
+	TempSlots      int      `json:"temp_slots"`
+	MinTempC       *float64 `json:"min_temp_c,omitempty"`
+	MaxTempC       *float64 `json:"max_temp_c,omitempty"`
+}
+
+type ScheduleProgram struct {
+	Zone      int                  `json:"zone"`
+	HC        string               `json:"hc"`
+	Config    *ScheduleConfig      `json:"config,omitempty"`
+	SlotsUsed []int                `json:"slots_used,omitempty"`
+	Days      []ScheduleDayProgram `json:"days,omitempty"`
+}
+
+type ScheduleStatus struct {
+	Programs []ScheduleProgram `json:"programs"`
+}
+
 type SemanticProvider interface {
 	Zones() []Zone
 	DHW() *DhwStatus
@@ -279,6 +315,7 @@ type SemanticProvider interface {
 	EnergyTotals() *EnergyTotals
 	BoilerStatus() *BoilerStatus
 	System() *SystemStatus
+	Schedules() *ScheduleStatus
 }
 
 type Server struct {
@@ -306,6 +343,7 @@ const (
 	toolSemanticEnergyGetName    = "ebus.v1.semantic.energy_totals.get"
 	toolSemanticBoilerGetName    = "ebus.v1.semantic.boiler_status.get"
 	toolSemanticSystemGetName    = "ebus.v1.semantic.system.get"
+	toolSemanticSchedulesGetName = "ebus.v1.semantic.schedules.get"
 	toolSemanticSnapshotName     = "ebus.v1.semantic.snapshot.get"
 	toolSnapshotCaptureName      = "ebus.v1.snapshot.capture"
 	toolSnapshotDropName         = "ebus.v1.snapshot.drop"
@@ -392,6 +430,10 @@ func (staticSemanticProvider) System() *SystemStatus {
 	return nil
 }
 
+func (staticSemanticProvider) Schedules() *ScheduleStatus {
+	return nil
+}
+
 type idempotencyEntry struct {
 	signature string
 	result    any
@@ -426,6 +468,7 @@ type snapshotState struct {
 	energy    *EnergyTotals
 	boiler    *BoilerStatus
 	system    *SystemStatus
+	schedules *ScheduleStatus
 	devices   []deviceInfo
 }
 
@@ -576,6 +619,17 @@ func NewServer(reg Registry, invoker Invoker) (*Server, error) {
 			},
 		},
 		{
+			Name:        toolSemanticSchedulesGetName,
+			Description: "Get semantic weekly timer schedules snapshot (B555 protocol).",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"consistency": consistencyInputProperty(),
+				},
+				"additionalProperties": false,
+			},
+		},
+		{
 			Name:        toolSemanticSnapshotName,
 			Description: "Get a consistent semantic snapshot across selected semantic planes.",
 			InputSchema: map[string]any{
@@ -585,7 +639,7 @@ func NewServer(reg Registry, invoker Invoker) (*Server, error) {
 						"type": "array",
 						"items": map[string]any{
 							"type": "string",
-							"enum": []string{"runtime_status", "zones", "dhw", "energy_totals", "boiler_status", "system", "circuits", "radio_devices", "fm5_mode", "solar", "cylinders"},
+							"enum": []string{"runtime_status", "zones", "dhw", "energy_totals", "boiler_status", "system", "circuits", "radio_devices", "fm5_mode", "solar", "cylinders", "schedules"},
 						},
 					},
 					"timeout_ms": map[string]any{"type": "integer", "minimum": 1},
@@ -911,6 +965,12 @@ func (s *Server) handleToolsCall(ctx context.Context, params json.RawMessage) (a
 			return callToolResultText(mustJSON(newToolEnvelope(nil, err)), true), nil
 		}
 		return callToolResultText(mustJSON(newToolEnvelopeWithConsistency(s.snapshotSystem(snapshot), nil, consistency)), false), nil
+	case toolSemanticSchedulesGetName:
+		consistency, snapshot, err := s.resolveConsistency(call.Arguments)
+		if err != nil {
+			return callToolResultText(mustJSON(newToolEnvelope(nil, err)), true), nil
+		}
+		return callToolResultText(mustJSON(newToolEnvelopeWithConsistency(s.snapshotSchedules(snapshot), nil, consistency)), false), nil
 	case toolSemanticSnapshotName:
 		consistency, snapshot, err := s.resolveConsistency(call.Arguments)
 		if err != nil {
@@ -1084,6 +1144,7 @@ func (s *Server) captureSnapshot() (snapshotID string, createdAt time.Time, err 
 		energy:    s.snapshotEnergyTotals(nil),
 		boiler:    s.snapshotBoilerStatus(nil),
 		system:    s.snapshotSystem(nil),
+		schedules: s.snapshotSchedules(nil),
 		devices:   s.listDevices(nil),
 	}
 
@@ -1163,6 +1224,10 @@ func cloneSnapshotState(snapshot snapshotState) snapshotState {
 	if snapshot.system != nil {
 		systemCopy = cloneMCPSystemStatus(snapshot.system)
 	}
+	var schedulesCopy *ScheduleStatus
+	if snapshot.schedules != nil {
+		schedulesCopy = cloneMCPScheduleStatus(snapshot.schedules)
+	}
 	var solarCopy *SolarStatus
 	if snapshot.solar != nil {
 		solarCopy = cloneMCPSolarStatus(snapshot.solar)
@@ -1183,6 +1248,7 @@ func cloneSnapshotState(snapshot snapshotState) snapshotState {
 		energy:    energyCopy,
 		boiler:    boilerCopy,
 		system:    systemCopy,
+		schedules: schedulesCopy,
 		devices:   cloneDeviceInfoList(snapshot.devices),
 	}
 }
@@ -1992,6 +2058,76 @@ func (s *Server) snapshotSystem(snapshot *snapshotState) *SystemStatus {
 	return cloneMCPSystemStatus(source)
 }
 
+func (s *Server) snapshotSchedules(snapshot *snapshotState) *ScheduleStatus {
+	if snapshot != nil {
+		if snapshot.schedules == nil {
+			return nil
+		}
+		return cloneMCPScheduleStatus(snapshot.schedules)
+	}
+	if s == nil || s.semantic == nil {
+		return nil
+	}
+	source := s.semantic.Schedules()
+	if source == nil {
+		return nil
+	}
+	return cloneMCPScheduleStatus(source)
+}
+
+func cloneMCPScheduleStatus(status *ScheduleStatus) *ScheduleStatus {
+	if status == nil {
+		return nil
+	}
+	cp := ScheduleStatus{}
+	if len(status.Programs) > 0 {
+		cp.Programs = make([]ScheduleProgram, len(status.Programs))
+		for i, prog := range status.Programs {
+			out := prog
+			if prog.Config != nil {
+				cfgCopy := *prog.Config
+				if prog.Config.MinTempC != nil {
+					v := *prog.Config.MinTempC
+					cfgCopy.MinTempC = &v
+				}
+				if prog.Config.MaxTempC != nil {
+					v := *prog.Config.MaxTempC
+					cfgCopy.MaxTempC = &v
+				}
+				out.Config = &cfgCopy
+			}
+			if len(prog.SlotsUsed) > 0 {
+				out.SlotsUsed = make([]int, len(prog.SlotsUsed))
+				copy(out.SlotsUsed, prog.SlotsUsed)
+			}
+			if len(prog.Days) > 0 {
+				out.Days = make([]ScheduleDayProgram, len(prog.Days))
+				for j, day := range prog.Days {
+					dayCopy := day
+					if len(day.Slots) > 0 {
+						dayCopy.Slots = make([]ScheduleTimerSlot, len(day.Slots))
+						for k, slot := range day.Slots {
+							slotCopy := slot
+							if slot.TemperatureC != nil {
+								v := *slot.TemperatureC
+								slotCopy.TemperatureC = &v
+							}
+							if slot.TemperatureRaw != nil {
+								v := *slot.TemperatureRaw
+								slotCopy.TemperatureRaw = &v
+							}
+							dayCopy.Slots[k] = slotCopy
+						}
+					}
+					out.Days[j] = dayCopy
+				}
+			}
+			cp.Programs[i] = out
+		}
+	}
+	return &cp
+}
+
 func cloneMCPBoilerStatus(status *BoilerStatus) *BoilerStatus {
 	if status == nil {
 		return nil
@@ -2303,7 +2439,7 @@ func (s *Server) readSemanticSnapshot(ctx context.Context, args map[string]any, 
 
 func parseSemanticSnapshotOptions(args map[string]any) (semanticSnapshotOptions, error) {
 	options := semanticSnapshotOptions{
-		planes:       []string{"runtime_status", "zones", "dhw", "energy_totals", "boiler_status", "system", "circuits", "radio_devices", "fm5_mode", "solar", "cylinders"},
+		planes:       []string{"runtime_status", "zones", "dhw", "energy_totals", "boiler_status", "system", "circuits", "radio_devices", "fm5_mode", "solar", "cylinders", "schedules"},
 		timeout:      defaultSnapshotReadTTL,
 		allowPartial: false,
 	}
@@ -2369,7 +2505,7 @@ func parseSemanticSnapshotPlanes(raw any) ([]string, error) {
 		}
 		normalized := strings.ToLower(strings.TrimSpace(value))
 		switch normalized {
-		case "runtime_status", "zones", "dhw", "energy_totals", "boiler_status", "system", "circuits", "radio_devices", "fm5_mode", "solar", "cylinders":
+		case "runtime_status", "zones", "dhw", "energy_totals", "boiler_status", "system", "circuits", "radio_devices", "fm5_mode", "solar", "cylinders", "schedules":
 		default:
 			return nil, fmt.Errorf("unsupported plane %q: %w", value, ebuserrors.ErrInvalidPayload)
 		}
@@ -2416,6 +2552,8 @@ func (s *Server) readSemanticPlane(ctx context.Context, plane string, snapshot *
 		value = s.snapshotSolar(snapshot)
 	case "cylinders":
 		value = s.snapshotCylinders(snapshot)
+	case "schedules":
+		value = s.snapshotSchedules(snapshot)
 	default:
 		return nil, fmt.Errorf("unsupported plane %q: %w", plane, ebuserrors.ErrInvalidPayload)
 	}

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -169,6 +169,7 @@ type testSemanticProvider struct {
 	energy        *EnergyTotals
 	boiler        *BoilerStatus
 	system        *SystemStatus
+	schedules     *ScheduleStatus
 	zonesDelay    time.Duration
 	circuitsDelay time.Duration
 	radioDelay    time.Duration
@@ -247,6 +248,13 @@ func (p testSemanticProvider) System() *SystemStatus {
 		return nil
 	}
 	return cloneMCPSystemStatus(p.system)
+}
+
+func (p testSemanticProvider) Schedules() *ScheduleStatus {
+	if p.schedules == nil {
+		return nil
+	}
+	return cloneMCPScheduleStatus(p.schedules)
 }
 
 func (p testSemanticProvider) EnergyTotals() *EnergyTotals {
@@ -795,8 +803,8 @@ func TestServer_ToolsCallSemanticSnapshots(t *testing.T) {
 			t.Fatalf("snapshot data type = %T; want map", envelope["data"])
 		}
 		completed, ok := data["completed_planes"].([]any)
-		if !ok || len(completed) != 11 {
-			t.Fatalf("snapshot completed_planes = %#v; want 11 entries", data["completed_planes"])
+		if !ok || len(completed) != 12 {
+			t.Fatalf("snapshot completed_planes = %#v; want 12 entries", data["completed_planes"])
 		}
 		planes, ok := data["planes"].(map[string]any)
 		if !ok {

--- a/mcp/tool_classification_test.go
+++ b/mcp/tool_classification_test.go
@@ -47,6 +47,7 @@ func TestToolClassificationPolicy(t *testing.T) {
 		toolSemanticEnergyGetName:    toolClassCoreStable,
 		toolSemanticBoilerGetName:    toolClassCoreStable,
 		toolSemanticSystemGetName:    toolClassCoreStable,
+		toolSemanticSchedulesGetName: toolClassCoreStable,
 		toolSemanticSnapshotName:     toolClassCoreStable,
 		toolSnapshotCaptureName:      toolClassCoreStable,
 		toolSnapshotDropName:         toolClassCoreStable,


### PR DESCRIPTION
## Summary

- Add `ebus.v1.semantic.schedules.get` MCP tool backed by B555 protocol polling
- B555 poller reads timer programs for 3 zones × heating/cooling + zone-agnostic DHW/CC/Silent every 10min
- Each program includes config (A3 opcode), per-day slot availability (A4), and timer entries with temperature setpoints (A5)
- Full plumbing: graphql types → SemanticProvider interface → LiveSemanticProvider sync.Map → MCP tool + snapshot plane → adapter layer
- Bumps ebusreg to `ffe0bbc` (B555 plane provider from PR #110)

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./mcp/` — all pass (golden signatures, classification, snapshot planes)
- [x] Parity contract test updated with schedules tool signature
- [ ] CI green
- [ ] Deploy to RPi4 and verify schedule data appears via MCP

Closes #318