### PR TITLE
Enqueue initial B555 schedule poll at startup

### DIFF
--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -1033,6 +1033,7 @@ func (p *vaillantSemanticPoller) Start(ctx context.Context) {
 	// Discovery owns downstream controller/boiler priming and avoids duplicate startup bursts.
 	p.enqueueTask(semanticTaskPriorityHigh, p.refreshDiscovery)
 	p.enqueueTask(semanticTaskPriorityHigh, p.refreshState)
+	p.enqueueTask(semanticTaskPriorityLow, p.refreshSchedules)
 
 	go p.runLoop(ctx, p.regulatorRecheckInterval, semanticTaskPriorityLow, p.refreshRegulatorCapability)
 	go p.runLoop(ctx, p.discoveryInterval, semanticTaskPriorityLow, p.refreshDiscovery)


### PR DESCRIPTION
## Summary
- Add `p.enqueueTask(semanticTaskPriorityLow, p.refreshSchedules)` in `Start()` for immediate first schedule poll
- Schedule data was unavailable for ~10 minutes after startup while waiting for the first ticker tick
- Matches existing pattern used by `refreshDiscovery` and `refreshState`

Fixes #321

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] Verified schedule data appears via MCP `ebus.v1.semantic.snapshot.get` with `planes: ["schedules"]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)