### PR TITLE
Expose schedule data via GraphQL

### DIFF
--- a/graphql/queries.go
+++ b/graphql/queries.go
@@ -30,6 +30,7 @@ type graphqlSchemaTypes struct {
 	energyTotals       *graphqlgo.Object
 	boilerStatusType   *graphqlgo.Object
 	systemStatusType   *graphqlgo.Object
+	scheduleStatusType *graphqlgo.Object
 }
 
 func buildSchemaTypes() graphqlSchemaTypes {
@@ -2191,6 +2192,246 @@ func buildSchemaTypes() graphqlSchemaTypes {
 		},
 	})
 
+	scheduleTimerSlotType := graphqlgo.NewObject(graphqlgo.ObjectConfig{
+		Name: "ScheduleTimerSlot",
+		Fields: graphqlgo.Fields{
+			"startHour": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Int),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					slot, ok := params.Source.(ScheduleTimerSlot)
+					if !ok {
+						return nil, nil
+					}
+					return slot.StartHour, nil
+				},
+			},
+			"startMinute": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Int),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					slot, ok := params.Source.(ScheduleTimerSlot)
+					if !ok {
+						return nil, nil
+					}
+					return slot.StartMinute, nil
+				},
+			},
+			"endHour": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Int),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					slot, ok := params.Source.(ScheduleTimerSlot)
+					if !ok {
+						return nil, nil
+					}
+					return slot.EndHour, nil
+				},
+			},
+			"endMinute": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Int),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					slot, ok := params.Source.(ScheduleTimerSlot)
+					if !ok {
+						return nil, nil
+					}
+					return slot.EndMinute, nil
+				},
+			},
+			"temperatureC": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					slot, ok := params.Source.(ScheduleTimerSlot)
+					if !ok || slot.TemperatureC == nil {
+						return nil, nil
+					}
+					return *slot.TemperatureC, nil
+				},
+			},
+			"temperatureRaw": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					slot, ok := params.Source.(ScheduleTimerSlot)
+					if !ok || slot.TemperatureRaw == nil {
+						return nil, nil
+					}
+					return *slot.TemperatureRaw, nil
+				},
+			},
+		},
+	})
+
+	scheduleDayProgramType := graphqlgo.NewObject(graphqlgo.ObjectConfig{
+		Name: "ScheduleDayProgram",
+		Fields: graphqlgo.Fields{
+			"weekday": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.String),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					day, ok := params.Source.(ScheduleDayProgram)
+					if !ok {
+						return nil, nil
+					}
+					return day.Weekday, nil
+				},
+			},
+			"slots": &graphqlgo.Field{
+				Type: graphqlgo.NewList(graphqlgo.NewNonNull(scheduleTimerSlotType)),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					day, ok := params.Source.(ScheduleDayProgram)
+					if !ok {
+						return nil, nil
+					}
+					return day.Slots, nil
+				},
+			},
+		},
+	})
+
+	scheduleConfigType := graphqlgo.NewObject(graphqlgo.ObjectConfig{
+		Name: "ScheduleConfig",
+		Fields: graphqlgo.Fields{
+			"maxSlots": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Int),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					cfg, ok := params.Source.(*ScheduleConfig)
+					if !ok || cfg == nil {
+						return nil, nil
+					}
+					return cfg.MaxSlots, nil
+				},
+			},
+			"timeResolution": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Int),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					cfg, ok := params.Source.(*ScheduleConfig)
+					if !ok || cfg == nil {
+						return nil, nil
+					}
+					return cfg.TimeResolution, nil
+				},
+			},
+			"minDuration": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Int),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					cfg, ok := params.Source.(*ScheduleConfig)
+					if !ok || cfg == nil {
+						return nil, nil
+					}
+					return cfg.MinDuration, nil
+				},
+			},
+			"hasTemperature": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Boolean),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					cfg, ok := params.Source.(*ScheduleConfig)
+					if !ok || cfg == nil {
+						return nil, nil
+					}
+					return cfg.HasTemperature, nil
+				},
+			},
+			"tempSlots": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Int),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					cfg, ok := params.Source.(*ScheduleConfig)
+					if !ok || cfg == nil {
+						return nil, nil
+					}
+					return cfg.TempSlots, nil
+				},
+			},
+			"minTempC": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					cfg, ok := params.Source.(*ScheduleConfig)
+					if !ok || cfg == nil || cfg.MinTempC == nil {
+						return nil, nil
+					}
+					return *cfg.MinTempC, nil
+				},
+			},
+			"maxTempC": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					cfg, ok := params.Source.(*ScheduleConfig)
+					if !ok || cfg == nil || cfg.MaxTempC == nil {
+						return nil, nil
+					}
+					return *cfg.MaxTempC, nil
+				},
+			},
+		},
+	})
+
+	scheduleProgramType := graphqlgo.NewObject(graphqlgo.ObjectConfig{
+		Name: "ScheduleProgram",
+		Fields: graphqlgo.Fields{
+			"zone": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Int),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					prog, ok := params.Source.(ScheduleProgram)
+					if !ok {
+						return nil, nil
+					}
+					return prog.Zone, nil
+				},
+			},
+			"hc": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.String),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					prog, ok := params.Source.(ScheduleProgram)
+					if !ok {
+						return nil, nil
+					}
+					return prog.HC, nil
+				},
+			},
+			"config": &graphqlgo.Field{
+				Type: scheduleConfigType,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					prog, ok := params.Source.(ScheduleProgram)
+					if !ok {
+						return nil, nil
+					}
+					return prog.Config, nil
+				},
+			},
+			"slotsUsed": &graphqlgo.Field{
+				Type: graphqlgo.NewList(graphqlgo.NewNonNull(graphqlgo.Int)),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					prog, ok := params.Source.(ScheduleProgram)
+					if !ok {
+						return nil, nil
+					}
+					return prog.SlotsUsed, nil
+				},
+			},
+			"days": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.NewList(graphqlgo.NewNonNull(scheduleDayProgramType))),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					prog, ok := params.Source.(ScheduleProgram)
+					if !ok {
+						return nil, nil
+					}
+					return prog.Days, nil
+				},
+			},
+		},
+	})
+
+	scheduleStatusType := graphqlgo.NewObject(graphqlgo.ObjectConfig{
+		Name: "ScheduleStatus",
+		Fields: graphqlgo.Fields{
+			"programs": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.NewList(graphqlgo.NewNonNull(scheduleProgramType))),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					status, ok := params.Source.(*ScheduleStatus)
+					if !ok || status == nil {
+						return nil, nil
+					}
+					return status.Programs, nil
+				},
+			},
+		},
+	})
+
 	return graphqlSchemaTypes{
 		fieldType:          fieldType,
 		responseType:       responseType,
@@ -2212,6 +2453,7 @@ func buildSchemaTypes() graphqlSchemaTypes {
 		energyTotals:       energyTotalsType,
 		boilerStatusType:   boilerStatusType,
 		systemStatusType:   systemStatusType,
+		scheduleStatusType: scheduleStatusType,
 	}
 }
 
@@ -2313,6 +2555,12 @@ func buildQueryType(builder *Builder, types graphqlSchemaTypes) *graphqlgo.Objec
 				Type: types.systemStatusType,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					return builder.semanticProvider().System(), nil
+				},
+			},
+			"schedules": &graphqlgo.Field{
+				Type: types.scheduleStatusType,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					return builder.semanticProvider().Schedules(), nil
 				},
 			},
 			"devices": &graphqlgo.Field{

--- a/graphql/queries_test.go
+++ b/graphql/queries_test.go
@@ -26,6 +26,7 @@ var canonicalSemanticRootFields = []string{
 	"cylinders",
 	"boilerStatus",
 	"system",
+	"schedules",
 }
 
 func TestQueryResolvers_Integration(t *testing.T) {
@@ -480,6 +481,33 @@ func TestQueryResolvers_Integration(t *testing.T) {
 						moduleConfigurationVR71
 					}
 				}
+				schedules {
+					programs {
+						zone
+						hc
+						config {
+							maxSlots
+							timeResolution
+							minDuration
+							hasTemperature
+							tempSlots
+							minTempC
+							maxTempC
+						}
+						slotsUsed
+						days {
+							weekday
+							slots {
+								startHour
+								startMinute
+								endHour
+								endMinute
+								temperatureC
+								temperatureRaw
+							}
+						}
+					}
+				}
 			}
 		`)
 
@@ -606,6 +634,12 @@ func TestQueryResolvers_Integration(t *testing.T) {
 					ModuleConfigurationVR71 *int `json:"moduleConfigurationVR71"`
 				} `json:"properties"`
 			} `json:"system"`
+			Schedules *struct {
+				Programs []struct {
+					Zone int    `json:"zone"`
+					HC   string `json:"hc"`
+				} `json:"programs"`
+			} `json:"schedules"`
 		}
 
 		if err := client.Run(context.Background(), request, &response); err != nil {
@@ -640,6 +674,9 @@ func TestQueryResolvers_Integration(t *testing.T) {
 		}
 		if response.System != nil {
 			t.Fatalf("system expected nil with static provider")
+		}
+		if response.Schedules != nil {
+			t.Fatalf("schedules expected nil with static provider")
 		}
 	})
 
@@ -905,6 +942,148 @@ func TestQueryResolvers_Integration(t *testing.T) {
 			if len(response.Methods) != 1 || response.Methods[0].Name != "get_status" {
 				t.Fatalf("address %d methods = %+v; want [get_status]", address, response.Methods)
 			}
+		}
+	})
+
+	t.Run("schedules_populated", func(t *testing.T) {
+		tempC := 22.5
+		tempRaw := 225
+		minTemp := 5.0
+		maxTemp := 30.0
+		semantic.SetSchedules(&ScheduleStatus{
+			Programs: []ScheduleProgram{
+				{
+					Zone: 0,
+					HC:   "heating",
+					Config: &ScheduleConfig{
+						MaxSlots:       12,
+						TimeResolution: 10,
+						MinDuration:    5,
+						HasTemperature: true,
+						TempSlots:      12,
+						MinTempC:       &minTemp,
+						MaxTempC:       &maxTemp,
+					},
+					SlotsUsed: []int{1, 0, 1, 1, 1, 1, 1},
+					Days: []ScheduleDayProgram{
+						{
+							Weekday: "monday",
+							Slots: []ScheduleTimerSlot{
+								{
+									StartHour:      0,
+									StartMinute:    0,
+									EndHour:        24,
+									EndMinute:      0,
+									TemperatureC:   &tempC,
+									TemperatureRaw: &tempRaw,
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+		defer semantic.SetSchedules(nil)
+
+		request := graphqlclient.NewRequest(`
+			query {
+				schedules {
+					programs {
+						zone
+						hc
+						config {
+							maxSlots
+							timeResolution
+							minDuration
+							hasTemperature
+							tempSlots
+							minTempC
+							maxTempC
+						}
+						slotsUsed
+						days {
+							weekday
+							slots {
+								startHour
+								startMinute
+								endHour
+								endMinute
+								temperatureC
+								temperatureRaw
+							}
+						}
+					}
+				}
+			}
+		`)
+
+		var response struct {
+			Schedules *struct {
+				Programs []struct {
+					Zone   int    `json:"zone"`
+					HC     string `json:"hc"`
+					Config *struct {
+						MaxSlots       int      `json:"maxSlots"`
+						TimeResolution int      `json:"timeResolution"`
+						MinDuration    int      `json:"minDuration"`
+						HasTemperature bool     `json:"hasTemperature"`
+						TempSlots      int      `json:"tempSlots"`
+						MinTempC       *float64 `json:"minTempC"`
+						MaxTempC       *float64 `json:"maxTempC"`
+					} `json:"config"`
+					SlotsUsed []int `json:"slotsUsed"`
+					Days      []struct {
+						Weekday string `json:"weekday"`
+						Slots   []struct {
+							StartHour      int      `json:"startHour"`
+							StartMinute    int      `json:"startMinute"`
+							EndHour        int      `json:"endHour"`
+							EndMinute      int      `json:"endMinute"`
+							TemperatureC   *float64 `json:"temperatureC"`
+							TemperatureRaw *int     `json:"temperatureRaw"`
+						} `json:"slots"`
+					} `json:"days"`
+				} `json:"programs"`
+			} `json:"schedules"`
+		}
+
+		if err := client.Run(context.Background(), request, &response); err != nil {
+			t.Fatalf("schedules query error = %v", err)
+		}
+		if response.Schedules == nil {
+			t.Fatalf("schedules = nil; want non-nil")
+		}
+		if len(response.Schedules.Programs) != 1 {
+			t.Fatalf("programs = %d; want 1", len(response.Schedules.Programs))
+		}
+		prog := response.Schedules.Programs[0]
+		if prog.Zone != 0 || prog.HC != "heating" {
+			t.Fatalf("program zone=%d hc=%q; want 0/heating", prog.Zone, prog.HC)
+		}
+		if prog.Config == nil || prog.Config.MaxSlots != 12 {
+			t.Fatalf("config maxSlots = %v; want 12", prog.Config)
+		}
+		if prog.Config.MinTempC == nil || *prog.Config.MinTempC != 5.0 {
+			t.Fatalf("config minTempC = %v; want 5.0", prog.Config.MinTempC)
+		}
+		if len(prog.SlotsUsed) != 7 || prog.SlotsUsed[0] != 1 || prog.SlotsUsed[1] != 0 {
+			t.Fatalf("slotsUsed = %v; want [1 0 1 1 1 1 1]", prog.SlotsUsed)
+		}
+		if len(prog.Days) != 1 || prog.Days[0].Weekday != "monday" {
+			t.Fatalf("days = %+v; want [monday]", prog.Days)
+		}
+		if len(prog.Days[0].Slots) != 1 {
+			t.Fatalf("monday slots = %d; want 1", len(prog.Days[0].Slots))
+		}
+		slot := prog.Days[0].Slots[0]
+		if slot.StartHour != 0 || slot.EndHour != 24 {
+			t.Fatalf("slot hours = %d-%d; want 0-24", slot.StartHour, slot.EndHour)
+		}
+		if slot.TemperatureC == nil || *slot.TemperatureC != 22.5 {
+			t.Fatalf("slot temperatureC = %v; want 22.5", slot.TemperatureC)
+		}
+		if slot.TemperatureRaw == nil || *slot.TemperatureRaw != 225 {
+			t.Fatalf("slot temperatureRaw = %v; want 225", slot.TemperatureRaw)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- Add GraphQL types for schedule data: ScheduleTimerSlot, ScheduleDayProgram, ScheduleConfig, ScheduleProgram, ScheduleStatus
- Add root query field `schedules` through SemanticProvider.Schedules()
- Parity with MCP `ebus.v1.semantic.schedules.get` tool (PR #320)

Fixes #323

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` all pass
- [x] New test `schedules_populated` validates full query path with config, slotsUsed, days, and timer slots
- [x] Extended `zones_dhw` test verifies nil schedules with static provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)