### PR TITLE
feat: schedule GraphQL write mutations

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -79,6 +79,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 	semanticPoller := startVaillantSemanticPolling(ctx, cfg, gateway, semanticRuntime.Provider(), hub)
 	if semanticPoller != nil {
 		builder.SetBoilerConfigWriter(semanticPoller)
+		builder.SetScheduleWriter(semanticPoller)
 	}
 
 	if err := builder.Start(ctx); err != nil {

--- a/graphql/builder.go
+++ b/graphql/builder.go
@@ -11,6 +11,7 @@ type Builder struct {
 	status   StatusProvider
 	semantic SemanticProvider
 	boiler   BoilerConfigWriter
+	schedule ScheduleWriter
 
 	mu       sync.RWMutex
 	schema   Schema
@@ -155,6 +156,25 @@ func (b *Builder) boilerConfigWriter() BoilerConfigWriter {
 	}
 	b.mu.RLock()
 	writer := b.boiler
+	b.mu.RUnlock()
+	return writer
+}
+
+func (b *Builder) SetScheduleWriter(writer ScheduleWriter) {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	b.schedule = writer
+	b.mu.Unlock()
+}
+
+func (b *Builder) scheduleWriter() ScheduleWriter {
+	if b == nil {
+		return nil
+	}
+	b.mu.RLock()
+	writer := b.schedule
 	b.mu.RUnlock()
 	return writer
 }

--- a/graphql/mutations.go
+++ b/graphql/mutations.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -13,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
 	ebuserrors "github.com/Project-Helianthus/helianthus-ebusgo/errors"
 	"github.com/Project-Helianthus/helianthus-ebusgo/types"
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
@@ -50,6 +52,11 @@ type BoilerConfigMutationResult struct {
 
 type BoilerConfigWriter interface {
 	SetBoilerConfig(ctx context.Context, fieldName string, rawValue string) BoilerConfigMutationResult
+}
+
+type ScheduleWriter interface {
+	SetZoneTimeProgram(ctx context.Context, zone int, weekday int, slots []mcp.TimeProgramSlot) (*mcp.TimeProgramWriteResult, error)
+	SetDhwTimeProgram(ctx context.Context, weekday int, slots []mcp.TimeProgramSlot) (*mcp.TimeProgramWriteResult, error)
 }
 
 type ConfigMutationResult struct {
@@ -130,7 +137,7 @@ func NewSchema(builder *Builder, registry InvokeRegistry, invoker Invoker, hub *
 
 	var mutationType *graphqlgo.Object
 	if registry != nil && invoker != nil {
-		mutationType = buildMutationType(registry, invoker, builder.boilerConfigWriter())
+		mutationType = buildMutationType(registry, invoker, builder.boilerConfigWriter(), builder.scheduleWriter())
 	}
 
 	var subscriptionType *graphqlgo.Object
@@ -158,7 +165,7 @@ func NewInvokeHandler(builder *Builder, registry InvokeRegistry, invoker Invoker
 	}), nil
 }
 
-func buildMutationType(registry InvokeRegistry, invoker Invoker, boilerWriter BoilerConfigWriter) *graphqlgo.Object {
+func buildMutationType(registry InvokeRegistry, invoker Invoker, boilerWriter BoilerConfigWriter, scheduleWriter ScheduleWriter) *graphqlgo.Object {
 	jsonScalar := jsonScalarType()
 	errorType := graphqlgo.NewObject(graphqlgo.ObjectConfig{
 		Name: "InvokeError",
@@ -284,6 +291,88 @@ func buildMutationType(registry InvokeRegistry, invoker Invoker, boilerWriter Bo
 		},
 	})
 
+	scheduleSlotResultType := graphqlgo.NewObject(graphqlgo.ObjectConfig{
+		Name: "ScheduleSlotResult",
+		Fields: graphqlgo.Fields{
+			"slotIndex": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Int),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					result, ok := scheduleSlotResultFromSource(params)
+					if !ok {
+						return 0, nil
+					}
+					return result.SlotIndex, nil
+				},
+			},
+			"accepted": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Boolean),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					result, ok := scheduleSlotResultFromSource(params)
+					if !ok {
+						return false, nil
+					}
+					return result.Accepted, nil
+				},
+			},
+			"errorCode": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Int),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					result, ok := scheduleSlotResultFromSource(params)
+					if !ok {
+						return 0, nil
+					}
+					return result.ErrorCode, nil
+				},
+			},
+			"errorDescription": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					result, ok := scheduleSlotResultFromSource(params)
+					if !ok || result.ErrorDesc == "" {
+						return nil, nil
+					}
+					return result.ErrorDesc, nil
+				},
+			},
+		},
+	})
+
+	scheduleWriteResultType := graphqlgo.NewObject(graphqlgo.ObjectConfig{
+		Name: "ScheduleWriteResult",
+		Fields: graphqlgo.Fields{
+			"success": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Boolean),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					result, ok := scheduleWriteResultFromSource(params)
+					if !ok {
+						return false, nil
+					}
+					return result.Success, nil
+				},
+			},
+			"slotResults": &graphqlgo.Field{
+				Type: graphqlgo.NewList(graphqlgo.NewNonNull(scheduleSlotResultType)),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					result, ok := scheduleWriteResultFromSource(params)
+					if !ok {
+						return nil, nil
+					}
+					return result.SlotResults, nil
+				},
+			},
+			"error": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					result, ok := scheduleWriteResultFromSource(params)
+					if !ok || result.Error == "" {
+						return nil, nil
+					}
+					return result.Error, nil
+				},
+			},
+		},
+	})
+
 	return graphqlgo.NewObject(graphqlgo.ObjectConfig{
 		Name: "Mutation",
 		Fields: graphqlgo.Fields{
@@ -353,6 +442,27 @@ func buildMutationType(registry InvokeRegistry, invoker Invoker, boilerWriter Bo
 					return setZoneConfigResolve(params, registry, invoker), nil
 				},
 			},
+			"setZoneTimeProgram": &graphqlgo.Field{
+				Type: scheduleWriteResultType,
+				Args: graphqlgo.FieldConfigArgument{
+					"zone":    &graphqlgo.ArgumentConfig{Type: graphqlgo.NewNonNull(graphqlgo.Int)},
+					"weekday": &graphqlgo.ArgumentConfig{Type: graphqlgo.NewNonNull(graphqlgo.Int)},
+					"slots":   &graphqlgo.ArgumentConfig{Type: graphqlgo.NewNonNull(graphqlgo.String)},
+				},
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					return setZoneTimeProgramResolve(params, scheduleWriter), nil
+				},
+			},
+			"setDhwTimeProgram": &graphqlgo.Field{
+				Type: scheduleWriteResultType,
+				Args: graphqlgo.FieldConfigArgument{
+					"weekday": &graphqlgo.ArgumentConfig{Type: graphqlgo.NewNonNull(graphqlgo.Int)},
+					"slots":   &graphqlgo.ArgumentConfig{Type: graphqlgo.NewNonNull(graphqlgo.String)},
+				},
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					return setDhwTimeProgramResolve(params, scheduleWriter), nil
+				},
+			},
 		},
 	})
 }
@@ -400,6 +510,70 @@ func setZoneConfigResolve(params graphqlgo.ResolveParams, registry InvokeRegistr
 		return configMutationError(err)
 	}
 	return applyConfigMutation(params.Context, registry, invoker, spec, instance, fieldValue)
+}
+
+func setZoneTimeProgramResolve(params graphqlgo.ResolveParams, scheduleWriter ScheduleWriter) *mcp.TimeProgramWriteResult {
+	if scheduleWriter == nil {
+		return scheduleWriteMutationError(fmt.Errorf("schedule mutation missing writer: %w", ebuserrors.ErrInvalidPayload))
+	}
+
+	zone, err := parseScheduleMutationIntArg(params.Args["zone"], "zone")
+	if err != nil {
+		return scheduleWriteMutationError(err)
+	}
+	weekday, err := parseScheduleMutationIntArg(params.Args["weekday"], "weekday")
+	if err != nil {
+		return scheduleWriteMutationError(err)
+	}
+	rawSlots, _ := params.Args["slots"].(string)
+	slots, err := parseTimeProgramSlotsJSON(rawSlots, true)
+	if err != nil {
+		return scheduleWriteMutationError(err)
+	}
+
+	ctx := params.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	result, err := scheduleWriter.SetZoneTimeProgram(ctx, zone, weekday, slots)
+	if err != nil {
+		return scheduleWriteMutationError(err)
+	}
+	if result == nil {
+		return scheduleWriteMutationError(fmt.Errorf("schedule writer returned nil result: %w", ebuserrors.ErrInvalidPayload))
+	}
+	return result
+}
+
+func setDhwTimeProgramResolve(params graphqlgo.ResolveParams, scheduleWriter ScheduleWriter) *mcp.TimeProgramWriteResult {
+	if scheduleWriter == nil {
+		return scheduleWriteMutationError(fmt.Errorf("schedule mutation missing writer: %w", ebuserrors.ErrInvalidPayload))
+	}
+
+	weekday, err := parseScheduleMutationIntArg(params.Args["weekday"], "weekday")
+	if err != nil {
+		return scheduleWriteMutationError(err)
+	}
+	rawSlots, _ := params.Args["slots"].(string)
+	slots, err := parseTimeProgramSlotsJSON(rawSlots, false)
+	if err != nil {
+		return scheduleWriteMutationError(err)
+	}
+
+	ctx := params.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	result, err := scheduleWriter.SetDhwTimeProgram(ctx, weekday, slots)
+	if err != nil {
+		return scheduleWriteMutationError(err)
+	}
+	if result == nil {
+		return scheduleWriteMutationError(fmt.Errorf("schedule writer returned nil result: %w", ebuserrors.ErrInvalidPayload))
+	}
+	return result
 }
 
 func applyConfigMutation(ctx context.Context, registry InvokeRegistry, invoker Invoker, spec configFieldSpec, instance byte, rawValue string) ConfigMutationResult {
@@ -475,6 +649,97 @@ func parseConfigInstance(raw any) (byte, error) {
 		return 0, fmt.Errorf("circuit index out of range: %w", ebuserrors.ErrInvalidPayload)
 	}
 	return byte(index), nil
+}
+
+func parseScheduleMutationIntArg(raw any, name string) (int, error) {
+	value, ok := raw.(int)
+	if !ok {
+		return 0, fmt.Errorf("%s must be an integer: %w", name, ebuserrors.ErrInvalidPayload)
+	}
+	return value, nil
+}
+
+func parseTimeProgramSlotsJSON(raw string, tempRequired bool) ([]mcp.TimeProgramSlot, error) {
+	var slotsRaw []map[string]any
+	if err := json.Unmarshal([]byte(raw), &slotsRaw); err != nil {
+		return nil, fmt.Errorf("invalid slots JSON: %w", err)
+	}
+
+	slots := make([]mcp.TimeProgramSlot, 0, len(slotsRaw))
+	for i, slotRaw := range slotsRaw {
+		slot, err := parseTimeProgramSlot(slotRaw, tempRequired)
+		if err != nil {
+			return nil, fmt.Errorf("slot %d: %w", i, err)
+		}
+		slots = append(slots, slot)
+	}
+	return slots, nil
+}
+
+func parseTimeProgramSlot(raw map[string]any, tempRequired bool) (mcp.TimeProgramSlot, error) {
+	var slot mcp.TimeProgramSlot
+
+	startHour, err := parseTimeProgramIntegerField(raw, "start_hour")
+	if err != nil {
+		return slot, err
+	}
+	startMinute, err := parseTimeProgramIntegerField(raw, "start_minute")
+	if err != nil {
+		return slot, err
+	}
+	endHour, err := parseTimeProgramIntegerField(raw, "end_hour")
+	if err != nil {
+		return slot, err
+	}
+	endMinute, err := parseTimeProgramIntegerField(raw, "end_minute")
+	if err != nil {
+		return slot, err
+	}
+
+	slot.StartHour = startHour
+	slot.StartMinute = startMinute
+	slot.EndHour = endHour
+	slot.EndMinute = endMinute
+
+	tempValue, ok := raw["temperature_c"]
+	if ok && tempValue != nil {
+		temp, ok := tempValue.(float64)
+		if !ok {
+			return slot, fmt.Errorf("temperature_c must be a number")
+		}
+		slot.TemperatureC = &temp
+		return slot, nil
+	}
+	if tempRequired {
+		return slot, fmt.Errorf("temperature_c is required")
+	}
+
+	return slot, nil
+}
+
+func parseTimeProgramIntegerField(raw map[string]any, field string) (int, error) {
+	value, ok := raw[field]
+	if !ok || value == nil {
+		return 0, fmt.Errorf("%s is required", field)
+	}
+	coerced, ok := coerceFloatToInt(value)
+	if !ok {
+		return 0, fmt.Errorf("%s must be an integer, got %v", field, value)
+	}
+	return int(coerced), nil
+}
+
+func scheduleWriteMutationError(err error) *mcp.TimeProgramWriteResult {
+	if err == nil {
+		return &mcp.TimeProgramWriteResult{
+			Success: false,
+			Error:   "schedule mutation failed",
+		}
+	}
+	return &mcp.TimeProgramWriteResult{
+		Success: false,
+		Error:   err.Error(),
+	}
 }
 
 func resolveConfigFieldSpec(scope, fieldName string, specs map[string]configFieldSpec) (configFieldSpec, error) {
@@ -1133,6 +1398,34 @@ func configResultFromSource(params graphqlgo.ResolveParams) (ConfigMutationResul
 		return *value, true
 	default:
 		return ConfigMutationResult{}, false
+	}
+}
+
+func scheduleWriteResultFromSource(params graphqlgo.ResolveParams) (mcp.TimeProgramWriteResult, bool) {
+	switch value := params.Source.(type) {
+	case mcp.TimeProgramWriteResult:
+		return value, true
+	case *mcp.TimeProgramWriteResult:
+		if value == nil {
+			return mcp.TimeProgramWriteResult{}, false
+		}
+		return *value, true
+	default:
+		return mcp.TimeProgramWriteResult{}, false
+	}
+}
+
+func scheduleSlotResultFromSource(params graphqlgo.ResolveParams) (mcp.TimeProgramSlotResult, bool) {
+	switch value := params.Source.(type) {
+	case mcp.TimeProgramSlotResult:
+		return value, true
+	case *mcp.TimeProgramSlotResult:
+		if value == nil {
+			return mcp.TimeProgramSlotResult{}, false
+		}
+		return *value, true
+	default:
+		return mcp.TimeProgramSlotResult{}, false
 	}
 }
 

--- a/graphql/mutations_unit_test.go
+++ b/graphql/mutations_unit_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
 	ebuserrors "github.com/Project-Helianthus/helianthus-ebusgo/errors"
 	"github.com/Project-Helianthus/helianthus-ebusgo/types"
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
@@ -80,6 +81,48 @@ func (writer *mockBoilerWriter) SetBoilerConfig(_ context.Context, fieldName str
 		value string
 	}{field: fieldName, value: rawValue})
 	return writer.result
+}
+
+type mockScheduleWriter struct {
+	zoneResult *mcp.TimeProgramWriteResult
+	dhwResult  *mcp.TimeProgramWriteResult
+	zoneErr    error
+	dhwErr     error
+	zoneCalls  []struct {
+		zone    int
+		weekday int
+		slots   []mcp.TimeProgramSlot
+	}
+	dhwCalls []struct {
+		weekday int
+		slots   []mcp.TimeProgramSlot
+	}
+}
+
+func (writer *mockScheduleWriter) SetZoneTimeProgram(_ context.Context, zone int, weekday int, slots []mcp.TimeProgramSlot) (*mcp.TimeProgramWriteResult, error) {
+	cloned := append([]mcp.TimeProgramSlot(nil), slots...)
+	writer.zoneCalls = append(writer.zoneCalls, struct {
+		zone    int
+		weekday int
+		slots   []mcp.TimeProgramSlot
+	}{
+		zone:    zone,
+		weekday: weekday,
+		slots:   cloned,
+	})
+	return writer.zoneResult, writer.zoneErr
+}
+
+func (writer *mockScheduleWriter) SetDhwTimeProgram(_ context.Context, weekday int, slots []mcp.TimeProgramSlot) (*mcp.TimeProgramWriteResult, error) {
+	cloned := append([]mcp.TimeProgramSlot(nil), slots...)
+	writer.dhwCalls = append(writer.dhwCalls, struct {
+		weekday int
+		slots   []mcp.TimeProgramSlot
+	}{
+		weekday: weekday,
+		slots:   cloned,
+	})
+	return writer.dhwResult, writer.dhwErr
 }
 
 func TestValidateInvokeParams_SchemaCoercion(t *testing.T) {
@@ -216,7 +259,7 @@ func TestSetBoilerConfigMutation_UnsupportedInReducedProfile(t *testing.T) {
 			"noop": &graphqlgo.Field{Type: graphqlgo.String},
 		},
 	})
-	mutationType := buildMutationType(nil, nil, nil)
+	mutationType := buildMutationType(nil, nil, nil, nil)
 	schema, err := graphqlgo.NewSchema(graphqlgo.SchemaConfig{
 		Query:    queryType,
 		Mutation: mutationType,
@@ -271,7 +314,7 @@ func TestSetCircuitConfigMutation_Success(t *testing.T) {
 		},
 	}
 
-	data := executeMutation(t, buildMutationSchema(t, registry, invoker, nil), `mutation {
+	data := executeMutation(t, buildMutationSchema(t, registry, invoker, nil, nil), `mutation {
 		setCircuitConfig(index: 1, field: "heatingCurve", value: "1.5") {
 			success
 			error
@@ -330,7 +373,7 @@ func TestSetBoilerConfigMutation_DelegatesToWriter(t *testing.T) {
 		result: BoilerConfigMutationResult{Success: true},
 	}
 
-	data := executeMutation(t, buildMutationSchema(t, nil, nil, writer), `mutation {
+	data := executeMutation(t, buildMutationSchema(t, nil, nil, writer, nil), `mutation {
 		setBoilerConfig(field: "flowsetHcMaxC", value: "55") {
 			success
 			error
@@ -371,7 +414,7 @@ func TestSetSystemConfigMutation_Success(t *testing.T) {
 		},
 	}
 
-	data := executeMutation(t, buildMutationSchema(t, registry, invoker, nil), `mutation {
+	data := executeMutation(t, buildMutationSchema(t, registry, invoker, nil, nil), `mutation {
 		setSystemConfig(field: "adaptiveHeatingCurve", value: "true") {
 			success
 			error
@@ -424,7 +467,7 @@ func TestSetSystemConfigMutation_IntegerLikeFloatString(t *testing.T) {
 		},
 	}
 
-	data := executeMutation(t, buildMutationSchema(t, registry, invoker, nil), `mutation {
+	data := executeMutation(t, buildMutationSchema(t, registry, invoker, nil, nil), `mutation {
 		setSystemConfig(field: "maxRoomHumidityPct", value: "55.0") {
 			success
 			error
@@ -490,7 +533,7 @@ func TestSetCircuitConfigMutation_ValidationFailures(t *testing.T) {
 				order: []byte{0x15},
 			}
 			invoker := &mutationTestInvoker{}
-			data := executeMutation(t, buildMutationSchema(t, registry, invoker, nil), test.query)
+			data := executeMutation(t, buildMutationSchema(t, registry, invoker, nil, nil), test.query)
 
 			payload, ok := data["setCircuitConfig"].(map[string]any)
 			if !ok {
@@ -519,7 +562,7 @@ func TestSetSystemConfigMutation_FailureScenarios(t *testing.T) {
 			order: []byte{0x15},
 		}
 		invoker := &mutationTestInvoker{}
-		data := executeMutation(t, buildMutationSchema(t, registry, invoker, nil), `mutation {
+		data := executeMutation(t, buildMutationSchema(t, registry, invoker, nil, nil), `mutation {
 			setSystemConfig(field: "adaptiveHeatingCurve", value: "maybe") { success error }
 		}`)
 		payload, _ := data["setSystemConfig"].(map[string]any)
@@ -537,7 +580,7 @@ func TestSetSystemConfigMutation_FailureScenarios(t *testing.T) {
 	t.Run("missing controller", func(t *testing.T) {
 		registry := mutationTestRegistry{}
 		invoker := &mutationTestInvoker{}
-		data := executeMutation(t, buildMutationSchema(t, registry, invoker, nil), `mutation {
+		data := executeMutation(t, buildMutationSchema(t, registry, invoker, nil, nil), `mutation {
 			setSystemConfig(field: "adaptiveHeatingCurve", value: "true") { success error }
 		}`)
 		payload, _ := data["setSystemConfig"].(map[string]any)
@@ -557,7 +600,7 @@ func TestSetSystemConfigMutation_FailureScenarios(t *testing.T) {
 			order: []byte{0x15},
 		}
 		invoker := &mutationTestInvoker{}
-		data := executeMutation(t, buildMutationSchema(t, registry, invoker, nil), `mutation {
+		data := executeMutation(t, buildMutationSchema(t, registry, invoker, nil, nil), `mutation {
 			setSystemConfig(field: "adaptiveHeatingCurve", value: "true") { success error }
 		}`)
 		payload, _ := data["setSystemConfig"].(map[string]any)
@@ -588,7 +631,7 @@ func TestSetCircuitConfigMutation_ReadbackConfirmFailure(t *testing.T) {
 			},
 		},
 	}
-	data := executeMutation(t, buildMutationSchema(t, registry, invoker, nil), `mutation {
+	data := executeMutation(t, buildMutationSchema(t, registry, invoker, nil, nil), `mutation {
 		setCircuitConfig(index: 2, field: "heatingCurve", value: "1.5") { success error }
 	}`)
 	payload, _ := data["setCircuitConfig"].(map[string]any)
@@ -603,7 +646,172 @@ func TestSetCircuitConfigMutation_ReadbackConfirmFailure(t *testing.T) {
 	}
 }
 
-func buildMutationSchema(t *testing.T, registry InvokeRegistry, invoker Invoker, boilerWriter BoilerConfigWriter) graphqlgo.Schema {
+func TestSetZoneTimeProgramMutation_Success(t *testing.T) {
+	writer := &mockScheduleWriter{
+		zoneResult: &mcp.TimeProgramWriteResult{
+			Success: true,
+			SlotResults: []mcp.TimeProgramSlotResult{
+				{SlotIndex: 0, Accepted: true, ErrorCode: 0},
+			},
+		},
+	}
+
+	data := executeMutation(t, buildMutationSchema(t, nil, nil, nil, writer), `mutation {
+		setZoneTimeProgram(
+			zone: 2
+			weekday: 1
+			slots: "[{\"start_hour\":6,\"start_minute\":0,\"end_hour\":22,\"end_minute\":0,\"temperature_c\":21}]"
+		) {
+			success
+			error
+			slotResults {
+				slotIndex
+				accepted
+				errorCode
+				errorDescription
+			}
+		}
+	}`)
+
+	payload, ok := data["setZoneTimeProgram"].(map[string]any)
+	if !ok {
+		t.Fatalf("setZoneTimeProgram payload type = %T; want map", data["setZoneTimeProgram"])
+	}
+	if got, _ := payload["success"].(bool); !got {
+		t.Fatalf("setZoneTimeProgram success = %v; want true", got)
+	}
+	if got := payload["error"]; got != nil {
+		t.Fatalf("setZoneTimeProgram error = %#v; want nil", got)
+	}
+	slotResults, ok := payload["slotResults"].([]any)
+	if !ok || len(slotResults) != 1 {
+		t.Fatalf("setZoneTimeProgram slotResults = %#v; want one result", payload["slotResults"])
+	}
+	firstSlot, ok := slotResults[0].(map[string]any)
+	if !ok {
+		t.Fatalf("setZoneTimeProgram first slot type = %T; want map", slotResults[0])
+	}
+	if got, _ := firstSlot["slotIndex"].(int); got != 0 {
+		t.Fatalf("slotIndex = %v; want 0", got)
+	}
+	if got, _ := firstSlot["accepted"].(bool); !got {
+		t.Fatalf("accepted = %v; want true", got)
+	}
+	if got, _ := firstSlot["errorCode"].(int); got != 0 {
+		t.Fatalf("errorCode = %v; want 0", got)
+	}
+	if got := firstSlot["errorDescription"]; got != nil {
+		t.Fatalf("errorDescription = %#v; want nil", got)
+	}
+
+	if len(writer.zoneCalls) != 1 {
+		t.Fatalf("zone writer calls = %d; want 1", len(writer.zoneCalls))
+	}
+	call := writer.zoneCalls[0]
+	if call.zone != 2 || call.weekday != 1 {
+		t.Fatalf("zone writer call = %#v; want zone=2 weekday=1", call)
+	}
+	if len(call.slots) != 1 {
+		t.Fatalf("zone writer slots = %#v; want one slot", call.slots)
+	}
+	slot := call.slots[0]
+	if slot.StartHour != 6 || slot.StartMinute != 0 || slot.EndHour != 22 || slot.EndMinute != 0 {
+		t.Fatalf("zone slot = %#v; want 06:00-22:00", slot)
+	}
+	if slot.TemperatureC == nil || *slot.TemperatureC != 21 {
+		t.Fatalf("zone slot temperature = %#v; want 21", slot.TemperatureC)
+	}
+}
+
+func TestSetDhwTimeProgramMutation_Success(t *testing.T) {
+	writer := &mockScheduleWriter{
+		dhwResult: &mcp.TimeProgramWriteResult{
+			Success: true,
+			SlotResults: []mcp.TimeProgramSlotResult{
+				{SlotIndex: 0, Accepted: true, ErrorCode: 0},
+			},
+		},
+	}
+
+	data := executeMutation(t, buildMutationSchema(t, nil, nil, nil, writer), `mutation {
+		setDhwTimeProgram(
+			weekday: 5
+			slots: "[{\"start_hour\":5,\"start_minute\":30,\"end_hour\":7,\"end_minute\":0}]"
+		) {
+			success
+			error
+			slotResults {
+				slotIndex
+				accepted
+				errorCode
+				errorDescription
+			}
+		}
+	}`)
+
+	payload, ok := data["setDhwTimeProgram"].(map[string]any)
+	if !ok {
+		t.Fatalf("setDhwTimeProgram payload type = %T; want map", data["setDhwTimeProgram"])
+	}
+	if got, _ := payload["success"].(bool); !got {
+		t.Fatalf("setDhwTimeProgram success = %v; want true", got)
+	}
+	if got := payload["error"]; got != nil {
+		t.Fatalf("setDhwTimeProgram error = %#v; want nil", got)
+	}
+	if len(writer.dhwCalls) != 1 {
+		t.Fatalf("dhw writer calls = %d; want 1", len(writer.dhwCalls))
+	}
+	call := writer.dhwCalls[0]
+	if call.weekday != 5 {
+		t.Fatalf("dhw writer weekday = %d; want 5", call.weekday)
+	}
+	if len(call.slots) != 1 {
+		t.Fatalf("dhw writer slots = %#v; want one slot", call.slots)
+	}
+	slot := call.slots[0]
+	if slot.StartHour != 5 || slot.StartMinute != 30 || slot.EndHour != 7 || slot.EndMinute != 0 {
+		t.Fatalf("dhw slot = %#v; want 05:30-07:00", slot)
+	}
+	if slot.TemperatureC != nil {
+		t.Fatalf("dhw slot temperature = %#v; want nil", slot.TemperatureC)
+	}
+}
+
+func TestSetZoneTimeProgramMutation_InvalidJSON(t *testing.T) {
+	writer := &mockScheduleWriter{}
+
+	data := executeMutation(t, buildMutationSchema(t, nil, nil, nil, writer), `mutation {
+		setZoneTimeProgram(zone: 1, weekday: 2, slots: "not-json") {
+			success
+			error
+			slotResults {
+				slotIndex
+			}
+		}
+	}`)
+
+	payload, ok := data["setZoneTimeProgram"].(map[string]any)
+	if !ok {
+		t.Fatalf("setZoneTimeProgram payload type = %T; want map", data["setZoneTimeProgram"])
+	}
+	if got, _ := payload["success"].(bool); got {
+		t.Fatalf("setZoneTimeProgram success = %v; want false", got)
+	}
+	errMessage, _ := payload["error"].(string)
+	if !strings.Contains(errMessage, "invalid slots JSON") {
+		t.Fatalf("setZoneTimeProgram error = %q; want invalid slots JSON", errMessage)
+	}
+	slotResults, ok := payload["slotResults"].([]any)
+	if !ok || len(slotResults) != 0 {
+		t.Fatalf("setZoneTimeProgram slotResults = %#v; want empty list", payload["slotResults"])
+	}
+	if len(writer.zoneCalls) != 0 {
+		t.Fatalf("zone writer calls = %d; want 0", len(writer.zoneCalls))
+	}
+}
+
+func buildMutationSchema(t *testing.T, registry InvokeRegistry, invoker Invoker, boilerWriter BoilerConfigWriter, scheduleWriter ScheduleWriter) graphqlgo.Schema {
 	t.Helper()
 	queryType := graphqlgo.NewObject(graphqlgo.ObjectConfig{
 		Name: "Query",
@@ -611,7 +819,7 @@ func buildMutationSchema(t *testing.T, registry InvokeRegistry, invoker Invoker,
 			"noop": &graphqlgo.Field{Type: graphqlgo.String},
 		},
 	})
-	mutationType := buildMutationType(registry, invoker, boilerWriter)
+	mutationType := buildMutationType(registry, invoker, boilerWriter, scheduleWriter)
 	schema, err := graphqlgo.NewSchema(graphqlgo.SchemaConfig{
 		Query:    queryType,
 		Mutation: mutationType,


### PR DESCRIPTION
## Summary

- Add `setZoneTimeProgram(zone, weekday, slots)` GraphQL mutation for zone schedule writes
- Add `setDhwTimeProgram(weekday, slots)` GraphQL mutation for DHW schedule writes
- Both delegate to existing ScheduleWriter interface (shared with MCP path)
- Wire ScheduleWriter on GraphQL builder alongside BoilerConfigWriter

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` all pass
- [ ] Deploy binary and test GraphQL mutations on live system

Closes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)