### PR TITLE
Introduce passive bus tap for broadcast path

### DIFF
--- a/broadcast_listener.go
+++ b/broadcast_listener.go
@@ -2,7 +2,6 @@ package ebusgateway
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	ebuserrors "github.com/Project-Helianthus/helianthus-ebusgo/errors"
@@ -12,10 +11,9 @@ import (
 )
 
 type BroadcastListener struct {
-	transport transport.RawTransport
-	closeFn   func() error
-	router    *router.BusEventRouter
-	reader    *frameReader
+	router *router.BusEventRouter
+	parser *broadcastFrameParser
+	tap    *PassiveBusTap
 }
 
 func StartBroadcastListener(ctx context.Context, cfg Config, router *router.BusEventRouter) (*BroadcastListener, error) {
@@ -27,152 +25,71 @@ func StartBroadcastListenerWithTransport(ctx context.Context, cfg Config, router
 		return nil, fmt.Errorf("broadcast listener missing router: %w", ebuserrors.ErrInvalidPayload)
 	}
 
-	// Always use a fresh transport connection to avoid interfering with bus I/O.
-	cfg.Transport = nil
-	tr, closeFn, err := resolveBroadcastTransport(ctx, cfg)
+	listener := &BroadcastListener{
+		router: router,
+		parser: &broadcastFrameParser{},
+	}
+	tap, err := StartPassiveBusTapWithTransport(ctx, cfg, listener, wrap)
 	if err != nil {
 		return nil, err
 	}
-	if wrap != nil {
-		tr = wrap(tr)
-	}
-
-	listener := &BroadcastListener{
-		transport: tr,
-		closeFn:   closeFn,
-		router:    router,
-		reader:    newFrameReader(tr),
-	}
-	listener.Start(ctx)
+	listener.tap = tap
 	return listener, nil
 }
 
-func resolveBroadcastTransport(ctx context.Context, cfg Config) (transport.RawTransport, func() error, error) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-
-	config, err := normalizeTransportConfig(cfg.TransportConfig)
-	if err != nil {
-		return nil, nil, fmt.Errorf("broadcast transport config: %w", err)
-	}
-	if config.Network == "" {
-		return nil, nil, fmt.Errorf("broadcast transport missing network: %w", ebuserrors.ErrInvalidPayload)
-	}
-	if config.Address == "" {
-		return nil, nil, fmt.Errorf("broadcast transport missing address: %w", ebuserrors.ErrInvalidPayload)
-	}
-
-	dial := config.Dial
-	if dial == nil {
-		dial = dialContext
-	}
-
-	conn, err := dial(ctx, config.Network, config.Address, config.DialTimeout)
-	if err != nil {
-		return nil, nil, fmt.Errorf("broadcast transport dial failed: %w", err)
-	}
-
-	transportLayer, err := transportFromConn(config.Protocol, conn, config.ReadTimeout, config.WriteTimeout)
-	if err != nil {
-		_ = conn.Close()
-		return nil, nil, err
-	}
-
-	return transportLayer, conn.Close, nil
-}
-
 func (listener *BroadcastListener) Start(ctx context.Context) {
-	if listener == nil {
-		return
-	}
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	go listener.run(ctx)
+	_ = ctx
 }
 
 func (listener *BroadcastListener) Close() error {
-	if listener == nil || listener.closeFn == nil {
+	if listener == nil || listener.tap == nil {
 		return nil
 	}
-	return listener.closeFn()
+	return listener.tap.Close()
 }
 
-func (listener *BroadcastListener) run(ctx context.Context) {
-	for {
-		frame, ok, err := listener.reader.ReadFrame(ctx)
-		if err != nil {
-			if ctx.Err() != nil {
-				return
-			}
-			if errors.Is(err, ebuserrors.ErrTransportClosed) {
-				return
-			}
-			continue
-		}
+func (listener *BroadcastListener) OnPassiveTapEvent(event PassiveTapEvent) {
+	if listener == nil || listener.router == nil || listener.parser == nil {
+		return
+	}
+
+	switch event.Kind {
+	case PassiveTapEventSymbol:
+		frame, ok := listener.parser.push(event.Symbol)
 		if !ok {
-			continue
+			return
 		}
-		if frame.Target != protocol.AddressBroadcast {
-			continue
+		if frame.Target == protocol.AddressBroadcast {
+			_ = listener.router.HandleBroadcast(frame)
 		}
-		_ = listener.router.HandleBroadcast(frame)
+	default:
+		listener.parser.reset()
 	}
 }
 
-type frameReader struct {
-	transport transport.RawTransport
-	escape    bool
-	buffer    []byte
+type broadcastFrameParser struct {
+	buffer []byte
 }
 
-func newFrameReader(tr transport.RawTransport) *frameReader {
-	return &frameReader{transport: tr}
-}
-
-func (reader *frameReader) ReadFrame(ctx context.Context) (protocol.Frame, bool, error) {
-	for {
-		if ctx != nil && ctx.Err() != nil {
-			return protocol.Frame{}, false, ctx.Err()
-		}
-
-		symbol, err := reader.transport.ReadByte()
-		if err != nil {
-			if errors.Is(err, ebuserrors.ErrTimeout) {
-				reader.escape = false
-				continue
-			}
-			return protocol.Frame{}, false, err
-		}
-
-		if reader.escape {
-			reader.escape = false
-			switch symbol {
-			case 0x00:
-				reader.buffer = append(reader.buffer, protocol.SymbolEscape)
-			case 0x01:
-				reader.buffer = append(reader.buffer, protocol.SymbolSyn)
-			default:
-				reader.buffer = reader.buffer[:0]
-			}
-			continue
-		}
-
-		switch symbol {
-		case protocol.SymbolEscape:
-			reader.escape = true
-		case protocol.SymbolSyn:
-			if len(reader.buffer) == 0 {
-				continue
-			}
-			frame, ok := parseFrame(reader.buffer)
-			reader.buffer = reader.buffer[:0]
-			if ok {
-				return frame, true, nil
-			}
-		default:
-			reader.buffer = append(reader.buffer, symbol)
-		}
+func (parser *broadcastFrameParser) push(symbol byte) (protocol.Frame, bool) {
+	if parser == nil {
+		return protocol.Frame{}, false
 	}
+	if symbol == protocol.SymbolSyn {
+		if len(parser.buffer) == 0 {
+			return protocol.Frame{}, false
+		}
+		frame, ok := parseFrame(parser.buffer)
+		parser.buffer = parser.buffer[:0]
+		return frame, ok
+	}
+	parser.buffer = append(parser.buffer, symbol)
+	return protocol.Frame{}, false
+}
+
+func (parser *broadcastFrameParser) reset() {
+	if parser == nil {
+		return
+	}
+	parser.buffer = parser.buffer[:0]
 }

--- a/config.go
+++ b/config.go
@@ -70,6 +70,9 @@ type Config struct {
 	SemanticRegulatorAbsenceGrace         time.Duration
 	SemanticCachePath                     string
 	BroadcastListen                       bool
+	PassiveAbsenceThreshold               time.Duration
+	PassiveReconnectInitialDelay          time.Duration
+	PassiveReconnectMaxDelay              time.Duration
 	HTTPAddr                              string
 	GraphQLPath                           string
 	SnapshotPath                          string
@@ -121,6 +124,9 @@ func DefaultConfig() Config {
 		SemanticRegulatorRecheckInterval:      DefaultSemanticRegulatorRecheckInterval,
 		SemanticRegulatorAbsenceGrace:         DefaultSemanticRegulatorAbsenceGrace,
 		SemanticCachePath:                     "./semantic_cache.json",
+		PassiveAbsenceThreshold:               10 * time.Second,
+		PassiveReconnectInitialDelay:          1 * time.Second,
+		PassiveReconnectMaxDelay:              30 * time.Second,
 		HTTPAddr:                              ":8080",
 		GraphQLPath:                           "/graphql",
 		SnapshotPath:                          "/snapshot",
@@ -200,6 +206,15 @@ func applyDefaults(cfg Config) Config {
 	}
 	if cfg.SemanticCachePath == "" {
 		cfg.SemanticCachePath = "./semantic_cache.json"
+	}
+	if cfg.PassiveAbsenceThreshold <= 0 {
+		cfg.PassiveAbsenceThreshold = 10 * time.Second
+	}
+	if cfg.PassiveReconnectInitialDelay <= 0 {
+		cfg.PassiveReconnectInitialDelay = 1 * time.Second
+	}
+	if cfg.PassiveReconnectMaxDelay <= 0 {
+		cfg.PassiveReconnectMaxDelay = 30 * time.Second
 	}
 	if cfg.Transport == nil {
 		if cfg.TransportConfig.Protocol == "" {

--- a/passive_bus_tap.go
+++ b/passive_bus_tap.go
@@ -1,0 +1,469 @@
+package ebusgateway
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	ebuserrors "github.com/Project-Helianthus/helianthus-ebusgo/errors"
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+type PassiveTapEventKind uint8
+
+const (
+	PassiveTapEventConnected PassiveTapEventKind = iota + 1
+	PassiveTapEventDisconnected
+	PassiveTapEventSymbol
+	PassiveTapEventReset
+	PassiveTapEventDecodeFault
+)
+
+type PassiveEndpointState string
+
+const (
+	PassiveEndpointStateUnknown                    PassiveEndpointState = "unknown"
+	PassiveEndpointStateConnected                  PassiveEndpointState = "connected"
+	PassiveEndpointStateTemporarilyDisconnected    PassiveEndpointState = "temporarily_disconnected"
+	PassiveEndpointStateUnsupportedOrMisconfigured PassiveEndpointState = "unsupported_or_misconfigured"
+	PassiveEndpointStateClosed                     PassiveEndpointState = "closed"
+)
+
+type PassiveTapEvent struct {
+	Kind       PassiveTapEventKind
+	Symbol     byte
+	ObservedAt time.Time
+	Err        error
+}
+
+type PassiveTapConsumer interface {
+	OnPassiveTapEvent(PassiveTapEvent)
+}
+
+type PassiveTapStatus struct {
+	Connected          bool
+	EndpointState      PassiveEndpointState
+	LastError          string
+	ConnectCount       uint64
+	DisconnectCount    uint64
+	ResetCount         uint64
+	DecodeFaultCount   uint64
+	LastConnectAt      time.Time
+	LastDisconnectAt   time.Time
+	LastObservedSymbol time.Time
+}
+
+type PassiveBusTap struct {
+	cfg      Config
+	consumer PassiveTapConsumer
+	wrap     func(transport.RawTransport) transport.RawTransport
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	transportMu sync.Mutex
+	transport   transport.RawTransport
+
+	statusMu sync.RWMutex
+	status   PassiveTapStatus
+}
+
+type passiveEscapeDecoder struct {
+	escape bool
+}
+
+func StartPassiveBusTap(ctx context.Context, cfg Config, consumer PassiveTapConsumer) (*PassiveBusTap, error) {
+	return StartPassiveBusTapWithTransport(ctx, cfg, consumer, nil)
+}
+
+func StartPassiveBusTapWithTransport(ctx context.Context, cfg Config, consumer PassiveTapConsumer, wrap func(transport.RawTransport) transport.RawTransport) (*PassiveBusTap, error) {
+	if consumer == nil {
+		return nil, fmt.Errorf("passive bus tap missing consumer: %w", ebuserrors.ErrInvalidPayload)
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	cfg = applyDefaults(cfg)
+	tapCtx, cancel := context.WithCancel(ctx)
+	tap := &PassiveBusTap{
+		cfg:      cfg,
+		consumer: consumer,
+		wrap:     wrap,
+		ctx:      tapCtx,
+		cancel:   cancel,
+		status: PassiveTapStatus{
+			EndpointState: PassiveEndpointStateUnknown,
+		},
+	}
+
+	if err := tap.connect(tapCtx); err != nil {
+		cancel()
+		return nil, err
+	}
+
+	tap.wg.Add(1)
+	go tap.run()
+	return tap, nil
+}
+
+func (tap *PassiveBusTap) Close() error {
+	if tap == nil {
+		return nil
+	}
+
+	tap.cancel()
+	tap.closeCurrentTransport()
+	tap.wg.Wait()
+	return nil
+}
+
+func (tap *PassiveBusTap) Snapshot() PassiveTapStatus {
+	if tap == nil {
+		return PassiveTapStatus{}
+	}
+
+	tap.statusMu.RLock()
+	defer tap.statusMu.RUnlock()
+	return tap.status
+}
+
+func (tap *PassiveBusTap) run() {
+	defer tap.wg.Done()
+
+	retryAttempt := 0
+	for {
+		tr := tap.currentTransport()
+		if tr == nil {
+			if err := tap.ctx.Err(); err != nil {
+				tap.markClosed()
+				return
+			}
+
+			if err := tap.connect(tap.ctx); err != nil {
+				state := PassiveEndpointStateTemporarilyDisconnected
+				if tap.Snapshot().ConnectCount == 0 {
+					state = PassiveEndpointStateUnsupportedOrMisconfigured
+				}
+				tap.recordDisconnect(err, state)
+				if !tap.sleepReconnectDelay(retryAttempt) {
+					tap.markClosed()
+					return
+				}
+				retryAttempt++
+				continue
+			}
+			retryAttempt = 0
+			continue
+		}
+
+		err := tap.readLoop(tr)
+		tap.closeCurrentTransport()
+		if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || tap.ctx.Err() != nil {
+			tap.markClosed()
+			return
+		}
+
+		tap.recordDisconnect(err, PassiveEndpointStateTemporarilyDisconnected)
+		if !tap.sleepReconnectDelay(retryAttempt) {
+			tap.markClosed()
+			return
+		}
+		retryAttempt++
+	}
+}
+
+func (tap *PassiveBusTap) readLoop(tr transport.RawTransport) error {
+	decoder := passiveEscapeDecoder{}
+	lastSymbolAt := time.Now()
+
+	for {
+		if err := tap.ctx.Err(); err != nil {
+			return err
+		}
+
+		event, err := readPassiveTransportEvent(tr)
+		if err != nil {
+			if errors.Is(err, ebuserrors.ErrTimeout) {
+				threshold := tap.cfg.PassiveAbsenceThreshold
+				if threshold > 0 && time.Since(lastSymbolAt) >= threshold {
+					return fmt.Errorf("passive tap absence threshold exceeded after %s: %w", threshold, ebuserrors.ErrTimeout)
+				}
+				continue
+			}
+			if decoder.escape {
+				tap.recordDecodeFault(fmt.Errorf("incomplete escape sequence before disconnect: %w", ebuserrors.ErrInvalidPayload))
+				decoder.reset()
+			}
+			return err
+		}
+
+		now := time.Now()
+		switch event.Kind {
+		case transport.StreamEventReset:
+			if decoder.escape {
+				tap.recordDecodeFault(fmt.Errorf("incomplete escape sequence before reset: %w", ebuserrors.ErrInvalidPayload))
+				decoder.reset()
+			}
+			tap.recordReset(now)
+		case transport.StreamEventByte:
+			symbol, ok, decodeErr := decoder.push(event.Byte)
+			if decodeErr != nil {
+				tap.recordDecodeFault(decodeErr)
+				continue
+			}
+			if !ok {
+				continue
+			}
+
+			lastSymbolAt = now
+			tap.recordSymbol(now)
+			tap.emit(PassiveTapEvent{
+				Kind:       PassiveTapEventSymbol,
+				Symbol:     symbol,
+				ObservedAt: now,
+			})
+		}
+	}
+}
+
+func (tap *PassiveBusTap) connect(ctx context.Context) error {
+	tr, err := resolvePassiveTransport(ctx, tap.cfg)
+	if err != nil {
+		return err
+	}
+	if tap.wrap != nil {
+		tr = tap.wrap(tr)
+	}
+
+	tap.transportMu.Lock()
+	tap.transport = tr
+	tap.transportMu.Unlock()
+
+	tap.statusMu.Lock()
+	tap.status.Connected = true
+	tap.status.EndpointState = PassiveEndpointStateConnected
+	tap.status.ConnectCount++
+	tap.status.LastConnectAt = time.Now()
+	tap.status.LastError = ""
+	tap.statusMu.Unlock()
+
+	tap.emit(PassiveTapEvent{
+		Kind:       PassiveTapEventConnected,
+		ObservedAt: time.Now(),
+	})
+	return nil
+}
+
+func (tap *PassiveBusTap) currentTransport() transport.RawTransport {
+	tap.transportMu.Lock()
+	defer tap.transportMu.Unlock()
+	return tap.transport
+}
+
+func (tap *PassiveBusTap) closeCurrentTransport() {
+	tap.transportMu.Lock()
+	tr := tap.transport
+	tap.transport = nil
+	tap.transportMu.Unlock()
+	if tr != nil {
+		_ = tr.Close()
+	}
+}
+
+func (tap *PassiveBusTap) recordDisconnect(err error, state PassiveEndpointState) {
+	tap.statusMu.Lock()
+	tap.status.Connected = false
+	tap.status.EndpointState = state
+	tap.status.DisconnectCount++
+	tap.status.LastDisconnectAt = time.Now()
+	if err != nil {
+		tap.status.LastError = err.Error()
+	} else {
+		tap.status.LastError = ""
+	}
+	tap.statusMu.Unlock()
+
+	tap.emit(PassiveTapEvent{
+		Kind:       PassiveTapEventDisconnected,
+		ObservedAt: time.Now(),
+		Err:        err,
+	})
+}
+
+func (tap *PassiveBusTap) recordReset(observedAt time.Time) {
+	tap.statusMu.Lock()
+	tap.status.ResetCount++
+	tap.statusMu.Unlock()
+	tap.emit(PassiveTapEvent{
+		Kind:       PassiveTapEventReset,
+		ObservedAt: observedAt,
+	})
+}
+
+func (tap *PassiveBusTap) recordDecodeFault(err error) {
+	tap.statusMu.Lock()
+	tap.status.DecodeFaultCount++
+	if err != nil {
+		tap.status.LastError = err.Error()
+	}
+	tap.statusMu.Unlock()
+	tap.emit(PassiveTapEvent{
+		Kind:       PassiveTapEventDecodeFault,
+		ObservedAt: time.Now(),
+		Err:        err,
+	})
+}
+
+func (tap *PassiveBusTap) recordSymbol(observedAt time.Time) {
+	tap.statusMu.Lock()
+	tap.status.LastObservedSymbol = observedAt
+	tap.statusMu.Unlock()
+}
+
+func (tap *PassiveBusTap) markClosed() {
+	tap.statusMu.Lock()
+	tap.status.Connected = false
+	tap.status.EndpointState = PassiveEndpointStateClosed
+	tap.statusMu.Unlock()
+}
+
+func (tap *PassiveBusTap) sleepReconnectDelay(attempt int) bool {
+	delay := reconnectDelay(attempt, tap.cfg.PassiveReconnectInitialDelay, tap.cfg.PassiveReconnectMaxDelay)
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-tap.ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+func (tap *PassiveBusTap) emit(event PassiveTapEvent) {
+	if tap == nil || tap.consumer == nil {
+		return
+	}
+	if event.ObservedAt.IsZero() {
+		event.ObservedAt = time.Now()
+	}
+	tap.consumer.OnPassiveTapEvent(event)
+}
+
+func reconnectDelay(attempt int, initial, max time.Duration) time.Duration {
+	if initial <= 0 {
+		initial = time.Second
+	}
+	if max <= 0 {
+		max = 30 * time.Second
+	}
+	delay := initial
+	for i := 0; i < attempt; i++ {
+		if delay >= max {
+			return max
+		}
+		delay *= 2
+		if delay >= max {
+			return max
+		}
+	}
+	return delay
+}
+
+func readPassiveTransportEvent(tr transport.RawTransport) (transport.StreamEvent, error) {
+	if reader, ok := tr.(transport.StreamEventReader); ok {
+		return reader.ReadEvent()
+	}
+
+	value, err := tr.ReadByte()
+	if err != nil {
+		return transport.StreamEvent{}, err
+	}
+	return transport.StreamEvent{
+		Kind: transport.StreamEventByte,
+		Byte: value,
+	}, nil
+}
+
+func resolvePassiveTransport(ctx context.Context, cfg Config) (transport.RawTransport, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	config, err := normalizeTransportConfig(cfg.TransportConfig)
+	if err != nil {
+		return nil, fmt.Errorf("passive transport config: %w", err)
+	}
+	if config.Protocol == TransportEbusdTCP {
+		return nil, fmt.Errorf("passive transport unsupported on %s: %w", config.Protocol, ebuserrors.ErrInvalidPayload)
+	}
+	if config.Network == "" {
+		return nil, fmt.Errorf("passive transport missing network: %w", ebuserrors.ErrInvalidPayload)
+	}
+	if config.Address == "" {
+		return nil, fmt.Errorf("passive transport missing address: %w", ebuserrors.ErrInvalidPayload)
+	}
+
+	dial := config.Dial
+	if dial == nil {
+		dial = dialContext
+	}
+
+	conn, err := dial(ctx, config.Network, config.Address, config.DialTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("passive transport dial failed: %w", err)
+	}
+	if err := enablePassiveKeepalive(conn); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+
+	tr, err := transportFromConn(config.Protocol, conn, config.ReadTimeout, config.WriteTimeout)
+	if err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return tr, nil
+}
+
+func enablePassiveKeepalive(conn net.Conn) error {
+	tcpConn, ok := conn.(*net.TCPConn)
+	if !ok {
+		return nil
+	}
+	if err := tcpConn.SetKeepAlive(true); err != nil {
+		return fmt.Errorf("passive transport keepalive enable failed: %w", err)
+	}
+	_ = tcpConn.SetKeepAlivePeriod(30 * time.Second)
+	return nil
+}
+
+func (decoder *passiveEscapeDecoder) push(raw byte) (byte, bool, error) {
+	if decoder.escape {
+		decoder.escape = false
+		switch raw {
+		case 0x00:
+			return protocol.SymbolEscape, true, nil
+		case 0x01:
+			return protocol.SymbolSyn, true, nil
+		default:
+			return 0, false, fmt.Errorf("passive tap invalid escape sequence 0x%02x: %w", raw, ebuserrors.ErrInvalidPayload)
+		}
+	}
+
+	if raw == protocol.SymbolEscape {
+		decoder.escape = true
+		return 0, false, nil
+	}
+	return raw, true, nil
+}
+
+func (decoder *passiveEscapeDecoder) reset() {
+	decoder.escape = false
+}

--- a/passive_bus_tap_test.go
+++ b/passive_bus_tap_test.go
@@ -1,0 +1,341 @@
+package ebusgateway
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+	"github.com/Project-Helianthus/helianthus-ebusreg/router"
+)
+
+type passiveEventRecorder struct {
+	mu     sync.Mutex
+	events []PassiveTapEvent
+	notify chan struct{}
+}
+
+func newPassiveEventRecorder() *passiveEventRecorder {
+	return &passiveEventRecorder{
+		notify: make(chan struct{}, 32),
+	}
+}
+
+func (recorder *passiveEventRecorder) OnPassiveTapEvent(event PassiveTapEvent) {
+	recorder.mu.Lock()
+	recorder.events = append(recorder.events, event)
+	recorder.mu.Unlock()
+	select {
+	case recorder.notify <- struct{}{}:
+	default:
+	}
+}
+
+func (recorder *passiveEventRecorder) snapshot() []PassiveTapEvent {
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	return append([]PassiveTapEvent(nil), recorder.events...)
+}
+
+func TestStartPassiveBusTapRejectsEbusdTCP(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultConfig()
+	cfg.TransportConfig = TransportConfig{
+		Protocol: TransportEbusdTCP,
+		Network:  "tcp",
+		Address:  "127.0.0.1:9999",
+	}
+
+	if _, err := StartPassiveBusTap(context.Background(), cfg, newPassiveEventRecorder()); err == nil {
+		t.Fatal("StartPassiveBusTap error = nil; want unsupported transport error")
+	}
+}
+
+func TestPassiveBusTap_WrappedResetAndDecodeFaultsStillSurface(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	recorder := newPassiveEventRecorder()
+
+	cfg := DefaultConfig()
+	cfg.TransportConfig = TransportConfig{
+		Protocol:     TransportENH,
+		Network:      "tcp",
+		Address:      "127.0.0.1:9999",
+		ReadTimeout:  50 * time.Millisecond,
+		WriteTimeout: 50 * time.Millisecond,
+		DialTimeout:  time.Second,
+		Dial: func(ctx context.Context, network, address string, timeout time.Duration) (net.Conn, error) {
+			return client, nil
+		},
+	}
+	cfg.PassiveAbsenceThreshold = time.Second
+	cfg.PassiveReconnectInitialDelay = time.Second
+	cfg.PassiveReconnectMaxDelay = time.Second
+
+	go func() {
+		defer func() { _ = server.Close() }()
+		reset := transport.EncodeENH(transport.ENHResResetted, 0x00)
+		payload := append([]byte{}, reset[:]...)
+		payload = append(payload, enhReceivedBytes([]byte{0x11, protocol.SymbolEscape, 0x02, 0x22})...)
+		_, _ = server.Write(payload)
+	}()
+
+	wrap := func(inner transport.RawTransport) transport.RawTransport {
+		inner = &loggingTransport{inner: inner, logger: log.New(io.Discard, "", 0)}
+		return newWireLogTransport(inner, &wireLogger{writer: io.Discard}, "passive")
+	}
+
+	tap, err := StartPassiveBusTapWithTransport(context.Background(), cfg, recorder, wrap)
+	if err != nil {
+		t.Fatalf("StartPassiveBusTapWithTransport error = %v", err)
+	}
+	defer func() {
+		if err := tap.Close(); err != nil {
+			t.Fatalf("Close error = %v", err)
+		}
+	}()
+
+	events := waitForPassiveEvents(t, recorder, 2*time.Second, func(events []PassiveTapEvent) bool {
+		return countPassiveEventKind(events, PassiveTapEventReset) >= 1 &&
+			countPassiveEventKind(events, PassiveTapEventDecodeFault) >= 1 &&
+			hasPassiveSymbols(events, 0x11, 0x22)
+	})
+
+	if !hasPassiveSymbols(events, 0x11, 0x22) {
+		t.Fatalf("symbol events = %v; want [0x11, 0x22]", passiveSymbols(events))
+	}
+}
+
+func TestPassiveBusTap_ReconnectsAfterDisconnect(t *testing.T) {
+	t.Parallel()
+
+	recorder := newPassiveEventRecorder()
+	var dialMu sync.Mutex
+	dialCount := 0
+
+	cfg := DefaultConfig()
+	cfg.TransportConfig = TransportConfig{
+		Protocol:     TransportENH,
+		Network:      "tcp",
+		Address:      "127.0.0.1:9999",
+		ReadTimeout:  50 * time.Millisecond,
+		WriteTimeout: 50 * time.Millisecond,
+		DialTimeout:  time.Second,
+		Dial: func(ctx context.Context, network, address string, timeout time.Duration) (net.Conn, error) {
+			dialMu.Lock()
+			defer dialMu.Unlock()
+			dialCount++
+			client, server := net.Pipe()
+			switch dialCount {
+			case 1:
+				go writePassivePayload(server, enhReceivedBytes([]byte{0x11}))
+			case 2:
+				go writePassivePayload(server, enhReceivedBytes([]byte{0x22}))
+			default:
+				_ = server.Close()
+				return nil, fmt.Errorf("unexpected extra reconnect")
+			}
+			return client, nil
+		},
+	}
+	cfg.PassiveAbsenceThreshold = time.Second
+	cfg.PassiveReconnectInitialDelay = 5 * time.Millisecond
+	cfg.PassiveReconnectMaxDelay = 5 * time.Millisecond
+
+	tap, err := StartPassiveBusTap(context.Background(), cfg, recorder)
+	if err != nil {
+		t.Fatalf("StartPassiveBusTap error = %v", err)
+	}
+	defer func() {
+		if err := tap.Close(); err != nil {
+			t.Fatalf("Close error = %v", err)
+		}
+	}()
+
+	events := waitForPassiveEvents(t, recorder, 2*time.Second, func(events []PassiveTapEvent) bool {
+		return hasPassiveSymbols(events, 0x11, 0x22) &&
+			countPassiveEventKind(events, PassiveTapEventConnected) >= 2 &&
+			countPassiveEventKind(events, PassiveTapEventDisconnected) >= 1
+	})
+
+	if !hasPassiveSymbols(events, 0x11, 0x22) {
+		t.Fatalf("symbol events = %v; want reconnect sequence [0x11, 0x22]", passiveSymbols(events))
+	}
+
+	snapshot := tap.Snapshot()
+	if snapshot.ConnectCount < 2 {
+		t.Fatalf("ConnectCount = %d; want >= 2", snapshot.ConnectCount)
+	}
+	if snapshot.DisconnectCount < 1 {
+		t.Fatalf("DisconnectCount = %d; want >= 1", snapshot.DisconnectCount)
+	}
+}
+
+func TestBroadcastListener_RoutesBroadcastFramesViaPassiveTap(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	cfg := DefaultConfig()
+	cfg.TransportConfig = TransportConfig{
+		Protocol:     TransportENH,
+		Network:      "tcp",
+		Address:      "127.0.0.1:9999",
+		ReadTimeout:  50 * time.Millisecond,
+		WriteTimeout: 50 * time.Millisecond,
+		DialTimeout:  time.Second,
+		Dial: func(ctx context.Context, network, address string, timeout time.Duration) (net.Conn, error) {
+			return client, nil
+		},
+	}
+	cfg.PassiveAbsenceThreshold = time.Second
+	cfg.PassiveReconnectInitialDelay = time.Second
+	cfg.PassiveReconnectMaxDelay = time.Second
+
+	plane := &mockPlane{
+		name: "broadcast",
+		subscriptions: []router.Subscription{
+			{Primary: 0xB5, Secondary: 0x16},
+		},
+	}
+	eventRouter := router.NewBusEventRouter(nil)
+	eventRouter.SetPlanes([]router.Plane{plane})
+
+	go func() {
+		defer func() { _ = server.Close() }()
+		unicast := protocol.Frame{
+			Source:    0x10,
+			Target:    0x08,
+			Primary:   0xB5,
+			Secondary: 0x16,
+			Data:      []byte{0x01, 0x02},
+		}
+		broadcast := protocol.Frame{
+			Source:    0x10,
+			Target:    protocol.AddressBroadcast,
+			Primary:   0xB5,
+			Secondary: 0x16,
+			Data:      []byte{0x55, 0x66},
+		}
+		payload := append([]byte{}, enhReceivedBytes(frameBytes(unicast))...)
+		payload = append(payload, enhReceivedBytes(frameBytes(broadcast))...)
+		_, _ = server.Write(payload)
+	}()
+
+	listener, err := StartBroadcastListener(context.Background(), cfg, eventRouter)
+	if err != nil {
+		t.Fatalf("StartBroadcastListener error = %v", err)
+	}
+	defer func() {
+		if err := listener.Close(); err != nil {
+			t.Fatalf("Close error = %v", err)
+		}
+	}()
+
+	waitForCondition(t, 2*time.Second, func() bool {
+		return plane.broadcasts == 1
+	})
+	if plane.broadcasts != 1 {
+		t.Fatalf("OnBroadcast calls = %d; want 1", plane.broadcasts)
+	}
+}
+
+func waitForPassiveEvents(t *testing.T, recorder *passiveEventRecorder, timeout time.Duration, ready func([]PassiveTapEvent) bool) []PassiveTapEvent {
+	t.Helper()
+
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+
+	for {
+		events := recorder.snapshot()
+		if ready(events) {
+			return events
+		}
+
+		select {
+		case <-recorder.notify:
+		case <-deadline.C:
+			t.Fatalf("timeout waiting for passive events; got %#v", events)
+		}
+	}
+}
+
+func waitForCondition(t *testing.T, timeout time.Duration, ready func() bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if ready() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("timeout waiting for condition")
+}
+
+func countPassiveEventKind(events []PassiveTapEvent, kind PassiveTapEventKind) int {
+	count := 0
+	for _, event := range events {
+		if event.Kind == kind {
+			count++
+		}
+	}
+	return count
+}
+
+func passiveSymbols(events []PassiveTapEvent) []byte {
+	out := make([]byte, 0, len(events))
+	for _, event := range events {
+		if event.Kind == PassiveTapEventSymbol {
+			out = append(out, event.Symbol)
+		}
+	}
+	return out
+}
+
+func hasPassiveSymbols(events []PassiveTapEvent, want ...byte) bool {
+	got := passiveSymbols(events)
+	if len(got) < len(want) {
+		return false
+	}
+	index := 0
+	for _, symbol := range got {
+		if symbol != want[index] {
+			continue
+		}
+		index++
+		if index == len(want) {
+			return true
+		}
+	}
+	return false
+}
+
+func enhReceivedBytes(values []byte) []byte {
+	out := make([]byte, 0, len(values)*2)
+	for _, value := range values {
+		seq := transport.EncodeENH(transport.ENHResReceived, value)
+		out = append(out, seq[0], seq[1])
+	}
+	return out
+}
+
+func frameBytes(frame protocol.Frame) []byte {
+	raw := make([]byte, 0, 7+len(frame.Data))
+	raw = append(raw, frame.Source, frame.Target, frame.Primary, frame.Secondary, byte(len(frame.Data)))
+	raw = append(raw, frame.Data...)
+	raw = append(raw, protocol.CRC(raw), protocol.SymbolSyn)
+	return raw
+}
+
+func writePassivePayload(conn net.Conn, payload []byte) {
+	defer func() { _ = conn.Close() }()
+	_, _ = conn.Write(payload)
+}

--- a/smoke.go
+++ b/smoke.go
@@ -670,6 +670,31 @@ func (l *loggingTransport) ReadByte() (byte, error) {
 	return b, err
 }
 
+func (l *loggingTransport) ReadEvent() (transport.StreamEvent, error) {
+	if l == nil || l.inner == nil {
+		return transport.StreamEvent{}, fmt.Errorf("logging transport missing: %w", ebuserrors.ErrInvalidPayload)
+	}
+	if reader, ok := l.inner.(transport.StreamEventReader); ok {
+		event, err := reader.ReadEvent()
+		if l.logger != nil {
+			if err != nil {
+				l.logger.Printf("read event error: %v", err)
+			} else if event.Kind == transport.StreamEventReset {
+				l.logger.Printf("read reset")
+			} else {
+				l.logger.Printf("read 0x%02x", event.Byte)
+			}
+		}
+		return event, err
+	}
+
+	value, err := l.ReadByte()
+	if err != nil {
+		return transport.StreamEvent{}, err
+	}
+	return transport.StreamEvent{Kind: transport.StreamEventByte, Byte: value}, nil
+}
+
 func (l *loggingTransport) Write(data []byte) (int, error) {
 	if l == nil || l.inner == nil {
 		return 0, fmt.Errorf("logging transport missing: %w", ebuserrors.ErrInvalidPayload)

--- a/wire_log.go
+++ b/wire_log.go
@@ -115,44 +115,74 @@ func newWireLogTransport(inner transport.RawTransport, logger *wireLogger, connL
 	}
 }
 
-func (transport *wireLogTransport) ReadByte() (byte, error) {
-	if transport == nil || transport.inner == nil {
+func (wt *wireLogTransport) ReadByte() (byte, error) {
+	if wt == nil || wt.inner == nil {
 		return 0, fmt.Errorf("wire log transport missing")
 	}
-	value, err := transport.inner.ReadByte()
+	value, err := wt.inner.ReadByte()
 	if err != nil {
-		transport.logger.logError(transport.connLabel, "rx", err)
+		wt.logger.logError(wt.connLabel, "rx", err)
 		return value, err
 	}
-	transport.logger.logByte(transport.connLabel, "rx", value)
-	if frame, ok := transport.rx.push(value); ok {
-		transport.logger.logFrame(transport.connLabel, "rx", frame)
+	wt.logger.logByte(wt.connLabel, "rx", value)
+	if frame, ok := wt.rx.push(value); ok {
+		wt.logger.logFrame(wt.connLabel, "rx", frame)
 	}
 	return value, nil
 }
 
-func (transport *wireLogTransport) Write(data []byte) (int, error) {
-	if transport == nil || transport.inner == nil {
+func (wt *wireLogTransport) ReadEvent() (transport.StreamEvent, error) {
+	if wt == nil || wt.inner == nil {
+		return transport.StreamEvent{}, fmt.Errorf("wire log transport missing")
+	}
+	if reader, ok := wt.inner.(transport.StreamEventReader); ok {
+		event, err := reader.ReadEvent()
+		if err != nil {
+			wt.logger.logError(wt.connLabel, "rx", err)
+			return event, err
+		}
+		switch event.Kind {
+		case transport.StreamEventReset:
+			wt.rx.reset()
+			wt.logger.logf("%s conn=%s dir=rx reset\n", time.Now().Format(time.RFC3339Nano), wt.connLabel)
+		case transport.StreamEventByte:
+			wt.logger.logByte(wt.connLabel, "rx", event.Byte)
+			if frame, ok := wt.rx.push(event.Byte); ok {
+				wt.logger.logFrame(wt.connLabel, "rx", frame)
+			}
+		}
+		return event, nil
+	}
+
+	value, err := wt.ReadByte()
+	if err != nil {
+		return transport.StreamEvent{}, err
+	}
+	return transport.StreamEvent{Kind: transport.StreamEventByte, Byte: value}, nil
+}
+
+func (wt *wireLogTransport) Write(data []byte) (int, error) {
+	if wt == nil || wt.inner == nil {
 		return 0, fmt.Errorf("wire log transport missing")
 	}
 	for _, value := range data {
-		transport.logger.logByte(transport.connLabel, "tx", value)
-		if frame, ok := transport.tx.push(value); ok {
-			transport.logger.logFrame(transport.connLabel, "tx", frame)
+		wt.logger.logByte(wt.connLabel, "tx", value)
+		if frame, ok := wt.tx.push(value); ok {
+			wt.logger.logFrame(wt.connLabel, "tx", frame)
 		}
 	}
-	written, err := transport.inner.Write(data)
+	written, err := wt.inner.Write(data)
 	if err != nil {
-		transport.logger.logError(transport.connLabel, "tx", err)
+		wt.logger.logError(wt.connLabel, "tx", err)
 	}
 	return written, err
 }
 
-func (transport *wireLogTransport) Close() error {
-	if transport == nil || transport.inner == nil {
+func (wt *wireLogTransport) Close() error {
+	if wt == nil || wt.inner == nil {
 		return nil
 	}
-	return transport.inner.Close()
+	return wt.inner.Close()
 }
 
 type frameDecoder struct {
@@ -195,6 +225,14 @@ func (decoder *frameDecoder) push(symbol byte) (protocol.Frame, bool) {
 		decoder.buffer = append(decoder.buffer, symbol)
 		return protocol.Frame{}, false
 	}
+}
+
+func (decoder *frameDecoder) reset() {
+	if decoder == nil {
+		return
+	}
+	decoder.escape = false
+	decoder.buffer = decoder.buffer[:0]
 }
 
 func parseFrame(raw []byte) (protocol.Frame, bool) {


### PR DESCRIPTION
## What
Introduce `PassiveBusTap` as the single passive connection owner for the current broadcast path, with reset/decode-fault surfacing and reconnect handling.

## Why
This is the `ISSUE-GW-01` groundwork needed before the full passive transaction reconstructor lands. It removes the dedicated broadcast transport owner and routes broadcasts through the new passive tap abstraction.

## Validation
- `go test ./... -count=1`
- targeted passive-tap tests for reset, reconnect, decode fault, and broadcast routing

## Review
- attempted `claude -p --model opus` adversarial review on the gateway diff multiple times, but the CLI timed out repeatedly on this patch size
