### PR TITLE
Implement active/passive deduplicator

### DIFF
--- a/active_passive_deduplicator.go
+++ b/active_passive_deduplicator.go
@@ -1,0 +1,1240 @@
+package ebusgateway
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"expvar"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	ebuserrors "github.com/Project-Helianthus/helianthus-ebusgo/errors"
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+)
+
+const (
+	dedupAttemptBudgetUnit            = 250 * time.Millisecond
+	dedupCollisionResyncBudgetUnit    = 125 * time.Millisecond
+	dedupPublicationSlack             = 250 * time.Millisecond
+	dedupPendingMatchSlack            = 250 * time.Millisecond
+	defaultDedupPassiveDeliveryBudget = 500 * time.Millisecond
+	defaultDedupPendingCapacity       = 256
+	dedupRecoveryHealthyWindow        = 5 * time.Second
+	dedupRecoveryMinimumEvents        = 10
+	defaultDedupExpiryTick            = 100 * time.Millisecond
+
+	defaultDedupCriticalSubscriberBuffer    = 128
+	defaultDedupNonCriticalSubscriberBuffer = 32
+)
+
+var (
+	observeFirstDedupState                        = expvar.NewString("observe_first_dedup_state")
+	observeFirstDedupEpoch                        = expvar.NewInt("observe_first_dedup_epoch")
+	observeFirstDedupEpochResetTotal              = expvar.NewInt("observe_first_dedup_epoch_reset_total")
+	observeFirstDedupPendingFlushTotal            = expvar.NewMap("observe_first_dedup_pending_flush_total")
+	observeFirstDedupAdjudicationsTotal           = expvar.NewMap("observe_first_dedup_adjudications_total")
+	observeFirstDedupDegradedTransitionsTotal     = expvar.NewMap("observe_first_dedup_degraded_transitions_total")
+	observeFirstDedupLocalParticipantInboundTotal = expvar.NewInt("observe_first_dedup_local_participant_inbound_total")
+)
+
+type DedupTransactionClass string
+
+const (
+	DedupTransactionClassMasterTarget       DedupTransactionClass = "master_target"
+	DedupTransactionClassMasterMaster       DedupTransactionClass = "master_master"
+	DedupTransactionClassBroadcast          DedupTransactionClass = "broadcast"
+	DedupTransactionClassLocalParticipantIn DedupTransactionClass = "local_participant_inbound"
+	DedupTransactionClassAbandonedPartial   DedupTransactionClass = "abandoned_partial"
+)
+
+type DedupOutcomeClass string
+
+const (
+	DedupOutcomeSuccess        DedupOutcomeClass = "success"
+	DedupOutcomeNACK           DedupOutcomeClass = "nack"
+	DedupOutcomeTimeout        DedupOutcomeClass = "timeout"
+	DedupOutcomeCollision      DedupOutcomeClass = "collision"
+	DedupOutcomeTransportReset DedupOutcomeClass = "transport_reset"
+	DedupOutcomeDecodeReset    DedupOutcomeClass = "decode_reset"
+	DedupOutcomeAbandoned      DedupOutcomeClass = "abandoned"
+)
+
+type DedupResponseClass string
+
+const (
+	DedupResponseValueBearing     DedupResponseClass = "value_bearing"
+	DedupResponseACKOnly          DedupResponseClass = "ack_only"
+	DedupResponseHeaderOnly       DedupResponseClass = "header_only"
+	DedupResponseErrorOrAmbiguous DedupResponseClass = "error_or_ambiguous"
+)
+
+type DedupDisposition string
+
+const (
+	DedupDispositionUnmatchedThirdParty DedupDisposition = "unmatched_third_party"
+	DedupDispositionMatchedActiveCopy   DedupDisposition = "matched_active_duplicate"
+	DedupDispositionLocalParticipantIn  DedupDisposition = "local_participant_inbound"
+	DedupDispositionObservabilityOnly   DedupDisposition = "observability_only"
+	DedupDispositionDiscontinuity       DedupDisposition = "discontinuity"
+)
+
+type LocalAddressSnapshot struct {
+	Address byte
+	Known   bool
+	Epoch   uint64
+}
+
+type LocalBusAddressSnapshotter interface {
+	LocalAddressSnapshot() LocalAddressSnapshot
+}
+
+type ActiveTransactionFingerprint struct {
+	Epoch            uint64
+	TransactionClass DedupTransactionClass
+	OutcomeClass     DedupOutcomeClass
+	ResponseClass    DedupResponseClass
+	Source           byte
+	Target           byte
+	RequestBytes     []byte
+	ResponseBytes    []byte
+	Hash             [32]byte
+	ObservedAt       time.Time
+}
+
+type PassiveTransactionFingerprint struct {
+	Epoch            uint64
+	TransactionClass DedupTransactionClass
+	OutcomeClass     DedupOutcomeClass
+	ResponseClass    DedupResponseClass
+	Source           byte
+	Target           byte
+	RequestBytes     []byte
+	ResponseBytes    []byte
+	Hash             [32]byte
+	ObservedAt       time.Time
+}
+
+type AdjudicatedPassiveEvent struct {
+	Event                   PassiveClassifiedEvent
+	Fingerprint             PassiveTransactionFingerprint
+	Disposition             DedupDisposition
+	SuppressShadow          bool
+	SuppressWatchEfficiency bool
+	ThirdPartyEligible      bool
+	ObservabilityOnly       bool
+	LocalParticipantInbound bool
+	MatchedActiveDuplicate  bool
+	Epoch                   uint64
+}
+
+type DedupSubscriberPriority uint8
+
+const (
+	DedupSubscriberCritical DedupSubscriberPriority = iota + 1
+	DedupSubscriberNonCritical
+)
+
+type AdjudicatedPassiveSubscription struct {
+	id           uint64
+	name         string
+	priority     DedupSubscriberPriority
+	ch           chan AdjudicatedPassiveEvent
+	deduplicator *ActivePassiveDeduplicator
+	closeOnce    sync.Once
+}
+
+func (subscription *AdjudicatedPassiveSubscription) Events() <-chan AdjudicatedPassiveEvent {
+	if subscription == nil {
+		return nil
+	}
+	return subscription.ch
+}
+
+func (subscription *AdjudicatedPassiveSubscription) Close() {
+	if subscription == nil || subscription.deduplicator == nil {
+		return
+	}
+	subscription.deduplicator.unsubscribe(subscription)
+}
+
+type dedupTimingBudgets struct {
+	LogicalRequestEnvelope     time.Duration
+	ActivePublishBudget        time.Duration
+	PassiveDeliveryBudget      time.Duration
+	PendingGraceTimeout        time.Duration
+	ActiveFingerprintRetention time.Duration
+	PendingCapacity            int
+	RecoveryHysteresis         time.Duration
+	RecoveryEventThreshold     int
+}
+
+type retainedActiveFingerprint struct {
+	Fingerprint ActiveTransactionFingerprint
+	ExpiresAt   time.Time
+	Count       int
+}
+
+type pendingPassiveFingerprint struct {
+	Event       PassiveClassifiedEvent
+	Fingerprint PassiveTransactionFingerprint
+	InsertedAt  time.Time
+	ReleaseAt   time.Time
+	Epoch       uint64
+}
+
+type recoveryState struct {
+	StartedAt       time.Time
+	PassiveEvidence int
+}
+
+type ActivePassiveDeduplicator struct {
+	cfg     Config
+	nowFunc func() time.Time
+	budgets dedupTimingBudgets
+
+	ctx           context.Context
+	cancel        context.CancelFunc
+	wg            sync.WaitGroup
+	reconstructor *PassiveTransactionReconstructor
+
+	mu           sync.Mutex
+	currentEpoch uint64
+	degraded     bool
+	recovery     recoveryState
+	localAddr    LocalAddressSnapshot
+	active       map[[32]byte]retainedActiveFingerprint
+	pending      []pendingPassiveFingerprint
+
+	subscribersMu sync.Mutex
+	subscribers   map[uint64]*AdjudicatedPassiveSubscription
+	nextSubID     atomic.Uint64
+
+	closeOnce sync.Once
+}
+
+func NewActivePassiveDeduplicator(cfg Config) (*ActivePassiveDeduplicator, error) {
+	cfg = applyDefaults(cfg)
+	requiredBudgets, err := deriveDedupTimingBudgets(cfg.BusConfig.RetryEnvelope())
+	if err != nil {
+		return nil, err
+	}
+	budgets := dedupTimingBudgets{
+		LogicalRequestEnvelope:     requiredBudgets.LogicalRequestEnvelope,
+		ActivePublishBudget:        cfg.PassiveDedupActivePublishBudget,
+		PassiveDeliveryBudget:      cfg.PassiveDedupPassiveDeliveryBudget,
+		PendingGraceTimeout:        cfg.PassiveDedupPendingGraceTimeout,
+		ActiveFingerprintRetention: cfg.PassiveDedupActiveFingerprintRetention,
+		PendingCapacity:            cfg.PassiveDedupPendingCapacity,
+		RecoveryHysteresis:         cfg.PassiveDedupRecoveryHysteresis,
+		RecoveryEventThreshold:     cfg.PassiveDedupRecoveryEventThreshold,
+	}
+	if budgets.ActivePublishBudget < requiredBudgets.ActivePublishBudget ||
+		budgets.PendingGraceTimeout < requiredBudgets.PendingGraceTimeout ||
+		budgets.ActiveFingerprintRetention < requiredBudgets.ActiveFingerprintRetention ||
+		budgets.PendingCapacity < requiredBudgets.PendingCapacity ||
+		budgets.PassiveDeliveryBudget < requiredBudgets.PassiveDeliveryBudget {
+		return nil, fmt.Errorf("passive dedup budgets below validated minimums: %+v < %+v", budgets, requiredBudgets)
+	}
+
+	deduplicator := &ActivePassiveDeduplicator{
+		cfg:          cfg,
+		nowFunc:      time.Now,
+		budgets:      budgets,
+		currentEpoch: 1,
+		degraded:     true,
+		active:       make(map[[32]byte]retainedActiveFingerprint),
+		pending:      make([]pendingPassiveFingerprint, 0, budgets.PendingCapacity),
+		subscribers:  make(map[uint64]*AdjudicatedPassiveSubscription),
+	}
+	if cfg.LocalAddressSnapshotter != nil {
+		deduplicator.localAddr = cfg.LocalAddressSnapshotter.LocalAddressSnapshot()
+	}
+	deduplicator.updateExpvarsLocked()
+	return deduplicator, nil
+}
+
+func deriveDedupTimingBudgets(envelope protocol.BusRetryEnvelope) (dedupTimingBudgets, error) {
+	logicalEnvelope := logicalRequestRetryEnvelope(envelope)
+	if logicalEnvelope <= 0 {
+		return dedupTimingBudgets{}, fmt.Errorf("dedup retry envelope invalid")
+	}
+	activePublish := logicalEnvelope + dedupPublicationSlack
+	pendingGrace := maxDuration(activePublish, defaultDedupPassiveDeliveryBudget) + dedupPendingMatchSlack
+	return dedupTimingBudgets{
+		LogicalRequestEnvelope:     logicalEnvelope,
+		ActivePublishBudget:        activePublish,
+		PassiveDeliveryBudget:      defaultDedupPassiveDeliveryBudget,
+		PendingGraceTimeout:        pendingGrace,
+		ActiveFingerprintRetention: pendingGrace + defaultDedupPassiveDeliveryBudget,
+		PendingCapacity:            defaultDedupPendingCapacity,
+		RecoveryHysteresis:         dedupRecoveryHealthyWindow,
+		RecoveryEventThreshold:     dedupRecoveryMinimumEvents,
+	}, nil
+}
+
+func defaultPassiveDedupBudgets(envelope protocol.BusRetryEnvelope) dedupTimingBudgets {
+	budgets, err := deriveDedupTimingBudgets(envelope)
+	if err != nil {
+		return dedupTimingBudgets{
+			PendingCapacity:        defaultDedupPendingCapacity,
+			RecoveryHysteresis:     dedupRecoveryHealthyWindow,
+			RecoveryEventThreshold: dedupRecoveryMinimumEvents,
+		}
+	}
+	return budgets
+}
+
+func logicalRequestRetryEnvelope(envelope protocol.BusRetryEnvelope) time.Duration {
+	policy := envelope.InitiatorTarget
+	if envelope.InitiatorInitiator.TimeoutRetries+envelope.InitiatorInitiator.NACKRetries >
+		envelope.InitiatorTarget.TimeoutRetries+envelope.InitiatorTarget.NACKRetries {
+		policy = envelope.InitiatorInitiator
+	}
+
+	timeoutRetries := maxInt(policy.TimeoutRetries, 0)
+	nackRetries := maxInt(policy.NACKRetries, 0)
+	collisionResync := maxInt(envelope.CollisionResyncSYNCount, 0)
+
+	return time.Duration(1+timeoutRetries+nackRetries)*dedupAttemptBudgetUnit +
+		time.Duration(collisionResync)*dedupCollisionResyncBudgetUnit
+}
+
+func (deduplicator *ActivePassiveDeduplicator) Budgets() dedupTimingBudgets {
+	if deduplicator == nil {
+		return dedupTimingBudgets{}
+	}
+	return deduplicator.budgets
+}
+
+func (deduplicator *ActivePassiveDeduplicator) LocalAddressSnapshot() LocalAddressSnapshot {
+	if deduplicator == nil {
+		return LocalAddressSnapshot{}
+	}
+	deduplicator.mu.Lock()
+	defer deduplicator.mu.Unlock()
+	return deduplicator.localAddr
+}
+
+func (deduplicator *ActivePassiveDeduplicator) Subscribe(name string, priority DedupSubscriberPriority, buffer int) (*AdjudicatedPassiveSubscription, error) {
+	if deduplicator == nil {
+		return nil, fmt.Errorf("deduplicator missing: %w", ebuserrors.ErrInvalidPayload)
+	}
+	if name == "" {
+		return nil, fmt.Errorf("dedup subscriber missing name: %w", ebuserrors.ErrInvalidPayload)
+	}
+	if priority == 0 {
+		priority = DedupSubscriberNonCritical
+	}
+	if buffer <= 0 {
+		buffer = defaultDedupSubscriberBuffer(priority)
+	}
+
+	subscription := &AdjudicatedPassiveSubscription{
+		id:           deduplicator.nextSubID.Add(1),
+		name:         name,
+		priority:     priority,
+		ch:           make(chan AdjudicatedPassiveEvent, buffer),
+		deduplicator: deduplicator,
+	}
+
+	deduplicator.subscribersMu.Lock()
+	defer deduplicator.subscribersMu.Unlock()
+	if deduplicator.subscribers == nil {
+		return nil, fmt.Errorf("deduplicator closed: %w", ebuserrors.ErrTransportClosed)
+	}
+	deduplicator.subscribers[subscription.id] = subscription
+	return subscription, nil
+}
+
+func defaultDedupSubscriberBuffer(priority DedupSubscriberPriority) int {
+	if priority == DedupSubscriberCritical {
+		return defaultDedupCriticalSubscriberBuffer
+	}
+	return defaultDedupNonCriticalSubscriberBuffer
+}
+
+func (deduplicator *ActivePassiveDeduplicator) AttachReconstructor(ctx context.Context, reconstructor *PassiveTransactionReconstructor) error {
+	if deduplicator == nil {
+		return fmt.Errorf("deduplicator missing: %w", ebuserrors.ErrInvalidPayload)
+	}
+	if reconstructor == nil {
+		return fmt.Errorf("dedup reconstructor missing: %w", ebuserrors.ErrInvalidPayload)
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	deduplicator.mu.Lock()
+	defer deduplicator.mu.Unlock()
+	if deduplicator.ctx != nil {
+		return fmt.Errorf("dedup reconstructor already attached: %w", ebuserrors.ErrInvalidPayload)
+	}
+
+	dedupCtx, cancel := context.WithCancel(ctx)
+	deduplicator.ctx = dedupCtx
+	deduplicator.cancel = cancel
+	deduplicator.reconstructor = reconstructor
+
+	deduplicator.wg.Add(2)
+	go deduplicator.runPassiveLoop()
+	go deduplicator.runExpiryLoop()
+	return nil
+}
+
+func (deduplicator *ActivePassiveDeduplicator) Close() error {
+	if deduplicator == nil {
+		return nil
+	}
+
+	deduplicator.closeOnce.Do(func() {
+		if deduplicator.cancel != nil {
+			deduplicator.cancel()
+		}
+		deduplicator.wg.Wait()
+		deduplicator.closeAllSubscribers()
+	})
+	return nil
+}
+
+func (deduplicator *ActivePassiveDeduplicator) runPassiveLoop() {
+	defer deduplicator.wg.Done()
+
+	for {
+		ctx, reconstructor := deduplicator.snapshotRuntime()
+		if ctx == nil || reconstructor == nil {
+			return
+		}
+		if err := ctx.Err(); err != nil {
+			return
+		}
+
+		subscription, err := reconstructor.Subscribe("active-passive-dedup", PassiveSubscriberCritical, 0)
+		if err != nil {
+			timer := time.NewTimer(defaultDedupExpiryTick)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
+				continue
+			}
+		}
+
+		closedUnexpectedly := false
+		for {
+			select {
+			case <-ctx.Done():
+				subscription.Close()
+				return
+			case event, ok := <-subscription.Events():
+				if !ok {
+					closedUnexpectedly = ctx.Err() == nil
+					goto nextSubscription
+				}
+				deduplicator.OnPassiveClassifiedEvent(event)
+			}
+		}
+
+	nextSubscription:
+		if closedUnexpectedly {
+			deduplicator.handleCriticalReset(time.Now(), PassiveDiscontinuityCriticalSubscriberFault, "passive_subscription_reset")
+		}
+	}
+}
+
+func (deduplicator *ActivePassiveDeduplicator) runExpiryLoop() {
+	defer deduplicator.wg.Done()
+
+	ticker := time.NewTicker(defaultDedupExpiryTick)
+	defer ticker.Stop()
+
+	for {
+		ctx, _ := deduplicator.snapshotRuntime()
+		if ctx == nil {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			now := deduplicator.now()
+			outputs := deduplicator.releaseExpiredPending(now)
+			deduplicator.publishAll(outputs)
+		}
+	}
+}
+
+func (deduplicator *ActivePassiveDeduplicator) snapshotRuntime() (context.Context, *PassiveTransactionReconstructor) {
+	deduplicator.mu.Lock()
+	defer deduplicator.mu.Unlock()
+	return deduplicator.ctx, deduplicator.reconstructor
+}
+
+func (deduplicator *ActivePassiveDeduplicator) OnBusEvent(event protocol.BusEvent) error {
+	if deduplicator == nil {
+		return nil
+	}
+
+	now := deduplicator.now()
+	outputs := deduplicator.handleBusEvent(event, now)
+	deduplicator.publishAll(outputs)
+	return nil
+}
+
+func (deduplicator *ActivePassiveDeduplicator) OnPassiveClassifiedEvent(event PassiveClassifiedEvent) {
+	if deduplicator == nil {
+		return
+	}
+	observedAt := event.ObservedAt
+	if observedAt.IsZero() {
+		observedAt = deduplicator.now()
+		event.ObservedAt = observedAt
+	}
+	outputs := deduplicator.handlePassiveEvent(event, observedAt)
+	deduplicator.publishAll(outputs)
+}
+
+func (deduplicator *ActivePassiveDeduplicator) handleBusEvent(event protocol.BusEvent, now time.Time) []AdjudicatedPassiveEvent {
+	deduplicator.mu.Lock()
+	defer deduplicator.mu.Unlock()
+
+	outputs := deduplicator.releaseExpiredPendingLocked(now)
+	deduplicator.pruneActiveLocked(now)
+
+	switch event.Kind {
+	case protocol.BusEventObserverFault:
+		deduplicator.enterDegradedLocked("observer_fault")
+		return outputs
+	case protocol.BusEventAttemptComplete:
+	default:
+		return outputs
+	}
+
+	if event.Outcome != protocol.BusOutcomeSuccess || !event.HasRequest {
+		return outputs
+	}
+
+	if deduplicator.updateLocalAddressLocked(event.Request.Source, now) {
+		outputs = append(outputs, deduplicator.makeDiscontinuityLocked(now, PassiveDiscontinuityTransportReset, "local_address_epoch")...)
+	}
+
+	fingerprint, ok := buildActiveFingerprint(deduplicator.currentEpoch, event, now)
+	if !ok {
+		deduplicator.enterDegradedLocked("active_fingerprint_build")
+		return outputs
+	}
+
+	if existing, ok := deduplicator.active[fingerprint.Hash]; ok {
+		existing.Count++
+		existing.Fingerprint = fingerprint
+		existing.ExpiresAt = now.Add(deduplicator.budgets.ActiveFingerprintRetention)
+		deduplicator.active[fingerprint.Hash] = existing
+	} else {
+		deduplicator.active[fingerprint.Hash] = retainedActiveFingerprint{
+			Fingerprint: fingerprint,
+			ExpiresAt:   now.Add(deduplicator.budgets.ActiveFingerprintRetention),
+			Count:       1,
+		}
+	}
+
+	outputs = append(outputs, deduplicator.matchPendingLocked(fingerprint, now)...)
+	deduplicator.recordRecoveryEvidenceLocked(now)
+	return outputs
+}
+
+func (deduplicator *ActivePassiveDeduplicator) handlePassiveEvent(event PassiveClassifiedEvent, now time.Time) []AdjudicatedPassiveEvent {
+	deduplicator.mu.Lock()
+	defer deduplicator.mu.Unlock()
+
+	outputs := deduplicator.releaseExpiredPendingLocked(now)
+	deduplicator.pruneActiveLocked(now)
+
+	if event.Kind == PassiveClassifiedEventDiscontinuity {
+		return append(outputs, deduplicator.makeDiscontinuityLocked(now, event.DiscontinuityReason, "passive_epoch_boundary")...)
+	}
+
+	if event.Kind == PassiveClassifiedEventBroadcastFrame {
+		deduplicator.recordRecoveryEvidenceLocked(now)
+		return outputs
+	}
+
+	if event.Kind != PassiveClassifiedEventTransaction &&
+		event.Kind != PassiveClassifiedEventMasterFrame &&
+		event.Kind != PassiveClassifiedEventAbandonedTransaction {
+		return outputs
+	}
+
+	fingerprint, matchEligible, immediateDisposition := deduplicator.buildPassiveFingerprintLocked(event, now)
+	if !matchEligible {
+		outputs = append(outputs, deduplicator.publishImmediateLocked(event, fingerprint, immediateDisposition)...)
+		return outputs
+	}
+
+	if deduplicator.consumeActiveLocked(fingerprint.Hash) {
+		outputs = append(outputs, adjudicateMatchedActiveDuplicate(event, fingerprint, deduplicator.currentEpoch))
+		incrementExpvarMap(observeFirstDedupAdjudicationsTotal, string(DedupDispositionMatchedActiveCopy))
+		deduplicator.recordRecoveryEvidenceLocked(now)
+		return outputs
+	}
+
+	for len(deduplicator.pending) >= deduplicator.budgets.PendingCapacity {
+		index := deduplicator.oldestReleasablePendingLocked(now)
+		if index < 0 {
+			deduplicator.enterDegradedLocked("pending_capacity")
+			outputs = append(outputs, adjudicateObservabilityOnly(event, fingerprint, deduplicator.currentEpoch))
+			incrementExpvarMap(observeFirstDedupAdjudicationsTotal, string(DedupDispositionObservabilityOnly))
+			return outputs
+		}
+		outputs = append(outputs, deduplicator.releasePendingIndexLocked(index, now, "grace_expiry")...)
+	}
+
+	deduplicator.pending = append(deduplicator.pending, pendingPassiveFingerprint{
+		Event:       event,
+		Fingerprint: fingerprint,
+		InsertedAt:  now,
+		ReleaseAt:   now.Add(deduplicator.budgets.PendingGraceTimeout),
+		Epoch:       deduplicator.currentEpoch,
+	})
+	deduplicator.recordRecoveryEvidenceLocked(now)
+	return outputs
+}
+
+func (deduplicator *ActivePassiveDeduplicator) buildPassiveFingerprintLocked(event PassiveClassifiedEvent, observedAt time.Time) (PassiveTransactionFingerprint, bool, DedupDisposition) {
+	transactionClass := deduplicator.passiveTransactionClassLocked(event)
+	outcome := passiveOutcomeClass(event)
+	responseClass := passiveResponseClass(event, outcome)
+
+	fingerprint := PassiveTransactionFingerprint{
+		Epoch:            deduplicator.currentEpoch,
+		TransactionClass: transactionClass,
+		OutcomeClass:     outcome,
+		ResponseClass:    responseClass,
+		ObservedAt:       observedAt,
+	}
+	if event.HasRequest {
+		fingerprint.Source = event.Request.Source
+		fingerprint.Target = event.Request.Target
+		fingerprint.RequestBytes = canonicalFrameBytes(event.Request)
+	}
+	if event.HasResponse {
+		fingerprint.ResponseBytes = canonicalFrameBytes(event.Response)
+	}
+	fingerprint.Hash = hashTransactionIdentity(
+		transactionClass,
+		fingerprint.Source,
+		fingerprint.Target,
+		responseClass,
+		outcome,
+		fingerprint.RequestBytes,
+		fingerprint.ResponseBytes,
+	)
+
+	switch transactionClass {
+	case DedupTransactionClassBroadcast:
+		return fingerprint, false, DedupDispositionObservabilityOnly
+	case DedupTransactionClassLocalParticipantIn:
+		return fingerprint, false, DedupDispositionLocalParticipantIn
+	case DedupTransactionClassMasterMaster:
+		if !deduplicator.localAddr.Known {
+			return fingerprint, false, DedupDispositionObservabilityOnly
+		}
+	}
+
+	if outcome != DedupOutcomeSuccess {
+		return fingerprint, false, DedupDispositionObservabilityOnly
+	}
+	return fingerprint, true, ""
+}
+
+func (deduplicator *ActivePassiveDeduplicator) passiveTransactionClassLocked(event PassiveClassifiedEvent) DedupTransactionClass {
+	switch event.Kind {
+	case PassiveClassifiedEventBroadcastFrame:
+		return DedupTransactionClassBroadcast
+	case PassiveClassifiedEventMasterFrame:
+		if deduplicator.localAddr.Known && event.HasRequest && event.Request.Target == deduplicator.localAddr.Address {
+			return DedupTransactionClassLocalParticipantIn
+		}
+		return DedupTransactionClassMasterMaster
+	case PassiveClassifiedEventTransaction:
+		return DedupTransactionClassMasterTarget
+	case PassiveClassifiedEventAbandonedTransaction:
+		if event.FrameType == protocol.FrameTypeInitiatorInitiator &&
+			deduplicator.localAddr.Known &&
+			event.HasRequest &&
+			event.Request.Target == deduplicator.localAddr.Address {
+			return DedupTransactionClassLocalParticipantIn
+		}
+		return DedupTransactionClassAbandonedPartial
+	default:
+		return DedupTransactionClassAbandonedPartial
+	}
+}
+
+func passiveOutcomeClass(event PassiveClassifiedEvent) DedupOutcomeClass {
+	switch event.Kind {
+	case PassiveClassifiedEventTransaction, PassiveClassifiedEventMasterFrame, PassiveClassifiedEventBroadcastFrame:
+		return DedupOutcomeSuccess
+	case PassiveClassifiedEventAbandonedTransaction:
+		switch event.AbandonReason {
+		case PassiveAbandonReasonNACK:
+			return DedupOutcomeNACK
+		case PassiveAbandonReasonNoResponse, PassiveAbandonReasonNoProgress, PassiveAbandonReasonDisconnected, PassiveAbandonReasonShutdown:
+			return DedupOutcomeTimeout
+		case PassiveAbandonReasonTransportReset:
+			return DedupOutcomeTransportReset
+		case PassiveAbandonReasonDecodeFault:
+			return DedupOutcomeDecodeReset
+		case PassiveAbandonReasonAmbiguousRetransmit:
+			return DedupOutcomeCollision
+		default:
+			return DedupOutcomeAbandoned
+		}
+	case PassiveClassifiedEventDiscontinuity:
+		switch event.DiscontinuityReason {
+		case PassiveDiscontinuityTransportReset, PassiveDiscontinuityDisconnected, PassiveDiscontinuityConnected, PassiveDiscontinuityShutdown:
+			return DedupOutcomeTransportReset
+		default:
+			return DedupOutcomeDecodeReset
+		}
+	default:
+		return DedupOutcomeAbandoned
+	}
+}
+
+func passiveResponseClass(event PassiveClassifiedEvent, outcome DedupOutcomeClass) DedupResponseClass {
+	if outcome != DedupOutcomeSuccess {
+		return DedupResponseErrorOrAmbiguous
+	}
+	if !event.HasResponse {
+		if event.FrameType == protocol.FrameTypeInitiatorInitiator {
+			return DedupResponseACKOnly
+		}
+		return DedupResponseErrorOrAmbiguous
+	}
+	if len(event.Response.Data) == 0 {
+		return DedupResponseHeaderOnly
+	}
+	return DedupResponseValueBearing
+}
+
+func buildActiveFingerprint(epoch uint64, event protocol.BusEvent, observedAt time.Time) (ActiveTransactionFingerprint, bool) {
+	if !event.HasRequest {
+		return ActiveTransactionFingerprint{}, false
+	}
+
+	var transactionClass DedupTransactionClass
+	switch event.FrameType {
+	case protocol.FrameTypeBroadcast:
+		transactionClass = DedupTransactionClassBroadcast
+	case protocol.FrameTypeInitiatorInitiator:
+		transactionClass = DedupTransactionClassMasterMaster
+	case protocol.FrameTypeInitiatorTarget:
+		transactionClass = DedupTransactionClassMasterTarget
+	default:
+		return ActiveTransactionFingerprint{}, false
+	}
+
+	responseClass := activeResponseClass(event)
+	requestBytes := canonicalFrameBytes(event.Request)
+	var responseBytes []byte
+	if event.HasResponse {
+		responseBytes = canonicalFrameBytes(event.Response)
+	}
+
+	fingerprint := ActiveTransactionFingerprint{
+		Epoch:            epoch,
+		TransactionClass: transactionClass,
+		OutcomeClass:     DedupOutcomeSuccess,
+		ResponseClass:    responseClass,
+		Source:           event.Request.Source,
+		Target:           event.Request.Target,
+		RequestBytes:     requestBytes,
+		ResponseBytes:    responseBytes,
+		ObservedAt:       observedAt,
+	}
+	fingerprint.Hash = hashTransactionIdentity(
+		transactionClass,
+		fingerprint.Source,
+		fingerprint.Target,
+		responseClass,
+		DedupOutcomeSuccess,
+		requestBytes,
+		responseBytes,
+	)
+	return fingerprint, true
+}
+
+func activeResponseClass(event protocol.BusEvent) DedupResponseClass {
+	if !event.HasResponse {
+		if event.FrameType == protocol.FrameTypeInitiatorInitiator {
+			return DedupResponseACKOnly
+		}
+		return DedupResponseErrorOrAmbiguous
+	}
+	if len(event.Response.Data) == 0 {
+		return DedupResponseHeaderOnly
+	}
+	return DedupResponseValueBearing
+}
+
+func canonicalFrameBytes(frame protocol.Frame) []byte {
+	raw := make([]byte, 0, 7+len(frame.Data))
+	raw = append(raw, frame.Source, frame.Target, frame.Primary, frame.Secondary, byte(len(frame.Data)))
+	raw = append(raw, frame.Data...)
+	raw = append(raw, protocol.CRC(raw))
+	return raw
+}
+
+func hashTransactionIdentity(class DedupTransactionClass, source, target byte, responseClass DedupResponseClass, outcome DedupOutcomeClass, requestBytes, responseBytes []byte) [32]byte {
+	buf := make([]byte, 0, 4+len(requestBytes)+len(responseBytes)+16)
+	buf = append(buf, byte(len(class)))
+	buf = append(buf, []byte(class)...)
+	buf = append(buf, source, target)
+	buf = append(buf, byte(len(responseClass)))
+	buf = append(buf, []byte(responseClass)...)
+	buf = append(buf, byte(len(outcome)))
+	buf = append(buf, []byte(outcome)...)
+	buf = appendLengthPrefixed(buf, requestBytes)
+	buf = appendLengthPrefixed(buf, responseBytes)
+	return sha256.Sum256(buf)
+}
+
+func appendLengthPrefixed(buf, payload []byte) []byte {
+	var length [2]byte
+	binary.BigEndian.PutUint16(length[:], uint16(len(payload)))
+	buf = append(buf, length[:]...)
+	buf = append(buf, payload...)
+	return buf
+}
+
+func (deduplicator *ActivePassiveDeduplicator) matchPendingLocked(active ActiveTransactionFingerprint, now time.Time) []AdjudicatedPassiveEvent {
+	if len(deduplicator.pending) == 0 {
+		return nil
+	}
+
+	outputs := make([]AdjudicatedPassiveEvent, 0, 1)
+	next := deduplicator.pending[:0]
+	matched := false
+	for _, pending := range deduplicator.pending {
+		if pending.Epoch != deduplicator.currentEpoch || pending.Fingerprint.Epoch != deduplicator.currentEpoch {
+			continue
+		}
+		if !matched && pending.Fingerprint.Hash == active.Hash {
+			outputs = append(outputs, adjudicateMatchedActiveDuplicate(pending.Event, pending.Fingerprint, deduplicator.currentEpoch))
+			incrementExpvarMap(observeFirstDedupAdjudicationsTotal, string(DedupDispositionMatchedActiveCopy))
+			deduplicator.consumeActiveLocked(active.Hash)
+			matched = true
+			continue
+		}
+		next = append(next, pending)
+	}
+	deduplicator.pending = next
+	deduplicator.recordRecoveryEvidenceLocked(now)
+	return outputs
+}
+
+func (deduplicator *ActivePassiveDeduplicator) releaseExpiredPending(now time.Time) []AdjudicatedPassiveEvent {
+	deduplicator.mu.Lock()
+	defer deduplicator.mu.Unlock()
+	return deduplicator.releaseExpiredPendingLocked(now)
+}
+
+func (deduplicator *ActivePassiveDeduplicator) releaseExpiredPendingLocked(now time.Time) []AdjudicatedPassiveEvent {
+	if len(deduplicator.pending) == 0 {
+		return nil
+	}
+
+	outputs := make([]AdjudicatedPassiveEvent, 0)
+	next := deduplicator.pending[:0]
+	for _, pending := range deduplicator.pending {
+		if pending.ReleaseAt.After(now) {
+			next = append(next, pending)
+			continue
+		}
+		outputs = append(outputs, deduplicator.releasePendingAsOutputLocked(pending)...)
+		incrementExpvarMap(observeFirstDedupPendingFlushTotal, "grace_expiry")
+	}
+	deduplicator.pending = next
+	return outputs
+}
+
+func (deduplicator *ActivePassiveDeduplicator) oldestReleasablePendingLocked(now time.Time) int {
+	index := -1
+	var oldest time.Time
+	for i, pending := range deduplicator.pending {
+		if pending.ReleaseAt.After(now) {
+			continue
+		}
+		if index < 0 || pending.ReleaseAt.Before(oldest) {
+			index = i
+			oldest = pending.ReleaseAt
+		}
+	}
+	return index
+}
+
+func (deduplicator *ActivePassiveDeduplicator) releasePendingIndexLocked(index int, now time.Time, reason string) []AdjudicatedPassiveEvent {
+	if index < 0 || index >= len(deduplicator.pending) {
+		return nil
+	}
+	pending := deduplicator.pending[index]
+	copy(deduplicator.pending[index:], deduplicator.pending[index+1:])
+	deduplicator.pending = deduplicator.pending[:len(deduplicator.pending)-1]
+	incrementExpvarMap(observeFirstDedupPendingFlushTotal, reason)
+	return deduplicator.releasePendingAsOutputLocked(pending)
+}
+
+func (deduplicator *ActivePassiveDeduplicator) releasePendingAsOutputLocked(pending pendingPassiveFingerprint) []AdjudicatedPassiveEvent {
+	if deduplicator.degraded {
+		incrementExpvarMap(observeFirstDedupAdjudicationsTotal, string(DedupDispositionObservabilityOnly))
+		return []AdjudicatedPassiveEvent{adjudicateObservabilityOnly(pending.Event, pending.Fingerprint, deduplicator.currentEpoch)}
+	}
+	incrementExpvarMap(observeFirstDedupAdjudicationsTotal, string(DedupDispositionUnmatchedThirdParty))
+	return []AdjudicatedPassiveEvent{adjudicateUnmatchedThirdParty(pending.Event, pending.Fingerprint, deduplicator.currentEpoch)}
+}
+
+func (deduplicator *ActivePassiveDeduplicator) publishImmediateLocked(event PassiveClassifiedEvent, fingerprint PassiveTransactionFingerprint, disposition DedupDisposition) []AdjudicatedPassiveEvent {
+	switch disposition {
+	case DedupDispositionLocalParticipantIn:
+		observeFirstDedupLocalParticipantInboundTotal.Add(1)
+		incrementExpvarMap(observeFirstDedupAdjudicationsTotal, string(DedupDispositionLocalParticipantIn))
+		return []AdjudicatedPassiveEvent{adjudicateLocalParticipantInbound(event, fingerprint, deduplicator.currentEpoch)}
+	default:
+		incrementExpvarMap(observeFirstDedupAdjudicationsTotal, string(DedupDispositionObservabilityOnly))
+		return []AdjudicatedPassiveEvent{adjudicateObservabilityOnly(event, fingerprint, deduplicator.currentEpoch)}
+	}
+}
+
+func adjudicateMatchedActiveDuplicate(event PassiveClassifiedEvent, fingerprint PassiveTransactionFingerprint, epoch uint64) AdjudicatedPassiveEvent {
+	return AdjudicatedPassiveEvent{
+		Event:                   event,
+		Fingerprint:             fingerprint,
+		Disposition:             DedupDispositionMatchedActiveCopy,
+		SuppressShadow:          true,
+		SuppressWatchEfficiency: true,
+		MatchedActiveDuplicate:  true,
+		Epoch:                   epoch,
+	}
+}
+
+func adjudicateUnmatchedThirdParty(event PassiveClassifiedEvent, fingerprint PassiveTransactionFingerprint, epoch uint64) AdjudicatedPassiveEvent {
+	return AdjudicatedPassiveEvent{
+		Event:              event,
+		Fingerprint:        fingerprint,
+		Disposition:        DedupDispositionUnmatchedThirdParty,
+		ThirdPartyEligible: true,
+		Epoch:              epoch,
+	}
+}
+
+func adjudicateObservabilityOnly(event PassiveClassifiedEvent, fingerprint PassiveTransactionFingerprint, epoch uint64) AdjudicatedPassiveEvent {
+	return AdjudicatedPassiveEvent{
+		Event:             event,
+		Fingerprint:       fingerprint,
+		Disposition:       DedupDispositionObservabilityOnly,
+		ObservabilityOnly: true,
+		Epoch:             epoch,
+	}
+}
+
+func adjudicateLocalParticipantInbound(event PassiveClassifiedEvent, fingerprint PassiveTransactionFingerprint, epoch uint64) AdjudicatedPassiveEvent {
+	return AdjudicatedPassiveEvent{
+		Event:                   event,
+		Fingerprint:             fingerprint,
+		Disposition:             DedupDispositionLocalParticipantIn,
+		ObservabilityOnly:       true,
+		LocalParticipantInbound: true,
+		SuppressWatchEfficiency: true,
+		Epoch:                   epoch,
+	}
+}
+
+func makeAdjudicatedDiscontinuity(event PassiveClassifiedEvent, epoch uint64) AdjudicatedPassiveEvent {
+	return AdjudicatedPassiveEvent{
+		Event:             event,
+		Disposition:       DedupDispositionDiscontinuity,
+		ObservabilityOnly: true,
+		Epoch:             epoch,
+	}
+}
+
+func (deduplicator *ActivePassiveDeduplicator) makeDiscontinuityLocked(observedAt time.Time, reason PassiveDiscontinuityReason, degradeReason string) []AdjudicatedPassiveEvent {
+	pendingCount := len(deduplicator.pending)
+	if pendingCount > 0 {
+		for range deduplicator.pending {
+			incrementExpvarMap(observeFirstDedupPendingFlushTotal, "epoch_reset")
+		}
+	}
+	deduplicator.pending = deduplicator.pending[:0]
+	clear(deduplicator.active)
+	deduplicator.currentEpoch++
+	observeFirstDedupEpoch.Set(int64(deduplicator.currentEpoch))
+	observeFirstDedupEpochResetTotal.Add(1)
+	deduplicator.enterDegradedLocked(degradeReason)
+	deduplicator.recovery = recoveryState{}
+	deduplicator.updateExpvarsLocked()
+
+	event := PassiveClassifiedEvent{
+		Kind:                PassiveClassifiedEventDiscontinuity,
+		ObservedAt:          observedAt,
+		DiscontinuityReason: reason,
+		Err:                 context.Canceled,
+	}
+	incrementExpvarMap(observeFirstDedupAdjudicationsTotal, string(DedupDispositionDiscontinuity))
+	return []AdjudicatedPassiveEvent{makeAdjudicatedDiscontinuity(event, deduplicator.currentEpoch)}
+}
+
+func (deduplicator *ActivePassiveDeduplicator) handleCriticalReset(observedAt time.Time, reason PassiveDiscontinuityReason, degradeReason string) {
+	outputs := func() []AdjudicatedPassiveEvent {
+		deduplicator.mu.Lock()
+		defer deduplicator.mu.Unlock()
+		return deduplicator.makeDiscontinuityLocked(observedAt, reason, degradeReason)
+	}()
+	deduplicator.publishAll(outputs)
+}
+
+func (deduplicator *ActivePassiveDeduplicator) updateLocalAddressLocked(address byte, observedAt time.Time) bool {
+	if address == 0 {
+		return false
+	}
+	if deduplicator.localAddr.Known && deduplicator.localAddr.Address == address {
+		return false
+	}
+
+	deduplicator.localAddr.Known = true
+	deduplicator.localAddr.Address = address
+	deduplicator.localAddr.Epoch++
+	_ = observedAt
+	return true
+}
+
+func (deduplicator *ActivePassiveDeduplicator) pruneActiveLocked(now time.Time) {
+	for key, active := range deduplicator.active {
+		if active.ExpiresAt.After(now) {
+			continue
+		}
+		delete(deduplicator.active, key)
+	}
+}
+
+func (deduplicator *ActivePassiveDeduplicator) consumeActiveLocked(hash [32]byte) bool {
+	active, ok := deduplicator.active[hash]
+	if !ok || active.Count <= 0 {
+		return false
+	}
+	if active.Count == 1 {
+		delete(deduplicator.active, hash)
+		return true
+	}
+	active.Count--
+	deduplicator.active[hash] = active
+	return true
+}
+
+func (deduplicator *ActivePassiveDeduplicator) enterDegradedLocked(reason string) {
+	if !deduplicator.degraded {
+		incrementExpvarMap(observeFirstDedupDegradedTransitionsTotal, reason)
+	}
+	deduplicator.degraded = true
+	deduplicator.recovery = recoveryState{}
+	deduplicator.updateExpvarsLocked()
+}
+
+func (deduplicator *ActivePassiveDeduplicator) recordRecoveryEvidenceLocked(now time.Time) {
+	if !deduplicator.degraded {
+		return
+	}
+	if deduplicator.recovery.StartedAt.IsZero() {
+		deduplicator.recovery.StartedAt = now
+	}
+	deduplicator.recovery.PassiveEvidence++
+	if now.Sub(deduplicator.recovery.StartedAt) < deduplicator.budgets.RecoveryHysteresis {
+		return
+	}
+	if deduplicator.recovery.PassiveEvidence < deduplicator.budgets.RecoveryEventThreshold {
+		return
+	}
+	deduplicator.degraded = false
+	deduplicator.updateExpvarsLocked()
+}
+
+func (deduplicator *ActivePassiveDeduplicator) updateExpvarsLocked() {
+	if deduplicator.degraded {
+		observeFirstDedupState.Set("degraded")
+	} else {
+		observeFirstDedupState.Set("healthy")
+	}
+	observeFirstDedupEpoch.Set(int64(deduplicator.currentEpoch))
+}
+
+func (deduplicator *ActivePassiveDeduplicator) publishAll(events []AdjudicatedPassiveEvent) {
+	for _, event := range events {
+		deduplicator.publish(event)
+	}
+}
+
+func (deduplicator *ActivePassiveDeduplicator) publish(event AdjudicatedPassiveEvent) {
+	deduplicator.subscribersMu.Lock()
+	subscribers := make([]*AdjudicatedPassiveSubscription, 0, len(deduplicator.subscribers))
+	for _, subscription := range deduplicator.subscribers {
+		subscribers = append(subscribers, subscription)
+	}
+	deduplicator.subscribersMu.Unlock()
+
+	var criticalOverflow bool
+	for _, subscription := range subscribers {
+		if trySendAdjudicatedEvent(subscription.ch, event) {
+			continue
+		}
+		if subscription.priority != DedupSubscriberCritical {
+			continue
+		}
+		criticalOverflow = true
+		deduplicator.unsubscribeWithFault(subscription, event.Event.ObservedAt)
+	}
+	if criticalOverflow {
+		deduplicator.handleCriticalReset(event.Event.ObservedAt, PassiveDiscontinuityCriticalSubscriberFault, "dedup_output_overflow")
+	}
+}
+
+func trySendAdjudicatedEvent(ch chan AdjudicatedPassiveEvent, event AdjudicatedPassiveEvent) (sent bool) {
+	defer func() {
+		if recover() != nil {
+			sent = false
+		}
+	}()
+
+	select {
+	case ch <- event:
+		return true
+	default:
+		return false
+	}
+}
+
+func (deduplicator *ActivePassiveDeduplicator) unsubscribe(subscription *AdjudicatedPassiveSubscription) {
+	deduplicator.unsubscribeCore(subscription, nil)
+}
+
+func (deduplicator *ActivePassiveDeduplicator) unsubscribeWithFault(subscription *AdjudicatedPassiveSubscription, observedAt time.Time) {
+	deduplicator.unsubscribeCore(subscription, &AdjudicatedPassiveEvent{
+		Event: PassiveClassifiedEvent{
+			Kind:                PassiveClassifiedEventDiscontinuity,
+			ObservedAt:          observedAt,
+			DiscontinuityReason: PassiveDiscontinuityCriticalSubscriberFault,
+			Subscriber:          subscription.name,
+		},
+		Disposition:       DedupDispositionDiscontinuity,
+		ObservabilityOnly: true,
+		Epoch:             deduplicator.currentEpoch,
+	})
+}
+
+func (deduplicator *ActivePassiveDeduplicator) unsubscribeCore(subscription *AdjudicatedPassiveSubscription, fault *AdjudicatedPassiveEvent) {
+	if deduplicator == nil || subscription == nil {
+		return
+	}
+
+	subscription.closeOnce.Do(func() {
+		deduplicator.subscribersMu.Lock()
+		if deduplicator.subscribers != nil {
+			delete(deduplicator.subscribers, subscription.id)
+		}
+		deduplicator.subscribersMu.Unlock()
+
+		if fault != nil {
+			drainAdjudicatedSubscription(subscription.ch)
+			_ = trySendAdjudicatedEvent(subscription.ch, *fault)
+		}
+		close(subscription.ch)
+	})
+}
+
+func (deduplicator *ActivePassiveDeduplicator) closeAllSubscribers() {
+	deduplicator.subscribersMu.Lock()
+	subscribers := make([]*AdjudicatedPassiveSubscription, 0, len(deduplicator.subscribers))
+	for _, subscription := range deduplicator.subscribers {
+		subscribers = append(subscribers, subscription)
+	}
+	deduplicator.subscribers = nil
+	deduplicator.subscribersMu.Unlock()
+
+	for _, subscription := range subscribers {
+		deduplicator.unsubscribe(subscription)
+	}
+}
+
+func drainAdjudicatedSubscription(ch chan AdjudicatedPassiveEvent) {
+	for {
+		select {
+		case <-ch:
+		default:
+			return
+		}
+	}
+}
+
+func incrementExpvarMap(counter *expvar.Map, key string) {
+	if counter == nil || key == "" {
+		return
+	}
+	counter.Add(key, 1)
+}
+
+func (deduplicator *ActivePassiveDeduplicator) now() time.Time {
+	if deduplicator == nil || deduplicator.nowFunc == nil {
+		return time.Now()
+	}
+	return deduplicator.nowFunc()
+}
+
+func maxDuration(left, right time.Duration) time.Duration {
+	if left >= right {
+		return left
+	}
+	return right
+}
+
+func maxInt(left, right int) int {
+	if left >= right {
+		return left
+	}
+	return right
+}
+
+type chainedBusObserver []protocol.BusObserver
+
+func (chain chainedBusObserver) OnBusEvent(event protocol.BusEvent) error {
+	for _, observer := range chain {
+		if observer == nil {
+			continue
+		}
+		if err := observer.OnBusEvent(event); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ChainBusObservers(observers ...protocol.BusObserver) protocol.BusObserver {
+	filtered := make(chainedBusObserver, 0, len(observers))
+	for _, observer := range observers {
+		if observer == nil {
+			continue
+		}
+		if chain, ok := observer.(chainedBusObserver); ok {
+			filtered = append(filtered, chain...)
+			continue
+		}
+		filtered = append(filtered, observer)
+	}
+	if len(filtered) == 0 {
+		return nil
+	}
+	if len(filtered) == 1 {
+		return filtered[0]
+	}
+	return filtered
+}

--- a/active_passive_deduplicator_test.go
+++ b/active_passive_deduplicator_test.go
@@ -1,0 +1,422 @@
+package ebusgateway
+
+import (
+	"expvar"
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+)
+
+func TestActivePassiveDeduplicator_DefaultBudgetsStayFrozenToM1Envelope(t *testing.T) {
+	cfg := DefaultConfig()
+
+	deduplicator, err := NewActivePassiveDeduplicator(cfg)
+	if err != nil {
+		t.Fatalf("NewActivePassiveDeduplicator error = %v", err)
+	}
+
+	budgets := deduplicator.Budgets()
+	if budgets.LogicalRequestEnvelope != 1250*time.Millisecond {
+		t.Fatalf("LogicalRequestEnvelope = %s; want 1250ms", budgets.LogicalRequestEnvelope)
+	}
+	if budgets.ActivePublishBudget != 1500*time.Millisecond {
+		t.Fatalf("ActivePublishBudget = %s; want 1500ms", budgets.ActivePublishBudget)
+	}
+	if budgets.PendingGraceTimeout != 1750*time.Millisecond {
+		t.Fatalf("PendingGraceTimeout = %s; want 1750ms", budgets.PendingGraceTimeout)
+	}
+	if budgets.ActiveFingerprintRetention != 2250*time.Millisecond {
+		t.Fatalf("ActiveFingerprintRetention = %s; want 2250ms", budgets.ActiveFingerprintRetention)
+	}
+	if budgets.PendingCapacity != 256 {
+		t.Fatalf("PendingCapacity = %d; want 256", budgets.PendingCapacity)
+	}
+}
+
+func TestActivePassiveDeduplicator_MatchesPendingPassiveFirstArrival(t *testing.T) {
+	deduplicator := newTestDeduplicator(t)
+	subscription, err := deduplicator.Subscribe("test", DedupSubscriberCritical, 16)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	base := time.Unix(0, 0)
+	deduplicator.nowFunc = func() time.Time { return base }
+
+	request, response := directTransactionPair()
+	setKnownLocalAddress(deduplicator, request.Source)
+	deduplicator.OnPassiveClassifiedEvent(passiveTransactionEvent(base, request, response))
+
+	select {
+	case event := <-subscription.Events():
+		t.Fatalf("unexpected early adjudicated event: %+v", event)
+	default:
+	}
+
+	deduplicator.nowFunc = func() time.Time { return base.Add(500 * time.Millisecond) }
+	if err := deduplicator.OnBusEvent(activeAttemptEvent(request, response)); err != nil {
+		t.Fatalf("OnBusEvent error = %v", err)
+	}
+
+	event := requireAdjudicatedEvent(t, subscription, DedupDispositionMatchedActiveCopy)
+	if !event.MatchedActiveDuplicate {
+		t.Fatal("MatchedActiveDuplicate = false; want true")
+	}
+	if !event.SuppressShadow || !event.SuppressWatchEfficiency {
+		t.Fatalf("suppression flags = shadow:%t watch:%t; want both true", event.SuppressShadow, event.SuppressWatchEfficiency)
+	}
+	if event.ThirdPartyEligible {
+		t.Fatal("ThirdPartyEligible = true; want false for matched duplicate")
+	}
+}
+
+func TestActivePassiveDeduplicator_MatchesDelayedPassiveWithinRetention(t *testing.T) {
+	deduplicator := newTestDeduplicator(t)
+	subscription, err := deduplicator.Subscribe("test", DedupSubscriberCritical, 16)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	base := time.Unix(0, 0)
+	deduplicator.nowFunc = func() time.Time { return base }
+
+	request, response := directTransactionPair()
+	setKnownLocalAddress(deduplicator, request.Source)
+	if err := deduplicator.OnBusEvent(activeAttemptEvent(request, response)); err != nil {
+		t.Fatalf("OnBusEvent error = %v", err)
+	}
+
+	deduplicator.nowFunc = func() time.Time { return base.Add(2 * time.Second) }
+	deduplicator.OnPassiveClassifiedEvent(passiveTransactionEvent(base.Add(2*time.Second), request, response))
+
+	event := requireAdjudicatedEvent(t, subscription, DedupDispositionMatchedActiveCopy)
+	if !event.MatchedActiveDuplicate {
+		t.Fatal("MatchedActiveDuplicate = false; want true")
+	}
+	if got, want := event.Fingerprint.Source, request.Source; got != want {
+		t.Fatalf("fingerprint source = 0x%02x; want 0x%02x", got, want)
+	}
+}
+
+func TestActivePassiveDeduplicator_ConsumesActiveFingerprintAfterSingleMatch(t *testing.T) {
+	deduplicator := newTestDeduplicator(t)
+	subscription, err := deduplicator.Subscribe("test", DedupSubscriberCritical, 16)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	forceHealthyDedup(deduplicator)
+
+	base := time.Unix(0, 0)
+	deduplicator.nowFunc = func() time.Time { return base }
+
+	request, response := directTransactionPair()
+	setKnownLocalAddress(deduplicator, request.Source)
+	if err := deduplicator.OnBusEvent(activeAttemptEvent(request, response)); err != nil {
+		t.Fatalf("OnBusEvent error = %v", err)
+	}
+
+	deduplicator.OnPassiveClassifiedEvent(passiveTransactionEvent(base.Add(10*time.Millisecond), request, response))
+	requireAdjudicatedEvent(t, subscription, DedupDispositionMatchedActiveCopy)
+
+	deduplicator.OnPassiveClassifiedEvent(passiveTransactionEvent(base.Add(20*time.Millisecond), request, response))
+	assertNoAdjudicatedEvent(t, subscription, 25*time.Millisecond)
+
+	deduplicator.nowFunc = func() time.Time { return base.Add(deduplicator.budgets.PendingGraceTimeout + time.Second) }
+	deduplicator.publishAll(deduplicator.releaseExpiredPending(deduplicator.now()))
+
+	event := requireAdjudicatedEvent(t, subscription, DedupDispositionUnmatchedThirdParty)
+	if !event.ThirdPartyEligible {
+		t.Fatal("ThirdPartyEligible = false; want true")
+	}
+}
+
+func TestActivePassiveDeduplicator_OneActiveFingerprintMatchesOnlyOnePendingEntry(t *testing.T) {
+	deduplicator := newTestDeduplicator(t)
+	subscription, err := deduplicator.Subscribe("test", DedupSubscriberCritical, 16)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	forceHealthyDedup(deduplicator)
+
+	base := time.Unix(0, 0)
+	deduplicator.nowFunc = func() time.Time { return base }
+
+	request, response := directTransactionPair()
+	setKnownLocalAddress(deduplicator, request.Source)
+	deduplicator.OnPassiveClassifiedEvent(passiveTransactionEvent(base, request, response))
+	deduplicator.OnPassiveClassifiedEvent(passiveTransactionEvent(base.Add(10*time.Millisecond), request, response))
+	assertNoAdjudicatedEvent(t, subscription, 25*time.Millisecond)
+
+	deduplicator.nowFunc = func() time.Time { return base.Add(500 * time.Millisecond) }
+	if err := deduplicator.OnBusEvent(activeAttemptEvent(request, response)); err != nil {
+		t.Fatalf("OnBusEvent error = %v", err)
+	}
+
+	requireAdjudicatedEvent(t, subscription, DedupDispositionMatchedActiveCopy)
+	assertNoAdjudicatedEvent(t, subscription, 25*time.Millisecond)
+
+	deduplicator.nowFunc = func() time.Time { return base.Add(deduplicator.budgets.PendingGraceTimeout + time.Second) }
+	deduplicator.publishAll(deduplicator.releaseExpiredPending(deduplicator.now()))
+
+	event := requireAdjudicatedEvent(t, subscription, DedupDispositionUnmatchedThirdParty)
+	if !event.ThirdPartyEligible {
+		t.Fatal("ThirdPartyEligible = false; want true")
+	}
+}
+
+func TestActivePassiveDeduplicator_ObserverFaultKeepsPendingReleaseObservabilityOnly(t *testing.T) {
+	deduplicator := newTestDeduplicator(t)
+	subscription, err := deduplicator.Subscribe("test", DedupSubscriberCritical, 16)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	forceHealthyDedup(deduplicator)
+
+	base := time.Unix(0, 0)
+	deduplicator.nowFunc = func() time.Time { return base }
+
+	request, response := directTransactionPair()
+	setKnownLocalAddress(deduplicator, request.Source)
+	deduplicator.OnPassiveClassifiedEvent(passiveTransactionEvent(base, request, response))
+
+	deduplicator.nowFunc = func() time.Time { return base.Add(100 * time.Millisecond) }
+	if err := deduplicator.OnBusEvent(protocol.BusEvent{
+		Kind:    protocol.BusEventObserverFault,
+		Outcome: protocol.BusOutcomeObserverFault,
+	}); err != nil {
+		t.Fatalf("observer fault event error = %v", err)
+	}
+
+	deduplicator.nowFunc = func() time.Time { return base.Add(deduplicator.budgets.PendingGraceTimeout + time.Millisecond) }
+	deduplicator.publishAll(deduplicator.releaseExpiredPending(deduplicator.now()))
+
+	event := requireAdjudicatedEvent(t, subscription, DedupDispositionObservabilityOnly)
+	if !event.ObservabilityOnly {
+		t.Fatal("ObservabilityOnly = false; want true")
+	}
+	if event.ThirdPartyEligible {
+		t.Fatal("ThirdPartyEligible = true; want false while degraded")
+	}
+}
+
+func TestActivePassiveDeduplicator_LocalParticipantInboundUsesRuntimeAddress(t *testing.T) {
+	deduplicator := newTestDeduplicator(t)
+	subscription, err := deduplicator.Subscribe("test", DedupSubscriberCritical, 16)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	base := time.Unix(0, 0)
+	deduplicator.nowFunc = func() time.Time { return base }
+
+	request, response := directTransactionPair()
+	if err := deduplicator.OnBusEvent(activeAttemptEvent(request, response)); err != nil {
+		t.Fatalf("OnBusEvent error = %v", err)
+	}
+
+	masterFrame := protocol.Frame{
+		Source:    0x10,
+		Target:    request.Source,
+		Primary:   0x01,
+		Secondary: 0x02,
+		Data:      []byte{0x03},
+	}
+	deduplicator.OnPassiveClassifiedEvent(PassiveClassifiedEvent{
+		Kind:       PassiveClassifiedEventMasterFrame,
+		FrameType:  protocol.FrameTypeInitiatorInitiator,
+		Request:    masterFrame,
+		HasRequest: true,
+		ObservedAt: base.Add(100 * time.Millisecond),
+	})
+
+	event := requireAdjudicatedEvent(t, subscription, DedupDispositionLocalParticipantIn)
+	if !event.LocalParticipantInbound {
+		t.Fatal("LocalParticipantInbound = false; want true")
+	}
+	if !event.SuppressWatchEfficiency {
+		t.Fatal("SuppressWatchEfficiency = false; want true")
+	}
+	if event.ThirdPartyEligible {
+		t.Fatal("ThirdPartyEligible = true; want false")
+	}
+}
+
+func TestActivePassiveDeduplicator_DiscontinuityResetsEpochAndFlushesPending(t *testing.T) {
+	deduplicator := newTestDeduplicator(t)
+	subscription, err := deduplicator.Subscribe("test", DedupSubscriberCritical, 16)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	forceHealthyDedup(deduplicator)
+	base := time.Unix(0, 0)
+	deduplicator.nowFunc = func() time.Time { return base }
+	request, response := directTransactionPair()
+	setKnownLocalAddress(deduplicator, request.Source)
+
+	deduplicator.OnPassiveClassifiedEvent(passiveTransactionEvent(base, request, response))
+
+	beforeEpochResets := expvarIntValue(observeFirstDedupEpochResetTotal)
+	beforePendingEpochFlush := expvarMapInt64(observeFirstDedupPendingFlushTotal, "epoch_reset")
+
+	deduplicator.OnPassiveClassifiedEvent(PassiveClassifiedEvent{
+		Kind:                PassiveClassifiedEventDiscontinuity,
+		ObservedAt:          base.Add(100 * time.Millisecond),
+		DiscontinuityReason: PassiveDiscontinuityTransportReset,
+	})
+
+	discontinuity := requireAdjudicatedEvent(t, subscription, DedupDispositionDiscontinuity)
+	if discontinuity.Event.DiscontinuityReason != PassiveDiscontinuityTransportReset {
+		t.Fatalf("DiscontinuityReason = %q; want %q", discontinuity.Event.DiscontinuityReason, PassiveDiscontinuityTransportReset)
+	}
+	assertNoAdjudicatedEvent(t, subscription, 25*time.Millisecond)
+	if got := expvarIntValue(observeFirstDedupEpochResetTotal); got != beforeEpochResets+1 {
+		t.Fatalf("epoch reset total = %d; want %d", got, beforeEpochResets+1)
+	}
+	if got := expvarMapInt64(observeFirstDedupPendingFlushTotal, "epoch_reset"); got != beforePendingEpochFlush+1 {
+		t.Fatalf("pending epoch_reset flush total = %d; want %d", got, beforePendingEpochFlush+1)
+	}
+	if len(deduplicator.pending) != 0 {
+		t.Fatalf("pending entries = %d; want 0 after epoch reset", len(deduplicator.pending))
+	}
+}
+
+func newTestDeduplicator(t *testing.T) *ActivePassiveDeduplicator {
+	t.Helper()
+
+	deduplicator, err := NewActivePassiveDeduplicator(DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewActivePassiveDeduplicator error = %v", err)
+	}
+	return deduplicator
+}
+
+func forceHealthyDedup(deduplicator *ActivePassiveDeduplicator) {
+	deduplicator.mu.Lock()
+	defer deduplicator.mu.Unlock()
+	deduplicator.degraded = false
+	deduplicator.recovery = recoveryState{}
+	deduplicator.updateExpvarsLocked()
+}
+
+func setKnownLocalAddress(deduplicator *ActivePassiveDeduplicator, address byte) {
+	deduplicator.mu.Lock()
+	defer deduplicator.mu.Unlock()
+	deduplicator.localAddr = LocalAddressSnapshot{
+		Address: address,
+		Known:   true,
+		Epoch:   deduplicator.currentEpoch,
+	}
+}
+
+func directTransactionPair() (protocol.Frame, protocol.Frame) {
+	request := protocol.Frame{
+		Source:    0x31,
+		Target:    0x08,
+		Primary:   0xB5,
+		Secondary: 0x09,
+		Data:      []byte{0x01},
+	}
+	response := protocol.Frame{
+		Source:    request.Target,
+		Target:    request.Source,
+		Primary:   request.Primary,
+		Secondary: request.Secondary,
+		Data:      []byte{0x11, 0x22},
+	}
+	return request, response
+}
+
+func passiveTransactionEvent(observedAt time.Time, request, response protocol.Frame) PassiveClassifiedEvent {
+	return PassiveClassifiedEvent{
+		Kind:        PassiveClassifiedEventTransaction,
+		FrameType:   protocol.FrameTypeInitiatorTarget,
+		Request:     request,
+		Response:    response,
+		HasRequest:  true,
+		HasResponse: true,
+		ObservedAt:  observedAt,
+	}
+}
+
+func activeAttemptEvent(request, response protocol.Frame) protocol.BusEvent {
+	return protocol.BusEvent{
+		Kind:        protocol.BusEventAttemptComplete,
+		FrameType:   request.Type(),
+		Outcome:     protocol.BusOutcomeSuccess,
+		Request:     request,
+		Response:    response,
+		HasRequest:  true,
+		HasResponse: true,
+	}
+}
+
+func requireAdjudicatedEvent(t *testing.T, subscription *AdjudicatedPassiveSubscription, disposition DedupDisposition) AdjudicatedPassiveEvent {
+	t.Helper()
+
+	timeout := time.NewTimer(time.Second)
+	defer timeout.Stop()
+
+	for {
+		select {
+		case event, ok := <-subscription.Events():
+			if !ok {
+				t.Fatal("subscription closed before adjudicated event arrived")
+			}
+			if event.Disposition == disposition {
+				return event
+			}
+		case <-timeout.C:
+			t.Fatalf("timeout waiting for adjudicated disposition %q", disposition)
+		}
+	}
+}
+
+func assertNoAdjudicatedEvent(t *testing.T, subscription *AdjudicatedPassiveSubscription, wait time.Duration) {
+	t.Helper()
+
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+
+	select {
+	case event, ok := <-subscription.Events():
+		if !ok {
+			return
+		}
+		t.Fatalf("unexpected adjudicated event: %+v", event)
+	case <-timer.C:
+	}
+}
+
+func expvarIntValue(value *expvar.Int) int64 {
+	if value == nil {
+		return 0
+	}
+	return value.Value()
+}
+
+func expvarMapInt64(value *expvar.Map, key string) int64 {
+	if value == nil {
+		return 0
+	}
+	variable := value.Get(key)
+	if variable == nil {
+		return 0
+	}
+	counter, ok := variable.(*expvar.Int)
+	if !ok {
+		return 0
+	}
+	return counter.Value()
+}

--- a/broadcast_listener.go
+++ b/broadcast_listener.go
@@ -13,6 +13,7 @@ import (
 type BroadcastListener struct {
 	router        *router.BusEventRouter
 	reconstructor *PassiveTransactionReconstructor
+	ownsSource    bool
 	ctx           context.Context
 	cancel        context.CancelFunc
 	wg            sync.WaitGroup
@@ -50,6 +51,36 @@ func StartBroadcastListenerWithTransport(ctx context.Context, cfg Config, router
 	listener := &BroadcastListener{
 		router:        router,
 		reconstructor: reconstructor,
+		ownsSource:    true,
+		ctx:           listenerCtx,
+		cancel:        cancel,
+	}
+	listener.wg.Add(1)
+	go listener.run(subscription)
+	return listener, nil
+}
+
+func StartBroadcastListenerWithReconstructor(ctx context.Context, router *router.BusEventRouter, reconstructor *PassiveTransactionReconstructor) (*BroadcastListener, error) {
+	if router == nil {
+		return nil, fmt.Errorf("broadcast listener missing router: %w", ebuserrors.ErrInvalidPayload)
+	}
+	if reconstructor == nil {
+		return nil, fmt.Errorf("broadcast listener missing reconstructor: %w", ebuserrors.ErrInvalidPayload)
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	listenerCtx, cancel := context.WithCancel(ctx)
+	subscription, err := reconstructor.Subscribe("broadcast-listener", PassiveSubscriberCritical, 0)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	listener := &BroadcastListener{
+		router:        router,
+		reconstructor: reconstructor,
 		ctx:           listenerCtx,
 		cancel:        cancel,
 	}
@@ -70,7 +101,7 @@ func (listener *BroadcastListener) Close() error {
 		listener.cancel()
 	}
 	listener.wg.Wait()
-	if listener.reconstructor == nil {
+	if listener.reconstructor == nil || !listener.ownsSource {
 		return nil
 	}
 	return listener.reconstructor.Close()

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -54,6 +54,16 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 		cfg.Providers = vaillantproviders.Default()
 	}
 
+	var deduplicator *ebusgateway.ActivePassiveDeduplicator
+	if cfg.BroadcastListen {
+		dedup, err := ebusgateway.NewActivePassiveDeduplicator(cfg)
+		if err != nil {
+			return err
+		}
+		cfg.BusConfig.Observer = ebusgateway.ChainBusObservers(cfg.BusConfig.Observer, dedup)
+		deduplicator = dedup
+	}
+
 	gateway, err := ebusgateway.New(ctx, cfg)
 	if err != nil {
 		return err
@@ -97,9 +107,33 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 		return err
 	}
 	var listener *ebusgateway.BroadcastListener
+	var reconstructor *ebusgateway.PassiveTransactionReconstructor
 	if cfg.BroadcastListen {
-		listener, err = ebusgateway.StartBroadcastListener(ctx, cfg, gateway.Router)
+		reconstructor, err = ebusgateway.StartPassiveTransactionReconstructor(ctx, cfg)
 		if err != nil {
+			if advertiser != nil {
+				_ = advertiser.Close()
+			}
+			if server != nil {
+				_ = server.Close()
+			}
+			return err
+		}
+		if deduplicator != nil {
+			if err := deduplicator.AttachReconstructor(ctx, reconstructor); err != nil {
+				_ = reconstructor.Close()
+				if advertiser != nil {
+					_ = advertiser.Close()
+				}
+				if server != nil {
+					_ = server.Close()
+				}
+				return err
+			}
+		}
+		listener, err = ebusgateway.StartBroadcastListenerWithReconstructor(ctx, gateway.Router, reconstructor)
+		if err != nil {
+			_ = reconstructor.Close()
 			if advertiser != nil {
 				_ = advertiser.Close()
 			}
@@ -113,6 +147,16 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 		if listener != nil {
 			if err := listener.Close(); err != nil {
 				log.Printf("broadcast listener close: %v", err)
+			}
+		}
+		if deduplicator != nil {
+			if err := deduplicator.Close(); err != nil {
+				log.Printf("deduplicator close: %v", err)
+			}
+		}
+		if reconstructor != nil {
+			if err := reconstructor.Close(); err != nil {
+				log.Printf("reconstructor close: %v", err)
 			}
 		}
 		if advertiser != nil {

--- a/config.go
+++ b/config.go
@@ -53,43 +53,52 @@ type Config struct {
 	BootLiveTimeout    time.Duration
 	// SemanticInterval is a legacy single-interval semantic polling configuration.
 	// Prefer SemanticDiscoveryInterval / SemanticConfigInterval / SemanticStateInterval.
-	SemanticInterval                      time.Duration
-	SemanticDiscoveryInterval             time.Duration
-	SemanticConfigInterval                time.Duration
-	SemanticStateInterval                 time.Duration
-	SemanticEnergyInterval                time.Duration
-	SemanticRequestTimeout                time.Duration
-	SemanticReadBreakerFailureBudget      int
-	SemanticReadBreakerFailureBudgetSet   bool
-	SemanticReadBreakerOpenCooldown       time.Duration
-	SemanticReadBreakerHalfOpenProbeLimit int
-	SemanticZonePresenceMissThreshold     int
-	SemanticZonePresenceHitThreshold      int
-	SemanticDHWStaleTTL                   time.Duration
-	SemanticRegulatorRecheckInterval      time.Duration
-	SemanticRegulatorAbsenceGrace         time.Duration
-	SemanticCachePath                     string
-	BroadcastListen                       bool
-	PassiveAbsenceThreshold               time.Duration
-	PassiveTransactionWatchdog            time.Duration
-	PassiveReconnectInitialDelay          time.Duration
-	PassiveReconnectMaxDelay              time.Duration
-	HTTPAddr                              string
-	GraphQLPath                           string
-	SnapshotPath                          string
-	SubscriptionPath                      string
-	MCPPath                               string
-	UIPath                                string
-	PortalPath                            string
-	MDNSAdvertise                         bool
-	MDNSInstance                          string
-	DumpOutputDir                         string
-	DumpUploadPath                        string
-	DumpUploadURL                         string
-	DumpIncludePII                        bool
+	SemanticInterval                       time.Duration
+	SemanticDiscoveryInterval              time.Duration
+	SemanticConfigInterval                 time.Duration
+	SemanticStateInterval                  time.Duration
+	SemanticEnergyInterval                 time.Duration
+	SemanticRequestTimeout                 time.Duration
+	SemanticReadBreakerFailureBudget       int
+	SemanticReadBreakerFailureBudgetSet    bool
+	SemanticReadBreakerOpenCooldown        time.Duration
+	SemanticReadBreakerHalfOpenProbeLimit  int
+	SemanticZonePresenceMissThreshold      int
+	SemanticZonePresenceHitThreshold       int
+	SemanticDHWStaleTTL                    time.Duration
+	SemanticRegulatorRecheckInterval       time.Duration
+	SemanticRegulatorAbsenceGrace          time.Duration
+	SemanticCachePath                      string
+	BroadcastListen                        bool
+	PassiveAbsenceThreshold                time.Duration
+	PassiveTransactionWatchdog             time.Duration
+	PassiveReconnectInitialDelay           time.Duration
+	PassiveReconnectMaxDelay               time.Duration
+	PassiveDedupActivePublishBudget        time.Duration
+	PassiveDedupPassiveDeliveryBudget      time.Duration
+	PassiveDedupPendingGraceTimeout        time.Duration
+	PassiveDedupActiveFingerprintRetention time.Duration
+	PassiveDedupPendingCapacity            int
+	PassiveDedupRecoveryHysteresis         time.Duration
+	PassiveDedupRecoveryEventThreshold     int
+	LocalAddressSnapshotter                LocalBusAddressSnapshotter
+	HTTPAddr                               string
+	GraphQLPath                            string
+	SnapshotPath                           string
+	SubscriptionPath                       string
+	MCPPath                                string
+	UIPath                                 string
+	PortalPath                             string
+	MDNSAdvertise                          bool
+	MDNSInstance                           string
+	DumpOutputDir                          string
+	DumpUploadPath                         string
+	DumpUploadURL                          string
+	DumpIncludePII                         bool
 }
 
 func DefaultConfig() Config {
+	dedupDefaults := defaultPassiveDedupBudgets(protocol.DefaultBusConfig().RetryEnvelope())
 	return Config{
 		TransportConfig: TransportConfig{
 			Protocol:     TransportENH,
@@ -107,38 +116,45 @@ func DefaultConfig() Config {
 		ScanTimeout: 3 * time.Minute,
 		// Per-request scan timeout must accommodate bus/transport latency.
 		// 150ms is too aggressive for real-world ENH over TCP setups.
-		ScanRequestTimeout:                    400 * time.Millisecond,
-		ScanInterval:                          30 * time.Second,
-		BootLiveTimeout:                       2 * time.Minute,
-		SemanticInterval:                      1 * time.Minute,
-		SemanticDiscoveryInterval:             10 * time.Minute,
-		SemanticConfigInterval:                5 * time.Minute,
-		SemanticStateInterval:                 1 * time.Minute,
-		SemanticEnergyInterval:                DefaultSemanticEnergyInterval,
-		SemanticRequestTimeout:                2 * time.Second,
-		SemanticReadBreakerFailureBudget:      DefaultSemanticReadFailureBudget,
-		SemanticReadBreakerOpenCooldown:       DefaultSemanticReadOpenCooldown,
-		SemanticReadBreakerHalfOpenProbeLimit: DefaultSemanticReadHalfOpenProbeLimit,
-		SemanticZonePresenceMissThreshold:     DefaultSemanticZonePresenceMissThreshold,
-		SemanticZonePresenceHitThreshold:      DefaultSemanticZonePresenceHitThreshold,
-		SemanticDHWStaleTTL:                   DefaultSemanticDHWStaleTTL,
-		SemanticRegulatorRecheckInterval:      DefaultSemanticRegulatorRecheckInterval,
-		SemanticRegulatorAbsenceGrace:         DefaultSemanticRegulatorAbsenceGrace,
-		SemanticCachePath:                     "./semantic_cache.json",
-		PassiveAbsenceThreshold:               10 * time.Second,
-		PassiveTransactionWatchdog:            1 * time.Second,
-		PassiveReconnectInitialDelay:          1 * time.Second,
-		PassiveReconnectMaxDelay:              30 * time.Second,
-		HTTPAddr:                              ":8080",
-		GraphQLPath:                           "/graphql",
-		SnapshotPath:                          "/snapshot",
-		SubscriptionPath:                      "/graphql/subscriptions",
-		MCPPath:                               "/mcp",
-		UIPath:                                "/ui",
-		PortalPath:                            "/portal",
-		MDNSAdvertise:                         true,
-		MDNSInstance:                          "helianthus",
-		DumpOutputDir:                         "./dumps",
+		ScanRequestTimeout:                     400 * time.Millisecond,
+		ScanInterval:                           30 * time.Second,
+		BootLiveTimeout:                        2 * time.Minute,
+		SemanticInterval:                       1 * time.Minute,
+		SemanticDiscoveryInterval:              10 * time.Minute,
+		SemanticConfigInterval:                 5 * time.Minute,
+		SemanticStateInterval:                  1 * time.Minute,
+		SemanticEnergyInterval:                 DefaultSemanticEnergyInterval,
+		SemanticRequestTimeout:                 2 * time.Second,
+		SemanticReadBreakerFailureBudget:       DefaultSemanticReadFailureBudget,
+		SemanticReadBreakerOpenCooldown:        DefaultSemanticReadOpenCooldown,
+		SemanticReadBreakerHalfOpenProbeLimit:  DefaultSemanticReadHalfOpenProbeLimit,
+		SemanticZonePresenceMissThreshold:      DefaultSemanticZonePresenceMissThreshold,
+		SemanticZonePresenceHitThreshold:       DefaultSemanticZonePresenceHitThreshold,
+		SemanticDHWStaleTTL:                    DefaultSemanticDHWStaleTTL,
+		SemanticRegulatorRecheckInterval:       DefaultSemanticRegulatorRecheckInterval,
+		SemanticRegulatorAbsenceGrace:          DefaultSemanticRegulatorAbsenceGrace,
+		SemanticCachePath:                      "./semantic_cache.json",
+		PassiveAbsenceThreshold:                10 * time.Second,
+		PassiveTransactionWatchdog:             1 * time.Second,
+		PassiveReconnectInitialDelay:           1 * time.Second,
+		PassiveReconnectMaxDelay:               30 * time.Second,
+		PassiveDedupActivePublishBudget:        dedupDefaults.ActivePublishBudget,
+		PassiveDedupPassiveDeliveryBudget:      dedupDefaults.PassiveDeliveryBudget,
+		PassiveDedupPendingGraceTimeout:        dedupDefaults.PendingGraceTimeout,
+		PassiveDedupActiveFingerprintRetention: dedupDefaults.ActiveFingerprintRetention,
+		PassiveDedupPendingCapacity:            dedupDefaults.PendingCapacity,
+		PassiveDedupRecoveryHysteresis:         dedupDefaults.RecoveryHysteresis,
+		PassiveDedupRecoveryEventThreshold:     dedupDefaults.RecoveryEventThreshold,
+		HTTPAddr:                               ":8080",
+		GraphQLPath:                            "/graphql",
+		SnapshotPath:                           "/snapshot",
+		SubscriptionPath:                       "/graphql/subscriptions",
+		MCPPath:                                "/mcp",
+		UIPath:                                 "/ui",
+		PortalPath:                             "/portal",
+		MDNSAdvertise:                          true,
+		MDNSInstance:                           "helianthus",
+		DumpOutputDir:                          "./dumps",
 	}
 }
 
@@ -220,6 +236,28 @@ func applyDefaults(cfg Config) Config {
 	}
 	if cfg.PassiveReconnectMaxDelay <= 0 {
 		cfg.PassiveReconnectMaxDelay = 30 * time.Second
+	}
+	dedupDefaults := defaultPassiveDedupBudgets(cfg.BusConfig.RetryEnvelope())
+	if cfg.PassiveDedupActivePublishBudget <= 0 {
+		cfg.PassiveDedupActivePublishBudget = dedupDefaults.ActivePublishBudget
+	}
+	if cfg.PassiveDedupPassiveDeliveryBudget <= 0 {
+		cfg.PassiveDedupPassiveDeliveryBudget = dedupDefaults.PassiveDeliveryBudget
+	}
+	if cfg.PassiveDedupPendingGraceTimeout <= 0 {
+		cfg.PassiveDedupPendingGraceTimeout = dedupDefaults.PendingGraceTimeout
+	}
+	if cfg.PassiveDedupActiveFingerprintRetention <= 0 {
+		cfg.PassiveDedupActiveFingerprintRetention = dedupDefaults.ActiveFingerprintRetention
+	}
+	if cfg.PassiveDedupPendingCapacity <= 0 {
+		cfg.PassiveDedupPendingCapacity = dedupDefaults.PendingCapacity
+	}
+	if cfg.PassiveDedupRecoveryHysteresis <= 0 {
+		cfg.PassiveDedupRecoveryHysteresis = dedupDefaults.RecoveryHysteresis
+	}
+	if cfg.PassiveDedupRecoveryEventThreshold <= 0 {
+		cfg.PassiveDedupRecoveryEventThreshold = dedupDefaults.RecoveryEventThreshold
 	}
 	if cfg.Transport == nil {
 		if cfg.TransportConfig.Protocol == "" {

--- a/smoke.go
+++ b/smoke.go
@@ -163,6 +163,14 @@ func RunSmoke(ctx context.Context, cfg smokeConfig, opts SmokeOptions) (runErr e
 	gatewayCfg.TransportConfig = transportCfg
 	gatewayCfg.Providers = providers
 
+	var deduplicator *ActivePassiveDeduplicator
+	dedup, err := NewActivePassiveDeduplicator(gatewayCfg)
+	if err != nil {
+		return err
+	}
+	gatewayCfg.BusConfig.Observer = ChainBusObservers(gatewayCfg.BusConfig.Observer, dedup)
+	deduplicator = dedup
+
 	wireLogger, err := newWireLogger(cfg.Smoke.WireLogPath)
 	if err != nil {
 		return err
@@ -192,10 +200,21 @@ func RunSmoke(ctx context.Context, cfg smokeConfig, opts SmokeOptions) (runErr e
 		return err
 	}
 	var broadcastListener *BroadcastListener
+	var reconstructor *PassiveTransactionReconstructor
 	defer func() {
 		if broadcastListener != nil {
 			if err := broadcastListener.Close(); err != nil {
 				logger.Printf("broadcast listener close: %v", err)
+			}
+		}
+		if deduplicator != nil {
+			if err := deduplicator.Close(); err != nil {
+				logger.Printf("deduplicator close: %v", err)
+			}
+		}
+		if reconstructor != nil {
+			if err := reconstructor.Close(); err != nil {
+				logger.Printf("reconstructor close: %v", err)
 			}
 		}
 		if err := gateway.Close(); err != nil {
@@ -307,12 +326,28 @@ func RunSmoke(ctx context.Context, cfg smokeConfig, opts SmokeOptions) (runErr e
 			})
 		}
 
-		listener, err := StartBroadcastListenerWithTransport(ctx, gatewayCfg, gateway.Router, broadcastWrap)
+		reconstructor, err = StartPassiveTransactionReconstructorWithTransport(ctx, gatewayCfg, broadcastWrap)
 		if err != nil {
 			logger.Printf("broadcast listener start: %v", err)
 		} else {
-			broadcastListener = listener
-			logger.Printf("broadcast listener started")
+			if deduplicator != nil {
+				if err := deduplicator.AttachReconstructor(ctx, reconstructor); err != nil {
+					logger.Printf("deduplicator attach: %v", err)
+					_ = reconstructor.Close()
+					reconstructor = nil
+				}
+			}
+			if reconstructor != nil {
+				listener, err := StartBroadcastListenerWithReconstructor(ctx, gateway.Router, reconstructor)
+				if err != nil {
+					logger.Printf("broadcast listener start: %v", err)
+					_ = reconstructor.Close()
+					reconstructor = nil
+				} else {
+					broadcastListener = listener
+					logger.Printf("broadcast listener started")
+				}
+			}
 		}
 	}
 	if opts.OnGatewayReady != nil {


### PR DESCRIPTION
## What
Implement the GW-01C active/passive deduplicator, including active observer fingerprinting, pending-passive grace buffering, degraded/epoch handling, and shared passive-source wiring so broadcast and dedup run off one reconstructor.

## Why
This is the next observe-first passive-pipeline contract in the M0/M1 plan. Shadow/watch consumers need one adjudicated passive stream that suppresses Helianthus-originated passive duplicates without losing whole-bus observability, and the runtime must not reintroduce a third passive connection.

## Acceptance Criteria
- [x] Active dedup inputs come from successful `BusEventAttemptComplete` observer events.
- [x] Active retention, grace timeout, and retry-envelope validation are derived from the frozen M1 budgets.
- [x] Passive duplicates remain visible for whole-bus observability while being suppressed for shadow/watch eligibility.
- [x] Pending passive buffering is bounded and flushed on grace expiry or epoch reset.
- [x] Observer-fault and passive-discontinuity paths drive degraded mode and epoch resets with metrics.
- [x] Local-participant inbound master-master traffic is tagged separately from third-party passive traffic.
- [x] Unit tests cover active-first/passive-first matching, degraded release behavior, local participant classification, and epoch reset metrics.
- [x] CI green.
- [ ] Smoke test required: NO

## Validation
- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `TRANSPORT_GATE_OWNER_OVERRIDE=OVERRIDE_TRANSPORT_GATE_BY_OWNER TRANSPORT_GATE_OWNER_REASON='GW-01C active/passive deduplicator validated with local functional and race tests; T01-T88 matrix artifact not available in current workspace.' ./scripts/ci_local.sh`

## Dependencies
- Depends on GW-01B already merged on `main`.
