### PR TITLE
Surface broadcast router overflow in passive supervisor

### DIFF
--- a/broadcast_listener.go
+++ b/broadcast_listener.go
@@ -2,12 +2,25 @@ package ebusgateway
 
 import (
 	"context"
+	"errors"
+	"expvar"
 	"fmt"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	ebuserrors "github.com/Project-Helianthus/helianthus-ebusgo/errors"
 	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
 	"github.com/Project-Helianthus/helianthus-ebusreg/router"
+)
+
+const broadcastSupervisorRecoveryWindow = 5 * time.Second
+
+var (
+	observeFirstBroadcastSupervisorState            = expvar.NewString("observe_first_broadcast_supervisor_state")
+	observeFirstBroadcastSupervisorTransitionsTotal = expvar.NewMap("observe_first_broadcast_supervisor_transitions_total")
+	observeFirstBroadcastSupervisorFaultsTotal      = expvar.NewMap("observe_first_broadcast_supervisor_faults_total")
+	observeFirstBroadcastSupervisorResubscribeTotal = expvar.NewInt("observe_first_broadcast_supervisor_resubscribe_total")
 )
 
 type BroadcastListener struct {
@@ -17,6 +30,10 @@ type BroadcastListener struct {
 	ctx           context.Context
 	cancel        context.CancelFunc
 	wg            sync.WaitGroup
+
+	stateMu            sync.Mutex
+	degraded           bool
+	recoveryGeneration atomic.Uint64
 }
 
 func StartBroadcastListener(ctx context.Context, cfg Config, router *router.BusEventRouter) (*BroadcastListener, error) {
@@ -56,6 +73,7 @@ func StartBroadcastListenerWithTransport(ctx context.Context, cfg Config, router
 		cancel:        cancel,
 	}
 	listener.wg.Add(1)
+	observeFirstBroadcastSupervisorState.Set("healthy")
 	go listener.run(subscription)
 	return listener, nil
 }
@@ -85,6 +103,7 @@ func StartBroadcastListenerWithReconstructor(ctx context.Context, router *router
 		cancel:        cancel,
 	}
 	listener.wg.Add(1)
+	observeFirstBroadcastSupervisorState.Set("healthy")
 	go listener.run(subscription)
 	return listener, nil
 }
@@ -115,8 +134,10 @@ func (listener *BroadcastListener) run(initial *PassiveClassifiedSubscription) {
 		if subscription == nil {
 			next, err := listener.reconstructor.Subscribe("broadcast-listener", PassiveSubscriberCritical, 0)
 			if err != nil {
+				listener.markDegraded("resubscribe_failed")
 				return
 			}
+			observeFirstBroadcastSupervisorResubscribeTotal.Add(1)
 			subscription = next
 		}
 		if !listener.consume(subscription) {
@@ -137,10 +158,84 @@ func (listener *BroadcastListener) consume(subscription *PassiveClassifiedSubscr
 			if !ok {
 				return listener.ctx.Err() == nil
 			}
-			if listener.router == nil || event.Kind != PassiveClassifiedEventBroadcastFrame {
+			if event.Kind != PassiveClassifiedEventBroadcastFrame || listener.router == nil {
+				listener.markHealthy("post_reset_event")
 				continue
 			}
-			_ = listener.router.HandleBroadcast(event.Request)
+			if listener.handleRouterFault(listener.router.HandleBroadcast(event.Request)) {
+				return true
+			}
+			listener.markHealthy("post_reset_event")
 		}
 	}
+}
+
+func (listener *BroadcastListener) handleRouterFault(errs []error) bool {
+	overflow := false
+	for _, err := range errs {
+		if errors.Is(err, router.ErrBroadcastEventOverflow) {
+			overflow = true
+			break
+		}
+	}
+	if !overflow {
+		return false
+	}
+	observeFirstBroadcastSupervisorFaultsTotal.Add("router_overflow", 1)
+	listener.markDegraded("router_overflow")
+	return true
+}
+
+func (listener *BroadcastListener) markDegraded(reason string) {
+	if listener == nil {
+		return
+	}
+
+	generation := listener.recoveryGeneration.Add(1)
+
+	listener.stateMu.Lock()
+	if !listener.degraded {
+		observeFirstBroadcastSupervisorTransitionsTotal.Add(fmt.Sprintf("healthy->degraded:%s", reason), 1)
+	}
+	listener.degraded = true
+	observeFirstBroadcastSupervisorState.Set("degraded")
+	listener.stateMu.Unlock()
+
+	go listener.recoverAfterFaultFreeWindow(generation)
+}
+
+func (listener *BroadcastListener) recoverAfterFaultFreeWindow(generation uint64) {
+	timer := time.NewTimer(broadcastSupervisorRecoveryWindow)
+	defer timer.Stop()
+
+	select {
+	case <-listener.ctx.Done():
+		return
+	case <-timer.C:
+		listener.markHealthyIfGeneration(generation, "fault_free_window")
+	}
+}
+
+func (listener *BroadcastListener) markHealthy(reason string) {
+	if listener == nil {
+		return
+	}
+	listener.markHealthyIfGeneration(0, reason)
+}
+
+func (listener *BroadcastListener) markHealthyIfGeneration(generation uint64, reason string) {
+	listener.stateMu.Lock()
+	defer listener.stateMu.Unlock()
+
+	if !listener.degraded {
+		return
+	}
+	if generation != 0 && listener.recoveryGeneration.Load() != generation {
+		return
+	}
+
+	listener.degraded = false
+	listener.recoveryGeneration.Add(1)
+	observeFirstBroadcastSupervisorTransitionsTotal.Add(fmt.Sprintf("degraded->healthy:%s", reason), 1)
+	observeFirstBroadcastSupervisorState.Set("healthy")
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.0.0-20260310063657-9dbc1ba5b968
-	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260308222957-ffe0bbc91386
+	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260310082814-4f08ad81bfed
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Project-Helianthus/helianthus-ebusgo v0.0.0-20260310063657-9dbc1ba5b968 h1:nmBgRJsXqrAHrWiuTXtkD9YSSS+brsoGnAZvOzFHnO0=
 github.com/Project-Helianthus/helianthus-ebusgo v0.0.0-20260310063657-9dbc1ba5b968/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260308222957-ffe0bbc91386 h1:LB2qsODNxkORRsnKJ5HrTAwJ2UmEIlN9+Rlr6SHx06c=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260308222957-ffe0bbc91386/go.mod h1:FrDhh/Q0KQhP+11jGrQFJLur/kLjAA2mQ7UjJYthOlE=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260310082814-4f08ad81bfed h1:y70nrD3dvoSPlZ1rIdT6AVCEn/ISdfGNLzigR5Lshu4=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260310082814-4f08ad81bfed/go.mod h1:FrDhh/Q0KQhP+11jGrQFJLur/kLjAA2mQ7UjJYthOlE=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=

--- a/passive_bus_tap_test.go
+++ b/passive_bus_tap_test.go
@@ -2,6 +2,7 @@ package ebusgateway
 
 import (
 	"context"
+	"expvar"
 	"fmt"
 	"io"
 	"log"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
 	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+	"github.com/Project-Helianthus/helianthus-ebusgo/types"
 	"github.com/Project-Helianthus/helianthus-ebusreg/router"
 )
 
@@ -187,8 +189,6 @@ func TestPassiveBusTap_ReconnectsAfterDisconnect(t *testing.T) {
 }
 
 func TestBroadcastListener_RoutesBroadcastFramesViaPassiveTap(t *testing.T) {
-	t.Parallel()
-
 	client, server := net.Pipe()
 	cfg := DefaultConfig()
 	cfg.TransportConfig = TransportConfig{
@@ -257,6 +257,101 @@ func TestBroadcastListener_RoutesBroadcastFramesViaPassiveTap(t *testing.T) {
 	}
 }
 
+func TestBroadcastListener_RouterOverflowMarksDegradedAndResubscribes(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	reconstructor.ctx, reconstructor.cancel = context.WithCancel(ctx)
+	defer func() {
+		if err := reconstructor.Close(); err != nil {
+			t.Fatalf("reconstructor close: %v", err)
+		}
+	}()
+
+	plane := &decodingRouterPlane{
+		mockPlane: &mockPlane{
+			name: "broadcast",
+			subscriptions: []router.Subscription{
+				{Primary: 0xB5, Secondary: 0x16},
+			},
+		},
+		decoded: map[string]types.Value{
+			"energy": {Value: uint8(1), Valid: true},
+		},
+		handled: true,
+	}
+	eventRouter := router.NewBusEventRouter(nil)
+	eventRouter.SetPlanes([]router.Plane{plane})
+
+	beforeFaults := expvarMapInt64Value(observeFirstBroadcastSupervisorFaultsTotal, "router_overflow")
+	beforeResubscribes := observeFirstBroadcastSupervisorResubscribeTotal.Value()
+	listener, err := StartBroadcastListenerWithReconstructor(ctx, eventRouter, reconstructor)
+	if err != nil {
+		t.Fatalf("StartBroadcastListenerWithReconstructor error = %v", err)
+	}
+	defer func() {
+		if err := listener.Close(); err != nil {
+			t.Fatalf("listener close: %v", err)
+		}
+	}()
+
+	broadcast := protocol.Frame{
+		Source:    0x10,
+		Target:    protocol.AddressBroadcast,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{0x55, 0x66},
+	}
+	for i := 0; i < 65; i++ {
+		reconstructor.publish(PassiveClassifiedEvent{
+			Kind:       PassiveClassifiedEventBroadcastFrame,
+			Request:    broadcast,
+			HasRequest: true,
+			ObservedAt: time.Unix(0, int64(i+1)),
+		})
+	}
+
+	waitForCondition(t, 2*time.Second, func() bool {
+		return observeFirstBroadcastSupervisorState.Value() == "degraded" &&
+			expvarMapInt64Value(observeFirstBroadcastSupervisorFaultsTotal, "router_overflow") >= beforeFaults+1 &&
+			observeFirstBroadcastSupervisorResubscribeTotal.Value() >= beforeResubscribes+1
+	})
+
+	drainBroadcastEvents(eventRouter.Events())
+
+	reconstructor.publish(PassiveClassifiedEvent{
+		Kind:       PassiveClassifiedEventBroadcastFrame,
+		Request:    broadcast,
+		HasRequest: true,
+		ObservedAt: time.Unix(0, 1000),
+	})
+
+	waitForCondition(t, 2*time.Second, func() bool {
+		return observeFirstBroadcastSupervisorState.Value() == "healthy"
+	})
+
+	select {
+	case event := <-eventRouter.Events():
+		if event.Plane != "broadcast" {
+			t.Fatalf("event.Plane = %q; want broadcast", event.Plane)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for post-resubscribe broadcast event")
+	}
+}
+
+type decodingRouterPlane struct {
+	*mockPlane
+	decoded map[string]types.Value
+	handled bool
+	err     error
+}
+
+func (plane *decodingRouterPlane) DecodeBroadcast(frame protocol.Frame) (map[string]types.Value, bool, error) {
+	return plane.decoded, plane.handled, plane.err
+}
+
 func waitForPassiveEvents(t *testing.T, recorder *passiveEventRecorder, timeout time.Duration, ready func([]PassiveTapEvent) bool) []PassiveTapEvent {
 	t.Helper()
 
@@ -288,6 +383,31 @@ func waitForCondition(t *testing.T, timeout time.Duration, ready func() bool) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatal("timeout waiting for condition")
+}
+
+func drainBroadcastEvents(ch <-chan router.BroadcastEvent) {
+	for {
+		select {
+		case <-ch:
+		default:
+			return
+		}
+	}
+}
+
+func expvarMapInt64Value(m *expvar.Map, key string) int64 {
+	if m == nil {
+		return 0
+	}
+	variable := m.Get(key)
+	if variable == nil {
+		return 0
+	}
+	counter, ok := variable.(*expvar.Int)
+	if !ok {
+		return 0
+	}
+	return counter.Value()
 }
 
 func countPassiveEventKind(events []PassiveTapEvent, kind PassiveTapEventKind) int {


### PR DESCRIPTION
## What
Wire `GW-02` end-to-end in the gateway by treating router broadcast queue overflow as an explicit passive-supervisor fault instead of silently continuing.

## Why
`helianthus-ebusreg#112` now surfaces `router.ErrBroadcastEventOverflow`, but the gateway broadcast path was still ignoring `HandleBroadcast` errors entirely. That left correctness-critical broadcast loss silent and skipped the reset/resubscribe path required by the passive-pipeline contract.

## Acceptance Criteria
- [x] Broadcast path continues to consume pre-dedup classified events from `PassiveTransactionReconstructor`.
- [x] No separate passive connection is owned when a reconstructor is supplied.
- [x] Router event overflow is surfaced as explicit supervisor fault/metric instead of silent drop.
- [x] Broadcast supervisor enters degraded state on overflow and resets/resubscribes before normal delivery resumes.
- [x] B516 broadcast delivery remains pre-dedup.
- [x] Unit tests cover the overflow/fault path.
- [x] CI green.
- [ ] Smoke test required: NO

## Validation
- `go test ./... -run '^(TestBroadcastListener_(RoutesBroadcastFramesViaPassiveTap|RouterOverflowMarksDegradedAndResubscribes))$' -count=1`\n- `go test ./... -count=1`\n- `go test -race ./... -count=1`\n- `TRANSPORT_GATE_OWNER_OVERRIDE=OVERRIDE_TRANSPORT_GATE_BY_OWNER TRANSPORT_GATE_OWNER_REASON='GW-02 broadcast supervisor follow-up validated with local functional and race tests; T01-T88 matrix artifact not available in current workspace.' ./scripts/ci_local.sh`\n\n## Dependencies\n- Depends on Project-Helianthus/helianthus-ebusreg#112\n- Closes #339