### PR TITLE
GW-03A/B: fix warmup bootstrap and local snapshot wiring

### DIFF
--- a/bus_observability_store.go
+++ b/bus_observability_store.go
@@ -280,6 +280,13 @@ func (store *BusObservabilityStore) runPassiveLoop() {
 			}
 		}
 
+		snapshot := reconstructor.Snapshot()
+		now := store.now()
+		store.mu.Lock()
+		store.refreshPassiveStateLocked(now, snapshot.TapStatus)
+		store.bootstrapPassiveWarmupFromSnapshotLocked(now, snapshot)
+		store.mu.Unlock()
+
 		closedUnexpectedly := false
 		for {
 			select {
@@ -302,6 +309,24 @@ func (store *BusObservabilityStore) runPassiveLoop() {
 			store.mu.Unlock()
 		}
 	}
+}
+
+func (store *BusObservabilityStore) bootstrapPassiveWarmupFromSnapshotLocked(now time.Time, snapshot PassiveReconstructorSnapshot) {
+	if store.passive.probeAttemptsTotal != 0 {
+		return
+	}
+	if store.passive.state == "warming_up" || store.passive.state == "available" {
+		return
+	}
+	if !snapshot.TapStatus.Connected {
+		return
+	}
+
+	observedAt := snapshot.TapStatus.LastConnectAt
+	if observedAt.IsZero() {
+		observedAt = now
+	}
+	store.passiveStartWarmupLocked(observedAt, false)
 }
 
 func (store *BusObservabilityStore) OnPassiveClassifiedEvent(event PassiveClassifiedEvent) {

--- a/bus_observability_store_test.go
+++ b/bus_observability_store_test.go
@@ -1,6 +1,7 @@
 package ebusgateway
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -133,6 +134,52 @@ func TestBusObservabilityStoreMarksPassiveDisabledAsCapabilityWithdrawn(t *testi
 	if strings.Contains(metrics, `ebus_passive_capability_unavailable_reason{reason="startup_timeout"} 1`) {
 		t.Fatalf("RenderPrometheus reported startup_timeout for disabled passive mode:\n%s", metrics)
 	}
+}
+
+func TestBusObservabilityStoreBootstrapsWarmupFromConnectedSnapshotAfterAttach(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.BroadcastListen = true
+
+	reconstructor := newPassiveTransactionReconstructorCore(cfg)
+	reconstructor.tap = &PassiveBusTap{
+		status: PassiveTapStatus{
+			Connected:     true,
+			EndpointState: PassiveEndpointStateConnected,
+			ConnectCount:  1,
+			LastConnectAt: time.Unix(1700000000, 0).UTC(),
+		},
+	}
+
+	store := NewBusObservabilityStore(cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	defer func() {
+		if err := store.Close(); err != nil {
+			t.Fatalf("store.Close error = %v", err)
+		}
+	}()
+
+	if err := store.AttachReconstructor(ctx, reconstructor); err != nil {
+		t.Fatalf("AttachReconstructor error = %v", err)
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		store.mu.RLock()
+		state := store.passive.state
+		probeAttempts := store.passive.probeAttemptsTotal
+		sessionStartedAt := store.passive.sessionStartedAt
+		store.mu.RUnlock()
+		if state == "warming_up" && probeAttempts == 1 && sessionStartedAt.Equal(reconstructor.tap.status.LastConnectAt) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+	t.Fatalf("passive warmup state = %q, probeAttempts=%d, sessionStartedAt=%s; want warming_up bootstrap from connected snapshot",
+		store.passive.state, store.passive.probeAttemptsTotal, store.passive.sessionStartedAt)
 }
 
 func TestBusObservabilityStoreExportsBusyMetricsWhenPassiveAvailable(t *testing.T) {

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -54,17 +54,9 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 		cfg.Providers = vaillantproviders.Default()
 	}
 
-	busObservability := ebusgateway.NewBusObservabilityStore(cfg)
-	cfg.BusConfig.Observer = ebusgateway.ChainBusObservers(cfg.BusConfig.Observer, busObservability)
-
-	var deduplicator *ebusgateway.ActivePassiveDeduplicator
-	if cfg.BroadcastListen {
-		dedup, err := ebusgateway.NewActivePassiveDeduplicator(cfg)
-		if err != nil {
-			return err
-		}
-		cfg.BusConfig.Observer = ebusgateway.ChainBusObservers(cfg.BusConfig.Observer, dedup)
-		deduplicator = dedup
+	busObservability, deduplicator, err := wireObserveFirstObservers(&cfg)
+	if err != nil {
+		return err
 	}
 
 	gateway, err := ebusgateway.New(ctx, cfg)
@@ -193,6 +185,32 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 
 	<-ctx.Done()
 	return nil
+}
+
+func wireObserveFirstObservers(cfg *ebusgateway.Config) (*ebusgateway.BusObservabilityStore, *ebusgateway.ActivePassiveDeduplicator, error) {
+	if cfg == nil {
+		return nil, nil, nil
+	}
+
+	observerCfg := *cfg
+
+	var deduplicator *ebusgateway.ActivePassiveDeduplicator
+	if cfg.BroadcastListen {
+		dedup, err := ebusgateway.NewActivePassiveDeduplicator(observerCfg)
+		if err != nil {
+			return nil, nil, err
+		}
+		deduplicator = dedup
+		observerCfg.LocalAddressSnapshotter = deduplicator
+	}
+
+	busObservability := ebusgateway.NewBusObservabilityStore(observerCfg)
+	cfg.BusConfig.Observer = ebusgateway.ChainBusObservers(cfg.BusConfig.Observer, busObservability)
+	if deduplicator != nil {
+		cfg.BusConfig.Observer = ebusgateway.ChainBusObservers(cfg.BusConfig.Observer, deduplicator)
+	}
+
+	return busObservability, deduplicator, nil
 }
 
 func applyTransportSourcePolicy(cfg *ebusgateway.Config) {

--- a/cmd/gateway/main_test.go
+++ b/cmd/gateway/main_test.go
@@ -2,11 +2,21 @@ package main
 
 import (
 	"flag"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/Project-Helianthus/helianthus-ebusgateway"
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
 )
+
+type fixedLocalSnapshotter struct {
+	snapshot ebusgateway.LocalAddressSnapshot
+}
+
+func (snapshotter fixedLocalSnapshotter) LocalAddressSnapshot() ebusgateway.LocalAddressSnapshot {
+	return snapshotter.snapshot
+}
 
 func TestBindFlags_SourceAddrAuto(t *testing.T) {
 	cfg := ebusgateway.DefaultConfig()
@@ -89,6 +99,58 @@ func TestApplyTransportSourcePolicy_EbusdTCPDefaultF0PromotesToEbusdSource(t *te
 
 	if cfg.ScanSource != 0x31 {
 		t.Fatalf("ScanSource = 0x%02x; want 0x31", cfg.ScanSource)
+	}
+}
+
+func TestWireObserveFirstObserversWiresDedupSnapshotterIntoObservabilityStore(t *testing.T) {
+	cfg := ebusgateway.DefaultConfig()
+	cfg.BroadcastListen = true
+	cfg.LocalAddressSnapshotter = fixedLocalSnapshotter{
+		snapshot: ebusgateway.LocalAddressSnapshot{
+			Address: 0x31,
+			Known:   true,
+			Epoch:   1,
+		},
+	}
+
+	busObservability, deduplicator, err := wireObserveFirstObservers(&cfg)
+	if err != nil {
+		t.Fatalf("wireObserveFirstObservers error = %v", err)
+	}
+	if busObservability == nil {
+		t.Fatal("busObservability = nil")
+	}
+	if deduplicator == nil {
+		t.Fatal("deduplicator = nil")
+	}
+
+	local := deduplicator.LocalAddressSnapshot()
+	if !local.Known || local.Address != 0x31 {
+		t.Fatalf("LocalAddressSnapshot = %+v; want known 0x31", local)
+	}
+
+	request := protocol.Frame{
+		Source:    0x10,
+		Target:    0x31,
+		Primary:   0x01,
+		Secondary: 0x02,
+		Data:      []byte{0x03},
+	}
+	if got := request.Type(); got != protocol.FrameTypeInitiatorInitiator {
+		t.Fatalf("request.Type() = %v; want %v", got, protocol.FrameTypeInitiatorInitiator)
+	}
+
+	if err := busObservability.OnBusEvent(protocol.BusEvent{
+		Kind:       protocol.BusEventAttemptComplete,
+		Request:    request,
+		HasRequest: true,
+	}); err != nil {
+		t.Fatalf("OnBusEvent error = %v", err)
+	}
+
+	metrics := busObservability.RenderPrometheus()
+	if !strings.Contains(metrics, `frame_type="local_participant_inbound"`) {
+		t.Fatalf("RenderPrometheus missing local_participant_inbound classification:\n%s", metrics)
 	}
 }
 


### PR DESCRIPTION
## What
- bootstrap passive warmup from the current reconstructor snapshot when the observability store subscribes after the passive tap already emitted the initial `connected` discontinuity
- wire the deduplicator-backed runtime local-address snapshotter into `BusObservabilityStore` so `local_participant_inbound` labeling is live in the gateway binary
- add regression coverage for both runtime paths

## Why
This secondary fix PR settles the post-review blockers discovered on `GW-03`:
- `#344` passive warmup could stay stuck in `unavailable` on a clean boot because the initial `connected` discontinuity was emitted before the store subscribed
- `#345` `local_participant_inbound` labeling was effectively dead in `cmd/gateway/run()` because `LocalAddressSnapshotter` was never wired from the deduplicator into the observability store

## Validation
- `go test ./... -count=1`
- `go test -race . ./cmd/gateway -count=1`
- `go test ./cmd/gateway -run 'TestWireObserveFirstObserversWiresDedupSnapshotterIntoObservabilityStore' -count=1`
- `go test . -run 'TestBusObservabilityStoreBootstrapsWarmupFromConnectedSnapshotAfterAttach|TestBusObservabilityStoreMarksPassiveDisabledAsCapabilityWithdrawn' -count=1`
- `TRANSPORT_MATRIX_REPORT=results-matrix-ha/20260310T143425Z-gw03-fix-344-345-full88-v2/index.json ./scripts/transport_gate.sh`
  - matrix artifact: `results-matrix-ha/20260310T143425Z-gw03-fix-344-345-full88-v2/index.json`
  - outcome: `46 pass`, `9 xfail`, `33 blocked-infra`, `0 fail`, `0 xpass`
  - gate result: `PASS`

## Notes
- The matrix artifact contains significant live-lab `adapter_no_signal` noise, but no product `fail` cases.
- Base branch is `issue/342-bus-observability-store`; this PR is intended to squash-merge into the active GW-03 branch, not into `main`.
