### PR TITLE
Fix live GraphQL devices parity after late discovery

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -386,7 +386,7 @@ func startHTTPServer(ctx context.Context, cfg ebusgateway.Config, gateway *ebusg
 			GatewayVersion:   buildVersion,
 			BuildID:          buildID,
 			ListRegistry: func() []portal.RegistryDevice {
-				schemaSnapshot := builder.Schema()
+				schemaSnapshot := builder.FreshSchema()
 				schemaByAddr := make(map[byte]graphql.Device, len(schemaSnapshot.Devices))
 				for _, sd := range schemaSnapshot.Devices {
 					schemaByAddr[sd.Address] = sd
@@ -456,7 +456,7 @@ func startHTTPServer(ctx context.Context, cfg ebusgateway.Config, gateway *ebusg
 				}
 			},
 			ListProjections: func() []portal.ProjectionDevice {
-				snapshot := builder.Schema()
+				snapshot := builder.FreshSchema()
 				items := make([]portal.ProjectionDevice, 0, len(snapshot.Devices))
 				for _, device := range snapshot.Devices {
 					summaries := make([]portal.ProjectionSummary, 0, len(device.Projections))
@@ -478,7 +478,7 @@ func startHTTPServer(ctx context.Context, cfg ebusgateway.Config, gateway *ebusg
 				return items
 			},
 			GetProjection: func(address byte, plane string) (portal.ProjectionGraph, bool) {
-				snapshot := builder.Schema()
+				snapshot := builder.FreshSchema()
 				for _, device := range snapshot.Devices {
 					if device.Address != address {
 						continue

--- a/graphql/builder.go
+++ b/graphql/builder.go
@@ -88,6 +88,21 @@ func (b *Builder) Schema() Schema {
 	return cloneSchema(b.schema)
 }
 
+func (b *Builder) FreshSchema() Schema {
+	if b == nil {
+		return Schema{}
+	}
+
+	// Registry mutations can arrive outside explicit builder change hooks,
+	// for example from semantic discovery after boot. Rebuild on read so
+	// schema-backed device views do not stay pinned to an empty startup snapshot.
+	_ = b.Rebuild()
+
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return cloneSchema(b.schema)
+}
+
 func (b *Builder) Revision() uint64 {
 	if b == nil {
 		return 0

--- a/graphql/builder_test.go
+++ b/graphql/builder_test.go
@@ -369,6 +369,40 @@ func TestBuilder_StopsOnClosedChannel(t *testing.T) {
 	}
 }
 
+func TestBuilder_FreshSchemaRebuildsWithoutChangeChannel(t *testing.T) {
+	entry := mockEntry{
+		info: registry.DeviceInfo{
+			Address:         0x10,
+			Manufacturer:    "vaillant",
+			DeviceID:        "device-a",
+			HardwareVersion: "7603",
+		},
+		planes: []registry.Plane{
+			mockPlane{name: "heating"},
+		},
+	}
+
+	reg := &mutableRegistry{}
+	builder := NewBuilder(reg, nil)
+	if err := builder.Start(context.Background()); err != nil {
+		t.Fatalf("Start error = %v", err)
+	}
+
+	if len(builder.Schema().Devices) != 0 {
+		t.Fatalf("Schema devices = %d; want 0", len(builder.Schema().Devices))
+	}
+
+	reg.SetEntries([]registry.DeviceEntry{entry})
+
+	fresh := builder.FreshSchema()
+	if len(fresh.Devices) != 1 {
+		t.Fatalf("FreshSchema devices = %d; want 1", len(fresh.Devices))
+	}
+	if fresh.Devices[0].Address != 0x10 {
+		t.Fatalf("FreshSchema address = 0x%02x; want 0x10", fresh.Devices[0].Address)
+	}
+}
+
 func waitForRevision(t *testing.T, builder *Builder, last uint64) {
 	t.Helper()
 

--- a/graphql/queries.go
+++ b/graphql/queries.go
@@ -2706,7 +2706,7 @@ func buildQueryType(builder *Builder, types graphqlSchemaTypes) *graphqlgo.Objec
 			"devices": &graphqlgo.Field{
 				Type: graphqlgo.NewNonNull(graphqlgo.NewList(graphqlgo.NewNonNull(types.deviceType))),
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
-					snapshot := builder.Schema()
+					snapshot := builder.FreshSchema()
 					return snapshot.Devices, nil
 				},
 			},
@@ -2720,7 +2720,7 @@ func buildQueryType(builder *Builder, types graphqlSchemaTypes) *graphqlgo.Objec
 					if err != nil {
 						return nil, err
 					}
-					snapshot := builder.Schema()
+					snapshot := builder.FreshSchema()
 					device, ok := findDevice(snapshot.Devices, address)
 					if !ok {
 						return nil, nil
@@ -2738,7 +2738,7 @@ func buildQueryType(builder *Builder, types graphqlSchemaTypes) *graphqlgo.Objec
 					if err != nil {
 						return nil, err
 					}
-					snapshot := builder.Schema()
+					snapshot := builder.FreshSchema()
 					device, ok := findDevice(snapshot.Devices, address)
 					if !ok {
 						return []Plane{}, nil
@@ -2758,7 +2758,7 @@ func buildQueryType(builder *Builder, types graphqlSchemaTypes) *graphqlgo.Objec
 						return nil, err
 					}
 					planeName, _ := params.Args["plane"].(string)
-					snapshot := builder.Schema()
+					snapshot := builder.FreshSchema()
 					device, ok := findDevice(snapshot.Devices, address)
 					if !ok {
 						return []Method{}, nil

--- a/graphql/queries_test.go
+++ b/graphql/queries_test.go
@@ -1157,3 +1157,65 @@ func intPtr(value int) *int {
 	v := value
 	return &v
 }
+
+func TestQueryResolvers_DevicesReflectLateRegistryPopulation(t *testing.T) {
+	gateway, err := ebusgateway.New(context.Background(), ebusgateway.Config{
+		Transport: transport.NewLoopback(),
+	})
+	if err != nil {
+		t.Fatalf("gateway.New error = %v", err)
+	}
+	defer func() {
+		if err := gateway.Close(); err != nil {
+			t.Fatalf("gateway.Close error = %v", err)
+		}
+	}()
+
+	builder := NewBuilder(gateway.Registry, nil)
+	if err := builder.Start(context.Background()); err != nil {
+		t.Fatalf("builder.Start error = %v", err)
+	}
+
+	handler, err := NewHandler(builder)
+	if err != nil {
+		t.Fatalf("NewHandler error = %v", err)
+	}
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	gateway.Registry.Register(registry.DeviceInfo{
+		Address:         0x15,
+		Manufacturer:    "Vaillant",
+		DeviceID:        "BASV2",
+		SoftwareVersion: "0507",
+		HardwareVersion: "1704",
+	})
+
+	client := graphqlclient.NewClient(server.URL)
+	request := graphqlclient.NewRequest(`
+		query {
+			devices {
+				address
+				deviceId
+			}
+		}
+	`)
+
+	var response struct {
+		Devices []struct {
+			Address  int    `json:"address"`
+			DeviceID string `json:"deviceId"`
+		} `json:"devices"`
+	}
+
+	if err := client.Run(context.Background(), request, &response); err != nil {
+		t.Fatalf("devices query error = %v", err)
+	}
+	if len(response.Devices) != 1 {
+		t.Fatalf("devices = %d; want 1", len(response.Devices))
+	}
+	if response.Devices[0].Address != 21 || response.Devices[0].DeviceID != "BASV2" {
+		t.Fatalf("device payload = %+v; want address=21 deviceId=BASV2", response.Devices[0])
+	}
+}

--- a/graphql/snapshot_handler.go
+++ b/graphql/snapshot_handler.go
@@ -48,7 +48,7 @@ func NewProjectionSnapshotHandler(builder *Builder) (http.Handler, error) {
 			return
 		}
 
-		snapshot := builder.Schema()
+		snapshot := builder.FreshSchema()
 		device, ok := findDevice(snapshot.Devices, address)
 		if !ok {
 			http.Error(w, "device not found", http.StatusNotFound)


### PR DESCRIPTION
## What
Refresh GraphQL device/projection schema from the live registry on read so `devices` and projection endpoints do not stay pinned to an empty startup snapshot.

## Why
Live runtime can populate the registry after boot through semantic discovery, which MCP and the portal registry endpoint already see. GraphQL `devices` remained empty because the builder snapshot was taken at boot and never refreshed for these late registry mutations. This blocks live `devices` parity.

## Acceptance Criteria
- [x] GraphQL `devices` reflects devices registered after boot
- [x] Regression tests cover the stale-at-boot then registry-populated-later path
- [x] Unit tests cover the implemented code
- [x] CI green locally
- [x] Smoke test required: YES

## Dependencies
- Depends on #347
- Targets #343 branch parity