### PR TITLE
GW-07: implement bounded ShadowCache

### DIFF
--- a/shadow_cache.go
+++ b/shadow_cache.go
@@ -810,6 +810,10 @@ func (cache *ShadowCache) applyPinClassLocked(entry *shadowEntry, desired shadow
 		if desired == shadowPinClassNone && entry.evictableElem == nil {
 			entry.evictableElem = cache.evictableLRU.PushBack(entry.canonicalKey)
 		}
+		if desired != shadowPinClassNone && entry.evictableElem != nil {
+			cache.evictableLRU.Remove(entry.evictableElem)
+			entry.evictableElem = nil
+		}
 		return
 	}
 	if entry.evictableElem != nil {

--- a/shadow_cache_test.go
+++ b/shadow_cache_test.go
@@ -560,6 +560,62 @@ func TestShadowCacheSnapshotEligibilityAndLookupFollowFreshness(t *testing.T) {
 	}
 }
 
+func TestShadowCacheInvalidateRepinnedEntryLeavesEvictionLRU(t *testing.T) {
+	t.Parallel()
+
+	repinnedKey := NewB509WatchKey(0x08, 0x0200)
+	evictableKey := NewB509WatchKey(0x08, 0x0201)
+	newcomerKey := NewB509WatchKey(0x08, 0x0202)
+	catalog, activations := testShadowCatalogAndActivations(t, []WatchKey{repinnedKey, evictableKey, newcomerKey}, WatchActivationSourceTooling)
+	cache := newTestShadowCache(t, catalog, activations, time.Unix(100, 0), ShadowCacheOptions{
+		Capacity:              2,
+		PinnedCapacity:        2,
+		WriteConfirmPinnedCap: 1,
+	})
+
+	writeShadow(t, cache, repinnedKey, ShadowWriteSourcePassive, time.Unix(100, 0), []byte{0x20})
+	writeShadow(t, cache, evictableKey, ShadowWriteSourcePassive, time.Unix(101, 0), []byte{0x21})
+
+	if err := activations.Activate(WatchActivationSourceWriteConfirm, repinnedKey); err != nil {
+		t.Fatalf("Activate(write_confirm repinnedKey) error = %v", err)
+	}
+
+	invalidation := cache.Invalidate(ShadowInvalidation{
+		Key:           repinnedKey,
+		Reason:        ShadowInvalidationReasonExternalWrite,
+		Source:        ShadowInvalidationSourcePassive,
+		InvalidatedAt: time.Unix(102, 0),
+	})
+	if invalidation.State != ShadowEntryStateInvalidated {
+		t.Fatalf("Invalidate() state = %s; want %s for cached entry with retained payload", invalidation.State, ShadowEntryStateInvalidated)
+	}
+
+	entry, ok := cache.entries[repinnedKey.Canonical()]
+	if !ok {
+		t.Fatal("repinned entry missing after invalidation")
+	}
+	if entry.pinClass != shadowPinClassWriteConfirm {
+		t.Fatalf("repinned entry pinClass = %v; want %v", entry.pinClass, shadowPinClassWriteConfirm)
+	}
+	if entry.evictableElem != nil {
+		t.Fatal("repinned entry still linked in eviction LRU after invalidation")
+	}
+
+	writeShadow(t, cache, newcomerKey, ShadowWriteSourcePassive, time.Unix(103, 0), []byte{0x22})
+
+	if _, ok := cache.Entry(repinnedKey); !ok {
+		t.Fatal("repinned invalidated entry was evicted under capacity pressure")
+	}
+	if _, ok := cache.Entry(evictableKey); ok {
+		t.Fatal("unrelated evictable entry remained; want it evicted before the repinned tombstone")
+	}
+
+	summary := cache.Summary()
+	if summary.WriteConfirmPinnedActive != 1 {
+		t.Fatalf("Summary().WriteConfirmPinnedActive = %d; want 1", summary.WriteConfirmPinnedActive)
+	}
+}
+
 func TestShadowCacheEvictionStoresAbsentSnapshot(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #382

## What
- add the bounded adapter-scoped `ShadowCache` foundation
- enforce pinned vs evictable admission rules and pinned-budget degraded startup state
- add precedence, invalidation-generation, tombstone compaction, and de-pin lifecycle handling
- expose a scheduler-facing eligibility snapshot API without integrating scheduler behavior yet
- add focused unit coverage for the GW-07 acceptance slice

## Scope
- intentionally limited to GW-07 only
- does not implement GW-08 flags, GW-09 family policy, GW-10 scheduler integration, or docs changes

## Validation
- `go test . -run \TestShadowCache' -count=1`\n- `go test . -count=1`\n- `go test ./... -count=1`\n- `./scripts/ci_local.sh`\n