### PR TITLE
GW-14: add first portal bus observability UI slice

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -521,6 +521,12 @@ func startHTTPServer(
 	}
 	if cfg.PortalPath != "" {
 		portalPath := normalizeMountPath(cfg.PortalPath, "/portal")
+		var getPortalBusObservability func() any
+		if busObservability != nil {
+			getPortalBusObservability = func() any {
+				return busObservability.Snapshot().Summary
+			}
+		}
 		portalHandler := portal.NewHandler(portal.Options{
 			GraphQLPath:      cfg.GraphQLPath,
 			SnapshotPath:     cfg.SnapshotPath,
@@ -598,6 +604,7 @@ func startHTTPServer(
 					CapturedUTC:  time.Now().UTC().Format(time.RFC3339),
 				}
 			},
+			GetBusObservability: getPortalBusObservability,
 			ListProjections: func() []portal.ProjectionDevice {
 				snapshot := builder.FreshSchema()
 				items := make([]portal.ProjectionDevice, 0, len(snapshot.Devices))

--- a/portal/handler.go
+++ b/portal/handler.go
@@ -48,18 +48,19 @@ var (
 )
 
 type Options struct {
-	GraphQLPath      string
-	SnapshotPath     string
-	SubscriptionPath string
-	MCPPath          string
-	GatewayVersion   string
-	BuildID          string
-	ListRegistry     func() []RegistryDevice
-	ListSemantic     func() SemanticSnapshot
-	ListProjections  func() []ProjectionDevice
-	GetProjection    func(address byte, plane string) (ProjectionGraph, bool)
-	ExplorerBus      ExplorerBus // nil disables explorer
-	ExplorerSource   byte        // default eBUS source address (0xF0 if zero)
+	GraphQLPath         string
+	SnapshotPath        string
+	SubscriptionPath    string
+	MCPPath             string
+	GatewayVersion      string
+	BuildID             string
+	ListRegistry        func() []RegistryDevice
+	ListSemantic        func() SemanticSnapshot
+	GetBusObservability func() any
+	ListProjections     func() []ProjectionDevice
+	GetProjection       func(address byte, plane string) (ProjectionGraph, bool)
+	ExplorerBus         ExplorerBus // nil disables explorer
+	ExplorerSource      byte        // default eBUS source address (0xF0 if zero)
 }
 
 type handler struct {
@@ -851,26 +852,28 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 		streamEnabled := h.opts.ListRegistry != nil || h.opts.ListSemantic != nil || h.opts.ListProjections != nil
 		writeJSON(w, http.StatusOK, map[string]any{
 			"capabilities": map[string]bool{
-				"registry":      h.opts.ListRegistry != nil,
-				"semantic":      h.opts.ListSemantic != nil,
-				"projection":    h.opts.ListProjections != nil && h.opts.GetProjection != nil,
-				"search":        h.opts.ListRegistry != nil || h.opts.ListSemantic != nil || h.opts.ListProjections != nil,
-				"stream":        streamEnabled,
-				"timeline":      streamEnabled,
-				"provenance":    streamEnabled,
-				"snapshots":     streamEnabled,
-				"snapshot_diff": streamEnabled,
-				"snapshot_view": streamEnabled,
-				"sessions":      true,
-				"issue_builder": true,
-				"migration":     false,
-				"explorer":      h.explorer != nil,
+				"registry":          h.opts.ListRegistry != nil,
+				"semantic":          h.opts.ListSemantic != nil,
+				"bus_observability": h.opts.GetBusObservability != nil,
+				"projection":        h.opts.ListProjections != nil && h.opts.GetProjection != nil,
+				"search":            h.opts.ListRegistry != nil || h.opts.ListSemantic != nil || h.opts.ListProjections != nil,
+				"stream":            streamEnabled,
+				"timeline":          streamEnabled,
+				"provenance":        streamEnabled,
+				"snapshots":         streamEnabled,
+				"snapshot_diff":     streamEnabled,
+				"snapshot_view":     streamEnabled,
+				"sessions":          true,
+				"issue_builder":     true,
+				"migration":         false,
+				"explorer":          h.explorer != nil,
 			},
 			"endpoints": map[string]string{
 				"graphql":               h.opts.GraphQLPath,
 				"snapshot":              h.opts.SnapshotPath,
 				"subscriptions":         h.opts.SubscriptionPath,
 				"mcp":                   h.opts.MCPPath,
+				"bus_observability":     "/portal/api/v1/bus/observability",
 				"search":                "/portal/api/v1/search",
 				"stream":                "/portal/api/v1/stream",
 				"timeline":              "/portal/api/v1/timeline/events",
@@ -903,6 +906,8 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 		h.handleRegistryDevices(w, r)
 	case "semantic/snapshot":
 		h.handleSemanticSnapshot(w)
+	case "bus/observability":
+		h.handleBusObservability(w)
 	case "projection/devices":
 		h.handleProjectionDevices(w, r)
 	case "projection/graph":
@@ -979,6 +984,8 @@ func classifyRoute(path string) string {
 		return "api.registry.devices"
 	case strings.HasPrefix(path, "/api/v1/semantic/snapshot"):
 		return "api.semantic.snapshot"
+	case strings.HasPrefix(path, "/api/v1/bus/observability"):
+		return "api.bus.observability"
 	case strings.HasPrefix(path, "/api/v1/projection/devices"):
 		return "api.projection.devices"
 	case strings.HasPrefix(path, "/api/v1/projection/graph"):
@@ -1161,6 +1168,19 @@ func (h *handler) handleSemanticSnapshot(w http.ResponseWriter) {
 		snapshot.Zones = []SemanticZone{}
 	}
 	writeJSON(w, http.StatusOK, snapshot)
+}
+
+func (h *handler) handleBusObservability(w http.ResponseWriter) {
+	if h.opts.GetBusObservability == nil {
+		http.Error(w, "bus observability unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	payload := h.opts.GetBusObservability()
+	if payload == nil {
+		http.Error(w, "bus observability unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	writeJSON(w, http.StatusOK, payload)
 }
 
 func (h *handler) handleProjectionDevices(w http.ResponseWriter, r *http.Request) {

--- a/portal/handler_test.go
+++ b/portal/handler_test.go
@@ -155,6 +155,19 @@ func TestBootstrapEndpoint(t *testing.T) {
 		ListSemantic: func() SemanticSnapshot {
 			return SemanticSnapshot{Zones: []SemanticZone{{ID: "z1", Name: "Zone 1"}}}
 		},
+		GetBusObservability: func() any {
+			return map[string]any{
+				"status": map[string]any{
+					"transport_class": "ens",
+					"warmup": map[string]any{
+						"state": "available",
+					},
+					"degraded": map[string]any{
+						"active": false,
+					},
+				},
+			}
+		},
 		ListProjections: func() []ProjectionDevice {
 			return []ProjectionDevice{{Address: 0x10, Projections: []ProjectionSummary{{Plane: "Service"}}}}
 		},
@@ -183,6 +196,9 @@ func TestBootstrapEndpoint(t *testing.T) {
 	}
 	if endpoints["search"] != "/portal/api/v1/search" {
 		t.Fatalf("search endpoint=%v; want /portal/api/v1/search", endpoints["search"])
+	}
+	if endpoints["bus_observability"] != "/portal/api/v1/bus/observability" {
+		t.Fatalf("bus_observability endpoint=%v; want /portal/api/v1/bus/observability", endpoints["bus_observability"])
 	}
 	if endpoints["timeline"] != "/portal/api/v1/timeline/events" {
 		t.Fatalf("timeline endpoint=%v; want /portal/api/v1/timeline/events", endpoints["timeline"])
@@ -223,6 +239,9 @@ func TestBootstrapEndpoint(t *testing.T) {
 	}
 	if capabilities["semantic"] != true {
 		t.Fatalf("capabilities.semantic=%v; want true", capabilities["semantic"])
+	}
+	if capabilities["bus_observability"] != true {
+		t.Fatalf("capabilities.bus_observability=%v; want true", capabilities["bus_observability"])
 	}
 	if capabilities["projection"] != true {
 		t.Fatalf("capabilities.projection=%v; want true", capabilities["projection"])
@@ -268,6 +287,58 @@ func TestAPIMethodNotAllowed(t *testing.T) {
 	}
 	if got := rec.Header().Get("Allow"); got != http.MethodGet {
 		t.Fatalf("Allow=%q; want GET", got)
+	}
+}
+
+func TestBusObservabilityEndpointUnavailable(t *testing.T) {
+	h := NewHandler(Options{})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/bus/observability", nil)
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d; want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+}
+
+func TestBusObservabilityEndpoint(t *testing.T) {
+	h := NewHandler(Options{
+		GetBusObservability: func() any {
+			return map[string]any{
+				"status": map[string]any{
+					"transport_class": "ebusd-tcp",
+					"warmup": map[string]any{
+						"state": "warming_up",
+					},
+					"degraded": map[string]any{
+						"active": true,
+						"reasons": []string{
+							"unsupported_or_misconfigured",
+						},
+					},
+				},
+			}
+		},
+	})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/bus/observability", nil)
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d; want %d", rec.Code, http.StatusOK)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	status, ok := payload["status"].(map[string]any)
+	if !ok {
+		t.Fatalf("status missing or invalid")
+	}
+	if status["transport_class"] != "ebusd-tcp" {
+		t.Fatalf("status.transport_class=%v; want ebusd-tcp", status["transport_class"])
 	}
 }
 

--- a/portal/static/assets/app.css
+++ b/portal/static/assets/app.css
@@ -202,6 +202,34 @@ body {
   color: var(--muted);
 }
 
+.bus-banner {
+  margin: 0 0 0.65rem;
+  padding: 0.55rem 0.7rem;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.bus-state-available {
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+  background: color-mix(in srgb, var(--accent) 16%, var(--panel-soft));
+  color: var(--text);
+}
+
+.bus-state-warming_up {
+  border-color: color-mix(in srgb, var(--warn) 60%, var(--border));
+  background: color-mix(in srgb, var(--warn) 14%, var(--panel-soft));
+  color: var(--text);
+}
+
+.bus-state-degraded,
+.bus-state-unavailable {
+  border-color: color-mix(in srgb, #d96f6f 70%, var(--border));
+  background: color-mix(in srgb, #d96f6f 14%, var(--panel-soft));
+  color: var(--text);
+}
+
 .timeline-filter {
   width: 100%;
   margin: 0 0 0.6rem;

--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -173,6 +173,10 @@ class PortalShell extends HTMLElement {
       clearInterval(this.snapshotInterval);
       this.snapshotInterval = undefined;
     }
+    if (this.busObservabilityInterval) {
+      clearInterval(this.busObservabilityInterval);
+      this.busObservabilityInterval = undefined;
+    }
     if (this._explorerPollTimer) {
       clearInterval(this._explorerPollTimer);
       this._explorerPollTimer = undefined;
@@ -273,6 +277,7 @@ class PortalShell extends HTMLElement {
     const sectionMap = {
       "section-registry": ["section-registry"],
       "section-semantic": ["section-semantic"],
+      "section-bus": ["section-bus"],
       "section-projection": ["section-projection"],
       "section-explorer": ["section-explorer"],
       "section-timeline": ["section-timeline", "section-provenance"],
@@ -295,6 +300,7 @@ class PortalShell extends HTMLElement {
     const metaEl = this.querySelector('[data-role="meta"]');
     const listEl = this.querySelector('[data-role="registry-list"]');
     const semanticEl = this.querySelector('[data-role="semantic-list"]');
+    const busObservabilityEl = this.querySelector('[data-role="bus-observability"]');
     const projectionEl = this.querySelector('[data-role="projection-list"]');
     const searchInput = this.querySelector('[data-role="search-input"]');
     const searchList = this.querySelector('[data-role="search-list"]');
@@ -336,6 +342,20 @@ class PortalShell extends HTMLElement {
       }
       if (capabilities.semantic && semanticEl) {
         await this.loadSemanticPreview(semanticEl);
+      }
+      if (busObservabilityEl) {
+        busObservabilityEl.innerHTML = capabilities.bus_observability
+          ? "<li>Loading bus observability...</li>"
+          : "<li>Bus observability unavailable.</li>";
+      }
+      if (capabilities.bus_observability) {
+        await this.refreshBusObservability();
+        if (this.busObservabilityInterval) {
+          clearInterval(this.busObservabilityInterval);
+        }
+        this.busObservabilityInterval = setInterval(() => {
+          this.refreshBusObservability();
+        }, 3000);
       }
       if (capabilities.projection && projectionEl) {
         await this.loadProjectionPreview(projectionEl);
@@ -430,6 +450,7 @@ class PortalShell extends HTMLElement {
     const cap = capabilities || {};
     this.setNavState("registry", cap.registry);
     this.setNavState("semantic", cap.semantic);
+    this.setNavState("bus", cap.bus_observability);
     this.setNavState("projection", cap.projection);
     this.setNavState("explorer", cap.explorer);
     this.setNavState("timeline", cap.timeline || cap.provenance);
@@ -448,6 +469,89 @@ class PortalShell extends HTMLElement {
     if (bullet) {
       bullet.classList.toggle("available", Boolean(enabled));
       bullet.classList.toggle("unavailable", !enabled);
+    }
+  }
+
+  async refreshBusObservability() {
+    const listEl = this.querySelector('[data-role="bus-observability"]');
+    const bannerEl = this.querySelector('[data-role="bus-banner"]');
+    if (!listEl || !bannerEl) {
+      return;
+    }
+    try {
+      const response = await fetch("api/v1/bus/observability");
+      if (!response.ok) {
+        throw new Error(`status ${response.status}`);
+      }
+      const payload = await response.json();
+      const summary = payload && payload.status ? payload : payload?.summary;
+      if (!summary || !summary.status) {
+        throw new Error("missing status");
+      }
+      const status = summary.status || {};
+      const capability = status.capability || {};
+      const warmup = status.warmup || {};
+      const degraded = status.degraded || {};
+      const featureFlags = status.feature_flags || {};
+      const transportClass = String(status.transport_class || "unknown");
+      const passiveState = String(warmup.state || capability.passive_state || "unknown");
+      const warmupState = passiveState === "warming_up";
+      const degradedState = !warmupState && degraded.active === true;
+      const unavailableState =
+        !warmupState &&
+        !degradedState &&
+        (passiveState === "unavailable" || capability.passive_supported === false);
+      const viewState = warmupState
+        ? "warming_up"
+        : degradedState
+          ? "degraded"
+          : unavailableState
+            ? "unavailable"
+            : "available";
+
+      const stateLabel = {
+        available: "Passive observability available",
+        warming_up: "Passive warmup in progress",
+        degraded: "Observability degraded",
+        unavailable: "Passive observability unavailable",
+      }[viewState] || "Passive observability state unknown";
+
+      const reasons = Array.isArray(degraded.reasons) ? degraded.reasons : [];
+      const endpoint = capability.endpoint_state ? ` endpoint=${capability.endpoint_state}` : "";
+      const connected = capability.tap_connected === true ? " connected" : " disconnected";
+      let bannerText = `${stateLabel} (${transportClass}${endpoint}${connected})`;
+      if (transportClass === "ebusd-tcp" && (viewState === "degraded" || viewState === "unavailable")) {
+        bannerText += " | ebusd-tcp transport limits passive observe-first coverage.";
+      }
+      bannerEl.className = `bus-banner bus-state-${viewState}`;
+      bannerEl.textContent = bannerText;
+
+      const elapsedSeconds = Number(warmup.elapsed_seconds);
+      const elapsedLabel = Number.isFinite(elapsedSeconds) ? `${formatFixed(elapsedSeconds, 1)}s` : "n/a";
+      const completedTransactions = formatInteger(warmup.completed_transactions);
+      const requiredTransactions = formatInteger(warmup.required_transactions);
+      const passiveReason = capability.passive_reason ? String(capability.passive_reason) : "none";
+      const warmupBlocker = warmup.blocker ? String(warmup.blocker) : "none";
+      const completionMode = warmup.completion_mode ? String(warmup.completion_mode) : "n/a";
+      const normalization = Array.isArray(featureFlags.normalizations) && featureFlags.normalizations.length > 0
+        ? featureFlags.normalizations.join(", ")
+        : "none";
+
+      const rows = [
+        `transport=${escapeHtml(transportClass)} passive_supported=${escapeHtml(formatYesNo(capability.passive_supported))} passive_available=${escapeHtml(formatYesNo(capability.passive_available))}`,
+        `passive_state=${escapeHtml(passiveState)} passive_reason=${escapeHtml(passiveReason)}`,
+        `warmup blocker=${escapeHtml(warmupBlocker)} elapsed=${escapeHtml(elapsedLabel)} transactions=${escapeHtml(completedTransactions)}/${escapeHtml(requiredTransactions)} completion_mode=${escapeHtml(completionMode)}`,
+        `feature_flags observe_first_enabled=${escapeHtml(formatYesNo(featureFlags.observe_first_enabled))} state_direct_apply=${escapeHtml(formatYesNo(featureFlags.passive_state_direct_apply))} config_direct_apply=${escapeHtml(formatYesNo(featureFlags.passive_config_direct_apply))} external_write_policy=${escapeHtml(String(featureFlags.external_write_policy || "n/a"))} normalizations=${escapeHtml(normalization)}`,
+      ];
+      if (reasons.length > 0) {
+        rows.push(`degraded_reasons=${escapeHtml(reasons.join(", "))}`);
+      }
+      listEl.innerHTML = rows.map((row) => `<li>${row}</li>`).join("");
+    } catch (err) {
+      bannerEl.className = "bus-banner bus-state-unavailable";
+      bannerEl.textContent = "Bus observability endpoint unavailable";
+      listEl.innerHTML = "<li>Bus observability fetch failed.</li>";
+      console.error("bus observability query failed", err);
     }
   }
 
@@ -470,6 +574,7 @@ class PortalShell extends HTMLElement {
         streamStatus.textContent = `Stream live: layer=${layer} at=${at}`;
         this.scheduleTimelineRefresh();
         this.scheduleProvenanceRefresh();
+        this.refreshBusObservability();
         this.refreshSnapshots();
       } catch (err) {
         streamStatus.textContent = "Stream payload parse error";
@@ -1577,6 +1682,7 @@ class PortalShell extends HTMLElement {
             <h2>Views</h2>
             <button data-role="nav-registry" data-nav-target="section-registry" disabled><span class="nav-bullet"></span> Registry</button>
             <button data-role="nav-semantic" data-nav-target="section-semantic" disabled><span class="nav-bullet"></span> Semantic</button>
+            <button data-role="nav-bus" data-nav-target="section-bus" disabled><span class="nav-bullet"></span> Bus</button>
             <button data-role="nav-projection" data-nav-target="section-projection" disabled><span class="nav-bullet"></span> Projection</button>
             <button data-role="nav-explorer" data-nav-target="section-explorer" disabled><span class="nav-bullet"></span> Explorer</button>
             <button data-role="nav-timeline" data-nav-target="section-timeline" disabled><span class="nav-bullet"></span> Timeline</button>
@@ -1596,6 +1702,13 @@ class PortalShell extends HTMLElement {
               <h2>Semantic Preview</h2>
               <ul data-role="semantic-list">
                 <li>Loading semantic snapshot...</li>
+              </ul>
+            </section>
+            <section id="section-bus" class="registry-preview">
+              <h2>Bus Observability</h2>
+              <div class="bus-banner bus-state-unavailable" data-role="bus-banner">Loading bus observability...</div>
+              <ul data-role="bus-observability">
+                <li>Loading bus observability...</li>
               </ul>
             </section>
             <section id="section-projection" class="registry-preview">

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,12 +2,12 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 79694,
-      "sha256": "cbb2e11c90bedcaf22d49609c2197011a089c7b0d3da0282e2f4d7a093c9e15c"
+      "bytes": 85774,
+      "sha256": "c829b7714b19f49cbebde04aa995f7c1683481cad30046b6408930d9a50c8789"
     },
     "app.css": {
-      "bytes": 7370,
-      "sha256": "e8ca020672476a1946273ec1e68d682749008fc7b519ff3dfd4d2be83761f842"
+      "bytes": 8115,
+      "sha256": "b5889363539020740002eb18216ab2b650a994b2d282fabb36f37f11757671d9"
     }
   }
 }

--- a/portal/web/src/app.css
+++ b/portal/web/src/app.css
@@ -201,6 +201,34 @@ body {
   color: var(--muted);
 }
 
+.bus-banner {
+  margin: 0 0 0.65rem;
+  padding: 0.55rem 0.7rem;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.bus-state-available {
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+  background: color-mix(in srgb, var(--accent) 16%, var(--panel-soft));
+  color: var(--text);
+}
+
+.bus-state-warming_up {
+  border-color: color-mix(in srgb, var(--warn) 60%, var(--border));
+  background: color-mix(in srgb, var(--warn) 14%, var(--panel-soft));
+  color: var(--text);
+}
+
+.bus-state-degraded,
+.bus-state-unavailable {
+  border-color: color-mix(in srgb, #d96f6f 70%, var(--border));
+  background: color-mix(in srgb, #d96f6f 14%, var(--panel-soft));
+  color: var(--text);
+}
+
 .timeline-filter {
   width: 100%;
   margin: 0 0 0.6rem;

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -172,6 +172,10 @@ class PortalShell extends HTMLElement {
       clearInterval(this.snapshotInterval);
       this.snapshotInterval = undefined;
     }
+    if (this.busObservabilityInterval) {
+      clearInterval(this.busObservabilityInterval);
+      this.busObservabilityInterval = undefined;
+    }
     if (this._explorerPollTimer) {
       clearInterval(this._explorerPollTimer);
       this._explorerPollTimer = undefined;
@@ -272,6 +276,7 @@ class PortalShell extends HTMLElement {
     const sectionMap = {
       "section-registry": ["section-registry"],
       "section-semantic": ["section-semantic"],
+      "section-bus": ["section-bus"],
       "section-projection": ["section-projection"],
       "section-explorer": ["section-explorer"],
       "section-timeline": ["section-timeline", "section-provenance"],
@@ -294,6 +299,7 @@ class PortalShell extends HTMLElement {
     const metaEl = this.querySelector('[data-role="meta"]');
     const listEl = this.querySelector('[data-role="registry-list"]');
     const semanticEl = this.querySelector('[data-role="semantic-list"]');
+    const busObservabilityEl = this.querySelector('[data-role="bus-observability"]');
     const projectionEl = this.querySelector('[data-role="projection-list"]');
     const searchInput = this.querySelector('[data-role="search-input"]');
     const searchList = this.querySelector('[data-role="search-list"]');
@@ -335,6 +341,20 @@ class PortalShell extends HTMLElement {
       }
       if (capabilities.semantic && semanticEl) {
         await this.loadSemanticPreview(semanticEl);
+      }
+      if (busObservabilityEl) {
+        busObservabilityEl.innerHTML = capabilities.bus_observability
+          ? "<li>Loading bus observability...</li>"
+          : "<li>Bus observability unavailable.</li>";
+      }
+      if (capabilities.bus_observability) {
+        await this.refreshBusObservability();
+        if (this.busObservabilityInterval) {
+          clearInterval(this.busObservabilityInterval);
+        }
+        this.busObservabilityInterval = setInterval(() => {
+          this.refreshBusObservability();
+        }, 3000);
       }
       if (capabilities.projection && projectionEl) {
         await this.loadProjectionPreview(projectionEl);
@@ -429,6 +449,7 @@ class PortalShell extends HTMLElement {
     const cap = capabilities || {};
     this.setNavState("registry", cap.registry);
     this.setNavState("semantic", cap.semantic);
+    this.setNavState("bus", cap.bus_observability);
     this.setNavState("projection", cap.projection);
     this.setNavState("explorer", cap.explorer);
     this.setNavState("timeline", cap.timeline || cap.provenance);
@@ -447,6 +468,89 @@ class PortalShell extends HTMLElement {
     if (bullet) {
       bullet.classList.toggle("available", Boolean(enabled));
       bullet.classList.toggle("unavailable", !enabled);
+    }
+  }
+
+  async refreshBusObservability() {
+    const listEl = this.querySelector('[data-role="bus-observability"]');
+    const bannerEl = this.querySelector('[data-role="bus-banner"]');
+    if (!listEl || !bannerEl) {
+      return;
+    }
+    try {
+      const response = await fetch("api/v1/bus/observability");
+      if (!response.ok) {
+        throw new Error(`status ${response.status}`);
+      }
+      const payload = await response.json();
+      const summary = payload && payload.status ? payload : payload?.summary;
+      if (!summary || !summary.status) {
+        throw new Error("missing status");
+      }
+      const status = summary.status || {};
+      const capability = status.capability || {};
+      const warmup = status.warmup || {};
+      const degraded = status.degraded || {};
+      const featureFlags = status.feature_flags || {};
+      const transportClass = String(status.transport_class || "unknown");
+      const passiveState = String(warmup.state || capability.passive_state || "unknown");
+      const warmupState = passiveState === "warming_up";
+      const degradedState = !warmupState && degraded.active === true;
+      const unavailableState =
+        !warmupState &&
+        !degradedState &&
+        (passiveState === "unavailable" || capability.passive_supported === false);
+      const viewState = warmupState
+        ? "warming_up"
+        : degradedState
+          ? "degraded"
+          : unavailableState
+            ? "unavailable"
+            : "available";
+
+      const stateLabel = {
+        available: "Passive observability available",
+        warming_up: "Passive warmup in progress",
+        degraded: "Observability degraded",
+        unavailable: "Passive observability unavailable",
+      }[viewState] || "Passive observability state unknown";
+
+      const reasons = Array.isArray(degraded.reasons) ? degraded.reasons : [];
+      const endpoint = capability.endpoint_state ? ` endpoint=${capability.endpoint_state}` : "";
+      const connected = capability.tap_connected === true ? " connected" : " disconnected";
+      let bannerText = `${stateLabel} (${transportClass}${endpoint}${connected})`;
+      if (transportClass === "ebusd-tcp" && (viewState === "degraded" || viewState === "unavailable")) {
+        bannerText += " | ebusd-tcp transport limits passive observe-first coverage.";
+      }
+      bannerEl.className = `bus-banner bus-state-${viewState}`;
+      bannerEl.textContent = bannerText;
+
+      const elapsedSeconds = Number(warmup.elapsed_seconds);
+      const elapsedLabel = Number.isFinite(elapsedSeconds) ? `${formatFixed(elapsedSeconds, 1)}s` : "n/a";
+      const completedTransactions = formatInteger(warmup.completed_transactions);
+      const requiredTransactions = formatInteger(warmup.required_transactions);
+      const passiveReason = capability.passive_reason ? String(capability.passive_reason) : "none";
+      const warmupBlocker = warmup.blocker ? String(warmup.blocker) : "none";
+      const completionMode = warmup.completion_mode ? String(warmup.completion_mode) : "n/a";
+      const normalization = Array.isArray(featureFlags.normalizations) && featureFlags.normalizations.length > 0
+        ? featureFlags.normalizations.join(", ")
+        : "none";
+
+      const rows = [
+        `transport=${escapeHtml(transportClass)} passive_supported=${escapeHtml(formatYesNo(capability.passive_supported))} passive_available=${escapeHtml(formatYesNo(capability.passive_available))}`,
+        `passive_state=${escapeHtml(passiveState)} passive_reason=${escapeHtml(passiveReason)}`,
+        `warmup blocker=${escapeHtml(warmupBlocker)} elapsed=${escapeHtml(elapsedLabel)} transactions=${escapeHtml(completedTransactions)}/${escapeHtml(requiredTransactions)} completion_mode=${escapeHtml(completionMode)}`,
+        `feature_flags observe_first_enabled=${escapeHtml(formatYesNo(featureFlags.observe_first_enabled))} state_direct_apply=${escapeHtml(formatYesNo(featureFlags.passive_state_direct_apply))} config_direct_apply=${escapeHtml(formatYesNo(featureFlags.passive_config_direct_apply))} external_write_policy=${escapeHtml(String(featureFlags.external_write_policy || "n/a"))} normalizations=${escapeHtml(normalization)}`,
+      ];
+      if (reasons.length > 0) {
+        rows.push(`degraded_reasons=${escapeHtml(reasons.join(", "))}`);
+      }
+      listEl.innerHTML = rows.map((row) => `<li>${row}</li>`).join("");
+    } catch (err) {
+      bannerEl.className = "bus-banner bus-state-unavailable";
+      bannerEl.textContent = "Bus observability endpoint unavailable";
+      listEl.innerHTML = "<li>Bus observability fetch failed.</li>";
+      console.error("bus observability query failed", err);
     }
   }
 
@@ -469,6 +573,7 @@ class PortalShell extends HTMLElement {
         streamStatus.textContent = `Stream live: layer=${layer} at=${at}`;
         this.scheduleTimelineRefresh();
         this.scheduleProvenanceRefresh();
+        this.refreshBusObservability();
         this.refreshSnapshots();
       } catch (err) {
         streamStatus.textContent = "Stream payload parse error";
@@ -1576,6 +1681,7 @@ class PortalShell extends HTMLElement {
             <h2>Views</h2>
             <button data-role="nav-registry" data-nav-target="section-registry" disabled><span class="nav-bullet"></span> Registry</button>
             <button data-role="nav-semantic" data-nav-target="section-semantic" disabled><span class="nav-bullet"></span> Semantic</button>
+            <button data-role="nav-bus" data-nav-target="section-bus" disabled><span class="nav-bullet"></span> Bus</button>
             <button data-role="nav-projection" data-nav-target="section-projection" disabled><span class="nav-bullet"></span> Projection</button>
             <button data-role="nav-explorer" data-nav-target="section-explorer" disabled><span class="nav-bullet"></span> Explorer</button>
             <button data-role="nav-timeline" data-nav-target="section-timeline" disabled><span class="nav-bullet"></span> Timeline</button>
@@ -1595,6 +1701,13 @@ class PortalShell extends HTMLElement {
               <h2>Semantic Preview</h2>
               <ul data-role="semantic-list">
                 <li>Loading semantic snapshot...</li>
+              </ul>
+            </section>
+            <section id="section-bus" class="registry-preview">
+              <h2>Bus Observability</h2>
+              <div class="bus-banner bus-state-unavailable" data-role="bus-banner">Loading bus observability...</div>
+              <ul data-role="bus-observability">
+                <li>Loading bus observability...</li>
               </ul>
             </section>
             <section id="section-projection" class="registry-preview">


### PR DESCRIPTION
Closes #398

## What
Add the first narrow Portal bus observability UI slice for the observe-first rollout.

## Why
This is the first implementation step for GW-14 after GW-13 merged. It exposes bus observability state in Portal without introducing a second Portal-only semantic aggregate contract.

## Validation
- go test ./portal -count=1
- go test ./cmd/gateway -count=1
- go test -race -count=1 ./portal ./cmd/gateway
- ./scripts/build_portal_assets.sh
- go vet ./...
- go build ./...

## Notes
- `./scripts/ci_local.sh` is currently blocked by the portal asset freshness gate on the edited tree because this PR intentionally updates generated portal assets.