### PR TITLE
GW-15: add P03 canary proof verdict gate

### DIFF
--- a/scripts/passive_canary_verifier.py
+++ b/scripts/passive_canary_verifier.py
@@ -22,6 +22,9 @@ MAX_RETRIES = 3
 CANARY_PHASE_PREFIX = "canary_phase_"
 MANIFEST_SCHEMA = "p03_canary_manifest_v1"
 P03_ALLOWED_METHODS = {"get_register", "get_ext_register"}
+CANARY_VERDICT_SCHEMA = "p03_canary_verdict_v1"
+OVERALL_INTERVAL_CONCLUSIVE_MIN = 0.90
+PER_CANARY_INTERVAL_CONCLUSIVE_MIN = 0.75
 
 
 def utc_now() -> str:
@@ -275,6 +278,16 @@ def phase_sort_key(phase: str) -> Tuple[int, int, str]:
     return (1, 0, normalized)
 
 
+def is_interval_phase(phase: str) -> bool:
+    return re.fullmatch(r"sample_[0-9]+", phase.strip().lower()) is not None
+
+
+def safe_ratio(numerator: int, denominator: int) -> float:
+    if denominator <= 0:
+        return 0.0
+    return float(numerator) / float(denominator)
+
+
 def verify_phase(
     canaries: List[CanarySpec],
     graphql_url: str,
@@ -391,8 +404,10 @@ def summarize_run(
     phases_seen = set()
     interval_phase_count = 0
     totals = {"results": 0, "pass": 0, "mismatch": 0, "inconclusive": 0, "conclusive": 0}
+    interval_totals = {"results": 0, "pass": 0, "mismatch": 0, "inconclusive": 0, "conclusive": 0}
     per_canary: Dict[str, Dict[str, Any]] = {}
-    phase_payloads: List[Tuple[Tuple[int, int, str], Dict[str, Any]]] = []
+    per_canary_interval: Dict[str, Dict[str, Any]] = {}
+    phase_payloads: List[Tuple[Tuple[int, int, str], str, Dict[str, Any]]] = []
     for path in phase_files:
         payload = load_json(path)
         if not isinstance(payload, dict):
@@ -400,11 +415,12 @@ def summarize_run(
         phase = str(payload.get("phase", "")).strip()
         if phase:
             phases_seen.add(phase)
-            if re.fullmatch(r"sample_[0-9]+", phase):
+            if is_interval_phase(phase):
                 interval_phase_count += 1
-        phase_payloads.append((phase_sort_key(phase), payload))
+        phase_payloads.append((phase_sort_key(phase), phase, payload))
 
-    for _, payload in sorted(phase_payloads, key=lambda item: item[0]):
+    for _, phase, payload in sorted(phase_payloads, key=lambda item: item[0]):
+        interval_phase = is_interval_phase(phase)
         entries = payload.get("results")
         if not isinstance(entries, list):
             continue
@@ -428,6 +444,19 @@ def summarize_run(
                 canary_bucket["conclusive"] += 1
             canary_bucket["last_status"] = status
 
+            if interval_phase:
+                interval_totals["results"] += 1
+                interval_totals[status] += 1
+                if status in ("pass", "mismatch"):
+                    interval_totals["conclusive"] += 1
+                canary_interval_bucket = per_canary_interval.setdefault(
+                    canary_id,
+                    {"pass": 0, "mismatch": 0, "inconclusive": 0, "conclusive": 0},
+                )
+                canary_interval_bucket[status] += 1
+                if status in ("pass", "mismatch"):
+                    canary_interval_bucket["conclusive"] += 1
+
     if "start" not in phases_seen or "end" not in phases_seen:
         raise ValueError("missing current-run start/end canary artifacts (stale artifact rejection)")
     if require_interval_phase and interval_phase_count < 1:
@@ -446,8 +475,106 @@ def summarize_run(
         "interval_phase_count": interval_phase_count,
         "interval_phase_required": require_interval_phase,
         "totals": totals,
+        "interval_totals": interval_totals,
         "per_canary": per_canary,
+        "per_canary_interval": per_canary_interval,
         "overall_conclusive_count": totals["conclusive"],
+        "overall_interval_conclusive_count": interval_totals["conclusive"],
+    }
+
+
+def build_canary_verdict(summary: Dict[str, Any]) -> Dict[str, Any]:
+    if not isinstance(summary, dict):
+        raise ValueError("summary must be a JSON object")
+
+    totals = summary.get("totals")
+    if not isinstance(totals, dict):
+        totals = {}
+    interval_totals = summary.get("interval_totals")
+    if not isinstance(interval_totals, dict):
+        interval_totals = {}
+    per_canary = summary.get("per_canary")
+    if not isinstance(per_canary, dict):
+        per_canary = {}
+    per_canary_interval = summary.get("per_canary_interval")
+    if not isinstance(per_canary_interval, dict):
+        per_canary_interval = {}
+
+    mismatch_count = int(totals.get("mismatch", 0) or 0)
+    no_mismatches_ok = mismatch_count == 0
+
+    interval_required = bool(summary.get("interval_phase_required", True))
+    overall_interval_total = int(interval_totals.get("results", 0) or 0)
+    overall_interval_conclusive = int(interval_totals.get("conclusive", 0) or 0)
+    overall_interval_rate = safe_ratio(overall_interval_conclusive, overall_interval_total)
+    if interval_required:
+        overall_interval_ok = overall_interval_rate >= OVERALL_INTERVAL_CONCLUSIVE_MIN
+        overall_interval_waived = False
+    else:
+        overall_interval_ok = True
+        overall_interval_waived = True
+
+    per_canary_details: Dict[str, Dict[str, Any]] = {}
+    failing_canaries: List[str] = []
+    for canary_id in sorted(per_canary.keys()):
+        bucket = per_canary_interval.get(canary_id)
+        if not isinstance(bucket, dict):
+            bucket = {}
+        pass_count = int(bucket.get("pass", 0) or 0)
+        mismatch_bucket = int(bucket.get("mismatch", 0) or 0)
+        inconclusive_count = int(bucket.get("inconclusive", 0) or 0)
+        interval_total = pass_count + mismatch_bucket + inconclusive_count
+        interval_conclusive = int(bucket.get("conclusive", pass_count + mismatch_bucket) or 0)
+        interval_rate = safe_ratio(interval_conclusive, interval_total)
+        if interval_required:
+            canary_ok = interval_rate >= PER_CANARY_INTERVAL_CONCLUSIVE_MIN
+            canary_waived = False
+        else:
+            canary_ok = True
+            canary_waived = True
+        if not canary_ok:
+            failing_canaries.append(canary_id)
+        per_canary_details[canary_id] = {
+            "interval_conclusive": interval_conclusive,
+            "interval_total": interval_total,
+            "interval_conclusive_rate": interval_rate,
+            "threshold": PER_CANARY_INTERVAL_CONCLUSIVE_MIN,
+            "ok": canary_ok,
+            "waived": canary_waived,
+        }
+
+    per_canary_ok = len(failing_canaries) == 0
+    verdict_ok = no_mismatches_ok and overall_interval_ok and per_canary_ok
+
+    return {
+        "schema": CANARY_VERDICT_SCHEMA,
+        "captured_at": utc_now(),
+        "run_id": str(summary.get("run_id", "")).strip(),
+        "summary_schema": str(summary.get("schema", "")).strip(),
+        "ok": verdict_ok,
+        "status": "pass" if verdict_ok else "fail",
+        "criteria": {
+            "no_mismatches": {
+                "ok": no_mismatches_ok,
+                "mismatch_count": mismatch_count,
+            },
+            "overall_interval_conclusive_rate": {
+                "ok": overall_interval_ok,
+                "waived": overall_interval_waived,
+                "interval_conclusive": overall_interval_conclusive,
+                "interval_total": overall_interval_total,
+                "interval_conclusive_rate": overall_interval_rate,
+                "threshold": OVERALL_INTERVAL_CONCLUSIVE_MIN,
+            },
+            "per_canary_interval_conclusive_rate": {
+                "ok": per_canary_ok,
+                "waived": not interval_required,
+                "threshold": PER_CANARY_INTERVAL_CONCLUSIVE_MIN,
+                "failing_canaries": failing_canaries,
+                "canaries_evaluated": len(per_canary_details),
+            },
+        },
+        "per_canary": per_canary_details,
     }
 
 
@@ -507,6 +634,13 @@ def summarize_command(args: argparse.Namespace) -> int:
     return 0
 
 
+def verdict_command(args: argparse.Namespace) -> int:
+    summary = load_json(pathlib.Path(args.summary))
+    verdict = build_canary_verdict(summary)
+    write_json(pathlib.Path(args.output), verdict)
+    return 0 if bool(verdict.get("ok", False)) else 1
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="P03 canary manifest verifier")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -534,6 +668,11 @@ def build_parser() -> argparse.ArgumentParser:
     summarize.add_argument("--output", required=True)
     summarize.add_argument("--require-interval-phase", choices=("0", "1"), default="1")
     summarize.set_defaults(func=summarize_command)
+
+    verdict = sub.add_parser("verdict", help="build proof-mode canary verdict from summary")
+    verdict.add_argument("--summary", required=True)
+    verdict.add_argument("--output", required=True)
+    verdict.set_defaults(func=verdict_command)
     return parser
 
 

--- a/scripts/passive_canary_verifier_test.py
+++ b/scripts/passive_canary_verifier_test.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 import json
+import os
 import pathlib
+import subprocess
 import sys
 import tempfile
+import textwrap
 import unittest
 
 SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
@@ -341,6 +344,294 @@ class StaleArtifactRejectionTests(unittest.TestCase):
             summary = verifier.summarize_run(proof_dir, "run-1", require_interval_phase=False)
             self.assertEqual(summary["interval_phase_count"], 0)
             self.assertFalse(summary["interval_phase_required"])
+
+
+class CanaryVerdictTests(unittest.TestCase):
+    def build_summary_payload(
+        self,
+        *,
+        mismatch_count: int,
+        interval_required: bool,
+        interval_results: int,
+        interval_conclusive: int,
+        per_canary_interval: dict[str, dict[str, int]],
+    ) -> dict:
+        per_canary = {canary_id: {"last_status": "pass"} for canary_id in per_canary_interval}
+        return {
+            "schema": "p03_canary_overall_summary_v1",
+            "run_id": "run-1",
+            "interval_phase_required": interval_required,
+            "totals": {
+                "results": 20,
+                "pass": 20 - mismatch_count,
+                "mismatch": mismatch_count,
+                "inconclusive": 0,
+                "conclusive": 20,
+            },
+            "interval_totals": {
+                "results": interval_results,
+                "conclusive": interval_conclusive,
+                "pass": max(interval_conclusive - mismatch_count, 0),
+                "mismatch": mismatch_count,
+                "inconclusive": max(interval_results - interval_conclusive, 0),
+            },
+            "per_canary": per_canary,
+            "per_canary_interval": per_canary_interval,
+        }
+
+    def test_verdict_fails_on_any_mismatch(self) -> None:
+        summary = self.build_summary_payload(
+            mismatch_count=1,
+            interval_required=True,
+            interval_results=10,
+            interval_conclusive=10,
+            per_canary_interval={
+                "a": {"pass": 5, "mismatch": 0, "inconclusive": 0, "conclusive": 5},
+                "b": {"pass": 4, "mismatch": 1, "inconclusive": 0, "conclusive": 5},
+            },
+        )
+        verdict = verifier.build_canary_verdict(summary)
+        self.assertFalse(verdict["ok"])
+        self.assertFalse(verdict["criteria"]["no_mismatches"]["ok"])
+
+    def test_verdict_fails_when_overall_interval_conclusive_ratio_below_threshold(self) -> None:
+        summary = self.build_summary_payload(
+            mismatch_count=0,
+            interval_required=True,
+            interval_results=10,
+            interval_conclusive=8,
+            per_canary_interval={
+                "a": {"pass": 4, "mismatch": 0, "inconclusive": 1, "conclusive": 4},
+                "b": {"pass": 4, "mismatch": 0, "inconclusive": 1, "conclusive": 4},
+            },
+        )
+        verdict = verifier.build_canary_verdict(summary)
+        self.assertFalse(verdict["ok"])
+        self.assertFalse(verdict["criteria"]["overall_interval_conclusive_rate"]["ok"])
+
+    def test_verdict_fails_when_any_canary_interval_conclusive_ratio_below_threshold(self) -> None:
+        summary = self.build_summary_payload(
+            mismatch_count=0,
+            interval_required=True,
+            interval_results=20,
+            interval_conclusive=18,
+            per_canary_interval={
+                "a": {"pass": 9, "mismatch": 0, "inconclusive": 0, "conclusive": 9},
+                "b": {"pass": 9, "mismatch": 0, "inconclusive": 0, "conclusive": 9},
+                "c": {"pass": 0, "mismatch": 0, "inconclusive": 2, "conclusive": 0},
+            },
+        )
+        verdict = verifier.build_canary_verdict(summary)
+        self.assertFalse(verdict["ok"])
+        self.assertFalse(verdict["criteria"]["per_canary_interval_conclusive_rate"]["ok"])
+        self.assertEqual(verdict["criteria"]["per_canary_interval_conclusive_rate"]["failing_canaries"], ["c"])
+
+    def test_verdict_passes_when_all_thresholds_are_healthy(self) -> None:
+        summary = self.build_summary_payload(
+            mismatch_count=0,
+            interval_required=True,
+            interval_results=10,
+            interval_conclusive=9,
+            per_canary_interval={
+                "a": {"pass": 4, "mismatch": 0, "inconclusive": 1, "conclusive": 4},
+                "b": {"pass": 5, "mismatch": 0, "inconclusive": 0, "conclusive": 5},
+            },
+        )
+        verdict = verifier.build_canary_verdict(summary)
+        self.assertTrue(verdict["ok"])
+        self.assertTrue(verdict["criteria"]["no_mismatches"]["ok"])
+        self.assertTrue(verdict["criteria"]["overall_interval_conclusive_rate"]["ok"])
+        self.assertTrue(verdict["criteria"]["per_canary_interval_conclusive_rate"]["ok"])
+
+    def test_verdict_waives_interval_thresholds_when_interval_phase_not_required(self) -> None:
+        summary = self.build_summary_payload(
+            mismatch_count=0,
+            interval_required=False,
+            interval_results=0,
+            interval_conclusive=0,
+            per_canary_interval={
+                "a": {"pass": 0, "mismatch": 0, "inconclusive": 0, "conclusive": 0},
+                "b": {"pass": 0, "mismatch": 0, "inconclusive": 0, "conclusive": 0},
+            },
+        )
+        verdict = verifier.build_canary_verdict(summary)
+        self.assertTrue(verdict["ok"])
+        self.assertTrue(verdict["criteria"]["overall_interval_conclusive_rate"]["waived"])
+        self.assertTrue(verdict["criteria"]["per_canary_interval_conclusive_rate"]["waived"])
+
+
+class PassiveSmokeCanaryVerdictGateTests(unittest.TestCase):
+    def run_smoke_with_fake_tools(self, canary_status: str) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = pathlib.Path(temp_dir)
+            fake_bin = temp_path / "bin"
+            fake_bin.mkdir(parents=True, exist_ok=True)
+            log_dir = temp_path / "logs"
+            log_dir.mkdir(parents=True, exist_ok=True)
+
+            fake_python = fake_bin / "python3"
+            fake_python.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    real_python="${REAL_PYTHON3:?REAL_PYTHON3 is required}"
+
+                    if [[ "$#" -ge 2 && "$1" == *"/scripts/passive_canary_verifier.py" && "$2" == "verify-phase" ]]; then
+                      shift 2
+                      output=""
+                      phase=""
+                      run_id=""
+                      baseline=""
+                      while [[ "$#" -gt 0 ]]; do
+                        case "$1" in
+                          --output) output="$2"; shift 2 ;;
+                          --phase) phase="$2"; shift 2 ;;
+                          --run-id) run_id="$2"; shift 2 ;;
+                          --baseline) baseline="$2"; shift 2 ;;
+                          *) shift ;;
+                        esac
+                      done
+                      status="${FAKE_CANARY_STATUS:-pass}"
+                      pass_count=0
+                      mismatch_count=0
+                      if [[ "${status}" == "pass" ]]; then
+                        pass_count=1
+                      elif [[ "${status}" == "mismatch" ]]; then
+                        mismatch_count=1
+                      fi
+                      mkdir -p "$(dirname "${output}")"
+                      cat > "${output}" <<JSON
+                    {
+                      "schema": "p03_canary_phase_result_v1",
+                      "run_id": "${run_id}",
+                      "phase": "${phase}",
+                      "results": [
+                        {
+                          "id": "canary_1",
+                          "family": "B524",
+                          "status": "${status}",
+                          "conclusive": true
+                        }
+                      ],
+                      "summary": {
+                        "total": 1,
+                        "pass": ${pass_count},
+                        "mismatch": ${mismatch_count},
+                        "inconclusive": 0,
+                        "conclusive": 1
+                      }
+                    }
+                    JSON
+                      if [[ -n "${baseline}" ]]; then
+                        mkdir -p "$(dirname "${baseline}")"
+                        printf '{"canary_1":"BEEF"}\\n' > "${baseline}"
+                      fi
+                      exit 0
+                    fi
+
+                    exec "${real_python}" "$@"
+                    """
+                ),
+                encoding="utf-8",
+            )
+            fake_python.chmod(0o755)
+
+            fake_curl = fake_bin / "curl"
+            fake_curl.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+
+                    url="${@: -1}"
+                    data=""
+                    while [[ "$#" -gt 0 ]]; do
+                      case "$1" in
+                        -d)
+                          data="$2"
+                          shift 2
+                          ;;
+                        *)
+                          shift
+                          ;;
+                      esac
+                    done
+
+                    if [[ "${url}" == *"/metrics" ]]; then
+                      cat <<'EOF'
+                    ebus_passive_capability_probe_outcomes_total{outcome="timed_out"} 0
+                    ebus_passive_tap_connected 1
+                    ebus_passive_warmup_state{state="available"} 1
+                    ebus_passive_capability_probe_outcomes_total{outcome="confirmed"} 1
+                    EOF
+                      exit 0
+                    fi
+
+                    if [[ "${url}" == *"/portal/api/v1/bus/observability" ]]; then
+                      cat <<'EOF'
+                    {"summary":{"status":{"feature_flags":{"observeFirstEnabled":true}}}}
+                    EOF
+                      exit 0
+                    fi
+
+                    if [[ "${url}" == *"/graphql" ]]; then
+                      if [[ "${data}" == *"busSummary"* ]]; then
+                        cat <<'EOF'
+                    {"data":{"busSummary":{"status":{"featureFlags":{"observeFirstEnabled":true}}},"watchSummary":{"inventory":{"totalEntries":1},"activationCounts":{"catalogDescriptors":1,"activeKeys":1,"sourceClasses":[]},"directApplyEligibilityClasses":[],"degraded":{"active":false,"shadowingEnabled":false,"pinnedBudgetDegraded":false,"compactorDegraded":false,"reasons":[]}}}}
+                    EOF
+                        exit 0
+                      fi
+                      cat <<'EOF'
+                    {"data":{"devices":[{"address":"0x15","deviceId":"BASV2"}]}}
+                    EOF
+                      exit 0
+                    fi
+
+                    echo "unsupported fake curl url: ${url}" >&2
+                    exit 22
+                    """
+                ),
+                encoding="utf-8",
+            )
+            fake_curl.chmod(0o755)
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "MATRIX_CASE_ID": "P03",
+                    "MATRIX_PASSIVE_MODE": "required",
+                    "MATRIX_GW15_PROOF_MODE": "1",
+                    "PASSIVE_SMOKE_TIMEOUT_SEC": "6",
+                    "PASSIVE_SMOKE_POLL_INTERVAL_SEC": "1",
+                    "PASSIVE_PROOF_SAMPLE_INTERVAL_SEC": "3600",
+                    "MATRIX_LOG_DIR": str(log_dir),
+                    "MATRIX_GATEWAY_BASE_URL": "http://fake-gateway:18083",
+                    "MATRIX_GRAPHQL_URL": "http://fake-gateway:18083/graphql",
+                    "MATRIX_METRICS_URL": "http://fake-gateway:18083/metrics",
+                    "REAL_PYTHON3": sys.executable,
+                    "FAKE_CANARY_STATUS": canary_status,
+                    "PATH": f"{fake_bin}:{env.get('PATH', '')}",
+                }
+            )
+            script_path = SCRIPT_DIR / "passive_smoke_check.sh"
+            return subprocess.run(
+                ["bash", str(script_path)],
+                cwd=SCRIPT_DIR.parent,
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+    def test_smoke_exits_non_zero_when_canary_verdict_is_bad(self) -> None:
+        result = self.run_smoke_with_fake_tools("mismatch")
+        self.assertNotEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("canary verdict gate failed", result.stderr)
+
+    def test_smoke_exits_zero_when_canary_verdict_is_good(self) -> None:
+        result = self.run_smoke_with_fake_tools("pass")
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/passive_smoke_check.sh
+++ b/scripts/passive_smoke_check.sh
@@ -82,6 +82,7 @@ canary_manifest_path="${PASSIVE_P03_CANARY_MANIFEST:-${REPO_ROOT}/testdata/passi
 canary_manifest_validation_path="${proof_dir}/canary_manifest_validation.json"
 canary_baseline_path="${proof_dir}/canary_baseline.json"
 canary_summary_path="${proof_dir}/canary_summary.json"
+canary_verdict_path="${proof_dir}/canary_verdict.json"
 canary_retries_raw="${PASSIVE_CANARY_MAX_RETRIES:-3}"
 canary_retries=3
 canary_enabled=0
@@ -399,6 +400,12 @@ build_canary_summary() {
     --output "${canary_summary_path}"
 }
 
+build_canary_verdict() {
+  python3 "${canary_verifier_script}" verdict \
+    --summary "${canary_summary_path}" \
+    --output "${canary_verdict_path}"
+}
+
 if [[ "${proof_artifacts_enabled}" == "1" ]]; then
   start_captured=0
   for _ in $(seq 1 5); do
@@ -480,6 +487,10 @@ if [[ "${proof_artifacts_enabled}" == "1" ]]; then
     fi
     if ! build_canary_summary "${canary_require_interval_phase}"; then
       echo "proof mode: failed to build canary summary" >&2
+      exit 1
+    fi
+    if ! build_canary_verdict; then
+      echo "proof mode: canary verdict gate failed (see ${canary_verdict_path})" >&2
       exit 1
     fi
   fi


### PR DESCRIPTION
## What
Add fail-closed P03 canary verdict enforcement to proof-mode smoke.

## Why
GW-15 now produces P03 canary artifacts, but the proof path still goes green without enforcing mismatch or conclusive-coverage thresholds. This slice turns those artifacts into an actual proof gate under parent issue #400.

## Acceptance Criteria
- [ ] Any canary mismatch fails the proof verdict
- [ ] Overall scheduled-interval conclusive rate below 90% fails the proof verdict
- [ ] Any canary scheduled-interval conclusive rate below 75% fails the proof verdict
- [ ] Bounded-run interval waiver preserves mismatch failure while waiving interval-rate failure when interval evidence is intentionally not required
- [ ] Proof mode exits non-zero on bad verdict while still writing the verdict artifact
- [ ] Unit tests cover the verdict logic and shell-path failure propagation
- [ ] CI green
- [ ] Smoke test required: NO

## Dependencies
- Depends on #400
- Follows merged bounded slices #401 and #402