### PR TITLE
GW-15: canonicalize P03 proof gating and canary manifest

### DIFF
--- a/bus_observability_api.go
+++ b/bus_observability_api.go
@@ -37,12 +37,19 @@ type BusObservabilityDegraded struct {
 	Reasons []string `json:"reasons,omitempty"`
 }
 
+type BusObservabilityStartup struct {
+	Phase      string `json:"phase"`
+	CacheEpoch uint64 `json:"cache_epoch"`
+	LiveEpoch  uint64 `json:"live_epoch"`
+}
+
 type BusObservabilityStatus struct {
 	TransportClass string                        `json:"transport_class"`
 	Capability     BusObservabilityCapability    `json:"capability"`
 	Warmup         BusObservabilityWarmup        `json:"warmup"`
 	TimingQuality  BusObservabilityTimingQuality `json:"timing_quality"`
 	Degraded       BusObservabilityDegraded      `json:"degraded"`
+	Startup        *BusObservabilityStartup      `json:"startup,omitempty"`
 	FeatureFlags   ObserveFirstFeatureFlagState  `json:"feature_flags"`
 }
 
@@ -74,6 +81,8 @@ func (store *BusObservabilityStore) Snapshot() BusObservabilitySnapshot {
 		return BusObservabilitySnapshot{}
 	}
 
+	startup := store.startupSurface()
+
 	store.mu.Lock()
 	defer store.mu.Unlock()
 
@@ -83,7 +92,7 @@ func (store *BusObservabilityStore) Snapshot() BusObservabilitySnapshot {
 	store.evictStalePeriodicityLocked(now)
 
 	return BusObservabilitySnapshot{
-		Summary:     store.summaryLocked(now, reconstructor.TapStatus),
+		Summary:     store.summaryLocked(now, reconstructor.TapStatus, startup),
 		Messages:    store.recentMessagesLocked(store.recentLen),
 		Periodicity: store.periodicitySnapshotLocked(),
 	}
@@ -129,7 +138,7 @@ func (store *BusObservabilityStore) periodicitySnapshotLocked() []BusPeriodicity
 	return items
 }
 
-func (store *BusObservabilityStore) summaryLocked(now time.Time, tapStatus PassiveTapStatus) BusObservabilitySummary {
+func (store *BusObservabilityStore) summaryLocked(now time.Time, tapStatus PassiveTapStatus, startup *BusObservabilityStartup) BusObservabilitySummary {
 	passiveSupported := store.cfg.BroadcastListen && PassiveTransportSupported(store.cfg)
 	reasons := make([]string, 0, 2)
 	if store.passive.state == "unavailable" && store.passive.unavailableReason != "" {
@@ -175,6 +184,7 @@ func (store *BusObservabilityStore) summaryLocked(now time.Time, tapStatus Passi
 				Active:  len(reasons) > 0,
 				Reasons: reasons,
 			},
+			Startup:      cloneBusObservabilityStartup(startup),
 			FeatureFlags: store.cfg.ObserveFirstFlags.State(),
 		},
 		Messages: BusObservabilityBoundedList{
@@ -190,4 +200,12 @@ func (store *BusObservabilityStore) summaryLocked(now time.Time, tapStatus Passi
 			PeriodicityBudgetOverflowTotal: store.periodicityOverflowTotal,
 		},
 	}
+}
+
+func cloneBusObservabilityStartup(source *BusObservabilityStartup) *BusObservabilityStartup {
+	if source == nil {
+		return nil
+	}
+	out := *source
+	return &out
 }

--- a/bus_observability_store.go
+++ b/bus_observability_store.go
@@ -85,6 +85,8 @@ type BusObservabilityStore struct {
 
 	passive passiveWarmupRuntime
 
+	startupSurfaceProvider func() *BusObservabilityStartup
+
 	energyFreshnessMetricsRefresher func(now time.Time, passiveState string)
 }
 
@@ -242,6 +244,28 @@ func NewBusObservabilityStore(cfg Config) *BusObservabilityStore {
 		store.passive.unavailableReason = reason
 	}
 	return store
+}
+
+func (store *BusObservabilityStore) SetStartupSurfaceProvider(provider func() *BusObservabilityStartup) {
+	if store == nil {
+		return
+	}
+	store.mu.Lock()
+	store.startupSurfaceProvider = provider
+	store.mu.Unlock()
+}
+
+func (store *BusObservabilityStore) startupSurface() *BusObservabilityStartup {
+	if store == nil {
+		return nil
+	}
+	store.mu.RLock()
+	provider := store.startupSurfaceProvider
+	store.mu.RUnlock()
+	if provider == nil {
+		return nil
+	}
+	return cloneBusObservabilityStartup(provider())
 }
 
 func (store *BusObservabilityStore) OnBusEvent(event protocol.BusEvent) error {

--- a/bus_observability_store_test.go
+++ b/bus_observability_store_test.go
@@ -222,6 +222,30 @@ func TestBusObservabilityStoreExportsNormalizedFeatureFlags(t *testing.T) {
 	}
 }
 
+func TestBusObservabilityStoreIncludesStartupSurfaceInSnapshot(t *testing.T) {
+	cfg := DefaultConfig()
+	store := NewBusObservabilityStore(cfg)
+	store.SetStartupSurfaceProvider(func() *BusObservabilityStartup {
+		return &BusObservabilityStartup{
+			Phase:      string(graphql.SemanticStartupPhaseLiveReady),
+			CacheEpoch: 2,
+			LiveEpoch:  5,
+		}
+	})
+
+	snapshot := store.Snapshot()
+	startup := snapshot.Summary.Status.Startup
+	if startup == nil {
+		t.Fatal("Snapshot().Summary.Status.Startup = nil; want startup surface")
+	}
+	if startup.Phase != string(graphql.SemanticStartupPhaseLiveReady) {
+		t.Fatalf("Startup.Phase = %q; want LIVE_READY", startup.Phase)
+	}
+	if startup.CacheEpoch != 2 || startup.LiveEpoch != 5 {
+		t.Fatalf("Startup epochs = (%d,%d); want (2,5)", startup.CacheEpoch, startup.LiveEpoch)
+	}
+}
+
 func TestBusObservabilityStoreKeepsUnsupportedPassiveTransportOutOfStartupTimeout(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.BroadcastListen = true

--- a/cmd/gateway/bus_observability_provider.go
+++ b/cmd/gateway/bus_observability_provider.go
@@ -117,6 +117,7 @@ func mapGraphQLBusStatus(status ebusgateway.BusObservabilityStatus) *graphql.Bus
 			Active:  status.Degraded.Active,
 			Reasons: append([]string(nil), status.Degraded.Reasons...),
 		},
+		Startup: mapGraphQLBusStartup(status.Startup),
 		FeatureFlags: graphql.ObserveFirstFeatureFlagState{
 			ObserveFirstEnabled:      status.FeatureFlags.ObserveFirstEnabled,
 			PassiveStateDirectApply:  status.FeatureFlags.PassiveStateDirectApply,
@@ -158,6 +159,7 @@ func mapMCPBusStatus(status ebusgateway.BusObservabilityStatus) *mcp.BusObservab
 			Active:  status.Degraded.Active,
 			Reasons: append([]string(nil), status.Degraded.Reasons...),
 		},
+		Startup: mapMCPBusStartup(status.Startup),
 		FeatureFlags: mcp.ObserveFirstFeatureFlagState{
 			ObserveFirstEnabled:      status.FeatureFlags.ObserveFirstEnabled,
 			PassiveStateDirectApply:  status.FeatureFlags.PassiveStateDirectApply,
@@ -165,6 +167,28 @@ func mapMCPBusStatus(status ebusgateway.BusObservabilityStatus) *mcp.BusObservab
 			ExternalWritePolicy:      string(status.FeatureFlags.ExternalWritePolicy),
 			Normalizations:           append([]string(nil), status.FeatureFlags.Normalizations...),
 		},
+	}
+}
+
+func mapGraphQLBusStartup(startup *ebusgateway.BusObservabilityStartup) *graphql.BusObservabilityStartup {
+	if startup == nil {
+		return nil
+	}
+	return &graphql.BusObservabilityStartup{
+		Phase:      startup.Phase,
+		CacheEpoch: startup.CacheEpoch,
+		LiveEpoch:  startup.LiveEpoch,
+	}
+}
+
+func mapMCPBusStartup(startup *ebusgateway.BusObservabilityStartup) *mcp.BusObservabilityStartup {
+	if startup == nil {
+		return nil
+	}
+	return &mcp.BusObservabilityStartup{
+		Phase:      startup.Phase,
+		CacheEpoch: startup.CacheEpoch,
+		LiveEpoch:  startup.LiveEpoch,
 	}
 }
 

--- a/cmd/gateway/graphql_bus_observability_integration_test.go
+++ b/cmd/gateway/graphql_bus_observability_integration_test.go
@@ -27,6 +27,13 @@ func TestGraphQLBusObservabilityProviderAdapter_ParityWithMCPAdapter(t *testing.
 	if store == nil {
 		t.Fatal("NewBusObservabilityStore() = nil")
 	}
+	store.SetStartupSurfaceProvider(func() *ebusgateway.BusObservabilityStartup {
+		return &ebusgateway.BusObservabilityStartup{
+			Phase:      string(graphql.SemanticStartupPhaseLiveReady),
+			CacheEpoch: 4,
+			LiveEpoch:  9,
+		}
+	})
 
 	if err := store.OnBusEvent(protocol.BusEvent{
 		Kind: protocol.BusEventAttemptComplete,
@@ -68,6 +75,13 @@ func TestRun_WiresBusObservabilityIntoGraphQLQueries(t *testing.T) {
 
 	wireObserveFirstObserversFn = func(cfg *ebusgateway.Config) (*ebusgateway.BusObservabilityStore, *ebusgateway.ActivePassiveDeduplicator, error) {
 		store := ebusgateway.NewBusObservabilityStore(*cfg)
+		store.SetStartupSurfaceProvider(func() *ebusgateway.BusObservabilityStartup {
+			return &ebusgateway.BusObservabilityStartup{
+				Phase:      string(graphql.SemanticStartupPhaseLiveReady),
+				CacheEpoch: 1,
+				LiveEpoch:  3,
+			}
+		})
 		if err := store.OnBusEvent(protocol.BusEvent{
 			Kind: protocol.BusEventAttemptComplete,
 			Request: protocol.Frame{
@@ -102,7 +116,7 @@ func TestRun_WiresBusObservabilityIntoGraphQLQueries(t *testing.T) {
 			t.Fatalf("NewInvokeHandler error = %v", err)
 		}
 
-		body := bytes.NewBufferString(`{"query":"{ busSummary { messages { count capacity } status { transportClass capability { activeSupported } } } busMessages(limit: 1) { count items { family sourceAddress targetAddress } } }"}`)
+		body := bytes.NewBufferString(`{"query":"{ busSummary { messages { count capacity } status { transportClass capability { activeSupported } startup { phase cacheEpoch liveEpoch } } } busMessages(limit: 1) { count items { family sourceAddress targetAddress } } }"}`)
 		req := httptest.NewRequest(http.MethodPost, cfg.GraphQLPath, body)
 		req.Header.Set("Content-Type", "application/json")
 		rec := httptest.NewRecorder()
@@ -124,6 +138,11 @@ func TestRun_WiresBusObservabilityIntoGraphQLQueries(t *testing.T) {
 						Capability     struct {
 							ActiveSupported bool `json:"activeSupported"`
 						} `json:"capability"`
+						Startup struct {
+							Phase      string `json:"phase"`
+							CacheEpoch string `json:"cacheEpoch"`
+							LiveEpoch  string `json:"liveEpoch"`
+						} `json:"startup"`
 					} `json:"status"`
 				} `json:"busSummary"`
 				BusMessages struct {
@@ -151,6 +170,12 @@ func TestRun_WiresBusObservabilityIntoGraphQLQueries(t *testing.T) {
 		}
 		if !response.Data.BusSummary.Status.Capability.ActiveSupported {
 			t.Fatal("busSummary.status.capability.activeSupported = false; want true")
+		}
+		if response.Data.BusSummary.Status.Startup.Phase != string(graphql.SemanticStartupPhaseBootInit) {
+			t.Fatalf("busSummary.status.startup.phase = %q; want BOOT_INIT", response.Data.BusSummary.Status.Startup.Phase)
+		}
+		if response.Data.BusSummary.Status.Startup.CacheEpoch != "0" || response.Data.BusSummary.Status.Startup.LiveEpoch != "0" {
+			t.Fatalf("busSummary.status.startup epochs = (%s,%s); want (0,0)", response.Data.BusSummary.Status.Startup.CacheEpoch, response.Data.BusSummary.Status.Startup.LiveEpoch)
 		}
 		if response.Data.BusMessages.Count != 1 || len(response.Data.BusMessages.Items) != 1 {
 			t.Fatalf("busMessages = %+v; want one wired item", response.Data.BusMessages)
@@ -263,6 +288,14 @@ func graphQLStatusToMCP(status *graphql.BusObservabilityStatus) *mcp.BusObservab
 	if status == nil {
 		return nil
 	}
+	var startup *mcp.BusObservabilityStartup
+	if status.Startup != nil {
+		startup = &mcp.BusObservabilityStartup{
+			Phase:      status.Startup.Phase,
+			CacheEpoch: status.Startup.CacheEpoch,
+			LiveEpoch:  status.Startup.LiveEpoch,
+		}
+	}
 	return &mcp.BusObservabilityStatus{
 		TransportClass: status.TransportClass,
 		Capability: mcp.BusObservabilityCapability{
@@ -293,6 +326,7 @@ func graphQLStatusToMCP(status *graphql.BusObservabilityStatus) *mcp.BusObservab
 			Active:  status.Degraded.Active,
 			Reasons: append([]string(nil), status.Degraded.Reasons...),
 		},
+		Startup: startup,
 		FeatureFlags: mcp.ObserveFirstFeatureFlagState{
 			ObserveFirstEnabled:      status.FeatureFlags.ObserveFirstEnabled,
 			PassiveStateDirectApply:  status.FeatureFlags.PassiveStateDirectApply,

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -113,6 +113,14 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 	semanticRuntime.SetBootLiveTimeout(cfg.BootLiveTimeout)
 	semanticRuntime.Start(ctx)
 	if busObservability != nil && semanticRuntime.Provider() != nil {
+		busObservability.SetStartupSurfaceProvider(func() *ebusgateway.BusObservabilityStartup {
+			cacheEpoch, liveEpoch := semanticRuntime.Provider().StartupEpochs()
+			return &ebusgateway.BusObservabilityStartup{
+				Phase:      string(semanticRuntime.Provider().StartupPhase()),
+				CacheEpoch: cacheEpoch,
+				LiveEpoch:  liveEpoch,
+			}
+		})
 		semanticRuntime.Provider().SetEnergyPassiveStateProvider(func() string {
 			snapshot := busObservability.Snapshot()
 			return snapshot.Summary.Status.Capability.PassiveState

--- a/graphql/bus_observability.go
+++ b/graphql/bus_observability.go
@@ -41,12 +41,19 @@ type BusObservabilityDegraded struct {
 	Reasons []string
 }
 
+type BusObservabilityStartup struct {
+	Phase      string
+	CacheEpoch uint64
+	LiveEpoch  uint64
+}
+
 type BusObservabilityStatus struct {
 	TransportClass string
 	Capability     BusObservabilityCapability
 	Warmup         BusObservabilityWarmup
 	TimingQuality  BusObservabilityTimingQuality
 	Degraded       BusObservabilityDegraded
+	Startup        *BusObservabilityStartup
 	FeatureFlags   ObserveFirstFeatureFlagState
 }
 
@@ -205,12 +212,21 @@ func cloneBusObservabilityStatus(source *BusObservabilityStatus) *BusObservabili
 		return nil
 	}
 	out := *source
+	out.Startup = cloneBusObservabilityStartup(source.Startup)
 	if len(source.Degraded.Reasons) > 0 {
 		out.Degraded.Reasons = append([]string(nil), source.Degraded.Reasons...)
 	}
 	if len(source.FeatureFlags.Normalizations) > 0 {
 		out.FeatureFlags.Normalizations = append([]string(nil), source.FeatureFlags.Normalizations...)
 	}
+	return &out
+}
+
+func cloneBusObservabilityStartup(source *BusObservabilityStartup) *BusObservabilityStartup {
+	if source == nil {
+		return nil
+	}
+	out := *source
 	return &out
 }
 
@@ -483,6 +499,54 @@ func buildBusObservabilityTypes() (*graphqlgo.Object, *graphqlgo.Object, *graphq
 		},
 	})
 
+	startupType := graphqlgo.NewObject(graphqlgo.ObjectConfig{
+		Name: "BusObservabilityStartup",
+		Fields: graphqlgo.Fields{
+			"phase": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.String),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					startup, ok := params.Source.(*BusObservabilityStartup)
+					if ok && startup != nil {
+						return startup.Phase, nil
+					}
+					value, ok := params.Source.(BusObservabilityStartup)
+					if !ok {
+						return "", nil
+					}
+					return value.Phase, nil
+				},
+			},
+			"cacheEpoch": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.String),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					startup, ok := params.Source.(*BusObservabilityStartup)
+					if ok && startup != nil {
+						return strconv.FormatUint(startup.CacheEpoch, 10), nil
+					}
+					value, ok := params.Source.(BusObservabilityStartup)
+					if !ok {
+						return "0", nil
+					}
+					return strconv.FormatUint(value.CacheEpoch, 10), nil
+				},
+			},
+			"liveEpoch": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.String),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					startup, ok := params.Source.(*BusObservabilityStartup)
+					if ok && startup != nil {
+						return strconv.FormatUint(startup.LiveEpoch, 10), nil
+					}
+					value, ok := params.Source.(BusObservabilityStartup)
+					if !ok {
+						return "0", nil
+					}
+					return strconv.FormatUint(value.LiveEpoch, 10), nil
+				},
+			},
+		},
+	})
+
 	featureFlagStateType := graphqlgo.NewObject(graphqlgo.ObjectConfig{
 		Name: "ObserveFirstFeatureFlagState",
 		Fields: graphqlgo.Fields{
@@ -610,6 +674,20 @@ func buildBusObservabilityTypes() (*graphqlgo.Object, *graphqlgo.Object, *graphq
 						return BusObservabilityDegraded{}, nil
 					}
 					return value.Degraded, nil
+				},
+			},
+			"startup": &graphqlgo.Field{
+				Type: startupType,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					status, ok := params.Source.(*BusObservabilityStatus)
+					if ok && status != nil {
+						return status.Startup, nil
+					}
+					value, ok := params.Source.(BusObservabilityStatus)
+					if !ok {
+						return nil, nil
+					}
+					return value.Startup, nil
 				},
 			},
 			"featureFlags": &graphqlgo.Field{

--- a/mcp/bus.go
+++ b/mcp/bus.go
@@ -34,12 +34,19 @@ type BusObservabilityDegraded struct {
 	Reasons []string `json:"reasons,omitempty"`
 }
 
+type BusObservabilityStartup struct {
+	Phase      string `json:"phase"`
+	CacheEpoch uint64 `json:"cache_epoch"`
+	LiveEpoch  uint64 `json:"live_epoch"`
+}
+
 type BusObservabilityStatus struct {
 	TransportClass string                        `json:"transport_class"`
 	Capability     BusObservabilityCapability    `json:"capability"`
 	Warmup         BusObservabilityWarmup        `json:"warmup"`
 	TimingQuality  BusObservabilityTimingQuality `json:"timing_quality"`
 	Degraded       BusObservabilityDegraded      `json:"degraded"`
+	Startup        *BusObservabilityStartup      `json:"startup,omitempty"`
 	FeatureFlags   ObserveFirstFeatureFlagState  `json:"feature_flags"`
 }
 
@@ -141,12 +148,21 @@ func cloneBusObservabilityStatus(source *BusObservabilityStatus) *BusObservabili
 		return nil
 	}
 	out := *source
+	out.Startup = cloneBusObservabilityStartup(source.Startup)
 	if len(source.Degraded.Reasons) > 0 {
 		out.Degraded.Reasons = append([]string(nil), source.Degraded.Reasons...)
 	}
 	if len(source.FeatureFlags.Normalizations) > 0 {
 		out.FeatureFlags.Normalizations = append([]string(nil), source.FeatureFlags.Normalizations...)
 	}
+	return &out
+}
+
+func cloneBusObservabilityStartup(source *BusObservabilityStartup) *BusObservabilityStartup {
+	if source == nil {
+		return nil
+	}
+	out := *source
 	return &out
 }
 

--- a/scripts/passive_canary_verifier.py
+++ b/scripts/passive_canary_verifier.py
@@ -25,6 +25,7 @@ P03_ALLOWED_METHODS = {"get_register", "get_ext_register"}
 CANARY_VERDICT_SCHEMA = "p03_canary_verdict_v1"
 OVERALL_INTERVAL_CONCLUSIVE_MIN = 0.90
 PER_CANARY_INTERVAL_CONCLUSIVE_MIN = 0.75
+CANARY_NONCE_PARAM = "_canary_nonce"
 
 
 def utc_now() -> str:
@@ -199,6 +200,7 @@ def invoke_canary(
     graphql_url: str,
     canary: CanarySpec,
     timeout_sec: float,
+    nonce: str | None = None,
 ) -> str:
     mutation = """
 mutation($address:Int!, $plane:String!, $method:String!, $params: JSON) {
@@ -209,13 +211,16 @@ mutation($address:Int!, $plane:String!, $method:String!, $params: JSON) {
   }
 }
 """.strip()
+    params = dict(canary.params)
+    if nonce:
+        params[CANARY_NONCE_PARAM] = nonce
     payload = {
         "query": mutation,
         "variables": {
             "address": canary.address,
             "plane": canary.plane,
             "method": canary.method,
-            "params": canary.params,
+            "params": params,
         },
     }
     body = json.dumps(payload).encode("utf-8")
@@ -326,8 +331,14 @@ def verify_phase(
 
         for attempt in range(1, retries + 1):
             attempts_used = attempt
+            attempt_nonce = f"{run_id}:{phase}:{canary.canary_id}:{attempt}"
             try:
-                candidate_hex = invoke_canary(graphql_url, canary, timeout_sec)
+                candidate_hex = invoke_canary(
+                    graphql_url,
+                    canary,
+                    timeout_sec,
+                    nonce=attempt_nonce,
+                )
                 value_hex = normalize_hex(candidate_hex)
                 status, reason = classify_canary_value(canary, value_hex, baseline_hex)
                 if baseline_hex is None and allow_baseline_seed:

--- a/scripts/passive_canary_verifier_test.py
+++ b/scripts/passive_canary_verifier_test.py
@@ -22,6 +22,25 @@ def write_json(path: pathlib.Path, payload: object) -> None:
 
 
 class ManifestValidationTests(unittest.TestCase):
+    def test_manifest_matches_canonical_proxy_p03_stable_set(self) -> None:
+        _, canaries = verifier.load_and_validate_manifest(
+            SCRIPT_DIR.parent / "testdata" / "passive_proof" / "p03_canary_manifest.json",
+            "P03",
+        )
+        self.assertEqual(
+            [item.canary_id for item in canaries],
+            [
+                "b524_dhw_mode",
+                "b524_dhw_target",
+                "b524_circuit_type",
+                "b524_room_temp_control",
+                "b509_a0200",
+                "b509_a0f04",
+            ],
+        )
+        for item in canaries:
+            self.assertEqual(item.params["source"], 0xF7)
+
     def test_manifest_requires_expected_schema(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             manifest_path = pathlib.Path(temp_dir) / "manifest.json"
@@ -127,6 +146,83 @@ class ManifestValidationTests(unittest.TestCase):
 
 
 class RetryClassificationTests(unittest.TestCase):
+    def test_invoke_canary_adds_internal_nonce_without_mutating_manifest_params(self) -> None:
+        _, canaries = verifier.load_and_validate_manifest(
+            SCRIPT_DIR.parent / "testdata" / "passive_proof" / "p03_canary_manifest.json",
+            "P03",
+        )
+        captured_request = {}
+        original_urlopen = verifier.urllib.request.urlopen
+
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return b'{"data":{"invoke":{"ok":true,"result":{"value":"BEEF"}}}}'
+
+        def fake_urlopen(request, timeout):
+            captured_request["timeout"] = timeout
+            captured_request["payload"] = json.loads(request.data.decode("utf-8"))
+            return FakeResponse()
+
+        verifier.urllib.request.urlopen = fake_urlopen
+        try:
+            result = verifier.invoke_canary(
+                "http://unused/graphql",
+                canaries[0],
+                0.25,
+                nonce="nonce-1",
+            )
+        finally:
+            verifier.urllib.request.urlopen = original_urlopen
+
+        self.assertEqual(result, "BEEF")
+        params = captured_request["payload"]["variables"]["params"]
+        self.assertEqual(params[verifier.CANARY_NONCE_PARAM], "nonce-1")
+        self.assertNotIn(verifier.CANARY_NONCE_PARAM, canaries[0].params)
+
+    def test_verify_phase_uses_distinct_nonce_per_retry(self) -> None:
+        _, canaries = verifier.load_and_validate_manifest(
+            SCRIPT_DIR.parent / "testdata" / "passive_proof" / "p03_canary_manifest.json",
+            "P03",
+        )
+        original_invoke = verifier.invoke_canary
+        seen_nonces: list[str | None] = []
+
+        def flaky_invoke(_graphql_url, _canary, _timeout_sec, nonce=None):
+            seen_nonces.append(nonce)
+            if len(seen_nonces) < 3:
+                raise RuntimeError("timeout")
+            return "BEEF"
+
+        verifier.invoke_canary = flaky_invoke
+        try:
+            results = verifier.verify_phase(
+                canaries=canaries[:1],
+                graphql_url="http://unused/graphql",
+                phase="start",
+                run_id="run-retry",
+                retries=3,
+                timeout_sec=0.01,
+                baseline_map={},
+            )
+        finally:
+            verifier.invoke_canary = original_invoke
+
+        self.assertEqual(results["results"][0]["status"], "pass")
+        self.assertEqual(
+            seen_nonces,
+            [
+                "run-retry:start:b524_dhw_mode:1",
+                "run-retry:start:b524_dhw_mode:2",
+                "run-retry:start:b524_dhw_mode:3",
+            ],
+        )
+
     def test_inconclusive_after_three_retries(self) -> None:
         _, canaries = verifier.load_and_validate_manifest(
             SCRIPT_DIR.parent / "testdata" / "passive_proof" / "p03_canary_manifest.json",
@@ -510,6 +606,13 @@ class PassiveSmokeCanaryVerdictGateTests(unittest.TestCase):
                       elif [[ "${status}" == "mismatch" ]]; then
                         mismatch_count=1
                       fi
+                      if [[ -n "${FAKE_CANARY_PHASE_LOG:-}" ]]; then
+                        metrics_count="unknown"
+                        if [[ -n "${FAKE_METRICS_STATE_FILE:-}" && -f "${FAKE_METRICS_STATE_FILE}" ]]; then
+                          metrics_count="$(cat "${FAKE_METRICS_STATE_FILE}")"
+                        fi
+                        printf '%s:%s\\n' "${phase}" "${metrics_count}" >> "${FAKE_CANARY_PHASE_LOG}"
+                      fi
                       mkdir -p "$(dirname "${output}")"
                       cat > "${output}" <<JSON
                     {
@@ -599,6 +702,24 @@ class PassiveSmokeCanaryVerdictGateTests(unittest.TestCase):
                           echo "simulated hard metrics poll failure on call ${metrics_count}" >&2
                           exit 28
                         fi
+                      elif [[ "${metrics_mode}" == "initially_unhealthy_then_healthy" ]]; then
+                        state_file="${FAKE_METRICS_STATE_FILE:?FAKE_METRICS_STATE_FILE is required}"
+                        unhealthy_calls="${FAKE_METRICS_UNHEALTHY_CALLS:-1}"
+                        metrics_count=0
+                        if [[ -f "${state_file}" ]]; then
+                          metrics_count="$(cat "${state_file}")"
+                        fi
+                        metrics_count=$((metrics_count + 1))
+                        printf '%s\\n' "${metrics_count}" > "${state_file}"
+                        if [[ "${metrics_count}" -le "${unhealthy_calls}" ]]; then
+                          cat <<EOF
+                    ebus_passive_capability_probe_outcomes_total{outcome="timed_out"} 0
+                    ebus_passive_tap_connected 1
+                    ebus_passive_warmup_state{state="available"} 0
+                    ebus_passive_capability_probe_outcomes_total{outcome="confirmed"} 0
+                    EOF
+                          exit 0
+                        fi
                       fi
                       cat <<EOF
                     ebus_passive_capability_probe_outcomes_total{outcome="timed_out"} ${timed_out}
@@ -610,8 +731,21 @@ class PassiveSmokeCanaryVerdictGateTests(unittest.TestCase):
                     fi
 
                     if [[ "${url}" == *"/portal/api/v1/bus/observability" ]]; then
-                      cat <<'EOF'
-                    {"summary":{"status":{"feature_flags":{"observeFirstEnabled":true}}}}
+                      startup_mode="${FAKE_BUS_STARTUP_MODE:-always_live_ready}"
+                      phase="LIVE_READY"
+                      if [[ "${startup_mode}" == "initially_live_warmup_then_live_ready" ]]; then
+                        state_file="${FAKE_METRICS_STATE_FILE:?FAKE_METRICS_STATE_FILE is required}"
+                        warmup_calls="${FAKE_BUS_LIVE_WARMUP_CALLS:-1}"
+                        metrics_count=0
+                        if [[ -f "${state_file}" ]]; then
+                          metrics_count="$(cat "${state_file}")"
+                        fi
+                        if [[ "${metrics_count}" -le "${warmup_calls}" ]]; then
+                          phase="LIVE_WARMUP"
+                        fi
+                      fi
+                      cat <<EOF
+                    {"status":{"startup":{"phase":"${phase}"},"feature_flags":{"observeFirstEnabled":true}}}
                     EOF
                       exit 0
                     fi
@@ -652,6 +786,7 @@ class PassiveSmokeCanaryVerdictGateTests(unittest.TestCase):
                     "MATRIX_METRICS_URL": "http://fake-gateway:18083/metrics",
                     "REAL_PYTHON3": sys.executable,
                     "FAKE_CANARY_STATUS": canary_status,
+                    "FAKE_CANARY_PHASE_LOG": str(temp_path / "fake_canary_phase_log.txt"),
                     "FAKE_METRICS_STATE_FILE": str(temp_path / "fake_metrics_count.txt"),
                     "PATH": f"{fake_bin}:{env.get('PATH', '')}",
                 }
@@ -674,10 +809,17 @@ class PassiveSmokeCanaryVerdictGateTests(unittest.TestCase):
                 proof_dir = log_dir / "proof_artifacts"
                 summary_path = proof_dir / "canary_summary.json"
                 verdict_path = proof_dir / "canary_verdict.json"
+                phase_log_path = temp_path / "fake_canary_phase_log.txt"
                 if summary_path.exists():
                     artifacts["summary"] = json.loads(summary_path.read_text(encoding="utf-8"))
                 if verdict_path.exists():
                     artifacts["verdict"] = json.loads(verdict_path.read_text(encoding="utf-8"))
+                if phase_log_path.exists():
+                    artifacts["phase_log"] = [
+                        line.strip()
+                        for line in phase_log_path.read_text(encoding="utf-8").splitlines()
+                        if line.strip()
+                    ]
                 artifacts["sample_phase_files"] = sorted(
                     path.name for path in proof_dir.glob("canary_phase_sample_*.json")
                 )
@@ -733,6 +875,46 @@ class PassiveSmokeCanaryVerdictGateTests(unittest.TestCase):
         self.assertTrue(summary["interval_phase_required"])
         self.assertGreaterEqual(summary["interval_phase_count"], 1)
         self.assertGreaterEqual(len(artifacts.get("sample_phase_files", [])), 1)
+
+    def test_smoke_defers_start_canary_until_first_healthy_snapshot(self) -> None:
+        result, artifacts = self.run_smoke_with_fake_tools_detailed(
+            "pass",
+            extra_env={
+                "PASSIVE_PROOF_HOLD_SEC": "4",
+                "PASSIVE_SMOKE_TIMEOUT_SEC": "8",
+                "PASSIVE_SMOKE_POLL_INTERVAL_SEC": "1",
+                "PASSIVE_PROOF_SAMPLE_INTERVAL_SEC": "3600",
+                "FAKE_METRICS_MODE": "initially_unhealthy_then_healthy",
+                "FAKE_METRICS_UNHEALTHY_CALLS": "2",
+            },
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        phase_log = artifacts.get("phase_log")
+        self.assertIsInstance(phase_log, list)
+        self.assertGreaterEqual(len(phase_log), 1)
+        self.assertEqual(phase_log[0].split(":", 1)[0], "start")
+        self.assertGreaterEqual(int(phase_log[0].split(":", 1)[1]), 3)
+
+    def test_smoke_defers_start_canary_until_bus_startup_phase_is_live_ready(self) -> None:
+        result, artifacts = self.run_smoke_with_fake_tools_detailed(
+            "pass",
+            extra_env={
+                "PASSIVE_PROOF_HOLD_SEC": "4",
+                "PASSIVE_SMOKE_TIMEOUT_SEC": "8",
+                "PASSIVE_SMOKE_POLL_INTERVAL_SEC": "1",
+                "PASSIVE_PROOF_SAMPLE_INTERVAL_SEC": "3600",
+                "FAKE_METRICS_MODE": "initially_unhealthy_then_healthy",
+                "FAKE_METRICS_UNHEALTHY_CALLS": "0",
+                "FAKE_BUS_STARTUP_MODE": "initially_live_warmup_then_live_ready",
+                "FAKE_BUS_LIVE_WARMUP_CALLS": "2",
+            },
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        phase_log = artifacts.get("phase_log")
+        self.assertIsInstance(phase_log, list)
+        self.assertGreaterEqual(len(phase_log), 1)
+        self.assertEqual(phase_log[0].split(":", 1)[0], "start")
+        self.assertGreaterEqual(int(phase_log[0].split(":", 1)[1]), 3)
 
     def test_smoke_fails_when_hold_times_out_before_window_completion_despite_slow_cleanup(self) -> None:
         result, artifacts = self.run_smoke_with_fake_tools_detailed(

--- a/scripts/passive_matrix_case_ha.sh
+++ b/scripts/passive_matrix_case_ha.sh
@@ -172,6 +172,11 @@ build_observe_first_cli_flags() {
     esac
   fi
 
+  if [[ "${#flags[@]}" -eq 0 ]]; then
+    printf '\n'
+    return 0
+  fi
+
   printf '%s\n' "${flags[*]}"
 }
 

--- a/scripts/passive_smoke_check.sh
+++ b/scripts/passive_smoke_check.sh
@@ -38,6 +38,7 @@ gateway_http_port=$((18080 + 10#${exec_case_num}))
 gateway_base_url="${MATRIX_GATEWAY_BASE_URL:-http://${ha_host}:${gateway_http_port}}"
 graphql_url="${MATRIX_GRAPHQL_URL:-${gateway_base_url}/graphql}"
 metrics_url="${MATRIX_METRICS_URL:-${gateway_base_url}/metrics}"
+bus_observability_url="${MATRIX_BUS_OBSERVABILITY_URL:-${gateway_base_url}/portal/api/v1/bus/observability}"
 poll_interval_sec="${PASSIVE_SMOKE_POLL_INTERVAL_SEC:-2}"
 timeout_sec="${PASSIVE_SMOKE_TIMEOUT_SEC:-120}"
 log_dir="${MATRIX_LOG_DIR:-${REPO_ROOT}/results/${case_id}/logs}"
@@ -89,6 +90,7 @@ canary_retries=3
 canary_enabled=0
 canary_require_interval_phase=1
 canary_run_id="p03-$(date +%s)-$$"
+canary_start_pending=0
 proof_hold_sec=0
 proof_window_start_epoch=0
 proof_window_end_epoch=0
@@ -277,6 +279,35 @@ raise SystemExit(1)
 PY
 }
 
+bus_startup_live_ready() {
+  BUS_PAYLOAD="${1:-}" python3 - <<'PY'
+import json
+import os
+import sys
+
+payload_text = os.environ.get("BUS_PAYLOAD", "")
+try:
+    payload = json.loads(payload_text)
+except Exception:
+    raise SystemExit(1)
+
+status = payload.get("status")
+if not isinstance(status, dict):
+    status = ((payload.get("summary") or {}).get("status"))
+if not isinstance(status, dict):
+    raise SystemExit(1)
+
+startup = status.get("startup")
+if not isinstance(startup, dict):
+    raise SystemExit(1)
+
+phase = startup.get("phase")
+if phase == "LIVE_READY":
+    raise SystemExit(0)
+raise SystemExit(1)
+PY
+}
+
 write_feature_flag_snapshot() {
   local graphql_file="$1"
   local bus_file="$2"
@@ -374,7 +405,7 @@ capture_proof_snapshot() {
     have_metrics=1
   fi
 
-  if bus_payload="$(curl -fsS -m 8 "${gateway_base_url}/portal/api/v1/bus/observability" 2>/dev/null)"; then
+  if bus_payload="$(curl -fsS -m 8 "${bus_observability_url}" 2>/dev/null)"; then
     printf '%s\n' "${bus_payload}" > "${bus_file}"
     have_bus=1
   fi
@@ -454,27 +485,39 @@ if [[ "${proof_artifacts_enabled}" == "1" ]]; then
     proof_next_sample_epoch="$(date +%s)"
   fi
   if [[ "${canary_enabled}" == "1" ]]; then
-    if ! run_canary_phase "start"; then
-      echo "proof mode: failed to run start canary verification" >&2
-      exit 1
-    fi
+    # Defer the start canary until bus observability reports semantic startup
+    # phase LIVE_READY, while still requiring validate_snapshot() to pass.
+    canary_start_pending=1
   fi
 fi
 
 while [[ "$(date +%s)" -lt "${deadline}" ]]; do
+  bus_payload=""
+  startup_live_ready=0
   if metrics="$(curl -fsS -m 8 "${metrics_url}" 2>/dev/null)" && \
      graphql="$(curl -fsS -m 8 -H 'Content-Type: application/json' \
-       -d '{"query":"{ devices { address deviceId } }"}' "${graphql_url}" 2>/dev/null)"; then
+       -d '{"query":"{ devices { address deviceId } }"}' "${graphql_url}" 2>/dev/null)" && \
+     bus_payload="$(curl -fsS -m 8 "${bus_observability_url}" 2>/dev/null)"; then
     now_epoch="$(date +%s)"
     snapshot_healthy=0
     last_metrics="${metrics}"
     last_graphql="${graphql}"
+    if bus_startup_live_ready "${bus_payload}"; then
+      startup_live_ready=1
+    fi
     printf '%s\n' "${metrics}" > "${metrics_path}"
     printf '%s\n' "${graphql}" > "${graphql_path}"
     if validate_snapshot "${metrics}" "${graphql}"; then
       smoke_ok=1
       snapshot_healthy=1
-      if [[ "${gw15_proof_mode}" == "1" && "${proof_hold_sec}" -gt 0 && "${proof_window_started}" != "1" ]]; then
+      if [[ "${canary_start_pending}" == "1" && "${startup_live_ready}" == "1" ]]; then
+        if ! run_canary_phase "start"; then
+          echo "proof mode: failed to run start canary verification" >&2
+          exit 1
+        fi
+        canary_start_pending=0
+      fi
+      if [[ "${gw15_proof_mode}" == "1" && "${proof_hold_sec}" -gt 0 && "${proof_window_started}" != "1" && "${canary_start_pending}" != "1" ]]; then
         proof_window_started=1
         proof_window_start_epoch="${now_epoch}"
         proof_window_end_epoch=$((now_epoch + proof_hold_sec))

--- a/scripts/transport_gate.sh
+++ b/scripts/transport_gate.sh
@@ -26,9 +26,31 @@ if [[ -z "${changed_files}" ]]; then
 fi
 
 requires_gate=0
+
+requires_transport_gate() {
+  local file="$1"
+  case "${file}" in
+    config.go|\
+    gateway.go|\
+    cmd/gateway/startup_scan*.go|\
+    cmd/matrix-runner/*|\
+    internal/matrix/*|\
+    smoke.go|\
+    smoke_config.go|\
+    cmd/smoke/*|\
+    cmd/ebusdscan/*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
 while IFS= read -r file; do
   [[ -z "${file}" ]] && continue
-  if [[ "${file}" =~ ^(config\.go|gateway\.go|cmd/gateway/|cmd/matrix-runner/|internal/matrix/|smoke\.go|smoke_config\.go|cmd/smoke/|cmd/ebusdscan/) ]]; then
+  # The transport gate is for transport/protocol and matrix topology execution
+  # surfaces. Public observability/API changes under cmd/gateway must not demand
+  # an unrelated 88-case transport report.
+  if requires_transport_gate "${file}"; then
     requires_gate=1
     break
   fi

--- a/testdata/passive_proof/p03_canary_manifest.json
+++ b/testdata/passive_proof/p03_canary_manifest.json
@@ -1,48 +1,62 @@
 {
   "schema": "p03_canary_manifest_v1",
   "case_id": "P03",
-  "description": "Fixed active direct-read canaries for proof-mode P03 runs.",
+  "description": "Stable active direct-read canaries for proof-mode P03 runs on the proxy-backed ENS topology.",
   "canaries": [
     {
-      "id": "b524_g00_i00_a5c00",
+      "id": "b524_dhw_mode",
       "family": "B524",
       "address": 21,
       "plane": "system",
       "method": "get_ext_register",
       "params": {
-        "source": 16,
+        "source": 247,
         "opcode": 2,
-        "group": 0,
+        "group": 1,
         "instance": 0,
-        "addr": 23552
+        "addr": 3
       }
     },
     {
-      "id": "b524_g00_i00_a5e00",
+      "id": "b524_dhw_target",
       "family": "B524",
       "address": 21,
       "plane": "system",
       "method": "get_ext_register",
       "params": {
-        "source": 16,
+        "source": 247,
         "opcode": 2,
-        "group": 0,
+        "group": 1,
         "instance": 0,
-        "addr": 24064
+        "addr": 4
       }
     },
     {
-      "id": "b524_g00_i00_a6200",
+      "id": "b524_circuit_type",
       "family": "B524",
       "address": 21,
       "plane": "system",
       "method": "get_ext_register",
       "params": {
-        "source": 16,
+        "source": 247,
         "opcode": 2,
-        "group": 0,
+        "group": 2,
         "instance": 0,
-        "addr": 25088
+        "addr": 2
+      }
+    },
+    {
+      "id": "b524_room_temp_control",
+      "family": "B524",
+      "address": 21,
+      "plane": "system",
+      "method": "get_ext_register",
+      "params": {
+        "source": 247,
+        "opcode": 2,
+        "group": 2,
+        "instance": 0,
+        "addr": 21
       }
     },
     {
@@ -52,30 +66,19 @@
       "plane": "system",
       "method": "get_register",
       "params": {
-        "source": 16,
+        "source": 247,
         "addr": 512
       }
     },
     {
-      "id": "b509_a1800",
+      "id": "b509_a0f04",
       "family": "B509",
       "address": 8,
       "plane": "system",
       "method": "get_register",
       "params": {
-        "source": 16,
-        "addr": 6144
-      }
-    },
-    {
-      "id": "b509_aab00",
-      "family": "B509",
-      "address": 8,
-      "plane": "system",
-      "method": "get_register",
-      "params": {
-        "source": 16,
-        "addr": 43776
+        "source": 247,
+        "addr": 3844
       }
     }
   ]


### PR DESCRIPTION
## What
- expose semantic startup readiness through bus observability (`status.startup.phase/cache_epoch/live_epoch`)
- defer the proof-mode `start` canary until the runtime is smoke-healthy and `LIVE_READY`
- replace the canonical `P03` canary manifest with the validated stable proxy-backed ENS set
- make canary retries use real uncached invoke attempts
- narrow the local transport gate so observability-only `cmd/gateway` changes do not falsely demand an 88-case transport report
- fix `passive_matrix_case_ha.sh` so non-proof passive cases can run with an empty observe-first flag list under `set -u`

## Why
GW-15 needed the first canonical bounded proof artifact on source/main instead of an ad-hoc manifest override. The failure chain combined early canary start, initiator lease mismatch, unstable canary choices, and a local CI false positive around transport gating.

## Validation
- `python3 scripts/passive_canary_verifier_test.py`
- `python3 scripts/passive_canary_verifier.py validate-manifest --manifest testdata/passive_proof/p03_canary_manifest.json --require-case-id P03`
- `go test ./...`
- `./scripts/ci_local.sh` with passive smoke report from `results-matrix-ha/20260315T070728Z-passive-suite-ci-gate-rerun/index.json`
- bounded HA proof PASS: `results-matrix-ha/20260315T070147Z-gw15-proof-p03-canonical-rerun/`

## Runtime evidence
- canonical bounded P03 PASS artifact: `results-matrix-ha/20260315T070147Z-gw15-proof-p03-canonical-rerun/`
- passive suite PASS artifact: `results-matrix-ha/20260315T070728Z-passive-suite-ci-gate-rerun/`

Closes #405
Parent: #400
Docs: Project-Helianthus/helianthus-docs-ebus#227
