### PR TITLE
Fix passive proof follow-up regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,12 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.22'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
       - run: go test -race -count=1 ./...
+      - run: python3 scripts/passive_canary_verifier_test.py
+      - run: python3 scripts/transport_gate_test.py
 
   lint:
     runs-on: ubuntu-latest

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -34,6 +34,10 @@ go build ./...
 echo "==> go test (race)"
 go test -race -count=1 ./...
 
+echo "==> python script tests"
+python3 scripts/passive_canary_verifier_test.py
+python3 scripts/transport_gate_test.py
+
 if command -v golangci-lint >/dev/null 2>&1; then
   echo "==> golangci-lint"
   golangci-lint run ./...

--- a/scripts/passive_canary_verifier_test.py
+++ b/scripts/passive_canary_verifier_test.py
@@ -916,6 +916,51 @@ class PassiveSmokeCanaryVerdictGateTests(unittest.TestCase):
         self.assertEqual(phase_log[0].split(":", 1)[0], "start")
         self.assertGreaterEqual(int(phase_log[0].split(":", 1)[1]), 3)
 
+    def test_smoke_hold_zero_still_waits_for_deferred_start_canary(self) -> None:
+        result, artifacts = self.run_smoke_with_fake_tools_detailed(
+            "pass",
+            extra_env={
+                "PASSIVE_PROOF_HOLD_SEC": "0",
+                "PASSIVE_SMOKE_TIMEOUT_SEC": "8",
+                "PASSIVE_SMOKE_POLL_INTERVAL_SEC": "1",
+                "FAKE_METRICS_MODE": "initially_unhealthy_then_healthy",
+                "FAKE_METRICS_UNHEALTHY_CALLS": "0",
+                "FAKE_BUS_STARTUP_MODE": "initially_live_warmup_then_live_ready",
+                "FAKE_BUS_LIVE_WARMUP_CALLS": "2",
+            },
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        phase_log = artifacts.get("phase_log")
+        self.assertIsInstance(phase_log, list)
+        self.assertGreaterEqual(len(phase_log), 2)
+        self.assertEqual(phase_log[0].split(":", 1)[0], "start")
+        self.assertGreaterEqual(int(phase_log[0].split(":", 1)[1]), 3)
+        self.assertEqual(phase_log[-1].split(":", 1)[0], "end")
+        self.assertEqual(artifacts.get("sample_phase_files", []), [])
+
+    def test_smoke_hold_zero_waits_for_first_interval_when_interval_phase_is_required(self) -> None:
+        result, artifacts = self.run_smoke_with_fake_tools_detailed(
+            "pass",
+            extra_env={
+                "PASSIVE_PROOF_HOLD_SEC": "0",
+                "PASSIVE_SMOKE_TIMEOUT_SEC": "8",
+                "PASSIVE_SMOKE_POLL_INTERVAL_SEC": "1",
+                "PASSIVE_PROOF_SAMPLE_INTERVAL_SEC": "1",
+                "FAKE_METRICS_MODE": "initially_unhealthy_then_healthy",
+                "FAKE_METRICS_UNHEALTHY_CALLS": "0",
+                "FAKE_BUS_STARTUP_MODE": "initially_live_warmup_then_live_ready",
+                "FAKE_BUS_LIVE_WARMUP_CALLS": "2",
+            },
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        phase_log = artifacts.get("phase_log")
+        self.assertIsInstance(phase_log, list)
+        self.assertGreaterEqual(len(phase_log), 3)
+        self.assertEqual(phase_log[0].split(":", 1)[0], "start")
+        self.assertIn("sample_0001", [entry.split(":", 1)[0] for entry in phase_log])
+        self.assertEqual(phase_log[-1].split(":", 1)[0], "end")
+        self.assertEqual(artifacts.get("sample_phase_files", []), ["canary_phase_sample_0001.json"])
+
     def test_smoke_fails_when_hold_times_out_before_window_completion_despite_slow_cleanup(self) -> None:
         result, artifacts = self.run_smoke_with_fake_tools_detailed(
             "pass",

--- a/scripts/passive_smoke_check.sh
+++ b/scripts/passive_smoke_check.sh
@@ -516,6 +516,9 @@ while [[ "$(date +%s)" -lt "${deadline}" ]]; do
           exit 1
         fi
         canary_start_pending=0
+        if [[ "${gw15_proof_mode}" == "1" && "${proof_hold_sec}" -le 0 ]]; then
+          proof_next_sample_epoch=$((now_epoch + proof_first_sample_delay_sec))
+        fi
       fi
       if [[ "${gw15_proof_mode}" == "1" && "${proof_hold_sec}" -gt 0 && "${proof_window_started}" != "1" && "${canary_start_pending}" != "1" ]]; then
         proof_window_started=1
@@ -526,6 +529,9 @@ while [[ "$(date +%s)" -lt "${deadline}" ]]; do
     fi
     if [[ "${proof_artifacts_enabled}" == "1" ]]; then
       sample_allowed=1
+      if [[ "${canary_start_pending}" == "1" ]]; then
+        sample_allowed=0
+      fi
       if [[ "${gw15_proof_mode}" == "1" && "${proof_hold_sec}" -gt 0 && "${proof_window_started}" != "1" ]]; then
         sample_allowed=0
       fi
@@ -552,6 +558,14 @@ while [[ "$(date +%s)" -lt "${deadline}" ]]; do
           proof_window_completed=1
           break
         fi
+      elif [[ "${canary_start_pending}" == "1" ]]; then
+        # In the default hold=0 path, a healthy passive snapshot is not enough:
+        # proof-mode still needs the deferred start canary after LIVE_READY.
+        :
+      elif [[ "${canary_enabled}" == "1" && "${canary_require_interval_phase}" == "1" && "${proof_sample_index}" -lt 1 ]]; then
+        # When the verifier still requires an interval phase, do not exit until
+        # the first sample_* canary has been emitted after the deferred start.
+        :
       else
         break
       fi
@@ -583,6 +597,10 @@ if [[ "${proof_artifacts_enabled}" == "1" ]]; then
     exit 1
   fi
   if [[ "${canary_enabled}" == "1" ]]; then
+    if [[ "${canary_start_pending}" == "1" ]]; then
+      echo "proof mode: timed out before deferred start canary reached LIVE_READY" >&2
+      exit 1
+    fi
     if ! run_canary_phase "end"; then
       echo "proof mode: failed to run end canary verification" >&2
       exit 1

--- a/scripts/transport_gate.sh
+++ b/scripts/transport_gate.sh
@@ -32,6 +32,7 @@ requires_transport_gate() {
   case "${file}" in
     config.go|\
     gateway.go|\
+    cmd/gateway/main.go|\
     cmd/gateway/startup_scan*.go|\
     cmd/matrix-runner/*|\
     internal/matrix/*|\

--- a/scripts/transport_gate_test.py
+++ b/scripts/transport_gate_test.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+TRANSPORT_GATE_SCRIPT = REPO_ROOT / "scripts" / "transport_gate.sh"
+
+
+class TransportGateTests(unittest.TestCase):
+    def _create_temp_repo(self, changed_file: str) -> tuple[pathlib.Path, pathlib.Path]:
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        repo_path = pathlib.Path(temp_dir.name)
+
+        subprocess.run(["git", "init", "-b", "main"], cwd=repo_path, check=True, capture_output=True, text=True)
+        subprocess.run(["git", "config", "user.name", "Codex"], cwd=repo_path, check=True, capture_output=True, text=True)
+        subprocess.run(
+            ["git", "config", "user.email", "codex@example.com"],
+            cwd=repo_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        (repo_path / "scripts").mkdir(parents=True, exist_ok=True)
+        shutil.copy2(TRANSPORT_GATE_SCRIPT, repo_path / "scripts" / "transport_gate.sh")
+
+        tracked_file = repo_path / changed_file
+        tracked_file.parent.mkdir(parents=True, exist_ok=True)
+        tracked_file.write_text("// base\n", encoding="utf-8")
+
+        subprocess.run(["git", "add", "."], cwd=repo_path, check=True, capture_output=True, text=True)
+        subprocess.run(
+            ["git", "commit", "-m", "base"],
+            cwd=repo_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        tracked_file.write_text("// modified\n", encoding="utf-8")
+
+        report_path = repo_path / "report.json"
+        report_path.write_text(
+            json.dumps({"cases": [{"case_id": f"T{i:02d}", "outcome": "pass"} for i in range(1, 89)]}),
+            encoding="utf-8",
+        )
+        return repo_path, report_path
+
+    def test_transport_gate_triggers_for_cmd_gateway_main(self) -> None:
+        repo_path, report_path = self._create_temp_repo("cmd/gateway/main.go")
+        result = subprocess.run(
+            ["bash", "scripts/transport_gate.sh"],
+            cwd=repo_path,
+            env={
+                **dict(os.environ),
+                "TRANSPORT_GATE_BASE_REF": "HEAD",
+                "TRANSPORT_MATRIX_REPORT": str(report_path),
+            },
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("transport gate: PASS", result.stdout)
+
+    def test_transport_gate_skips_non_transport_gateway_observability_file(self) -> None:
+        repo_path, _ = self._create_temp_repo("cmd/gateway/bus_observability_provider.go")
+        result = subprocess.run(
+            ["bash", "scripts/transport_gate.sh"],
+            cwd=repo_path,
+            env={**dict(os.environ), "TRANSPORT_GATE_BASE_REF": "HEAD"},
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("transport gate: not triggered.", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix the deferred start canary default hold=0 path so proof mode waits for start and, when required, the first sample interval before exiting
- restore the transport gate trigger for cmd/gateway/main.go
- wire the Python script regression tests into both local CI and GitHub Actions

## Validation
- bash -n scripts/passive_smoke_check.sh scripts/transport_gate.sh scripts/ci_local.sh
- python3 scripts/passive_canary_verifier_test.py
- python3 scripts/transport_gate_test.py
- PASSIVE_SMOKE_REPORT=results-matrix-ha/20260315T073335Z-passive-suite-followup-gate/index.json ./scripts/ci_local.sh

## Runtime Evidence
- passive suite report: results-matrix-ha/20260315T073335Z-passive-suite-followup-gate/index.json
- all passive cases P01..P06 passed

Closes #407
Related to #400
