### PR TITLE
GW-15 child: add rollback-smoke proof artifact (#418)

### DIFF
--- a/scripts/passive_canary_verifier.py
+++ b/scripts/passive_canary_verifier.py
@@ -38,7 +38,7 @@ PROOF_WINDOW_DIRECT_APPLY_CANDIDATES_EVALUATED_METRIC = "ebus_passive_direct_app
 PROOF_WINDOW_COMPLETED_TRANSACTIONS_MIN_DELTA = 1000.0
 PROOF_WINDOW_DIRECT_APPLY_CANDIDATES_EVALUATED_MIN_DELTA = 100.0
 ROLLBACK_SMOKE_ARTIFACT_SCHEMA = "gw15_rollback_smoke_v1"
-ROLLBACK_SMOKE_ACTION_MARKER_SCHEMA = "gw15_rollback_smoke_action_v1"
+ROLLBACK_SMOKE_RESULT_PRIMITIVE_SCHEMA = "gw15_rollback_smoke_result_v1"
 ROLLBACK_TARGET_FEATURE_FLAGS = {
     "observeFirstEnabled": False,
     "passiveStateDirectApply": False,
@@ -743,34 +743,15 @@ def load_feature_flag_snapshot(path: pathlib.Path) -> Dict[str, Any]:
     }
 
 
-def load_rollback_smoke_action_marker(path: pathlib.Path, run_id: str) -> Dict[str, Any]:
-    if not path.exists():
-        raise ValueError(f"missing rollback smoke action marker: {path}")
-    payload = load_json(path)
-    if not isinstance(payload, dict):
-        raise ValueError(f"rollback smoke action marker must be object: {path}")
-    if str(payload.get("schema", "")).strip() != ROLLBACK_SMOKE_ACTION_MARKER_SCHEMA:
-        raise ValueError(f"rollback smoke action marker schema mismatch: {path}")
-    if str(payload.get("run_id", "")).strip() != run_id:
-        raise ValueError(f"rollback smoke action marker run_id mismatch: {path}")
-    if str(payload.get("action", "")).strip() != "rollback_smoke_attempted":
-        raise ValueError(f"rollback smoke action marker action mismatch: {path}")
-    if str(payload.get("status", "")).strip() != "attempted":
-        raise ValueError(f"rollback smoke action marker status mismatch: {path}")
-    return payload
-
-
-def build_rollback_smoke_artifact(proof_dir: pathlib.Path, run_id: str) -> Dict[str, Any]:
+def evaluate_rollback_smoke_state(proof_dir: pathlib.Path, run_id: str) -> Dict[str, Any]:
     start_snapshot_path = proof_dir / "start_feature_flags.json"
     end_snapshot_path = proof_dir / "end_feature_flags.json"
-    action_marker_path = proof_dir / "rollback_smoke_action.json"
     canary_verdict_path = proof_dir / "canary_verdict.json"
     target_state = dict(ROLLBACK_TARGET_FEATURE_FLAGS)
     issues: List[str] = []
 
     pre_snapshot: Dict[str, Any] | None = None
     post_snapshot: Dict[str, Any] | None = None
-    action_marker: Dict[str, Any] | None = None
     canary_verdict: Dict[str, Any] | None = None
     try:
         pre_snapshot = load_feature_flag_snapshot(start_snapshot_path)
@@ -778,10 +759,6 @@ def build_rollback_smoke_artifact(proof_dir: pathlib.Path, run_id: str) -> Dict[
         issues.append(str(exc))
     try:
         post_snapshot = load_feature_flag_snapshot(end_snapshot_path)
-    except Exception as exc:  # noqa: BLE001 - fail closed with reason.
-        issues.append(str(exc))
-    try:
-        action_marker = load_rollback_smoke_action_marker(action_marker_path, run_id)
     except Exception as exc:  # noqa: BLE001 - fail closed with reason.
         issues.append(str(exc))
     try:
@@ -821,38 +798,125 @@ def build_rollback_smoke_artifact(proof_dir: pathlib.Path, run_id: str) -> Dict[
 
     ok = len(issues) == 0
     reason = "ok" if ok else "; ".join(issues)
+    return {
+        "target_state": target_state,
+        "pre_snapshot": pre_snapshot,
+        "post_snapshot": post_snapshot,
+        "canary_verdict": canary_verdict,
+        "pre_matches_target": pre_matches_target,
+        "post_matches_target": post_matches_target,
+        "observed_transition": observed_transition,
+        "ok": ok,
+        "reason": reason,
+        "issues": issues,
+    }
+
+
+def load_rollback_smoke_result_primitive(path: pathlib.Path, run_id: str) -> Dict[str, Any]:
+    if not path.exists():
+        raise ValueError(f"missing rollback smoke result primitive: {path}")
+    payload = load_json(path)
+    if not isinstance(payload, dict):
+        raise ValueError(f"rollback smoke result primitive must be object: {path}")
+    if str(payload.get("schema", "")).strip() != ROLLBACK_SMOKE_RESULT_PRIMITIVE_SCHEMA:
+        raise ValueError(f"rollback smoke result primitive schema mismatch: {path}")
+    if str(payload.get("run_id", "")).strip() != run_id:
+        raise ValueError(f"rollback smoke result primitive run_id mismatch: {path}")
+    if str(payload.get("status", "")).strip() not in {"pass", "fail"}:
+        raise ValueError(f"rollback smoke result primitive status mismatch: {path}")
+    if not isinstance(payload.get("pre_matches_target"), bool):
+        raise ValueError(f"rollback smoke result primitive missing pre_matches_target: {path}")
+    if not isinstance(payload.get("post_matches_target"), bool):
+        raise ValueError(f"rollback smoke result primitive missing post_matches_target: {path}")
+    if not isinstance(payload.get("observed_transition"), bool):
+        raise ValueError(f"rollback smoke result primitive missing observed_transition: {path}")
+    return payload
+
+
+def build_rollback_smoke_artifact(proof_dir: pathlib.Path, run_id: str) -> Dict[str, Any]:
+    result_primitive_path = proof_dir / "rollback_smoke_action.json"
+    state = evaluate_rollback_smoke_state(proof_dir, run_id)
+    issues: List[str] = list(state["issues"])
+    result_primitive: Dict[str, Any] | None = None
+
+    try:
+        result_primitive = load_rollback_smoke_result_primitive(result_primitive_path, run_id)
+    except Exception as exc:  # noqa: BLE001 - fail closed with reason.
+        issues.append(str(exc))
+
+    canary_status = "missing"
+    if isinstance(state["canary_verdict"], dict):
+        canary_status = str(state["canary_verdict"].get("status", "")).strip() or "missing"
+
+    if not issues:
+        expected_status = "pass" if state["ok"] else "fail"
+        if result_primitive["status"] != expected_status:
+            issues.append("rollback smoke result primitive status mismatch")
+        if result_primitive["reason"] != state["reason"]:
+            issues.append("rollback smoke result primitive reason mismatch")
+        if result_primitive["pre_matches_target"] != state["pre_matches_target"]:
+            issues.append("rollback smoke result primitive pre_matches_target mismatch")
+        if result_primitive["post_matches_target"] != state["post_matches_target"]:
+            issues.append("rollback smoke result primitive post_matches_target mismatch")
+        if result_primitive["observed_transition"] != state["observed_transition"]:
+            issues.append("rollback smoke result primitive observed_transition mismatch")
+        if str(result_primitive.get("canary_status", "")).strip() != canary_status:
+            issues.append("rollback smoke result primitive canary_status mismatch")
+
+    ok = len(issues) == 0
+    reason = "ok" if ok else "; ".join(issues)
     artifact = {
         "schema": ROLLBACK_SMOKE_ARTIFACT_SCHEMA,
         "captured_at": utc_now(),
         "run_id": run_id,
-        "rollback_action_marker": action_marker,
-        "upstream_canary_verdict": canary_verdict,
-        "pre_rollback_feature_flags": pre_snapshot,
-        "rollback_target_state": target_state,
-        "post_rollback_feature_flags": post_snapshot,
+        "rollback_result_primitive": result_primitive,
+        "upstream_canary_verdict": state["canary_verdict"],
+        "pre_rollback_feature_flags": state["pre_snapshot"],
+        "rollback_target_state": state["target_state"],
+        "post_rollback_feature_flags": state["post_snapshot"],
         "rollback_execution": {
-            "action": action_marker,
+            "result_primitive": result_primitive,
             "result": {
                 "status": "pass" if ok else "fail",
                 "reason": reason,
-                "pre_matches_target": pre_matches_target,
-                "post_matches_target": post_matches_target,
-                "observed_transition": observed_transition,
+                "pre_matches_target": state["pre_matches_target"],
+                "post_matches_target": state["post_matches_target"],
+                "observed_transition": state["observed_transition"],
                 "fail_closed": not ok,
             },
         },
         "rollback_outcome": {
             "status": "pass" if ok else "fail",
             "reason": reason,
-            "pre_matches_target": pre_matches_target,
-            "post_matches_target": post_matches_target,
-            "observed_transition": observed_transition,
+            "pre_matches_target": state["pre_matches_target"],
+            "post_matches_target": state["post_matches_target"],
+            "observed_transition": state["observed_transition"],
             "fail_closed": not ok,
         },
         "ok": ok,
         "status": "pass" if ok else "fail",
     }
     return artifact
+
+
+def build_rollback_smoke_result_primitive(proof_dir: pathlib.Path, run_id: str) -> Dict[str, Any]:
+    state = evaluate_rollback_smoke_state(proof_dir, run_id)
+    canary_status = "missing"
+    if isinstance(state["canary_verdict"], dict):
+        canary_status = str(state["canary_verdict"].get("status", "")).strip() or "missing"
+    return {
+        "schema": ROLLBACK_SMOKE_RESULT_PRIMITIVE_SCHEMA,
+        "captured_at": utc_now(),
+        "run_id": run_id,
+        "source": "passive_smoke_check.sh",
+        "status": "pass" if state["ok"] else "fail",
+        "reason": state["reason"],
+        "canary_status": canary_status,
+        "pre_matches_target": state["pre_matches_target"],
+        "post_matches_target": state["post_matches_target"],
+        "observed_transition": state["observed_transition"],
+        "fail_closed": not state["ok"],
+    }
 
 
 def load_replay_behavior_artifact(path: pathlib.Path) -> Dict[str, Any]:
@@ -1577,6 +1641,13 @@ def rollback_smoke_command(args: argparse.Namespace) -> int:
     return 0 if bool(artifact.get("ok", False)) else 1
 
 
+def rollback_smoke_result_command(args: argparse.Namespace) -> int:
+    proof_dir = pathlib.Path(args.proof_dir)
+    primitive = build_rollback_smoke_result_primitive(proof_dir, str(args.run_id).strip())
+    write_json(pathlib.Path(args.output), primitive)
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="P03 canary manifest verifier")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -1628,6 +1699,15 @@ def build_parser() -> argparse.ArgumentParser:
     rollback_smoke.add_argument("--run-id", required=True)
     rollback_smoke.add_argument("--output", required=True)
     rollback_smoke.set_defaults(func=rollback_smoke_command)
+
+    rollback_smoke_result = sub.add_parser(
+        "rollback-smoke-result",
+        help="build rollback smoke result primitive from feature-flag snapshots",
+    )
+    rollback_smoke_result.add_argument("--proof-dir", required=True)
+    rollback_smoke_result.add_argument("--run-id", required=True)
+    rollback_smoke_result.add_argument("--output", required=True)
+    rollback_smoke_result.set_defaults(func=rollback_smoke_result_command)
     return parser
 
 

--- a/scripts/passive_canary_verifier_test.py
+++ b/scripts/passive_canary_verifier_test.py
@@ -87,17 +87,32 @@ def write_replay_behavior_artifact(proof_dir: pathlib.Path) -> dict:
     return artifact
 
 
-def write_rollback_smoke_action_marker(proof_dir: pathlib.Path, run_id: str, *, status: str = "attempted") -> dict:
-    marker = {
-        "schema": verifier.ROLLBACK_SMOKE_ACTION_MARKER_SCHEMA,
+def write_rollback_smoke_result_primitive(
+    proof_dir: pathlib.Path,
+    run_id: str,
+    *,
+    status: str = "pass",
+    reason: str = "ok",
+    pre_matches_target: bool = False,
+    post_matches_target: bool = True,
+    observed_transition: bool = True,
+    canary_status: str = "pass",
+) -> dict:
+    primitive = {
+        "schema": verifier.ROLLBACK_SMOKE_RESULT_PRIMITIVE_SCHEMA,
         "captured_at": "2026-03-28T00:00:00+00:00",
         "run_id": run_id,
-        "action": "rollback_smoke_attempted",
-        "status": status,
         "source": "passive_smoke_check.sh",
+        "status": status,
+        "reason": reason,
+        "canary_status": canary_status,
+        "pre_matches_target": pre_matches_target,
+        "post_matches_target": post_matches_target,
+        "observed_transition": observed_transition,
+        "fail_closed": status != "pass",
     }
-    write_json(proof_dir / "rollback_smoke_action.json", marker)
-    return marker
+    write_json(proof_dir / "rollback_smoke_action.json", primitive)
+    return primitive
 
 
 def write_canary_verdict_marker(proof_dir: pathlib.Path, run_id: str, *, status: str = "pass") -> dict:
@@ -1702,7 +1717,7 @@ class PassiveSmokeCanaryVerdictGateTests(unittest.TestCase):
                 if rollback_smoke_path.exists():
                     artifacts["rollback_smoke"] = json.loads(rollback_smoke_path.read_text(encoding="utf-8"))
                 if rollback_smoke_action_path.exists():
-                    artifacts["rollback_smoke_action"] = json.loads(rollback_smoke_action_path.read_text(encoding="utf-8"))
+                    artifacts["rollback_smoke_result"] = json.loads(rollback_smoke_action_path.read_text(encoding="utf-8"))
                 if phase_log_path.exists():
                     artifacts["phase_log"] = [
                         line.strip()
@@ -1762,17 +1777,18 @@ class PassiveSmokeCanaryVerdictGateTests(unittest.TestCase):
     def test_smoke_emits_rollback_smoke_artifact_when_canary_verdict_is_good(self) -> None:
         result, artifacts = self.run_smoke_with_fake_tools_detailed("pass")
         self.assertEqual(result.returncode, 0, msg=result.stderr)
-        rollback_smoke_action = artifacts.get("rollback_smoke_action")
-        self.assertIsInstance(rollback_smoke_action, dict)
-        self.assertEqual(rollback_smoke_action["action"], "rollback_smoke_attempted")
+        rollback_smoke_result = artifacts.get("rollback_smoke_result")
+        self.assertIsInstance(rollback_smoke_result, dict)
+        self.assertEqual(rollback_smoke_result["status"], "pass")
+        self.assertEqual(rollback_smoke_result["canary_status"], "pass")
         rollback_smoke = artifacts.get("rollback_smoke")
         self.assertIsInstance(rollback_smoke, dict)
         self.assertTrue(rollback_smoke["ok"])
         self.assertEqual(rollback_smoke["status"], "pass")
         self.assertIsInstance(rollback_smoke["rollback_execution"], dict)
         self.assertEqual(
-            rollback_smoke["rollback_execution"]["action"]["action"],
-            "rollback_smoke_attempted",
+            rollback_smoke["rollback_execution"]["result_primitive"]["status"],
+            "pass",
         )
         self.assertEqual(
             rollback_smoke["rollback_execution"]["result"]["post_matches_target"],
@@ -1792,8 +1808,8 @@ class PassiveSmokeCanaryVerdictGateTests(unittest.TestCase):
         self.assertEqual(rollback_smoke["status"], "fail")
         self.assertIsInstance(rollback_smoke["rollback_execution"], dict)
         self.assertEqual(
-            rollback_smoke["rollback_execution"]["action"]["status"],
-            "attempted",
+            rollback_smoke["rollback_execution"]["result_primitive"]["status"],
+            "fail",
         )
 
     def test_smoke_holds_until_proof_window_end_and_requires_interval_phase(self) -> None:
@@ -1861,7 +1877,6 @@ class PassiveSmokeCanaryVerdictGateTests(unittest.TestCase):
     def test_rollback_smoke_builder_fails_closed_on_missing_end_snapshot(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             proof_dir = pathlib.Path(temp_dir)
-            write_rollback_smoke_action_marker(proof_dir, "run-1")
             write_canary_verdict_marker(proof_dir, "run-1")
             write_json(
                 proof_dir / "start_feature_flags.json",
@@ -1883,13 +1898,17 @@ class PassiveSmokeCanaryVerdictGateTests(unittest.TestCase):
                     },
                 },
             )
+            write_json(
+                proof_dir / "rollback_smoke_action.json",
+                verifier.build_rollback_smoke_result_primitive(proof_dir, "run-1"),
+            )
             artifact = verifier.build_rollback_smoke_artifact(proof_dir, "run-1")
 
         self.assertEqual(artifact["status"], "fail")
         self.assertFalse(artifact["ok"])
         self.assertIn("missing feature flag snapshot", artifact["rollback_outcome"]["reason"])
 
-    def test_rollback_smoke_builder_fails_closed_when_action_marker_missing(self) -> None:
+    def test_rollback_smoke_builder_fails_closed_when_result_primitive_missing(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             proof_dir = pathlib.Path(temp_dir)
             write_canary_verdict_marker(proof_dir, "run-4")
@@ -1937,12 +1956,11 @@ class PassiveSmokeCanaryVerdictGateTests(unittest.TestCase):
 
         self.assertEqual(artifact["status"], "fail")
         self.assertFalse(artifact["ok"])
-        self.assertIn("missing rollback smoke action marker", artifact["rollback_outcome"]["reason"])
+        self.assertIn("missing rollback smoke result primitive", artifact["rollback_outcome"]["reason"])
 
     def test_rollback_smoke_builder_fails_closed_on_post_mismatch(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             proof_dir = pathlib.Path(temp_dir)
-            write_rollback_smoke_action_marker(proof_dir, "run-2")
             write_canary_verdict_marker(proof_dir, "run-2")
             write_json(
                 proof_dir / "start_feature_flags.json",
@@ -1984,6 +2002,10 @@ class PassiveSmokeCanaryVerdictGateTests(unittest.TestCase):
                     },
                 },
             )
+            write_json(
+                proof_dir / "rollback_smoke_action.json",
+                verifier.build_rollback_smoke_result_primitive(proof_dir, "run-2"),
+            )
             artifact = verifier.build_rollback_smoke_artifact(proof_dir, "run-2")
 
         self.assertEqual(artifact["status"], "fail")
@@ -1993,7 +2015,7 @@ class PassiveSmokeCanaryVerdictGateTests(unittest.TestCase):
     def test_rollback_smoke_builder_passes_on_enabled_to_disabled_transition(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             proof_dir = pathlib.Path(temp_dir)
-            write_rollback_smoke_action_marker(proof_dir, "run-3")
+            write_rollback_smoke_result_primitive(proof_dir, "run-3")
             write_canary_verdict_marker(proof_dir, "run-3")
             write_json(
                 proof_dir / "start_feature_flags.json",

--- a/scripts/passive_smoke_check.sh
+++ b/scripts/passive_smoke_check.sh
@@ -474,9 +474,12 @@ build_replay_falsification_verdict() {
 }
 
 build_rollback_smoke_artifact() {
-  cat > "${rollback_smoke_action_path}" <<EOF
-{"schema":"gw15_rollback_smoke_action_v1","captured_at":"$(date -u +%Y-%m-%dT%H:%M:%SZ)","run_id":"${canary_run_id}","action":"rollback_smoke_attempted","status":"attempted","source":"passive_smoke_check.sh"}
-EOF
+  if ! python3 "${canary_verifier_script}" rollback-smoke-result \
+    --proof-dir "${proof_dir}" \
+    --run-id "${canary_run_id}" \
+    --output "${rollback_smoke_action_path}"; then
+    return 1
+  fi
   local status=0
   if python3 "${canary_verifier_script}" rollback-smoke \
     --proof-dir "${proof_dir}" \


### PR DESCRIPTION
Adds the bounded GW-15 rollback-smoke proof artifact.

Validation:
- `python3 -m unittest scripts.passive_canary_verifier_test`
- `PASSIVE_SMOKE_REPORT='results-matrix-ha/20260315T073335Z-passive-suite-followup-gate/index.json' ./scripts/ci_local.sh`

Emits `rollback_smoke.json` from the proof artifact set and fail-closes on missing artifact, post-rollback mismatch, or rollback smoke failure.