### PR TITLE
GW-15: add proxy-log timing reference producer (#433)

### DIFF
--- a/scripts/passive_canary_verifier_test.py
+++ b/scripts/passive_canary_verifier_test.py
@@ -4409,6 +4409,32 @@ class PassiveSmokeCanaryVerdictGateTests(unittest.TestCase):
             fake_bin.mkdir(parents=True, exist_ok=True)
             log_dir = temp_path / "logs"
             log_dir.mkdir(parents=True, exist_ok=True)
+            fake_proxy_log = log_dir / "proxy.log"
+            fake_proxy_log.write_text(
+                "\n".join(
+                    [
+                        "2026/03/28 00:00:00 session=1 start initiator=0x31",
+                        "2026/03/28 00:00:00 session=1 send symbol=0x15",
+                        "2026/03/28 00:00:00 session=1 send symbol=0xB5",
+                        "2026/03/28 00:00:00 session=1 send symbol=0x09",
+                        "2026/03/28 00:00:00 session=1 send symbol=0x01",
+                        "2026/03/28 00:00:00 session=1 send symbol=0x24",
+                        "2026/03/28 00:00:00 session=1 send symbol=0xD3",
+                        "2026/03/28 00:00:00 session=1 send symbol=0x00",
+                        "2026/03/28 00:00:00 session=1 send symbol=0xAA",
+                        "2026/03/28 00:00:00 wire_rx symbol=0x31",
+                        "2026/03/28 00:00:00 wire_rx symbol=0x15",
+                        "2026/03/28 00:00:00 wire_rx symbol=0xB5",
+                        "2026/03/28 00:00:00 wire_rx symbol=0x09",
+                        "2026/03/28 00:00:00 wire_rx symbol=0x01",
+                        "2026/03/28 00:00:00 wire_rx symbol=0x24",
+                        "2026/03/28 00:00:00 wire_rx symbol=0xD3",
+                        "2026/03/28 00:00:00 wire_rx symbol=0xAA",
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
             canonical_canary_ids_literal = json.dumps(canonical_family_proof_canary_ids())
 
             fake_python = fake_bin / "python3"
@@ -4532,6 +4558,70 @@ class PassiveSmokeCanaryVerdictGateTests(unittest.TestCase):
 
                     real_go="${REAL_GO:?REAL_GO is required}"
                     if [[ "${1:-}" == "test" ]]; then
+                      timing_out_path="${WIRE_TIMING_REFERENCE_ARTIFACT_PATH:-}"
+                      if [[ -n "${timing_out_path}" ]]; then
+                        proxy_log_path="${WIRE_TIMING_REFERENCE_PROXY_LOG_PATH:-}"
+                        if [[ -z "${proxy_log_path}" ]]; then
+                          echo "WIRE_TIMING_REFERENCE_PROXY_LOG_PATH is required" >&2
+                          exit 2
+                        fi
+                        if [[ ! -f "${proxy_log_path}" ]]; then
+                          echo "proxy log missing: ${proxy_log_path}" >&2
+                          exit 2
+                        fi
+                        if [[ " $* " != *" TestWireTimingReferenceArtifact "* ]]; then
+                          echo "timing reference producer must invoke TestWireTimingReferenceArtifact" >&2
+                          exit 2
+                        fi
+                        last_arg="${@: -1}"
+                        if [[ "${last_arg}" != "." ]]; then
+                          echo "timing reference producer must target package ." >&2
+                          exit 2
+                        fi
+                        mkdir -p "$(dirname "${timing_out_path}")"
+                        cat > "${timing_out_path}" <<EOF
+                    {
+                      "schema": "observe_first_wire_timing_reference_v1",
+                      "captured_at": "2026-03-28T00:00:00+00:00",
+                      "source": "proxy_log_session_send_plus_wire_rx",
+                      "claim_scope": "bounded_proof_window_timing_reference_source",
+                      "ok": true,
+                      "evidence": {
+                        "proxy_log_path": "${proxy_log_path}",
+                        "proxy_log_line_count": 42,
+                        "session_start_count": 2,
+                        "send_symbol_count": 16,
+                        "wire_symbol_count": 42,
+                        "synthetic_symbol_spacing_ms": 4,
+                        "timestamp_resolution": "proxy_log_seconds_plus_symbol_spacing"
+                      },
+                      "summary": {
+                        "classified_event_count": 3,
+                        "transaction_count": 3,
+                        "master_frame_count": 0,
+                        "abandoned_count": 0,
+                        "busy_seconds_total": 1.2,
+                        "families_with_intervals": 1
+                      },
+                      "periodicity": [
+                        {
+                          "source_bucket": "0x08",
+                          "target_bucket": "0x15",
+                          "primary": 181,
+                          "secondary": 9,
+                          "family": "B509",
+                          "sample_count": 2,
+                          "last_seen": "2026-03-28T00:00:10Z",
+                          "last_interval_sec": 10,
+                          "mean_interval_sec": 10,
+                          "min_interval_sec": 10,
+                          "max_interval_sec": 10
+                        }
+                      ]
+                    }
+                    EOF
+                        exit 0
+                      fi
                       out_path="${REPLAY_BEHAVIOR_ARTIFACT_PATH:-}"
                       if [[ -z "${out_path}" ]]; then
                         echo "REPLAY_BEHAVIOR_ARTIFACT_PATH is required" >&2
@@ -4967,6 +5057,7 @@ class PassiveSmokeCanaryVerdictGateTests(unittest.TestCase):
                 promotion_eligibility_path = proof_dir / "promotion_eligibility.json"
                 publisher_cadence_path = proof_dir / "publisher_cadence.json"
                 cross_plane_skew_path = proof_dir / "cross_plane_skew.json"
+                wire_timing_reference_path = proof_dir / "wire_timing_reference.json"
                 phase_log_path = temp_path / "fake_canary_phase_log.txt"
                 if summary_path.exists():
                     artifacts["summary"] = json.loads(summary_path.read_text(encoding="utf-8"))
@@ -4991,6 +5082,10 @@ class PassiveSmokeCanaryVerdictGateTests(unittest.TestCase):
                 if cross_plane_skew_path.exists():
                     artifacts["cross_plane_skew"] = json.loads(
                         cross_plane_skew_path.read_text(encoding="utf-8")
+                    )
+                if wire_timing_reference_path.exists():
+                    artifacts["wire_timing_reference"] = json.loads(
+                        wire_timing_reference_path.read_text(encoding="utf-8")
                     )
                 if phase_log_path.exists():
                     artifacts["phase_log"] = [
@@ -5092,6 +5187,28 @@ class PassiveSmokeCanaryVerdictGateTests(unittest.TestCase):
         self.assertEqual(cross_plane_skew["status"], "pass")
         self.assertEqual(cross_plane_skew["summary"]["target_max_skew_sec"], 300.0)
         self.assertTrue(cross_plane_skew["summary"]["phases_within_target"])
+
+    def test_smoke_emits_wire_timing_reference_artifact_when_canary_verdict_is_good(self) -> None:
+        result, artifacts = self.run_smoke_with_fake_tools_detailed("pass")
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        wire_timing_reference = artifacts.get("wire_timing_reference")
+        self.assertIsInstance(wire_timing_reference, dict)
+        self.assertTrue(wire_timing_reference["ok"])
+        self.assertEqual(
+            wire_timing_reference["schema"],
+            "observe_first_wire_timing_reference_v1",
+        )
+        self.assertEqual(
+            wire_timing_reference["source"],
+            "proxy_log_session_send_plus_wire_rx",
+        )
+        self.assertTrue(
+            wire_timing_reference["evidence"]["proxy_log_path"].endswith("/proxy.log")
+        )
+        self.assertEqual(
+            wire_timing_reference["summary"]["families_with_intervals"],
+            1,
+        )
 
     def test_smoke_emits_family_eligibility_artifact_for_not_proven_family(self) -> None:
         result, artifacts = self.run_smoke_with_fake_tools_detailed(

--- a/scripts/passive_smoke_check.sh
+++ b/scripts/passive_smoke_check.sh
@@ -119,6 +119,7 @@ canary_summary_path="${proof_dir}/canary_summary.json"
 canary_verdict_path="${proof_dir}/canary_verdict.json"
 publisher_cadence_path="${proof_dir}/publisher_cadence.json"
 cross_plane_skew_path="${proof_dir}/cross_plane_skew.json"
+wire_timing_reference_path="${proof_dir}/wire_timing_reference.json"
 replay_behavior_path="${proof_dir}/replay_behavior.json"
 replay_falsification_path="${proof_dir}/replay_falsification.json"
 family_eligibility_path="${proof_dir}/family_proof_eligibility.json"
@@ -627,6 +628,17 @@ build_cross_plane_skew_artifact() {
     --output "${cross_plane_skew_path}"
 }
 
+build_wire_timing_reference_artifact() {
+  if ! (
+    cd "${REPO_ROOT}" && \
+      WIRE_TIMING_REFERENCE_ARTIFACT_PATH="${wire_timing_reference_path}" \
+      WIRE_TIMING_REFERENCE_PROXY_LOG_PATH="${log_dir}/proxy.log" \
+      go test -run TestWireTimingReferenceArtifact -count=1 . >/dev/null
+  ); then
+    return 1
+  fi
+}
+
 build_replay_behavior_artifact() {
   if ! (
     cd "${REPO_ROOT}" && \
@@ -813,6 +825,10 @@ if [[ "${proof_artifacts_enabled}" == "1" ]]; then
     fi
     if ! build_cross_plane_skew_artifact; then
       echo "proof mode: cross-plane skew gate failed (see ${cross_plane_skew_path})" >&2
+      exit 1
+    fi
+    if ! build_wire_timing_reference_artifact; then
+      echo "proof mode: wire timing reference producer failed (see ${wire_timing_reference_path})" >&2
       exit 1
     fi
   fi

--- a/timing_reference_artifact_test.go
+++ b/timing_reference_artifact_test.go
@@ -1,0 +1,602 @@
+package ebusgateway
+
+import (
+	"bufio"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+)
+
+const (
+	wireTimingReferenceArtifactSchema = "observe_first_wire_timing_reference_v1"
+	proxyLogTimestampLayout           = "2006/01/02 15:04:05"
+	proxyLogSyntheticSymbolSpacing    = 4 * time.Millisecond
+)
+
+var (
+	proxyLogWireRXLineRE       = regexp.MustCompile(`^(\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}) wire_rx symbol=0x([0-9A-Fa-f]{2})$`)
+	proxyLogSessionStartLineRE = regexp.MustCompile(`^(\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}) session=(\d+) start initiator=0x([0-9A-Fa-f]{2})$`)
+	proxyLogSessionSendLineRE  = regexp.MustCompile(`^(\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}) session=(\d+) send symbol=0x([0-9A-Fa-f]{2})$`)
+)
+
+type wireTimingReferenceArtifact struct {
+	Schema      string                           `json:"schema"`
+	CapturedAt  string                           `json:"captured_at"`
+	Source      string                           `json:"source"`
+	ClaimScope  string                           `json:"claim_scope"`
+	OK          bool                             `json:"ok"`
+	Evidence    wireTimingReferenceEvidence      `json:"evidence"`
+	Summary     wireTimingReferenceSummary       `json:"summary"`
+	Periodicity []wireTimingReferencePeriodicity `json:"periodicity"`
+}
+
+type wireTimingReferenceEvidence struct {
+	ProxyLogPath             string  `json:"proxy_log_path"`
+	ProxyLogLineCount        int     `json:"proxy_log_line_count"`
+	SessionStartCount        int     `json:"session_start_count"`
+	SendSymbolCount          int     `json:"send_symbol_count"`
+	WireSymbolCount          int     `json:"wire_symbol_count"`
+	SyntheticSymbolSpacingMS float64 `json:"synthetic_symbol_spacing_ms"`
+	TimestampResolution      string  `json:"timestamp_resolution"`
+}
+
+type wireTimingReferenceSummary struct {
+	ClassifiedEventCount  int     `json:"classified_event_count"`
+	TransactionCount      int     `json:"transaction_count"`
+	MasterFrameCount      int     `json:"master_frame_count"`
+	AbandonedCount        int     `json:"abandoned_count"`
+	BusySecondsTotal      float64 `json:"busy_seconds_total"`
+	FamiliesWithIntervals int     `json:"families_with_intervals"`
+}
+
+type wireTimingReferencePeriodicity struct {
+	SourceBucket    string  `json:"source_bucket"`
+	TargetBucket    string  `json:"target_bucket"`
+	Primary         int     `json:"primary"`
+	Secondary       int     `json:"secondary"`
+	Family          string  `json:"family"`
+	SampleCount     int     `json:"sample_count"`
+	LastSeen        string  `json:"last_seen"`
+	LastIntervalSec float64 `json:"last_interval_sec,omitempty"`
+	MeanIntervalSec float64 `json:"mean_interval_sec,omitempty"`
+	MinIntervalSec  float64 `json:"min_interval_sec,omitempty"`
+	MaxIntervalSec  float64 `json:"max_interval_sec,omitempty"`
+}
+
+type proxyLogTransaction struct {
+	lineNo          int
+	startObservedAt time.Time
+	initiator       byte
+	sendSymbols     []byte
+	firstWireAt     time.Time
+	lastWireAt      time.Time
+	wireSymbolCount int
+}
+
+type wireTimingPeriodicityKey struct {
+	Source    byte
+	Target    byte
+	Primary   byte
+	Secondary byte
+	Family    string
+}
+
+type periodicityAccumulator struct {
+	starts   []time.Time
+	lastSeen time.Time
+}
+
+func TestWireTimingReferenceArtifact(t *testing.T) {
+	outPath := strings.TrimSpace(os.Getenv("WIRE_TIMING_REFERENCE_ARTIFACT_PATH"))
+	if outPath == "" {
+		t.Skip("WIRE_TIMING_REFERENCE_ARTIFACT_PATH not set")
+	}
+	proxyLogPath := strings.TrimSpace(os.Getenv("WIRE_TIMING_REFERENCE_PROXY_LOG_PATH"))
+	if proxyLogPath == "" {
+		t.Fatalf("WIRE_TIMING_REFERENCE_PROXY_LOG_PATH not set")
+	}
+
+	artifact, err := buildWireTimingReferenceArtifactFromProxyLog(proxyLogPath)
+	if err != nil {
+		t.Fatalf("build timing reference artifact error = %v", err)
+	}
+	payload, err := json.MarshalIndent(artifact, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent timing reference artifact error = %v", err)
+	}
+	payload = append(payload, '\n')
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s) error = %v", filepath.Dir(outPath), err)
+	}
+	if err := os.WriteFile(outPath, payload, 0o644); err != nil {
+		t.Fatalf("WriteFile(%s) error = %v", outPath, err)
+	}
+}
+
+func buildWireTimingReferenceArtifactFromProxyLog(proxyLogPath string) (wireTimingReferenceArtifact, error) {
+	transactions, lineCount, sessionStartCount, sendSymbolCount, wireSymbolCount, err := loadProxyLogTransactions(proxyLogPath)
+	if err != nil {
+		return wireTimingReferenceArtifact{}, err
+	}
+
+	busySecondsTotal := 0.0
+	transactionCount := 0
+	periodicity := make(map[wireTimingPeriodicityKey]*periodicityAccumulator)
+
+	for _, transaction := range transactions {
+		request, usable, err := transaction.requestFrame(proxyLogPath)
+		if err != nil {
+			return wireTimingReferenceArtifact{}, err
+		}
+		if !usable {
+			continue
+		}
+		transactionCount++
+		if transaction.wireSymbolCount > 0 {
+			duration := transaction.lastWireAt.Sub(transaction.startObservedAt).Seconds()
+			if duration < 0 || !isFiniteFloat(duration) {
+				return wireTimingReferenceArtifact{}, fmt.Errorf("%s:%d: invalid busy duration %v", proxyLogPath, transaction.lineNo, duration)
+			}
+			if duration == 0 {
+				duration = float64(transaction.wireSymbolCount) * proxyLogSyntheticSymbolSpacing.Seconds()
+			}
+			busySecondsTotal += duration
+		}
+
+		family := classifyFamily(request)
+		if family == "" || family == "other" {
+			continue
+		}
+		key := wireTimingPeriodicityKey{
+			Source:    request.Source,
+			Target:    request.Target,
+			Primary:   request.Primary,
+			Secondary: request.Secondary,
+			Family:    family,
+		}
+		acc := periodicity[key]
+		if acc == nil {
+			acc = &periodicityAccumulator{}
+			periodicity[key] = acc
+		}
+		acc.starts = append(acc.starts, transaction.startObservedAt.UTC())
+		lastSeen := transaction.lastWireAt
+		if lastSeen.IsZero() {
+			lastSeen = transaction.startObservedAt
+		}
+		if acc.lastSeen.IsZero() || lastSeen.After(acc.lastSeen) {
+			acc.lastSeen = lastSeen.UTC()
+		}
+	}
+
+	if transactionCount == 0 {
+		return wireTimingReferenceArtifact{}, fmt.Errorf("%s: proxy log did not yield any session transactions", proxyLogPath)
+	}
+	if busySecondsTotal <= 0 {
+		return wireTimingReferenceArtifact{}, fmt.Errorf("%s: proxy log did not yield positive busy timing evidence", proxyLogPath)
+	}
+
+	items := make([]wireTimingReferencePeriodicity, 0, len(periodicity))
+	familiesWithIntervals := 0
+	for key, acc := range periodicity {
+		sort.Slice(acc.starts, func(i, j int) bool {
+			return acc.starts[i].Before(acc.starts[j])
+		})
+		item := wireTimingReferencePeriodicity{
+			SourceBucket: fmt.Sprintf("0x%02X", key.Source),
+			TargetBucket: fmt.Sprintf("0x%02X", key.Target),
+			Primary:      int(key.Primary),
+			Secondary:    int(key.Secondary),
+			Family:       key.Family,
+			SampleCount:  len(acc.starts),
+			LastSeen:     acc.lastSeen.Format(time.RFC3339Nano),
+		}
+		if len(acc.starts) >= 2 {
+			intervals := make([]float64, 0, len(acc.starts)-1)
+			for index := 1; index < len(acc.starts); index++ {
+				interval := acc.starts[index].Sub(acc.starts[index-1]).Seconds()
+				if interval < 0 || !isFiniteFloat(interval) {
+					return wireTimingReferenceArtifact{}, fmt.Errorf("%s: proxy log produced invalid interval %v for %s", proxyLogPath, interval, key.Family)
+				}
+				intervals = append(intervals, interval)
+			}
+			item.LastIntervalSec = intervals[len(intervals)-1]
+			item.MinIntervalSec = intervals[0]
+			item.MaxIntervalSec = intervals[0]
+			total := 0.0
+			for _, interval := range intervals {
+				total += interval
+				if interval < item.MinIntervalSec {
+					item.MinIntervalSec = interval
+				}
+				if interval > item.MaxIntervalSec {
+					item.MaxIntervalSec = interval
+				}
+			}
+			item.MeanIntervalSec = total / float64(len(intervals))
+			familiesWithIntervals++
+		}
+		items = append(items, item)
+	}
+
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Family != items[j].Family {
+			return items[i].Family < items[j].Family
+		}
+		if items[i].SourceBucket != items[j].SourceBucket {
+			return items[i].SourceBucket < items[j].SourceBucket
+		}
+		if items[i].TargetBucket != items[j].TargetBucket {
+			return items[i].TargetBucket < items[j].TargetBucket
+		}
+		if items[i].Primary != items[j].Primary {
+			return items[i].Primary < items[j].Primary
+		}
+		return items[i].Secondary < items[j].Secondary
+	})
+
+	if familiesWithIntervals == 0 {
+		return wireTimingReferenceArtifact{}, fmt.Errorf("%s: proxy log did not yield any periodicity intervals", proxyLogPath)
+	}
+
+	return wireTimingReferenceArtifact{
+		Schema:     wireTimingReferenceArtifactSchema,
+		CapturedAt: time.Now().UTC().Format(time.RFC3339Nano),
+		Source:     "proxy_log_session_send_plus_wire_rx",
+		ClaimScope: "bounded_proof_window_timing_reference_source",
+		OK:         true,
+		Evidence: wireTimingReferenceEvidence{
+			ProxyLogPath:             proxyLogPath,
+			ProxyLogLineCount:        lineCount,
+			SessionStartCount:        sessionStartCount,
+			SendSymbolCount:          sendSymbolCount,
+			WireSymbolCount:          wireSymbolCount,
+			SyntheticSymbolSpacingMS: float64(proxyLogSyntheticSymbolSpacing) / float64(time.Millisecond),
+			TimestampResolution:      "proxy_log_seconds_plus_symbol_spacing",
+		},
+		Summary: wireTimingReferenceSummary{
+			ClassifiedEventCount:  transactionCount,
+			TransactionCount:      transactionCount,
+			MasterFrameCount:      0,
+			AbandonedCount:        0,
+			BusySecondsTotal:      busySecondsTotal,
+			FamiliesWithIntervals: familiesWithIntervals,
+		},
+		Periodicity: items,
+	}, nil
+}
+
+func loadProxyLogTransactions(path string) ([]proxyLogTransaction, int, int, int, int, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, 0, 0, 0, 0, fmt.Errorf("proxy log path is empty")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, 0, 0, 0, 0, fmt.Errorf("open proxy log %s: %w", path, err)
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+
+	scanner := bufio.NewScanner(file)
+	lineCount := 0
+	sessionStartCount := 0
+	sendSymbolCount := 0
+	wireSymbolCount := 0
+	var lastObservedAt time.Time
+	transactions := make([]proxyLogTransaction, 0, 64)
+	var current *proxyLogTransaction
+
+	finalizeCurrent := func() error {
+		if current == nil {
+			return nil
+		}
+		if len(current.sendSymbols) == 0 {
+			current = nil
+			return nil
+		}
+		transactions = append(transactions, *current)
+		current = nil
+		return nil
+	}
+
+	for scanner.Scan() {
+		lineCount++
+		line := scanner.Text()
+
+		switch {
+		case proxyLogSessionStartLineRE.MatchString(line):
+			match := proxyLogSessionStartLineRE.FindStringSubmatch(line)
+			observedAt, err := nextProxyLogObservedAt(match[1], lastObservedAt)
+			if err != nil {
+				return nil, lineCount, sessionStartCount, sendSymbolCount, wireSymbolCount, fmt.Errorf("%s:%d: parse start timestamp: %w", path, lineCount, err)
+			}
+			lastObservedAt = observedAt
+			if err := finalizeCurrent(); err != nil {
+				return nil, lineCount, sessionStartCount, sendSymbolCount, wireSymbolCount, err
+			}
+			initiator, err := decodeProxyLogHexByte(match[3])
+			if err != nil {
+				return nil, lineCount, sessionStartCount, sendSymbolCount, wireSymbolCount, fmt.Errorf("%s:%d: parse initiator %q: %w", path, lineCount, match[3], err)
+			}
+			sessionStartCount++
+			current = &proxyLogTransaction{
+				lineNo:          lineCount,
+				startObservedAt: observedAt,
+				initiator:       initiator,
+				sendSymbols:     make([]byte, 0, 16),
+			}
+		case proxyLogSessionSendLineRE.MatchString(line):
+			match := proxyLogSessionSendLineRE.FindStringSubmatch(line)
+			observedAt, err := nextProxyLogObservedAt(match[1], lastObservedAt)
+			if err != nil {
+				return nil, lineCount, sessionStartCount, sendSymbolCount, wireSymbolCount, fmt.Errorf("%s:%d: parse send timestamp: %w", path, lineCount, err)
+			}
+			lastObservedAt = observedAt
+			if current == nil {
+				return nil, lineCount, sessionStartCount, sendSymbolCount, wireSymbolCount, fmt.Errorf("%s:%d: send symbol without preceding session start", path, lineCount)
+			}
+			symbol, err := decodeProxyLogHexByte(match[3])
+			if err != nil {
+				return nil, lineCount, sessionStartCount, sendSymbolCount, wireSymbolCount, fmt.Errorf("%s:%d: parse send symbol %q: %w", path, lineCount, match[3], err)
+			}
+			current.sendSymbols = append(current.sendSymbols, symbol)
+			sendSymbolCount++
+		case proxyLogWireRXLineRE.MatchString(line):
+			match := proxyLogWireRXLineRE.FindStringSubmatch(line)
+			observedAt, err := nextProxyLogObservedAt(match[1], lastObservedAt)
+			if err != nil {
+				return nil, lineCount, sessionStartCount, sendSymbolCount, wireSymbolCount, fmt.Errorf("%s:%d: parse wire_rx timestamp: %w", path, lineCount, err)
+			}
+			lastObservedAt = observedAt
+			if _, err := decodeProxyLogHexByte(match[2]); err != nil {
+				return nil, lineCount, sessionStartCount, sendSymbolCount, wireSymbolCount, fmt.Errorf("%s:%d: parse wire_rx symbol %q: %w", path, lineCount, match[2], err)
+			}
+			wireSymbolCount++
+			if current != nil {
+				current.wireSymbolCount++
+				if current.firstWireAt.IsZero() {
+					current.firstWireAt = observedAt
+				}
+				current.lastWireAt = observedAt
+			}
+		case strings.Contains(line, "wire_rx"):
+			return nil, lineCount, sessionStartCount, sendSymbolCount, wireSymbolCount, fmt.Errorf("%s:%d: malformed wire_rx line", path, lineCount)
+		case strings.Contains(line, " start initiator="):
+			return nil, lineCount, sessionStartCount, sendSymbolCount, wireSymbolCount, fmt.Errorf("%s:%d: malformed session start line", path, lineCount)
+		case strings.Contains(line, " send symbol="):
+			return nil, lineCount, sessionStartCount, sendSymbolCount, wireSymbolCount, fmt.Errorf("%s:%d: malformed session send line", path, lineCount)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, lineCount, sessionStartCount, sendSymbolCount, wireSymbolCount, fmt.Errorf("scan proxy log %s: %w", path, err)
+	}
+	if err := finalizeCurrent(); err != nil {
+		return nil, lineCount, sessionStartCount, sendSymbolCount, wireSymbolCount, err
+	}
+	if len(transactions) == 0 {
+		return nil, lineCount, sessionStartCount, sendSymbolCount, wireSymbolCount, fmt.Errorf("%s: missing session start timing evidence", path)
+	}
+	if wireSymbolCount == 0 {
+		return nil, lineCount, sessionStartCount, sendSymbolCount, wireSymbolCount, fmt.Errorf("%s: missing wire_rx timing evidence", path)
+	}
+	return transactions, lineCount, sessionStartCount, sendSymbolCount, wireSymbolCount, nil
+}
+
+func (transaction proxyLogTransaction) requestFrame(path string) (protocol.Frame, bool, error) {
+	if len(transaction.sendSymbols) == 0 {
+		return protocol.Frame{}, false, nil
+	}
+	if transaction.sendSymbols[len(transaction.sendSymbols)-1] != protocol.SymbolSyn {
+		return protocol.Frame{}, false, nil
+	}
+	requestSymbols := transaction.sendSymbols[:len(transaction.sendSymbols)-1]
+	if len(requestSymbols) > 0 && requestSymbols[len(requestSymbols)-1] == protocol.SymbolAck {
+		requestSymbols = requestSymbols[:len(requestSymbols)-1]
+	}
+	raw := make([]byte, 0, 1+len(requestSymbols))
+	raw = append(raw, transaction.initiator)
+	raw = append(raw, requestSymbols...)
+	frame, ok := parseFrame(raw)
+	if !ok {
+		return protocol.Frame{}, false, fmt.Errorf("%s:%d: session send sequence did not decode to a valid initiator frame", path, transaction.lineNo)
+	}
+	return frame, true, nil
+}
+
+func nextProxyLogObservedAt(raw string, previous time.Time) (time.Time, error) {
+	baseTime, err := time.ParseInLocation(proxyLogTimestampLayout, raw, time.UTC)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if previous.IsZero() || baseTime.After(previous) {
+		return baseTime, nil
+	}
+	return previous.Add(proxyLogSyntheticSymbolSpacing), nil
+}
+
+func decodeProxyLogHexByte(value string) (byte, error) {
+	symbolBytes, err := hex.DecodeString(value)
+	if err != nil || len(symbolBytes) != 1 {
+		return 0, fmt.Errorf("invalid byte %q", value)
+	}
+	return symbolBytes[0], nil
+}
+
+func TestBuildWireTimingReferenceArtifactFromProxyLog(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, time.March, 28, 21, 0, 0, 0, time.UTC)
+	requestB509 := protocol.Frame{
+		Source:    0x31,
+		Target:    0x15,
+		Primary:   0xB5,
+		Secondary: 0x09,
+		Data:      []byte{0x24},
+	}
+	requestB524 := protocol.Frame{
+		Source:    0x31,
+		Target:    0x08,
+		Primary:   0xB5,
+		Secondary: 0x24,
+		Data:      []byte{0x08, 0x10},
+	}
+
+	withTempFile(t, func(path string) {
+		lines := make([]string, 0, 128)
+		lines = append(lines, proxyLogLinesForTransaction(base, requestB509, []byte{0x11, 0x22})...)
+		lines = append(lines, proxyLogLinesForTransaction(base.Add(10*time.Second), requestB509, []byte{0x33, 0x44})...)
+		lines = append(lines, proxyLogLinesForTransaction(base.Add(20*time.Second), requestB524, []byte{0x55, 0x66})...)
+		if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s) error = %v", path, err)
+		}
+
+		artifact, err := buildWireTimingReferenceArtifactFromProxyLog(path)
+		if err != nil {
+			t.Fatalf("buildWireTimingReferenceArtifactFromProxyLog error = %v", err)
+		}
+		if !artifact.OK {
+			t.Fatal("artifact.OK = false; want true")
+		}
+		if artifact.Schema != wireTimingReferenceArtifactSchema {
+			t.Fatalf("schema = %q; want %q", artifact.Schema, wireTimingReferenceArtifactSchema)
+		}
+		if artifact.Source != "proxy_log_session_send_plus_wire_rx" {
+			t.Fatalf("source = %q; want proxy_log_session_send_plus_wire_rx", artifact.Source)
+		}
+		if artifact.Evidence.SessionStartCount != 3 {
+			t.Fatalf("session_start_count = %d; want 3", artifact.Evidence.SessionStartCount)
+		}
+		if artifact.Summary.TransactionCount != 3 {
+			t.Fatalf("transaction_count = %d; want 3", artifact.Summary.TransactionCount)
+		}
+		if artifact.Summary.FamiliesWithIntervals != 1 {
+			t.Fatalf("families_with_intervals = %d; want 1", artifact.Summary.FamiliesWithIntervals)
+		}
+		if artifact.Summary.BusySecondsTotal <= 0 {
+			t.Fatalf("busy_seconds_total = %v; want > 0", artifact.Summary.BusySecondsTotal)
+		}
+		var b509 *wireTimingReferencePeriodicity
+		for index := range artifact.Periodicity {
+			if artifact.Periodicity[index].Family == "B509" {
+				b509 = &artifact.Periodicity[index]
+				break
+			}
+		}
+		if b509 == nil {
+			t.Fatalf("periodicity = %+v; want B509 item", artifact.Periodicity)
+		}
+		if b509.SourceBucket != "0x31" || b509.TargetBucket != "0x15" {
+			t.Fatalf("B509 buckets = %s -> %s; want 0x31 -> 0x15", b509.SourceBucket, b509.TargetBucket)
+		}
+		if b509.SampleCount != 2 {
+			t.Fatalf("B509 sample_count = %d; want 2", b509.SampleCount)
+		}
+		if diff := math.Abs(b509.LastIntervalSec - 10.0); diff > 0.5 {
+			t.Fatalf("B509 last_interval_sec = %v; want ~10s", b509.LastIntervalSec)
+		}
+	})
+}
+
+func TestBuildWireTimingReferenceArtifactFailsOnMissingProxyLog(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildWireTimingReferenceArtifactFromProxyLog("/definitely/missing/proxy.log")
+	if err == nil {
+		t.Fatal("missing proxy log error = nil; want error")
+	}
+}
+
+func TestBuildWireTimingReferenceArtifactFailsOnMalformedWireRXLine(t *testing.T) {
+	t.Parallel()
+
+	withTempFile(t, func(path string) {
+		lines := []string{
+			"2026/03/28 21:00:00 session=1 start initiator=0x31",
+			"2026/03/28 21:00:00 session=1 send symbol=0x15",
+			"2026/03/28 21:00:00 session=1 send symbol=0xB5",
+			"2026/03/28 21:00:00 session=1 send symbol=0x09",
+			"2026/03/28 21:00:00 session=1 send symbol=0x01",
+			"2026/03/28 21:00:00 session=1 send symbol=0x24",
+			"2026/03/28 21:00:00 session=1 send symbol=0xD3",
+			"2026/03/28 21:00:00 session=1 send symbol=0x00",
+			"2026/03/28 21:00:00 session=1 send symbol=0xAA",
+			"2026/03/28 21:00:00 wire_rx nope",
+		}
+		if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s) error = %v", path, err)
+		}
+		_, err := buildWireTimingReferenceArtifactFromProxyLog(path)
+		if err == nil {
+			t.Fatal("malformed proxy log error = nil; want error")
+		}
+		if !strings.Contains(err.Error(), "malformed wire_rx line") {
+			t.Fatalf("malformed proxy log error = %v; want malformed wire_rx line", err)
+		}
+	})
+}
+
+func TestBuildWireTimingReferenceArtifactFailsOnMalformedSessionSendLine(t *testing.T) {
+	t.Parallel()
+
+	withTempFile(t, func(path string) {
+		lines := []string{
+			"2026/03/28 21:00:00 session=1 start initiator=0x31",
+			"2026/03/28 21:00:00 session=1 send symbol=nope",
+			"2026/03/28 21:00:00 wire_rx symbol=0xAA",
+		}
+		if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s) error = %v", path, err)
+		}
+		_, err := buildWireTimingReferenceArtifactFromProxyLog(path)
+		if err == nil {
+			t.Fatal("malformed session send error = nil; want error")
+		}
+		if !strings.Contains(err.Error(), "malformed session send line") {
+			t.Fatalf("malformed session send error = %v; want malformed session send line", err)
+		}
+	})
+}
+
+func transactionPayload(request protocol.Frame, responseData []byte) []byte {
+	payload := append([]byte{}, frameBytes(request)...)
+	payload = append(payload, protocol.SymbolAck)
+	payload = append(payload, responseSegmentBytes(responseData)...)
+	payload = append(payload, protocol.SymbolAck, protocol.SymbolSyn)
+	return payload
+}
+
+func proxyLogLinesForTransaction(at time.Time, request protocol.Frame, responseData []byte) []string {
+	lines := make([]string, 0, 32)
+	prefix := at.UTC().Format(proxyLogTimestampLayout)
+	lines = append(lines, fmt.Sprintf("%s session=1 start initiator=0x%02X", prefix, request.Source))
+	sendSymbols := frameBytes(request)
+	sendSymbols = append(sendSymbols[1:len(sendSymbols)-1], protocol.SymbolAck, protocol.SymbolSyn)
+	for _, symbol := range sendSymbols {
+		lines = append(lines, fmt.Sprintf("%s session=1 send symbol=0x%02X", prefix, symbol))
+	}
+	for _, symbol := range transactionPayload(request, responseData) {
+		lines = append(lines, fmt.Sprintf("%s wire_rx symbol=0x%02X", prefix, symbol))
+	}
+	return lines
+}
+
+func withTempFile(t *testing.T, fn func(path string)) {
+	t.Helper()
+	dir := t.TempDir()
+	fn(filepath.Join(dir, "proxy.log"))
+}
+
+func isFiniteFloat(value float64) bool {
+	return !math.IsNaN(value) && !math.IsInf(value, 0)
+}


### PR DESCRIPTION
## What
Add the bounded proof-window timing-reference producer for GW-15 by deriving an independent artifact from `proxy.log` session-start, session-send, and `wire_rx` evidence.

## Why
`#416` needs an honest downstream comparator, but the direct comparator lane was premature without an independent timing-reference source. This slice closes `#433` first so the timing-reference artifact exists and passes on real bounded `P03` proof logs.

## Validation
- `bash -n scripts/passive_smoke_check.sh`
- `go test -run 'TestWireTimingReferenceArtifact|TestBuildWireTimingReferenceArtifact' .`
- real artifact replay against `results-matrix-ha/20260315T070147Z-gw15-proof-p03-canonical-rerun/P03/logs/proxy.log`
- `python3 -m unittest -v scripts.passive_canary_verifier_test`
- `go test ./...`
- `PASSIVE_SMOKE_REPORT=/Users/razvan/Desktop/Helianthus Project/helianthus-ebusgateway/results-matrix-ha/20260315T070728Z-passive-suite-ci-gate-rerun/index.json ./scripts/ci_local.sh`

## Notes
- malformed relevant `session start` / `session send` / `wire_rx` lines now fail closed
- incomplete proxy sessions that never produce a decodable initiator request are skipped as unusable timing evidence rather than poisoning otherwise valid proof-window artifacts
- fake smoke now requires the real timing-reference producer target and a non-empty proxy-log path instead of fabricating a green artifact from env presence alone

Refs #433
