### PR TITLE
GW-15: add wire-derived timing reference comparator verdict (#416)

### DIFF
--- a/scripts/passive_canary_verifier.py
+++ b/scripts/passive_canary_verifier.py
@@ -39,6 +39,12 @@ PUBLISHER_CADENCE_SOURCE_ANCHOR = "config.semantic_state_interval"
 CROSS_PLANE_SKEW_ARTIFACT_SCHEMA = "p03_cross_plane_skew_v1"
 ROLLBACK_EXECUTION_ARTIFACT_SCHEMA = "observe_first_rollback_execution_v1"
 ROLLBACK_RESULT_ARTIFACT_SCHEMA = "observe_first_rollback_result_v1"
+TIMING_REFERENCE_VERDICT_SCHEMA = "p03_timing_reference_verdict_v1"
+TIMING_REFERENCE_BUSY_RELATIVE_ERROR_MAX = 0.15
+TIMING_REFERENCE_PERIODICITY_RELATIVE_ERROR_MAX = 0.20
+TIMING_REFERENCE_PERIODICITY_ABSOLUTE_ERROR_SEC_MAX = 2.0
+TIMING_REFERENCE_PERIODICITY_MIN_SAMPLES = 10
+TIMING_REFERENCE_BUSY_METRIC = "ebus_bus_busy_seconds_total"
 ROLLBACK_TARGET_FEATURE_FLAGS = {
     "observeFirstEnabled": False,
     "passiveStateDirectApply": False,
@@ -93,6 +99,7 @@ FEATURE_FLAG_FIELD_ALIASES = {
 FEATURE_FLAG_CONSISTENCY_SCHEMA = "p03_feature_flag_consistency_v1"
 REPLAY_EXPECTED_DISPOSITIONS = {"ambiguity", "falsification"}
 PROM_SAMPLE_RE = re.compile(r"^([a-zA-Z_:][a-zA-Z0-9_:]*)(\{[^}]*\})?\s+([^\s]+)$")
+GO_DURATION_COMPONENT_RE = re.compile(r"(\d+(?:\.\d+)?)(ns|us|µs|μs|ms|s|m|h)")
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 CANONICAL_FAMILY_PROOF_CASE_ID = "P03"
 CANONICAL_P03_CANARY_MANIFEST_PATH = REPO_ROOT / "testdata" / "passive_proof" / "p03_canary_manifest.json"
@@ -146,6 +153,53 @@ def timestamp_not_before_boundary(captured_at: datetime, boundary: datetime, bou
     if timestamp_has_subsecond_precision(boundary_raw):
         return captured_at >= boundary
     return captured_at.replace(microsecond=0) >= boundary.replace(microsecond=0)
+
+
+def parse_duration_seconds(value: Any, field_name: str) -> float:
+    if isinstance(value, (int, float)):
+        seconds = float(value)
+        if abs(seconds) >= 1e6:
+            seconds /= 1e9
+    else:
+        text = str(value).strip()
+        if text == "":
+            raise ValueError(f"{field_name} must be non-empty duration")
+        try:
+            seconds = float(text)
+        except ValueError:
+            if text.startswith(("+", "-")):
+                raise ValueError(f"{field_name} must be non-negative finite duration")
+            seconds = 0.0
+            consumed = 0
+            factors = {
+                "ns": 1e-9,
+                "us": 1e-6,
+                "µs": 1e-6,
+                "μs": 1e-6,
+                "ms": 1e-3,
+                "s": 1.0,
+                "m": 60.0,
+                "h": 3600.0,
+            }
+            for match in GO_DURATION_COMPONENT_RE.finditer(text):
+                if match.start() != consumed:
+                    raise ValueError(f"{field_name} must be non-negative finite duration")
+                amount = float(match.group(1))
+                unit = match.group(2)
+                seconds += amount * factors[unit]
+                consumed = match.end()
+            if consumed != len(text) or consumed == 0:
+                raise ValueError(f"{field_name} must be non-negative finite duration")
+    if not math.isfinite(seconds) or seconds < 0:
+        raise ValueError(f"{field_name} must be non-negative finite duration")
+    return seconds
+
+
+def extract_mapping_value(payload: Dict[str, Any], aliases: Tuple[str, ...]) -> Any:
+    for alias in aliases:
+        if alias in payload:
+            return payload.get(alias)
+    return None
 
 
 def parse_cli_bool(value: Any, field_name: str) -> bool:
@@ -755,6 +809,380 @@ def build_rollback_result_artifact(proof_dir: pathlib.Path, run_id: str) -> Dict
                         if not post_live_ready
                         else "ok"
                     )
+                ),
+            },
+        },
+        "ok": status == "pass",
+        "status": status,
+        "reason": reason,
+    }
+
+
+def load_wire_timing_reference_artifact(path: pathlib.Path) -> Dict[str, Any]:
+    if not path.exists():
+        raise ValueError(f"missing wire timing reference artifact at {path}")
+    payload = load_json(path)
+    if not isinstance(payload, dict):
+        raise ValueError("wire timing reference artifact must be a JSON object")
+    if str(payload.get("schema", "")).strip() != "observe_first_wire_timing_reference_v1":
+        raise ValueError("wire timing reference artifact schema mismatch")
+    if str(payload.get("source", "")).strip() != "proxy_log_session_send_plus_wire_rx":
+        raise ValueError("wire timing reference artifact source mismatch")
+    if bool(payload.get("ok")) is not True:
+        raise ValueError("wire timing reference artifact is not ok")
+    summary = payload.get("summary")
+    if not isinstance(summary, dict):
+        raise ValueError("wire timing reference artifact missing summary object")
+    busy_seconds_total = summary.get("busy_seconds_total")
+    if not isinstance(busy_seconds_total, (int, float)) or not math.isfinite(float(busy_seconds_total)):
+        raise ValueError("wire timing reference artifact missing finite summary.busy_seconds_total")
+    if float(busy_seconds_total) <= 0:
+        raise ValueError("wire timing reference artifact summary.busy_seconds_total must be > 0")
+    families_with_intervals = summary.get("families_with_intervals")
+    if not isinstance(families_with_intervals, int) or families_with_intervals <= 0:
+        raise ValueError("wire timing reference artifact missing positive summary.families_with_intervals")
+    periodicity = payload.get("periodicity")
+    if not isinstance(periodicity, list):
+        raise ValueError("wire timing reference artifact missing periodicity array")
+    evidence = payload.get("evidence")
+    if not isinstance(evidence, dict):
+        raise ValueError("wire timing reference artifact missing evidence object")
+    if str(evidence.get("proxy_log_path", "")).strip() == "":
+        raise ValueError("wire timing reference artifact missing evidence.proxy_log_path")
+    return payload
+
+
+def proof_log_bundle_root(proof_dir: pathlib.Path) -> pathlib.Path:
+    resolved = proof_dir.resolve()
+    if resolved.name == "proof_artifacts":
+        return resolved.parent
+    return resolved
+
+
+def require_wire_reference_proxy_log_path(
+    proof_dir: pathlib.Path,
+    wire_reference_path: pathlib.Path,
+    wire_reference: Dict[str, Any],
+) -> pathlib.Path:
+    evidence = wire_reference.get("evidence")
+    if not isinstance(evidence, dict):
+        raise ValueError("wire timing reference artifact missing evidence object")
+    raw_proxy_log_path = str(evidence.get("proxy_log_path", "")).strip()
+    if raw_proxy_log_path == "":
+        raise ValueError("wire timing reference artifact missing evidence.proxy_log_path")
+    candidate = pathlib.Path(raw_proxy_log_path)
+    if not candidate.is_absolute():
+        candidate = wire_reference_path.parent / candidate
+    resolved = candidate.resolve()
+    bundle_root = proof_log_bundle_root(proof_dir)
+    try:
+        resolved.relative_to(bundle_root)
+    except ValueError as exc:
+        raise ValueError(
+            "wire timing reference artifact evidence.proxy_log_path must stay within the current proof log bundle"
+        ) from exc
+    if resolved.name != "proxy.log":
+        raise ValueError("wire timing reference artifact evidence.proxy_log_path must reference proxy.log")
+    if not resolved.is_file():
+        raise ValueError("wire timing reference artifact evidence.proxy_log_path is missing")
+    if resolved.stat().st_size <= 0:
+        raise ValueError("wire timing reference artifact evidence.proxy_log_path is empty")
+    return resolved
+
+
+def normalize_periodicity_entry(
+    raw: Dict[str, Any],
+    field_name: str,
+    *,
+    require_available_state: bool = False,
+    require_complete_intervals: bool = False,
+) -> Dict[str, Any]:
+    source_bucket = str(
+        extract_mapping_value(raw, ("source_bucket", "sourceBucket", "SourceBucket")) or ""
+    ).strip().upper()
+    target_bucket = str(
+        extract_mapping_value(raw, ("target_bucket", "targetBucket", "TargetBucket")) or ""
+    ).strip().upper()
+    family = str(extract_mapping_value(raw, ("family", "Family")) or "").strip().upper()
+    primary_raw = extract_mapping_value(raw, ("primary", "Primary"))
+    secondary_raw = extract_mapping_value(raw, ("secondary", "Secondary"))
+    sample_count_raw = extract_mapping_value(raw, ("sample_count", "sampleCount", "SampleCount"))
+    state_raw = extract_mapping_value(raw, ("state", "State"))
+    last_interval_raw = extract_mapping_value(
+        raw,
+        ("last_interval_sec", "last_interval", "lastInterval", "LastInterval"),
+    )
+    mean_interval_raw = extract_mapping_value(
+        raw,
+        ("mean_interval_sec", "mean_interval", "meanInterval", "MeanInterval"),
+    )
+    min_interval_raw = extract_mapping_value(
+        raw,
+        ("min_interval_sec", "min_interval", "minInterval", "MinInterval"),
+    )
+    max_interval_raw = extract_mapping_value(
+        raw,
+        ("max_interval_sec", "max_interval", "maxInterval", "MaxInterval"),
+    )
+    if source_bucket == "" or target_bucket == "" or family == "":
+        raise ValueError(f"{field_name} missing tuple identity")
+    if not isinstance(primary_raw, int) or not isinstance(secondary_raw, int):
+        raise ValueError(f"{field_name} missing integer primary/secondary")
+    if not isinstance(sample_count_raw, int) or sample_count_raw < 0:
+        raise ValueError(f"{field_name} missing non-negative sample_count")
+    state = None
+    if state_raw is not None:
+        state = str(state_raw).strip().lower()
+        if state == "":
+            raise ValueError(f"{field_name} has empty state")
+    if require_available_state and state != "available":
+        raise ValueError(f"{field_name} must be state=available")
+    if require_complete_intervals:
+        last_interval_sec = parse_duration_seconds(last_interval_raw, f"{field_name}.last_interval")
+        min_interval_sec = parse_duration_seconds(min_interval_raw, f"{field_name}.min_interval")
+        max_interval_sec = parse_duration_seconds(max_interval_raw, f"{field_name}.max_interval")
+    else:
+        last_interval_sec = (
+            None if last_interval_raw is None else parse_duration_seconds(last_interval_raw, f"{field_name}.last_interval")
+        )
+        min_interval_sec = (
+            None if min_interval_raw is None else parse_duration_seconds(min_interval_raw, f"{field_name}.min_interval")
+        )
+        max_interval_sec = (
+            None if max_interval_raw is None else parse_duration_seconds(max_interval_raw, f"{field_name}.max_interval")
+        )
+    mean_interval_sec = parse_duration_seconds(mean_interval_raw, f"{field_name}.mean_interval")
+    return {
+        "key": f"{source_bucket}>{target_bucket}:{primary_raw}:{secondary_raw}:{family}",
+        "source_bucket": source_bucket,
+        "target_bucket": target_bucket,
+        "family": family,
+        "primary": primary_raw,
+        "secondary": secondary_raw,
+        "sample_count": sample_count_raw,
+        "state": state,
+        "last_interval_sec": last_interval_sec,
+        "mean_interval_sec": mean_interval_sec,
+        "min_interval_sec": min_interval_sec,
+        "max_interval_sec": max_interval_sec,
+    }
+
+
+def build_timing_reference_verdict(
+    proof_dir: pathlib.Path,
+    run_id: str,
+    wire_reference_path: pathlib.Path | None = None,
+) -> Dict[str, Any]:
+    if wire_reference_path is None:
+        wire_reference_path = proof_dir / "wire_timing_reference.json"
+    reasons: List[str] = []
+    start_bundle: Dict[str, Any] | None = None
+    end_bundle: Dict[str, Any] | None = None
+    wire_reference: Dict[str, Any] | None = None
+    wire_reference_valid = False
+    wire_proxy_log_path: str | None = None
+    observed_busy_seconds = 0.0
+    reference_busy_seconds = 0.0
+    busy_relative_error: float | None = None
+    busy_within_tolerance = False
+    stable_reference_tuple_count = 0
+    matched_tuple_count = 0
+    tuple_comparisons: List[Dict[str, Any]] = []
+
+    try:
+        wire_reference = load_wire_timing_reference_artifact(wire_reference_path)
+        wire_proxy_log_path = str(
+            require_wire_reference_proxy_log_path(proof_dir, wire_reference_path, wire_reference)
+        )
+        wire_reference_valid = True
+    except Exception as exc:  # noqa: BLE001
+        reasons.append(str(exc))
+
+    for phase_name, slot_name in (("start", "start"), ("end", "end")):
+        try:
+            snapshot = load_structured_snapshot_bundle(proof_dir, phase_name)
+        except Exception as exc:  # noqa: BLE001
+            reasons.append(str(exc))
+            continue
+        if slot_name == "start":
+            start_bundle = snapshot
+        else:
+            end_bundle = snapshot
+
+    if start_bundle is not None and end_bundle is not None:
+        try:
+            start_samples = parse_prometheus_samples(
+                pathlib.Path(start_bundle["snapshot_paths"]["metrics"]).read_text(encoding="utf-8")
+            )
+            end_samples = parse_prometheus_samples(
+                pathlib.Path(end_bundle["snapshot_paths"]["metrics"]).read_text(encoding="utf-8")
+            )
+            start_busy_total = aggregate_metric_total(start_samples, TIMING_REFERENCE_BUSY_METRIC, required=True)
+            end_busy_total = aggregate_metric_total(end_samples, TIMING_REFERENCE_BUSY_METRIC, required=True)
+            if start_busy_total is None or end_busy_total is None:
+                reasons.append("missing busy metrics for timing comparator")
+            elif end_busy_total < start_busy_total:
+                reasons.append("busy metric regressed across proof window")
+            else:
+                observed_busy_seconds = end_busy_total - start_busy_total
+        except Exception as exc:  # noqa: BLE001
+            reasons.append(str(exc))
+
+    if wire_reference_valid and wire_reference is not None:
+        reference_busy_seconds = float(((wire_reference.get("summary") or {}).get("busy_seconds_total")) or 0.0)
+
+    if reference_busy_seconds > 0 and observed_busy_seconds >= 0:
+        busy_relative_error = abs(observed_busy_seconds - reference_busy_seconds) / reference_busy_seconds
+        busy_within_tolerance = busy_relative_error <= TIMING_REFERENCE_BUSY_RELATIVE_ERROR_MAX
+        if not busy_within_tolerance:
+            reasons.append(
+                "busy timing mismatch exceeds tolerance "
+                f"(observed={observed_busy_seconds:.6f}s reference={reference_busy_seconds:.6f}s "
+                f"relative_error={busy_relative_error:.6f} max={TIMING_REFERENCE_BUSY_RELATIVE_ERROR_MAX:.6f})"
+            )
+
+    if wire_reference_valid and wire_reference is not None and end_bundle is not None:
+        reference_entries: Dict[str, Dict[str, Any]] = {}
+        for index, raw_entry in enumerate(wire_reference.get("periodicity") or []):
+            if not isinstance(raw_entry, dict):
+                reasons.append(f"wire timing reference periodicity[{index}] must be object")
+                continue
+            try:
+                normalized = normalize_periodicity_entry(raw_entry, f"wire_timing_reference.periodicity[{index}]")
+            except Exception as exc:  # noqa: BLE001
+                reasons.append(str(exc))
+                continue
+            if normalized["key"] in reference_entries:
+                reasons.append(f"duplicate wire timing reference periodicity tuple {normalized['key']}")
+                continue
+            reference_entries[normalized["key"]] = normalized
+
+        bus_observability = end_bundle["bus_observability"] or {}
+        observed_raw = bus_observability.get("periodicity")
+        if not isinstance(observed_raw, list):
+            observed_raw = (((bus_observability.get("summary") or {}).get("status") or {}).get("periodicity"))
+        if not isinstance(observed_raw, list):
+            reasons.append("end bus observability snapshot missing periodicity list")
+        else:
+            observed_entries: Dict[str, Dict[str, Any]] = {}
+            for index, raw_entry in enumerate(observed_raw):
+                if not isinstance(raw_entry, dict):
+                    reasons.append(f"end bus periodicity[{index}] must be object")
+                    continue
+                try:
+                    normalized = normalize_periodicity_entry(
+                        raw_entry,
+                        f"end.bus_observability.periodicity[{index}]",
+                        require_available_state=True,
+                        require_complete_intervals=True,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    reasons.append(str(exc))
+                    continue
+                if normalized["key"] in observed_entries:
+                    reasons.append(f"duplicate observed periodicity tuple {normalized['key']}")
+                    continue
+                observed_entries[normalized["key"]] = normalized
+
+            for key, reference_entry in reference_entries.items():
+                if reference_entry["sample_count"] < TIMING_REFERENCE_PERIODICITY_MIN_SAMPLES:
+                    continue
+                stable_reference_tuple_count += 1
+                observed_entry = observed_entries.get(key)
+                if observed_entry is None:
+                    reasons.append(f"missing observed periodicity tuple {key}")
+                    tuple_comparisons.append({"key": key, "ok": False, "reason": "missing_observed_tuple"})
+                    continue
+                if observed_entry["sample_count"] < TIMING_REFERENCE_PERIODICITY_MIN_SAMPLES:
+                    reasons.append(
+                        f"observed periodicity tuple {key} has sample_count={observed_entry['sample_count']}; "
+                        f"want >= {TIMING_REFERENCE_PERIODICITY_MIN_SAMPLES}"
+                    )
+                    tuple_comparisons.append({"key": key, "ok": False, "reason": "observed_sample_count_below_min"})
+                    continue
+                tolerance_sec = max(
+                    reference_entry["mean_interval_sec"] * TIMING_REFERENCE_PERIODICITY_RELATIVE_ERROR_MAX,
+                    TIMING_REFERENCE_PERIODICITY_ABSOLUTE_ERROR_SEC_MAX,
+                )
+                delta_sec = abs(observed_entry["mean_interval_sec"] - reference_entry["mean_interval_sec"])
+                ok = delta_sec <= tolerance_sec
+                if not ok:
+                    reasons.append(
+                        "periodicity timing mismatch exceeds tolerance "
+                        f"for {key} (observed={observed_entry['mean_interval_sec']:.6f}s "
+                        f"reference={reference_entry['mean_interval_sec']:.6f}s "
+                        f"delta={delta_sec:.6f}s max={tolerance_sec:.6f}s)"
+                    )
+                else:
+                    matched_tuple_count += 1
+                tuple_comparisons.append(
+                    {
+                        "key": key,
+                        "ok": ok,
+                        "observed_mean_interval_sec": observed_entry["mean_interval_sec"],
+                        "reference_mean_interval_sec": reference_entry["mean_interval_sec"],
+                        "delta_sec": delta_sec,
+                        "tolerance_sec": tolerance_sec,
+                        "observed_sample_count": observed_entry["sample_count"],
+                        "reference_sample_count": reference_entry["sample_count"],
+                    }
+                )
+            if stable_reference_tuple_count == 0:
+                reasons.append(
+                    f"wire timing reference has no stable periodicity tuples with >= {TIMING_REFERENCE_PERIODICITY_MIN_SAMPLES} samples"
+                )
+
+    status = "pass" if len(reasons) == 0 else "fail"
+    reason = "ok" if status == "pass" else "; ".join(reasons)
+    periodicity_within_tolerance = stable_reference_tuple_count > 0 and matched_tuple_count == stable_reference_tuple_count
+
+    return {
+        "schema": TIMING_REFERENCE_VERDICT_SCHEMA,
+        "captured_at": utc_now(),
+        "run_id": run_id,
+        "source": "wire_timing_reference_plus_structured_snapshots",
+        "claim_scope": "bounded_proof_window_busy_periodicity_comparator",
+        "evidence": {
+            "wire_timing_reference_path": str(wire_reference_path),
+            "wire_proxy_log_path": wire_proxy_log_path,
+            "start_snapshot_paths": None if start_bundle is None else start_bundle["snapshot_paths"],
+            "end_snapshot_paths": None if end_bundle is None else end_bundle["snapshot_paths"],
+        },
+        "summary": {
+            "reference_busy_seconds_total": reference_busy_seconds,
+            "observed_busy_seconds_total": observed_busy_seconds,
+            "busy_relative_error": busy_relative_error,
+            "busy_relative_error_max": TIMING_REFERENCE_BUSY_RELATIVE_ERROR_MAX,
+            "stable_reference_tuple_count": stable_reference_tuple_count,
+            "matched_tuple_count": matched_tuple_count,
+            "periodicity_relative_error_max": TIMING_REFERENCE_PERIODICITY_RELATIVE_ERROR_MAX,
+            "periodicity_absolute_error_sec_max": TIMING_REFERENCE_PERIODICITY_ABSOLUTE_ERROR_SEC_MAX,
+            "periodicity_min_samples": TIMING_REFERENCE_PERIODICITY_MIN_SAMPLES,
+        },
+        "periodicity": tuple_comparisons,
+        "criteria": {
+            "wire_reference_valid": {
+                "ok": wire_reference_valid,
+                "reason": "ok" if wire_reference_valid else "missing or invalid wire timing reference artifact",
+            },
+            "busy_within_tolerance": {
+                "ok": wire_reference_valid and start_bundle is not None and end_bundle is not None and busy_within_tolerance,
+                "reason": "ok" if busy_within_tolerance else "busy timing mismatch exceeds tolerance or evidence is incomplete",
+            },
+            "stable_periodicity_reference_present": {
+                "ok": stable_reference_tuple_count > 0,
+                "reason": (
+                    "ok"
+                    if stable_reference_tuple_count > 0
+                    else f"wire timing reference has no stable periodicity tuples with >= {TIMING_REFERENCE_PERIODICITY_MIN_SAMPLES} samples"
+                ),
+            },
+            "periodicity_within_tolerance": {
+                "ok": periodicity_within_tolerance,
+                "reason": (
+                    "ok"
+                    if periodicity_within_tolerance
+                    else "periodicity timing mismatch exceeds tolerance or evidence is incomplete"
                 ),
             },
         },
@@ -5516,6 +5944,21 @@ def cross_plane_skew_command(args: argparse.Namespace) -> int:
     return 0 if bool(artifact.get("ok", False)) else 1
 
 
+def timing_reference_verdict_command(args: argparse.Namespace) -> int:
+    wire_reference_path = (
+        pathlib.Path(args.wire_reference_path)
+        if args.wire_reference_path
+        else pathlib.Path(args.proof_dir) / "wire_timing_reference.json"
+    )
+    artifact = build_timing_reference_verdict(
+        pathlib.Path(args.proof_dir),
+        args.run_id,
+        wire_reference_path=wire_reference_path,
+    )
+    write_json(pathlib.Path(args.output), artifact)
+    return 0 if bool(artifact.get("ok", False)) else 1
+
+
 def rollback_execution_command(args: argparse.Namespace) -> int:
     artifact = build_rollback_execution_artifact(
         run_id=args.run_id,
@@ -5642,6 +6085,16 @@ def build_parser() -> argparse.ArgumentParser:
     cross_plane_skew.add_argument("--publisher-cadence", default=None)
     cross_plane_skew.add_argument("--output", required=True)
     cross_plane_skew.set_defaults(func=cross_plane_skew_command)
+
+    timing_reference_verdict = sub.add_parser(
+        "timing-reference-verdict",
+        help="build timing-reference comparator artifact from wire timing evidence",
+    )
+    timing_reference_verdict.add_argument("--proof-dir", required=True)
+    timing_reference_verdict.add_argument("--run-id", required=True)
+    timing_reference_verdict.add_argument("--wire-reference-path", default=None)
+    timing_reference_verdict.add_argument("--output", required=True)
+    timing_reference_verdict.set_defaults(func=timing_reference_verdict_command)
 
     rollback_execution = sub.add_parser(
         "rollback-execution",

--- a/scripts/passive_canary_verifier_test.py
+++ b/scripts/passive_canary_verifier_test.py
@@ -5,6 +5,7 @@ import io
 import json
 import os
 import pathlib
+import re
 import subprocess
 import shutil
 import sys
@@ -20,6 +21,10 @@ if str(SCRIPT_DIR) not in sys.path:
 import passive_canary_verifier as verifier  # noqa: E402
 
 CANONICAL_NO_EBUSD_TRANSPORT = verifier.CANONICAL_NO_EBUSD_TRANSPORT
+
+
+def normalize_shell_fixture(text: str) -> str:
+    return re.sub(r"(?m)^[ \t]+EOF$", "EOF", textwrap.dedent(text))
 
 
 def write_json(path: pathlib.Path, payload: object) -> None:
@@ -4499,6 +4504,362 @@ class CrossPlaneSkewArtifactTests(unittest.TestCase):
         self.assertIn("skew exceeded", " ".join(artifact["reasons"]).lower())
 
 
+class TimingReferenceVerdictCommandTests(unittest.TestCase):
+    @staticmethod
+    def build_periodicity_entry(
+        *,
+        source_bucket: str = "0x08",
+        target_bucket: str = "0x15",
+        primary: int = 181,
+        secondary: int = 9,
+        family: str = "B509",
+        sample_count: int = 12,
+        mean_interval: object = 10.0,
+        last_interval: object = 10.0,
+        min_interval: object = 10.0,
+        max_interval: object = 10.0,
+        state: str | None = None,
+        bus_style: bool = False,
+    ) -> dict:
+        entry = {
+            "source_bucket": source_bucket,
+            "target_bucket": target_bucket,
+            "primary": primary,
+            "secondary": secondary,
+            "family": family,
+            "sample_count": sample_count,
+            "last_seen": "2026-03-28T00:05:10Z",
+        }
+        if state is not None:
+            entry["state"] = state
+        if bus_style:
+            entry["mean_interval"] = mean_interval
+            entry["last_interval"] = last_interval
+            entry["min_interval"] = min_interval
+            entry["max_interval"] = max_interval
+        else:
+            entry["mean_interval_sec"] = mean_interval
+            entry["last_interval_sec"] = last_interval
+            entry["min_interval_sec"] = min_interval
+            entry["max_interval_sec"] = max_interval
+        return entry
+
+    @staticmethod
+    def write_wire_reference_artifact(
+        proof_dir: pathlib.Path,
+        *,
+        busy_seconds_total: float = 1.0,
+        periodicity_sample_count: int = 12,
+        periodicity_mean_interval_sec: float = 10.0,
+        proxy_log_path: pathlib.Path | None = None,
+    ) -> None:
+        if proxy_log_path is None:
+            proxy_log_path = proof_dir / "proxy.log"
+        proxy_log_path.parent.mkdir(parents=True, exist_ok=True)
+        proxy_log_path.write_text("wire\n", encoding="utf-8")
+        write_json(
+            proof_dir / "wire_timing_reference.json",
+            {
+                "schema": "observe_first_wire_timing_reference_v1",
+                "captured_at": "2026-03-28T00:00:00+00:00",
+                "source": "proxy_log_session_send_plus_wire_rx",
+                "claim_scope": "bounded_proof_window_timing_reference_source",
+                "ok": True,
+                "evidence": {
+                    "proxy_log_path": str(proxy_log_path),
+                    "proxy_log_line_count": 42,
+                    "session_start_count": 2,
+                    "send_symbol_count": 16,
+                    "wire_symbol_count": 42,
+                    "synthetic_symbol_spacing_ms": 4,
+                    "timestamp_resolution": "proxy_log_seconds_plus_symbol_spacing",
+                },
+                "summary": {
+                    "classified_event_count": 3,
+                    "transaction_count": 3,
+                    "master_frame_count": 0,
+                    "abandoned_count": 0,
+                    "busy_seconds_total": busy_seconds_total,
+                    "families_with_intervals": 1,
+                },
+                "periodicity": [
+                    {
+                        **TimingReferenceVerdictCommandTests.build_periodicity_entry(
+                            sample_count=periodicity_sample_count,
+                            mean_interval=periodicity_mean_interval_sec,
+                        )
+                    }
+                ],
+            }
+        )
+
+    @staticmethod
+    def attach_bus_periodicity(path: pathlib.Path, *, entry: dict) -> None:
+        payload = verifier.load_json(path)
+        if not isinstance(payload, dict):
+            raise AssertionError(f"unexpected payload at {path}")
+        payload["periodicity"] = [entry]
+        summary = payload.get("summary")
+        if not isinstance(summary, dict):
+            raise AssertionError(f"missing summary at {path}")
+        status = summary.get("status")
+        if not isinstance(status, dict):
+            raise AssertionError(f"missing summary.status at {path}")
+        status["periodicity"] = [entry]
+        write_json(path, payload)
+
+    def write_timing_reference_evidence_artifacts(
+        self,
+        proof_dir: pathlib.Path,
+        *,
+        start_busy: float = 1.0,
+        end_busy: float = 2.0,
+        include_end_busy: bool = True,
+        periodicity_sample_count: int = 12,
+        periodicity_mean_interval: object = "10s",
+        bus_periodicity_state: str = "available",
+    ) -> None:
+        start_metrics = [
+            "ebus_passive_tap_connected 1",
+            f"ebus_bus_busy_seconds_total {start_busy}",
+        ]
+        end_metrics = ["ebus_passive_tap_connected 1"]
+        if include_end_busy:
+            end_metrics.append(f"ebus_bus_busy_seconds_total {end_busy}")
+        periodicity_entry = self.build_periodicity_entry(
+            sample_count=periodicity_sample_count,
+            mean_interval=periodicity_mean_interval,
+            last_interval=periodicity_mean_interval,
+            min_interval=periodicity_mean_interval,
+            max_interval=periodicity_mean_interval,
+            state=bus_periodicity_state,
+            bus_style=True,
+        )
+        write_metrics(proof_dir / "start_metrics.prom", start_metrics)
+        write_metrics(proof_dir / "end_metrics.prom", end_metrics)
+        write_structured_warmup_snapshot_bundle(
+            proof_dir,
+            "start",
+            startup_phase="LIVE_WARMUP",
+            warmup_state="warming_up",
+            cache_epoch=1,
+            live_epoch=0,
+            transport_class="ens",
+            publisher_cadence_sec=60.0,
+        )
+        write_structured_warmup_snapshot_bundle(
+            proof_dir,
+            "end",
+            startup_phase="LIVE_READY",
+            warmup_state="available",
+            cache_epoch=1,
+            live_epoch=1,
+            transport_class="ens",
+            publisher_cadence_sec=60.0,
+        )
+        start_bus_path = proof_dir / "start_bus_observability.json"
+        end_bus_path = proof_dir / "end_bus_observability.json"
+        self.attach_bus_periodicity(start_bus_path, entry=periodicity_entry)
+        self.attach_bus_periodicity(end_bus_path, entry=periodicity_entry)
+
+    def run_timing_reference_verdict_command(
+        self,
+        proof_dir: pathlib.Path,
+        output_path: pathlib.Path,
+        *,
+        wire_reference_path: pathlib.Path | None = None,
+    ) -> tuple[int, str]:
+        stderr = io.StringIO()
+        if wire_reference_path is None:
+            wire_reference_path = proof_dir / "wire_timing_reference.json"
+        with contextlib.redirect_stderr(stderr):
+            exit_code = verifier.main(
+                [
+                    "timing-reference-verdict",
+                    "--proof-dir",
+                    str(proof_dir),
+                    "--run-id",
+                    "run-1",
+                    "--wire-reference-path",
+                    str(wire_reference_path),
+                    "--output",
+                    str(output_path),
+                ]
+            )
+        return exit_code, stderr.getvalue()
+
+    def test_timing_reference_verdict_command_passes_with_matching_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            proof_dir = pathlib.Path(temp_dir)
+            output_path = proof_dir / "timing_reference_verdict.json"
+            self.write_wire_reference_artifact(proof_dir)
+            self.write_timing_reference_evidence_artifacts(
+                proof_dir,
+                start_busy=1.0,
+                end_busy=2.0,
+                include_end_busy=True,
+            )
+
+            exit_code, stderr = self.run_timing_reference_verdict_command(proof_dir, output_path)
+            artifact = verifier.load_json(output_path)
+
+        self.assertEqual(exit_code, 0, msg=stderr)
+        self.assertEqual(artifact["schema"], verifier.TIMING_REFERENCE_VERDICT_SCHEMA)
+        self.assertTrue(artifact["ok"])
+        self.assertEqual(artifact["status"], "pass")
+        self.assertEqual(artifact["summary"]["stable_reference_tuple_count"], 1)
+        self.assertEqual(artifact["summary"]["matched_tuple_count"], 1)
+
+    def test_timing_reference_verdict_command_fails_closed_when_busy_metric_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            proof_dir = pathlib.Path(temp_dir)
+            output_path = proof_dir / "timing_reference_verdict.json"
+            self.write_wire_reference_artifact(proof_dir)
+            self.write_timing_reference_evidence_artifacts(
+                proof_dir,
+                start_busy=1.0,
+                include_end_busy=False,
+            )
+
+            exit_code, stderr = self.run_timing_reference_verdict_command(proof_dir, output_path)
+            artifact = verifier.load_json(output_path)
+
+        self.assertNotEqual(exit_code, 0)
+        self.assertEqual(artifact["schema"], verifier.TIMING_REFERENCE_VERDICT_SCHEMA)
+        self.assertFalse(artifact["ok"])
+        self.assertEqual(artifact["status"], "fail")
+        self.assertIn("missing required metric sample", artifact["reason"])
+
+    def test_timing_reference_verdict_command_fails_closed_when_periodicity_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            proof_dir = pathlib.Path(temp_dir)
+            output_path = proof_dir / "timing_reference_verdict.json"
+            self.write_wire_reference_artifact(
+                proof_dir,
+                periodicity_mean_interval_sec=10.0,
+            )
+            self.write_timing_reference_evidence_artifacts(
+                proof_dir,
+                start_busy=1.0,
+                end_busy=2.0,
+                periodicity_mean_interval="14.5s",
+            )
+
+            exit_code, stderr = self.run_timing_reference_verdict_command(proof_dir, output_path)
+            artifact = verifier.load_json(output_path)
+
+        self.assertNotEqual(exit_code, 0)
+        self.assertEqual(artifact["schema"], verifier.TIMING_REFERENCE_VERDICT_SCHEMA)
+        self.assertFalse(artifact["ok"])
+        self.assertEqual(artifact["status"], "fail")
+        self.assertIn("periodicity timing mismatch exceeds tolerance", artifact["reason"])
+
+    def test_timing_reference_verdict_command_fails_closed_when_reference_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            proof_dir = pathlib.Path(temp_dir)
+            output_path = proof_dir / "timing_reference_verdict.json"
+            self.write_timing_reference_evidence_artifacts(proof_dir)
+
+            exit_code, stderr = self.run_timing_reference_verdict_command(proof_dir, output_path)
+            artifact = verifier.load_json(output_path)
+
+        self.assertNotEqual(exit_code, 0, msg=stderr)
+        self.assertFalse(artifact["ok"])
+        self.assertIn("missing wire timing reference artifact", artifact["reason"])
+
+    def test_timing_reference_verdict_command_fails_closed_when_reference_is_malformed(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            proof_dir = pathlib.Path(temp_dir)
+            output_path = proof_dir / "timing_reference_verdict.json"
+            write_json(proof_dir / "wire_timing_reference.json", {"schema": "unexpected"})
+            self.write_timing_reference_evidence_artifacts(proof_dir)
+
+            exit_code, stderr = self.run_timing_reference_verdict_command(proof_dir, output_path)
+            artifact = verifier.load_json(output_path)
+
+        self.assertNotEqual(exit_code, 0, msg=stderr)
+        self.assertFalse(artifact["ok"])
+        self.assertIn("schema mismatch", artifact["reason"])
+
+    def test_timing_reference_verdict_command_fails_closed_when_observed_tuple_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            proof_dir = pathlib.Path(temp_dir)
+            output_path = proof_dir / "timing_reference_verdict.json"
+            self.write_wire_reference_artifact(proof_dir)
+            self.write_timing_reference_evidence_artifacts(proof_dir)
+            end_bus_path = proof_dir / "end_bus_observability.json"
+            payload = verifier.load_json(end_bus_path)
+            payload.pop("periodicity", None)
+            summary = payload.get("summary", {})
+            status = summary.get("status", {})
+            status["periodicity"] = []
+            write_json(end_bus_path, payload)
+
+            exit_code, stderr = self.run_timing_reference_verdict_command(proof_dir, output_path)
+            artifact = verifier.load_json(output_path)
+
+        self.assertNotEqual(exit_code, 0, msg=stderr)
+        self.assertFalse(artifact["ok"])
+        self.assertIn("missing observed periodicity tuple", artifact["reason"])
+
+    def test_timing_reference_verdict_command_fails_closed_when_observed_tuple_is_not_available(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            proof_dir = pathlib.Path(temp_dir)
+            output_path = proof_dir / "timing_reference_verdict.json"
+            self.write_wire_reference_artifact(proof_dir)
+            self.write_timing_reference_evidence_artifacts(
+                proof_dir,
+                bus_periodicity_state="warming_up",
+            )
+
+            exit_code, stderr = self.run_timing_reference_verdict_command(proof_dir, output_path)
+            artifact = verifier.load_json(output_path)
+
+        self.assertNotEqual(exit_code, 0, msg=stderr)
+        self.assertFalse(artifact["ok"])
+        self.assertIn("must be state=available", artifact["reason"])
+
+    def test_timing_reference_verdict_command_accepts_go_style_duration_strings(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            proof_dir = pathlib.Path(temp_dir)
+            output_path = proof_dir / "timing_reference_verdict.json"
+            self.write_wire_reference_artifact(
+                proof_dir,
+                periodicity_mean_interval_sec=60.0,
+            )
+            self.write_timing_reference_evidence_artifacts(
+                proof_dir,
+                start_busy=1.0,
+                end_busy=2.0,
+                periodicity_mean_interval="1m0s",
+            )
+
+            exit_code, stderr = self.run_timing_reference_verdict_command(proof_dir, output_path)
+            artifact = verifier.load_json(output_path)
+
+        self.assertEqual(exit_code, 0, msg=stderr)
+        self.assertTrue(artifact["ok"])
+
+    def test_timing_reference_verdict_command_fails_closed_when_proxy_log_is_outside_bundle(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            proof_dir = pathlib.Path(temp_dir)
+            output_path = proof_dir / "timing_reference_verdict.json"
+            outside_dir = pathlib.Path(tempfile.mkdtemp())
+            self.addCleanup(shutil.rmtree, outside_dir, ignore_errors=True)
+            self.write_wire_reference_artifact(
+                proof_dir,
+                proxy_log_path=outside_dir / "proxy.log",
+            )
+            self.write_timing_reference_evidence_artifacts(proof_dir)
+
+            exit_code, stderr = self.run_timing_reference_verdict_command(proof_dir, output_path)
+            artifact = verifier.load_json(output_path)
+
+        self.assertNotEqual(exit_code, 0, msg=stderr)
+        self.assertFalse(artifact["ok"])
+        self.assertIn("must stay within the current proof log bundle", artifact["reason"])
+
+
 class RollbackExecutionArtifactValidationTests(unittest.TestCase):
     def _write_rollback_execution_artifact(
         self,
@@ -5031,7 +5392,7 @@ class PassiveSmokeCanaryVerdictGateTests(unittest.TestCase):
 
             fake_go = fake_bin / "go"
             fake_go.write_text(
-                textwrap.dedent(
+                normalize_shell_fixture(
                     """\
                     #!/usr/bin/env bash
                     set -euo pipefail
@@ -5041,6 +5402,10 @@ class PassiveSmokeCanaryVerdictGateTests(unittest.TestCase):
                       timing_out_path="${WIRE_TIMING_REFERENCE_ARTIFACT_PATH:-}"
                       if [[ -n "${timing_out_path}" ]]; then
                         proxy_log_path="${WIRE_TIMING_REFERENCE_PROXY_LOG_PATH:-}"
+                        proof_dir="$(dirname "${timing_out_path}")"
+                        start_metrics_path="${proof_dir}/start_metrics.prom"
+                        end_metrics_path="${proof_dir}/end_metrics.prom"
+                        reference_busy_seconds=2.0
                         if [[ -z "${proxy_log_path}" ]]; then
                           echo "WIRE_TIMING_REFERENCE_PROXY_LOG_PATH is required" >&2
                           exit 2
@@ -5057,6 +5422,11 @@ class PassiveSmokeCanaryVerdictGateTests(unittest.TestCase):
                         if [[ "${last_arg}" != "." ]]; then
                           echo "timing reference producer must target package ." >&2
                           exit 2
+                        fi
+                        start_busy_total="$(awk '$1 == \"ebus_bus_busy_seconds_total\" {print $2}' \"${start_metrics_path}\" 2>/dev/null | tail -n 1)"
+                        end_busy_total="$(awk '$1 == \"ebus_bus_busy_seconds_total\" {print $2}' \"${end_metrics_path}\" 2>/dev/null | tail -n 1)"
+                        if [[ -n "${start_busy_total}" && -n "${end_busy_total}" ]]; then
+                          reference_busy_seconds="$(awk -v start=\"${start_busy_total}\" -v end=\"${end_busy_total}\" 'BEGIN { delta = end - start; if (delta > 0) printf \"%.6f\", delta; else printf \"2.000000\" }')"
                         fi
                         mkdir -p "$(dirname "${timing_out_path}")"
                         cat > "${timing_out_path}" <<EOF
@@ -5075,14 +5445,14 @@ class PassiveSmokeCanaryVerdictGateTests(unittest.TestCase):
                         "synthetic_symbol_spacing_ms": 4,
                         "timestamp_resolution": "proxy_log_seconds_plus_symbol_spacing"
                       },
-                      "summary": {
-                        "classified_event_count": 3,
-                        "transaction_count": 3,
-                        "master_frame_count": 0,
-                        "abandoned_count": 0,
-                        "busy_seconds_total": 1.2,
-                        "families_with_intervals": 1
-                      },
+                        "summary": {
+                          "classified_event_count": 3,
+                          "transaction_count": 3,
+                          "master_frame_count": 0,
+                          "abandoned_count": 0,
+                          "busy_seconds_total": ${reference_busy_seconds},
+                          "families_with_intervals": 1
+                        },
                       "periodicity": [
                         {
                           "source_bucket": "0x08",
@@ -5090,7 +5460,7 @@ class PassiveSmokeCanaryVerdictGateTests(unittest.TestCase):
                           "primary": 181,
                           "secondary": 9,
                           "family": "B509",
-                          "sample_count": 2,
+                          "sample_count": 12,
                           "last_seen": "2026-03-28T00:00:10Z",
                           "last_interval_sec": 10,
                           "mean_interval_sec": 10,
@@ -5176,7 +5546,7 @@ class PassiveSmokeCanaryVerdictGateTests(unittest.TestCase):
 
             fake_rollback_executor = fake_bin / "rollback_executor"
             fake_rollback_executor.write_text(
-                textwrap.dedent(
+                normalize_shell_fixture(
                     """\
                     #!/usr/bin/env bash
                     set -euo pipefail
@@ -5283,7 +5653,7 @@ PY
 
             fake_curl = fake_bin / "curl"
             fake_curl.write_text(
-                textwrap.dedent(
+                normalize_shell_fixture(
                     """\
                     #!/usr/bin/env bash
                     set -euo pipefail
@@ -5356,6 +5726,7 @@ PY
                       printf '%s\\n' "${metrics_count}" > "${state_file}"
                       completed_total=$((metrics_count * 1200))
                       candidates_total=$((metrics_count * 120))
+                      busy_total_seconds=$((metrics_count))
 
                       if [[ "${metrics_quality}" == "missing_read_avoidance" ]]; then
                         cat <<EOF
@@ -5363,7 +5734,22 @@ PY
                     ebus_passive_tap_connected 1
                     ebus_passive_warmup_state{state="available"} 1
                     ebus_passive_capability_probe_outcomes_total{outcome="confirmed"} 1
+                    ebus_bus_busy_seconds_total ${busy_total_seconds}
                     EOF
+                        exit 0
+                      fi
+                      if [[ "${metrics_quality}" == "missing_timing_busy" ]]; then
+                        cat <<EOF
+                    ebus_passive_capability_probe_outcomes_total{outcome="timed_out"} ${timed_out}
+                    ebus_passive_tap_connected 1
+                    ebus_passive_warmup_state{state="available"} 1
+                    ebus_passive_capability_probe_outcomes_total{outcome="confirmed"} 1
+                    direct_apply_total{family="B524",freshness_profile="state_fast"} 2
+                    active_reads_avoided_total{family="B524",freshness_profile="state_fast"} 3
+                    active_read_saved_seconds{family="B524",freshness_profile="state_fast"} 1
+                    ebus_passive_completed_transactions_total ${completed_total}
+                    ebus_passive_direct_apply_candidates_evaluated_total ${candidates_total}
+EOF
                         exit 0
                       fi
                       if [[ "${metrics_quality}" == "corrupt_read_avoidance" ]]; then
@@ -5374,6 +5760,7 @@ PY
                     ebus_passive_capability_probe_outcomes_total{outcome="confirmed"} 1
                     direct_apply_total{family="B524",freshness_profile="state_fast"} not_a_number
                     active_reads_avoided_total{family="B524",freshness_profile="state_fast"} 1
+                    ebus_bus_busy_seconds_total ${busy_total_seconds}
                     ebus_passive_completed_transactions_total ${completed_total}
                     ebus_passive_direct_apply_candidates_evaluated_total ${candidates_total}
                     EOF
@@ -5404,13 +5791,14 @@ PY
                     direct_apply_total{family="B524",freshness_profile="state_fast"} 2
                     active_reads_avoided_total{family="B524",freshness_profile="state_fast"} 3
                     active_read_saved_seconds{family="B524",freshness_profile="state_fast"} 1
+                    ebus_bus_busy_seconds_total ${busy_total_seconds}
                     ebus_passive_completed_transactions_total ${completed_total}
                     ebus_passive_direct_apply_candidates_evaluated_total ${candidates_total}
                     EOF
                           exit 0
                         fi
                       fi
-                      cat <<EOF
+                    cat <<EOF
                     ebus_passive_capability_probe_outcomes_total{outcome="timed_out"} ${timed_out}
                     ebus_passive_tap_connected 1
                     ebus_passive_warmup_state{state="available"} 1
@@ -5418,6 +5806,7 @@ PY
                     direct_apply_total{family="B524",freshness_profile="state_fast"} 2
                     active_reads_avoided_total{family="B524",freshness_profile="state_fast"} 3
                     active_read_saved_seconds{family="B524",freshness_profile="state_fast"} 1
+                    ebus_bus_busy_seconds_total ${busy_total_seconds}
                     ebus_passive_completed_transactions_total ${completed_total}
                     ebus_passive_direct_apply_candidates_evaluated_total ${candidates_total}
                     EOF
@@ -5463,12 +5852,48 @@ PY
                         publisher_cadence_sec="not_a_number"
                       fi
                       if [[ "${include_publisher_cadence}" == "1" ]]; then
+                        periodicity_state="warming_up"
+                        if [[ "${phase}" == "LIVE_READY" ]]; then
+                          periodicity_state="available"
+                        fi
+                        periodicity_block='{
+  "source_bucket":"0x08",
+  "target_bucket":"0x15",
+  "primary":181,
+  "secondary":9,
+  "family":"B509",
+  "state":"'"${periodicity_state}"'",
+  "sample_count":12,
+  "mean_interval":"10s",
+  "last_seen":"2026-03-28T00:05:10Z",
+  "last_interval":"10s",
+  "min_interval":"10s",
+  "max_interval":"10s"
+}'
                         cat <<EOF
-                    {"summary":{"last_updated_at":"${summary_last_updated_at}","status":{"last_updated_at":"${status_last_updated_at}","startup":{"phase":"${phase}","cache_epoch":${cache_epoch},"live_epoch":${live_epoch},"last_updated_at":"${startup_last_updated_at}"},"publisher_cadence_sec":${publisher_cadence_sec},"publisher_cadence_source":"${publisher_cadence_source}","feature_flags":{"observe_first_enabled":${observe_first_enabled_json},"passive_state_direct_apply":${passive_state_direct_apply_json},"passive_config_direct_apply":${passive_config_direct_apply_json},"external_write_policy":"${external_write_policy}","normalizations":[],"last_updated_at":"${feature_flags_last_updated_at}"}}}}
+                    {"summary":{"last_updated_at":"${summary_last_updated_at}","status":{"last_updated_at":"${status_last_updated_at}","startup":{"phase":"${phase}","cache_epoch":${cache_epoch},"live_epoch":${live_epoch},"last_updated_at":"${startup_last_updated_at}"},"publisher_cadence_sec":${publisher_cadence_sec},"publisher_cadence_source":"${publisher_cadence_source}","feature_flags":{"observe_first_enabled":${observe_first_enabled_json},"passive_state_direct_apply":${passive_state_direct_apply_json},"passive_config_direct_apply":${passive_config_direct_apply_json},"external_write_policy":"${external_write_policy}","normalizations":[],"last_updated_at":"${feature_flags_last_updated_at}"}}},"periodicity":[${periodicity_block}]}
                     EOF
                       else
+                        periodicity_state="warming_up"
+                        if [[ "${phase}" == "LIVE_READY" ]]; then
+                          periodicity_state="available"
+                        fi
+                        periodicity_block='{
+  "source_bucket":"0x08",
+  "target_bucket":"0x15",
+  "primary":181,
+  "secondary":9,
+  "family":"B509",
+  "state":"'"${periodicity_state}"'",
+  "sample_count":12,
+  "mean_interval":"10s",
+  "last_seen":"2026-03-28T00:05:10Z",
+  "last_interval":"10s",
+  "min_interval":"10s",
+  "max_interval":"10s"
+}'
                         cat <<EOF
-                    {"summary":{"last_updated_at":"${summary_last_updated_at}","status":{"last_updated_at":"${status_last_updated_at}","startup":{"phase":"${phase}","cache_epoch":${cache_epoch},"live_epoch":${live_epoch},"last_updated_at":"${startup_last_updated_at}"},"feature_flags":{"observe_first_enabled":${observe_first_enabled_json},"passive_state_direct_apply":${passive_state_direct_apply_json},"passive_config_direct_apply":${passive_config_direct_apply_json},"external_write_policy":"${external_write_policy}","normalizations":[],"last_updated_at":"${feature_flags_last_updated_at}"}}}}
+                    {"summary":{"last_updated_at":"${summary_last_updated_at}","status":{"last_updated_at":"${status_last_updated_at}","startup":{"phase":"${phase}","cache_epoch":${cache_epoch},"live_epoch":${live_epoch},"last_updated_at":"${startup_last_updated_at}"},"feature_flags":{"observe_first_enabled":${observe_first_enabled_json},"passive_state_direct_apply":${passive_state_direct_apply_json},"passive_config_direct_apply":${passive_config_direct_apply_json},"external_write_policy":"${external_write_policy}","normalizations":[],"last_updated_at":"${feature_flags_last_updated_at}"}}},"periodicity":[${periodicity_block}]}
                     EOF
                       fi
                       exit 0
@@ -5519,6 +5944,20 @@ PY
                       if [[ "${phase}" == "LIVE_READY" ]]; then
                         warmup_state="available"
                       fi
+                      periodicity_block='{
+  "source_bucket":"0x08",
+  "target_bucket":"0x15",
+  "primary":181,
+  "secondary":9,
+  "family":"B509",
+  "state":"'"${warmup_state}"'",
+  "sample_count":12,
+  "mean_interval":"10s",
+  "last_seen":"2026-03-28T00:05:10Z",
+  "last_interval":"10s",
+  "min_interval":"10s",
+  "max_interval":"10s"
+}'
                       if [[ "${include_publisher_cadence}" == "1" ]]; then
                         cat <<EOF
                     {
@@ -5551,7 +5990,8 @@ PY
                               "passiveConfigDirectApply": ${passive_config_direct_apply_json},
                               "externalWritePolicy": "${external_write_policy}",
                               "normalizations": []
-                            }
+                            },
+                            "periodicity": [${periodicity_block}]
                           }
                         },
                         "watchSummary": {
@@ -5600,7 +6040,8 @@ PY
                               "passiveConfigDirectApply": ${passive_config_direct_apply_json},
                               "externalWritePolicy": "${external_write_policy}",
                               "normalizations": []
-                            }
+                            },
+                            "periodicity": [${periodicity_block}]
                           }
                         },
                         "watchSummary": {
@@ -5692,6 +6133,7 @@ PY
                 promotion_eligibility_path = proof_dir / "promotion_eligibility.json"
                 publisher_cadence_path = proof_dir / "publisher_cadence.json"
                 cross_plane_skew_path = proof_dir / "cross_plane_skew.json"
+                timing_reference_verdict_path = proof_dir / "timing_reference_verdict.json"
                 wire_timing_reference_path = proof_dir / "wire_timing_reference.json"
                 rollback_execution_path = proof_dir / "rollback_execution.json"
                 rollback_result_path = proof_dir / "rollback_result.json"
@@ -5723,6 +6165,10 @@ PY
                 if wire_timing_reference_path.exists():
                     artifacts["wire_timing_reference"] = json.loads(
                         wire_timing_reference_path.read_text(encoding="utf-8")
+                    )
+                if timing_reference_verdict_path.exists():
+                    artifacts["timing_reference_verdict"] = json.loads(
+                        timing_reference_verdict_path.read_text(encoding="utf-8")
                     )
                 if rollback_execution_path.exists():
                     artifacts["rollback_execution"] = json.loads(
@@ -5854,6 +6300,33 @@ PY
             wire_timing_reference["summary"]["families_with_intervals"],
             1,
         )
+
+    def test_smoke_emits_timing_reference_verdict_artifact_when_canary_verdict_is_good(self) -> None:
+        result, artifacts = self.run_smoke_with_fake_tools_detailed("pass")
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        timing_reference_verdict = artifacts.get("timing_reference_verdict")
+        self.assertIsInstance(timing_reference_verdict, dict)
+        self.assertEqual(timing_reference_verdict["schema"], verifier.TIMING_REFERENCE_VERDICT_SCHEMA)
+        self.assertTrue(timing_reference_verdict["ok"])
+        self.assertEqual(timing_reference_verdict["status"], "pass")
+        self.assertEqual(timing_reference_verdict["summary"]["stable_reference_tuple_count"], 1)
+        self.assertEqual(timing_reference_verdict["summary"]["matched_tuple_count"], 1)
+        self.assertTrue(timing_reference_verdict["criteria"]["busy_within_tolerance"]["ok"])
+        self.assertTrue(timing_reference_verdict["criteria"]["periodicity_within_tolerance"]["ok"])
+
+    def test_smoke_exits_non_zero_when_timing_reference_verdict_fails(self) -> None:
+        result, artifacts = self.run_smoke_with_fake_tools_detailed(
+            "pass",
+            extra_env={"FAKE_METRICS_QUALITY_MODE": "missing_timing_busy"},
+        )
+        self.assertNotEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("timing-reference verdict gate failed", result.stderr)
+        timing_reference_verdict = artifacts.get("timing_reference_verdict")
+        self.assertIsInstance(timing_reference_verdict, dict)
+        self.assertEqual(timing_reference_verdict["schema"], verifier.TIMING_REFERENCE_VERDICT_SCHEMA)
+        self.assertFalse(timing_reference_verdict["ok"])
+        self.assertEqual(timing_reference_verdict["status"], "fail")
+        self.assertIn("missing required metric sample", timing_reference_verdict["reason"])
 
     def test_smoke_emits_rollback_result_artifact_when_canary_verdict_is_good(self) -> None:
         result, artifacts = self.run_smoke_with_fake_tools_detailed("pass")

--- a/scripts/passive_smoke_check.sh
+++ b/scripts/passive_smoke_check.sh
@@ -120,6 +120,7 @@ canary_verdict_path="${proof_dir}/canary_verdict.json"
 publisher_cadence_path="${proof_dir}/publisher_cadence.json"
 cross_plane_skew_path="${proof_dir}/cross_plane_skew.json"
 wire_timing_reference_path="${proof_dir}/wire_timing_reference.json"
+timing_reference_verdict_path="${proof_dir}/timing_reference_verdict.json"
 rollback_execution_path="${proof_dir}/rollback_execution.json"
 rollback_result_path="${proof_dir}/rollback_result.json"
 replay_behavior_path="${proof_dir}/replay_behavior.json"
@@ -642,6 +643,14 @@ build_wire_timing_reference_artifact() {
   fi
 }
 
+build_timing_reference_verdict_artifact() {
+  python3 "${canary_verifier_script}" timing-reference-verdict \
+    --proof-dir "${proof_dir}" \
+    --run-id "${canary_run_id}" \
+    --wire-reference-path "${wire_timing_reference_path}" \
+    --output "${timing_reference_verdict_path}"
+}
+
 build_rollback_execution_artifact() {
   if ! (
     ROLLBACK_EXECUTION_ARTIFACT_PATH="${rollback_execution_path}" \
@@ -902,6 +911,10 @@ if [[ "${proof_artifacts_enabled}" == "1" ]]; then
     fi
     if ! build_wire_timing_reference_artifact; then
       echo "proof mode: wire timing reference producer failed (see ${wire_timing_reference_path})" >&2
+      exit 1
+    fi
+    if ! build_timing_reference_verdict_artifact; then
+      echo "proof mode: timing-reference verdict gate failed (see ${timing_reference_verdict_path})" >&2
       exit 1
     fi
     if ! build_rollback_result_artifact; then


### PR DESCRIPTION
## What
Add the bounded wire-derived timing reference comparator/verdict artifact for GW-15 proof mode.

## Why
Parent issue #400 is now narrowed to the remaining non-deferred timing/reference gate under #416. This slice compares proof-window busy and periodicity outputs against the independent wire-derived timing reference, fails closed on missing or malformed evidence, and wires the verdict into the passive smoke proof finalizer.

## Validation
- `python3 -m unittest scripts.passive_canary_verifier_test`
- `PASSIVE_SMOKE_REPORT=results-matrix-ha/20260315T073335Z-passive-suite-followup-gate/index.json ./scripts/ci_local.sh`

## Depends On
- Closes #416