### PR TITLE
feat: stable instance GUID identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@
 - Suitable for onboarding and issue-focused runtime/API changes.
 - Smoke mode is intentionally opt-in and environment-backed (`EBUS_SMOKE=1` + local config file).
 
+## Stable Instance Identity
+
+- The gateway can expose an installation-scoped stable GUID with `-instance-guid <uuid>`.
+- When configured, the same GUID is published through GraphQL at `gatewayIdentity.instanceGuid`.
+- Zeroconf advertisement keeps `_helianthus-graphql._tcp` and adds TXT `instance_guid=<uuid>`.
+- Home Assistant should treat this GUID as canonical identity and treat `host`, `port`, `path`, and `transport`
+  as rediscoverable transport coordinates.
+
 ## Helianthus Dependency Chain
 
 ```text
@@ -87,6 +95,10 @@ go run ./cmd/gateway \
 curl -fsS http://127.0.0.1:8080/graphql \
   -H 'content-type: application/json' \
   --data '{"query":"{ __typename }"}'
+
+curl -fsS http://127.0.0.1:8080/graphql \
+  -H 'content-type: application/json' \
+  --data '{"query":"{ gatewayIdentity { instanceGuid } }"}'
 
 curl -fsS http://127.0.0.1:8080/mcp \
   -H 'content-type: application/json' \
@@ -158,6 +170,7 @@ go run ./cmd/gateway -address tcp-plain://203.0.113.10:9999 -http-addr :8080
 | `-mcp-path` | `/mcp` | MCP JSON-RPC endpoint |
 | `-ui-path` | `/ui` | set empty to disable UI |
 | `-portal-path` | `/portal` | set empty to disable dynamic portal surface |
+| `-instance-guid` | _empty_ | lowercase UUIDv4 published via GraphQL and Zeroconf |
 | `-mdns` | `true` | set `false` outside trusted LAN |
 | `-dump-upload-path` | _disabled_ | unknown-device dump upload endpoint path |
 

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"regexp"
 	"strconv"
 	"strings"
 	"syscall"
@@ -34,6 +35,7 @@ var (
 	startPassiveTransactionReconstructor      = ebusgateway.StartPassiveTransactionReconstructor
 	startBroadcastListenerWithReconstructorFn = ebusgateway.StartBroadcastListenerWithReconstructor
 	startHTTPServerFn                         = startHTTPServer
+	instanceGUIDPattern                       = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
 )
 
 type runtimeWatchObserver struct {
@@ -104,6 +106,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 	if busObservability != nil {
 		builder.SetBusObservabilityProvider(newGraphQLBusObservabilityProvider(busObservability))
 	}
+	builder.SetGatewayIdentityProvider(newRuntimeGatewayIdentityProvider(cfg))
 	hub := graphql.NewBroadcastHub(nil)
 	gateway.AddRouterPlane(hub)
 	gateway.RefreshRouterPlanes()
@@ -357,6 +360,29 @@ func applyTransportSourcePolicy(cfg *ebusgateway.Config) {
 	}
 }
 
+func normalizeInstanceGUID(value string) (string, error) {
+	normalized := strings.TrimSpace(strings.ToLower(value))
+	if normalized == "" {
+		return "", nil
+	}
+	if !instanceGUIDPattern.MatchString(normalized) {
+		return "", fmt.Errorf("invalid instance-guid %q", value)
+	}
+	return normalized, nil
+}
+
+func gatewayMDNSText(cfg ebusgateway.Config) []string {
+	text := []string{
+		"path=" + cfg.GraphQLPath,
+		"transport=http",
+		"version=1",
+	}
+	if cfg.InstanceGUID != "" {
+		text = append(text, "instance_guid="+cfg.InstanceGUID)
+	}
+	return text
+}
+
 func bindFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) {
 	if fs == nil || cfg == nil {
 		return
@@ -416,6 +442,14 @@ func bindFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) {
 	fs.StringVar(&cfg.DumpUploadPath, "dump-upload-path", cfg.DumpUploadPath, "register dump upload endpoint path")
 	fs.BoolVar(&cfg.MDNSAdvertise, "mdns", cfg.MDNSAdvertise, "advertise graphql endpoint via mdns")
 	fs.StringVar(&cfg.MDNSInstance, "mdns-instance", cfg.MDNSInstance, "mdns instance name")
+	fs.Func("instance-guid", "stable gateway instance UUIDv4 (lowercase)", func(value string) error {
+		normalized, err := normalizeInstanceGUID(value)
+		if err != nil {
+			return err
+		}
+		cfg.InstanceGUID = normalized
+		return nil
+	})
 	fs.StringVar(&cfg.DumpOutputDir, "dump-output-dir", cfg.DumpOutputDir, "unknown device dump output dir")
 	fs.StringVar(&cfg.DumpUploadURL, "dump-upload-url", cfg.DumpUploadURL, "unknown device dump upload url (internal)")
 	fs.BoolVar(&cfg.DumpIncludePII, "dump-include-pii", cfg.DumpIncludePII, "include identifiers in unknown device dumps")
@@ -705,11 +739,7 @@ func startHTTPServer(
 			Instance: cfg.MDNSInstance,
 			Service:  mdns.ServiceTypeGateway,
 			Port:     port,
-			Text: []string{
-				"path=" + cfg.GraphQLPath,
-				"transport=http",
-				"version=1",
-			},
+			Text:     gatewayMDNSText(cfg),
 		})
 		if err != nil {
 			_ = server.Close()

--- a/cmd/gateway/main_test.go
+++ b/cmd/gateway/main_test.go
@@ -797,6 +797,44 @@ func TestBindFlags_PortalPath(t *testing.T) {
 	}
 }
 
+func TestBindFlags_InstanceGUID(t *testing.T) {
+	cfg := ebusgateway.DefaultConfig()
+	fs := flag.NewFlagSet("gateway-test", flag.ContinueOnError)
+	bindFlags(fs, &cfg)
+	if err := fs.Parse([]string{"-instance-guid", "4d9336aa-f125-4f12-8b07-fcd18dbfcb10"}); err != nil {
+		t.Fatalf("parse instance-guid: %v", err)
+	}
+	if cfg.InstanceGUID != "4d9336aa-f125-4f12-8b07-fcd18dbfcb10" {
+		t.Fatalf("InstanceGUID = %q; want parsed UUID", cfg.InstanceGUID)
+	}
+}
+
+func TestBindFlags_InstanceGUIDRejectsInvalidValue(t *testing.T) {
+	cfg := ebusgateway.DefaultConfig()
+	fs := flag.NewFlagSet("gateway-test", flag.ContinueOnError)
+	bindFlags(fs, &cfg)
+	if err := fs.Parse([]string{"-instance-guid", "not-a-guid"}); err == nil {
+		t.Fatal("parse invalid instance-guid error = nil; want error")
+	}
+}
+
+func TestGatewayMDNSTextIncludesInstanceGUID(t *testing.T) {
+	cfg := ebusgateway.DefaultConfig()
+	cfg.GraphQLPath = "/graphql"
+	cfg.InstanceGUID = "4d9336aa-f125-4f12-8b07-fcd18dbfcb10"
+
+	got := gatewayMDNSText(cfg)
+	want := []string{
+		"path=/graphql",
+		"transport=http",
+		"version=1",
+		"instance_guid=4d9336aa-f125-4f12-8b07-fcd18dbfcb10",
+	}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Fatalf("gatewayMDNSText() = %#v; want %#v", got, want)
+	}
+}
+
 func TestBindFlags_BootLiveTimeout(t *testing.T) {
 	cfg := ebusgateway.DefaultConfig()
 	fs := flag.NewFlagSet("gateway-test", flag.ContinueOnError)

--- a/cmd/gateway/status_provider.go
+++ b/cmd/gateway/status_provider.go
@@ -13,12 +13,20 @@ type runtimeStatusProvider struct {
 	semantic graphql.SemanticProvider
 }
 
+type runtimeGatewayIdentityProvider struct {
+	instanceGUID string
+}
+
 func (p runtimeStatusProvider) DaemonStatus() graphql.ServiceStatus {
 	return p.daemon
 }
 
 func (p runtimeStatusProvider) AdapterStatus() graphql.ServiceStatus {
 	return adapterGraphQLStatusFromSemantic(p.semantic)
+}
+
+func (p runtimeGatewayIdentityProvider) GatewayIdentity() graphql.GatewayIdentity {
+	return graphql.GatewayIdentity{InstanceGUID: p.instanceGUID}
 }
 
 func newRuntimeStatusProvider(cfg ebusgateway.Config, semantic graphql.SemanticProvider) graphql.StatusProvider {
@@ -31,6 +39,10 @@ func newRuntimeStatusProvider(cfg ebusgateway.Config, semantic graphql.SemanticP
 		},
 		semantic: semantic,
 	}
+}
+
+func newRuntimeGatewayIdentityProvider(cfg ebusgateway.Config) graphql.GatewayIdentityProvider {
+	return runtimeGatewayIdentityProvider{instanceGUID: cfg.InstanceGUID}
 }
 
 type runtimeMCPStatusProvider struct {

--- a/cmd/gateway/status_provider_test.go
+++ b/cmd/gateway/status_provider_test.go
@@ -63,6 +63,17 @@ func TestRuntimeStatusProviderReflectsAdapterFirmwareVersion(t *testing.T) {
 	}
 }
 
+func TestRuntimeGatewayIdentityProviderExposesConfiguredGUID(t *testing.T) {
+	cfg := ebusgateway.DefaultConfig()
+	cfg.InstanceGUID = "4d9336aa-f125-4f12-8b07-fcd18dbfcb10"
+
+	provider := newRuntimeGatewayIdentityProvider(cfg)
+	identity := provider.GatewayIdentity()
+	if identity.InstanceGUID != "4d9336aa-f125-4f12-8b07-fcd18dbfcb10" {
+		t.Fatalf("gateway identity GUID = %q; want configured GUID", identity.InstanceGUID)
+	}
+}
+
 func TestRuntimeStatusProviderKeepsUnknownWithoutAdapterIdentity(t *testing.T) {
 	cfg := ebusgateway.DefaultConfig()
 	semantic := graphql.NewLiveSemanticProvider()

--- a/config.go
+++ b/config.go
@@ -3,6 +3,7 @@ package ebusgateway
 import (
 	"context"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
@@ -109,6 +110,7 @@ type Config struct {
 	PortalPath                              string
 	MDNSAdvertise                           bool
 	MDNSInstance                            string
+	InstanceGUID                            string
 	DumpOutputDir                           string
 	DumpUploadPath                          string
 	DumpUploadURL                           string
@@ -188,6 +190,7 @@ func DefaultConfig() Config {
 		PortalPath:                              "/portal",
 		MDNSAdvertise:                           true,
 		MDNSInstance:                            "helianthus",
+		InstanceGUID:                            "",
 		DumpOutputDir:                           "./dumps",
 		ObserveFirstEnabled:                     featureFlags.ObserveFirstEnabled(),
 		PassiveStateDirectApply:                 featureFlags.PassiveStateDirectApply(),
@@ -354,6 +357,7 @@ func applyDefaults(cfg Config) Config {
 	if cfg.MDNSInstance == "" {
 		cfg.MDNSInstance = "helianthus"
 	}
+	cfg.InstanceGUID = strings.TrimSpace(cfg.InstanceGUID)
 	if cfg.DumpOutputDir == "" {
 		cfg.DumpOutputDir = "./dumps"
 	}

--- a/graphql/builder.go
+++ b/graphql/builder.go
@@ -9,6 +9,7 @@ type Builder struct {
 	registry Registry
 	changes  <-chan struct{}
 	status   StatusProvider
+	identity GatewayIdentityProvider
 	semantic SemanticProvider
 	bus      BusObservabilityProvider
 	watch    WatchSummaryProvider
@@ -25,6 +26,7 @@ func NewBuilder(reg Registry, changes <-chan struct{}) *Builder {
 		registry: reg,
 		changes:  changes,
 		status:   staticStatusProvider{},
+		identity: staticGatewayIdentityProvider{},
 		semantic: staticSemanticProvider{},
 		bus:      staticBusObservabilityProvider{},
 		watch:    staticWatchSummaryProvider{},
@@ -123,6 +125,28 @@ func (b *Builder) SetStatusProvider(provider StatusProvider) {
 	b.mu.Lock()
 	b.status = provider
 	b.mu.Unlock()
+}
+
+func (b *Builder) SetGatewayIdentityProvider(provider GatewayIdentityProvider) {
+	if b == nil || provider == nil {
+		return
+	}
+	b.mu.Lock()
+	b.identity = provider
+	b.mu.Unlock()
+}
+
+func (b *Builder) gatewayIdentityProvider() GatewayIdentityProvider {
+	if b == nil {
+		return staticGatewayIdentityProvider{}
+	}
+	b.mu.RLock()
+	provider := b.identity
+	b.mu.RUnlock()
+	if provider == nil {
+		return staticGatewayIdentityProvider{}
+	}
+	return provider
 }
 
 func (b *Builder) statusProvider() StatusProvider {

--- a/graphql/identity.go
+++ b/graphql/identity.go
@@ -1,0 +1,15 @@
+package graphql
+
+type GatewayIdentity struct {
+	InstanceGUID string
+}
+
+type GatewayIdentityProvider interface {
+	GatewayIdentity() GatewayIdentity
+}
+
+type staticGatewayIdentityProvider struct{}
+
+func (staticGatewayIdentityProvider) GatewayIdentity() GatewayIdentity {
+	return GatewayIdentity{}
+}

--- a/graphql/queries.go
+++ b/graphql/queries.go
@@ -21,6 +21,7 @@ type graphqlSchemaTypes struct {
 	deviceType              *graphqlgo.Object
 	broadcastType           *graphqlgo.Object
 	statusType              *graphqlgo.Object
+	gatewayIdentityType     *graphqlgo.Object
 	zoneType                *graphqlgo.Object
 	dhwType                 *graphqlgo.Object
 	circuitStatusType       *graphqlgo.Object
@@ -2015,6 +2016,25 @@ func buildSchemaTypes() graphqlSchemaTypes {
 		},
 	})
 
+	gatewayIdentityType := graphqlgo.NewObject(graphqlgo.ObjectConfig{
+		Name: "GatewayIdentity",
+		Fields: graphqlgo.Fields{
+			"instanceGuid": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					identity, ok := params.Source.(GatewayIdentity)
+					if !ok {
+						return nil, nil
+					}
+					if identity.InstanceGUID == "" {
+						return nil, nil
+					}
+					return identity.InstanceGUID, nil
+				},
+			},
+		},
+	})
+
 	fieldType := graphqlgo.NewObject(graphqlgo.ObjectConfig{
 		Name: "Field",
 		Fields: graphqlgo.Fields{
@@ -2818,6 +2838,7 @@ func buildSchemaTypes() graphqlSchemaTypes {
 		deviceType:              deviceType,
 		broadcastType:           buildBroadcastType(),
 		statusType:              statusType,
+		gatewayIdentityType:     gatewayIdentityType,
 		zoneType:                zoneType,
 		dhwType:                 dhwType,
 		circuitStatusType:       circuitStatusType,
@@ -2861,6 +2882,12 @@ func buildQueryType(builder *Builder, types graphqlSchemaTypes) *graphqlgo.Objec
 				Type: graphqlgo.NewNonNull(types.statusType),
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					return builder.statusProvider().DaemonStatus(), nil
+				},
+			},
+			"gatewayIdentity": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(types.gatewayIdentityType),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					return builder.gatewayIdentityProvider().GatewayIdentity(), nil
 				},
 			},
 			"adapterStatus": &graphqlgo.Field{

--- a/graphql/queries_test.go
+++ b/graphql/queries_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 var canonicalQueryRootFields = []string{
+	"gatewayIdentity",
 	"zones",
 	"dhw",
 	"energyTotals",
@@ -43,6 +44,14 @@ type testBusObservabilityProvider struct {
 
 func (provider testBusObservabilityProvider) Snapshot() BusObservabilitySnapshot {
 	return cloneBusObservabilitySnapshot(provider.snapshot)
+}
+
+type testGatewayIdentityProvider struct {
+	identity GatewayIdentity
+}
+
+func (provider testGatewayIdentityProvider) GatewayIdentity() GatewayIdentity {
+	return provider.identity
 }
 
 type driftingBusObservabilityProvider struct {
@@ -130,6 +139,9 @@ func TestQueryResolvers_Integration(t *testing.T) {
 	})
 
 	builder := NewBuilder(gateway.Registry, nil)
+	builder.SetGatewayIdentityProvider(testGatewayIdentityProvider{
+		identity: GatewayIdentity{InstanceGUID: "4d9336aa-f125-4f12-8b07-fcd18dbfcb10"},
+	})
 	if err := builder.Start(context.Background()); err != nil {
 		t.Fatalf("builder.Start error = %v", err)
 	}
@@ -1067,6 +1079,29 @@ func TestQueryResolvers_Integration(t *testing.T) {
 					},
 				},
 			},
+		})
+
+		t.Run("gateway_identity", func(t *testing.T) {
+			request := graphqlclient.NewRequest(`
+				query {
+					gatewayIdentity {
+						instanceGuid
+					}
+				}
+			`)
+
+			var response struct {
+				GatewayIdentity struct {
+					InstanceGUID string `json:"instanceGuid"`
+				} `json:"gatewayIdentity"`
+			}
+
+			if err := client.Run(context.Background(), request, &response); err != nil {
+				t.Fatalf("gateway identity query error = %v", err)
+			}
+			if response.GatewayIdentity.InstanceGUID != "4d9336aa-f125-4f12-8b07-fcd18dbfcb10" {
+				t.Fatalf("gateway identity instanceGuid = %q; want configured GUID", response.GatewayIdentity.InstanceGUID)
+			}
 		})
 
 		handler, err := NewHandler(builder)


### PR DESCRIPTION
## What
- add gateway instance GUID config/flag plumbing
- expose `gatewayIdentity.instanceGuid` in GraphQL
- advertise `instance_guid` in Zeroconf TXT
- cover the identity surfaces with gateway tests

## Why
- fixes HA identity drift away from mutable host/IP coordinates
- provides the canonical identity contract consumed by the add-on and HA integration

## Validation
- `TRANSPORT_MATRIX_REPORT=results-matrix-ha/20260312T163936Z-pr377-gw04-26ee758-full88/index.json PASSIVE_SMOKE_REPORT=results-matrix-ha/20260315T073335Z-passive-suite-followup-gate/index.json ./scripts/ci_local.sh`
- live GraphQL on HA: `{ gatewayIdentity { instanceGuid } }` => `3678381d-034e-4f6a-ab72-fce6eaa91245`
- live mDNS TXT from add-on host network includes `instance_guid=3678381d-034e-4f6a-ab72-fce6eaa91245`

Refs #443