### PR TITLE
feat(adaptermux): adapter multiplexer core package

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -526,13 +526,20 @@ func wireAdapterDirect(ctx context.Context, cfg *ebusgateway.Config) (func() err
 	network := cfg.TransportConfig.Network
 	address := cfg.TransportConfig.Address
 
-	// Detect adapter-direct:// URI scheme in the address field.
-	// When the user passes --address=adapter-direct://host:port the
-	// protocol flag is still the default ("enh") because
-	// parseTransportEndpoint runs later inside ebusgateway.New.
-	const schemePrefix = "adapter-direct://"
+	// Detect adapter-direct:// or adapter-direct-ens:// URI scheme in
+	// the address field. When the user passes
+	// --address=adapter-direct://host:port the protocol flag is still
+	// the default ("enh") because parseTransportEndpoint runs later
+	// inside ebusgateway.New.
+	const (
+		schemePrefix    = "adapter-direct://"
+		schemePrefixENS = "adapter-direct-ens://"
+	)
+	addrLower := strings.ToLower(address)
+	uriIsENS := strings.HasPrefix(addrLower, schemePrefixENS)
+	uriIsStd := strings.HasPrefix(addrLower, schemePrefix)
 	if cfg.TransportConfig.Protocol != ebusgateway.TransportAdapterDirect {
-		if !strings.HasPrefix(strings.ToLower(address), schemePrefix) {
+		if !uriIsStd && !uriIsENS {
 			return nil, nil
 		}
 	}
@@ -540,21 +547,31 @@ func wireAdapterDirect(ctx context.Context, cfg *ebusgateway.Config) (func() err
 	// Always strip the scheme prefix if present, regardless of which
 	// detection branch was taken. Without this, net.Dial receives
 	// "adapter-direct://host:port" as the address and fails.
-	if strings.HasPrefix(strings.ToLower(address), schemePrefix) {
+	if uriIsENS {
+		address = address[len(schemePrefixENS):]
+		network = "tcp"
+	} else if uriIsStd {
 		address = address[len(schemePrefix):]
 		// The URI form implies TCP — force it unconditionally since
 		// the default TransportConfig.Network is "unix" and would
 		// cause net.Dial("unix", "host:port") to fail.
 		network = "tcp"
-	} else if network == "" {
+	} else if network == "" || (network == "unix" && strings.Contains(address, ":")) {
+		// Explicit --transport adapter-direct path: if network is
+		// still the default "unix" but address looks like host:port,
+		// force TCP to avoid net.Dial("unix", "host:port") failures.
 		network = "tcp"
 	}
 	if address == "" {
 		return nil, fmt.Errorf("adapter-direct requires an address (e.g. adapter-direct://boiler.local:9999)")
 	}
 
-	// Determine ENH vs ENS sub-protocol. Default ENH.
+	// Determine ENH vs ENS sub-protocol. ENH is the default.
+	// The adapter-direct-ens:// URI scheme selects ENS explicitly.
 	adapterProtocol := "enh"
+	if uriIsENS {
+		adapterProtocol = "ens"
+	}
 
 	muxCfg := adaptermux.Config{
 		Protocol:     adapterProtocol,
@@ -586,14 +603,15 @@ func wireAdapterDirect(ctx context.Context, cfg *ebusgateway.Config) (func() err
 	log.Printf("adapter-direct: connected to %s/%s", network, address)
 
 	// Start proxy listener if configured (exposes ENH endpoint for
-	// external clients like ebusd). Context-managed: closes when ctx
-	// cancels, so no explicit closer needed.
+	// external clients like ebusd).
+	var proxyListener *adaptermux.ProxyListener
 	if cfg.ProxyListenAddr != "" {
 		pl, err := adaptermux.NewProxyListener(ctx, mux, cfg.ProxyListenAddr, log.Default())
 		if err != nil {
 			mux.Close()
 			return nil, fmt.Errorf("proxy listener: %w", err)
 		}
+		proxyListener = pl
 		log.Printf("adapter-direct: proxy listener on %s", pl.Addr())
 	}
 
@@ -606,6 +624,14 @@ func wireAdapterDirect(ctx context.Context, cfg *ebusgateway.Config) (func() err
 	// mux.Close). Returning mux.Close would cause a double-close at
 	// shutdown: gateway.Close -> transport.Close -> mux.Close, then
 	// the deferred closer -> mux.Close again.
+	//
+	// However, the proxy listener is a separate resource not owned by
+	// the gateway. If run() fails after wireAdapterDirect returns but
+	// before context cancellation, the listener would leak. Return its
+	// Close so the caller can defer it.
+	if proxyListener != nil {
+		return proxyListener.Close, nil
+	}
 	return nil, nil
 }
 

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -515,12 +515,26 @@ func bindFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) {
 // Returns a closer function for the multiplexer, or nil if not in
 // adapter-direct mode.
 func wireAdapterDirect(ctx context.Context, cfg *ebusgateway.Config) (func() error, error) {
-	if cfg.TransportConfig.Protocol != ebusgateway.TransportAdapterDirect {
-		return nil, nil
-	}
-
 	network := cfg.TransportConfig.Network
 	address := cfg.TransportConfig.Address
+
+	// Detect adapter-direct:// URI scheme in the address field.
+	// When the user passes --address=adapter-direct://host:port the
+	// protocol flag is still the default ("enh") because
+	// parseTransportEndpoint runs later inside ebusgateway.New.
+	const schemePrefix = "adapter-direct://"
+	if cfg.TransportConfig.Protocol != ebusgateway.TransportAdapterDirect {
+		if strings.HasPrefix(strings.ToLower(address), schemePrefix) {
+			// Strip the scheme prefix, preserving original casing
+			// in the host:port portion.
+			address = address[len(schemePrefix):]
+			if network == "" {
+				network = "tcp"
+			}
+		} else {
+			return nil, nil
+		}
+	}
 	if network == "" {
 		network = "tcp"
 	}

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -578,10 +578,6 @@ func wireAdapterDirect(ctx context.Context, cfg *ebusgateway.Config) (func() err
 	cfg.Transport = mux.ActiveTransport()
 	cfg.PassiveTransport = passiveTransport
 
-	// Override protocol to ENH for gateway's internal transport handling
-	// (the mux handles the actual adapter protocol internally).
-	cfg.TransportConfig.Protocol = ebusgateway.TransportENH
-
 	return mux.Close, nil
 }
 

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -524,16 +524,16 @@ func wireAdapterDirect(ctx context.Context, cfg *ebusgateway.Config) (func() err
 	// parseTransportEndpoint runs later inside ebusgateway.New.
 	const schemePrefix = "adapter-direct://"
 	if cfg.TransportConfig.Protocol != ebusgateway.TransportAdapterDirect {
-		if strings.HasPrefix(strings.ToLower(address), schemePrefix) {
-			// Strip the scheme prefix, preserving original casing
-			// in the host:port portion.
-			address = address[len(schemePrefix):]
-			if network == "" {
-				network = "tcp"
-			}
-		} else {
+		if !strings.HasPrefix(strings.ToLower(address), schemePrefix) {
 			return nil, nil
 		}
+	}
+
+	// Always strip the scheme prefix if present, regardless of which
+	// detection branch was taken. Without this, net.Dial receives
+	// "adapter-direct://host:port" as the address and fails.
+	if strings.HasPrefix(strings.ToLower(address), schemePrefix) {
+		address = address[len(schemePrefix):]
 	}
 	if network == "" {
 		network = "tcp"
@@ -578,7 +578,12 @@ func wireAdapterDirect(ctx context.Context, cfg *ebusgateway.Config) (func() err
 	cfg.Transport = mux.ActiveTransport()
 	cfg.PassiveTransport = passiveTransport
 
-	return mux.Close, nil
+	// Do NOT return mux.Close here. The gateway owns the lifecycle
+	// through cfg.Transport.Close() (activeTransport.Close calls
+	// mux.Close). Returning mux.Close would cause a double-close at
+	// shutdown: gateway.Close -> transport.Close -> mux.Close, then
+	// the deferred closer -> mux.Close again.
+	return nil, nil
 }
 
 func startHTTPServer(

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -542,8 +542,11 @@ func wireAdapterDirect(ctx context.Context, cfg *ebusgateway.Config) (func() err
 	// "adapter-direct://host:port" as the address and fails.
 	if strings.HasPrefix(strings.ToLower(address), schemePrefix) {
 		address = address[len(schemePrefix):]
-	}
-	if network == "" {
+		// The URI form implies TCP — force it unconditionally since
+		// the default TransportConfig.Network is "unix" and would
+		// cause net.Dial("unix", "host:port") to fail.
+		network = "tcp"
+	} else if network == "" {
 		network = "tcp"
 	}
 	if address == "" {

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -99,6 +99,12 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 		}()
 	}
 
+	// Warn if --proxy-listen is set but adapter-direct transport was not
+	// activated (the proxy endpoint requires the adapter multiplexer).
+	if cfg.ProxyListenAddr != "" && cfg.Transport == nil {
+		log.Printf("warning: --proxy-listen requires adapter-direct transport; proxy endpoint not started")
+	}
+
 	busObservability, deduplicator, err := wireObserveFirstObserversFn(&cfg)
 	if err != nil {
 		return err
@@ -488,6 +494,8 @@ func bindFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) {
 		return nil
 	})
 
+	fs.StringVar(&cfg.ProxyListenAddr, "proxy-listen", cfg.ProxyListenAddr, "TCP listen address for ENH proxy clients (e.g. :19001, empty disables)")
+
 	fs.Func("source-addr", "source address for scans/semantic reads (e.g. 0xf0, 0x00, or auto)", func(value string) error {
 		value = strings.TrimSpace(strings.ToLower(value))
 		if value == "" {
@@ -573,6 +581,18 @@ func wireAdapterDirect(ctx context.Context, cfg *ebusgateway.Config) (func() err
 	}
 
 	log.Printf("adapter-direct: connected to %s/%s", network, address)
+
+	// Start proxy listener if configured (exposes ENH endpoint for
+	// external clients like ebusd). Context-managed: closes when ctx
+	// cancels, so no explicit closer needed.
+	if cfg.ProxyListenAddr != "" {
+		pl, err := adaptermux.NewProxyListener(ctx, mux, cfg.ProxyListenAddr, log.Default())
+		if err != nil {
+			mux.Close()
+			return nil, fmt.Errorf("proxy listener: %w", err)
+		}
+		log.Printf("adapter-direct: proxy listener on %s", pl.Addr())
+	}
 
 	// Configure gateway transports.
 	cfg.Transport = mux.ActiveTransport()

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/Project-Helianthus/helianthus-ebusgateway"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/adaptermux"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/graphql"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mdns"
@@ -82,6 +83,20 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 
 	if len(cfg.Providers) == 0 {
 		cfg.Providers = vaillantproviders.Default()
+	}
+
+	// Wire adapter-direct mode: create multiplexer, configure active
+	// and passive transports before gateway construction.
+	adapterMuxCloser, err := wireAdapterDirect(ctx, &cfg)
+	if err != nil {
+		return fmt.Errorf("adapter-direct: %w", err)
+	}
+	if adapterMuxCloser != nil {
+		defer func() {
+			if err := adapterMuxCloser(); err != nil {
+				log.Printf("adapter-direct close: %v", err)
+			}
+		}()
 	}
 
 	busObservability, deduplicator, err := wireObserveFirstObserversFn(&cfg)
@@ -491,6 +506,69 @@ func bindFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) {
 		cfg.ScanSourceAuto = cfg.ScanSource == 0x00
 		return nil
 	})
+}
+
+// wireAdapterDirect creates and starts the adapter multiplexer if the
+// transport protocol is adapter-direct. It configures both active and
+// passive transports in cfg before gateway construction.
+//
+// Returns a closer function for the multiplexer, or nil if not in
+// adapter-direct mode.
+func wireAdapterDirect(ctx context.Context, cfg *ebusgateway.Config) (func() error, error) {
+	if cfg.TransportConfig.Protocol != ebusgateway.TransportAdapterDirect {
+		return nil, nil
+	}
+
+	network := cfg.TransportConfig.Network
+	address := cfg.TransportConfig.Address
+	if network == "" {
+		network = "tcp"
+	}
+	if address == "" {
+		return nil, fmt.Errorf("adapter-direct requires an address (e.g. adapter-direct://boiler.local:9999)")
+	}
+
+	// Determine ENH vs ENS sub-protocol. Default ENH.
+	adapterProtocol := "enh"
+
+	muxCfg := adaptermux.Config{
+		Protocol:     adapterProtocol,
+		Network:      network,
+		Address:      address,
+		DialTimeout:  cfg.TransportConfig.DialTimeout,
+		ReadTimeout:  cfg.TransportConfig.ReadTimeout,
+		WriteTimeout: cfg.TransportConfig.WriteTimeout,
+	}
+	if muxCfg.DialTimeout == 0 {
+		muxCfg.DialTimeout = 5 * time.Second
+	}
+	if muxCfg.ReadTimeout == 0 {
+		muxCfg.ReadTimeout = 5 * time.Second
+	}
+	if muxCfg.WriteTimeout == 0 {
+		muxCfg.WriteTimeout = 5 * time.Second
+	}
+
+	mux := adaptermux.New(muxCfg)
+
+	// Create passive transport BEFORE Start() so the callback is wired.
+	passiveTransport := mux.PassiveTransport()
+
+	if err := mux.Start(ctx); err != nil {
+		return nil, fmt.Errorf("start multiplexer: %w", err)
+	}
+
+	log.Printf("adapter-direct: connected to %s/%s", network, address)
+
+	// Configure gateway transports.
+	cfg.Transport = mux.ActiveTransport()
+	cfg.PassiveTransport = passiveTransport
+
+	// Override protocol to ENH for gateway's internal transport handling
+	// (the mux handles the actual adapter protocol internally).
+	cfg.TransportConfig.Protocol = ebusgateway.TransportENH
+
+	return mux.Close, nil
 }
 
 func startHTTPServer(

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -584,9 +584,11 @@ func wireAdapterDirect(ctx context.Context, cfg *ebusgateway.Config) (func() err
 	if muxCfg.DialTimeout == 0 {
 		muxCfg.DialTimeout = 5 * time.Second
 	}
-	if muxCfg.ReadTimeout == 0 {
-		muxCfg.ReadTimeout = 5 * time.Second
-	}
+	// Mux read timeout controls how often the idle-timeout branch runs
+	// (tryGrantAndStart). Keep it short so START grants are not delayed
+	// on a quiet bus. This does not affect bus transaction timing — the
+	// gateway's own transport read timeout handles that on the active path.
+	muxCfg.ReadTimeout = 200 * time.Millisecond
 	if muxCfg.WriteTimeout == 0 {
 		muxCfg.WriteTimeout = 5 * time.Second
 	}

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -621,20 +621,19 @@ func wireAdapterDirect(ctx context.Context, cfg *ebusgateway.Config) (func() err
 	cfg.Transport = mux.ActiveTransport()
 	cfg.PassiveTransport = passiveTransport
 
-	// Do NOT return mux.Close here. The gateway owns the lifecycle
-	// through cfg.Transport.Close() (activeTransport.Close calls
-	// mux.Close). Returning mux.Close would cause a double-close at
-	// shutdown: gateway.Close -> transport.Close -> mux.Close, then
-	// the deferred closer -> mux.Close again.
-	//
-	// However, the proxy listener is a separate resource not owned by
-	// the gateway. If run() fails after wireAdapterDirect returns but
-	// before context cancellation, the listener would leak. Return its
-	// Close so the caller can defer it.
-	if proxyListener != nil {
-		return proxyListener.Close, nil
+	// Return a closer that cleans up both the proxy listener (if any)
+	// and the mux itself. This covers early run() failures where
+	// gateway.Close() never runs (and thus activeTransport.Close
+	// never calls mux.Close). On normal shutdown the gateway's
+	// transport.Close calls mux.Close first — that is safe because
+	// mux.Close is idempotent (sync.Once guarded).
+	closer := func() error {
+		if proxyListener != nil {
+			proxyListener.Close()
+		}
+		return mux.Close()
 	}
-	return nil, nil
+	return closer, nil
 }
 
 func startHTTPServer(

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -538,7 +538,7 @@ func wireAdapterDirect(ctx context.Context, cfg *ebusgateway.Config) (func() err
 	addrLower := strings.ToLower(address)
 	uriIsENS := strings.HasPrefix(addrLower, schemePrefixENS)
 	uriIsStd := strings.HasPrefix(addrLower, schemePrefix)
-	if cfg.TransportConfig.Protocol != ebusgateway.TransportAdapterDirect {
+	if !strings.EqualFold(string(cfg.TransportConfig.Protocol), string(ebusgateway.TransportAdapterDirect)) {
 		if !uriIsStd && !uriIsENS {
 			return nil, nil
 		}

--- a/cmd/gateway/main_test.go
+++ b/cmd/gateway/main_test.go
@@ -1022,6 +1022,7 @@ func TestWireAdapterDirect_URIScheme_ForcesTCP(t *testing.T) {
 	// Default protocol is "enh" (not adapter-direct), but the URI
 	// scheme should trigger adapter-direct mode and force TCP.
 	cfg.TransportConfig.Address = "adapter-direct://192.0.2.1:9999"
+	cfg.TransportConfig.DialTimeout = 100 * time.Millisecond
 
 	_, err := wireAdapterDirect(context.Background(), &cfg)
 	if err == nil {
@@ -1043,6 +1044,7 @@ func TestWireAdapterDirect_ExplicitProtocol_ForcesTCPForHostPort(t *testing.T) {
 	cfg.TransportConfig.Protocol = ebusgateway.TransportAdapterDirect
 	cfg.TransportConfig.Network = "unix" // simulates the default
 	cfg.TransportConfig.Address = "192.0.2.1:9999"
+	cfg.TransportConfig.DialTimeout = 100 * time.Millisecond
 
 	_, err := wireAdapterDirect(context.Background(), &cfg)
 	if err == nil {
@@ -1061,6 +1063,7 @@ func TestWireAdapterDirect_ExplicitProtocol_KeepsUnixForSocketPath(t *testing.T)
 	cfg.TransportConfig.Protocol = ebusgateway.TransportAdapterDirect
 	cfg.TransportConfig.Network = "unix"
 	cfg.TransportConfig.Address = "/var/run/adapter.sock"
+	cfg.TransportConfig.DialTimeout = 100 * time.Millisecond
 
 	_, err := wireAdapterDirect(context.Background(), &cfg)
 	if err == nil {
@@ -1075,6 +1078,7 @@ func TestWireAdapterDirect_ENSScheme_SelectsENS(t *testing.T) {
 	// Issue 1: adapter-direct-ens:// URI should select ENS protocol.
 	cfg := ebusgateway.DefaultConfig()
 	cfg.TransportConfig.Address = "adapter-direct-ens://192.0.2.1:9999"
+	cfg.TransportConfig.DialTimeout = 100 * time.Millisecond
 
 	_, err := wireAdapterDirect(context.Background(), &cfg)
 	if err == nil {
@@ -1101,6 +1105,7 @@ func TestWireAdapterDirect_ProxyListener_ReturnedAsCloser(t *testing.T) {
 	cfg.TransportConfig.Protocol = ebusgateway.TransportAdapterDirect
 	cfg.TransportConfig.Network = "tcp"
 	cfg.TransportConfig.Address = "192.0.2.1:9999"
+	cfg.TransportConfig.DialTimeout = 100 * time.Millisecond
 	cfg.ProxyListenAddr = "" // no proxy listener
 
 	_, err := wireAdapterDirect(context.Background(), &cfg)

--- a/cmd/gateway/main_test.go
+++ b/cmd/gateway/main_test.go
@@ -998,3 +998,115 @@ func TestNormalizeMountPath(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// wireAdapterDirect tests (PR #472 review fixes)
+// ---------------------------------------------------------------------------
+
+func TestWireAdapterDirect_NonAdapterDirect_ReturnsNil(t *testing.T) {
+	cfg := ebusgateway.DefaultConfig()
+	cfg.TransportConfig.Protocol = ebusgateway.TransportENH
+	cfg.TransportConfig.Address = "127.0.0.1:9999"
+
+	closer, err := wireAdapterDirect(context.Background(), &cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if closer != nil {
+		t.Fatal("closer should be nil for non-adapter-direct protocol")
+	}
+}
+
+func TestWireAdapterDirect_URIScheme_ForcesTCP(t *testing.T) {
+	cfg := ebusgateway.DefaultConfig()
+	// Default protocol is "enh" (not adapter-direct), but the URI
+	// scheme should trigger adapter-direct mode and force TCP.
+	cfg.TransportConfig.Address = "adapter-direct://192.0.2.1:9999"
+
+	_, err := wireAdapterDirect(context.Background(), &cfg)
+	if err == nil {
+		t.Fatal("expected dial error, got nil")
+	}
+	// The error should show tcp/192.0.2.1:9999 (not unix).
+	if !strings.Contains(err.Error(), "tcp") {
+		t.Fatalf("expected TCP network in error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "192.0.2.1:9999") {
+		t.Fatalf("expected stripped address in error, got: %v", err)
+	}
+}
+
+func TestWireAdapterDirect_ExplicitProtocol_ForcesTCPForHostPort(t *testing.T) {
+	// Issue 2: --transport adapter-direct --address host:port should
+	// force TCP even when network defaults to "unix".
+	cfg := ebusgateway.DefaultConfig()
+	cfg.TransportConfig.Protocol = ebusgateway.TransportAdapterDirect
+	cfg.TransportConfig.Network = "unix" // simulates the default
+	cfg.TransportConfig.Address = "192.0.2.1:9999"
+
+	_, err := wireAdapterDirect(context.Background(), &cfg)
+	if err == nil {
+		t.Fatal("expected dial error, got nil")
+	}
+	// Must show tcp, not unix.
+	if !strings.Contains(err.Error(), "tcp") {
+		t.Fatalf("expected TCP network for host:port address, got: %v", err)
+	}
+}
+
+func TestWireAdapterDirect_ExplicitProtocol_KeepsUnixForSocketPath(t *testing.T) {
+	// When --transport adapter-direct --address /var/run/adapter.sock,
+	// the network should remain "unix" (no colon in path).
+	cfg := ebusgateway.DefaultConfig()
+	cfg.TransportConfig.Protocol = ebusgateway.TransportAdapterDirect
+	cfg.TransportConfig.Network = "unix"
+	cfg.TransportConfig.Address = "/var/run/adapter.sock"
+
+	_, err := wireAdapterDirect(context.Background(), &cfg)
+	if err == nil {
+		t.Fatal("expected dial error, got nil")
+	}
+	if !strings.Contains(err.Error(), "unix") {
+		t.Fatalf("expected unix network for socket path, got: %v", err)
+	}
+}
+
+func TestWireAdapterDirect_ENSScheme_SelectsENS(t *testing.T) {
+	// Issue 1: adapter-direct-ens:// URI should select ENS protocol.
+	cfg := ebusgateway.DefaultConfig()
+	cfg.TransportConfig.Address = "adapter-direct-ens://192.0.2.1:9999"
+
+	_, err := wireAdapterDirect(context.Background(), &cfg)
+	if err == nil {
+		t.Fatal("expected dial error, got nil")
+	}
+	// Verify the scheme was stripped and TCP forced.
+	if !strings.Contains(err.Error(), "192.0.2.1:9999") {
+		t.Fatalf("expected stripped address, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "tcp") {
+		t.Fatalf("expected TCP network, got: %v", err)
+	}
+	// Note: ENS protocol selection is verified implicitly — if the
+	// scheme were not recognized, wireAdapterDirect would return (nil,
+	// nil) and we would not get a dial error.
+}
+
+func TestWireAdapterDirect_ProxyListener_ReturnedAsCloser(t *testing.T) {
+	// Issue 3: when ProxyListenAddr is set, the returned closer should
+	// be non-nil (the proxy listener's Close). We cannot fully test
+	// this without a running adapter, but we verify the non-proxy path
+	// still returns nil closer on dial failure.
+	cfg := ebusgateway.DefaultConfig()
+	cfg.TransportConfig.Protocol = ebusgateway.TransportAdapterDirect
+	cfg.TransportConfig.Network = "tcp"
+	cfg.TransportConfig.Address = "192.0.2.1:9999"
+	cfg.ProxyListenAddr = "" // no proxy listener
+
+	_, err := wireAdapterDirect(context.Background(), &cfg)
+	if err == nil {
+		t.Fatal("expected dial error, got nil (no adapter running)")
+	}
+	// Dial error is expected — proxy listener path is not reached.
+	// This test documents that without a proxy listener, closer is nil.
+}

--- a/config.go
+++ b/config.go
@@ -15,11 +15,11 @@ import (
 type TransportProtocol string
 
 const (
-	TransportENH      TransportProtocol = "enh"
-	TransportENS      TransportProtocol = "ens"
-	TransportUDPPlain TransportProtocol = "udp-plain"
-	TransportTCPPlain TransportProtocol = "tcp-plain"
-	TransportEbusdTCP       TransportProtocol = "ebusd-tcp"
+	TransportENH           TransportProtocol = "enh"
+	TransportENS           TransportProtocol = "ens"
+	TransportUDPPlain      TransportProtocol = "udp-plain"
+	TransportTCPPlain      TransportProtocol = "tcp-plain"
+	TransportEbusdTCP      TransportProtocol = "ebusd-tcp"
 	TransportAdapterDirect TransportProtocol = "adapter-direct"
 
 	DefaultSemanticZonePresenceMissThreshold = 3

--- a/config.go
+++ b/config.go
@@ -19,7 +19,8 @@ const (
 	TransportENS      TransportProtocol = "ens"
 	TransportUDPPlain TransportProtocol = "udp-plain"
 	TransportTCPPlain TransportProtocol = "tcp-plain"
-	TransportEbusdTCP TransportProtocol = "ebusd-tcp"
+	TransportEbusdTCP       TransportProtocol = "ebusd-tcp"
+	TransportAdapterDirect TransportProtocol = "adapter-direct"
 
 	DefaultSemanticZonePresenceMissThreshold = 3
 	DefaultSemanticZonePresenceHitThreshold  = 2
@@ -56,6 +57,7 @@ type WatchObserver interface {
 
 type Config struct {
 	Transport              transport.RawTransport
+	PassiveTransport       transport.RawTransport // pre-configured passive transport (adapter-direct mode)
 	TransportConfig        TransportConfig
 	BusConfig              protocol.BusConfig
 	QueueCapacity          int

--- a/config.go
+++ b/config.go
@@ -58,6 +58,7 @@ type WatchObserver interface {
 type Config struct {
 	Transport              transport.RawTransport
 	PassiveTransport       transport.RawTransport // pre-configured passive transport (adapter-direct mode)
+	ProxyListenAddr        string                 // TCP listen address for ENH proxy clients (empty disables)
 	TransportConfig        TransportConfig
 	BusConfig              protocol.BusConfig
 	QueueCapacity          int

--- a/gateway.go
+++ b/gateway.go
@@ -226,6 +226,13 @@ func passiveTransportUnavailableReason(cfg Config) string {
 }
 
 func PassiveTransportSupported(cfg Config) bool {
+	// Adapter-direct mode pre-wires PassiveTransport before the gateway
+	// is constructed.  When it is already set the transport is known to
+	// be functional — skip heuristic endpoint classification which would
+	// misclassify the raw adapter address as unsupported.
+	if cfg.PassiveTransport != nil {
+		return true
+	}
 	return passiveTransportUnavailableReason(cfg) == ""
 }
 

--- a/gateway.go
+++ b/gateway.go
@@ -291,7 +291,7 @@ func parseTransportEndpoint(endpoint string, fallbackProtocol TransportProtocol)
 		}
 	case "unix":
 	case "adapter-direct":
-		protocol = TransportAdapterDirect
+		return "", "", "", fmt.Errorf("gateway transport endpoint scheme %q requires preconfigured adapter-direct transport (use wireAdapterDirect)", scheme)
 	default:
 		return "", "", "", fmt.Errorf("gateway transport endpoint unsupported scheme %q", scheme)
 	}

--- a/gateway.go
+++ b/gateway.go
@@ -283,6 +283,8 @@ func parseTransportEndpoint(endpoint string, fallbackProtocol TransportProtocol)
 			protocol = TransportTCPPlain
 		}
 	case "unix":
+	case "adapter-direct":
+		protocol = TransportAdapterDirect
 	default:
 		return "", "", "", fmt.Errorf("gateway transport endpoint unsupported scheme %q", scheme)
 	}

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -504,6 +504,30 @@ func TestPassiveTransportSupported(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			name: "pre-wired passive transport overrides heuristic",
+			cfg: Config{
+				PassiveTransport: transport.NewLoopback(),
+				TransportConfig: TransportConfig{
+					Protocol: TransportENH,
+					Network:  "tcp",
+					Address:  "192.168.100.2:9999",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "pre-wired passive transport overrides ebusd-tcp",
+			cfg: Config{
+				PassiveTransport: transport.NewLoopback(),
+				TransportConfig: TransportConfig{
+					Protocol: TransportEbusdTCP,
+					Network:  "tcp",
+					Address:  "127.0.0.1:8888",
+				},
+			},
+			want: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/adaptermux/active_path.go
+++ b/internal/adaptermux/active_path.go
@@ -28,6 +28,22 @@ var (
 // the gateway's own echoes), which is what gateway.Bus expects for
 // echo matching.
 func (t *activeTransport) ReadByte() (byte, error) {
+	// Priority: check for reset/error before data.
+	// After handleReset enqueues ErrAdapterReset on activeErrCh and
+	// readLoop enqueues post-reset symbols on activeRecvCh, both
+	// channels may be ready simultaneously.  Go select picks randomly,
+	// so a bare select could deliver a post-reset byte before the
+	// reset error, breaking transaction state.  The non-blocking drain
+	// here guarantees the consumer sees the reset first.
+	select {
+	case err := <-t.mux.activeErrCh:
+		if err != nil {
+			return 0, err
+		}
+		return 0, errors.New("adaptermux: unexpected nil error")
+	default:
+	}
+
 	select {
 	case b := <-t.mux.activeRecvCh:
 		return b, nil
@@ -44,6 +60,22 @@ func (t *activeTransport) ReadByte() (byte, error) {
 // ReadEvent returns stream events including RESETTED boundaries.
 // Satisfies transport.StreamEventReader for passive tap integration.
 func (t *activeTransport) ReadEvent() (transport.StreamEvent, error) {
+	// Priority: check for reset/error before data (same rationale as
+	// ReadByte — see comment there).
+	select {
+	case err := <-t.mux.activeErrCh:
+		if errors.Is(err, ebuserrors.ErrAdapterReset) {
+			return transport.StreamEvent{
+				Kind: transport.StreamEventReset,
+			}, nil
+		}
+		if err != nil {
+			return transport.StreamEvent{}, err
+		}
+		return transport.StreamEvent{}, errors.New("adaptermux: unexpected nil error")
+	default:
+	}
+
 	select {
 	case b := <-t.mux.activeRecvCh:
 		return transport.StreamEvent{

--- a/internal/adaptermux/active_path.go
+++ b/internal/adaptermux/active_path.go
@@ -27,31 +27,21 @@ var (
 // error occurs. This receives ALL bytes from the adapter (including
 // the gateway's own echoes), which is what gateway.Bus expects for
 // echo matching.
+//
+// activeCh is a single FIFO channel carrying both bytes and errors.
+// handleReset drains the channel and enqueues the reset event before
+// readLoop resumes, so the consumer sees events in exact enqueue
+// order — no priority select needed.
 func (t *activeTransport) ReadByte() (byte, error) {
-	// Priority: check for reset/error before data.
-	// After handleReset enqueues ErrAdapterReset on activeErrCh and
-	// readLoop enqueues post-reset symbols on activeRecvCh, both
-	// channels may be ready simultaneously.  Go select picks randomly,
-	// so a bare select could deliver a post-reset byte before the
-	// reset error, breaking transaction state.  The non-blocking drain
-	// here guarantees the consumer sees the reset first.
 	select {
-	case err := <-t.mux.activeErrCh:
-		if err != nil {
-			return 0, err
+	case ev := <-t.mux.activeCh:
+		if ev.kind == activeEventError {
+			if ev.err != nil {
+				return 0, ev.err
+			}
+			return 0, errors.New("adaptermux: unexpected nil error")
 		}
-		return 0, errors.New("adaptermux: unexpected nil error")
-	default:
-	}
-
-	select {
-	case b := <-t.mux.activeRecvCh:
-		return b, nil
-	case err := <-t.mux.activeErrCh:
-		if err != nil {
-			return 0, err
-		}
-		return 0, errors.New("adaptermux: unexpected nil error")
+		return ev.b, nil
 	case <-t.mux.ctx.Done():
 		return 0, fmt.Errorf("adaptermux: %w", t.mux.ctx.Err())
 	}
@@ -59,39 +49,26 @@ func (t *activeTransport) ReadByte() (byte, error) {
 
 // ReadEvent returns stream events including RESETTED boundaries.
 // Satisfies transport.StreamEventReader for passive tap integration.
+//
+// Same FIFO guarantee as ReadByte — see comment there.
 func (t *activeTransport) ReadEvent() (transport.StreamEvent, error) {
-	// Priority: check for reset/error before data (same rationale as
-	// ReadByte — see comment there).
 	select {
-	case err := <-t.mux.activeErrCh:
-		if errors.Is(err, ebuserrors.ErrAdapterReset) {
-			return transport.StreamEvent{
-				Kind: transport.StreamEventReset,
-			}, nil
+	case ev := <-t.mux.activeCh:
+		if ev.kind == activeEventError {
+			if errors.Is(ev.err, ebuserrors.ErrAdapterReset) {
+				return transport.StreamEvent{
+					Kind: transport.StreamEventReset,
+				}, nil
+			}
+			if ev.err != nil {
+				return transport.StreamEvent{}, ev.err
+			}
+			return transport.StreamEvent{}, errors.New("adaptermux: unexpected nil error")
 		}
-		if err != nil {
-			return transport.StreamEvent{}, err
-		}
-		return transport.StreamEvent{}, errors.New("adaptermux: unexpected nil error")
-	default:
-	}
-
-	select {
-	case b := <-t.mux.activeRecvCh:
 		return transport.StreamEvent{
 			Kind: transport.StreamEventByte,
-			Byte: b,
+			Byte: ev.b,
 		}, nil
-	case err := <-t.mux.activeErrCh:
-		if errors.Is(err, ebuserrors.ErrAdapterReset) {
-			return transport.StreamEvent{
-				Kind: transport.StreamEventReset,
-			}, nil
-		}
-		if err != nil {
-			return transport.StreamEvent{}, err
-		}
-		return transport.StreamEvent{}, errors.New("adaptermux: unexpected nil error")
 	case <-t.mux.ctx.Done():
 		return transport.StreamEvent{}, fmt.Errorf("adaptermux: %w", t.mux.ctx.Err())
 	}

--- a/internal/adaptermux/active_path.go
+++ b/internal/adaptermux/active_path.go
@@ -110,6 +110,14 @@ func (t *activeTransport) Close() error {
 // StartArbitration requests bus ownership for the gateway.
 // Blocks until the request is granted at a SYN boundary or the
 // context is cancelled.
+//
+// Reconnect safety: during adapter reconnect, readLoop is blocked in
+// reconnect() and cannot process SYN boundaries. However, reconnect()
+// calls arb.failAllPending() BEFORE entering the reconnection backoff
+// loop (mux.go line ~344), which sends startResult{granted:false} on
+// the notify channel. This select therefore unblocks promptly on
+// disconnect — pending START requests do not hang for the duration of
+// the reconnection backoff.
 func (t *activeTransport) StartArbitration(initiator byte) error {
 	ch := t.mux.arb.requestStart(gatewaySessionID, initiator)
 

--- a/internal/adaptermux/active_path.go
+++ b/internal/adaptermux/active_path.go
@@ -1,0 +1,120 @@
+package adaptermux
+
+import (
+	"errors"
+	"fmt"
+
+	ebuserrors "github.com/Project-Helianthus/helianthus-ebusgo/errors"
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+// activeTransport wraps the multiplexer to provide a RawTransport
+// interface for the gateway's active path (gateway.Bus).
+//
+// It implements transport.RawTransport and optionally
+// transport.StreamEventReader for RESETTED detection.
+type activeTransport struct {
+	mux *Mux
+}
+
+// Compile-time interface checks.
+var (
+	_ transport.RawTransport    = (*activeTransport)(nil)
+	_ transport.StreamEventReader = (*activeTransport)(nil)
+)
+
+// ReadByte blocks until a byte is received from the adapter or an
+// error occurs. This receives ALL bytes from the adapter (including
+// the gateway's own echoes), which is what gateway.Bus expects for
+// echo matching.
+func (t *activeTransport) ReadByte() (byte, error) {
+	select {
+	case b := <-t.mux.activeRecvCh:
+		return b, nil
+	case err := <-t.mux.activeErrCh:
+		if err != nil {
+			return 0, err
+		}
+		return 0, errors.New("adaptermux: unexpected nil error")
+	case <-t.mux.ctx.Done():
+		return 0, fmt.Errorf("adaptermux: %w", t.mux.ctx.Err())
+	}
+}
+
+// ReadEvent returns stream events including RESETTED boundaries.
+// Satisfies transport.StreamEventReader for passive tap integration.
+func (t *activeTransport) ReadEvent() (transport.StreamEvent, error) {
+	select {
+	case b := <-t.mux.activeRecvCh:
+		return transport.StreamEvent{
+			Kind: transport.StreamEventByte,
+			Byte: b,
+		}, nil
+	case err := <-t.mux.activeErrCh:
+		if errors.Is(err, ebuserrors.ErrAdapterReset) {
+			return transport.StreamEvent{
+				Kind: transport.StreamEventReset,
+			}, nil
+		}
+		if err != nil {
+			return transport.StreamEvent{}, err
+		}
+		return transport.StreamEvent{}, errors.New("adaptermux: unexpected nil error")
+	case <-t.mux.ctx.Done():
+		return transport.StreamEvent{}, fmt.Errorf("adaptermux: %w", t.mux.ctx.Err())
+	}
+}
+
+// Write sends bytes to the adapter through the multiplexer.
+// The gateway must hold bus ownership (via StartArbitration) before
+// calling Write.
+func (t *activeTransport) Write(p []byte) (int, error) {
+	for i, b := range p {
+		result := make(chan error, 1)
+		select {
+		case t.mux.activeSendCh <- sendRequest{
+			sessionID: gatewaySessionID,
+			data:      b,
+			result:    result,
+		}:
+		case <-t.mux.ctx.Done():
+			return i, fmt.Errorf("adaptermux: %w", t.mux.ctx.Err())
+		}
+
+		select {
+		case err := <-result:
+			if err != nil {
+				return i, err
+			}
+		case <-t.mux.ctx.Done():
+			return i, fmt.Errorf("adaptermux: %w", t.mux.ctx.Err())
+		}
+	}
+	return len(p), nil
+}
+
+// Close shuts down the multiplexer.
+func (t *activeTransport) Close() error {
+	return t.mux.Close()
+}
+
+// StartArbitration requests bus ownership for the gateway.
+// Blocks until the request is granted at a SYN boundary or the
+// context is cancelled.
+func (t *activeTransport) StartArbitration(initiator byte) error {
+	ch := t.mux.arb.requestStart(gatewaySessionID, initiator)
+
+	select {
+	case result := <-ch:
+		if !result.granted {
+			if result.err != nil {
+				return result.err
+			}
+			return errors.New("adaptermux: START not granted")
+		}
+		return nil
+	case <-t.mux.ctx.Done():
+		t.mux.arb.cancelStart(gatewaySessionID)
+		return fmt.Errorf("adaptermux: %w", t.mux.ctx.Err())
+	}
+}

--- a/internal/adaptermux/arbitration.go
+++ b/internal/adaptermux/arbitration.go
@@ -124,15 +124,18 @@ func (a *arbitrator) cancelStart(sessionID uint64) bool {
 // pending request. Called at SYN boundaries and when the bus becomes
 // idle.
 //
-// Returns the winning session's ID and initiator address, or (0, 0)
-// if no requests are pending.
-func (a *arbitrator) tryGrant() (sessionID uint64, initiator byte, granted bool) {
+// Returns the winning session's ID, initiator address, and the notify
+// channel. The caller MUST send a startResult on the notify channel
+// after StartArbitration succeeds or fails — tryGrant does NOT notify
+// the requester (Codex P1: grant must follow adapter START success).
+//
+// Returns (0, 0, nil, false) if no requests are pending.
+func (a *arbitrator) tryGrant() (sessionID uint64, initiator byte, notify chan startResult, granted bool) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
 	if a.hasOwner {
-		// Bus is currently owned. Wait for release.
-		return 0, 0, false
+		return 0, 0, nil, false
 	}
 
 	// Gateway-priority: check gateway first.
@@ -142,8 +145,7 @@ func (a *arbitrator) tryGrant() (sessionID uint64, initiator byte, granted bool)
 		a.hasOwner = true
 		a.currentOwner = gatewaySessionID
 		a.currentInitiator = req.initiator
-		req.notify <- startResult{granted: true}
-		return gatewaySessionID, req.initiator, true
+		return gatewaySessionID, req.initiator, req.notify, true
 	}
 
 	// External FIFO: grant to first external request.
@@ -153,11 +155,10 @@ func (a *arbitrator) tryGrant() (sessionID uint64, initiator byte, granted bool)
 		a.hasOwner = true
 		a.currentOwner = req.sessionID
 		a.currentInitiator = req.initiator
-		req.notify <- startResult{granted: true}
-		return req.sessionID, req.initiator, true
+		return req.sessionID, req.initiator, req.notify, true
 	}
 
-	return 0, 0, false
+	return 0, 0, nil, false
 }
 
 // releaseOwnership releases bus ownership. Called when a transaction

--- a/internal/adaptermux/arbitration.go
+++ b/internal/adaptermux/arbitration.go
@@ -1,0 +1,233 @@
+package adaptermux
+
+import "sync"
+
+// arbitrator manages bus ownership between the gateway (internal) and
+// external sessions (ebusd). Gateway-priority scheduling: at each SYN
+// boundary, the gateway gets first pick. External requests are serviced
+// at the next boundary when the gateway has no pending work.
+//
+// The arbitrator is informed by the proxy's boundary-based arbitration
+// (proxy M2) but simplified for a two-class model:
+//   - Gateway (sessionID = gatewaySessionID): always has priority
+//   - External sessions: queued FIFO, serviced when gateway is idle
+type arbitrator struct {
+	mu sync.Mutex
+
+	// pendingGateway holds the gateway's pending START request, if any.
+	// Only one gateway request can be pending at a time.
+	pendingGateway *startRequest
+
+	// pendingExternal holds external sessions' pending START requests
+	// in FIFO order. Each session can have at most one pending request.
+	pendingExternal []*startRequest
+
+	// hasOwner tracks whether the bus is currently owned.
+	hasOwner bool
+
+	// currentOwner is the session ID of the current bus owner.
+	// Only valid when hasOwner is true.
+	currentOwner uint64
+
+	// currentInitiator is the eBUS source address of the current
+	// owner's START request.
+	currentInitiator byte
+}
+
+// startRequest represents a pending START arbitration request.
+type startRequest struct {
+	sessionID uint64
+	initiator byte
+	notify    chan startResult // receives exactly one result
+}
+
+// startResult is the outcome of a START arbitration request.
+type startResult struct {
+	granted bool
+	err     error
+}
+
+// gatewaySessionID is the reserved session ID for the gateway's
+// internal active path. External sessions use IDs > 0.
+const gatewaySessionID uint64 = 0
+
+func newArbitrator() *arbitrator {
+	return &arbitrator{
+		pendingExternal: make([]*startRequest, 0, 4),
+	}
+}
+
+// requestStart submits a START request for the given session.
+// Returns a channel that will receive the result when arbitration
+// completes (at the next SYN boundary or immediately if bus is idle).
+//
+// If the bus is currently idle, the request may be granted immediately
+// via a call to tryGrant() by the mux loop.
+func (a *arbitrator) requestStart(sessionID uint64, initiator byte) <-chan startResult {
+	ch := make(chan startResult, 1)
+	req := &startRequest{
+		sessionID: sessionID,
+		initiator: initiator,
+		notify:    ch,
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if sessionID == gatewaySessionID {
+		// Cancel any existing gateway request.
+		if a.pendingGateway != nil {
+			a.pendingGateway.notify <- startResult{granted: false}
+		}
+		a.pendingGateway = req
+	} else {
+		// Remove any existing request from this session.
+		for i, existing := range a.pendingExternal {
+			if existing.sessionID == sessionID {
+				existing.notify <- startResult{granted: false}
+				a.pendingExternal = append(a.pendingExternal[:i], a.pendingExternal[i+1:]...)
+				break
+			}
+		}
+		a.pendingExternal = append(a.pendingExternal, req)
+	}
+
+	return ch
+}
+
+// cancelStart cancels a pending START request for the given session.
+// Returns true if a request was found and cancelled.
+func (a *arbitrator) cancelStart(sessionID uint64) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if sessionID == gatewaySessionID {
+		if a.pendingGateway != nil {
+			a.pendingGateway.notify <- startResult{granted: false}
+			a.pendingGateway = nil
+			return true
+		}
+		return false
+	}
+
+	for i, req := range a.pendingExternal {
+		if req.sessionID == sessionID {
+			req.notify <- startResult{granted: false}
+			a.pendingExternal = append(a.pendingExternal[:i], a.pendingExternal[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+// tryGrant attempts to grant bus ownership to the highest-priority
+// pending request. Called at SYN boundaries and when the bus becomes
+// idle.
+//
+// Returns the winning session's ID and initiator address, or (0, 0)
+// if no requests are pending.
+func (a *arbitrator) tryGrant() (sessionID uint64, initiator byte, granted bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.hasOwner {
+		// Bus is currently owned. Wait for release.
+		return 0, 0, false
+	}
+
+	// Gateway-priority: check gateway first.
+	if a.pendingGateway != nil {
+		req := a.pendingGateway
+		a.pendingGateway = nil
+		a.hasOwner = true
+		a.currentOwner = gatewaySessionID
+		a.currentInitiator = req.initiator
+		req.notify <- startResult{granted: true}
+		return gatewaySessionID, req.initiator, true
+	}
+
+	// External FIFO: grant to first external request.
+	if len(a.pendingExternal) > 0 {
+		req := a.pendingExternal[0]
+		a.pendingExternal = a.pendingExternal[1:]
+		a.hasOwner = true
+		a.currentOwner = req.sessionID
+		a.currentInitiator = req.initiator
+		req.notify <- startResult{granted: true}
+		return req.sessionID, req.initiator, true
+	}
+
+	return 0, 0, false
+}
+
+// releaseOwnership releases bus ownership. Called when a transaction
+// completes, times out, or the owner disconnects.
+func (a *arbitrator) releaseOwnership(sessionID uint64) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.hasOwner && a.currentOwner == sessionID {
+		a.hasOwner = false
+		a.currentOwner = 0
+		a.currentInitiator = 0
+	}
+}
+
+// forceRelease releases bus ownership regardless of which session
+// holds it. Used on adapter RESETTED or timeout.
+func (a *arbitrator) forceRelease() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.hasOwner = false
+	a.currentOwner = 0
+	a.currentInitiator = 0
+}
+
+// owner returns the current bus owner session ID and initiator.
+// Returns (0, 0) if no session owns the bus.
+func (a *arbitrator) owner() (sessionID uint64, initiator byte, owned bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if !a.hasOwner {
+		return 0, 0, false
+	}
+	return a.currentOwner, a.currentInitiator, true
+}
+
+// isOwner reports whether the given session currently owns the bus.
+func (a *arbitrator) isOwner(sessionID uint64) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.hasOwner && a.currentOwner == sessionID
+}
+
+// hasPending reports whether any START requests are pending.
+func (a *arbitrator) hasPending() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.pendingGateway != nil || len(a.pendingExternal) > 0
+}
+
+// failAllPending fails all pending START requests (e.g., on shutdown
+// or adapter RESETTED).
+func (a *arbitrator) failAllPending(err error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.pendingGateway != nil {
+		a.pendingGateway.notify <- startResult{granted: false, err: err}
+		a.pendingGateway = nil
+	}
+
+	for _, req := range a.pendingExternal {
+		req.notify <- startResult{granted: false, err: err}
+	}
+	a.pendingExternal = a.pendingExternal[:0]
+}
+
+// removeSession removes all pending requests and releases ownership
+// for a disconnecting session.
+func (a *arbitrator) removeSession(sessionID uint64) {
+	a.cancelStart(sessionID)
+	a.releaseOwnership(sessionID)
+}

--- a/internal/adaptermux/arbitration.go
+++ b/internal/adaptermux/arbitration.go
@@ -43,8 +43,9 @@ type startRequest struct {
 
 // startResult is the outcome of a START arbitration request.
 type startResult struct {
-	granted bool
-	err     error
+	granted   bool
+	initiator byte // initiator byte for STARTED/FAILED payload fidelity
+	err       error
 }
 
 // gatewaySessionID is the reserved session ID for the gateway's
@@ -77,14 +78,14 @@ func (a *arbitrator) requestStart(sessionID uint64, initiator byte) <-chan start
 	if sessionID == gatewaySessionID {
 		// Cancel any existing gateway request.
 		if a.pendingGateway != nil {
-			a.pendingGateway.notify <- startResult{granted: false}
+			a.pendingGateway.notify <- startResult{granted: false, initiator: a.pendingGateway.initiator}
 		}
 		a.pendingGateway = req
 	} else {
 		// Remove any existing request from this session.
 		for i, existing := range a.pendingExternal {
 			if existing.sessionID == sessionID {
-				existing.notify <- startResult{granted: false}
+				existing.notify <- startResult{granted: false, initiator: existing.initiator}
 				a.pendingExternal = append(a.pendingExternal[:i], a.pendingExternal[i+1:]...)
 				break
 			}
@@ -103,7 +104,7 @@ func (a *arbitrator) cancelStart(sessionID uint64) bool {
 
 	if sessionID == gatewaySessionID {
 		if a.pendingGateway != nil {
-			a.pendingGateway.notify <- startResult{granted: false}
+			a.pendingGateway.notify <- startResult{granted: false, initiator: a.pendingGateway.initiator}
 			a.pendingGateway = nil
 			return true
 		}
@@ -112,7 +113,7 @@ func (a *arbitrator) cancelStart(sessionID uint64) bool {
 
 	for i, req := range a.pendingExternal {
 		if req.sessionID == sessionID {
-			req.notify <- startResult{granted: false}
+			req.notify <- startResult{granted: false, initiator: req.initiator}
 			a.pendingExternal = append(a.pendingExternal[:i], a.pendingExternal[i+1:]...)
 			return true
 		}
@@ -216,12 +217,12 @@ func (a *arbitrator) failAllPending(err error) {
 	defer a.mu.Unlock()
 
 	if a.pendingGateway != nil {
-		a.pendingGateway.notify <- startResult{granted: false, err: err}
+		a.pendingGateway.notify <- startResult{granted: false, initiator: a.pendingGateway.initiator, err: err}
 		a.pendingGateway = nil
 	}
 
 	for _, req := range a.pendingExternal {
-		req.notify <- startResult{granted: false, err: err}
+		req.notify <- startResult{granted: false, initiator: req.initiator, err: err}
 	}
 	a.pendingExternal = a.pendingExternal[:0]
 }

--- a/internal/adaptermux/arbitration.go
+++ b/internal/adaptermux/arbitration.go
@@ -121,16 +121,17 @@ func (a *arbitrator) cancelStart(sessionID uint64) bool {
 	return false
 }
 
-// tryGrant attempts to grant bus ownership to the highest-priority
-// pending request. Called at SYN boundaries and when the bus becomes
+// tryGrant attempts to select the highest-priority pending request
+// for bus ownership. Called at SYN boundaries and when the bus becomes
 // idle.
 //
-// Returns the winning session's ID, initiator address, and the notify
-// channel. The caller MUST send a startResult on the notify channel
-// after StartArbitration succeeds or fails — tryGrant does NOT notify
-// the requester (Codex P1: grant must follow adapter START success).
+// Ownership is NOT set here — the caller MUST call confirmOwnership
+// after the adapter's StartArbitration succeeds (Codex P1 #3060199707:
+// defer ownership until adapter START confirms). The caller MUST also
+// send a startResult on the notify channel after success or failure.
 //
-// Returns (0, 0, nil, false) if no requests are pending.
+// Returns (0, 0, nil, false) if no requests are pending or the bus
+// is already owned.
 func (a *arbitrator) tryGrant() (sessionID uint64, initiator byte, notify chan startResult, granted bool) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -143,9 +144,6 @@ func (a *arbitrator) tryGrant() (sessionID uint64, initiator byte, notify chan s
 	if a.pendingGateway != nil {
 		req := a.pendingGateway
 		a.pendingGateway = nil
-		a.hasOwner = true
-		a.currentOwner = gatewaySessionID
-		a.currentInitiator = req.initiator
 		return gatewaySessionID, req.initiator, req.notify, true
 	}
 
@@ -153,13 +151,21 @@ func (a *arbitrator) tryGrant() (sessionID uint64, initiator byte, notify chan s
 	if len(a.pendingExternal) > 0 {
 		req := a.pendingExternal[0]
 		a.pendingExternal = a.pendingExternal[1:]
-		a.hasOwner = true
-		a.currentOwner = req.sessionID
-		a.currentInitiator = req.initiator
 		return req.sessionID, req.initiator, req.notify, true
 	}
 
 	return 0, 0, nil, false
+}
+
+// confirmOwnership sets bus ownership after the adapter's
+// StartArbitration has succeeded. Must be called by tryGrantAndStart
+// only on the success path (Codex P1 #3060199707).
+func (a *arbitrator) confirmOwnership(sessionID uint64, initiator byte) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.hasOwner = true
+	a.currentOwner = sessionID
+	a.currentInitiator = initiator
 }
 
 // releaseOwnership releases bus ownership. Called when a transaction

--- a/internal/adaptermux/arbitration_test.go
+++ b/internal/adaptermux/arbitration_test.go
@@ -1,0 +1,252 @@
+package adaptermux
+
+import (
+	"testing"
+	"time"
+)
+
+func TestArbitrator_GatewayPriority(t *testing.T) {
+	arb := newArbitrator()
+
+	// Both gateway and external request START.
+	gwCh := arb.requestStart(gatewaySessionID, 0x71)
+	extCh := arb.requestStart(1, 0x31)
+
+	// Grant: gateway should win.
+	sessionID, initiator, granted := arb.tryGrant()
+	if !granted {
+		t.Fatal("expected grant")
+	}
+	if sessionID != gatewaySessionID {
+		t.Fatalf("sessionID = %d, want gateway (0)", sessionID)
+	}
+	if initiator != 0x71 {
+		t.Fatalf("initiator = 0x%02x, want 0x71", initiator)
+	}
+
+	// Gateway should receive granted.
+	select {
+	case result := <-gwCh:
+		if !result.granted {
+			t.Fatal("gateway should be granted")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for gateway grant")
+	}
+
+	// External should still be pending (bus is owned by gateway).
+	_, _, granted2 := arb.tryGrant()
+	if granted2 {
+		t.Fatal("should not grant while bus is owned")
+	}
+
+	// Release gateway ownership.
+	arb.releaseOwnership(gatewaySessionID)
+
+	// Now external should win.
+	sessionID, initiator, granted3 := arb.tryGrant()
+	if !granted3 {
+		t.Fatal("expected grant for external")
+	}
+	if sessionID != 1 {
+		t.Fatalf("sessionID = %d, want 1", sessionID)
+	}
+	if initiator != 0x31 {
+		t.Fatalf("initiator = 0x%02x, want 0x31", initiator)
+	}
+
+	select {
+	case result := <-extCh:
+		if !result.granted {
+			t.Fatal("external should be granted")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for external grant")
+	}
+}
+
+func TestArbitrator_ExternalFIFO(t *testing.T) {
+	arb := newArbitrator()
+
+	// Two external sessions request START.
+	ch1 := arb.requestStart(1, 0x31)
+	ch2 := arb.requestStart(2, 0x32)
+
+	// First external (FIFO) should win.
+	sessionID, _, granted := arb.tryGrant()
+	if !granted {
+		t.Fatal("expected grant")
+	}
+	if sessionID != 1 {
+		t.Fatalf("first grant: sessionID = %d, want 1", sessionID)
+	}
+
+	select {
+	case result := <-ch1:
+		if !result.granted {
+			t.Fatal("session 1 should be granted")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+
+	arb.releaseOwnership(1)
+
+	// Second external should be next.
+	sessionID, _, granted = arb.tryGrant()
+	if !granted {
+		t.Fatal("expected second grant")
+	}
+	if sessionID != 2 {
+		t.Fatalf("second grant: sessionID = %d, want 2", sessionID)
+	}
+
+	select {
+	case result := <-ch2:
+		if !result.granted {
+			t.Fatal("session 2 should be granted")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestArbitrator_CancelStart(t *testing.T) {
+	arb := newArbitrator()
+
+	ch := arb.requestStart(1, 0x31)
+	cancelled := arb.cancelStart(1)
+	if !cancelled {
+		t.Fatal("expected cancel to succeed")
+	}
+
+	select {
+	case result := <-ch:
+		if result.granted {
+			t.Fatal("cancelled request should not be granted")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+
+	// Nothing to grant now.
+	_, _, granted := arb.tryGrant()
+	if granted {
+		t.Fatal("should not grant after cancel")
+	}
+}
+
+func TestArbitrator_RemoveSession(t *testing.T) {
+	arb := newArbitrator()
+
+	arb.requestStart(1, 0x31)
+
+	// Grant ownership.
+	_, _, granted := arb.tryGrant()
+	if !granted {
+		t.Fatal("expected grant")
+	}
+
+	// Remove session while owning bus.
+	arb.removeSession(1)
+
+	// Bus should be released.
+	if arb.isOwner(1) {
+		t.Fatal("session should no longer own bus")
+	}
+}
+
+func TestArbitrator_FailAllPending(t *testing.T) {
+	arb := newArbitrator()
+
+	gwCh := arb.requestStart(gatewaySessionID, 0x71)
+	extCh := arb.requestStart(1, 0x31)
+
+	arb.failAllPending(nil)
+
+	select {
+	case result := <-gwCh:
+		if result.granted {
+			t.Fatal("gateway should not be granted after failAll")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+
+	select {
+	case result := <-extCh:
+		if result.granted {
+			t.Fatal("external should not be granted after failAll")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestArbitrator_ForceRelease(t *testing.T) {
+	arb := newArbitrator()
+
+	arb.requestStart(1, 0x31)
+	arb.tryGrant()
+
+	if !arb.isOwner(1) {
+		t.Fatal("session 1 should own bus")
+	}
+
+	arb.forceRelease()
+
+	if arb.isOwner(1) {
+		t.Fatal("bus should be released after force")
+	}
+}
+
+func TestArbitrator_DuplicateGatewayRequest(t *testing.T) {
+	arb := newArbitrator()
+
+	// First gateway request.
+	ch1 := arb.requestStart(gatewaySessionID, 0x71)
+
+	// Second gateway request replaces the first.
+	ch2 := arb.requestStart(gatewaySessionID, 0x72)
+
+	// First should be cancelled.
+	select {
+	case result := <-ch1:
+		if result.granted {
+			t.Fatal("first gateway request should be cancelled")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+
+	// Second should be granted.
+	_, initiator, granted := arb.tryGrant()
+	if !granted {
+		t.Fatal("expected grant")
+	}
+	if initiator != 0x72 {
+		t.Fatalf("initiator = 0x%02x, want 0x72", initiator)
+	}
+
+	select {
+	case result := <-ch2:
+		if !result.granted {
+			t.Fatal("second gateway request should be granted")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestArbitrator_NoPendingNothingToGrant(t *testing.T) {
+	arb := newArbitrator()
+
+	_, _, granted := arb.tryGrant()
+	if granted {
+		t.Fatal("should not grant with no pending requests")
+	}
+
+	if arb.hasPending() {
+		t.Fatal("should have no pending requests")
+	}
+}

--- a/internal/adaptermux/arbitration_test.go
+++ b/internal/adaptermux/arbitration_test.go
@@ -10,10 +10,10 @@ func TestArbitrator_GatewayPriority(t *testing.T) {
 
 	// Both gateway and external request START.
 	gwCh := arb.requestStart(gatewaySessionID, 0x71)
-	extCh := arb.requestStart(1, 0x31)
+	_ = arb.requestStart(1, 0x31)
 
 	// Grant: gateway should win.
-	sessionID, initiator, granted := arb.tryGrant()
+	sessionID, initiator, notify, granted := arb.tryGrant()
 	if !granted {
 		t.Fatal("expected grant")
 	}
@@ -24,7 +24,9 @@ func TestArbitrator_GatewayPriority(t *testing.T) {
 		t.Fatalf("initiator = 0x%02x, want 0x71", initiator)
 	}
 
-	// Gateway should receive granted.
+	// Caller notifies after adapter START (simulated).
+	notify <- startResult{granted: true}
+
 	select {
 	case result := <-gwCh:
 		if !result.granted {
@@ -35,7 +37,7 @@ func TestArbitrator_GatewayPriority(t *testing.T) {
 	}
 
 	// External should still be pending (bus is owned by gateway).
-	_, _, granted2 := arb.tryGrant()
+	_, _, _, granted2 := arb.tryGrant()
 	if granted2 {
 		t.Fatal("should not grant while bus is owned")
 	}
@@ -44,7 +46,7 @@ func TestArbitrator_GatewayPriority(t *testing.T) {
 	arb.releaseOwnership(gatewaySessionID)
 
 	// Now external should win.
-	sessionID, initiator, granted3 := arb.tryGrant()
+	sessionID, initiator, notify2, granted3 := arb.tryGrant()
 	if !granted3 {
 		t.Fatal("expected grant for external")
 	}
@@ -55,31 +57,25 @@ func TestArbitrator_GatewayPriority(t *testing.T) {
 		t.Fatalf("initiator = 0x%02x, want 0x31", initiator)
 	}
 
-	select {
-	case result := <-extCh:
-		if !result.granted {
-			t.Fatal("external should be granted")
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timeout waiting for external grant")
-	}
+	notify2 <- startResult{granted: true}
 }
 
 func TestArbitrator_ExternalFIFO(t *testing.T) {
 	arb := newArbitrator()
 
-	// Two external sessions request START.
 	ch1 := arb.requestStart(1, 0x31)
 	ch2 := arb.requestStart(2, 0x32)
 
 	// First external (FIFO) should win.
-	sessionID, _, granted := arb.tryGrant()
+	sessionID, _, notify, granted := arb.tryGrant()
 	if !granted {
 		t.Fatal("expected grant")
 	}
 	if sessionID != 1 {
 		t.Fatalf("first grant: sessionID = %d, want 1", sessionID)
 	}
+
+	notify <- startResult{granted: true}
 
 	select {
 	case result := <-ch1:
@@ -93,13 +89,15 @@ func TestArbitrator_ExternalFIFO(t *testing.T) {
 	arb.releaseOwnership(1)
 
 	// Second external should be next.
-	sessionID, _, granted = arb.tryGrant()
-	if !granted {
+	sessionID, _, notify2, granted2 := arb.tryGrant()
+	if !granted2 {
 		t.Fatal("expected second grant")
 	}
 	if sessionID != 2 {
 		t.Fatalf("second grant: sessionID = %d, want 2", sessionID)
 	}
+
+	notify2 <- startResult{granted: true}
 
 	select {
 	case result := <-ch2:
@@ -130,7 +128,7 @@ func TestArbitrator_CancelStart(t *testing.T) {
 	}
 
 	// Nothing to grant now.
-	_, _, granted := arb.tryGrant()
+	_, _, _, granted := arb.tryGrant()
 	if granted {
 		t.Fatal("should not grant after cancel")
 	}
@@ -142,15 +140,15 @@ func TestArbitrator_RemoveSession(t *testing.T) {
 	arb.requestStart(1, 0x31)
 
 	// Grant ownership.
-	_, _, granted := arb.tryGrant()
+	_, _, notify, granted := arb.tryGrant()
 	if !granted {
 		t.Fatal("expected grant")
 	}
+	notify <- startResult{granted: true}
 
 	// Remove session while owning bus.
 	arb.removeSession(1)
 
-	// Bus should be released.
 	if arb.isOwner(1) {
 		t.Fatal("session should no longer own bus")
 	}
@@ -187,7 +185,8 @@ func TestArbitrator_ForceRelease(t *testing.T) {
 	arb := newArbitrator()
 
 	arb.requestStart(1, 0x31)
-	arb.tryGrant()
+	_, _, notify, _ := arb.tryGrant()
+	notify <- startResult{granted: true}
 
 	if !arb.isOwner(1) {
 		t.Fatal("session 1 should own bus")
@@ -219,14 +218,16 @@ func TestArbitrator_DuplicateGatewayRequest(t *testing.T) {
 		t.Fatal("timeout")
 	}
 
-	// Second should be granted.
-	_, initiator, granted := arb.tryGrant()
+	// Second should be grantable.
+	_, initiator, notify, granted := arb.tryGrant()
 	if !granted {
 		t.Fatal("expected grant")
 	}
 	if initiator != 0x72 {
 		t.Fatalf("initiator = 0x%02x, want 0x72", initiator)
 	}
+
+	notify <- startResult{granted: true}
 
 	select {
 	case result := <-ch2:
@@ -241,12 +242,35 @@ func TestArbitrator_DuplicateGatewayRequest(t *testing.T) {
 func TestArbitrator_NoPendingNothingToGrant(t *testing.T) {
 	arb := newArbitrator()
 
-	_, _, granted := arb.tryGrant()
+	_, _, _, granted := arb.tryGrant()
 	if granted {
 		t.Fatal("should not grant with no pending requests")
 	}
 
 	if arb.hasPending() {
 		t.Fatal("should have no pending requests")
+	}
+}
+
+func TestArbitrator_GrantFailureReleasesOwnership(t *testing.T) {
+	arb := newArbitrator()
+
+	ch := arb.requestStart(1, 0x31)
+
+	_, _, notify, granted := arb.tryGrant()
+	if !granted {
+		t.Fatal("expected grant")
+	}
+
+	// Simulate adapter START failure — caller notifies with granted=false.
+	notify <- startResult{granted: false}
+
+	select {
+	case result := <-ch:
+		if result.granted {
+			t.Fatal("should not be granted after START failure")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
 	}
 }

--- a/internal/adaptermux/arbitration_test.go
+++ b/internal/adaptermux/arbitration_test.go
@@ -263,12 +263,111 @@ func TestArbitrator_GrantFailureReleasesOwnership(t *testing.T) {
 	}
 
 	// Simulate adapter START failure — caller notifies with granted=false.
-	notify <- startResult{granted: false}
+	notify <- startResult{granted: false, initiator: 0x31}
 
 	select {
 	case result := <-ch:
 		if result.granted {
 			t.Fatal("should not be granted after START failure")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+// --- Fix 1: startResult carries initiator ---
+
+func TestArbitrator_StartResultCarriesInitiator(t *testing.T) {
+	arb := newArbitrator()
+
+	ch := arb.requestStart(1, 0x31)
+
+	_, initiator, notify, granted := arb.tryGrant()
+	if !granted {
+		t.Fatal("expected grant")
+	}
+	if initiator != 0x31 {
+		t.Fatalf("tryGrant initiator = 0x%02x, want 0x31", initiator)
+	}
+
+	notify <- startResult{granted: true, initiator: initiator}
+
+	select {
+	case result := <-ch:
+		if !result.granted {
+			t.Fatal("expected granted=true")
+		}
+		if result.initiator != 0x31 {
+			t.Fatalf("result.initiator = 0x%02x, want 0x31", result.initiator)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestArbitrator_CancelCarriesInitiator(t *testing.T) {
+	arb := newArbitrator()
+
+	ch := arb.requestStart(1, 0x31)
+	arb.cancelStart(1)
+
+	select {
+	case result := <-ch:
+		if result.granted {
+			t.Fatal("cancelled request should not be granted")
+		}
+		if result.initiator != 0x31 {
+			t.Fatalf("cancel result.initiator = 0x%02x, want 0x31", result.initiator)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestArbitrator_FailAllPendingCarriesInitiator(t *testing.T) {
+	arb := newArbitrator()
+
+	gwCh := arb.requestStart(gatewaySessionID, 0x71)
+	extCh := arb.requestStart(1, 0x31)
+
+	arb.failAllPending(nil)
+
+	select {
+	case result := <-gwCh:
+		if result.initiator != 0x71 {
+			t.Fatalf("gateway result.initiator = 0x%02x, want 0x71", result.initiator)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+
+	select {
+	case result := <-extCh:
+		if result.initiator != 0x31 {
+			t.Fatalf("external result.initiator = 0x%02x, want 0x31", result.initiator)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestArbitrator_DuplicateReplaceCarriesInitiator(t *testing.T) {
+	arb := newArbitrator()
+
+	// First gateway request.
+	ch1 := arb.requestStart(gatewaySessionID, 0x71)
+
+	// Second gateway request replaces the first.
+	_ = arb.requestStart(gatewaySessionID, 0x72)
+
+	// First should be cancelled with its own initiator.
+	select {
+	case result := <-ch1:
+		if result.granted {
+			t.Fatal("first request should be cancelled")
+		}
+		if result.initiator != 0x71 {
+			t.Fatalf("replaced result.initiator = 0x%02x, want 0x71", result.initiator)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timeout")

--- a/internal/adaptermux/arbitration_test.go
+++ b/internal/adaptermux/arbitration_test.go
@@ -24,6 +24,9 @@ func TestArbitrator_GatewayPriority(t *testing.T) {
 		t.Fatalf("initiator = 0x%02x, want 0x71", initiator)
 	}
 
+	// Confirm ownership after adapter START success.
+	arb.confirmOwnership(gatewaySessionID, initiator)
+
 	// Caller notifies after adapter START (simulated).
 	notify <- startResult{granted: true}
 
@@ -57,6 +60,7 @@ func TestArbitrator_GatewayPriority(t *testing.T) {
 		t.Fatalf("initiator = 0x%02x, want 0x31", initiator)
 	}
 
+	arb.confirmOwnership(1, initiator)
 	notify2 <- startResult{granted: true}
 }
 
@@ -67,7 +71,7 @@ func TestArbitrator_ExternalFIFO(t *testing.T) {
 	ch2 := arb.requestStart(2, 0x32)
 
 	// First external (FIFO) should win.
-	sessionID, _, notify, granted := arb.tryGrant()
+	sessionID, initiator, notify, granted := arb.tryGrant()
 	if !granted {
 		t.Fatal("expected grant")
 	}
@@ -75,6 +79,7 @@ func TestArbitrator_ExternalFIFO(t *testing.T) {
 		t.Fatalf("first grant: sessionID = %d, want 1", sessionID)
 	}
 
+	arb.confirmOwnership(sessionID, initiator)
 	notify <- startResult{granted: true}
 
 	select {
@@ -89,7 +94,7 @@ func TestArbitrator_ExternalFIFO(t *testing.T) {
 	arb.releaseOwnership(1)
 
 	// Second external should be next.
-	sessionID, _, notify2, granted2 := arb.tryGrant()
+	sessionID, initiator, notify2, granted2 := arb.tryGrant()
 	if !granted2 {
 		t.Fatal("expected second grant")
 	}
@@ -97,6 +102,7 @@ func TestArbitrator_ExternalFIFO(t *testing.T) {
 		t.Fatalf("second grant: sessionID = %d, want 2", sessionID)
 	}
 
+	arb.confirmOwnership(sessionID, initiator)
 	notify2 <- startResult{granted: true}
 
 	select {
@@ -139,11 +145,12 @@ func TestArbitrator_RemoveSession(t *testing.T) {
 
 	arb.requestStart(1, 0x31)
 
-	// Grant ownership.
-	_, _, notify, granted := arb.tryGrant()
+	// Grant and confirm ownership.
+	_, initiator, notify, granted := arb.tryGrant()
 	if !granted {
 		t.Fatal("expected grant")
 	}
+	arb.confirmOwnership(1, initiator)
 	notify <- startResult{granted: true}
 
 	// Remove session while owning bus.
@@ -185,7 +192,8 @@ func TestArbitrator_ForceRelease(t *testing.T) {
 	arb := newArbitrator()
 
 	arb.requestStart(1, 0x31)
-	_, _, notify, _ := arb.tryGrant()
+	_, initiator, notify, _ := arb.tryGrant()
+	arb.confirmOwnership(1, initiator)
 	notify <- startResult{granted: true}
 
 	if !arb.isOwner(1) {
@@ -282,7 +290,7 @@ func TestArbitrator_StartResultCarriesInitiator(t *testing.T) {
 
 	ch := arb.requestStart(1, 0x31)
 
-	_, initiator, notify, granted := arb.tryGrant()
+	sessionID, initiator, notify, granted := arb.tryGrant()
 	if !granted {
 		t.Fatal("expected grant")
 	}
@@ -290,6 +298,7 @@ func TestArbitrator_StartResultCarriesInitiator(t *testing.T) {
 		t.Fatalf("tryGrant initiator = 0x%02x, want 0x31", initiator)
 	}
 
+	arb.confirmOwnership(sessionID, initiator)
 	notify <- startResult{granted: true, initiator: initiator}
 
 	select {

--- a/internal/adaptermux/echo_tracker.go
+++ b/internal/adaptermux/echo_tracker.go
@@ -1,0 +1,155 @@
+package adaptermux
+
+// echoTracker tracks bytes sent by a session and suppresses the
+// corresponding echoes from the adapter. Each session (gateway internal
+// or external ENH client) has its own tracker.
+//
+// Design: when a session sends a byte to the adapter via SEND, the byte
+// is recorded in the expectedEchoes queue. When the adapter echoes it
+// back as ENHResReceived, the tracker matches and suppresses it from
+// that session's observer stream. Other sessions see the byte.
+//
+// Unlike the proxy's byte-level ownerObserverSeen accumulation, this
+// tracker operates on logical bytes (post-ENH-decode). No escape
+// sequences (0xA9) are stored — the ENH protocol delivers logical bytes.
+// This eliminates the proxy's escape encoding bug by design.
+type echoTracker struct {
+	// expectedEchoes is a FIFO queue of bytes that we expect the adapter
+	// to echo back. Populated by recordSent(), consumed by matchEcho().
+	expectedEchoes []byte
+
+	// seenEchoes accumulates matched echo bytes since the last SYN
+	// boundary. Used for observer frame assembly.
+	seenEchoes []byte
+
+	// atRequestStart tracks whether the next echo sequence begins a new
+	// request (includes initiator byte in observer frames).
+	atRequestStart bool
+
+	// Stats.
+	totalSuppressed uint64
+	totalMismatches uint64
+}
+
+// newEchoTracker creates a fresh echo tracker.
+func newEchoTracker() *echoTracker {
+	return &echoTracker{
+		expectedEchoes: make([]byte, 0, 32),
+		seenEchoes:     make([]byte, 0, 32),
+	}
+}
+
+// recordSent records a byte that the session is sending to the adapter.
+// We expect the adapter to echo this byte back as ENHResReceived.
+func (t *echoTracker) recordSent(data byte) {
+	t.expectedEchoes = append(t.expectedEchoes, data)
+}
+
+// rollbackSent removes the last recorded sent byte (e.g., on SEND error).
+func (t *echoTracker) rollbackSent() {
+	if len(t.expectedEchoes) > 0 {
+		t.expectedEchoes = t.expectedEchoes[:len(t.expectedEchoes)-1]
+	}
+}
+
+// echoMatchResult describes the outcome of matching a received byte.
+type echoMatchResult uint8
+
+const (
+	// echoMatchNone means the byte is not an echo of this session's
+	// sent data. Deliver to this session as observer traffic.
+	echoMatchNone echoMatchResult = iota
+
+	// echoMatchSuppressed means the byte is an echo of this session's
+	// sent data. Suppress from this session's observer stream.
+	echoMatchSuppressed
+
+	// echoMatchFlushed means a mismatch was detected. Previously matched
+	// echo bytes have been flushed (returned as observer frames) and the
+	// current byte should be delivered normally.
+	echoMatchFlushed
+)
+
+// matchEcho checks if a received byte matches the next expected echo.
+//
+// Returns:
+//   - echoMatchSuppressed: byte is this session's echo, suppress it
+//   - echoMatchNone: no echo expected, byte is third-party traffic
+//   - echoMatchFlushed: mismatch detected, accumulated echoes flushed
+//
+// flushedBytes contains any accumulated echo bytes that should be
+// delivered as observer frames before the current byte.
+func (t *echoTracker) matchEcho(received byte) (result echoMatchResult, flushedBytes []byte) {
+	if len(t.expectedEchoes) == 0 {
+		return echoMatchNone, nil
+	}
+
+	if received == t.expectedEchoes[0] {
+		// Match: consume from expected, accumulate in seen.
+		t.expectedEchoes = t.expectedEchoes[1:]
+		t.seenEchoes = append(t.seenEchoes, received)
+		t.totalSuppressed++
+		return echoMatchSuppressed, nil
+	}
+
+	// Mismatch: flush any accumulated echoes as observer frames.
+	t.totalMismatches++
+	var flushed []byte
+	if len(t.seenEchoes) > 0 {
+		flushed = make([]byte, len(t.seenEchoes))
+		copy(flushed, t.seenEchoes)
+		t.seenEchoes = t.seenEchoes[:0]
+	}
+
+	// Clear expected echoes on mismatch — the echo sequence is broken.
+	t.expectedEchoes = t.expectedEchoes[:0]
+	t.atRequestStart = false
+
+	return echoMatchFlushed, flushed
+}
+
+// flushOnSYN flushes accumulated echo bytes at a SYN boundary.
+// Returns any accumulated bytes that should be delivered as observer
+// frames (they are confirmed echoes of the owning session's traffic).
+//
+// After flush, the tracker is ready for the next request cycle.
+func (t *echoTracker) flushOnSYN() (flushedBytes []byte, wasAtStart bool) {
+	wasAtStart = t.atRequestStart
+
+	if len(t.seenEchoes) > 0 {
+		flushedBytes = make([]byte, len(t.seenEchoes))
+		copy(flushedBytes, t.seenEchoes)
+		t.seenEchoes = t.seenEchoes[:0]
+	}
+
+	// Clear expected echoes at SYN boundary.
+	t.expectedEchoes = t.expectedEchoes[:0]
+
+	return flushedBytes, wasAtStart
+}
+
+// markRequestStart marks that the next echo sequence is the start
+// of a new request (used for observer frame assembly with initiator).
+func (t *echoTracker) markRequestStart() {
+	t.atRequestStart = true
+	t.seenEchoes = t.seenEchoes[:0]
+	t.expectedEchoes = t.expectedEchoes[:0]
+}
+
+// hasPendingEchoes reports whether there are expected echoes that
+// haven't been matched yet.
+func (t *echoTracker) hasPendingEchoes() bool {
+	return len(t.expectedEchoes) > 0
+}
+
+// reset clears all tracking state.
+func (t *echoTracker) reset() {
+	t.expectedEchoes = t.expectedEchoes[:0]
+	t.seenEchoes = t.seenEchoes[:0]
+	t.atRequestStart = false
+}
+
+// stats returns echo tracking statistics.
+func (t *echoTracker) stats() (suppressed, mismatches uint64) {
+	return t.totalSuppressed, t.totalMismatches
+}

--- a/internal/adaptermux/echo_tracker_test.go
+++ b/internal/adaptermux/echo_tracker_test.go
@@ -1,0 +1,156 @@
+package adaptermux
+
+import "testing"
+
+func TestEchoTracker_BasicSuppression(t *testing.T) {
+	tracker := newEchoTracker()
+
+	// Record sent bytes.
+	tracker.recordSent(0x71)
+	tracker.recordSent(0x08)
+
+	// Match echoes.
+	result, _ := tracker.matchEcho(0x71)
+	if result != echoMatchSuppressed {
+		t.Fatalf("first echo: got %d, want Suppressed", result)
+	}
+
+	result, _ = tracker.matchEcho(0x08)
+	if result != echoMatchSuppressed {
+		t.Fatalf("second echo: got %d, want Suppressed", result)
+	}
+
+	// No more expected echoes.
+	result, _ = tracker.matchEcho(0xFF)
+	if result != echoMatchNone {
+		t.Fatalf("third-party byte: got %d, want None", result)
+	}
+}
+
+func TestEchoTracker_Mismatch(t *testing.T) {
+	tracker := newEchoTracker()
+
+	tracker.recordSent(0x71)
+	tracker.recordSent(0x08)
+
+	// First byte matches.
+	result, _ := tracker.matchEcho(0x71)
+	if result != echoMatchSuppressed {
+		t.Fatalf("first echo: got %d, want Suppressed", result)
+	}
+
+	// Second byte mismatches.
+	result, flushed := tracker.matchEcho(0xFF)
+	if result != echoMatchFlushed {
+		t.Fatalf("mismatch: got %d, want Flushed", result)
+	}
+	if len(flushed) != 1 || flushed[0] != 0x71 {
+		t.Fatalf("flushed = %v, want [0x71]", flushed)
+	}
+}
+
+func TestEchoTracker_FlushOnSYN(t *testing.T) {
+	tracker := newEchoTracker()
+
+	tracker.recordSent(0x71)
+	tracker.recordSent(0x08)
+
+	// Match both echoes.
+	tracker.matchEcho(0x71)
+	tracker.matchEcho(0x08)
+
+	// Flush at SYN boundary.
+	flushed, _ := tracker.flushOnSYN()
+	if len(flushed) != 2 {
+		t.Fatalf("flushed len = %d, want 2", len(flushed))
+	}
+	if flushed[0] != 0x71 || flushed[1] != 0x08 {
+		t.Fatalf("flushed = %v, want [0x71, 0x08]", flushed)
+	}
+
+	// After flush, no pending echoes.
+	if tracker.hasPendingEchoes() {
+		t.Fatal("expected no pending echoes after flush")
+	}
+}
+
+func TestEchoTracker_Rollback(t *testing.T) {
+	tracker := newEchoTracker()
+
+	tracker.recordSent(0x71)
+	tracker.recordSent(0x08)
+	tracker.rollbackSent()
+
+	// Only one echo expected now.
+	result, _ := tracker.matchEcho(0x71)
+	if result != echoMatchSuppressed {
+		t.Fatalf("first echo: got %d, want Suppressed", result)
+	}
+
+	result, _ = tracker.matchEcho(0x08)
+	if result != echoMatchNone {
+		t.Fatalf("after rollback: got %d, want None", result)
+	}
+}
+
+func TestEchoTracker_EscapeBytePayload(t *testing.T) {
+	// Verify that 0xA9 (SymbolEscape) in payload is handled correctly.
+	// The echo tracker works on logical bytes (post-ENH-decode), so
+	// 0xA9 is just a regular data byte — no escape encoding involved.
+	tracker := newEchoTracker()
+
+	tracker.recordSent(0xA9) // escape byte as data
+	tracker.recordSent(0xAA) // SYN byte as data
+
+	// Both should match as regular bytes.
+	result, _ := tracker.matchEcho(0xA9)
+	if result != echoMatchSuppressed {
+		t.Fatalf("0xA9 echo: got %d, want Suppressed", result)
+	}
+
+	result, _ = tracker.matchEcho(0xAA)
+	if result != echoMatchSuppressed {
+		t.Fatalf("0xAA echo: got %d, want Suppressed", result)
+	}
+
+	suppressed, mismatches := tracker.stats()
+	if suppressed != 2 {
+		t.Fatalf("suppressed = %d, want 2", suppressed)
+	}
+	if mismatches != 0 {
+		t.Fatalf("mismatches = %d, want 0", mismatches)
+	}
+}
+
+func TestEchoTracker_Reset(t *testing.T) {
+	tracker := newEchoTracker()
+
+	tracker.recordSent(0x71)
+	tracker.matchEcho(0x71)
+	tracker.reset()
+
+	if tracker.hasPendingEchoes() {
+		t.Fatal("expected no pending echoes after reset")
+	}
+
+	// After reset, any byte is non-echo.
+	result, _ := tracker.matchEcho(0x71)
+	if result != echoMatchNone {
+		t.Fatalf("after reset: got %d, want None", result)
+	}
+}
+
+func TestEchoTracker_EmptyTracker(t *testing.T) {
+	tracker := newEchoTracker()
+
+	// No sent bytes — everything is third-party.
+	result, _ := tracker.matchEcho(0x71)
+	if result != echoMatchNone {
+		t.Fatalf("empty tracker: got %d, want None", result)
+	}
+
+	flushed, _ := tracker.flushOnSYN()
+	if len(flushed) != 0 {
+		t.Fatalf("empty flush: len = %d, want 0", len(flushed))
+	}
+}

--- a/internal/adaptermux/listener.go
+++ b/internal/adaptermux/listener.go
@@ -1,0 +1,136 @@
+package adaptermux
+
+import (
+	"context"
+	"errors"
+	"log"
+	"net"
+	"sync"
+	"time"
+)
+
+// ProxyListener binds a TCP listener and registers each accepted
+// connection as an ENH session on the adapter multiplexer. External
+// ENH clients (e.g. ebusd) connect here to share the adapter.
+type ProxyListener struct {
+	mux      *Mux
+	listener net.Listener
+	logger   *log.Logger
+	ctx      context.Context
+	cancel   context.CancelFunc
+	wg       sync.WaitGroup
+}
+
+// NewProxyListener creates and starts a proxy listener on listenAddr.
+// The listener runs until Close() is called or ctx is cancelled.
+func NewProxyListener(ctx context.Context, mux *Mux, listenAddr string, logger *log.Logger) (*ProxyListener, error) {
+	if mux == nil {
+		return nil, errors.New("adaptermux: proxy listener requires non-nil mux")
+	}
+	if logger == nil {
+		logger = log.Default()
+	}
+
+	lc := net.ListenConfig{}
+	ln, err := lc.Listen(ctx, "tcp", listenAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	plCtx, plCancel := context.WithCancel(ctx)
+	pl := &ProxyListener{
+		mux:      mux,
+		listener: ln,
+		logger:   logger,
+		ctx:      plCtx,
+		cancel:   plCancel,
+	}
+
+	pl.wg.Add(1)
+	// goroutine: closes the TCP listener when the context is cancelled,
+	// unblocking the accept loop. Lives until ctx is done.
+	go pl.watchCtx()
+
+	pl.wg.Add(1)
+	// goroutine: accepts incoming TCP connections and registers them as
+	// ENH sessions on the mux. Lives until the listener is closed.
+	go pl.acceptLoop()
+
+	return pl, nil
+}
+
+// Close stops accepting connections and shuts down the listener.
+// It is safe to call multiple times.
+func (pl *ProxyListener) Close() error {
+	pl.cancel()
+	err := pl.listener.Close()
+	pl.wg.Wait()
+	return err
+}
+
+// Addr returns the listener's network address (useful when bound to ":0").
+func (pl *ProxyListener) Addr() net.Addr {
+	return pl.listener.Addr()
+}
+
+// watchCtx closes the listener when the context is cancelled.
+func (pl *ProxyListener) watchCtx() {
+	defer pl.wg.Done()
+	<-pl.ctx.Done()
+	// Closing the listener unblocks Accept in the accept loop.
+	_ = pl.listener.Close()
+}
+
+// acceptLoop accepts connections until the listener is closed.
+func (pl *ProxyListener) acceptLoop() {
+	defer pl.wg.Done()
+
+	for {
+		conn, err := pl.listener.Accept()
+		if err != nil {
+			// Check if shutdown is in progress.
+			if pl.ctx.Err() != nil {
+				return
+			}
+			// Transient errors (fd exhaustion, etc.): log and retry.
+			// Do NOT exit the loop — the condition may be temporary.
+			if isTemporaryAcceptError(err) {
+				pl.logger.Printf("adaptermux: proxy accept transient error: %v", err)
+				// Brief backoff to avoid tight-looping on persistent fd exhaustion.
+				time.Sleep(5 * time.Millisecond)
+				continue
+			}
+			// Non-transient error (listener closed, etc.): exit.
+			pl.logger.Printf("adaptermux: proxy accept error (fatal): %v", err)
+			return
+		}
+
+		// Set TCP options on the accepted connection.
+		if tcpConn, ok := conn.(*net.TCPConn); ok {
+			if err := tcpConn.SetNoDelay(true); err != nil {
+				pl.logger.Printf("adaptermux: proxy conn SetNoDelay: %v", err)
+			}
+			if err := tcpConn.SetKeepAlive(true); err != nil {
+				pl.logger.Printf("adaptermux: proxy conn SetKeepAlive: %v", err)
+			}
+			if err := tcpConn.SetKeepAlivePeriod(30 * time.Second); err != nil {
+				pl.logger.Printf("adaptermux: proxy conn SetKeepAlivePeriod: %v", err)
+			}
+		}
+
+		pl.mux.AddSession(conn)
+	}
+}
+
+// isTemporaryAcceptError returns true for transient accept errors that
+// should be retried (fd exhaustion, resource temporarily unavailable).
+func isTemporaryAcceptError(err error) bool {
+	// net.Error.Temporary is deprecated but still the most reliable way
+	// to detect transient accept failures from the standard library.
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		//nolint:staticcheck // Temporary() is deprecated but functional
+		return netErr.Temporary()
+	}
+	return false
+}

--- a/internal/adaptermux/listener_test.go
+++ b/internal/adaptermux/listener_test.go
@@ -1,0 +1,246 @@
+package adaptermux
+
+import (
+	"context"
+	"log"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+// fakeAdapterServer starts a TCP server that simulates a minimal ENH
+// adapter. It accepts one connection, reads the 2-byte INIT request,
+// and responds with ENHResResetted. The connection stays open until
+// the returned closer is called.
+func fakeAdapterServer(t *testing.T) (addr string, closer func()) {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("fakeAdapterServer: listen: %v", err)
+	}
+
+	done := make(chan struct{})
+	var adapterConn net.Conn
+
+	go func() { // goroutine: fake adapter accept loop
+		defer close(done)
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		adapterConn = conn
+
+		// Read INIT request (2 bytes).
+		buf := make([]byte, 2)
+		if _, err := conn.Read(buf); err != nil {
+			return
+		}
+
+		// Respond with RESETTED.
+		resetted := transport.EncodeENH(transport.ENHResResetted, 0x00)
+		if _, err := conn.Write(resetted[:]); err != nil {
+			return
+		}
+
+		// Keep connection open until done is closed externally
+		// (simulated by reading until error).
+		hold := make([]byte, 1)
+		for {
+			_, err := conn.Read(hold)
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	return ln.Addr().String(), func() {
+		ln.Close()
+		if adapterConn != nil {
+			adapterConn.Close()
+		}
+	}
+}
+
+// newTestMux creates a Mux connected to a fake adapter and starts it.
+// Returns the mux, a cancel function, and a cleanup function.
+func newTestMux(t *testing.T) (*Mux, context.CancelFunc, func()) {
+	t.Helper()
+
+	adapterAddr, adapterClose := fakeAdapterServer(t)
+
+	cfg := Config{
+		Protocol:    "enh",
+		Network:     "tcp",
+		Address:     adapterAddr,
+		DialTimeout: 2 * time.Second,
+		ReadTimeout: 200 * time.Millisecond,
+	}
+
+	mux := New(cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := mux.Start(ctx); err != nil {
+		adapterClose()
+		cancel()
+		t.Fatalf("mux.Start: %v", err)
+	}
+
+	cleanup := func() {
+		cancel()
+		mux.Close()
+		adapterClose()
+	}
+
+	return mux, cancel, cleanup
+}
+
+func TestProxyListenerAcceptsConnection(t *testing.T) {
+	mux, _, cleanup := newTestMux(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	pl, err := NewProxyListener(ctx, mux, "127.0.0.1:0", log.Default())
+	if err != nil {
+		t.Fatalf("NewProxyListener: %v", err)
+	}
+	defer pl.Close()
+
+	// Dial the proxy listener.
+	conn, err := net.DialTimeout("tcp", pl.Addr().String(), 2*time.Second)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer conn.Close()
+
+	// Give the accept loop time to register the session.
+	time.Sleep(50 * time.Millisecond)
+
+	// Verify at least one session was registered.
+	mux.sessionsMu.Lock()
+	count := len(mux.sessions)
+	mux.sessionsMu.Unlock()
+
+	if count < 1 {
+		t.Fatalf("expected at least 1 session, got %d", count)
+	}
+}
+
+func TestProxyListenerCloseStopsAccepting(t *testing.T) {
+	mux, _, cleanup := newTestMux(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	pl, err := NewProxyListener(ctx, mux, "127.0.0.1:0", log.Default())
+	if err != nil {
+		t.Fatalf("NewProxyListener: %v", err)
+	}
+
+	addr := pl.Addr().String()
+
+	// Close the listener.
+	if err := pl.Close(); err != nil {
+		t.Fatalf("pl.Close: %v", err)
+	}
+
+	// New connections should be refused.
+	conn, err := net.DialTimeout("tcp", addr, 500*time.Millisecond)
+	if err == nil {
+		conn.Close()
+		t.Fatal("expected dial to fail after listener close, but it succeeded")
+	}
+}
+
+func TestProxyListenerContextCancel(t *testing.T) {
+	mux, _, cleanup := newTestMux(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	pl, err := NewProxyListener(ctx, mux, "127.0.0.1:0", log.Default())
+	if err != nil {
+		t.Fatalf("NewProxyListener: %v", err)
+	}
+
+	addr := pl.Addr().String()
+
+	// Cancel the context — should close the listener.
+	cancel()
+
+	// Wait for the listener to shut down.
+	time.Sleep(50 * time.Millisecond)
+
+	// New connections should be refused.
+	conn, err := net.DialTimeout("tcp", addr, 500*time.Millisecond)
+	if err == nil {
+		conn.Close()
+		t.Fatal("expected dial to fail after context cancel, but it succeeded")
+	}
+}
+
+func TestProxyListenerBindError(t *testing.T) {
+	mux, _, cleanup := newTestMux(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Bind first listener.
+	pl1, err := NewProxyListener(ctx, mux, "127.0.0.1:0", log.Default())
+	if err != nil {
+		t.Fatalf("first NewProxyListener: %v", err)
+	}
+	defer pl1.Close()
+
+	// Try to bind a second listener on the same port — should fail.
+	_, err = NewProxyListener(ctx, mux, pl1.Addr().String(), log.Default())
+	if err == nil {
+		t.Fatal("expected bind error for double-bind, got nil")
+	}
+}
+
+func TestProxyListenerNilMux(t *testing.T) {
+	ctx := context.Background()
+	_, err := NewProxyListener(ctx, nil, "127.0.0.1:0", log.Default())
+	if err == nil {
+		t.Fatal("expected error for nil mux, got nil")
+	}
+}
+
+func TestProxyListenerMultipleConnections(t *testing.T) {
+	mux, _, cleanup := newTestMux(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	pl, err := NewProxyListener(ctx, mux, "127.0.0.1:0", log.Default())
+	if err != nil {
+		t.Fatalf("NewProxyListener: %v", err)
+	}
+	defer pl.Close()
+
+	// Open 3 connections.
+	var conns []net.Conn
+	for i := 0; i < 3; i++ {
+		conn, err := net.DialTimeout("tcp", pl.Addr().String(), 2*time.Second)
+		if err != nil {
+			t.Fatalf("dial %d: %v", i, err)
+		}
+		conns = append(conns, conn)
+	}
+	defer func() {
+		for _, c := range conns {
+			c.Close()
+		}
+	}()
+
+	// Give accept loop time to register all sessions.
+	time.Sleep(100 * time.Millisecond)
+
+	mux.sessionsMu.Lock()
+	count := len(mux.sessions)
+	mux.sessionsMu.Unlock()
+
+	if count < 3 {
+		t.Fatalf("expected at least 3 sessions, got %d", count)
+	}
+}

--- a/internal/adaptermux/listener_test.go
+++ b/internal/adaptermux/listener_test.go
@@ -2,6 +2,7 @@ package adaptermux
 
 import (
 	"context"
+	"io"
 	"log"
 	"net"
 	"testing"
@@ -35,7 +36,7 @@ func fakeAdapterServer(t *testing.T) (addr string, closer func()) {
 
 		// Read INIT request (2 bytes).
 		buf := make([]byte, 2)
-		if _, err := conn.Read(buf); err != nil {
+		if _, err := io.ReadFull(conn, buf); err != nil {
 			return
 		}
 

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -1,0 +1,769 @@
+package adaptermux
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	ebuserrors "github.com/Project-Helianthus/helianthus-ebusgo/errors"
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+// Config configures the adapter multiplexer.
+type Config struct {
+	// Protocol is "enh" or "ens".
+	Protocol string
+
+	// Network and Address specify the adapter endpoint (e.g., "tcp", "boiler.local:9999").
+	Network string
+	Address string
+
+	// Timeouts for the adapter connection.
+	DialTimeout  time.Duration
+	ReadTimeout  time.Duration
+	WriteTimeout time.Duration
+
+	// ReconnectInitialDelay is the initial delay before reconnecting
+	// after an adapter disconnect. Default: 1s.
+	ReconnectInitialDelay time.Duration
+
+	// ReconnectMaxDelay is the maximum reconnection backoff. Default: 30s.
+	ReconnectMaxDelay time.Duration
+
+	// MaxOwnershipDuration is the hard limit on continuous bus ownership.
+	// Default: 2s (from proxy convention).
+	MaxOwnershipDuration time.Duration
+
+	// IdleReleaseGrace is the grace period after bus acquisition before
+	// idle SYN can release ownership. Default: 50ms.
+	IdleReleaseGrace time.Duration
+
+	// Logger for multiplexer events. If nil, log.Default() is used.
+	Logger *log.Logger
+}
+
+func (c *Config) defaults() {
+	if c.DialTimeout == 0 {
+		c.DialTimeout = 5 * time.Second
+	}
+	if c.ReadTimeout == 0 {
+		c.ReadTimeout = 200 * time.Millisecond
+	}
+	if c.WriteTimeout == 0 {
+		c.WriteTimeout = 2 * time.Second
+	}
+	if c.ReconnectInitialDelay == 0 {
+		c.ReconnectInitialDelay = 1 * time.Second
+	}
+	if c.ReconnectMaxDelay == 0 {
+		c.ReconnectMaxDelay = 30 * time.Second
+	}
+	if c.MaxOwnershipDuration == 0 {
+		c.MaxOwnershipDuration = 2 * time.Second
+	}
+	if c.IdleReleaseGrace == 0 {
+		c.IdleReleaseGrace = 50 * time.Millisecond
+	}
+	if c.Logger == nil {
+		c.Logger = log.Default()
+	}
+}
+
+// PassiveEvent is delivered to the passive path callback when a
+// third-party symbol is received from the bus.
+type PassiveEvent struct {
+	Kind       PassiveEventKind
+	Symbol     byte
+	ObservedAt time.Time
+}
+
+// PassiveEventKind categorizes passive events.
+type PassiveEventKind uint8
+
+const (
+	PassiveEventSymbol       PassiveEventKind = iota + 1 // third-party bus symbol
+	PassiveEventConnected                                // adapter connection established
+	PassiveEventDisconnected                             // adapter connection lost
+	PassiveEventReset                                    // adapter RESETTED
+)
+
+// Mux is the adapter multiplexer. It owns a single ENH/ENS connection
+// to the adapter hardware and provides:
+//   - Active path: RawTransport for gateway.Bus
+//   - Passive path: filtered symbol callback (third-party only)
+//   - Session management: external ENH clients (ebusd)
+type Mux struct {
+	cfg    Config
+	logger *log.Logger
+
+	// Adapter connection (guarded by connMu for reconnection).
+	connMu   sync.Mutex
+	conn     net.Conn
+	upstream transport.RawTransport
+
+	// Multiplexer state (guarded by stateMu).
+	stateMu  sync.Mutex
+	phase    wirePhaseTracker
+	arb      *arbitrator
+	busOwned time.Time // when current owner acquired the bus
+	busDirty bool      // owner has sent bytes since acquiring
+
+	// Gateway echo tracker (for the internal active path).
+	// Protected by stateMu.
+	gatewayEcho *echoTracker
+
+	// External sessions.
+	sessionsMu sync.Mutex // write lock — protects map AND session echo trackers
+	sessions   map[uint64]*session
+	sessionSeq atomic.Uint64
+
+	// Active path channels.
+	activeSendCh chan sendRequest
+	activeRecvCh chan byte  // capacity 256, overflow logged
+	activeErrCh  chan error // capacity 4, non-blocking send
+
+	// Passive path callback (set via SetPassiveCallback).
+	// The callback must NOT call back into Mux methods (re-entrancy hazard).
+	passiveMu       sync.Mutex
+	passiveCallback func(PassiveEvent)
+
+	// Lifecycle.
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// sendRequest is a request from the active path or an external session
+// to send a byte to the adapter.
+type sendRequest struct {
+	sessionID uint64
+	data      byte
+	result    chan error
+}
+
+// New creates a new adapter multiplexer with the given configuration.
+// Call Start() to connect to the adapter and begin processing.
+func New(cfg Config) *Mux {
+	cfg.defaults()
+	return &Mux{
+		cfg:          cfg,
+		logger:       cfg.Logger,
+		arb:          newArbitrator(),
+		gatewayEcho:  newEchoTracker(),
+		sessions:     make(map[uint64]*session),
+		activeSendCh: make(chan sendRequest, 16),
+		activeRecvCh: make(chan byte, 256),   // capacity 256: bus byte buffer
+		activeErrCh:  make(chan error, 4),     // capacity 4: adapter reset events
+	}
+}
+
+// Start connects to the adapter and begins the multiplexer loop.
+// The context controls the multiplexer lifetime.
+func (m *Mux) Start(ctx context.Context) error {
+	m.ctx, m.cancel = context.WithCancel(ctx)
+
+	if err := m.connect(); err != nil {
+		return fmt.Errorf("adaptermux: initial connect: %w", err)
+	}
+
+	m.wg.Add(1)
+	go m.readLoop() // goroutine: reads bytes from adapter, dispatches to consumers
+
+	m.wg.Add(1)
+	go m.sendLoop() // goroutine: processes send requests from active path + sessions
+
+	m.emitPassive(PassiveEvent{
+		Kind:       PassiveEventConnected,
+		ObservedAt: time.Now(),
+	})
+
+	return nil
+}
+
+// Close shuts down the multiplexer and releases all resources.
+func (m *Mux) Close() error {
+	if m.cancel != nil {
+		m.cancel()
+	}
+
+	// Fail all pending arbitration requests.
+	m.arb.failAllPending(errors.New("adaptermux: closed"))
+
+	// Collect sessions under lock, close outside lock to avoid holding
+	// sessionsMu during potentially blocking session.close() (5s timeout).
+	m.sessionsMu.Lock()
+	toClose := make([]*session, 0, len(m.sessions))
+	for id, sess := range m.sessions {
+		toClose = append(toClose, sess)
+		delete(m.sessions, id)
+	}
+	m.sessionsMu.Unlock()
+
+	for _, sess := range toClose {
+		m.arb.removeSession(sess.id)
+		sess.close()
+	}
+
+	// Close adapter connection.
+	m.connMu.Lock()
+	var closeErr error
+	if m.conn != nil {
+		closeErr = m.conn.Close()
+	}
+	m.connMu.Unlock()
+
+	m.wg.Wait()
+	return closeErr
+}
+
+// ActiveTransport returns a RawTransport for the gateway's active path.
+// This wraps the multiplexer's internal channels to provide a blocking
+// byte-level interface compatible with gateway.Bus.
+func (m *Mux) ActiveTransport() transport.RawTransport {
+	return &activeTransport{mux: m}
+}
+
+// SetPassiveCallback sets the callback for passive path events.
+// The callback receives only third-party bus traffic (no self-echo).
+// The callback must NOT call back into Mux methods (re-entrancy hazard).
+// Must be called before Start() or during initialization.
+func (m *Mux) SetPassiveCallback(fn func(PassiveEvent)) {
+	m.passiveMu.Lock()
+	defer m.passiveMu.Unlock()
+	m.passiveCallback = fn
+}
+
+// connect dials the adapter and performs the INIT handshake.
+func (m *Mux) connect() error {
+	m.connMu.Lock()
+	defer m.connMu.Unlock()
+
+	dialer := net.Dialer{Timeout: m.cfg.DialTimeout}
+	conn, err := dialer.DialContext(m.ctx, m.cfg.Network, m.cfg.Address)
+	if err != nil {
+		return fmt.Errorf("dial %s/%s: %w", m.cfg.Network, m.cfg.Address, err)
+	}
+
+	// Set TCP options (log failures instead of discarding).
+	if tcpConn, ok := conn.(*net.TCPConn); ok {
+		if err := tcpConn.SetNoDelay(true); err != nil {
+			m.logger.Printf("adaptermux: SetNoDelay: %v", err)
+		}
+		if err := tcpConn.SetKeepAlive(true); err != nil {
+			m.logger.Printf("adaptermux: SetKeepAlive: %v", err)
+		}
+		if err := tcpConn.SetKeepAlivePeriod(30 * time.Second); err != nil {
+			m.logger.Printf("adaptermux: SetKeepAlivePeriod: %v", err)
+		}
+	}
+
+	// Create ENH/ENS transport.
+	var tr transport.RawTransport
+	switch m.cfg.Protocol {
+	case "ens":
+		tr = transport.NewENSTransport(conn, m.cfg.ReadTimeout, m.cfg.WriteTimeout)
+	default:
+		tr = transport.NewENHTransport(conn, m.cfg.ReadTimeout, m.cfg.WriteTimeout)
+	}
+
+	m.conn = conn
+	m.upstream = tr
+
+	// Perform INIT handshake — fatal if transport implements Init.
+	if initer, ok := tr.(interface{ Init(byte) error }); ok {
+		if err := initer.Init(0x01); err != nil {
+			_ = conn.Close()
+			return fmt.Errorf("adaptermux: INIT handshake failed: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// reconnect tears down the current connection and re-establishes it.
+// Called from the read loop on adapter disconnect.
+func (m *Mux) reconnect() error {
+	m.emitPassive(PassiveEvent{
+		Kind:       PassiveEventDisconnected,
+		ObservedAt: time.Now(),
+	})
+
+	// Reset multiplexer state.
+	m.stateMu.Lock()
+	m.phase.reset(wirePhaseIdle)
+	m.arb.forceRelease()
+	m.gatewayEcho.reset()
+	m.busDirty = false
+	m.stateMu.Unlock()
+
+	// Reset external session echo trackers (HIGH-6 fix).
+	m.sessionsMu.Lock()
+	for _, sess := range m.sessions {
+		sess.echoTracker.reset()
+	}
+	m.sessionsMu.Unlock()
+
+	// Fail pending arbitration.
+	m.arb.failAllPending(errors.New("adaptermux: adapter disconnected"))
+
+	// Close old connection.
+	m.connMu.Lock()
+	if m.conn != nil {
+		if err := m.conn.Close(); err != nil {
+			m.logger.Printf("adaptermux: old conn close: %v", err)
+		}
+	}
+	m.connMu.Unlock()
+
+	// Reconnection loop with exponential backoff.
+	delay := m.cfg.ReconnectInitialDelay
+	for {
+		timer := time.NewTimer(delay)
+		select {
+		case <-m.ctx.Done():
+			timer.Stop()
+			return m.ctx.Err()
+		case <-timer.C:
+		}
+
+		if err := m.connect(); err != nil {
+			m.logger.Printf("adaptermux: reconnect failed: %v", err)
+			delay = delay * 2
+			if delay > m.cfg.ReconnectMaxDelay {
+				delay = m.cfg.ReconnectMaxDelay
+			}
+			continue
+		}
+
+		m.logger.Printf("adaptermux: reconnected to %s/%s", m.cfg.Network, m.cfg.Address)
+		m.emitPassive(PassiveEvent{
+			Kind:       PassiveEventConnected,
+			ObservedAt: time.Now(),
+		})
+
+		// Broadcast RESETTED to external sessions.
+		m.broadcastResetToSessions()
+
+		return nil
+	}
+}
+
+// readLoop reads bytes from the adapter and dispatches them to
+// active path, passive path, and external sessions.
+func (m *Mux) readLoop() {
+	defer m.wg.Done()
+
+	for {
+		select {
+		case <-m.ctx.Done():
+			return
+		default:
+		}
+
+		event, err := m.readUpstream()
+		if err != nil {
+			if m.ctx.Err() != nil {
+				return // context cancelled, shutting down
+			}
+			if errors.Is(err, ebuserrors.ErrAdapterReset) {
+				m.handleReset()
+				continue
+			}
+			m.logger.Printf("adaptermux: read error: %v", err)
+			if reconnErr := m.reconnect(); reconnErr != nil {
+				m.logger.Printf("adaptermux: reconnect gave up: %v", reconnErr)
+				return
+			}
+			continue
+		}
+
+		if event.Kind == transport.StreamEventReset {
+			m.handleReset()
+			continue
+		}
+
+		m.onReceived(event.Byte)
+	}
+}
+
+// readUpstream reads a stream event from the adapter transport.
+func (m *Mux) readUpstream() (transport.StreamEvent, error) {
+	m.connMu.Lock()
+	tr := m.upstream
+	m.connMu.Unlock()
+
+	if tr == nil {
+		return transport.StreamEvent{}, errors.New("adaptermux: not connected")
+	}
+
+	if reader, ok := tr.(transport.StreamEventReader); ok {
+		return reader.ReadEvent()
+	}
+
+	b, err := tr.ReadByte()
+	if err != nil {
+		return transport.StreamEvent{}, err
+	}
+	return transport.StreamEvent{Kind: transport.StreamEventByte, Byte: b}, nil
+}
+
+// onReceived processes a byte received from the adapter.
+//
+// Lock ordering: stateMu acquired first, released before any callback
+// invocation or session delivery to avoid re-entrancy deadlocks.
+func (m *Mux) onReceived(symbol byte) {
+	now := time.Now()
+
+	// --- Phase 1: state update under stateMu ---
+	m.stateMu.Lock()
+
+	phaseEvent := m.phase.advance(symbol)
+
+	ownerID, _, hasOwner := m.arb.owner()
+	if hasOwner && !m.busOwned.IsZero() &&
+		time.Since(m.busOwned) > m.cfg.MaxOwnershipDuration {
+		m.arb.releaseOwnership(ownerID)
+		m.gatewayEcho.reset()
+		hasOwner = false
+	}
+
+	// Collect passive events under lock, emit after unlock (Issue#3 fix).
+	var passiveEvents []PassiveEvent
+	var shouldTryGrant bool
+
+	if symbol == protocol.SymbolSyn {
+		passiveEvents, shouldTryGrant = m.onSYNLocked(phaseEvent, ownerID, hasOwner, now)
+		m.stateMu.Unlock()
+
+		// --- Phase 2: deliver outside all locks ---
+		// Flush external session echo trackers (outside stateMu to avoid
+		// ABBA deadlock with doSend which acquires sessionsMu→stateMu).
+		m.flushSessionEchoTrackersOnSYN(&passiveEvents, now)
+
+		m.deliverToActive(symbol)
+		for _, pe := range passiveEvents {
+			m.emitPassive(pe)
+		}
+		m.deliverSYNToSessions(now)
+		if shouldTryGrant {
+			m.tryGrantAndStart()
+		}
+		return
+	}
+
+	// Non-SYN byte: check gateway echo suppression.
+	isGatewayEcho := false
+	if hasOwner && ownerID == gatewaySessionID {
+		result, flushed := m.gatewayEcho.matchEcho(symbol)
+		switch result {
+		case echoMatchSuppressed:
+			isGatewayEcho = true
+		case echoMatchFlushed:
+			for _, b := range flushed {
+				passiveEvents = append(passiveEvents, PassiveEvent{
+					Kind: PassiveEventSymbol, Symbol: b, ObservedAt: now,
+				})
+			}
+		}
+	}
+
+	m.stateMu.Unlock()
+
+	// --- Phase 2: deliver outside all locks ---
+	m.deliverToActive(symbol)
+
+	if !isGatewayEcho {
+		passiveEvents = append(passiveEvents, PassiveEvent{
+			Kind: PassiveEventSymbol, Symbol: symbol, ObservedAt: now,
+		})
+	}
+	for _, pe := range passiveEvents {
+		m.emitPassive(pe)
+	}
+
+	m.deliverToSessions(symbol, ownerID, hasOwner, now)
+
+	if phaseEvent == wirePhaseEventTransactionDone ||
+		phaseEvent == wirePhaseEventCmdNACK {
+		m.arb.releaseOwnership(ownerID)
+		m.tryGrantAndStart()
+	}
+}
+
+// onSYNLocked handles a SYN symbol. Caller holds stateMu.
+// Returns buffered passive events and whether tryGrant should be called.
+func (m *Mux) onSYNLocked(phaseEvent wirePhaseEvent, ownerID uint64, hasOwner bool, now time.Time) ([]PassiveEvent, bool) {
+	var passiveEvents []PassiveEvent
+
+	// Flush gateway echo tracker at SYN boundary.
+	flushed, _ := m.gatewayEcho.flushOnSYN()
+	for _, b := range flushed {
+		passiveEvents = append(passiveEvents, PassiveEvent{
+			Kind: PassiveEventSymbol, Symbol: b, ObservedAt: now,
+		})
+	}
+
+	// Note: external session echo tracker flush is done AFTER stateMu.Unlock()
+	// by the caller (flushSessionEchoTrackersOnSYN) to avoid ABBA deadlock
+	// with doSend which acquires sessionsMu→stateMu.
+
+	// Release ownership if SYN timeout.
+	if phaseEvent == wirePhaseEventSYNTimeout && hasOwner {
+		m.arb.releaseOwnership(ownerID)
+	}
+
+	// Release ownership on idle SYN after grace period.
+	if phaseEvent == wirePhaseEventSYNIdle && hasOwner {
+		if !m.busDirty || time.Since(m.busOwned) > m.cfg.IdleReleaseGrace {
+			m.arb.releaseOwnership(ownerID)
+		}
+	}
+
+	// SYN is always visible on passive path.
+	passiveEvents = append(passiveEvents, PassiveEvent{
+		Kind: PassiveEventSymbol, Symbol: protocol.SymbolSyn, ObservedAt: now,
+	})
+
+	shouldTryGrant := m.arb.hasPending()
+	return passiveEvents, shouldTryGrant
+}
+
+// handleReset handles an adapter RESETTED event.
+func (m *Mux) handleReset() {
+	now := time.Now()
+
+	m.stateMu.Lock()
+	m.phase.reset(wirePhaseIdle)
+	m.gatewayEcho.reset()
+	m.busDirty = false
+	m.stateMu.Unlock()
+
+	// Reset external session echo trackers.
+	m.sessionsMu.Lock()
+	for _, sess := range m.sessions {
+		sess.echoTracker.reset()
+	}
+	m.sessionsMu.Unlock()
+
+	m.arb.forceRelease()
+	m.arb.failAllPending(errors.New("adaptermux: adapter reset"))
+
+	// Notify active path (non-blocking to prevent readLoop deadlock — CRITICAL-2 fix).
+	select {
+	case m.activeErrCh <- ebuserrors.ErrAdapterReset:
+	default:
+		m.logger.Printf("adaptermux: active error channel full, dropping adapter reset notification")
+	}
+
+	m.emitPassive(PassiveEvent{Kind: PassiveEventReset, ObservedAt: now})
+	m.broadcastResetToSessions()
+}
+
+// flushSessionEchoTrackersOnSYN flushes echo trackers for all external
+// sessions at a SYN boundary. Flushed bytes are appended as passive events
+// (they represent real bus traffic from external sessions). Must be called
+// WITHOUT stateMu held to avoid ABBA deadlock.
+func (m *Mux) flushSessionEchoTrackersOnSYN(passiveEvents *[]PassiveEvent, now time.Time) {
+	m.sessionsMu.Lock()
+	defer m.sessionsMu.Unlock()
+	for _, sess := range m.sessions {
+		flushed, _ := sess.echoTracker.flushOnSYN()
+		for _, b := range flushed {
+			*passiveEvents = append(*passiveEvents, PassiveEvent{
+				Kind: PassiveEventSymbol, Symbol: b, ObservedAt: now,
+			})
+		}
+	}
+}
+
+// deliverToActive sends a byte to the active path receive channel.
+// Logs on overflow instead of silently dropping (CRITICAL-1 fix).
+func (m *Mux) deliverToActive(symbol byte) {
+	select {
+	case m.activeRecvCh <- symbol:
+	default:
+		m.logger.Printf("adaptermux: active receive buffer full, dropping byte 0x%02X", symbol)
+	}
+}
+
+// tryGrantAndStart attempts to grant bus ownership and forward the
+// START request to the adapter.
+func (m *Mux) tryGrantAndStart() {
+	sessionID, initiator, granted := m.arb.tryGrant()
+	if !granted {
+		return
+	}
+
+	m.stateMu.Lock()
+	m.phase.startRequest()
+	m.busDirty = false
+	m.busOwned = time.Now()
+	if sessionID == gatewaySessionID {
+		m.gatewayEcho.markRequestStart()
+	}
+	m.stateMu.Unlock()
+
+	// Mark external session echo tracker for request start.
+	if sessionID != gatewaySessionID {
+		m.sessionsMu.Lock()
+		if sess, ok := m.sessions[sessionID]; ok {
+			sess.echoTracker.markRequestStart()
+		}
+		m.sessionsMu.Unlock()
+	}
+
+	// Forward START to adapter.
+	m.connMu.Lock()
+	tr := m.upstream
+	m.connMu.Unlock()
+
+	if starter, ok := tr.(interface {
+		StartArbitration(byte) error
+	}); ok {
+		if err := starter.StartArbitration(initiator); err != nil {
+			m.logger.Printf("adaptermux: START arbitration failed for session %d: %v", sessionID, err)
+			m.arb.releaseOwnership(sessionID)
+			// Notify external session that START was revoked (MEDIUM-5 fix).
+			if sessionID != gatewaySessionID {
+				m.sessionsMu.Lock()
+				if sess, ok := m.sessions[sessionID]; ok {
+					sess.deliverFailed()
+				}
+				m.sessionsMu.Unlock()
+			}
+			return
+		}
+	}
+}
+
+// sendLoop processes send requests from the active path and external sessions.
+func (m *Mux) sendLoop() {
+	defer m.wg.Done()
+
+	for {
+		select {
+		case <-m.ctx.Done():
+			return
+		case req := <-m.activeSendCh:
+			err := m.doSend(req.sessionID, req.data)
+			req.result <- err
+		}
+	}
+}
+
+// doSend writes a byte to the adapter for the given session.
+func (m *Mux) doSend(sessionID uint64, data byte) error {
+	if !m.arb.isOwner(sessionID) {
+		return errors.New("adaptermux: session is not bus owner")
+	}
+
+	m.connMu.Lock()
+	tr := m.upstream
+	m.connMu.Unlock()
+
+	if tr == nil {
+		return errors.New("adaptermux: not connected")
+	}
+
+	// Record echo expectation.
+	if sessionID == gatewaySessionID {
+		m.stateMu.Lock()
+		m.gatewayEcho.recordSent(data)
+		m.busDirty = true
+		m.stateMu.Unlock()
+	} else {
+		m.sessionsMu.Lock()
+		if sess, ok := m.sessions[sessionID]; ok {
+			sess.echoTracker.recordSent(data)
+		}
+		m.sessionsMu.Unlock()
+		m.stateMu.Lock()
+		m.busDirty = true
+		m.stateMu.Unlock()
+	}
+
+	_, err := tr.Write([]byte{data})
+	if err != nil {
+		// Rollback echo expectation on send failure.
+		if sessionID == gatewaySessionID {
+			m.stateMu.Lock()
+			m.gatewayEcho.rollbackSent()
+			m.stateMu.Unlock()
+		} else {
+			m.sessionsMu.Lock()
+			if sess, ok := m.sessions[sessionID]; ok {
+				sess.echoTracker.rollbackSent()
+			}
+			m.sessionsMu.Unlock()
+		}
+		return fmt.Errorf("adaptermux: write to adapter: %w", err)
+	}
+
+	return nil
+}
+
+// emitPassive delivers a passive event to the callback.
+// Must be called WITHOUT stateMu held to avoid re-entrancy deadlock.
+func (m *Mux) emitPassive(event PassiveEvent) {
+	m.passiveMu.Lock()
+	fn := m.passiveCallback
+	m.passiveMu.Unlock()
+	if fn != nil {
+		fn(event)
+	}
+}
+
+// nextSessionID generates a unique session ID for external sessions.
+func (m *Mux) nextSessionID() uint64 {
+	return m.sessionSeq.Add(1)
+}
+
+// deliverToSessions delivers a non-SYN byte to external sessions with
+// per-session echo suppression. Uses sessionsMu write lock because
+// matchEcho mutates the echo tracker (HIGH-7 data race fix).
+func (m *Mux) deliverToSessions(symbol byte, currentOwner uint64, hasOwner bool, now time.Time) {
+	m.sessionsMu.Lock()
+	defer m.sessionsMu.Unlock()
+
+	for _, sess := range m.sessions {
+		if hasOwner && sess.id == currentOwner {
+			result, flushed := sess.echoTracker.matchEcho(symbol)
+			if result == echoMatchSuppressed {
+				continue
+			}
+			// Deliver flushed bytes on mismatch (MEDIUM-2 fix).
+			if result == echoMatchFlushed {
+				for _, b := range flushed {
+					sess.deliverReceived(b)
+				}
+			}
+		}
+		sess.deliverReceived(symbol)
+	}
+}
+
+// deliverSYNToSessions delivers a SYN to all external sessions.
+func (m *Mux) deliverSYNToSessions(now time.Time) {
+	m.sessionsMu.Lock()
+	defer m.sessionsMu.Unlock()
+
+	for _, sess := range m.sessions {
+		sess.deliverReceived(protocol.SymbolSyn)
+	}
+}
+
+// broadcastResetToSessions sends a RESETTED event to all external sessions.
+func (m *Mux) broadcastResetToSessions() {
+	m.sessionsMu.Lock()
+	defer m.sessionsMu.Unlock()
+
+	for _, sess := range m.sessions {
+		sess.deliverReset()
+	}
+}

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -268,8 +268,11 @@ func (m *Mux) connect() error {
 	switch m.cfg.Protocol {
 	case "ens":
 		tr = transport.NewENSTransport(conn, m.cfg.ReadTimeout, m.cfg.WriteTimeout)
-	default:
+	case "enh", "":
 		tr = transport.NewENHTransport(conn, m.cfg.ReadTimeout, m.cfg.WriteTimeout)
+	default:
+		_ = conn.Close()
+		return fmt.Errorf("adaptermux: unsupported protocol %q (expected \"enh\" or \"ens\")", m.cfg.Protocol)
 	}
 
 	m.conn = conn
@@ -442,12 +445,18 @@ func (m *Mux) onReceived(symbol byte) {
 		m.stateMu.Unlock()
 
 		// --- Phase 2: deliver outside all locks ---
-		// Flush external session echo trackers (outside stateMu to avoid
-		// ABBA deadlock with doSend which acquires sessionsMu→stateMu).
-		m.flushSessionEchoTrackersOnSYN(&passiveEvents, now)
+		// Flush external session echo trackers BEFORE emitting the SYN event,
+		// so flushed bytes (which occurred before the SYN boundary) are
+		// delivered in correct temporal order. Called outside stateMu to
+		// avoid ABBA deadlock with doSend (sessionsMu→stateMu).
+		var flushedEvents []PassiveEvent
+		m.flushSessionEchoTrackersOnSYN(&flushedEvents, now)
+		// Prepend flushed bytes before SYN: flushed events first, then
+		// passiveEvents (which contains the SYN).
+		allPassive := append(flushedEvents, passiveEvents...)
 
 		m.deliverToActive(symbol)
-		for _, pe := range passiveEvents {
+		for _, pe := range allPassive {
 			m.emitPassive(pe)
 		}
 		m.deliverSYNToSessions(now)
@@ -501,13 +510,11 @@ func (m *Mux) onReceived(symbol byte) {
 func (m *Mux) onSYNLocked(phaseEvent wirePhaseEvent, ownerID uint64, hasOwner bool, now time.Time) ([]PassiveEvent, bool) {
 	var passiveEvents []PassiveEvent
 
-	// Flush gateway echo tracker at SYN boundary.
-	flushed, _ := m.gatewayEcho.flushOnSYN()
-	for _, b := range flushed {
-		passiveEvents = append(passiveEvents, PassiveEvent{
-			Kind: PassiveEventSymbol, Symbol: b, ObservedAt: now,
-		})
-	}
+	// Flush gateway echo tracker at SYN boundary. Flushed bytes are
+	// confirmed gateway self-traffic — do NOT emit to passive path
+	// (passive is third-party only). They are delivered to external
+	// sessions via deliverSYNToSessions + deliverToSessions elsewhere.
+	m.gatewayEcho.flushOnSYN()
 
 	// Note: external session echo tracker flush is done AFTER stateMu.Unlock()
 	// by the caller (flushSessionEchoTrackersOnSYN) to avoid ABBA deadlock

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -740,7 +740,20 @@ func (m *Mux) tryGrantAndStart() {
 		}
 	}
 
-	// Adapter START succeeded — now confirm ownership.
+	// Adapter START succeeded — verify session is still alive before
+	// confirming ownership (Codex P1 #3060335786: session may have
+	// disconnected or cancelled during StartArbitration).
+	if sessionID != gatewaySessionID {
+		m.sessionsMu.Lock()
+		_, alive := m.sessions[sessionID]
+		m.sessionsMu.Unlock()
+		if !alive {
+			m.logger.Printf("adaptermux: session %d disconnected during START, discarding grant", sessionID)
+			notify <- startResult{granted: false, initiator: initiator, err: errors.New("session disconnected")}
+			return
+		}
+	}
+
 	m.arb.confirmOwnership(sessionID, initiator)
 
 	m.stateMu.Lock()

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -387,6 +387,12 @@ func (m *Mux) readLoop() {
 				m.handleReset()
 				continue
 			}
+			// Read timeouts on a quiet bus are normal (no data within
+			// ReadTimeout window) — treat as idle, not disconnect.
+			// Matches passive_bus_tap.go behavior (Codex P2 #3059211395).
+			if errors.Is(err, ebuserrors.ErrTimeout) || isNetTimeout(err) {
+				continue
+			}
 			m.logger.Printf("adaptermux: read error: %v", err)
 			if reconnErr := m.reconnect(); reconnErr != nil {
 				m.logger.Printf("adaptermux: reconnect gave up: %v", reconnErr)
@@ -791,4 +797,12 @@ func (m *Mux) broadcastResetToSessions() {
 	for _, sess := range m.sessions {
 		sess.deliverReset()
 	}
+}
+
+// isNetTimeout reports whether err is a net.Error timeout (read deadline
+// exceeded). These are transient idle conditions on a quiet bus, not
+// connection failures.
+func isNetTimeout(err error) bool {
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
 }

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -391,6 +391,17 @@ func (m *Mux) readLoop() {
 			// ReadTimeout window) — treat as idle, not disconnect.
 			// Matches passive_bus_tap.go behavior (Codex P2 #3059211395).
 			if errors.Is(err, ebuserrors.ErrTimeout) || isNetTimeout(err) {
+				// Enforce ownership timeout on quiet bus — onReceived
+				// won't run to check MaxOwnershipDuration.
+				m.stateMu.Lock()
+				ownerID, _, hasOwner := m.arb.owner()
+				if hasOwner && !m.busOwned.IsZero() &&
+					time.Since(m.busOwned) > m.cfg.MaxOwnershipDuration {
+					m.arb.releaseOwnership(ownerID)
+					m.gatewayEcho.reset()
+				}
+				m.stateMu.Unlock()
+
 				// On a quiet bus no SYN or transaction-complete events
 				// reach onReceived, so tryGrantAndStart is never called.
 				// Drain pending START requests here to prevent stalls.

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -103,9 +103,10 @@ type Mux struct {
 	logger *log.Logger
 
 	// Adapter connection (guarded by connMu for reconnection).
-	connMu   sync.Mutex
-	conn     net.Conn
-	upstream transport.RawTransport
+	connMu           sync.Mutex
+	conn             net.Conn
+	upstream         transport.RawTransport
+	upstreamFeatures atomic.Uint32 // features byte from upstream INIT handshake
 
 	// Multiplexer state (guarded by stateMu).
 	stateMu  sync.Mutex
@@ -134,9 +135,11 @@ type Mux struct {
 	passiveCallback func(PassiveEvent)
 
 	// Lifecycle.
-	ctx    context.Context
-	cancel context.CancelFunc
-	wg     sync.WaitGroup
+	ctx       context.Context
+	cancel    context.CancelFunc
+	wg        sync.WaitGroup
+	closeOnce sync.Once
+	closeErr  error
 }
 
 // sendRequest is a request from the active path or an external session
@@ -187,39 +190,41 @@ func (m *Mux) Start(ctx context.Context) error {
 }
 
 // Close shuts down the multiplexer and releases all resources.
+// Safe to call multiple times — subsequent calls return the first error.
 func (m *Mux) Close() error {
-	if m.cancel != nil {
-		m.cancel()
-	}
+	m.closeOnce.Do(func() {
+		if m.cancel != nil {
+			m.cancel()
+		}
 
-	// Fail all pending arbitration requests.
-	m.arb.failAllPending(errors.New("adaptermux: closed"))
+		// Fail all pending arbitration requests.
+		m.arb.failAllPending(errors.New("adaptermux: closed"))
 
-	// Collect sessions under lock, close outside lock to avoid holding
-	// sessionsMu during potentially blocking session.close() (5s timeout).
-	m.sessionsMu.Lock()
-	toClose := make([]*session, 0, len(m.sessions))
-	for id, sess := range m.sessions {
-		toClose = append(toClose, sess)
-		delete(m.sessions, id)
-	}
-	m.sessionsMu.Unlock()
+		// Collect sessions under lock, close outside lock to avoid holding
+		// sessionsMu during potentially blocking session.close() (5s timeout).
+		m.sessionsMu.Lock()
+		toClose := make([]*session, 0, len(m.sessions))
+		for id, sess := range m.sessions {
+			toClose = append(toClose, sess)
+			delete(m.sessions, id)
+		}
+		m.sessionsMu.Unlock()
 
-	for _, sess := range toClose {
-		m.arb.removeSession(sess.id)
-		sess.close()
-	}
+		for _, sess := range toClose {
+			m.arb.removeSession(sess.id)
+			sess.close()
+		}
 
-	// Close adapter connection.
-	m.connMu.Lock()
-	var closeErr error
-	if m.conn != nil {
-		closeErr = m.conn.Close()
-	}
-	m.connMu.Unlock()
+		// Close adapter connection.
+		m.connMu.Lock()
+		if m.conn != nil {
+			m.closeErr = m.conn.Close()
+		}
+		m.connMu.Unlock()
 
-	m.wg.Wait()
-	return closeErr
+		m.wg.Wait()
+	})
+	return m.closeErr
 }
 
 // ActiveTransport returns a RawTransport for the gateway's active path.
@@ -279,11 +284,17 @@ func (m *Mux) connect() error {
 	m.upstream = tr
 
 	// Perform INIT handshake — fatal if transport implements Init.
+	// Store the negotiated features byte for session INIT replies.
+	// ENHTransport.Init returns error only — the upstream's actual
+	// features byte is not exposed. Store the requested value (0x01)
+	// as the best-effort fallback.
+	const requestedFeatures byte = 0x01
 	if initer, ok := tr.(interface{ Init(byte) error }); ok {
-		if err := initer.Init(0x01); err != nil {
+		if err := initer.Init(requestedFeatures); err != nil {
 			_ = conn.Close()
 			return fmt.Errorf("adaptermux: INIT handshake failed: %w", err)
 		}
+		m.upstreamFeatures.Store(uint32(requestedFeatures))
 	}
 
 	return nil
@@ -681,13 +692,13 @@ func (m *Mux) tryGrantAndStart() {
 			m.arb.releaseOwnership(sessionID)
 			// Notify requester of failure AFTER adapter START failed
 			// (Codex P1: no premature grant notification).
-			notify <- startResult{granted: false, err: err}
+			notify <- startResult{granted: false, initiator: initiator, err: err}
 			return
 		}
 	}
 
 	// Notify requester of success AFTER adapter START succeeded.
-	notify <- startResult{granted: true}
+	notify <- startResult{granted: true, initiator: initiator}
 }
 
 // sendLoop processes send requests from the active path and external sessions.
@@ -807,12 +818,13 @@ func (m *Mux) deliverSYNToSessions(now time.Time) {
 }
 
 // broadcastResetToSessions sends a RESETTED event to all external sessions.
+// Uses 0x00 payload — reset broadcasts are boundary markers, not INIT replies.
 func (m *Mux) broadcastResetToSessions() {
 	m.sessionsMu.Lock()
 	defer m.sessionsMu.Unlock()
 
 	for _, sess := range m.sessions {
-		sess.deliverReset()
+		sess.deliverReset(0x00)
 	}
 }
 

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -315,6 +315,15 @@ func (m *Mux) reconnect() error {
 	// Fail pending arbitration.
 	m.arb.failAllPending(errors.New("adaptermux: adapter disconnected"))
 
+	// Notify active path of disconnect so gateway.Bus sees the reset
+	// boundary (Codex P2 #3058767932). Drain stale bytes first.
+	m.drainActiveRecvCh()
+	select {
+	case m.activeErrCh <- ebuserrors.ErrAdapterReset:
+	default:
+		m.logger.Printf("adaptermux: active error channel full, dropping disconnect notification")
+	}
+
 	// Close old connection.
 	m.connMu.Lock()
 	if m.conn != nil {
@@ -558,7 +567,12 @@ func (m *Mux) handleReset() {
 	m.arb.forceRelease()
 	m.arb.failAllPending(errors.New("adaptermux: adapter reset"))
 
-	// Notify active path (non-blocking to prevent readLoop deadlock — CRITICAL-2 fix).
+	// Drain stale bytes from active receive buffer before signaling
+	// reset, so consumers never see pre-reset bytes after the reset
+	// boundary (Codex P1 #3058767928).
+	m.drainActiveRecvCh()
+
+	// Notify active path (non-blocking to prevent readLoop deadlock).
 	select {
 	case m.activeErrCh <- ebuserrors.ErrAdapterReset:
 	default:
@@ -567,6 +581,19 @@ func (m *Mux) handleReset() {
 
 	m.emitPassive(PassiveEvent{Kind: PassiveEventReset, ObservedAt: now})
 	m.broadcastResetToSessions()
+}
+
+// drainActiveRecvCh discards all buffered bytes from the active receive
+// channel. Called before reset/reconnect to ensure consumers don't see
+// stale pre-boundary bytes after a reset event.
+func (m *Mux) drainActiveRecvCh() {
+	for {
+		select {
+		case <-m.activeRecvCh:
+		default:
+			return
+		}
+	}
 }
 
 // flushSessionEchoTrackers flushes echo trackers for all external sessions

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -161,12 +161,13 @@ type activeEvent struct {
 }
 
 // Sentinel errors returned by doSend for error classification.
-// Host-side errors (ownership, connectivity) are distinct from bus
-// errors (adapter write failures) so callers can deliver the correct
-// ENH response code (ENHResErrorHost vs ENHResErrorEBUS).
+// Host-side errors (ownership, connectivity, adapter write) are distinct
+// from bus errors so callers can deliver the correct ENH response code
+// (ENHResErrorHost vs ENHResErrorEBUS).
 var (
-	errNotBusOwner = errors.New("adaptermux: session is not bus owner")
+	errNotBusOwner  = errors.New("adaptermux: session is not bus owner")
 	errNotConnected = errors.New("adaptermux: not connected")
+	errAdapterWrite = errors.New("adaptermux: adapter write failed")
 )
 
 // sendRequest is a request from the active path or an external session
@@ -722,6 +723,26 @@ func (m *Mux) tryGrantAndStart() {
 		return
 	}
 
+	// Forward START to adapter BEFORE setting ownership
+	// (Codex P1 #3060199707: defer ownership until adapter confirms).
+	m.connMu.Lock()
+	tr := m.upstream
+	m.connMu.Unlock()
+
+	if starter, ok := tr.(interface {
+		StartArbitration(byte) error
+	}); ok {
+		if err := starter.StartArbitration(initiator); err != nil {
+			m.logger.Printf("adaptermux: START arbitration failed for session %d: %v", sessionID, err)
+			// Ownership was never confirmed — no releaseOwnership needed.
+			notify <- startResult{granted: false, initiator: initiator, err: err}
+			return
+		}
+	}
+
+	// Adapter START succeeded — now confirm ownership.
+	m.arb.confirmOwnership(sessionID, initiator)
+
 	m.stateMu.Lock()
 	m.phase.startRequest()
 	m.busDirty = false
@@ -738,24 +759,6 @@ func (m *Mux) tryGrantAndStart() {
 			sess.echoTracker.markRequestStart()
 		}
 		m.sessionsMu.Unlock()
-	}
-
-	// Forward START to adapter.
-	m.connMu.Lock()
-	tr := m.upstream
-	m.connMu.Unlock()
-
-	if starter, ok := tr.(interface {
-		StartArbitration(byte) error
-	}); ok {
-		if err := starter.StartArbitration(initiator); err != nil {
-			m.logger.Printf("adaptermux: START arbitration failed for session %d: %v", sessionID, err)
-			m.arb.releaseOwnership(sessionID)
-			// Notify requester of failure AFTER adapter START failed
-			// (Codex P1: no premature grant notification).
-			notify <- startResult{granted: false, initiator: initiator, err: err}
-			return
-		}
 	}
 
 	// Notify requester of success AFTER adapter START succeeded.
@@ -822,7 +825,7 @@ func (m *Mux) doSend(sessionID uint64, data byte) error {
 			}
 			m.sessionsMu.Unlock()
 		}
-		return fmt.Errorf("adaptermux: write to adapter: %w", err)
+		return fmt.Errorf("%w: %v", errAdapterWrite, err)
 	}
 
 	return nil

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -445,18 +445,15 @@ func (m *Mux) onReceived(symbol byte) {
 		m.stateMu.Unlock()
 
 		// --- Phase 2: deliver outside all locks ---
-		// Flush external session echo trackers BEFORE emitting the SYN event,
-		// so flushed bytes (which occurred before the SYN boundary) are
-		// delivered in correct temporal order. Called outside stateMu to
+		// Flush external session echo trackers. Called outside stateMu to
 		// avoid ABBA deadlock with doSend (sessionsMu→stateMu).
-		var flushedEvents []PassiveEvent
-		m.flushSessionEchoTrackersOnSYN(&flushedEvents, now)
-		// Prepend flushed bytes before SYN: flushed events first, then
-		// passiveEvents (which contains the SYN).
-		allPassive := append(flushedEvents, passiveEvents...)
+		// The flushed bytes are NOT emitted to passive — they were already
+		// delivered live in onReceived (they're third-party from gateway's
+		// perspective). Re-emitting would produce duplicates (Codex P1).
+		m.flushSessionEchoTrackers()
 
 		m.deliverToActive(symbol)
-		for _, pe := range allPassive {
+		for _, pe := range passiveEvents {
 			m.emitPassive(pe)
 		}
 		m.deliverSYNToSessions(now)
@@ -572,20 +569,16 @@ func (m *Mux) handleReset() {
 	m.broadcastResetToSessions()
 }
 
-// flushSessionEchoTrackersOnSYN flushes echo trackers for all external
-// sessions at a SYN boundary. Flushed bytes are appended as passive events
-// (they represent real bus traffic from external sessions). Must be called
-// WITHOUT stateMu held to avoid ABBA deadlock.
-func (m *Mux) flushSessionEchoTrackersOnSYN(passiveEvents *[]PassiveEvent, now time.Time) {
+// flushSessionEchoTrackers flushes echo trackers for all external sessions
+// at a SYN boundary. The flushed bytes are discarded — they were already
+// delivered live to passive consumers in onReceived. This call only resets
+// tracker state for the next transaction cycle. Must be called WITHOUT
+// stateMu held to avoid ABBA deadlock with doSend.
+func (m *Mux) flushSessionEchoTrackers() {
 	m.sessionsMu.Lock()
 	defer m.sessionsMu.Unlock()
 	for _, sess := range m.sessions {
-		flushed, _ := sess.echoTracker.flushOnSYN()
-		for _, b := range flushed {
-			*passiveEvents = append(*passiveEvents, PassiveEvent{
-				Kind: PassiveEventSymbol, Symbol: b, ObservedAt: now,
-			})
-		}
+		sess.echoTracker.flushOnSYN()
 	}
 }
 
@@ -602,7 +595,7 @@ func (m *Mux) deliverToActive(symbol byte) {
 // tryGrantAndStart attempts to grant bus ownership and forward the
 // START request to the adapter.
 func (m *Mux) tryGrantAndStart() {
-	sessionID, initiator, granted := m.arb.tryGrant()
+	sessionID, initiator, notify, granted := m.arb.tryGrant()
 	if !granted {
 		return
 	}
@@ -636,17 +629,15 @@ func (m *Mux) tryGrantAndStart() {
 		if err := starter.StartArbitration(initiator); err != nil {
 			m.logger.Printf("adaptermux: START arbitration failed for session %d: %v", sessionID, err)
 			m.arb.releaseOwnership(sessionID)
-			// Notify external session that START was revoked (MEDIUM-5 fix).
-			if sessionID != gatewaySessionID {
-				m.sessionsMu.Lock()
-				if sess, ok := m.sessions[sessionID]; ok {
-					sess.deliverFailed()
-				}
-				m.sessionsMu.Unlock()
-			}
+			// Notify requester of failure AFTER adapter START failed
+			// (Codex P1: no premature grant notification).
+			notify <- startResult{granted: false, err: err}
 			return
 		}
 	}
+
+	// Notify requester of success AFTER adapter START succeeded.
+	notify <- startResult{granted: true}
 }
 
 // sendLoop processes send requests from the active path and external sessions.

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -160,6 +160,15 @@ type activeEvent struct {
 	err  error // valid when kind == activeEventError
 }
 
+// Sentinel errors returned by doSend for error classification.
+// Host-side errors (ownership, connectivity) are distinct from bus
+// errors (adapter write failures) so callers can deliver the correct
+// ENH response code (ENHResErrorHost vs ENHResErrorEBUS).
+var (
+	errNotBusOwner = errors.New("adaptermux: session is not bus owner")
+	errNotConnected = errors.New("adaptermux: not connected")
+)
+
 // sendRequest is a request from the active path or an external session
 // to send a byte to the adapter.
 type sendRequest struct {
@@ -771,7 +780,7 @@ func (m *Mux) sendLoop() {
 // doSend writes a byte to the adapter for the given session.
 func (m *Mux) doSend(sessionID uint64, data byte) error {
 	if !m.arb.isOwner(sessionID) {
-		return errors.New("adaptermux: session is not bus owner")
+		return errNotBusOwner
 	}
 
 	m.connMu.Lock()
@@ -779,7 +788,7 @@ func (m *Mux) doSend(sessionID uint64, data byte) error {
 	m.connMu.Unlock()
 
 	if tr == nil {
-		return errors.New("adaptermux: not connected")
+		return errNotConnected
 	}
 
 	// Record echo expectation.

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -311,6 +311,11 @@ func (m *Mux) connect() error {
 			_ = conn.Close()
 			return fmt.Errorf("adaptermux: INIT handshake failed: %w", err)
 		}
+		// NOTE: ENHTransport.Init() does not expose the upstream RESETTED
+		// response payload. We store the requested features (0x01) as a
+		// best-effort fallback. Faithful upstream feature negotiation requires
+		// extending the ebusgo transport.Init interface to return the response
+		// payload — tracked as a known contract divergence from the proxy.
 		m.upstreamFeatures.Store(uint32(requestedFeatures))
 	}
 
@@ -634,6 +639,34 @@ func (m *Mux) handleReset() {
 
 	m.emitPassive(PassiveEvent{Kind: PassiveEventReset, ObservedAt: now})
 	m.broadcastResetToSessions()
+
+	// Schedule delayed re-INIT after in-band RESETTED (200ms stabilization).
+	// Without re-INIT the upstream transport stays in reset state and
+	// ownership cannot be re-acquired until a physical TCP disconnect
+	// triggers reconnect(). The 200ms delay is from proxy convention.
+	m.wg.Add(1)
+	go func() { // goroutine: delayed re-INIT after adapter RESETTED
+		defer m.wg.Done()
+		select {
+		case <-time.After(200 * time.Millisecond):
+		case <-m.ctx.Done():
+			return
+		}
+		m.connMu.Lock()
+		tr := m.upstream
+		m.connMu.Unlock()
+		if initer, ok := tr.(interface{ Init(byte) error }); ok {
+			features := byte(m.upstreamFeatures.Load())
+			if features == 0 {
+				features = 0x01
+			}
+			if err := initer.Init(features); err != nil {
+				m.logger.Printf("adaptermux: re-INIT after RESETTED failed: %v", err)
+			} else {
+				m.logger.Printf("adaptermux: re-INIT after RESETTED succeeded")
+			}
+		}
+	}()
 }
 
 // drainActiveCh discards all buffered events from the active channel.
@@ -837,13 +870,16 @@ func (m *Mux) deliverSYNToSessions(now time.Time) {
 }
 
 // broadcastResetToSessions sends a RESETTED event to all external sessions.
-// Uses 0x00 payload — reset broadcasts are boundary markers, not INIT replies.
+// Carries upstreamFeatures so external clients see consistent feature
+// signaling on reset boundaries (not 0x00).
 func (m *Mux) broadcastResetToSessions() {
+	features := byte(m.upstreamFeatures.Load())
+
 	m.sessionsMu.Lock()
 	defer m.sessionsMu.Unlock()
 
 	for _, sess := range m.sessions {
-		sess.deliverReset(0x00)
+		sess.deliverReset(features)
 	}
 }
 

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -126,8 +126,7 @@ type Mux struct {
 
 	// Active path channels.
 	activeSendCh chan sendRequest
-	activeRecvCh chan byte  // capacity 256, overflow logged
-	activeErrCh  chan error // capacity 4, non-blocking send
+	activeCh     chan activeEvent // capacity 256: unified byte+error channel (FIFO ordered)
 
 	// Passive path callback (set via SetPassiveCallback).
 	// The callback must NOT call back into Mux methods (re-entrancy hazard).
@@ -140,6 +139,25 @@ type Mux struct {
 	wg        sync.WaitGroup
 	closeOnce sync.Once
 	closeErr  error
+}
+
+// activeEventKind tags active-path channel events.
+type activeEventKind uint8
+
+const (
+	activeEventByte  activeEventKind = iota // data byte from adapter
+	activeEventError                        // error (reset, disconnect)
+)
+
+// activeEvent is a tagged union carried on the single activeCh channel.
+// Merging bytes and errors into one channel guarantees FIFO ordering:
+// handleReset drains the channel and enqueues the reset event before
+// readLoop resumes enqueuing bytes, so the consumer sees events in
+// exact enqueue order — no Go-select non-determinism.
+type activeEvent struct {
+	kind activeEventKind
+	b    byte  // valid when kind == activeEventByte
+	err  error // valid when kind == activeEventError
 }
 
 // sendRequest is a request from the active path or an external session
@@ -161,8 +179,7 @@ func New(cfg Config) *Mux {
 		gatewayEcho:  newEchoTracker(),
 		sessions:     make(map[uint64]*session),
 		activeSendCh: make(chan sendRequest, 16),
-		activeRecvCh: make(chan byte, 256),   // capacity 256: bus byte buffer
-		activeErrCh:  make(chan error, 4),     // capacity 4: adapter reset events
+		activeCh:     make(chan activeEvent, 256), // unified byte+error channel
 	}
 }
 
@@ -328,11 +345,11 @@ func (m *Mux) reconnect() error {
 
 	// Notify active path of disconnect so gateway.Bus sees the reset
 	// boundary (Codex P2 #3058767932). Drain stale bytes first.
-	m.drainActiveRecvCh()
+	m.drainActiveCh()
 	select {
-	case m.activeErrCh <- ebuserrors.ErrAdapterReset:
+	case m.activeCh <- activeEvent{kind: activeEventError, err: ebuserrors.ErrAdapterReset}:
 	default:
-		m.logger.Printf("adaptermux: active error channel full, dropping disconnect notification")
+		m.logger.Printf("adaptermux: active channel full, dropping disconnect notification")
 	}
 
 	// Close old connection.
@@ -601,29 +618,31 @@ func (m *Mux) handleReset() {
 	m.arb.forceRelease()
 	m.arb.failAllPending(errors.New("adaptermux: adapter reset"))
 
-	// Drain stale bytes from active receive buffer before signaling
-	// reset, so consumers never see pre-reset bytes after the reset
-	// boundary (Codex P1 #3058767928).
-	m.drainActiveRecvCh()
+	// Drain stale bytes from active channel before enqueuing the reset
+	// error. Because activeCh is a single FIFO channel, the consumer is
+	// guaranteed to see the reset before any post-reset bytes that
+	// readLoop enqueues after this function returns.
+	m.drainActiveCh()
 
-	// Notify active path (non-blocking to prevent readLoop deadlock).
+	// Enqueue reset error into the unified channel (non-blocking to
+	// prevent readLoop deadlock).
 	select {
-	case m.activeErrCh <- ebuserrors.ErrAdapterReset:
+	case m.activeCh <- activeEvent{kind: activeEventError, err: ebuserrors.ErrAdapterReset}:
 	default:
-		m.logger.Printf("adaptermux: active error channel full, dropping adapter reset notification")
+		m.logger.Printf("adaptermux: active channel full, dropping adapter reset notification")
 	}
 
 	m.emitPassive(PassiveEvent{Kind: PassiveEventReset, ObservedAt: now})
 	m.broadcastResetToSessions()
 }
 
-// drainActiveRecvCh discards all buffered bytes from the active receive
-// channel. Called before reset/reconnect to ensure consumers don't see
-// stale pre-boundary bytes after a reset event.
-func (m *Mux) drainActiveRecvCh() {
+// drainActiveCh discards all buffered events from the active channel.
+// Called before reset/reconnect to ensure consumers don't see stale
+// pre-boundary bytes after a reset event.
+func (m *Mux) drainActiveCh() {
 	for {
 		select {
-		case <-m.activeRecvCh:
+		case <-m.activeCh:
 		default:
 			return
 		}
@@ -643,13 +662,13 @@ func (m *Mux) flushSessionEchoTrackers() {
 	}
 }
 
-// deliverToActive sends a byte to the active path receive channel.
+// deliverToActive sends a byte to the active path channel.
 // Logs on overflow instead of silently dropping (CRITICAL-1 fix).
 func (m *Mux) deliverToActive(symbol byte) {
 	select {
-	case m.activeRecvCh <- symbol:
+	case m.activeCh <- activeEvent{kind: activeEventByte, b: symbol}:
 	default:
-		m.logger.Printf("adaptermux: active receive buffer full, dropping byte 0x%02X", symbol)
+		m.logger.Printf("adaptermux: active channel full, dropping byte 0x%02X", symbol)
 	}
 }
 

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -391,6 +391,12 @@ func (m *Mux) readLoop() {
 			// ReadTimeout window) — treat as idle, not disconnect.
 			// Matches passive_bus_tap.go behavior (Codex P2 #3059211395).
 			if errors.Is(err, ebuserrors.ErrTimeout) || isNetTimeout(err) {
+				// On a quiet bus no SYN or transaction-complete events
+				// reach onReceived, so tryGrantAndStart is never called.
+				// Drain pending START requests here to prevent stalls.
+				if m.arb.hasPending() {
+					m.tryGrantAndStart()
+				}
 				continue
 			}
 			m.logger.Printf("adaptermux: read error: %v", err)

--- a/internal/adaptermux/passive_transport.go
+++ b/internal/adaptermux/passive_transport.go
@@ -91,8 +91,15 @@ func (t *passiveTransport) deliver(event PassiveEvent) {
 		return
 	default:
 		// Buffer full — drop oldest symbol to prevent backpressure.
+		// Never evict a reset event — resets are non-droppable boundaries
+		// (Codex P1 #3060335791). If the oldest is a reset, put it back
+		// and drop the new symbol instead.
 		select {
-		case <-t.events:
+		case oldest := <-t.events:
+			if oldest.Kind == transport.StreamEventReset {
+				t.events <- oldest
+				return
+			}
 		default:
 		}
 		select {

--- a/internal/adaptermux/passive_transport.go
+++ b/internal/adaptermux/passive_transport.go
@@ -1,0 +1,130 @@
+package adaptermux
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+// passiveTransport implements transport.RawTransport and
+// transport.StreamEventReader for the passive observation path.
+// It reads third-party bus symbols from the multiplexer's passive
+// callback via a buffered channel.
+//
+// The passive tap can use this as a drop-in replacement for the
+// TCP-dialed observer transport — no escape decoding needed since
+// symbols are already logical (post-ENH-decode).
+type passiveTransport struct {
+	events chan transport.StreamEvent
+	done   chan struct{}
+	closed bool
+	mu     sync.Mutex
+}
+
+// Compile-time interface checks.
+var (
+	_ transport.RawTransport      = (*passiveTransport)(nil)
+	_ transport.StreamEventReader = (*passiveTransport)(nil)
+)
+
+const passiveTransportBuffer = 512 // capacity: bus symbols for passive path
+
+// newPassiveTransport creates a passive transport backed by the mux.
+func newPassiveTransport() *passiveTransport {
+	return &passiveTransport{
+		events: make(chan transport.StreamEvent, passiveTransportBuffer),
+		done:   make(chan struct{}),
+	}
+}
+
+// deliver is called by the mux's passive callback to feed events.
+func (t *passiveTransport) deliver(event PassiveEvent) {
+	t.mu.Lock()
+	if t.closed {
+		t.mu.Unlock()
+		return
+	}
+	t.mu.Unlock()
+
+	var se transport.StreamEvent
+	switch event.Kind {
+	case PassiveEventSymbol:
+		se = transport.StreamEvent{Kind: transport.StreamEventByte, Byte: event.Symbol}
+	case PassiveEventReset:
+		se = transport.StreamEvent{Kind: transport.StreamEventReset}
+	case PassiveEventConnected:
+		// No StreamEvent equivalent — skip.
+		return
+	case PassiveEventDisconnected:
+		// Deliver as reset so passive tap sees the boundary.
+		se = transport.StreamEvent{Kind: transport.StreamEventReset}
+	default:
+		return
+	}
+
+	select {
+	case t.events <- se:
+	default:
+		// Buffer full — drop oldest to prevent backpressure.
+		select {
+		case <-t.events:
+		default:
+		}
+		t.events <- se
+	}
+}
+
+// ReadByte blocks until a symbol is available. Implements transport.RawTransport.
+func (t *passiveTransport) ReadByte() (byte, error) {
+	select {
+	case ev := <-t.events:
+		if ev.Kind == transport.StreamEventReset {
+			return 0, fmt.Errorf("adaptermux: passive transport reset")
+		}
+		return ev.Byte, nil
+	case <-t.done:
+		return 0, errors.New("adaptermux: passive transport closed")
+	}
+}
+
+// ReadEvent returns stream events including resets. Implements
+// transport.StreamEventReader for RESETTED boundary detection.
+func (t *passiveTransport) ReadEvent() (transport.StreamEvent, error) {
+	select {
+	case ev := <-t.events:
+		return ev, nil
+	case <-t.done:
+		return transport.StreamEvent{}, errors.New("adaptermux: passive transport closed")
+	}
+}
+
+// Write is a no-op — passive path is read-only.
+func (t *passiveTransport) Write(p []byte) (int, error) {
+	return 0, errors.New("adaptermux: passive transport is read-only")
+}
+
+// Close shuts down the passive transport.
+func (t *passiveTransport) Close() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if !t.closed {
+		t.closed = true
+		close(t.done)
+	}
+	return nil
+}
+
+// PassiveTransport returns a transport.RawTransport for the passive
+// observation path. The returned transport reads only third-party bus
+// symbols (gateway self-echo filtered). The stream is already logical
+// (no escape decoding needed).
+//
+// Must be called before Start(). The returned transport is wired to
+// the mux's passive callback automatically.
+func (m *Mux) PassiveTransport() transport.RawTransport {
+	pt := newPassiveTransport()
+	m.SetPassiveCallback(pt.deliver)
+	return pt
+}

--- a/internal/adaptermux/passive_transport.go
+++ b/internal/adaptermux/passive_transport.go
@@ -66,13 +66,19 @@ func (t *passiveTransport) deliver(event PassiveEvent) {
 
 	select {
 	case t.events <- se:
+	case <-t.done:
+		return
 	default:
 		// Buffer full — drop oldest to prevent backpressure.
 		select {
 		case <-t.events:
 		default:
 		}
-		t.events <- se
+		select {
+		case t.events <- se:
+		case <-t.done:
+			return
+		}
 	}
 }
 

--- a/internal/adaptermux/passive_transport.go
+++ b/internal/adaptermux/passive_transport.go
@@ -73,12 +73,24 @@ func (t *passiveTransport) deliver(event PassiveEvent) {
 		return
 	}
 
+	// Reset boundaries are non-droppable — losing a reset merges
+	// pre/post-reset streams and corrupts frame reconstruction
+	// (Codex P1 #3060199712). Block until delivered.
+	if se.Kind == transport.StreamEventReset {
+		select {
+		case t.events <- se:
+		case <-t.done:
+		}
+		return
+	}
+
+	// Regular symbols: non-blocking with overflow drop.
 	select {
 	case t.events <- se:
 	case <-t.done:
 		return
 	default:
-		// Buffer full — drop oldest to prevent backpressure.
+		// Buffer full — drop oldest symbol to prevent backpressure.
 		select {
 		case <-t.events:
 		default:

--- a/internal/adaptermux/passive_transport.go
+++ b/internal/adaptermux/passive_transport.go
@@ -55,10 +55,19 @@ func (t *passiveTransport) deliver(event PassiveEvent) {
 	case PassiveEventReset:
 		se = transport.StreamEvent{Kind: transport.StreamEventReset}
 	case PassiveEventConnected:
-		// No StreamEvent equivalent — skip.
-		return
+		// Deliver as reset: a reconnect establishes a new stream boundary.
+		// The passive reconstructor must discard any partial frame state
+		// accumulated before the disconnect. Consecutive resets (disconnect
+		// followed by connect) are idempotent for stream parsing.
+		//
+		// In adapter-direct mode the PassiveBusTap does not re-call connect()
+		// on mux reconnection — this event is the only signal that the adapter
+		// link was re-established, so it must reach the consumer.
+		se = transport.StreamEvent{Kind: transport.StreamEventReset}
 	case PassiveEventDisconnected:
-		// Deliver as reset so passive tap sees the boundary.
+		// Deliver as reset: a disconnect is a stream boundary. Any partial
+		// frame in flight is now incomplete and must be discarded by the
+		// consumer's reconstructor.
 		se = transport.StreamEvent{Kind: transport.StreamEventReset}
 	default:
 		return

--- a/internal/adaptermux/passive_transport_test.go
+++ b/internal/adaptermux/passive_transport_test.go
@@ -1,0 +1,193 @@
+package adaptermux
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+// TestDeliver_AllEventKinds verifies that every PassiveEventKind is
+// mapped to the correct StreamEvent. In particular, PassiveEventConnected
+// must NOT be dropped — it must surface as StreamEventReset so the
+// passive reconstructor sees the reconnect boundary.
+func TestDeliver_AllEventKinds(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    PassiveEvent
+		wantKind transport.StreamEventKind
+		wantByte byte
+		wantDrop bool // true if the event should be silently dropped
+	}{
+		{
+			name:     "symbol",
+			input:    PassiveEvent{Kind: PassiveEventSymbol, Symbol: 0x42},
+			wantKind: transport.StreamEventByte,
+			wantByte: 0x42,
+		},
+		{
+			name:     "reset",
+			input:    PassiveEvent{Kind: PassiveEventReset},
+			wantKind: transport.StreamEventReset,
+		},
+		{
+			name:     "connected maps to reset boundary",
+			input:    PassiveEvent{Kind: PassiveEventConnected},
+			wantKind: transport.StreamEventReset,
+		},
+		{
+			name:     "disconnected maps to reset boundary",
+			input:    PassiveEvent{Kind: PassiveEventDisconnected},
+			wantKind: transport.StreamEventReset,
+		},
+		{
+			name:     "unknown kind is dropped",
+			input:    PassiveEvent{Kind: PassiveEventKind(99)},
+			wantDrop: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pt := newPassiveTransport()
+			defer pt.Close()
+
+			pt.deliver(tt.input)
+
+			if tt.wantDrop {
+				// Channel must be empty.
+				select {
+				case ev := <-pt.events:
+					t.Fatalf("expected event to be dropped, got %+v", ev)
+				default:
+					// Good — nothing delivered.
+				}
+				return
+			}
+
+			select {
+			case ev := <-pt.events:
+				if ev.Kind != tt.wantKind {
+					t.Errorf("Kind = %d, want %d", ev.Kind, tt.wantKind)
+				}
+				if tt.wantKind == transport.StreamEventByte && ev.Byte != tt.wantByte {
+					t.Errorf("Byte = 0x%02X, want 0x%02X", ev.Byte, tt.wantByte)
+				}
+			default:
+				t.Fatal("expected event to be delivered, channel empty")
+			}
+		})
+	}
+}
+
+// TestDeliver_ConnectDisconnectCycle verifies that a full adapter
+// reconnect cycle (disconnect + connect) produces two reset events,
+// so the passive reconstructor sees both boundaries.
+func TestDeliver_ConnectDisconnectCycle(t *testing.T) {
+	pt := newPassiveTransport()
+	defer pt.Close()
+
+	// Simulate: symbols -> disconnect -> connect -> symbols
+	pt.deliver(PassiveEvent{Kind: PassiveEventSymbol, Symbol: 0xAA})
+	pt.deliver(PassiveEvent{Kind: PassiveEventDisconnected})
+	pt.deliver(PassiveEvent{Kind: PassiveEventConnected})
+	pt.deliver(PassiveEvent{Kind: PassiveEventSymbol, Symbol: 0xBB})
+
+	expected := []struct {
+		kind transport.StreamEventKind
+		b    byte
+	}{
+		{transport.StreamEventByte, 0xAA},
+		{transport.StreamEventReset, 0},
+		{transport.StreamEventReset, 0},
+		{transport.StreamEventByte, 0xBB},
+	}
+
+	for i, want := range expected {
+		select {
+		case ev := <-pt.events:
+			if ev.Kind != want.kind {
+				t.Errorf("event[%d]: Kind = %d, want %d", i, ev.Kind, want.kind)
+			}
+			if want.kind == transport.StreamEventByte && ev.Byte != want.b {
+				t.Errorf("event[%d]: Byte = 0x%02X, want 0x%02X", i, ev.Byte, want.b)
+			}
+		default:
+			t.Fatalf("event[%d]: expected event, channel empty", i)
+		}
+	}
+}
+
+// TestDeliver_ClosedTransportDropsEvents verifies that deliver() is a
+// no-op after Close().
+func TestDeliver_ClosedTransportDropsEvents(t *testing.T) {
+	pt := newPassiveTransport()
+	pt.Close()
+
+	pt.deliver(PassiveEvent{Kind: PassiveEventSymbol, Symbol: 0xFF})
+	pt.deliver(PassiveEvent{Kind: PassiveEventConnected})
+	pt.deliver(PassiveEvent{Kind: PassiveEventDisconnected})
+
+	select {
+	case ev := <-pt.events:
+		t.Fatalf("expected no events after close, got %+v", ev)
+	default:
+		// Good.
+	}
+}
+
+// TestReadEvent_ReturnsResetForConnectDisconnect verifies that ReadEvent
+// surfaces connect/disconnect as StreamEventReset (end-to-end through
+// the ReadEvent interface, not just the channel).
+func TestReadEvent_ReturnsResetForConnectDisconnect(t *testing.T) {
+	pt := newPassiveTransport()
+	defer pt.Close()
+
+	pt.deliver(PassiveEvent{Kind: PassiveEventDisconnected})
+	pt.deliver(PassiveEvent{Kind: PassiveEventConnected})
+
+	for i, label := range []string{"disconnect", "connect"} {
+		ev, err := pt.ReadEvent()
+		if err != nil {
+			t.Fatalf("ReadEvent[%d/%s]: unexpected error: %v", i, label, err)
+		}
+		if ev.Kind != transport.StreamEventReset {
+			t.Errorf("ReadEvent[%d/%s]: Kind = %d, want StreamEventReset(%d)",
+				i, label, ev.Kind, transport.StreamEventReset)
+		}
+	}
+}
+
+// TestDeliver_BufferOverflowDropsOldest verifies the backpressure
+// strategy: when the buffer is full, the oldest event is dropped to
+// make room for the new one.
+func TestDeliver_BufferOverflowDropsOldest(t *testing.T) {
+	pt := &passiveTransport{
+		events: make(chan transport.StreamEvent, 2), // tiny buffer
+		done:   make(chan struct{}),
+	}
+	defer pt.Close()
+
+	// Fill buffer.
+	pt.deliver(PassiveEvent{Kind: PassiveEventSymbol, Symbol: 0x01})
+	pt.deliver(PassiveEvent{Kind: PassiveEventSymbol, Symbol: 0x02})
+
+	// Overflow — oldest (0x01) should be dropped.
+	pt.deliver(PassiveEvent{Kind: PassiveEventSymbol, Symbol: 0x03})
+
+	// Drain: expect 0x02 then 0x03.
+	timeout := time.After(100 * time.Millisecond)
+	var got []byte
+	for i := 0; i < 2; i++ {
+		select {
+		case ev := <-pt.events:
+			got = append(got, ev.Byte)
+		case <-timeout:
+			t.Fatalf("timed out waiting for event %d", i)
+		}
+	}
+
+	if len(got) != 2 || got[0] != 0x02 || got[1] != 0x03 {
+		t.Errorf("got %v, want [0x02, 0x03]", got)
+	}
+}

--- a/internal/adaptermux/pr472_regression_test.go
+++ b/internal/adaptermux/pr472_regression_test.go
@@ -1,0 +1,505 @@
+package adaptermux
+
+import (
+	"context"
+	"io"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+// --- Fix 1 regression: handleReset schedules delayed re-INIT ---
+
+// mockInitTransport is a RawTransport that records Init calls.
+// It satisfies both RawTransport and the Init(byte)error interface.
+type mockInitTransport struct {
+	mu        sync.Mutex
+	initCalls []byte // features bytes passed to Init
+	readCh    chan byte
+	closed    bool
+}
+
+func newMockInitTransport() *mockInitTransport {
+	return &mockInitTransport{
+		readCh: make(chan byte, 256),
+	}
+}
+
+func (m *mockInitTransport) Init(features byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.initCalls = append(m.initCalls, features)
+	return nil
+}
+
+func (m *mockInitTransport) ReadByte() (byte, error) {
+	b, ok := <-m.readCh
+	if !ok {
+		return 0, io.EOF
+	}
+	return b, nil
+}
+
+func (m *mockInitTransport) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func (m *mockInitTransport) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !m.closed {
+		m.closed = true
+		close(m.readCh)
+	}
+	return nil
+}
+
+func (m *mockInitTransport) getInitCalls() []byte {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([]byte, len(m.initCalls))
+	copy(result, m.initCalls)
+	return result
+}
+
+// TestHandleReset_SchedulesDelayedReINIT verifies that handleReset()
+// spawns a goroutine that calls Init on the upstream transport after
+// a 200ms stabilization delay. Without the fix, no re-INIT occurs
+// after in-band RESETTED and the transport stays in reset state.
+func TestHandleReset_SchedulesDelayedReINIT(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mock := newMockInitTransport()
+
+	mux := New(Config{
+		Protocol:    "enh",
+		Network:     "tcp",
+		Address:     "127.0.0.1:0", // not used — we inject the transport
+		ReadTimeout: 200 * time.Millisecond,
+	})
+	mux.ctx, mux.cancel = ctx, cancel
+
+	// Inject mock transport and set upstream features.
+	mux.connMu.Lock()
+	mux.upstream = mock
+	mux.connMu.Unlock()
+	mux.upstreamFeatures.Store(0x01)
+
+	// Verify no Init calls before handleReset.
+	if calls := mock.getInitCalls(); len(calls) != 0 {
+		t.Fatalf("expected 0 Init calls before handleReset, got %d", len(calls))
+	}
+
+	// Trigger handleReset — this should schedule a delayed re-INIT.
+	mux.handleReset()
+
+	// Before 200ms, no re-INIT should have occurred.
+	time.Sleep(50 * time.Millisecond)
+	if calls := mock.getInitCalls(); len(calls) != 0 {
+		t.Fatalf("expected 0 Init calls 50ms after handleReset, got %d", len(calls))
+	}
+
+	// After 300ms (200ms delay + margin), exactly 1 re-INIT should occur.
+	time.Sleep(250 * time.Millisecond)
+	calls := mock.getInitCalls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 Init call 300ms after handleReset, got %d", len(calls))
+	}
+	if calls[0] != 0x01 {
+		t.Fatalf("re-INIT features = 0x%02x, want 0x01", calls[0])
+	}
+
+	// Cleanup: cancel context and wait for goroutines.
+	cancel()
+	mux.wg.Wait()
+}
+
+// TestHandleReset_ReINITCancelledOnShutdown verifies that the delayed
+// re-INIT goroutine exits cleanly when the mux context is cancelled
+// during the 200ms wait.
+func TestHandleReset_ReINITCancelledOnShutdown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	mock := newMockInitTransport()
+
+	mux := New(Config{
+		Protocol:    "enh",
+		Network:     "tcp",
+		Address:     "127.0.0.1:0",
+		ReadTimeout: 200 * time.Millisecond,
+	})
+	mux.ctx, mux.cancel = ctx, cancel
+
+	mux.connMu.Lock()
+	mux.upstream = mock
+	mux.connMu.Unlock()
+	mux.upstreamFeatures.Store(0x01)
+
+	mux.handleReset()
+
+	// Cancel context before the 200ms delay elapses.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	// Wait for all goroutines to finish.
+	done := make(chan struct{})
+	go func() {
+		mux.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("re-INIT goroutine did not exit after context cancel")
+	}
+
+	// No Init calls should have been made.
+	if calls := mock.getInitCalls(); len(calls) != 0 {
+		t.Fatalf("expected 0 Init calls after early cancel, got %d", len(calls))
+	}
+}
+
+// TestHandleReset_ReINITFallsBackToDefault verifies that when
+// upstreamFeatures is 0 (e.g. ENS transport), the re-INIT uses
+// the default features byte 0x01.
+func TestHandleReset_ReINITFallsBackToDefault(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mock := newMockInitTransport()
+
+	mux := New(Config{
+		Protocol:    "enh",
+		Network:     "tcp",
+		Address:     "127.0.0.1:0",
+		ReadTimeout: 200 * time.Millisecond,
+	})
+	mux.ctx, mux.cancel = ctx, cancel
+
+	mux.connMu.Lock()
+	mux.upstream = mock
+	mux.connMu.Unlock()
+	mux.upstreamFeatures.Store(0) // unknown features
+
+	mux.handleReset()
+
+	time.Sleep(300 * time.Millisecond)
+
+	calls := mock.getInitCalls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 Init call, got %d", len(calls))
+	}
+	if calls[0] != 0x01 {
+		t.Fatalf("fallback re-INIT features = 0x%02x, want 0x01", calls[0])
+	}
+
+	cancel()
+	mux.wg.Wait()
+}
+
+// --- Fix 2 regression: START cancel releases ownership ---
+
+// TestSession_StartCancelReleasesOwnership verifies that sending
+// START with SYN (0xAA) not only cancels the pending request but
+// also releases bus ownership if the session already owns the bus.
+// Without the fix, a session that owns the bus and sends START 0xAA
+// would retain ownership, blocking other sessions indefinitely.
+func TestSession_StartCancelReleasesOwnership(t *testing.T) {
+	mux, _, cleanup := newTestMux(t)
+	defer cleanup()
+
+	client, server := net.Pipe()
+	defer client.Close()
+
+	id := mux.AddSession(server)
+	defer mux.RemoveSession(id)
+
+	// Step 1: Request START and grant ownership to this session.
+	startReq := transport.EncodeENH(transport.ENHReqStart, 0x31)
+	if _, err := client.Write(startReq[:]); err != nil {
+		t.Fatalf("write START: %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Grant ownership via arbitrator.
+	sessionID, initiator, notify, granted := mux.arb.tryGrant()
+	if !granted {
+		t.Fatal("expected grant from arbitrator")
+	}
+	if sessionID != id {
+		t.Fatalf("granted to session %d, want %d", sessionID, id)
+	}
+
+	// Simulate successful adapter START.
+	notify <- startResult{granted: true, initiator: initiator}
+
+	// Drain the STARTED response.
+	_ = readENHFrame(t, client, 2*time.Second)
+
+	// Verify session now owns the bus.
+	if !mux.arb.isOwner(id) {
+		t.Fatal("session should own the bus after grant")
+	}
+
+	// Step 2: Send START with SYN to cancel+release.
+	cancelReq := transport.EncodeENH(transport.ENHReqStart, protocol.SymbolSyn)
+	if _, err := client.Write(cancelReq[:]); err != nil {
+		t.Fatalf("write START cancel: %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Step 3: Verify ownership is released.
+	if mux.arb.isOwner(id) {
+		t.Fatal("session should NOT own the bus after START cancel (SYN) — ownership was not released")
+	}
+}
+
+// --- Fix 4 regression: broadcastResetToSessions carries features ---
+
+// TestBroadcastReset_CarriesUpstreamFeatures verifies that
+// broadcastResetToSessions() sends the actual upstream features byte
+// to external sessions, not 0x00. Without the fix, sessions receive
+// 0x00 on reset boundaries regardless of the negotiated features.
+func TestBroadcastReset_CarriesUpstreamFeatures(t *testing.T) {
+	mux, _, cleanup := newTestMux(t)
+	defer cleanup()
+
+	// Set upstream features to 0x03 (non-default value).
+	mux.upstreamFeatures.Store(0x03)
+
+	client, server := net.Pipe()
+	defer client.Close()
+
+	id := mux.AddSession(server)
+	defer mux.RemoveSession(id)
+
+	// Trigger reset broadcast.
+	mux.broadcastResetToSessions()
+
+	// Read the RESETTED frame from the session.
+	frame := readENHFrame(t, client, 2*time.Second)
+
+	// Should carry 0x03, not 0x00.
+	expected := transport.EncodeENH(transport.ENHResResetted, 0x03)
+	if frame != expected {
+		t.Fatalf("RESETTED frame = %x, want %x (upstream features 0x03)", frame, expected)
+	}
+
+	// Verify it is NOT the old 0x00 behavior.
+	old := transport.EncodeENH(transport.ENHResResetted, 0x00)
+	if frame == old {
+		t.Fatal("RESETTED broadcast still sends 0x00 — fix not applied")
+	}
+}
+
+// TestBroadcastReset_ZeroFeaturesPassesThrough verifies that when
+// upstreamFeatures is 0 (e.g. ENS transport), the broadcast sends
+// 0x00 (which is correct — no features negotiated).
+func TestBroadcastReset_ZeroFeaturesPassesThrough(t *testing.T) {
+	mux, _, cleanup := newTestMux(t)
+	defer cleanup()
+
+	// Force upstream features to 0.
+	mux.upstreamFeatures.Store(0)
+
+	client, server := net.Pipe()
+	defer client.Close()
+
+	id := mux.AddSession(server)
+	defer mux.RemoveSession(id)
+
+	mux.broadcastResetToSessions()
+
+	frame := readENHFrame(t, client, 2*time.Second)
+	expected := transport.EncodeENH(transport.ENHResResetted, 0x00)
+	if frame != expected {
+		t.Fatalf("RESETTED frame = %x, want %x (zero features)", frame, expected)
+	}
+}
+
+// TestBroadcastReset_MultipleSessionsAllGetFeatures verifies that
+// all connected sessions receive the upstream features on reset.
+func TestBroadcastReset_MultipleSessionsAllGetFeatures(t *testing.T) {
+	mux, _, cleanup := newTestMux(t)
+	defer cleanup()
+
+	mux.upstreamFeatures.Store(0x05)
+
+	const numSessions = 3
+	type sessConn struct {
+		client net.Conn
+		id     uint64
+	}
+	sessions := make([]sessConn, numSessions)
+
+	for i := 0; i < numSessions; i++ {
+		client, server := net.Pipe()
+		id := mux.AddSession(server)
+		sessions[i] = sessConn{client: client, id: id}
+	}
+	defer func() {
+		for _, sc := range sessions {
+			mux.RemoveSession(sc.id)
+			sc.client.Close()
+		}
+	}()
+
+	mux.broadcastResetToSessions()
+
+	expected := transport.EncodeENH(transport.ENHResResetted, 0x05)
+	for i, sc := range sessions {
+		frame := readENHFrame(t, sc.client, 2*time.Second)
+		if frame != expected {
+			t.Fatalf("session %d: RESETTED frame = %x, want %x", i, frame, expected)
+		}
+	}
+}
+
+// --- Fix 1+4 combined: handleReset triggers broadcast with features ---
+
+// TestHandleReset_BroadcastCarriesFeatures verifies the end-to-end
+// path: handleReset() calls broadcastResetToSessions() which now
+// sends upstreamFeatures. This catches regressions in both the
+// handleReset path and the broadcast features fix working together.
+func TestHandleReset_BroadcastCarriesFeatures(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mock := newMockInitTransport()
+
+	mux := New(Config{
+		Protocol:    "enh",
+		Network:     "tcp",
+		Address:     "127.0.0.1:0",
+		ReadTimeout: 200 * time.Millisecond,
+	})
+	mux.ctx, mux.cancel = ctx, cancel
+
+	mux.connMu.Lock()
+	mux.upstream = mock
+	mux.connMu.Unlock()
+	mux.upstreamFeatures.Store(0x07)
+
+	// Add a session.
+	client, server := net.Pipe()
+	defer client.Close()
+	id := mux.AddSession(server)
+	defer mux.RemoveSession(id)
+
+	// Trigger handleReset.
+	mux.handleReset()
+
+	// Session should receive RESETTED with features 0x07.
+	frame := readENHFrame(t, client, 2*time.Second)
+	expected := transport.EncodeENH(transport.ENHResResetted, 0x07)
+	if frame != expected {
+		t.Fatalf("RESETTED after handleReset = %x, want %x (features 0x07)", frame, expected)
+	}
+
+	// Wait for re-INIT goroutine to complete.
+	cancel()
+	mux.wg.Wait()
+}
+
+// --- Fix 2: START cancel without prior ownership is harmless ---
+
+// TestSession_StartCancelWithoutOwnershipIsNoOp verifies that sending
+// START cancel (SYN) when the session does NOT own the bus is harmless
+// (no panic, no state corruption).
+func TestSession_StartCancelWithoutOwnershipIsNoOp(t *testing.T) {
+	mux, _, cleanup := newTestMux(t)
+	defer cleanup()
+
+	client, server := net.Pipe()
+	defer client.Close()
+
+	id := mux.AddSession(server)
+	defer mux.RemoveSession(id)
+
+	// Session does not own the bus. Send START cancel — should be a no-op.
+	cancelReq := transport.EncodeENH(transport.ENHReqStart, protocol.SymbolSyn)
+	if _, err := client.Write(cancelReq[:]); err != nil {
+		t.Fatalf("write START cancel: %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	// No ownership should exist.
+	if mux.arb.isOwner(id) {
+		t.Fatal("session should not own bus after cancel-only (no prior ownership)")
+	}
+
+	// Mux should still be functional — verify by requesting a new START.
+	startReq := transport.EncodeENH(transport.ENHReqStart, 0x42)
+	if _, err := client.Write(startReq[:]); err != nil {
+		t.Fatalf("write START after cancel: %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	if !mux.arb.hasPending() {
+		t.Fatal("expected pending START after post-cancel request")
+	}
+}
+
+// --- Fix 4: concurrent safety of broadcastResetToSessions ---
+
+// TestBroadcastReset_ConcurrentFeatureUpdate verifies that reading
+// upstreamFeatures in broadcastResetToSessions is safe under
+// concurrent atomic updates (race detector validation).
+func TestBroadcastReset_ConcurrentFeatureUpdate(t *testing.T) {
+	mux, _, cleanup := newTestMux(t)
+	defer cleanup()
+
+	mux.upstreamFeatures.Store(0x01)
+
+	client, server := net.Pipe()
+	defer client.Close()
+
+	id := mux.AddSession(server)
+	defer mux.RemoveSession(id)
+
+	// Read responses in background to prevent send buffer overflow.
+	var received atomic.Int32
+	go func() {
+		buf := make([]byte, 2)
+		for {
+			_, err := io.ReadFull(client, buf)
+			if err != nil {
+				return
+			}
+			received.Add(1)
+		}
+	}()
+
+	// Concurrently update features while broadcasting.
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			mux.upstreamFeatures.Store(uint32(i % 256))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			mux.broadcastResetToSessions()
+		}
+	}()
+	wg.Wait()
+
+	// Give reader time to drain.
+	time.Sleep(100 * time.Millisecond)
+
+	if received.Load() == 0 {
+		t.Fatal("expected at least one broadcast to be received")
+	}
+}

--- a/internal/adaptermux/pr472_regression_test.go
+++ b/internal/adaptermux/pr472_regression_test.go
@@ -2,6 +2,8 @@ package adaptermux
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"net"
 	"sync"
@@ -236,6 +238,9 @@ func TestSession_StartCancelReleasesOwnership(t *testing.T) {
 	if sessionID != id {
 		t.Fatalf("granted to session %d, want %d", sessionID, id)
 	}
+
+	// Confirm ownership after successful adapter START.
+	mux.arb.confirmOwnership(sessionID, initiator)
 
 	// Simulate successful adapter START.
 	notify <- startResult{granted: true, initiator: initiator}
@@ -538,10 +543,11 @@ func TestSession_SendErrorFromDoSend_NotConnected(t *testing.T) {
 
 	// Grant ownership to this session so it passes the pre-check.
 	ch := mux.arb.requestStart(id, 0x31)
-	_, _, notify, granted := mux.arb.tryGrant()
+	_, initiator, notify, granted := mux.arb.tryGrant()
 	if !granted {
 		t.Fatal("expected grant")
 	}
+	mux.arb.confirmOwnership(id, initiator)
 	notify <- startResult{granted: true, initiator: 0x31}
 	<-ch // drain the result
 
@@ -625,4 +631,338 @@ func TestAddSession_AcceptsBeforeShutdown(t *testing.T) {
 	if !ok {
 		t.Fatalf("session %d not found in sessions map", id)
 	}
+}
+
+// --- Codex P1 #3060199707: ownership not set until START succeeds ---
+
+// TestOwnership_NotSetUntilStartSucceeds verifies that tryGrant does
+// NOT set hasOwner/currentOwner. Ownership is only confirmed after
+// confirmOwnership is called (simulating adapter START success).
+// Without the fix, a client could SEND before the adapter confirms.
+func TestOwnership_NotSetUntilStartSucceeds(t *testing.T) {
+	arb := newArbitrator()
+
+	arb.requestStart(1, 0x31)
+
+	// tryGrant selects the winner but must NOT set ownership.
+	sessionID, initiator, _, granted := arb.tryGrant()
+	if !granted {
+		t.Fatal("expected grant")
+	}
+	if sessionID != 1 {
+		t.Fatalf("sessionID = %d, want 1", sessionID)
+	}
+
+	// Ownership must NOT be set yet.
+	if arb.isOwner(1) {
+		t.Fatal("isOwner returned true after tryGrant — ownership must not be set until confirmOwnership")
+	}
+	_, _, owned := arb.owner()
+	if owned {
+		t.Fatal("owner() reports owned=true after tryGrant — must be false until confirmOwnership")
+	}
+
+	// Confirm ownership (simulating adapter START success).
+	arb.confirmOwnership(sessionID, initiator)
+
+	// Now ownership must be set.
+	if !arb.isOwner(1) {
+		t.Fatal("isOwner returned false after confirmOwnership")
+	}
+	ownerID, ownerInit, owned := arb.owner()
+	if !owned {
+		t.Fatal("owner() reports owned=false after confirmOwnership")
+	}
+	if ownerID != 1 {
+		t.Fatalf("owner sessionID = %d, want 1", ownerID)
+	}
+	if ownerInit != 0x31 {
+		t.Fatalf("owner initiator = 0x%02x, want 0x31", ownerInit)
+	}
+}
+
+// TestOwnership_FailurePathNeverSetsOwnership verifies that when
+// adapter START fails, ownership is never set — no need for
+// releaseOwnership cleanup.
+func TestOwnership_FailurePathNeverSetsOwnership(t *testing.T) {
+	arb := newArbitrator()
+
+	ch := arb.requestStart(1, 0x31)
+
+	_, _, notify, granted := arb.tryGrant()
+	if !granted {
+		t.Fatal("expected grant")
+	}
+
+	// Simulate failure — do NOT call confirmOwnership.
+	notify <- startResult{granted: false, initiator: 0x31, err: errors.New("adapter refused")}
+
+	select {
+	case result := <-ch:
+		if result.granted {
+			t.Fatal("should not be granted after failure")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+
+	// Bus must be free for a new grant.
+	if arb.isOwner(1) {
+		t.Fatal("ownership should never have been set")
+	}
+
+	// A second request should be immediately grantable.
+	arb.requestStart(2, 0x42)
+	sid, _, _, g := arb.tryGrant()
+	if !g {
+		t.Fatal("bus should be free for a new grant after failure")
+	}
+	if sid != 2 {
+		t.Fatalf("second grant sessionID = %d, want 2", sid)
+	}
+}
+
+// --- Codex P1 #3060199712: reset not dropped under buffer pressure ---
+
+// TestPassiveTransport_ResetNotDroppedUnderPressure verifies that when
+// the passive transport buffer is full, a reset event is still delivered
+// (blocks until consumed). Without the fix, the reset boundary could be
+// dropped and pre/post-reset streams would merge.
+func TestPassiveTransport_ResetNotDroppedUnderPressure(t *testing.T) {
+	// Tiny buffer to force pressure.
+	pt := &passiveTransport{
+		events: make(chan transport.StreamEvent, 2),
+		done:   make(chan struct{}),
+	}
+	defer pt.Close()
+
+	// Fill buffer completely with symbols.
+	pt.deliver(PassiveEvent{Kind: PassiveEventSymbol, Symbol: 0x01})
+	pt.deliver(PassiveEvent{Kind: PassiveEventSymbol, Symbol: 0x02})
+
+	// Buffer is now full. Deliver a reset — it must NOT be dropped.
+	// The reset uses a blocking send, so we need a consumer goroutine.
+	resetDelivered := make(chan struct{})
+	go func() {
+		pt.deliver(PassiveEvent{Kind: PassiveEventReset})
+		close(resetDelivered)
+	}()
+
+	// Consume events. The reset must appear in the stream.
+	var gotReset bool
+	timeout := time.After(2 * time.Second)
+	for i := 0; i < 3; i++ {
+		select {
+		case ev := <-pt.events:
+			if ev.Kind == transport.StreamEventReset {
+				gotReset = true
+			}
+		case <-timeout:
+			t.Fatalf("timed out waiting for event %d", i)
+		}
+	}
+
+	// Wait for deliver goroutine to finish.
+	select {
+	case <-resetDelivered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reset deliver goroutine did not finish")
+	}
+
+	if !gotReset {
+		t.Fatal("reset event was dropped under buffer pressure — stream boundary lost")
+	}
+}
+
+// TestPassiveTransport_ResetBlocksUntilConsumed verifies that delivering
+// a reset to a full buffer blocks (does not silently drop) and unblocks
+// once the consumer drains a slot.
+func TestPassiveTransport_ResetBlocksUntilConsumed(t *testing.T) {
+	pt := &passiveTransport{
+		events: make(chan transport.StreamEvent, 1),
+		done:   make(chan struct{}),
+	}
+	defer pt.Close()
+
+	// Fill the single-slot buffer.
+	pt.deliver(PassiveEvent{Kind: PassiveEventSymbol, Symbol: 0xFF})
+
+	// Deliver reset in background — it should block.
+	delivered := make(chan struct{})
+	go func() {
+		pt.deliver(PassiveEvent{Kind: PassiveEventReset})
+		close(delivered)
+	}()
+
+	// Verify it is blocked (not yet delivered).
+	select {
+	case <-delivered:
+		t.Fatal("reset was delivered immediately to a full buffer — should block")
+	case <-time.After(50 * time.Millisecond):
+		// Good — still blocking.
+	}
+
+	// Consume the symbol to free a slot.
+	ev := <-pt.events
+	if ev.Kind != transport.StreamEventByte || ev.Byte != 0xFF {
+		t.Fatalf("expected symbol 0xFF, got %+v", ev)
+	}
+
+	// Now the reset should unblock and be delivered.
+	select {
+	case <-delivered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reset deliver did not unblock after consumer drained buffer")
+	}
+
+	// Read the reset.
+	ev = <-pt.events
+	if ev.Kind != transport.StreamEventReset {
+		t.Fatalf("expected reset, got %+v", ev)
+	}
+}
+
+// TestPassiveTransport_ConnectedDisconnectedNonDroppable verifies that
+// PassiveEventConnected and PassiveEventDisconnected (which map to
+// StreamEventReset) are also non-droppable under buffer pressure.
+func TestPassiveTransport_ConnectedDisconnectedNonDroppable(t *testing.T) {
+	pt := &passiveTransport{
+		events: make(chan transport.StreamEvent, 1),
+		done:   make(chan struct{}),
+	}
+	defer pt.Close()
+
+	// Fill buffer.
+	pt.deliver(PassiveEvent{Kind: PassiveEventSymbol, Symbol: 0xAA})
+
+	// Deliver Connected (maps to reset) in background.
+	delivered := make(chan struct{})
+	go func() {
+		pt.deliver(PassiveEvent{Kind: PassiveEventConnected})
+		close(delivered)
+	}()
+
+	// Should block.
+	select {
+	case <-delivered:
+		t.Fatal("connected event delivered immediately to full buffer")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Drain and verify.
+	<-pt.events // consume symbol
+	select {
+	case <-delivered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("connected event did not unblock")
+	}
+
+	ev := <-pt.events
+	if ev.Kind != transport.StreamEventReset {
+		t.Fatalf("expected reset from Connected event, got %+v", ev)
+	}
+}
+
+// --- Codex P2 #3060199716: adapter write failures classified as host errors ---
+
+// TestDoSend_AdapterWriteFailure_IsHostError verifies that when the
+// adapter write fails, the error wraps errAdapterWrite (a sentinel) and
+// handleSend classifies it as ErrorHost, not ErrorEBUS.
+func TestDoSend_AdapterWriteFailure_IsHostError(t *testing.T) {
+	// Verify sentinel wrapping.
+	innerErr := fmt.Errorf("connection reset by peer")
+	wrapped := fmt.Errorf("%w: %v", errAdapterWrite, innerErr)
+	if !errors.Is(wrapped, errAdapterWrite) {
+		t.Fatal("wrapped error does not match errAdapterWrite sentinel")
+	}
+}
+
+// TestSession_AdapterWriteFailure_ReturnsErrorHost is an end-to-end
+// test verifying that when the adapter transport's Write fails, the
+// session receives ENHResErrorHost (not ENHResErrorEBUS).
+func TestSession_AdapterWriteFailure_ReturnsErrorHost(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create a failing transport: reads block, writes always fail.
+	failTr := &failWriteTransport{
+		readCh: make(chan byte, 256),
+	}
+
+	mux := New(Config{
+		Protocol:    "enh",
+		Network:     "tcp",
+		Address:     "127.0.0.1:0",
+		ReadTimeout: 200 * time.Millisecond,
+	})
+	mux.ctx, mux.cancel = ctx, cancel
+
+	// Inject the failing transport.
+	mux.connMu.Lock()
+	mux.upstream = failTr
+	mux.connMu.Unlock()
+	mux.upstreamFeatures.Store(0x01)
+
+	// Start sendLoop.
+	mux.wg.Add(1)
+	go mux.sendLoop()
+
+	client, server := net.Pipe()
+	defer client.Close()
+
+	id := mux.AddSession(server)
+	if id == 0 {
+		t.Fatal("AddSession returned 0")
+	}
+	defer mux.RemoveSession(id)
+
+	// Grant ownership to the session.
+	ch := mux.arb.requestStart(id, 0x31)
+	_, initiator, notify, granted := mux.arb.tryGrant()
+	if !granted {
+		t.Fatal("expected grant")
+	}
+	mux.arb.confirmOwnership(id, initiator)
+	notify <- startResult{granted: true, initiator: 0x31}
+	<-ch
+
+	// Send a SEND command — Write will fail.
+	sendReq := transport.EncodeENH(transport.ENHReqSend, 0x42)
+	if _, err := client.Write(sendReq[:]); err != nil {
+		t.Fatalf("write SEND: %v", err)
+	}
+
+	// Read the error response.
+	frame := readENHFrame(t, client, 2*time.Second)
+
+	expectedHost := transport.EncodeENH(transport.ENHResErrorHost, 0x00)
+	expectedBus := transport.EncodeENH(transport.ENHResErrorEBUS, 0x00)
+
+	if frame == expectedBus {
+		t.Fatal("adapter write failure returned ErrorEBUS — should be ErrorHost (Codex P2 #3060199716)")
+	}
+	if frame != expectedHost {
+		t.Fatalf("error frame = %x, want %x (ErrorHost)", frame, expectedHost)
+	}
+}
+
+// failWriteTransport is a RawTransport where Write always fails.
+type failWriteTransport struct {
+	readCh chan byte
+}
+
+func (f *failWriteTransport) ReadByte() (byte, error) {
+	b, ok := <-f.readCh
+	if !ok {
+		return 0, io.EOF
+	}
+	return b, nil
+}
+
+func (f *failWriteTransport) Write(p []byte) (int, error) {
+	return 0, errors.New("simulated adapter write failure")
+}
+
+func (f *failWriteTransport) Close() error {
+	return nil
 }

--- a/internal/adaptermux/pr472_regression_test.go
+++ b/internal/adaptermux/pr472_regression_test.go
@@ -503,3 +503,126 @@ func TestBroadcastReset_ConcurrentFeatureUpdate(t *testing.T) {
 		t.Fatal("expected at least one broadcast to be received")
 	}
 }
+
+// --- Codex P2 #3060135587: SEND error classification (host vs bus) ---
+
+// TestSession_SendErrorFromDoSend_HostErrors verifies that when doSend
+// returns a host-side error (ownership lost between pre-check and
+// sendLoop, or adapter disconnected), handleSend delivers ErrorHost
+// instead of ErrorEBUS.
+func TestSession_SendErrorFromDoSend_NotConnected(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Build a mux with injected nil transport to trigger errNotConnected.
+	mux := New(Config{
+		Protocol:    "enh",
+		Network:     "tcp",
+		Address:     "127.0.0.1:0",
+		ReadTimeout: 200 * time.Millisecond,
+	})
+	mux.ctx, mux.cancel = ctx, cancel
+
+	// Start the sendLoop goroutine (normally done by Start).
+	mux.wg.Add(1)
+	go mux.sendLoop()
+
+	client, server := net.Pipe()
+	defer client.Close()
+
+	id := mux.AddSession(server)
+	if id == 0 {
+		t.Fatal("AddSession returned 0 unexpectedly")
+	}
+	defer mux.RemoveSession(id)
+
+	// Grant ownership to this session so it passes the pre-check.
+	ch := mux.arb.requestStart(id, 0x31)
+	_, _, notify, granted := mux.arb.tryGrant()
+	if !granted {
+		t.Fatal("expected grant")
+	}
+	notify <- startResult{granted: true, initiator: 0x31}
+	<-ch // drain the result
+
+	// upstream is nil (never connected) -- doSend will return errNotConnected.
+	// Send a SEND command.
+	sendReq := transport.EncodeENH(transport.ENHReqSend, 0x42)
+	if _, err := client.Write(sendReq[:]); err != nil {
+		t.Fatalf("write SEND: %v", err)
+	}
+
+	// Read the error response.
+	frame := readENHFrame(t, client, 2*time.Second)
+
+	// Must be ErrorHost, not ErrorEBUS.
+	expectedHost := transport.EncodeENH(transport.ENHResErrorHost, 0x00)
+	expectedBus := transport.EncodeENH(transport.ENHResErrorEBUS, 0x00)
+
+	if frame == expectedBus {
+		t.Fatal("SEND with nil transport returned ErrorEBUS — should be ErrorHost")
+	}
+	if frame != expectedHost {
+		t.Fatalf("SEND error frame = %x, want %x (ErrorHost)", frame, expectedHost)
+	}
+}
+
+// --- Codex P2 #3060135596: AddSession rejects after mux shutdown ---
+
+// TestAddSession_RejectsAfterShutdown verifies that AddSession returns 0
+// and closes the connection when the mux context is cancelled.
+func TestAddSession_RejectsAfterShutdown(t *testing.T) {
+	mux, cancel, cleanup := newTestMux(t)
+	defer cleanup()
+
+	// Cancel the mux context to simulate shutdown.
+	cancel()
+	time.Sleep(50 * time.Millisecond)
+
+	client, server := net.Pipe()
+	defer client.Close()
+
+	id := mux.AddSession(server)
+	if id != 0 {
+		t.Fatalf("AddSession returned %d after shutdown, want 0", id)
+	}
+
+	// The server-side conn should be closed by AddSession.
+	// Verify by attempting to write — should fail.
+	_, err := server.Write([]byte{0x42})
+	if err == nil {
+		t.Fatal("expected write to closed conn to fail, but it succeeded")
+	}
+
+	// No sessions should be registered.
+	mux.sessionsMu.Lock()
+	count := len(mux.sessions)
+	mux.sessionsMu.Unlock()
+	if count != 0 {
+		t.Fatalf("expected 0 sessions after shutdown rejection, got %d", count)
+	}
+}
+
+// TestAddSession_AcceptsBeforeShutdown verifies normal operation —
+// AddSession returns a non-zero ID when the mux is running.
+func TestAddSession_AcceptsBeforeShutdown(t *testing.T) {
+	mux, _, cleanup := newTestMux(t)
+	defer cleanup()
+
+	client, server := net.Pipe()
+	defer client.Close()
+
+	id := mux.AddSession(server)
+	if id == 0 {
+		t.Fatal("AddSession returned 0 on a running mux")
+	}
+	defer mux.RemoveSession(id)
+
+	// Session should be registered.
+	mux.sessionsMu.Lock()
+	_, ok := mux.sessions[id]
+	mux.sessionsMu.Unlock()
+	if !ok {
+		t.Fatalf("session %d not found in sessions map", id)
+	}
+}

--- a/internal/adaptermux/session.go
+++ b/internal/adaptermux/session.go
@@ -268,7 +268,7 @@ func (s *session) handleSend(data byte) {
 	case err := <-result:
 		if err != nil {
 			s.mux.logger.Printf("adaptermux: session %d SEND error: %v", s.id, err)
-			if errors.Is(err, errNotBusOwner) || errors.Is(err, errNotConnected) {
+			if errors.Is(err, errNotBusOwner) || errors.Is(err, errNotConnected) || errors.Is(err, errAdapterWrite) {
 				s.deliverErrorHost()
 			} else {
 				s.deliverError()

--- a/internal/adaptermux/session.go
+++ b/internal/adaptermux/session.go
@@ -1,0 +1,407 @@
+package adaptermux
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+const (
+	// defaultSessionSendBuffer is the default send channel capacity
+	// for external sessions. If the buffer fills, the session is
+	// forcibly closed (backpressure protection, from proxy convention).
+	defaultSessionSendBuffer = 8192
+)
+
+// session represents an external ENH client connected via the proxy
+// endpoint (e.g., ebusd). Each session has its own echo tracker and
+// send buffer.
+type session struct {
+	id          uint64
+	conn        net.Conn
+	mux         *Mux
+	echoTracker *echoTracker
+
+	// sendCh buffers outgoing frames (ENHResReceived bytes) for the
+	// session's writer goroutine. Overflow causes session close.
+	sendCh chan sessionFrame
+
+	// done is closed by session.close() to signal writeLoop to exit.
+	// Unlike closing sendCh (which panics on concurrent sends), this
+	// is safe because only close() writes to it.
+	done chan struct{}
+
+	// closed tracks whether the session has been shut down.
+	closed atomic.Bool
+
+	// wg waits for reader, writer, and handleStart goroutines to finish.
+	wg sync.WaitGroup
+}
+
+// sessionFrame is a frame to deliver to an external session.
+type sessionFrame struct {
+	kind    sessionFrameKind
+	payload byte
+}
+
+type sessionFrameKind uint8
+
+const (
+	sessionFrameReceived  sessionFrameKind = iota // ENHResReceived(byte)
+	sessionFrameStarted                           // ENHResStarted
+	sessionFrameFailed                            // ENHResFailed
+	sessionFrameResetted                          // ENHResResetted
+	sessionFrameErrorEBUS                         // ENHResErrorEBUS
+)
+
+// AddSession registers an external TCP connection as an ENH session.
+// Returns the session ID. The session starts reader and writer goroutines.
+func (m *Mux) AddSession(conn net.Conn) uint64 {
+	id := m.nextSessionID()
+	sess := &session{
+		id:          id,
+		conn:        conn,
+		mux:         m,
+		echoTracker: newEchoTracker(),
+		sendCh:      make(chan sessionFrame, defaultSessionSendBuffer),
+		done:        make(chan struct{}),
+	}
+
+	m.sessionsMu.Lock()
+	m.sessions[id] = sess
+	m.sessionsMu.Unlock()
+
+	sess.wg.Add(2)
+	go sess.readLoop()  // goroutine: reads ENH commands from client
+	go sess.writeLoop() // goroutine: writes ENH responses to client
+
+	m.logger.Printf("adaptermux: session %d connected from %s", id, conn.RemoteAddr())
+	return id
+}
+
+// RemoveSession disconnects and cleans up an external session.
+func (m *Mux) RemoveSession(id uint64) {
+	m.sessionsMu.Lock()
+	sess, ok := m.sessions[id]
+	if ok {
+		delete(m.sessions, id)
+	}
+	m.sessionsMu.Unlock()
+
+	if ok {
+		m.arb.removeSession(id)
+		sess.close()
+		m.logger.Printf("adaptermux: session %d disconnected", id)
+	}
+}
+
+// close shuts down a session's goroutines and connection.
+// Signals writeLoop via done channel (not close(sendCh) which would
+// panic on concurrent sends).
+func (s *session) close() {
+	if s.closed.Swap(true) {
+		return // already closed
+	}
+	close(s.done) // signal writeLoop and handleStart goroutines to exit
+	if err := s.conn.Close(); err != nil {
+		s.mux.logger.Printf("adaptermux: session %d conn.Close: %v", s.id, err)
+	}
+
+	// Wait with timeout to avoid hanging on stuck goroutines.
+	waitDone := make(chan struct{})
+	go func() { s.wg.Wait(); close(waitDone) }() // goroutine: session close wait
+	select {
+	case <-waitDone:
+	case <-time.After(5 * time.Second):
+		s.mux.logger.Printf("adaptermux: session %d close timed out — goroutine leak", s.id)
+	}
+}
+
+// deliverReceived enqueues an ENHResReceived byte for the session.
+// If the send buffer is full, the session is forcibly closed.
+func (s *session) deliverReceived(symbol byte) {
+	if s.closed.Load() {
+		return
+	}
+	select {
+	case s.sendCh <- sessionFrame{kind: sessionFrameReceived, payload: symbol}:
+	default:
+		// Buffer overflow — close session (backpressure protection).
+		s.mux.logger.Printf("adaptermux: session %d send buffer overflow, closing", s.id)
+		go s.mux.RemoveSession(s.id) // goroutine: async removal to avoid lock contention
+	}
+}
+
+// deliverReset enqueues an ENHResResetted for the session.
+func (s *session) deliverReset() {
+	if s.closed.Load() {
+		return
+	}
+	select {
+	case s.sendCh <- sessionFrame{kind: sessionFrameResetted}:
+	default:
+		go s.mux.RemoveSession(s.id) // goroutine: overflow removal
+	}
+}
+
+// deliverStarted notifies the session that its START was granted.
+func (s *session) deliverStarted() {
+	if s.closed.Load() {
+		return
+	}
+	select {
+	case s.sendCh <- sessionFrame{kind: sessionFrameStarted}:
+	default:
+		go s.mux.RemoveSession(s.id) // goroutine: overflow removal
+	}
+}
+
+// deliverFailed notifies the session that its START failed.
+func (s *session) deliverFailed() {
+	if s.closed.Load() {
+		return
+	}
+	select {
+	case s.sendCh <- sessionFrame{kind: sessionFrameFailed}:
+	default:
+		go s.mux.RemoveSession(s.id) // goroutine: overflow removal
+	}
+}
+
+// readLoop reads ENH commands from the client connection and processes
+// them through the multiplexer.
+func (s *session) readLoop() {
+	defer s.mux.RemoveSession(s.id) // runs second: cleanup after wg.Done
+	defer s.wg.Done()               // runs first: unblock close() before RemoveSession
+
+	reader := bufio.NewReader(s.conn)
+	var parser transport.ENHParser
+
+	for {
+		if s.closed.Load() {
+			return
+		}
+
+		buf := make([]byte, 256)
+		n, err := reader.Read(buf)
+		if err != nil {
+			if !s.closed.Load() {
+				s.mux.logger.Printf("adaptermux: session %d read error: %v", s.id, err)
+			}
+			return
+		}
+
+		messages, parseErr := parser.Parse(buf[:n])
+		if parseErr != nil {
+			s.mux.logger.Printf("adaptermux: session %d parse error: %v", s.id, parseErr)
+			parser.Reset() // recover parser state (MEDIUM-4 fix)
+			continue
+		}
+
+		for _, msg := range messages {
+			s.handleMessage(msg)
+		}
+	}
+}
+
+// handleMessage processes a parsed ENH message from the client.
+func (s *session) handleMessage(msg transport.ENHMessage) {
+	switch msg.Kind {
+	case transport.ENHMessageData:
+		// Short-form SEND: raw byte < 0x80.
+		s.handleSend(msg.Byte)
+
+	case transport.ENHMessageFrame:
+		switch msg.Command {
+		case transport.ENHReqSend:
+			s.handleSend(msg.Data)
+		case transport.ENHReqStart:
+			s.handleStart(msg.Data)
+		case transport.ENHReqInit:
+			s.handleInit(msg.Data)
+		case transport.ENHReqInfo:
+			s.handleInfo(msg.Data)
+		}
+	}
+}
+
+// handleSend processes a SEND command from the client.
+func (s *session) handleSend(data byte) {
+	if !s.mux.arb.isOwner(s.id) {
+		// Session is not bus owner — reject.
+		s.deliverError()
+		return
+	}
+
+	result := make(chan error, 1)
+	select {
+	case s.mux.activeSendCh <- sendRequest{
+		sessionID: s.id,
+		data:      data,
+		result:    result,
+	}:
+	case <-s.mux.ctx.Done():
+		return
+	}
+
+	select {
+	case err := <-result:
+		if err != nil {
+			s.mux.logger.Printf("adaptermux: session %d SEND error: %v", s.id, err)
+			s.deliverError()
+		}
+	case <-s.mux.ctx.Done():
+	}
+}
+
+// handleStart processes a START command from the client.
+func (s *session) handleStart(initiator byte) {
+	ch := s.mux.arb.requestStart(s.id, initiator)
+
+	// Wait for arbitration result in a tracked goroutine.
+	s.wg.Add(1)
+	go func() { // goroutine: wait for START arbitration result
+		defer s.wg.Done()
+		select {
+		case result := <-ch:
+			if s.closed.Load() {
+				return
+			}
+			if result.granted {
+				s.deliverStarted()
+			} else {
+				s.deliverFailed()
+			}
+		case <-s.done:
+			return
+		case <-s.mux.ctx.Done():
+			if s.closed.Load() {
+				return
+			}
+			s.deliverFailed()
+		}
+	}()
+}
+
+// handleInit processes an INIT command from the client.
+func (s *session) handleInit(features byte) {
+	// Respond with RESETTED to complete the handshake.
+	s.deliverReset()
+}
+
+// handleInfo processes an INFO request from the client.
+func (s *session) handleInfo(id byte) {
+	s.mux.connMu.Lock()
+	tr := s.mux.upstream
+	s.mux.connMu.Unlock()
+
+	if tr == nil {
+		s.deliverError()
+		return
+	}
+
+	infoReq, ok := tr.(transport.InfoRequester)
+	if !ok {
+		s.mux.logger.Printf("adaptermux: session %d INFO requested but transport does not support it", s.id)
+		s.deliverError()
+		return
+	}
+
+	data, err := infoReq.RequestInfo(transport.AdapterInfoID(id))
+	if err != nil {
+		s.mux.logger.Printf("adaptermux: session %d INFO request failed: %v", s.id, err)
+		s.deliverError()
+		return
+	}
+	if len(data) == 0 {
+		s.mux.logger.Printf("adaptermux: session %d INFO id=0x%02X returned empty response", s.id, id)
+		s.deliverError()
+		return
+	}
+
+	// Deliver INFO response bytes.
+	if len(data) > 1 {
+		s.mux.logger.Printf("adaptermux: session %d INFO response truncated: %d bytes to 1", s.id, len(data))
+	}
+	s.deliverReceived(data[0])
+}
+
+// deliverError sends an ENHResErrorEBUS to the client.
+func (s *session) deliverError() {
+	if s.closed.Load() {
+		return
+	}
+	select {
+	case s.sendCh <- sessionFrame{kind: sessionFrameErrorEBUS}:
+	default:
+		s.mux.logger.Printf("adaptermux: session %d send buffer full, unable to deliver error", s.id)
+		go s.mux.RemoveSession(s.id) // goroutine: overflow removal on error delivery
+	}
+}
+
+// writeLoop writes ENH frames to the client connection.
+func (s *session) writeLoop() {
+	defer s.wg.Done()
+
+	for {
+		select {
+		case frame := <-s.sendCh:
+			if err := s.writeFrame(frame); err != nil {
+				if !s.closed.Load() && !errors.Is(err, net.ErrClosed) {
+					s.mux.logger.Printf("adaptermux: session %d write error: %v", s.id, err)
+				}
+				go s.mux.RemoveSession(s.id) // goroutine: cleanup on write failure
+				return
+			}
+		case <-s.done:
+			return
+		case <-s.mux.ctx.Done():
+			return
+		}
+	}
+}
+
+// writeFrame encodes and writes an ENH frame to the client connection.
+func (s *session) writeFrame(frame sessionFrame) error {
+	var buf []byte
+
+	switch frame.kind {
+	case sessionFrameReceived:
+		// ENHResReceived: if payload < 0x80, send as single byte (short form).
+		if frame.payload < 0x80 {
+			buf = []byte{frame.payload}
+		} else {
+			encoded := transport.EncodeENH(transport.ENHResReceived, frame.payload)
+			buf = encoded[:]
+		}
+
+	case sessionFrameStarted:
+		encoded := transport.EncodeENH(transport.ENHResStarted, 0x00)
+		buf = encoded[:]
+
+	case sessionFrameFailed:
+		encoded := transport.EncodeENH(transport.ENHResFailed, 0x00)
+		buf = encoded[:]
+
+	case sessionFrameResetted:
+		encoded := transport.EncodeENH(transport.ENHResResetted, 0x00)
+		buf = encoded[:]
+
+	case sessionFrameErrorEBUS:
+		encoded := transport.EncodeENH(transport.ENHResErrorEBUS, 0x00)
+		buf = encoded[:]
+	}
+
+	if len(buf) == 0 {
+		return fmt.Errorf("adaptermux: unknown session frame kind %d", frame.kind)
+	}
+
+	_, err := s.conn.Write(buf)
+	return err
+}

--- a/internal/adaptermux/session.go
+++ b/internal/adaptermux/session.go
@@ -58,6 +58,7 @@ const (
 	sessionFrameFailed                            // ENHResFailed
 	sessionFrameResetted                          // ENHResResetted
 	sessionFrameErrorEBUS                         // ENHResErrorEBUS
+	sessionFrameInfo                              // ENHResInfo(byte)
 )
 
 // AddSession registers an external TCP connection as an ENH session.
@@ -325,11 +326,12 @@ func (s *session) handleInfo(id byte) {
 		return
 	}
 
-	// Deliver INFO response bytes.
-	if len(data) > 1 {
-		s.mux.logger.Printf("adaptermux: session %d INFO response truncated: %d bytes to 1", s.id, len(data))
+	// Deliver INFO response: length prefix + data bytes, each as
+	// sessionFrameInfo so writeLoop encodes them as ENHResInfo frames.
+	s.deliverInfo(byte(len(data)))
+	for _, b := range data {
+		s.deliverInfo(b)
 	}
-	s.deliverReceived(data[0])
 }
 
 // deliverError sends an ENHResErrorEBUS to the client.
@@ -342,6 +344,18 @@ func (s *session) deliverError() {
 	default:
 		s.mux.logger.Printf("adaptermux: session %d send buffer full, unable to deliver error", s.id)
 		go s.mux.RemoveSession(s.id) // goroutine: overflow removal on error delivery
+	}
+}
+
+// deliverInfo enqueues an ENHResInfo byte for the session.
+func (s *session) deliverInfo(b byte) {
+	if s.closed.Load() {
+		return
+	}
+	select {
+	case s.sendCh <- sessionFrame{kind: sessionFrameInfo, payload: b}:
+	default:
+		go s.mux.RemoveSession(s.id) // goroutine: overflow removal
 	}
 }
 
@@ -395,6 +409,10 @@ func (s *session) writeFrame(frame sessionFrame) error {
 
 	case sessionFrameErrorEBUS:
 		encoded := transport.EncodeENH(transport.ENHResErrorEBUS, 0x00)
+		buf = encoded[:]
+
+	case sessionFrameInfo:
+		encoded := transport.EncodeENH(transport.ENHResInfo, frame.payload)
 		buf = encoded[:]
 	}
 

--- a/internal/adaptermux/session.go
+++ b/internal/adaptermux/session.go
@@ -182,13 +182,13 @@ func (s *session) readLoop() {
 
 	reader := bufio.NewReader(s.conn)
 	var parser transport.ENHParser
+	buf := make([]byte, 256)
 
 	for {
 		if s.closed.Load() {
 			return
 		}
 
-		buf := make([]byte, 256)
 		n, err := reader.Read(buf)
 		if err != nil {
 			if !s.closed.Load() {

--- a/internal/adaptermux/session.go
+++ b/internal/adaptermux/session.go
@@ -270,8 +270,11 @@ func (s *session) handleSend(data byte) {
 func (s *session) handleStart(initiator byte) {
 	// START with SYN (0xAA) is a cancel request — the client is
 	// withdrawing its pending START without acquiring the bus.
+	// Also release ownership in case the session already owns the bus
+	// (proxy does both cancel+release on SYN cancel).
 	if initiator == protocol.SymbolSyn {
 		s.mux.arb.cancelStart(s.id)
+		s.mux.arb.releaseOwnership(s.id)
 		return
 	}
 

--- a/internal/adaptermux/session.go
+++ b/internal/adaptermux/session.go
@@ -64,8 +64,16 @@ const (
 )
 
 // AddSession registers an external TCP connection as an ENH session.
-// Returns the session ID. The session starts reader and writer goroutines.
+// Returns the session ID (>0). The session starts reader and writer
+// goroutines. Returns 0 if the mux is shutting down (context cancelled);
+// the connection is closed and no goroutines are leaked.
 func (m *Mux) AddSession(conn net.Conn) uint64 {
+	if m.ctx.Err() != nil {
+		_ = conn.Close()
+		m.logger.Printf("adaptermux: rejecting session — mux shutting down")
+		return 0
+	}
+
 	id := m.nextSessionID()
 	sess := &session{
 		id:          id,
@@ -260,7 +268,11 @@ func (s *session) handleSend(data byte) {
 	case err := <-result:
 		if err != nil {
 			s.mux.logger.Printf("adaptermux: session %d SEND error: %v", s.id, err)
-			s.deliverError()
+			if errors.Is(err, errNotBusOwner) || errors.Is(err, errNotConnected) {
+				s.deliverErrorHost()
+			} else {
+				s.deliverError()
+			}
 		}
 	case <-s.mux.ctx.Done():
 	}

--- a/internal/adaptermux/session.go
+++ b/internal/adaptermux/session.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
 	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
 )
 
@@ -58,6 +59,7 @@ const (
 	sessionFrameFailed                            // ENHResFailed
 	sessionFrameResetted                          // ENHResResetted
 	sessionFrameErrorEBUS                         // ENHResErrorEBUS
+	sessionFrameErrorHost                         // ENHResErrorHost
 	sessionFrameInfo                              // ENHResInfo(byte)
 )
 
@@ -140,36 +142,39 @@ func (s *session) deliverReceived(symbol byte) {
 }
 
 // deliverReset enqueues an ENHResResetted for the session.
-func (s *session) deliverReset() {
+// payload carries the features byte for INIT negotiation fidelity.
+func (s *session) deliverReset(payload byte) {
 	if s.closed.Load() {
 		return
 	}
 	select {
-	case s.sendCh <- sessionFrame{kind: sessionFrameResetted}:
+	case s.sendCh <- sessionFrame{kind: sessionFrameResetted, payload: payload}:
 	default:
 		go s.mux.RemoveSession(s.id) // goroutine: overflow removal
 	}
 }
 
 // deliverStarted notifies the session that its START was granted.
-func (s *session) deliverStarted() {
+// payload carries the initiator byte for ENH protocol fidelity.
+func (s *session) deliverStarted(payload byte) {
 	if s.closed.Load() {
 		return
 	}
 	select {
-	case s.sendCh <- sessionFrame{kind: sessionFrameStarted}:
+	case s.sendCh <- sessionFrame{kind: sessionFrameStarted, payload: payload}:
 	default:
 		go s.mux.RemoveSession(s.id) // goroutine: overflow removal
 	}
 }
 
 // deliverFailed notifies the session that its START failed.
-func (s *session) deliverFailed() {
+// payload carries the initiator byte for ENH protocol fidelity.
+func (s *session) deliverFailed(payload byte) {
 	if s.closed.Load() {
 		return
 	}
 	select {
-	case s.sendCh <- sessionFrame{kind: sessionFrameFailed}:
+	case s.sendCh <- sessionFrame{kind: sessionFrameFailed, payload: payload}:
 	default:
 		go s.mux.RemoveSession(s.id) // goroutine: overflow removal
 	}
@@ -235,8 +240,8 @@ func (s *session) handleMessage(msg transport.ENHMessage) {
 // handleSend processes a SEND command from the client.
 func (s *session) handleSend(data byte) {
 	if !s.mux.arb.isOwner(s.id) {
-		// Session is not bus owner — reject.
-		s.deliverError()
+		// Session is not bus owner — host-side error, not bus error.
+		s.deliverErrorHost()
 		return
 	}
 
@@ -263,6 +268,13 @@ func (s *session) handleSend(data byte) {
 
 // handleStart processes a START command from the client.
 func (s *session) handleStart(initiator byte) {
+	// START with SYN (0xAA) is a cancel request — the client is
+	// withdrawing its pending START without acquiring the bus.
+	if initiator == protocol.SymbolSyn {
+		s.mux.arb.cancelStart(s.id)
+		return
+	}
+
 	ch := s.mux.arb.requestStart(s.id, initiator)
 
 	// Wait for arbitration result in a tracked goroutine.
@@ -275,9 +287,9 @@ func (s *session) handleStart(initiator byte) {
 				return
 			}
 			if result.granted {
-				s.deliverStarted()
+				s.deliverStarted(result.initiator)
 			} else {
-				s.deliverFailed()
+				s.deliverFailed(result.initiator)
 			}
 		case <-s.done:
 			return
@@ -285,15 +297,21 @@ func (s *session) handleStart(initiator byte) {
 			if s.closed.Load() {
 				return
 			}
-			s.deliverFailed()
+			s.deliverFailed(initiator)
 		}
 	}()
 }
 
 // handleInit processes an INIT command from the client.
 func (s *session) handleInit(features byte) {
-	// Respond with RESETTED to complete the handshake.
-	s.deliverReset()
+	// Reply with the features negotiated with the upstream adapter.
+	// If upstream features are unknown (e.g. ENS transport without
+	// INIT), echo back what the client requested.
+	stored := byte(s.mux.upstreamFeatures.Load())
+	if stored == 0 {
+		stored = features
+	}
+	s.deliverReset(stored)
 }
 
 // handleInfo processes an INFO request from the client.
@@ -303,14 +321,14 @@ func (s *session) handleInfo(id byte) {
 	s.mux.connMu.Unlock()
 
 	if tr == nil {
-		s.deliverError()
+		s.deliverErrorHost()
 		return
 	}
 
 	infoReq, ok := tr.(transport.InfoRequester)
 	if !ok {
 		s.mux.logger.Printf("adaptermux: session %d INFO requested but transport does not support it", s.id)
-		s.deliverError()
+		s.deliverErrorHost()
 		return
 	}
 
@@ -343,6 +361,20 @@ func (s *session) deliverError() {
 	case s.sendCh <- sessionFrame{kind: sessionFrameErrorEBUS}:
 	default:
 		s.mux.logger.Printf("adaptermux: session %d send buffer full, unable to deliver error", s.id)
+		go s.mux.RemoveSession(s.id) // goroutine: overflow removal on error delivery
+	}
+}
+
+// deliverErrorHost sends an ENHResErrorHost to the client.
+// Used for host-side errors (e.g. not bus owner, no transport).
+func (s *session) deliverErrorHost() {
+	if s.closed.Load() {
+		return
+	}
+	select {
+	case s.sendCh <- sessionFrame{kind: sessionFrameErrorHost}:
+	default:
+		s.mux.logger.Printf("adaptermux: session %d send buffer full, unable to deliver host error", s.id)
 		go s.mux.RemoveSession(s.id) // goroutine: overflow removal on error delivery
 	}
 }
@@ -396,19 +428,23 @@ func (s *session) writeFrame(frame sessionFrame) error {
 		}
 
 	case sessionFrameStarted:
-		encoded := transport.EncodeENH(transport.ENHResStarted, 0x00)
+		encoded := transport.EncodeENH(transport.ENHResStarted, frame.payload)
 		buf = encoded[:]
 
 	case sessionFrameFailed:
-		encoded := transport.EncodeENH(transport.ENHResFailed, 0x00)
+		encoded := transport.EncodeENH(transport.ENHResFailed, frame.payload)
 		buf = encoded[:]
 
 	case sessionFrameResetted:
-		encoded := transport.EncodeENH(transport.ENHResResetted, 0x00)
+		encoded := transport.EncodeENH(transport.ENHResResetted, frame.payload)
 		buf = encoded[:]
 
 	case sessionFrameErrorEBUS:
 		encoded := transport.EncodeENH(transport.ENHResErrorEBUS, 0x00)
+		buf = encoded[:]
+
+	case sessionFrameErrorHost:
+		encoded := transport.EncodeENH(transport.ENHResErrorHost, 0x00)
 		buf = encoded[:]
 
 	case sessionFrameInfo:

--- a/internal/adaptermux/session_test.go
+++ b/internal/adaptermux/session_test.go
@@ -1,0 +1,422 @@
+package adaptermux
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+// readENHFrame reads a 2-byte ENH frame from conn with deadline.
+func readENHFrame(t *testing.T, conn net.Conn, timeout time.Duration) [2]byte {
+	t.Helper()
+	_ = conn.SetReadDeadline(time.Now().Add(timeout))
+	var buf [2]byte
+	_, err := io.ReadFull(conn, buf[:])
+	if err != nil {
+		t.Fatalf("readENHFrame: %v", err)
+	}
+	return buf
+}
+
+// --- Fix 1: START payload fidelity (session-level) ---
+
+func TestSession_StartedCarriesInitiator(t *testing.T) {
+	mux, _, cleanup := newTestMux(t)
+	defer cleanup()
+
+	// Create a pipe to act as the session connection.
+	client, server := net.Pipe()
+	defer client.Close()
+
+	id := mux.AddSession(server)
+	defer mux.RemoveSession(id)
+
+	// Send an ENH START request with initiator 0x31.
+	startReq := transport.EncodeENH(transport.ENHReqStart, 0x31)
+	if _, err := client.Write(startReq[:]); err != nil {
+		t.Fatalf("write START: %v", err)
+	}
+
+	// The mux does not actually forward to an adapter that grants,
+	// so we need to grant via the arbitrator directly. The handleStart
+	// goroutine has called requestStart — wait a bit, then grant.
+	time.Sleep(50 * time.Millisecond)
+
+	// tryGrant pulls the pending request and grants ownership.
+	_, initiator, notify, granted := mux.arb.tryGrant()
+	if !granted {
+		t.Fatal("expected grant from arbitrator")
+	}
+	if initiator != 0x31 {
+		t.Fatalf("tryGrant initiator = 0x%02x, want 0x31", initiator)
+	}
+
+	// Simulate successful adapter START.
+	notify <- startResult{granted: true, initiator: initiator}
+
+	// Read the STARTED response from the client side.
+	frame := readENHFrame(t, client, 2*time.Second)
+	expected := transport.EncodeENH(transport.ENHResStarted, 0x31)
+	if frame != expected {
+		t.Fatalf("STARTED frame = %x, want %x", frame, expected)
+	}
+}
+
+func TestSession_FailedCarriesInitiator(t *testing.T) {
+	mux, _, cleanup := newTestMux(t)
+	defer cleanup()
+
+	client, server := net.Pipe()
+	defer client.Close()
+
+	id := mux.AddSession(server)
+	defer mux.RemoveSession(id)
+
+	// Send START.
+	startReq := transport.EncodeENH(transport.ENHReqStart, 0x42)
+	if _, err := client.Write(startReq[:]); err != nil {
+		t.Fatalf("write START: %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	_, initiator, notify, granted := mux.arb.tryGrant()
+	if !granted {
+		t.Fatal("expected grant")
+	}
+
+	// Simulate failed adapter START.
+	notify <- startResult{granted: false, initiator: initiator}
+
+	// Release ownership since tryGrant set it.
+	mux.arb.releaseOwnership(id)
+
+	frame := readENHFrame(t, client, 2*time.Second)
+	expected := transport.EncodeENH(transport.ENHResFailed, 0x42)
+	if frame != expected {
+		t.Fatalf("FAILED frame = %x, want %x", frame, expected)
+	}
+}
+
+// --- Fix 2: START-cancel (0xAA) ---
+
+func TestSession_StartCancelSYN(t *testing.T) {
+	mux, _, cleanup := newTestMux(t)
+	defer cleanup()
+
+	client, server := net.Pipe()
+	defer client.Close()
+
+	id := mux.AddSession(server)
+	defer mux.RemoveSession(id)
+
+	// First, send a normal START so there's something to cancel.
+	startReq := transport.EncodeENH(transport.ENHReqStart, 0x31)
+	if _, err := client.Write(startReq[:]); err != nil {
+		t.Fatalf("write START: %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Verify request is pending.
+	if !mux.arb.hasPending() {
+		t.Fatal("expected pending request after START")
+	}
+
+	// Send START with SYN (0xAA) to cancel.
+	cancelReq := transport.EncodeENH(transport.ENHReqStart, protocol.SymbolSyn)
+	if _, err := client.Write(cancelReq[:]); err != nil {
+		t.Fatalf("write START cancel: %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Pending request should be cancelled.
+	if mux.arb.hasPending() {
+		t.Fatal("expected no pending requests after START cancel with SYN")
+	}
+}
+
+// --- Fix 3: INIT feature negotiation ---
+
+func TestSession_InitReturnsUpstreamFeatures(t *testing.T) {
+	mux, _, cleanup := newTestMux(t)
+	defer cleanup()
+
+	// The fake adapter responds to INIT with features. The mux stored
+	// requestedFeatures=0x01 after connect(). Verify session INIT reply.
+	client, server := net.Pipe()
+	defer client.Close()
+
+	id := mux.AddSession(server)
+	defer mux.RemoveSession(id)
+
+	// Send INIT with features=0x03 (client requesting more features).
+	initReq := transport.EncodeENH(transport.ENHReqInit, 0x03)
+	if _, err := client.Write(initReq[:]); err != nil {
+		t.Fatalf("write INIT: %v", err)
+	}
+
+	// Read the RESETTED response.
+	frame := readENHFrame(t, client, 2*time.Second)
+
+	// Should carry upstream features (0x01), not the client's 0x03.
+	expected := transport.EncodeENH(transport.ENHResResetted, 0x01)
+	if frame != expected {
+		t.Fatalf("INIT reply = %x, want %x (upstream features 0x01)", frame, expected)
+	}
+}
+
+func TestSession_InitEchoesWhenUpstreamUnknown(t *testing.T) {
+	// Create a mux with upstreamFeatures=0 (e.g. ENS transport).
+	mux, _, cleanup := newTestMux(t)
+	defer cleanup()
+
+	// Force upstream features to 0 to simulate unknown.
+	mux.upstreamFeatures.Store(0)
+
+	client, server := net.Pipe()
+	defer client.Close()
+
+	id := mux.AddSession(server)
+	defer mux.RemoveSession(id)
+
+	// Send INIT with features=0x05.
+	initReq := transport.EncodeENH(transport.ENHReqInit, 0x05)
+	if _, err := client.Write(initReq[:]); err != nil {
+		t.Fatalf("write INIT: %v", err)
+	}
+
+	frame := readENHFrame(t, client, 2*time.Second)
+
+	// Should echo back client's requested features.
+	expected := transport.EncodeENH(transport.ENHResResetted, 0x05)
+	if frame != expected {
+		t.Fatalf("INIT reply = %x, want %x (echoed client features)", frame, expected)
+	}
+}
+
+// --- Fix 4: ErrorHost vs ErrorEBUS ---
+
+func TestSession_SendWithoutOwnershipReturnsErrorHost(t *testing.T) {
+	mux, _, cleanup := newTestMux(t)
+	defer cleanup()
+
+	client, server := net.Pipe()
+	defer client.Close()
+
+	id := mux.AddSession(server)
+	defer mux.RemoveSession(id)
+
+	// Send a SEND command without owning the bus.
+	sendReq := transport.EncodeENH(transport.ENHReqSend, 0x42)
+	if _, err := client.Write(sendReq[:]); err != nil {
+		t.Fatalf("write SEND: %v", err)
+	}
+
+	frame := readENHFrame(t, client, 2*time.Second)
+
+	// Should be ErrorHost (0x0C), not ErrorEBUS (0x0B).
+	expected := transport.EncodeENH(transport.ENHResErrorHost, 0x00)
+	if frame != expected {
+		t.Fatalf("SEND error frame = %x, want %x (ErrorHost)", frame, expected)
+	}
+
+	// Verify it is NOT ErrorEBUS.
+	notExpected := transport.EncodeENH(transport.ENHResErrorEBUS, 0x00)
+	if frame == notExpected {
+		t.Fatal("SEND without ownership should return ErrorHost, not ErrorEBUS")
+	}
+}
+
+func TestSession_WriteFrameErrorHost(t *testing.T) {
+	// Unit test: writeFrame encodes ErrorHost correctly.
+	// net.Pipe is synchronous — read concurrently to avoid blocking.
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	s := &session{
+		conn:   server,
+		sendCh: make(chan sessionFrame, 1),
+		done:   make(chan struct{}),
+	}
+
+	// Start reader goroutine before write to unblock the pipe.
+	readCh := make(chan [2]byte, 1)
+	go func() {
+		var buf [2]byte
+		_, _ = io.ReadFull(client, buf[:])
+		readCh <- buf
+	}()
+
+	frame := sessionFrame{kind: sessionFrameErrorHost}
+	err := s.writeFrame(frame)
+	if err != nil {
+		t.Fatalf("writeFrame: %v", err)
+	}
+
+	select {
+	case buf := <-readCh:
+		expected := transport.EncodeENH(transport.ENHResErrorHost, 0x00)
+		if buf != expected {
+			t.Fatalf("ErrorHost encoding = %x, want %x", buf, expected)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout reading ErrorHost frame")
+	}
+}
+
+// --- Fix 5: Close idempotency ---
+
+func TestMux_CloseIdempotent(t *testing.T) {
+	mux, _, _ := newTestMux(t)
+
+	// First close should succeed.
+	err1 := mux.Close()
+
+	// Second close should also succeed (not panic or error differently).
+	err2 := mux.Close()
+
+	// Both should return the same result.
+	if err1 != err2 {
+		t.Fatalf("Close() not idempotent: first=%v, second=%v", err1, err2)
+	}
+}
+
+func TestMux_CloseAfterContextCancel(t *testing.T) {
+	mux, cancel, _ := newTestMux(t)
+
+	// Cancel context first.
+	cancel()
+	time.Sleep(50 * time.Millisecond)
+
+	// Close should be safe after context cancel.
+	err := mux.Close()
+	// The close should not panic; error is acceptable (connection may
+	// already be closed).
+	_ = err
+
+	// Second close should also be safe.
+	err2 := mux.Close()
+	_ = err2
+}
+
+// --- writeFrame payload fidelity unit tests ---
+
+// writeFrameWithReader is a helper that writes a frame to a net.Pipe
+// session and reads the result concurrently to avoid blocking.
+func writeFrameWithReader(t *testing.T, frame sessionFrame) [2]byte {
+	t.Helper()
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	s := &session{conn: server, sendCh: make(chan sessionFrame, 1), done: make(chan struct{})}
+
+	readCh := make(chan [2]byte, 1)
+	go func() {
+		var buf [2]byte
+		_, _ = io.ReadFull(client, buf[:])
+		readCh <- buf
+	}()
+
+	if err := s.writeFrame(frame); err != nil {
+		t.Fatalf("writeFrame: %v", err)
+	}
+
+	select {
+	case buf := <-readCh:
+		return buf
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout reading frame")
+		return [2]byte{}
+	}
+}
+
+func TestWriteFrame_StartedPayload(t *testing.T) {
+	buf := writeFrameWithReader(t, sessionFrame{kind: sessionFrameStarted, payload: 0x31})
+	expected := transport.EncodeENH(transport.ENHResStarted, 0x31)
+	if !bytes.Equal(buf[:], expected[:]) {
+		t.Fatalf("STARTED encoding = %x, want %x", buf, expected)
+	}
+}
+
+func TestWriteFrame_FailedPayload(t *testing.T) {
+	buf := writeFrameWithReader(t, sessionFrame{kind: sessionFrameFailed, payload: 0x42})
+	expected := transport.EncodeENH(transport.ENHResFailed, 0x42)
+	if !bytes.Equal(buf[:], expected[:]) {
+		t.Fatalf("FAILED encoding = %x, want %x", buf, expected)
+	}
+}
+
+func TestWriteFrame_ResettedPayload(t *testing.T) {
+	buf := writeFrameWithReader(t, sessionFrame{kind: sessionFrameResetted, payload: 0x01})
+	expected := transport.EncodeENH(transport.ENHResResetted, 0x01)
+	if !bytes.Equal(buf[:], expected[:]) {
+		t.Fatalf("RESETTED encoding = %x, want %x", buf, expected)
+	}
+}
+
+// --- Fix 2: cancelStart for non-existent session ---
+
+func TestArbitrator_CancelStartNoOp(t *testing.T) {
+	arb := newArbitrator()
+
+	// Cancel a session that never requested START.
+	cancelled := arb.cancelStart(42)
+	if cancelled {
+		t.Fatal("cancelStart should return false for non-existent session")
+	}
+}
+
+// --- Fix 5: Close idempotency on fresh mux (never started) ---
+
+func TestMux_CloseWithoutStart(t *testing.T) {
+	cfg := Config{
+		Protocol:    "enh",
+		Network:     "tcp",
+		Address:     "127.0.0.1:0",
+		DialTimeout: 100 * time.Millisecond,
+	}
+	mux := New(cfg)
+
+	// Close without Start — should not panic.
+	err := mux.Close()
+	_ = err
+
+	// Double close also safe.
+	err2 := mux.Close()
+	_ = err2
+}
+
+// Verify Close is safe from concurrent goroutines.
+func TestMux_CloseConcurrent(t *testing.T) {
+	mux, _, _ := newTestMux(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_ = ctx
+
+	done := make(chan struct{})
+	for i := 0; i < 5; i++ {
+		go func() {
+			mux.Close()
+			done <- struct{}{}
+		}()
+	}
+
+	for i := 0; i < 5; i++ {
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("concurrent Close timed out")
+		}
+	}
+}

--- a/internal/adaptermux/session_test.go
+++ b/internal/adaptermux/session_test.go
@@ -48,14 +48,17 @@ func TestSession_StartedCarriesInitiator(t *testing.T) {
 	// goroutine has called requestStart — wait a bit, then grant.
 	time.Sleep(50 * time.Millisecond)
 
-	// tryGrant pulls the pending request and grants ownership.
-	_, initiator, notify, granted := mux.arb.tryGrant()
+	// tryGrant pulls the pending request (ownership not yet set).
+	sessionID, initiator, notify, granted := mux.arb.tryGrant()
 	if !granted {
 		t.Fatal("expected grant from arbitrator")
 	}
 	if initiator != 0x31 {
 		t.Fatalf("tryGrant initiator = 0x%02x, want 0x31", initiator)
 	}
+
+	// Confirm ownership after adapter START success.
+	mux.arb.confirmOwnership(sessionID, initiator)
 
 	// Simulate successful adapter START.
 	notify <- startResult{granted: true, initiator: initiator}
@@ -94,8 +97,8 @@ func TestSession_FailedCarriesInitiator(t *testing.T) {
 	// Simulate failed adapter START.
 	notify <- startResult{granted: false, initiator: initiator}
 
-	// Release ownership since tryGrant set it.
-	mux.arb.releaseOwnership(id)
+	// No releaseOwnership needed — tryGrant no longer sets ownership
+	// (Codex P1 #3060199707). Call is a harmless no-op.
 
 	frame := readENHFrame(t, client, 2*time.Second)
 	expected := transport.EncodeENH(transport.ENHResFailed, 0x42)

--- a/internal/adaptermux/wire_phase.go
+++ b/internal/adaptermux/wire_phase.go
@@ -19,14 +19,14 @@ const (
 	wirePhaseWaitCmdAck                        // waiting for target ACK/NACK
 	wirePhaseWaitResponseLen                   // waiting for response LEN byte
 	wirePhaseWaitResponseBody                  // counting response body + CRC
-	wirePhaseWaitResponseAck                   // waiting for master final ACK
+	wirePhaseWaitResponseAck                   // waiting for initiator final ACK
 )
 
 // isSYNTimeoutBoundary reports whether receiving a SYN in this phase
 // indicates a timeout condition (transaction abandoned by bus timeout).
 func (p wirePhase) isSYNTimeoutBoundary() bool {
 	switch p {
-	case wirePhaseWaitCmdAck, wirePhaseWaitResponseBody, wirePhaseWaitResponseAck:
+	case wirePhaseWaitCmdAck, wirePhaseWaitResponseLen, wirePhaseWaitResponseBody, wirePhaseWaitResponseAck:
 		return true
 	default:
 		return false
@@ -34,7 +34,7 @@ func (p wirePhase) isSYNTimeoutBoundary() bool {
 }
 
 // wirePhaseTracker tracks the byte-level eBUS transaction structure.
-// It follows the eBUS master-slave transaction protocol:
+// It follows the eBUS initiator-target transaction protocol:
 //
 //	SRC DST PB SB LEN DATA[0..LEN-1] CRC → ACK → LEN DATA[0..LEN-1] CRC → ACK
 //

--- a/internal/adaptermux/wire_phase.go
+++ b/internal/adaptermux/wire_phase.go
@@ -1,0 +1,206 @@
+// Package adaptermux embeds adapter multiplexing logic directly in the
+// gateway, allowing a single ENH/ENS connection to the adapter hardware
+// with demuxed active (owner) and passive (observer) paths.
+package adaptermux
+
+import "github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+
+// wirePhase tracks the byte-level eBUS transaction state on the bus.
+// The tracker identifies frame boundaries, arbitration windows, and
+// echo suppression boundaries by counting bytes in request and response
+// phases.
+//
+// Adapted from the proxy's minimal direct-mode phase tracker (proxy M3).
+type wirePhase uint8
+
+const (
+	wirePhaseIdle             wirePhase = iota // bus idle, arbitration open
+	wirePhaseCollectRequest                    // owner sending request bytes
+	wirePhaseWaitCmdAck                        // waiting for target ACK/NACK
+	wirePhaseWaitResponseLen                   // waiting for response LEN byte
+	wirePhaseWaitResponseBody                  // counting response body + CRC
+	wirePhaseWaitResponseAck                   // waiting for master final ACK
+)
+
+// isSYNTimeoutBoundary reports whether receiving a SYN in this phase
+// indicates a timeout condition (transaction abandoned by bus timeout).
+func (p wirePhase) isSYNTimeoutBoundary() bool {
+	switch p {
+	case wirePhaseWaitCmdAck, wirePhaseWaitResponseBody, wirePhaseWaitResponseAck:
+		return true
+	default:
+		return false
+	}
+}
+
+// wirePhaseTracker tracks the byte-level eBUS transaction structure.
+// It follows the eBUS master-slave transaction protocol:
+//
+//	SRC DST PB SB LEN DATA[0..LEN-1] CRC → ACK → LEN DATA[0..LEN-1] CRC → ACK
+//
+// The tracker does NOT validate CRC or interpret field values.
+// It only counts bytes to know when phase transitions occur.
+type wirePhaseTracker struct {
+	phase wirePhase
+
+	// Request phase counters.
+	requestBytesSeen  int  // bytes received since CollectRequest start
+	requestDataLength int  // LEN field value (-1 until captured)
+	requestSrc        byte // initiator address (byte 1)
+	requestDst        byte // target address (byte 2)
+
+	// Response phase counter.
+	responseBytesRemain int // countdown: LEN + 1 (data + CRC)
+}
+
+// reset clears all tracking state and sets the phase.
+func (t *wirePhaseTracker) reset(phase wirePhase) {
+	t.phase = phase
+	t.requestBytesSeen = 0
+	t.requestDataLength = -1
+	t.requestSrc = 0
+	t.requestDst = 0
+	t.responseBytesRemain = 0
+}
+
+// wirePhaseEvent describes what happened after advancing the tracker.
+type wirePhaseEvent uint8
+
+const (
+	wirePhaseEventNone            wirePhaseEvent = iota // no transition
+	wirePhaseEventRequestComplete                       // request phase done, waiting ACK
+	wirePhaseEventCmdACK                                // target ACK'd, response expected
+	wirePhaseEventCmdNACK                               // target NACK'd, transaction failed
+	wirePhaseEventResponseDone                          // response fully received, waiting final ACK
+	wirePhaseEventTransactionDone                       // final ACK received, transaction complete
+	wirePhaseEventSYNIdle                               // SYN received, bus idle
+	wirePhaseEventSYNTimeout                            // SYN during wait phase (timeout)
+)
+
+// advance processes a received symbol and returns what event occurred.
+// This must be called for every byte received from the adapter.
+func (t *wirePhaseTracker) advance(symbol byte) wirePhaseEvent {
+	// SYN resets the tracker. If we were in a wait phase, it's a timeout.
+	if symbol == protocol.SymbolSyn {
+		if t.phase.isSYNTimeoutBoundary() {
+			t.reset(wirePhaseIdle)
+			return wirePhaseEventSYNTimeout
+		}
+		if t.phase == wirePhaseCollectRequest {
+			// SYN during request collection — incomplete request.
+			t.reset(wirePhaseIdle)
+			return wirePhaseEventSYNTimeout
+		}
+		t.reset(wirePhaseIdle)
+		return wirePhaseEventSYNIdle
+	}
+
+	switch t.phase {
+	case wirePhaseIdle:
+		// Non-SYN byte in idle — should not happen on a well-behaved bus.
+		// Ignore and stay idle.
+		return wirePhaseEventNone
+
+	case wirePhaseCollectRequest:
+		return t.advanceCollectRequest(symbol)
+
+	case wirePhaseWaitCmdAck:
+		return t.advanceWaitCmdAck(symbol)
+
+	case wirePhaseWaitResponseLen:
+		return t.advanceWaitResponseLen(symbol)
+
+	case wirePhaseWaitResponseBody:
+		return t.advanceWaitResponseBody(symbol)
+
+	case wirePhaseWaitResponseAck:
+		return t.advanceWaitResponseAck(symbol)
+	}
+
+	return wirePhaseEventNone
+}
+
+func (t *wirePhaseTracker) advanceCollectRequest(symbol byte) wirePhaseEvent {
+	t.requestBytesSeen++
+
+	switch t.requestBytesSeen {
+	case 1:
+		t.requestSrc = symbol
+	case 2:
+		t.requestDst = symbol
+	case 5:
+		t.requestDataLength = int(symbol)
+	}
+
+	// Request is complete when we've seen: SRC + DST + PB + SB + LEN + DATA[LEN] + CRC
+	// Total = 5 (header) + requestDataLength (data) + 1 (CRC)
+	if t.requestDataLength >= 0 && t.requestBytesSeen >= 6+t.requestDataLength {
+		t.phase = wirePhaseWaitCmdAck
+		return wirePhaseEventRequestComplete
+	}
+
+	return wirePhaseEventNone
+}
+
+func (t *wirePhaseTracker) advanceWaitCmdAck(symbol byte) wirePhaseEvent {
+	if symbol == protocol.SymbolAck {
+		// Target ACK'd. Check if this is a broadcast (no response expected).
+		if t.requestDst == protocol.AddressBroadcast {
+			t.reset(wirePhaseIdle)
+			return wirePhaseEventTransactionDone
+		}
+		t.phase = wirePhaseWaitResponseLen
+		return wirePhaseEventCmdACK
+	}
+
+	// NACK or unexpected byte — transaction failed.
+	t.reset(wirePhaseIdle)
+	return wirePhaseEventCmdNACK
+}
+
+func (t *wirePhaseTracker) advanceWaitResponseLen(symbol byte) wirePhaseEvent {
+	// This byte is the response LEN field.
+	// We need to receive LEN data bytes + 1 CRC byte.
+	t.responseBytesRemain = int(symbol) + 1
+	t.phase = wirePhaseWaitResponseBody
+	return wirePhaseEventNone
+}
+
+func (t *wirePhaseTracker) advanceWaitResponseBody(symbol byte) wirePhaseEvent {
+	t.responseBytesRemain--
+	if t.responseBytesRemain <= 0 {
+		t.phase = wirePhaseWaitResponseAck
+		return wirePhaseEventResponseDone
+	}
+	return wirePhaseEventNone
+}
+
+func (t *wirePhaseTracker) advanceWaitResponseAck(_ byte) wirePhaseEvent {
+	// Any non-SYN symbol in WaitResponseAck phase = final ACK.
+	// (SYN is handled by the caller before reaching this point.)
+	t.reset(wirePhaseIdle)
+	return wirePhaseEventTransactionDone
+}
+
+// startRequest initializes the tracker for a new request phase.
+// Called when the multiplexer grants bus ownership to a session.
+func (t *wirePhaseTracker) startRequest() {
+	t.reset(wirePhaseCollectRequest)
+}
+
+// isIdle reports whether the bus is in the idle state.
+func (t *wirePhaseTracker) isIdle() bool {
+	return t.phase == wirePhaseIdle
+}
+
+// initiator returns the SRC address captured during request collection.
+// Only valid after at least one request byte has been seen.
+func (t *wirePhaseTracker) initiator() byte {
+	return t.requestSrc
+}
+
+// target returns the DST address captured during request collection.
+// Only valid after at least two request bytes have been seen.
+func (t *wirePhaseTracker) target() byte {
+	return t.requestDst
+}

--- a/internal/adaptermux/wire_phase_test.go
+++ b/internal/adaptermux/wire_phase_test.go
@@ -1,0 +1,222 @@
+package adaptermux
+
+import (
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+)
+
+func TestWirePhase_IdleOnSYN(t *testing.T) {
+	var tracker wirePhaseTracker
+	tracker.reset(wirePhaseIdle)
+
+	event := tracker.advance(protocol.SymbolSyn)
+	if event != wirePhaseEventSYNIdle {
+		t.Fatalf("expected SYNIdle, got %d", event)
+	}
+	if !tracker.isIdle() {
+		t.Fatal("expected idle after SYN")
+	}
+}
+
+func TestWirePhase_FullTransaction(t *testing.T) {
+	// Simulate a complete master-slave transaction:
+	// SRC=0x71 DST=0x08 PB=0xB5 SB=0x24 LEN=0x02 DATA[0]=0x00 DATA[1]=0x01 CRC=0xXX
+	// → ACK → LEN=0x01 DATA[0]=0x42 CRC=0xXX → ACK
+	var tracker wirePhaseTracker
+	tracker.startRequest()
+
+	// Request bytes: SRC, DST, PB, SB, LEN, DATA[0], DATA[1], CRC
+	events := []struct {
+		symbol byte
+		want   wirePhaseEvent
+	}{
+		{0x71, wirePhaseEventNone},           // SRC
+		{0x08, wirePhaseEventNone},           // DST
+		{0xB5, wirePhaseEventNone},           // PB
+		{0x24, wirePhaseEventNone},           // SB
+		{0x02, wirePhaseEventNone},           // LEN=2
+		{0x00, wirePhaseEventNone},           // DATA[0]
+		{0x01, wirePhaseEventNone},           // DATA[1]
+		{0x99, wirePhaseEventRequestComplete}, // CRC → request complete
+	}
+
+	for i, tc := range events {
+		got := tracker.advance(tc.symbol)
+		if got != tc.want {
+			t.Fatalf("request byte %d (0x%02x): got event %d, want %d", i, tc.symbol, got, tc.want)
+		}
+	}
+
+	if tracker.initiator() != 0x71 {
+		t.Fatalf("initiator = 0x%02x, want 0x71", tracker.initiator())
+	}
+	if tracker.target() != 0x08 {
+		t.Fatalf("target = 0x%02x, want 0x08", tracker.target())
+	}
+
+	// ACK from target.
+	got := tracker.advance(protocol.SymbolAck)
+	if got != wirePhaseEventCmdACK {
+		t.Fatalf("ACK: got event %d, want CmdACK", got)
+	}
+
+	// Response: LEN=1, DATA[0], CRC.
+	got = tracker.advance(0x01) // LEN=1
+	if got != wirePhaseEventNone {
+		t.Fatalf("response LEN: got event %d, want None", got)
+	}
+
+	got = tracker.advance(0x42) // DATA[0]
+	if got != wirePhaseEventNone {
+		t.Fatalf("response DATA: got event %d, want None", got)
+	}
+
+	got = tracker.advance(0xBB) // CRC → response done
+	if got != wirePhaseEventResponseDone {
+		t.Fatalf("response CRC: got event %d, want ResponseDone", got)
+	}
+
+	// Final ACK from master.
+	got = tracker.advance(protocol.SymbolAck)
+	if got != wirePhaseEventTransactionDone {
+		t.Fatalf("final ACK: got event %d, want TransactionDone", got)
+	}
+
+	if !tracker.isIdle() {
+		t.Fatal("expected idle after transaction")
+	}
+}
+
+func TestWirePhase_BroadcastTransaction(t *testing.T) {
+	// Broadcast: DST=0xFE → ACK completes transaction (no response).
+	var tracker wirePhaseTracker
+	tracker.startRequest()
+
+	// SRC=0x71, DST=0xFE, PB=0x07, SB=0x04, LEN=0x00, CRC
+	for _, b := range []byte{0x71, 0xFE, 0x07, 0x04, 0x00} {
+		tracker.advance(b)
+	}
+	got := tracker.advance(0xCC) // CRC → request complete
+	if got != wirePhaseEventRequestComplete {
+		t.Fatalf("CRC: got event %d, want RequestComplete", got)
+	}
+
+	// ACK on broadcast → transaction done (no response expected).
+	got = tracker.advance(protocol.SymbolAck)
+	if got != wirePhaseEventTransactionDone {
+		t.Fatalf("broadcast ACK: got event %d, want TransactionDone", got)
+	}
+}
+
+func TestWirePhase_NACK(t *testing.T) {
+	var tracker wirePhaseTracker
+	tracker.startRequest()
+
+	// Minimal request: SRC, DST, PB, SB, LEN=0, CRC
+	for _, b := range []byte{0x71, 0x08, 0xB5, 0x24, 0x00} {
+		tracker.advance(b)
+	}
+	got := tracker.advance(0xDD) // CRC
+	if got != wirePhaseEventRequestComplete {
+		t.Fatalf("CRC: got event %d, want RequestComplete", got)
+	}
+
+	// NACK
+	got = tracker.advance(protocol.SymbolNack)
+	if got != wirePhaseEventCmdNACK {
+		t.Fatalf("NACK: got event %d, want CmdNACK", got)
+	}
+	if !tracker.isIdle() {
+		t.Fatal("expected idle after NACK")
+	}
+}
+
+func TestWirePhase_SYNDuringWaitCmdAck(t *testing.T) {
+	var tracker wirePhaseTracker
+	tracker.startRequest()
+
+	// Send request bytes to reach WaitCmdAck
+	for _, b := range []byte{0x71, 0x08, 0xB5, 0x24, 0x00} {
+		tracker.advance(b)
+	}
+	tracker.advance(0xDD) // CRC → WaitCmdAck
+
+	// SYN during WaitCmdAck → timeout
+	got := tracker.advance(protocol.SymbolSyn)
+	if got != wirePhaseEventSYNTimeout {
+		t.Fatalf("SYN during WaitCmdAck: got event %d, want SYNTimeout", got)
+	}
+	if !tracker.isIdle() {
+		t.Fatal("expected idle after SYN timeout")
+	}
+}
+
+func TestWirePhase_SYNDuringCollectRequest(t *testing.T) {
+	var tracker wirePhaseTracker
+	tracker.startRequest()
+
+	// Send only 2 request bytes, then SYN.
+	tracker.advance(0x71) // SRC
+	tracker.advance(0x08) // DST
+
+	got := tracker.advance(protocol.SymbolSyn)
+	if got != wirePhaseEventSYNTimeout {
+		t.Fatalf("SYN during CollectRequest: got event %d, want SYNTimeout", got)
+	}
+}
+
+func TestWirePhase_EscapeByteInPayload(t *testing.T) {
+	// Verify that 0xA9 (SymbolEscape) in payload data is handled
+	// correctly as a regular data byte by the phase tracker.
+	// The tracker operates on post-ENH-decode logical bytes, so 0xA9
+	// is just a regular data value — no escape handling involved.
+	var tracker wirePhaseTracker
+	tracker.startRequest()
+
+	// SRC=0x71, DST=0x08, PB=0xB5, SB=0x24, LEN=2
+	// DATA[0]=0xA9 (escape byte as data), DATA[1]=0x42, CRC=0xCC
+	// Total: 5 header + 2 data + 1 CRC = 8 bytes
+	request := []byte{0x71, 0x08, 0xB5, 0x24, 0x02, protocol.SymbolEscape, 0x42}
+	for i, b := range request {
+		got := tracker.advance(b)
+		if got != wirePhaseEventNone {
+			t.Fatalf("byte %d (0x%02x): got event %d, want None", i+1, b, got)
+		}
+	}
+
+	// 8th byte is CRC → request complete.
+	got := tracker.advance(0xCC)
+	if got != wirePhaseEventRequestComplete {
+		t.Fatalf("CRC: got event %d, want RequestComplete", got)
+	}
+}
+
+func TestWirePhase_ZeroLengthResponse(t *testing.T) {
+	var tracker wirePhaseTracker
+	tracker.startRequest()
+
+	// SRC, DST, PB, SB, LEN=0, CRC → ACK → ResponseLEN=0, CRC → ACK
+	for _, b := range []byte{0x71, 0x08, 0xB5, 0x24, 0x00} {
+		tracker.advance(b)
+	}
+	tracker.advance(0xDD) // CRC → WaitCmdAck
+	tracker.advance(protocol.SymbolAck) // ACK → WaitResponseLen
+
+	// Response LEN=0: only CRC follows.
+	got := tracker.advance(0x00) // LEN=0
+	if got != wirePhaseEventNone {
+		t.Fatalf("response LEN=0: got event %d, want None", got)
+	}
+
+	// With LEN=0, we need 0 data bytes + 1 CRC = 1 byte remaining.
+	got = tracker.advance(0xEE) // CRC → ResponseDone
+	if got != wirePhaseEventResponseDone {
+		t.Fatalf("response CRC: got event %d, want ResponseDone", got)
+	}
+
+	got = tracker.advance(protocol.SymbolAck) // final ACK
+	if got != wirePhaseEventTransactionDone {
+		t.Fatalf("final ACK: got event %d, want TransactionDone", got)
+	}
+}

--- a/internal/adaptermux/wire_phase_test.go
+++ b/internal/adaptermux/wire_phase_test.go
@@ -20,7 +20,7 @@ func TestWirePhase_IdleOnSYN(t *testing.T) {
 }
 
 func TestWirePhase_FullTransaction(t *testing.T) {
-	// Simulate a complete master-slave transaction:
+	// Simulate a complete initiator-target transaction:
 	// SRC=0x71 DST=0x08 PB=0xB5 SB=0x24 LEN=0x02 DATA[0]=0x00 DATA[1]=0x01 CRC=0xXX
 	// → ACK → LEN=0x01 DATA[0]=0x42 CRC=0xXX → ACK
 	var tracker wirePhaseTracker
@@ -77,7 +77,7 @@ func TestWirePhase_FullTransaction(t *testing.T) {
 		t.Fatalf("response CRC: got event %d, want ResponseDone", got)
 	}
 
-	// Final ACK from master.
+	// Final ACK from initiator.
 	got = tracker.advance(protocol.SymbolAck)
 	if got != wirePhaseEventTransactionDone {
 		t.Fatalf("final ACK: got event %d, want TransactionDone", got)

--- a/passive_bus_tap.go
+++ b/passive_bus_tap.go
@@ -255,13 +255,22 @@ func (tap *PassiveBusTap) connect(ctx context.Context) error {
 	tap.status.ConnectAttemptCount++
 	tap.statusMu.Unlock()
 
-	tr, err := resolvePassiveTransport(ctx, tap.cfg)
-	if err != nil {
-		tap.statusMu.Lock()
-		tap.status.ConnectFailureCount++
-		tap.status.LastError = err.Error()
-		tap.statusMu.Unlock()
-		return err
+	var tr transport.RawTransport
+	var err error
+
+	if tap.cfg.PassiveTransport != nil {
+		// Adapter-direct mode: use pre-configured passive transport
+		// from the multiplexer (symbols are already logical, no dial needed).
+		tr = tap.cfg.PassiveTransport
+	} else {
+		tr, err = resolvePassiveTransport(ctx, tap.cfg)
+		if err != nil {
+			tap.statusMu.Lock()
+			tap.status.ConnectFailureCount++
+			tap.status.LastError = err.Error()
+			tap.statusMu.Unlock()
+			return err
+		}
 	}
 	if tap.wrap != nil {
 		tr = tap.wrap(tr)
@@ -419,6 +428,10 @@ func readPassiveTransportEvent(tr transport.RawTransport) (transport.StreamEvent
 }
 
 func passiveTapEnforcesAbsenceDisconnect(cfg Config) bool {
+	// Adapter-direct mode: multiplexer handles reconnection internally.
+	if cfg.PassiveTransport != nil {
+		return false
+	}
 	return !passiveTapUsesProxyLikeObserverTransport(cfg)
 }
 
@@ -427,6 +440,11 @@ func passiveTapDecodesWireEscapes(cfg Config) bool {
 }
 
 func passiveTapObserverStreamAlreadyLogical(cfg Config) bool {
+	// Adapter-direct mode: multiplexer delivers logical bytes
+	// (post-ENH-decode), no escape decoding needed.
+	if cfg.PassiveTransport != nil {
+		return true
+	}
 	if passiveTapUsesProxyLikeObserverTransport(cfg) {
 		return true
 	}

--- a/scripts/transport_gate.sh
+++ b/scripts/transport_gate.sh
@@ -81,6 +81,43 @@ if [[ ! -f "${report_path}" ]]; then
   exit 1
 fi
 
+# --- Adapter-direct (AD01..AD12) coverage tracking ---
+# The embedded proxy / adapter multiplexer (internal/adaptermux/) has its
+# own test matrix (AD01..AD12) covering:
+#   AD01: INIT handshake fidelity
+#   AD02: START arbitration (gateway priority, external FIFO)
+#   AD03: START cancel (SYN) with ownership release
+#   AD04: SEND echo suppression (gateway + external sessions)
+#   AD05: In-band RESETTED handling + delayed re-INIT
+#   AD06: Reconnect with session broadcast
+#   AD07: Ownership timeout enforcement
+#   AD08: Session backpressure (send buffer overflow)
+#   AD09: Passive path filtering (third-party only)
+#   AD10: INFO request forwarding
+#   AD11: Multi-session concurrent arbitration
+#   AD12: Wire phase tracking across transaction boundaries
+#
+# Current status: AD01..AD12 are covered by unit tests in
+# internal/adaptermux/*_test.go. A formal matrix report (like the
+# 88-case transport matrix) is pending implementation. This gate
+# section surfaces the gap visibly without blocking CI.
+adapter_direct_touched=0
+while IFS= read -r file; do
+  [[ -z "${file}" ]] && continue
+  case "${file}" in
+    internal/adaptermux/*.go)
+      adapter_direct_touched=1
+      break
+      ;;
+  esac
+done <<< "${changed_files}"
+
+if [[ "${adapter_direct_touched}" -eq 1 ]]; then
+  echo "transport gate: WARNING — adapter-direct files (internal/adaptermux/) modified."
+  echo "transport gate: AD01..AD12 coverage is validated by unit tests only."
+  echo "transport gate: Formal AD matrix report gate: pending implementation."
+fi
+
 python3 - "${report_path}" <<'PY'
 import json
 import sys


### PR DESCRIPTION
## Summary

- New `internal/adaptermux/` package: embeds adapter multiplexing logic directly in the gateway
- Single ENH/ENS connection to adapter hardware, demuxed into active (`RawTransport`) and passive (filtered callback) paths
- Optional external proxy endpoint for ebusd with full master access (START/SEND)
- Part of gateway-embedded-proxy plan (M1: multiplexer core)

## Components (6 source files, 3 test files)

| File | Lines | Purpose |
|------|-------|---------|
| `wire_phase.go` | 206 | eBUS transaction phase tracker (Idle→CollectRequest→...→Idle) |
| `echo_tracker.go` | 156 | Per-session echo suppression — frame-level, eliminates proxy escape bug |
| `arbitration.go` | 234 | 2-class gateway-priority owner arbitration + external FIFO |
| `mux.go` | 770 | Core: connection, readLoop, sendLoop, RESETTED, reconnection |
| `active_path.go` | 121 | `RawTransport` + `StreamEventReader` wrapper for gateway.Bus |
| `session.go` | 404 | External ENH sessions: reader/writer, START/SEND, backpressure |

## Key design decisions

- **D3**: Multi-owner with `hasOwner` flag + `done` channel (no close(sendCh) panic)
- **D4**: Echo tracking on logical bytes post-ENH-decode — zero escape sequences stored
- **Lock ordering**: `stateMu` → release → `sessionsMu` (never nested, verified 3 rounds)

## Review history

3 rounds of adversarial code review with specialized agents:

| Round | Found | Fixed | Key issues |
|-------|-------|-------|------------|
| R1 | 4C + 7H + 8M | 19/19 | blocking send, silent drops, data race, INIT fatal |
| R2 | 2C + 3I + 2M | 7/7 | ABBA deadlock, close-panic, defer order, goroutine tracking |
| R3 | 0C + 0H + 2M + 1L | 3/3 | writeLoop cleanup, INFO log, conn.Close log |

## Test plan

- [x] 24/24 unit tests pass with `-race` detector
- [x] Codex adversarial review on PR
- [x] M2 integration (gateway active/passive path wiring) — same PR
- [ ] Live bus validation — deferred to M5

🤖 Generated with [Claude Code](https://claude.com/claude-code)