### PR TITLE
fix(adaptermux): Init consumer update + P0/P1 fixes

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -596,7 +596,12 @@ func wireAdapterDirect(ctx context.Context, cfg *ebusgateway.Config) (func() err
 	mux := adaptermux.New(muxCfg)
 
 	// Create passive transport BEFORE Start() so the callback is wired.
-	passiveTransport := mux.PassiveTransport()
+	// Only create it when BroadcastListen is enabled — otherwise no
+	// consumer reads from the passive channel and reset delivery blocks
+	// readLoop (P0 deadlock fix).
+	if cfg.BroadcastListen {
+		cfg.PassiveTransport = mux.PassiveTransport()
+	}
 
 	if err := mux.Start(ctx); err != nil {
 		return nil, fmt.Errorf("start multiplexer: %w", err)
@@ -619,7 +624,6 @@ func wireAdapterDirect(ctx context.Context, cfg *ebusgateway.Config) (func() err
 
 	// Configure gateway transports.
 	cfg.Transport = mux.ActiveTransport()
-	cfg.PassiveTransport = passiveTransport
 
 	// Return a closer that cleans up both the proxy listener (if any)
 	// and the mux itself. This covers early run() failures where

--- a/gateway.go
+++ b/gateway.go
@@ -3,6 +3,7 @@ package ebusgateway
 import (
 	"context"
 	"fmt"
+	"log"
 	"net"
 	"net/url"
 	"strings"
@@ -353,7 +354,7 @@ func transportFromConn(protocolName TransportProtocol, conn net.Conn, readTimeou
 }
 
 type initTransport interface {
-	Init(features byte) error
+	Init(features byte) (byte, error)
 }
 
 func initTransportIfSupported(tr transport.RawTransport) error {
@@ -364,9 +365,11 @@ func initTransportIfSupported(tr transport.RawTransport) error {
 	// Match ebusd behavior: request additional infos (bit0) during INIT.
 	// Some adapters gate optional capabilities behind this feature flag.
 	const defaultInitFeatures = byte(0x01)
-	if err := initializer.Init(defaultInitFeatures); err != nil {
+	features, err := initializer.Init(defaultInitFeatures)
+	if err != nil {
 		return fmt.Errorf("gateway transport init failed: %w", err)
 	}
+	log.Printf("gateway: transport INIT succeeded, upstream features=0x%02X", features)
 	return nil
 }
 

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -667,10 +667,10 @@ type mockInitTransport struct {
 	features []byte
 }
 
-func (m *mockInitTransport) Init(features byte) error {
+func (m *mockInitTransport) Init(features byte) (byte, error) {
 	m.called = true
 	m.features = append(m.features, features)
-	return nil
+	return features, nil
 }
 
 func (m *mockInitTransport) ReadByte() (byte, error) { return 0, nil }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Project-Helianthus/helianthus-ebusgateway
 go 1.22
 
 require (
-	github.com/Project-Helianthus/helianthus-ebusgo v0.0.0-20260408195421-c3a36d29202f
+	github.com/Project-Helianthus/helianthus-ebusgo v0.0.0-20260410043834-6cdf98eb2cb6
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260330094734-6ef17332ab77
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Project-Helianthus/helianthus-ebusgo v0.0.0-20260408195421-c3a36d29202f h1:VegPSvk2uiw0qwVLTNifcPMr5FjztobHNd1mK0BRQK0=
-github.com/Project-Helianthus/helianthus-ebusgo v0.0.0-20260408195421-c3a36d29202f/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
+github.com/Project-Helianthus/helianthus-ebusgo v0.0.0-20260410043834-6cdf98eb2cb6 h1:iKIkyWqHC1tjhxAakj/+JruiGBYVWrWHrU26cV8vRe8=
+github.com/Project-Helianthus/helianthus-ebusgo v0.0.0-20260410043834-6cdf98eb2cb6/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260330094734-6ef17332ab77 h1:l4tLnidcf3Xr9gwMT1etgZg231UCpe9cLQcdXAotgRU=
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260330094734-6ef17332ab77/go.mod h1:FrDhh/Q0KQhP+11jGrQFJLur/kLjAA2mQ7UjJYthOlE=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=

--- a/internal/adaptermux/listener_test.go
+++ b/internal/adaptermux/listener_test.go
@@ -40,8 +40,8 @@ func fakeAdapterServer(t *testing.T) (addr string, closer func()) {
 			return
 		}
 
-		// Respond with RESETTED.
-		resetted := transport.EncodeENH(transport.ENHResResetted, 0x00)
+		// Respond with RESETTED carrying upstream features=0x01.
+		resetted := transport.EncodeENH(transport.ENHResResetted, 0x01)
 		if _, err := conn.Write(resetted[:]); err != nil {
 			return
 		}

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -311,22 +311,17 @@ func (m *Mux) connect() error {
 	m.upstream = tr
 
 	// Perform INIT handshake — fatal if transport implements Init.
-	// Store the negotiated features byte for session INIT replies.
-	// ENHTransport.Init returns error only — the upstream's actual
-	// features byte is not exposed. Store the requested value (0x01)
-	// as the best-effort fallback.
+	// Store the negotiated features byte from the upstream RESETTED
+	// response for session INIT reply fidelity.
 	const requestedFeatures byte = 0x01
-	if initer, ok := tr.(interface{ Init(byte) error }); ok {
-		if err := initer.Init(requestedFeatures); err != nil {
+	if initer, ok := tr.(interface{ Init(byte) (byte, error) }); ok {
+		features, err := initer.Init(requestedFeatures)
+		if err != nil {
 			_ = conn.Close()
 			return fmt.Errorf("adaptermux: INIT handshake failed: %w", err)
 		}
-		// NOTE: ENHTransport.Init() does not expose the upstream RESETTED
-		// response payload. We store the requested features (0x01) as a
-		// best-effort fallback. Faithful upstream feature negotiation requires
-		// extending the ebusgo transport.Init interface to return the response
-		// payload — tracked as a known contract divergence from the proxy.
-		m.upstreamFeatures.Store(uint32(requestedFeatures))
+		m.upstreamFeatures.Store(uint32(features))
+		m.logger.Printf("adaptermux: INIT handshake succeeded, upstream features=0x%02X", features)
 	}
 
 	return nil
@@ -665,15 +660,17 @@ func (m *Mux) handleReset() {
 		m.connMu.Lock()
 		tr := m.upstream
 		m.connMu.Unlock()
-		if initer, ok := tr.(interface{ Init(byte) error }); ok {
-			features := byte(m.upstreamFeatures.Load())
-			if features == 0 {
-				features = 0x01
+		if initer, ok := tr.(interface{ Init(byte) (byte, error) }); ok {
+			reqFeatures := byte(m.upstreamFeatures.Load())
+			if reqFeatures == 0 {
+				reqFeatures = 0x01
 			}
-			if err := initer.Init(features); err != nil {
+			features, err := initer.Init(reqFeatures)
+			if err != nil {
 				m.logger.Printf("adaptermux: re-INIT after RESETTED failed: %v", err)
 			} else {
-				m.logger.Printf("adaptermux: re-INIT after RESETTED succeeded")
+				m.upstreamFeatures.Store(uint32(features))
+				m.logger.Printf("adaptermux: re-INIT after RESETTED succeeded, features=0x%02X", features)
 			}
 		}
 	}()

--- a/internal/adaptermux/pr472_regression_test.go
+++ b/internal/adaptermux/pr472_regression_test.go
@@ -18,12 +18,13 @@ import (
 // --- Fix 1 regression: handleReset schedules delayed re-INIT ---
 
 // mockInitTransport is a RawTransport that records Init calls.
-// It satisfies both RawTransport and the Init(byte)error interface.
+// It satisfies both RawTransport and the Init(byte)(byte,error) interface.
 type mockInitTransport struct {
-	mu        sync.Mutex
-	initCalls []byte // features bytes passed to Init
-	readCh    chan byte
-	closed    bool
+	mu             sync.Mutex
+	initCalls      []byte // features bytes passed to Init
+	returnFeatures byte   // features byte to return from Init (0 = echo request)
+	readCh         chan byte
+	closed         bool
 }
 
 func newMockInitTransport() *mockInitTransport {
@@ -32,11 +33,15 @@ func newMockInitTransport() *mockInitTransport {
 	}
 }
 
-func (m *mockInitTransport) Init(features byte) error {
+func (m *mockInitTransport) Init(features byte) (byte, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.initCalls = append(m.initCalls, features)
-	return nil
+	ret := m.returnFeatures
+	if ret == 0 {
+		ret = features
+	}
+	return ret, nil
 }
 
 func (m *mockInitTransport) ReadByte() (byte, error) {
@@ -199,6 +204,50 @@ func TestHandleReset_ReINITFallsBackToDefault(t *testing.T) {
 	}
 	if calls[0] != 0x01 {
 		t.Fatalf("fallback re-INIT features = 0x%02x, want 0x01", calls[0])
+	}
+
+	cancel()
+	mux.wg.Wait()
+}
+
+// TestHandleReset_ReINITStoresUpstreamFeatures verifies that the
+// features byte returned by Init is stored in upstreamFeatures,
+// replacing the previously stored value (PR-B breaking change fix).
+func TestHandleReset_ReINITStoresUpstreamFeatures(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mock := newMockInitTransport()
+	mock.returnFeatures = 0x03 // adapter returns different features
+
+	mux := New(Config{
+		Protocol:    "enh",
+		Network:     "tcp",
+		Address:     "127.0.0.1:0",
+		ReadTimeout: 200 * time.Millisecond,
+	})
+	mux.ctx, mux.cancel = ctx, cancel
+
+	mux.connMu.Lock()
+	mux.upstream = mock
+	mux.connMu.Unlock()
+	mux.upstreamFeatures.Store(0x01) // initial features
+
+	mux.handleReset()
+
+	// Wait for re-INIT to complete.
+	time.Sleep(300 * time.Millisecond)
+
+	calls := mock.getInitCalls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 Init call, got %d", len(calls))
+	}
+
+	// Verify the returned features (0x03) were stored, not the
+	// requested features (0x01).
+	stored := byte(mux.upstreamFeatures.Load())
+	if stored != 0x03 {
+		t.Fatalf("upstreamFeatures after re-INIT = 0x%02X, want 0x03", stored)
 	}
 
 	cancel()

--- a/internal/adaptermux/session.go
+++ b/internal/adaptermux/session.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -303,6 +304,11 @@ func (s *session) handleStart(initiator byte) {
 			}
 			if result.granted {
 				s.deliverStarted(result.initiator)
+			} else if result.err != nil && isResetOrDisconnectError(result.err) {
+				// Reset/disconnect caused the START failure — deliver
+				// RESETTED so the client sees the correct boundary event
+				// instead of a spurious collision (P1 fix).
+				s.deliverReset(byte(s.mux.upstreamFeatures.Load()))
 			} else {
 				s.deliverFailed(result.initiator)
 			}
@@ -473,4 +479,17 @@ func (s *session) writeFrame(frame sessionFrame) error {
 
 	_, err := s.conn.Write(buf)
 	return err
+}
+
+// isResetOrDisconnectError reports whether err represents a bus reset
+// or adapter disconnect, as opposed to an arbitration collision. When
+// a pending START fails due to reset/disconnect, the session should
+// see RESETTED (not FAILED) so the client can distinguish boundary
+// events from normal collision backoff.
+func isResetOrDisconnectError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "reset") || strings.Contains(msg, "disconnect")
 }

--- a/internal/adaptermux/session_test.go
+++ b/internal/adaptermux/session_test.go
@@ -3,6 +3,7 @@ package adaptermux
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net"
 	"testing"
@@ -397,6 +398,110 @@ func TestMux_CloseWithoutStart(t *testing.T) {
 	// Double close also safe.
 	err2 := mux.Close()
 	_ = err2
+}
+
+// --- P1 fix: reset/disconnect errors deliver RESETTED not FAILED ---
+
+func TestIsResetOrDisconnectError(t *testing.T) {
+	tests := []struct {
+		err  error
+		want bool
+	}{
+		{nil, false},
+		{errors.New("arbitration collision"), false},
+		{errors.New("adapter refused"), false},
+		{errors.New("adaptermux: adapter reset"), true},
+		{errors.New("adaptermux: adapter disconnected"), true},
+		{errors.New("RESET during arbitration"), true},
+		{errors.New("connection disconnect"), true},
+	}
+	for _, tt := range tests {
+		got := isResetOrDisconnectError(tt.err)
+		label := "<nil>"
+		if tt.err != nil {
+			label = tt.err.Error()
+		}
+		if got != tt.want {
+			t.Errorf("isResetOrDisconnectError(%q) = %v, want %v", label, got, tt.want)
+		}
+	}
+}
+
+func TestSession_StartFailedByResetDeliversResetted(t *testing.T) {
+	mux, _, cleanup := newTestMux(t)
+	defer cleanup()
+
+	client, server := net.Pipe()
+	defer client.Close()
+
+	id := mux.AddSession(server)
+	defer mux.RemoveSession(id)
+
+	// Send START.
+	startReq := transport.EncodeENH(transport.ENHReqStart, 0x31)
+	if _, err := client.Write(startReq[:]); err != nil {
+		t.Fatalf("write START: %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	_, _, notify, granted := mux.arb.tryGrant()
+	if !granted {
+		t.Fatal("expected grant")
+	}
+
+	// Simulate failure caused by adapter reset (not collision).
+	notify <- startResult{granted: false, initiator: 0x31, err: errors.New("adaptermux: adapter reset")}
+
+	frame := readENHFrame(t, client, 2*time.Second)
+
+	// Should be RESETTED (not FAILED) since the cause was a reset.
+	features := byte(mux.upstreamFeatures.Load())
+	expected := transport.EncodeENH(transport.ENHResResetted, features)
+	if frame != expected {
+		t.Fatalf("reset-caused START failure: got %x, want %x (RESETTED)", frame, expected)
+	}
+
+	// Verify it is NOT FAILED.
+	notExpected := transport.EncodeENH(transport.ENHResFailed, 0x31)
+	if frame == notExpected {
+		t.Fatal("reset-caused START failure should deliver RESETTED, not FAILED")
+	}
+}
+
+func TestSession_StartFailedByCollisionDeliversFailed(t *testing.T) {
+	mux, _, cleanup := newTestMux(t)
+	defer cleanup()
+
+	client, server := net.Pipe()
+	defer client.Close()
+
+	id := mux.AddSession(server)
+	defer mux.RemoveSession(id)
+
+	// Send START.
+	startReq := transport.EncodeENH(transport.ENHReqStart, 0x42)
+	if _, err := client.Write(startReq[:]); err != nil {
+		t.Fatalf("write START: %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	_, initiator, notify, granted := mux.arb.tryGrant()
+	if !granted {
+		t.Fatal("expected grant")
+	}
+
+	// Simulate collision failure (not reset).
+	notify <- startResult{granted: false, initiator: initiator, err: errors.New("adapter refused")}
+
+	frame := readENHFrame(t, client, 2*time.Second)
+
+	// Should be FAILED (collision), not RESETTED.
+	expected := transport.EncodeENH(transport.ENHResFailed, 0x42)
+	if frame != expected {
+		t.Fatalf("collision START failure: got %x, want %x (FAILED)", frame, expected)
+	}
 }
 
 // Verify Close is safe from concurrent goroutines.

--- a/scripts/transport_gate.sh
+++ b/scripts/transport_gate.sh
@@ -113,9 +113,18 @@ while IFS= read -r file; do
 done <<< "${changed_files}"
 
 if [[ "${adapter_direct_touched}" -eq 1 ]]; then
-  echo "transport gate: WARNING — adapter-direct files (internal/adaptermux/) modified."
-  echo "transport gate: AD01..AD12 coverage is validated by unit tests only."
-  echo "transport gate: Formal AD matrix report gate: pending implementation."
+  # AD gate: adaptermux changes require AD01..AD12 coverage evidence.
+  # Until the formal AD matrix report is implemented, allow explicit
+  # bypass via HELIANTHUS_AD_GATE_SKIP with a documented reason.
+  if [[ -n "${HELIANTHUS_AD_GATE_SKIP:-}" ]]; then
+    echo "transport gate: AD gate bypassed — ${HELIANTHUS_AD_GATE_SKIP}"
+  else
+    echo "transport gate: FAIL — adapter-direct files (internal/adaptermux/) modified."
+    echo "transport gate: AD01..AD12 coverage evidence required."
+    echo "transport gate: Unit tests in internal/adaptermux/*_test.go must pass."
+    echo "transport gate: Set HELIANTHUS_AD_GATE_SKIP='<reason>' to bypass with documented reason."
+    exit 1
+  fi
 fi
 
 python3 - "${report_path}" <<'PY'

--- a/scripts/transport_gate.sh
+++ b/scripts/transport_gate.sh
@@ -39,7 +39,8 @@ requires_transport_gate() {
     smoke.go|\
     smoke_config.go|\
     cmd/smoke/*|\
-    cmd/ebusdscan/*)
+    cmd/ebusdscan/*|\
+    internal/adaptermux/*)
       return 0
       ;;
   esac


### PR DESCRIPTION
## Summary

- **Init interface update (PR-B breaking change)**: Update all `Init(byte) error` type assertions to `Init(byte) (byte, error)` matching ebusgo 6cdf98e. The old interface caused a silent runtime regression where Init handshakes were skipped because the type assertion failed.
- **P0: Passive transport deadlock**: Only create `PassiveTransport()` when `BroadcastListen` is enabled. Previously it was always created in adapter-direct mode even when no consumer was reading, causing blocking reset sends to wedge `readLoop`.
- **P1: Reset-caused START failures**: When a pending START fails due to adapter reset/disconnect, deliver `RESETTED` instead of `FAILED` so external clients distinguish bus boundary events from arbitration collisions.
- **P0: AD gate enforcement**: transport_gate.sh now blocks CI when adaptermux files are modified without AD01..AD12 coverage evidence. `HELIANTHUS_AD_GATE_SKIP` env var allows documented bypass.

## Test plan

- [x] All existing tests pass (go test ./... -race -count=1)
- [x] New test: `TestHandleReset_ReINITStoresUpstreamFeatures` -- verifies re-INIT stores returned features
- [x] New test: `TestIsResetOrDisconnectError` -- table-driven error classification
- [x] New test: `TestSession_StartFailedByResetDeliversResetted` -- reset errors deliver RESETTED
- [x] New test: `TestSession_StartFailedByCollisionDeliversFailed` -- collision errors still deliver FAILED
- [x] Fake adapter updated to return features=0x01 (realistic behavior)
- [x] Zero race conditions under `-race`

## AD gate

```bash
HELIANTHUS_AD_GATE_SKIP="PR-D: Init consumer update + P0/P1 fixes, AD01 re-validated by TestHandleReset_ReINITStoresUpstreamFeatures"
```

Generated with [Claude Code](https://claude.com/claude-code)