### PR TITLE
fix(adaptermux): remove re-INIT on in-band RESETTED

### DIFF
--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -700,35 +700,12 @@ func (m *Mux) handleReset() {
 	m.emitPassive(PassiveEvent{Kind: PassiveEventReset, ObservedAt: now})
 	m.broadcastResetToSessions()
 
-	// Schedule delayed re-INIT after in-band RESETTED (200ms stabilization).
-	// Without re-INIT the upstream transport stays in reset state and
-	// ownership cannot be re-acquired until a physical TCP disconnect
-	// triggers reconnect(). The 200ms delay is from proxy convention.
-	m.wg.Add(1)
-	go func() { // goroutine: delayed re-INIT after adapter RESETTED
-		defer m.wg.Done()
-		select {
-		case <-time.After(200 * time.Millisecond):
-		case <-m.ctx.Done():
-			return
-		}
-		m.connMu.Lock()
-		tr := m.upstream
-		m.connMu.Unlock()
-		if initer, ok := tr.(interface{ Init(byte) (byte, error) }); ok {
-			reqFeatures := byte(m.upstreamFeatures.Load())
-			if reqFeatures == 0 {
-				reqFeatures = 0x01
-			}
-			features, err := initer.Init(reqFeatures)
-			if err != nil {
-				m.logger.Printf("adaptermux: re-INIT after RESETTED failed: %v", err)
-			} else {
-				m.upstreamFeatures.Store(uint32(features))
-				m.logger.Printf("adaptermux: re-INIT after RESETTED succeeded, features=0x%02X", features)
-			}
-		}
-	}()
+	// NOTE: We intentionally do NOT re-INIT after in-band RESETTED.
+	// Re-INIT sends ENHReqInit which the adapter answers with another
+	// RESETTED, creating an infinite reset loop on ENS adapters.
+	// The INIT handshake is performed once in connect() at TCP connection
+	// time and again in reconnect() after a TCP disconnect. In-band
+	// RESETTED only requires state cleanup (above), not re-negotiation.
 }
 
 // drainActiveCh discards all buffered events from the active channel.

--- a/internal/adaptermux/pr472_regression_test.go
+++ b/internal/adaptermux/pr472_regression_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
 )
 
-// --- Fix 1 regression: handleReset schedules delayed re-INIT ---
+// --- Fix 1 regression: handleReset does NOT re-INIT (reset loop prevention) ---
 
 // mockInitTransport is a RawTransport that records Init calls.
 // It satisfies both RawTransport and the Init(byte)(byte,error) interface.
@@ -74,64 +74,15 @@ func (m *mockInitTransport) getInitCalls() []byte {
 	return result
 }
 
-// TestHandleReset_SchedulesDelayedReINIT verifies that handleReset()
-// spawns a goroutine that calls Init on the upstream transport after
-// a 200ms stabilization delay. Without the fix, no re-INIT occurs
-// after in-band RESETTED and the transport stays in reset state.
-func TestHandleReset_SchedulesDelayedReINIT(t *testing.T) {
+// TestHandleReset_NoReINIT verifies that handleReset() does NOT call
+// Init on the upstream transport. Re-INIT after in-band RESETTED
+// causes an infinite reset loop on ENS adapters: Init sends ENHReqInit,
+// adapter responds with RESETTED, which triggers another handleReset,
+// ad infinitum. INIT is only performed at TCP connection time in
+// connect(). upstreamFeatures must be preserved across in-band resets.
+func TestHandleReset_NoReINIT(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-
-	mock := newMockInitTransport()
-
-	mux := New(Config{
-		Protocol:    "enh",
-		Network:     "tcp",
-		Address:     "127.0.0.1:0", // not used — we inject the transport
-		ReadTimeout: 200 * time.Millisecond,
-	})
-	mux.ctx, mux.cancel = ctx, cancel
-
-	// Inject mock transport and set upstream features.
-	mux.connMu.Lock()
-	mux.upstream = mock
-	mux.connMu.Unlock()
-	mux.upstreamFeatures.Store(0x01)
-
-	// Verify no Init calls before handleReset.
-	if calls := mock.getInitCalls(); len(calls) != 0 {
-		t.Fatalf("expected 0 Init calls before handleReset, got %d", len(calls))
-	}
-
-	// Trigger handleReset — this should schedule a delayed re-INIT.
-	mux.handleReset()
-
-	// Before 200ms, no re-INIT should have occurred.
-	time.Sleep(50 * time.Millisecond)
-	if calls := mock.getInitCalls(); len(calls) != 0 {
-		t.Fatalf("expected 0 Init calls 50ms after handleReset, got %d", len(calls))
-	}
-
-	// After 300ms (200ms delay + margin), exactly 1 re-INIT should occur.
-	time.Sleep(250 * time.Millisecond)
-	calls := mock.getInitCalls()
-	if len(calls) != 1 {
-		t.Fatalf("expected 1 Init call 300ms after handleReset, got %d", len(calls))
-	}
-	if calls[0] != 0x01 {
-		t.Fatalf("re-INIT features = 0x%02x, want 0x01", calls[0])
-	}
-
-	// Cleanup: cancel context and wait for goroutines.
-	cancel()
-	mux.wg.Wait()
-}
-
-// TestHandleReset_ReINITCancelledOnShutdown verifies that the delayed
-// re-INIT goroutine exits cleanly when the mux context is cancelled
-// during the 200ms wait.
-func TestHandleReset_ReINITCancelledOnShutdown(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
 
 	mock := newMockInitTransport()
 
@@ -148,106 +99,22 @@ func TestHandleReset_ReINITCancelledOnShutdown(t *testing.T) {
 	mux.connMu.Unlock()
 	mux.upstreamFeatures.Store(0x01)
 
+	// Trigger handleReset multiple times to simulate repeated in-band RESETTED.
+	mux.handleReset()
+	mux.handleReset()
 	mux.handleReset()
 
-	// Cancel context before the 200ms delay elapses.
-	time.Sleep(50 * time.Millisecond)
-	cancel()
+	// Wait well past the old 200ms re-INIT delay.
+	time.Sleep(400 * time.Millisecond)
 
-	// Wait for all goroutines to finish.
-	done := make(chan struct{})
-	go func() {
-		mux.wg.Wait()
-		close(done)
-	}()
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("re-INIT goroutine did not exit after context cancel")
-	}
-
-	// No Init calls should have been made.
+	// No Init calls should have occurred — re-INIT was removed.
 	if calls := mock.getInitCalls(); len(calls) != 0 {
-		t.Fatalf("expected 0 Init calls after early cancel, got %d", len(calls))
-	}
-}
-
-// TestHandleReset_ReINITFallsBackToDefault verifies that when
-// upstreamFeatures is 0 (e.g. ENS transport), the re-INIT uses
-// the default features byte 0x01.
-func TestHandleReset_ReINITFallsBackToDefault(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	mock := newMockInitTransport()
-
-	mux := New(Config{
-		Protocol:    "enh",
-		Network:     "tcp",
-		Address:     "127.0.0.1:0",
-		ReadTimeout: 200 * time.Millisecond,
-	})
-	mux.ctx, mux.cancel = ctx, cancel
-
-	mux.connMu.Lock()
-	mux.upstream = mock
-	mux.connMu.Unlock()
-	mux.upstreamFeatures.Store(0) // unknown features
-
-	mux.handleReset()
-
-	time.Sleep(300 * time.Millisecond)
-
-	calls := mock.getInitCalls()
-	if len(calls) != 1 {
-		t.Fatalf("expected 1 Init call, got %d", len(calls))
-	}
-	if calls[0] != 0x01 {
-		t.Fatalf("fallback re-INIT features = 0x%02x, want 0x01", calls[0])
+		t.Fatalf("expected 0 Init calls after handleReset, got %d (reset loop not fixed)", len(calls))
 	}
 
-	cancel()
-	mux.wg.Wait()
-}
-
-// TestHandleReset_ReINITStoresUpstreamFeatures verifies that the
-// features byte returned by Init is stored in upstreamFeatures,
-// replacing the previously stored value (PR-B breaking change fix).
-func TestHandleReset_ReINITStoresUpstreamFeatures(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	mock := newMockInitTransport()
-	mock.returnFeatures = 0x03 // adapter returns different features
-
-	mux := New(Config{
-		Protocol:    "enh",
-		Network:     "tcp",
-		Address:     "127.0.0.1:0",
-		ReadTimeout: 200 * time.Millisecond,
-	})
-	mux.ctx, mux.cancel = ctx, cancel
-
-	mux.connMu.Lock()
-	mux.upstream = mock
-	mux.connMu.Unlock()
-	mux.upstreamFeatures.Store(0x01) // initial features
-
-	mux.handleReset()
-
-	// Wait for re-INIT to complete.
-	time.Sleep(300 * time.Millisecond)
-
-	calls := mock.getInitCalls()
-	if len(calls) != 1 {
-		t.Fatalf("expected 1 Init call, got %d", len(calls))
-	}
-
-	// Verify the returned features (0x03) were stored, not the
-	// requested features (0x01).
-	stored := byte(mux.upstreamFeatures.Load())
-	if stored != 0x03 {
-		t.Fatalf("upstreamFeatures after re-INIT = 0x%02X, want 0x03", stored)
+	// upstreamFeatures must be preserved (not cleared).
+	if f := mux.upstreamFeatures.Load(); f != 0x01 {
+		t.Fatalf("upstreamFeatures = 0x%02X after handleReset, want 0x01 (should be preserved)", f)
 	}
 
 	cancel()
@@ -420,9 +287,9 @@ func TestBroadcastReset_MultipleSessionsAllGetFeatures(t *testing.T) {
 // --- Fix 1+4 combined: handleReset triggers broadcast with features ---
 
 // TestHandleReset_BroadcastCarriesFeatures verifies the end-to-end
-// path: handleReset() calls broadcastResetToSessions() which now
-// sends upstreamFeatures. This catches regressions in both the
-// handleReset path and the broadcast features fix working together.
+// path: handleReset() calls broadcastResetToSessions() which sends
+// upstreamFeatures. This catches regressions in both the handleReset
+// path and the broadcast features fix working together.
 func TestHandleReset_BroadcastCarriesFeatures(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -458,7 +325,7 @@ func TestHandleReset_BroadcastCarriesFeatures(t *testing.T) {
 		t.Fatalf("RESETTED after handleReset = %x, want %x (features 0x07)", frame, expected)
 	}
 
-	// Wait for re-INIT goroutine to complete.
+	// No re-INIT goroutine to wait for — handleReset no longer spawns one.
 	cancel()
 	mux.wg.Wait()
 }


### PR DESCRIPTION
## Summary

- Removes the re-INIT goroutine from `handleReset()` that caused an infinite RESETTED loop on ENS adapters in adapter-direct mode
- On real hardware, `Init()` sends `ENHReqInit` which the adapter answers with `RESETTED`, triggering another `handleReset` -> another `Init()` -> loop (~1/sec indefinitely)
- INIT handshake is already performed at TCP connection time in `connect()` and on `reconnect()` -- in-band RESETTED only needs state cleanup, not re-negotiation

## Root cause

```
adapter sends RESETTED -> handleReset() -> 200ms delay -> Init() -> adapter sends RESETTED -> handleReset() -> ...
```

## Test plan

- [x] Replaced 4 re-INIT tests with `TestHandleReset_NoReINIT` that verifies Init is NOT called (3x handleReset, 400ms wait, zero Init calls)
- [x] Updated `TestHandleReset_BroadcastCarriesFeatures` -- removed re-INIT goroutine wait
- [x] Full test suite passes with `-race`: `go test ./internal/adaptermux/ -count=1 -race`
- [ ] Deploy to RPi4 and verify no RESETTED loop in adapter-direct mode