### PR TITLE
fix(adaptermux): proxy listener + ReadByte timeout

### DIFF
--- a/internal/adaptermux/active_path.go
+++ b/internal/adaptermux/active_path.go
@@ -3,6 +3,7 @@ package adaptermux
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	ebuserrors "github.com/Project-Helianthus/helianthus-ebusgo/errors"
 	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
@@ -40,6 +41,15 @@ var (
 // readLoop resumes, so the consumer sees events in exact enqueue
 // order — no priority select needed.
 func (t *activeTransport) ReadByte() (byte, error) {
+	// Use the upstream ReadTimeout as a deadline for activeCh reads.
+	// Without this, ReadByte blocks indefinitely when the bus is quiet
+	// or when ownership is lost mid-transaction (activeCh stops receiving
+	// new bytes). The timeout allows bus.readByte's caller to check its
+	// context and retry or abort, matching ENH/ENS transport behavior
+	// where TCP read timeout provides the same boundary.
+	timer := time.NewTimer(t.mux.cfg.ReadTimeout)
+	defer timer.Stop()
+
 	select {
 	case ev := <-t.mux.activeCh:
 		if ev.kind == activeEventError {
@@ -49,6 +59,8 @@ func (t *activeTransport) ReadByte() (byte, error) {
 			return 0, errors.New("adaptermux: unexpected nil error")
 		}
 		return ev.b, nil
+	case <-timer.C:
+		return 0, fmt.Errorf("adaptermux: %w", ebuserrors.ErrTimeout)
 	case <-t.mux.ctx.Done():
 		return 0, fmt.Errorf("adaptermux: %w", t.mux.ctx.Err())
 	}
@@ -59,6 +71,9 @@ func (t *activeTransport) ReadByte() (byte, error) {
 //
 // Same FIFO guarantee as ReadByte — see comment there.
 func (t *activeTransport) ReadEvent() (transport.StreamEvent, error) {
+	timer := time.NewTimer(t.mux.cfg.ReadTimeout)
+	defer timer.Stop()
+
 	select {
 	case ev := <-t.mux.activeCh:
 		if ev.kind == activeEventError {
@@ -76,6 +91,8 @@ func (t *activeTransport) ReadEvent() (transport.StreamEvent, error) {
 			Kind: transport.StreamEventByte,
 			Byte: ev.b,
 		}, nil
+	case <-timer.C:
+		return transport.StreamEvent{}, fmt.Errorf("adaptermux: %w", ebuserrors.ErrTimeout)
 	case <-t.mux.ctx.Done():
 		return transport.StreamEvent{}, fmt.Errorf("adaptermux: %w", t.mux.ctx.Err())
 	}


### PR DESCRIPTION
## Summary

- **Proxy listener (BUG #2):** The HA addon run script was not passing `--proxy-listen` to the gateway binary. The gateway code correctly creates and starts `ProxyListener` when `ProxyListenAddr != ""`, but the flag was never passed. Companion fix in helianthus-ha-addon adds `--proxy-listen 0.0.0.0:19001` when adapter-direct is enabled. Port 19001 now listens for external ebusd/VRC Explorer/Wireshark ENS/ENH connections.

- **ReadByte/ReadEvent deadlock (BUG #3):** `activeTransport.ReadByte()` blocked indefinitely on `activeCh` with no timeout — only `mux.ctx.Done()` could cancel it. When `bus.Send` context expired, `bus.readByte` stayed blocked in `transport.ReadByte()`. The bus `runLoop` could not process the next request, and `readLoop` kept pushing bytes to `activeCh` until it filled up (4096 cap), killing all bus communication. Fix adds `time.NewTimer(cfg.ReadTimeout)` (50ms) to both `ReadByte` and `ReadEvent`, returning `ErrTimeout` on expiry. This matches ENH/ENS transport behavior where TCP read timeout provides the same boundary.

## Test plan

- [x] `go test -count=1 ./internal/adaptermux/...` — PASS (52s)
- [x] `go test -count=1 ./cmd/gateway/...` — PASS (4.5s)
- [x] `go vet ./...` — clean
- [ ] Deploy to RPi4, verify port 19001 is listening
- [ ] Monitor for 5+ minutes — no "active channel full" messages
- [ ] Verify ebusd connects to `local-helianthus.local.hass.io:19001`