### PR TITLE
deps: update helianthus-ebusgo — remove timeout retries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Project-Helianthus/helianthus-ebusgateway
 go 1.22
 
 require (
-	github.com/Project-Helianthus/helianthus-ebusgo v0.0.0-20260410050005-f3bb7c58ee1c
+	github.com/Project-Helianthus/helianthus-ebusgo v0.4.1-0.20260412064839-8e012dc6925b
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260330094734-6ef17332ab77
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Project-Helianthus/helianthus-ebusgo v0.0.0-20260410050005-f3bb7c58ee1c h1:yvGdMJ3ojykTv/UPVe0Y0ssfZefEAFiRHV+/CxBfhVY=
-github.com/Project-Helianthus/helianthus-ebusgo v0.0.0-20260410050005-f3bb7c58ee1c/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
+github.com/Project-Helianthus/helianthus-ebusgo v0.4.1-0.20260412064839-8e012dc6925b h1:SWFol85yYAuhCZUolMr6nEajMCzCCvMt84g6hbk1XEg=
+github.com/Project-Helianthus/helianthus-ebusgo v0.4.1-0.20260412064839-8e012dc6925b/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260330094734-6ef17332ab77 h1:l4tLnidcf3Xr9gwMT1etgZg231UCpe9cLQcdXAotgRU=
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260330094734-6ef17332ab77/go.mod h1:FrDhh/Q0KQhP+11jGrQFJLur/kLjAA2mQ7UjJYthOlE=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=


### PR DESCRIPTION
## Summary
- Updates helianthus-ebusgo to latest main (8e012dc) which removes timeout retries from bus protocol layer (PR ebusgo#128)

## Test plan
- [x] `go test ./internal/adaptermux/... ./cmd/gateway/...` — pass
- [ ] Deploy binary override to RPi4 and verify startup