### PR TITLE
deps: bump ebusreg to f4374c0 (pace all scan probes)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.4.1-0.20260412064839-8e012dc6925b
-	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260412074057-c13f0a1305fb
+	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260412075531-f4374c04417e
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Project-Helianthus/helianthus-ebusgo v0.4.1-0.20260412064839-8e012dc6925b h1:SWFol85yYAuhCZUolMr6nEajMCzCCvMt84g6hbk1XEg=
 github.com/Project-Helianthus/helianthus-ebusgo v0.4.1-0.20260412064839-8e012dc6925b/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260412074057-c13f0a1305fb h1:I4zstMZmps/RyBImYyBU6A/M0df5XDV5n0sHFbKD4kw=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260412074057-c13f0a1305fb/go.mod h1:FrDhh/Q0KQhP+11jGrQFJLur/kLjAA2mQ7UjJYthOlE=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260412075531-f4374c04417e h1:PMbm+AGrCSW4s2qkZ6urjJVpffGxUMZuQ/TOZA+Roew=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260412075531-f4374c04417e/go.mod h1:FrDhh/Q0KQhP+11jGrQFJLur/kLjAA2mQ7UjJYthOlE=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=


### PR DESCRIPTION
## Summary

- Bump `helianthus-ebusreg` to f4374c0 (PR helianthus-ebusreg#119)
- Fixes scan pacing to cover ALL probe outcomes (timeouts, NACKs, skips), not just successful ones
- Addresses Codex review comment on ebusreg#118

## Test plan

- [x] `go test ./cmd/gateway/... ./internal/adaptermux/...` passes locally
- [ ] CI green
- [ ] Deploy and verify correct pacing on RPi4