### PR TITLE
GraphQL snake_case field aliases for semantic types (#492)

### DIFF
--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -216,22 +216,22 @@ var b555HCNames = map[byte]string{
 	b555HCSilent:  "silent",
 }
 
-// B5.24 energy registers (VRC 720f TSP 15.720, group=0, instance=0).
+// --- Energy registers: GG=0x00/OP=0x02 (shared with system/regulator) ---
 // energy4 type = ULG (unsigned 32-bit LE) in kWh.
 const (
-	energy_fuel_sum_hc    = uint16(0x0056) // PrFuelSumHc: total gas consumption heating
-	energy_electricity_sum_hc  = uint16(0x0057) // PrEnergySumHc: total electricity consumption heating
-	energy_electricity_sum_hwc = uint16(0x0058) // PrEnergySumHwc: total electricity consumption hot water
-	energy_fuel_sum_hwc   = uint16(0x0059) // PrFuelSumHwc: total gas consumption hot water
-
-	energy_fuel_sum_hc_this_month    = uint16(0x004E) // PrFuelSumHcThisMonth: gas heating this month
-	energy_electricity_sum_hc_this_month  = uint16(0x004F) // PrEnergySumHcThisMonth: electricity heating this month
+	// STATE registers (read-only counters)
+	energy_fuel_sum_hc                   = uint16(0x0056) // PrFuelSumHc: total gas consumption heating
+	energy_electricity_sum_hc            = uint16(0x0057) // PrEnergySumHc: total electricity consumption heating
+	energy_electricity_sum_hwc           = uint16(0x0058) // PrEnergySumHwc: total electricity consumption hot water
+	energy_fuel_sum_hwc                  = uint16(0x0059) // PrFuelSumHwc: total gas consumption hot water
+	energy_fuel_sum_hc_this_month        = uint16(0x004E) // PrFuelSumHcThisMonth: gas heating this month
+	energy_electricity_sum_hc_this_month = uint16(0x004F) // PrEnergySumHcThisMonth: electricity heating this month
 	energy_electricity_sum_hwc_this_month = uint16(0x0050) // PrEnergySumHwcThisMonth: electricity hot water this month
-	energy_fuel_sum_hwc_this_month   = uint16(0x0051) // PrFuelSumHwcThisMonth: gas hot water this month
-	energy_fuel_sum_hc_last_month    = uint16(0x0052) // PrFuelSumHcLastMonth: gas heating last month
-	energy_electricity_sum_hc_last_month  = uint16(0x0053) // PrEnergySumHcLastMonth: electricity heating last month
+	energy_fuel_sum_hwc_this_month       = uint16(0x0051) // PrFuelSumHwcThisMonth: gas hot water this month
+	energy_fuel_sum_hc_last_month        = uint16(0x0052) // PrFuelSumHcLastMonth: gas heating last month
+	energy_electricity_sum_hc_last_month = uint16(0x0053) // PrEnergySumHcLastMonth: electricity heating last month
 	energy_electricity_sum_hwc_last_month = uint16(0x0054) // PrEnergySumHwcLastMonth: electricity hot water last month
-	energy_fuel_sum_hwc_last_month   = uint16(0x0055) // PrFuelSumHwcLastMonth: gas hot water last month
+	energy_fuel_sum_hwc_last_month       = uint16(0x0055) // PrFuelSumHwcLastMonth: gas hot water last month
 )
 
 type regulatorAbsenceState string

--- a/cmd/gateway/semantic_vaillant_test.go
+++ b/cmd/gateway/semantic_vaillant_test.go
@@ -2311,8 +2311,8 @@ func TestBoilerStatusRegisterDefinitionsForTier_NoReturnTemperatureMapping(t *te
 		boilerStatusTierSlow,
 	} {
 		for _, register := range boilerStatusRegisterDefinitionsForTier(tier) {
-			if register.group == localCircuits.group && register.addr == uint16(0x0008) {
-				t.Fatalf("tier %v maps GG=0x02 RR=0x0008; closed decision forbids using this as boiler return temperature", tier)
+			if register.group == localCircuits.group && register.addr == circuit_flow_temp {
+				t.Fatalf("tier %v maps GG=0x%02x RR=0x%04x; closed decision forbids using this as boiler return temperature", tier, localCircuits.group, circuit_flow_temp)
 			}
 		}
 	}

--- a/graphql/queries.go
+++ b/graphql/queries.go
@@ -57,7 +57,33 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *state.CurrentTempC, nil
 				},
 			},
+			"current_temp_c": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(ZoneState)
+					if !ok {
+						return nil, nil
+					}
+					if state.CurrentTempC == nil {
+						return nil, nil
+					}
+					return *state.CurrentTempC, nil
+				},
+			},
 			"currentHumidityPct": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(ZoneState)
+					if !ok {
+						return nil, nil
+					}
+					if state.CurrentHumidityPct == nil {
+						return nil, nil
+					}
+					return *state.CurrentHumidityPct, nil
+				},
+			},
+			"current_humidity_pct": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					state, ok := params.Source.(ZoneState)
@@ -83,7 +109,33 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return state.HvacAction, nil
 				},
 			},
+			"hvac_action": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(ZoneState)
+					if !ok {
+						return nil, nil
+					}
+					if state.HvacAction == "" {
+						return nil, nil
+					}
+					return state.HvacAction, nil
+				},
+			},
 			"specialFunction": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(ZoneState)
+					if !ok {
+						return nil, nil
+					}
+					if state.SpecialFunction == "" {
+						return nil, nil
+					}
+					return state.SpecialFunction, nil
+				},
+			},
+			"special_function": &graphqlgo.Field{
 				Type: graphqlgo.String,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					state, ok := params.Source.(ZoneState)
@@ -109,7 +161,33 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *state.HeatingDemandPct, nil
 				},
 			},
+			"heating_demand_pct": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(ZoneState)
+					if !ok {
+						return nil, nil
+					}
+					if state.HeatingDemandPct == nil {
+						return nil, nil
+					}
+					return *state.HeatingDemandPct, nil
+				},
+			},
 			"valvePositionPct": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(ZoneState)
+					if !ok {
+						return nil, nil
+					}
+					if state.ValvePositionPct == nil {
+						return nil, nil
+					}
+					return *state.ValvePositionPct, nil
+				},
+			},
+			"valve_position_pct": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					state, ok := params.Source.(ZoneState)
@@ -129,6 +207,19 @@ func buildSchemaTypes() graphqlSchemaTypes {
 		Name: "ZoneConfig",
 		Fields: graphqlgo.Fields{
 			"operatingMode": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(ZoneConfig)
+					if !ok {
+						return nil, nil
+					}
+					if config.OperatingMode == "" {
+						return nil, nil
+					}
+					return config.OperatingMode, nil
+				},
+			},
+			"operating_mode": &graphqlgo.Field{
 				Type: graphqlgo.String,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					config, ok := params.Source.(ZoneConfig)
@@ -167,7 +258,33 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *config.TargetTempC, nil
 				},
 			},
+			"target_temp_c": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(ZoneConfig)
+					if !ok {
+						return nil, nil
+					}
+					if config.TargetTempC == nil {
+						return nil, nil
+					}
+					return *config.TargetTempC, nil
+				},
+			},
 			"allowedModes": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.NewList(graphqlgo.NewNonNull(graphqlgo.String))),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(ZoneConfig)
+					if !ok {
+						return []string{}, nil
+					}
+					if len(config.AllowedModes) == 0 {
+						return []string{"off", "auto", "heat"}, nil
+					}
+					return config.AllowedModes, nil
+				},
+			},
+			"allowed_modes": &graphqlgo.Field{
 				Type: graphqlgo.NewNonNull(graphqlgo.NewList(graphqlgo.NewNonNull(graphqlgo.String))),
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					config, ok := params.Source.(ZoneConfig)
@@ -193,7 +310,33 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return config.CircuitType, nil
 				},
 			},
+			"circuit_type": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(ZoneConfig)
+					if !ok {
+						return nil, nil
+					}
+					if config.CircuitType == "" {
+						return nil, nil
+					}
+					return config.CircuitType, nil
+				},
+			},
 			"associatedCircuit": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(ZoneConfig)
+					if !ok {
+						return nil, nil
+					}
+					if config.AssociatedCircuit == nil {
+						return nil, nil
+					}
+					return *config.AssociatedCircuit, nil
+				},
+			},
+			"associated_circuit": &graphqlgo.Field{
 				Type: graphqlgo.Int,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					config, ok := params.Source.(ZoneConfig)
@@ -219,6 +362,19 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *config.RoomTemperatureZoneMapping, nil
 				},
 			},
+			"room_temperature_zone_mapping": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(ZoneConfig)
+					if !ok {
+						return nil, nil
+					}
+					if config.RoomTemperatureZoneMapping == nil {
+						return nil, nil
+					}
+					return *config.RoomTemperatureZoneMapping, nil
+				},
+			},
 			"quickVeto": &graphqlgo.Field{
 				Type: graphqlgo.NewNonNull(graphqlgo.Boolean),
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
@@ -229,7 +385,30 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return config.QuickVeto, nil
 				},
 			},
+			"quick_veto": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Boolean),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(ZoneConfig)
+					if !ok {
+						return false, nil
+					}
+					return config.QuickVeto, nil
+				},
+			},
 			"quickVetoSetpoint": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(ZoneConfig)
+					if !ok {
+						return nil, nil
+					}
+					if config.QuickVetoSetpointC == nil {
+						return nil, nil
+					}
+					return *config.QuickVetoSetpointC, nil
+				},
+			},
+			"quick_veto_setpoint": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					config, ok := params.Source.(ZoneConfig)
@@ -255,7 +434,33 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *config.QuickVetoDurationH, nil
 				},
 			},
+			"quick_veto_duration": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(ZoneConfig)
+					if !ok {
+						return nil, nil
+					}
+					if config.QuickVetoDurationH == nil {
+						return nil, nil
+					}
+					return *config.QuickVetoDurationH, nil
+				},
+			},
 			"quickVetoExpiry": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(ZoneConfig)
+					if !ok {
+						return nil, nil
+					}
+					if config.QuickVetoExpiry == "" {
+						return nil, nil
+					}
+					return config.QuickVetoExpiry, nil
+				},
+			},
+			"quick_veto_expiry": &graphqlgo.Field{
 				Type: graphqlgo.String,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					config, ok := params.Source.(ZoneConfig)
@@ -281,7 +486,33 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return config.HolidayStartDate, nil
 				},
 			},
+			"holiday_start_date": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(ZoneConfig)
+					if !ok {
+						return nil, nil
+					}
+					if config.HolidayStartDate == "" {
+						return nil, nil
+					}
+					return config.HolidayStartDate, nil
+				},
+			},
 			"holidayEndDate": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(ZoneConfig)
+					if !ok {
+						return nil, nil
+					}
+					if config.HolidayEndDate == "" {
+						return nil, nil
+					}
+					return config.HolidayEndDate, nil
+				},
+			},
+			"holiday_end_date": &graphqlgo.Field{
 				Type: graphqlgo.String,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					config, ok := params.Source.(ZoneConfig)
@@ -307,6 +538,19 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *config.HolidaySetpointC, nil
 				},
 			},
+			"holiday_setpoint": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(ZoneConfig)
+					if !ok {
+						return nil, nil
+					}
+					if config.HolidaySetpointC == nil {
+						return nil, nil
+					}
+					return *config.HolidaySetpointC, nil
+				},
+			},
 			"holidayStartTime": &graphqlgo.Field{
 				Type: graphqlgo.String,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
@@ -320,7 +564,33 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return config.HolidayStartTime, nil
 				},
 			},
+			"holiday_start_time": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(ZoneConfig)
+					if !ok {
+						return nil, nil
+					}
+					if config.HolidayStartTime == "" {
+						return nil, nil
+					}
+					return config.HolidayStartTime, nil
+				},
+			},
 			"holidayEndTime": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(ZoneConfig)
+					if !ok {
+						return nil, nil
+					}
+					if config.HolidayEndTime == "" {
+						return nil, nil
+					}
+					return config.HolidayEndTime, nil
+				},
+			},
+			"holiday_end_time": &graphqlgo.Field{
 				Type: graphqlgo.String,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					config, ok := params.Source.(ZoneConfig)
@@ -398,6 +668,19 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return string(meta.FreshnessState), nil
 				},
 			},
+			"freshness_state": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.String),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					meta, ok := params.Source.(EnergyPointMeta)
+					if !ok {
+						return string(EnergyFreshnessStateNeverSeen), nil
+					}
+					if meta.FreshnessState == "" {
+						return string(EnergyFreshnessStateNeverSeen), nil
+					}
+					return string(meta.FreshnessState), nil
+				},
+			},
 			"provenance": &graphqlgo.Field{
 				Type: graphqlgo.NewNonNull(graphqlgo.String),
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
@@ -421,7 +704,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return meta.LastObservedUTC, nil
 				},
 			},
+			"last_observed_utc": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					meta, ok := params.Source.(EnergyPointMeta)
+					if !ok || meta.LastObservedUTC == "" {
+						return nil, nil
+					}
+					return meta.LastObservedUTC, nil
+				},
+			},
 			"ageSeconds": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					meta, ok := params.Source.(EnergyPointMeta)
+					if !ok || meta.LastObservedUTC == "" {
+						return nil, nil
+					}
+					return meta.AgeSeconds, nil
+				},
+			},
+			"age_seconds": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					meta, ok := params.Source.(EnergyPointMeta)
@@ -487,6 +790,16 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return series.TodayMeta, nil
 				},
 			},
+			"today_meta": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(energyPointMetaType),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					series, ok := params.Source.(EnergySeries)
+					if !ok {
+						return EnergyPointMeta{}, nil
+					}
+					return series.TodayMeta, nil
+				},
+			},
 			"yearlyMeta": &graphqlgo.Field{
 				Type: graphqlgo.NewNonNull(graphqlgo.NewList(graphqlgo.NewNonNull(energyPointMetaType))),
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
@@ -500,7 +813,30 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return series.YearlyMeta, nil
 				},
 			},
+			"yearly_meta": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.NewList(graphqlgo.NewNonNull(energyPointMetaType))),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					series, ok := params.Source.(EnergySeries)
+					if !ok {
+						return []EnergyPointMeta{}, nil
+					}
+					if len(series.YearlyMeta) == 0 {
+						return []EnergyPointMeta{}, nil
+					}
+					return series.YearlyMeta, nil
+				},
+			},
 			"monthlyMeta": &graphqlgo.Field{
+				Type: graphqlgo.NewList(graphqlgo.NewNonNull(energyPointMetaType)),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					series, ok := params.Source.(EnergySeries)
+					if !ok {
+						return nil, nil
+					}
+					return series.MonthlyMeta, nil
+				},
+			},
+			"monthly_meta": &graphqlgo.Field{
 				Type: graphqlgo.NewList(graphqlgo.NewNonNull(energyPointMetaType)),
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					series, ok := params.Source.(EnergySeries)
@@ -591,7 +927,33 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *state.CurrentTempC, nil
 				},
 			},
+			"current_temp_c": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(DhwState)
+					if !ok {
+						return nil, nil
+					}
+					if state.CurrentTempC == nil {
+						return nil, nil
+					}
+					return *state.CurrentTempC, nil
+				},
+			},
 			"specialFunction": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(DhwState)
+					if !ok {
+						return nil, nil
+					}
+					if state.SpecialFunction == "" {
+						return nil, nil
+					}
+					return state.SpecialFunction, nil
+				},
+			},
+			"special_function": &graphqlgo.Field{
 				Type: graphqlgo.String,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					state, ok := params.Source.(DhwState)
@@ -617,6 +979,19 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *state.HeatingDemandPct, nil
 				},
 			},
+			"heating_demand_pct": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(DhwState)
+					if !ok {
+						return nil, nil
+					}
+					if state.HeatingDemandPct == nil {
+						return nil, nil
+					}
+					return *state.HeatingDemandPct, nil
+				},
+			},
 		},
 	})
 
@@ -624,6 +999,19 @@ func buildSchemaTypes() graphqlSchemaTypes {
 		Name: "DhwConfig",
 		Fields: graphqlgo.Fields{
 			"operatingMode": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(DhwConfig)
+					if !ok {
+						return nil, nil
+					}
+					if config.OperatingMode == "" {
+						return nil, nil
+					}
+					return config.OperatingMode, nil
+				},
+			},
+			"operating_mode": &graphqlgo.Field{
 				Type: graphqlgo.String,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					config, ok := params.Source.(DhwConfig)
@@ -662,6 +1050,19 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *config.TargetTempC, nil
 				},
 			},
+			"target_temp_c": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(DhwConfig)
+					if !ok {
+						return nil, nil
+					}
+					if config.TargetTempC == nil {
+						return nil, nil
+					}
+					return *config.TargetTempC, nil
+				},
+			},
 			"holidayStartDate": &graphqlgo.Field{
 				Type: graphqlgo.String,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
@@ -675,7 +1076,33 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return config.HolidayStartDate, nil
 				},
 			},
+			"holiday_start_date": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(DhwConfig)
+					if !ok {
+						return nil, nil
+					}
+					if config.HolidayStartDate == "" {
+						return nil, nil
+					}
+					return config.HolidayStartDate, nil
+				},
+			},
 			"holidayEndDate": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(DhwConfig)
+					if !ok {
+						return nil, nil
+					}
+					if config.HolidayEndDate == "" {
+						return nil, nil
+					}
+					return config.HolidayEndDate, nil
+				},
+			},
+			"holiday_end_date": &graphqlgo.Field{
 				Type: graphqlgo.String,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					config, ok := params.Source.(DhwConfig)
@@ -730,7 +1157,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *state.PumpActive, nil
 				},
 			},
+			"pump_active": &graphqlgo.Field{
+				Type: graphqlgo.Boolean,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(CircuitState)
+					if !ok || state.PumpActive == nil {
+						return nil, nil
+					}
+					return *state.PumpActive, nil
+				},
+			},
 			"mixerPositionPct": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(CircuitState)
+					if !ok || state.MixerPositionPct == nil {
+						return nil, nil
+					}
+					return *state.MixerPositionPct, nil
+				},
+			},
+			"mixer_position_pct": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					state, ok := params.Source.(CircuitState)
@@ -750,7 +1197,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *state.FlowTemperatureC, nil
 				},
 			},
+			"flow_temperature_c": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(CircuitState)
+					if !ok || state.FlowTemperatureC == nil {
+						return nil, nil
+					}
+					return *state.FlowTemperatureC, nil
+				},
+			},
 			"flowSetpointC": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(CircuitState)
+					if !ok || state.FlowSetpointC == nil {
+						return nil, nil
+					}
+					return *state.FlowSetpointC, nil
+				},
+			},
+			"flow_setpoint_c": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					state, ok := params.Source.(CircuitState)
@@ -770,7 +1237,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *state.CalcFlowTempC, nil
 				},
 			},
+			"calc_flow_temp_c": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(CircuitState)
+					if !ok || state.CalcFlowTempC == nil {
+						return nil, nil
+					}
+					return *state.CalcFlowTempC, nil
+				},
+			},
 			"circuitState": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(CircuitState)
+					if !ok || state.CircuitState == "" {
+						return nil, nil
+					}
+					return state.CircuitState, nil
+				},
+			},
+			"circuit_state": &graphqlgo.Field{
 				Type: graphqlgo.String,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					state, ok := params.Source.(CircuitState)
@@ -800,6 +1287,16 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *state.DewPoint, nil
 				},
 			},
+			"dew_point": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(CircuitState)
+					if !ok || state.DewPoint == nil {
+						return nil, nil
+					}
+					return *state.DewPoint, nil
+				},
+			},
 			"pumpHours": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
@@ -810,7 +1307,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *state.PumpHours, nil
 				},
 			},
+			"pump_hours": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(CircuitState)
+					if !ok || state.PumpHours == nil {
+						return nil, nil
+					}
+					return *state.PumpHours, nil
+				},
+			},
 			"pumpStarts": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(CircuitState)
+					if !ok || state.PumpStarts == nil {
+						return nil, nil
+					}
+					return *state.PumpStarts, nil
+				},
+			},
+			"pump_starts": &graphqlgo.Field{
 				Type: graphqlgo.Int,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					state, ok := params.Source.(CircuitState)
@@ -836,7 +1353,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *config.HeatingCurve, nil
 				},
 			},
+			"heating_curve": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(CircuitConfig)
+					if !ok || config.HeatingCurve == nil {
+						return nil, nil
+					}
+					return *config.HeatingCurve, nil
+				},
+			},
 			"flowTempMaxC": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(CircuitConfig)
+					if !ok || config.FlowTempMaxC == nil {
+						return nil, nil
+					}
+					return *config.FlowTempMaxC, nil
+				},
+			},
+			"flow_temp_max_c": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					config, ok := params.Source.(CircuitConfig)
@@ -856,7 +1393,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *config.FlowTempMinC, nil
 				},
 			},
+			"flow_temp_min_c": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(CircuitConfig)
+					if !ok || config.FlowTempMinC == nil {
+						return nil, nil
+					}
+					return *config.FlowTempMinC, nil
+				},
+			},
 			"summerLimitC": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(CircuitConfig)
+					if !ok || config.SummerLimitC == nil {
+						return nil, nil
+					}
+					return *config.SummerLimitC, nil
+				},
+			},
+			"summer_limit_c": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					config, ok := params.Source.(CircuitConfig)
@@ -876,6 +1433,16 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *config.FrostProtC, nil
 				},
 			},
+			"frost_prot_c": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(CircuitConfig)
+					if !ok || config.FrostProtC == nil {
+						return nil, nil
+					}
+					return *config.FrostProtC, nil
+				},
+			},
 			"roomTempControl": &graphqlgo.Field{
 				Type: graphqlgo.String,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
@@ -886,7 +1453,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return config.RoomTempControl, nil
 				},
 			},
+			"room_temp_control": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(CircuitConfig)
+					if !ok || config.RoomTempControl == "" {
+						return nil, nil
+					}
+					return config.RoomTempControl, nil
+				},
+			},
 			"coolingEnabled": &graphqlgo.Field{
+				Type: graphqlgo.Boolean,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(CircuitConfig)
+					if !ok || config.CoolingEnabled == nil {
+						return nil, nil
+					}
+					return *config.CoolingEnabled, nil
+				},
+			},
+			"cooling_enabled": &graphqlgo.Field{
 				Type: graphqlgo.Boolean,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					config, ok := params.Source.(CircuitConfig)
@@ -922,6 +1509,16 @@ func buildSchemaTypes() graphqlSchemaTypes {
 				},
 			},
 			"deviceId": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					device, ok := params.Source.(ManagingDevice)
+					if !ok || device.DeviceID == nil {
+						return nil, nil
+					}
+					return *device.DeviceID, nil
+				},
+			},
+			"device_id": &graphqlgo.Field{
 				Type: graphqlgo.String,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					device, ok := params.Source.(ManagingDevice)
@@ -967,7 +1564,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return status.CircuitType, nil
 				},
 			},
+			"circuit_type": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.String),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					status, ok := params.Source.(CircuitStatus)
+					if !ok {
+						return nil, nil
+					}
+					return status.CircuitType, nil
+				},
+			},
 			"hasMixer": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Boolean),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					status, ok := params.Source.(CircuitStatus)
+					if !ok {
+						return nil, nil
+					}
+					return status.HasMixer, nil
+				},
+			},
+			"has_mixer": &graphqlgo.Field{
 				Type: graphqlgo.NewNonNull(graphqlgo.Boolean),
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					status, ok := params.Source.(CircuitStatus)
@@ -998,6 +1615,16 @@ func buildSchemaTypes() graphqlSchemaTypes {
 				},
 			},
 			"managingDevice": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(circuitManagingDeviceType),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					status, ok := params.Source.(CircuitStatus)
+					if !ok {
+						return ManagingDevice{Role: ManagingDeviceRoleUnknown}, nil
+					}
+					return status.ManagingDevice, nil
+				},
+			},
+			"managing_device": &graphqlgo.Field{
 				Type: graphqlgo.NewNonNull(circuitManagingDeviceType),
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					status, ok := params.Source.(CircuitStatus)
@@ -1046,7 +1673,30 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return device.SlotMode, nil
 				},
 			},
+			"slot_mode": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.String),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					device, ok := params.Source.(RadioDevice)
+					if !ok {
+						return nil, nil
+					}
+					if device.SlotMode == "" {
+						return "active", nil
+					}
+					return device.SlotMode, nil
+				},
+			},
 			"deviceConnected": &graphqlgo.Field{
+				Type: graphqlgo.Boolean,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					device, ok := params.Source.(RadioDevice)
+					if !ok || device.DeviceConnected == nil {
+						return nil, nil
+					}
+					return *device.DeviceConnected, nil
+				},
+			},
+			"device_connected": &graphqlgo.Field{
 				Type: graphqlgo.Boolean,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					device, ok := params.Source.(RadioDevice)
@@ -1066,7 +1716,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *device.DeviceClassAddress, nil
 				},
 			},
+			"device_class_address": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					device, ok := params.Source.(RadioDevice)
+					if !ok || device.DeviceClassAddress == nil {
+						return nil, nil
+					}
+					return *device.DeviceClassAddress, nil
+				},
+			},
 			"deviceModel": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					device, ok := params.Source.(RadioDevice)
+					if !ok || device.DeviceModel == "" {
+						return nil, nil
+					}
+					return device.DeviceModel, nil
+				},
+			},
+			"device_model": &graphqlgo.Field{
 				Type: graphqlgo.String,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					device, ok := params.Source.(RadioDevice)
@@ -1086,7 +1756,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *device.FirmwareVersion, nil
 				},
 			},
+			"firmware_version": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					device, ok := params.Source.(RadioDevice)
+					if !ok || device.FirmwareVersion == nil {
+						return nil, nil
+					}
+					return *device.FirmwareVersion, nil
+				},
+			},
 			"hardwareIdentifier": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					device, ok := params.Source.(RadioDevice)
+					if !ok || device.HardwareIdentifier == nil {
+						return nil, nil
+					}
+					return *device.HardwareIdentifier, nil
+				},
+			},
+			"hardware_identifier": &graphqlgo.Field{
 				Type: graphqlgo.Int,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					device, ok := params.Source.(RadioDevice)
@@ -1106,7 +1796,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *device.RemoteControlAddress, nil
 				},
 			},
+			"remote_control_address": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					device, ok := params.Source.(RadioDevice)
+					if !ok || device.RemoteControlAddress == nil {
+						return nil, nil
+					}
+					return *device.RemoteControlAddress, nil
+				},
+			},
 			"devicePaired": &graphqlgo.Field{
+				Type: graphqlgo.Boolean,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					device, ok := params.Source.(RadioDevice)
+					if !ok || device.DevicePaired == nil {
+						return nil, nil
+					}
+					return *device.DevicePaired, nil
+				},
+			},
+			"device_paired": &graphqlgo.Field{
 				Type: graphqlgo.Boolean,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					device, ok := params.Source.(RadioDevice)
@@ -1126,7 +1836,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *device.ReceptionStrength, nil
 				},
 			},
+			"reception_strength": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					device, ok := params.Source.(RadioDevice)
+					if !ok || device.ReceptionStrength == nil {
+						return nil, nil
+					}
+					return *device.ReceptionStrength, nil
+				},
+			},
 			"zoneAssignment": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					device, ok := params.Source.(RadioDevice)
+					if !ok || device.ZoneAssignment == nil {
+						return nil, nil
+					}
+					return *device.ZoneAssignment, nil
+				},
+			},
+			"zone_assignment": &graphqlgo.Field{
 				Type: graphqlgo.Int,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					device, ok := params.Source.(RadioDevice)
@@ -1146,7 +1876,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *device.RoomTemperatureC, nil
 				},
 			},
+			"room_temperature_c": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					device, ok := params.Source.(RadioDevice)
+					if !ok || device.RoomTemperatureC == nil {
+						return nil, nil
+					}
+					return *device.RoomTemperatureC, nil
+				},
+			},
 			"roomHumidityPct": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					device, ok := params.Source.(RadioDevice)
+					if !ok || device.RoomHumidityPct == nil {
+						return nil, nil
+					}
+					return *device.RoomHumidityPct, nil
+				},
+			},
+			"room_humidity_pct": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					device, ok := params.Source.(RadioDevice)
@@ -1181,7 +1931,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *status.CollectorTemperatureC, nil
 				},
 			},
+			"collector_temperature_c": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					status, ok := params.Source.(*SolarStatus)
+					if !ok || status == nil || status.CollectorTemperatureC == nil {
+						return nil, nil
+					}
+					return *status.CollectorTemperatureC, nil
+				},
+			},
 			"returnTemperatureC": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					status, ok := params.Source.(*SolarStatus)
+					if !ok || status == nil || status.ReturnTemperatureC == nil {
+						return nil, nil
+					}
+					return *status.ReturnTemperatureC, nil
+				},
+			},
+			"return_temperature_c": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					status, ok := params.Source.(*SolarStatus)
@@ -1201,7 +1971,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *status.PumpActive, nil
 				},
 			},
+			"pump_active": &graphqlgo.Field{
+				Type: graphqlgo.Boolean,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					status, ok := params.Source.(*SolarStatus)
+					if !ok || status == nil || status.PumpActive == nil {
+						return nil, nil
+					}
+					return *status.PumpActive, nil
+				},
+			},
 			"currentYield": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					status, ok := params.Source.(*SolarStatus)
+					if !ok || status == nil || status.CurrentYield == nil {
+						return nil, nil
+					}
+					return *status.CurrentYield, nil
+				},
+			},
+			"current_yield": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					status, ok := params.Source.(*SolarStatus)
@@ -1221,6 +2011,16 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *status.PumpHours, nil
 				},
 			},
+			"pump_hours": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					status, ok := params.Source.(*SolarStatus)
+					if !ok || status == nil || status.PumpHours == nil {
+						return nil, nil
+					}
+					return *status.PumpHours, nil
+				},
+			},
 			"solarEnabled": &graphqlgo.Field{
 				Type: graphqlgo.Boolean,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
@@ -1231,7 +2031,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *status.SolarEnabled, nil
 				},
 			},
+			"solar_enabled": &graphqlgo.Field{
+				Type: graphqlgo.Boolean,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					status, ok := params.Source.(*SolarStatus)
+					if !ok || status == nil || status.SolarEnabled == nil {
+						return nil, nil
+					}
+					return *status.SolarEnabled, nil
+				},
+			},
 			"functionMode": &graphqlgo.Field{
+				Type: graphqlgo.Boolean,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					status, ok := params.Source.(*SolarStatus)
+					if !ok || status == nil || status.FunctionMode == nil {
+						return nil, nil
+					}
+					return *status.FunctionMode, nil
+				},
+			},
+			"function_mode": &graphqlgo.Field{
 				Type: graphqlgo.Boolean,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					status, ok := params.Source.(*SolarStatus)
@@ -1267,7 +2087,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *status.TemperatureC, nil
 				},
 			},
+			"temperature_c": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					status, ok := params.Source.(CylinderStatus)
+					if !ok || status.TemperatureC == nil {
+						return nil, nil
+					}
+					return *status.TemperatureC, nil
+				},
+			},
 			"maxSetpointC": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					status, ok := params.Source.(CylinderStatus)
+					if !ok || status.MaxSetpointC == nil {
+						return nil, nil
+					}
+					return *status.MaxSetpointC, nil
+				},
+			},
+			"max_setpoint_c": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					status, ok := params.Source.(CylinderStatus)
@@ -1287,7 +2127,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *status.ChargeHysteresisC, nil
 				},
 			},
+			"charge_hysteresis_c": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					status, ok := params.Source.(CylinderStatus)
+					if !ok || status.ChargeHysteresisC == nil {
+						return nil, nil
+					}
+					return *status.ChargeHysteresisC, nil
+				},
+			},
 			"chargeOffsetC": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					status, ok := params.Source.(CylinderStatus)
+					if !ok || status.ChargeOffsetC == nil {
+						return nil, nil
+					}
+					return *status.ChargeOffsetC, nil
+				},
+			},
+			"charge_offset_c": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					status, ok := params.Source.(CylinderStatus)
@@ -1316,7 +2176,33 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *state.FlowTemperatureC, nil
 				},
 			},
+			"flow_temperature_c": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(BoilerState)
+					if !ok {
+						return nil, nil
+					}
+					if state.FlowTemperatureC == nil {
+						return nil, nil
+					}
+					return *state.FlowTemperatureC, nil
+				},
+			},
 			"returnTemperatureC": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(BoilerState)
+					if !ok {
+						return nil, nil
+					}
+					if state.ReturnTemperatureC == nil {
+						return nil, nil
+					}
+					return *state.ReturnTemperatureC, nil
+				},
+			},
+			"return_temperature_c": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					state, ok := params.Source.(BoilerState)
@@ -1342,7 +2228,30 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *state.CentralHeatingPumpActive, nil
 				},
 			},
+			"central_heating_pump_active": &graphqlgo.Field{
+				Type: graphqlgo.Boolean,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(BoilerState)
+					if !ok {
+						return nil, nil
+					}
+					if state.CentralHeatingPumpActive == nil {
+						return nil, nil
+					}
+					return *state.CentralHeatingPumpActive, nil
+				},
+			},
 			"waterPressureBar": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(BoilerState)
+					if !ok || state.WaterPressureBar == nil {
+						return nil, nil
+					}
+					return *state.WaterPressureBar, nil
+				},
+			},
+			"water_pressure_bar": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					state, ok := params.Source.(BoilerState)
@@ -1362,7 +2271,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *state.ExternalPumpActive, nil
 				},
 			},
+			"external_pump_active": &graphqlgo.Field{
+				Type: graphqlgo.Boolean,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(BoilerState)
+					if !ok || state.ExternalPumpActive == nil {
+						return nil, nil
+					}
+					return *state.ExternalPumpActive, nil
+				},
+			},
 			"circulationPumpActive": &graphqlgo.Field{
+				Type: graphqlgo.Boolean,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(BoilerState)
+					if !ok || state.CirculationPumpActive == nil {
+						return nil, nil
+					}
+					return *state.CirculationPumpActive, nil
+				},
+			},
+			"circulation_pump_active": &graphqlgo.Field{
 				Type: graphqlgo.Boolean,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					state, ok := params.Source.(BoilerState)
@@ -1382,7 +2311,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *state.GasValveActive, nil
 				},
 			},
+			"gas_valve_active": &graphqlgo.Field{
+				Type: graphqlgo.Boolean,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(BoilerState)
+					if !ok || state.GasValveActive == nil {
+						return nil, nil
+					}
+					return *state.GasValveActive, nil
+				},
+			},
 			"flameActive": &graphqlgo.Field{
+				Type: graphqlgo.Boolean,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(BoilerState)
+					if !ok || state.FlameActive == nil {
+						return nil, nil
+					}
+					return *state.FlameActive, nil
+				},
+			},
+			"flame_active": &graphqlgo.Field{
 				Type: graphqlgo.Boolean,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					state, ok := params.Source.(BoilerState)
@@ -1402,7 +2351,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *state.DiverterValvePositionPct, nil
 				},
 			},
+			"diverter_valve_position_pct": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(BoilerState)
+					if !ok || state.DiverterValvePositionPct == nil {
+						return nil, nil
+					}
+					return *state.DiverterValvePositionPct, nil
+				},
+			},
 			"fanSpeedRpm": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(BoilerState)
+					if !ok || state.FanSpeedRpm == nil {
+						return nil, nil
+					}
+					return *state.FanSpeedRpm, nil
+				},
+			},
+			"fan_speed_rpm": &graphqlgo.Field{
 				Type: graphqlgo.Int,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					state, ok := params.Source.(BoilerState)
@@ -1422,7 +2391,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *state.TargetFanSpeedRpm, nil
 				},
 			},
+			"target_fan_speed_rpm": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(BoilerState)
+					if !ok || state.TargetFanSpeedRpm == nil {
+						return nil, nil
+					}
+					return *state.TargetFanSpeedRpm, nil
+				},
+			},
 			"ionisationVoltageUa": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(BoilerState)
+					if !ok || state.IonisationVoltageUa == nil {
+						return nil, nil
+					}
+					return *state.IonisationVoltageUa, nil
+				},
+			},
+			"ionisation_voltage_ua": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					state, ok := params.Source.(BoilerState)
@@ -1442,7 +2431,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *state.DhwWaterFlowLpm, nil
 				},
 			},
+			"dhw_water_flow_lpm": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(BoilerState)
+					if !ok || state.DhwWaterFlowLpm == nil {
+						return nil, nil
+					}
+					return *state.DhwWaterFlowLpm, nil
+				},
+			},
 			"dhwDemandActive": &graphqlgo.Field{
+				Type: graphqlgo.Boolean,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(BoilerState)
+					if !ok || state.DhwDemandActive == nil {
+						return nil, nil
+					}
+					return *state.DhwDemandActive, nil
+				},
+			},
+			"dhw_demand_active": &graphqlgo.Field{
 				Type: graphqlgo.Boolean,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					state, ok := params.Source.(BoilerState)
@@ -1462,7 +2471,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *state.HeatingSwitchActive, nil
 				},
 			},
+			"heating_switch_active": &graphqlgo.Field{
+				Type: graphqlgo.Boolean,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(BoilerState)
+					if !ok || state.HeatingSwitchActive == nil {
+						return nil, nil
+					}
+					return *state.HeatingSwitchActive, nil
+				},
+			},
 			"storageLoadPumpPct": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(BoilerState)
+					if !ok || state.StorageLoadPumpPct == nil {
+						return nil, nil
+					}
+					return *state.StorageLoadPumpPct, nil
+				},
+			},
+			"storage_load_pump_pct": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					state, ok := params.Source.(BoilerState)
@@ -1482,7 +2511,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *state.ModulationPct, nil
 				},
 			},
+			"modulation_pct": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(BoilerState)
+					if !ok || state.ModulationPct == nil {
+						return nil, nil
+					}
+					return *state.ModulationPct, nil
+				},
+			},
 			"primaryCircuitFlowLpm": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(BoilerState)
+					if !ok || state.PrimaryCircuitFlowLpm == nil {
+						return nil, nil
+					}
+					return *state.PrimaryCircuitFlowLpm, nil
+				},
+			},
+			"primary_circuit_flow_lpm": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					state, ok := params.Source.(BoilerState)
@@ -1502,7 +2551,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *state.FlowTempDesiredC, nil
 				},
 			},
+			"flow_temp_desired_c": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(BoilerState)
+					if !ok || state.FlowTempDesiredC == nil {
+						return nil, nil
+					}
+					return *state.FlowTempDesiredC, nil
+				},
+			},
 			"dhwTempDesiredC": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(BoilerState)
+					if !ok || state.DhwTempDesiredC == nil {
+						return nil, nil
+					}
+					return *state.DhwTempDesiredC, nil
+				},
+			},
+			"dhw_temp_desired_c": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					state, ok := params.Source.(BoilerState)
@@ -1522,6 +2591,16 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *state.StateNumber, nil
 				},
 			},
+			"state_number": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(BoilerState)
+					if !ok || state.StateNumber == nil {
+						return nil, nil
+					}
+					return *state.StateNumber, nil
+				},
+			},
 			"dhwTemperatureC": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
@@ -1532,7 +2611,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *state.DhwTemperatureC, nil
 				},
 			},
+			"dhw_temperature_c": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(BoilerState)
+					if !ok || state.DhwTemperatureC == nil {
+						return nil, nil
+					}
+					return *state.DhwTemperatureC, nil
+				},
+			},
 			"dhwTargetTemperatureC": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(BoilerState)
+					if !ok || state.DhwTargetTemperatureC == nil {
+						return nil, nil
+					}
+					return *state.DhwTargetTemperatureC, nil
+				},
+			},
+			"dhw_target_temperature_c": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					state, ok := params.Source.(BoilerState)
@@ -1558,7 +2657,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *config.DhwOperatingMode, nil
 				},
 			},
+			"dhw_operating_mode": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(BoilerConfig)
+					if !ok || config.DhwOperatingMode == nil {
+						return nil, nil
+					}
+					return *config.DhwOperatingMode, nil
+				},
+			},
 			"flowsetHcMaxC": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(BoilerConfig)
+					if !ok || config.FlowsetHcMaxC == nil {
+						return nil, nil
+					}
+					return *config.FlowsetHcMaxC, nil
+				},
+			},
+			"flowset_hc_max_c": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					config, ok := params.Source.(BoilerConfig)
@@ -1578,7 +2697,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *config.FlowsetHwcMaxC, nil
 				},
 			},
+			"flowset_hwc_max_c": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(BoilerConfig)
+					if !ok || config.FlowsetHwcMaxC == nil {
+						return nil, nil
+					}
+					return *config.FlowsetHwcMaxC, nil
+				},
+			},
 			"partloadHcKW": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(BoilerConfig)
+					if !ok || config.PartloadHcKW == nil {
+						return nil, nil
+					}
+					return *config.PartloadHcKW, nil
+				},
+			},
+			"partload_hc_kw": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					config, ok := params.Source.(BoilerConfig)
@@ -1598,7 +2737,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *config.PartloadHwcKW, nil
 				},
 			},
+			"partload_hwc_kw": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(BoilerConfig)
+					if !ok || config.PartloadHwcKW == nil {
+						return nil, nil
+					}
+					return *config.PartloadHwcKW, nil
+				},
+			},
 			"installerMenuCode": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(BoilerConfig)
+					if !ok || config.InstallerMenuCode == nil {
+						return nil, nil
+					}
+					return *config.InstallerMenuCode, nil
+				},
+			},
+			"installer_menu_code": &graphqlgo.Field{
 				Type: graphqlgo.Int,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					config, ok := params.Source.(BoilerConfig)
@@ -1618,7 +2777,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *config.PhoneNumber, nil
 				},
 			},
+			"phone_number": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(BoilerConfig)
+					if !ok || config.PhoneNumber == nil {
+						return nil, nil
+					}
+					return *config.PhoneNumber, nil
+				},
+			},
 			"hoursTillService": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(BoilerConfig)
+					if !ok || config.HoursTillService == nil {
+						return nil, nil
+					}
+					return *config.HoursTillService, nil
+				},
+			},
+			"hours_till_service": &graphqlgo.Field{
 				Type: graphqlgo.Int,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					config, ok := params.Source.(BoilerConfig)
@@ -1647,7 +2826,30 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *diag.HeatingStatusRaw, nil
 				},
 			},
+			"heating_status_raw": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					diag, ok := params.Source.(BoilerDiagnostics)
+					if !ok {
+						return nil, nil
+					}
+					if diag.HeatingStatusRaw == nil {
+						return nil, nil
+					}
+					return *diag.HeatingStatusRaw, nil
+				},
+			},
 			"dhwStatusRaw": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					diag, ok := params.Source.(BoilerDiagnostics)
+					if !ok || diag.DhwStatusRaw == nil {
+						return nil, nil
+					}
+					return *diag.DhwStatusRaw, nil
+				},
+			},
+			"dhw_status_raw": &graphqlgo.Field{
 				Type: graphqlgo.Int,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					diag, ok := params.Source.(BoilerDiagnostics)
@@ -1667,7 +2869,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *diag.CentralHeatingHours, nil
 				},
 			},
+			"central_heating_hours": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					diag, ok := params.Source.(BoilerDiagnostics)
+					if !ok || diag.CentralHeatingHours == nil {
+						return nil, nil
+					}
+					return *diag.CentralHeatingHours, nil
+				},
+			},
 			"dhwHours": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					diag, ok := params.Source.(BoilerDiagnostics)
+					if !ok || diag.DhwHours == nil {
+						return nil, nil
+					}
+					return *diag.DhwHours, nil
+				},
+			},
+			"dhw_hours": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					diag, ok := params.Source.(BoilerDiagnostics)
@@ -1687,7 +2909,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *diag.CentralHeatingStarts, nil
 				},
 			},
+			"central_heating_starts": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					diag, ok := params.Source.(BoilerDiagnostics)
+					if !ok || diag.CentralHeatingStarts == nil {
+						return nil, nil
+					}
+					return *diag.CentralHeatingStarts, nil
+				},
+			},
 			"dhwStarts": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					diag, ok := params.Source.(BoilerDiagnostics)
+					if !ok || diag.DhwStarts == nil {
+						return nil, nil
+					}
+					return *diag.DhwStarts, nil
+				},
+			},
+			"dhw_starts": &graphqlgo.Field{
 				Type: graphqlgo.Int,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					diag, ok := params.Source.(BoilerDiagnostics)
@@ -1707,7 +2949,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *diag.PumpHours, nil
 				},
 			},
+			"pump_hours": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					diag, ok := params.Source.(BoilerDiagnostics)
+					if !ok || diag.PumpHours == nil {
+						return nil, nil
+					}
+					return *diag.PumpHours, nil
+				},
+			},
 			"fanHours": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					diag, ok := params.Source.(BoilerDiagnostics)
+					if !ok || diag.FanHours == nil {
+						return nil, nil
+					}
+					return *diag.FanHours, nil
+				},
+			},
+			"fan_hours": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					diag, ok := params.Source.(BoilerDiagnostics)
@@ -1727,7 +2989,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *diag.DeactivationsIFC, nil
 				},
 			},
+			"deactivations_ifc": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					diag, ok := params.Source.(BoilerDiagnostics)
+					if !ok || diag.DeactivationsIFC == nil {
+						return nil, nil
+					}
+					return *diag.DeactivationsIFC, nil
+				},
+			},
 			"deactivationsTemplimiter": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					diag, ok := params.Source.(BoilerDiagnostics)
+					if !ok || diag.DeactivationsTemplimiter == nil {
+						return nil, nil
+					}
+					return *diag.DeactivationsTemplimiter, nil
+				},
+			},
+			"deactivations_templimiter": &graphqlgo.Field{
 				Type: graphqlgo.Int,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					diag, ok := params.Source.(BoilerDiagnostics)
@@ -1789,7 +3071,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *state.SystemOff, nil
 				},
 			},
+			"system_off": &graphqlgo.Field{
+				Type: graphqlgo.Boolean,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(SystemState)
+					if !ok || state.SystemOff == nil {
+						return nil, nil
+					}
+					return *state.SystemOff, nil
+				},
+			},
 			"systemWaterPressure": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(SystemState)
+					if !ok || state.SystemWaterPressure == nil {
+						return nil, nil
+					}
+					return *state.SystemWaterPressure, nil
+				},
+			},
+			"system_water_pressure": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					state, ok := params.Source.(SystemState)
@@ -1809,7 +3111,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *state.SystemFlowTemperature, nil
 				},
 			},
+			"system_flow_temperature": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(SystemState)
+					if !ok || state.SystemFlowTemperature == nil {
+						return nil, nil
+					}
+					return *state.SystemFlowTemperature, nil
+				},
+			},
 			"outdoorTemperature": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(SystemState)
+					if !ok || state.OutdoorTemperature == nil {
+						return nil, nil
+					}
+					return *state.OutdoorTemperature, nil
+				},
+			},
+			"outdoor_temperature": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					state, ok := params.Source.(SystemState)
@@ -1829,7 +3151,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *state.OutdoorTemperatureAvg24h, nil
 				},
 			},
+			"outdoor_temperature_avg24h": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(SystemState)
+					if !ok || state.OutdoorTemperatureAvg24h == nil {
+						return nil, nil
+					}
+					return *state.OutdoorTemperatureAvg24h, nil
+				},
+			},
 			"maintenanceDue": &graphqlgo.Field{
+				Type: graphqlgo.Boolean,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(SystemState)
+					if !ok || state.MaintenanceDue == nil {
+						return nil, nil
+					}
+					return *state.MaintenanceDue, nil
+				},
+			},
+			"maintenance_due": &graphqlgo.Field{
 				Type: graphqlgo.Boolean,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					state, ok := params.Source.(SystemState)
@@ -1849,7 +3191,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *state.HwcCylinderTemperatureTop, nil
 				},
 			},
+			"hwc_cylinder_temperature_top": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(SystemState)
+					if !ok || state.HwcCylinderTemperatureTop == nil {
+						return nil, nil
+					}
+					return *state.HwcCylinderTemperatureTop, nil
+				},
+			},
 			"hwcCylinderTemperatureBottom": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					state, ok := params.Source.(SystemState)
+					if !ok || state.HwcCylinderTemperatureBottom == nil {
+						return nil, nil
+					}
+					return *state.HwcCylinderTemperatureBottom, nil
+				},
+			},
+			"hwc_cylinder_temperature_bottom": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					state, ok := params.Source.(SystemState)
@@ -1875,7 +3237,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *config.AdaptiveHeatingCurve, nil
 				},
 			},
+			"adaptive_heating_curve": &graphqlgo.Field{
+				Type: graphqlgo.Boolean,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(SystemConfig)
+					if !ok || config.AdaptiveHeatingCurve == nil {
+						return nil, nil
+					}
+					return *config.AdaptiveHeatingCurve, nil
+				},
+			},
 			"alternativePoint": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(SystemConfig)
+					if !ok || config.AlternativePoint == nil {
+						return nil, nil
+					}
+					return *config.AlternativePoint, nil
+				},
+			},
+			"alternative_point": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					config, ok := params.Source.(SystemConfig)
@@ -1895,7 +3277,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *config.HeatingCircuitBivalencePoint, nil
 				},
 			},
+			"heating_circuit_bivalence_point": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(SystemConfig)
+					if !ok || config.HeatingCircuitBivalencePoint == nil {
+						return nil, nil
+					}
+					return *config.HeatingCircuitBivalencePoint, nil
+				},
+			},
 			"dhwBivalencePoint": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(SystemConfig)
+					if !ok || config.DhwBivalencePoint == nil {
+						return nil, nil
+					}
+					return *config.DhwBivalencePoint, nil
+				},
+			},
+			"dhw_bivalence_point": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					config, ok := params.Source.(SystemConfig)
@@ -1915,7 +3317,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *config.HcEmergencyTemperature, nil
 				},
 			},
+			"hc_emergency_temperature": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(SystemConfig)
+					if !ok || config.HcEmergencyTemperature == nil {
+						return nil, nil
+					}
+					return *config.HcEmergencyTemperature, nil
+				},
+			},
 			"hwcMaxFlowTempDesired": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(SystemConfig)
+					if !ok || config.HwcMaxFlowTempDesired == nil {
+						return nil, nil
+					}
+					return *config.HwcMaxFlowTempDesired, nil
+				},
+			},
+			"hwc_max_flow_temp_desired": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					config, ok := params.Source.(SystemConfig)
@@ -1935,7 +3357,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *config.MaxRoomHumidity, nil
 				},
 			},
+			"max_room_humidity": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(SystemConfig)
+					if !ok || config.MaxRoomHumidity == nil {
+						return nil, nil
+					}
+					return *config.MaxRoomHumidity, nil
+				},
+			},
 			"maintenanceDate": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(SystemConfig)
+					if !ok || config.MaintenanceDate == nil {
+						return nil, nil
+					}
+					return *config.MaintenanceDate, nil
+				},
+			},
+			"maintenance_date": &graphqlgo.Field{
 				Type: graphqlgo.String,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					config, ok := params.Source.(SystemConfig)
@@ -1955,6 +3397,16 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *config.InstallerName, nil
 				},
 			},
+			"installer_name": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(SystemConfig)
+					if !ok || config.InstallerName == nil {
+						return nil, nil
+					}
+					return *config.InstallerName, nil
+				},
+			},
 			"installerPhone": &graphqlgo.Field{
 				Type: graphqlgo.String,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
@@ -1965,7 +3417,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *config.InstallerPhone, nil
 				},
 			},
+			"installer_phone": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(SystemConfig)
+					if !ok || config.InstallerPhone == nil {
+						return nil, nil
+					}
+					return *config.InstallerPhone, nil
+				},
+			},
 			"installerMenuCode": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					config, ok := params.Source.(SystemConfig)
+					if !ok || config.InstallerMenuCode == nil {
+						return nil, nil
+					}
+					return *config.InstallerMenuCode, nil
+				},
+			},
+			"installer_menu_code": &graphqlgo.Field{
 				Type: graphqlgo.Int,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					config, ok := params.Source.(SystemConfig)
@@ -1991,7 +3463,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *props.SystemScheme, nil
 				},
 			},
+			"system_scheme": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					props, ok := params.Source.(SystemProperties)
+					if !ok || props.SystemScheme == nil {
+						return nil, nil
+					}
+					return *props.SystemScheme, nil
+				},
+			},
 			"moduleConfigurationVR71": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					props, ok := params.Source.(SystemProperties)
+					if !ok || props.ModuleConfigurationVR71 == nil {
+						return nil, nil
+					}
+					return *props.ModuleConfigurationVR71, nil
+				},
+			},
+			"module_configuration_vr71": &graphqlgo.Field{
 				Type: graphqlgo.Int,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					props, ok := params.Source.(SystemProperties)
@@ -2536,7 +4028,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return slot.StartHour, nil
 				},
 			},
+			"start_hour": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Int),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					slot, ok := params.Source.(ScheduleTimerSlot)
+					if !ok {
+						return nil, nil
+					}
+					return slot.StartHour, nil
+				},
+			},
 			"startMinute": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Int),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					slot, ok := params.Source.(ScheduleTimerSlot)
+					if !ok {
+						return nil, nil
+					}
+					return slot.StartMinute, nil
+				},
+			},
+			"start_minute": &graphqlgo.Field{
 				Type: graphqlgo.NewNonNull(graphqlgo.Int),
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					slot, ok := params.Source.(ScheduleTimerSlot)
@@ -2556,7 +4068,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return slot.EndHour, nil
 				},
 			},
+			"end_hour": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Int),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					slot, ok := params.Source.(ScheduleTimerSlot)
+					if !ok {
+						return nil, nil
+					}
+					return slot.EndHour, nil
+				},
+			},
 			"endMinute": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Int),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					slot, ok := params.Source.(ScheduleTimerSlot)
+					if !ok {
+						return nil, nil
+					}
+					return slot.EndMinute, nil
+				},
+			},
+			"end_minute": &graphqlgo.Field{
 				Type: graphqlgo.NewNonNull(graphqlgo.Int),
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					slot, ok := params.Source.(ScheduleTimerSlot)
@@ -2576,7 +4108,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *slot.TemperatureC, nil
 				},
 			},
+			"temperature_c": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					slot, ok := params.Source.(ScheduleTimerSlot)
+					if !ok || slot.TemperatureC == nil {
+						return nil, nil
+					}
+					return *slot.TemperatureC, nil
+				},
+			},
 			"temperatureRaw": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					slot, ok := params.Source.(ScheduleTimerSlot)
+					if !ok || slot.TemperatureRaw == nil {
+						return nil, nil
+					}
+					return *slot.TemperatureRaw, nil
+				},
+			},
+			"temperature_raw": &graphqlgo.Field{
 				Type: graphqlgo.Int,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					slot, ok := params.Source.(ScheduleTimerSlot)
@@ -2628,7 +4180,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return cfg.MaxSlots, nil
 				},
 			},
+			"max_slots": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Int),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					cfg, ok := params.Source.(*ScheduleConfig)
+					if !ok || cfg == nil {
+						return nil, nil
+					}
+					return cfg.MaxSlots, nil
+				},
+			},
 			"timeResolution": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Int),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					cfg, ok := params.Source.(*ScheduleConfig)
+					if !ok || cfg == nil {
+						return nil, nil
+					}
+					return cfg.TimeResolution, nil
+				},
+			},
+			"time_resolution": &graphqlgo.Field{
 				Type: graphqlgo.NewNonNull(graphqlgo.Int),
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					cfg, ok := params.Source.(*ScheduleConfig)
@@ -2648,7 +4220,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return cfg.MinDuration, nil
 				},
 			},
+			"min_duration": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Int),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					cfg, ok := params.Source.(*ScheduleConfig)
+					if !ok || cfg == nil {
+						return nil, nil
+					}
+					return cfg.MinDuration, nil
+				},
+			},
 			"hasTemperature": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Boolean),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					cfg, ok := params.Source.(*ScheduleConfig)
+					if !ok || cfg == nil {
+						return nil, nil
+					}
+					return cfg.HasTemperature, nil
+				},
+			},
+			"has_temperature": &graphqlgo.Field{
 				Type: graphqlgo.NewNonNull(graphqlgo.Boolean),
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					cfg, ok := params.Source.(*ScheduleConfig)
@@ -2668,6 +4260,16 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return cfg.TempSlots, nil
 				},
 			},
+			"temp_slots": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Int),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					cfg, ok := params.Source.(*ScheduleConfig)
+					if !ok || cfg == nil {
+						return nil, nil
+					}
+					return cfg.TempSlots, nil
+				},
+			},
 			"minTempC": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
@@ -2678,7 +4280,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *cfg.MinTempC, nil
 				},
 			},
+			"min_temp_c": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					cfg, ok := params.Source.(*ScheduleConfig)
+					if !ok || cfg == nil || cfg.MinTempC == nil {
+						return nil, nil
+					}
+					return *cfg.MinTempC, nil
+				},
+			},
 			"maxTempC": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					cfg, ok := params.Source.(*ScheduleConfig)
+					if !ok || cfg == nil || cfg.MaxTempC == nil {
+						return nil, nil
+					}
+					return *cfg.MaxTempC, nil
+				},
+			},
+			"max_temp_c": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					cfg, ok := params.Source.(*ScheduleConfig)
@@ -2734,6 +4356,16 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return prog.SlotsUsed, nil
 				},
 			},
+			"slots_used": &graphqlgo.Field{
+				Type: graphqlgo.NewList(graphqlgo.NewNonNull(graphqlgo.Int)),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					prog, ok := params.Source.(ScheduleProgram)
+					if !ok {
+						return nil, nil
+					}
+					return prog.SlotsUsed, nil
+				},
+			},
 			"days": &graphqlgo.Field{
 				Type: graphqlgo.NewNonNull(graphqlgo.NewList(graphqlgo.NewNonNull(scheduleDayProgramType))),
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
@@ -2767,11 +4399,17 @@ func buildSchemaTypes() graphqlSchemaTypes {
 		Name: "AdapterHardwareInfo",
 		Fields: graphqlgo.Fields{
 			"firmwareVersion":    &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
+			"firmware_version":    &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
 			"firmwareChecksum":   &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
+			"firmware_checksum":   &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
 			"bootloaderVersion":  &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
+			"bootloader_version":  &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
 			"bootloaderChecksum": &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
+			"bootloader_checksum": &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
 			"hardwareID":         &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
+			"hardware_id":         &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
 			"hardwareConfig":     &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
+			"hardware_config":     &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
 			"features":           &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.Int)},
 			"jumpers":            &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.Int)},
 			"jumperFlags": &graphqlgo.Field{
@@ -2787,9 +4425,34 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return info.JumperFlags, nil
 				},
 			},
+			"jumper_flags": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.NewList(graphqlgo.NewNonNull(graphqlgo.String))),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					info, ok := params.Source.(*AdapterHardwareInfo)
+					if !ok || info == nil {
+						return []string{}, nil
+					}
+					if info.JumperFlags == nil {
+						return []string{}, nil
+					}
+					return info.JumperFlags, nil
+				},
+			},
 			"isWifi":     &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.Boolean)},
+			"is_wifi":     &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.Boolean)},
 			"isEthernet": &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.Boolean)},
+			"is_ethernet": &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.Boolean)},
 			"temperatureC": &graphqlgo.Field{
+				Type: graphqlgo.Float,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					info, ok := params.Source.(*AdapterHardwareInfo)
+					if !ok || info == nil || info.TemperatureC == nil {
+						return nil, nil
+					}
+					return *info.TemperatureC, nil
+				},
+			},
+			"temperature_c": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					info, ok := params.Source.(*AdapterHardwareInfo)
@@ -2809,7 +4472,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *info.SupplyVoltageMV, nil
 				},
 			},
+			"supply_voltage_mv": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					info, ok := params.Source.(*AdapterHardwareInfo)
+					if !ok || info == nil || info.SupplyVoltageMV == nil {
+						return nil, nil
+					}
+					return *info.SupplyVoltageMV, nil
+				},
+			},
 			"busVoltageMaxDv": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					info, ok := params.Source.(*AdapterHardwareInfo)
+					if !ok || info == nil || info.BusVoltageMaxDV == nil {
+						return nil, nil
+					}
+					return *info.BusVoltageMaxDV, nil
+				},
+			},
+			"bus_voltage_max_dv": &graphqlgo.Field{
 				Type: graphqlgo.Int,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					info, ok := params.Source.(*AdapterHardwareInfo)
@@ -2829,7 +4512,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *info.BusVoltageMinDV, nil
 				},
 			},
+			"bus_voltage_min_dv": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					info, ok := params.Source.(*AdapterHardwareInfo)
+					if !ok || info == nil || info.BusVoltageMinDV == nil {
+						return nil, nil
+					}
+					return *info.BusVoltageMinDV, nil
+				},
+			},
 			"resetCause": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					info, ok := params.Source.(*AdapterHardwareInfo)
+					if !ok || info == nil || info.ResetCause == nil {
+						return nil, nil
+					}
+					return *info.ResetCause, nil
+				},
+			},
+			"reset_cause": &graphqlgo.Field{
 				Type: graphqlgo.String,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					info, ok := params.Source.(*AdapterHardwareInfo)
@@ -2849,7 +4552,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return int(*info.ResetCauseCode), nil
 				},
 			},
+			"reset_cause_code": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					info, ok := params.Source.(*AdapterHardwareInfo)
+					if !ok || info == nil || info.ResetCauseCode == nil {
+						return nil, nil
+					}
+					return int(*info.ResetCauseCode), nil
+				},
+			},
 			"restartCount": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					info, ok := params.Source.(*AdapterHardwareInfo)
+					if !ok || info == nil || info.RestartCount == nil {
+						return nil, nil
+					}
+					return int(*info.RestartCount), nil
+				},
+			},
+			"restart_count": &graphqlgo.Field{
 				Type: graphqlgo.Int,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					info, ok := params.Source.(*AdapterHardwareInfo)
@@ -2869,7 +4592,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return *info.WiFiRSSIDBm, nil
 				},
 			},
+			"wifi_rssi_dbm": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					info, ok := params.Source.(*AdapterHardwareInfo)
+					if !ok || info == nil || info.WiFiRSSIDBm == nil {
+						return nil, nil
+					}
+					return *info.WiFiRSSIDBm, nil
+				},
+			},
 			"lastIdentityQuery": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					info, ok := params.Source.(*AdapterHardwareInfo)
+					if !ok || info == nil || info.LastIdentityQuery == nil {
+						return nil, nil
+					}
+					return info.LastIdentityQuery.UTC().Format("2006-01-02T15:04:05Z"), nil
+				},
+			},
+			"last_identity_query": &graphqlgo.Field{
 				Type: graphqlgo.String,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					info, ok := params.Source.(*AdapterHardwareInfo)
@@ -2889,8 +4632,20 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return info.LastTelemetryQuery.UTC().Format("2006-01-02T15:04:05Z"), nil
 				},
 			},
+			"last_telemetry_query": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					info, ok := params.Source.(*AdapterHardwareInfo)
+					if !ok || info == nil || info.LastTelemetryQuery == nil {
+						return nil, nil
+					}
+					return info.LastTelemetryQuery.UTC().Format("2006-01-02T15:04:05Z"), nil
+				},
+			},
 			"versionResponseLen": &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.Int)},
+			"version_response_len": &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.Int)},
 			"infoSupported":      &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.Boolean)},
+			"info_supported":      &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.Boolean)},
 		},
 	})
 


### PR DESCRIPTION
## Summary
- Add 174 snake_case GraphQL field aliases across 22 semantic types
- Both camelCase and snake_case work simultaneously (backward compat)
- Integrates two Copilot findings from PR #491: energy register STATE header, test magic number fix

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test -race -count=1 ./...` — all pass
- [ ] Query with both `currentTempC` and `current_temp_c` returns identical data

Closes #492

🤖 Generated with [Claude Code](https://claude.com/claude-code)