### PR TITLE
fix: snake_case aliases for GraphQL subscription schema

### DIFF
--- a/graphql/queries.go
+++ b/graphql/queries.go
@@ -4399,17 +4399,71 @@ func buildSchemaTypes() graphqlSchemaTypes {
 		Name: "AdapterHardwareInfo",
 		Fields: graphqlgo.Fields{
 			"firmwareVersion":    &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
-			"firmware_version":    &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
+			"firmware_version": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.String),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					info, ok := params.Source.(*AdapterHardwareInfo)
+					if !ok || info == nil {
+						return "", nil
+					}
+					return info.FirmwareVersion, nil
+				},
+			},
 			"firmwareChecksum":   &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
-			"firmware_checksum":   &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
+			"firmware_checksum": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.String),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					info, ok := params.Source.(*AdapterHardwareInfo)
+					if !ok || info == nil {
+						return "", nil
+					}
+					return info.FirmwareChecksum, nil
+				},
+			},
 			"bootloaderVersion":  &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
-			"bootloader_version":  &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
+			"bootloader_version": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.String),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					info, ok := params.Source.(*AdapterHardwareInfo)
+					if !ok || info == nil {
+						return "", nil
+					}
+					return info.BootloaderVersion, nil
+				},
+			},
 			"bootloaderChecksum": &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
-			"bootloader_checksum": &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
+			"bootloader_checksum": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.String),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					info, ok := params.Source.(*AdapterHardwareInfo)
+					if !ok || info == nil {
+						return "", nil
+					}
+					return info.BootloaderChecksum, nil
+				},
+			},
 			"hardwareID":         &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
-			"hardware_id":         &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
+			"hardware_id": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.String),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					info, ok := params.Source.(*AdapterHardwareInfo)
+					if !ok || info == nil {
+						return "", nil
+					}
+					return info.HardwareID, nil
+				},
+			},
 			"hardwareConfig":     &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
-			"hardware_config":     &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
+			"hardware_config": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.String),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					info, ok := params.Source.(*AdapterHardwareInfo)
+					if !ok || info == nil {
+						return "", nil
+					}
+					return info.HardwareConfig, nil
+				},
+			},
 			"features":           &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.Int)},
 			"jumpers":            &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.Int)},
 			"jumperFlags": &graphqlgo.Field{
@@ -4439,9 +4493,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 				},
 			},
 			"isWifi":     &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.Boolean)},
-			"is_wifi":     &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.Boolean)},
+			"is_wifi": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Boolean),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					info, ok := params.Source.(*AdapterHardwareInfo)
+					if !ok || info == nil {
+						return false, nil
+					}
+					return info.IsWiFi, nil
+				},
+			},
 			"isEthernet": &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.Boolean)},
-			"is_ethernet": &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.Boolean)},
+			"is_ethernet": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Boolean),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					info, ok := params.Source.(*AdapterHardwareInfo)
+					if !ok || info == nil {
+						return false, nil
+					}
+					return info.IsEthernet, nil
+				},
+			},
 			"temperatureC": &graphqlgo.Field{
 				Type: graphqlgo.Float,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
@@ -4643,9 +4715,27 @@ func buildSchemaTypes() graphqlSchemaTypes {
 				},
 			},
 			"versionResponseLen": &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.Int)},
-			"version_response_len": &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.Int)},
+			"version_response_len": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Int),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					info, ok := params.Source.(*AdapterHardwareInfo)
+					if !ok || info == nil {
+						return 0, nil
+					}
+					return info.VersionResponseLen, nil
+				},
+			},
 			"infoSupported":      &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.Boolean)},
-			"info_supported":      &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.Boolean)},
+			"info_supported": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Boolean),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					info, ok := params.Source.(*AdapterHardwareInfo)
+					if !ok || info == nil {
+						return false, nil
+					}
+					return info.InfoSupported, nil
+				},
+			},
 		},
 	})
 

--- a/graphql/subscription_schema.go
+++ b/graphql/subscription_schema.go
@@ -128,7 +128,39 @@ func buildSubscriptionType(hub *BroadcastHub, types graphqlSchemaTypes) *graphql
 					return params.Source, nil
 				},
 			},
+			"zone_update": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(types.zoneType),
+				Subscribe: func(params graphqlgo.ResolveParams) (any, error) {
+					ctx := params.Context
+					if ctx == nil {
+						ctx = context.Background()
+					}
+					return hub.SubscribeZones(ctx)
+				},
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					if params.Source == nil {
+						return nil, fmt.Errorf("graphql subscription missing zone payload: %w", ebuserrors.ErrInvalidPayload)
+					}
+					return params.Source, nil
+				},
+			},
 			"dhwUpdate": &graphqlgo.Field{
+				Type: types.dhwType,
+				Subscribe: func(params graphqlgo.ResolveParams) (any, error) {
+					ctx := params.Context
+					if ctx == nil {
+						ctx = context.Background()
+					}
+					return hub.SubscribeDHW(ctx)
+				},
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					if params.Source == nil {
+						return nil, fmt.Errorf("graphql subscription missing dhw payload: %w", ebuserrors.ErrInvalidPayload)
+					}
+					return params.Source, nil
+				},
+			},
+			"dhw_update": &graphqlgo.Field{
 				Type: types.dhwType,
 				Subscribe: func(params graphqlgo.ResolveParams) (any, error) {
 					ctx := params.Context
@@ -160,6 +192,22 @@ func buildSubscriptionType(hub *BroadcastHub, types graphqlSchemaTypes) *graphql
 					return params.Source, nil
 				},
 			},
+			"energy_update": &graphqlgo.Field{
+				Type: types.energyTotals,
+				Subscribe: func(params graphqlgo.ResolveParams) (any, error) {
+					ctx := params.Context
+					if ctx == nil {
+						ctx = context.Background()
+					}
+					return hub.SubscribeEnergy(ctx)
+				},
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					if params.Source == nil {
+						return nil, fmt.Errorf("graphql subscription missing energy payload: %w", ebuserrors.ErrInvalidPayload)
+					}
+					return params.Source, nil
+				},
+			},
 			"boilerStatusUpdate": &graphqlgo.Field{
 				Type: types.boilerStatusType,
 				Subscribe: func(params graphqlgo.ResolveParams) (any, error) {
@@ -176,7 +224,39 @@ func buildSubscriptionType(hub *BroadcastHub, types graphqlSchemaTypes) *graphql
 					return params.Source, nil
 				},
 			},
+			"boiler_status_update": &graphqlgo.Field{
+				Type: types.boilerStatusType,
+				Subscribe: func(params graphqlgo.ResolveParams) (any, error) {
+					ctx := params.Context
+					if ctx == nil {
+						ctx = context.Background()
+					}
+					return hub.SubscribeBoiler(ctx)
+				},
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					if params.Source == nil {
+						return nil, fmt.Errorf("graphql subscription missing boiler status payload: %w", ebuserrors.ErrInvalidPayload)
+					}
+					return params.Source, nil
+				},
+			},
 			"radioDevicesUpdate": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.NewList(graphqlgo.NewNonNull(types.radioDeviceType))),
+				Subscribe: func(params graphqlgo.ResolveParams) (any, error) {
+					ctx := params.Context
+					if ctx == nil {
+						ctx = context.Background()
+					}
+					return hub.SubscribeRadioDevices(ctx)
+				},
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					if params.Source == nil {
+						return nil, fmt.Errorf("graphql subscription missing radio devices payload: %w", ebuserrors.ErrInvalidPayload)
+					}
+					return params.Source, nil
+				},
+			},
+			"radio_devices_update": &graphqlgo.Field{
 				Type: graphqlgo.NewNonNull(graphqlgo.NewList(graphqlgo.NewNonNull(types.radioDeviceType))),
 				Subscribe: func(params graphqlgo.ResolveParams) (any, error) {
 					ctx := params.Context


### PR DESCRIPTION
## Summary
Add 5 snake_case subscription field aliases (zone_update, dhw_update, energy_update, boiler_status_update, radio_devices_update) to match the HA integration's migrated subscriptions.py.

PR #493 added snake_case aliases to queries but missed the subscription schema, causing `'NoneType' object has no attribute 'get'` errors on live HA deployment.

## Test plan
- [x] `go test -race -count=1 ./...` — all pass
- [ ] Deploy gateway + HA integration, verify subscription updates work

🤖 Generated with [Claude Code](https://claude.com/claude-code)