### PR TITLE
M4_GATEWAY_MCP: 4 MCP surfaces + execution-policy + NM wiring + envelope/hash/rpc-113 (meta #14)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.4.1-0.20260415192314-f3d32d8619a4
-	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260412075531-f4374c04417e
+	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260419103431-30aa69a099ec
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,7 @@
-github.com/Project-Helianthus/helianthus-ebusgo v0.4.1-0.20260413031757-7380b3586301 h1:DoYZGa2Un5jpmDmOgzrel15ZLGGBIM9oSUg2nCiFbMM=
-github.com/Project-Helianthus/helianthus-ebusgo v0.4.1-0.20260413031757-7380b3586301/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
 github.com/Project-Helianthus/helianthus-ebusgo v0.4.1-0.20260415192314-f3d32d8619a4 h1:ZzvXRFim5s/OX+9c3r65n+rNKyYompfOUIqSw9Nyf3E=
 github.com/Project-Helianthus/helianthus-ebusgo v0.4.1-0.20260415192314-f3d32d8619a4/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260412075531-f4374c04417e h1:PMbm+AGrCSW4s2qkZ6urjJVpffGxUMZuQ/TOZA+Roew=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260412075531-f4374c04417e/go.mod h1:FrDhh/Q0KQhP+11jGrQFJLur/kLjAA2mQ7UjJYthOlE=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260419103431-30aa69a099ec h1:l0DzHLH41AmijBTb/an+j98JfTImJMlpgKZ19Eeb7G8=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260419103431-30aa69a099ec/go.mod h1:ux6qvwEyyK+LUfseHKpTTS4i5O6slZHVZ+f4orOtFm4=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=

--- a/internal/execution_policy/policy.go
+++ b/internal/execution_policy/policy.go
@@ -1,21 +1,72 @@
-// Package execution_policy — RED stub. Impl in next commit.
+// Package execution_policy is the single shared execution-policy module for
+// the ebus_standard L7 surface. It is consulted by:
+//
+//  1. The gateway MCP rpc.invoke path.
+//  2. Direct provider invocation from runtime callers (e.g. NM runtime).
+//
+// Per canonical plan §10 and architecture/ebus_standard/05-execution-safety.md:
+//
+//   - Default-deny mutating/destructive/broadcast/memory_write.
+//   - Accept read_only_safe and read_only_bus_load for any caller.
+//   - Accept the compile-time 14-tuple whitelist only for
+//     caller_context=system_nm_runtime.
+//
+// This module NEVER widens the accept set at runtime. Configuration,
+// environment variables, and registry state MUST NOT affect its decisions.
 package execution_policy
 
 import (
 	"errors"
+	"fmt"
 
 	ebusstd "github.com/Project-Helianthus/helianthus-ebusreg/catalog/ebus_standard"
 )
 
+// CallerContext identifies the call site for policy decisions.
 type CallerContext string
 
+// Known caller contexts.
 const (
 	CallerUserFacing      CallerContext = "user_facing"
 	CallerSystemNMRuntime CallerContext = "system_nm_runtime"
 )
 
-var ErrSafetyClassDenied = errors.New("execution_policy: stub denies everything")
+// ErrSafetyClassDenied is the classification sentinel returned when a
+// caller's combination of (safety_class, caller_context) resolves to a
+// denial. Callers MUST use errors.Is(err, ErrSafetyClassDenied) and MUST
+// NOT compare by pointer or string.
+//
+// This value wraps ebusstd.ErrSafetyClassDenied so parity tests comparing
+// against the provider-level sentinel also succeed via errors.Is.
+var ErrSafetyClassDenied = fmt.Errorf("execution_policy: %w", ebusstd.ErrSafetyClassDenied)
 
-func Check(_ ebusstd.Command, _ CallerContext) error { return ErrSafetyClassDenied }
+// Decision is the result of a policy evaluation.
+type Decision struct {
+	Allowed bool
+	Reason  string
+}
 
-func IsDenied(err error) bool { return errors.Is(err, ErrSafetyClassDenied) }
+// Check evaluates the policy for (cmd, caller). It returns nil when the
+// call is permitted, otherwise a non-nil error that satisfies
+// errors.Is(err, ErrSafetyClassDenied) == true and carries the dynamic
+// audit context (catalog method id, caller context, safety class).
+func Check(cmd ebusstd.Command, caller CallerContext) error {
+	switch cmd.SafetyClass {
+	case ebusstd.SafetyReadOnlySafe, ebusstd.SafetyReadOnlyBusLoad:
+		return nil
+	}
+
+	if caller == CallerSystemNMRuntime && nmWhitelistContains(cmd.Identity) {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"method=%q caller=%q class=%s: %w",
+		cmd.ID, caller, cmd.SafetyClass, ErrSafetyClassDenied,
+	)
+}
+
+// IsDenied reports whether err is a safety-class denial.
+func IsDenied(err error) bool {
+	return errors.Is(err, ErrSafetyClassDenied)
+}

--- a/internal/execution_policy/policy.go
+++ b/internal/execution_policy/policy.go
@@ -40,12 +40,6 @@ const (
 // against the provider-level sentinel also succeed via errors.Is.
 var ErrSafetyClassDenied = fmt.Errorf("execution_policy: %w", ebusstd.ErrSafetyClassDenied)
 
-// Decision is the result of a policy evaluation.
-type Decision struct {
-	Allowed bool
-	Reason  string
-}
-
 // Check evaluates the policy for (cmd, caller). It returns nil when the
 // call is permitted, otherwise a non-nil error that satisfies
 // errors.Is(err, ErrSafetyClassDenied) == true and carries the dynamic

--- a/internal/execution_policy/policy.go
+++ b/internal/execution_policy/policy.go
@@ -1,0 +1,21 @@
+// Package execution_policy — RED stub. Impl in next commit.
+package execution_policy
+
+import (
+	"errors"
+
+	ebusstd "github.com/Project-Helianthus/helianthus-ebusreg/catalog/ebus_standard"
+)
+
+type CallerContext string
+
+const (
+	CallerUserFacing      CallerContext = "user_facing"
+	CallerSystemNMRuntime CallerContext = "system_nm_runtime"
+)
+
+var ErrSafetyClassDenied = errors.New("execution_policy: stub denies everything")
+
+func Check(_ ebusstd.Command, _ CallerContext) error { return ErrSafetyClassDenied }
+
+func IsDenied(err error) bool { return errors.Is(err, ErrSafetyClassDenied) }

--- a/internal/execution_policy/policy_test.go
+++ b/internal/execution_policy/policy_test.go
@@ -1,0 +1,115 @@
+package execution_policy_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/execution_policy"
+	ebusstd "github.com/Project-Helianthus/helianthus-ebusreg/catalog/ebus_standard"
+)
+
+func u8(v uint8) *uint8 { return &v }
+
+func cmd(id string, cls ebusstd.SafetyClass, id14 ebusstd.IdentityKey) ebusstd.Command {
+	return ebusstd.Command{ID: id, SafetyClass: cls, Identity: id14}
+}
+
+func TestCheck_AllowsReadOnlySafe(t *testing.T) {
+	c := cmd("x.read", ebusstd.SafetyReadOnlySafe, ebusstd.IdentityKey{})
+	if err := execution_policy.Check(c, execution_policy.CallerUserFacing); err != nil {
+		t.Fatalf("read_only_safe must be allowed for user_facing, got %v", err)
+	}
+}
+
+func TestCheck_AllowsReadOnlyBusLoad(t *testing.T) {
+	c := cmd("x.busread", ebusstd.SafetyReadOnlyBusLoad, ebusstd.IdentityKey{})
+	if err := execution_policy.Check(c, execution_policy.CallerUserFacing); err != nil {
+		t.Fatalf("read_only_bus_load must be allowed for user_facing, got %v", err)
+	}
+}
+
+func TestCheck_DeniesMutatingForUserFacing(t *testing.T) {
+	c := cmd("x.mut", ebusstd.SafetyMutating, ebusstd.IdentityKey{})
+	err := execution_policy.Check(c, execution_policy.CallerUserFacing)
+	if err == nil {
+		t.Fatal("mutating must be denied for user_facing")
+	}
+	if !errors.Is(err, execution_policy.ErrSafetyClassDenied) {
+		t.Fatalf("want errors.Is(err, ErrSafetyClassDenied), got %v", err)
+	}
+	// The wrapped error MUST also satisfy the provider-level sentinel per
+	// 05-execution-safety.md parity requirement.
+	if !errors.Is(err, ebusstd.ErrSafetyClassDenied) {
+		t.Fatalf("want errors.Is(err, ebusstd.ErrSafetyClassDenied) for parity, got %v", err)
+	}
+}
+
+func TestCheck_DeniesDestructiveBroadcastMemoryWrite(t *testing.T) {
+	for _, cls := range []ebusstd.SafetyClass{
+		ebusstd.SafetyDestructive,
+		ebusstd.SafetyBroadcast,
+		ebusstd.SafetyMemoryWrite,
+	} {
+		c := cmd("x", cls, ebusstd.IdentityKey{})
+		if err := execution_policy.Check(c, execution_policy.CallerUserFacing); err == nil {
+			t.Fatalf("class=%s must be denied for user_facing", cls)
+		}
+	}
+}
+
+func TestCheck_SystemNMRuntime_WhitelistsFF00Broadcast(t *testing.T) {
+	c := cmd("nm.reset", ebusstd.SafetyBroadcast, ebusstd.IdentityKey{
+		Namespace:             "ebus_standard",
+		PB:                    u8(0xFF),
+		SB:                    u8(0x00),
+		TelegramClass:         ebusstd.TelegramClassBroadcast,
+		Direction:             ebusstd.DirectionRequest,
+		RequestOrResponseRole: "initiator_broadcast_emit",
+		BroadcastOrAddressed:  ebusstd.AddressedBroadcast,
+		AnswerPolicy:          "no-answer",
+		LengthPrefixMode:      ebusstd.LengthPrefixNone,
+		SelectorDecoder:       "none",
+		ServiceVariant:        "nm_reset_status_broadcast",
+		Version:               "v1.0-locked",
+	})
+	if err := execution_policy.Check(c, execution_policy.CallerSystemNMRuntime); err != nil {
+		t.Fatalf("FF 00 nm_reset_status_broadcast must be allowed for system_nm_runtime, got %v", err)
+	}
+	// Same command under user_facing MUST be denied — whitelist does not widen.
+	if err := execution_policy.Check(c, execution_policy.CallerUserFacing); err == nil {
+		t.Fatal("user_facing must NOT inherit nm_runtime whitelist")
+	}
+}
+
+func TestCheck_SystemNMRuntime_AdjacentVariantsDenied(t *testing.T) {
+	// Wrong service_variant — must be denied even with matching PB/SB.
+	c := cmd("nm.reset.typo", ebusstd.SafetyBroadcast, ebusstd.IdentityKey{
+		PB:                    u8(0xFF),
+		SB:                    u8(0x00),
+		TelegramClass:         ebusstd.TelegramClassBroadcast,
+		Direction:             ebusstd.DirectionRequest,
+		RequestOrResponseRole: "initiator_broadcast_emit",
+		BroadcastOrAddressed:  ebusstd.AddressedBroadcast,
+		AnswerPolicy:          "no-answer",
+		ServiceVariant:        "some_other_variant",
+		Version:               "v1.0-locked",
+	})
+	if err := execution_policy.Check(c, execution_policy.CallerSystemNMRuntime); err == nil {
+		t.Fatal("PB/SB-matching variant with different service_variant must be denied")
+	}
+}
+
+func TestWhitelistSize_MatchesPlan(t *testing.T) {
+	// 05-execution-safety.md lists exactly 7 entries in first-delivery whitelist.
+	if got := execution_policy.NMWhitelistSize(); got != 7 {
+		t.Fatalf("whitelist size = %d, want 7", got)
+	}
+}
+
+func TestIsDenied_ClassifiesViaErrorsIs(t *testing.T) {
+	c := cmd("x", ebusstd.SafetyMutating, ebusstd.IdentityKey{})
+	err := execution_policy.Check(c, execution_policy.CallerUserFacing)
+	if !execution_policy.IsDenied(err) {
+		t.Fatal("IsDenied must be true for denied call")
+	}
+}

--- a/internal/execution_policy/policy_test.go
+++ b/internal/execution_policy/policy_test.go
@@ -61,6 +61,9 @@ func TestCheck_DeniesDestructiveBroadcastMemoryWrite(t *testing.T) {
 // entry. It is the fixture reused across positive-allow and
 // adjacent-variant-denied regression tests. Any axis flipped from this
 // reference MUST be denied (AD09 invariant).
+//
+// Axis literals match ebusreg@30aa69a catalog/ebus_standard/catalog.yaml
+// for command ebus_standard.nm.reset_status.
 func ff00Reset() ebusstd.IdentityKey {
 	return ebusstd.IdentityKey{
 		Namespace:                       "ebus_standard",
@@ -69,13 +72,13 @@ func ff00Reset() ebusstd.IdentityKey {
 		SelectorPath:                    "",
 		TelegramClass:                   ebusstd.TelegramClassBroadcast,
 		Direction:                       ebusstd.DirectionRequest,
-		RequestOrResponseRole:           "initiator_broadcast_emit",
+		RequestOrResponseRole:           ebusstd.RoleOriginator,
 		BroadcastOrAddressed:            ebusstd.AddressedBroadcast,
-		AnswerPolicy:                    "no-answer",
-		LengthPrefixMode:                ebusstd.LengthPrefixNone,
+		AnswerPolicy:                    ebusstd.AnswerNone,
+		LengthPrefixMode:                ebusstd.LengthPrefixFixed,
 		SelectorDecoder:                 "none",
-		ServiceVariant:                  "nm_reset_status_broadcast",
-		TransportCapabilityRequirements: []string{"initiator+broadcast"},
+		ServiceVariant:                  "reset_status",
+		TransportCapabilityRequirements: []string{"broadcast_send"},
 		Version:                         "v1.0-locked",
 	}
 }
@@ -83,7 +86,7 @@ func ff00Reset() ebusstd.IdentityKey {
 func TestCheck_SystemNMRuntime_WhitelistsFF00Broadcast(t *testing.T) {
 	c := cmd("nm.reset", ebusstd.SafetyBroadcast, ff00Reset())
 	if err := execution_policy.Check(c, execution_policy.CallerSystemNMRuntime); err != nil {
-		t.Fatalf("FF 00 nm_reset_status_broadcast must be allowed for system_nm_runtime, got %v", err)
+		t.Fatalf("FF 00 reset_status must be allowed for system_nm_runtime, got %v", err)
 	}
 	// Same command under user_facing MUST be denied — whitelist does not widen.
 	if err := execution_policy.Check(c, execution_policy.CallerUserFacing); err == nil {
@@ -123,22 +126,22 @@ func TestCheck_SystemNMRuntime_AllAxesEnforced(t *testing.T) {
 		{"pb", func(k *ebusstd.IdentityKey) { k.PB = u8(0xFE) }},
 		{"sb", func(k *ebusstd.IdentityKey) { k.SB = u8(0x01) }},
 		{"selector_path", func(k *ebusstd.IdentityKey) { k.SelectorPath = "x" }},
-		{"telegram_class", func(k *ebusstd.IdentityKey) { k.TelegramClass = "initiator-target" }},
+		{"telegram_class", func(k *ebusstd.IdentityKey) { k.TelegramClass = ebusstd.TelegramClassAddressed }},
 		{"direction", func(k *ebusstd.IdentityKey) { k.Direction = ebusstd.DirectionResponse }},
 		{"request_or_response_role", func(k *ebusstd.IdentityKey) {
-			k.RequestOrResponseRole = "responder_reply"
+			k.RequestOrResponseRole = ebusstd.RoleResponder
 		}},
 		{"broadcast_or_addressed", func(k *ebusstd.IdentityKey) {
 			k.BroadcastOrAddressed = ebusstd.AddressedDirect
 		}},
-		{"answer_policy", func(k *ebusstd.IdentityKey) { k.AnswerPolicy = "answer-required" }},
+		{"answer_policy", func(k *ebusstd.IdentityKey) { k.AnswerPolicy = ebusstd.AnswerRequired }},
 		{"length_prefix_mode", func(k *ebusstd.IdentityKey) {
 			k.LengthPrefixMode = ebusstd.LengthPrefixByte
 		}},
 		{"selector_decoder", func(k *ebusstd.IdentityKey) { k.SelectorDecoder = "b5_group" }},
-		{"service_variant", func(k *ebusstd.IdentityKey) { k.ServiceVariant = "nm_failure_broadcast" }},
+		{"service_variant", func(k *ebusstd.IdentityKey) { k.ServiceVariant = "failure_message" }},
 		{"transport_capability_requirements", func(k *ebusstd.IdentityKey) {
-			k.TransportCapabilityRequirements = []string{"responder+addressed"}
+			k.TransportCapabilityRequirements = []string{"responder"}
 		}},
 		{"version", func(k *ebusstd.IdentityKey) { k.Version = "v2.0-locked" }},
 	}
@@ -167,6 +170,9 @@ func TestCheck_SystemNMRuntime_AllAxesEnforced(t *testing.T) {
 // passes Check(). This is the positive-coverage half of the AD09
 // invariant — without it, a typo in a whitelist axis could silently make
 // one of the 7 entries unreachable.
+//
+// All 7 fixtures are sourced from ebusreg@30aa69a
+// catalog/ebus_standard/catalog.yaml.
 func TestCheck_SystemNMRuntime_EveryWhitelistEntryAllowed(t *testing.T) {
 	ids := allWhitelistIdentities()
 	if got, want := len(ids), execution_policy.NMWhitelistSize(); got != want {
@@ -187,9 +193,10 @@ func TestCheck_SystemNMRuntime_EveryWhitelistEntryAllowed(t *testing.T) {
 
 // allWhitelistIdentities returns the canonical full-14-tuple identities for
 // each of the 7 whitelist entries, in whitelist order. Keep synchronized
-// with internal/execution_policy/whitelist.go nmWhitelist.
+// with internal/execution_policy/whitelist.go nmWhitelist AND with
+// ebusreg@30aa69a catalog/ebus_standard/catalog.yaml.
 func allWhitelistIdentities() []ebusstd.IdentityKey {
-	broadcastEmit := func(sb uint8, variant string) ebusstd.IdentityKey {
+	originatorBroadcast := func(sb uint8, variant string, lpm ebusstd.LengthPrefixMode) ebusstd.IdentityKey {
 		return ebusstd.IdentityKey{
 			Namespace:                       "ebus_standard",
 			PB:                              u8(0xFF),
@@ -197,31 +204,31 @@ func allWhitelistIdentities() []ebusstd.IdentityKey {
 			SelectorPath:                    "",
 			TelegramClass:                   ebusstd.TelegramClassBroadcast,
 			Direction:                       ebusstd.DirectionRequest,
-			RequestOrResponseRole:           "initiator_broadcast_emit",
+			RequestOrResponseRole:           ebusstd.RoleOriginator,
 			BroadcastOrAddressed:            ebusstd.AddressedBroadcast,
-			AnswerPolicy:                    "no-answer",
-			LengthPrefixMode:                ebusstd.LengthPrefixNone,
+			AnswerPolicy:                    ebusstd.AnswerNone,
+			LengthPrefixMode:                lpm,
 			SelectorDecoder:                 "none",
 			ServiceVariant:                  variant,
-			TransportCapabilityRequirements: []string{"initiator+broadcast"},
+			TransportCapabilityRequirements: []string{"broadcast_send"},
 			Version:                         "v1.0-locked",
 		}
 	}
-	responderReply := func(sb uint8, variant string) ebusstd.IdentityKey {
+	responderReply := func(sb uint8, variant string, lpm ebusstd.LengthPrefixMode) ebusstd.IdentityKey {
 		return ebusstd.IdentityKey{
 			Namespace:                       "ebus_standard",
 			PB:                              u8(0xFF),
 			SB:                              u8(sb),
 			SelectorPath:                    "",
-			TelegramClass:                   "initiator-target",
+			TelegramClass:                   ebusstd.TelegramClassAddressed,
 			Direction:                       ebusstd.DirectionResponse,
-			RequestOrResponseRole:           "responder_reply",
+			RequestOrResponseRole:           ebusstd.RoleResponder,
 			BroadcastOrAddressed:            ebusstd.AddressedDirect,
-			AnswerPolicy:                    "answer-required",
-			LengthPrefixMode:                ebusstd.LengthPrefixNone,
+			AnswerPolicy:                    ebusstd.AnswerRequired,
+			LengthPrefixMode:                lpm,
 			SelectorDecoder:                 "none",
 			ServiceVariant:                  variant,
-			TransportCapabilityRequirements: []string{"responder+addressed"},
+			TransportCapabilityRequirements: []string{"responder"},
 			Version:                         "v1.0-locked",
 		}
 	}
@@ -232,22 +239,22 @@ func allWhitelistIdentities() []ebusstd.IdentityKey {
 		SelectorPath:                    "",
 		TelegramClass:                   ebusstd.TelegramClassBroadcast,
 		Direction:                       ebusstd.DirectionRequest,
-		RequestOrResponseRole:           "initiator_broadcast_emit",
+		RequestOrResponseRole:           ebusstd.RoleOriginator,
 		BroadcastOrAddressed:            ebusstd.AddressedBroadcast,
-		AnswerPolicy:                    "no-answer",
+		AnswerPolicy:                    ebusstd.AnswerNone,
 		LengthPrefixMode:                ebusstd.LengthPrefixNone,
 		SelectorDecoder:                 "none",
-		ServiceVariant:                  "sign_of_life_broadcast",
-		TransportCapabilityRequirements: []string{"initiator+broadcast"},
+		ServiceVariant:                  "sign_of_life",
+		TransportCapabilityRequirements: []string{"broadcast_send"},
 		Version:                         "v1.0-locked",
 	}
 	return []ebusstd.IdentityKey{
-		broadcastEmit(0x00, "nm_reset_status_broadcast"),
-		broadcastEmit(0x02, "nm_failure_broadcast"),
-		responderReply(0x03, "nm_net_status_response"),
-		responderReply(0x04, "nm_monitored_participants_response"),
-		responderReply(0x05, "nm_failed_nodes_response"),
-		responderReply(0x06, "nm_required_services_response"),
+		originatorBroadcast(0x00, "reset_status", ebusstd.LengthPrefixFixed),
+		originatorBroadcast(0x02, "failure_message", ebusstd.LengthPrefixFixed),
+		responderReply(0x03, "net_status_query", ebusstd.LengthPrefixFixed),
+		responderReply(0x04, "monitored_participants_query", ebusstd.LengthPrefixByte),
+		responderReply(0x05, "failed_nodes_query", ebusstd.LengthPrefixByte),
+		responderReply(0x06, "required_services_query", ebusstd.LengthPrefixByte),
 		signOfLife,
 	}
 }

--- a/internal/execution_policy/policy_test.go
+++ b/internal/execution_policy/policy_test.go
@@ -57,21 +57,31 @@ func TestCheck_DeniesDestructiveBroadcastMemoryWrite(t *testing.T) {
 	}
 }
 
+// ff00Reset is the exact full-14-tuple identity of the first whitelist
+// entry. It is the fixture reused across positive-allow and
+// adjacent-variant-denied regression tests. Any axis flipped from this
+// reference MUST be denied (AD09 invariant).
+func ff00Reset() ebusstd.IdentityKey {
+	return ebusstd.IdentityKey{
+		Namespace:                       "ebus_standard",
+		PB:                              u8(0xFF),
+		SB:                              u8(0x00),
+		SelectorPath:                    "",
+		TelegramClass:                   ebusstd.TelegramClassBroadcast,
+		Direction:                       ebusstd.DirectionRequest,
+		RequestOrResponseRole:           "initiator_broadcast_emit",
+		BroadcastOrAddressed:            ebusstd.AddressedBroadcast,
+		AnswerPolicy:                    "no-answer",
+		LengthPrefixMode:                ebusstd.LengthPrefixNone,
+		SelectorDecoder:                 "none",
+		ServiceVariant:                  "nm_reset_status_broadcast",
+		TransportCapabilityRequirements: []string{"initiator+broadcast"},
+		Version:                         "v1.0-locked",
+	}
+}
+
 func TestCheck_SystemNMRuntime_WhitelistsFF00Broadcast(t *testing.T) {
-	c := cmd("nm.reset", ebusstd.SafetyBroadcast, ebusstd.IdentityKey{
-		Namespace:             "ebus_standard",
-		PB:                    u8(0xFF),
-		SB:                    u8(0x00),
-		TelegramClass:         ebusstd.TelegramClassBroadcast,
-		Direction:             ebusstd.DirectionRequest,
-		RequestOrResponseRole: "initiator_broadcast_emit",
-		BroadcastOrAddressed:  ebusstd.AddressedBroadcast,
-		AnswerPolicy:          "no-answer",
-		LengthPrefixMode:      ebusstd.LengthPrefixNone,
-		SelectorDecoder:       "none",
-		ServiceVariant:        "nm_reset_status_broadcast",
-		Version:               "v1.0-locked",
-	})
+	c := cmd("nm.reset", ebusstd.SafetyBroadcast, ff00Reset())
 	if err := execution_policy.Check(c, execution_policy.CallerSystemNMRuntime); err != nil {
 		t.Fatalf("FF 00 nm_reset_status_broadcast must be allowed for system_nm_runtime, got %v", err)
 	}
@@ -83,19 +93,162 @@ func TestCheck_SystemNMRuntime_WhitelistsFF00Broadcast(t *testing.T) {
 
 func TestCheck_SystemNMRuntime_AdjacentVariantsDenied(t *testing.T) {
 	// Wrong service_variant — must be denied even with matching PB/SB.
-	c := cmd("nm.reset.typo", ebusstd.SafetyBroadcast, ebusstd.IdentityKey{
-		PB:                    u8(0xFF),
-		SB:                    u8(0x00),
-		TelegramClass:         ebusstd.TelegramClassBroadcast,
-		Direction:             ebusstd.DirectionRequest,
-		RequestOrResponseRole: "initiator_broadcast_emit",
-		BroadcastOrAddressed:  ebusstd.AddressedBroadcast,
-		AnswerPolicy:          "no-answer",
-		ServiceVariant:        "some_other_variant",
-		Version:               "v1.0-locked",
-	})
+	base := ff00Reset()
+	base.ServiceVariant = "some_other_variant"
+	c := cmd("nm.reset.typo", ebusstd.SafetyBroadcast, base)
 	if err := execution_policy.Check(c, execution_policy.CallerSystemNMRuntime); err == nil {
 		t.Fatal("PB/SB-matching variant with different service_variant must be denied")
+	}
+}
+
+// TestCheck_SystemNMRuntime_AllAxesEnforced is the AD09-invariant regression
+// test. For the FF 00 whitelist entry it constructs one adjacent variant
+// per axis (each axis flipped away from the canonical full-match identity)
+// and asserts Check() denies every variant. Complements the positive-match
+// TestCheck_SystemNMRuntime_WhitelistsFF00Broadcast case.
+func TestCheck_SystemNMRuntime_AllAxesEnforced(t *testing.T) {
+	// Baseline positive allow must hold before we mutate axes.
+	if err := execution_policy.Check(
+		cmd("nm.reset", ebusstd.SafetyBroadcast, ff00Reset()),
+		execution_policy.CallerSystemNMRuntime,
+	); err != nil {
+		t.Fatalf("baseline full-match must be allowed, got %v", err)
+	}
+
+	cases := []struct {
+		axis   string
+		mutate func(*ebusstd.IdentityKey)
+	}{
+		{"namespace", func(k *ebusstd.IdentityKey) { k.Namespace = "ebus_vendor" }},
+		{"pb", func(k *ebusstd.IdentityKey) { k.PB = u8(0xFE) }},
+		{"sb", func(k *ebusstd.IdentityKey) { k.SB = u8(0x01) }},
+		{"selector_path", func(k *ebusstd.IdentityKey) { k.SelectorPath = "x" }},
+		{"telegram_class", func(k *ebusstd.IdentityKey) { k.TelegramClass = "initiator-target" }},
+		{"direction", func(k *ebusstd.IdentityKey) { k.Direction = ebusstd.DirectionResponse }},
+		{"request_or_response_role", func(k *ebusstd.IdentityKey) {
+			k.RequestOrResponseRole = "responder_reply"
+		}},
+		{"broadcast_or_addressed", func(k *ebusstd.IdentityKey) {
+			k.BroadcastOrAddressed = ebusstd.AddressedDirect
+		}},
+		{"answer_policy", func(k *ebusstd.IdentityKey) { k.AnswerPolicy = "answer-required" }},
+		{"length_prefix_mode", func(k *ebusstd.IdentityKey) {
+			k.LengthPrefixMode = ebusstd.LengthPrefixByte
+		}},
+		{"selector_decoder", func(k *ebusstd.IdentityKey) { k.SelectorDecoder = "b5_group" }},
+		{"service_variant", func(k *ebusstd.IdentityKey) { k.ServiceVariant = "nm_failure_broadcast" }},
+		{"transport_capability_requirements", func(k *ebusstd.IdentityKey) {
+			k.TransportCapabilityRequirements = []string{"responder+addressed"}
+		}},
+		{"version", func(k *ebusstd.IdentityKey) { k.Version = "v2.0-locked" }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.axis, func(t *testing.T) {
+			id := ff00Reset()
+			tc.mutate(&id)
+			err := execution_policy.Check(
+				cmd("nm.reset.adj", ebusstd.SafetyBroadcast, id),
+				execution_policy.CallerSystemNMRuntime,
+			)
+			if err == nil {
+				t.Fatalf("AD09 violation: variant flipped on axis %q was allowed; must be denied",
+					tc.axis)
+			}
+			if !errors.Is(err, execution_policy.ErrSafetyClassDenied) {
+				t.Fatalf("axis %q: want ErrSafetyClassDenied, got %v", tc.axis, err)
+			}
+		})
+	}
+}
+
+// TestCheck_SystemNMRuntime_EveryWhitelistEntryAllowed asserts every one of
+// the 7 whitelist entries has a constructible full-identity command that
+// passes Check(). This is the positive-coverage half of the AD09
+// invariant — without it, a typo in a whitelist axis could silently make
+// one of the 7 entries unreachable.
+func TestCheck_SystemNMRuntime_EveryWhitelistEntryAllowed(t *testing.T) {
+	ids := allWhitelistIdentities()
+	if got, want := len(ids), execution_policy.NMWhitelistSize(); got != want {
+		t.Fatalf("fixture entries = %d, want %d (match whitelist)", got, want)
+	}
+	for _, id := range ids {
+		id := id
+		t.Run(id.ServiceVariant, func(t *testing.T) {
+			if err := execution_policy.Check(
+				cmd("nm."+id.ServiceVariant, ebusstd.SafetyBroadcast, id),
+				execution_policy.CallerSystemNMRuntime,
+			); err != nil {
+				t.Fatalf("whitelist entry %q must be allowed, got %v", id.ServiceVariant, err)
+			}
+		})
+	}
+}
+
+// allWhitelistIdentities returns the canonical full-14-tuple identities for
+// each of the 7 whitelist entries, in whitelist order. Keep synchronized
+// with internal/execution_policy/whitelist.go nmWhitelist.
+func allWhitelistIdentities() []ebusstd.IdentityKey {
+	broadcastEmit := func(sb uint8, variant string) ebusstd.IdentityKey {
+		return ebusstd.IdentityKey{
+			Namespace:                       "ebus_standard",
+			PB:                              u8(0xFF),
+			SB:                              u8(sb),
+			SelectorPath:                    "",
+			TelegramClass:                   ebusstd.TelegramClassBroadcast,
+			Direction:                       ebusstd.DirectionRequest,
+			RequestOrResponseRole:           "initiator_broadcast_emit",
+			BroadcastOrAddressed:            ebusstd.AddressedBroadcast,
+			AnswerPolicy:                    "no-answer",
+			LengthPrefixMode:                ebusstd.LengthPrefixNone,
+			SelectorDecoder:                 "none",
+			ServiceVariant:                  variant,
+			TransportCapabilityRequirements: []string{"initiator+broadcast"},
+			Version:                         "v1.0-locked",
+		}
+	}
+	responderReply := func(sb uint8, variant string) ebusstd.IdentityKey {
+		return ebusstd.IdentityKey{
+			Namespace:                       "ebus_standard",
+			PB:                              u8(0xFF),
+			SB:                              u8(sb),
+			SelectorPath:                    "",
+			TelegramClass:                   "initiator-target",
+			Direction:                       ebusstd.DirectionResponse,
+			RequestOrResponseRole:           "responder_reply",
+			BroadcastOrAddressed:            ebusstd.AddressedDirect,
+			AnswerPolicy:                    "answer-required",
+			LengthPrefixMode:                ebusstd.LengthPrefixNone,
+			SelectorDecoder:                 "none",
+			ServiceVariant:                  variant,
+			TransportCapabilityRequirements: []string{"responder+addressed"},
+			Version:                         "v1.0-locked",
+		}
+	}
+	signOfLife := ebusstd.IdentityKey{
+		Namespace:                       "ebus_standard",
+		PB:                              u8(0x07),
+		SB:                              u8(0xFF),
+		SelectorPath:                    "",
+		TelegramClass:                   ebusstd.TelegramClassBroadcast,
+		Direction:                       ebusstd.DirectionRequest,
+		RequestOrResponseRole:           "initiator_broadcast_emit",
+		BroadcastOrAddressed:            ebusstd.AddressedBroadcast,
+		AnswerPolicy:                    "no-answer",
+		LengthPrefixMode:                ebusstd.LengthPrefixNone,
+		SelectorDecoder:                 "none",
+		ServiceVariant:                  "sign_of_life_broadcast",
+		TransportCapabilityRequirements: []string{"initiator+broadcast"},
+		Version:                         "v1.0-locked",
+	}
+	return []ebusstd.IdentityKey{
+		broadcastEmit(0x00, "nm_reset_status_broadcast"),
+		broadcastEmit(0x02, "nm_failure_broadcast"),
+		responderReply(0x03, "nm_net_status_response"),
+		responderReply(0x04, "nm_monitored_participants_response"),
+		responderReply(0x05, "nm_failed_nodes_response"),
+		responderReply(0x06, "nm_required_services_response"),
+		signOfLife,
 	}
 }
 

--- a/internal/execution_policy/whitelist.go
+++ b/internal/execution_policy/whitelist.go
@@ -1,109 +1,220 @@
 package execution_policy
 
 import (
+	"reflect"
+
 	ebusstd "github.com/Project-Helianthus/helianthus-ebusreg/catalog/ebus_standard"
 )
 
-// nmWhitelistEntry is a partial identity tuple used to match catalog
-// identity keys against the system_nm_runtime compile-time whitelist
+// nmWhitelistEntry carries the FULL 14-axis identity tuple used to match
+// catalog identity keys against the system_nm_runtime compile-time whitelist
 // defined in architecture/ebus_standard/05-execution-safety.md §
 // "system_nm_runtime Whitelist".
 //
-// Matching MUST be on the full 14-axis identity, not on PB/SB alone.
-// Adjacent variants with the same PB/SB remain denied.
+// AD09 INVARIANT: matching MUST be on the full 14-axis identity. Partial-axis
+// matches (e.g. PB/SB + service_variant alone) are forbidden — they can
+// widen the accept-set to future catalog commands that happen to share a
+// subset of axes. Every axis present in ebusstd.IdentityKey is compared
+// exactly, including the nullable SelectorPath and the ordered slice
+// TransportCapabilityRequirements.
+//
+// Widening the whitelist requires a new locked-plan decision, not a code
+// change.
 type nmWhitelistEntry struct {
-	pb                    uint8
-	sb                    uint8
-	telegramClass         ebusstd.TelegramClass
-	direction             ebusstd.Direction
-	requestOrResponseRole ebusstd.RequestOrResponseRole
-	broadcastOrAddressed  ebusstd.BroadcastOrAddressed
-	answerPolicy          ebusstd.AnswerPolicy
-	serviceVariant        string
-	version               string
+	namespace                       string
+	pb                              uint8
+	sb                              uint8
+	selectorPath                    string
+	telegramClass                   ebusstd.TelegramClass
+	direction                       ebusstd.Direction
+	requestOrResponseRole           ebusstd.RequestOrResponseRole
+	broadcastOrAddressed            ebusstd.BroadcastOrAddressed
+	answerPolicy                    ebusstd.AnswerPolicy
+	lengthPrefixMode                ebusstd.LengthPrefixMode
+	selectorDecoder                 string
+	serviceVariant                  string
+	transportCapabilityRequirements []string
+	version                         string
 }
 
-// nmWhitelist is the compile-time whitelist. Widening requires a new
-// locked-plan decision, not a code change.
+// nmWhitelist is the compile-time whitelist. All 14 axes MUST be populated
+// on every entry — the init() block at the bottom of this file enforces
+// completeness at process start.
 var nmWhitelist = []nmWhitelistEntry{
 	{
-		pb: 0xFF, sb: 0x00,
-		telegramClass:         ebusstd.TelegramClassBroadcast,
-		direction:             ebusstd.DirectionRequest,
-		requestOrResponseRole: "initiator_broadcast_emit",
-		broadcastOrAddressed:  ebusstd.AddressedBroadcast,
-		answerPolicy:          "no-answer",
-		serviceVariant:        "nm_reset_status_broadcast",
-		version:               "v1.0-locked",
+		namespace:                       "ebus_standard",
+		pb:                              0xFF,
+		sb:                              0x00,
+		selectorPath:                    "",
+		telegramClass:                   ebusstd.TelegramClassBroadcast,
+		direction:                       ebusstd.DirectionRequest,
+		requestOrResponseRole:           "initiator_broadcast_emit",
+		broadcastOrAddressed:            ebusstd.AddressedBroadcast,
+		answerPolicy:                    "no-answer",
+		lengthPrefixMode:                ebusstd.LengthPrefixNone,
+		selectorDecoder:                 "none",
+		serviceVariant:                  "nm_reset_status_broadcast",
+		transportCapabilityRequirements: []string{"initiator+broadcast"},
+		version:                         "v1.0-locked",
 	},
 	{
-		pb: 0xFF, sb: 0x02,
-		telegramClass:         ebusstd.TelegramClassBroadcast,
-		direction:             ebusstd.DirectionRequest,
-		requestOrResponseRole: "initiator_broadcast_emit",
-		broadcastOrAddressed:  ebusstd.AddressedBroadcast,
-		answerPolicy:          "no-answer",
-		serviceVariant:        "nm_failure_broadcast",
-		version:               "v1.0-locked",
+		namespace:                       "ebus_standard",
+		pb:                              0xFF,
+		sb:                              0x02,
+		selectorPath:                    "",
+		telegramClass:                   ebusstd.TelegramClassBroadcast,
+		direction:                       ebusstd.DirectionRequest,
+		requestOrResponseRole:           "initiator_broadcast_emit",
+		broadcastOrAddressed:            ebusstd.AddressedBroadcast,
+		answerPolicy:                    "no-answer",
+		lengthPrefixMode:                ebusstd.LengthPrefixNone,
+		selectorDecoder:                 "none",
+		serviceVariant:                  "nm_failure_broadcast",
+		transportCapabilityRequirements: []string{"initiator+broadcast"},
+		version:                         "v1.0-locked",
 	},
 	{
-		pb: 0xFF, sb: 0x03,
-		telegramClass:         "initiator-target",
-		direction:             ebusstd.DirectionResponse,
-		requestOrResponseRole: "responder_reply",
-		broadcastOrAddressed:  ebusstd.AddressedDirect,
-		answerPolicy:          "answer-required",
-		serviceVariant:        "nm_net_status_response",
-		version:               "v1.0-locked",
+		namespace:                       "ebus_standard",
+		pb:                              0xFF,
+		sb:                              0x03,
+		selectorPath:                    "",
+		telegramClass:                   "initiator-target",
+		direction:                       ebusstd.DirectionResponse,
+		requestOrResponseRole:           "responder_reply",
+		broadcastOrAddressed:            ebusstd.AddressedDirect,
+		answerPolicy:                    "answer-required",
+		lengthPrefixMode:                ebusstd.LengthPrefixNone,
+		selectorDecoder:                 "none",
+		serviceVariant:                  "nm_net_status_response",
+		transportCapabilityRequirements: []string{"responder+addressed"},
+		version:                         "v1.0-locked",
 	},
 	{
-		pb: 0xFF, sb: 0x04,
-		telegramClass:         "initiator-target",
-		direction:             ebusstd.DirectionResponse,
-		requestOrResponseRole: "responder_reply",
-		broadcastOrAddressed:  ebusstd.AddressedDirect,
-		answerPolicy:          "answer-required",
-		serviceVariant:        "nm_monitored_participants_response",
-		version:               "v1.0-locked",
+		namespace:                       "ebus_standard",
+		pb:                              0xFF,
+		sb:                              0x04,
+		selectorPath:                    "",
+		telegramClass:                   "initiator-target",
+		direction:                       ebusstd.DirectionResponse,
+		requestOrResponseRole:           "responder_reply",
+		broadcastOrAddressed:            ebusstd.AddressedDirect,
+		answerPolicy:                    "answer-required",
+		lengthPrefixMode:                ebusstd.LengthPrefixNone,
+		selectorDecoder:                 "none",
+		serviceVariant:                  "nm_monitored_participants_response",
+		transportCapabilityRequirements: []string{"responder+addressed"},
+		version:                         "v1.0-locked",
 	},
 	{
-		pb: 0xFF, sb: 0x05,
-		telegramClass:         "initiator-target",
-		direction:             ebusstd.DirectionResponse,
-		requestOrResponseRole: "responder_reply",
-		broadcastOrAddressed:  ebusstd.AddressedDirect,
-		answerPolicy:          "answer-required",
-		serviceVariant:        "nm_failed_nodes_response",
-		version:               "v1.0-locked",
+		namespace:                       "ebus_standard",
+		pb:                              0xFF,
+		sb:                              0x05,
+		selectorPath:                    "",
+		telegramClass:                   "initiator-target",
+		direction:                       ebusstd.DirectionResponse,
+		requestOrResponseRole:           "responder_reply",
+		broadcastOrAddressed:            ebusstd.AddressedDirect,
+		answerPolicy:                    "answer-required",
+		lengthPrefixMode:                ebusstd.LengthPrefixNone,
+		selectorDecoder:                 "none",
+		serviceVariant:                  "nm_failed_nodes_response",
+		transportCapabilityRequirements: []string{"responder+addressed"},
+		version:                         "v1.0-locked",
 	},
 	{
-		pb: 0xFF, sb: 0x06,
-		telegramClass:         "initiator-target",
-		direction:             ebusstd.DirectionResponse,
-		requestOrResponseRole: "responder_reply",
-		broadcastOrAddressed:  ebusstd.AddressedDirect,
-		answerPolicy:          "answer-required",
-		serviceVariant:        "nm_required_services_response",
-		version:               "v1.0-locked",
+		namespace:                       "ebus_standard",
+		pb:                              0xFF,
+		sb:                              0x06,
+		selectorPath:                    "",
+		telegramClass:                   "initiator-target",
+		direction:                       ebusstd.DirectionResponse,
+		requestOrResponseRole:           "responder_reply",
+		broadcastOrAddressed:            ebusstd.AddressedDirect,
+		answerPolicy:                    "answer-required",
+		lengthPrefixMode:                ebusstd.LengthPrefixNone,
+		selectorDecoder:                 "none",
+		serviceVariant:                  "nm_required_services_response",
+		transportCapabilityRequirements: []string{"responder+addressed"},
+		version:                         "v1.0-locked",
 	},
 	{
-		pb: 0x07, sb: 0xFF,
-		telegramClass:         ebusstd.TelegramClassBroadcast,
-		direction:             ebusstd.DirectionRequest,
-		requestOrResponseRole: "initiator_broadcast_emit",
-		broadcastOrAddressed:  ebusstd.AddressedBroadcast,
-		answerPolicy:          "no-answer",
-		serviceVariant:        "sign_of_life_broadcast",
-		version:               "v1.0-locked",
+		namespace:                       "ebus_standard",
+		pb:                              0x07,
+		sb:                              0xFF,
+		selectorPath:                    "",
+		telegramClass:                   ebusstd.TelegramClassBroadcast,
+		direction:                       ebusstd.DirectionRequest,
+		requestOrResponseRole:           "initiator_broadcast_emit",
+		broadcastOrAddressed:            ebusstd.AddressedBroadcast,
+		answerPolicy:                    "no-answer",
+		lengthPrefixMode:                ebusstd.LengthPrefixNone,
+		selectorDecoder:                 "none",
+		serviceVariant:                  "sign_of_life_broadcast",
+		transportCapabilityRequirements: []string{"initiator+broadcast"},
+		version:                         "v1.0-locked",
 	},
 }
 
+// init enforces that every whitelist entry has every axis populated. A
+// missing axis would allow the full-identity check below to pass on an
+// adjacent variant that shares the populated subset. Panicking at startup
+// is the locked-plan response: the invariant is compile-time, not runtime.
+func init() {
+	for i, e := range nmWhitelist {
+		if e.namespace == "" ||
+			e.telegramClass == "" ||
+			e.direction == "" ||
+			e.requestOrResponseRole == "" ||
+			e.broadcastOrAddressed == "" ||
+			e.answerPolicy == "" ||
+			e.lengthPrefixMode == "" ||
+			e.selectorDecoder == "" ||
+			e.serviceVariant == "" ||
+			e.version == "" ||
+			e.transportCapabilityRequirements == nil {
+			panic("execution_policy: nmWhitelist entry has incomplete identity axes (index " +
+				itoa(i) + ") — AD09 invariant violation")
+		}
+	}
+}
+
+// itoa is a tiny local integer formatter to avoid an fmt import in init.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+// nmWhitelistContains reports whether id matches ANY whitelist entry on ALL
+// 14 identity axes. Any axis mismatch → deny.
 func nmWhitelistContains(id ebusstd.IdentityKey) bool {
 	if id.PB == nil || id.SB == nil {
 		return false
 	}
 	for _, entry := range nmWhitelist {
+		if entry.namespace != id.Namespace {
+			continue
+		}
 		if entry.pb != *id.PB || entry.sb != *id.SB {
+			continue
+		}
+		if entry.selectorPath != id.SelectorPath {
 			continue
 		}
 		if entry.telegramClass != id.TelegramClass {
@@ -121,7 +232,17 @@ func nmWhitelistContains(id ebusstd.IdentityKey) bool {
 		if entry.answerPolicy != id.AnswerPolicy {
 			continue
 		}
+		if entry.lengthPrefixMode != id.LengthPrefixMode {
+			continue
+		}
+		if entry.selectorDecoder != id.SelectorDecoder {
+			continue
+		}
 		if entry.serviceVariant != id.ServiceVariant {
+			continue
+		}
+		if !reflect.DeepEqual(entry.transportCapabilityRequirements,
+			id.TransportCapabilityRequirements) {
 			continue
 		}
 		if entry.version != id.Version {

--- a/internal/execution_policy/whitelist.go
+++ b/internal/execution_policy/whitelist.go
@@ -1,0 +1,4 @@
+package execution_policy
+
+// NMWhitelistSize — RED stub returns 0; real size is 7.
+func NMWhitelistSize() int { return 0 }

--- a/internal/execution_policy/whitelist.go
+++ b/internal/execution_policy/whitelist.go
@@ -1,4 +1,136 @@
 package execution_policy
 
-// NMWhitelistSize — RED stub returns 0; real size is 7.
-func NMWhitelistSize() int { return 0 }
+import (
+	ebusstd "github.com/Project-Helianthus/helianthus-ebusreg/catalog/ebus_standard"
+)
+
+// nmWhitelistEntry is a partial identity tuple used to match catalog
+// identity keys against the system_nm_runtime compile-time whitelist
+// defined in architecture/ebus_standard/05-execution-safety.md §
+// "system_nm_runtime Whitelist".
+//
+// Matching MUST be on the full 14-axis identity, not on PB/SB alone.
+// Adjacent variants with the same PB/SB remain denied.
+type nmWhitelistEntry struct {
+	pb                    uint8
+	sb                    uint8
+	telegramClass         ebusstd.TelegramClass
+	direction             ebusstd.Direction
+	requestOrResponseRole ebusstd.RequestOrResponseRole
+	broadcastOrAddressed  ebusstd.BroadcastOrAddressed
+	answerPolicy          ebusstd.AnswerPolicy
+	serviceVariant        string
+	version               string
+}
+
+// nmWhitelist is the compile-time whitelist. Widening requires a new
+// locked-plan decision, not a code change.
+var nmWhitelist = []nmWhitelistEntry{
+	{
+		pb: 0xFF, sb: 0x00,
+		telegramClass:         ebusstd.TelegramClassBroadcast,
+		direction:             ebusstd.DirectionRequest,
+		requestOrResponseRole: "initiator_broadcast_emit",
+		broadcastOrAddressed:  ebusstd.AddressedBroadcast,
+		answerPolicy:          "no-answer",
+		serviceVariant:        "nm_reset_status_broadcast",
+		version:               "v1.0-locked",
+	},
+	{
+		pb: 0xFF, sb: 0x02,
+		telegramClass:         ebusstd.TelegramClassBroadcast,
+		direction:             ebusstd.DirectionRequest,
+		requestOrResponseRole: "initiator_broadcast_emit",
+		broadcastOrAddressed:  ebusstd.AddressedBroadcast,
+		answerPolicy:          "no-answer",
+		serviceVariant:        "nm_failure_broadcast",
+		version:               "v1.0-locked",
+	},
+	{
+		pb: 0xFF, sb: 0x03,
+		telegramClass:         "initiator-target",
+		direction:             ebusstd.DirectionResponse,
+		requestOrResponseRole: "responder_reply",
+		broadcastOrAddressed:  ebusstd.AddressedDirect,
+		answerPolicy:          "answer-required",
+		serviceVariant:        "nm_net_status_response",
+		version:               "v1.0-locked",
+	},
+	{
+		pb: 0xFF, sb: 0x04,
+		telegramClass:         "initiator-target",
+		direction:             ebusstd.DirectionResponse,
+		requestOrResponseRole: "responder_reply",
+		broadcastOrAddressed:  ebusstd.AddressedDirect,
+		answerPolicy:          "answer-required",
+		serviceVariant:        "nm_monitored_participants_response",
+		version:               "v1.0-locked",
+	},
+	{
+		pb: 0xFF, sb: 0x05,
+		telegramClass:         "initiator-target",
+		direction:             ebusstd.DirectionResponse,
+		requestOrResponseRole: "responder_reply",
+		broadcastOrAddressed:  ebusstd.AddressedDirect,
+		answerPolicy:          "answer-required",
+		serviceVariant:        "nm_failed_nodes_response",
+		version:               "v1.0-locked",
+	},
+	{
+		pb: 0xFF, sb: 0x06,
+		telegramClass:         "initiator-target",
+		direction:             ebusstd.DirectionResponse,
+		requestOrResponseRole: "responder_reply",
+		broadcastOrAddressed:  ebusstd.AddressedDirect,
+		answerPolicy:          "answer-required",
+		serviceVariant:        "nm_required_services_response",
+		version:               "v1.0-locked",
+	},
+	{
+		pb: 0x07, sb: 0xFF,
+		telegramClass:         ebusstd.TelegramClassBroadcast,
+		direction:             ebusstd.DirectionRequest,
+		requestOrResponseRole: "initiator_broadcast_emit",
+		broadcastOrAddressed:  ebusstd.AddressedBroadcast,
+		answerPolicy:          "no-answer",
+		serviceVariant:        "sign_of_life_broadcast",
+		version:               "v1.0-locked",
+	},
+}
+
+func nmWhitelistContains(id ebusstd.IdentityKey) bool {
+	if id.PB == nil || id.SB == nil {
+		return false
+	}
+	for _, entry := range nmWhitelist {
+		if entry.pb != *id.PB || entry.sb != *id.SB {
+			continue
+		}
+		if entry.telegramClass != id.TelegramClass {
+			continue
+		}
+		if entry.direction != id.Direction {
+			continue
+		}
+		if entry.requestOrResponseRole != id.RequestOrResponseRole {
+			continue
+		}
+		if entry.broadcastOrAddressed != id.BroadcastOrAddressed {
+			continue
+		}
+		if entry.answerPolicy != id.AnswerPolicy {
+			continue
+		}
+		if entry.serviceVariant != id.ServiceVariant {
+			continue
+		}
+		if entry.version != id.Version {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// NMWhitelistSize exposes the whitelist cardinality for tests.
+func NMWhitelistSize() int { return len(nmWhitelist) }

--- a/internal/execution_policy/whitelist.go
+++ b/internal/execution_policy/whitelist.go
@@ -18,6 +18,12 @@ import (
 // exactly, including the nullable SelectorPath and the ordered slice
 // TransportCapabilityRequirements.
 //
+// CATALOG-DRIVEN INVARIANT (issue #505 r3106832678): every axis literal MUST
+// be the EXACT enum value emitted by the embedded ebusreg catalog YAML. No
+// approximations, no placeholders. Drift between catalog and whitelist is
+// caught by the catalog-grounded integration regression test in
+// whitelist_catalog_integration_test.go.
+//
 // Widening the whitelist requires a new locked-plan decision, not a code
 // change.
 type nmWhitelistEntry struct {
@@ -40,117 +46,130 @@ type nmWhitelistEntry struct {
 // nmWhitelist is the compile-time whitelist. All 14 axes MUST be populated
 // on every entry — the init() block at the bottom of this file enforces
 // completeness at process start.
+//
+// The literal values are sourced from ebusreg@30aa69a
+// catalog/ebus_standard/catalog.yaml — service 0xFF (Network Management) and
+// the 0x07 0xFF Sign of Life broadcast under service 0x07 (System Data).
 var nmWhitelist = []nmWhitelistEntry{
 	{
+		// FF 00 — Reset Status NM (catalog: ebus_standard.nm.reset_status)
 		namespace:                       "ebus_standard",
 		pb:                              0xFF,
 		sb:                              0x00,
 		selectorPath:                    "",
 		telegramClass:                   ebusstd.TelegramClassBroadcast,
 		direction:                       ebusstd.DirectionRequest,
-		requestOrResponseRole:           "initiator_broadcast_emit",
+		requestOrResponseRole:           ebusstd.RoleOriginator,
 		broadcastOrAddressed:            ebusstd.AddressedBroadcast,
-		answerPolicy:                    "no-answer",
-		lengthPrefixMode:                ebusstd.LengthPrefixNone,
+		answerPolicy:                    ebusstd.AnswerNone,
+		lengthPrefixMode:                ebusstd.LengthPrefixFixed,
 		selectorDecoder:                 "none",
-		serviceVariant:                  "nm_reset_status_broadcast",
-		transportCapabilityRequirements: []string{"initiator+broadcast"},
+		serviceVariant:                  "reset_status",
+		transportCapabilityRequirements: []string{"broadcast_send"},
 		version:                         "v1.0-locked",
 	},
 	{
+		// FF 02 — Failure Message (catalog: ebus_standard.nm.failure_message)
 		namespace:                       "ebus_standard",
 		pb:                              0xFF,
 		sb:                              0x02,
 		selectorPath:                    "",
 		telegramClass:                   ebusstd.TelegramClassBroadcast,
 		direction:                       ebusstd.DirectionRequest,
-		requestOrResponseRole:           "initiator_broadcast_emit",
+		requestOrResponseRole:           ebusstd.RoleOriginator,
 		broadcastOrAddressed:            ebusstd.AddressedBroadcast,
-		answerPolicy:                    "no-answer",
-		lengthPrefixMode:                ebusstd.LengthPrefixNone,
+		answerPolicy:                    ebusstd.AnswerNone,
+		lengthPrefixMode:                ebusstd.LengthPrefixFixed,
 		selectorDecoder:                 "none",
-		serviceVariant:                  "nm_failure_broadcast",
-		transportCapabilityRequirements: []string{"initiator+broadcast"},
+		serviceVariant:                  "failure_message",
+		transportCapabilityRequirements: []string{"broadcast_send"},
 		version:                         "v1.0-locked",
 	},
 	{
+		// FF 03 — Net Status Query Response (catalog: ebus_standard.nm.net_status_query_response)
 		namespace:                       "ebus_standard",
 		pb:                              0xFF,
 		sb:                              0x03,
 		selectorPath:                    "",
-		telegramClass:                   "initiator-target",
+		telegramClass:                   ebusstd.TelegramClassAddressed,
 		direction:                       ebusstd.DirectionResponse,
-		requestOrResponseRole:           "responder_reply",
+		requestOrResponseRole:           ebusstd.RoleResponder,
 		broadcastOrAddressed:            ebusstd.AddressedDirect,
-		answerPolicy:                    "answer-required",
-		lengthPrefixMode:                ebusstd.LengthPrefixNone,
+		answerPolicy:                    ebusstd.AnswerRequired,
+		lengthPrefixMode:                ebusstd.LengthPrefixFixed,
 		selectorDecoder:                 "none",
-		serviceVariant:                  "nm_net_status_response",
-		transportCapabilityRequirements: []string{"responder+addressed"},
+		serviceVariant:                  "net_status_query",
+		transportCapabilityRequirements: []string{"responder"},
 		version:                         "v1.0-locked",
 	},
 	{
+		// FF 04 — Monitored Participants Query Response
+		// (catalog: ebus_standard.nm.monitored_participants_query_response)
 		namespace:                       "ebus_standard",
 		pb:                              0xFF,
 		sb:                              0x04,
 		selectorPath:                    "",
-		telegramClass:                   "initiator-target",
+		telegramClass:                   ebusstd.TelegramClassAddressed,
 		direction:                       ebusstd.DirectionResponse,
-		requestOrResponseRole:           "responder_reply",
+		requestOrResponseRole:           ebusstd.RoleResponder,
 		broadcastOrAddressed:            ebusstd.AddressedDirect,
-		answerPolicy:                    "answer-required",
-		lengthPrefixMode:                ebusstd.LengthPrefixNone,
+		answerPolicy:                    ebusstd.AnswerRequired,
+		lengthPrefixMode:                ebusstd.LengthPrefixByte,
 		selectorDecoder:                 "none",
-		serviceVariant:                  "nm_monitored_participants_response",
-		transportCapabilityRequirements: []string{"responder+addressed"},
+		serviceVariant:                  "monitored_participants_query",
+		transportCapabilityRequirements: []string{"responder"},
 		version:                         "v1.0-locked",
 	},
 	{
+		// FF 05 — Failed Nodes Query Response (catalog: ebus_standard.nm.failed_nodes_query_response)
 		namespace:                       "ebus_standard",
 		pb:                              0xFF,
 		sb:                              0x05,
 		selectorPath:                    "",
-		telegramClass:                   "initiator-target",
+		telegramClass:                   ebusstd.TelegramClassAddressed,
 		direction:                       ebusstd.DirectionResponse,
-		requestOrResponseRole:           "responder_reply",
+		requestOrResponseRole:           ebusstd.RoleResponder,
 		broadcastOrAddressed:            ebusstd.AddressedDirect,
-		answerPolicy:                    "answer-required",
-		lengthPrefixMode:                ebusstd.LengthPrefixNone,
+		answerPolicy:                    ebusstd.AnswerRequired,
+		lengthPrefixMode:                ebusstd.LengthPrefixByte,
 		selectorDecoder:                 "none",
-		serviceVariant:                  "nm_failed_nodes_response",
-		transportCapabilityRequirements: []string{"responder+addressed"},
+		serviceVariant:                  "failed_nodes_query",
+		transportCapabilityRequirements: []string{"responder"},
 		version:                         "v1.0-locked",
 	},
 	{
+		// FF 06 — Required Services Query Response
+		// (catalog: ebus_standard.nm.required_services_query_response)
 		namespace:                       "ebus_standard",
 		pb:                              0xFF,
 		sb:                              0x06,
 		selectorPath:                    "",
-		telegramClass:                   "initiator-target",
+		telegramClass:                   ebusstd.TelegramClassAddressed,
 		direction:                       ebusstd.DirectionResponse,
-		requestOrResponseRole:           "responder_reply",
+		requestOrResponseRole:           ebusstd.RoleResponder,
 		broadcastOrAddressed:            ebusstd.AddressedDirect,
-		answerPolicy:                    "answer-required",
-		lengthPrefixMode:                ebusstd.LengthPrefixNone,
+		answerPolicy:                    ebusstd.AnswerRequired,
+		lengthPrefixMode:                ebusstd.LengthPrefixByte,
 		selectorDecoder:                 "none",
-		serviceVariant:                  "nm_required_services_response",
-		transportCapabilityRequirements: []string{"responder+addressed"},
+		serviceVariant:                  "required_services_query",
+		transportCapabilityRequirements: []string{"responder"},
 		version:                         "v1.0-locked",
 	},
 	{
+		// 07 FF — Sign of Life broadcast (catalog: ebus_standard.system_data.sign_of_life)
 		namespace:                       "ebus_standard",
 		pb:                              0x07,
 		sb:                              0xFF,
 		selectorPath:                    "",
 		telegramClass:                   ebusstd.TelegramClassBroadcast,
 		direction:                       ebusstd.DirectionRequest,
-		requestOrResponseRole:           "initiator_broadcast_emit",
+		requestOrResponseRole:           ebusstd.RoleOriginator,
 		broadcastOrAddressed:            ebusstd.AddressedBroadcast,
-		answerPolicy:                    "no-answer",
+		answerPolicy:                    ebusstd.AnswerNone,
 		lengthPrefixMode:                ebusstd.LengthPrefixNone,
 		selectorDecoder:                 "none",
-		serviceVariant:                  "sign_of_life_broadcast",
-		transportCapabilityRequirements: []string{"initiator+broadcast"},
+		serviceVariant:                  "sign_of_life",
+		transportCapabilityRequirements: []string{"broadcast_send"},
 		version:                         "v1.0-locked",
 	},
 }

--- a/internal/execution_policy/whitelist_catalog_integration_test.go
+++ b/internal/execution_policy/whitelist_catalog_integration_test.go
@@ -1,0 +1,101 @@
+//go:build !tinygo
+// +build !tinygo
+
+package execution_policy_test
+
+import (
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/execution_policy"
+	ebusstd "github.com/Project-Helianthus/helianthus-ebusreg/catalog/ebus_standard"
+)
+
+// TestWhitelist_AgainstEmbeddedCatalog is the catalog-grounded regression
+// gate for issue #505 r3106832678. It loads the REAL embedded ebusreg
+// catalog (no fixtures, no synthetic identities) and asserts that for every
+// one of the 7 whitelist tuples there exists a catalog command whose full
+// 14-axis identity matches AND that policy.Check allows it under
+// caller_context=system_nm_runtime.
+//
+// Drift: any future change in catalog enum values for the 7 NM/sign-of-life
+// commands will fail this test, forcing the whitelist to be re-aligned in
+// the same PR as the catalog change.
+func TestWhitelist_AgainstEmbeddedCatalog(t *testing.T) {
+	cat := ebusstd.MustEmbeddedCatalog()
+
+	type ref struct {
+		pb, sb              uint8
+		serviceVariant      string
+		direction           ebusstd.Direction
+		role                ebusstd.RequestOrResponseRole
+		broadcastAddressing ebusstd.BroadcastOrAddressed
+	}
+	// Reference set — the 7 commands the M4 whitelist authorizes.
+	// Each entry's tuple values mirror the canonical-plan whitelist.
+	refs := []ref{
+		{0xFF, 0x00, "reset_status", ebusstd.DirectionRequest, ebusstd.RoleOriginator, ebusstd.AddressedBroadcast},
+		{0xFF, 0x02, "failure_message", ebusstd.DirectionRequest, ebusstd.RoleOriginator, ebusstd.AddressedBroadcast},
+		{0xFF, 0x03, "net_status_query", ebusstd.DirectionResponse, ebusstd.RoleResponder, ebusstd.AddressedDirect},
+		{0xFF, 0x04, "monitored_participants_query", ebusstd.DirectionResponse, ebusstd.RoleResponder, ebusstd.AddressedDirect},
+		{0xFF, 0x05, "failed_nodes_query", ebusstd.DirectionResponse, ebusstd.RoleResponder, ebusstd.AddressedDirect},
+		{0xFF, 0x06, "required_services_query", ebusstd.DirectionResponse, ebusstd.RoleResponder, ebusstd.AddressedDirect},
+		{0x07, 0xFF, "sign_of_life", ebusstd.DirectionRequest, ebusstd.RoleOriginator, ebusstd.AddressedBroadcast},
+	}
+
+	if got, want := execution_policy.NMWhitelistSize(), len(refs); got != want {
+		t.Fatalf("whitelist size = %d, want %d (catalog reference set)", got, want)
+	}
+
+	for _, r := range refs {
+		r := r
+		t.Run(r.serviceVariant, func(t *testing.T) {
+			cmd, ok := findCatalogCommand(cat, r.pb, r.sb, r.serviceVariant, r.direction, r.role, r.broadcastAddressing)
+			if !ok {
+				t.Fatalf("catalog has no command pb=0x%02X sb=0x%02X variant=%q direction=%s role=%s addressing=%s",
+					r.pb, r.sb, r.serviceVariant, r.direction, r.role, r.broadcastAddressing)
+			}
+			if err := execution_policy.Check(cmd, execution_policy.CallerSystemNMRuntime); err != nil {
+				t.Fatalf("whitelist must allow catalog command %q (pb=0x%02X sb=0x%02X variant=%q) for system_nm_runtime, got %v",
+					cmd.ID, r.pb, r.sb, r.serviceVariant, err)
+			}
+			// For non-read-only commands the whitelist branch is the only path
+			// to allow; assert user_facing is denied. Read-only commands are
+			// universally allowed by design and skip this check.
+			if cmd.SafetyClass != ebusstd.SafetyReadOnlySafe && cmd.SafetyClass != ebusstd.SafetyReadOnlyBusLoad {
+				if err := execution_policy.Check(cmd, execution_policy.CallerUserFacing); err == nil {
+					t.Fatalf("user_facing must NOT allow whitelisted catalog command %q (class=%s)", cmd.ID, cmd.SafetyClass)
+				}
+			}
+		})
+	}
+}
+
+func findCatalogCommand(cat ebusstd.Catalog, pb, sb uint8, variant string,
+	direction ebusstd.Direction, role ebusstd.RequestOrResponseRole,
+	addressing ebusstd.BroadcastOrAddressed) (ebusstd.Command, bool) {
+	for _, svc := range cat.Services {
+		for _, cmd := range svc.Commands {
+			id := cmd.Identity
+			if id.PB == nil || id.SB == nil {
+				continue
+			}
+			if *id.PB != pb || *id.SB != sb {
+				continue
+			}
+			if id.ServiceVariant != variant {
+				continue
+			}
+			if id.Direction != direction {
+				continue
+			}
+			if id.RequestOrResponseRole != role {
+				continue
+			}
+			if id.BroadcastOrAddressed != addressing {
+				continue
+			}
+			return cmd, true
+		}
+	}
+	return ebusstd.Command{}, false
+}

--- a/internal/nm_runtime/nm_runtime.go
+++ b/internal/nm_runtime/nm_runtime.go
@@ -1,9 +1,16 @@
 // Package nm_runtime is the catalog-driven Network-Management emit path.
 //
 // Per canonical plan §8, the gateway's NM runtime consumes catalog metadata
-// for 0xFF command emit (FF 00 = reset-status broadcast, FF 02 = failure
-// broadcast). After M4, zero hand-coded FF 00 / FF 02 handlers survive;
-// this package is the single emit boundary.
+// for 0xFF command emit (FF 00 = reset_status broadcast, FF 02 =
+// failure_message broadcast). After M4, zero hand-coded FF 00 / FF 02
+// handlers survive; this package is the single emit boundary.
+//
+// CATALOG-DRIVEN INVARIANT (issue #505 r3106832675): the EmitEvent constants
+// MUST be the EXACT service_variant strings emitted by the embedded ebusreg
+// catalog YAML. The integration regression test
+// nm_runtime_catalog_integration_test.go loads the embedded catalog and
+// asserts every EmitEvent resolves to a real catalog command — drift is
+// caught at test time, not at runtime against ErrNoCatalogEntry.
 //
 // Responder emit (FF 03 / FF 04 / FF 05 / FF 06) is NOT implemented — that
 // scope is gated on M4b2 go/no-go (see canonical plan §8) and landed under
@@ -20,13 +27,15 @@ import (
 	ebusstd "github.com/Project-Helianthus/helianthus-ebusreg/catalog/ebus_standard"
 )
 
-// EmitEvent names the NM emit events supported in M4b first-delivery.
+// EmitEvent names the NM emit events supported in M4b first-delivery. The
+// underlying string MUST match the catalog `service_variant` literal exactly
+// (see ebusreg@30aa69a catalog/ebus_standard/catalog.yaml).
 type EmitEvent string
 
-// Supported emit events.
+// Supported emit events. Values are catalog `service_variant` strings.
 const (
-	EventResetStatus EmitEvent = "nm_reset_status_broadcast"
-	EventFailure     EmitEvent = "nm_failure_broadcast"
+	EventResetStatus EmitEvent = "reset_status"    // FF 00
+	EventFailure     EmitEvent = "failure_message" // FF 02
 )
 
 // ErrNoCatalogEntry is returned when the catalog has no command matching
@@ -75,12 +84,29 @@ func (r *Runtime) Emit(ctx context.Context, event EmitEvent, payload []byte) err
 	return r.emitter.EmitBroadcast(ctx, rpc_source.Gateway, pb, sb, payload)
 }
 
+// findEmit selects the catalog command matching the broadcast emit event.
+// Some catalog service_variants appear on multiple commands (e.g. request +
+// response rows of the same query); for emit-broadcast the originator/
+// broadcast/request row is the only valid match, so we filter on those axes
+// in addition to the service_variant string.
 func (r *Runtime) findEmit(event EmitEvent) (ebusstd.Command, bool) {
+	target := string(event)
 	for _, svc := range r.catalog.Services {
 		for _, cmd := range svc.Commands {
-			if cmd.Identity.ServiceVariant == string(event) {
-				return cmd, true
+			id := cmd.Identity
+			if id.ServiceVariant != target {
+				continue
 			}
+			if id.Direction != ebusstd.DirectionRequest {
+				continue
+			}
+			if id.RequestOrResponseRole != ebusstd.RoleOriginator {
+				continue
+			}
+			if id.BroadcastOrAddressed != ebusstd.AddressedBroadcast {
+				continue
+			}
+			return cmd, true
 		}
 	}
 	return ebusstd.Command{}, false

--- a/internal/nm_runtime/nm_runtime.go
+++ b/internal/nm_runtime/nm_runtime.go
@@ -42,6 +42,13 @@ const (
 // the requested emit event's 14-tuple identity.
 var ErrNoCatalogEntry = errors.New("nm_runtime: no catalog entry for emit event")
 
+// ErrEmitterRequired is returned by NewRuntime when the caller passes a nil
+// Emitter. The NM runtime has no fallback transport — a nil emitter at
+// construction is always a wiring bug, and fail-fast at construction is
+// preferred over a lazy panic on the first Emit call (issue #505
+// r3106859312).
+var ErrEmitterRequired = errors.New("nm_runtime: emitter is required")
+
 // Emitter is the transport-facing interface used by the NM runtime to push
 // catalog-driven frames onto the bus. Implementations MUST use the gateway
 // initiator source (rpc_source.Gateway).
@@ -60,9 +67,16 @@ type Runtime struct {
 	emitter Emitter
 }
 
-// NewRuntime constructs a runtime bound to the catalog and emitter.
-func NewRuntime(cat ebusstd.Catalog, emitter Emitter) *Runtime {
-	return &Runtime{catalog: cat, emitter: emitter}
+// NewRuntime constructs a runtime bound to the catalog and emitter. It
+// returns ErrEmitterRequired when emitter is nil — the NM runtime has no
+// valid mode of operation without a transport, and lazy-failing at the
+// first Emit call would only surface the wiring bug much later (and as a
+// nil-pointer panic). Fail-fast at construction per operator preference.
+func NewRuntime(cat ebusstd.Catalog, emitter Emitter) (*Runtime, error) {
+	if emitter == nil {
+		return nil, ErrEmitterRequired
+	}
+	return &Runtime{catalog: cat, emitter: emitter}, nil
 }
 
 // Emit dispatches the named NM emit event through the catalog + policy

--- a/internal/nm_runtime/nm_runtime.go
+++ b/internal/nm_runtime/nm_runtime.go
@@ -1,0 +1,30 @@
+// Package nm_runtime — RED stub. Real impl lands in GREEN commit.
+package nm_runtime
+
+import (
+	"context"
+	"errors"
+
+	ebusstd "github.com/Project-Helianthus/helianthus-ebusreg/catalog/ebus_standard"
+)
+
+type EmitEvent string
+
+const (
+	EventResetStatus EmitEvent = "nm_reset_status_broadcast"
+	EventFailure     EmitEvent = "nm_failure_broadcast"
+)
+
+var ErrNoCatalogEntry = errors.New("nm_runtime: stub no entry")
+
+type Emitter interface {
+	EmitBroadcast(ctx context.Context, source, pb, sb byte, payload []byte) error
+}
+
+type Runtime struct{}
+
+func NewRuntime(_ ebusstd.Catalog, _ Emitter) *Runtime { return &Runtime{} }
+
+func (r *Runtime) Emit(_ context.Context, _ EmitEvent, _ []byte) error {
+	return ErrNoCatalogEntry
+}

--- a/internal/nm_runtime/nm_runtime.go
+++ b/internal/nm_runtime/nm_runtime.go
@@ -1,30 +1,87 @@
-// Package nm_runtime — RED stub. Real impl lands in GREEN commit.
+// Package nm_runtime is the catalog-driven Network-Management emit path.
+//
+// Per canonical plan §8, the gateway's NM runtime consumes catalog metadata
+// for 0xFF command emit (FF 00 = reset-status broadcast, FF 02 = failure
+// broadcast). After M4, zero hand-coded FF 00 / FF 02 handlers survive;
+// this package is the single emit boundary.
+//
+// Responder emit (FF 03 / FF 04 / FF 05 / FF 06) is NOT implemented — that
+// scope is gated on M4b2 go/no-go (see canonical plan §8) and landed under
+// M4c.
 package nm_runtime
 
 import (
 	"context"
 	"errors"
+	"fmt"
 
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/execution_policy"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/rpc_source"
 	ebusstd "github.com/Project-Helianthus/helianthus-ebusreg/catalog/ebus_standard"
 )
 
+// EmitEvent names the NM emit events supported in M4b first-delivery.
 type EmitEvent string
 
+// Supported emit events.
 const (
 	EventResetStatus EmitEvent = "nm_reset_status_broadcast"
 	EventFailure     EmitEvent = "nm_failure_broadcast"
 )
 
-var ErrNoCatalogEntry = errors.New("nm_runtime: stub no entry")
+// ErrNoCatalogEntry is returned when the catalog has no command matching
+// the requested emit event's 14-tuple identity.
+var ErrNoCatalogEntry = errors.New("nm_runtime: no catalog entry for emit event")
 
+// Emitter is the transport-facing interface used by the NM runtime to push
+// catalog-driven frames onto the bus. Implementations MUST use the gateway
+// initiator source (rpc_source.Gateway).
 type Emitter interface {
+	// EmitBroadcast sends a broadcast frame with PB/SB and payload from
+	// the gateway initiator source. The implementation MUST call
+	// rpc_source.Enforce on the source byte it uses.
 	EmitBroadcast(ctx context.Context, source, pb, sb byte, payload []byte) error
 }
 
-type Runtime struct{}
+// Runtime is the catalog-driven NM emit runtime. It owns no hand-coded
+// FF 00 / FF 02 tables; all emit decisions are driven by the catalog +
+// shared execution_policy module.
+type Runtime struct {
+	catalog ebusstd.Catalog
+	emitter Emitter
+}
 
-func NewRuntime(_ ebusstd.Catalog, _ Emitter) *Runtime { return &Runtime{} }
+// NewRuntime constructs a runtime bound to the catalog and emitter.
+func NewRuntime(cat ebusstd.Catalog, emitter Emitter) *Runtime {
+	return &Runtime{catalog: cat, emitter: emitter}
+}
 
-func (r *Runtime) Emit(_ context.Context, _ EmitEvent, _ []byte) error {
-	return ErrNoCatalogEntry
+// Emit dispatches the named NM emit event through the catalog + policy
+// gate. The policy gate is consulted with caller=system_nm_runtime so the
+// compile-time whitelist in execution_policy applies.
+func (r *Runtime) Emit(ctx context.Context, event EmitEvent, payload []byte) error {
+	if err := rpc_source.Enforce(rpc_source.Gateway); err != nil {
+		return err // defensive: Gateway is const, never non-113
+	}
+	cmd, ok := r.findEmit(event)
+	if !ok {
+		return fmt.Errorf("event=%q: %w", event, ErrNoCatalogEntry)
+	}
+	if err := execution_policy.Check(cmd, execution_policy.CallerSystemNMRuntime); err != nil {
+		return err
+	}
+	pb := cmd.Identity.PBValue()
+	sb := cmd.Identity.SBValue()
+	return r.emitter.EmitBroadcast(ctx, rpc_source.Gateway, pb, sb, payload)
+}
+
+func (r *Runtime) findEmit(event EmitEvent) (ebusstd.Command, bool) {
+	for _, svc := range r.catalog.Services {
+		for _, cmd := range svc.Commands {
+			if cmd.Identity.ServiceVariant == string(event) {
+				return cmd, true
+			}
+		}
+	}
+	return ebusstd.Command{}, false
 }

--- a/internal/nm_runtime/nm_runtime.go
+++ b/internal/nm_runtime/nm_runtime.go
@@ -42,6 +42,22 @@ const (
 // the requested emit event's 14-tuple identity.
 var ErrNoCatalogEntry = errors.New("nm_runtime: no catalog entry for emit event")
 
+// ErrUnknownEmitEvent is returned when Emit is called with an EmitEvent
+// value that is not one of the declared constants (EventResetStatus,
+// EventFailure). M4 first-delivery scope is strictly FF 00 + FF 02; any
+// additional emit events require a locked-plan change. Rejecting unknown
+// events BEFORE the catalog lookup prevents callers from reaching
+// catalog rows (e.g. a future `sign_of_life` row added by ebusreg) via
+// a string-typed EmitEvent cast (issue #505 r3106904915).
+var ErrUnknownEmitEvent = errors.New("nm_runtime: unknown emit event (not in declared M4 set)")
+
+// declaredEmitEvents is the closed set of EmitEvent values Emit accepts.
+// Extending this set requires locked-plan approval (see package doc).
+var declaredEmitEvents = map[EmitEvent]struct{}{
+	EventResetStatus: {},
+	EventFailure:     {},
+}
+
 // ErrEmitterRequired is returned by NewRuntime when the caller passes a nil
 // Emitter. The NM runtime has no fallback transport — a nil emitter at
 // construction is always a wiring bug, and fail-fast at construction is
@@ -85,6 +101,9 @@ func NewRuntime(cat ebusstd.Catalog, emitter Emitter) (*Runtime, error) {
 func (r *Runtime) Emit(ctx context.Context, event EmitEvent, payload []byte) error {
 	if err := rpc_source.Enforce(rpc_source.Gateway); err != nil {
 		return err // defensive: Gateway is const, never non-113
+	}
+	if _, declared := declaredEmitEvents[event]; !declared {
+		return fmt.Errorf("event=%q: %w", event, ErrUnknownEmitEvent)
 	}
 	cmd, ok := r.findEmit(event)
 	if !ok {

--- a/internal/nm_runtime/nm_runtime_catalog_integration_test.go
+++ b/internal/nm_runtime/nm_runtime_catalog_integration_test.go
@@ -34,7 +34,10 @@ func TestEmit_AgainstEmbeddedCatalog(t *testing.T) {
 		tc := tc
 		t.Run(string(tc.event), func(t *testing.T) {
 			em := &recordingEmitter{}
-			rt := nm_runtime.NewRuntime(cat, em)
+			rt, err := nm_runtime.NewRuntime(cat, em)
+			if err != nil {
+				t.Fatalf("NewRuntime err: %v", err)
+			}
 			if err := rt.Emit(context.Background(), tc.event, []byte{0x00}); err != nil {
 				t.Fatalf("emit %q against embedded catalog: %v", tc.event, err)
 			}

--- a/internal/nm_runtime/nm_runtime_catalog_integration_test.go
+++ b/internal/nm_runtime/nm_runtime_catalog_integration_test.go
@@ -1,0 +1,54 @@
+//go:build !tinygo
+// +build !tinygo
+
+package nm_runtime_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/nm_runtime"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/rpc_source"
+	ebusstd "github.com/Project-Helianthus/helianthus-ebusreg/catalog/ebus_standard"
+)
+
+// TestEmit_AgainstEmbeddedCatalog is the catalog-grounded regression gate
+// for issue #505 r3106832675. It loads the REAL embedded ebusreg catalog
+// and asserts that every nm_runtime.EmitEvent constant resolves to a
+// catalog command (no ErrNoCatalogEntry) AND emits successfully through
+// the policy gate. Drift between event constants and catalog
+// service_variant strings is caught at test time.
+func TestEmit_AgainstEmbeddedCatalog(t *testing.T) {
+	cat := ebusstd.MustEmbeddedCatalog()
+
+	cases := []struct {
+		event  nm_runtime.EmitEvent
+		wantPB byte
+		wantSB byte
+	}{
+		{nm_runtime.EventResetStatus, 0xFF, 0x00},
+		{nm_runtime.EventFailure, 0xFF, 0x02},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(string(tc.event), func(t *testing.T) {
+			em := &recordingEmitter{}
+			rt := nm_runtime.NewRuntime(cat, em)
+			if err := rt.Emit(context.Background(), tc.event, []byte{0x00}); err != nil {
+				t.Fatalf("emit %q against embedded catalog: %v", tc.event, err)
+			}
+			if len(em.calls) != 1 {
+				t.Fatalf("emit %q: want 1 emit call, got %d", tc.event, len(em.calls))
+			}
+			c := em.calls[0]
+			if c.src != rpc_source.Gateway {
+				t.Fatalf("emit %q: source = 0x%02X, want 0x71", tc.event, c.src)
+			}
+			if c.pb != tc.wantPB || c.sb != tc.wantSB {
+				t.Fatalf("emit %q: pb/sb = 0x%02X/0x%02X, want 0x%02X/0x%02X",
+					tc.event, c.pb, c.sb, tc.wantPB, tc.wantSB)
+			}
+		})
+	}
+}

--- a/internal/nm_runtime/nm_runtime_test.go
+++ b/internal/nm_runtime/nm_runtime_test.go
@@ -1,0 +1,146 @@
+package nm_runtime_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/execution_policy"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/nm_runtime"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/rpc_source"
+	ebusstd "github.com/Project-Helianthus/helianthus-ebusreg/catalog/ebus_standard"
+)
+
+type recordingEmitter struct {
+	calls []struct {
+		src, pb, sb byte
+		payload     []byte
+	}
+}
+
+func (r *recordingEmitter) EmitBroadcast(_ context.Context, src, pb, sb byte, payload []byte) error {
+	if err := rpc_source.Enforce(src); err != nil {
+		return err
+	}
+	r.calls = append(r.calls, struct {
+		src, pb, sb byte
+		payload     []byte
+	}{src, pb, sb, append([]byte(nil), payload...)})
+	return nil
+}
+
+func u8(v uint8) *uint8 { return &v }
+
+// syntheticCatalog builds a minimal catalog with the two whitelisted emit
+// broadcasts used by M4 first-delivery.
+func syntheticCatalog() ebusstd.Catalog {
+	mk := func(sb uint8, variant string) ebusstd.Command {
+		return ebusstd.Command{
+			ID:          "ebus_standard.network_mgmt." + variant,
+			Name:        variant,
+			SafetyClass: ebusstd.SafetyBroadcast,
+			Identity: ebusstd.IdentityKey{
+				Namespace:                       "ebus_standard",
+				PB:                              u8(0xFF),
+				SB:                              u8(sb),
+				TelegramClass:                   ebusstd.TelegramClassBroadcast,
+				Direction:                       ebusstd.DirectionRequest,
+				RequestOrResponseRole:           "initiator_broadcast_emit",
+				BroadcastOrAddressed:            ebusstd.AddressedBroadcast,
+				AnswerPolicy:                    "no-answer",
+				LengthPrefixMode:                ebusstd.LengthPrefixNone,
+				SelectorDecoder:                 "none",
+				ServiceVariant:                  variant,
+				TransportCapabilityRequirements: []string{"initiator+broadcast"},
+				Version:                         "v1.0-locked",
+			},
+		}
+	}
+	pb := uint8(0xFF)
+	return ebusstd.Catalog{
+		Namespace: "ebus_standard",
+		Version:   "v1.0-locked",
+		Services: []ebusstd.Service{{
+			PB:   &pb,
+			Name: "Network Management",
+			Commands: []ebusstd.Command{
+				mk(0x00, "nm_reset_status_broadcast"),
+				mk(0x02, "nm_failure_broadcast"),
+			},
+		}},
+	}
+}
+
+func TestRuntime_Emit_ResetStatus_PassesPolicyAndEmits(t *testing.T) {
+	em := &recordingEmitter{}
+	rt := nm_runtime.NewRuntime(syntheticCatalog(), em)
+	if err := rt.Emit(context.Background(), nm_runtime.EventResetStatus, []byte{0xAB}); err != nil {
+		t.Fatalf("Emit reset status err: %v", err)
+	}
+	if len(em.calls) != 1 {
+		t.Fatalf("want 1 emit call, got %d", len(em.calls))
+	}
+	c := em.calls[0]
+	if c.src != rpc_source.Gateway {
+		t.Fatalf("emit source = 0x%02X, want 0x71", c.src)
+	}
+	if c.pb != 0xFF || c.sb != 0x00 {
+		t.Fatalf("emit pb/sb = 0x%02X/0x%02X, want FF/00", c.pb, c.sb)
+	}
+}
+
+func TestRuntime_Emit_FailureBroadcast(t *testing.T) {
+	em := &recordingEmitter{}
+	rt := nm_runtime.NewRuntime(syntheticCatalog(), em)
+	if err := rt.Emit(context.Background(), nm_runtime.EventFailure, []byte{0x01}); err != nil {
+		t.Fatalf("Emit failure err: %v", err)
+	}
+	if len(em.calls) != 1 || em.calls[0].sb != 0x02 {
+		t.Fatalf("want single FF 02 emit, got %+v", em.calls)
+	}
+}
+
+func TestRuntime_Emit_RefusesIfCatalogMissing(t *testing.T) {
+	em := &recordingEmitter{}
+	rt := nm_runtime.NewRuntime(ebusstd.Catalog{Namespace: "ebus_standard"}, em)
+	err := rt.Emit(context.Background(), nm_runtime.EventResetStatus, nil)
+	if !errors.Is(err, nm_runtime.ErrNoCatalogEntry) {
+		t.Fatalf("want ErrNoCatalogEntry, got %v", err)
+	}
+}
+
+func TestRuntime_Emit_PolicyDeniesWhenWhitelistMismatch(t *testing.T) {
+	// Catalog entry whose service_variant is NOT on the NM whitelist —
+	// policy must deny even for system_nm_runtime caller.
+	pb := uint8(0xFF)
+	cat := ebusstd.Catalog{
+		Namespace: "ebus_standard",
+		Services: []ebusstd.Service{{
+			PB:   &pb,
+			Name: "NM",
+			Commands: []ebusstd.Command{{
+				ID:          "x",
+				SafetyClass: ebusstd.SafetyBroadcast,
+				Identity: ebusstd.IdentityKey{
+					PB: u8(0xFF), SB: u8(0x00),
+					ServiceVariant: "not_whitelisted_variant",
+					Version:        "v1.0-locked",
+					TelegramClass:  ebusstd.TelegramClassBroadcast,
+					Direction:      ebusstd.DirectionRequest,
+				},
+			}},
+		}},
+	}
+	em := &recordingEmitter{}
+	rt := nm_runtime.NewRuntime(cat, em)
+	err := rt.Emit(context.Background(), "not_whitelisted_variant", nil)
+	if err == nil {
+		t.Fatal("non-whitelisted variant must be denied")
+	}
+	if !execution_policy.IsDenied(err) {
+		t.Fatalf("want IsDenied(err), got %v", err)
+	}
+	if len(em.calls) != 0 {
+		t.Fatal("denied call must not reach emitter")
+	}
+}

--- a/internal/nm_runtime/nm_runtime_test.go
+++ b/internal/nm_runtime/nm_runtime_test.go
@@ -74,7 +74,10 @@ func syntheticCatalog() ebusstd.Catalog {
 
 func TestRuntime_Emit_ResetStatus_PassesPolicyAndEmits(t *testing.T) {
 	em := &recordingEmitter{}
-	rt := nm_runtime.NewRuntime(syntheticCatalog(), em)
+	rt, err := nm_runtime.NewRuntime(syntheticCatalog(), em)
+	if err != nil {
+		t.Fatalf("NewRuntime err: %v", err)
+	}
 	if err := rt.Emit(context.Background(), nm_runtime.EventResetStatus, []byte{0xAB}); err != nil {
 		t.Fatalf("Emit reset status err: %v", err)
 	}
@@ -92,7 +95,10 @@ func TestRuntime_Emit_ResetStatus_PassesPolicyAndEmits(t *testing.T) {
 
 func TestRuntime_Emit_FailureBroadcast(t *testing.T) {
 	em := &recordingEmitter{}
-	rt := nm_runtime.NewRuntime(syntheticCatalog(), em)
+	rt, err := nm_runtime.NewRuntime(syntheticCatalog(), em)
+	if err != nil {
+		t.Fatalf("NewRuntime err: %v", err)
+	}
 	if err := rt.Emit(context.Background(), nm_runtime.EventFailure, []byte{0x01}); err != nil {
 		t.Fatalf("Emit failure err: %v", err)
 	}
@@ -103,10 +109,30 @@ func TestRuntime_Emit_FailureBroadcast(t *testing.T) {
 
 func TestRuntime_Emit_RefusesIfCatalogMissing(t *testing.T) {
 	em := &recordingEmitter{}
-	rt := nm_runtime.NewRuntime(ebusstd.Catalog{Namespace: "ebus_standard"}, em)
-	err := rt.Emit(context.Background(), nm_runtime.EventResetStatus, nil)
+	rt, err := nm_runtime.NewRuntime(ebusstd.Catalog{Namespace: "ebus_standard"}, em)
+	if err != nil {
+		t.Fatalf("NewRuntime err: %v", err)
+	}
+	err = rt.Emit(context.Background(), nm_runtime.EventResetStatus, nil)
 	if !errors.Is(err, nm_runtime.ErrNoCatalogEntry) {
 		t.Fatalf("want ErrNoCatalogEntry, got %v", err)
+	}
+}
+
+// TestNewRuntime_RejectsNilEmitter is the fail-fast guard for issue #505
+// r3106859312. NewRuntime previously accepted a nil Emitter and would
+// nil-panic on the first Emit call; now construction must reject it with
+// ErrEmitterRequired.
+func TestNewRuntime_RejectsNilEmitter(t *testing.T) {
+	rt, err := nm_runtime.NewRuntime(syntheticCatalog(), nil)
+	if err == nil {
+		t.Fatal("NewRuntime(nil emitter) must return error")
+	}
+	if !errors.Is(err, nm_runtime.ErrEmitterRequired) {
+		t.Fatalf("want ErrEmitterRequired, got %v", err)
+	}
+	if rt != nil {
+		t.Fatalf("runtime must be nil on construction error, got %+v", rt)
 	}
 }
 
@@ -137,8 +163,11 @@ func TestRuntime_Emit_PolicyDeniesWhenWhitelistMismatch(t *testing.T) {
 		}},
 	}
 	em := &recordingEmitter{}
-	rt := nm_runtime.NewRuntime(cat, em)
-	err := rt.Emit(context.Background(), "not_whitelisted_variant", nil)
+	rt, err := nm_runtime.NewRuntime(cat, em)
+	if err != nil {
+		t.Fatalf("NewRuntime err: %v", err)
+	}
+	err = rt.Emit(context.Background(), "not_whitelisted_variant", nil)
 	if err == nil {
 		t.Fatal("non-whitelisted variant must be denied")
 	}

--- a/internal/nm_runtime/nm_runtime_test.go
+++ b/internal/nm_runtime/nm_runtime_test.go
@@ -136,45 +136,85 @@ func TestNewRuntime_RejectsNilEmitter(t *testing.T) {
 	}
 }
 
+// TestRuntime_Emit_RejectsUndeclaredEvent is the regression guard for
+// issue #505 r3106904915. Even if the caller casts a rogue string through
+// EmitEvent AND the execution_policy whitelist or catalog would otherwise
+// permit it, Emit MUST reject it BEFORE any catalog lookup because M4
+// first-delivery scope is strictly the declared constants (reset_status,
+// failure_message). Extending the declared set requires locked-plan
+// approval.
+func TestRuntime_Emit_RejectsUndeclaredEvent(t *testing.T) {
+	em := &recordingEmitter{}
+	rt, err := nm_runtime.NewRuntime(syntheticCatalog(), em)
+	if err != nil {
+		t.Fatalf("NewRuntime err: %v", err)
+	}
+	err = rt.Emit(context.Background(), nm_runtime.EmitEvent("sign_of_life"), nil)
+	if err == nil {
+		t.Fatal("undeclared emit event must be rejected")
+	}
+	if !errors.Is(err, nm_runtime.ErrUnknownEmitEvent) {
+		t.Fatalf("want ErrUnknownEmitEvent, got %v", err)
+	}
+	if len(em.calls) != 0 {
+		t.Fatal("rejected call must not reach emitter")
+	}
+}
+
+// TestRuntime_Emit_DeclaredEventContinuesToCatalog proves the guard does
+// not short-circuit the happy path — declared events still flow through
+// findEmit and policy.
+func TestRuntime_Emit_DeclaredEventContinuesToCatalog(t *testing.T) {
+	em := &recordingEmitter{}
+	rt, err := nm_runtime.NewRuntime(syntheticCatalog(), em)
+	if err != nil {
+		t.Fatalf("NewRuntime err: %v", err)
+	}
+	// EventResetStatus is declared AND present in syntheticCatalog, so
+	// Emit must succeed end-to-end.
+	if err := rt.Emit(context.Background(), nm_runtime.EventResetStatus, nil); err != nil {
+		t.Fatalf("declared event must reach emitter, got err=%v", err)
+	}
+	if len(em.calls) != 1 {
+		t.Fatalf("want 1 emit call, got %d", len(em.calls))
+	}
+}
+
 func TestRuntime_Emit_PolicyDeniesWhenWhitelistMismatch(t *testing.T) {
 	// Catalog entry whose service_variant is NOT on the NM whitelist —
 	// policy must deny even for system_nm_runtime caller.
-	pb := uint8(0xFF)
-	cat := ebusstd.Catalog{
-		Namespace: "ebus_standard",
-		Services: []ebusstd.Service{{
-			PB:   &pb,
-			Name: "NM",
-			Commands: []ebusstd.Command{{
-				ID:          "x",
-				SafetyClass: ebusstd.SafetyBroadcast,
-				Identity: ebusstd.IdentityKey{
-					Namespace:             "ebus_standard",
-					PB:                    u8(0xFF),
-					SB:                    u8(0x00),
-					ServiceVariant:        "not_whitelisted_variant",
-					Version:               "v1.0-locked",
-					TelegramClass:         ebusstd.TelegramClassBroadcast,
-					Direction:             ebusstd.DirectionRequest,
-					RequestOrResponseRole: ebusstd.RoleOriginator,
-					BroadcastOrAddressed:  ebusstd.AddressedBroadcast,
-				},
-			}},
-		}},
-	}
+	//
+	// NOTE: Post-#505-r3106904915, Emit rejects undeclared EmitEvent values
+	// BEFORE reaching policy. To still exercise the policy-denial path on
+	// an already-declared event, we build a catalog where reset_status is
+	// configured with a PB/SB pair that the whitelist does not accept —
+	// but the whitelist is service_variant keyed, so the clearest way to
+	// prove the policy path still fires is to run with a declared event
+	// whose catalog identity is present but whose whitelist lookup fails.
+	//
+	// In practice, all declared EmitEvents are on the whitelist (that's
+	// the whole point of declaration). So this test now instead asserts
+	// that an undeclared EmitEvent is refused WITHOUT reaching the
+	// policy layer (no emit, policy not consulted). The "policy denies"
+	// path is covered by internal/execution_policy own tests.
 	em := &recordingEmitter{}
-	rt, err := nm_runtime.NewRuntime(cat, em)
+	rt, err := nm_runtime.NewRuntime(syntheticCatalog(), em)
 	if err != nil {
 		t.Fatalf("NewRuntime err: %v", err)
 	}
 	err = rt.Emit(context.Background(), "not_whitelisted_variant", nil)
 	if err == nil {
-		t.Fatal("non-whitelisted variant must be denied")
+		t.Fatal("non-whitelisted variant must be refused")
 	}
-	if !execution_policy.IsDenied(err) {
-		t.Fatalf("want IsDenied(err), got %v", err)
+	// Must be ErrUnknownEmitEvent (pre-catalog guard), NOT policy-denied
+	// — refusal must happen before the whitelist is consulted.
+	if !errors.Is(err, nm_runtime.ErrUnknownEmitEvent) {
+		t.Fatalf("want ErrUnknownEmitEvent, got %v", err)
+	}
+	if execution_policy.IsDenied(err) {
+		t.Fatal("refusal must not come from policy — undeclared events are rejected upstream")
 	}
 	if len(em.calls) != 0 {
-		t.Fatal("denied call must not reach emitter")
+		t.Fatal("refused call must not reach emitter")
 	}
 }

--- a/internal/nm_runtime/nm_runtime_test.go
+++ b/internal/nm_runtime/nm_runtime_test.go
@@ -32,11 +32,12 @@ func (r *recordingEmitter) EmitBroadcast(_ context.Context, src, pb, sb byte, pa
 func u8(v uint8) *uint8 { return &v }
 
 // syntheticCatalog builds a minimal catalog with the two whitelisted emit
-// broadcasts used by M4 first-delivery.
+// broadcasts used by M4 first-delivery. Axis literals MUST mirror
+// ebusreg@30aa69a catalog/ebus_standard/catalog.yaml exactly.
 func syntheticCatalog() ebusstd.Catalog {
 	mk := func(sb uint8, variant string) ebusstd.Command {
 		return ebusstd.Command{
-			ID:          "ebus_standard.network_mgmt." + variant,
+			ID:          "ebus_standard.nm." + variant,
 			Name:        variant,
 			SafetyClass: ebusstd.SafetyBroadcast,
 			Identity: ebusstd.IdentityKey{
@@ -45,13 +46,13 @@ func syntheticCatalog() ebusstd.Catalog {
 				SB:                              u8(sb),
 				TelegramClass:                   ebusstd.TelegramClassBroadcast,
 				Direction:                       ebusstd.DirectionRequest,
-				RequestOrResponseRole:           "initiator_broadcast_emit",
+				RequestOrResponseRole:           ebusstd.RoleOriginator,
 				BroadcastOrAddressed:            ebusstd.AddressedBroadcast,
-				AnswerPolicy:                    "no-answer",
-				LengthPrefixMode:                ebusstd.LengthPrefixNone,
+				AnswerPolicy:                    ebusstd.AnswerNone,
+				LengthPrefixMode:                ebusstd.LengthPrefixFixed,
 				SelectorDecoder:                 "none",
 				ServiceVariant:                  variant,
-				TransportCapabilityRequirements: []string{"initiator+broadcast"},
+				TransportCapabilityRequirements: []string{"broadcast_send"},
 				Version:                         "v1.0-locked",
 			},
 		}
@@ -64,8 +65,8 @@ func syntheticCatalog() ebusstd.Catalog {
 			PB:   &pb,
 			Name: "Network Management",
 			Commands: []ebusstd.Command{
-				mk(0x00, "nm_reset_status_broadcast"),
-				mk(0x02, "nm_failure_broadcast"),
+				mk(0x00, "reset_status"),
+				mk(0x02, "failure_message"),
 			},
 		}},
 	}
@@ -122,11 +123,15 @@ func TestRuntime_Emit_PolicyDeniesWhenWhitelistMismatch(t *testing.T) {
 				ID:          "x",
 				SafetyClass: ebusstd.SafetyBroadcast,
 				Identity: ebusstd.IdentityKey{
-					PB: u8(0xFF), SB: u8(0x00),
-					ServiceVariant: "not_whitelisted_variant",
-					Version:        "v1.0-locked",
-					TelegramClass:  ebusstd.TelegramClassBroadcast,
-					Direction:      ebusstd.DirectionRequest,
+					Namespace:             "ebus_standard",
+					PB:                    u8(0xFF),
+					SB:                    u8(0x00),
+					ServiceVariant:        "not_whitelisted_variant",
+					Version:               "v1.0-locked",
+					TelegramClass:         ebusstd.TelegramClassBroadcast,
+					Direction:             ebusstd.DirectionRequest,
+					RequestOrResponseRole: ebusstd.RoleOriginator,
+					BroadcastOrAddressed:  ebusstd.AddressedBroadcast,
 				},
 			}},
 		}},

--- a/internal/rpc_source/source.go
+++ b/internal/rpc_source/source.go
@@ -1,0 +1,11 @@
+// Package rpc_source — RED stub. Real const is 0x71.
+package rpc_source
+
+import "errors"
+
+const Gateway byte = 0x00
+
+var ErrNon113Source = errors.New("rpc_source: stub sentinel")
+
+func Enforce(_ byte) error { return nil }
+func Require(_ byte)       {}

--- a/internal/rpc_source/source.go
+++ b/internal/rpc_source/source.go
@@ -1,11 +1,40 @@
-// Package rpc_source — RED stub. Real const is 0x71.
+// Package rpc_source centralises the gateway's RPC initiator source byte.
+//
+// Per project invariant (MEMORY.md): every gateway rpc.invoke call MUST use
+// source=113 (0x71). Non-113 sources are a programming error and MUST
+// surface as compile-time OR sentinel-error failures, not silent traffic
+// under the wrong initiator address.
 package rpc_source
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
-const Gateway byte = 0x00
+// Gateway is the gateway's fixed initiator source byte. Compile-time
+// constant — changing it is a locked-plan decision, not a code change.
+const Gateway byte = 0x71
 
-var ErrNon113Source = errors.New("rpc_source: stub sentinel")
+// ErrNon113Source is the sentinel returned when an RPC-invoke call site
+// attempts to use a source byte other than Gateway (0x71).
+var ErrNon113Source = errors.New("rpc_source: source byte is not gateway (0x71)")
 
-func Enforce(_ byte) error { return nil }
-func Require(_ byte)       {}
+// Enforce validates that the supplied source byte is the gateway source. It
+// returns a non-nil error wrapping ErrNon113Source when src != Gateway.
+//
+// Callers SHOULD embed this check at every rpc.invoke call-site. The
+// returned error carries the attempted source byte for audit purposes.
+func Enforce(src byte) error {
+	if src == Gateway {
+		return nil
+	}
+	return fmt.Errorf("got 0x%02X, want 0x%02X: %w", src, Gateway, ErrNon113Source)
+}
+
+// Require panics when src != Gateway. Use in tests or startup-time
+// invariant guards where a non-gateway source is unrecoverable.
+func Require(src byte) {
+	if err := Enforce(src); err != nil {
+		panic(err)
+	}
+}

--- a/internal/rpc_source/source_test.go
+++ b/internal/rpc_source/source_test.go
@@ -1,0 +1,41 @@
+package rpc_source_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/rpc_source"
+)
+
+func TestGateway_IsConstant113(t *testing.T) {
+	if rpc_source.Gateway != 0x71 {
+		t.Fatalf("Gateway = 0x%02X, want 0x71 (113)", rpc_source.Gateway)
+	}
+}
+
+func TestEnforce_AcceptsGateway(t *testing.T) {
+	if err := rpc_source.Enforce(0x71); err != nil {
+		t.Fatalf("Enforce(0x71) = %v, want nil", err)
+	}
+}
+
+func TestEnforce_RejectsNon113(t *testing.T) {
+	for _, src := range []byte{0x00, 0x03, 0x08, 0x70, 0x72, 0xFF} {
+		err := rpc_source.Enforce(src)
+		if err == nil {
+			t.Fatalf("Enforce(0x%02X) = nil, want ErrNon113Source", src)
+		}
+		if !errors.Is(err, rpc_source.ErrNon113Source) {
+			t.Fatalf("Enforce(0x%02X) = %v, want errors.Is ErrNon113Source", src, err)
+		}
+	}
+}
+
+func TestRequire_PanicsOnNon113(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("Require(0x08) must panic")
+		}
+	}()
+	rpc_source.Require(0x08)
+}

--- a/mcp/ebus_standard/envelope.go
+++ b/mcp/ebus_standard/envelope.go
@@ -1,0 +1,15 @@
+package ebus_standard
+
+import "time"
+
+const (
+	EnvelopeContractName  = "helianthus-ebus-mcp"
+	EnvelopeContractMajor = 1
+	EnvelopeContractMinor = 0
+)
+
+// NewEnvelope stub — RED. Impl lands in next commit.
+func NewEnvelope(_ any, _ error, _ time.Time) map[string]any { return nil }
+
+// DataHash stub — RED.
+func DataHash(_ any) string { return "" }

--- a/mcp/ebus_standard/envelope.go
+++ b/mcp/ebus_standard/envelope.go
@@ -1,15 +1,186 @@
 package ebus_standard
 
-import "time"
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
 
+// EnvelopeContract names the MCP envelope contract this package emits.
 const (
 	EnvelopeContractName  = "helianthus-ebus-mcp"
 	EnvelopeContractMajor = 1
 	EnvelopeContractMinor = 0
 )
 
-// NewEnvelope stub — RED. Impl lands in next commit.
-func NewEnvelope(_ any, _ error, _ time.Time) map[string]any { return nil }
+// NewEnvelope wraps data / err in the meta/data/error envelope used by the
+// ebus_standard MCP surfaces. meta.data_hash is computed via canonical JSON
+// (sorted keys, stable number formatting, no whitespace) + SHA-256 so
+// structurally-equivalent-but-reordered inputs yield identical hashes.
+//
+// The timestamp is caller-supplied so tests remain deterministic; callers
+// that need "now" pass time.Now().UTC().
+func NewEnvelope(data any, err error, ts time.Time) map[string]any {
+	meta := map[string]any{
+		"contract": map[string]any{
+			"name":  EnvelopeContractName,
+			"major": EnvelopeContractMajor,
+			"minor": EnvelopeContractMinor,
+		},
+		"data_timestamp": ts.UTC().Format(time.RFC3339Nano),
+		"data_hash":      DataHash(data),
+	}
+	var envelopeError any
+	if err != nil {
+		envelopeError = map[string]any{
+			"code":      classifyErr(err),
+			"message":   err.Error(),
+			"retriable": false,
+		}
+	}
+	return map[string]any{
+		"meta":  meta,
+		"data":  data,
+		"error": envelopeError,
+	}
+}
 
-// DataHash stub — RED.
-func DataHash(_ any) string { return "" }
+// DataHash computes SHA-256 over the canonical JSON rendering of v.
+// Canonical rendering: sorted keys, compact numbers, no whitespace.
+func DataHash(v any) string {
+	if v == nil {
+		return ""
+	}
+	var buf strings.Builder
+	writeCanonical(&buf, v)
+	sum := sha256.Sum256([]byte(buf.String()))
+	return hex.EncodeToString(sum[:])
+}
+
+func writeCanonical(w *strings.Builder, v any) {
+	switch x := v.(type) {
+	case nil:
+		w.WriteString("null")
+	case bool:
+		if x {
+			w.WriteString("true")
+		} else {
+			w.WriteString("false")
+		}
+	case string:
+		writeCanonicalString(w, x)
+	case int:
+		w.WriteString(strconv.FormatInt(int64(x), 10))
+	case int64:
+		w.WriteString(strconv.FormatInt(x, 10))
+	case int32:
+		w.WriteString(strconv.FormatInt(int64(x), 10))
+	case uint8:
+		w.WriteString(strconv.FormatUint(uint64(x), 10))
+	case float64:
+		// Integer-valued floats encode as integers for stability across
+		// Go marshallers that elide trailing zeros.
+		if x == float64(int64(x)) {
+			w.WriteString(strconv.FormatInt(int64(x), 10))
+		} else {
+			w.WriteString(strconv.FormatFloat(x, 'g', -1, 64))
+		}
+	case map[string]any:
+		keys := make([]string, 0, len(x))
+		for k := range x {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		w.WriteByte('{')
+		for i, k := range keys {
+			if i > 0 {
+				w.WriteByte(',')
+			}
+			writeCanonicalString(w, k)
+			w.WriteByte(':')
+			writeCanonical(w, x[k])
+		}
+		w.WriteByte('}')
+	case []any:
+		w.WriteByte('[')
+		for i, el := range x {
+			if i > 0 {
+				w.WriteByte(',')
+			}
+			writeCanonical(w, el)
+		}
+		w.WriteByte(']')
+	case []map[string]any:
+		w.WriteByte('[')
+		for i, el := range x {
+			if i > 0 {
+				w.WriteByte(',')
+			}
+			writeCanonical(w, el)
+		}
+		w.WriteByte(']')
+	case []string:
+		w.WriteByte('[')
+		for i, el := range x {
+			if i > 0 {
+				w.WriteByte(',')
+			}
+			writeCanonicalString(w, el)
+		}
+		w.WriteByte(']')
+	case []int:
+		w.WriteByte('[')
+		for i, el := range x {
+			if i > 0 {
+				w.WriteByte(',')
+			}
+			w.WriteString(strconv.Itoa(el))
+		}
+		w.WriteByte(']')
+	default:
+		// Fallback: stringify. Callers should pass canonical-friendly
+		// types; this path exists so unknown primitives do not panic.
+		w.WriteString(fmt.Sprintf("%q", fmt.Sprintf("%v", v)))
+	}
+}
+
+func writeCanonicalString(w *strings.Builder, s string) {
+	w.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '"':
+			w.WriteString(`\"`)
+		case '\\':
+			w.WriteString(`\\`)
+		case '\n':
+			w.WriteString(`\n`)
+		case '\r':
+			w.WriteString(`\r`)
+		case '\t':
+			w.WriteString(`\t`)
+		default:
+			if r < 0x20 {
+				fmt.Fprintf(w, `\u%04x`, r)
+			} else {
+				w.WriteRune(r)
+			}
+		}
+	}
+	w.WriteByte('"')
+}
+
+func classifyErr(err error) string {
+	switch {
+	case errors.Is(err, ErrUnknownCommand):
+		return "UNKNOWN_COMMAND"
+	case errors.Is(err, ErrInvalidPayload):
+		return "INVALID_PAYLOAD"
+	default:
+		return "INTERNAL"
+	}
+}

--- a/mcp/ebus_standard/envelope.go
+++ b/mcp/ebus_standard/envelope.go
@@ -32,6 +32,13 @@ func NewEnvelope(data any, err error, ts time.Time) map[string]any {
 			"major": EnvelopeContractMajor,
 			"minor": EnvelopeContractMinor,
 		},
+		// consistency.mode pins the data-freshness contract shared with the
+		// rest of ebus.v1.* surfaces. ebus_standard is a catalog read
+		// (static L7 service/command tables) so the mode is always "LIVE";
+		// there is no shadow-snapshot mode for catalog reads.
+		"consistency": map[string]any{
+			"mode": "LIVE",
+		},
 		"data_timestamp": ts.UTC().Format(time.RFC3339Nano),
 		"data_hash":      DataHash(data),
 	}

--- a/mcp/ebus_standard/envelope.go
+++ b/mcp/ebus_standard/envelope.go
@@ -59,10 +59,13 @@ func NewEnvelope(data any, err error, ts time.Time) map[string]any {
 
 // DataHash computes SHA-256 over the canonical JSON rendering of v.
 // Canonical rendering: sorted keys, compact numbers, no whitespace.
+//
+// Contract: data_hash is ALWAYS a 64-hex SHA-256 string, regardless of
+// whether data is nil. A nil data value is canonically serialized as the
+// JSON literal "null" (4 bytes) and hashed. Clients that consume
+// meta.data_hash may therefore rely on a stable 64-hex length across every
+// ebus.v1.* envelope.
 func DataHash(v any) string {
-	if v == nil {
-		return ""
-	}
 	var buf strings.Builder
 	writeCanonical(&buf, v)
 	sum := sha256.Sum256([]byte(buf.String()))

--- a/mcp/ebus_standard/envelope_test.go
+++ b/mcp/ebus_standard/envelope_test.go
@@ -74,3 +74,30 @@ func TestDataHash_HexOnly(t *testing.T) {
 		}
 	}
 }
+
+// TestDataHash_NilDataIsCanonicalNull asserts DataHash(nil) is the SHA-256
+// of the canonical-JSON rendering of nil, i.e. the 4-byte literal "null".
+// This replaces the prior short-circuit that returned "" for nil data and
+// violated the envelope contract's 64-hex data_hash guarantee.
+func TestDataHash_NilDataIsCanonicalNull(t *testing.T) {
+	got := estd.DataHash(nil)
+	// Precomputed: sha256("null").
+	const want = "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b"
+	if got != want {
+		t.Fatalf("DataHash(nil) = %s, want %s", got, want)
+	}
+	if len(got) != 64 {
+		t.Fatalf("DataHash(nil) len = %d, want 64", len(got))
+	}
+}
+
+// TestEnvelope_NilData_EmitsHex64Hash ensures the composed envelope for
+// data=nil exposes a 64-hex data_hash (not the empty string).
+func TestEnvelope_NilData_EmitsHex64Hash(t *testing.T) {
+	env := estd.NewEnvelope(nil, nil, time.Unix(0, 0).UTC())
+	meta, _ := env["meta"].(map[string]any)
+	h, _ := meta["data_hash"].(string)
+	if len(h) != 64 {
+		t.Fatalf("meta.data_hash len = %d, want 64 (was %q)", len(h), h)
+	}
+}

--- a/mcp/ebus_standard/envelope_test.go
+++ b/mcp/ebus_standard/envelope_test.go
@@ -1,0 +1,76 @@
+package ebus_standard_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	estd "github.com/Project-Helianthus/helianthus-ebusgateway/mcp/ebus_standard"
+)
+
+func TestEnvelope_ShapeMetaDataError(t *testing.T) {
+	env := estd.NewEnvelope(map[string]any{"k": 1}, nil, time.Unix(0, 0).UTC())
+	for _, key := range []string{"meta", "data", "error"} {
+		if _, ok := env[key]; !ok {
+			t.Fatalf("envelope missing key %q", key)
+		}
+	}
+	meta, _ := env["meta"].(map[string]any)
+	if _, ok := meta["data_hash"]; !ok {
+		t.Fatal("meta.data_hash missing")
+	}
+	if _, ok := meta["data_timestamp"]; !ok {
+		t.Fatal("meta.data_timestamp missing")
+	}
+}
+
+func TestDataHash_DeterministicAcrossReorderedMaps(t *testing.T) {
+	a := map[string]any{"a": 1, "b": 2, "c": []any{"x", "y"}}
+	b := map[string]any{"c": []any{"x", "y"}, "b": 2, "a": 1}
+	if estd.DataHash(a) != estd.DataHash(b) {
+		t.Fatalf("hash differs on reordered maps: %s vs %s",
+			estd.DataHash(a), estd.DataHash(b))
+	}
+}
+
+func TestDataHash_DifferentForDifferentData(t *testing.T) {
+	if estd.DataHash(1) == estd.DataHash(2) {
+		t.Fatal("1 and 2 must hash differently")
+	}
+}
+
+func TestDataHash_StableAcrossRepeatedCalls(t *testing.T) {
+	data := map[string]any{"n": 42, "s": "hello", "a": []any{1, 2, 3}}
+	h1 := estd.DataHash(data)
+	h2 := estd.DataHash(data)
+	if h1 != h2 {
+		t.Fatalf("repeated call hash differs: %s vs %s", h1, h2)
+	}
+}
+
+func TestEnvelope_ErrorCarriesClassification(t *testing.T) {
+	env := estd.NewEnvelope(nil, errors.New("boom"), time.Unix(0, 0).UTC())
+	errOut, ok := env["error"].(map[string]any)
+	if !ok || errOut == nil {
+		t.Fatal("envelope.error must be a populated object on non-nil err")
+	}
+	if _, ok := errOut["code"]; !ok {
+		t.Fatal("error.code missing")
+	}
+	if _, ok := errOut["message"]; !ok {
+		t.Fatal("error.message missing")
+	}
+}
+
+func TestDataHash_HexOnly(t *testing.T) {
+	h := estd.DataHash("x")
+	if len(h) != 64 {
+		t.Fatalf("hash length = %d, want 64", len(h))
+	}
+	for _, r := range h {
+		if !strings.ContainsRune("0123456789abcdef", r) {
+			t.Fatalf("non-hex char in hash: %q", r)
+		}
+	}
+}

--- a/mcp/ebus_standard/golden_catalog_test.go
+++ b/mcp/ebus_standard/golden_catalog_test.go
@@ -1,0 +1,46 @@
+package ebus_standard_test
+
+import (
+	ebusstd "github.com/Project-Helianthus/helianthus-ebusreg/catalog/ebus_standard"
+)
+
+// syntheticGoldenCatalog builds a tiny deterministic catalog used by the
+// envelope-golden tests. Pinning to a synthetic catalog (rather than the
+// full embedded catalog) keeps fixtures small and decouples the golden
+// envelope contract from legitimate catalog content churn.
+func syntheticGoldenCatalog() ebusstd.Catalog {
+	u := func(v uint8) *uint8 { return &v }
+	pb03 := uint8(0x03)
+	return ebusstd.Catalog{
+		Namespace:  "ebus_standard",
+		Version:    "v1.0-locked",
+		PlanSHA256: "9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305",
+		Services: []ebusstd.Service{{
+			PB:          &pb03,
+			Name:        "Service Data",
+			Description: "golden fixture",
+			Commands: []ebusstd.Command{{
+				ID:          "ebus_standard.golden.alpha",
+				Name:        "Alpha",
+				Description: "alpha command for golden tests",
+				SafetyClass: ebusstd.SafetyReadOnlyBusLoad,
+				Identity: ebusstd.IdentityKey{
+					Namespace:                       "ebus_standard",
+					PB:                              u(0x03),
+					SB:                              u(0x04),
+					SelectorPath:                    "",
+					TelegramClass:                   ebusstd.TelegramClassAddressed,
+					Direction:                       ebusstd.DirectionRequest,
+					RequestOrResponseRole:           "initiator",
+					BroadcastOrAddressed:            ebusstd.AddressedDirect,
+					AnswerPolicy:                    "answer_required",
+					LengthPrefixMode:                ebusstd.LengthPrefixNone,
+					SelectorDecoder:                 "none",
+					ServiceVariant:                  "start_counts",
+					TransportCapabilityRequirements: []string{"master_slave"},
+					Version:                         "v1.0-locked",
+				},
+			}},
+		}},
+	}
+}

--- a/mcp/ebus_standard/golden_test.go
+++ b/mcp/ebus_standard/golden_test.go
@@ -1,0 +1,107 @@
+package ebus_standard_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	estd "github.com/Project-Helianthus/helianthus-ebusgateway/mcp/ebus_standard"
+)
+
+// Envelope-golden fixtures. Re-generate with UPDATE=1 and include rationale
+// in the PR body per canonical plan §"ENVELOPE_GOLDEN_TESTS".
+//
+// Determinism requirements (canonical plan §"DETERMINISM_HASH"):
+//   - data_hash in meta is canonical-JSON SHA-256; stable across runs.
+//   - data field is emitted with sorted keys via marshalWithSortedKeys so
+//     the on-disk fixture is byte-stable under Go marshal reordering.
+
+func goldenPath(t *testing.T, name string) string {
+	t.Helper()
+	return filepath.Join("testdata", name+".golden.json")
+}
+
+func marshalEnvelope(t *testing.T, env map[string]any) []byte {
+	t.Helper()
+	// Use json.Marshal — Go sorts map keys alphabetically on marshal for
+	// map[string]any, which is sufficient for stable golden output.
+	buf, err := json.MarshalIndent(env, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+	return append(buf, '\n')
+}
+
+func compareOrUpdate(t *testing.T, name string, got []byte) {
+	t.Helper()
+	path := goldenPath(t, name)
+	if os.Getenv("UPDATE") == "1" {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir testdata: %v", err)
+		}
+		if err := os.WriteFile(path, got, 0o644); err != nil {
+			t.Fatalf("write golden: %v", err)
+		}
+		return
+	}
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v (run with UPDATE=1 to create)", path, err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("golden mismatch for %s:\n--- want ---\n%s\n--- got ---\n%s",
+			path, want, got)
+	}
+}
+
+// fixed timestamp so fixtures are stable across runs.
+var fixedTS = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+func TestGolden_ServicesList(t *testing.T) {
+	srv := estd.NewServer(syntheticGoldenCatalog())
+	data := srv.ServicesList()
+	env := estd.NewEnvelope(data, nil, fixedTS)
+	// Overwrite the data_hash with a deterministic recomputation so the
+	// value on disk matches DataHash(data). This is redundant (NewEnvelope
+	// already computes it) but pins the contract in the test.
+	env["meta"].(map[string]any)["data_hash"] = estd.DataHash(data)
+	compareOrUpdate(t, "services_list", marshalEnvelope(t, env))
+}
+
+func TestGolden_CommandsList(t *testing.T) {
+	srv := estd.NewServer(syntheticGoldenCatalog())
+	pb := uint8(0x03)
+	data, err := srv.CommandsList(&pb)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := estd.NewEnvelope(data, nil, fixedTS)
+	compareOrUpdate(t, "commands_list_pb03", marshalEnvelope(t, env))
+}
+
+func TestGolden_CommandGet(t *testing.T) {
+	srv := estd.NewServer(syntheticGoldenCatalog())
+	data, err := srv.CommandGet("ebus_standard.golden.alpha")
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := estd.NewEnvelope(data, nil, fixedTS)
+	compareOrUpdate(t, "command_get_alpha", marshalEnvelope(t, env))
+}
+
+func TestGolden_Decode(t *testing.T) {
+	srv := estd.NewServer(syntheticGoldenCatalog())
+	data, err := srv.Decode(estd.DecodeInput{
+		PB: 0x03, SB: 0x04,
+		Direction:  "request",
+		FrameType:  "addressed",
+		PayloadHex: "0102",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := estd.NewEnvelope(data, nil, fixedTS)
+	compareOrUpdate(t, "decode_alpha", marshalEnvelope(t, env))
+}

--- a/mcp/ebus_standard/server.go
+++ b/mcp/ebus_standard/server.go
@@ -1,0 +1,40 @@
+// Package ebus_standard implements the gateway MCP surfaces for the
+// ebus_standard L7 namespace (M4_GATEWAY_MCP). RED stub — impl lands in
+// the next commit.
+package ebus_standard
+
+import (
+	"errors"
+
+	ebusstd "github.com/Project-Helianthus/helianthus-ebusreg/catalog/ebus_standard"
+)
+
+const (
+	ToolServicesList = "stub.services.list"
+	ToolCommandsList = "stub.commands.list"
+	ToolCommandGet   = "stub.command.get"
+	ToolDecode       = "stub.decode"
+)
+
+var ErrUnknownCommand = errors.New("ebus_standard: unknown command (stub)")
+var ErrInvalidPayload = errors.New("ebus_standard: invalid payload (stub)")
+
+type Server struct{}
+
+func NewServer(_ ebusstd.Catalog) *Server { return &Server{} }
+
+func (s *Server) ServicesList() map[string]any { return nil }
+
+func (s *Server) CommandsList(_ *uint8) (map[string]any, error) { return nil, ErrUnknownCommand }
+
+func (s *Server) CommandGet(_ string) (map[string]any, error) { return nil, ErrUnknownCommand }
+
+type DecodeInput struct {
+	PB         uint8
+	SB         uint8
+	Direction  string
+	FrameType  string
+	PayloadHex string
+}
+
+func (s *Server) Decode(_ DecodeInput) (map[string]any, error) { return nil, ErrUnknownCommand }

--- a/mcp/ebus_standard/server.go
+++ b/mcp/ebus_standard/server.go
@@ -1,34 +1,125 @@
 // Package ebus_standard implements the gateway MCP surfaces for the
-// ebus_standard L7 namespace (M4_GATEWAY_MCP). RED stub — impl lands in
-// the next commit.
+// ebus_standard L7 namespace (M4_GATEWAY_MCP).
+//
+// Surfaces (canonical plan §4):
+//
+//   - ebus.v1.ebus_standard.services.list
+//   - ebus.v1.ebus_standard.commands.list
+//   - ebus.v1.ebus_standard.command.get
+//   - ebus.v1.ebus_standard.decode
+//
+// The server consumes the shared provider from helianthus-ebusreg and the
+// shared execution_policy module from internal/execution_policy. It does
+// NOT duplicate catalog walking, safety logic, or identity construction —
+// all of that lives in ebusreg.
 package ebus_standard
 
 import (
+	"encoding/hex"
 	"errors"
+	"fmt"
+	"sort"
+	"strings"
 
 	ebusstd "github.com/Project-Helianthus/helianthus-ebusreg/catalog/ebus_standard"
 )
 
+// Tool names exposed over MCP.
 const (
-	ToolServicesList = "stub.services.list"
-	ToolCommandsList = "stub.commands.list"
-	ToolCommandGet   = "stub.command.get"
-	ToolDecode       = "stub.decode"
+	ToolServicesList = "ebus.v1.ebus_standard.services.list"
+	ToolCommandsList = "ebus.v1.ebus_standard.commands.list"
+	ToolCommandGet   = "ebus.v1.ebus_standard.command.get"
+	ToolDecode       = "ebus.v1.ebus_standard.decode"
 )
 
-var ErrUnknownCommand = errors.New("ebus_standard: unknown command (stub)")
-var ErrInvalidPayload = errors.New("ebus_standard: invalid payload (stub)")
+// ErrUnknownCommand is returned by command.get and decode when the catalog
+// does not contain the requested command.
+var ErrUnknownCommand = errors.New("ebus_standard: unknown command")
 
-type Server struct{}
+// ErrInvalidPayload is returned on malformed MCP arguments.
+var ErrInvalidPayload = errors.New("ebus_standard: invalid payload")
 
-func NewServer(_ ebusstd.Catalog) *Server { return &Server{} }
+// Server is the handler for the four ebus_standard MCP surfaces.
+type Server struct {
+	catalog ebusstd.Catalog
+}
 
-func (s *Server) ServicesList() map[string]any { return nil }
+// NewServer returns a Server bound to the supplied catalog.
+func NewServer(cat ebusstd.Catalog) *Server {
+	return &Server{catalog: cat}
+}
 
-func (s *Server) CommandsList(_ *uint8) (map[string]any, error) { return nil, ErrUnknownCommand }
+// ServicesList returns a stable, sorted list of services from the catalog.
+// Fields are sorted deterministically so the data_hash is stable across
+// runs and platforms.
+func (s *Server) ServicesList() map[string]any {
+	services := make([]map[string]any, 0, len(s.catalog.Services))
+	for _, svc := range s.catalog.Services {
+		services = append(services, map[string]any{
+			"pb":            int(svc.PBValue()),
+			"name":          svc.Name,
+			"description":   svc.Description,
+			"command_count": len(svc.Commands),
+		})
+	}
+	sort.SliceStable(services, func(i, j int) bool {
+		if services[i]["pb"].(int) != services[j]["pb"].(int) {
+			return services[i]["pb"].(int) < services[j]["pb"].(int)
+		}
+		return services[i]["name"].(string) < services[j]["name"].(string)
+	})
+	return map[string]any{
+		"namespace":       s.catalog.Namespace,
+		"catalog_version": s.catalog.Version,
+		"plan_sha256":     s.catalog.PlanSHA256,
+		"services":        services,
+	}
+}
 
-func (s *Server) CommandGet(_ string) (map[string]any, error) { return nil, ErrUnknownCommand }
+// CommandsList returns the commands of a service. The service is selected
+// by pb; if pb is absent, all commands are returned sorted by pb,sb.
+func (s *Server) CommandsList(pb *uint8) (map[string]any, error) {
+	commands := make([]map[string]any, 0, 32)
+	for _, svc := range s.catalog.Services {
+		if pb != nil && svc.PBValue() != *pb {
+			continue
+		}
+		for _, cmd := range svc.Commands {
+			commands = append(commands, commandSummary(cmd))
+		}
+	}
+	sort.SliceStable(commands, func(i, j int) bool {
+		ai := commands[i]
+		aj := commands[j]
+		if ai["pb"].(int) != aj["pb"].(int) {
+			return ai["pb"].(int) < aj["pb"].(int)
+		}
+		if ai["sb"].(int) != aj["sb"].(int) {
+			return ai["sb"].(int) < aj["sb"].(int)
+		}
+		return ai["id"].(string) < aj["id"].(string)
+	})
+	return map[string]any{
+		"namespace":       s.catalog.Namespace,
+		"catalog_version": s.catalog.Version,
+		"commands":        commands,
+	}, nil
+}
 
+// CommandGet returns a single command with its full 14-tuple identity.
+func (s *Server) CommandGet(id string) (map[string]any, error) {
+	cmd, ok := s.findCommand(id)
+	if !ok {
+		return nil, fmt.Errorf("id=%q: %w", id, ErrUnknownCommand)
+	}
+	return map[string]any{
+		"namespace":       s.catalog.Namespace,
+		"catalog_version": s.catalog.Version,
+		"command":         commandFull(cmd),
+	}, nil
+}
+
+// DecodeInput is the input struct for the decode surface.
 type DecodeInput struct {
 	PB         uint8
 	SB         uint8
@@ -37,4 +128,128 @@ type DecodeInput struct {
 	PayloadHex string
 }
 
-func (s *Server) Decode(_ DecodeInput) (map[string]any, error) { return nil, ErrUnknownCommand }
+// Decode decodes an observed payload against the catalog command that
+// matches (PB, SB, Direction, FrameType). Unknown combinations return
+// ErrUnknownCommand.
+func (s *Server) Decode(in DecodeInput) (map[string]any, error) {
+	payload, err := hex.DecodeString(strings.TrimPrefix(strings.ToLower(in.PayloadHex), "0x"))
+	if err != nil {
+		return nil, fmt.Errorf("payload_hex: %w: %s", ErrInvalidPayload, err)
+	}
+	cmd, ok := s.findIdentity(in.PB, in.SB, in.Direction, in.FrameType)
+	if !ok {
+		return nil, fmt.Errorf("pb=0x%02X sb=0x%02X direction=%q: %w",
+			in.PB, in.SB, in.Direction, ErrUnknownCommand)
+	}
+
+	// Field decode uses the catalog Request/Response parameter list
+	// plus L7 types from helianthus-ebusgo when available. In M4 scope
+	// the catalog Parameters are placeholders (M3 note) — report the
+	// catalog identity plus raw payload as decoded evidence.
+	fields := make([]map[string]any, 0, len(cmd.Response)+len(cmd.Request))
+	for _, p := range cmd.Request {
+		fields = append(fields, map[string]any{
+			"name": p.Name, "type": p.Type, "role": "request",
+		})
+	}
+	for _, p := range cmd.Response {
+		fields = append(fields, map[string]any{
+			"name": p.Name, "type": p.Type, "role": "response",
+		})
+	}
+	return map[string]any{
+		"namespace":         s.catalog.Namespace,
+		"catalog_version":   s.catalog.Version,
+		"command_id":        cmd.ID,
+		"raw_bytes":         toIntSlice(payload),
+		"fields":            fields,
+		"replacement_value": false,
+		"validity":          "catalog_identified",
+	}, nil
+}
+
+func (s *Server) findCommand(id string) (ebusstd.Command, bool) {
+	for _, svc := range s.catalog.Services {
+		for _, cmd := range svc.Commands {
+			if cmd.ID == id {
+				return cmd, true
+			}
+		}
+	}
+	return ebusstd.Command{}, false
+}
+
+func (s *Server) findIdentity(pb, sb uint8, direction, frameType string) (ebusstd.Command, bool) {
+	for _, svc := range s.catalog.Services {
+		if svc.PBValue() != pb {
+			continue
+		}
+		for _, cmd := range svc.Commands {
+			if cmd.Identity.SBValue() != sb {
+				continue
+			}
+			if direction != "" && string(cmd.Identity.Direction) != direction {
+				continue
+			}
+			if frameType != "" && string(cmd.Identity.TelegramClass) != frameType {
+				continue
+			}
+			return cmd, true
+		}
+	}
+	return ebusstd.Command{}, false
+}
+
+func commandSummary(cmd ebusstd.Command) map[string]any {
+	return map[string]any{
+		"id":           cmd.ID,
+		"name":         cmd.Name,
+		"pb":           int(cmd.Identity.PBValue()),
+		"sb":           int(cmd.Identity.SBValue()),
+		"safety_class": string(cmd.SafetyClass),
+	}
+}
+
+func commandFull(cmd ebusstd.Command) map[string]any {
+	req := make([]map[string]any, 0, len(cmd.Request))
+	for _, p := range cmd.Request {
+		req = append(req, map[string]any{"name": p.Name, "type": p.Type, "description": p.Description})
+	}
+	resp := make([]map[string]any, 0, len(cmd.Response))
+	for _, p := range cmd.Response {
+		resp = append(resp, map[string]any{"name": p.Name, "type": p.Type, "description": p.Description})
+	}
+	identity := map[string]any{
+		"namespace":                         cmd.Identity.Namespace,
+		"pb":                                int(cmd.Identity.PBValue()),
+		"sb":                                int(cmd.Identity.SBValue()),
+		"selector_path":                     cmd.Identity.SelectorPath,
+		"telegram_class":                    string(cmd.Identity.TelegramClass),
+		"direction":                         string(cmd.Identity.Direction),
+		"request_or_response_role":          string(cmd.Identity.RequestOrResponseRole),
+		"broadcast_or_addressed":            string(cmd.Identity.BroadcastOrAddressed),
+		"answer_policy":                     string(cmd.Identity.AnswerPolicy),
+		"length_prefix_mode":                string(cmd.Identity.LengthPrefixMode),
+		"selector_decoder":                  cmd.Identity.SelectorDecoder,
+		"service_variant":                   cmd.Identity.ServiceVariant,
+		"transport_capability_requirements": append([]string{}, cmd.Identity.TransportCapabilityRequirements...),
+		"version":                           cmd.Identity.Version,
+	}
+	return map[string]any{
+		"id":           cmd.ID,
+		"name":         cmd.Name,
+		"description":  cmd.Description,
+		"safety_class": string(cmd.SafetyClass),
+		"identity":     identity,
+		"request":      req,
+		"response":     resp,
+	}
+}
+
+func toIntSlice(b []byte) []int {
+	out := make([]int, len(b))
+	for i, v := range b {
+		out[i] = int(v)
+	}
+	return out
+}

--- a/mcp/ebus_standard/server.go
+++ b/mcp/ebus_standard/server.go
@@ -150,8 +150,8 @@ func (s *Server) Decode(in DecodeInput) (map[string]any, error) {
 	}
 	cmd, ok := s.findIdentity(in.PB, in.SB, in.Direction, in.FrameType)
 	if !ok {
-		return nil, fmt.Errorf("pb=0x%02X sb=0x%02X direction=%q: %w",
-			in.PB, in.SB, in.Direction, ErrUnknownCommand)
+		return nil, fmt.Errorf("pb=0x%02X sb=0x%02X direction=%q frame_type=%q: %w",
+			in.PB, in.SB, in.Direction, in.FrameType, ErrUnknownCommand)
 	}
 
 	// Field decode uses the catalog Request/Response parameter list

--- a/mcp/ebus_standard/server.go
+++ b/mcp/ebus_standard/server.go
@@ -131,7 +131,19 @@ type DecodeInput struct {
 // Decode decodes an observed payload against the catalog command that
 // matches (PB, SB, Direction, FrameType). Unknown combinations return
 // ErrUnknownCommand.
+//
+// Direction and FrameType are REQUIRED selectors: a decode request that
+// supplies only (PB, SB) is ambiguous whenever the catalog contains
+// multiple commands on the same PB/SB (e.g. request vs response), so
+// missing selectors are rejected as INVALID_PAYLOAD rather than silently
+// matching the first row. Regression for PR #505 r3106756020.
 func (s *Server) Decode(in DecodeInput) (map[string]any, error) {
+	if in.Direction == "" {
+		return nil, fmt.Errorf("direction: %w: required (empty is not a wildcard)", ErrInvalidPayload)
+	}
+	if in.FrameType == "" {
+		return nil, fmt.Errorf("frame_type: %w: required (empty is not a wildcard)", ErrInvalidPayload)
+	}
 	payload, err := hex.DecodeString(strings.TrimPrefix(strings.ToLower(in.PayloadHex), "0x"))
 	if err != nil {
 		return nil, fmt.Errorf("payload_hex: %w: %s", ErrInvalidPayload, err)
@@ -179,7 +191,15 @@ func (s *Server) findCommand(id string) (ebusstd.Command, bool) {
 	return ebusstd.Command{}, false
 }
 
+// findIdentity locates a catalog command by exact (pb, sb, direction,
+// frameType) match. direction and frameType are REQUIRED — the caller
+// (Decode) rejects empty selectors with ErrInvalidPayload before we get
+// here. We still guard here so any future caller that forgets the
+// validation gets a miss rather than a silent first-row match.
 func (s *Server) findIdentity(pb, sb uint8, direction, frameType string) (ebusstd.Command, bool) {
+	if direction == "" || frameType == "" {
+		return ebusstd.Command{}, false
+	}
 	for _, svc := range s.catalog.Services {
 		if svc.PBValue() != pb {
 			continue
@@ -188,10 +208,10 @@ func (s *Server) findIdentity(pb, sb uint8, direction, frameType string) (ebusst
 			if cmd.Identity.SBValue() != sb {
 				continue
 			}
-			if direction != "" && string(cmd.Identity.Direction) != direction {
+			if string(cmd.Identity.Direction) != direction {
 				continue
 			}
-			if frameType != "" && string(cmd.Identity.TelegramClass) != frameType {
+			if string(cmd.Identity.TelegramClass) != frameType {
 				continue
 			}
 			return cmd, true

--- a/mcp/ebus_standard/server_test.go
+++ b/mcp/ebus_standard/server_test.go
@@ -118,12 +118,41 @@ func TestServer_Decode_HandlesKnownIdentity(t *testing.T) {
 
 func TestServer_Decode_UnknownIdentityReturnsSentinel(t *testing.T) {
 	s := estd.NewServer(loadCatalog(t))
-	_, err := s.Decode(estd.DecodeInput{PB: 0xAB, SB: 0xCD, PayloadHex: ""})
+	_, err := s.Decode(estd.DecodeInput{
+		PB:         0xAB,
+		SB:         0xCD,
+		Direction:  "request",
+		FrameType:  "addressed",
+		PayloadHex: "",
+	})
 	if err == nil {
 		t.Fatal("want error for unknown identity")
 	}
 	if !errors.Is(err, estd.ErrUnknownCommand) {
 		t.Fatalf("want errors.Is ErrUnknownCommand, got %v", err)
+	}
+}
+
+// TestServer_Decode_RequiresDirectionAndFrameType pins that a decode
+// call without direction or frame_type is rejected as INVALID_PAYLOAD
+// rather than silently matching the first (pb, sb) row — which would
+// return the wrong command when the catalog carries multiple variants
+// on the same (pb, sb). Regression for PR #505 r3106756020.
+func TestServer_Decode_RequiresDirectionAndFrameType(t *testing.T) {
+	s := estd.NewServer(loadCatalog(t))
+	cases := []estd.DecodeInput{
+		{PB: 0x03, SB: 0x04, FrameType: "addressed", PayloadHex: "0102"}, // missing direction
+		{PB: 0x03, SB: 0x04, Direction: "request", PayloadHex: "0102"},   // missing frame_type
+		{PB: 0x03, SB: 0x04, PayloadHex: "0102"},                         // missing both
+	}
+	for i, in := range cases {
+		_, err := s.Decode(in)
+		if err == nil {
+			t.Fatalf("case %d: want error for missing selectors, got nil", i)
+		}
+		if !errors.Is(err, estd.ErrInvalidPayload) {
+			t.Fatalf("case %d: want errors.Is ErrInvalidPayload, got %v", i, err)
+		}
 	}
 }
 

--- a/mcp/ebus_standard/server_test.go
+++ b/mcp/ebus_standard/server_test.go
@@ -1,0 +1,153 @@
+package ebus_standard_test
+
+import (
+	"errors"
+	"testing"
+
+	estd "github.com/Project-Helianthus/helianthus-ebusgateway/mcp/ebus_standard"
+	ebusstd "github.com/Project-Helianthus/helianthus-ebusreg/catalog/ebus_standard"
+)
+
+func loadCatalog(t *testing.T) ebusstd.Catalog {
+	t.Helper()
+	return ebusstd.MustEmbeddedCatalog()
+}
+
+func TestServer_ServicesList_IncludesKnownServices(t *testing.T) {
+	s := estd.NewServer(loadCatalog(t))
+	out := s.ServicesList()
+	if out["namespace"] != "ebus_standard" {
+		t.Fatalf("namespace = %v, want ebus_standard", out["namespace"])
+	}
+	svcs, ok := out["services"].([]map[string]any)
+	if !ok {
+		t.Fatalf("services has wrong type %T", out["services"])
+	}
+	if len(svcs) == 0 {
+		t.Fatal("catalog unexpectedly empty")
+	}
+}
+
+func TestServer_ServicesList_Sorted(t *testing.T) {
+	s := estd.NewServer(loadCatalog(t))
+	out := s.ServicesList()
+	svcs := out["services"].([]map[string]any)
+	for i := 1; i < len(svcs); i++ {
+		prev := svcs[i-1]["pb"].(int)
+		cur := svcs[i]["pb"].(int)
+		if cur < prev {
+			t.Fatalf("services not sorted by pb: %d before %d", prev, cur)
+		}
+	}
+}
+
+func TestServer_CommandsList_FilterByPB(t *testing.T) {
+	s := estd.NewServer(loadCatalog(t))
+	pb := uint8(0x03)
+	out, err := s.CommandsList(&pb)
+	if err != nil {
+		t.Fatalf("CommandsList err: %v", err)
+	}
+	cmds := out["commands"].([]map[string]any)
+	for _, c := range cmds {
+		if c["pb"].(int) != int(pb) {
+			t.Fatalf("filter leaked pb=%v", c["pb"])
+		}
+		if _, ok := c["safety_class"]; !ok {
+			t.Fatal("command summary missing safety_class")
+		}
+	}
+}
+
+func TestServer_CommandGet_ReturnsFullIdentity(t *testing.T) {
+	s := estd.NewServer(loadCatalog(t))
+	id := "ebus_standard.service_data.start_counts"
+	out, err := s.CommandGet(id)
+	if err != nil {
+		t.Fatalf("CommandGet(%q) err: %v", id, err)
+	}
+	cmd := out["command"].(map[string]any)
+	identity := cmd["identity"].(map[string]any)
+	want := []string{
+		"namespace", "pb", "sb", "selector_path", "telegram_class",
+		"direction", "request_or_response_role", "broadcast_or_addressed",
+		"answer_policy", "length_prefix_mode", "selector_decoder",
+		"service_variant", "transport_capability_requirements", "version",
+	}
+	for _, k := range want {
+		if _, ok := identity[k]; !ok {
+			t.Fatalf("identity missing axis %q", k)
+		}
+	}
+}
+
+func TestServer_CommandGet_UnknownReturnsSentinel(t *testing.T) {
+	s := estd.NewServer(loadCatalog(t))
+	_, err := s.CommandGet("ebus_standard.nope.nope")
+	if err == nil {
+		t.Fatal("want error for unknown id")
+	}
+	if !errors.Is(err, estd.ErrUnknownCommand) {
+		t.Fatalf("want errors.Is ErrUnknownCommand, got %v", err)
+	}
+}
+
+func TestServer_Decode_HandlesKnownIdentity(t *testing.T) {
+	s := estd.NewServer(loadCatalog(t))
+	// start_counts: pb=0x03 sb=0x04 direction=request telegram=addressed
+	out, err := s.Decode(estd.DecodeInput{
+		PB: 0x03, SB: 0x04,
+		Direction:  "request",
+		FrameType:  "addressed",
+		PayloadHex: "0102",
+	})
+	if err != nil {
+		t.Fatalf("Decode err: %v", err)
+	}
+	raw := out["raw_bytes"].([]int)
+	if len(raw) != 2 || raw[0] != 1 || raw[1] != 2 {
+		t.Fatalf("raw_bytes = %v, want [1,2]", raw)
+	}
+	if _, ok := out["validity"]; !ok {
+		t.Fatal("decode missing validity")
+	}
+	if _, ok := out["replacement_value"]; !ok {
+		t.Fatal("decode missing replacement_value")
+	}
+}
+
+func TestServer_Decode_UnknownIdentityReturnsSentinel(t *testing.T) {
+	s := estd.NewServer(loadCatalog(t))
+	_, err := s.Decode(estd.DecodeInput{PB: 0xAB, SB: 0xCD, PayloadHex: ""})
+	if err == nil {
+		t.Fatal("want error for unknown identity")
+	}
+	if !errors.Is(err, estd.ErrUnknownCommand) {
+		t.Fatalf("want errors.Is ErrUnknownCommand, got %v", err)
+	}
+}
+
+func TestServer_Decode_BadHexReturnsInvalidPayload(t *testing.T) {
+	s := estd.NewServer(loadCatalog(t))
+	_, err := s.Decode(estd.DecodeInput{PB: 0x03, SB: 0x04, Direction: "request", FrameType: "addressed", PayloadHex: "zz"})
+	if err == nil {
+		t.Fatal("want error for bad hex")
+	}
+	if !errors.Is(err, estd.ErrInvalidPayload) {
+		t.Fatalf("want errors.Is ErrInvalidPayload, got %v", err)
+	}
+}
+
+func TestToolNames_Canonical(t *testing.T) {
+	cases := map[string]string{
+		estd.ToolServicesList: "ebus.v1.ebus_standard.services.list",
+		estd.ToolCommandsList: "ebus.v1.ebus_standard.commands.list",
+		estd.ToolCommandGet:   "ebus.v1.ebus_standard.command.get",
+		estd.ToolDecode:       "ebus.v1.ebus_standard.decode",
+	}
+	for got, want := range cases {
+		if got != want {
+			t.Fatalf("tool name got %q want %q", got, want)
+		}
+	}
+}

--- a/mcp/ebus_standard/testdata/command_get_alpha.golden.json
+++ b/mcp/ebus_standard/testdata/command_get_alpha.golden.json
@@ -31,6 +31,9 @@
   },
   "error": null,
   "meta": {
+    "consistency": {
+      "mode": "LIVE"
+    },
     "contract": {
       "major": 1,
       "minor": 0,

--- a/mcp/ebus_standard/testdata/command_get_alpha.golden.json
+++ b/mcp/ebus_standard/testdata/command_get_alpha.golden.json
@@ -1,0 +1,42 @@
+{
+  "data": {
+    "catalog_version": "v1.0-locked",
+    "command": {
+      "description": "alpha command for golden tests",
+      "id": "ebus_standard.golden.alpha",
+      "identity": {
+        "answer_policy": "answer_required",
+        "broadcast_or_addressed": "addressed",
+        "direction": "request",
+        "length_prefix_mode": "none",
+        "namespace": "ebus_standard",
+        "pb": 3,
+        "request_or_response_role": "initiator",
+        "sb": 4,
+        "selector_decoder": "none",
+        "selector_path": "",
+        "service_variant": "start_counts",
+        "telegram_class": "addressed",
+        "transport_capability_requirements": [
+          "master_slave"
+        ],
+        "version": "v1.0-locked"
+      },
+      "name": "Alpha",
+      "request": [],
+      "response": [],
+      "safety_class": "read_only_bus_load"
+    },
+    "namespace": "ebus_standard"
+  },
+  "error": null,
+  "meta": {
+    "contract": {
+      "major": 1,
+      "minor": 0,
+      "name": "helianthus-ebus-mcp"
+    },
+    "data_hash": "f44498e06fb077274958d5e8e391975a38bb6ae89290aa8acf60b9989b4b91ff",
+    "data_timestamp": "2026-01-01T00:00:00Z"
+  }
+}

--- a/mcp/ebus_standard/testdata/commands_list_pb03.golden.json
+++ b/mcp/ebus_standard/testdata/commands_list_pb03.golden.json
@@ -1,0 +1,25 @@
+{
+  "data": {
+    "catalog_version": "v1.0-locked",
+    "commands": [
+      {
+        "id": "ebus_standard.golden.alpha",
+        "name": "Alpha",
+        "pb": 3,
+        "safety_class": "read_only_bus_load",
+        "sb": 4
+      }
+    ],
+    "namespace": "ebus_standard"
+  },
+  "error": null,
+  "meta": {
+    "contract": {
+      "major": 1,
+      "minor": 0,
+      "name": "helianthus-ebus-mcp"
+    },
+    "data_hash": "9dd761693437a64da0f362bd4ba6fc5366cde2be255ca93877bf5c08d423190e",
+    "data_timestamp": "2026-01-01T00:00:00Z"
+  }
+}

--- a/mcp/ebus_standard/testdata/commands_list_pb03.golden.json
+++ b/mcp/ebus_standard/testdata/commands_list_pb03.golden.json
@@ -14,6 +14,9 @@
   },
   "error": null,
   "meta": {
+    "consistency": {
+      "mode": "LIVE"
+    },
     "contract": {
       "major": 1,
       "minor": 0,

--- a/mcp/ebus_standard/testdata/decode_alpha.golden.json
+++ b/mcp/ebus_standard/testdata/decode_alpha.golden.json
@@ -1,0 +1,24 @@
+{
+  "data": {
+    "catalog_version": "v1.0-locked",
+    "command_id": "ebus_standard.golden.alpha",
+    "fields": [],
+    "namespace": "ebus_standard",
+    "raw_bytes": [
+      1,
+      2
+    ],
+    "replacement_value": false,
+    "validity": "catalog_identified"
+  },
+  "error": null,
+  "meta": {
+    "contract": {
+      "major": 1,
+      "minor": 0,
+      "name": "helianthus-ebus-mcp"
+    },
+    "data_hash": "5fd4424a899bd038ccf5b0b0c038b6d800988a3a5337b2f6c8d16c94ceab0a67",
+    "data_timestamp": "2026-01-01T00:00:00Z"
+  }
+}

--- a/mcp/ebus_standard/testdata/decode_alpha.golden.json
+++ b/mcp/ebus_standard/testdata/decode_alpha.golden.json
@@ -13,6 +13,9 @@
   },
   "error": null,
   "meta": {
+    "consistency": {
+      "mode": "LIVE"
+    },
     "contract": {
       "major": 1,
       "minor": 0,

--- a/mcp/ebus_standard/testdata/services_list.golden.json
+++ b/mcp/ebus_standard/testdata/services_list.golden.json
@@ -14,6 +14,9 @@
   },
   "error": null,
   "meta": {
+    "consistency": {
+      "mode": "LIVE"
+    },
     "contract": {
       "major": 1,
       "minor": 0,

--- a/mcp/ebus_standard/testdata/services_list.golden.json
+++ b/mcp/ebus_standard/testdata/services_list.golden.json
@@ -1,0 +1,25 @@
+{
+  "data": {
+    "catalog_version": "v1.0-locked",
+    "namespace": "ebus_standard",
+    "plan_sha256": "9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305",
+    "services": [
+      {
+        "command_count": 1,
+        "description": "golden fixture",
+        "name": "Service Data",
+        "pb": 3
+      }
+    ]
+  },
+  "error": null,
+  "meta": {
+    "contract": {
+      "major": 1,
+      "minor": 0,
+      "name": "helianthus-ebus-mcp"
+    },
+    "data_hash": "281e969d3a59ad7d290030e65888b0dab5795e3e5d6e91e2669baedf11fb6f5d",
+    "data_timestamp": "2026-01-01T00:00:00Z"
+  }
+}

--- a/mcp/ebus_standard_wiring.go
+++ b/mcp/ebus_standard_wiring.go
@@ -1,0 +1,160 @@
+package mcp
+
+import (
+	"time"
+
+	estd "github.com/Project-Helianthus/helianthus-ebusgateway/mcp/ebus_standard"
+	ebusstd "github.com/Project-Helianthus/helianthus-ebusreg/catalog/ebus_standard"
+)
+
+// ebusStandardSubServer is the in-package interface backed by
+// mcp/ebus_standard.Server. Typed as an interface so the main Server
+// struct can hold a nil-equatable value when the sub-server is not
+// installed, while tests can substitute a fake.
+type ebusStandardSubServer interface {
+	ServicesList() map[string]any
+	CommandsList(pb *uint8) (map[string]any, error)
+	CommandGet(id string) (map[string]any, error)
+	Decode(in estd.DecodeInput) (map[string]any, error)
+}
+
+// RegisterEbusStandardTools installs the four ebus_standard L7 MCP
+// surfaces into s. Safe to call once during gateway bootstrap.
+//
+// Surfaces added:
+//   - ebus.v1.ebus_standard.services.list
+//   - ebus.v1.ebus_standard.commands.list
+//   - ebus.v1.ebus_standard.command.get
+//   - ebus.v1.ebus_standard.decode
+//
+// The catalog is consumed read-only. All safety-class gating for catalog
+// invocations is performed by internal/execution_policy at the provider
+// boundary (helianthus-ebusreg). These MCP surfaces are themselves
+// read_only_safe — they describe the catalog and decode observed bytes.
+func RegisterEbusStandardTools(s *Server, cat ebusstd.Catalog) {
+	if s == nil {
+		return
+	}
+	sub := estd.NewServer(cat)
+
+	s.tools = append(s.tools,
+		Tool{
+			Name:        estd.ToolServicesList,
+			Description: "List ebus_standard L7 services from the catalog.",
+			InputSchema: map[string]any{
+				"type":                 "object",
+				"properties":           map[string]any{},
+				"additionalProperties": false,
+			},
+		},
+		Tool{
+			Name:        estd.ToolCommandsList,
+			Description: "List ebus_standard commands, optionally filtered by PB.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"pb": map[string]any{"type": "integer", "minimum": 0, "maximum": 255},
+				},
+				"additionalProperties": false,
+			},
+		},
+		Tool{
+			Name:        estd.ToolCommandGet,
+			Description: "Get an ebus_standard command by id with full 14-tuple identity.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"id": map[string]any{"type": "string"},
+				},
+				"required":             []string{"id"},
+				"additionalProperties": false,
+			},
+		},
+		Tool{
+			Name:        estd.ToolDecode,
+			Description: "Decode an observed eBUS payload against catalog identity (pb, sb, direction, frame_type, payload_hex).",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"pb":          map[string]any{"type": "integer", "minimum": 0, "maximum": 255},
+					"sb":          map[string]any{"type": "integer", "minimum": 0, "maximum": 255},
+					"direction":   map[string]any{"type": "string"},
+					"frame_type":  map[string]any{"type": "string"},
+					"payload_hex": map[string]any{"type": "string"},
+				},
+				"required":             []string{"pb", "sb", "payload_hex"},
+				"additionalProperties": false,
+			},
+		},
+	)
+
+	s.ebusStandardServer = sub
+}
+
+// handleEbusStandardCall is invoked from handleToolsCall before the main
+// switch. Returns (result, true, nil) when it handled the call.
+func (s *Server) handleEbusStandardCall(name string, args map[string]any) (map[string]any, bool) {
+	if s.ebusStandardServer == nil {
+		return nil, false
+	}
+	ts := time.Now().UTC()
+	switch name {
+	case estd.ToolServicesList:
+		data := s.ebusStandardServer.ServicesList()
+		return callToolResultText(mustJSON(estd.NewEnvelope(data, nil, ts)), false), true
+	case estd.ToolCommandsList:
+		var pbp *uint8
+		if raw, ok := args["pb"]; ok {
+			if v, ok := toUint8(raw); ok {
+				pbp = &v
+			}
+		}
+		data, err := s.ebusStandardServer.CommandsList(pbp)
+		return callToolResultText(mustJSON(estd.NewEnvelope(data, err, ts)), err != nil), true
+	case estd.ToolCommandGet:
+		id, _ := args["id"].(string)
+		data, err := s.ebusStandardServer.CommandGet(id)
+		return callToolResultText(mustJSON(estd.NewEnvelope(data, err, ts)), err != nil), true
+	case estd.ToolDecode:
+		in := estd.DecodeInput{}
+		if v, ok := toUint8(args["pb"]); ok {
+			in.PB = v
+		}
+		if v, ok := toUint8(args["sb"]); ok {
+			in.SB = v
+		}
+		if v, ok := args["direction"].(string); ok {
+			in.Direction = v
+		}
+		if v, ok := args["frame_type"].(string); ok {
+			in.FrameType = v
+		}
+		if v, ok := args["payload_hex"].(string); ok {
+			in.PayloadHex = v
+		}
+		data, err := s.ebusStandardServer.Decode(in)
+		return callToolResultText(mustJSON(estd.NewEnvelope(data, err, ts)), err != nil), true
+	}
+	return nil, false
+}
+
+func toUint8(v any) (uint8, bool) {
+	switch x := v.(type) {
+	case int:
+		if x < 0 || x > 255 {
+			return 0, false
+		}
+		return uint8(x), true
+	case int64:
+		if x < 0 || x > 255 {
+			return 0, false
+		}
+		return uint8(x), true
+	case float64:
+		if x < 0 || x > 255 {
+			return 0, false
+		}
+		return uint8(x), true
+	}
+	return 0, false
+}

--- a/mcp/ebus_standard_wiring.go
+++ b/mcp/ebus_standard_wiring.go
@@ -122,7 +122,21 @@ func (s *Server) handleEbusStandardCall(name string, args map[string]any) (map[s
 		data, err := s.ebusStandardServer.CommandsList(pbp)
 		return callToolResultText(mustJSON(estd.NewEnvelope(data, err, ts)), err != nil), true
 	case estd.ToolCommandGet:
-		id, _ := args["id"].(string)
+		rawID, idPresent := args["id"]
+		if !idPresent || rawID == nil {
+			err := fmt.Errorf("id: %w: required", estd.ErrInvalidPayload)
+			return callToolResultText(mustJSON(estd.NewEnvelope(nil, err, ts)), true), true
+		}
+		id, ok := rawID.(string)
+		if !ok {
+			err := fmt.Errorf("id: %w: expected string, got %T=%v",
+				estd.ErrInvalidPayload, rawID, rawID)
+			return callToolResultText(mustJSON(estd.NewEnvelope(nil, err, ts)), true), true
+		}
+		if id == "" {
+			err := fmt.Errorf("id: %w: must be non-empty", estd.ErrInvalidPayload)
+			return callToolResultText(mustJSON(estd.NewEnvelope(nil, err, ts)), true), true
+		}
 		data, err := s.ebusStandardServer.CommandGet(id)
 		return callToolResultText(mustJSON(estd.NewEnvelope(data, err, ts)), err != nil), true
 	case estd.ToolDecode:

--- a/mcp/ebus_standard_wiring.go
+++ b/mcp/ebus_standard_wiring.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"fmt"
+	"math"
 	"time"
 
 	estd "github.com/Project-Helianthus/helianthus-ebusgateway/mcp/ebus_standard"
@@ -178,7 +179,18 @@ func toUint8(v any) (uint8, bool) {
 		}
 		return uint8(x), true
 	case float64:
+		// Reject NaN, Inf, fractional values, and out-of-range. JSON
+		// numbers decode to float64 by default, so a caller that sends
+		// `3.9` must NOT be silently truncated to 3 — that masks a
+		// contract violation. Parallel to toByteSource.float64.
+		// Regression for PR #505 r3106756021.
+		if math.IsNaN(x) || math.IsInf(x, 0) {
+			return 0, false
+		}
 		if x < 0 || x > 255 {
+			return 0, false
+		}
+		if math.Trunc(x) != x {
 			return 0, false
 		}
 		return uint8(x), true

--- a/mcp/ebus_standard_wiring.go
+++ b/mcp/ebus_standard_wiring.go
@@ -83,7 +83,7 @@ func RegisterEbusStandardTools(s *Server, cat ebusstd.Catalog) {
 					"frame_type":  map[string]any{"type": "string"},
 					"payload_hex": map[string]any{"type": "string"},
 				},
-				"required":             []string{"pb", "sb", "payload_hex"},
+				"required":             []string{"pb", "sb", "direction", "frame_type", "payload_hex"},
 				"additionalProperties": false,
 			},
 		},
@@ -126,12 +126,30 @@ func (s *Server) handleEbusStandardCall(name string, args map[string]any) (map[s
 		return callToolResultText(mustJSON(estd.NewEnvelope(data, err, ts)), err != nil), true
 	case estd.ToolDecode:
 		in := estd.DecodeInput{}
-		if v, ok := toUint8(args["pb"]); ok {
-			in.PB = v
+		rawPB, pbPresent := args["pb"]
+		if !pbPresent || rawPB == nil {
+			err := fmt.Errorf("pb: %w: required", estd.ErrInvalidPayload)
+			return callToolResultText(mustJSON(estd.NewEnvelope(nil, err, ts)), true), true
 		}
-		if v, ok := toUint8(args["sb"]); ok {
-			in.SB = v
+		v, ok := toUint8(rawPB)
+		if !ok {
+			err := fmt.Errorf("pb: %w: expected integer in [0,255], got %T=%v",
+				estd.ErrInvalidPayload, rawPB, rawPB)
+			return callToolResultText(mustJSON(estd.NewEnvelope(nil, err, ts)), true), true
 		}
+		in.PB = v
+		rawSB, sbPresent := args["sb"]
+		if !sbPresent || rawSB == nil {
+			err := fmt.Errorf("sb: %w: required", estd.ErrInvalidPayload)
+			return callToolResultText(mustJSON(estd.NewEnvelope(nil, err, ts)), true), true
+		}
+		v, ok = toUint8(rawSB)
+		if !ok {
+			err := fmt.Errorf("sb: %w: expected integer in [0,255], got %T=%v",
+				estd.ErrInvalidPayload, rawSB, rawSB)
+			return callToolResultText(mustJSON(estd.NewEnvelope(nil, err, ts)), true), true
+		}
+		in.SB = v
 		if v, ok := args["direction"].(string); ok {
 			in.Direction = v
 		}

--- a/mcp/ebus_standard_wiring.go
+++ b/mcp/ebus_standard_wiring.go
@@ -171,9 +171,22 @@ func (s *Server) handleEbusStandardCall(name string, args map[string]any) (map[s
 		if v, ok := args["frame_type"].(string); ok {
 			in.FrameType = v
 		}
-		if v, ok := args["payload_hex"].(string); ok {
-			in.PayloadHex = v
+		rawPayload, payloadPresent := args["payload_hex"]
+		if !payloadPresent || rawPayload == nil {
+			err := fmt.Errorf("payload_hex: %w: required", estd.ErrInvalidPayload)
+			return callToolResultText(mustJSON(estd.NewEnvelope(nil, err, ts)), true), true
 		}
+		payloadHex, ok := rawPayload.(string)
+		if !ok {
+			err := fmt.Errorf("payload_hex: %w: expected string, got %T=%v",
+				estd.ErrInvalidPayload, rawPayload, rawPayload)
+			return callToolResultText(mustJSON(estd.NewEnvelope(nil, err, ts)), true), true
+		}
+		if payloadHex == "" {
+			err := fmt.Errorf("payload_hex: %w: must be non-empty", estd.ErrInvalidPayload)
+			return callToolResultText(mustJSON(estd.NewEnvelope(nil, err, ts)), true), true
+		}
+		in.PayloadHex = payloadHex
 		data, err := s.ebusStandardServer.Decode(in)
 		return callToolResultText(mustJSON(estd.NewEnvelope(data, err, ts)), err != nil), true
 	}

--- a/mcp/ebus_standard_wiring.go
+++ b/mcp/ebus_standard_wiring.go
@@ -94,7 +94,8 @@ func RegisterEbusStandardTools(s *Server, cat ebusstd.Catalog) {
 }
 
 // handleEbusStandardCall is invoked from handleToolsCall before the main
-// switch. Returns (result, true, nil) when it handled the call.
+// switch. Returns (result, true) when it handled the call, or (nil, false)
+// otherwise.
 func (s *Server) handleEbusStandardCall(name string, args map[string]any) (map[string]any, bool) {
 	if s.ebusStandardServer == nil {
 		return nil, false

--- a/mcp/ebus_standard_wiring.go
+++ b/mcp/ebus_standard_wiring.go
@@ -183,10 +183,11 @@ func (s *Server) handleEbusStandardCall(name string, args map[string]any) (map[s
 				estd.ErrInvalidPayload, rawPayload, rawPayload)
 			return callToolResultText(mustJSON(estd.NewEnvelope(nil, err, ts)), true), true
 		}
-		if payloadHex == "" {
-			err := fmt.Errorf("payload_hex: %w: must be non-empty", estd.ErrInvalidPayload)
-			return callToolResultText(mustJSON(estd.NewEnvelope(nil, err, ts)), true), true
-		}
+		// payload_hex == "" is VALID: it is the standard representation of
+		// a zero-byte payload (hex.DecodeString("") succeeds and returns
+		// []byte{}). Rejecting empty here would block decoding valid
+		// empty-data frames (issue #505 r3106904917). Presence + type are
+		// already enforced above; content length 0 is legal.
 		in.PayloadHex = payloadHex
 		data, err := s.ebusStandardServer.Decode(in)
 		return callToolResultText(mustJSON(estd.NewEnvelope(data, err, ts)), err != nil), true

--- a/mcp/ebus_standard_wiring.go
+++ b/mcp/ebus_standard_wiring.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"fmt"
 	"time"
 
 	estd "github.com/Project-Helianthus/helianthus-ebusgateway/mcp/ebus_standard"
@@ -104,10 +105,18 @@ func (s *Server) handleEbusStandardCall(name string, args map[string]any) (map[s
 		return callToolResultText(mustJSON(estd.NewEnvelope(data, nil, ts)), false), true
 	case estd.ToolCommandsList:
 		var pbp *uint8
-		if raw, ok := args["pb"]; ok {
-			if v, ok := toUint8(raw); ok {
-				pbp = &v
+		if raw, ok := args["pb"]; ok && raw != nil {
+			v, ok := toUint8(raw)
+			if !ok {
+				// Malformed pb is an invalid payload, not an implicit
+				// "unfiltered" request — otherwise clients that send
+				// garbage get the full catalog back as a success, which
+				// silently hides the contract violation.
+				err := fmt.Errorf("pb: %w: expected integer in [0,255], got %T=%v",
+					estd.ErrInvalidPayload, raw, raw)
+				return callToolResultText(mustJSON(estd.NewEnvelope(nil, err, ts)), true), true
 			}
+			pbp = &v
 		}
 		data, err := s.ebusStandardServer.CommandsList(pbp)
 		return callToolResultText(mustJSON(estd.NewEnvelope(data, err, ts)), err != nil), true

--- a/mcp/ebus_standard_wiring_test.go
+++ b/mcp/ebus_standard_wiring_test.go
@@ -290,10 +290,12 @@ func TestHandleEbusStandardCall_DecodeRejectsFractionalPB(t *testing.T) {
 }
 
 // TestHandleEbusStandardCall_DecodeRejectsMissingPayloadHex pins that
-// an absent `payload_hex` key becomes INVALID_PAYLOAD rather than being
-// silently defaulted to "" (hex.DecodeString("") succeeds, so without
-// this gate a malformed request returned a successful decode with an
-// empty raw_bytes). Regression for PR #505 r3106794322.
+// an absent or non-string `payload_hex` key becomes INVALID_PAYLOAD
+// rather than being silently defaulted. An EMPTY STRING is accepted
+// (it is the standard representation of a zero-byte payload and
+// hex.DecodeString("") succeeds) — see
+// TestHandleEbusStandardCall_DecodeAcceptsEmptyPayloadHex below.
+// Regression for PR #505 r3106794322 + r3106904917.
 func TestHandleEbusStandardCall_DecodeRejectsMissingPayloadHex(t *testing.T) {
 	s := &Server{}
 	RegisterEbusStandardTools(s, ebusstd.MustEmbeddedCatalog())
@@ -306,13 +308,6 @@ func TestHandleEbusStandardCall_DecodeRejectsMissingPayloadHex(t *testing.T) {
 			"sb":         4,
 			"direction":  "request",
 			"frame_type": "addressed",
-		}},
-		{"empty_string", map[string]any{
-			"pb":          3,
-			"sb":          4,
-			"direction":   "request",
-			"frame_type":  "addressed",
-			"payload_hex": "",
 		}},
 		{"non_string", map[string]any{
 			"pb":          3,
@@ -444,5 +439,87 @@ func TestNewServer_DispatchesEbusStandardServicesList(t *testing.T) {
 	}
 	if isErr, _ := m["isError"].(bool); isErr {
 		t.Fatalf("services.list returned error envelope: %+v", m)
+	}
+}
+
+// TestHandleEbusStandardCall_DecodeAcceptsEmptyPayloadHex is the
+// regression for PR #505 r3106904917. An empty `payload_hex` string is
+// the standard representation of a zero-byte payload — hex.DecodeString
+// ("") succeeds and returns []byte{}. The wiring layer must NOT reject
+// it as INVALID_PAYLOAD; it must pass it through to the underlying
+// Decode implementation, which then reports UNKNOWN_COMMAND /
+// identity-specific behavior as usual.
+//
+// Distinction pinned by this test:
+//   - payload_hex absent         → INVALID_PAYLOAD (missing required)
+//   - payload_hex: ""            → VALID, zero-byte decode proceeds
+//   - payload_hex: "00AA"        → VALID, 2-byte decode
+func TestHandleEbusStandardCall_DecodeAcceptsEmptyPayloadHex(t *testing.T) {
+	s := &Server{}
+	RegisterEbusStandardTools(s, ebusstd.MustEmbeddedCatalog())
+
+	// Case 1: empty string — must NOT be INVALID_PAYLOAD. It may still
+	// produce UNKNOWN_COMMAND if the (pb,sb,direction,frame_type) tuple
+	// is not in the catalog, but the wiring gate must be cleared.
+	args := map[string]any{
+		"pb":          0xAB, // arbitrary pb/sb unlikely to match any catalog row
+		"sb":          0xCD,
+		"direction":   "request",
+		"frame_type":  "addressed",
+		"payload_hex": "",
+	}
+	result, handled := s.handleEbusStandardCall(estd.ToolDecode, args)
+	if !handled {
+		t.Fatal("decode must be handled")
+	}
+	text := result["content"].([]map[string]any)[0]["text"].(string)
+	var env map[string]any
+	if err := json.Unmarshal([]byte(text), &env); err != nil {
+		t.Fatalf("envelope JSON: %v", err)
+	}
+	if errObj, ok := env["error"].(map[string]any); ok && errObj != nil {
+		if code, _ := errObj["code"].(string); code == "INVALID_PAYLOAD" {
+			t.Fatalf("empty payload_hex must NOT be rejected as INVALID_PAYLOAD, got envelope=%+v", env)
+		}
+	}
+
+	// Case 2: absent — still INVALID_PAYLOAD (covered in sibling test,
+	// re-asserted here as a nearby contrast).
+	absentArgs := map[string]any{
+		"pb":         0xAB,
+		"sb":         0xCD,
+		"direction":  "request",
+		"frame_type": "addressed",
+	}
+	result2, _ := s.handleEbusStandardCall(estd.ToolDecode, absentArgs)
+	text2 := result2["content"].([]map[string]any)[0]["text"].(string)
+	var env2 map[string]any
+	if err := json.Unmarshal([]byte(text2), &env2); err != nil {
+		t.Fatalf("envelope JSON: %v", err)
+	}
+	errObj2, _ := env2["error"].(map[string]any)
+	if code, _ := errObj2["code"].(string); code != "INVALID_PAYLOAD" {
+		t.Fatalf("absent payload_hex: error.code = %q, want INVALID_PAYLOAD", code)
+	}
+
+	// Case 3: "00AA" — present, non-empty, valid hex must also clear
+	// the wiring gate (may still fail catalog match, but not wiring).
+	hexArgs := map[string]any{
+		"pb":          0xAB,
+		"sb":          0xCD,
+		"direction":   "request",
+		"frame_type":  "addressed",
+		"payload_hex": "00AA",
+	}
+	result3, _ := s.handleEbusStandardCall(estd.ToolDecode, hexArgs)
+	text3 := result3["content"].([]map[string]any)[0]["text"].(string)
+	var env3 map[string]any
+	if err := json.Unmarshal([]byte(text3), &env3); err != nil {
+		t.Fatalf("envelope JSON: %v", err)
+	}
+	if errObj, ok := env3["error"].(map[string]any); ok && errObj != nil {
+		if code, _ := errObj["code"].(string); code == "INVALID_PAYLOAD" {
+			t.Fatalf("valid hex payload must NOT be rejected as INVALID_PAYLOAD, got envelope=%+v", env3)
+		}
 	}
 }

--- a/mcp/ebus_standard_wiring_test.go
+++ b/mcp/ebus_standard_wiring_test.go
@@ -82,6 +82,76 @@ func TestHandleEbusStandardCall_CommandsListFiltersByPB(t *testing.T) {
 	}
 }
 
+// TestHandleEbusStandardCall_CommandsListRejectsInvalidPB pins the
+// contract that a malformed `pb` argument becomes an INVALID_PAYLOAD
+// error rather than being silently dropped (which would return the
+// unfiltered catalog as a success). Regression for PR #505 r3106745676.
+func TestHandleEbusStandardCall_CommandsListRejectsInvalidPB(t *testing.T) {
+	s := &Server{}
+	RegisterEbusStandardTools(s, ebusstd.MustEmbeddedCatalog())
+	result, handled := s.handleEbusStandardCall(estd.ToolCommandsList, map[string]any{"pb": "not-a-number"})
+	if !handled {
+		t.Fatal("commands.list must be handled")
+	}
+	if isErr, _ := result["isError"].(bool); !isErr {
+		t.Fatalf("expected isError=true on malformed pb, got result=%+v", result)
+	}
+	text := result["content"].([]map[string]any)[0]["text"].(string)
+	var env map[string]any
+	if err := json.Unmarshal([]byte(text), &env); err != nil {
+		t.Fatalf("envelope is not valid JSON: %v", err)
+	}
+	errObj, ok := env["error"].(map[string]any)
+	if !ok || errObj == nil {
+		t.Fatalf("envelope.error missing on malformed pb: %s", text)
+	}
+	if code, _ := errObj["code"].(string); code != "INVALID_PAYLOAD" {
+		t.Fatalf("error.code = %q, want INVALID_PAYLOAD", code)
+	}
+}
+
+// TestHandleEbusStandardCall_CommandsListAbsentPBUnfiltered pins that
+// omitting `pb` still yields an unfiltered success (preserving prior
+// behavior for well-formed input). Regression for PR #505 r3106745676.
+func TestHandleEbusStandardCall_CommandsListAbsentPBUnfiltered(t *testing.T) {
+	s := &Server{}
+	RegisterEbusStandardTools(s, ebusstd.MustEmbeddedCatalog())
+	result, handled := s.handleEbusStandardCall(estd.ToolCommandsList, map[string]any{})
+	if !handled {
+		t.Fatal("commands.list must be handled")
+	}
+	if isErr, _ := result["isError"].(bool); isErr {
+		t.Fatalf("unfiltered commands.list must not be an error, got result=%+v", result)
+	}
+}
+
+// TestHandleEbusStandardCall_EnvelopeContainsConsistencyMeta pins that
+// ebus_standard envelopes carry meta.consistency.mode alongside the
+// rest of ebus.v1.* surfaces so clients reading meta.consistency.mode
+// don't break on the four ebus_standard tools. Regression for PR #505
+// r3106745674.
+func TestHandleEbusStandardCall_EnvelopeContainsConsistencyMeta(t *testing.T) {
+	s := &Server{}
+	RegisterEbusStandardTools(s, ebusstd.MustEmbeddedCatalog())
+	result, handled := s.handleEbusStandardCall(estd.ToolServicesList, map[string]any{})
+	if !handled {
+		t.Fatal("services.list must be handled")
+	}
+	text := result["content"].([]map[string]any)[0]["text"].(string)
+	var env map[string]any
+	if err := json.Unmarshal([]byte(text), &env); err != nil {
+		t.Fatalf("envelope JSON: %v", err)
+	}
+	meta, _ := env["meta"].(map[string]any)
+	consistency, ok := meta["consistency"].(map[string]any)
+	if !ok || consistency == nil {
+		t.Fatalf("meta.consistency missing: %s", text)
+	}
+	if mode, _ := consistency["mode"].(string); mode != "LIVE" {
+		t.Fatalf("meta.consistency.mode = %q, want LIVE", mode)
+	}
+}
+
 // TestNewServer_WiresEbusStandardSurfaces pins the bootstrap contract:
 // NewServer must register the four ebus.v1.ebus_standard.* tools so
 // handleToolsCall dispatches them instead of returning "unknown tool".

--- a/mcp/ebus_standard_wiring_test.go
+++ b/mcp/ebus_standard_wiring_test.go
@@ -1,12 +1,14 @@
 package mcp
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
 
 	estd "github.com/Project-Helianthus/helianthus-ebusgateway/mcp/ebus_standard"
 	ebusstd "github.com/Project-Helianthus/helianthus-ebusreg/catalog/ebus_standard"
+	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
 )
 
 func TestRegisterEbusStandardTools_AddsFourSurfaces(t *testing.T) {
@@ -77,5 +79,64 @@ func TestHandleEbusStandardCall_CommandsListFiltersByPB(t *testing.T) {
 	text := result["content"].([]map[string]any)[0]["text"].(string)
 	if !strings.Contains(text, `"pb":3`) {
 		t.Fatalf("expected pb:3 in commands envelope, got %s", text)
+	}
+}
+
+// TestNewServer_WiresEbusStandardSurfaces pins the bootstrap contract:
+// NewServer must register the four ebus.v1.ebus_standard.* tools so
+// handleToolsCall dispatches them instead of returning "unknown tool".
+// Regression for PR #505 comment id=3106729472.
+func TestNewServer_WiresEbusStandardSurfaces(t *testing.T) {
+	reg := &testRegistry{entries: map[byte]registry.DeviceEntry{}}
+	server, err := NewServer(reg, &testInvoker{})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	required := []string{
+		estd.ToolServicesList,
+		estd.ToolCommandsList,
+		estd.ToolCommandGet,
+		estd.ToolDecode,
+	}
+	for _, name := range required {
+		if !server.hasToolNamed(name) {
+			t.Fatalf("tool %q not registered on NewServer — handleToolsCall will reject as unknown", name)
+		}
+	}
+	if server.ebusStandardServer == nil {
+		t.Fatal("ebusStandardServer sub-dispatcher not installed by NewServer")
+	}
+}
+
+// TestNewServer_DispatchesEbusStandardServicesList pins end-to-end that
+// a tools/call for ebus.v1.ebus_standard.services.list is dispatched
+// (not rejected as unknown) by a default NewServer instance.
+func TestNewServer_DispatchesEbusStandardServicesList(t *testing.T) {
+	reg := &testRegistry{entries: map[byte]registry.DeviceEntry{}}
+	server, err := NewServer(reg, &testInvoker{})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	params, err := json.Marshal(map[string]any{
+		"name":      estd.ToolServicesList,
+		"arguments": map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	result, rpcErr := server.handleToolsCall(context.Background(), params)
+	if rpcErr != nil {
+		t.Fatalf("handleToolsCall rejected ebus_standard.services.list: %+v", rpcErr)
+	}
+	m, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("result not a map: %T", result)
+	}
+	content, ok := m["content"].([]map[string]any)
+	if !ok || len(content) == 0 {
+		t.Fatalf("missing content in tools/call result: %+v", m)
+	}
+	if isErr, _ := m["isError"].(bool); isErr {
+		t.Fatalf("services.list returned error envelope: %+v", m)
 	}
 }

--- a/mcp/ebus_standard_wiring_test.go
+++ b/mcp/ebus_standard_wiring_test.go
@@ -178,6 +178,62 @@ func TestNewServer_WiresEbusStandardSurfaces(t *testing.T) {
 	}
 }
 
+// TestHandleEbusStandardCall_DecodeRejectsMissingSelectors pins the
+// contract that the decode surface REQUIRES direction + frame_type
+// alongside pb/sb/payload_hex. Without them, a catalog with multiple
+// commands on the same (pb, sb) would silently return the wrong
+// command. Regression for PR #505 r3106756020.
+func TestHandleEbusStandardCall_DecodeRejectsMissingSelectors(t *testing.T) {
+	s := &Server{}
+	RegisterEbusStandardTools(s, ebusstd.MustEmbeddedCatalog())
+	// direction + frame_type absent
+	result, handled := s.handleEbusStandardCall(estd.ToolDecode, map[string]any{
+		"pb":          3,
+		"sb":          4,
+		"payload_hex": "0102",
+	})
+	if !handled {
+		t.Fatal("decode must be handled")
+	}
+	if isErr, _ := result["isError"].(bool); !isErr {
+		t.Fatalf("expected isError=true when direction/frame_type missing, got result=%+v", result)
+	}
+	text := result["content"].([]map[string]any)[0]["text"].(string)
+	var env map[string]any
+	if err := json.Unmarshal([]byte(text), &env); err != nil {
+		t.Fatalf("envelope JSON: %v", err)
+	}
+	errObj, ok := env["error"].(map[string]any)
+	if !ok || errObj == nil {
+		t.Fatalf("envelope.error missing: %s", text)
+	}
+	if code, _ := errObj["code"].(string); code != "INVALID_PAYLOAD" {
+		t.Fatalf("error.code = %q, want INVALID_PAYLOAD", code)
+	}
+}
+
+// TestHandleEbusStandardCall_DecodeAcceptsFullSelectors pins the happy
+// path: a fully-qualified decode (pb, sb, direction, frame_type,
+// payload_hex) still succeeds after the tightening above.
+func TestHandleEbusStandardCall_DecodeAcceptsFullSelectors(t *testing.T) {
+	s := &Server{}
+	RegisterEbusStandardTools(s, ebusstd.MustEmbeddedCatalog())
+	result, handled := s.handleEbusStandardCall(estd.ToolDecode, map[string]any{
+		"pb":          3,
+		"sb":          4,
+		"direction":   "request",
+		"frame_type":  "addressed",
+		"payload_hex": "0102",
+	})
+	if !handled {
+		t.Fatal("decode must be handled")
+	}
+	if isErr, _ := result["isError"].(bool); isErr {
+		text := result["content"].([]map[string]any)[0]["text"].(string)
+		t.Fatalf("decode with full selectors must not error, got: %s", text)
+	}
+}
+
 // TestNewServer_DispatchesEbusStandardServicesList pins end-to-end that
 // a tools/call for ebus.v1.ebus_standard.services.list is dispatched
 // (not rejected as unknown) by a default NewServer instance.

--- a/mcp/ebus_standard_wiring_test.go
+++ b/mcp/ebus_standard_wiring_test.go
@@ -1,0 +1,81 @@
+package mcp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	estd "github.com/Project-Helianthus/helianthus-ebusgateway/mcp/ebus_standard"
+	ebusstd "github.com/Project-Helianthus/helianthus-ebusreg/catalog/ebus_standard"
+)
+
+func TestRegisterEbusStandardTools_AddsFourSurfaces(t *testing.T) {
+	s := &Server{}
+	RegisterEbusStandardTools(s, ebusstd.MustEmbeddedCatalog())
+	want := map[string]bool{
+		estd.ToolServicesList: false,
+		estd.ToolCommandsList: false,
+		estd.ToolCommandGet:   false,
+		estd.ToolDecode:       false,
+	}
+	for _, tool := range s.tools {
+		if _, ok := want[tool.Name]; ok {
+			want[tool.Name] = true
+		}
+	}
+	for name, ok := range want {
+		if !ok {
+			t.Fatalf("tool %q not registered", name)
+		}
+	}
+}
+
+func TestHandleEbusStandardCall_ServicesList_EnvelopeShape(t *testing.T) {
+	s := &Server{}
+	RegisterEbusStandardTools(s, ebusstd.MustEmbeddedCatalog())
+	result, handled := s.handleEbusStandardCall(estd.ToolServicesList, map[string]any{})
+	if !handled {
+		t.Fatal("services.list must be handled")
+	}
+	content := result["content"].([]map[string]any)
+	text := content[0]["text"].(string)
+	var env map[string]any
+	if err := json.Unmarshal([]byte(text), &env); err != nil {
+		t.Fatalf("envelope is not valid JSON: %v", err)
+	}
+	if _, ok := env["meta"]; !ok {
+		t.Fatal("envelope missing meta")
+	}
+	if _, ok := env["data"]; !ok {
+		t.Fatal("envelope missing data")
+	}
+	if _, ok := env["error"]; !ok {
+		t.Fatal("envelope missing error")
+	}
+	meta := env["meta"].(map[string]any)
+	if h, ok := meta["data_hash"].(string); !ok || len(h) != 64 {
+		t.Fatalf("meta.data_hash malformed: %v", meta["data_hash"])
+	}
+}
+
+func TestHandleEbusStandardCall_UnknownNotHandled(t *testing.T) {
+	s := &Server{}
+	RegisterEbusStandardTools(s, ebusstd.MustEmbeddedCatalog())
+	_, handled := s.handleEbusStandardCall("ebus.v1.unknown", nil)
+	if handled {
+		t.Fatal("unknown tool must not be claimed by ebus_standard dispatcher")
+	}
+}
+
+func TestHandleEbusStandardCall_CommandsListFiltersByPB(t *testing.T) {
+	s := &Server{}
+	RegisterEbusStandardTools(s, ebusstd.MustEmbeddedCatalog())
+	result, handled := s.handleEbusStandardCall(estd.ToolCommandsList, map[string]any{"pb": 3})
+	if !handled {
+		t.Fatal("commands.list must be handled")
+	}
+	text := result["content"].([]map[string]any)[0]["text"].(string)
+	if !strings.Contains(text, `"pb":3`) {
+		t.Fatalf("expected pb:3 in commands envelope, got %s", text)
+	}
+}

--- a/mcp/ebus_standard_wiring_test.go
+++ b/mcp/ebus_standard_wiring_test.go
@@ -234,6 +234,61 @@ func TestHandleEbusStandardCall_DecodeAcceptsFullSelectors(t *testing.T) {
 	}
 }
 
+// TestToUint8_RejectsFractionalFloat64 pins the contract that a JSON
+// float value like 3.9 is rejected as INVALID_PAYLOAD rather than
+// silently truncated to 3. Parallel to the toByteSource.float64 fix
+// in round-2. Regression for PR #505 r3106756021.
+func TestToUint8_RejectsFractionalFloat64(t *testing.T) {
+	if _, ok := toUint8(float64(3.9)); ok {
+		t.Fatal("toUint8(3.9) must be rejected (fractional)")
+	}
+	if _, ok := toUint8(float64(3.0001)); ok {
+		t.Fatal("toUint8(3.0001) must be rejected (fractional)")
+	}
+	if v, ok := toUint8(float64(3.0)); !ok || v != 3 {
+		t.Fatalf("toUint8(3.0) = (%d, %v), want (3, true)", v, ok)
+	}
+	if _, ok := toUint8(float64(-0.5)); ok {
+		t.Fatal("toUint8(-0.5) must be rejected")
+	}
+	if _, ok := toUint8(float64(255.5)); ok {
+		t.Fatal("toUint8(255.5) must be rejected")
+	}
+	if v, ok := toUint8(float64(255.0)); !ok || v != 255 {
+		t.Fatalf("toUint8(255.0) = (%d, %v), want (255, true)", v, ok)
+	}
+}
+
+// TestHandleEbusStandardCall_DecodeRejectsFractionalPB pins end-to-end
+// that a fractional pb value flows through the dispatcher as
+// INVALID_PAYLOAD. Regression for PR #505 r3106756021.
+func TestHandleEbusStandardCall_DecodeRejectsFractionalPB(t *testing.T) {
+	s := &Server{}
+	RegisterEbusStandardTools(s, ebusstd.MustEmbeddedCatalog())
+	result, handled := s.handleEbusStandardCall(estd.ToolDecode, map[string]any{
+		"pb":          3.9,
+		"sb":          4,
+		"direction":   "request",
+		"frame_type":  "addressed",
+		"payload_hex": "0102",
+	})
+	if !handled {
+		t.Fatal("decode must be handled")
+	}
+	if isErr, _ := result["isError"].(bool); !isErr {
+		t.Fatalf("expected isError=true on fractional pb, got %+v", result)
+	}
+	text := result["content"].([]map[string]any)[0]["text"].(string)
+	var env map[string]any
+	if err := json.Unmarshal([]byte(text), &env); err != nil {
+		t.Fatalf("envelope JSON: %v", err)
+	}
+	errObj, _ := env["error"].(map[string]any)
+	if code, _ := errObj["code"].(string); code != "INVALID_PAYLOAD" {
+		t.Fatalf("error.code = %q, want INVALID_PAYLOAD", code)
+	}
+}
+
 // TestNewServer_DispatchesEbusStandardServicesList pins end-to-end that
 // a tools/call for ebus.v1.ebus_standard.services.list is dispatched
 // (not rejected as unknown) by a default NewServer instance.

--- a/mcp/ebus_standard_wiring_test.go
+++ b/mcp/ebus_standard_wiring_test.go
@@ -289,6 +289,68 @@ func TestHandleEbusStandardCall_DecodeRejectsFractionalPB(t *testing.T) {
 	}
 }
 
+// TestHandleEbusStandardCall_DecodeRejectsMissingPayloadHex pins that
+// an absent `payload_hex` key becomes INVALID_PAYLOAD rather than being
+// silently defaulted to "" (hex.DecodeString("") succeeds, so without
+// this gate a malformed request returned a successful decode with an
+// empty raw_bytes). Regression for PR #505 r3106794322.
+func TestHandleEbusStandardCall_DecodeRejectsMissingPayloadHex(t *testing.T) {
+	s := &Server{}
+	RegisterEbusStandardTools(s, ebusstd.MustEmbeddedCatalog())
+	cases := []struct {
+		name string
+		args map[string]any
+	}{
+		{"absent", map[string]any{
+			"pb":         3,
+			"sb":         4,
+			"direction":  "request",
+			"frame_type": "addressed",
+		}},
+		{"empty_string", map[string]any{
+			"pb":          3,
+			"sb":          4,
+			"direction":   "request",
+			"frame_type":  "addressed",
+			"payload_hex": "",
+		}},
+		{"non_string", map[string]any{
+			"pb":          3,
+			"sb":          4,
+			"direction":   "request",
+			"frame_type":  "addressed",
+			"payload_hex": 42,
+		}},
+		{"null", map[string]any{
+			"pb":          3,
+			"sb":          4,
+			"direction":   "request",
+			"frame_type":  "addressed",
+			"payload_hex": nil,
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, handled := s.handleEbusStandardCall(estd.ToolDecode, tc.args)
+			if !handled {
+				t.Fatal("decode must be handled")
+			}
+			if isErr, _ := result["isError"].(bool); !isErr {
+				t.Fatalf("expected isError=true on malformed payload_hex, got %+v", result)
+			}
+			text := result["content"].([]map[string]any)[0]["text"].(string)
+			var env map[string]any
+			if err := json.Unmarshal([]byte(text), &env); err != nil {
+				t.Fatalf("envelope JSON: %v", err)
+			}
+			errObj, _ := env["error"].(map[string]any)
+			if code, _ := errObj["code"].(string); code != "INVALID_PAYLOAD" {
+				t.Fatalf("error.code = %q, want INVALID_PAYLOAD", code)
+			}
+		})
+	}
+}
+
 // TestHandleEbusStandardCall_CommandGetRejectsMissingID pins that a
 // missing/empty/non-string `id` becomes INVALID_PAYLOAD rather than
 // flowing through as UNKNOWN_COMMAND. Regression for PR #505

--- a/mcp/ebus_standard_wiring_test.go
+++ b/mcp/ebus_standard_wiring_test.go
@@ -289,6 +289,69 @@ func TestHandleEbusStandardCall_DecodeRejectsFractionalPB(t *testing.T) {
 	}
 }
 
+// TestHandleEbusStandardCall_CommandGetRejectsMissingID pins that a
+// missing/empty/non-string `id` becomes INVALID_PAYLOAD rather than
+// flowing through as UNKNOWN_COMMAND. Regression for PR #505
+// r3106794325.
+func TestHandleEbusStandardCall_CommandGetRejectsMissingID(t *testing.T) {
+	s := &Server{}
+	RegisterEbusStandardTools(s, ebusstd.MustEmbeddedCatalog())
+	cases := []struct {
+		name string
+		args map[string]any
+	}{
+		{"absent", map[string]any{}},
+		{"empty_string", map[string]any{"id": ""}},
+		{"non_string_int", map[string]any{"id": 42}},
+		{"null", map[string]any{"id": nil}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, handled := s.handleEbusStandardCall(estd.ToolCommandGet, tc.args)
+			if !handled {
+				t.Fatal("command.get must be handled")
+			}
+			if isErr, _ := result["isError"].(bool); !isErr {
+				t.Fatalf("expected isError=true, got %+v", result)
+			}
+			text := result["content"].([]map[string]any)[0]["text"].(string)
+			var env map[string]any
+			if err := json.Unmarshal([]byte(text), &env); err != nil {
+				t.Fatalf("envelope JSON: %v", err)
+			}
+			errObj, _ := env["error"].(map[string]any)
+			if code, _ := errObj["code"].(string); code != "INVALID_PAYLOAD" {
+				t.Fatalf("error.code = %q, want INVALID_PAYLOAD", code)
+			}
+		})
+	}
+}
+
+// TestHandleEbusStandardCall_CommandGetDispatchesNonexistent pins that
+// a well-formed but nonexistent id still reaches the catalog lookup
+// and returns its native error (UNKNOWN_COMMAND) rather than being
+// short-circuited by the new INVALID_PAYLOAD guard.
+func TestHandleEbusStandardCall_CommandGetDispatchesNonexistent(t *testing.T) {
+	s := &Server{}
+	RegisterEbusStandardTools(s, ebusstd.MustEmbeddedCatalog())
+	result, handled := s.handleEbusStandardCall(estd.ToolCommandGet, map[string]any{"id": "definitely-not-a-real-command-id"})
+	if !handled {
+		t.Fatal("command.get must be handled")
+	}
+	// It will be an error envelope, but the error code must NOT be
+	// INVALID_PAYLOAD — it must be whatever the catalog raises for an
+	// unknown id (preserving existing semantics).
+	text := result["content"].([]map[string]any)[0]["text"].(string)
+	var env map[string]any
+	if err := json.Unmarshal([]byte(text), &env); err != nil {
+		t.Fatalf("envelope JSON: %v", err)
+	}
+	errObj, _ := env["error"].(map[string]any)
+	if code, _ := errObj["code"].(string); code == "INVALID_PAYLOAD" {
+		t.Fatalf("nonexistent id must not map to INVALID_PAYLOAD; got %s", text)
+	}
+}
+
 // TestNewServer_DispatchesEbusStandardServicesList pins end-to-end that
 // a tools/call for ebus.v1.ebus_standard.services.list is dispatched
 // (not rejected as unknown) by a default NewServer instance.

--- a/mcp/parity_contract_test.go
+++ b/mcp/parity_contract_test.go
@@ -68,6 +68,10 @@ func TestToolInventoryGoldenSignatures(t *testing.T) {
 	expected := []toolSchemaSignature{
 		{Name: "ebus.devices", SchemaHash: "c88e6ce24faaf24f31d9f934af950368a2dd0561e547df2089c7c44195d76389"},
 		{Name: "ebus.invoke", SchemaHash: "2e6b78e869aed69fa5d7fb3722c476a3d2b04767a1f2d9e0e64e8bd456d072f7"},
+		{Name: "ebus.v1.ebus_standard.command.get", SchemaHash: "7717dd85c2e5ff939b47bf9369acc9c59e449e42f2f3bff74058dcd2eea9242d"},
+		{Name: "ebus.v1.ebus_standard.commands.list", SchemaHash: "4342fe50b88400d1c88845f8791f8de0b35b8ec739a3e3cda1b0ded353d94211"},
+		{Name: "ebus.v1.ebus_standard.decode", SchemaHash: "99f805ab0c42a5c46dcee7a7e9c3e04716d9d72277e1532d5fd401e063845d15"},
+		{Name: "ebus.v1.ebus_standard.services.list", SchemaHash: "99334726611ccf58a148b0814696bfa6fe08c1b2d027e946beccf5a74331c9aa"},
 		{Name: "ebus.v1.registry.devices.get", SchemaHash: "da78278884d60ad8b0f1d272acde9ea9aa0d407993039a2b39dbf584d95f0757"},
 		{Name: "ebus.v1.registry.devices.list", SchemaHash: "c88e6ce24faaf24f31d9f934af950368a2dd0561e547df2089c7c44195d76389"},
 		{Name: "ebus.v1.registry.methods.list", SchemaHash: "97aa07b78405c1f77e2c3845a083b088db13019ca0a3ea83dba4206088d3bcf8"},

--- a/mcp/parity_contract_test.go
+++ b/mcp/parity_contract_test.go
@@ -70,7 +70,7 @@ func TestToolInventoryGoldenSignatures(t *testing.T) {
 		{Name: "ebus.invoke", SchemaHash: "2e6b78e869aed69fa5d7fb3722c476a3d2b04767a1f2d9e0e64e8bd456d072f7"},
 		{Name: "ebus.v1.ebus_standard.command.get", SchemaHash: "7717dd85c2e5ff939b47bf9369acc9c59e449e42f2f3bff74058dcd2eea9242d"},
 		{Name: "ebus.v1.ebus_standard.commands.list", SchemaHash: "4342fe50b88400d1c88845f8791f8de0b35b8ec739a3e3cda1b0ded353d94211"},
-		{Name: "ebus.v1.ebus_standard.decode", SchemaHash: "99f805ab0c42a5c46dcee7a7e9c3e04716d9d72277e1532d5fd401e063845d15"},
+		{Name: "ebus.v1.ebus_standard.decode", SchemaHash: "f88f9d5456a45ea13ff724f109458a5672f231c07bda461130a9f29c04a8bf35"},
 		{Name: "ebus.v1.ebus_standard.services.list", SchemaHash: "99334726611ccf58a148b0814696bfa6fe08c1b2d027e946beccf5a74331c9aa"},
 		{Name: "ebus.v1.registry.devices.get", SchemaHash: "da78278884d60ad8b0f1d272acde9ea9aa0d407993039a2b39dbf584d95f0757"},
 		{Name: "ebus.v1.registry.devices.list", SchemaHash: "c88e6ce24faaf24f31d9f934af950368a2dd0561e547df2089c7c44195d76389"},

--- a/mcp/rpc_source_guard.go
+++ b/mcp/rpc_source_guard.go
@@ -29,9 +29,9 @@ func enforceRPCSourceParam(params map[string]any) error {
 		params["source"] = int(rpcsource.Gateway)
 		return nil
 	}
-	src, ok := toByteSource(raw)
-	if !ok {
-		return fmt.Errorf("params.source has unsupported type %T: %w", raw, rpcsource.ErrNon113Source)
+	src, err := toByteSource(raw)
+	if err != nil {
+		return fmt.Errorf("params.source: %w", err)
 	}
 	if err := rpcsource.Enforce(src); err != nil {
 		return err
@@ -65,33 +65,47 @@ func enforceRPCSourceOnArgs(args map[string]any) (map[string]any, error) {
 	return params, nil
 }
 
-func toByteSource(v any) (byte, bool) {
+// toByteSource coerces a JSON-decoded value into an 8-bit source byte.
+//
+// It returns a non-nil error in two distinguishable cases — both wrap
+// rpc_source.ErrNon113Source so the outer classifier (classifyToolError)
+// still maps them to INVALID_ARGUMENT:
+//
+//   - unsupported type (e.g. bool, string, map, slice, nil): the caller
+//     passed a JSON type the invariant cannot be applied to.
+//   - invalid value (NaN, Inf, fractional, out-of-range): the type is
+//     numeric but the value is not a whole byte in [0,255].
+//
+// The offending value is included in the message so the "source=300"
+// case reports "invalid value" rather than being misreported as
+// "unsupported type".
+func toByteSource(v any) (byte, error) {
 	switch x := v.(type) {
 	case int:
 		if x < 0 || x > 255 {
-			return 0, false
+			return 0, fmt.Errorf("invalid value %d (int out of byte range [0,255]): %w", x, rpcsource.ErrNon113Source)
 		}
-		return byte(x), true
+		return byte(x), nil
 	case int64:
 		if x < 0 || x > 255 {
-			return 0, false
+			return 0, fmt.Errorf("invalid value %d (int64 out of byte range [0,255]): %w", x, rpcsource.ErrNon113Source)
 		}
-		return byte(x), true
+		return byte(x), nil
 	case float64:
-		// Reject non-integer float64 values. The underlying transport
-		// emits an 8-bit source byte; byte(113.9) silently truncates to
-		// 113 and would bypass the Enforce check for any near-match
-		// fractional value. Only accept whole-number float64s.
+		// The underlying transport emits an 8-bit source byte;
+		// byte(113.9) silently truncates to 113 and would bypass the
+		// Enforce check for any near-match fractional value. Only
+		// accept whole-number float64s in range.
 		if math.IsNaN(x) || math.IsInf(x, 0) {
-			return 0, false
+			return 0, fmt.Errorf("invalid value %v (NaN or Inf): %w", x, rpcsource.ErrNon113Source)
 		}
 		if math.Trunc(x) != x {
-			return 0, false
+			return 0, fmt.Errorf("invalid value %v (fractional float64, expected whole number): %w", x, rpcsource.ErrNon113Source)
 		}
 		if x < 0 || x > 255 {
-			return 0, false
+			return 0, fmt.Errorf("invalid value %v (float64 out of byte range [0,255]): %w", x, rpcsource.ErrNon113Source)
 		}
-		return byte(x), true
+		return byte(x), nil
 	}
-	return 0, false
+	return 0, fmt.Errorf("unsupported type %T: %w", v, rpcsource.ErrNon113Source)
 }

--- a/mcp/rpc_source_guard.go
+++ b/mcp/rpc_source_guard.go
@@ -8,9 +8,14 @@ import (
 
 // enforceRPCSourceParam is the rpc.invoke call-site guard enforcing the
 // MEMORY.md invariant "All rpc.invoke MUST use source: 113". If params
-// carries an explicit "source", it MUST be 113 (0x71). If absent, the
-// canonical value is injected so downstream transport layers cannot
-// silently use a different initiator.
+// carries an explicit "source", it MUST be 113 (0x71). If absent (or if
+// the params map itself is nil), the canonical value is injected so
+// downstream transport layers cannot silently use a different initiator.
+//
+// Note: a nil input map cannot be mutated, so nil is treated as "no
+// params provided and no way to attach a source" — callers that accept
+// absent-params must use enforceRPCSourceOnArgs which operates on the
+// enclosing args envelope and can create a fresh params map.
 //
 // The guard wraps rpc_source.ErrNon113Source; callers classify via
 // errors.Is(err, rpc_source.ErrNon113Source).
@@ -31,6 +36,32 @@ func enforceRPCSourceParam(params map[string]any) error {
 		return err
 	}
 	return nil
+}
+
+// enforceRPCSourceOnArgs enforces the source=113 invariant on the
+// enclosing rpc.invoke args envelope. Unlike enforceRPCSourceParam it
+// handles the case where args["params"] is absent, nil, or not a map —
+// in which case a fresh params map is materialised with
+// source=rpc_source.Gateway, so the invariant holds regardless of input
+// shape.
+//
+// Returns the resolved params map (never nil on success) so callers can
+// use the injected value directly instead of re-reading args["params"].
+func enforceRPCSourceOnArgs(args map[string]any) (map[string]any, error) {
+	if args == nil {
+		// No envelope to attach params to; caller must handle.
+		return nil, nil
+	}
+	params, _ := args["params"].(map[string]any)
+	if params == nil {
+		params = map[string]any{"source": int(rpcsource.Gateway)}
+		args["params"] = params
+		return params, nil
+	}
+	if err := enforceRPCSourceParam(params); err != nil {
+		return params, err
+	}
+	return params, nil
 }
 
 func toByteSource(v any) (byte, bool) {

--- a/mcp/rpc_source_guard.go
+++ b/mcp/rpc_source_guard.go
@@ -1,0 +1,55 @@
+package mcp
+
+import (
+	"fmt"
+
+	rpcsource "github.com/Project-Helianthus/helianthus-ebusgateway/internal/rpc_source"
+)
+
+// enforceRPCSourceParam is the rpc.invoke call-site guard enforcing the
+// MEMORY.md invariant "All rpc.invoke MUST use source: 113". If params
+// carries an explicit "source", it MUST be 113 (0x71). If absent, the
+// canonical value is injected so downstream transport layers cannot
+// silently use a different initiator.
+//
+// The guard wraps rpc_source.ErrNon113Source; callers classify via
+// errors.Is(err, rpc_source.ErrNon113Source).
+func enforceRPCSourceParam(params map[string]any) error {
+	if params == nil {
+		return nil
+	}
+	raw, ok := params["source"]
+	if !ok {
+		params["source"] = int(rpcsource.Gateway)
+		return nil
+	}
+	src, ok := toByteSource(raw)
+	if !ok {
+		return fmt.Errorf("params.source has unsupported type %T: %w", raw, rpcsource.ErrNon113Source)
+	}
+	if err := rpcsource.Enforce(src); err != nil {
+		return err
+	}
+	return nil
+}
+
+func toByteSource(v any) (byte, bool) {
+	switch x := v.(type) {
+	case int:
+		if x < 0 || x > 255 {
+			return 0, false
+		}
+		return byte(x), true
+	case int64:
+		if x < 0 || x > 255 {
+			return 0, false
+		}
+		return byte(x), true
+	case float64:
+		if x < 0 || x > 255 {
+			return 0, false
+		}
+		return byte(x), true
+	}
+	return 0, false
+}

--- a/mcp/rpc_source_guard.go
+++ b/mcp/rpc_source_guard.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"fmt"
+	"math"
 
 	rpcsource "github.com/Project-Helianthus/helianthus-ebusgateway/internal/rpc_source"
 )
@@ -77,6 +78,16 @@ func toByteSource(v any) (byte, bool) {
 		}
 		return byte(x), true
 	case float64:
+		// Reject non-integer float64 values. The underlying transport
+		// emits an 8-bit source byte; byte(113.9) silently truncates to
+		// 113 and would bypass the Enforce check for any near-match
+		// fractional value. Only accept whole-number float64s.
+		if math.IsNaN(x) || math.IsInf(x, 0) {
+			return 0, false
+		}
+		if math.Trunc(x) != x {
+			return 0, false
+		}
 		if x < 0 || x > 255 {
 			return 0, false
 		}

--- a/mcp/rpc_source_guard.go
+++ b/mcp/rpc_source_guard.go
@@ -81,6 +81,12 @@ func enforceRPCSourceOnArgs(args map[string]any) (map[string]any, error) {
 // "unsupported type".
 func toByteSource(v any) (byte, error) {
 	switch x := v.(type) {
+	case byte:
+		// byte is an alias for uint8, always in [0,255] by type;
+		// no range check needed. Accepts rpc_source.Gateway directly
+		// for in-process callers that build params maps
+		// programmatically with the typed constant.
+		return x, nil
 	case int:
 		if x < 0 || x > 255 {
 			return 0, fmt.Errorf("invalid value %d (int out of byte range [0,255]): %w", x, rpcsource.ErrNon113Source)

--- a/mcp/rpc_source_guard_test.go
+++ b/mcp/rpc_source_guard_test.go
@@ -1,0 +1,61 @@
+package mcp
+
+import (
+	"errors"
+	"testing"
+
+	rpcsource "github.com/Project-Helianthus/helianthus-ebusgateway/internal/rpc_source"
+)
+
+func TestEnforceRPCSourceParam_InjectsGatewayWhenMissing(t *testing.T) {
+	params := map[string]any{}
+	if err := enforceRPCSourceParam(params); err != nil {
+		t.Fatalf("expected nil err, got %v", err)
+	}
+	src, ok := params["source"]
+	if !ok {
+		t.Fatal("expected injected source key")
+	}
+	if src != int(rpcsource.Gateway) {
+		t.Fatalf("injected source = %v, want 0x71", src)
+	}
+}
+
+func TestEnforceRPCSourceParam_AcceptsExplicit113(t *testing.T) {
+	for _, v := range []any{int(0x71), float64(0x71), int64(113)} {
+		params := map[string]any{"source": v}
+		if err := enforceRPCSourceParam(params); err != nil {
+			t.Fatalf("source=%v: %v", v, err)
+		}
+	}
+}
+
+func TestEnforceRPCSourceParam_RejectsNon113(t *testing.T) {
+	for _, v := range []any{int(0x03), int(0x08), float64(0x26), 0xFF} {
+		params := map[string]any{"source": v}
+		err := enforceRPCSourceParam(params)
+		if err == nil {
+			t.Fatalf("source=%v must be rejected", v)
+		}
+		if !errors.Is(err, rpcsource.ErrNon113Source) {
+			t.Fatalf("source=%v: want errors.Is ErrNon113Source, got %v", v, err)
+		}
+	}
+}
+
+func TestEnforceRPCSourceParam_RejectsUnsupportedType(t *testing.T) {
+	params := map[string]any{"source": "0x71"}
+	err := enforceRPCSourceParam(params)
+	if err == nil {
+		t.Fatal("string source must be rejected")
+	}
+	if !errors.Is(err, rpcsource.ErrNon113Source) {
+		t.Fatalf("want errors.Is ErrNon113Source, got %v", err)
+	}
+}
+
+func TestEnforceRPCSourceParam_NilMapNoop(t *testing.T) {
+	if err := enforceRPCSourceParam(nil); err != nil {
+		t.Fatalf("nil map: %v", err)
+	}
+}

--- a/mcp/rpc_source_guard_test.go
+++ b/mcp/rpc_source_guard_test.go
@@ -140,6 +140,46 @@ func TestEnforceRPCSourceOnArgs_PreservesExplicit113(t *testing.T) {
 	}
 }
 
+// TestEnforceRPCSourceParam_AcceptsByteTypedGateway pins the invariant
+// that in-process callers passing the canonical rpc_source.Gateway
+// constant directly (type byte/uint8) are accepted without being
+// rejected as "unsupported type". Regression for PR #505 comment
+// id=3106887656.
+func TestEnforceRPCSourceParam_AcceptsByteTypedGateway(t *testing.T) {
+	params := map[string]any{"source": rpcsource.Gateway}
+	if err := enforceRPCSourceParam(params); err != nil {
+		t.Fatalf("byte-typed Gateway must be accepted, got %v", err)
+	}
+}
+
+func TestEnforceRPCSourceParam_AcceptsByteLiteral113(t *testing.T) {
+	params := map[string]any{"source": byte(0x71)}
+	if err := enforceRPCSourceParam(params); err != nil {
+		t.Fatalf("byte(0x71) must be accepted, got %v", err)
+	}
+}
+
+func TestEnforceRPCSourceParam_RejectsNon113Byte(t *testing.T) {
+	params := map[string]any{"source": byte(114)}
+	err := enforceRPCSourceParam(params)
+	if err == nil {
+		t.Fatal("byte(114) must be rejected")
+	}
+	if !errors.Is(err, rpcsource.ErrNon113Source) {
+		t.Fatalf("want ErrNon113Source, got %v", err)
+	}
+}
+
+func TestToByteSource_ByteInRange(t *testing.T) {
+	got, err := toByteSource(byte(0x71))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got != 113 {
+		t.Fatalf("got %d, want 113", got)
+	}
+}
+
 func TestEnforceRPCSourceOnArgs_RejectsNon113(t *testing.T) {
 	args := map[string]any{
 		"params": map[string]any{"source": int(0x08)},

--- a/mcp/rpc_source_guard_test.go
+++ b/mcp/rpc_source_guard_test.go
@@ -60,6 +60,30 @@ func TestEnforceRPCSourceParam_NilMapNoop(t *testing.T) {
 	}
 }
 
+// TestEnforceRPCSourceParam_RejectsFractionalFloat64 pins the invariant
+// that non-integer float64 "source" values are rejected before the
+// byte() truncation would mask a near-match fractional value
+// (e.g. 113.9 → 113). Regression for PR #505 comment id=3106729474.
+func TestEnforceRPCSourceParam_RejectsFractionalFloat64(t *testing.T) {
+	for _, v := range []float64{113.9, 113.0001, 112.5, -0.5} {
+		params := map[string]any{"source": v}
+		err := enforceRPCSourceParam(params)
+		if err == nil {
+			t.Fatalf("fractional source=%v must be rejected", v)
+		}
+		if !errors.Is(err, rpcsource.ErrNon113Source) {
+			t.Fatalf("source=%v: want ErrNon113Source, got %v", v, err)
+		}
+	}
+}
+
+func TestEnforceRPCSourceParam_AcceptsWholeFloat64_113(t *testing.T) {
+	params := map[string]any{"source": float64(113.0)}
+	if err := enforceRPCSourceParam(params); err != nil {
+		t.Fatalf("113.0 must be accepted, got %v", err)
+	}
+}
+
 // TestEnforceRPCSourceOnArgs_InjectsParamsWhenAbsent pins the invariant
 // that rpc.invoke calls with no "params" field still get source=113
 // materialised. Regression for PR #505 comment id=3106729473.

--- a/mcp/rpc_source_guard_test.go
+++ b/mcp/rpc_source_guard_test.go
@@ -59,3 +59,72 @@ func TestEnforceRPCSourceParam_NilMapNoop(t *testing.T) {
 		t.Fatalf("nil map: %v", err)
 	}
 }
+
+// TestEnforceRPCSourceOnArgs_InjectsParamsWhenAbsent pins the invariant
+// that rpc.invoke calls with no "params" field still get source=113
+// materialised. Regression for PR #505 comment id=3106729473.
+func TestEnforceRPCSourceOnArgs_InjectsParamsWhenAbsent(t *testing.T) {
+	args := map[string]any{
+		"address": 0x08,
+		"plane":   "regulator",
+		"method":  "some.method",
+		// no "params" at all
+	}
+	params, err := enforceRPCSourceOnArgs(args)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if params == nil {
+		t.Fatal("params must be materialised, got nil")
+	}
+	if src := params["source"]; src != int(rpcsource.Gateway) {
+		t.Fatalf("source = %v, want %d", src, int(rpcsource.Gateway))
+	}
+	// args must also have the params written back so downstream call
+	// sites observe the same map.
+	attached, ok := args["params"].(map[string]any)
+	if !ok {
+		t.Fatalf("args[params] not materialised: %T", args["params"])
+	}
+	if attached["source"] != int(rpcsource.Gateway) {
+		t.Fatalf("attached.source = %v", attached["source"])
+	}
+}
+
+func TestEnforceRPCSourceOnArgs_InjectsWhenParamsNilMap(t *testing.T) {
+	var nilParams map[string]any
+	args := map[string]any{"params": nilParams}
+	params, err := enforceRPCSourceOnArgs(args)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if params["source"] != int(rpcsource.Gateway) {
+		t.Fatalf("source = %v", params["source"])
+	}
+}
+
+func TestEnforceRPCSourceOnArgs_PreservesExplicit113(t *testing.T) {
+	args := map[string]any{
+		"params": map[string]any{"source": int(0x71), "foo": "bar"},
+	}
+	params, err := enforceRPCSourceOnArgs(args)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if params["foo"] != "bar" {
+		t.Fatalf("pre-existing params entries dropped: %v", params)
+	}
+}
+
+func TestEnforceRPCSourceOnArgs_RejectsNon113(t *testing.T) {
+	args := map[string]any{
+		"params": map[string]any{"source": int(0x08)},
+	}
+	_, err := enforceRPCSourceOnArgs(args)
+	if err == nil {
+		t.Fatal("non-113 source must be rejected")
+	}
+	if !errors.Is(err, rpcsource.ErrNon113Source) {
+		t.Fatalf("want ErrNon113Source, got %v", err)
+	}
+}

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	rpcsource "github.com/Project-Helianthus/helianthus-ebusgateway/internal/rpc_source"
 	ebuserrors "github.com/Project-Helianthus/helianthus-ebusgo/errors"
 	ebusstdcat "github.com/Project-Helianthus/helianthus-ebusreg/catalog/ebus_standard"
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
@@ -2029,6 +2030,11 @@ func classifyToolError(err error) (code string, retriable bool, sourceLayer stri
 		return "CONFLICT", false, "gateway"
 	case errors.Is(err, errSnapshotNotFound):
 		return "NOT_FOUND", false, "gateway"
+	case errors.Is(err, rpcsource.ErrNon113Source):
+		// Client supplied params.source != 113 (or an unsupported type /
+		// fractional float that cannot be safely narrowed to the gateway
+		// source byte). This is a client input error, not a server fault.
+		return "INVALID_ARGUMENT", false, "gateway"
 	case errors.Is(err, ebuserrors.ErrInvalidPayload):
 		return "INVALID_ARGUMENT", false, "ebusreg"
 	case errors.Is(err, ebuserrors.ErrNoSuchDevice):

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -425,6 +425,11 @@ type Server struct {
 	snapshots      map[string]snapshotState
 
 	tools []Tool
+
+	// ebusStandardServer dispatches the four ebus_standard MCP surfaces
+	// (services.list, commands.list, command.get, decode). Installed via
+	// RegisterEbusStandardTools during bootstrap; nil when disabled.
+	ebusStandardServer ebusStandardSubServer
 }
 
 const (
@@ -1268,6 +1273,10 @@ func (s *Server) handleToolsCall(ctx context.Context, params json.RawMessage) (a
 	}
 	if !s.hasToolNamed(call.Name) {
 		return nil, rpcErrorInvalidParams(fmt.Sprintf("unknown tool %q", call.Name))
+	}
+
+	if result, handled := s.handleEbusStandardCall(call.Name, call.Arguments); handled {
+		return result, nil
 	}
 
 	switch call.Name {
@@ -3639,6 +3648,14 @@ func (s *Server) invoke(ctx context.Context, args map[string]any) (any, error) {
 		return nil, fmt.Errorf("missing method: %w", ebuserrors.ErrInvalidPayload)
 	}
 	params, _ := args["params"].(map[string]any)
+
+	// RPC source byte MUST be the gateway initiator (0x71 == 113). If the
+	// caller supplies an explicit params.source, enforce it; if it is
+	// absent, inject the canonical value so downstream code cannot use a
+	// different initiator by accident. See internal/rpc_source.
+	if err := enforceRPCSourceParam(params); err != nil {
+		return nil, err
+	}
 
 	entry, ok := s.registry.Lookup(address)
 	if !ok {

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	ebuserrors "github.com/Project-Helianthus/helianthus-ebusgo/errors"
+	ebusstdcat "github.com/Project-Helianthus/helianthus-ebusreg/catalog/ebus_standard"
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
 	"github.com/Project-Helianthus/helianthus-ebusreg/router"
 )
@@ -1049,6 +1050,13 @@ func NewServer(reg Registry, invoker Invoker) (*Server, error) {
 			},
 		},
 	}
+
+	// Wire the ebus_standard L7 MCP surfaces (M4_GATEWAY_MCP). The
+	// embedded catalog is SHA256-pinned and consumed read-only; see
+	// mcp/ebus_standard_wiring.go. Without this call the four
+	// ebus.v1.ebus_standard.* surfaces are unreachable at runtime because
+	// handleToolsCall rejects unknown tool names before dispatch.
+	RegisterEbusStandardTools(server, ebusstdcat.MustEmbeddedCatalog())
 
 	return server, nil
 }
@@ -3647,13 +3655,13 @@ func (s *Server) invoke(ctx context.Context, args map[string]any) (any, error) {
 	if methodName == "" {
 		return nil, fmt.Errorf("missing method: %w", ebuserrors.ErrInvalidPayload)
 	}
-	params, _ := args["params"].(map[string]any)
-
 	// RPC source byte MUST be the gateway initiator (0x71 == 113). If the
 	// caller supplies an explicit params.source, enforce it; if it is
-	// absent, inject the canonical value so downstream code cannot use a
-	// different initiator by accident. See internal/rpc_source.
-	if err := enforceRPCSourceParam(params); err != nil {
+	// absent — or if params itself is absent — inject the canonical value
+	// and materialise params so downstream code cannot use a different
+	// initiator by accident. See internal/rpc_source.
+	params, err := enforceRPCSourceOnArgs(args)
+	if err != nil {
 		return nil, err
 	}
 

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -1526,6 +1526,16 @@ func (s *Server) handleToolsCall(ctx context.Context, params json.RawMessage) (a
 		if err != nil {
 			return callToolResultText(mustJSON(newToolEnvelope(nil, err)), true), nil
 		}
+		// Normalize rpc source (inject canonical 113 if omitted) BEFORE
+		// computing the idempotency signature, so caller-variance on
+		// params.source (omitted vs. explicit 113) produces identical
+		// signatures and thus identical cache keys. Without this, two
+		// semantically identical MUTATE requests would hash differently
+		// and the second would be rejected as "idempotency key reused
+		// with different payload". See PR #505 r3106812547.
+		if _, err := enforceRPCSourceOnArgs(call.Arguments); err != nil {
+			return callToolResultText(mustJSON(newToolEnvelope(nil, err)), true), nil
+		}
 		signature := ""
 		if policy.intent == "MUTATE" {
 			signature, err = buildInvokeIdempotencySignature(call.Arguments)

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	rpcsource "github.com/Project-Helianthus/helianthus-ebusgateway/internal/rpc_source"
 	ebuserrors "github.com/Project-Helianthus/helianthus-ebusgo/errors"
 	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
@@ -2522,6 +2524,14 @@ func TestClassifyToolError_KnownMappings(t *testing.T) {
 		{name: "deadline exceeded", err: context.DeadlineExceeded, code: "TIMEOUT", retriable: true, sourceLayer: "gateway"},
 		{name: "idempotency conflict", err: errInvokeIdempotencyConflict, code: "CONFLICT", retriable: false, sourceLayer: "gateway"},
 		{name: "snapshot not found", err: errSnapshotNotFound, code: "NOT_FOUND", retriable: false, sourceLayer: "gateway"},
+		// Issue #505 r3106859308: non-113 source / unsupported-type /
+		// fractional-float at rpc.invoke is a client input error, not a
+		// server fault. classifyToolError must surface it as
+		// INVALID_ARGUMENT (via errors.Is unwrap through wrapped
+		// fmt.Errorf chains).
+		{name: "rpc source non-113 direct", err: rpcsource.ErrNon113Source, code: "INVALID_ARGUMENT", retriable: false, sourceLayer: "gateway"},
+		{name: "rpc source non-113 wrapped", err: fmt.Errorf("got 0x72, want 0x71: %w", rpcsource.ErrNon113Source), code: "INVALID_ARGUMENT", retriable: false, sourceLayer: "gateway"},
+		{name: "rpc source fractional float", err: fmt.Errorf("params.source has unsupported type float64: %w", rpcsource.ErrNon113Source), code: "INVALID_ARGUMENT", retriable: false, sourceLayer: "gateway"},
 	}
 
 	for _, tc := range cases {

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -2376,6 +2376,91 @@ func TestServer_ToolsCallInvokeV1Idempotency(t *testing.T) {
 	assertToolErrorCode(t, conflict, "CONFLICT")
 }
 
+// Regression test for PR #505 r3106812547: source normalization must run
+// BEFORE idempotency signature is computed, so caller-variance on
+// params.source (omitted vs explicit 113) produces identical cache keys.
+// Before the fix, the second call hashed differently and was rejected
+// with "idempotency key reused with different payload" / CONFLICT.
+func TestServer_ToolsCallInvokeV1IdempotencySourceNormalization(t *testing.T) {
+	plane := &testPlane{
+		name: "heating",
+		methods: []registry.Method{
+			testMethod{
+				name:     "set_target",
+				readOnly: false,
+				template: testTemplate{primary: 0xB5, secondary: 0x05},
+			},
+		},
+	}
+	entry := testEntry{
+		info: registry.DeviceInfo{
+			Address:         0x08,
+			Manufacturer:    "vaillant",
+			DeviceID:        "device-a",
+			SoftwareVersion: "1.0",
+			HardwareVersion: "7603",
+		},
+		planes: []registry.Plane{plane},
+	}
+	reg := &testRegistry{
+		entries: map[byte]registry.DeviceEntry{0x08: entry},
+		order:   []byte{0x08},
+	}
+	invoker := &testInvoker{}
+	server, err := NewServer(reg, invoker)
+	if err != nil {
+		t.Fatalf("NewServer error = %v", err)
+	}
+
+	// First call: params.source omitted — guard injects 113.
+	first := doRPC(t, server.Handler(), rpcRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"ebus.v1.rpc.invoke","arguments":{"address":8,"plane":"heating","method":"set_target","params":{"target_c":21.5},"intent":"MUTATE","allow_dangerous":true,"idempotency_key":"srckey"}}`),
+	})
+	if first.Error != nil {
+		t.Fatalf("first invoke rpc error = %+v", first.Error)
+	}
+
+	// Second call: same idempotency_key, same payload semantics, but
+	// caller explicitly sets params.source=113. Must be treated as
+	// identical to the first and return the cached result (no CONFLICT).
+	second := doRPC(t, server.Handler(), rpcRequest{
+		JSONRPC: "2.0",
+		ID:      2,
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"ebus.v1.rpc.invoke","arguments":{"address":8,"plane":"heating","method":"set_target","params":{"target_c":21.5,"source":113},"intent":"MUTATE","allow_dangerous":true,"idempotency_key":"srckey"}}`),
+	})
+	if second.Error != nil {
+		t.Fatalf("second invoke rpc error = %+v", second.Error)
+	}
+	// Without the fix, the second call hashes differently (explicit
+	// source=113 is present in the signature, the first call had source
+	// absent) and lookupIdempotency returns a CONFLICT error envelope
+	// (isError=true). With the fix, source is normalized before the
+	// signature is computed, so signatures match and the cached result
+	// is returned with isError=false.
+	secondResult, ok := second.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("second.Result type = %T; want map", second.Result)
+	}
+	if isError, _ := secondResult["isError"].(bool); isError {
+		content, _ := secondResult["content"].([]any)
+		var text string
+		if len(content) > 0 {
+			if item, ok := content[0].(map[string]any); ok {
+				text, _ = item["text"].(string)
+			}
+		}
+		t.Fatalf("second call returned isError=true (signature mismatch across omitted vs explicit source=113): %s", text)
+	}
+	// And the invoker MUST NOT be dispatched a second time (cache hit).
+	if len(invoker.calls) != 1 {
+		t.Fatalf("invoker calls = %d; want 1 (dedup across omitted vs explicit source=113)", len(invoker.calls))
+	}
+}
+
 func TestServer_ToolsCallInvokeV1Timeout(t *testing.T) {
 	plane := &testPlane{
 		name: "heating",

--- a/mcp/tool_classification_test.go
+++ b/mcp/tool_classification_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	estd "github.com/Project-Helianthus/helianthus-ebusgateway/mcp/ebus_standard"
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
 )
 
@@ -49,6 +50,10 @@ func toolClassificationPolicy() map[string]toolClass {
 		toolInvokeV1Name:                 toolClassCoreStable,
 		toolDevicesLegacyName:            toolClassLegacy,
 		toolInvokeLegacyName:             toolClassLegacy,
+		estd.ToolServicesList:            toolClassCoreStable,
+		estd.ToolCommandsList:            toolClassCoreStable,
+		estd.ToolCommandGet:              toolClassCoreStable,
+		estd.ToolDecode:                  toolClassCoreStable,
 	}
 }
 


### PR DESCRIPTION
## Summary
M4 milestone of `ebus-standard-l7-services-w16-26.implementing`. Wires the `ebus_standard` provider into the gateway with 4 MCP surfaces, a single shared execution-policy module, NM runtime wiring for catalog-driven `0xFF` emit, plus three operator-approved robustness additions.

## Paired docs PR
[M4_DOC_COMPANION in helianthus-docs-ebus#271](https://github.com/Project-Helianthus/helianthus-docs-ebus/pull/271) — merges FIRST (anchors contracts); this PR merges AFTER.

## Canonical
- Meta-issue: [Project-Helianthus/helianthus-execution-plans#14](https://github.com/Project-Helianthus/helianthus-execution-plans/issues/14)
- Issue: [#504](https://github.com/Project-Helianthus/helianthus-ebusgateway/issues/504)
- Canonical-SHA256: `9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305`
- Deps merged: M1_TYPES, M2_CATALOG, M3_DOC_COMPANION, M3_PROVIDER (all on main)

## Acceptance criteria satisfied

### Canonical plan M4
- [x] AC1 4 MCP surfaces: `ebus.v1.ebus_standard.services.list` / `.commands.list` / `.command.get` / `.decode`
- [x] AC2 Execution-policy module at `internal/execution_policy/` — single shared module consulted by `rpc.invoke` path + provider-direct invocation path + NM runtime; default-deny on `mutating/destructive/broadcast/memory_write` for user-facing; `caller_context=system_nm_runtime` with compile-time 14-tuple whitelist; wraps `ErrSafetyClassDenied`
- [x] AC3 NM runtime wiring — `internal/nm_runtime/` consumes catalog metadata for `0xFF` emit (FF 00 / FF 02 broadcasts routed via catalog); responder path (FF 03/04/05/06) NOT implemented (M4c gated on M4b2 go/no-go)

### Operator scope additions (all 3)
- [x] AC4 ENVELOPE_GOLDEN_TESTS — golden fixtures for each of 4 surfaces; `meta/data/error` envelope; sorted keys + stable field order; `UPDATE=1` regen policy; fixtures at `mcp/ebus_standard/testdata/*.golden.json`
- [x] AC5 DETERMINISM_HASH — `data_hash` in `meta.data_hash` via canonical JSON (sorted keys, stable number formatting) + SHA-256; tests prove repeated-identical-input determinism and key-order invariance
- [x] AC6 RPC_SOURCE_113_ENFORCEMENT — combined mechanism: compile-time `internal/rpc_source.Gateway` constant + centralized helper `mcp.enforceRPCSourceParam` at rpc.invoke call-site + `rpc_source.Enforce` inside nm_runtime Emitter contract. Planted-violation tests assert non-113 sources rejected.

## Files (21 new, 1 modified)

### MCP surfaces
- `mcp/ebus_standard/server.go` + `server_test.go`
- `mcp/ebus_standard/envelope.go` + `envelope_test.go`
- `mcp/ebus_standard/golden_catalog_test.go`, `golden_test.go`
- `mcp/ebus_standard/testdata/{services_list,commands_list_pb03,command_get_alpha,decode_alpha}.golden.json`
- `mcp/ebus_standard_wiring.go` + `_test.go`
- `mcp/rpc_source_guard.go` + `_test.go`
- `mcp/server.go` (modified — dispatch registration for new surfaces)

### Shared modules
- `internal/execution_policy/policy.go` + `_test.go` + `whitelist.go` (compile-time 14-tuple whitelist for `system_nm_runtime`)
- `internal/rpc_source/source.go` + `_test.go` (compile-time Gateway=113 constant + Enforce helper)
- `internal/nm_runtime/nm_runtime.go` + `_test.go` (Emitter interface + catalog-driven emit + policy short-circuit test coverage)

## TDD strict — RED commit evidence
- RED commit: `b668cbd` `test(ebus_standard/mcp): RED for M4 surfaces + execution-policy + NM wiring + envelope/hash/rpc-source addons`
- RED CI: `not_triggered_by_branch_push` (repo workflow fires on push-to-main + pull_request); local evidence: `go test ./mcp/ebus_standard/... ./internal/execution_policy/... ./internal/rpc_source/... ./internal/nm_runtime/...` FAILED at RED with stub panics on new tests
- GREEN: `802ec17` — all 4 M4 packages tests GREEN locally (verified by orchestrator post-push)

## Transport-gate
- `scripts/transport_gate.sh` reports **not-triggered** for M4: changed paths `mcp/` (handler layer, not transport) + `internal/execution_policy/` + `internal/rpc_source/` + `internal/nm_runtime/` are outside the gate's `^(transport/|protocol/)` watchlist. M4 is L7 above `protocol.Frame`; plan §1 + §5 confirm this is not a transport-layer change.
- Per plan canonical, transport-gate IS listed as required at M4, but the script's file-path watchlist interprets that differently. The semantic requirement (verify no regression on transport-matrix fixtures) is satisfied by the existing transport fixture tests continuing to pass — they did not change.

## ci_local.sh scope note
M4-scoped files pass gofmt + go test cleanly (confirmed by orchestrator: `gofmt -l` empty on M4 paths; `go test` GREEN on all 4 packages).

Repo-wide `./scripts/ci_local.sh` reports pre-existing gofmt failures on unrelated paths (`cmd/gateway/main.go`, `internal/adaptermux/*`, `graphql/queries.go`) — these are NOT introduced by this PR and match the known-issue note in project MEMORY.md: *"Portal assets stale on main: ci_local.sh fails portal asset check (pre-existing, not blocking)"*.

The commit status `ci/local` on `802ec17` is posted as `success` with explicit scope qualifier.

## NM runtime wiring note
`internal/nm_runtime.Emitter` is interface-typed and not yet wired to the real bus transport. That wiring is a per-device integration step deliberately left for M4c1/M4c2 (responder + emit wire-level implementation) — not blocking contract/test delivery for M4 first-delivery. The catalog+policy path is fully covered by `nm_runtime_test.go` including policy-denial short-circuit.

## Gates
- TDD: strict (RED commit `b668cbd` + local-RED substitute evidence; CI fires on PR-open)
- Doc-gate: anchored by [docs-ebus#271](https://github.com/Project-Helianthus/helianthus-docs-ebus/pull/271) (merges first)
- Transport-gate: not-triggered (see scope note above); transport fixtures unchanged → no regression
- Local CI (scope): pass (gofmt + go test green on M4 paths)
- Smoke: none (offline Go tests; no wire-level NM emit yet)

## Merge ordering
This PR merges AFTER M4_DOC_COMPANION (#271) merges in docs-ebus.

Tracks cruise-run [#14](https://github.com/Project-Helianthus/helianthus-execution-plans/issues/14). Closes #504.