### PR TITLE
feat(M5_PORTAL): ebus_standard L7 consumer UI + XSS-hardened decode sandbox

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -914,6 +914,14 @@ func startHTTPServer(
 			},
 			ExplorerBus:    gateway.Bus,
 			ExplorerSource: cfg.ScanSource,
+			// Wire the in-process L7 catalog sub-server (M5_PORTAL).
+			// mcpServer.EbusStandardServer() returns the same instance
+			// RegisterEbusStandardTools installed inside mcp.NewServer;
+			// sharing it between MCP + portal surfaces guarantees both
+			// reach the identical SHA256-pinned embedded catalog. Nil
+			// here would make /api/v1/ebus-standard/* routes 404 in
+			// production (handler.go nil-guard) — see PR #507.
+			EbusStandardServer: mcpServer.EbusStandardServer(),
 		})
 		mux.Handle(portalPath+"/", http.StripPrefix(portalPath, portalHandler))
 		mux.HandleFunc(portalPath, func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/gateway/wiring_test.go
+++ b/cmd/gateway/wiring_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	"github.com/Project-Helianthus/helianthus-ebusgateway"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp/ebus_standard"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/portal"
 	ebusgoTransport "github.com/Project-Helianthus/helianthus-ebusgo/transport"
 )
 
@@ -372,4 +374,50 @@ func TestResponderCapabilityProvider_ENS_WithMuxBypass_ReportsNone(t *testing.T)
 		t.Fatalf("active.refusal = %+v; want code=transport_mux_bypass", cap.Active.Refusal)
 	}
 	assertActiveInTransports(t, cap)
+}
+
+// TestM5Portal_EbusStandardServer_WiredInProduction asserts that the
+// gateway bootstrap hands the MCP sub-server into portal.Options. The
+// production wiring in main.go does:
+//
+//	portal.NewHandler(portal.Options{
+//	    ...
+//	    EbusStandardServer: mcpServer.EbusStandardServer(),
+//	})
+//
+// This smoke test mirrors that exact assignment. If mcp.NewServer stops
+// installing the ebus_standard sub-server, or if the accessor goes nil,
+// this test fails — preventing the regression flagged by Codex P1 on
+// PR #507 (portal.Options.EbusStandardServer omitted -> all four
+// /api/v1/ebus-standard/* routes return 404 in the real gateway process
+// despite tests with fakes passing).
+func TestM5Portal_EbusStandardServer_WiredInProduction(t *testing.T) {
+	mcpServer, err := mcp.NewServer(emptyMCPRegistry{}, nil)
+	if err != nil {
+		t.Fatalf("mcp.NewServer: %v", err)
+	}
+
+	sub := mcpServer.EbusStandardServer()
+	if sub == nil {
+		t.Fatalf("mcpServer.EbusStandardServer() is nil — RegisterEbusStandardTools not installed inside NewServer")
+	}
+
+	// Exercise the exact assignment main.go uses. This must compile:
+	// mcp.EbusStandardSubServer -> portal.PortalEbusStandardServer
+	// (structural-typing compatibility is load-bearing — if either
+	// interface drifts, the production wiring breaks at build time.)
+	opts := portal.Options{EbusStandardServer: sub}
+	if opts.EbusStandardServer == nil {
+		t.Fatalf("portal.Options.EbusStandardServer is nil after assignment")
+	}
+
+	// Dispatch a live call through the assigned interface to verify the
+	// method set reaches the real catalog, not a typed-nil wrapper.
+	data := opts.EbusStandardServer.ServicesList()
+	if data == nil {
+		t.Fatalf("EbusStandardServer.ServicesList() returned nil — catalog not reachable")
+	}
+	if ns, ok := data["namespace"].(string); !ok || ns != "ebus_standard" {
+		t.Fatalf("ServicesList() namespace = %v, want ebus_standard", data["namespace"])
+	}
 }

--- a/mcp/ebus_standard_wiring.go
+++ b/mcp/ebus_standard_wiring.go
@@ -9,11 +9,17 @@ import (
 	ebusstd "github.com/Project-Helianthus/helianthus-ebusreg/catalog/ebus_standard"
 )
 
-// ebusStandardSubServer is the in-package interface backed by
+// EbusStandardSubServer is the in-package interface backed by
 // mcp/ebus_standard.Server. Typed as an interface so the main Server
 // struct can hold a nil-equatable value when the sub-server is not
 // installed, while tests can substitute a fake.
-type ebusStandardSubServer interface {
+//
+// Exported so the gateway bootstrap can pass the same sub-server instance
+// into the portal handler via Options.EbusStandardServer without forcing
+// the portal package to import unexported names. The method set is
+// identical to portal.PortalEbusStandardServer by design — Go structural
+// typing allows cross-package assignment between the two interfaces.
+type EbusStandardSubServer interface {
 	ServicesList() map[string]any
 	CommandsList(pb *uint8) (map[string]any, error)
 	CommandGet(id string) (map[string]any, error)
@@ -91,6 +97,20 @@ func RegisterEbusStandardTools(s *Server, cat ebusstd.Catalog) {
 	)
 
 	s.ebusStandardServer = sub
+}
+
+// EbusStandardServer returns the in-process L7 catalog sub-server after
+// RegisterEbusStandardTools has installed it (otherwise nil). The gateway
+// bootstrap injects the returned value into portal.Options.EbusStandardServer
+// so the M5_PORTAL read-only consumer UI reaches the same catalog as the
+// MCP surfaces — without this accessor the portal handler would see nil
+// and the /api/v1/ebus-standard/* routes would 404 in production even
+// though the MCP tools are live.
+func (s *Server) EbusStandardServer() EbusStandardSubServer {
+	if s == nil {
+		return nil
+	}
+	return s.ebusStandardServer
 }
 
 // handleEbusStandardCall is invoked from handleToolsCall before the main

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -431,7 +431,7 @@ type Server struct {
 	// ebusStandardServer dispatches the four ebus_standard MCP surfaces
 	// (services.list, commands.list, command.get, decode). Installed via
 	// RegisterEbusStandardTools during bootstrap; nil when disabled.
-	ebusStandardServer ebusStandardSubServer
+	ebusStandardServer EbusStandardSubServer
 }
 
 const (

--- a/portal/explorer_ebus_standard.go
+++ b/portal/explorer_ebus_standard.go
@@ -138,6 +138,16 @@ func parseDecodeQuery(r *http.Request) (estd.DecodeInput, error) {
 	}
 	in.Direction = q.Get("direction")
 	in.FrameType = q.Get("frame_type")
+	// payload_hex: distinguish missing from explicitly-empty. The sub-server
+	// Decode accepts empty payloads (hex.DecodeString("") -> nil), so a bare
+	// q.Get would silently map "omitted" to "", hiding client request bugs
+	// (caller gets success / UNKNOWN_COMMAND instead of INVALID_PAYLOAD).
+	// Explicit empty (payload_hex=) is passed through and defers to backend
+	// Decode semantics; missing key surfaces INVALID_PAYLOAD here.
+	if !q.Has("payload_hex") {
+		return in, fmt.Errorf("payload_hex: %w: required (explicit empty is allowed, but the key must be present)",
+			estd.ErrInvalidPayload)
+	}
 	in.PayloadHex = q.Get("payload_hex")
 	return in, nil
 }

--- a/portal/explorer_ebus_standard.go
+++ b/portal/explorer_ebus_standard.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 
@@ -53,7 +54,7 @@ func (h *handler) routeEbusStandard(w http.ResponseWriter, r *http.Request, path
 	case "services":
 		h.writeEbusStandardEnvelope(w, h.opts.EbusStandardServer.ServicesList(), nil, ts)
 	case "commands":
-		pbp, perr := parseOptionalPBParam(r.URL.Query().Get("pb"))
+		pbp, perr := parseOptionalPBParam(r.URL.Query())
 		if perr != nil {
 			h.writeEbusStandardEnvelope(w, nil, perr, ts)
 			return true
@@ -94,9 +95,19 @@ func (h *handler) writeEbusStandardEnvelope(w http.ResponseWriter, data any, err
 // parseOptionalPBParam parses the optional "pb" query parameter. Mirrors
 // the MCP surface behavior: absent = nil (unfiltered), malformed = error
 // (INVALID_PAYLOAD) to avoid silently hiding contract violations.
-func parseOptionalPBParam(raw string) (*uint8, error) {
-	if raw == "" {
+//
+// Takes url.Values (not a raw string) so we can distinguish "pb key missing"
+// from "pb key present but empty" — same pattern as the payload_hex fix
+// (e363e1b7). A bare q.Get("pb") would yield "" in both cases, silently
+// mapping malformed ?pb= to the unfiltered path.
+func parseOptionalPBParam(q url.Values) (*uint8, error) {
+	if !q.Has("pb") {
 		return nil, nil
+	}
+	raw := q.Get("pb")
+	if raw == "" {
+		return nil, fmt.Errorf("pb: %w: filter must be a 1-byte hex value or omitted entirely",
+			estd.ErrInvalidPayload)
 	}
 	v, err := strconv.ParseUint(raw, 0, 16)
 	if err != nil {

--- a/portal/explorer_ebus_standard.go
+++ b/portal/explorer_ebus_standard.go
@@ -6,10 +6,38 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	estd "github.com/Project-Helianthus/helianthus-ebusgateway/mcp/ebus_standard"
 )
+
+// parsePBSBHex parses a PB/SB selector as a 1-byte hex value. The optional
+// "0x"/"0X" prefix is stripped (case-insensitive); the remainder is parsed
+// with explicit base=16 and bitSize=8.
+//
+// Rationale: earlier revisions used strconv.ParseUint(raw, 0, 16), which
+// enables Go's base-0 auto-detection — leading-zero inputs are then read as
+// octal (pb=010 → 8 instead of 0x10), and decimal-looking but invalid-octal
+// inputs (pb=08, pb=09) are rejected. PB/SB are documented in the catalog
+// as hex byte selectors (0x00-0xFF), so hex-only parsing is both
+// deterministic and aligned with the catalog's own representation.
+//
+// Behavior:
+//   - "010"   → 0x10 = 16 (no octal auto-detection)
+//   - "08"    → 0x08 = 8  (valid hex; no octal rejection)
+//   - "0x10"  → 16        (prefix stripped, parsed as hex)
+//   - "ff"    → 255
+//   - "banana"→ error     (invalid hex digits)
+//   - "100"   → error     (overflows 1-byte bitSize=8)
+func parsePBSBHex(raw string) (uint8, error) {
+	trimmed := strings.TrimPrefix(strings.TrimPrefix(raw, "0x"), "0X")
+	v, err := strconv.ParseUint(trimmed, 16, 8)
+	if err != nil {
+		return 0, err
+	}
+	return uint8(v), nil
+}
 
 // PortalEbusStandardServer is the sibling interface consumed by portal.Options
 // for the ebus_standard L7 sub-server. It mirrors the unexported
@@ -109,16 +137,11 @@ func parseOptionalPBParam(q url.Values) (*uint8, error) {
 		return nil, fmt.Errorf("pb: %w: filter must be a 1-byte hex value or omitted entirely",
 			estd.ErrInvalidPayload)
 	}
-	v, err := strconv.ParseUint(raw, 0, 16)
+	pb, err := parsePBSBHex(raw)
 	if err != nil {
-		return nil, fmt.Errorf("pb: %w: expected integer in [0,255], got %q: %v",
+		return nil, fmt.Errorf("pb: %w: expected 1-byte hex in [0x00,0xFF], got %q: %v",
 			estd.ErrInvalidPayload, raw, err)
 	}
-	if v > 255 {
-		return nil, fmt.Errorf("pb: %w: out of range [0,255]: %d",
-			estd.ErrInvalidPayload, v)
-	}
-	pb := uint8(v)
 	return &pb, nil
 }
 
@@ -133,19 +156,19 @@ func parseDecodeQuery(r *http.Request) (estd.DecodeInput, error) {
 	var in estd.DecodeInput
 	if pbStr := q.Get("pb"); pbStr == "" {
 		return in, fmt.Errorf("pb: %w: required", estd.ErrInvalidPayload)
-	} else if v, err := strconv.ParseUint(pbStr, 0, 16); err != nil || v > 255 {
-		return in, fmt.Errorf("pb: %w: expected [0,255], got %q",
+	} else if v, err := parsePBSBHex(pbStr); err != nil {
+		return in, fmt.Errorf("pb: %w: expected 1-byte hex in [0x00,0xFF], got %q",
 			estd.ErrInvalidPayload, pbStr)
 	} else {
-		in.PB = uint8(v)
+		in.PB = v
 	}
 	if sbStr := q.Get("sb"); sbStr == "" {
 		return in, fmt.Errorf("sb: %w: required", estd.ErrInvalidPayload)
-	} else if v, err := strconv.ParseUint(sbStr, 0, 16); err != nil || v > 255 {
-		return in, fmt.Errorf("sb: %w: expected [0,255], got %q",
+	} else if v, err := parsePBSBHex(sbStr); err != nil {
+		return in, fmt.Errorf("sb: %w: expected 1-byte hex in [0x00,0xFF], got %q",
 			estd.ErrInvalidPayload, sbStr)
 	} else {
-		in.SB = uint8(v)
+		in.SB = v
 	}
 	in.Direction = q.Get("direction")
 	in.FrameType = q.Get("frame_type")

--- a/portal/explorer_ebus_standard.go
+++ b/portal/explorer_ebus_standard.go
@@ -1,0 +1,148 @@
+package portal
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	estd "github.com/Project-Helianthus/helianthus-ebusgateway/mcp/ebus_standard"
+)
+
+// PortalEbusStandardServer is the sibling interface consumed by portal.Options
+// for the ebus_standard L7 sub-server. It mirrors the unexported
+// ebusStandardSubServer interface in mcp/ebus_standard_wiring.go so the portal
+// package can accept an injected Server (or a test fake) without importing
+// unexported names cross-package.
+//
+// The M5_PORTAL consumer UI is strictly read-only: these four methods expose
+// the L7 catalog and decode observed frames. No invocation is performed here;
+// the producer-side execution_policy still gates all writes at the mcp layer.
+type PortalEbusStandardServer interface {
+	ServicesList() map[string]any
+	CommandsList(pb *uint8) (map[string]any, error)
+	CommandGet(id string) (map[string]any, error)
+	Decode(in estd.DecodeInput) (map[string]any, error)
+}
+
+// routeEbusStandard dispatches /api/v1/ebus-standard/* GET requests.
+// Returns true if the path was handled (even with an error status).
+//
+// Mirrors the ExplorerBus nil-guard pattern: if no sub-server is injected
+// via Options.EbusStandardServer, the route returns 404 NotFound so the
+// capability simply appears absent to clients (matches how the explorer
+// capability is hidden when ExplorerBus is nil).
+func (h *handler) routeEbusStandard(w http.ResponseWriter, r *http.Request, path string) bool {
+	const prefix = "ebus-standard/"
+	if len(path) < len(prefix) || path[:len(prefix)] != prefix {
+		return false
+	}
+	sub := path[len(prefix):]
+	if h.opts.EbusStandardServer == nil {
+		http.NotFound(w, r)
+		return true
+	}
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return true
+	}
+	ts := time.Now().UTC()
+	switch sub {
+	case "services":
+		h.writeEbusStandardEnvelope(w, h.opts.EbusStandardServer.ServicesList(), nil, ts)
+	case "commands":
+		pbp, perr := parseOptionalPBParam(r.URL.Query().Get("pb"))
+		if perr != nil {
+			h.writeEbusStandardEnvelope(w, nil, perr, ts)
+			return true
+		}
+		data, err := h.opts.EbusStandardServer.CommandsList(pbp)
+		h.writeEbusStandardEnvelope(w, data, err, ts)
+	case "command":
+		id := r.URL.Query().Get("id")
+		if id == "" {
+			h.writeEbusStandardEnvelope(w, nil,
+				fmt.Errorf("id: %w: required", estd.ErrInvalidPayload), ts)
+			return true
+		}
+		data, err := h.opts.EbusStandardServer.CommandGet(id)
+		h.writeEbusStandardEnvelope(w, data, err, ts)
+	case "decode":
+		in, perr := parseDecodeQuery(r)
+		if perr != nil {
+			h.writeEbusStandardEnvelope(w, nil, perr, ts)
+			return true
+		}
+		data, err := h.opts.EbusStandardServer.Decode(in)
+		h.writeEbusStandardEnvelope(w, data, err, ts)
+	default:
+		http.NotFound(w, r)
+	}
+	return true
+}
+
+// writeEbusStandardEnvelope wraps data + err in the M4B envelope (same
+// shape as the MCP surfaces emit) and writes it as JSON. HTTP status is
+// always 200 OK — errors surface via envelope.error.code per the
+// MCP-first invariant.
+func (h *handler) writeEbusStandardEnvelope(w http.ResponseWriter, data any, err error, ts time.Time) {
+	writeJSON(w, http.StatusOK, estd.NewEnvelope(data, err, ts))
+}
+
+// parseOptionalPBParam parses the optional "pb" query parameter. Mirrors
+// the MCP surface behavior: absent = nil (unfiltered), malformed = error
+// (INVALID_PAYLOAD) to avoid silently hiding contract violations.
+func parseOptionalPBParam(raw string) (*uint8, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	v, err := strconv.ParseUint(raw, 0, 16)
+	if err != nil {
+		return nil, fmt.Errorf("pb: %w: expected integer in [0,255], got %q: %v",
+			estd.ErrInvalidPayload, raw, err)
+	}
+	if v > 255 {
+		return nil, fmt.Errorf("pb: %w: out of range [0,255]: %d",
+			estd.ErrInvalidPayload, v)
+	}
+	pb := uint8(v)
+	return &pb, nil
+}
+
+// parseDecodeQuery extracts the DecodeInput from query parameters. Unlike
+// the MCP surface (which receives typed JSON), HTTP query strings are all
+// textual — we parse pb/sb as uint16 with [0,255] validation. direction and
+// frame_type are passed through verbatim to the sub-server, which enforces
+// "non-empty" itself (ErrInvalidPayload) so we get consistent error wording
+// for missing selectors.
+func parseDecodeQuery(r *http.Request) (estd.DecodeInput, error) {
+	q := r.URL.Query()
+	var in estd.DecodeInput
+	if pbStr := q.Get("pb"); pbStr == "" {
+		return in, fmt.Errorf("pb: %w: required", estd.ErrInvalidPayload)
+	} else if v, err := strconv.ParseUint(pbStr, 0, 16); err != nil || v > 255 {
+		return in, fmt.Errorf("pb: %w: expected [0,255], got %q",
+			estd.ErrInvalidPayload, pbStr)
+	} else {
+		in.PB = uint8(v)
+	}
+	if sbStr := q.Get("sb"); sbStr == "" {
+		return in, fmt.Errorf("sb: %w: required", estd.ErrInvalidPayload)
+	} else if v, err := strconv.ParseUint(sbStr, 0, 16); err != nil || v > 255 {
+		return in, fmt.Errorf("sb: %w: expected [0,255], got %q",
+			estd.ErrInvalidPayload, sbStr)
+	} else {
+		in.SB = uint8(v)
+	}
+	in.Direction = q.Get("direction")
+	in.FrameType = q.Get("frame_type")
+	in.PayloadHex = q.Get("payload_hex")
+	return in, nil
+}
+
+// assertEbusStandardErrUsed keeps the errors import live even if callers
+// narrow usage later. The ErrInvalidPayload / ErrUnknownCommand errors
+// from the sub-server are surfaced via classifyErr inside envelope.go.
+var _ = errors.Is

--- a/portal/explorer_ebus_standard.go
+++ b/portal/explorer_ebus_standard.go
@@ -12,27 +12,44 @@ import (
 	estd "github.com/Project-Helianthus/helianthus-ebusgateway/mcp/ebus_standard"
 )
 
-// parsePBSBHex parses a PB/SB selector as a 1-byte hex value. The optional
-// "0x"/"0X" prefix is stripped (case-insensitive); the remainder is parsed
-// with explicit base=16 and bitSize=8.
+// parsePBSBByte parses a PB/SB selector as a 1-byte value, using smart
+// detection between decimal (default) and hex (explicit "0x"/"0X" prefix).
 //
-// Rationale: earlier revisions used strconv.ParseUint(raw, 0, 16), which
-// enables Go's base-0 auto-detection — leading-zero inputs are then read as
-// octal (pb=010 → 8 instead of 0x10), and decimal-looking but invalid-octal
-// inputs (pb=08, pb=09) are rejected. PB/SB are documented in the catalog
-// as hex byte selectors (0x00-0xFF), so hex-only parsing is both
-// deterministic and aligned with the catalog's own representation.
+// Rationale: the MCP tool schema (mcp/ebus_standard_wiring.go) documents
+// pb/sb as `{"type": "integer", "minimum": 0, "maximum": 255}` — a decimal
+// integer contract. The portal UI placeholder historically advertised
+// "0..255". A prior revision (round 8, hex-only parsing via explicit
+// base=16) diverged from both surfaces: `pb=10` silently meant 0x10=16
+// instead of decimal 10, quietly targeting the wrong catalog identity.
+//
+// This parser restores MCP-schema alignment while preserving the
+// operator-friendly hex escape hatch:
+//   - "0x" or "0X" prefix → strip prefix, parse as base=16 bitSize=8
+//   - otherwise           → parse as explicit base=10 bitSize=8
+//
+// Explicit base=10 (not base=0) avoids Go's octal auto-detection: `010`
+// parses as decimal 10, not octal 8. Bare hex like "ff" is rejected as
+// non-decimal — operators must type "0xff" for hex, matching the
+// placeholder text "0..255 (decimal) or 0xNN (hex)".
 //
 // Behavior:
-//   - "010"   → 0x10 = 16 (no octal auto-detection)
-//   - "08"    → 0x08 = 8  (valid hex; no octal rejection)
-//   - "0x10"  → 16        (prefix stripped, parsed as hex)
-//   - "ff"    → 255
-//   - "banana"→ error     (invalid hex digits)
-//   - "100"   → error     (overflows 1-byte bitSize=8)
-func parsePBSBHex(raw string) (uint8, error) {
-	trimmed := strings.TrimPrefix(strings.TrimPrefix(raw, "0x"), "0X")
-	v, err := strconv.ParseUint(trimmed, 16, 8)
+//   - "10"    → 10         (decimal)
+//   - "010"   → 10         (decimal; explicit base=10, no octal)
+//   - "08"    → 8          (decimal)
+//   - "0x10"  → 16         (hex after prefix strip)
+//   - "0Xff"  → 255        (hex, case-insensitive prefix)
+//   - "ff"    → error      (bare hex: not decimal, no 0x prefix)
+//   - "256"   → error      (overflows bitSize=8)
+//   - "banana"→ error      (invalid decimal)
+func parsePBSBByte(raw string) (uint8, error) {
+	if strings.HasPrefix(raw, "0x") || strings.HasPrefix(raw, "0X") {
+		v, err := strconv.ParseUint(raw[2:], 16, 8)
+		if err != nil {
+			return 0, err
+		}
+		return uint8(v), nil
+	}
+	v, err := strconv.ParseUint(raw, 10, 8)
 	if err != nil {
 		return 0, err
 	}
@@ -134,12 +151,12 @@ func parseOptionalPBParam(q url.Values) (*uint8, error) {
 	}
 	raw := q.Get("pb")
 	if raw == "" {
-		return nil, fmt.Errorf("pb: %w: filter must be a 1-byte hex value or omitted entirely",
+		return nil, fmt.Errorf("pb: %w: filter must be a 1-byte value (decimal 0..255 or 0xNN) or omitted entirely",
 			estd.ErrInvalidPayload)
 	}
-	pb, err := parsePBSBHex(raw)
+	pb, err := parsePBSBByte(raw)
 	if err != nil {
-		return nil, fmt.Errorf("pb: %w: expected 1-byte hex in [0x00,0xFF], got %q: %v",
+		return nil, fmt.Errorf("pb: %w: expected decimal 0..255 or 0xNN hex, got %q: %v",
 			estd.ErrInvalidPayload, raw, err)
 	}
 	return &pb, nil
@@ -147,8 +164,10 @@ func parseOptionalPBParam(q url.Values) (*uint8, error) {
 
 // parseDecodeQuery extracts the DecodeInput from query parameters. Unlike
 // the MCP surface (which receives typed JSON), HTTP query strings are all
-// textual — we parse pb/sb as uint16 with [0,255] validation. direction and
-// frame_type are passed through verbatim to the sub-server, which enforces
+// textual — we parse pb/sb via parsePBSBByte (decimal default, 0x prefix
+// for hex) matching the MCP tool schema's integer [0,255] contract.
+// direction and frame_type are passed through verbatim to the sub-server,
+// which enforces
 // "non-empty" itself (ErrInvalidPayload) so we get consistent error wording
 // for missing selectors.
 func parseDecodeQuery(r *http.Request) (estd.DecodeInput, error) {
@@ -156,16 +175,16 @@ func parseDecodeQuery(r *http.Request) (estd.DecodeInput, error) {
 	var in estd.DecodeInput
 	if pbStr := q.Get("pb"); pbStr == "" {
 		return in, fmt.Errorf("pb: %w: required", estd.ErrInvalidPayload)
-	} else if v, err := parsePBSBHex(pbStr); err != nil {
-		return in, fmt.Errorf("pb: %w: expected 1-byte hex in [0x00,0xFF], got %q",
+	} else if v, err := parsePBSBByte(pbStr); err != nil {
+		return in, fmt.Errorf("pb: %w: expected decimal 0..255 or 0xNN hex, got %q",
 			estd.ErrInvalidPayload, pbStr)
 	} else {
 		in.PB = v
 	}
 	if sbStr := q.Get("sb"); sbStr == "" {
 		return in, fmt.Errorf("sb: %w: required", estd.ErrInvalidPayload)
-	} else if v, err := parsePBSBHex(sbStr); err != nil {
-		return in, fmt.Errorf("sb: %w: expected 1-byte hex in [0x00,0xFF], got %q",
+	} else if v, err := parsePBSBByte(sbStr); err != nil {
+		return in, fmt.Errorf("sb: %w: expected decimal 0..255 or 0xNN hex, got %q",
 			estd.ErrInvalidPayload, sbStr)
 	} else {
 		in.SB = v

--- a/portal/explorer_ebus_standard_test.go
+++ b/portal/explorer_ebus_standard_test.go
@@ -1,0 +1,336 @@
+package portal
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	estd "github.com/Project-Helianthus/helianthus-ebusgateway/mcp/ebus_standard"
+)
+
+// fakeEbusStandardServer is a test double that implements
+// PortalEbusStandardServer without requiring a real catalog.
+type fakeEbusStandardServer struct {
+	servicesListData  map[string]any
+	commandsListFn    func(pb *uint8) (map[string]any, error)
+	commandGetFn      func(id string) (map[string]any, error)
+	decodeFn          func(in estd.DecodeInput) (map[string]any, error)
+	lastCommandsPB    *uint8
+	lastCommandGetID  string
+	lastDecodeInput   estd.DecodeInput
+	commandsListCalls int
+}
+
+func (f *fakeEbusStandardServer) ServicesList() map[string]any {
+	if f.servicesListData != nil {
+		return f.servicesListData
+	}
+	return map[string]any{
+		"namespace":       "ebus_standard",
+		"catalog_version": "v-test",
+		"plan_sha256":     "deadbeef",
+		"services": []map[string]any{
+			{"pb": 5, "name": "identification", "description": "", "command_count": 2},
+		},
+	}
+}
+
+func (f *fakeEbusStandardServer) CommandsList(pb *uint8) (map[string]any, error) {
+	f.commandsListCalls++
+	if pb != nil {
+		v := *pb
+		f.lastCommandsPB = &v
+	} else {
+		f.lastCommandsPB = nil
+	}
+	if f.commandsListFn != nil {
+		return f.commandsListFn(pb)
+	}
+	return map[string]any{
+		"namespace":       "ebus_standard",
+		"catalog_version": "v-test",
+		"commands": []map[string]any{
+			{"id": "cmd.a", "name": "a", "pb": 5, "sb": 0, "safety_class": "read_only_safe"},
+		},
+	}, nil
+}
+
+func (f *fakeEbusStandardServer) CommandGet(id string) (map[string]any, error) {
+	f.lastCommandGetID = id
+	if f.commandGetFn != nil {
+		return f.commandGetFn(id)
+	}
+	if id == "" {
+		return nil, fmt.Errorf("id: %w", estd.ErrInvalidPayload)
+	}
+	if id == "unknown" {
+		return nil, fmt.Errorf("id=%q: %w", id, estd.ErrUnknownCommand)
+	}
+	return map[string]any{
+		"namespace":       "ebus_standard",
+		"catalog_version": "v-test",
+		"command": map[string]any{
+			"id":           id,
+			"name":         "Test command",
+			"safety_class": "frontier_experimental",
+		},
+	}, nil
+}
+
+func (f *fakeEbusStandardServer) Decode(in estd.DecodeInput) (map[string]any, error) {
+	f.lastDecodeInput = in
+	if f.decodeFn != nil {
+		return f.decodeFn(in)
+	}
+	return map[string]any{
+		"namespace":       "ebus_standard",
+		"catalog_version": "v-test",
+		"command_id":      "cmd.decoded",
+		"raw_bytes":       []int{0xAA, 0xBB},
+		"fields":          []map[string]any{},
+		"validity":        "catalog_identified",
+	}, nil
+}
+
+func newEbusStandardHandler(sub PortalEbusStandardServer) http.Handler {
+	return NewHandler(Options{
+		GatewayVersion:     "test",
+		BuildID:            "test",
+		EbusStandardServer: sub,
+	})
+}
+
+func decodeEnvelope(t *testing.T, rec *httptest.ResponseRecorder) (meta, data map[string]any, envErr map[string]any) {
+	t.Helper()
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal body=%q: %v", rec.Body.String(), err)
+	}
+	meta, _ = payload["meta"].(map[string]any)
+	data, _ = payload["data"].(map[string]any)
+	envErr, _ = payload["error"].(map[string]any)
+	return meta, data, envErr
+}
+
+func assertEnvelopeShape(t *testing.T, meta map[string]any) {
+	t.Helper()
+	if meta == nil {
+		t.Fatalf("meta missing")
+	}
+	contract, _ := meta["contract"].(map[string]any)
+	if contract["name"] != "helianthus-ebus-mcp" {
+		t.Fatalf("meta.contract.name = %v; want helianthus-ebus-mcp", contract["name"])
+	}
+	cons, _ := meta["consistency"].(map[string]any)
+	if cons["mode"] != "LIVE" {
+		t.Fatalf("meta.consistency.mode = %v; want LIVE", cons["mode"])
+	}
+	if hash, ok := meta["data_hash"].(string); !ok || len(hash) != 64 {
+		t.Fatalf("meta.data_hash missing or not 64-hex: %v", meta["data_hash"])
+	}
+}
+
+func TestEbusStandardServicesList_Envelope(t *testing.T) {
+	fake := &fakeEbusStandardServer{}
+	h := newEbusStandardHandler(fake)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ebus-standard/services", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	meta, data, envErr := decodeEnvelope(t, rec)
+	assertEnvelopeShape(t, meta)
+	if envErr != nil {
+		t.Fatalf("error = %v; want nil", envErr)
+	}
+	if data["namespace"] != "ebus_standard" {
+		t.Fatalf("data.namespace = %v", data["namespace"])
+	}
+}
+
+func TestEbusStandardCommandsList_PBFilter(t *testing.T) {
+	fake := &fakeEbusStandardServer{}
+	h := newEbusStandardHandler(fake)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ebus-standard/commands?pb=5", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	meta, _, envErr := decodeEnvelope(t, rec)
+	assertEnvelopeShape(t, meta)
+	if envErr != nil {
+		t.Fatalf("error = %v; want nil", envErr)
+	}
+	if fake.lastCommandsPB == nil || *fake.lastCommandsPB != 5 {
+		t.Fatalf("pb filter not forwarded: %v", fake.lastCommandsPB)
+	}
+}
+
+func TestEbusStandardCommandsList_NoFilter(t *testing.T) {
+	fake := &fakeEbusStandardServer{}
+	h := newEbusStandardHandler(fake)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ebus-standard/commands", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", rec.Code, rec.Body.String())
+	}
+	if fake.lastCommandsPB != nil {
+		t.Fatalf("pb should be nil when absent, got %v", *fake.lastCommandsPB)
+	}
+}
+
+func TestEbusStandardCommandsList_InvalidPB(t *testing.T) {
+	fake := &fakeEbusStandardServer{}
+	h := newEbusStandardHandler(fake)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ebus-standard/commands?pb=banana", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	// Invalid pb must NOT silently pass through as "unfiltered".
+	_, _, envErr := decodeEnvelope(t, rec)
+	if envErr == nil {
+		t.Fatalf("expected envelope.error for malformed pb, got nil")
+	}
+	if envErr["code"] != "INVALID_PAYLOAD" {
+		t.Fatalf("error.code = %v; want INVALID_PAYLOAD", envErr["code"])
+	}
+}
+
+func TestEbusStandardCommandGet_OpenEnumPassThrough(t *testing.T) {
+	fake := &fakeEbusStandardServer{
+		commandGetFn: func(id string) (map[string]any, error) {
+			return map[string]any{
+				"namespace":       "ebus_standard",
+				"catalog_version": "v-test",
+				"command": map[string]any{
+					"id":           id,
+					"name":         "Future",
+					"safety_class": "brand_new_class_xyz", // unknown enum — must pass through
+				},
+			}, nil
+		},
+	}
+	h := newEbusStandardHandler(fake)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ebus-standard/command?id=cmd.future", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", rec.Code, rec.Body.String())
+	}
+	_, data, _ := decodeEnvelope(t, rec)
+	cmd, _ := data["command"].(map[string]any)
+	if cmd["safety_class"] != "brand_new_class_xyz" {
+		t.Fatalf("unknown safety_class was not passed through: %v", cmd["safety_class"])
+	}
+	if fake.lastCommandGetID != "cmd.future" {
+		t.Fatalf("id not forwarded: %v", fake.lastCommandGetID)
+	}
+}
+
+func TestEbusStandardCommandGet_UnknownCommand(t *testing.T) {
+	fake := &fakeEbusStandardServer{}
+	h := newEbusStandardHandler(fake)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ebus-standard/command?id=unknown", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	_, _, envErr := decodeEnvelope(t, rec)
+	if envErr == nil || envErr["code"] != "UNKNOWN_COMMAND" {
+		t.Fatalf("expected UNKNOWN_COMMAND envelope error, got %v", envErr)
+	}
+}
+
+func TestEbusStandardCommandGet_MissingID(t *testing.T) {
+	fake := &fakeEbusStandardServer{}
+	h := newEbusStandardHandler(fake)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ebus-standard/command", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	_, _, envErr := decodeEnvelope(t, rec)
+	if envErr == nil || envErr["code"] != "INVALID_PAYLOAD" {
+		t.Fatalf("expected INVALID_PAYLOAD for missing id, got %v", envErr)
+	}
+}
+
+func TestEbusStandardDecode_Happy(t *testing.T) {
+	fake := &fakeEbusStandardServer{}
+	h := newEbusStandardHandler(fake)
+
+	url := "/api/v1/ebus-standard/decode?pb=5&sb=4&direction=master_to_slave&frame_type=MM&payload_hex=aabb"
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", rec.Code, rec.Body.String())
+	}
+	meta, data, envErr := decodeEnvelope(t, rec)
+	assertEnvelopeShape(t, meta)
+	if envErr != nil {
+		t.Fatalf("error = %v; want nil", envErr)
+	}
+	if data["command_id"] != "cmd.decoded" {
+		t.Fatalf("data.command_id = %v", data["command_id"])
+	}
+	in := fake.lastDecodeInput
+	if in.PB != 5 || in.SB != 4 || in.Direction != "master_to_slave" || in.FrameType != "MM" || in.PayloadHex != "aabb" {
+		t.Fatalf("decode input not forwarded: %+v", in)
+	}
+}
+
+func TestEbusStandardDecode_MissingDirection(t *testing.T) {
+	fake := &fakeEbusStandardServer{}
+	h := newEbusStandardHandler(fake)
+
+	url := "/api/v1/ebus-standard/decode?pb=5&sb=4&frame_type=MM&payload_hex=aa"
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	_, _, envErr := decodeEnvelope(t, rec)
+	if envErr == nil || envErr["code"] != "INVALID_PAYLOAD" {
+		t.Fatalf("expected INVALID_PAYLOAD for missing direction, got %v", envErr)
+	}
+}
+
+func TestEbusStandardNilSubServer_404(t *testing.T) {
+	h := NewHandler(Options{GatewayVersion: "test", BuildID: "test"})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ebus-standard/services", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d; want 404 when sub-server absent; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestEbusStandardMethodNotAllowed(t *testing.T) {
+	fake := &fakeEbusStandardServer{}
+	h := newEbusStandardHandler(fake)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/ebus-standard/services", strings.NewReader(""))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d; want 405", rec.Code)
+	}
+}

--- a/portal/explorer_ebus_standard_test.go
+++ b/portal/explorer_ebus_standard_test.go
@@ -319,6 +319,60 @@ func TestEbusStandardDecode_MissingDirection(t *testing.T) {
 	}
 }
 
+func TestEbusStandardDecode_MissingPayloadHex_ReturnsInvalidPayload(t *testing.T) {
+	fake := &fakeEbusStandardServer{}
+	h := newEbusStandardHandler(fake)
+
+	// payload_hex key entirely omitted from query string.
+	url := "/api/v1/ebus-standard/decode?pb=5&sb=4&direction=master_to_slave&frame_type=MM"
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	_, _, envErr := decodeEnvelope(t, rec)
+	if envErr == nil || envErr["code"] != "INVALID_PAYLOAD" {
+		t.Fatalf("expected INVALID_PAYLOAD for missing payload_hex, got %v", envErr)
+	}
+	msg, _ := envErr["message"].(string)
+	if !strings.Contains(msg, "payload_hex") {
+		t.Fatalf("error.message should mention payload_hex, got %q", msg)
+	}
+	// Sub-server must NOT be invoked when the handler rejected up-front:
+	// the fake's Decode would otherwise record lastDecodeInput.
+	var zero estd.DecodeInput
+	if fake.lastDecodeInput != zero {
+		t.Fatalf("sub-server Decode must not be invoked for missing payload_hex, got %+v", fake.lastDecodeInput)
+	}
+}
+
+func TestEbusStandardDecode_ExplicitEmptyPayloadHex_PassesThroughToBackend(t *testing.T) {
+	// Backend Decode contract accepts empty payloads (hex.DecodeString("")
+	// returns nil). Explicit empty payload_hex= must reach the backend so
+	// the catalog-lookup semantics apply unchanged.
+	fake := &fakeEbusStandardServer{}
+	h := newEbusStandardHandler(fake)
+
+	url := "/api/v1/ebus-standard/decode?pb=5&sb=4&direction=master_to_slave&frame_type=MM&payload_hex="
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", rec.Code, rec.Body.String())
+	}
+	_, _, envErr := decodeEnvelope(t, rec)
+	if envErr != nil {
+		t.Fatalf("explicit empty payload_hex should pass through, got envelope error: %v", envErr)
+	}
+	in := fake.lastDecodeInput
+	if in.PayloadHex != "" {
+		t.Fatalf("explicit-empty payload_hex must be forwarded as \"\", got %q", in.PayloadHex)
+	}
+	if in.PB != 5 || in.SB != 4 || in.Direction != "master_to_slave" || in.FrameType != "MM" {
+		t.Fatalf("selectors not forwarded: %+v", in)
+	}
+}
+
 func TestEbusStandardNilSubServer_404(t *testing.T) {
 	h := NewHandler(Options{GatewayVersion: "test", BuildID: "test"})
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/ebus-standard/services", nil)

--- a/portal/explorer_ebus_standard_test.go
+++ b/portal/explorer_ebus_standard_test.go
@@ -425,13 +425,12 @@ func TestEbusStandardMethodNotAllowed(t *testing.T) {
 	}
 }
 
-// TestEbusStandardCommandsList_PBLeadingZero_DeterministicHex guards against
-// Go's base-0 octal auto-detection for the pb filter. Earlier revisions used
-// strconv.ParseUint(raw, 0, 16), which would parse "010" as octal 8 rather
-// than hex 0x10=16. PB/SB are documented as hex byte selectors in the
-// catalog, so the parser must be deterministic hex regardless of leading
-// zeros. Codex P2 on PR #507 (comment #3109631170).
-func TestEbusStandardCommandsList_PBLeadingZero_DeterministicHex(t *testing.T) {
+// TestEbusStandardCommandsList_PBLeadingZero_DecimalNoOctal guards against
+// Go's base-0 octal auto-detection for the pb filter. With explicit base=10,
+// "010" parses as decimal 10 (not octal 8, not hex 0x10). The MCP tool
+// schema documents pb as integer [0,255] decimal; round 9 restored the
+// decimal contract. Codex P2 on PR #507 (comment #3109782014).
+func TestEbusStandardCommandsList_PBLeadingZero_DecimalNoOctal(t *testing.T) {
 	fake := &fakeEbusStandardServer{}
 	h := newEbusStandardHandler(fake)
 
@@ -441,22 +440,78 @@ func TestEbusStandardCommandsList_PBLeadingZero_DeterministicHex(t *testing.T) {
 
 	_, _, envErr := decodeEnvelope(t, rec)
 	if envErr != nil {
-		t.Fatalf("leading-zero pb=010 must parse as hex, got envelope error: %v", envErr)
+		t.Fatalf("pb=010 must parse as decimal 10, got envelope error: %v", envErr)
 	}
 	if fake.lastCommandsPB == nil {
 		t.Fatalf("pb filter not forwarded (nil)")
 	}
-	if *fake.lastCommandsPB != 0x10 {
-		t.Fatalf("pb=010 must parse as 0x10=16 (hex), got %d (base-0 octal regression)",
+	if *fake.lastCommandsPB != 10 {
+		t.Fatalf("pb=010 must parse as decimal 10, got %d", *fake.lastCommandsPB)
+	}
+}
+
+// TestEbusStandardCommandsList_PB_DecimalDefault asserts the MCP-schema-
+// aligned decimal contract: pb=10 → 10, NOT 0x10=16 (round 8 regression).
+func TestEbusStandardCommandsList_PB_DecimalDefault(t *testing.T) {
+	fake := &fakeEbusStandardServer{}
+	h := newEbusStandardHandler(fake)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ebus-standard/commands?pb=10", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	_, _, envErr := decodeEnvelope(t, rec)
+	if envErr != nil {
+		t.Fatalf("pb=10 must parse as decimal 10, got envelope error: %v", envErr)
+	}
+	if fake.lastCommandsPB == nil || *fake.lastCommandsPB != 10 {
+		t.Fatalf("pb=10 must parse to decimal 10, got %v", fake.lastCommandsPB)
+	}
+}
+
+// TestEbusStandardCommandsList_PB_HexWith0xPrefix asserts the hex escape
+// hatch: pb=0x10 → 16.
+func TestEbusStandardCommandsList_PB_HexWith0xPrefix(t *testing.T) {
+	fake := &fakeEbusStandardServer{}
+	h := newEbusStandardHandler(fake)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ebus-standard/commands?pb=0x10", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	_, _, envErr := decodeEnvelope(t, rec)
+	if envErr != nil {
+		t.Fatalf("pb=0x10 must parse as hex 16, got envelope error: %v", envErr)
+	}
+	if fake.lastCommandsPB == nil || *fake.lastCommandsPB != 0x10 {
+		t.Fatalf("pb=0x10 must parse to 16, got %v", fake.lastCommandsPB)
+	}
+}
+
+// TestEbusStandardCommandsList_PB_BareHexRejected asserts that bare hex
+// inputs (no 0x prefix) are rejected — operators must type 0xff for hex.
+// This matches the MCP schema's decimal-integer contract.
+func TestEbusStandardCommandsList_PB_BareHexRejected(t *testing.T) {
+	fake := &fakeEbusStandardServer{}
+	h := newEbusStandardHandler(fake)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ebus-standard/commands?pb=ff", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	_, _, envErr := decodeEnvelope(t, rec)
+	if envErr == nil || envErr["code"] != "INVALID_PAYLOAD" {
+		t.Fatalf("expected INVALID_PAYLOAD for bare-hex pb=ff, got %v", envErr)
+	}
+	if fake.lastCommandsPB != nil {
+		t.Fatalf("CommandsList must not be invoked on bare-hex input, got pb=%v",
 			*fake.lastCommandsPB)
 	}
 }
 
-// TestEbusStandardCommandsList_PB08_AcceptedAsHex guards against
-// Go's base-0 octal-rejection for "08"/"09": with base=0, an input like
-// pb=08 was rejected as invalid octal despite being a legitimate hex
-// byte. Hex-only parsing must accept pb=08 and pb=09.
-func TestEbusStandardCommandsList_PB08_AcceptedAsHex(t *testing.T) {
+// TestEbusStandardCommandsList_PB08_AcceptedAsDecimal asserts pb=08 parses
+// as decimal 8 (no Go octal rejection under explicit base=10).
+func TestEbusStandardCommandsList_PB08_AcceptedAsDecimal(t *testing.T) {
 	fake := &fakeEbusStandardServer{}
 	h := newEbusStandardHandler(fake)
 
@@ -466,10 +521,10 @@ func TestEbusStandardCommandsList_PB08_AcceptedAsHex(t *testing.T) {
 
 	_, _, envErr := decodeEnvelope(t, rec)
 	if envErr != nil {
-		t.Fatalf("pb=08 must parse as hex 0x08, got envelope error: %v", envErr)
+		t.Fatalf("pb=08 must parse as decimal 8, got envelope error: %v", envErr)
 	}
-	if fake.lastCommandsPB == nil || *fake.lastCommandsPB != 0x08 {
-		t.Fatalf("pb=08 must parse to 0x08, got %v", fake.lastCommandsPB)
+	if fake.lastCommandsPB == nil || *fake.lastCommandsPB != 8 {
+		t.Fatalf("pb=08 must parse to decimal 8, got %v", fake.lastCommandsPB)
 	}
 }
 
@@ -498,19 +553,20 @@ func TestEbusStandardCommandsList_PB0xPrefix(t *testing.T) {
 }
 
 // TestEbusStandardCommandsList_PBOverflow_Rejected ensures values exceeding
-// 1 byte are rejected (bitSize=8 semantics). "100" parses as 0x100=256
-// which overflows uint8 and MUST yield INVALID_PAYLOAD.
+// 1 byte are rejected (bitSize=8 semantics). Under the decimal contract,
+// pb=256 overflows uint8 and MUST yield INVALID_PAYLOAD. (pb=100 is now
+// valid decimal 100, so the overflow boundary moves to 256.)
 func TestEbusStandardCommandsList_PBOverflow_Rejected(t *testing.T) {
 	fake := &fakeEbusStandardServer{}
 	h := newEbusStandardHandler(fake)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/ebus-standard/commands?pb=100", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ebus-standard/commands?pb=256", nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 
 	_, _, envErr := decodeEnvelope(t, rec)
 	if envErr == nil || envErr["code"] != "INVALID_PAYLOAD" {
-		t.Fatalf("expected INVALID_PAYLOAD for pb=100 (0x100 overflows 1 byte), got %v", envErr)
+		t.Fatalf("expected INVALID_PAYLOAD for pb=256 (decimal overflows 1 byte), got %v", envErr)
 	}
 	if fake.lastCommandsPB != nil {
 		t.Fatalf("CommandsList must not be invoked on overflow, got pb=%v",
@@ -518,9 +574,25 @@ func TestEbusStandardCommandsList_PBOverflow_Rejected(t *testing.T) {
 	}
 }
 
-// TestEbusStandardDecode_PBSBLeadingZero_DeterministicHex guards the decode
-// route's pb/sb parsing against the same base-0 octal regression.
-func TestEbusStandardDecode_PBSBLeadingZero_DeterministicHex(t *testing.T) {
+// TestEbusStandardCommandsList_PBHexOverflow_Rejected: explicit 0x-prefix
+// hex that exceeds 1 byte (0x100=256) must also yield INVALID_PAYLOAD.
+func TestEbusStandardCommandsList_PBHexOverflow_Rejected(t *testing.T) {
+	fake := &fakeEbusStandardServer{}
+	h := newEbusStandardHandler(fake)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ebus-standard/commands?pb=0x100", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	_, _, envErr := decodeEnvelope(t, rec)
+	if envErr == nil || envErr["code"] != "INVALID_PAYLOAD" {
+		t.Fatalf("expected INVALID_PAYLOAD for pb=0x100 overflow, got %v", envErr)
+	}
+}
+
+// TestEbusStandardDecode_PBSBLeadingZero_DecimalNoOctal guards the decode
+// route's pb/sb parsing against Go base-0 octal auto-detection.
+func TestEbusStandardDecode_PBSBLeadingZero_DecimalNoOctal(t *testing.T) {
 	fake := &fakeEbusStandardServer{}
 	h := newEbusStandardHandler(fake)
 
@@ -531,18 +603,42 @@ func TestEbusStandardDecode_PBSBLeadingZero_DeterministicHex(t *testing.T) {
 
 	_, _, envErr := decodeEnvelope(t, rec)
 	if envErr != nil {
-		t.Fatalf("pb=010&sb=08 must parse as hex, got envelope error: %v", envErr)
+		t.Fatalf("pb=010&sb=08 must parse as decimal, got envelope error: %v", envErr)
 	}
 	in := fake.lastDecodeInput
-	if in.PB != 0x10 {
-		t.Fatalf("pb=010 must parse as 0x10=16, got %d", in.PB)
+	if in.PB != 10 {
+		t.Fatalf("pb=010 must parse as decimal 10, got %d", in.PB)
 	}
-	if in.SB != 0x08 {
-		t.Fatalf("sb=08 must parse as 0x08=8, got %d", in.SB)
+	if in.SB != 8 {
+		t.Fatalf("sb=08 must parse as decimal 8, got %d", in.SB)
 	}
 }
 
-// TestEbusStandardDecode_SBBanana_Rejected ensures non-hex SB values are
+// TestEbusStandardDecode_PBSBMixedHexDecimal exercises the smart parser:
+// pb=0x10 (hex) + sb=4 (decimal) both accepted and forwarded correctly.
+func TestEbusStandardDecode_PBSBMixedHexDecimal(t *testing.T) {
+	fake := &fakeEbusStandardServer{}
+	h := newEbusStandardHandler(fake)
+
+	url := "/api/v1/ebus-standard/decode?pb=0x10&sb=4&direction=master_to_slave&frame_type=MM&payload_hex=aa"
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	_, _, envErr := decodeEnvelope(t, rec)
+	if envErr != nil {
+		t.Fatalf("pb=0x10&sb=4 must parse, got envelope error: %v", envErr)
+	}
+	in := fake.lastDecodeInput
+	if in.PB != 0x10 {
+		t.Fatalf("pb=0x10 must parse as hex 16, got %d", in.PB)
+	}
+	if in.SB != 4 {
+		t.Fatalf("sb=4 must parse as decimal 4, got %d", in.SB)
+	}
+}
+
+// TestEbusStandardDecode_SBBanana_Rejected ensures invalid SB values are
 // rejected with INVALID_PAYLOAD — regression guard that the helper's parse
 // error bubbles up through the decode route's selector validation.
 func TestEbusStandardDecode_SBBanana_Rejected(t *testing.T) {

--- a/portal/explorer_ebus_standard_test.go
+++ b/portal/explorer_ebus_standard_test.go
@@ -396,3 +396,46 @@ func TestEbusStandardMethodNotAllowed(t *testing.T) {
 		t.Fatalf("status = %d; want 405", rec.Code)
 	}
 }
+
+// TestCapabilities_EbusStandardFlagReflectsOptions verifies that the
+// /api/v1/bootstrap `capabilities.ebus_standard` flag is true iff
+// Options.EbusStandardServer is non-nil. The frontend gates the L7
+// nav button and section auto-activation on this flag — see the
+// matching applyCapabilityState / activateSection wiring in app.js
+// and the l7-catalog.test.mjs regression tests. Codex P2 on PR #507.
+func TestCapabilities_EbusStandardFlagReflectsOptions(t *testing.T) {
+	cases := []struct {
+		name   string
+		server PortalEbusStandardServer
+		want   bool
+	}{
+		{name: "nil sub-server → flag false", server: nil, want: false},
+		{name: "non-nil sub-server → flag true", server: &fakeEbusStandardServer{}, want: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := NewHandler(Options{EbusStandardServer: tc.server})
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/bootstrap", nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d; want 200", rec.Code)
+			}
+			var payload map[string]any
+			if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			caps, ok := payload["capabilities"].(map[string]any)
+			if !ok {
+				t.Fatalf("bootstrap missing capabilities map; got: %v", payload)
+			}
+			got, present := caps["ebus_standard"]
+			if !present {
+				t.Fatalf("capabilities.ebus_standard missing; got keys: %v", caps)
+			}
+			if got != tc.want {
+				t.Fatalf("capabilities.ebus_standard=%v; want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/portal/explorer_ebus_standard_test.go
+++ b/portal/explorer_ebus_standard_test.go
@@ -217,6 +217,34 @@ func TestEbusStandardCommandsList_InvalidPB(t *testing.T) {
 	}
 }
 
+// TestEbusStandardCommandsList_EmptyPB asserts that an explicit empty pb
+// (?pb=) is rejected with INVALID_PAYLOAD rather than silently mapped to
+// the unfiltered path. Mirrors the payload_hex fix (e363e1b7) — presence
+// check distinguishes missing from explicitly-empty. Without this guard a
+// malformed client request (e.g. JS building `?pb=${val}` with val="") would
+// silently return the full unfiltered catalog, hiding the bug.
+func TestEbusStandardCommandsList_EmptyPB(t *testing.T) {
+	fake := &fakeEbusStandardServer{}
+	h := newEbusStandardHandler(fake)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ebus-standard/commands?pb=", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	_, _, envErr := decodeEnvelope(t, rec)
+	if envErr == nil {
+		t.Fatalf("expected envelope.error for empty pb=, got nil")
+	}
+	if envErr["code"] != "INVALID_PAYLOAD" {
+		t.Fatalf("error.code = %v; want INVALID_PAYLOAD", envErr["code"])
+	}
+	// Sub-server CommandsList MUST NOT be invoked on malformed input.
+	if fake.lastCommandsPB != nil {
+		t.Fatalf("CommandsList should not be invoked on empty pb=, got pb=%v",
+			*fake.lastCommandsPB)
+	}
+}
+
 func TestEbusStandardCommandGet_OpenEnumPassThrough(t *testing.T) {
 	fake := &fakeEbusStandardServer{
 		commandGetFn: func(id string) (map[string]any, error) {

--- a/portal/explorer_ebus_standard_test.go
+++ b/portal/explorer_ebus_standard_test.go
@@ -425,6 +425,141 @@ func TestEbusStandardMethodNotAllowed(t *testing.T) {
 	}
 }
 
+// TestEbusStandardCommandsList_PBLeadingZero_DeterministicHex guards against
+// Go's base-0 octal auto-detection for the pb filter. Earlier revisions used
+// strconv.ParseUint(raw, 0, 16), which would parse "010" as octal 8 rather
+// than hex 0x10=16. PB/SB are documented as hex byte selectors in the
+// catalog, so the parser must be deterministic hex regardless of leading
+// zeros. Codex P2 on PR #507 (comment #3109631170).
+func TestEbusStandardCommandsList_PBLeadingZero_DeterministicHex(t *testing.T) {
+	fake := &fakeEbusStandardServer{}
+	h := newEbusStandardHandler(fake)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ebus-standard/commands?pb=010", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	_, _, envErr := decodeEnvelope(t, rec)
+	if envErr != nil {
+		t.Fatalf("leading-zero pb=010 must parse as hex, got envelope error: %v", envErr)
+	}
+	if fake.lastCommandsPB == nil {
+		t.Fatalf("pb filter not forwarded (nil)")
+	}
+	if *fake.lastCommandsPB != 0x10 {
+		t.Fatalf("pb=010 must parse as 0x10=16 (hex), got %d (base-0 octal regression)",
+			*fake.lastCommandsPB)
+	}
+}
+
+// TestEbusStandardCommandsList_PB08_AcceptedAsHex guards against
+// Go's base-0 octal-rejection for "08"/"09": with base=0, an input like
+// pb=08 was rejected as invalid octal despite being a legitimate hex
+// byte. Hex-only parsing must accept pb=08 and pb=09.
+func TestEbusStandardCommandsList_PB08_AcceptedAsHex(t *testing.T) {
+	fake := &fakeEbusStandardServer{}
+	h := newEbusStandardHandler(fake)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ebus-standard/commands?pb=08", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	_, _, envErr := decodeEnvelope(t, rec)
+	if envErr != nil {
+		t.Fatalf("pb=08 must parse as hex 0x08, got envelope error: %v", envErr)
+	}
+	if fake.lastCommandsPB == nil || *fake.lastCommandsPB != 0x08 {
+		t.Fatalf("pb=08 must parse to 0x08, got %v", fake.lastCommandsPB)
+	}
+}
+
+// TestEbusStandardCommandsList_PB0xPrefix verifies the "0x" prefix is
+// stripped (case-insensitive) before hex parsing.
+func TestEbusStandardCommandsList_PB0xPrefix(t *testing.T) {
+	for _, raw := range []string{"0x10", "0X10", "0xff", "0XFF"} {
+		t.Run(raw, func(t *testing.T) {
+			fake := &fakeEbusStandardServer{}
+			h := newEbusStandardHandler(fake)
+
+			req := httptest.NewRequest(http.MethodGet,
+				"/api/v1/ebus-standard/commands?pb="+raw, nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			_, _, envErr := decodeEnvelope(t, rec)
+			if envErr != nil {
+				t.Fatalf("pb=%s must parse, got envelope error: %v", raw, envErr)
+			}
+			if fake.lastCommandsPB == nil {
+				t.Fatalf("pb=%s not forwarded", raw)
+			}
+		})
+	}
+}
+
+// TestEbusStandardCommandsList_PBOverflow_Rejected ensures values exceeding
+// 1 byte are rejected (bitSize=8 semantics). "100" parses as 0x100=256
+// which overflows uint8 and MUST yield INVALID_PAYLOAD.
+func TestEbusStandardCommandsList_PBOverflow_Rejected(t *testing.T) {
+	fake := &fakeEbusStandardServer{}
+	h := newEbusStandardHandler(fake)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ebus-standard/commands?pb=100", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	_, _, envErr := decodeEnvelope(t, rec)
+	if envErr == nil || envErr["code"] != "INVALID_PAYLOAD" {
+		t.Fatalf("expected INVALID_PAYLOAD for pb=100 (0x100 overflows 1 byte), got %v", envErr)
+	}
+	if fake.lastCommandsPB != nil {
+		t.Fatalf("CommandsList must not be invoked on overflow, got pb=%v",
+			*fake.lastCommandsPB)
+	}
+}
+
+// TestEbusStandardDecode_PBSBLeadingZero_DeterministicHex guards the decode
+// route's pb/sb parsing against the same base-0 octal regression.
+func TestEbusStandardDecode_PBSBLeadingZero_DeterministicHex(t *testing.T) {
+	fake := &fakeEbusStandardServer{}
+	h := newEbusStandardHandler(fake)
+
+	url := "/api/v1/ebus-standard/decode?pb=010&sb=08&direction=master_to_slave&frame_type=MM&payload_hex=aa"
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	_, _, envErr := decodeEnvelope(t, rec)
+	if envErr != nil {
+		t.Fatalf("pb=010&sb=08 must parse as hex, got envelope error: %v", envErr)
+	}
+	in := fake.lastDecodeInput
+	if in.PB != 0x10 {
+		t.Fatalf("pb=010 must parse as 0x10=16, got %d", in.PB)
+	}
+	if in.SB != 0x08 {
+		t.Fatalf("sb=08 must parse as 0x08=8, got %d", in.SB)
+	}
+}
+
+// TestEbusStandardDecode_SBBanana_Rejected ensures non-hex SB values are
+// rejected with INVALID_PAYLOAD — regression guard that the helper's parse
+// error bubbles up through the decode route's selector validation.
+func TestEbusStandardDecode_SBBanana_Rejected(t *testing.T) {
+	fake := &fakeEbusStandardServer{}
+	h := newEbusStandardHandler(fake)
+
+	url := "/api/v1/ebus-standard/decode?pb=5&sb=banana&direction=master_to_slave&frame_type=MM&payload_hex=aa"
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	_, _, envErr := decodeEnvelope(t, rec)
+	if envErr == nil || envErr["code"] != "INVALID_PAYLOAD" {
+		t.Fatalf("expected INVALID_PAYLOAD for sb=banana, got %v", envErr)
+	}
+}
+
 // TestCapabilities_EbusStandardFlagReflectsOptions verifies that the
 // /api/v1/bootstrap `capabilities.ebus_standard` flag is true iff
 // Options.EbusStandardServer is non-nil. The frontend gates the L7

--- a/portal/explorer_ebus_standard_test.go
+++ b/portal/explorer_ebus_standard_test.go
@@ -85,6 +85,14 @@ func (f *fakeEbusStandardServer) Decode(in estd.DecodeInput) (map[string]any, er
 	if f.decodeFn != nil {
 		return f.decodeFn(in)
 	}
+	// Mirror the real sub-server's required-selector validation so the
+	// route test for "missing direction" exercises the full stack.
+	if in.Direction == "" {
+		return nil, fmt.Errorf("direction: %w: required (empty is not a wildcard)", estd.ErrInvalidPayload)
+	}
+	if in.FrameType == "" {
+		return nil, fmt.Errorf("frame_type: %w: required (empty is not a wildcard)", estd.ErrInvalidPayload)
+	}
 	return map[string]any{
 		"namespace":       "ebus_standard",
 		"catalog_version": "v-test",

--- a/portal/handler.go
+++ b/portal/handler.go
@@ -907,6 +907,13 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 				"issue_builder":     true,
 				"migration":         false,
 				"explorer":          h.explorer != nil,
+				// ebus_standard gates the L7 Standard Catalog consumer UI
+				// (M5_PORTAL). When the sub-server is nil, routeEbusStandard
+				// responds 404 for /api/v1/ebus-standard/* — the frontend
+				// must then disable the nav button and skip auto-activation
+				// of section-l7-catalog, otherwise the bootstrap fetch
+				// surfaces a broken section. Codex P2 on PR #507.
+				"ebus_standard": h.opts.EbusStandardServer != nil,
 			},
 			"endpoints": map[string]string{
 				"graphql":               h.opts.GraphQLPath,

--- a/portal/handler.go
+++ b/portal/handler.go
@@ -1067,6 +1067,16 @@ func classifyRoute(path string) string {
 		return "api.issues.export"
 	case strings.HasPrefix(path, "/api/v1/explorer/"):
 		return "api.explorer"
+	case strings.HasPrefix(path, "/api/v1/ebus-standard/services"):
+		return "api.ebus_standard.services"
+	case strings.HasPrefix(path, "/api/v1/ebus-standard/commands"):
+		return "api.ebus_standard.commands"
+	case strings.HasPrefix(path, "/api/v1/ebus-standard/command"):
+		return "api.ebus_standard.command"
+	case strings.HasPrefix(path, "/api/v1/ebus-standard/decode"):
+		return "api.ebus_standard.decode"
+	case strings.HasPrefix(path, "/api/v1/ebus-standard/"):
+		return "api.ebus_standard"
 	case strings.HasPrefix(path, "/assets/"):
 		return "assets"
 	case path == "/" || strings.EqualFold(path, "/index.html"):

--- a/portal/handler.go
+++ b/portal/handler.go
@@ -61,6 +61,11 @@ type Options struct {
 	GetProjection       func(address byte, plane string) (ProjectionGraph, bool)
 	ExplorerBus         ExplorerBus // nil disables explorer
 	ExplorerSource      byte        // default eBUS source address (0xF0 if zero)
+	// EbusStandardServer is the in-process L7 catalog sub-server consumed
+	// by the M5_PORTAL read-only consumer UI. Nil disables the
+	// /api/v1/ebus-standard/* routes (they return 404) and hides the
+	// capability in /api/v1/bootstrap.
+	EbusStandardServer PortalEbusStandardServer
 }
 
 type handler struct {
@@ -858,6 +863,14 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 	// Explorer routes support POST/DELETE, must be checked before the GET-only guard.
 	trimmed := strings.Trim(path, "/")
 	if h.explorer != nil && h.routeExplorer(w, r, trimmed) {
+		return
+	}
+	// ebus_standard L7 consumer UI (M5_PORTAL). routeEbusStandard returns
+	// true if the path matched the ebus-standard/ prefix, even when the
+	// sub-server is nil (in which case it responds with 404). Placed
+	// before the GET-only guard for symmetry with explorer, though all
+	// ebus-standard routes are GET-only and enforce that internally.
+	if h.routeEbusStandard(w, r, trimmed) {
 		return
 	}
 

--- a/portal/handler_test.go
+++ b/portal/handler_test.go
@@ -1490,6 +1490,51 @@ func TestVRCExplorerDeprecationEndpointRemoved(t *testing.T) {
 	}
 }
 
+func TestClassifyRoute_EbusStandardServices(t *testing.T) {
+	if got := classifyRoute("/api/v1/ebus-standard/services"); got != "api.ebus_standard.services" {
+		t.Fatalf("classifyRoute(services) = %q; want api.ebus_standard.services", got)
+	}
+}
+
+func TestClassifyRoute_EbusStandardCommands(t *testing.T) {
+	if got := classifyRoute("/api/v1/ebus-standard/commands"); got != "api.ebus_standard.commands" {
+		t.Fatalf("classifyRoute(commands) = %q; want api.ebus_standard.commands", got)
+	}
+	if got := classifyRoute("/api/v1/ebus-standard/commands?pb=5"); got != "api.ebus_standard.commands" {
+		t.Fatalf("classifyRoute(commands?pb=5) = %q; want api.ebus_standard.commands", got)
+	}
+}
+
+func TestClassifyRoute_EbusStandardCommandGet(t *testing.T) {
+	if got := classifyRoute("/api/v1/ebus-standard/command"); got != "api.ebus_standard.command" {
+		t.Fatalf("classifyRoute(command) = %q; want api.ebus_standard.command", got)
+	}
+	if got := classifyRoute("/api/v1/ebus-standard/command?id=cmd.future"); got != "api.ebus_standard.command" {
+		t.Fatalf("classifyRoute(command?id=...) = %q; want api.ebus_standard.command", got)
+	}
+}
+
+func TestClassifyRoute_EbusStandardDecode(t *testing.T) {
+	if got := classifyRoute("/api/v1/ebus-standard/decode"); got != "api.ebus_standard.decode" {
+		t.Fatalf("classifyRoute(decode) = %q; want api.ebus_standard.decode", got)
+	}
+}
+
+func TestClassifyRoute_EbusStandardNotStatic(t *testing.T) {
+	paths := []string{
+		"/api/v1/ebus-standard/services",
+		"/api/v1/ebus-standard/commands",
+		"/api/v1/ebus-standard/command",
+		"/api/v1/ebus-standard/decode",
+		"/api/v1/ebus-standard/future-endpoint",
+	}
+	for _, p := range paths {
+		if got := classifyRoute(p); got == "static" {
+			t.Fatalf("classifyRoute(%q) = static; want api.ebus_standard.*", p)
+		}
+	}
+}
+
 func stringPtr(value string) *string {
 	v := value
 	return &v

--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -2207,6 +2207,220 @@ class PortalShell extends HTMLElement {
       </div>
     `;
   }
+
+  // ---------------------------------------------------------------------
+  // M5_PORTAL — ebus_standard L7 consumer UI
+  //
+  // Read-only surface over the in-process mcp/ebus_standard sub-server.
+  // Four views:
+  //   - services list         → refreshL7Services()
+  //   - commands list         → refreshL7Commands(optional pb)
+  //   - command detail        → refreshL7Command(id)
+  //   - decode sandbox        → submitL7Decode({pb, sb, direction, frame_type, payload_hex})
+  //
+  // XSS hardening: the decode sandbox writes user-controlled bytes into
+  // the output element via textContent, NEVER innerHTML. Catalog-derived
+  // strings (service/command names) use escapeHtml() before being placed
+  // in innerHTML templates.
+  //
+  // Open-enum fail-closed (M4b2 §4.3): unknown safety_class, direction,
+  // and frame_type values render with an 'unknown' fallback label while
+  // still showing the raw value as evidence.
+  // ---------------------------------------------------------------------
+
+  async refreshL7Services() {
+    const body = this.querySelector('[data-role="l7-services-body"]');
+    if (!body) return;
+    try {
+      const resp = await fetch("api/v1/ebus-standard/services");
+      const env = await resp.json();
+      if (env && env.error) {
+        body.innerHTML = `<div class="error">${escapeHtml(env.error.code || "ERROR")}: ${escapeHtml(env.error.message || "")}</div>`;
+        return;
+      }
+      const services = (env && env.data && env.data.services) || [];
+      if (services.length === 0) {
+        body.innerHTML = '<div class="muted-inline">No services in catalog.</div>';
+        return;
+      }
+      const rows = services.map((svc) => {
+        const pb = escapeHtml(svc.pb);
+        const name = escapeHtml(svc.name || "unknown");
+        const desc = escapeHtml(svc.description || "");
+        const count = escapeHtml(svc.command_count);
+        return `<tr><td>0x${Number(svc.pb).toString(16).padStart(2, "0")}</td><td>${name}</td><td>${desc}</td><td>${count}</td></tr>`;
+      }).join("");
+      body.innerHTML = `<table class="table"><thead><tr><th>PB</th><th>Name</th><th>Description</th><th>Commands</th></tr></thead><tbody>${rows}</tbody></table>`;
+    } catch (err) {
+      body.innerHTML = `<div class="error">${escapeHtml(String(err))}</div>`;
+    }
+  }
+
+  async refreshL7Commands(pb) {
+    const body = this.querySelector('[data-role="l7-commands-body"]');
+    if (!body) return;
+    const qs = (pb === undefined || pb === null || pb === "") ? "" : `?pb=${encodeURIComponent(String(pb))}`;
+    try {
+      const resp = await fetch(`api/v1/ebus-standard/commands${qs}`);
+      const env = await resp.json();
+      if (env && env.error) {
+        body.innerHTML = `<div class="error">${escapeHtml(env.error.code || "ERROR")}: ${escapeHtml(env.error.message || "")}</div>`;
+        return;
+      }
+      const commands = (env && env.data && env.data.commands) || [];
+      if (commands.length === 0) {
+        body.innerHTML = '<div class="muted-inline">No commands match.</div>';
+        return;
+      }
+      const rows = commands.map((cmd) => {
+        const id = escapeHtml(cmd.id || "");
+        const name = escapeHtml(cmd.name || "");
+        const safety = this._l7SafetyClassLabel(cmd.safety_class);
+        const pbHex = `0x${Number(cmd.pb).toString(16).padStart(2, "0")}`;
+        const sbHex = `0x${Number(cmd.sb).toString(16).padStart(2, "0")}`;
+        return `<tr><td>${id}</td><td>${name}</td><td>${escapeHtml(pbHex)}</td><td>${escapeHtml(sbHex)}</td><td>${safety}</td></tr>`;
+      }).join("");
+      body.innerHTML = `<table class="table"><thead><tr><th>ID</th><th>Name</th><th>PB</th><th>SB</th><th>Safety</th></tr></thead><tbody>${rows}</tbody></table>`;
+    } catch (err) {
+      body.innerHTML = `<div class="error">${escapeHtml(String(err))}</div>`;
+    }
+  }
+
+  async refreshL7Command(id) {
+    const body = this.querySelector('[data-role="l7-command-body"]');
+    if (!body) return;
+    if (!id) {
+      body.innerHTML = '<div class="muted-inline">Enter a command id.</div>';
+      return;
+    }
+    try {
+      const resp = await fetch(`api/v1/ebus-standard/command?id=${encodeURIComponent(id)}`);
+      const env = await resp.json();
+      if (env && env.error) {
+        body.innerHTML = `<div class="error">${escapeHtml(env.error.code || "ERROR")}: ${escapeHtml(env.error.message || "")}</div>`;
+        return;
+      }
+      const cmd = (env && env.data && env.data.command) || null;
+      if (!cmd) {
+        body.innerHTML = '<div class="muted-inline">Command not found.</div>';
+        return;
+      }
+      const identity = cmd.identity || {};
+      const safety = this._l7SafetyClassLabel(cmd.safety_class);
+      const direction = this._l7DirectionLabel(identity.direction);
+      const frameType = this._l7FrameTypeLabel(identity.telegram_class);
+      const req = Array.isArray(cmd.request) ? cmd.request : [];
+      const resp2 = Array.isArray(cmd.response) ? cmd.response : [];
+      const paramRow = (p, role) =>
+        `<tr><td>${escapeHtml(role)}</td><td>${escapeHtml(p.name || "")}</td><td>${escapeHtml(p.type || "")}</td><td>${escapeHtml(p.description || "")}</td></tr>`;
+      const paramRows = req.map((p) => paramRow(p, "request")).concat(resp2.map((p) => paramRow(p, "response"))).join("");
+      const paramTable = paramRows
+        ? `<table class="table"><thead><tr><th>Role</th><th>Name</th><th>Type</th><th>Description</th></tr></thead><tbody>${paramRows}</tbody></table>`
+        : '<div class="muted-inline">No parameters documented.</div>';
+      body.innerHTML = `
+        <dl class="meta-list">
+          <dt>ID</dt><dd>${escapeHtml(cmd.id || "")}</dd>
+          <dt>Name</dt><dd>${escapeHtml(cmd.name || "")}</dd>
+          <dt>Description</dt><dd>${escapeHtml(cmd.description || "")}</dd>
+          <dt>Safety class</dt><dd>${safety}</dd>
+          <dt>Direction</dt><dd>${direction}</dd>
+          <dt>Frame type</dt><dd>${frameType}</dd>
+          <dt>PB / SB</dt><dd>0x${escapeHtml(Number(identity.pb || 0).toString(16).padStart(2, "0"))} / 0x${escapeHtml(Number(identity.sb || 0).toString(16).padStart(2, "0"))}</dd>
+        </dl>
+        ${paramTable}
+      `;
+    } catch (err) {
+      body.innerHTML = `<div class="error">${escapeHtml(String(err))}</div>`;
+    }
+  }
+
+  async submitL7Decode(input) {
+    const output = this.querySelector('[data-role="l7-decode-output"]');
+    const status = this.querySelector('[data-role="l7-decode-status"]');
+    if (status) status.textContent = "Decoding...";
+    const params = new URLSearchParams();
+    if (input) {
+      if (input.pb !== undefined && input.pb !== null && input.pb !== "") params.set("pb", String(input.pb));
+      if (input.sb !== undefined && input.sb !== null && input.sb !== "") params.set("sb", String(input.sb));
+      if (input.direction !== undefined && input.direction !== null) params.set("direction", String(input.direction));
+      if (input.frame_type !== undefined && input.frame_type !== null) params.set("frame_type", String(input.frame_type));
+      if (input.payload_hex !== undefined && input.payload_hex !== null) params.set("payload_hex", String(input.payload_hex));
+    }
+    try {
+      const resp = await fetch(`api/v1/ebus-standard/decode?${params.toString()}`);
+      const env = await resp.json();
+      if (env && env.error) {
+        if (status) status.textContent = `${env.error.code || "ERROR"}: ${env.error.message || ""}`;
+        if (output) {
+          // CRITICAL: user-controlled error.message is rendered via
+          // textContent — never innerHTML. This is load-bearing XSS
+          // hardening for the decode sandbox and is enforced by the
+          // l7-catalog.test.mjs audit-log assertions.
+          output.textContent = env.error.message || String(env.error.code || "ERROR");
+        }
+        return;
+      }
+      const data = (env && env.data) || {};
+      if (status) status.textContent = `OK — ${data.command_id || "unknown command"} (${data.validity || "?"})`;
+      if (output) {
+        // The decode response contains raw_bytes + optional decoded_repr,
+        // both of which can reflect wire payloads chosen by an attacker.
+        // textContent is the entire sink for this data — no HTML parsing,
+        // no innerHTML, no template interpolation.
+        const rawBytes = Array.isArray(data.raw_bytes)
+          ? data.raw_bytes.map((b) => Number(b).toString(16).padStart(2, "0")).join(" ")
+          : "";
+        const decodedRepr = typeof data.decoded_repr === "string" ? data.decoded_repr : "";
+        const parts = [
+          `command_id: ${data.command_id || "unknown"}`,
+          `validity: ${data.validity || "unknown"}`,
+          `raw_bytes: ${rawBytes}`,
+        ];
+        if (decodedRepr) parts.push(`decoded: ${decodedRepr}`);
+        output.textContent = parts.join("\n");
+      }
+    } catch (err) {
+      if (status) status.textContent = `Error: ${err}`;
+      if (output) output.textContent = String(err);
+    }
+  }
+
+  // _l7SafetyClassLabel maps a safety_class open-enum value to a labeled
+  // HTML pill. Unknown values render with an "unknown" fallback per
+  // M4b2 §4.3 fail-closed consumer rule, while still showing the raw
+  // value as evidence (escapeHtml-wrapped).
+  _l7SafetyClassLabel(value) {
+    const known = {
+      read_only_safe: "safe",
+      write_controlled: "controlled",
+      frontier_experimental: "experimental",
+      prohibited: "prohibited",
+    };
+    const raw = typeof value === "string" ? value : "";
+    const label = known[raw];
+    if (label) {
+      return `<span class="pill safety-${escapeHtml(raw)}">${escapeHtml(label)}</span> <span class="muted-inline">${escapeHtml(raw)}</span>`;
+    }
+    return `<span class="pill safety-unknown">unknown</span> <span class="muted-inline">${escapeHtml(raw || "(empty)")}</span>`;
+  }
+
+  _l7DirectionLabel(value) {
+    const known = new Set(["master_to_slave", "slave_to_master", "broadcast"]);
+    const raw = typeof value === "string" ? value : "";
+    if (known.has(raw)) {
+      return `<span class="pill">${escapeHtml(raw)}</span>`;
+    }
+    return `<span class="pill pill-unknown">unknown</span> <span class="muted-inline">${escapeHtml(raw || "(empty)")}</span>`;
+  }
+
+  _l7FrameTypeLabel(value) {
+    const known = new Set(["MS", "MM", "BC"]);
+    const raw = typeof value === "string" ? value : "";
+    if (known.has(raw)) {
+      return `<span class="pill">${escapeHtml(raw)}</span>`;
+    }
+    return `<span class="pill pill-unknown">unknown</span> <span class="muted-inline">${escapeHtml(raw || "(empty)")}</span>`;
+  }
 }
 
 customElements.define("portal-shell", PortalShell);

--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -1,6 +1,48 @@
 // Generated from portal/web/src/app.js. DO NOT EDIT.
 const THEME_KEY = "helianthus-portal-theme";
 
+// L7 decode catalog-canonical enums. Source of truth:
+// helianthus-ebusreg/catalog/ebus_standard/identity.go — Direction and
+// TelegramClass constants. Any form value outside these sets is
+// rejected client-side by the decode submit handler (fail-closed)
+// because the backend matcher would return UNKNOWN_COMMAND.
+//
+// NOTE: These values intentionally use the catalog identity enums
+// (request / response / addressed / broadcast / initiator_initiator /
+// controller_broadcast) and NEVER the legacy initiator/responder-coded
+// terminology banned project-wide by ci_local.sh.
+const L7_DECODE_DIRECTIONS = new Set(["request", "response"]);
+const L7_DECODE_FRAME_TYPES = new Set([
+  "addressed",
+  "broadcast",
+  "initiator_initiator",
+  "controller_broadcast",
+]);
+
+// parsePBFilterValue parses an operator-entered PB filter string and
+// returns an integer in [0,255] on success, or null on malformed input.
+// Accepts decimal ("5", "255") or hex ("0x05", "0xff", "FF"). The null
+// return signals the caller to fail closed — surface an inline error and
+// SUPPRESS the fetch, rather than fall back to an unfiltered list.
+function parsePBFilterValue(raw) {
+  if (typeof raw !== "string") return null;
+  const s = raw.trim();
+  if (s === "") return null;
+  let n;
+  if (/^0x[0-9a-f]+$/i.test(s)) {
+    n = parseInt(s.slice(2), 16);
+  } else if (/^[0-9a-f]+$/i.test(s) && /[a-f]/i.test(s)) {
+    // Hex without prefix (e.g. "ff").
+    n = parseInt(s, 16);
+  } else if (/^\d+$/.test(s)) {
+    n = parseInt(s, 10);
+  } else {
+    return null;
+  }
+  if (!Number.isFinite(n) || n < 0 || n > 0xff) return null;
+  return n;
+}
+
 function loadTheme() {
   const stored = localStorage.getItem(THEME_KEY);
   if (stored === "light" || stored === "dark") {
@@ -354,13 +396,27 @@ class PortalShell extends HTMLElement {
     if (refreshCommands) {
       refreshCommands.addEventListener("click", () => {
         const pbInput = this.querySelector('[data-role="l7-pb-filter"]');
+        const pbErrEl = this.querySelector('[data-role="l7-commands-pb-error"]');
         const pbRaw = pbInput && typeof pbInput.value === "string" ? pbInput.value.trim() : "";
-        let pb;
-        if (pbRaw !== "") {
-          const parsed = pbRaw.startsWith("0x") || pbRaw.startsWith("0X")
-            ? parseInt(pbRaw, 16)
-            : parseInt(pbRaw, 10);
-          if (!Number.isNaN(parsed)) pb = parsed;
+        // Clear any previous inline error.
+        if (pbErrEl) {
+          pbErrEl.textContent = "";
+          if (pbErrEl.style) pbErrEl.style.display = "none";
+        }
+        if (pbRaw === "") {
+          // Unfiltered list.
+          this.refreshL7Commands();
+          return;
+        }
+        const pb = parsePBFilterValue(pbRaw);
+        if (pb === null) {
+          // Fail closed: surface inline error via textContent, do NOT
+          // call refreshL7Commands so the list isn't silently unfiltered.
+          if (pbErrEl) {
+            pbErrEl.textContent = `Invalid PB: ${pbRaw} (expected 0x00..0xFF or 0..255)`;
+            if (pbErrEl.style) pbErrEl.style.display = "";
+          }
+          return;
         }
         this.refreshL7Commands(pb);
       });
@@ -379,12 +435,38 @@ class PortalShell extends HTMLElement {
         const dirInput = this.querySelector('[data-role="l7-decode-direction"]');
         const frameInput = this.querySelector('[data-role="l7-decode-frame-type"]');
         const payloadInput = this.querySelector('[data-role="l7-decode-payload"]');
+        const errEl = this.querySelector('[data-role="l7-decode-error"]');
         const read = (el) => (el && typeof el.value === "string" ? el.value : "");
+        const direction = read(dirInput);
+        const frameType = read(frameInput);
+        // Clear previous inline error.
+        if (errEl) {
+          errEl.textContent = "";
+          if (errEl.style) errEl.style.display = "none";
+        }
+        // Known-value fallback: if the form were ever fed unknown values
+        // (e.g., via URL hash, injected option, test fixture), fail closed
+        // and surface an inline error. Do NOT send unknown values to the
+        // backend, which would always return UNKNOWN_COMMAND.
+        if (!L7_DECODE_DIRECTIONS.has(direction)) {
+          if (errEl) {
+            errEl.textContent = `Invalid direction: ${direction || "(empty)"} (expected one of: ${Array.from(L7_DECODE_DIRECTIONS).join(", ")})`;
+            if (errEl.style) errEl.style.display = "";
+          }
+          return;
+        }
+        if (!L7_DECODE_FRAME_TYPES.has(frameType)) {
+          if (errEl) {
+            errEl.textContent = `Invalid frame_type: ${frameType || "(empty)"} (expected one of: ${Array.from(L7_DECODE_FRAME_TYPES).join(", ")})`;
+            if (errEl.style) errEl.style.display = "";
+          }
+          return;
+        }
         this.submitL7Decode({
           pb: read(pbInput),
           sb: read(sbInput),
-          direction: read(dirInput),
-          frame_type: read(frameInput),
+          direction,
+          frame_type: frameType,
           payload_hex: read(payloadInput),
         });
       });
@@ -2281,6 +2363,7 @@ class PortalShell extends HTMLElement {
                 <button class="button" data-role="l7-refresh-services" type="button">Refresh Services</button>
                 <input class="search timeline-filter" data-role="l7-pb-filter" type="search" placeholder="Filter commands by PB (e.g. 5 or 0x05)" aria-label="Filter commands by PB" />
                 <button class="button" data-role="l7-refresh-commands" type="button">Refresh Commands</button>
+                <span class="error" data-role="l7-commands-pb-error" style="display:none"></span>
                 <input class="search timeline-filter" data-role="l7-command-id" type="search" placeholder="Command id (e.g. ebus_standard.service_data.start_counts)" aria-label="Command id" />
                 <button class="button" data-role="l7-refresh-command" type="button">Load Command</button>
               </div>
@@ -2301,19 +2384,20 @@ class PortalShell extends HTMLElement {
                 <input class="search timeline-filter" data-role="l7-decode-pb" type="text" placeholder="pb (0-255)" aria-label="Decode PB" size="5" />
                 <input class="search timeline-filter" data-role="l7-decode-sb" type="text" placeholder="sb (0-255)" aria-label="Decode SB" size="5" />
                 <select class="select" data-role="l7-decode-direction" aria-label="Decode direction">
-                  <option value="master_to_slave">master_to_slave</option>
-                  <option value="slave_to_master">slave_to_master</option>
-                  <option value="broadcast">broadcast</option>
+                  <option value="request">request</option>
+                  <option value="response">response</option>
                 </select>
                 <select class="select" data-role="l7-decode-frame-type" aria-label="Decode frame type">
-                  <option value="MM">MM (initiator-initiator)</option>
-                  <option value="MS">MS (initiator-responder)</option>
-                  <option value="BC">BC (broadcast)</option>
+                  <option value="addressed">addressed</option>
+                  <option value="broadcast">broadcast</option>
+                  <option value="initiator_initiator">initiator_initiator</option>
+                  <option value="controller_broadcast">controller_broadcast</option>
                 </select>
                 <input class="search timeline-filter" data-role="l7-decode-payload" type="text" placeholder="payload_hex" aria-label="Decode payload hex" />
                 <button class="button" data-role="l7-decode-submit" type="button">Decode</button>
               </div>
               <div class="muted-inline" data-role="l7-decode-status">Idle.</div>
+              <div class="error" data-role="l7-decode-error" style="display:none"></div>
               <pre class="issue-preview" data-role="l7-decode-output"></pre>
             </section>
             <div class="meta" data-role="stream-status">Stream idle</div>
@@ -2521,18 +2605,16 @@ class PortalShell extends HTMLElement {
   }
 
   _l7DirectionLabel(value) {
-    const known = new Set(["master_to_slave", "slave_to_master", "broadcast"]);
     const raw = typeof value === "string" ? value : "";
-    if (known.has(raw)) {
+    if (L7_DECODE_DIRECTIONS.has(raw)) {
       return `<span class="pill">${escapeHtml(raw)}</span>`;
     }
     return `<span class="pill pill-unknown">unknown</span> <span class="muted-inline">${escapeHtml(raw || "(empty)")}</span>`;
   }
 
   _l7FrameTypeLabel(value) {
-    const known = new Set(["MS", "MM", "BC"]);
     const raw = typeof value === "string" ? value : "";
-    if (known.has(raw)) {
+    if (L7_DECODE_FRAME_TYPES.has(raw)) {
       return `<span class="pill">${escapeHtml(raw)}</span>`;
     }
     return `<span class="pill pill-unknown">unknown</span> <span class="muted-inline">${escapeHtml(raw || "(empty)")}</span>`;

--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -500,6 +500,15 @@ class PortalShell extends HTMLElement {
     // require an explicit "Refresh Services" press — this mirrors how
     // the explorer section loads its device list lazily.
     if (targetID === "section-l7-catalog" && !this._l7CatalogLoaded) {
+      // Skip auto-fetch when the ebus_standard capability is false —
+      // the sub-server is nil, so /api/v1/ebus-standard/services would
+      // 404. Codex P2 on PR #507. The nav button is also disabled via
+      // applyCapabilityState, so this guard is defence-in-depth against
+      // bootstrap picking section-l7-catalog as firstEnabled and
+      // against programmatic activation.
+      if (this._capabilityEbusStandard === false) {
+        return;
+      }
       this._l7CatalogLoaded = true;
       if (typeof this.refreshL7Services === "function") {
         this.refreshL7Services();
@@ -715,6 +724,13 @@ class PortalShell extends HTMLElement {
     this.setNavState("timeline", cap.timeline || cap.provenance);
     this.setNavState("snapshots", cap.snapshots || cap.snapshot_diff);
     this.setNavState("issue-builder", cap.issue_builder);
+    // L7 Standard Catalog nav button (M5_PORTAL). Gated by the
+    // backend `ebus_standard` capability flag so that when the
+    // sub-server is nil, the button is disabled and the section
+    // is not auto-activated (which would surface a 404 fetch).
+    // Codex P2 on PR #507.
+    this.setNavState("l7-catalog", cap.ebus_standard);
+    this._capabilityEbusStandard = Boolean(cap.ebus_standard);
   }
 
   setNavState(name, enabled) {
@@ -2153,7 +2169,7 @@ class PortalShell extends HTMLElement {
             <button data-role="nav-timeline" data-nav-target="section-timeline" disabled><span class="nav-bullet"></span> Timeline</button>
             <button data-role="nav-snapshots" data-nav-target="section-snapshots" disabled><span class="nav-bullet"></span> Snapshots</button>
             <button data-role="nav-issue-builder" data-nav-target="section-issue-builder" disabled><span class="nav-bullet"></span> Issue Builder</button>
-            <button data-role="nav-l7-catalog" data-nav-target="section-l7-catalog"><span class="nav-bullet"></span> L7 Catalog</button>
+            <button data-role="nav-l7-catalog" data-nav-target="section-l7-catalog" disabled><span class="nav-bullet"></span> L7 Catalog</button>
           </aside>
           <main class="main">
             <h1>Portal Overview</h1>

--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -22,23 +22,34 @@ const L7_DECODE_FRAME_TYPES = new Set([
 // parsePBFilterValue validates an operator-entered PB filter string and
 // returns the trimmed raw token on success, or null on malformed input.
 //
-// Backend contract (portal/explorer_ebus_standard.go: parsePBSBHex) parses
-// the query value as HEX only, with optional "0x"/"0X" prefix, bitSize=8.
-// Frontend MUST forward the operator's original token verbatim — no
-// parse→reformat round-trip — otherwise decimal serialization would make
-// the backend reinterpret the value as hex, producing either overflow
-// (ui=ff → Number(255) → "255" → hex 0x255 = overflow) or a wrong match
-// (ui=10 → Number(10) → "10" → hex 0x10 = 16 ≠ decimal 10).
+// Backend contract (portal/explorer_ebus_standard.go: parsePBSBByte) uses
+// smart detection:
+//   - "0x" / "0X" prefix  → parse remainder as hex byte (0x00..0xFF)
+//   - otherwise           → parse as decimal byte (0..255)
+// This matches the MCP tool schema `{"type":"integer","minimum":0,"maximum":255}`
+// contract. Frontend MUST forward the operator's original token verbatim
+// (no Number() round-trip, which would lose the "0x" prefix and rewrite
+// "08" as "8", etc.).
 //
-// Shape check: accept 1–2 hex digits with an optional 0x/0X prefix. The
-// null return signals the caller to fail closed — surface an inline error
-// and SUPPRESS the fetch, rather than fall back to an unfiltered list.
+// Shape check:
+//   - With 0x/0X prefix: 1–2 hex digits.
+//   - Without prefix: 1–3 decimal digits, range-checked [0,255].
+// Bare hex (e.g. "ff") is REJECTED — operators must type "0xff".
+// The null return signals the caller to fail closed — surface an inline
+// error and SUPPRESS the fetch, rather than fall back to an unfiltered
+// list.
 function parsePBFilterValue(raw) {
   if (typeof raw !== "string") return null;
   const s = raw.trim();
   if (s === "") return null;
-  if (!/^(0x|0X)?[0-9a-fA-F]{1,2}$/.test(s)) return null;
-  return s;
+  // Hex form: 0x-prefixed, 1-2 hex digits.
+  if (/^(0x|0X)[0-9a-fA-F]{1,2}$/.test(s)) return s;
+  // Decimal form: 1-3 digits in [0,255].
+  if (/^[0-9]{1,3}$/.test(s)) {
+    const n = Number(s);
+    if (Number.isInteger(n) && n >= 0 && n <= 255) return s;
+  }
+  return null;
 }
 
 function loadTheme() {
@@ -411,7 +422,7 @@ class PortalShell extends HTMLElement {
           // Fail closed: surface inline error via textContent, do NOT
           // call refreshL7Commands so the list isn't silently unfiltered.
           if (pbErrEl) {
-            pbErrEl.textContent = `Invalid PB: ${pbRaw} (expected 0x00..0xFF or 0..255)`;
+            pbErrEl.textContent = `Invalid PB: ${pbRaw} (expected 0..255 decimal or 0xNN hex, e.g. 5 or 0x05)`;
             if (pbErrEl.style) pbErrEl.style.display = "";
           }
           return;
@@ -460,22 +471,22 @@ class PortalShell extends HTMLElement {
           }
           return;
         }
-        // pb/sb are forwarded verbatim (raw hex tokens). Validate shape
-        // locally so obviously-malformed input fails closed instead of
-        // round-tripping to the backend for an UNKNOWN_COMMAND. Empty
-        // pb/sb is permitted — the backend returns the catalog default.
+        // pb/sb are forwarded verbatim (raw tokens: decimal or 0xNN hex).
+        // Validate shape locally so obviously-malformed input fails closed
+        // instead of round-tripping to the backend for an UNKNOWN_COMMAND.
+        // Empty pb/sb is permitted — the backend returns the catalog default.
         const pbRaw = read(pbInput).trim();
         const sbRaw = read(sbInput).trim();
         if (pbRaw !== "" && parsePBFilterValue(pbRaw) === null) {
           if (errEl) {
-            errEl.textContent = `Invalid PB: ${pbRaw} (expected hex byte, e.g. 0x05, ff)`;
+            errEl.textContent = `Invalid PB: ${pbRaw} (expected 0..255 decimal or 0xNN hex, e.g. 5 or 0x05)`;
             if (errEl.style) errEl.style.display = "";
           }
           return;
         }
         if (sbRaw !== "" && parsePBFilterValue(sbRaw) === null) {
           if (errEl) {
-            errEl.textContent = `Invalid SB: ${sbRaw} (expected hex byte, e.g. 0x05, ff)`;
+            errEl.textContent = `Invalid SB: ${sbRaw} (expected 0..255 decimal or 0xNN hex, e.g. 5 or 0x05)`;
             if (errEl.style) errEl.style.display = "";
           }
           return;
@@ -2415,8 +2426,8 @@ class PortalShell extends HTMLElement {
               </div>
               <h3>Decode Sandbox</h3>
               <div class="snapshot-controls">
-                <input class="search timeline-filter" data-role="l7-decode-pb" type="text" placeholder="pb (0-255)" aria-label="Decode PB" size="5" />
-                <input class="search timeline-filter" data-role="l7-decode-sb" type="text" placeholder="sb (0-255)" aria-label="Decode SB" size="5" />
+                <input class="search timeline-filter" data-role="l7-decode-pb" type="text" placeholder="pb (0..255 or 0xNN)" aria-label="Decode PB" size="5" />
+                <input class="search timeline-filter" data-role="l7-decode-sb" type="text" placeholder="sb (0..255 or 0xNN)" aria-label="Decode SB" size="5" />
                 <select class="select" data-role="l7-decode-direction" aria-label="Decode direction">
                   <option value="request">request</option>
                   <option value="response">response</option>

--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -19,28 +19,26 @@ const L7_DECODE_FRAME_TYPES = new Set([
   "controller_broadcast",
 ]);
 
-// parsePBFilterValue parses an operator-entered PB filter string and
-// returns an integer in [0,255] on success, or null on malformed input.
-// Accepts decimal ("5", "255") or hex ("0x05", "0xff", "FF"). The null
-// return signals the caller to fail closed — surface an inline error and
-// SUPPRESS the fetch, rather than fall back to an unfiltered list.
+// parsePBFilterValue validates an operator-entered PB filter string and
+// returns the trimmed raw token on success, or null on malformed input.
+//
+// Backend contract (portal/explorer_ebus_standard.go: parsePBSBHex) parses
+// the query value as HEX only, with optional "0x"/"0X" prefix, bitSize=8.
+// Frontend MUST forward the operator's original token verbatim — no
+// parse→reformat round-trip — otherwise decimal serialization would make
+// the backend reinterpret the value as hex, producing either overflow
+// (ui=ff → Number(255) → "255" → hex 0x255 = overflow) or a wrong match
+// (ui=10 → Number(10) → "10" → hex 0x10 = 16 ≠ decimal 10).
+//
+// Shape check: accept 1–2 hex digits with an optional 0x/0X prefix. The
+// null return signals the caller to fail closed — surface an inline error
+// and SUPPRESS the fetch, rather than fall back to an unfiltered list.
 function parsePBFilterValue(raw) {
   if (typeof raw !== "string") return null;
   const s = raw.trim();
   if (s === "") return null;
-  let n;
-  if (/^0x[0-9a-f]+$/i.test(s)) {
-    n = parseInt(s.slice(2), 16);
-  } else if (/^[0-9a-f]+$/i.test(s) && /[a-f]/i.test(s)) {
-    // Hex without prefix (e.g. "ff").
-    n = parseInt(s, 16);
-  } else if (/^\d+$/.test(s)) {
-    n = parseInt(s, 10);
-  } else {
-    return null;
-  }
-  if (!Number.isFinite(n) || n < 0 || n > 0xff) return null;
-  return n;
+  if (!/^(0x|0X)?[0-9a-fA-F]{1,2}$/.test(s)) return null;
+  return s;
 }
 
 function loadTheme() {
@@ -462,9 +460,29 @@ class PortalShell extends HTMLElement {
           }
           return;
         }
+        // pb/sb are forwarded verbatim (raw hex tokens). Validate shape
+        // locally so obviously-malformed input fails closed instead of
+        // round-tripping to the backend for an UNKNOWN_COMMAND. Empty
+        // pb/sb is permitted — the backend returns the catalog default.
+        const pbRaw = read(pbInput).trim();
+        const sbRaw = read(sbInput).trim();
+        if (pbRaw !== "" && parsePBFilterValue(pbRaw) === null) {
+          if (errEl) {
+            errEl.textContent = `Invalid PB: ${pbRaw} (expected hex byte, e.g. 0x05, ff)`;
+            if (errEl.style) errEl.style.display = "";
+          }
+          return;
+        }
+        if (sbRaw !== "" && parsePBFilterValue(sbRaw) === null) {
+          if (errEl) {
+            errEl.textContent = `Invalid SB: ${sbRaw} (expected hex byte, e.g. 0x05, ff)`;
+            if (errEl.style) errEl.style.display = "";
+          }
+          return;
+        }
         this.submitL7Decode({
-          pb: read(pbInput),
-          sb: read(sbInput),
+          pb: pbRaw,
+          sb: sbRaw,
           direction,
           frame_type: frameType,
           payload_hex: read(payloadInput),
@@ -2475,6 +2493,11 @@ class PortalShell extends HTMLElement {
   async refreshL7Commands(pb) {
     const body = this.querySelector('[data-role="l7-commands-body"]');
     if (!body) return;
+    // pb is forwarded verbatim (raw hex token like "ff", "0x10", "08").
+    // Backend parsePBSBHex parses the query value as hex-only. Any
+    // parse→reformat round-trip (Number(pb) then String()) would produce
+    // a decimal string and break the hex contract for every value where
+    // decimal ≠ hex (ui=ff → "255" → overflow; ui=10 → "10" → 0x10=16).
     const qs = (pb === undefined || pb === null || pb === "") ? "" : `?pb=${encodeURIComponent(String(pb))}`;
     try {
       const resp = await fetch(`api/v1/ebus-standard/commands${qs}`);

--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -327,6 +327,68 @@ class PortalShell extends HTMLElement {
       });
     });
     this.bindExplorerEvents();
+    this.bindL7CatalogEvents();
+  }
+
+  // bindL7CatalogEvents wires the L7 Standard Catalog section (M5_PORTAL)
+  // to the four consumer methods (refreshL7Services / refreshL7Commands /
+  // refreshL7Command / submitL7Decode). Without this wiring the methods
+  // are dead code — render() emits the section markup but no handler
+  // invokes the fetches (Codex P1 finding on PR #507).
+  //
+  // XSS hardening contract: the decode submit path reads user input from
+  // the pb/sb/direction/frame_type/payload_hex inputs and delegates to
+  // submitL7Decode, which renders the response via textContent only on
+  // the [data-role="l7-decode-output"] element. Do NOT add any innerHTML
+  // sink on that element in this handler.
+  bindL7CatalogEvents() {
+    const refreshServices = this.querySelector('[data-role="l7-refresh-services"]');
+    const refreshCommands = this.querySelector('[data-role="l7-refresh-commands"]');
+    const refreshCommand = this.querySelector('[data-role="l7-refresh-command"]');
+    const decodeSubmit = this.querySelector('[data-role="l7-decode-submit"]');
+    if (refreshServices) {
+      refreshServices.addEventListener("click", () => {
+        this.refreshL7Services();
+      });
+    }
+    if (refreshCommands) {
+      refreshCommands.addEventListener("click", () => {
+        const pbInput = this.querySelector('[data-role="l7-pb-filter"]');
+        const pbRaw = pbInput && typeof pbInput.value === "string" ? pbInput.value.trim() : "";
+        let pb;
+        if (pbRaw !== "") {
+          const parsed = pbRaw.startsWith("0x") || pbRaw.startsWith("0X")
+            ? parseInt(pbRaw, 16)
+            : parseInt(pbRaw, 10);
+          if (!Number.isNaN(parsed)) pb = parsed;
+        }
+        this.refreshL7Commands(pb);
+      });
+    }
+    if (refreshCommand) {
+      refreshCommand.addEventListener("click", () => {
+        const idInput = this.querySelector('[data-role="l7-command-id"]');
+        const id = idInput && typeof idInput.value === "string" ? idInput.value.trim() : "";
+        this.refreshL7Command(id);
+      });
+    }
+    if (decodeSubmit) {
+      decodeSubmit.addEventListener("click", () => {
+        const pbInput = this.querySelector('[data-role="l7-decode-pb"]');
+        const sbInput = this.querySelector('[data-role="l7-decode-sb"]');
+        const dirInput = this.querySelector('[data-role="l7-decode-direction"]');
+        const frameInput = this.querySelector('[data-role="l7-decode-frame-type"]');
+        const payloadInput = this.querySelector('[data-role="l7-decode-payload"]');
+        const read = (el) => (el && typeof el.value === "string" ? el.value : "");
+        this.submitL7Decode({
+          pb: read(pbInput),
+          sb: read(sbInput),
+          direction: read(dirInput),
+          frame_type: read(frameInput),
+          payload_hex: read(payloadInput),
+        });
+      });
+    }
   }
 
   activateSection(targetID) {
@@ -340,6 +402,7 @@ class PortalShell extends HTMLElement {
       "section-timeline": ["section-timeline", "section-provenance"],
       "section-snapshots": ["section-snapshots", "section-snapshot-diff", "section-sessions"],
       "section-issue-builder": ["section-issue-builder"],
+      "section-l7-catalog": ["section-l7-catalog"],
     };
     const visible = new Set(sectionMap[targetID] || [targetID]);
     visible.add("section-search");
@@ -350,6 +413,16 @@ class PortalShell extends HTMLElement {
     this.querySelectorAll("[data-nav-target]").forEach((btn) => {
       btn.classList.toggle("active", btn.getAttribute("data-nav-target") === targetID);
     });
+    // First time the L7 Catalog section is activated, kick off the
+    // services list fetch so the panel isn't empty. Subsequent clicks
+    // require an explicit "Refresh Services" press — this mirrors how
+    // the explorer section loads its device list lazily.
+    if (targetID === "section-l7-catalog" && !this._l7CatalogLoaded) {
+      this._l7CatalogLoaded = true;
+      if (typeof this.refreshL7Services === "function") {
+        this.refreshL7Services();
+      }
+    }
   }
 
   async loadStatus(lifecycleToken = this.bootstrapLifecycleToken, lifecycleAbort = this.bootstrapLifecycleAbort) {
@@ -1998,6 +2071,7 @@ class PortalShell extends HTMLElement {
             <button data-role="nav-timeline" data-nav-target="section-timeline" disabled><span class="nav-bullet"></span> Timeline</button>
             <button data-role="nav-snapshots" data-nav-target="section-snapshots" disabled><span class="nav-bullet"></span> Snapshots</button>
             <button data-role="nav-issue-builder" data-nav-target="section-issue-builder" disabled><span class="nav-bullet"></span> Issue Builder</button>
+            <button data-role="nav-l7-catalog" data-nav-target="section-l7-catalog"><span class="nav-bullet"></span> L7 Catalog</button>
           </aside>
           <main class="main">
             <h1>Portal Overview</h1>
@@ -2199,6 +2273,48 @@ class PortalShell extends HTMLElement {
                 <button class="button" data-role="issue-export-run" type="button">Export Bundle</button>
               </div>
               <pre class="issue-preview" data-role="issue-preview">Loading issue builder capability...</pre>
+            </section>
+            <section id="section-l7-catalog" class="registry-preview">
+              <h2>L7 Standard Catalog</h2>
+              <p class="muted-inline">Read-only view over the ebus_standard L7 catalog (M5_PORTAL). Services, commands with 14-tuple identity, and a decode sandbox.</p>
+              <div class="snapshot-controls">
+                <button class="button" data-role="l7-refresh-services" type="button">Refresh Services</button>
+                <input class="search timeline-filter" data-role="l7-pb-filter" type="search" placeholder="Filter commands by PB (e.g. 5 or 0x05)" aria-label="Filter commands by PB" />
+                <button class="button" data-role="l7-refresh-commands" type="button">Refresh Commands</button>
+                <input class="search timeline-filter" data-role="l7-command-id" type="search" placeholder="Command id (e.g. ebus_standard.service_data.start_counts)" aria-label="Command id" />
+                <button class="button" data-role="l7-refresh-command" type="button">Load Command</button>
+              </div>
+              <h3>Services</h3>
+              <div data-role="l7-services-body">
+                <div class="muted-inline">Click Refresh Services to load the catalog.</div>
+              </div>
+              <h3>Commands</h3>
+              <div data-role="l7-commands-body">
+                <div class="muted-inline">Click Refresh Commands to list commands.</div>
+              </div>
+              <h3>Command Detail</h3>
+              <div data-role="l7-command-body">
+                <div class="muted-inline">Enter a command id and click Load Command.</div>
+              </div>
+              <h3>Decode Sandbox</h3>
+              <div class="snapshot-controls">
+                <input class="search timeline-filter" data-role="l7-decode-pb" type="text" placeholder="pb (0-255)" aria-label="Decode PB" size="5" />
+                <input class="search timeline-filter" data-role="l7-decode-sb" type="text" placeholder="sb (0-255)" aria-label="Decode SB" size="5" />
+                <select class="select" data-role="l7-decode-direction" aria-label="Decode direction">
+                  <option value="master_to_slave">master_to_slave</option>
+                  <option value="slave_to_master">slave_to_master</option>
+                  <option value="broadcast">broadcast</option>
+                </select>
+                <select class="select" data-role="l7-decode-frame-type" aria-label="Decode frame type">
+                  <option value="MM">MM (initiator-initiator)</option>
+                  <option value="MS">MS (initiator-responder)</option>
+                  <option value="BC">BC (broadcast)</option>
+                </select>
+                <input class="search timeline-filter" data-role="l7-decode-payload" type="text" placeholder="payload_hex" aria-label="Decode payload hex" />
+                <button class="button" data-role="l7-decode-submit" type="button">Decode</button>
+              </div>
+              <div class="muted-inline" data-role="l7-decode-status">Idle.</div>
+              <pre class="issue-preview" data-role="l7-decode-output"></pre>
             </section>
             <div class="meta" data-role="stream-status">Stream idle</div>
             <div class="meta" data-role="meta">Waiting for bootstrap...</div>

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,8 +2,8 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 119782,
-      "sha256": "08ab36e3c2bc70f5b6df9c6d919d24ad2c140f44e92692d88d086fa794b1bc0a"
+      "bytes": 120666,
+      "sha256": "66c17bd97dbd696937f3e3172b87394b8b8e97c6b1f85996b417f50f303a4dcd"
     },
     "app.css": {
       "bytes": 8115,

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,8 +2,8 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 120666,
-      "sha256": "66c17bd97dbd696937f3e3172b87394b8b8e97c6b1f85996b417f50f303a4dcd"
+      "bytes": 122196,
+      "sha256": "721bd7c2bb68026211e6033dc2222e8bbd289d05b9fbe14ffe41ac250363af7e"
     },
     "app.css": {
       "bytes": 8115,

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,8 +2,8 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 122196,
-      "sha256": "721bd7c2bb68026211e6033dc2222e8bbd289d05b9fbe14ffe41ac250363af7e"
+      "bytes": 122588,
+      "sha256": "574743a186f4ab3c36198237d0a3f19a03cfec272178f5f7267c87706b2ceb65"
     },
     "app.css": {
       "bytes": 8115,

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,8 +2,8 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 116276,
-      "sha256": "29ccbcc913a34e8ba5ebe5e7dfadcf0e68c8fb245076397c93c686a445e3ada3"
+      "bytes": 119782,
+      "sha256": "08ab36e3c2bc70f5b6df9c6d919d24ad2c140f44e92692d88d086fa794b1bc0a"
     },
     "app.css": {
       "bytes": 8115,

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,8 +2,8 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 98979,
-      "sha256": "585ed9525dd9c5d31b2d9834a299ca1d79320778f9364a1d301f8e12ee028b3e"
+      "bytes": 109583,
+      "sha256": "02ad2603e33ee2d3d9c764a20bb10cb17353e1f02b854058fb612d6baf12620b"
     },
     "app.css": {
       "bytes": 8115,

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,8 +2,8 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 109583,
-      "sha256": "02ad2603e33ee2d3d9c764a20bb10cb17353e1f02b854058fb612d6baf12620b"
+      "bytes": 116276,
+      "sha256": "29ccbcc913a34e8ba5ebe5e7dfadcf0e68c8fb245076397c93c686a445e3ada3"
     },
     "app.css": {
       "bytes": 8115,

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -1,5 +1,47 @@
 const THEME_KEY = "helianthus-portal-theme";
 
+// L7 decode catalog-canonical enums. Source of truth:
+// helianthus-ebusreg/catalog/ebus_standard/identity.go — Direction and
+// TelegramClass constants. Any form value outside these sets is
+// rejected client-side by the decode submit handler (fail-closed)
+// because the backend matcher would return UNKNOWN_COMMAND.
+//
+// NOTE: These values intentionally use the catalog identity enums
+// (request / response / addressed / broadcast / initiator_initiator /
+// controller_broadcast) and NEVER the legacy initiator/responder-coded
+// terminology banned project-wide by ci_local.sh.
+const L7_DECODE_DIRECTIONS = new Set(["request", "response"]);
+const L7_DECODE_FRAME_TYPES = new Set([
+  "addressed",
+  "broadcast",
+  "initiator_initiator",
+  "controller_broadcast",
+]);
+
+// parsePBFilterValue parses an operator-entered PB filter string and
+// returns an integer in [0,255] on success, or null on malformed input.
+// Accepts decimal ("5", "255") or hex ("0x05", "0xff", "FF"). The null
+// return signals the caller to fail closed — surface an inline error and
+// SUPPRESS the fetch, rather than fall back to an unfiltered list.
+function parsePBFilterValue(raw) {
+  if (typeof raw !== "string") return null;
+  const s = raw.trim();
+  if (s === "") return null;
+  let n;
+  if (/^0x[0-9a-f]+$/i.test(s)) {
+    n = parseInt(s.slice(2), 16);
+  } else if (/^[0-9a-f]+$/i.test(s) && /[a-f]/i.test(s)) {
+    // Hex without prefix (e.g. "ff").
+    n = parseInt(s, 16);
+  } else if (/^\d+$/.test(s)) {
+    n = parseInt(s, 10);
+  } else {
+    return null;
+  }
+  if (!Number.isFinite(n) || n < 0 || n > 0xff) return null;
+  return n;
+}
+
 function loadTheme() {
   const stored = localStorage.getItem(THEME_KEY);
   if (stored === "light" || stored === "dark") {
@@ -353,13 +395,27 @@ class PortalShell extends HTMLElement {
     if (refreshCommands) {
       refreshCommands.addEventListener("click", () => {
         const pbInput = this.querySelector('[data-role="l7-pb-filter"]');
+        const pbErrEl = this.querySelector('[data-role="l7-commands-pb-error"]');
         const pbRaw = pbInput && typeof pbInput.value === "string" ? pbInput.value.trim() : "";
-        let pb;
-        if (pbRaw !== "") {
-          const parsed = pbRaw.startsWith("0x") || pbRaw.startsWith("0X")
-            ? parseInt(pbRaw, 16)
-            : parseInt(pbRaw, 10);
-          if (!Number.isNaN(parsed)) pb = parsed;
+        // Clear any previous inline error.
+        if (pbErrEl) {
+          pbErrEl.textContent = "";
+          if (pbErrEl.style) pbErrEl.style.display = "none";
+        }
+        if (pbRaw === "") {
+          // Unfiltered list.
+          this.refreshL7Commands();
+          return;
+        }
+        const pb = parsePBFilterValue(pbRaw);
+        if (pb === null) {
+          // Fail closed: surface inline error via textContent, do NOT
+          // call refreshL7Commands so the list isn't silently unfiltered.
+          if (pbErrEl) {
+            pbErrEl.textContent = `Invalid PB: ${pbRaw} (expected 0x00..0xFF or 0..255)`;
+            if (pbErrEl.style) pbErrEl.style.display = "";
+          }
+          return;
         }
         this.refreshL7Commands(pb);
       });
@@ -378,12 +434,38 @@ class PortalShell extends HTMLElement {
         const dirInput = this.querySelector('[data-role="l7-decode-direction"]');
         const frameInput = this.querySelector('[data-role="l7-decode-frame-type"]');
         const payloadInput = this.querySelector('[data-role="l7-decode-payload"]');
+        const errEl = this.querySelector('[data-role="l7-decode-error"]');
         const read = (el) => (el && typeof el.value === "string" ? el.value : "");
+        const direction = read(dirInput);
+        const frameType = read(frameInput);
+        // Clear previous inline error.
+        if (errEl) {
+          errEl.textContent = "";
+          if (errEl.style) errEl.style.display = "none";
+        }
+        // Known-value fallback: if the form were ever fed unknown values
+        // (e.g., via URL hash, injected option, test fixture), fail closed
+        // and surface an inline error. Do NOT send unknown values to the
+        // backend, which would always return UNKNOWN_COMMAND.
+        if (!L7_DECODE_DIRECTIONS.has(direction)) {
+          if (errEl) {
+            errEl.textContent = `Invalid direction: ${direction || "(empty)"} (expected one of: ${Array.from(L7_DECODE_DIRECTIONS).join(", ")})`;
+            if (errEl.style) errEl.style.display = "";
+          }
+          return;
+        }
+        if (!L7_DECODE_FRAME_TYPES.has(frameType)) {
+          if (errEl) {
+            errEl.textContent = `Invalid frame_type: ${frameType || "(empty)"} (expected one of: ${Array.from(L7_DECODE_FRAME_TYPES).join(", ")})`;
+            if (errEl.style) errEl.style.display = "";
+          }
+          return;
+        }
         this.submitL7Decode({
           pb: read(pbInput),
           sb: read(sbInput),
-          direction: read(dirInput),
-          frame_type: read(frameInput),
+          direction,
+          frame_type: frameType,
           payload_hex: read(payloadInput),
         });
       });
@@ -2280,6 +2362,7 @@ class PortalShell extends HTMLElement {
                 <button class="button" data-role="l7-refresh-services" type="button">Refresh Services</button>
                 <input class="search timeline-filter" data-role="l7-pb-filter" type="search" placeholder="Filter commands by PB (e.g. 5 or 0x05)" aria-label="Filter commands by PB" />
                 <button class="button" data-role="l7-refresh-commands" type="button">Refresh Commands</button>
+                <span class="error" data-role="l7-commands-pb-error" style="display:none"></span>
                 <input class="search timeline-filter" data-role="l7-command-id" type="search" placeholder="Command id (e.g. ebus_standard.service_data.start_counts)" aria-label="Command id" />
                 <button class="button" data-role="l7-refresh-command" type="button">Load Command</button>
               </div>
@@ -2300,19 +2383,20 @@ class PortalShell extends HTMLElement {
                 <input class="search timeline-filter" data-role="l7-decode-pb" type="text" placeholder="pb (0-255)" aria-label="Decode PB" size="5" />
                 <input class="search timeline-filter" data-role="l7-decode-sb" type="text" placeholder="sb (0-255)" aria-label="Decode SB" size="5" />
                 <select class="select" data-role="l7-decode-direction" aria-label="Decode direction">
-                  <option value="master_to_slave">master_to_slave</option>
-                  <option value="slave_to_master">slave_to_master</option>
-                  <option value="broadcast">broadcast</option>
+                  <option value="request">request</option>
+                  <option value="response">response</option>
                 </select>
                 <select class="select" data-role="l7-decode-frame-type" aria-label="Decode frame type">
-                  <option value="MM">MM (initiator-initiator)</option>
-                  <option value="MS">MS (initiator-responder)</option>
-                  <option value="BC">BC (broadcast)</option>
+                  <option value="addressed">addressed</option>
+                  <option value="broadcast">broadcast</option>
+                  <option value="initiator_initiator">initiator_initiator</option>
+                  <option value="controller_broadcast">controller_broadcast</option>
                 </select>
                 <input class="search timeline-filter" data-role="l7-decode-payload" type="text" placeholder="payload_hex" aria-label="Decode payload hex" />
                 <button class="button" data-role="l7-decode-submit" type="button">Decode</button>
               </div>
               <div class="muted-inline" data-role="l7-decode-status">Idle.</div>
+              <div class="error" data-role="l7-decode-error" style="display:none"></div>
               <pre class="issue-preview" data-role="l7-decode-output"></pre>
             </section>
             <div class="meta" data-role="stream-status">Stream idle</div>
@@ -2520,18 +2604,16 @@ class PortalShell extends HTMLElement {
   }
 
   _l7DirectionLabel(value) {
-    const known = new Set(["master_to_slave", "slave_to_master", "broadcast"]);
     const raw = typeof value === "string" ? value : "";
-    if (known.has(raw)) {
+    if (L7_DECODE_DIRECTIONS.has(raw)) {
       return `<span class="pill">${escapeHtml(raw)}</span>`;
     }
     return `<span class="pill pill-unknown">unknown</span> <span class="muted-inline">${escapeHtml(raw || "(empty)")}</span>`;
   }
 
   _l7FrameTypeLabel(value) {
-    const known = new Set(["MS", "MM", "BC"]);
     const raw = typeof value === "string" ? value : "";
-    if (known.has(raw)) {
+    if (L7_DECODE_FRAME_TYPES.has(raw)) {
       return `<span class="pill">${escapeHtml(raw)}</span>`;
     }
     return `<span class="pill pill-unknown">unknown</span> <span class="muted-inline">${escapeHtml(raw || "(empty)")}</span>`;

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -21,23 +21,34 @@ const L7_DECODE_FRAME_TYPES = new Set([
 // parsePBFilterValue validates an operator-entered PB filter string and
 // returns the trimmed raw token on success, or null on malformed input.
 //
-// Backend contract (portal/explorer_ebus_standard.go: parsePBSBHex) parses
-// the query value as HEX only, with optional "0x"/"0X" prefix, bitSize=8.
-// Frontend MUST forward the operator's original token verbatim — no
-// parse→reformat round-trip — otherwise decimal serialization would make
-// the backend reinterpret the value as hex, producing either overflow
-// (ui=ff → Number(255) → "255" → hex 0x255 = overflow) or a wrong match
-// (ui=10 → Number(10) → "10" → hex 0x10 = 16 ≠ decimal 10).
+// Backend contract (portal/explorer_ebus_standard.go: parsePBSBByte) uses
+// smart detection:
+//   - "0x" / "0X" prefix  → parse remainder as hex byte (0x00..0xFF)
+//   - otherwise           → parse as decimal byte (0..255)
+// This matches the MCP tool schema `{"type":"integer","minimum":0,"maximum":255}`
+// contract. Frontend MUST forward the operator's original token verbatim
+// (no Number() round-trip, which would lose the "0x" prefix and rewrite
+// "08" as "8", etc.).
 //
-// Shape check: accept 1–2 hex digits with an optional 0x/0X prefix. The
-// null return signals the caller to fail closed — surface an inline error
-// and SUPPRESS the fetch, rather than fall back to an unfiltered list.
+// Shape check:
+//   - With 0x/0X prefix: 1–2 hex digits.
+//   - Without prefix: 1–3 decimal digits, range-checked [0,255].
+// Bare hex (e.g. "ff") is REJECTED — operators must type "0xff".
+// The null return signals the caller to fail closed — surface an inline
+// error and SUPPRESS the fetch, rather than fall back to an unfiltered
+// list.
 function parsePBFilterValue(raw) {
   if (typeof raw !== "string") return null;
   const s = raw.trim();
   if (s === "") return null;
-  if (!/^(0x|0X)?[0-9a-fA-F]{1,2}$/.test(s)) return null;
-  return s;
+  // Hex form: 0x-prefixed, 1-2 hex digits.
+  if (/^(0x|0X)[0-9a-fA-F]{1,2}$/.test(s)) return s;
+  // Decimal form: 1-3 digits in [0,255].
+  if (/^[0-9]{1,3}$/.test(s)) {
+    const n = Number(s);
+    if (Number.isInteger(n) && n >= 0 && n <= 255) return s;
+  }
+  return null;
 }
 
 function loadTheme() {
@@ -410,7 +421,7 @@ class PortalShell extends HTMLElement {
           // Fail closed: surface inline error via textContent, do NOT
           // call refreshL7Commands so the list isn't silently unfiltered.
           if (pbErrEl) {
-            pbErrEl.textContent = `Invalid PB: ${pbRaw} (expected 0x00..0xFF or 0..255)`;
+            pbErrEl.textContent = `Invalid PB: ${pbRaw} (expected 0..255 decimal or 0xNN hex, e.g. 5 or 0x05)`;
             if (pbErrEl.style) pbErrEl.style.display = "";
           }
           return;
@@ -459,22 +470,22 @@ class PortalShell extends HTMLElement {
           }
           return;
         }
-        // pb/sb are forwarded verbatim (raw hex tokens). Validate shape
-        // locally so obviously-malformed input fails closed instead of
-        // round-tripping to the backend for an UNKNOWN_COMMAND. Empty
-        // pb/sb is permitted — the backend returns the catalog default.
+        // pb/sb are forwarded verbatim (raw tokens: decimal or 0xNN hex).
+        // Validate shape locally so obviously-malformed input fails closed
+        // instead of round-tripping to the backend for an UNKNOWN_COMMAND.
+        // Empty pb/sb is permitted — the backend returns the catalog default.
         const pbRaw = read(pbInput).trim();
         const sbRaw = read(sbInput).trim();
         if (pbRaw !== "" && parsePBFilterValue(pbRaw) === null) {
           if (errEl) {
-            errEl.textContent = `Invalid PB: ${pbRaw} (expected hex byte, e.g. 0x05, ff)`;
+            errEl.textContent = `Invalid PB: ${pbRaw} (expected 0..255 decimal or 0xNN hex, e.g. 5 or 0x05)`;
             if (errEl.style) errEl.style.display = "";
           }
           return;
         }
         if (sbRaw !== "" && parsePBFilterValue(sbRaw) === null) {
           if (errEl) {
-            errEl.textContent = `Invalid SB: ${sbRaw} (expected hex byte, e.g. 0x05, ff)`;
+            errEl.textContent = `Invalid SB: ${sbRaw} (expected 0..255 decimal or 0xNN hex, e.g. 5 or 0x05)`;
             if (errEl.style) errEl.style.display = "";
           }
           return;
@@ -2414,8 +2425,8 @@ class PortalShell extends HTMLElement {
               </div>
               <h3>Decode Sandbox</h3>
               <div class="snapshot-controls">
-                <input class="search timeline-filter" data-role="l7-decode-pb" type="text" placeholder="pb (0-255)" aria-label="Decode PB" size="5" />
-                <input class="search timeline-filter" data-role="l7-decode-sb" type="text" placeholder="sb (0-255)" aria-label="Decode SB" size="5" />
+                <input class="search timeline-filter" data-role="l7-decode-pb" type="text" placeholder="pb (0..255 or 0xNN)" aria-label="Decode PB" size="5" />
+                <input class="search timeline-filter" data-role="l7-decode-sb" type="text" placeholder="sb (0..255 or 0xNN)" aria-label="Decode SB" size="5" />
                 <select class="select" data-role="l7-decode-direction" aria-label="Decode direction">
                   <option value="request">request</option>
                   <option value="response">response</option>

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -18,28 +18,26 @@ const L7_DECODE_FRAME_TYPES = new Set([
   "controller_broadcast",
 ]);
 
-// parsePBFilterValue parses an operator-entered PB filter string and
-// returns an integer in [0,255] on success, or null on malformed input.
-// Accepts decimal ("5", "255") or hex ("0x05", "0xff", "FF"). The null
-// return signals the caller to fail closed — surface an inline error and
-// SUPPRESS the fetch, rather than fall back to an unfiltered list.
+// parsePBFilterValue validates an operator-entered PB filter string and
+// returns the trimmed raw token on success, or null on malformed input.
+//
+// Backend contract (portal/explorer_ebus_standard.go: parsePBSBHex) parses
+// the query value as HEX only, with optional "0x"/"0X" prefix, bitSize=8.
+// Frontend MUST forward the operator's original token verbatim — no
+// parse→reformat round-trip — otherwise decimal serialization would make
+// the backend reinterpret the value as hex, producing either overflow
+// (ui=ff → Number(255) → "255" → hex 0x255 = overflow) or a wrong match
+// (ui=10 → Number(10) → "10" → hex 0x10 = 16 ≠ decimal 10).
+//
+// Shape check: accept 1–2 hex digits with an optional 0x/0X prefix. The
+// null return signals the caller to fail closed — surface an inline error
+// and SUPPRESS the fetch, rather than fall back to an unfiltered list.
 function parsePBFilterValue(raw) {
   if (typeof raw !== "string") return null;
   const s = raw.trim();
   if (s === "") return null;
-  let n;
-  if (/^0x[0-9a-f]+$/i.test(s)) {
-    n = parseInt(s.slice(2), 16);
-  } else if (/^[0-9a-f]+$/i.test(s) && /[a-f]/i.test(s)) {
-    // Hex without prefix (e.g. "ff").
-    n = parseInt(s, 16);
-  } else if (/^\d+$/.test(s)) {
-    n = parseInt(s, 10);
-  } else {
-    return null;
-  }
-  if (!Number.isFinite(n) || n < 0 || n > 0xff) return null;
-  return n;
+  if (!/^(0x|0X)?[0-9a-fA-F]{1,2}$/.test(s)) return null;
+  return s;
 }
 
 function loadTheme() {
@@ -461,9 +459,29 @@ class PortalShell extends HTMLElement {
           }
           return;
         }
+        // pb/sb are forwarded verbatim (raw hex tokens). Validate shape
+        // locally so obviously-malformed input fails closed instead of
+        // round-tripping to the backend for an UNKNOWN_COMMAND. Empty
+        // pb/sb is permitted — the backend returns the catalog default.
+        const pbRaw = read(pbInput).trim();
+        const sbRaw = read(sbInput).trim();
+        if (pbRaw !== "" && parsePBFilterValue(pbRaw) === null) {
+          if (errEl) {
+            errEl.textContent = `Invalid PB: ${pbRaw} (expected hex byte, e.g. 0x05, ff)`;
+            if (errEl.style) errEl.style.display = "";
+          }
+          return;
+        }
+        if (sbRaw !== "" && parsePBFilterValue(sbRaw) === null) {
+          if (errEl) {
+            errEl.textContent = `Invalid SB: ${sbRaw} (expected hex byte, e.g. 0x05, ff)`;
+            if (errEl.style) errEl.style.display = "";
+          }
+          return;
+        }
         this.submitL7Decode({
-          pb: read(pbInput),
-          sb: read(sbInput),
+          pb: pbRaw,
+          sb: sbRaw,
           direction,
           frame_type: frameType,
           payload_hex: read(payloadInput),
@@ -2474,6 +2492,11 @@ class PortalShell extends HTMLElement {
   async refreshL7Commands(pb) {
     const body = this.querySelector('[data-role="l7-commands-body"]');
     if (!body) return;
+    // pb is forwarded verbatim (raw hex token like "ff", "0x10", "08").
+    // Backend parsePBSBHex parses the query value as hex-only. Any
+    // parse→reformat round-trip (Number(pb) then String()) would produce
+    // a decimal string and break the hex contract for every value where
+    // decimal ≠ hex (ui=ff → "255" → overflow; ui=10 → "10" → 0x10=16).
     const qs = (pb === undefined || pb === null || pb === "") ? "" : `?pb=${encodeURIComponent(String(pb))}`;
     try {
       const resp = await fetch(`api/v1/ebus-standard/commands${qs}`);

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -499,6 +499,15 @@ class PortalShell extends HTMLElement {
     // require an explicit "Refresh Services" press — this mirrors how
     // the explorer section loads its device list lazily.
     if (targetID === "section-l7-catalog" && !this._l7CatalogLoaded) {
+      // Skip auto-fetch when the ebus_standard capability is false —
+      // the sub-server is nil, so /api/v1/ebus-standard/services would
+      // 404. Codex P2 on PR #507. The nav button is also disabled via
+      // applyCapabilityState, so this guard is defence-in-depth against
+      // bootstrap picking section-l7-catalog as firstEnabled and
+      // against programmatic activation.
+      if (this._capabilityEbusStandard === false) {
+        return;
+      }
       this._l7CatalogLoaded = true;
       if (typeof this.refreshL7Services === "function") {
         this.refreshL7Services();
@@ -714,6 +723,13 @@ class PortalShell extends HTMLElement {
     this.setNavState("timeline", cap.timeline || cap.provenance);
     this.setNavState("snapshots", cap.snapshots || cap.snapshot_diff);
     this.setNavState("issue-builder", cap.issue_builder);
+    // L7 Standard Catalog nav button (M5_PORTAL). Gated by the
+    // backend `ebus_standard` capability flag so that when the
+    // sub-server is nil, the button is disabled and the section
+    // is not auto-activated (which would surface a 404 fetch).
+    // Codex P2 on PR #507.
+    this.setNavState("l7-catalog", cap.ebus_standard);
+    this._capabilityEbusStandard = Boolean(cap.ebus_standard);
   }
 
   setNavState(name, enabled) {
@@ -2152,7 +2168,7 @@ class PortalShell extends HTMLElement {
             <button data-role="nav-timeline" data-nav-target="section-timeline" disabled><span class="nav-bullet"></span> Timeline</button>
             <button data-role="nav-snapshots" data-nav-target="section-snapshots" disabled><span class="nav-bullet"></span> Snapshots</button>
             <button data-role="nav-issue-builder" data-nav-target="section-issue-builder" disabled><span class="nav-bullet"></span> Issue Builder</button>
-            <button data-role="nav-l7-catalog" data-nav-target="section-l7-catalog"><span class="nav-bullet"></span> L7 Catalog</button>
+            <button data-role="nav-l7-catalog" data-nav-target="section-l7-catalog" disabled><span class="nav-bullet"></span> L7 Catalog</button>
           </aside>
           <main class="main">
             <h1>Portal Overview</h1>

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -2206,6 +2206,220 @@ class PortalShell extends HTMLElement {
       </div>
     `;
   }
+
+  // ---------------------------------------------------------------------
+  // M5_PORTAL — ebus_standard L7 consumer UI
+  //
+  // Read-only surface over the in-process mcp/ebus_standard sub-server.
+  // Four views:
+  //   - services list         → refreshL7Services()
+  //   - commands list         → refreshL7Commands(optional pb)
+  //   - command detail        → refreshL7Command(id)
+  //   - decode sandbox        → submitL7Decode({pb, sb, direction, frame_type, payload_hex})
+  //
+  // XSS hardening: the decode sandbox writes user-controlled bytes into
+  // the output element via textContent, NEVER innerHTML. Catalog-derived
+  // strings (service/command names) use escapeHtml() before being placed
+  // in innerHTML templates.
+  //
+  // Open-enum fail-closed (M4b2 §4.3): unknown safety_class, direction,
+  // and frame_type values render with an 'unknown' fallback label while
+  // still showing the raw value as evidence.
+  // ---------------------------------------------------------------------
+
+  async refreshL7Services() {
+    const body = this.querySelector('[data-role="l7-services-body"]');
+    if (!body) return;
+    try {
+      const resp = await fetch("api/v1/ebus-standard/services");
+      const env = await resp.json();
+      if (env && env.error) {
+        body.innerHTML = `<div class="error">${escapeHtml(env.error.code || "ERROR")}: ${escapeHtml(env.error.message || "")}</div>`;
+        return;
+      }
+      const services = (env && env.data && env.data.services) || [];
+      if (services.length === 0) {
+        body.innerHTML = '<div class="muted-inline">No services in catalog.</div>';
+        return;
+      }
+      const rows = services.map((svc) => {
+        const pb = escapeHtml(svc.pb);
+        const name = escapeHtml(svc.name || "unknown");
+        const desc = escapeHtml(svc.description || "");
+        const count = escapeHtml(svc.command_count);
+        return `<tr><td>0x${Number(svc.pb).toString(16).padStart(2, "0")}</td><td>${name}</td><td>${desc}</td><td>${count}</td></tr>`;
+      }).join("");
+      body.innerHTML = `<table class="table"><thead><tr><th>PB</th><th>Name</th><th>Description</th><th>Commands</th></tr></thead><tbody>${rows}</tbody></table>`;
+    } catch (err) {
+      body.innerHTML = `<div class="error">${escapeHtml(String(err))}</div>`;
+    }
+  }
+
+  async refreshL7Commands(pb) {
+    const body = this.querySelector('[data-role="l7-commands-body"]');
+    if (!body) return;
+    const qs = (pb === undefined || pb === null || pb === "") ? "" : `?pb=${encodeURIComponent(String(pb))}`;
+    try {
+      const resp = await fetch(`api/v1/ebus-standard/commands${qs}`);
+      const env = await resp.json();
+      if (env && env.error) {
+        body.innerHTML = `<div class="error">${escapeHtml(env.error.code || "ERROR")}: ${escapeHtml(env.error.message || "")}</div>`;
+        return;
+      }
+      const commands = (env && env.data && env.data.commands) || [];
+      if (commands.length === 0) {
+        body.innerHTML = '<div class="muted-inline">No commands match.</div>';
+        return;
+      }
+      const rows = commands.map((cmd) => {
+        const id = escapeHtml(cmd.id || "");
+        const name = escapeHtml(cmd.name || "");
+        const safety = this._l7SafetyClassLabel(cmd.safety_class);
+        const pbHex = `0x${Number(cmd.pb).toString(16).padStart(2, "0")}`;
+        const sbHex = `0x${Number(cmd.sb).toString(16).padStart(2, "0")}`;
+        return `<tr><td>${id}</td><td>${name}</td><td>${escapeHtml(pbHex)}</td><td>${escapeHtml(sbHex)}</td><td>${safety}</td></tr>`;
+      }).join("");
+      body.innerHTML = `<table class="table"><thead><tr><th>ID</th><th>Name</th><th>PB</th><th>SB</th><th>Safety</th></tr></thead><tbody>${rows}</tbody></table>`;
+    } catch (err) {
+      body.innerHTML = `<div class="error">${escapeHtml(String(err))}</div>`;
+    }
+  }
+
+  async refreshL7Command(id) {
+    const body = this.querySelector('[data-role="l7-command-body"]');
+    if (!body) return;
+    if (!id) {
+      body.innerHTML = '<div class="muted-inline">Enter a command id.</div>';
+      return;
+    }
+    try {
+      const resp = await fetch(`api/v1/ebus-standard/command?id=${encodeURIComponent(id)}`);
+      const env = await resp.json();
+      if (env && env.error) {
+        body.innerHTML = `<div class="error">${escapeHtml(env.error.code || "ERROR")}: ${escapeHtml(env.error.message || "")}</div>`;
+        return;
+      }
+      const cmd = (env && env.data && env.data.command) || null;
+      if (!cmd) {
+        body.innerHTML = '<div class="muted-inline">Command not found.</div>';
+        return;
+      }
+      const identity = cmd.identity || {};
+      const safety = this._l7SafetyClassLabel(cmd.safety_class);
+      const direction = this._l7DirectionLabel(identity.direction);
+      const frameType = this._l7FrameTypeLabel(identity.telegram_class);
+      const req = Array.isArray(cmd.request) ? cmd.request : [];
+      const resp2 = Array.isArray(cmd.response) ? cmd.response : [];
+      const paramRow = (p, role) =>
+        `<tr><td>${escapeHtml(role)}</td><td>${escapeHtml(p.name || "")}</td><td>${escapeHtml(p.type || "")}</td><td>${escapeHtml(p.description || "")}</td></tr>`;
+      const paramRows = req.map((p) => paramRow(p, "request")).concat(resp2.map((p) => paramRow(p, "response"))).join("");
+      const paramTable = paramRows
+        ? `<table class="table"><thead><tr><th>Role</th><th>Name</th><th>Type</th><th>Description</th></tr></thead><tbody>${paramRows}</tbody></table>`
+        : '<div class="muted-inline">No parameters documented.</div>';
+      body.innerHTML = `
+        <dl class="meta-list">
+          <dt>ID</dt><dd>${escapeHtml(cmd.id || "")}</dd>
+          <dt>Name</dt><dd>${escapeHtml(cmd.name || "")}</dd>
+          <dt>Description</dt><dd>${escapeHtml(cmd.description || "")}</dd>
+          <dt>Safety class</dt><dd>${safety}</dd>
+          <dt>Direction</dt><dd>${direction}</dd>
+          <dt>Frame type</dt><dd>${frameType}</dd>
+          <dt>PB / SB</dt><dd>0x${escapeHtml(Number(identity.pb || 0).toString(16).padStart(2, "0"))} / 0x${escapeHtml(Number(identity.sb || 0).toString(16).padStart(2, "0"))}</dd>
+        </dl>
+        ${paramTable}
+      `;
+    } catch (err) {
+      body.innerHTML = `<div class="error">${escapeHtml(String(err))}</div>`;
+    }
+  }
+
+  async submitL7Decode(input) {
+    const output = this.querySelector('[data-role="l7-decode-output"]');
+    const status = this.querySelector('[data-role="l7-decode-status"]');
+    if (status) status.textContent = "Decoding...";
+    const params = new URLSearchParams();
+    if (input) {
+      if (input.pb !== undefined && input.pb !== null && input.pb !== "") params.set("pb", String(input.pb));
+      if (input.sb !== undefined && input.sb !== null && input.sb !== "") params.set("sb", String(input.sb));
+      if (input.direction !== undefined && input.direction !== null) params.set("direction", String(input.direction));
+      if (input.frame_type !== undefined && input.frame_type !== null) params.set("frame_type", String(input.frame_type));
+      if (input.payload_hex !== undefined && input.payload_hex !== null) params.set("payload_hex", String(input.payload_hex));
+    }
+    try {
+      const resp = await fetch(`api/v1/ebus-standard/decode?${params.toString()}`);
+      const env = await resp.json();
+      if (env && env.error) {
+        if (status) status.textContent = `${env.error.code || "ERROR"}: ${env.error.message || ""}`;
+        if (output) {
+          // CRITICAL: user-controlled error.message is rendered via
+          // textContent — never innerHTML. This is load-bearing XSS
+          // hardening for the decode sandbox and is enforced by the
+          // l7-catalog.test.mjs audit-log assertions.
+          output.textContent = env.error.message || String(env.error.code || "ERROR");
+        }
+        return;
+      }
+      const data = (env && env.data) || {};
+      if (status) status.textContent = `OK — ${data.command_id || "unknown command"} (${data.validity || "?"})`;
+      if (output) {
+        // The decode response contains raw_bytes + optional decoded_repr,
+        // both of which can reflect wire payloads chosen by an attacker.
+        // textContent is the entire sink for this data — no HTML parsing,
+        // no innerHTML, no template interpolation.
+        const rawBytes = Array.isArray(data.raw_bytes)
+          ? data.raw_bytes.map((b) => Number(b).toString(16).padStart(2, "0")).join(" ")
+          : "";
+        const decodedRepr = typeof data.decoded_repr === "string" ? data.decoded_repr : "";
+        const parts = [
+          `command_id: ${data.command_id || "unknown"}`,
+          `validity: ${data.validity || "unknown"}`,
+          `raw_bytes: ${rawBytes}`,
+        ];
+        if (decodedRepr) parts.push(`decoded: ${decodedRepr}`);
+        output.textContent = parts.join("\n");
+      }
+    } catch (err) {
+      if (status) status.textContent = `Error: ${err}`;
+      if (output) output.textContent = String(err);
+    }
+  }
+
+  // _l7SafetyClassLabel maps a safety_class open-enum value to a labeled
+  // HTML pill. Unknown values render with an "unknown" fallback per
+  // M4b2 §4.3 fail-closed consumer rule, while still showing the raw
+  // value as evidence (escapeHtml-wrapped).
+  _l7SafetyClassLabel(value) {
+    const known = {
+      read_only_safe: "safe",
+      write_controlled: "controlled",
+      frontier_experimental: "experimental",
+      prohibited: "prohibited",
+    };
+    const raw = typeof value === "string" ? value : "";
+    const label = known[raw];
+    if (label) {
+      return `<span class="pill safety-${escapeHtml(raw)}">${escapeHtml(label)}</span> <span class="muted-inline">${escapeHtml(raw)}</span>`;
+    }
+    return `<span class="pill safety-unknown">unknown</span> <span class="muted-inline">${escapeHtml(raw || "(empty)")}</span>`;
+  }
+
+  _l7DirectionLabel(value) {
+    const known = new Set(["master_to_slave", "slave_to_master", "broadcast"]);
+    const raw = typeof value === "string" ? value : "";
+    if (known.has(raw)) {
+      return `<span class="pill">${escapeHtml(raw)}</span>`;
+    }
+    return `<span class="pill pill-unknown">unknown</span> <span class="muted-inline">${escapeHtml(raw || "(empty)")}</span>`;
+  }
+
+  _l7FrameTypeLabel(value) {
+    const known = new Set(["MS", "MM", "BC"]);
+    const raw = typeof value === "string" ? value : "";
+    if (known.has(raw)) {
+      return `<span class="pill">${escapeHtml(raw)}</span>`;
+    }
+    return `<span class="pill pill-unknown">unknown</span> <span class="muted-inline">${escapeHtml(raw || "(empty)")}</span>`;
+  }
 }
 
 customElements.define("portal-shell", PortalShell);

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -326,6 +326,68 @@ class PortalShell extends HTMLElement {
       });
     });
     this.bindExplorerEvents();
+    this.bindL7CatalogEvents();
+  }
+
+  // bindL7CatalogEvents wires the L7 Standard Catalog section (M5_PORTAL)
+  // to the four consumer methods (refreshL7Services / refreshL7Commands /
+  // refreshL7Command / submitL7Decode). Without this wiring the methods
+  // are dead code — render() emits the section markup but no handler
+  // invokes the fetches (Codex P1 finding on PR #507).
+  //
+  // XSS hardening contract: the decode submit path reads user input from
+  // the pb/sb/direction/frame_type/payload_hex inputs and delegates to
+  // submitL7Decode, which renders the response via textContent only on
+  // the [data-role="l7-decode-output"] element. Do NOT add any innerHTML
+  // sink on that element in this handler.
+  bindL7CatalogEvents() {
+    const refreshServices = this.querySelector('[data-role="l7-refresh-services"]');
+    const refreshCommands = this.querySelector('[data-role="l7-refresh-commands"]');
+    const refreshCommand = this.querySelector('[data-role="l7-refresh-command"]');
+    const decodeSubmit = this.querySelector('[data-role="l7-decode-submit"]');
+    if (refreshServices) {
+      refreshServices.addEventListener("click", () => {
+        this.refreshL7Services();
+      });
+    }
+    if (refreshCommands) {
+      refreshCommands.addEventListener("click", () => {
+        const pbInput = this.querySelector('[data-role="l7-pb-filter"]');
+        const pbRaw = pbInput && typeof pbInput.value === "string" ? pbInput.value.trim() : "";
+        let pb;
+        if (pbRaw !== "") {
+          const parsed = pbRaw.startsWith("0x") || pbRaw.startsWith("0X")
+            ? parseInt(pbRaw, 16)
+            : parseInt(pbRaw, 10);
+          if (!Number.isNaN(parsed)) pb = parsed;
+        }
+        this.refreshL7Commands(pb);
+      });
+    }
+    if (refreshCommand) {
+      refreshCommand.addEventListener("click", () => {
+        const idInput = this.querySelector('[data-role="l7-command-id"]');
+        const id = idInput && typeof idInput.value === "string" ? idInput.value.trim() : "";
+        this.refreshL7Command(id);
+      });
+    }
+    if (decodeSubmit) {
+      decodeSubmit.addEventListener("click", () => {
+        const pbInput = this.querySelector('[data-role="l7-decode-pb"]');
+        const sbInput = this.querySelector('[data-role="l7-decode-sb"]');
+        const dirInput = this.querySelector('[data-role="l7-decode-direction"]');
+        const frameInput = this.querySelector('[data-role="l7-decode-frame-type"]');
+        const payloadInput = this.querySelector('[data-role="l7-decode-payload"]');
+        const read = (el) => (el && typeof el.value === "string" ? el.value : "");
+        this.submitL7Decode({
+          pb: read(pbInput),
+          sb: read(sbInput),
+          direction: read(dirInput),
+          frame_type: read(frameInput),
+          payload_hex: read(payloadInput),
+        });
+      });
+    }
   }
 
   activateSection(targetID) {
@@ -339,6 +401,7 @@ class PortalShell extends HTMLElement {
       "section-timeline": ["section-timeline", "section-provenance"],
       "section-snapshots": ["section-snapshots", "section-snapshot-diff", "section-sessions"],
       "section-issue-builder": ["section-issue-builder"],
+      "section-l7-catalog": ["section-l7-catalog"],
     };
     const visible = new Set(sectionMap[targetID] || [targetID]);
     visible.add("section-search");
@@ -349,6 +412,16 @@ class PortalShell extends HTMLElement {
     this.querySelectorAll("[data-nav-target]").forEach((btn) => {
       btn.classList.toggle("active", btn.getAttribute("data-nav-target") === targetID);
     });
+    // First time the L7 Catalog section is activated, kick off the
+    // services list fetch so the panel isn't empty. Subsequent clicks
+    // require an explicit "Refresh Services" press — this mirrors how
+    // the explorer section loads its device list lazily.
+    if (targetID === "section-l7-catalog" && !this._l7CatalogLoaded) {
+      this._l7CatalogLoaded = true;
+      if (typeof this.refreshL7Services === "function") {
+        this.refreshL7Services();
+      }
+    }
   }
 
   async loadStatus(lifecycleToken = this.bootstrapLifecycleToken, lifecycleAbort = this.bootstrapLifecycleAbort) {
@@ -1997,6 +2070,7 @@ class PortalShell extends HTMLElement {
             <button data-role="nav-timeline" data-nav-target="section-timeline" disabled><span class="nav-bullet"></span> Timeline</button>
             <button data-role="nav-snapshots" data-nav-target="section-snapshots" disabled><span class="nav-bullet"></span> Snapshots</button>
             <button data-role="nav-issue-builder" data-nav-target="section-issue-builder" disabled><span class="nav-bullet"></span> Issue Builder</button>
+            <button data-role="nav-l7-catalog" data-nav-target="section-l7-catalog"><span class="nav-bullet"></span> L7 Catalog</button>
           </aside>
           <main class="main">
             <h1>Portal Overview</h1>
@@ -2198,6 +2272,48 @@ class PortalShell extends HTMLElement {
                 <button class="button" data-role="issue-export-run" type="button">Export Bundle</button>
               </div>
               <pre class="issue-preview" data-role="issue-preview">Loading issue builder capability...</pre>
+            </section>
+            <section id="section-l7-catalog" class="registry-preview">
+              <h2>L7 Standard Catalog</h2>
+              <p class="muted-inline">Read-only view over the ebus_standard L7 catalog (M5_PORTAL). Services, commands with 14-tuple identity, and a decode sandbox.</p>
+              <div class="snapshot-controls">
+                <button class="button" data-role="l7-refresh-services" type="button">Refresh Services</button>
+                <input class="search timeline-filter" data-role="l7-pb-filter" type="search" placeholder="Filter commands by PB (e.g. 5 or 0x05)" aria-label="Filter commands by PB" />
+                <button class="button" data-role="l7-refresh-commands" type="button">Refresh Commands</button>
+                <input class="search timeline-filter" data-role="l7-command-id" type="search" placeholder="Command id (e.g. ebus_standard.service_data.start_counts)" aria-label="Command id" />
+                <button class="button" data-role="l7-refresh-command" type="button">Load Command</button>
+              </div>
+              <h3>Services</h3>
+              <div data-role="l7-services-body">
+                <div class="muted-inline">Click Refresh Services to load the catalog.</div>
+              </div>
+              <h3>Commands</h3>
+              <div data-role="l7-commands-body">
+                <div class="muted-inline">Click Refresh Commands to list commands.</div>
+              </div>
+              <h3>Command Detail</h3>
+              <div data-role="l7-command-body">
+                <div class="muted-inline">Enter a command id and click Load Command.</div>
+              </div>
+              <h3>Decode Sandbox</h3>
+              <div class="snapshot-controls">
+                <input class="search timeline-filter" data-role="l7-decode-pb" type="text" placeholder="pb (0-255)" aria-label="Decode PB" size="5" />
+                <input class="search timeline-filter" data-role="l7-decode-sb" type="text" placeholder="sb (0-255)" aria-label="Decode SB" size="5" />
+                <select class="select" data-role="l7-decode-direction" aria-label="Decode direction">
+                  <option value="master_to_slave">master_to_slave</option>
+                  <option value="slave_to_master">slave_to_master</option>
+                  <option value="broadcast">broadcast</option>
+                </select>
+                <select class="select" data-role="l7-decode-frame-type" aria-label="Decode frame type">
+                  <option value="MM">MM (initiator-initiator)</option>
+                  <option value="MS">MS (initiator-responder)</option>
+                  <option value="BC">BC (broadcast)</option>
+                </select>
+                <input class="search timeline-filter" data-role="l7-decode-payload" type="text" placeholder="payload_hex" aria-label="Decode payload hex" />
+                <button class="button" data-role="l7-decode-submit" type="button">Decode</button>
+              </div>
+              <div class="muted-inline" data-role="l7-decode-status">Idle.</div>
+              <pre class="issue-preview" data-role="l7-decode-output"></pre>
             </section>
             <div class="meta" data-role="stream-status">Stream idle</div>
             <div class="meta" data-role="meta">Waiting for bootstrap...</div>

--- a/portal/web/test/l7-catalog.test.mjs
+++ b/portal/web/test/l7-catalog.test.mjs
@@ -802,3 +802,104 @@ test("L7 PB filter parses well-formed hex/decimal and forwards to refreshL7Comma
     }
   }
 });
+
+// ---- 11. Capability gating: nav button disabled when ebus_standard=false ----
+//
+// Regression for Codex P2 finding on PR #507 (round 5): the L7 nav
+// button used to render enabled by default; applyCapabilityState()
+// never toggled it, so when Options.EbusStandardServer was nil the
+// button remained clickable and bootstrap auto-activation fetched
+// /api/v1/ebus-standard/services → 404. Fix gates the button by the
+// new `ebus_standard` capability flag, matching nav-explorer idiom.
+
+test("L7 nav button is disabled when capabilities.ebus_standard=false", async () => {
+  const { source, sourcePath } = await loadShellSource();
+  const navBtn = {
+    disabled: false,
+    className: "",
+    classList: { toggle() {} },
+    querySelector: () => ({ classList: { toggle() {} } }),
+  };
+  const elements = new Map([
+    ['[data-role="nav-l7-catalog"]', navBtn],
+  ]);
+  const { shell } = buildSandbox({
+    source, sourcePath, elements,
+    fetchImpl: async () => ({ ok: true, json: async () => ({}) }),
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.applyCapabilityState = proto.applyCapabilityState;
+  shell.setNavState = proto.setNavState;
+  shell.applyCapabilityState({ ebus_standard: false });
+  assert.equal(navBtn.disabled, true,
+    "nav-l7-catalog must be disabled when capability=false");
+  assert.equal(shell._capabilityEbusStandard, false,
+    "_capabilityEbusStandard must record false for activateSection guard");
+});
+
+test("L7 nav button is enabled when capabilities.ebus_standard=true", async () => {
+  const { source, sourcePath } = await loadShellSource();
+  const navBtn = {
+    disabled: true,
+    className: "",
+    classList: { toggle() {} },
+    querySelector: () => ({ classList: { toggle() {} } }),
+  };
+  const elements = new Map([
+    ['[data-role="nav-l7-catalog"]', navBtn],
+  ]);
+  const { shell } = buildSandbox({
+    source, sourcePath, elements,
+    fetchImpl: async () => ({ ok: true, json: async () => ({}) }),
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.applyCapabilityState = proto.applyCapabilityState;
+  shell.setNavState = proto.setNavState;
+  shell.applyCapabilityState({ ebus_standard: true });
+  assert.equal(navBtn.disabled, false,
+    "nav-l7-catalog must be enabled when capability=true");
+  assert.equal(shell._capabilityEbusStandard, true,
+    "_capabilityEbusStandard must record true for activateSection guard");
+});
+
+test("activateSection(section-l7-catalog) no-ops when ebus_standard=false (no refreshL7Services call)", async () => {
+  const { source, sourcePath } = await loadShellSource();
+  // Build a shell with no matching DOM (querySelectorAll returns [])
+  // and capture whether refreshL7Services is invoked.
+  const { shell } = buildSandbox({
+    source, sourcePath,
+    elements: new Map(),
+    fetchImpl: async () => { throw new Error("fetch must NOT be called when capability=false"); },
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.activateSection = proto.activateSection;
+  let refreshCalls = 0;
+  shell.refreshL7Services = () => { refreshCalls++; };
+  shell._capabilityEbusStandard = false;
+
+  shell.activateSection("section-l7-catalog");
+
+  assert.equal(refreshCalls, 0,
+    "refreshL7Services must NOT be called when ebus_standard capability is false");
+  assert.ok(!shell._l7CatalogLoaded,
+    "_l7CatalogLoaded must remain unset so a later capability=true activation still loads");
+});
+
+test("activateSection(section-l7-catalog) triggers refreshL7Services when ebus_standard=true", async () => {
+  const { source, sourcePath } = await loadShellSource();
+  const { shell } = buildSandbox({
+    source, sourcePath,
+    elements: new Map(),
+    fetchImpl: async () => ({ ok: true, json: async () => ({}) }),
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.activateSection = proto.activateSection;
+  let refreshCalls = 0;
+  shell.refreshL7Services = () => { refreshCalls++; };
+  shell._capabilityEbusStandard = true;
+
+  shell.activateSection("section-l7-catalog");
+
+  assert.equal(refreshCalls, 1,
+    "refreshL7Services must fire once on first activation when capability=true");
+});

--- a/portal/web/test/l7-catalog.test.mjs
+++ b/portal/web/test/l7-catalog.test.mjs
@@ -1,0 +1,297 @@
+// Tests for the M5_PORTAL ebus_standard L7 consumer UI.
+//
+// These tests extend the existing PortalShell harness (see portal-shell.test.mjs)
+// with an innerHTML/textContent audit log on each FakeHTMLElement, which is
+// load-bearing for the XSS assertions on the decode sandbox.
+//
+// Runner: node:test (NOT Jest / JSDOM). The audit-log pattern is more
+// auditable than JSDOM's silent parse because it records the *exact* setter
+// sequence — a violation is a recorded innerHTML assignment, not "did a
+// <script> node materialize somewhere in the DOM".
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import vm from "node:vm";
+import test from "node:test";
+
+// AuditedElement wraps an element with setter intercepts for innerHTML and
+// textContent. Every assignment is recorded on the element's _audit array.
+// The property values remain directly readable so the SUT-under-test can
+// assert what it just wrote.
+function makeAuditedElement(extra = {}) {
+  const audit = [];
+  let innerHTMLValue = "";
+  let textContentValue = "";
+  const el = {
+    _audit: audit,
+    get innerHTML() {
+      return innerHTMLValue;
+    },
+    set innerHTML(v) {
+      innerHTMLValue = String(v);
+      audit.push({ prop: "innerHTML", value: String(v) });
+    },
+    get textContent() {
+      return textContentValue;
+    },
+    set textContent(v) {
+      textContentValue = String(v);
+      audit.push({ prop: "textContent", value: String(v) });
+    },
+    className: "",
+    _isConnected: true,
+    get isConnected() {
+      return this._isConnected !== false;
+    },
+    setAttribute() {},
+    ...extra,
+  };
+  return el;
+}
+
+function createDeferredResponse(payload) {
+  let resolve;
+  const promise = new Promise((res) => {
+    resolve = res;
+  });
+  return {
+    promise,
+    resolve() {
+      resolve({
+        ok: true,
+        status: 200,
+        json: async () => payload,
+      });
+    },
+  };
+}
+
+function flush() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+async function loadShellSource() {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const sourcePath = path.resolve(here, "../src/app.js");
+  const source = await readFile(sourcePath, "utf8");
+  return { source, sourcePath };
+}
+
+function buildSandbox({ source, sourcePath, elements, fetchImpl }) {
+  class FakeHTMLElement {
+    constructor() {
+      this._isConnected = true;
+    }
+    get isConnected() {
+      return this._isConnected !== false;
+    }
+  }
+  const fetchRequests = [];
+  const sandbox = {
+    console: { error() {}, log() {}, warn() {} },
+    document: { documentElement: { setAttribute() {} } },
+    customElements: { define() {} },
+    HTMLElement: FakeHTMLElement,
+    localStorage: { getItem: () => null, setItem() {} },
+    setInterval: () => ({}),
+    clearInterval: () => {},
+    setTimeout,
+    clearTimeout,
+    AbortController,
+    URLSearchParams,
+    TextDecoder,
+    fetch: (url, init) => {
+      fetchRequests.push({ url, init });
+      return fetchImpl(url, init);
+    },
+  };
+  sandbox.globalThis = sandbox;
+  vm.createContext(sandbox);
+  vm.runInContext(
+    `${source}\n;globalThis.__PortalShell = PortalShell;`,
+    sandbox,
+    { filename: pathToFileURL(sourcePath).href },
+  );
+  const PortalShell = sandbox.__PortalShell;
+  const shell = new PortalShell();
+  shell._isConnected = true;
+  shell.render = () => {};
+  shell.bindEvents = () => {};
+  shell.querySelector = (selector) => elements.get(selector) || null;
+  shell.querySelectorAll = () => [];
+  return { shell, fetchRequests };
+}
+
+// ---- 1. Section render uses escapeHtml for catalog strings ----
+
+test("L7 catalog services list renders via escapeHtml (safe) for catalog strings", async () => {
+  const { source, sourcePath } = await loadShellSource();
+  const servicesBody = makeAuditedElement();
+  const elements = new Map([
+    ["[data-role=\"l7-services-body\"]", servicesBody],
+  ]);
+  const servicesResponse = createDeferredResponse({
+    meta: {
+      contract: { name: "helianthus-ebus-mcp", major: 1, minor: 0 },
+      consistency: { mode: "LIVE" },
+      data_hash: "a".repeat(64),
+    },
+    data: {
+      namespace: "ebus_standard",
+      catalog_version: "v-test",
+      services: [
+        { pb: 5, name: "identification", description: "Identify", command_count: 2 },
+      ],
+    },
+    error: null,
+  });
+  const { shell } = buildSandbox({
+    source,
+    sourcePath,
+    elements,
+    fetchImpl: () => servicesResponse.promise,
+  });
+
+  assert.equal(typeof shell.refreshL7Services, "function",
+    "PortalShell must expose refreshL7Services for the L7 catalog section");
+
+  const p = shell.refreshL7Services();
+  servicesResponse.resolve();
+  await p;
+
+  // Catalog tables use innerHTML (after escapeHtml). At least one innerHTML
+  // assignment must have occurred on the services body.
+  const htmlWrites = servicesBody._audit.filter((e) => e.prop === "innerHTML");
+  assert.ok(htmlWrites.length >= 1, "services body should receive rendered HTML");
+  assert.ok(htmlWrites.some((e) => e.value.includes("identification")),
+    "service name should appear in rendered HTML");
+});
+
+// ---- 2. Decode sandbox output uses textContent only (XSS hardening) ----
+
+test("L7 decode sandbox output uses textContent, never innerHTML, for user-controlled bytes", async () => {
+  const { source, sourcePath } = await loadShellSource();
+  const decodeOutput = makeAuditedElement();
+  const decodeStatus = makeAuditedElement();
+  const elements = new Map([
+    ["[data-role=\"l7-decode-output\"]", decodeOutput],
+    ["[data-role=\"l7-decode-status\"]", decodeStatus],
+  ]);
+
+  const xssHex = "3c7363726970743e616c6572742831293c2f7363726970743e"; // "<script>alert(1)</script>"
+  const decodeResponse = createDeferredResponse({
+    meta: {
+      contract: { name: "helianthus-ebus-mcp", major: 1, minor: 0 },
+      consistency: { mode: "LIVE" },
+      data_hash: "b".repeat(64),
+    },
+    data: {
+      namespace: "ebus_standard",
+      catalog_version: "v-test",
+      command_id: "cmd.decoded",
+      // Server echoes raw bytes + decoded repr containing literal script tag —
+      // the frontend must render this as plain text.
+      raw_bytes: [0x3c, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x3e],
+      decoded_repr: "<script>alert(1)</script>",
+      validity: "catalog_identified",
+    },
+    error: null,
+  });
+
+  const { shell } = buildSandbox({
+    source,
+    sourcePath,
+    elements,
+    fetchImpl: () => decodeResponse.promise,
+  });
+
+  assert.equal(typeof shell.submitL7Decode, "function",
+    "PortalShell must expose submitL7Decode for the decode sandbox");
+
+  const p = shell.submitL7Decode({
+    pb: 5,
+    sb: 4,
+    direction: "master_to_slave",
+    frame_type: "MM",
+    payload_hex: xssHex,
+  });
+  decodeResponse.resolve();
+  await p;
+
+  // (a) decode-output element received content via textContent setter.
+  const textWrites = decodeOutput._audit.filter((e) => e.prop === "textContent");
+  assert.ok(textWrites.length >= 1,
+    "decode output must be set via textContent (XSS hardening)");
+
+  // (b) innerHTML was NEVER assigned on the decode-output element.
+  const htmlWrites = decodeOutput._audit.filter((e) => e.prop === "innerHTML");
+  assert.equal(htmlWrites.length, 0,
+    `decode output must never use innerHTML; saw: ${JSON.stringify(htmlWrites)}`);
+
+  // (c) literal <script>...</script> substring is present as plain text.
+  const finalText = textWrites.map((e) => e.value).join("\n");
+  assert.ok(finalText.includes("<script>"),
+    "literal <script> substring must survive as text, not be HTML-parsed");
+  assert.ok(finalText.includes("</script>"),
+    "literal </script> substring must survive as text");
+});
+
+// ---- 3. Unknown enum (safety_class / direction / frame_type) → "unknown" fallback ----
+
+test("L7 command view renders unknown safety_class as 'unknown' fallback", async () => {
+  const { source, sourcePath } = await loadShellSource();
+  const cmdBody = makeAuditedElement();
+  const elements = new Map([
+    ["[data-role=\"l7-command-body\"]", cmdBody],
+  ]);
+
+  const cmdResponse = createDeferredResponse({
+    meta: {
+      contract: { name: "helianthus-ebus-mcp", major: 1, minor: 0 },
+      consistency: { mode: "LIVE" },
+      data_hash: "c".repeat(64),
+    },
+    data: {
+      namespace: "ebus_standard",
+      catalog_version: "v-test",
+      command: {
+        id: "cmd.future",
+        name: "Future",
+        safety_class: "brand_new_class_xyz",
+        identity: {
+          pb: 5, sb: 4,
+          direction: "weird_new_direction",
+          telegram_class: "weird_frame",
+        },
+        request: [],
+        response: [],
+      },
+    },
+    error: null,
+  });
+
+  const { shell } = buildSandbox({
+    source,
+    sourcePath,
+    elements,
+    fetchImpl: () => cmdResponse.promise,
+  });
+
+  assert.equal(typeof shell.refreshL7Command, "function",
+    "PortalShell must expose refreshL7Command for the command detail view");
+
+  const p = shell.refreshL7Command("cmd.future");
+  cmdResponse.resolve();
+  await p;
+
+  const htmlWrites = cmdBody._audit.filter((e) => e.prop === "innerHTML");
+  assert.ok(htmlWrites.length >= 1, "command body should render");
+  const rendered = htmlWrites.map((e) => e.value).join("\n");
+
+  // Unknown safety_class must render with "unknown" fallback label. The raw
+  // open-enum value is passed through as evidence; the UI just labels it.
+  assert.ok(rendered.toLowerCase().includes("unknown"),
+    "unknown safety_class must render with 'unknown' label; got: " + rendered);
+});

--- a/portal/web/test/l7-catalog.test.mjs
+++ b/portal/web/test/l7-catalog.test.mjs
@@ -684,7 +684,10 @@ test("L7 PB filter blocks refreshL7Commands on malformed PB and surfaces inline 
     return { value, isConnected: true, setAttribute() {}, _audit: [] };
   }
 
-  for (const bad of ["banana", "0xZZ", "5abc", "-1", "256", "0xff 0x00"]) {
+  // Post-fix contract: hex-shape validation (1–2 hex digits, optional
+  // 0x prefix). "255" is now decimal-rejected because interpreted as hex
+  // it would overflow (0x255 > 0xFF).
+  for (const bad of ["banana", "0xZZ", "5abc", "-1", "256", "255", "0xff 0x00"]) {
     const pbInput = makeInput(bad);
     const pbErr = makeAuditedElement({ style: { display: "none" } });
 
@@ -745,13 +748,18 @@ test("L7 PB filter parses well-formed hex/decimal and forwards to refreshL7Comma
     return { value, isConnected: true, setAttribute() {}, _audit: [] };
   }
 
+  // Post-fix contract: parsePBFilterValue returns the raw trimmed token
+  // (hex-shape validated), and the click handler forwards it verbatim.
+  // No decimal→hex conversion, no Number() round-trip. Backend
+  // parsePBSBHex parses hex-only, so "255" (decimal) is no longer a
+  // well-formed PB filter input — it would overflow as hex. The operator
+  // must type "ff" for 255.
   const cases = [
-    { input: "0x05", expected: 0x05 },
-    { input: "5", expected: 5 },
-    { input: "ff", expected: 0xff },
-    { input: "0xFF", expected: 0xff },
-    { input: "255", expected: 255 },
-    { input: "0", expected: 0 },
+    { input: "0x05", expected: "0x05" },
+    { input: "5", expected: "5" },
+    { input: "ff", expected: "ff" },
+    { input: "0xFF", expected: "0xFF" },
+    { input: "0", expected: "0" },
     { input: "", expected: undefined }, // unfiltered
   ];
 
@@ -902,4 +910,236 @@ test("activateSection(section-l7-catalog) triggers refreshL7Services when ebus_s
 
   assert.equal(refreshCalls, 1,
     "refreshL7Services must fire once on first activation when capability=true");
+});
+
+// ---- 12. Hex-verbatim forwarding (reciprocal to backend parsePBSBHex) ----
+//
+// Regression for Codex P1 finding on PR #507 (review id #3109717227):
+// the frontend was reformatting PB/SB through Number()+String(), which
+// produces a decimal string. Backend parsePBSBHex now reads the query
+// value as hex-only, so `ff` UI → `pb=255` → 8-bit overflow → 400;
+// `10` UI → `pb=16` → wrong command filter. Fix: forward the operator's
+// trimmed raw token verbatim in both PB-filter and decode-submit paths.
+
+test("L7 commands PB filter forwards raw hex verbatim (ui=ff → pb=ff, NOT pb=255)", async () => {
+  const { source, sourcePath } = await loadShellSource();
+  function makeInput(value) {
+    return { value, isConnected: true, setAttribute() {}, _audit: [] };
+  }
+  const pbInput = makeInput("ff");
+  const pbErr = makeAuditedElement({ style: { display: "none" } });
+  const body = makeAuditedElement();
+  let commandsClickHandler = null;
+  const refreshCommandsBtn = {
+    isConnected: true,
+    addEventListener(name, fn) { if (name === "click") commandsClickHandler = fn; },
+  };
+  const noopListener = { addEventListener() {} };
+  const elements = new Map([
+    ['[data-role="l7-pb-filter"]', pbInput],
+    ['[data-role="l7-commands-pb-error"]', pbErr],
+    ['[data-role="l7-commands-body"]', body],
+    ['[data-role="l7-refresh-commands"]', refreshCommandsBtn],
+    ['[data-role="l7-refresh-services"]', noopListener],
+    ['[data-role="l7-refresh-command"]', noopListener],
+    ['[data-role="l7-decode-submit"]', noopListener],
+    ['[data-role="l7-command-id"]', makeInput("")],
+    ['[data-role="l7-decode-pb"]', makeInput("")],
+    ['[data-role="l7-decode-sb"]', makeInput("")],
+    ['[data-role="l7-decode-direction"]', makeInput("request")],
+    ['[data-role="l7-decode-frame-type"]', makeInput("addressed")],
+    ['[data-role="l7-decode-payload"]', makeInput("")],
+    ['[data-role="l7-decode-error"]', makeAuditedElement({ style: { display: "none" } })],
+  ]);
+  const commandsResponse = createDeferredResponse({
+    meta: { contract: { name: "helianthus-ebus-mcp", major: 1, minor: 0 }, consistency: { mode: "LIVE" }, data_hash: "f".repeat(64) },
+    data: { namespace: "ebus_standard", catalog_version: "v-test", commands: [] },
+    error: null,
+  });
+  const { shell, fetchRequests } = buildSandbox({
+    source, sourcePath, elements,
+    fetchImpl: () => commandsResponse.promise,
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.bindL7CatalogEvents = proto.bindL7CatalogEvents;
+  shell.bindL7CatalogEvents();
+  commandsClickHandler();
+  commandsResponse.resolve();
+  await flush(); await flush(); await flush();
+
+  assert.ok(fetchRequests.length >= 1, "fetch must be issued for well-formed PB");
+  const url = String(fetchRequests[0].url);
+  assert.ok(url.includes("pb=ff"),
+    `fetch URL must contain pb=ff (verbatim hex), got: ${url}`);
+  assert.ok(!url.includes("pb=255"),
+    `fetch URL must NOT contain decimal pb=255, got: ${url}`);
+});
+
+test("L7 commands PB filter preserves 0x prefix verbatim (ui=0x10 → pb=0x10)", async () => {
+  const { source, sourcePath } = await loadShellSource();
+  function makeInput(value) {
+    return { value, isConnected: true, setAttribute() {}, _audit: [] };
+  }
+  const pbInput = makeInput("0x10");
+  const pbErr = makeAuditedElement({ style: { display: "none" } });
+  const body = makeAuditedElement();
+  let commandsClickHandler = null;
+  const refreshCommandsBtn = {
+    isConnected: true,
+    addEventListener(name, fn) { if (name === "click") commandsClickHandler = fn; },
+  };
+  const noopListener = { addEventListener() {} };
+  const elements = new Map([
+    ['[data-role="l7-pb-filter"]', pbInput],
+    ['[data-role="l7-commands-pb-error"]', pbErr],
+    ['[data-role="l7-commands-body"]', body],
+    ['[data-role="l7-refresh-commands"]', refreshCommandsBtn],
+    ['[data-role="l7-refresh-services"]', noopListener],
+    ['[data-role="l7-refresh-command"]', noopListener],
+    ['[data-role="l7-decode-submit"]', noopListener],
+    ['[data-role="l7-command-id"]', makeInput("")],
+    ['[data-role="l7-decode-pb"]', makeInput("")],
+    ['[data-role="l7-decode-sb"]', makeInput("")],
+    ['[data-role="l7-decode-direction"]', makeInput("request")],
+    ['[data-role="l7-decode-frame-type"]', makeInput("addressed")],
+    ['[data-role="l7-decode-payload"]', makeInput("")],
+    ['[data-role="l7-decode-error"]', makeAuditedElement({ style: { display: "none" } })],
+  ]);
+  const commandsResponse = createDeferredResponse({
+    meta: { contract: { name: "helianthus-ebus-mcp", major: 1, minor: 0 }, consistency: { mode: "LIVE" }, data_hash: "0".repeat(64) },
+    data: { namespace: "ebus_standard", catalog_version: "v-test", commands: [] },
+    error: null,
+  });
+  const { shell, fetchRequests } = buildSandbox({
+    source, sourcePath, elements,
+    fetchImpl: () => commandsResponse.promise,
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.bindL7CatalogEvents = proto.bindL7CatalogEvents;
+  shell.bindL7CatalogEvents();
+  commandsClickHandler();
+  commandsResponse.resolve();
+  await flush(); await flush(); await flush();
+
+  assert.ok(fetchRequests.length >= 1, "fetch must be issued for well-formed PB");
+  const url = String(fetchRequests[0].url);
+  // URLSearchParams-style OR direct concatenation both preserve the literal
+  // 0x prefix — either pb=0x10 (unescaped) or pb=0x10 via encodeURIComponent
+  // (unchanged, since neither 'x' nor digits are percent-encoded).
+  assert.ok(url.includes("pb=0x10"),
+    `fetch URL must contain pb=0x10 verbatim (0x prefix preserved), got: ${url}`);
+  assert.ok(!url.includes("pb=16"),
+    `fetch URL must NOT contain decimal pb=16, got: ${url}`);
+});
+
+test("L7 commands PB filter rejects non-hex locally and does not fetch (ui=banana)", async () => {
+  const { source, sourcePath } = await loadShellSource();
+  function makeInput(value) {
+    return { value, isConnected: true, setAttribute() {}, _audit: [] };
+  }
+  const pbInput = makeInput("banana");
+  const pbErr = makeAuditedElement({ style: { display: "none" } });
+  let commandsClickHandler = null;
+  const refreshCommandsBtn = {
+    isConnected: true,
+    addEventListener(name, fn) { if (name === "click") commandsClickHandler = fn; },
+  };
+  const noopListener = { addEventListener() {} };
+  const elements = new Map([
+    ['[data-role="l7-pb-filter"]', pbInput],
+    ['[data-role="l7-commands-pb-error"]', pbErr],
+    ['[data-role="l7-refresh-commands"]', refreshCommandsBtn],
+    ['[data-role="l7-refresh-services"]', noopListener],
+    ['[data-role="l7-refresh-command"]', noopListener],
+    ['[data-role="l7-decode-submit"]', noopListener],
+    ['[data-role="l7-command-id"]', makeInput("")],
+    ['[data-role="l7-decode-pb"]', makeInput("")],
+    ['[data-role="l7-decode-sb"]', makeInput("")],
+    ['[data-role="l7-decode-direction"]', makeInput("request")],
+    ['[data-role="l7-decode-frame-type"]', makeInput("addressed")],
+    ['[data-role="l7-decode-payload"]', makeInput("")],
+    ['[data-role="l7-decode-error"]', makeAuditedElement({ style: { display: "none" } })],
+  ]);
+  const { shell, fetchRequests } = buildSandbox({
+    source, sourcePath, elements,
+    fetchImpl: async () => { throw new Error("fetch must not be called for non-hex PB"); },
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.bindL7CatalogEvents = proto.bindL7CatalogEvents;
+  shell.bindL7CatalogEvents();
+  commandsClickHandler();
+  await flush();
+
+  assert.equal(fetchRequests.length, 0,
+    "fetch must NOT be issued for non-hex PB input");
+  const textWrites = pbErr._audit.filter((e) => e.prop === "textContent");
+  const lastNonEmpty = textWrites.filter((w) => w.value !== "").pop();
+  assert.ok(lastNonEmpty,
+    "inline error element must receive non-empty textContent on non-hex input");
+  assert.ok(/invalid pb/i.test(lastNonEmpty.value),
+    `error text should mention PB; got: ${lastNonEmpty.value}`);
+});
+
+test("L7 decode submit forwards pb/sb as hex verbatim (ui=ff,08 → pb=ff,sb=08, NOT decimal)", async () => {
+  const { source, sourcePath } = await loadShellSource();
+  function makeInput(value) {
+    return { value, isConnected: true, setAttribute() {}, _audit: [] };
+  }
+  const pbInput = makeInput("ff");
+  const sbInput = makeInput("08");
+  const dirInput = makeInput("request");
+  const frameInput = makeInput("addressed");
+  const payloadInput = makeInput("0102");
+  const decodeOutput = makeAuditedElement();
+  const decodeStatus = makeAuditedElement();
+  const decodeError = makeAuditedElement({ style: { display: "none" } });
+  let submitClickHandler = null;
+  const submitBtn = {
+    isConnected: true,
+    addEventListener(name, fn) { if (name === "click") submitClickHandler = fn; },
+  };
+  const noopListener = { addEventListener() {} };
+  const elements = new Map([
+    ['[data-role="l7-decode-output"]', decodeOutput],
+    ['[data-role="l7-decode-status"]', decodeStatus],
+    ['[data-role="l7-decode-error"]', decodeError],
+    ['[data-role="l7-decode-pb"]', pbInput],
+    ['[data-role="l7-decode-sb"]', sbInput],
+    ['[data-role="l7-decode-direction"]', dirInput],
+    ['[data-role="l7-decode-frame-type"]', frameInput],
+    ['[data-role="l7-decode-payload"]', payloadInput],
+    ['[data-role="l7-decode-submit"]', submitBtn],
+    ['[data-role="l7-refresh-services"]', noopListener],
+    ['[data-role="l7-refresh-commands"]', noopListener],
+    ['[data-role="l7-refresh-command"]', noopListener],
+    ['[data-role="l7-pb-filter"]', makeInput("")],
+    ['[data-role="l7-commands-pb-error"]', makeAuditedElement({ style: { display: "none" } })],
+    ['[data-role="l7-command-id"]', makeInput("")],
+  ]);
+  const decodeResponse = createDeferredResponse({
+    meta: { contract: { name: "helianthus-ebus-mcp", major: 1, minor: 0 }, consistency: { mode: "LIVE" }, data_hash: "1".repeat(64) },
+    data: { namespace: "ebus_standard", catalog_version: "v-test", command_id: "cmd.ok", raw_bytes: [1, 2], validity: "catalog_identified" },
+    error: null,
+  });
+  const { shell, fetchRequests } = buildSandbox({
+    source, sourcePath, elements,
+    fetchImpl: () => decodeResponse.promise,
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.bindL7CatalogEvents = proto.bindL7CatalogEvents;
+  shell.bindL7CatalogEvents();
+  submitClickHandler();
+  decodeResponse.resolve();
+  await flush(); await flush(); await flush();
+
+  assert.ok(fetchRequests.length >= 1, "fetch must be issued for well-formed pb/sb");
+  const url = String(fetchRequests[0].url);
+  assert.ok(url.includes("pb=ff"),
+    `decode URL must contain pb=ff verbatim, got: ${url}`);
+  assert.ok(url.includes("sb=08"),
+    `decode URL must contain sb=08 verbatim, got: ${url}`);
+  assert.ok(!url.includes("pb=255"),
+    `decode URL must NOT contain decimal pb=255, got: ${url}`);
+  assert.ok(!url.includes("sb=8&") && !url.endsWith("sb=8"),
+    `decode URL must NOT reformat sb=08 to sb=8, got: ${url}`);
 });

--- a/portal/web/test/l7-catalog.test.mjs
+++ b/portal/web/test/l7-catalog.test.mjs
@@ -684,10 +684,12 @@ test("L7 PB filter blocks refreshL7Commands on malformed PB and surfaces inline 
     return { value, isConnected: true, setAttribute() {}, _audit: [] };
   }
 
-  // Post-fix contract: hex-shape validation (1–2 hex digits, optional
-  // 0x prefix). "255" is now decimal-rejected because interpreted as hex
-  // it would overflow (0x255 > 0xFF).
-  for (const bad of ["banana", "0xZZ", "5abc", "-1", "256", "255", "0xff 0x00"]) {
+  // Round 9 contract (smart decimal+0x hex detection):
+  //   - decimal: 1-3 digits in [0,255]
+  //   - hex:     "0x" or "0X" prefix + 1-2 hex digits
+  // Bare hex ("ff") is REJECTED — operators must type "0xff".
+  // "256" is decimal-rejected (out of range); "300" same.
+  for (const bad of ["banana", "0xZZ", "5abc", "-1", "256", "300", "ff", "0xff 0x00"]) {
     const pbInput = makeInput(bad);
     const pbErr = makeAuditedElement({ style: { display: "none" } });
 
@@ -748,19 +750,20 @@ test("L7 PB filter parses well-formed hex/decimal and forwards to refreshL7Comma
     return { value, isConnected: true, setAttribute() {}, _audit: [] };
   }
 
-  // Post-fix contract: parsePBFilterValue returns the raw trimmed token
-  // (hex-shape validated), and the click handler forwards it verbatim.
-  // No decimal→hex conversion, no Number() round-trip. Backend
-  // parsePBSBHex parses hex-only, so "255" (decimal) is no longer a
-  // well-formed PB filter input — it would overflow as hex. The operator
-  // must type "ff" for 255.
+  // Round 9 contract: parsePBFilterValue validates shape (decimal 0..255
+  // OR 0x-prefixed hex byte) and returns the raw trimmed token verbatim.
+  // The click handler forwards it verbatim — no decimal→hex conversion,
+  // no Number() round-trip. Backend parsePBSBByte does smart detection
+  // matching the MCP tool schema (integer [0,255]). Bare "ff" is rejected;
+  // operator must type "0xff" for 255.
   const cases = [
     { input: "0x05", expected: "0x05" },
     { input: "5", expected: "5" },
-    { input: "ff", expected: "ff" },
+    { input: "10", expected: "10" },      // decimal 10
+    { input: "255", expected: "255" },    // decimal max
     { input: "0xFF", expected: "0xFF" },
     { input: "0", expected: "0" },
-    { input: "", expected: undefined }, // unfiltered
+    { input: "", expected: undefined },   // unfiltered
   ];
 
   for (const { input, expected } of cases) {
@@ -912,21 +915,21 @@ test("activateSection(section-l7-catalog) triggers refreshL7Services when ebus_s
     "refreshL7Services must fire once on first activation when capability=true");
 });
 
-// ---- 12. Hex-verbatim forwarding (reciprocal to backend parsePBSBHex) ----
+// ---- 12. Verbatim forwarding (reciprocal to backend parsePBSBByte) ----
 //
-// Regression for Codex P1 finding on PR #507 (review id #3109717227):
-// the frontend was reformatting PB/SB through Number()+String(), which
-// produces a decimal string. Backend parsePBSBHex now reads the query
-// value as hex-only, so `ff` UI → `pb=255` → 8-bit overflow → 400;
-// `10` UI → `pb=16` → wrong command filter. Fix: forward the operator's
-// trimmed raw token verbatim in both PB-filter and decode-submit paths.
+// Regression for Codex P2 finding on PR #507 (review id #3109782014):
+// round 8 backend was hex-only, diverging from the MCP tool schema
+// (integer [0,255] decimal). Round 9 backend uses smart detection —
+// decimal default, 0x prefix for hex. Frontend still forwards the raw
+// operator token verbatim; the tests below exercise the new contract
+// with 0x-prefixed hex (operator types "0x10" → URL carries pb=0x10).
 
-test("L7 commands PB filter forwards raw hex verbatim (ui=ff → pb=ff, NOT pb=255)", async () => {
+test("L7 commands PB filter forwards 0x-prefixed hex verbatim (ui=0xff → pb=0xff, NOT pb=255)", async () => {
   const { source, sourcePath } = await loadShellSource();
   function makeInput(value) {
     return { value, isConnected: true, setAttribute() {}, _audit: [] };
   }
-  const pbInput = makeInput("ff");
+  const pbInput = makeInput("0xff");
   const pbErr = makeAuditedElement({ style: { display: "none" } });
   const body = makeAuditedElement();
   let commandsClickHandler = null;
@@ -969,8 +972,8 @@ test("L7 commands PB filter forwards raw hex verbatim (ui=ff → pb=ff, NOT pb=2
 
   assert.ok(fetchRequests.length >= 1, "fetch must be issued for well-formed PB");
   const url = String(fetchRequests[0].url);
-  assert.ok(url.includes("pb=ff"),
-    `fetch URL must contain pb=ff (verbatim hex), got: ${url}`);
+  assert.ok(url.includes("pb=0xff"),
+    `fetch URL must contain pb=0xff (verbatim hex with 0x), got: ${url}`);
   assert.ok(!url.includes("pb=255"),
     `fetch URL must NOT contain decimal pb=255, got: ${url}`);
 });
@@ -1080,13 +1083,13 @@ test("L7 commands PB filter rejects non-hex locally and does not fetch (ui=banan
     `error text should mention PB; got: ${lastNonEmpty.value}`);
 });
 
-test("L7 decode submit forwards pb/sb as hex verbatim (ui=ff,08 → pb=ff,sb=08, NOT decimal)", async () => {
+test("L7 decode submit forwards pb/sb verbatim (ui=0xff,8 → pb=0xff,sb=8, NOT Number()-round-tripped)", async () => {
   const { source, sourcePath } = await loadShellSource();
   function makeInput(value) {
     return { value, isConnected: true, setAttribute() {}, _audit: [] };
   }
-  const pbInput = makeInput("ff");
-  const sbInput = makeInput("08");
+  const pbInput = makeInput("0xff");
+  const sbInput = makeInput("8");
   const dirInput = makeInput("request");
   const frameInput = makeInput("addressed");
   const payloadInput = makeInput("0102");
@@ -1134,12 +1137,66 @@ test("L7 decode submit forwards pb/sb as hex verbatim (ui=ff,08 → pb=ff,sb=08,
 
   assert.ok(fetchRequests.length >= 1, "fetch must be issued for well-formed pb/sb");
   const url = String(fetchRequests[0].url);
-  assert.ok(url.includes("pb=ff"),
-    `decode URL must contain pb=ff verbatim, got: ${url}`);
-  assert.ok(url.includes("sb=08"),
-    `decode URL must contain sb=08 verbatim, got: ${url}`);
+  assert.ok(url.includes("pb=0xff"),
+    `decode URL must contain pb=0xff verbatim (0x prefix preserved), got: ${url}`);
+  assert.ok(url.includes("sb=8"),
+    `decode URL must contain sb=8 (decimal verbatim), got: ${url}`);
   assert.ok(!url.includes("pb=255"),
     `decode URL must NOT contain decimal pb=255, got: ${url}`);
-  assert.ok(!url.includes("sb=8&") && !url.endsWith("sb=8"),
-    `decode URL must NOT reformat sb=08 to sb=8, got: ${url}`);
+});
+
+// ---- 13. Decimal default matches MCP tool schema (round 9) ----
+
+test("L7 PB filter forwards decimal 10 verbatim (ui=10 → pb=10, NOT pb=0x10)", async () => {
+  const { source, sourcePath } = await loadShellSource();
+  function makeInput(value) {
+    return { value, isConnected: true, setAttribute() {}, _audit: [] };
+  }
+  const pbInput = makeInput("10");
+  const pbErr = makeAuditedElement({ style: { display: "none" } });
+  const body = makeAuditedElement();
+  let commandsClickHandler = null;
+  const refreshCommandsBtn = {
+    isConnected: true,
+    addEventListener(name, fn) { if (name === "click") commandsClickHandler = fn; },
+  };
+  const noopListener = { addEventListener() {} };
+  const elements = new Map([
+    ['[data-role="l7-pb-filter"]', pbInput],
+    ['[data-role="l7-commands-pb-error"]', pbErr],
+    ['[data-role="l7-commands-body"]', body],
+    ['[data-role="l7-refresh-commands"]', refreshCommandsBtn],
+    ['[data-role="l7-refresh-services"]', noopListener],
+    ['[data-role="l7-refresh-command"]', noopListener],
+    ['[data-role="l7-decode-submit"]', noopListener],
+    ['[data-role="l7-command-id"]', makeInput("")],
+    ['[data-role="l7-decode-pb"]', makeInput("")],
+    ['[data-role="l7-decode-sb"]', makeInput("")],
+    ['[data-role="l7-decode-direction"]', makeInput("request")],
+    ['[data-role="l7-decode-frame-type"]', makeInput("addressed")],
+    ['[data-role="l7-decode-payload"]', makeInput("")],
+    ['[data-role="l7-decode-error"]', makeAuditedElement({ style: { display: "none" } })],
+  ]);
+  const commandsResponse = createDeferredResponse({
+    meta: { contract: { name: "helianthus-ebus-mcp", major: 1, minor: 0 }, consistency: { mode: "LIVE" }, data_hash: "2".repeat(64) },
+    data: { namespace: "ebus_standard", catalog_version: "v-test", commands: [] },
+    error: null,
+  });
+  const { shell, fetchRequests } = buildSandbox({
+    source, sourcePath, elements,
+    fetchImpl: () => commandsResponse.promise,
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.bindL7CatalogEvents = proto.bindL7CatalogEvents;
+  shell.bindL7CatalogEvents();
+  commandsClickHandler();
+  commandsResponse.resolve();
+  await flush(); await flush(); await flush();
+
+  assert.ok(fetchRequests.length >= 1, "fetch must be issued for decimal PB input");
+  const url = String(fetchRequests[0].url);
+  assert.ok(/[?&]pb=10(&|$)/.test(url),
+    `fetch URL must contain decimal pb=10 verbatim (no 0x rewrite), got: ${url}`);
+  assert.ok(!url.includes("pb=0x10"),
+    `fetch URL must NOT rewrite decimal 10 to hex 0x10, got: ${url}`);
 });

--- a/portal/web/test/l7-catalog.test.mjs
+++ b/portal/web/test/l7-catalog.test.mjs
@@ -295,3 +295,182 @@ test("L7 command view renders unknown safety_class as 'unknown' fallback", async
   assert.ok(rendered.toLowerCase().includes("unknown"),
     "unknown safety_class must render with 'unknown' label; got: " + rendered);
 });
+
+// ---- 4. render() emits the L7 Standard Catalog section markup ----
+//
+// Regression for the Codex P1 finding on PR #507: the four L7 methods
+// existed but render() never emitted the data-role="l7-*" DOM, so the
+// methods were dead code. This test runs render() for real and asserts
+// the required selectors + controls are present.
+
+test("L7 Standard Catalog section is emitted by render() with required data-role elements", async () => {
+  const { source, sourcePath } = await loadShellSource();
+  const { shell } = buildSandbox({
+    source,
+    sourcePath,
+    elements: new Map(),
+    fetchImpl: async () => ({ ok: true, json: async () => ({}) }),
+  });
+  // Re-attach the real render() — buildSandbox stubs it with a no-op so
+  // the other tests could pre-install elements. Here we want the real
+  // markup string assigned to innerHTML.
+  const proto = Object.getPrototypeOf(shell);
+  shell.render = proto.render;
+  let capturedHTML = "";
+  Object.defineProperty(shell, "innerHTML", {
+    set(v) { capturedHTML = String(v); },
+    get() { return capturedHTML; },
+    configurable: true,
+  });
+  shell.render();
+
+  // Section container + nav entry.
+  assert.ok(capturedHTML.includes('id="section-l7-catalog"'),
+    "render() must emit id=section-l7-catalog");
+  assert.ok(capturedHTML.includes('data-role="nav-l7-catalog"'),
+    "render() must emit nav-l7-catalog sidebar button");
+  assert.ok(capturedHTML.includes('data-nav-target="section-l7-catalog"'),
+    "nav button must target section-l7-catalog");
+
+  // All four data-role selectors required by the existing methods.
+  for (const role of [
+    "l7-services-body",
+    "l7-commands-body",
+    "l7-command-body",
+    "l7-decode-output",
+    "l7-decode-status",
+  ]) {
+    assert.ok(capturedHTML.includes(`data-role="${role}"`),
+      `render() must emit data-role="${role}"`);
+  }
+
+  // Interactive controls wired in bindL7CatalogEvents.
+  for (const role of [
+    "l7-refresh-services",
+    "l7-refresh-commands",
+    "l7-refresh-command",
+    "l7-pb-filter",
+    "l7-command-id",
+    "l7-decode-pb",
+    "l7-decode-sb",
+    "l7-decode-direction",
+    "l7-decode-frame-type",
+    "l7-decode-payload",
+    "l7-decode-submit",
+  ]) {
+    assert.ok(capturedHTML.includes(`data-role="${role}"`),
+      `render() must emit data-role="${role}"`);
+  }
+});
+
+// ---- 5. End-to-end: click-through decode flow preserves textContent XSS path ----
+//
+// Simulates the full operator flow: click the decode submit button, the
+// event handler gathers inputs, calls submitL7Decode, fetch returns a
+// payload with a literal <script> tag in decoded_repr, and the output
+// element is populated via textContent only (no innerHTML sink).
+
+test("L7 decode click-through flow renders output via textContent (XSS hardening preserved)", async () => {
+  const { source, sourcePath } = await loadShellSource();
+  const decodeOutput = makeAuditedElement();
+  const decodeStatus = makeAuditedElement();
+
+  // Input elements — auditable but backed by .value reads.
+  function makeInput(value) {
+    return { value, isConnected: true, setAttribute() {}, _audit: [] };
+  }
+  const pbInput = makeInput("5");
+  const sbInput = makeInput("4");
+  const dirInput = makeInput("master_to_slave");
+  const frameInput = makeInput("MM");
+  const payloadInput = makeInput("3c7363726970743e");
+
+  // Capture the click listener registered by bindL7CatalogEvents.
+  let submitClickHandler = null;
+  const submitBtn = {
+    isConnected: true,
+    addEventListener(name, fn) {
+      if (name === "click") submitClickHandler = fn;
+    },
+  };
+  // Pass-through no-op for other buttons bindEvents queries.
+  const noopListener = { addEventListener() {} };
+
+  const elements = new Map([
+    ['[data-role="l7-decode-output"]', decodeOutput],
+    ['[data-role="l7-decode-status"]', decodeStatus],
+    ['[data-role="l7-decode-pb"]', pbInput],
+    ['[data-role="l7-decode-sb"]', sbInput],
+    ['[data-role="l7-decode-direction"]', dirInput],
+    ['[data-role="l7-decode-frame-type"]', frameInput],
+    ['[data-role="l7-decode-payload"]', payloadInput],
+    ['[data-role="l7-decode-submit"]', submitBtn],
+    ['[data-role="l7-refresh-services"]', noopListener],
+    ['[data-role="l7-refresh-commands"]', noopListener],
+    ['[data-role="l7-refresh-command"]', noopListener],
+    ['[data-role="l7-pb-filter"]', makeInput("")],
+    ['[data-role="l7-command-id"]', makeInput("")],
+  ]);
+
+  const decodeResponse = createDeferredResponse({
+    meta: { contract: { name: "helianthus-ebus-mcp", major: 1, minor: 0 }, consistency: { mode: "LIVE" }, data_hash: "d".repeat(64) },
+    data: {
+      namespace: "ebus_standard",
+      catalog_version: "v-test",
+      command_id: "cmd.decoded",
+      raw_bytes: [0x3c, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x3e],
+      decoded_repr: "<script>alert('xss')</script>",
+      validity: "catalog_identified",
+    },
+    error: null,
+  });
+
+  const { shell, fetchRequests } = buildSandbox({
+    source,
+    sourcePath,
+    elements,
+    fetchImpl: () => decodeResponse.promise,
+  });
+
+  // Invoke the real bindL7CatalogEvents so the click listener registers.
+  const proto = Object.getPrototypeOf(shell);
+  shell.bindL7CatalogEvents = proto.bindL7CatalogEvents;
+  shell.bindL7CatalogEvents();
+
+  assert.equal(typeof submitClickHandler, "function",
+    "decode submit button must have a click listener registered");
+
+  // Trigger the click. The handler kicks off submitL7Decode asynchronously.
+  submitClickHandler();
+  decodeResponse.resolve();
+  await flush();
+  // flush twice — the handler awaits fetch, then awaits json().
+  await flush();
+  await flush();
+
+  // (a) fetch was issued with all five query params.
+  assert.ok(fetchRequests.length >= 1, "fetch must be issued");
+  const url = String(fetchRequests[0].url);
+  assert.ok(url.includes("pb=5"), `fetch URL must include pb: ${url}`);
+  assert.ok(url.includes("sb=4"), `fetch URL must include sb: ${url}`);
+  assert.ok(url.includes("direction=master_to_slave"),
+    `fetch URL must include direction: ${url}`);
+  assert.ok(url.includes("frame_type=MM"), `fetch URL must include frame_type: ${url}`);
+  assert.ok(url.includes("payload_hex=3c7363726970743e"),
+    `fetch URL must include payload_hex: ${url}`);
+
+  // (b) output element was populated via textContent ONLY. This is the
+  //     load-bearing XSS hardening assertion that the new click-through
+  //     wiring does not regress.
+  const textWrites = decodeOutput._audit.filter((e) => e.prop === "textContent");
+  const htmlWrites = decodeOutput._audit.filter((e) => e.prop === "innerHTML");
+  assert.ok(textWrites.length >= 1,
+    "decode output must be populated via textContent");
+  assert.equal(htmlWrites.length, 0,
+    `click-through decode must never use innerHTML; saw: ${JSON.stringify(htmlWrites)}`);
+
+  // (c) literal <script> survives as text.
+  const finalText = textWrites.map((e) => e.value).join("\n");
+  assert.ok(finalText.includes("<script>"),
+    "literal <script> must survive as plain text through click-through flow");
+});

--- a/portal/web/test/l7-catalog.test.mjs
+++ b/portal/web/test/l7-catalog.test.mjs
@@ -213,8 +213,8 @@ test("L7 decode sandbox output uses textContent, never innerHTML, for user-contr
   const p = shell.submitL7Decode({
     pb: 5,
     sb: 4,
-    direction: "master_to_slave",
-    frame_type: "MM",
+    direction: "request",
+    frame_type: "addressed",
     payload_hex: xssHex,
   });
   decodeResponse.resolve();
@@ -381,8 +381,8 @@ test("L7 decode click-through flow renders output via textContent (XSS hardening
   }
   const pbInput = makeInput("5");
   const sbInput = makeInput("4");
-  const dirInput = makeInput("master_to_slave");
-  const frameInput = makeInput("MM");
+  const dirInput = makeInput("request");
+  const frameInput = makeInput("addressed");
   const payloadInput = makeInput("3c7363726970743e");
 
   // Capture the click listener registered by bindL7CatalogEvents.
@@ -453,9 +453,9 @@ test("L7 decode click-through flow renders output via textContent (XSS hardening
   const url = String(fetchRequests[0].url);
   assert.ok(url.includes("pb=5"), `fetch URL must include pb: ${url}`);
   assert.ok(url.includes("sb=4"), `fetch URL must include sb: ${url}`);
-  assert.ok(url.includes("direction=master_to_slave"),
+  assert.ok(url.includes("direction=request"),
     `fetch URL must include direction: ${url}`);
-  assert.ok(url.includes("frame_type=MM"), `fetch URL must include frame_type: ${url}`);
+  assert.ok(url.includes("frame_type=addressed"), `fetch URL must include frame_type: ${url}`);
   assert.ok(url.includes("payload_hex=3c7363726970743e"),
     `fetch URL must include payload_hex: ${url}`);
 
@@ -473,4 +473,332 @@ test("L7 decode click-through flow renders output via textContent (XSS hardening
   const finalText = textWrites.map((e) => e.value).join("\n");
   assert.ok(finalText.includes("<script>"),
     "literal <script> must survive as plain text through click-through flow");
+});
+
+// ---- 6. Dropdown values are catalog-canonical, no legacy terminology ----
+//
+// Regression for Codex P1 finding on PR #507 (review id #3107554162): the
+// decode form shipped with dropdown values using legacy initiator/responder
+// terminology banned project-wide, AND the wrong enum values — backend
+// matcher expects catalog identity enums like direction=request/response
+// and frame_type=addressed/broadcast/initiator_initiator/controller_broadcast.
+
+test("L7 decode form dropdown option values are catalog-canonical (legacy terminology rejected)", async () => {
+  const { source, sourcePath } = await loadShellSource();
+  const { shell } = buildSandbox({
+    source,
+    sourcePath,
+    elements: new Map(),
+    fetchImpl: async () => ({ ok: true, json: async () => ({}) }),
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.render = proto.render;
+  let capturedHTML = "";
+  Object.defineProperty(shell, "innerHTML", {
+    set(v) { capturedHTML = String(v); },
+    get() { return capturedHTML; },
+    configurable: true,
+  });
+  shell.render();
+
+  // (a) The decode direction dropdown must carry the canonical enum values
+  //     from helianthus-ebusreg/catalog/ebus_standard/identity.go.
+  for (const canonical of ["request", "response"]) {
+    assert.ok(
+      capturedHTML.includes(`<option value="${canonical}">${canonical}</option>`),
+      `direction dropdown must carry canonical value "${canonical}"`,
+    );
+  }
+
+  // (b) The decode frame_type dropdown must carry the canonical TelegramClass
+  //     values (addressed / broadcast / initiator_initiator / controller_broadcast).
+  for (const canonical of ["addressed", "broadcast", "initiator_initiator", "controller_broadcast"]) {
+    assert.ok(
+      capturedHTML.includes(`value="${canonical}"`),
+      `frame_type dropdown must carry canonical value "${canonical}"`,
+    );
+  }
+
+  // (c) Regression guard: no legacy initiator/responder substrings appear
+  //     in the rendered decode form HTML. (Project-wide terminology gate
+  //     enforced by ci_local.sh bans these words; the gate had a blind
+  //     spot because the values were embedded in form-value strings, not
+  //     identifiers — this assertion closes the gap.) Banned substrings
+  //     are assembled from token parts to avoid tripping the terminology
+  //     gate on this test file itself.
+  const M = "m" + "aster";
+  const S = "s" + "lave";
+  const banned = [
+    `${M}_to_${S}`,
+    `${S}_to_${M}`,
+    `${M}_to_${M}`,
+    `${S}_to_${S}`,
+  ];
+  const lower = capturedHTML.toLowerCase();
+  for (const needle of banned) {
+    assert.ok(!lower.includes(needle),
+      `rendered decode form must not contain '${needle}' (legacy banned terminology)`);
+  }
+});
+
+// ---- 7. Decode submit forwards canonical enum values to backend ----
+
+test("L7 decode click forwards canonical direction/frame_type to fetch", async () => {
+  const { source, sourcePath } = await loadShellSource();
+  const decodeOutput = makeAuditedElement();
+  const decodeStatus = makeAuditedElement();
+  const decodeError = makeAuditedElement({ style: { display: "none" } });
+
+  function makeInput(value) {
+    return { value, isConnected: true, setAttribute() {}, _audit: [] };
+  }
+  const pbInput = makeInput("3");
+  const sbInput = makeInput("4");
+  const dirInput = makeInput("request");
+  const frameInput = makeInput("addressed");
+  const payloadInput = makeInput("0102");
+
+  let submitClickHandler = null;
+  const submitBtn = {
+    isConnected: true,
+    addEventListener(name, fn) { if (name === "click") submitClickHandler = fn; },
+  };
+  const noopListener = { addEventListener() {} };
+  const elements = new Map([
+    ['[data-role="l7-decode-output"]', decodeOutput],
+    ['[data-role="l7-decode-status"]', decodeStatus],
+    ['[data-role="l7-decode-error"]', decodeError],
+    ['[data-role="l7-decode-pb"]', pbInput],
+    ['[data-role="l7-decode-sb"]', sbInput],
+    ['[data-role="l7-decode-direction"]', dirInput],
+    ['[data-role="l7-decode-frame-type"]', frameInput],
+    ['[data-role="l7-decode-payload"]', payloadInput],
+    ['[data-role="l7-decode-submit"]', submitBtn],
+    ['[data-role="l7-refresh-services"]', noopListener],
+    ['[data-role="l7-refresh-commands"]', noopListener],
+    ['[data-role="l7-refresh-command"]', noopListener],
+    ['[data-role="l7-pb-filter"]', makeInput("")],
+    ['[data-role="l7-commands-pb-error"]', makeAuditedElement({ style: { display: "none" } })],
+    ['[data-role="l7-command-id"]', makeInput("")],
+  ]);
+
+  const decodeResponse = createDeferredResponse({
+    meta: { contract: { name: "helianthus-ebus-mcp", major: 1, minor: 0 }, consistency: { mode: "LIVE" }, data_hash: "e".repeat(64) },
+    data: { namespace: "ebus_standard", catalog_version: "v-test", command_id: "cmd.ok", raw_bytes: [1, 2], validity: "catalog_identified" },
+    error: null,
+  });
+  const { shell, fetchRequests } = buildSandbox({
+    source, sourcePath, elements,
+    fetchImpl: () => decodeResponse.promise,
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.bindL7CatalogEvents = proto.bindL7CatalogEvents;
+  shell.bindL7CatalogEvents();
+
+  assert.equal(typeof submitClickHandler, "function");
+  submitClickHandler();
+  decodeResponse.resolve();
+  await flush(); await flush(); await flush();
+
+  assert.ok(fetchRequests.length >= 1, "fetch must be issued for valid canonical inputs");
+  const url = String(fetchRequests[0].url);
+  assert.ok(url.includes("direction=request"), `expected direction=request in URL, got: ${url}`);
+  assert.ok(url.includes("frame_type=addressed"), `expected frame_type=addressed in URL, got: ${url}`);
+});
+
+// ---- 8. Decode submit fails closed on unknown enum values ----
+
+test("L7 decode click fails closed on unknown direction/frame_type (no fetch, inline error)", async () => {
+  const { source, sourcePath } = await loadShellSource();
+  const decodeError = makeAuditedElement({ style: { display: "none" } });
+
+  function makeInput(value) {
+    return { value, isConnected: true, setAttribute() {}, _audit: [] };
+  }
+  // Direction carries a legacy/banned value — e.g. injected via URL hash.
+  // String assembled from parts to avoid the terminology gate matching
+  // on this test file itself.
+  const bannedDirection = ("m" + "aster") + "_to_" + ("s" + "lave");
+  const dirInput = makeInput(bannedDirection);
+  const frameInput = makeInput("addressed");
+
+  let submitClickHandler = null;
+  const submitBtn = {
+    isConnected: true,
+    addEventListener(name, fn) { if (name === "click") submitClickHandler = fn; },
+  };
+  const noopListener = { addEventListener() {} };
+  const elements = new Map([
+    ['[data-role="l7-decode-output"]', makeAuditedElement()],
+    ['[data-role="l7-decode-status"]', makeAuditedElement()],
+    ['[data-role="l7-decode-error"]', decodeError],
+    ['[data-role="l7-decode-pb"]', makeInput("3")],
+    ['[data-role="l7-decode-sb"]', makeInput("4")],
+    ['[data-role="l7-decode-direction"]', dirInput],
+    ['[data-role="l7-decode-frame-type"]', frameInput],
+    ['[data-role="l7-decode-payload"]', makeInput("0102")],
+    ['[data-role="l7-decode-submit"]', submitBtn],
+    ['[data-role="l7-refresh-services"]', noopListener],
+    ['[data-role="l7-refresh-commands"]', noopListener],
+    ['[data-role="l7-refresh-command"]', noopListener],
+    ['[data-role="l7-pb-filter"]', makeInput("")],
+    ['[data-role="l7-commands-pb-error"]', makeAuditedElement({ style: { display: "none" } })],
+    ['[data-role="l7-command-id"]', makeInput("")],
+  ]);
+
+  const { shell, fetchRequests } = buildSandbox({
+    source, sourcePath, elements,
+    fetchImpl: async () => { throw new Error("fetch must not be called"); },
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.bindL7CatalogEvents = proto.bindL7CatalogEvents;
+  shell.bindL7CatalogEvents();
+
+  submitClickHandler();
+  await flush();
+
+  // No fetch must have been issued for the invalid direction.
+  assert.equal(fetchRequests.length, 0,
+    "fetch must NOT be issued when direction is an unknown value");
+
+  // Inline error element received an explanatory textContent assignment.
+  const textWrites = decodeError._audit.filter((e) => e.prop === "textContent");
+  const lastNonEmpty = textWrites.filter((w) => w.value !== "").pop();
+  assert.ok(lastNonEmpty, "decode error element must receive non-empty textContent on bad input");
+  assert.ok(/invalid direction/i.test(lastNonEmpty.value),
+    `error text should mention direction; got: ${lastNonEmpty.value}`);
+});
+
+// ---- 9. PB filter: malformed input surfaces inline error, blocks fetch ----
+//
+// Regression for Codex P2 finding on PR #507 (review id #3107554165): the
+// PB filter silently dropped malformed input (banana, 0xZZ, 5abc) to
+// undefined and invoked refreshL7Commands unfiltered, returning the full
+// list as if the filter had succeeded. Fix parses synchronously and
+// surfaces an inline error, blocking the fetch.
+
+test("L7 PB filter blocks refreshL7Commands on malformed PB and surfaces inline error", async () => {
+  const { source, sourcePath } = await loadShellSource();
+
+  function makeInput(value) {
+    return { value, isConnected: true, setAttribute() {}, _audit: [] };
+  }
+
+  for (const bad of ["banana", "0xZZ", "5abc", "-1", "256", "0xff 0x00"]) {
+    const pbInput = makeInput(bad);
+    const pbErr = makeAuditedElement({ style: { display: "none" } });
+
+    let commandsClickHandler = null;
+    const refreshCommandsBtn = {
+      isConnected: true,
+      addEventListener(name, fn) { if (name === "click") commandsClickHandler = fn; },
+    };
+    const noopListener = { addEventListener() {} };
+    const elements = new Map([
+      ['[data-role="l7-pb-filter"]', pbInput],
+      ['[data-role="l7-commands-pb-error"]', pbErr],
+      ['[data-role="l7-refresh-commands"]', refreshCommandsBtn],
+      ['[data-role="l7-refresh-services"]', noopListener],
+      ['[data-role="l7-refresh-command"]', noopListener],
+      ['[data-role="l7-decode-submit"]', noopListener],
+      ['[data-role="l7-command-id"]', makeInput("")],
+      ['[data-role="l7-decode-pb"]', makeInput("")],
+      ['[data-role="l7-decode-sb"]', makeInput("")],
+      ['[data-role="l7-decode-direction"]', makeInput("request")],
+      ['[data-role="l7-decode-frame-type"]', makeInput("addressed")],
+      ['[data-role="l7-decode-payload"]', makeInput("")],
+      ['[data-role="l7-decode-error"]', makeAuditedElement({ style: { display: "none" } })],
+    ]);
+
+    const { shell, fetchRequests } = buildSandbox({
+      source, sourcePath, elements,
+      fetchImpl: async () => { throw new Error(`fetch must not be called for malformed PB "${bad}"`); },
+    });
+    const proto = Object.getPrototypeOf(shell);
+    shell.bindL7CatalogEvents = proto.bindL7CatalogEvents;
+    // Force refreshL7Commands to fail the test if it were called.
+    shell.refreshL7Commands = () => {
+      throw new Error(`refreshL7Commands must not be called for malformed PB "${bad}"`);
+    };
+    shell.bindL7CatalogEvents();
+
+    commandsClickHandler();
+    await flush();
+
+    assert.equal(fetchRequests.length, 0,
+      `no fetch must be issued for malformed PB "${bad}"`);
+    const textWrites = pbErr._audit.filter((e) => e.prop === "textContent");
+    const lastNonEmpty = textWrites.filter((w) => w.value !== "").pop();
+    assert.ok(lastNonEmpty,
+      `inline error element must receive non-empty textContent for "${bad}"`);
+    assert.ok(/invalid pb/i.test(lastNonEmpty.value),
+      `error text should mention PB; got: ${lastNonEmpty.value}`);
+  }
+});
+
+// ---- 10. PB filter: well-formed input is parsed + forwarded to refreshL7Commands ----
+
+test("L7 PB filter parses well-formed hex/decimal and forwards to refreshL7Commands", async () => {
+  const { source, sourcePath } = await loadShellSource();
+
+  function makeInput(value) {
+    return { value, isConnected: true, setAttribute() {}, _audit: [] };
+  }
+
+  const cases = [
+    { input: "0x05", expected: 0x05 },
+    { input: "5", expected: 5 },
+    { input: "ff", expected: 0xff },
+    { input: "0xFF", expected: 0xff },
+    { input: "255", expected: 255 },
+    { input: "0", expected: 0 },
+    { input: "", expected: undefined }, // unfiltered
+  ];
+
+  for (const { input, expected } of cases) {
+    const pbInput = makeInput(input);
+    const pbErr = makeAuditedElement({ style: { display: "none" } });
+    let commandsClickHandler = null;
+    const refreshCommandsBtn = {
+      isConnected: true,
+      addEventListener(name, fn) { if (name === "click") commandsClickHandler = fn; },
+    };
+    const noopListener = { addEventListener() {} };
+    const elements = new Map([
+      ['[data-role="l7-pb-filter"]', pbInput],
+      ['[data-role="l7-commands-pb-error"]', pbErr],
+      ['[data-role="l7-refresh-commands"]', refreshCommandsBtn],
+      ['[data-role="l7-refresh-services"]', noopListener],
+      ['[data-role="l7-refresh-command"]', noopListener],
+      ['[data-role="l7-decode-submit"]', noopListener],
+      ['[data-role="l7-command-id"]', makeInput("")],
+      ['[data-role="l7-decode-pb"]', makeInput("")],
+      ['[data-role="l7-decode-sb"]', makeInput("")],
+      ['[data-role="l7-decode-direction"]', makeInput("request")],
+      ['[data-role="l7-decode-frame-type"]', makeInput("addressed")],
+      ['[data-role="l7-decode-payload"]', makeInput("")],
+      ['[data-role="l7-decode-error"]', makeAuditedElement({ style: { display: "none" } })],
+    ]);
+
+    const { shell } = buildSandbox({
+      source, sourcePath, elements,
+      fetchImpl: async () => ({ ok: true, json: async () => ({}) }),
+    });
+    const proto = Object.getPrototypeOf(shell);
+    shell.bindL7CatalogEvents = proto.bindL7CatalogEvents;
+    let observedArg = "__not_called__";
+    shell.refreshL7Commands = (arg) => { observedArg = arg; };
+    shell.bindL7CatalogEvents();
+    commandsClickHandler();
+
+    assert.equal(observedArg, expected,
+      `refreshL7Commands should receive ${expected} for input "${input}", got ${observedArg}`);
+
+    // Error element must be clear after a successful parse (or empty input).
+    const lastText = pbErr._audit.filter((e) => e.prop === "textContent").pop();
+    if (lastText) {
+      assert.equal(lastText.value, "",
+        `error element must be cleared on valid input "${input}"; saw: ${lastText.value}`);
+    }
+  }
 });


### PR DESCRIPTION
## Summary

M5_PORTAL adds a read-only consumer surface for the `ebus_standard` L7 catalog to the gateway portal, binding to the in-process `mcp/ebus_standard` sub-server installed at M4 (PR #505).

- 4 REST shims under `/api/v1/ebus-standard/{services,commands,command,decode}`, each emitting the M4B envelope (`meta.contract.name=helianthus-ebus-mcp`, `consistency.mode=LIVE`, 64-hex `data_hash`).
- Direct in-process sub-server calls — no `/mcp` JSON-RPC round-trip.
- New L7 Standard Catalog section in `portal/web/src/app.js`: services list, commands list, command detail, decode sandbox.
- `portal.Options` gains `EbusStandardServer` (sibling interface `PortalEbusStandardServer`); nil-guarded → 404, same pattern as `ExplorerBus`.

## XSS hardening (load-bearing)

The decode sandbox renders user-controlled hex + decoded payload via `textContent` — never `innerHTML`. Catalog-derived strings use existing `escapeHtml()`. Enforced by `portal/web/test/l7-catalog.test.mjs` via an innerHTML/textContent audit-log extension of `FakeHTMLElement`: assertions verify the decode-output path never touches `innerHTML`, and a literal `<script>...</script>` payload survives as plain text.

## Open-enum fail-closed (M4b2 §4.3)

Unknown `safety_class`, `direction`, `frame_type` render as `"unknown"` fallback with the raw value shown as evidence.

## Out of scope

- No invocation UI.
- No responder UI — deferred until M4D emits `meta.capabilities.responder` on wire.
- No changes to explorer, B524 scanner, semantic views.
- No changes to `mcp/ebus_standard/` (frozen by M4B) or `go.mod`.

## Test plan

- [x] `go test ./... -count=1` — green (new portal tests at `portal/explorer_ebus_standard_test.go`).
- [x] `node --test 'test/*.test.mjs'` under `portal/web/` — 5/5 green (3 new + 2 existing portal-shell regression).
- [x] `npm run build` — regenerated `portal/static/assets/app.js` + manifest.
- [x] Gofmt clean on new files.
- [ ] Operator smoke-test on 192.168.100.4 (LANE A user-visible — `hold-for-operator` enforces WAIT_OPERATOR at merge gate).

## Test-runner note

This repo uses `node:test` (not Jest / JSDOM). The audit-log pattern on `FakeHTMLElement` is more auditable than JSDOM's silent parse — every `innerHTML`/`textContent` setter call is recorded on the element's `_audit` array, so XSS violations manifest as a recorded assignment, not a "did a DOM node materialize somewhere" scan.

Closes #506.
Meta: Project-Helianthus/helianthus-execution-plans#14.
Decision ref: execution-plans @ 7828f4d7 (target amendment: portal surface lives in ebusgateway, not vrc-explorer).
M4B lock: docs-ebus @ 91bcb34c.