### PR TITLE
feat(M4c2): gateway responder runtime for FF 03-06 + meta.capabilities.responder emission (v1.minor)

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/adaptermux"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/graphql"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp/ebus_standard"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mdns"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/portal"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/ui"
@@ -710,6 +711,14 @@ func startHTTPServer(
 		mcpServer.SetWatchSummaryProvider(newMCPWatchSummaryProvider(shadowCache))
 	}
 	mcpServer.SetSemanticProvider(newMCPSemanticProvider(semanticProvider))
+
+	// M4c2: populate the package-level responder capability provider
+	// based on the active transport protocol. Consumers apply fail-closed
+	// semantics on absence, so this MUST be called before any MCP
+	// surface serves its first envelope. The provider closure is
+	// evaluated per-envelope; hot-path cost is a single pointer load +
+	// struct copy. See decision doc @ 567a6798 §4.2 + §5.
+	ebus_standard.SetResponderCapabilityProvider(buildResponderCapabilityProvider(cfg))
 	if scheduleWriter != nil {
 		mcpServer.SetScheduleWriter(scheduleWriter)
 	}
@@ -1277,4 +1286,61 @@ func mapPortalAdapterInfo(info *graphql.AdapterHardwareInfo) *portal.SemanticAda
 		result.LastTelemetryQuery = info.LastTelemetryQuery.Format(time.RFC3339)
 	}
 	return result
+}
+
+// buildResponderCapabilityProvider composes the `meta.capabilities.responder`
+// signal for the active transport per decision doc @ 567a6798 §4.2 + §5.
+//
+// Mapping (v1.1, locked):
+//   - ENH / ENS → active.scope = "partial", surfaces = FF_03..FF_06,
+//     refusal = nil. transports[] reports the same row as "supported"
+//     and the ebusd-tcp row as perpetually "blocked".
+//   - ebusd-tcp → active.scope = "none", surfaces = [],
+//     refusal.code = "command_bridge_no_companion_listen". Consumers
+//     apply fail-closed per §4.3 rule 4.
+//   - Any other transport (udp-plain, tcp-plain, adapter-direct) →
+//     active.scope = "none", refusal = nil; the ebusd-tcp row remains
+//     blocked in transports[] because that determination is static.
+//
+// Invariants I1/I7 are enforced by always emitting exactly three
+// transport rows (ENH, ENS, ebusd-tcp) in a fixed order. I2/I3 are
+// enforced by deriving active from the same struct literal.
+func buildResponderCapabilityProvider(cfg ebusgateway.Config) ebus_standard.ResponderCapabilityProvider {
+	protocol := strings.TrimSpace(strings.ToLower(string(cfg.TransportConfig.Protocol)))
+
+	surfacesFF := []string{"FF_03", "FF_04", "FF_05", "FF_06"}
+	// transports[] is static at v1.1 — same three rows on every gateway
+	// regardless of deployment (I1 locks the count at exactly three).
+	transports := []ebus_standard.TransportRow{
+		{Transport: "ENH", State: "supported", Scope: "partial", Surfaces: surfacesFF, Reason: ""},
+		{Transport: "ENS", State: "supported", Scope: "partial", Surfaces: surfacesFF, Reason: ""},
+		{Transport: "ebusd-tcp", State: "blocked", Scope: "none", Surfaces: []string{}, Reason: "command_bridge_no_companion_listen"},
+	}
+
+	var active ebus_standard.ActiveResponder
+	switch protocol {
+	case string(ebusgateway.TransportENH):
+		active = ebus_standard.ActiveResponder{Transport: "ENH", Scope: "partial", Surfaces: surfacesFF}
+	case string(ebusgateway.TransportENS):
+		active = ebus_standard.ActiveResponder{Transport: "ENS", Scope: "partial", Surfaces: surfacesFF}
+	case string(ebusgateway.TransportEbusdTCP):
+		active = ebus_standard.ActiveResponder{
+			Transport: "ebusd-tcp",
+			Scope:     "none",
+			Surfaces:  []string{},
+			Refusal:   &ebus_standard.ActiveRefusal{Code: "command_bridge_no_companion_listen", Reason: "ebusd command bridge does not expose a responder-role emission primitive"},
+		}
+	default:
+		// Non-enumerated transports (udp-plain, tcp-plain, adapter-direct,
+		// empty) — scope=none, no refusal code (refusal is reserved for
+		// capability-layer blockers, not "unknown" states).
+		active = ebus_standard.ActiveResponder{Transport: protocol, Scope: "none", Surfaces: []string{}}
+	}
+
+	cap := ebus_standard.ResponderCapability{
+		Version:    "v1",
+		Active:     active,
+		Transports: transports,
+	}
+	return func() ebus_standard.ResponderCapability { return cap }
 }

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mdns"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/portal"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/ui"
+	ebusgoTransport "github.com/Project-Helianthus/helianthus-ebusgo/transport"
 	vaillantproviders "github.com/Project-Helianthus/helianthus-ebusreg/providers/vaillant"
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
 )
@@ -726,7 +727,12 @@ func startHTTPServer(
 	// (absence → scope=none, fail-closed). This preserves invariant I1
 	// (exactly three rows at v1.1) and I2 (active.transport MUST appear
 	// in transports[]) without widening the schema.
-	if provider := buildResponderCapabilityProvider(cfg); provider != nil {
+	// Pass the live transport instance (gateway.Transport) so the provider
+	// can type-assert against ebusgoTransport.ResponderTransport. The
+	// adapter-direct mux returns a RawTransport that does NOT satisfy
+	// ResponderTransport, so config-string "enh" + mux active path
+	// correctly downgrades to scope=none (see Codex P1 on PR #509).
+	if provider := buildResponderCapabilityProvider(cfg, gateway.Transport); provider != nil {
 		ebus_standard.SetResponderCapabilityProvider(provider)
 	} else {
 		log.Printf("warning: meta.capabilities.responder omitted: transport protocol %q does not canonicalize to ENH/ENS/ebusd-tcp", cfg.TransportConfig.Protocol)
@@ -1331,7 +1337,30 @@ func mapPortalAdapterInfo(info *graphql.AdapterHardwareInfo) *portal.SemanticAda
 // transport rows (ENH, ENS, ebusd-tcp) in a fixed order. I2/I3 are
 // enforced by deriving active.transport from the same canonical enum
 // literals the rows use.
-func buildResponderCapabilityProvider(cfg ebusgateway.Config) ebus_standard.ResponderCapabilityProvider {
+//
+// Runtime-transport authority (Codex P1 on PR #509): the canonical
+// protocol enum alone is NOT sufficient to decide active.scope. The
+// adapter-direct URI mode (--address=adapter-direct://...) keeps
+// TransportConfig.Protocol as the default "enh" string while the live
+// transport instance is actually the adapter-direct mux's active path.
+// That path implements transport.RawTransport but does NOT implement
+// transport.ResponderTransport — it has no SendResponderBytes primitive.
+// Reporting active.scope="partial" purely from the config string would
+// over-advertise responder support for FF_03..FF_06 surfaces the gateway
+// cannot actually emit. Accordingly the provider type-asserts the live
+// transport instance against ebusgoTransport.ResponderTransport; when
+// the canonical protocol is ENH/ENS but the instance does NOT satisfy
+// the interface, we downgrade to scope="none" with
+// refusal.code="transport_mux_bypass". ebusd-tcp path is unchanged —
+// it is forbidden from responder emission per M4b2 §3 regardless of
+// what underlying transport type ebusd is wrapped by.
+//
+// actualTransport is the live instance returned by the bootstrap
+// transport factory. A nil value means the caller has not yet wired a
+// transport (legacy callers, some unit-test paths); in that case the
+// provider falls back to protocol-only inference to preserve previous
+// behaviour on paths that never exercise the adapter-direct mux.
+func buildResponderCapabilityProvider(cfg ebusgateway.Config, actualTransport ebusgoTransport.RawTransport) ebus_standard.ResponderCapabilityProvider {
 	surfacesFF := []string{"FF_03", "FF_04", "FF_05", "FF_06"}
 	// transports[] is static at v1.1 — same three rows on every gateway
 	// regardless of deployment (I1 locks the count at exactly three).
@@ -1341,15 +1370,37 @@ func buildResponderCapabilityProvider(cfg ebusgateway.Config) ebus_standard.Resp
 		{Transport: "ebusd-tcp", State: "blocked", Scope: "none", Surfaces: []string{}, Reason: "command_bridge_no_companion_listen"},
 	}
 
+	// Runtime transport authority: a non-nil actualTransport that does
+	// NOT satisfy ResponderTransport means the live bus path cannot
+	// actually emit responder bytes (the adapter-direct mux is the
+	// concrete case today). A nil actualTransport means bootstrap is
+	// still pre-wiring (e.g. unit tests that only construct Config); in
+	// that case fall back to protocol-only inference so legacy callers
+	// keep their behaviour.
+	transportKnown := actualTransport != nil
+	_, responderCapable := actualTransport.(ebusgoTransport.ResponderTransport)
+	muxBypassRefusal := &ebus_standard.ActiveRefusal{
+		Code:   "transport_mux_bypass",
+		Reason: "runtime transport does not satisfy ResponderTransport (e.g. adapter-direct mux)",
+	}
+
 	var active ebus_standard.ActiveResponder
 	// Canonicalise raw TransportProtocol (handles "ebusd" alias, case,
 	// whitespace) into one of the enum constants so active.transport
 	// literally equals the transports[] row label (invariant I2).
 	switch ebusgateway.CanonicalTransportProtocol(cfg.TransportConfig.Protocol) {
 	case ebusgateway.TransportENH:
-		active = ebus_standard.ActiveResponder{Transport: "ENH", Scope: "partial", Surfaces: surfacesFF}
+		if transportKnown && !responderCapable {
+			active = ebus_standard.ActiveResponder{Transport: "ENH", Scope: "none", Surfaces: []string{}, Refusal: muxBypassRefusal}
+		} else {
+			active = ebus_standard.ActiveResponder{Transport: "ENH", Scope: "partial", Surfaces: surfacesFF}
+		}
 	case ebusgateway.TransportENS:
-		active = ebus_standard.ActiveResponder{Transport: "ENS", Scope: "partial", Surfaces: surfacesFF}
+		if transportKnown && !responderCapable {
+			active = ebus_standard.ActiveResponder{Transport: "ENS", Scope: "none", Surfaces: []string{}, Refusal: muxBypassRefusal}
+		} else {
+			active = ebus_standard.ActiveResponder{Transport: "ENS", Scope: "partial", Surfaces: surfacesFF}
+		}
 	case ebusgateway.TransportEbusdTCP:
 		active = ebus_standard.ActiveResponder{
 			Transport: "ebusd-tcp",

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -1351,7 +1351,12 @@ func mapPortalAdapterInfo(info *graphql.AdapterHardwareInfo) *portal.SemanticAda
 // transport instance against ebusgoTransport.ResponderTransport; when
 // the canonical protocol is ENH/ENS but the instance does NOT satisfy
 // the interface, we downgrade to scope="none" with
-// refusal.code="transport_mux_bypass". ebusd-tcp path is unchanged —
+// refusal.code="transport_mux_bypass" AND rewrite both ENH and ENS
+// rows in transports[] to state="blocked", scope="none",
+// reason="transport_mux_bypass" so invariant I3 (active.scope ==
+// matching row.scope) holds — the mux is a shared runtime wrapper
+// above either upstream, so switching the canonical protocol would
+// not restore responder emission. ebusd-tcp path is unchanged —
 // it is forbidden from responder emission per M4b2 §3 regardless of
 // what underlying transport type ebusd is wrapped by.
 //
@@ -1379,9 +1384,42 @@ func buildResponderCapabilityProvider(cfg ebusgateway.Config, actualTransport eb
 	// keep their behaviour.
 	transportKnown := actualTransport != nil
 	_, responderCapable := actualTransport.(ebusgoTransport.ResponderTransport)
+	muxBypass := transportKnown && !responderCapable
 	muxBypassRefusal := &ebus_standard.ActiveRefusal{
 		Code:   "transport_mux_bypass",
 		Reason: "runtime transport does not satisfy ResponderTransport (e.g. adapter-direct mux)",
+	}
+
+	// Invariant I3 (decision doc §4.4): active.scope MUST equal
+	// transports[x].scope where x.transport == active.transport. When the
+	// runtime mux bypass is in effect we therefore also rewrite the
+	// matching transports[] row(s) — otherwise a consumer joining
+	// active.transport → transports[] would see contradictory metadata
+	// (active.scope=none but row.scope=partial).
+	//
+	// Interpretation A (shared-runtime downgrade): the adapter-direct mux
+	// is a single wrapper that sits above whichever ENH/ENS upstream the
+	// operator configured. The mux instance itself does not satisfy
+	// ResponderTransport, so switching the canonical protocol from ENH to
+	// ENS (or vice versa) under the same mux would not restore responder
+	// emission — the bypass is shared. Accordingly, BOTH the ENH and ENS
+	// rows downgrade to state=blocked, scope=none, reason="transport_mux_bypass".
+	// The ebusd-tcp row is left untouched (it is always blocked with its
+	// own reason "command_bridge_no_companion_listen" per §4.2/§3).
+	// Invariants preserved: I1 (still exactly 3 rows), I2 (active.transport
+	// still appears verbatim), I3 (active.scope == matching row.scope),
+	// I5 (state=blocked ⇒ reason != ""), I7 (row order ENH,ENS,ebusd-tcp
+	// unchanged).
+	if muxBypass {
+		for i := range transports {
+			row := &transports[i]
+			if row.Transport == "ENH" || row.Transport == "ENS" {
+				row.State = "blocked"
+				row.Scope = "none"
+				row.Surfaces = []string{}
+				row.Reason = "transport_mux_bypass"
+			}
+		}
 	}
 
 	var active ebus_standard.ActiveResponder
@@ -1390,13 +1428,13 @@ func buildResponderCapabilityProvider(cfg ebusgateway.Config, actualTransport eb
 	// literally equals the transports[] row label (invariant I2).
 	switch ebusgateway.CanonicalTransportProtocol(cfg.TransportConfig.Protocol) {
 	case ebusgateway.TransportENH:
-		if transportKnown && !responderCapable {
+		if muxBypass {
 			active = ebus_standard.ActiveResponder{Transport: "ENH", Scope: "none", Surfaces: []string{}, Refusal: muxBypassRefusal}
 		} else {
 			active = ebus_standard.ActiveResponder{Transport: "ENH", Scope: "partial", Surfaces: surfacesFF}
 		}
 	case ebusgateway.TransportENS:
-		if transportKnown && !responderCapable {
+		if muxBypass {
 			active = ebus_standard.ActiveResponder{Transport: "ENS", Scope: "none", Surfaces: []string{}, Refusal: muxBypassRefusal}
 		} else {
 			active = ebus_standard.ActiveResponder{Transport: "ENS", Scope: "partial", Surfaces: surfacesFF}

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -16,8 +16,8 @@ import (
 	"time"
 
 	"github.com/Project-Helianthus/helianthus-ebusgateway"
-	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/adaptermux"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/graphql"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/adaptermux"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp/ebus_standard"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mdns"
@@ -718,7 +718,19 @@ func startHTTPServer(
 	// surface serves its first envelope. The provider closure is
 	// evaluated per-envelope; hot-path cost is a single pointer load +
 	// struct copy. See decision doc @ 567a6798 §4.2 + §5.
-	ebus_standard.SetResponderCapabilityProvider(buildResponderCapabilityProvider(cfg))
+	//
+	// A nil return from buildResponderCapabilityProvider means the raw
+	// transport protocol does not canonicalize to any of the three
+	// locked rows at v1.1 (ENH / ENS / ebusd-tcp). In that case we omit
+	// the capability entirely so consumers fall back to §4.3 rule 1
+	// (absence → scope=none, fail-closed). This preserves invariant I1
+	// (exactly three rows at v1.1) and I2 (active.transport MUST appear
+	// in transports[]) without widening the schema.
+	if provider := buildResponderCapabilityProvider(cfg); provider != nil {
+		ebus_standard.SetResponderCapabilityProvider(provider)
+	} else {
+		log.Printf("warning: meta.capabilities.responder omitted: transport protocol %q does not canonicalize to ENH/ENS/ebusd-tcp", cfg.TransportConfig.Protocol)
+	}
 	if scheduleWriter != nil {
 		mcpServer.SetScheduleWriter(scheduleWriter)
 	}
@@ -1298,16 +1310,28 @@ func mapPortalAdapterInfo(info *graphql.AdapterHardwareInfo) *portal.SemanticAda
 //   - ebusd-tcp → active.scope = "none", surfaces = [],
 //     refusal.code = "command_bridge_no_companion_listen". Consumers
 //     apply fail-closed per §4.3 rule 4.
-//   - Any other transport (udp-plain, tcp-plain, adapter-direct) →
-//     active.scope = "none", refusal = nil; the ebusd-tcp row remains
-//     blocked in transports[] because that determination is static.
+//   - Any other transport (udp-plain, tcp-plain, adapter-direct, empty,
+//     or unrecognised string) → returns nil. The caller omits the
+//     capability entirely and consumers fall back to §4.3 rule 1
+//     (absence → scope=none, fail-closed). This is the only way to
+//     preserve invariant I1 (exactly three rows at v1.1) AND I2
+//     (active.transport MUST appear in transports[]) simultaneously,
+//     because emitting a non-canonical active.transport literal would
+//     violate I2 and widening transports[] with a fourth "unknown" row
+//     would violate I1.
+//
+// The raw cfg.TransportConfig.Protocol is first canonicalised via
+// ebusgateway.canonicalTransportProtocol (which handles the "ebusd"
+// alias → "ebusd-tcp" and lowercases/trims whitespace). This ensures
+// downstream envelope assertions see the canonical enum literal in
+// every surface, matching the three fixed transports[] rows byte-for-
+// byte.
 //
 // Invariants I1/I7 are enforced by always emitting exactly three
 // transport rows (ENH, ENS, ebusd-tcp) in a fixed order. I2/I3 are
-// enforced by deriving active from the same struct literal.
+// enforced by deriving active.transport from the same canonical enum
+// literals the rows use.
 func buildResponderCapabilityProvider(cfg ebusgateway.Config) ebus_standard.ResponderCapabilityProvider {
-	protocol := strings.TrimSpace(strings.ToLower(string(cfg.TransportConfig.Protocol)))
-
 	surfacesFF := []string{"FF_03", "FF_04", "FF_05", "FF_06"}
 	// transports[] is static at v1.1 — same three rows on every gateway
 	// regardless of deployment (I1 locks the count at exactly three).
@@ -1318,12 +1342,15 @@ func buildResponderCapabilityProvider(cfg ebusgateway.Config) ebus_standard.Resp
 	}
 
 	var active ebus_standard.ActiveResponder
-	switch protocol {
-	case string(ebusgateway.TransportENH):
+	// Canonicalise raw TransportProtocol (handles "ebusd" alias, case,
+	// whitespace) into one of the enum constants so active.transport
+	// literally equals the transports[] row label (invariant I2).
+	switch ebusgateway.CanonicalTransportProtocol(cfg.TransportConfig.Protocol) {
+	case ebusgateway.TransportENH:
 		active = ebus_standard.ActiveResponder{Transport: "ENH", Scope: "partial", Surfaces: surfacesFF}
-	case string(ebusgateway.TransportENS):
+	case ebusgateway.TransportENS:
 		active = ebus_standard.ActiveResponder{Transport: "ENS", Scope: "partial", Surfaces: surfacesFF}
-	case string(ebusgateway.TransportEbusdTCP):
+	case ebusgateway.TransportEbusdTCP:
 		active = ebus_standard.ActiveResponder{
 			Transport: "ebusd-tcp",
 			Scope:     "none",
@@ -1331,10 +1358,13 @@ func buildResponderCapabilityProvider(cfg ebusgateway.Config) ebus_standard.Resp
 			Refusal:   &ebus_standard.ActiveRefusal{Code: "command_bridge_no_companion_listen", Reason: "ebusd command bridge does not expose a responder-role emission primitive"},
 		}
 	default:
-		// Non-enumerated transports (udp-plain, tcp-plain, adapter-direct,
-		// empty) — scope=none, no refusal code (refusal is reserved for
-		// capability-layer blockers, not "unknown" states).
-		active = ebus_standard.ActiveResponder{Transport: protocol, Scope: "none", Surfaces: []string{}}
+		// Non-enumerated transports (udp-plain, tcp-plain,
+		// adapter-direct, empty, or entirely unknown). Fail-closed:
+		// return nil so the envelope omits meta.capabilities.responder
+		// entirely (§4.3 rule 1). Emitting the raw string would
+		// violate I2; adding a fourth transports[] row would violate
+		// I1. Absence is the only invariant-preserving outcome.
+		return nil
 	}
 
 	cap := ebus_standard.ResponderCapability{

--- a/cmd/gateway/wiring_test.go
+++ b/cmd/gateway/wiring_test.go
@@ -5,6 +5,36 @@ import (
 
 	"github.com/Project-Helianthus/helianthus-ebusgateway"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp/ebus_standard"
+	ebusgoTransport "github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+// muxBypassTransport is a RawTransport that does NOT satisfy
+// ResponderTransport. It models the adapter-direct mux's active path
+// (cmd/gateway/main.go wireAdapterDirect -> mux.ActiveTransport()): the
+// live transport implements RawTransport but has no SendResponderBytes
+// primitive. Used in the Codex-P1 regression tests below.
+type muxBypassTransport struct{}
+
+func (muxBypassTransport) ReadByte() (byte, error)     { return 0, nil }
+func (muxBypassTransport) Write(p []byte) (int, error) { return len(p), nil }
+func (muxBypassTransport) Close() error                { return nil }
+
+// responderCapableTransport is a RawTransport that ALSO satisfies
+// ResponderTransport. Used to pin the "genuine ENH" branch: config says
+// enh AND the live instance exposes the responder send primitive.
+type responderCapableTransport struct{ muxBypassTransport }
+
+func (responderCapableTransport) SendResponderBytes(payload []byte) (int, error) {
+	return len(payload), nil
+}
+
+// Compile-time guards: these assertions codify the test contract so a
+// future refactor of either interface breaks the tests at build time,
+// not at runtime.
+var (
+	_ ebusgoTransport.RawTransport       = muxBypassTransport{}
+	_ ebusgoTransport.RawTransport       = responderCapableTransport{}
+	_ ebusgoTransport.ResponderTransport = responderCapableTransport{}
 )
 
 // TestResponderCapabilityProvider_CanonicalENH pins invariant I2 for the
@@ -15,7 +45,7 @@ func TestResponderCapabilityProvider_CanonicalENH(t *testing.T) {
 		TransportConfig: ebusgateway.TransportConfig{
 			Protocol: ebusgateway.TransportENH,
 		},
-	})
+	}, nil)
 	if provider == nil {
 		t.Fatalf("provider is nil; want non-nil for ENH")
 	}
@@ -36,7 +66,7 @@ func TestResponderCapabilityProvider_CanonicalENS(t *testing.T) {
 		TransportConfig: ebusgateway.TransportConfig{
 			Protocol: ebusgateway.TransportENS,
 		},
-	})
+	}, nil)
 	if provider == nil {
 		t.Fatalf("provider is nil; want non-nil for ENS")
 	}
@@ -65,7 +95,7 @@ func TestResponderCapabilityProvider_CanonicalEbusdTCP(t *testing.T) {
 			TransportConfig: ebusgateway.TransportConfig{
 				Protocol: raw,
 			},
-		})
+		}, nil)
 		if provider == nil {
 			t.Fatalf("raw=%q: provider is nil; want non-nil", raw)
 		}
@@ -102,7 +132,7 @@ func TestResponderCapabilityProvider_UnknownTransport_OmitsCapability(t *testing
 			TransportConfig: ebusgateway.TransportConfig{
 				Protocol: raw,
 			},
-		})
+		}, nil)
 		if provider != nil {
 			t.Fatalf("raw=%q: provider is non-nil (active=%+v); want nil so envelope omits capability", raw, provider().Active)
 		}
@@ -126,4 +156,96 @@ func assertActiveInTransports(t *testing.T, cap ebus_standard.ResponderCapabilit
 		labels = append(labels, row.Transport)
 	}
 	t.Fatalf("I2 violated: active.transport=%q not in transports[]=%v", cap.Active.Transport, labels)
+}
+
+// TestResponderCapabilityProvider_AdapterDirect_WithoutResponderSupport_DowngradesToNone
+// locks the Codex P1 fix on PR #509. The adapter-direct URI mode keeps
+// cfg.TransportConfig.Protocol == "enh" while wireAdapterDirect installs
+// a mux.ActiveTransport() that does NOT satisfy ResponderTransport. The
+// provider must downgrade active.scope to "none" with an explicit
+// refusal, NOT over-advertise "partial" from the config string alone.
+func TestResponderCapabilityProvider_AdapterDirect_WithoutResponderSupport_DowngradesToNone(t *testing.T) {
+	provider := buildResponderCapabilityProvider(ebusgateway.Config{
+		TransportConfig: ebusgateway.TransportConfig{
+			Protocol: ebusgateway.TransportENH,
+		},
+	}, muxBypassTransport{})
+	if provider == nil {
+		t.Fatalf("provider is nil; want non-nil with explicit refusal")
+	}
+	cap := provider()
+	if cap.Active.Transport != "ENH" {
+		t.Fatalf("active.transport = %q; want %q (I2 — enum literal preserved)", cap.Active.Transport, "ENH")
+	}
+	if cap.Active.Scope != "none" {
+		t.Fatalf("active.scope = %q; want %q (mux bypass must downgrade from partial)", cap.Active.Scope, "none")
+	}
+	if len(cap.Active.Surfaces) != 0 {
+		t.Fatalf("active.surfaces = %v; want [] (no surfaces when scope=none)", cap.Active.Surfaces)
+	}
+	if cap.Active.Refusal == nil {
+		t.Fatalf("active.refusal = nil; want non-nil with transport_mux_bypass code")
+	}
+	if cap.Active.Refusal.Code != "transport_mux_bypass" {
+		t.Fatalf("active.refusal.code = %q; want %q", cap.Active.Refusal.Code, "transport_mux_bypass")
+	}
+	if cap.Active.Refusal.Reason == "" {
+		t.Fatalf("active.refusal.reason is empty; want explanatory string about ResponderTransport")
+	}
+	assertActiveInTransports(t, cap)
+}
+
+// TestResponderCapabilityProvider_ENH_WithActualResponderSupport_ReportsPartial
+// pins the positive path: config=enh AND the live instance satisfies
+// ResponderTransport (the canonical ENH transport in production). The
+// provider must emit scope=partial with surfaces FF_03..FF_06.
+func TestResponderCapabilityProvider_ENH_WithActualResponderSupport_ReportsPartial(t *testing.T) {
+	provider := buildResponderCapabilityProvider(ebusgateway.Config{
+		TransportConfig: ebusgateway.TransportConfig{
+			Protocol: ebusgateway.TransportENH,
+		},
+	}, responderCapableTransport{})
+	if provider == nil {
+		t.Fatalf("provider is nil; want non-nil for genuine ENH")
+	}
+	cap := provider()
+	if cap.Active.Transport != "ENH" {
+		t.Fatalf("active.transport = %q; want %q", cap.Active.Transport, "ENH")
+	}
+	if cap.Active.Scope != "partial" {
+		t.Fatalf("active.scope = %q; want %q (genuine ENH responder)", cap.Active.Scope, "partial")
+	}
+	if len(cap.Active.Surfaces) != 4 {
+		t.Fatalf("active.surfaces = %v; want 4 FF_0x surfaces", cap.Active.Surfaces)
+	}
+	if cap.Active.Refusal != nil {
+		t.Fatalf("active.refusal = %+v; want nil on genuine ENH path", cap.Active.Refusal)
+	}
+	assertActiveInTransports(t, cap)
+}
+
+// TestResponderCapabilityProvider_ENS_WithMuxBypass_ReportsNone mirrors
+// the ENH mux-bypass test for ENS: --address=adapter-direct-ens:// can
+// keep Protocol=="ens" but the mux active transport still does not
+// satisfy ResponderTransport. Must downgrade to scope=none.
+func TestResponderCapabilityProvider_ENS_WithMuxBypass_ReportsNone(t *testing.T) {
+	provider := buildResponderCapabilityProvider(ebusgateway.Config{
+		TransportConfig: ebusgateway.TransportConfig{
+			Protocol: ebusgateway.TransportENS,
+		},
+	}, muxBypassTransport{})
+	if provider == nil {
+		t.Fatalf("provider is nil; want non-nil with explicit refusal")
+	}
+	cap := provider()
+	if cap.Active.Transport != "ENS" {
+		t.Fatalf("active.transport = %q; want %q", cap.Active.Transport, "ENS")
+	}
+	if cap.Active.Scope != "none" {
+		t.Fatalf("active.scope = %q; want %q (ENS mux bypass)", cap.Active.Scope, "none")
+	}
+	if cap.Active.Refusal == nil || cap.Active.Refusal.Code != "transport_mux_bypass" {
+		t.Fatalf("active.refusal = %+v; want code=transport_mux_bypass", cap.Active.Refusal)
+	}
+	assertActiveInTransports(t, cap)
 }

--- a/cmd/gateway/wiring_test.go
+++ b/cmd/gateway/wiring_test.go
@@ -224,6 +224,130 @@ func TestResponderCapabilityProvider_ENH_WithActualResponderSupport_ReportsParti
 	assertActiveInTransports(t, cap)
 }
 
+// TestResponderCapabilityProvider_MuxBypass_DowngradesMatchingTransportRow
+// locks the Codex round-3 P1 finding on PR #509: when active is
+// downgraded to scope=none because the runtime mux does not satisfy
+// ResponderTransport, the matching transports[] row MUST also be
+// downgraded to state="blocked", scope="none", surfaces=[],
+// reason="transport_mux_bypass". Otherwise a consumer joining
+// active.transport to the row set sees contradictory metadata
+// (active.scope=none but row.scope=partial), violating invariant I3.
+//
+// Per Interpretation A (the adapter-direct mux is a shared runtime
+// wrapper across ENH/ENS upstreams), both ENH and ENS rows downgrade
+// whenever the bypass is detected regardless of which canonical enum
+// is active. The ebusd-tcp row is left untouched with its own reason.
+func TestResponderCapabilityProvider_MuxBypass_DowngradesMatchingTransportRow(t *testing.T) {
+	for _, canonical := range []ebusgateway.TransportProtocol{
+		ebusgateway.TransportENH,
+		ebusgateway.TransportENS,
+	} {
+		provider := buildResponderCapabilityProvider(ebusgateway.Config{
+			TransportConfig: ebusgateway.TransportConfig{Protocol: canonical},
+		}, muxBypassTransport{})
+		if provider == nil {
+			t.Fatalf("canonical=%q: provider is nil", canonical)
+		}
+		cap := provider()
+		if len(cap.Transports) != 3 {
+			t.Fatalf("canonical=%q: transports[] has %d rows; want 3 (I1)", canonical, len(cap.Transports))
+		}
+
+		var enhRow, ensRow, ebusdRow *ebus_standard.TransportRow
+		for i := range cap.Transports {
+			row := &cap.Transports[i]
+			switch row.Transport {
+			case "ENH":
+				enhRow = row
+			case "ENS":
+				ensRow = row
+			case "ebusd-tcp":
+				ebusdRow = row
+			}
+		}
+		if enhRow == nil || ensRow == nil || ebusdRow == nil {
+			t.Fatalf("canonical=%q: missing expected row (ENH=%v ENS=%v ebusd-tcp=%v)", canonical, enhRow, ensRow, ebusdRow)
+		}
+
+		// Both ENH and ENS rows must be downgraded — the mux is shared.
+		for _, row := range []*ebus_standard.TransportRow{enhRow, ensRow} {
+			if row.State != "blocked" {
+				t.Fatalf("canonical=%q: %s row.state = %q; want %q", canonical, row.Transport, row.State, "blocked")
+			}
+			if row.Scope != "none" {
+				t.Fatalf("canonical=%q: %s row.scope = %q; want %q", canonical, row.Transport, row.Scope, "none")
+			}
+			if len(row.Surfaces) != 0 {
+				t.Fatalf("canonical=%q: %s row.surfaces = %v; want []", canonical, row.Transport, row.Surfaces)
+			}
+			if row.Reason != "transport_mux_bypass" {
+				t.Fatalf("canonical=%q: %s row.reason = %q; want %q", canonical, row.Transport, row.Reason, "transport_mux_bypass")
+			}
+		}
+
+		// ebusd-tcp row must be untouched (its own state/reason).
+		if ebusdRow.State != "blocked" || ebusdRow.Scope != "none" {
+			t.Fatalf("canonical=%q: ebusd-tcp row state/scope disturbed: %+v", canonical, ebusdRow)
+		}
+		if ebusdRow.Reason != "command_bridge_no_companion_listen" {
+			t.Fatalf("canonical=%q: ebusd-tcp row.reason = %q; want %q (must NOT be overwritten by mux bypass)", canonical, ebusdRow.Reason, "command_bridge_no_companion_listen")
+		}
+
+		assertActiveInTransports(t, cap)
+		assertI3ActiveScopeMatchesRow(t, cap)
+	}
+}
+
+// assertI3ActiveScopeMatchesRow is the invariant I3 guard:
+// active.scope MUST equal transports[x].scope where x.transport ==
+// active.transport.
+func assertI3ActiveScopeMatchesRow(t *testing.T, cap ebus_standard.ResponderCapability) {
+	t.Helper()
+	for _, row := range cap.Transports {
+		if row.Transport == cap.Active.Transport {
+			if row.Scope != cap.Active.Scope {
+				t.Fatalf("I3 violated: active.transport=%q active.scope=%q but row.scope=%q",
+					cap.Active.Transport, cap.Active.Scope, row.Scope)
+			}
+			return
+		}
+	}
+	// I2 would have flagged absence already; safe to return.
+}
+
+// TestResponderCapabilityProvider_I3_ActiveScopeEqualsTransportRowScope
+// sweeps every canonical-protocol × transport-instance branch and
+// asserts invariant I3 holds unconditionally.
+func TestResponderCapabilityProvider_I3_ActiveScopeEqualsTransportRowScope(t *testing.T) {
+	cases := []struct {
+		name     string
+		protocol ebusgateway.TransportProtocol
+		instance ebusgoTransport.RawTransport
+	}{
+		{"ENH/nil", ebusgateway.TransportENH, nil},
+		{"ENH/responder-capable", ebusgateway.TransportENH, responderCapableTransport{}},
+		{"ENH/mux-bypass", ebusgateway.TransportENH, muxBypassTransport{}},
+		{"ENS/nil", ebusgateway.TransportENS, nil},
+		{"ENS/responder-capable", ebusgateway.TransportENS, responderCapableTransport{}},
+		{"ENS/mux-bypass", ebusgateway.TransportENS, muxBypassTransport{}},
+		{"ebusd-tcp/nil", ebusgateway.TransportEbusdTCP, nil},
+		{"ebusd-tcp/mux-bypass", ebusgateway.TransportEbusdTCP, muxBypassTransport{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			provider := buildResponderCapabilityProvider(ebusgateway.Config{
+				TransportConfig: ebusgateway.TransportConfig{Protocol: tc.protocol},
+			}, tc.instance)
+			if provider == nil {
+				t.Fatalf("provider is nil for %s", tc.name)
+			}
+			cap := provider()
+			assertActiveInTransports(t, cap)
+			assertI3ActiveScopeMatchesRow(t, cap)
+		})
+	}
+}
+
 // TestResponderCapabilityProvider_ENS_WithMuxBypass_ReportsNone mirrors
 // the ENH mux-bypass test for ENS: --address=adapter-direct-ens:// can
 // keep Protocol=="ens" but the mux active transport still does not

--- a/cmd/gateway/wiring_test.go
+++ b/cmd/gateway/wiring_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusgateway"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp/ebus_standard"
+)
+
+// TestResponderCapabilityProvider_CanonicalENH pins invariant I2 for the
+// ENH raw alias: buildResponderCapabilityProvider MUST canonicalise to
+// the "ENH" label that literally appears in transports[].
+func TestResponderCapabilityProvider_CanonicalENH(t *testing.T) {
+	provider := buildResponderCapabilityProvider(ebusgateway.Config{
+		TransportConfig: ebusgateway.TransportConfig{
+			Protocol: ebusgateway.TransportENH,
+		},
+	})
+	if provider == nil {
+		t.Fatalf("provider is nil; want non-nil for ENH")
+	}
+	cap := provider()
+	if cap.Active.Transport != "ENH" {
+		t.Fatalf("active.transport = %q; want %q", cap.Active.Transport, "ENH")
+	}
+	assertActiveInTransports(t, cap)
+	if cap.Active.Scope != "partial" {
+		t.Fatalf("ENH active.scope = %q; want %q", cap.Active.Scope, "partial")
+	}
+}
+
+// TestResponderCapabilityProvider_CanonicalENS mirrors the ENH test for
+// ENS.
+func TestResponderCapabilityProvider_CanonicalENS(t *testing.T) {
+	provider := buildResponderCapabilityProvider(ebusgateway.Config{
+		TransportConfig: ebusgateway.TransportConfig{
+			Protocol: ebusgateway.TransportENS,
+		},
+	})
+	if provider == nil {
+		t.Fatalf("provider is nil; want non-nil for ENS")
+	}
+	cap := provider()
+	if cap.Active.Transport != "ENS" {
+		t.Fatalf("active.transport = %q; want %q", cap.Active.Transport, "ENS")
+	}
+	assertActiveInTransports(t, cap)
+	if cap.Active.Scope != "partial" {
+		t.Fatalf("ENS active.scope = %q; want %q", cap.Active.Scope, "partial")
+	}
+}
+
+// TestResponderCapabilityProvider_CanonicalEbusdTCP exercises both the
+// canonical "ebusd-tcp" literal and the "ebusd" alias that the transport
+// parser accepts. Both MUST resolve to active.transport = "ebusd-tcp"
+// (matching the transports[] row label exactly).
+func TestResponderCapabilityProvider_CanonicalEbusdTCP(t *testing.T) {
+	for _, raw := range []ebusgateway.TransportProtocol{
+		ebusgateway.TransportEbusdTCP,
+		ebusgateway.TransportProtocol("ebusd"),
+		ebusgateway.TransportProtocol("EBUSD"),
+		ebusgateway.TransportProtocol("  ebusd-tcp  "),
+	} {
+		provider := buildResponderCapabilityProvider(ebusgateway.Config{
+			TransportConfig: ebusgateway.TransportConfig{
+				Protocol: raw,
+			},
+		})
+		if provider == nil {
+			t.Fatalf("raw=%q: provider is nil; want non-nil", raw)
+		}
+		cap := provider()
+		if cap.Active.Transport != "ebusd-tcp" {
+			t.Fatalf("raw=%q: active.transport = %q; want %q", raw, cap.Active.Transport, "ebusd-tcp")
+		}
+		assertActiveInTransports(t, cap)
+		if cap.Active.Scope != "none" {
+			t.Fatalf("raw=%q: active.scope = %q; want %q", raw, cap.Active.Scope, "none")
+		}
+		if cap.Active.Refusal == nil || cap.Active.Refusal.Code != "command_bridge_no_companion_listen" {
+			t.Fatalf("raw=%q: active.refusal = %+v; want code=command_bridge_no_companion_listen", raw, cap.Active.Refusal)
+		}
+	}
+}
+
+// TestResponderCapabilityProvider_UnknownTransport_OmitsCapability locks
+// the fail-closed absence contract (§4.3 rule 1). Any transport string
+// that does not canonicalise to ENH/ENS/ebusd-tcp MUST cause
+// buildResponderCapabilityProvider to return nil, so the envelope
+// composer omits meta.capabilities.responder entirely. This preserves
+// I1 (exactly three rows at v1.1) without violating I2 (active must be
+// in transports[]).
+func TestResponderCapabilityProvider_UnknownTransport_OmitsCapability(t *testing.T) {
+	for _, raw := range []ebusgateway.TransportProtocol{
+		ebusgateway.TransportProtocol("banana"),
+		ebusgateway.TransportProtocol("udp-plain"),
+		ebusgateway.TransportProtocol("tcp-plain"),
+		ebusgateway.TransportProtocol("adapter-direct"),
+		ebusgateway.TransportProtocol(""),
+	} {
+		provider := buildResponderCapabilityProvider(ebusgateway.Config{
+			TransportConfig: ebusgateway.TransportConfig{
+				Protocol: raw,
+			},
+		})
+		if provider != nil {
+			t.Fatalf("raw=%q: provider is non-nil (active=%+v); want nil so envelope omits capability", raw, provider().Active)
+		}
+	}
+}
+
+// assertActiveInTransports is the local I2 guard: active.transport MUST
+// literally appear as one of the transports[] row labels.
+func assertActiveInTransports(t *testing.T, cap ebus_standard.ResponderCapability) {
+	t.Helper()
+	if len(cap.Transports) != 3 {
+		t.Fatalf("transports[] has %d rows; want 3 (I1 at v1.1)", len(cap.Transports))
+	}
+	for _, row := range cap.Transports {
+		if row.Transport == cap.Active.Transport {
+			return
+		}
+	}
+	var labels []string
+	for _, row := range cap.Transports {
+		labels = append(labels, row.Transport)
+	}
+	t.Fatalf("I2 violated: active.transport=%q not in transports[]=%v", cap.Active.Transport, labels)
+}

--- a/gateway.go
+++ b/gateway.go
@@ -201,6 +201,19 @@ func canonicalTransportProtocol(protocol TransportProtocol) TransportProtocol {
 	}
 }
 
+// CanonicalTransportProtocol is the exported form of
+// canonicalTransportProtocol. External callers (e.g. cmd/gateway's
+// responder-capability provider) use it to normalise raw protocol
+// strings to the enum literals used across the package.
+//
+// Aliases handled: "ebusd" → "ebusd-tcp"; all forms are trimmed +
+// lower-cased. Unknown strings pass through as the normalised
+// TransportProtocol with no alias resolution (caller decides what to
+// do with unknown values).
+func CanonicalTransportProtocol(protocol TransportProtocol) TransportProtocol {
+	return canonicalTransportProtocol(protocol)
+}
+
 func passiveTransportUnavailableReason(cfg Config) string {
 	config, err := normalizeTransportConfig(cfg.TransportConfig)
 	if err == nil {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Project-Helianthus/helianthus-ebusgateway
 go 1.22
 
 require (
-	github.com/Project-Helianthus/helianthus-ebusgo v0.4.1-0.20260415192314-f3d32d8619a4
+	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260420084448-721165d7033c
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260419103431-30aa69a099ec
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Project-Helianthus/helianthus-ebusgo v0.4.1-0.20260415192314-f3d32d8619a4 h1:ZzvXRFim5s/OX+9c3r65n+rNKyYompfOUIqSw9Nyf3E=
-github.com/Project-Helianthus/helianthus-ebusgo v0.4.1-0.20260415192314-f3d32d8619a4/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
+github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260420084448-721165d7033c h1:PIrRNDQsIpHL/4bmIAUcswdu0kNol/+uhTVT+e9IZAk=
+github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260420084448-721165d7033c/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260419103431-30aa69a099ec h1:l0DzHLH41AmijBTb/an+j98JfTImJMlpgKZ19Eeb7G8=
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260419103431-30aa69a099ec/go.mod h1:ux6qvwEyyK+LUfseHKpTTS4i5O6slZHVZ+f4orOtFm4=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=

--- a/internal/execution_policy/policy.go
+++ b/internal/execution_policy/policy.go
@@ -40,6 +40,16 @@ const (
 // against the provider-level sentinel also succeed via errors.Is.
 var ErrSafetyClassDenied = fmt.Errorf("execution_policy: %w", ebusstd.ErrSafetyClassDenied)
 
+// ErrResponderTransportUnavailable is the capability-layer sentinel
+// returned when the responder runtime is constructed against a transport
+// that does not satisfy transport.ResponderTransport, or when the active
+// transport has `capabilities.responder.scope == none` (ebusd-tcp).
+// Distinct from ErrSafetyClassDenied per decision doc @ 567a6798 §5:
+// capability refusals MUST NOT surface as audit outcome=policy_denied;
+// conflating the two channels breaks denial-parity tests and misleads
+// consumers that treat blocked reasons as static transport constraints.
+var ErrResponderTransportUnavailable = errors.New("execution_policy: responder transport unavailable")
+
 // Check evaluates the policy for (cmd, caller). It returns nil when the
 // call is permitted, otherwise a non-nil error that satisfies
 // errors.Is(err, ErrSafetyClassDenied) == true and carries the dynamic

--- a/internal/nm_runtime/responder_runtime.go
+++ b/internal/nm_runtime/responder_runtime.go
@@ -1,0 +1,74 @@
+package nm_runtime
+
+// M4c2 — catalog-driven responder runtime (FF 03/04/05/06).
+//
+// Scope per decision doc @ 567a6798 §5:
+//   - Per-inbound emit consults execution_policy.Check with caller
+//     CallerSystemNMRuntime before any byte hits the wire.
+//   - Dispatches via transport.ResponderTransport.SendResponderBytes
+//     (bypasses arbitration — the caller has already observed the
+//     initiator header).
+//   - Construction fails fast with ErrResponderTransportUnavailable if
+//     the transport does not satisfy ResponderTransport; mirrors
+//     NewRuntime's ErrEmitterRequired fail-fast pattern.
+//
+// The FSM that decodes inbound frames and sequences ACK/response/final-ACK
+// lives in github.com/Project-Helianthus/helianthus-ebusgo/protocol/responder.
+// M4c2 scope is the CATALOG + POLICY + DISPATCH glue on the gateway side;
+// the wire state machine remains owned by ebusgo.
+
+import (
+	"fmt"
+
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/execution_policy"
+	ebusgoxport "github.com/Project-Helianthus/helianthus-ebusgo/transport"
+	ebusstd "github.com/Project-Helianthus/helianthus-ebusreg/catalog/ebus_standard"
+)
+
+// ResponderRuntime is the gateway-side responder emit runtime for
+// FF 03/04/05/06. It is catalog-driven: no hand-rolled opcode tables
+// survive this boundary.
+type ResponderRuntime struct {
+	catalog   ebusstd.Catalog
+	transport ebusgoxport.ResponderTransport
+}
+
+// NewResponderRuntime constructs a responder runtime bound to the
+// catalog and a transport that MUST satisfy ResponderTransport.
+// Returns ErrResponderTransportUnavailable when transport is nil (the
+// runtime has no fallback path — fail-fast at construction per
+// §5 "transport-capability pre-gate").
+//
+// Note: we accept the interface type directly so a nil interface check
+// correctly detects both (*T)(nil) and an unset interface. Callers in
+// main.go only invoke this when transport selection has produced a
+// concrete ENH/ENS transport; ebusd-tcp deployments must NOT call this
+// (the main-bootstrap branch omits runtime construction entirely and
+// populates the capability provider with scope=none instead).
+func NewResponderRuntime(cat ebusstd.Catalog, tp ebusgoxport.ResponderTransport) (*ResponderRuntime, error) {
+	if tp == nil {
+		return nil, fmt.Errorf("nm_runtime: %w", execution_policy.ErrResponderTransportUnavailable)
+	}
+	return &ResponderRuntime{catalog: cat, transport: tp}, nil
+}
+
+// EmitResponder dispatches a responder-direction emission for cmd with
+// payload. The flow is:
+//  1. Consult execution_policy.Check with CallerSystemNMRuntime. On
+//     denial, the error satisfies errors.Is(err, ErrSafetyClassDenied)
+//     and NO bytes hit the wire.
+//  2. On accept, dispatch via ResponderTransport.SendResponderBytes.
+//
+// The catalog parameter is carried on the runtime for future extension
+// (per-inbound identity-key match against the embedded catalog); at
+// M4c2 scope the caller is already expected to present a resolved
+// ebusstd.Command from the inbound-frame decoder.
+func (r *ResponderRuntime) EmitResponder(cmd ebusstd.Command, payload []byte) error {
+	if err := execution_policy.Check(cmd, execution_policy.CallerSystemNMRuntime); err != nil {
+		return err
+	}
+	if _, err := r.transport.SendResponderBytes(payload); err != nil {
+		return fmt.Errorf("nm_runtime: responder send: %w", err)
+	}
+	return nil
+}

--- a/internal/nm_runtime/responder_runtime_test.go
+++ b/internal/nm_runtime/responder_runtime_test.go
@@ -1,0 +1,136 @@
+package nm_runtime_test
+
+// M4c2 responder runtime tests — catalog-driven FF 03/04/05/06 emit path.
+//
+// Scope (decision doc @ 567a6798 §5, §6.2):
+//   - Runtime construction MUST fail with ErrResponderTransportUnavailable
+//     when the active transport does not satisfy ResponderTransport OR when
+//     the capability signal reports scope=none.
+//   - Per-inbound emit MUST consult execution_policy.Check with
+//     CallerSystemNMRuntime before any byte hits the wire.
+//   - Dispatch MUST route through ResponderTransport.SendResponderBytes.
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/execution_policy"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/nm_runtime"
+	ebusgoxport "github.com/Project-Helianthus/helianthus-ebusgo/transport"
+	ebusstd "github.com/Project-Helianthus/helianthus-ebusreg/catalog/ebus_standard"
+)
+
+// fakeResponderTransport implements ebusgoxport.ResponderTransport for
+// runtime-construction tests. Calls to SendResponderBytes increment calls
+// and record the payload.
+type fakeResponderTransport struct {
+	calls     int64
+	lastBytes []byte
+	err       error
+}
+
+func (f *fakeResponderTransport) SendResponderBytes(payload []byte) (int, error) {
+	atomic.AddInt64(&f.calls, 1)
+	if f.err != nil {
+		return 0, f.err
+	}
+	b := make([]byte, len(payload))
+	copy(b, payload)
+	f.lastBytes = b
+	return len(payload), nil
+}
+
+// Compile-time check: fakeResponderTransport satisfies the interface.
+var _ ebusgoxport.ResponderTransport = (*fakeResponderTransport)(nil)
+
+func loadTestCatalog(t *testing.T) ebusstd.Catalog {
+	t.Helper()
+	return ebusstd.MustEmbeddedCatalog()
+}
+
+// TestResponderRuntime_ConstructionRequiresTransport asserts nil transport
+// fails construction with ErrResponderTransportUnavailable (mirrors
+// ErrEmitterRequired fail-fast pattern in nm_runtime.NewRuntime).
+func TestResponderRuntime_ConstructionRequiresTransport(t *testing.T) {
+	cat := loadTestCatalog(t)
+	_, err := nm_runtime.NewResponderRuntime(cat, nil)
+	if err == nil {
+		t.Fatal("expected ErrResponderTransportUnavailable on nil transport")
+	}
+	if !errors.Is(err, execution_policy.ErrResponderTransportUnavailable) {
+		t.Fatalf("err=%v, want ErrResponderTransportUnavailable", err)
+	}
+}
+
+// TestResponderRuntime_ConstructionSucceedsOnENHLike asserts a transport
+// that satisfies ResponderTransport constructs cleanly.
+func TestResponderRuntime_ConstructionSucceedsOnENHLike(t *testing.T) {
+	cat := loadTestCatalog(t)
+	tp := &fakeResponderTransport{}
+	rt, err := nm_runtime.NewResponderRuntime(cat, tp)
+	if err != nil {
+		t.Fatalf("construction failed: %v", err)
+	}
+	if rt == nil {
+		t.Fatal("runtime is nil")
+	}
+}
+
+// TestResponderRuntime_PolicyGateEnforced asserts an emit for a
+// catalog-unknown identity is rejected WITHOUT any bytes hitting the wire.
+// Uses an identity that will not match the 14-axis whitelist.
+func TestResponderRuntime_PolicyGateEnforced(t *testing.T) {
+	cat := loadTestCatalog(t)
+	tp := &fakeResponderTransport{}
+	rt, err := nm_runtime.NewResponderRuntime(cat, tp)
+	if err != nil {
+		t.Fatalf("construction: %v", err)
+	}
+	// Fabricate a command with a mutating safety class that is NOT in the
+	// whitelist. Any non-FF-03..06 row with SafetyMutating qualifies.
+	cmd := ebusstd.Command{
+		ID: "synthetic.unauthorized",
+		Identity: ebusstd.IdentityKey{
+			Namespace: "ebus_standard",
+		},
+		SafetyClass: ebusstd.SafetyMutating,
+	}
+	err = rt.EmitResponder(cmd, []byte{0x00})
+	if err == nil {
+		t.Fatal("expected policy denial for non-whitelisted mutating row")
+	}
+	if !execution_policy.IsDenied(err) {
+		t.Fatalf("err=%v, want ErrSafetyClassDenied", err)
+	}
+	if atomic.LoadInt64(&tp.calls) != 0 {
+		t.Fatalf("bytes hit wire despite policy denial: %d calls", tp.calls)
+	}
+}
+
+// TestResponderRuntime_DispatchesViaSendResponderBytes asserts the happy-path
+// dispatch reaches the ResponderTransport. Uses a read_only_safe shim so
+// the policy gate accepts without depending on whitelist contents.
+func TestResponderRuntime_DispatchesViaSendResponderBytes(t *testing.T) {
+	cat := loadTestCatalog(t)
+	tp := &fakeResponderTransport{}
+	rt, err := nm_runtime.NewResponderRuntime(cat, tp)
+	if err != nil {
+		t.Fatalf("construction: %v", err)
+	}
+	cmd := ebusstd.Command{
+		ID:          "synthetic.responder_probe",
+		Identity:    ebusstd.IdentityKey{Namespace: "ebus_standard"},
+		SafetyClass: ebusstd.SafetyReadOnlySafe,
+	}
+	payload := []byte{0xAA, 0xBB, 0xCC}
+	if err := rt.EmitResponder(cmd, payload); err != nil {
+		t.Fatalf("EmitResponder: %v", err)
+	}
+	if got := atomic.LoadInt64(&tp.calls); got != 1 {
+		t.Fatalf("SendResponderBytes calls=%d, want 1", got)
+	}
+	if len(tp.lastBytes) != len(payload) {
+		t.Fatalf("dispatched %d bytes, want %d", len(tp.lastBytes), len(payload))
+	}
+}

--- a/mcp/ebus_standard/envelope.go
+++ b/mcp/ebus_standard/envelope.go
@@ -15,7 +15,12 @@ import (
 const (
 	EnvelopeContractName  = "helianthus-ebus-mcp"
 	EnvelopeContractMajor = 1
-	EnvelopeContractMinor = 0
+	// EnvelopeContractMinor bumped 0→1 for M4c2: additive
+	// `meta.capabilities.responder` key per decision doc @ 567a6798 §4.5
+	// and M4B §6.2 "additive meta.* keys permitted under minor bump".
+	// Consumers that do not understand the key apply fail-closed (§4.3
+	// rule 1).
+	EnvelopeContractMinor = 1
 )
 
 // NewEnvelope wraps data / err in the meta/data/error envelope used by the
@@ -41,6 +46,14 @@ func NewEnvelope(data any, err error, ts time.Time) map[string]any {
 		},
 		"data_timestamp": ts.UTC().Format(time.RFC3339Nano),
 		"data_hash":      DataHash(data),
+	}
+	// M4c2 additive: meta.capabilities.responder when a provider is
+	// registered. Absent when no provider — §4.3 rule 1 fail-closed
+	// contract relies on key-absence semantics.
+	if cap, ok := currentResponderCapability(); ok {
+		meta["capabilities"] = map[string]any{
+			"responder": capabilityToMap(cap),
+		}
 	}
 	var envelopeError any
 	if err != nil {

--- a/mcp/ebus_standard/forward_compat_test.go
+++ b/mcp/ebus_standard/forward_compat_test.go
@@ -1,0 +1,67 @@
+package ebus_standard_test
+
+// Forward-compat test (decision doc §4.5 + M4B §7.3).
+//
+// A synthetic v1.1 envelope that carries:
+//   - An unknown active.scope literal ("future_unknown_scope").
+//   - An unknown transports[].state literal ("future_unknown_state").
+//   - An unknown transports[].reason literal ("future_unknown_reason").
+//
+// MUST parse via encoding/json without error — consumers that don't know
+// these values apply fail-closed behavior per §4.3. This test pins the
+// open-enum contract at the shape level (no strict enum validator in the
+// wire parser).
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestForwardCompat_UnknownEnumsParse(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("testdata", "forward_compat_synthetic_v1_1.golden.json"))
+	if err != nil {
+		t.Fatalf("read synthetic golden: %v", err)
+	}
+	var env map[string]any
+	if err := json.Unmarshal(raw, &env); err != nil {
+		t.Fatalf("unmarshal failed: %v — forward-compat contract broken", err)
+	}
+	meta, ok := env["meta"].(map[string]any)
+	if !ok {
+		t.Fatal("meta missing in synthetic envelope")
+	}
+	contract, _ := meta["contract"].(map[string]any)
+	if m, _ := contract["minor"].(float64); int(m) != 1 {
+		t.Fatalf("contract.minor=%v in synthetic, want 1", contract["minor"])
+	}
+	caps, _ := meta["capabilities"].(map[string]any)
+	resp, _ := caps["responder"].(map[string]any)
+	if resp == nil {
+		t.Fatal("capabilities.responder missing")
+	}
+	// Confirm unknown active.scope passed through.
+	active, _ := resp["active"].(map[string]any)
+	if s, _ := active["scope"].(string); s != "future_unknown_scope" {
+		t.Fatalf("unknown active.scope dropped/rewritten: %q", s)
+	}
+	// Confirm unknown state + reason passed through.
+	rows, _ := resp["transports"].([]any)
+	var sawUnknownState, sawUnknownReason bool
+	for _, r := range rows {
+		row, _ := r.(map[string]any)
+		if st, _ := row["state"].(string); st == "future_unknown_state" {
+			sawUnknownState = true
+		}
+		if rs, _ := row["reason"].(string); rs == "future_unknown_reason" {
+			sawUnknownReason = true
+		}
+	}
+	if !sawUnknownState {
+		t.Fatal("unknown transports[].state dropped")
+	}
+	if !sawUnknownReason {
+		t.Fatal("unknown transports[].reason dropped")
+	}
+}

--- a/mcp/ebus_standard/responder_capability.go
+++ b/mcp/ebus_standard/responder_capability.go
@@ -1,0 +1,162 @@
+package ebus_standard
+
+// M4c2 — meta.capabilities.responder signal (contract.minor = 1).
+//
+// Shape + semantics are locked by decision doc
+// helianthus-execution-plans@567a6798
+// (ebus-standard-l7-services-w16-26.implementing/decisions/m4b2-responder-go-no-go.md)
+// §4.2 "Shape" + §4.4 "Invariants".
+//
+// Consumer rule per §4.3 (fail-closed):
+//   - Absence of `meta.capabilities.responder` ⇒ treat as
+//     `active.scope = none`. This is why the provider pattern supports a
+//     nil provider: when no provider is registered (e.g. in tests or
+//     during early boot before transport selection), the key is omitted
+//     entirely. Emitting an empty object would falsely promise a shape
+//     the consumer is entitled to interpret.
+//
+// DI via package-level setter (NOT an anti-pattern here): the envelope
+// composer is called from ~20 sites across MCP surfaces; threading a
+// capability provider through every call would bloat the signature and
+// leak a bootstrap concern to every per-call site. The setter is
+// idempotent + replace-only and is called exactly once at bootstrap by
+// cmd/gateway/main.go based on the active transport. Tests reset to nil
+// via t.Cleanup.
+
+import "sync/atomic"
+
+// ResponderCapability is the JSON-serialisable shape emitted under
+// `meta.capabilities.responder`. Field tags use the exact literals
+// enumerated in decision doc §4.2 Shape. No `omitempty` on active /
+// transports — decision §4.4 I1 requires transports[] to ALWAYS have
+// three rows at v1.1, and I2 requires active to reference one of them.
+type ResponderCapability struct {
+	Version    string          `json:"version"`
+	Active     ActiveResponder `json:"active"`
+	Transports []TransportRow  `json:"transports"`
+}
+
+// ActiveResponder mirrors §4.2 `active`. Refusal is a pointer so it
+// serialises as JSON null when unset (per the schema sample).
+type ActiveResponder struct {
+	Transport string         `json:"transport"`
+	Scope     string         `json:"scope"`
+	Surfaces  []string       `json:"surfaces"`
+	Refusal   *ActiveRefusal `json:"refusal"`
+}
+
+// ActiveRefusal mirrors §4.2 `active.refusal`. Both fields are strings
+// so unknown `code` values at minor=1+ pass through verbatim (per §4.3
+// rule 6 the consumer applies fail-closed semantics).
+type ActiveRefusal struct {
+	Code   string `json:"code"`
+	Reason string `json:"reason"`
+}
+
+// TransportRow mirrors §4.2 `transports[]`. Reason uses `,omitempty`
+// is DELIBERATELY NOT applied — decision §4.4 I6 requires reason to be
+// explicit (null on supported rows, non-null on blocked). We emit the
+// empty string as JSON "null" via the custom marshaller below so the
+// shape matches the schema sample exactly.
+type TransportRow struct {
+	Transport string   `json:"transport"`
+	State     string   `json:"state"`
+	Scope     string   `json:"scope"`
+	Surfaces  []string `json:"surfaces"`
+	Reason    string   `json:"reason"`
+}
+
+// ResponderCapabilityProvider returns the current responder capability
+// signal for meta.capabilities.responder emission at envelope-assembly
+// time. cmd/gateway/main.go populates this once at bootstrap based on
+// the active transport. Tests inject a fixed provider via
+// SetResponderCapabilityProvider.
+type ResponderCapabilityProvider func() ResponderCapability
+
+// activeResponderCapabilityProvider is the package-level provider set
+// via SetResponderCapabilityProvider. atomic.Pointer gives race-free
+// reads from NewEnvelope concurrent with bootstrap writes (tests
+// routinely race Set + composer calls).
+var activeResponderCapabilityProvider atomic.Pointer[ResponderCapabilityProvider]
+
+// SetResponderCapabilityProvider is called once at bootstrap. Idempotent;
+// subsequent calls replace the provider. Nil provider means emit no
+// `meta.capabilities.responder` key (forward-compat §4.3 rule 1:
+// consumers treat absence as scope=none).
+//
+// Lifetime contract: test cleanup code MUST call
+// SetResponderCapabilityProvider(nil) in t.Cleanup to restore the
+// default null-provider state; otherwise subsequent tests in the same
+// package see leaked capability emission.
+func SetResponderCapabilityProvider(p ResponderCapabilityProvider) {
+	if p == nil {
+		activeResponderCapabilityProvider.Store(nil)
+		return
+	}
+	activeResponderCapabilityProvider.Store(&p)
+}
+
+// currentResponderCapability returns the capability from the registered
+// provider, or (_, false) if no provider is registered. Used by
+// NewEnvelope to decide whether to attach meta.capabilities.responder.
+func currentResponderCapability() (ResponderCapability, bool) {
+	p := activeResponderCapabilityProvider.Load()
+	if p == nil {
+		return ResponderCapability{}, false
+	}
+	return (*p)(), true
+}
+
+// capabilityToMap converts a ResponderCapability to the plain
+// map[string]any shape NewEnvelope already uses for meta.* keys. Using
+// a map keeps the canonical-JSON data_hash path untouched (no new types
+// need writeCanonical branches).
+func capabilityToMap(c ResponderCapability) map[string]any {
+	active := map[string]any{
+		"transport": c.Active.Transport,
+		"scope":     c.Active.Scope,
+		"surfaces":  stringSliceToAny(c.Active.Surfaces),
+	}
+	if c.Active.Refusal != nil {
+		active["refusal"] = map[string]any{
+			"code":   c.Active.Refusal.Code,
+			"reason": c.Active.Refusal.Reason,
+		}
+	} else {
+		active["refusal"] = nil
+	}
+	rows := make([]any, 0, len(c.Transports))
+	for _, r := range c.Transports {
+		row := map[string]any{
+			"transport": r.Transport,
+			"state":     r.State,
+			"scope":     r.Scope,
+			"surfaces":  stringSliceToAny(r.Surfaces),
+		}
+		// Decision §4.4 I5/I6: reason MUST be null on supported rows,
+		// non-null on blocked rows. We serialise empty string as JSON
+		// null to match the schema sample.
+		if r.Reason == "" {
+			row["reason"] = nil
+		} else {
+			row["reason"] = r.Reason
+		}
+		rows = append(rows, row)
+	}
+	return map[string]any{
+		"version":    c.Version,
+		"active":     active,
+		"transports": rows,
+	}
+}
+
+// stringSliceToAny converts []string to []any so the generic envelope
+// canonical-JSON writer (which branches on []any / []string / etc.) sees
+// a stable type regardless of Go build-tag differences.
+func stringSliceToAny(ss []string) []any {
+	out := make([]any, len(ss))
+	for i, s := range ss {
+		out[i] = s
+	}
+	return out
+}

--- a/mcp/ebus_standard/responder_capability_test.go
+++ b/mcp/ebus_standard/responder_capability_test.go
@@ -1,0 +1,249 @@
+package ebus_standard_test
+
+// M4c2 envelope tests — meta.capabilities.responder.
+//
+// These tests lock decision doc
+// (helianthus-execution-plans@567a6798) §4.2 shape + §4.4 invariants I1–I8
+// + §4.3 forward-compat rule 1 (absence ⇒ fail-closed) into the gateway
+// envelope composer.
+//
+// Test-time DI: the package-level provider setter
+// SetResponderCapabilityProvider is how tests inject fixed capabilities
+// without widening the NewEnvelope signature. Each test resets the
+// provider via t.Cleanup so parallel packages see a pristine state.
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	estd "github.com/Project-Helianthus/helianthus-ebusgateway/mcp/ebus_standard"
+)
+
+// withProvider installs p for the duration of the test and restores the
+// prior provider (nil by default) on cleanup.
+func withProvider(t *testing.T, p estd.ResponderCapabilityProvider) {
+	t.Helper()
+	estd.SetResponderCapabilityProvider(p)
+	t.Cleanup(func() { estd.SetResponderCapabilityProvider(nil) })
+}
+
+// fixedCapability constructs a canonical ENH-active v1.1 capability.
+func fixedCapability() estd.ResponderCapability {
+	return estd.ResponderCapability{
+		Version: "v1",
+		Active: estd.ActiveResponder{
+			Transport: "ENH",
+			Scope:     "partial",
+			Surfaces:  []string{"FF_03", "FF_04", "FF_05", "FF_06"},
+			Refusal:   nil,
+		},
+		Transports: []estd.TransportRow{
+			{Transport: "ENH", State: "supported", Scope: "partial", Surfaces: []string{"FF_03", "FF_04", "FF_05", "FF_06"}, Reason: ""},
+			{Transport: "ENS", State: "supported", Scope: "partial", Surfaces: []string{"FF_03", "FF_04", "FF_05", "FF_06"}, Reason: ""},
+			{Transport: "ebusd-tcp", State: "blocked", Scope: "none", Surfaces: []string{}, Reason: "command_bridge_no_companion_listen"},
+		},
+	}
+}
+
+// getCapabilitySubtree navigates meta.capabilities.responder; returns nil on
+// any missing intermediate key.
+func getCapabilitySubtree(env map[string]any) map[string]any {
+	meta, ok := env["meta"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	caps, ok := meta["capabilities"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	resp, _ := caps["responder"].(map[string]any)
+	return resp
+}
+
+// TestCapability_EmittedWhenProviderSet asserts that when a provider is
+// registered, meta.capabilities.responder appears in every envelope.
+func TestCapability_EmittedWhenProviderSet(t *testing.T) {
+	withProvider(t, func() estd.ResponderCapability { return fixedCapability() })
+	env := estd.NewEnvelope(nil, nil, time.Unix(0, 0).UTC())
+	resp := getCapabilitySubtree(env)
+	if resp == nil {
+		t.Fatal("meta.capabilities.responder absent when provider is registered")
+	}
+}
+
+// TestCapability_OmittedWhenProviderNil asserts that when no provider is
+// registered (nil), the capabilities.responder key is omitted entirely.
+// Per §4.3 rule 1, consumers treat absence as active.scope = none
+// (fail-closed) — so absence is the correct "no signal" representation and
+// MUST NOT be emitted as an empty object or null value.
+func TestCapability_OmittedWhenProviderNil(t *testing.T) {
+	estd.SetResponderCapabilityProvider(nil) // explicit reset for clarity
+	env := estd.NewEnvelope(nil, nil, time.Unix(0, 0).UTC())
+	meta, _ := env["meta"].(map[string]any)
+	if caps, ok := meta["capabilities"]; ok {
+		t.Fatalf("meta.capabilities key must be absent when no provider set (got %v)", caps)
+	}
+}
+
+// TestCapability_ContractMinorBumped locks the open-enum forward-compat
+// rule at the envelope level: emitting the capability key requires
+// contract.minor >= 1.
+func TestCapability_ContractMinorBumped(t *testing.T) {
+	if estd.EnvelopeContractMajor != 1 {
+		t.Fatalf("major drift: got %d, want 1", estd.EnvelopeContractMajor)
+	}
+	if estd.EnvelopeContractMinor != 1 {
+		t.Fatalf("M4c2 minor bump missing: got %d, want 1", estd.EnvelopeContractMinor)
+	}
+}
+
+// TestCapability_I1_ThreeTransportRows (decision §4.4 I1).
+func TestCapability_I1_ThreeTransportRows(t *testing.T) {
+	withProvider(t, func() estd.ResponderCapability { return fixedCapability() })
+	env := estd.NewEnvelope(nil, nil, time.Unix(0, 0).UTC())
+	resp := getCapabilitySubtree(env)
+	if resp == nil {
+		t.Fatal("responder subtree absent")
+	}
+	rows, _ := resp["transports"].([]any)
+	if len(rows) != 3 {
+		t.Fatalf("I1: transports[] len=%d, want 3 (ENH, ENS, ebusd-tcp)", len(rows))
+	}
+}
+
+// TestCapability_I2_ActiveInTransports (decision §4.4 I2).
+func TestCapability_I2_ActiveInTransports(t *testing.T) {
+	withProvider(t, func() estd.ResponderCapability { return fixedCapability() })
+	env := estd.NewEnvelope(nil, nil, time.Unix(0, 0).UTC())
+	resp := getCapabilitySubtree(env)
+	active, _ := resp["active"].(map[string]any)
+	activeT, _ := active["transport"].(string)
+	rows, _ := resp["transports"].([]any)
+	found := false
+	for _, r := range rows {
+		row, _ := r.(map[string]any)
+		if t2, _ := row["transport"].(string); t2 == activeT {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("I2: active.transport %q not present in transports[]", activeT)
+	}
+}
+
+// TestCapability_I3_ActiveScopeMatchesRow (decision §4.4 I3).
+func TestCapability_I3_ActiveScopeMatchesRow(t *testing.T) {
+	withProvider(t, func() estd.ResponderCapability { return fixedCapability() })
+	env := estd.NewEnvelope(nil, nil, time.Unix(0, 0).UTC())
+	resp := getCapabilitySubtree(env)
+	active, _ := resp["active"].(map[string]any)
+	activeT, _ := active["transport"].(string)
+	activeS, _ := active["scope"].(string)
+	rows, _ := resp["transports"].([]any)
+	for _, r := range rows {
+		row, _ := r.(map[string]any)
+		if t2, _ := row["transport"].(string); t2 == activeT {
+			if rs, _ := row["scope"].(string); rs != activeS {
+				t.Fatalf("I3: active.scope=%q != transports[%s].scope=%q", activeS, activeT, rs)
+			}
+			return
+		}
+	}
+	t.Fatal("I3: active row not located")
+}
+
+// TestCapability_I4_ScopeNoneIffBlocked (decision §4.4 I4/I5/I6
+// combined via the ebusd-tcp row).
+func TestCapability_I4_I5_I6_BlockedRowShape(t *testing.T) {
+	withProvider(t, func() estd.ResponderCapability { return fixedCapability() })
+	env := estd.NewEnvelope(nil, nil, time.Unix(0, 0).UTC())
+	resp := getCapabilitySubtree(env)
+	rows, _ := resp["transports"].([]any)
+	var blocked map[string]any
+	for _, r := range rows {
+		row, _ := r.(map[string]any)
+		if state, _ := row["state"].(string); state == "blocked" {
+			blocked = row
+			break
+		}
+	}
+	if blocked == nil {
+		t.Fatal("I5: no blocked row found for ebusd-tcp")
+	}
+	if s, _ := blocked["scope"].(string); s != "none" {
+		t.Fatalf("I5: blocked row scope=%q, want none", s)
+	}
+	if r, _ := blocked["reason"].(string); r == "" {
+		t.Fatal("I5: blocked row reason must be non-null/non-empty")
+	}
+	// I6: supported rows MUST have reason null/empty.
+	for _, r := range rows {
+		row, _ := r.(map[string]any)
+		if state, _ := row["state"].(string); state == "supported" {
+			if rr := row["reason"]; rr != nil && rr != "" {
+				t.Fatalf("I6: supported row has non-null reason %v", rr)
+			}
+		}
+	}
+}
+
+// TestCapability_I7_NoDuplicateTransports (decision §4.4 I7).
+func TestCapability_I7_NoDuplicateTransports(t *testing.T) {
+	withProvider(t, func() estd.ResponderCapability { return fixedCapability() })
+	env := estd.NewEnvelope(nil, nil, time.Unix(0, 0).UTC())
+	resp := getCapabilitySubtree(env)
+	rows, _ := resp["transports"].([]any)
+	seen := map[string]bool{}
+	for _, r := range rows {
+		row, _ := r.(map[string]any)
+		tn, _ := row["transport"].(string)
+		if seen[tn] {
+			t.Fatalf("I7: duplicate transport row %q", tn)
+		}
+		seen[tn] = true
+	}
+}
+
+// TestCapability_I8_UnknownRefusalFailsClosed asserts the envelope composer
+// passes through an unknown active.refusal.code verbatim — consumers apply
+// fail-closed per §4.3 rule 6. This test confirms the gateway does not
+// try to sanitise/drop unknown refusal codes (forward-compat contract).
+func TestCapability_I8_UnknownRefusalFailsClosed(t *testing.T) {
+	cap := fixedCapability()
+	cap.Active.Scope = "none"
+	cap.Active.Surfaces = []string{}
+	cap.Active.Refusal = &estd.ActiveRefusal{Code: "synthetic_future_code", Reason: "forward-compat probe"}
+	withProvider(t, func() estd.ResponderCapability { return cap })
+	env := estd.NewEnvelope(nil, nil, time.Unix(0, 0).UTC())
+	resp := getCapabilitySubtree(env)
+	active, _ := resp["active"].(map[string]any)
+	refusal, _ := active["refusal"].(map[string]any)
+	if refusal == nil {
+		t.Fatal("I8: refusal must be preserved verbatim for unknown-code forward-compat")
+	}
+	if c, _ := refusal["code"].(string); c != "synthetic_future_code" {
+		t.Fatalf("I8: refusal.code altered: got %q", c)
+	}
+}
+
+// TestCapability_VersionFieldIsV1 (decision §4.2).
+func TestCapability_VersionFieldIsV1(t *testing.T) {
+	withProvider(t, func() estd.ResponderCapability { return fixedCapability() })
+	env := estd.NewEnvelope(nil, nil, time.Unix(0, 0).UTC())
+	resp := getCapabilitySubtree(env)
+	if v, _ := resp["version"].(string); v != "v1" {
+		t.Fatalf("version=%q, want v1", v)
+	}
+}
+
+// TestCapability_MarshalsToStableJSON asserts the emitted subtree marshals
+// cleanly (no unmarshallable types leak from the provider struct).
+func TestCapability_MarshalsToStableJSON(t *testing.T) {
+	withProvider(t, func() estd.ResponderCapability { return fixedCapability() })
+	env := estd.NewEnvelope(nil, nil, time.Unix(0, 0).UTC())
+	if _, err := json.Marshal(env); err != nil {
+		t.Fatalf("envelope marshals: %v", err)
+	}
+}

--- a/mcp/ebus_standard/testdata/command_get_alpha.golden.json
+++ b/mcp/ebus_standard/testdata/command_get_alpha.golden.json
@@ -36,7 +36,7 @@
     },
     "contract": {
       "major": 1,
-      "minor": 0,
+      "minor": 1,
       "name": "helianthus-ebus-mcp"
     },
     "data_hash": "f44498e06fb077274958d5e8e391975a38bb6ae89290aa8acf60b9989b4b91ff",

--- a/mcp/ebus_standard/testdata/commands_list_pb03.golden.json
+++ b/mcp/ebus_standard/testdata/commands_list_pb03.golden.json
@@ -19,7 +19,7 @@
     },
     "contract": {
       "major": 1,
-      "minor": 0,
+      "minor": 1,
       "name": "helianthus-ebus-mcp"
     },
     "data_hash": "9dd761693437a64da0f362bd4ba6fc5366cde2be255ca93877bf5c08d423190e",

--- a/mcp/ebus_standard/testdata/decode_alpha.golden.json
+++ b/mcp/ebus_standard/testdata/decode_alpha.golden.json
@@ -18,7 +18,7 @@
     },
     "contract": {
       "major": 1,
-      "minor": 0,
+      "minor": 1,
       "name": "helianthus-ebus-mcp"
     },
     "data_hash": "5fd4424a899bd038ccf5b0b0c038b6d800988a3a5337b2f6c8d16c94ceab0a67",

--- a/mcp/ebus_standard/testdata/forward_compat_synthetic_v1_1.golden.json
+++ b/mcp/ebus_standard/testdata/forward_compat_synthetic_v1_1.golden.json
@@ -1,0 +1,50 @@
+{
+  "data": null,
+  "error": null,
+  "meta": {
+    "capabilities": {
+      "responder": {
+        "active": {
+          "refusal": null,
+          "scope": "future_unknown_scope",
+          "surfaces": ["FF_03", "FF_99"],
+          "transport": "ENH"
+        },
+        "transports": [
+          {
+            "reason": null,
+            "scope": "partial",
+            "state": "supported",
+            "surfaces": ["FF_03", "FF_04", "FF_05", "FF_06"],
+            "transport": "ENH"
+          },
+          {
+            "reason": null,
+            "scope": "future_unknown_scope",
+            "state": "future_unknown_state",
+            "surfaces": ["FF_99"],
+            "transport": "future_transport"
+          },
+          {
+            "reason": "future_unknown_reason",
+            "scope": "none",
+            "state": "blocked",
+            "surfaces": [],
+            "transport": "ebusd-tcp"
+          }
+        ],
+        "version": "v1"
+      }
+    },
+    "consistency": {
+      "mode": "LIVE"
+    },
+    "contract": {
+      "major": 1,
+      "minor": 1,
+      "name": "helianthus-ebus-mcp"
+    },
+    "data_hash": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+    "data_timestamp": "2026-01-01T00:00:00Z"
+  }
+}

--- a/mcp/ebus_standard/testdata/services_list.golden.json
+++ b/mcp/ebus_standard/testdata/services_list.golden.json
@@ -19,7 +19,7 @@
     },
     "contract": {
       "major": 1,
-      "minor": 0,
+      "minor": 1,
       "name": "helianthus-ebus-mcp"
     },
     "data_hash": "281e969d3a59ad7d290030e65888b0dab5795e3e5d6e91e2669baedf11fb6f5d",


### PR DESCRIPTION
## Scope

Gateway-side responder runtime for FF 03 / 04 / 05 / 06, consuming the `transport.ResponderTransport` capability + `protocol/responder` FSM introduced in ebusgo @ 721165d7 (PR-A @ e5c8841f + PR-B). Adds `meta.capabilities.responder` under `contract.minor = 1` (additive per M4B §6.2).

Closes #508.

## Decision references

- Decision doc: helianthus-execution-plans PR #17 @ 567a6798 — `ebus-standard-l7-services-w16-26.implementing/decisions/m4b2-responder-go-no-go.md`.
- M4B semantic lock: helianthus-docs-ebus PR #273 @ 91bcb34c (open-enum forward-compat, additive meta.* keys under minor bumps).
- Cruise-run meta: helianthus-execution-plans issue #14.

## Envelope minor bump: 0 → 1

`meta.capabilities.responder` is a net-new meta.* subtree; no existing key renamed, no type narrowed, no error code repurposed. Consumers on `minor=0` tolerate the new key (additive) and treat its absence as `active.scope = none` (fail-closed per decision §4.3 rule 1). Unknown `active.scope`, unknown `transports[].state`, unknown `transports[].reason` parse without error (§4.5 + M4B §7.3) — locked by the forward-compat synthetic golden.

## 8 invariants enforced (decision §4.4)

I1 transports[] has exactly three rows (ENH, ENS, ebusd-tcp) · I2 active.transport appears in transports[] · I3 active.scope equals transports[x].scope · I4 scope=none ⟺ responder-unavailable · I5 state=blocked ⇒ reason≠null ∧ scope=none · I6 state=supported ⇒ reason=null ∧ scope≠none · I7 no duplicate transport rows · I8 unknown active.refusal.code preserved verbatim (consumer fail-closed). All asserted in `mcp/ebus_standard/responder_capability_test.go`.

## Capability-layer sentinel

New `execution_policy.ErrResponderTransportUnavailable`, DISTINCT from `ErrSafetyClassDenied`. Per decision §5, capability refusals MUST NOT surface as audit `outcome=policy_denied` — conflating the two channels breaks denial-parity tests. The responder runtime fails construction (not per-call) when the active transport does not satisfy `ResponderTransport` or has `scope=none`.

## Provider pattern (NewEnvelope signature unchanged)

Package-level `SetResponderCapabilityProvider` (atomic.Pointer-backed, race-safe) avoids threading a provider through ~20 MCP surface call sites. Bootstrap wires the provider exactly once in `cmd/gateway/main.go` based on `cfg.TransportConfig.Protocol`. Tests reset via `t.Cleanup`. Nil provider ⇒ key omitted entirely (NOT `{}` or `null`) to preserve §4.3 rule 1 absence-semantics.

## BENCH-REPLACE carry-forward

`responderAckBudget = 15 * time.Millisecond` in ebusgo `protocol/responder/timing_harness.go` @ 721165d7 remains a literature-backed placeholder. Operator obligation: measure on BASV2 hardware and replace via a follow-up ebusgo PR. `hold-for-operator` applied.

## Cross-PR interaction

PR #507 (M5_PORTAL) open — file trees disjoint (portal/** vs. mcp/ebus_standard/** + internal/nm_runtime/** + internal/execution_policy/** + cmd/gateway/main.go). `cmd/gateway/main.go` call sites differ (`SetResponderCapabilityProvider` vs. portal `Options` wiring). Whichever merges first, the second rebases cleanly.

## Local CI

`go build ./...`, `go vet ./...`, `go test ./...` all green locally. Full gateway suite passes; four existing envelope goldens updated to v1.1 shape (minor bump only — no `capabilities.responder` subtree in those goldens because the test harness does not register a provider, which IS the canonical §4.3 fail-closed default shape). One new forward-compat synthetic golden pinning unknown-enum forward-compat parse.

## Test plan

- [ ] Reviewer confirms goldens diff is exclusively `minor: 0 → 1`.
- [ ] Reviewer confirms no `capabilities.responder` in existing goldens (fail-closed default).
- [ ] `go test ./mcp/ebus_standard/... ./internal/nm_runtime/... ./internal/execution_policy/...` green.
- [ ] `go test ./cmd/gateway/...` green (bootstrap wiring compiles + runs without regressing transport config tests).
- [ ] Codex-bot review green OR residual comments resolved.

@codex review