### PR TITLE
chore(gofmt): branch-wide gofmt cleanup

### DIFF
--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -39,12 +39,12 @@ const (
 	// --- Zone registers: GG=0x03 / OP=0x02 ---
 
 	// STATE registers (read-only live values)
-	zone_current_temp                      = uint16(0x000F) // state.current_room_temperature
-	zone_special_function                  = uint16(0x000E) // state.current_special_function
-	zone_valve_status                      = uint16(0x0012) // state.valve_status
-	zone_current_humidity                  = uint16(0x0028) // state.current_room_humidity
-	zone_quick_veto_end_time               = uint16(0x001E) // state.quick_veto.end_time (HH:MM:SS)
-	zone_quick_veto_end_date               = uint16(0x0024) // state.quick_veto.end_date (DD.MM.YY)
+	zone_current_temp        = uint16(0x000F) // state.current_room_temperature
+	zone_special_function    = uint16(0x000E) // state.current_special_function
+	zone_valve_status        = uint16(0x0012) // state.valve_status
+	zone_current_humidity    = uint16(0x0028) // state.current_room_humidity
+	zone_quick_veto_end_time = uint16(0x001E) // state.quick_veto.end_time (HH:MM:SS)
+	zone_quick_veto_end_date = uint16(0x0024) // state.quick_veto.end_date (DD.MM.YY)
 
 	// CONFIG registers (user-writable settings)
 	zone_heating_op_mode                   = uint16(0x0006) // configuration.heating.operation_mode
@@ -60,34 +60,34 @@ const (
 	zone_holiday_start_time                = uint16(0x0021) // configuration.holiday.start_time (HH:MM)
 
 	// PARAMS registers (identification / metadata)
-	zone_name                              = uint16(0x0016)
-	zone_name_prefix                       = uint16(0x0017)
-	zone_name_suffix                       = uint16(0x0018)
-	zone_index                             = uint16(0x001C)
+	zone_name        = uint16(0x0016)
+	zone_name_prefix = uint16(0x0017)
+	zone_name_suffix = uint16(0x0018)
+	zone_index       = uint16(0x001C)
 
 	// --- Circuit registers: GG=0x02 / OP=0x02 ---
 
 	// STATE registers (read-only live values)
-	circuit_flow_setpoint    = uint16(0x0007) // flow_setpoint
-	circuit_flow_temp        = uint16(0x0008) // flow_temperature (VF[x])
-	circuit_circuit_state    = uint16(0x001B) // circuit_state
-	circuit_pump_status      = uint16(0x001E) // pump_status
-	circuit_calc_flow_temp   = uint16(0x0020) // calculated_flow_temperature
-	circuit_mixer_position   = uint16(0x0021) // mixer_position_pct
-	circuit_humidity         = uint16(0x0022) // room_humidity_pct
-	circuit_dew_point        = uint16(0x0023) // dew_point_temperature
-	circuit_pump_hours       = uint16(0x0024) // pump_operating_hours
-	circuit_pump_starts      = uint16(0x0025) // pump_starts
+	circuit_flow_setpoint  = uint16(0x0007) // flow_setpoint
+	circuit_flow_temp      = uint16(0x0008) // flow_temperature (VF[x])
+	circuit_circuit_state  = uint16(0x001B) // circuit_state
+	circuit_pump_status    = uint16(0x001E) // pump_status
+	circuit_calc_flow_temp = uint16(0x0020) // calculated_flow_temperature
+	circuit_mixer_position = uint16(0x0021) // mixer_position_pct
+	circuit_humidity       = uint16(0x0022) // room_humidity_pct
+	circuit_dew_point      = uint16(0x0023) // dew_point_temperature
+	circuit_pump_hours     = uint16(0x0024) // pump_operating_hours
+	circuit_pump_starts    = uint16(0x0025) // pump_starts
 
 	// CONFIG registers (user-writable settings)
-	circuit_type             = uint16(0x0002) // configuration.heating_circuit_type / mixer_circuit_type_external
-	circuit_cooling_enabled  = uint16(0x0006) // cooling_enabled
-	circuit_heating_curve    = uint16(0x000F) // heating_curve
-	circuit_flow_temp_max    = uint16(0x0010) // flow_temperature_max
-	circuit_flow_temp_min    = uint16(0x0012) // flow_temperature_min
-	circuit_summer_limit     = uint16(0x0014) // summer_limit
+	circuit_type              = uint16(0x0002) // configuration.heating_circuit_type / mixer_circuit_type_external
+	circuit_cooling_enabled   = uint16(0x0006) // cooling_enabled
+	circuit_heating_curve     = uint16(0x000F) // heating_curve
+	circuit_flow_temp_max     = uint16(0x0010) // flow_temperature_max
+	circuit_flow_temp_min     = uint16(0x0012) // flow_temperature_min
+	circuit_summer_limit      = uint16(0x0014) // summer_limit
 	circuit_room_temp_control = uint16(0x0015) // room_temperature_control_mode
-	circuit_frost_protection = uint16(0x001D) // frost_protection_threshold
+	circuit_frost_protection  = uint16(0x001D) // frost_protection_threshold
 
 	CircuitStateStandby = "standby"
 	CircuitStateHeating = "heating"
@@ -96,8 +96,8 @@ const (
 	// --- DHW registers: GG=0x01 / OP=0x02 ---
 
 	// STATE registers (read-only live values)
-	dhw_current_temp       = uint16(0x0005) // state.current_dhw_temperature
-	dhw_special_function   = uint16(0x000D) // state.current_special_function
+	dhw_current_temp     = uint16(0x0005) // state.current_dhw_temperature
+	dhw_special_function = uint16(0x000D) // state.current_special_function
 
 	// CONFIG registers (user-writable settings)
 	dhw_operation_mode     = uint16(0x0003) // configuration.domestic_hot_water.operation_mode
@@ -110,11 +110,11 @@ const (
 	// --- Device slot registers: OP=0x06 (remote) ---
 
 	// STATE registers (read-only live values)
-	device_slot_connected              = uint16(0x0001)
-	device_slot_room_humidity          = uint16(0x0007)
-	device_slot_room_temperature       = uint16(0x000F)
-	device_slot_paired                 = uint16(0x001E)
-	device_slot_reception_strength     = uint16(0x001F)
+	device_slot_connected          = uint16(0x0001)
+	device_slot_room_humidity      = uint16(0x0007)
+	device_slot_room_temperature   = uint16(0x000F)
+	device_slot_paired             = uint16(0x001E)
+	device_slot_reception_strength = uint16(0x001F)
 
 	// PARAMS registers (identification / metadata)
 	device_slot_class_address          = uint16(0x0002)
@@ -135,13 +135,13 @@ const (
 	solar_pump_hours     = uint16(0x000B)
 
 	// CONFIG registers (user-writable settings)
-	solar_enabled        = uint16(0x0001)
-	solar_function_mode  = uint16(0x0002)
+	solar_enabled       = uint16(0x0001)
+	solar_function_mode = uint16(0x0002)
 
 	// --- Cylinder registers: GG=0x05 / OP=0x02 ---
 
 	// STATE registers (read-only live values)
-	cylinder_temperature       = uint16(0x0004)
+	cylinder_temperature = uint16(0x0004)
 
 	// CONFIG registers (user-writable settings)
 	cylinder_max_setpoint      = uint16(0x0001)
@@ -220,18 +220,18 @@ var b555HCNames = map[byte]string{
 // energy4 type = ULG (unsigned 32-bit LE) in kWh.
 const (
 	// STATE registers (read-only counters)
-	energy_fuel_sum_hc                   = uint16(0x0056) // PrFuelSumHc: total gas consumption heating
-	energy_electricity_sum_hc            = uint16(0x0057) // PrEnergySumHc: total electricity consumption heating
-	energy_electricity_sum_hwc           = uint16(0x0058) // PrEnergySumHwc: total electricity consumption hot water
-	energy_fuel_sum_hwc                  = uint16(0x0059) // PrFuelSumHwc: total gas consumption hot water
-	energy_fuel_sum_hc_this_month        = uint16(0x004E) // PrFuelSumHcThisMonth: gas heating this month
-	energy_electricity_sum_hc_this_month = uint16(0x004F) // PrEnergySumHcThisMonth: electricity heating this month
+	energy_fuel_sum_hc                    = uint16(0x0056) // PrFuelSumHc: total gas consumption heating
+	energy_electricity_sum_hc             = uint16(0x0057) // PrEnergySumHc: total electricity consumption heating
+	energy_electricity_sum_hwc            = uint16(0x0058) // PrEnergySumHwc: total electricity consumption hot water
+	energy_fuel_sum_hwc                   = uint16(0x0059) // PrFuelSumHwc: total gas consumption hot water
+	energy_fuel_sum_hc_this_month         = uint16(0x004E) // PrFuelSumHcThisMonth: gas heating this month
+	energy_electricity_sum_hc_this_month  = uint16(0x004F) // PrEnergySumHcThisMonth: electricity heating this month
 	energy_electricity_sum_hwc_this_month = uint16(0x0050) // PrEnergySumHwcThisMonth: electricity hot water this month
-	energy_fuel_sum_hwc_this_month       = uint16(0x0051) // PrFuelSumHwcThisMonth: gas hot water this month
-	energy_fuel_sum_hc_last_month        = uint16(0x0052) // PrFuelSumHcLastMonth: gas heating last month
-	energy_electricity_sum_hc_last_month = uint16(0x0053) // PrEnergySumHcLastMonth: electricity heating last month
+	energy_fuel_sum_hwc_this_month        = uint16(0x0051) // PrFuelSumHwcThisMonth: gas hot water this month
+	energy_fuel_sum_hc_last_month         = uint16(0x0052) // PrFuelSumHcLastMonth: gas heating last month
+	energy_electricity_sum_hc_last_month  = uint16(0x0053) // PrEnergySumHcLastMonth: electricity heating last month
 	energy_electricity_sum_hwc_last_month = uint16(0x0054) // PrEnergySumHwcLastMonth: electricity hot water last month
-	energy_fuel_sum_hwc_last_month       = uint16(0x0055) // PrFuelSumHwcLastMonth: gas hot water last month
+	energy_fuel_sum_hwc_last_month        = uint16(0x0055) // PrFuelSumHwcLastMonth: gas hot water last month
 )
 
 type regulatorAbsenceState string
@@ -288,18 +288,18 @@ type vaillantSemanticPoller struct {
 	watchObserver   ebusgateway.WatchObserver
 	watchEfficiency ebusgateway.WatchEfficiencyObserver
 
-	source               byte
-	requestTimeout       time.Duration
-	discoveryInterval    time.Duration
-	configInterval       time.Duration
-	stateInterval        time.Duration
-	energyInterval       time.Duration
-	scheduleInterval     time.Duration
-	boilerFastInterval   time.Duration
-	boilerMediumInterval time.Duration
-	boilerSlowInterval   time.Duration
-	zoneMissThreshold    int
-	zoneHitThreshold     int
+	source                   byte
+	requestTimeout           time.Duration
+	discoveryInterval        time.Duration
+	configInterval           time.Duration
+	stateInterval            time.Duration
+	energyInterval           time.Duration
+	scheduleInterval         time.Duration
+	boilerFastInterval       time.Duration
+	boilerMediumInterval     time.Duration
+	boilerSlowInterval       time.Duration
+	zoneMissThreshold        int
+	zoneHitThreshold         int
 	dhwStaleTTL              time.Duration
 	deviceSlotRediscoveryTTL time.Duration
 
@@ -648,17 +648,17 @@ func newVaillantSemanticPoller(cfg ebusgateway.Config, gateway *ebusgateway.Gate
 		watchEfficiency: cfg.WatchEfficiencyObserver,
 		source:          cfg.ScanSource,
 
-		requestTimeout:       cfg.SemanticRequestTimeout,
-		discoveryInterval:    cfg.SemanticDiscoveryInterval,
-		configInterval:       cfg.SemanticConfigInterval,
-		stateInterval:        cfg.SemanticStateInterval,
-		energyInterval:       cfg.SemanticEnergyInterval,
-		scheduleInterval:     10 * time.Minute,
-		boilerFastInterval:   30 * time.Second,
-		boilerMediumInterval: 5 * time.Minute,
-		boilerSlowInterval:   10 * time.Minute,
-		zoneMissThreshold:    cfg.SemanticZonePresenceMissThreshold,
-		zoneHitThreshold:     cfg.SemanticZonePresenceHitThreshold,
+		requestTimeout:           cfg.SemanticRequestTimeout,
+		discoveryInterval:        cfg.SemanticDiscoveryInterval,
+		configInterval:           cfg.SemanticConfigInterval,
+		stateInterval:            cfg.SemanticStateInterval,
+		energyInterval:           cfg.SemanticEnergyInterval,
+		scheduleInterval:         10 * time.Minute,
+		boilerFastInterval:       30 * time.Second,
+		boilerMediumInterval:     5 * time.Minute,
+		boilerSlowInterval:       10 * time.Minute,
+		zoneMissThreshold:        cfg.SemanticZonePresenceMissThreshold,
+		zoneHitThreshold:         cfg.SemanticZonePresenceHitThreshold,
 		dhwStaleTTL:              cfg.SemanticDHWStaleTTL,
 		deviceSlotRediscoveryTTL: 30 * time.Minute,
 
@@ -3060,7 +3060,7 @@ const (
 	// CONFIG registers (user-writable settings)
 	system_adaptive_heating_curve          = uint16(0x0014)
 	system_alternative_point               = uint16(0x0022)
-	system_heating_circuit_bivalence_point  = uint16(0x0023)
+	system_heating_circuit_bivalence_point = uint16(0x0023)
 	system_dhw_bivalence_point             = uint16(0x0001)
 	system_hc_emergency_temperature        = uint16(0x0026)
 	system_hwc_max_flow_temp_desired       = uint16(0x0046)
@@ -3073,46 +3073,46 @@ const (
 	system_installer_menu_code             = uint16(0x0076)
 
 	// PARAMS registers (system topology / identification)
-	system_scheme                          = uint16(0x0036)
-	system_module_configuration_vr71       = uint16(0x002F)
+	system_scheme                    = uint16(0x0036)
+	system_module_configuration_vr71 = uint16(0x002F)
 
 	// --- Boiler B509 direct registers on BAI00 ---
-	boiler_b509_water_pressure         = uint16(0x0200)
-	boiler_b509_flame_active           = uint16(0x0500)
-	boiler_b509_partload_hc_kw          = uint16(0x0704)
-	boiler_b509_partload_hwc_kw         = uint16(0x0804)
-	boiler_b509_flowset_hc_max_c         = uint16(0x0E04)
+	boiler_b509_water_pressure            = uint16(0x0200)
+	boiler_b509_flame_active              = uint16(0x0500)
+	boiler_b509_partload_hc_kw            = uint16(0x0704)
+	boiler_b509_partload_hwc_kw           = uint16(0x0804)
+	boiler_b509_flowset_hc_max_c          = uint16(0x0E04)
 	boiler_b509_flowset_hc_max_c_fallback = uint16(0xA500)
-	boiler_b509_flowset_hwc_max_c        = uint16(0x0F04)
-	boiler_b509_pump_hours             = uint16(0x1400)
-	boiler_b509_flow_temperature       = uint16(0x1800)
-	boiler_b509_fan_hours              = uint16(0x1B00)
-	boiler_b509_deactivations_ifc      = uint16(0x1F00)
-	boiler_b509_hours_till_service      = uint16(0x2004)
-	boiler_b509_deactivations_limit    = uint16(0x2000)
-	boiler_b509_dhw_hours              = uint16(0x2200)
-	boiler_b509_dhw_starts             = uint16(0x2300)
-	boiler_b509_target_fan_speed_rpm     = uint16(0x2400)
-	boiler_b509_central_heating_hours   = uint16(0x2800)
-	boiler_b509_central_heating_starts  = uint16(0x2900)
-	boiler_b509_modulation_pct         = uint16(0x2E00)
-	boiler_b509_flow_temp_desired_c      = uint16(0x3900)
-	boiler_b509_external_pump_active    = uint16(0x3F00)
-	boiler_b509_installer_menu_code     = uint16(0x4904)
-	boiler_b509_central_heating_pump    = uint16(0x4400)
-	boiler_b509_diverter_valve_position = uint16(0x5400)
-	boiler_b509_dhw_water_flow_lpm       = uint16(0x5500)
-	boiler_b509_dhw_demand_active       = uint16(0x5800)
-	boiler_b509_circulation_pump_active = uint16(0x7B00)
-	boiler_b509_phone_number           = uint16(0x8104)
-	boiler_b509_fan_speed_rpm           = uint16(0x8300)
-	boiler_b509_storage_load_pump_pct    = uint16(0x9E00)
-	boiler_b509_ionisation_voltage_ua   = uint16(0xA400)
-	boiler_b509_state_number           = uint16(0xAB00)
-	boiler_b509_gas_valve_active        = uint16(0xBB00)
-	boiler_b509_heating_switch_active   = uint16(0xF203)
-	boiler_b509_dhw_temp_desired_c       = uint16(0xEA03)
-	boiler_b509_primary_circuit_flow_lpm = uint16(0xFB00)
+	boiler_b509_flowset_hwc_max_c         = uint16(0x0F04)
+	boiler_b509_pump_hours                = uint16(0x1400)
+	boiler_b509_flow_temperature          = uint16(0x1800)
+	boiler_b509_fan_hours                 = uint16(0x1B00)
+	boiler_b509_deactivations_ifc         = uint16(0x1F00)
+	boiler_b509_hours_till_service        = uint16(0x2004)
+	boiler_b509_deactivations_limit       = uint16(0x2000)
+	boiler_b509_dhw_hours                 = uint16(0x2200)
+	boiler_b509_dhw_starts                = uint16(0x2300)
+	boiler_b509_target_fan_speed_rpm      = uint16(0x2400)
+	boiler_b509_central_heating_hours     = uint16(0x2800)
+	boiler_b509_central_heating_starts    = uint16(0x2900)
+	boiler_b509_modulation_pct            = uint16(0x2E00)
+	boiler_b509_flow_temp_desired_c       = uint16(0x3900)
+	boiler_b509_external_pump_active      = uint16(0x3F00)
+	boiler_b509_installer_menu_code       = uint16(0x4904)
+	boiler_b509_central_heating_pump      = uint16(0x4400)
+	boiler_b509_diverter_valve_position   = uint16(0x5400)
+	boiler_b509_dhw_water_flow_lpm        = uint16(0x5500)
+	boiler_b509_dhw_demand_active         = uint16(0x5800)
+	boiler_b509_circulation_pump_active   = uint16(0x7B00)
+	boiler_b509_phone_number              = uint16(0x8104)
+	boiler_b509_fan_speed_rpm             = uint16(0x8300)
+	boiler_b509_storage_load_pump_pct     = uint16(0x9E00)
+	boiler_b509_ionisation_voltage_ua     = uint16(0xA400)
+	boiler_b509_state_number              = uint16(0xAB00)
+	boiler_b509_gas_valve_active          = uint16(0xBB00)
+	boiler_b509_heating_switch_active     = uint16(0xF203)
+	boiler_b509_dhw_temp_desired_c        = uint16(0xEA03)
+	boiler_b509_primary_circuit_flow_lpm  = uint16(0xFB00)
 )
 
 type vaillantBoilerSnapshot struct {

--- a/cmd/gateway/semantic_vaillant_test.go
+++ b/cmd/gateway/semantic_vaillant_test.go
@@ -5134,7 +5134,7 @@ func TestDeviceSlotCacheGating_OnlyPollsCachedSlots(t *testing.T) {
 
 	// Simulate discovery: 2 active slots out of 33.
 	cache := map[deviceSlotKey]bool{
-		{Group: remoteRegulators.group, Instance: 0x00}: true,
+		{Group: remoteRegulators.group, Instance: 0x00}:  true,
 		{Group: remoteThermostats.group, Instance: 0x01}: true,
 	}
 	poller.mu.Lock()

--- a/cmd/gateway/startup_scan.go
+++ b/cmd/gateway/startup_scan.go
@@ -238,9 +238,9 @@ func (b *statsBus) Send(ctx context.Context, frame protocol.Frame) (*protocol.Fr
 	// txn range it spans. Prefix / class are captured AFTER. If the
 	// classifier only implements LastTxnClass, we degrade to class-only.
 	var (
-		snap              activeTxnSnapshotter
-		preID             uint64
-		haveSnapshotter   bool
+		snap            activeTxnSnapshotter
+		preID           uint64
+		haveSnapshotter bool
 	)
 	if b.classifier != nil {
 		if snap, haveSnapshotter = b.classifier.(activeTxnSnapshotter); haveSnapshotter {

--- a/graphql/queries.go
+++ b/graphql/queries.go
@@ -4543,7 +4543,7 @@ func buildSchemaTypes() graphqlSchemaTypes {
 	adapterHardwareInfoType := graphqlgo.NewObject(graphqlgo.ObjectConfig{
 		Name: "AdapterHardwareInfo",
 		Fields: graphqlgo.Fields{
-			"firmwareVersion":    &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
+			"firmwareVersion": &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
 			"firmware_version": &graphqlgo.Field{
 				Type: graphqlgo.NewNonNull(graphqlgo.String),
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
@@ -4554,7 +4554,7 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return info.FirmwareVersion, nil
 				},
 			},
-			"firmwareChecksum":   &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
+			"firmwareChecksum": &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
 			"firmware_checksum": &graphqlgo.Field{
 				Type: graphqlgo.NewNonNull(graphqlgo.String),
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
@@ -4565,7 +4565,7 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return info.FirmwareChecksum, nil
 				},
 			},
-			"bootloaderVersion":  &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
+			"bootloaderVersion": &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
 			"bootloader_version": &graphqlgo.Field{
 				Type: graphqlgo.NewNonNull(graphqlgo.String),
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
@@ -4587,7 +4587,7 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return info.BootloaderChecksum, nil
 				},
 			},
-			"hardwareID":         &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
+			"hardwareID": &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
 			"hardware_id": &graphqlgo.Field{
 				Type: graphqlgo.NewNonNull(graphqlgo.String),
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
@@ -4598,7 +4598,7 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return info.HardwareID, nil
 				},
 			},
-			"hardwareConfig":     &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
+			"hardwareConfig": &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.String)},
 			"hardware_config": &graphqlgo.Field{
 				Type: graphqlgo.NewNonNull(graphqlgo.String),
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
@@ -4609,8 +4609,8 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return info.HardwareConfig, nil
 				},
 			},
-			"features":           &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.Int)},
-			"jumpers":            &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.Int)},
+			"features": &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.Int)},
+			"jumpers":  &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.Int)},
 			"jumperFlags": &graphqlgo.Field{
 				Type: graphqlgo.NewNonNull(graphqlgo.NewList(graphqlgo.NewNonNull(graphqlgo.String))),
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
@@ -4637,7 +4637,7 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return info.JumperFlags, nil
 				},
 			},
-			"isWifi":     &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.Boolean)},
+			"isWifi": &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.Boolean)},
 			"is_wifi": &graphqlgo.Field{
 				Type: graphqlgo.NewNonNull(graphqlgo.Boolean),
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
@@ -4870,7 +4870,7 @@ func buildSchemaTypes() graphqlSchemaTypes {
 					return info.VersionResponseLen, nil
 				},
 			},
-			"infoSupported":      &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.Boolean)},
+			"infoSupported": &graphqlgo.Field{Type: graphqlgo.NewNonNull(graphqlgo.Boolean)},
 			"info_supported": &graphqlgo.Field{
 				Type: graphqlgo.NewNonNull(graphqlgo.Boolean),
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {

--- a/internal/adaptermux/arbitration.go
+++ b/internal/adaptermux/arbitration.go
@@ -7,15 +7,15 @@ import "sync"
 //
 // XR_GATEWAY_PRIORITY — scheduling policy:
 //
-//   At each SYN boundary (or idle tick), tryGrant checks pendingGateway
-//   BEFORE pendingExternal. The gateway always gets first pick for bus
-//   ownership. External requests are serviced at the next boundary when
-//   the gateway has no pending work.
+//	At each SYN boundary (or idle tick), tryGrant checks pendingGateway
+//	BEFORE pendingExternal. The gateway always gets first pick for bus
+//	ownership. External requests are serviced at the next boundary when
+//	the gateway has no pending work.
 //
-//   This is a deliberate design choice: the gateway's semantic poller
-//   drives periodic register scans that must complete within their
-//   polling window. External clients (ebusd) are best-effort consumers
-//   that can tolerate arbitration delays without functional impact.
+//	This is a deliberate design choice: the gateway's semantic poller
+//	drives periodic register scans that must complete within their
+//	polling window. External clients (ebusd) are best-effort consumers
+//	that can tolerate arbitration delays without functional impact.
 //
 // The arbitrator is informed by the proxy's boundary-based arbitration
 // (proxy M2) but simplified for a two-class model:

--- a/internal/adaptermux/diag.go
+++ b/internal/adaptermux/diag.go
@@ -13,12 +13,12 @@ import (
 type TxnClass string
 
 const (
-	TxnClassUnknown              TxnClass = ""
-	TxnClassEchoOnlyTimeout      TxnClass = "echo_only_timeout"
-	TxnClassNonEchoInvalidFrame  TxnClass = "non_echo_invalid_frame"
-	TxnClassCandidateNoParse     TxnClass = "candidate_no_parse"
-	TxnClassSchemaError          TxnClass = "schema_error"
-	TxnClassSuccessLike          TxnClass = "success_like"
+	TxnClassUnknown             TxnClass = ""
+	TxnClassEchoOnlyTimeout     TxnClass = "echo_only_timeout"
+	TxnClassNonEchoInvalidFrame TxnClass = "non_echo_invalid_frame"
+	TxnClassCandidateNoParse    TxnClass = "candidate_no_parse"
+	TxnClassSchemaError         TxnClass = "schema_error"
+	TxnClassSuccessLike         TxnClass = "success_like"
 )
 
 // txnPrefixCap bounds how many leading bytes of write and read traffic are
@@ -32,10 +32,10 @@ const txnPrefixCap = 8
 type ActiveTxnInactiveReason string
 
 const (
-	ReasonNone              ActiveTxnInactiveReason = ""
-	ReasonTransactionDone   ActiveTxnInactiveReason = "transaction_done"
-	ReasonCmdNACK           ActiveTxnInactiveReason = "cmd_nack"
-	ReasonSYNIdle           ActiveTxnInactiveReason = "syn_idle"
+	ReasonNone            ActiveTxnInactiveReason = ""
+	ReasonTransactionDone ActiveTxnInactiveReason = "transaction_done"
+	ReasonCmdNACK         ActiveTxnInactiveReason = "cmd_nack"
+	ReasonSYNIdle         ActiveTxnInactiveReason = "syn_idle"
 	// ReasonSYNTerminator is recorded when a SYN arrives mid-transaction
 	// (bytesRead>0) and is treated as the legitimate frame terminator.
 	// Distinguished from ReasonSYNIdle (which historically covered both
@@ -57,13 +57,13 @@ const (
 // Counters in ActiveTxnSnapshot are atomic to permit lock-free reads
 // from the hot path (active_path.go Write/Read).
 type activeTxnDiag struct {
-	id            uint64    // monotonic transaction id (set at grant)
-	initiator     byte      // source/initiator byte for this grant
-	grantedAt     time.Time // timestamp of the grant
-	inactiveAt    time.Time // timestamp of the inactive transition
-	inactiveReas  ActiveTxnInactiveReason
-	bytesWritten  atomic.Uint64 // incremented by activeTransport.Write on success
-	bytesRead     atomic.Uint64 // incremented by activeTransport.ReadByte/ReadEvent success
+	id           uint64    // monotonic transaction id (set at grant)
+	initiator    byte      // source/initiator byte for this grant
+	grantedAt    time.Time // timestamp of the grant
+	inactiveAt   time.Time // timestamp of the inactive transition
+	inactiveReas ActiveTxnInactiveReason
+	bytesWritten atomic.Uint64 // incremented by activeTransport.Write on success
+	bytesRead    atomic.Uint64 // incremented by activeTransport.ReadByte/ReadEvent success
 	// bytesDeliveredToActive is the precise "at least one real adapter byte
 	// has been enqueued on activeCh during this gateway-owned txn" signal.
 	// Incremented by the readLoop byte-delivery path AFTER a successful
@@ -74,7 +74,7 @@ type activeTxnDiag struct {
 	// legitimate frame terminator or pre-echo idle-buffer noise. Codex PR
 	// #502 P1 — superseded bytesWritten as the terminator/suppression gate.
 	bytesDeliveredToActive atomic.Uint64
-	drainedOnGrant int          // count of stale bytes drained just before this grant
+	drainedOnGrant         int // count of stale bytes drained just before this grant
 
 	// totals across the mux lifetime (never reset)
 	grantsTotal    atomic.Uint64
@@ -113,9 +113,9 @@ type activeTxnDiag struct {
 	readPrefixLen  int
 	// Byte-class counters (atomic; hot-path increments in onReceived
 	// and Write paths).
-	echoLike    atomic.Uint64
-	nonEcho     atomic.Uint64
-	synMarkers  atomic.Uint64
+	echoLike   atomic.Uint64
+	nonEcho    atomic.Uint64
+	synMarkers atomic.Uint64
 	// Terminal classification computed at recordGatewayInactive time.
 	txnClass TxnClass
 	// lastClass persists the most recently classified txn's class so it
@@ -177,29 +177,29 @@ func (m *Mux) ActiveTxnSnapshot() ActiveTxnSnapshot {
 	rp := make([]byte, m.activeTxn.readPrefixLen)
 	copy(rp, m.activeTxn.readPrefix[:m.activeTxn.readPrefixLen])
 	return ActiveTxnSnapshot{
-		ID:             m.activeTxn.id,
-		Initiator:      m.activeTxn.initiator,
-		GrantedAt:      m.activeTxn.grantedAt,
-		InactiveAt:     m.activeTxn.inactiveAt,
-		InactiveReason: m.activeTxn.inactiveReas,
-		DrainedOnGrant: m.activeTxn.drainedOnGrant,
-		Active:         m.gatewayTxnActive,
-		BytesWritten:   m.activeTxn.bytesWritten.Load(),
-		BytesRead:      m.activeTxn.bytesRead.Load(),
-		GrantsTotal:    m.activeTxn.grantsTotal.Load(),
-		WriteErrTotal:  m.activeTxn.writeErrTotal.Load(),
-		ReadTimeoutTot: m.activeTxn.readTimeoutTot.Load(),
-		AfterInactive:         m.activeTxn.afterInactive.Load(),
+		ID:                     m.activeTxn.id,
+		Initiator:              m.activeTxn.initiator,
+		GrantedAt:              m.activeTxn.grantedAt,
+		InactiveAt:             m.activeTxn.inactiveAt,
+		InactiveReason:         m.activeTxn.inactiveReas,
+		DrainedOnGrant:         m.activeTxn.drainedOnGrant,
+		Active:                 m.gatewayTxnActive,
+		BytesWritten:           m.activeTxn.bytesWritten.Load(),
+		BytesRead:              m.activeTxn.bytesRead.Load(),
+		GrantsTotal:            m.activeTxn.grantsTotal.Load(),
+		WriteErrTotal:          m.activeTxn.writeErrTotal.Load(),
+		ReadTimeoutTot:         m.activeTxn.readTimeoutTot.Load(),
+		AfterInactive:          m.activeTxn.afterInactive.Load(),
 		TerminatorDropOnFullCh: m.activeTxn.terminatorDropOnFullCh.Load(),
 		SynSuppressedPreEcho:   m.activeTxn.synSuppressedPreEcho.Load(),
 		BytesDeliveredToActive: m.activeTxn.bytesDeliveredToActive.Load(),
-		WritePrefix:    wp,
-		ReadPrefix:     rp,
-		EchoLike:       m.activeTxn.echoLike.Load(),
-		NonEcho:        m.activeTxn.nonEcho.Load(),
-		SynMarkers:     m.activeTxn.synMarkers.Load(),
-		TxnClass:       m.activeTxn.txnClass,
-		LastTxnClass:   m.activeTxn.lastClass,
+		WritePrefix:            wp,
+		ReadPrefix:             rp,
+		EchoLike:               m.activeTxn.echoLike.Load(),
+		NonEcho:                m.activeTxn.nonEcho.Load(),
+		SynMarkers:             m.activeTxn.synMarkers.Load(),
+		TxnClass:               m.activeTxn.txnClass,
+		LastTxnClass:           m.activeTxn.lastClass,
 	}
 }
 
@@ -434,17 +434,17 @@ const synDiagRingCap = 16
 // SYN to activeCh for the Send consumer, or did onSYNLocked consume it
 // as an end-of-txn terminator? Which inactive reason (if any) was set?
 type SynDiagEntry struct {
-	ObservedAt          time.Time
-	TxnID               uint64
-	OwnerID             uint64
-	GatewayOwned        bool
-	GwActiveBefore      bool
-	GwActiveAfter       bool
-	LastWrittenByte     byte
-	HasLastWrittenByte  bool
-	BytesRead           uint64
+	ObservedAt           time.Time
+	TxnID                uint64
+	OwnerID              uint64
+	GatewayOwned         bool
+	GwActiveBefore       bool
+	GwActiveAfter        bool
+	LastWrittenByte      byte
+	HasLastWrittenByte   bool
+	BytesRead            uint64
 	SynDeliveredToActive bool
-	InactiveReason      ActiveTxnInactiveReason
+	InactiveReason       ActiveTxnInactiveReason
 }
 
 // synDiagRing is a bounded ring of SynDiagEntry. Wraps once it reaches

--- a/internal/adaptermux/diag_test.go
+++ b/internal/adaptermux/diag_test.go
@@ -285,7 +285,7 @@ func TestRegression_StartedButNoResponse(t *testing.T) {
 		Protocol:             "enh",
 		Network:              "tcp",
 		Address:              "127.0.0.1:0",
-		ReadTimeout:           200 * time.Millisecond,
+		ReadTimeout:          200 * time.Millisecond,
 		MaxOwnershipDuration: 10 * time.Second,
 		IdleReleaseGrace:     200 * time.Millisecond,
 	})

--- a/internal/adaptermux/e2e_test.go
+++ b/internal/adaptermux/e2e_test.go
@@ -65,12 +65,12 @@ func TestE2E_ScanB504_ToTarget0x08_SuccessFullFlow(t *testing.T) {
 		// Responder ACK=0x00, then response: NN=0x05, 5 data bytes, CRC=0x00,
 		// then initiator ACK=0x00, then trailing SYN=0xAA.
 		response := []byte{
-			0x00,                                     // responder ACK
-			0x05,                                     // NN (response data length)
-			0x56, 0x41, 0x49, 0x4C, 0x4C,             // "VAILL" identification data
-			0x00,                                     // response CRC placeholder
-			0x00,                                     // initiator ACK
-			protocol.SymbolSyn,                       // trailing SYN terminator
+			0x00,                         // responder ACK
+			0x05,                         // NN (response data length)
+			0x56, 0x41, 0x49, 0x4C, 0x4C, // "VAILL" identification data
+			0x00,               // response CRC placeholder
+			0x00,               // initiator ACK
+			protocol.SymbolSyn, // trailing SYN terminator
 		}
 		for _, b := range response {
 			mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: b}

--- a/internal/adaptermux/info_cache_test.go
+++ b/internal/adaptermux/info_cache_test.go
@@ -88,11 +88,11 @@ func TestPopulateInfoCache(t *testing.T) {
 
 	tr := &mockInfoTransport{
 		responses: map[transport.AdapterInfoID][]byte{
-			transport.AdapterInfoVersion:     {0x23, 0x01},
-			transport.AdapterInfoHardwareID:  {0x10, 0x20, 0x30},
+			transport.AdapterInfoVersion:      {0x23, 0x01},
+			transport.AdapterInfoHardwareID:   {0x10, 0x20, 0x30},
 			transport.AdapterInfoHardwareConf: {0x05},
-			transport.AdapterInfoTemperature: {0x1C}, // volatile — cached as startup snapshot
-			transport.AdapterInfoWiFiRSSI:    {0xE0}, // volatile — cached as startup snapshot
+			transport.AdapterInfoTemperature:  {0x1C}, // volatile — cached as startup snapshot
+			transport.AdapterInfoWiFiRSSI:     {0xE0}, // volatile — cached as startup snapshot
 		},
 	}
 

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -157,12 +157,12 @@ type Mux struct {
 	upstreamFeatures atomic.Uint32 // features byte from upstream INIT handshake
 
 	// Multiplexer state (guarded by stateMu).
-	stateMu      sync.Mutex
-	phase        wirePhaseTracker
-	arb          *arbitrator
-	busOwned     time.Time          // when current owner acquired the bus
+	stateMu            sync.Mutex
+	phase              wirePhaseTracker
+	arb                *arbitrator
+	busOwned           time.Time          // when current owner acquired the bus
 	pendingStart       *pendingStartState // in-flight START awaiting STARTED/FAILED
-	pendingStartAbsorb int               // stale adapter responses to absorb (FAILED/STARTED from cancelled requests)
+	pendingStartAbsorb int                // stale adapter responses to absorb (FAILED/STARTED from cancelled requests)
 	// Blocking StartArbitration tracking. blockingArbGen is monotonically
 	// increasing (never reset to 0 or reused) — reconnect/handleReset
 	// bump it forward so any stale goroutine's captured gen no longer
@@ -285,7 +285,7 @@ func New(cfg Config) *Mux {
 		gatewayEcho:  newEchoTracker(),
 		sessions:     make(map[uint64]*session),
 		infoCache:    make(map[transport.AdapterInfoID][]byte),
-		activeSendCh: make(chan sendRequest, 256), // AM49: increased from 16 for burst tolerance
+		activeSendCh: make(chan sendRequest, 256),  // AM49: increased from 16 for burst tolerance
 		activeCh:     make(chan activeEvent, 4096), // unified byte+error channel (4096: survives ~16s of bus traffic during arbitration waits)
 	}
 }
@@ -480,7 +480,7 @@ func (m *Mux) connect() error {
 				case <-m.ctx.Done():
 					_ = conn.Close()
 					m.conn = nil     // AM32: clear stale reference on ctx cancel
-					m.upstream = nil  // AM32: clear stale transport on ctx cancel
+					m.upstream = nil // AM32: clear stale transport on ctx cancel
 					return m.ctx.Err()
 				}
 			}
@@ -502,8 +502,8 @@ func (m *Mux) connect() error {
 			m.logger.Printf("adaptermux: INIT: adapter does not confirm features=0x%02X, proceeding with features=0x%02X", requestedFeatures, features)
 		} else if initErr != nil && !initOK {
 			_ = conn.Close()
-			m.conn = nil      // AM34: clear stale reference after INIT failure
-			m.upstream = nil   // AM34: clear stale transport after INIT failure
+			m.conn = nil     // AM34: clear stale reference after INIT failure
+			m.upstream = nil // AM34: clear stale transport after INIT failure
 			return fmt.Errorf("adaptermux: INIT handshake failed after 5 attempts: %w", initErr)
 		}
 		m.upstreamFeatures.Store(uint32(features))
@@ -523,7 +523,7 @@ func (m *Mux) connect() error {
 		case <-m.ctx.Done():
 			_ = conn.Close()
 			m.conn = nil     // AM32: clear stale reference on ctx cancel
-			m.upstream = nil  // AM32: clear stale transport on ctx cancel
+			m.upstream = nil // AM32: clear stale transport on ctx cancel
 			return m.ctx.Err()
 		}
 	}
@@ -543,7 +543,6 @@ func (m *Mux) connect() error {
 
 	return nil
 }
-
 
 // populateInfoCache queries the upstream transport for INFO metadata
 // and stores responses in the mux-level cache. Sessions and the active

--- a/internal/adaptermux/p3_test.go
+++ b/internal/adaptermux/p3_test.go
@@ -1038,7 +1038,7 @@ func (b *blockingStartTransport) getStartCalls() []byte {
 type failingStartTransport struct {
 	*p3MockTransport
 	startGate chan struct{} // blocks RequestStart until closed
-	startErr  error        // error to return after gate opens
+	startErr  error         // error to return after gate opens
 }
 
 func (f *failingStartTransport) RequestStart(initiator byte) error {
@@ -1598,7 +1598,7 @@ func TestConcurrentTryGrantAndStart(t *testing.T) {
 type gatedBlockingStartTransport struct {
 	readCh    chan byte
 	startGate chan struct{} // blocks StartArbitration until closed
-	startErr  error        // error to return after gate opens
+	startErr  error         // error to return after gate opens
 	mu        sync.Mutex
 	calls     []byte
 }
@@ -2052,11 +2052,11 @@ func TestPassive_NoGarbageDuringGatewayTransaction(t *testing.T) {
 // sees the reset boundary even under byte flood.
 //
 // Scenario:
-//   1. Grant gateway ownership so activeCh receives bytes.
-//   2. Flood activeCh to near-capacity with legitimate byte traffic.
-//   3. Trigger handleReset() (simulates in-band RESETTED).
-//   4. Assert that after handleReset, the consumer sees the reset
-//      error event — NOT lost behind stale bytes.
+//  1. Grant gateway ownership so activeCh receives bytes.
+//  2. Flood activeCh to near-capacity with legitimate byte traffic.
+//  3. Trigger handleReset() (simulates in-band RESETTED).
+//  4. Assert that after handleReset, the consumer sees the reset
+//     error event — NOT lost behind stale bytes.
 func TestResetErrorPriorityOverByteFlood(t *testing.T) {
 	mux, mock, _, cleanup := newP3TestMux(t)
 	defer cleanup()

--- a/internal/adaptermux/pr502_review_test.go
+++ b/internal/adaptermux/pr502_review_test.go
@@ -1064,11 +1064,11 @@ func (d *deadlineConnMock) Close() error {
 	close(d.closeC)
 	return nil
 }
-func (d *deadlineConnMock) LocalAddr() net.Addr                { return &net.TCPAddr{} }
-func (d *deadlineConnMock) RemoteAddr() net.Addr               { return &net.TCPAddr{} }
-func (d *deadlineConnMock) SetDeadline(time.Time) error        { return nil }
-func (d *deadlineConnMock) SetReadDeadline(time.Time) error    { return nil }
-func (d *deadlineConnMock) SetWriteDeadline(time.Time) error   { return nil }
+func (d *deadlineConnMock) LocalAddr() net.Addr              { return &net.TCPAddr{} }
+func (d *deadlineConnMock) RemoteAddr() net.Addr             { return &net.TCPAddr{} }
+func (d *deadlineConnMock) SetDeadline(time.Time) error      { return nil }
+func (d *deadlineConnMock) SetReadDeadline(time.Time) error  { return nil }
+func (d *deadlineConnMock) SetWriteDeadline(time.Time) error { return nil }
 
 // TestBlockingArbDeadline_TriggersReconnect_NoOverlap verifies C2: when a
 // blocking StartArbitration is hung and the AM8 deadline fires, the
@@ -1439,6 +1439,7 @@ func TestCancelPendingStart_BlockingArb_TriggersReconnect_NoOverlap(t *testing.T
 //   - (bytes enqueued on activeCh) + (afterInactive counter increments)
 //     must equal the total bytes pushed.
 //   - No byte is lost to "neither enqueued nor counted".
+//
 // Without the atomic recheck, a window exists where a byte is enqueued
 // after the flip — activeCh length + afterInactive < total bytes.
 func TestDeliverToActive_RechecksGatingAtomically(t *testing.T) {

--- a/internal/adaptermux/syn_diag_test.go
+++ b/internal/adaptermux/syn_diag_test.go
@@ -357,16 +357,16 @@ func TestEchoMismatch_SYNAfterGrantBeforeFirstEcho(t *testing.T) {
 // BEFORE the first echoed/response byte has been enqueued on activeCh.
 //
 // Sequence modeled:
-//   1. grantGateway → gatewayTxnActive=true, bytesDeliveredToActive=0.
-//   2. at.Write(0x71) — bytesWritten flips to 1 immediately (the Write
-//      method increments the counter before the byte even reaches the
-//      adapter). bytesDeliveredToActive is still 0 because readLoop has
-//      not yet seen the echo come back.
-//   3. Inject idle-chatter SYN (the buffered TCP SYN that sits in the
-//      adapter pipeline on busy links). Under the pre-fix gate this SYN
-//      would pass "bytesWritten>0" and be delivered to activeCh as a
-//      terminator, which races the real echo.
-//   4. Inject the real echo byte (0x71).
+//  1. grantGateway → gatewayTxnActive=true, bytesDeliveredToActive=0.
+//  2. at.Write(0x71) — bytesWritten flips to 1 immediately (the Write
+//     method increments the counter before the byte even reaches the
+//     adapter). bytesDeliveredToActive is still 0 because readLoop has
+//     not yet seen the echo come back.
+//  3. Inject idle-chatter SYN (the buffered TCP SYN that sits in the
+//     adapter pipeline on busy links). Under the pre-fix gate this SYN
+//     would pass "bytesWritten>0" and be delivered to activeCh as a
+//     terminator, which races the real echo.
+//  4. Inject the real echo byte (0x71).
 //
 // Post-fix invariant: because bytesDeliveredToActive is still 0 at step 3,
 // the SYN is classified as pre-echo noise (synSuppressedPreEcho++,

--- a/internal/adaptermux/wire_phase_test.go
+++ b/internal/adaptermux/wire_phase_test.go
@@ -31,13 +31,13 @@ func TestWirePhase_FullTransaction(t *testing.T) {
 		symbol byte
 		want   wirePhaseEvent
 	}{
-		{0x71, wirePhaseEventNone},           // SRC
-		{0x08, wirePhaseEventNone},           // DST
-		{0xB5, wirePhaseEventNone},           // PB
-		{0x24, wirePhaseEventNone},           // SB
-		{0x02, wirePhaseEventNone},           // LEN=2
-		{0x00, wirePhaseEventNone},           // DATA[0]
-		{0x01, wirePhaseEventNone},           // DATA[1]
+		{0x71, wirePhaseEventNone},            // SRC
+		{0x08, wirePhaseEventNone},            // DST
+		{0xB5, wirePhaseEventNone},            // PB
+		{0x24, wirePhaseEventNone},            // SB
+		{0x02, wirePhaseEventNone},            // LEN=2
+		{0x00, wirePhaseEventNone},            // DATA[0]
+		{0x01, wirePhaseEventNone},            // DATA[1]
 		{0x99, wirePhaseEventRequestComplete}, // CRC → request complete
 	}
 
@@ -145,7 +145,7 @@ func TestWirePhase_NACK_SecondGoesToIdle(t *testing.T) {
 	for _, b := range []byte{0x71, 0x08, 0xB5, 0x24, 0x00} {
 		tracker.advance(b)
 	}
-	tracker.advance(0xDD) // CRC
+	tracker.advance(0xDD)                // CRC
 	tracker.advance(protocol.SymbolNack) // first NACK -> retry
 
 	// Retransmitted request: SRC, DST, PB, SB, LEN=0, CRC
@@ -175,7 +175,7 @@ func TestWirePhase_NACK_RetryThenACK(t *testing.T) {
 	for _, b := range []byte{0x71, 0x08, 0xB5, 0x24, 0x00} {
 		tracker.advance(b)
 	}
-	tracker.advance(0xDD) // CRC
+	tracker.advance(0xDD)                // CRC
 	tracker.advance(protocol.SymbolNack) // first NACK -> retry
 
 	// Retransmitted request.
@@ -329,7 +329,7 @@ func TestWirePhase_StartRequestWithSource_B524(t *testing.T) {
 		0x02, 0x00, // D0-D1: opcode=local, read
 		0x00, 0x00, // D2-D3: group=0, instance=0
 		0x01, 0x00, // D4-D5: addr=0x0001
-		0x42,       // CRC (placeholder)
+		0x42, // CRC (placeholder)
 	}
 
 	var lastEvent wirePhaseEvent
@@ -406,7 +406,7 @@ func TestWirePhase_ZeroLengthResponse(t *testing.T) {
 	for _, b := range []byte{0x71, 0x08, 0xB5, 0x24, 0x00} {
 		tracker.advance(b)
 	}
-	tracker.advance(0xDD) // CRC → WaitCmdAck
+	tracker.advance(0xDD)               // CRC → WaitCmdAck
 	tracker.advance(protocol.SymbolAck) // ACK → WaitResponseLen
 
 	// Response LEN=0: only CRC follows.
@@ -444,8 +444,8 @@ func TestWirePhase_NACKResponseRetry(t *testing.T) {
 	tracker.advance(protocol.SymbolAck) // -> WaitResponseLen
 
 	// First response: LEN=1 DATA CRC.
-	tracker.advance(0x01) // LEN=1
-	tracker.advance(0xAB) // DATA[0]
+	tracker.advance(0x01)        // LEN=1
+	tracker.advance(0xAB)        // DATA[0]
 	got := tracker.advance(0xDD) // CRC -> ResponseDone -> WaitResponseAck
 	if got != wirePhaseEventResponseDone {
 		t.Fatalf("first response CRC: event=%d, want ResponseDone", got)
@@ -461,8 +461,8 @@ func TestWirePhase_NACKResponseRetry(t *testing.T) {
 	}
 
 	// Retry response: LEN=1 DATA CRC.
-	tracker.advance(0x01) // LEN=1
-	tracker.advance(0xAB) // DATA[0]
+	tracker.advance(0x01)       // LEN=1
+	tracker.advance(0xAB)       // DATA[0]
 	got = tracker.advance(0xEE) // CRC -> ResponseDone -> WaitResponseAck
 	if got != wirePhaseEventResponseDone {
 		t.Fatalf("retry response CRC: event=%d, want ResponseDone", got)
@@ -486,19 +486,19 @@ func TestWirePhase_ResponseDoubleNACK(t *testing.T) {
 	for _, b := range []byte{0x71, 0x08, 0xB5, 0x24, 0x01, 0x42} {
 		tracker.advance(b)
 	}
-	tracker.advance(0xCC) // CRC
+	tracker.advance(0xCC)               // CRC
 	tracker.advance(protocol.SymbolAck) // -> WaitResponseLen
 
 	// First response + NACK (retry).
-	tracker.advance(0x01) // LEN
-	tracker.advance(0xAB) // DATA
-	tracker.advance(0xDD) // CRC -> ResponseDone
+	tracker.advance(0x01)                // LEN
+	tracker.advance(0xAB)                // DATA
+	tracker.advance(0xDD)                // CRC -> ResponseDone
 	tracker.advance(protocol.SymbolNack) // first NACK -> retry
 
 	// Retry response + second NACK.
-	tracker.advance(0x01) // LEN
-	tracker.advance(0xAB) // DATA
-	tracker.advance(0xEE) // CRC -> ResponseDone
+	tracker.advance(0x01)                       // LEN
+	tracker.advance(0xAB)                       // DATA
+	tracker.advance(0xEE)                       // CRC -> ResponseDone
 	got := tracker.advance(protocol.SymbolNack) // second NACK -> done
 	if got != wirePhaseEventTransactionDone {
 		t.Fatalf("second response NACK: event=%d, want TransactionDone", got)
@@ -516,12 +516,12 @@ func TestWirePhase_InitiatorToInitiator(t *testing.T) {
 	tracker.startRequest()
 
 	// Simulate i2i request: SRC=0x71, DST=0x10 (both initiator-capable).
-	tracker.advance(0x71) // SRC
-	tracker.advance(0x10) // DST (initiator-capable)
-	tracker.advance(0x05) // PB
-	tracker.advance(0x07) // SB
-	tracker.advance(0x01) // LEN=1
-	tracker.advance(0x42) // DATA[0]
+	tracker.advance(0x71)       // SRC
+	tracker.advance(0x10)       // DST (initiator-capable)
+	tracker.advance(0x05)       // PB
+	tracker.advance(0x07)       // SB
+	tracker.advance(0x01)       // LEN=1
+	tracker.advance(0x42)       // DATA[0]
 	ev := tracker.advance(0xCC) // CRC -> RequestComplete
 	if ev != wirePhaseEventRequestComplete {
 		t.Fatalf("expected RequestComplete, got %d", ev)


### PR DESCRIPTION
## Summary

Branch-wide `gofmt -w ./...` cleanup across 14 files. Pre-existing drift noted during M4c2 (#509) and M5_PORTAL (#507) review rounds but deferred as out-of-scope of those PRs.

**Zero functional change** — purely whitespace/formatting normalization. All tests green.

## Files touched (14)

- `cmd/gateway/semantic_vaillant.go`
- `cmd/gateway/semantic_vaillant_test.go`
- `cmd/gateway/startup_scan.go`
- `graphql/queries.go`
- `internal/adaptermux/arbitration.go`
- `internal/adaptermux/diag.go`
- `internal/adaptermux/diag_test.go`
- `internal/adaptermux/e2e_test.go`
- `internal/adaptermux/info_cache_test.go`
- `internal/adaptermux/mux.go`
- `internal/adaptermux/p3_test.go`
- `internal/adaptermux/pr502_review_test.go`
- `internal/adaptermux/syn_diag_test.go`
- `internal/adaptermux/wire_phase_test.go`

## Why

Strict cruise-merge-gate's gofmt check was blocking on pre-existing drift on main (same 14 files). This chore unblocks future PRs from inheriting the drift as a gate failure.

## Verification

- `gofmt -l ./...` returns empty at HEAD
- `go build ./...` clean
- `go test ./...` green (all packages pass, incl. `internal/adaptermux` 81s suite)
- `./scripts/ci_local.sh` advances past gofmt gate (was blocking at that stage on main)

Pre-existing lint findings (37: 33 errcheck + 4 staticcheck) downstream of the gofmt gate are untouched and out-of-scope of this chore — they existed on main but were masked by the earlier gofmt failure.

## Test plan

- [x] `gofmt -l ./...` empty
- [x] `go build ./...` clean
- [x] `go test ./...` all green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>