### PR TITLE
feat(portal/vaillant_b503): M3_PORTAL — Vaillant B503 pane (errors/service/live-monitor tabs) (TDD)

### DIFF
--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -2847,7 +2847,21 @@ class PortalShell extends HTMLElement {
     const errorsTab = this.querySelector('[data-role="vaillant-b503-tab-errors"]');
     const serviceTab = this.querySelector('[data-role="vaillant-b503-tab-service"]');
     const liveTab = this.querySelector('[data-role="vaillant-b503-tab-live-monitor"]');
-    const swap = (name) => {
+    const swap = async (name) => {
+      const leavingLive =
+        this._vaillantB503ActiveTab === "live-monitor" &&
+        name !== "live-monitor" &&
+        this._vaillantB503LiveToken;
+      if (leavingLive) {
+        // Fire a best-effort disable before swapping. Matches the
+        // nav-away semantics so clicking Errors/Service while a live
+        // session is held does not leave the token active.
+        try {
+          await this.invokeVaillantLiveMonitor("disable");
+        } catch {
+          this._vaillantB503LiveToken = null;
+        }
+      }
       this._vaillantB503ActiveTab = name;
       // Re-render the pane body to swap tab contents. The capability
       // reason is cached on the shell instance, so we don't re-fetch.
@@ -2965,6 +2979,13 @@ class PortalShell extends HTMLElement {
       );
       if (env && env.errors && env.errors.length) {
         if (status) status.textContent = env.errors[0].message || "error";
+        // For the nav-away / tab-swap cleanup path: a disable that the
+        // backend rejects MUST still surface as an error so the caller
+        // can clear its stale token. Swallowing here caused the
+        // nav-away catch() never to run.
+        if (action === "disable") {
+          throw new Error(env.errors[0].message || "disable failed");
+        }
         return;
       }
       const payload = env && env.data && env.data.vaillantLiveMonitor;

--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -379,6 +379,7 @@ class PortalShell extends HTMLElement {
     });
     this.bindExplorerEvents();
     this.bindL7CatalogEvents();
+    this.bindVaillantB503Events();
   }
 
   // bindL7CatalogEvents wires the L7 Standard Catalog section (M5_PORTAL)
@@ -503,6 +504,18 @@ class PortalShell extends HTMLElement {
   }
 
   activateSection(targetID) {
+    // Plan AD02: when navigating AWAY from the Vaillant B503 pane while a
+    // live-monitor issuer token is held, fire an auto-disable so the
+    // session doesn't linger. This runs BEFORE the section swap so any
+    // follow-up render reflects the cleared token state.
+    const previousTarget = this._activeSectionTarget;
+    if (previousTarget === "section-vaillant-b503" && targetID !== "section-vaillant-b503") {
+      if (typeof this.handleVaillantB503NavAway === "function") {
+        this.handleVaillantB503NavAway();
+      }
+    }
+    this._activeSectionTarget = targetID;
+
     const sectionMap = {
       "section-registry": ["section-registry"],
       "section-semantic": ["section-semantic"],
@@ -514,6 +527,7 @@ class PortalShell extends HTMLElement {
       "section-snapshots": ["section-snapshots", "section-snapshot-diff", "section-sessions"],
       "section-issue-builder": ["section-issue-builder"],
       "section-l7-catalog": ["section-l7-catalog"],
+      "section-vaillant-b503": ["section-vaillant-b503"],
     };
     const visible = new Set(sectionMap[targetID] || [targetID]);
     visible.add("section-search");
@@ -541,6 +555,11 @@ class PortalShell extends HTMLElement {
       this._l7CatalogLoaded = true;
       if (typeof this.refreshL7Services === "function") {
         this.refreshL7Services();
+      }
+    }
+    if (targetID === "section-vaillant-b503") {
+      if (typeof this.refreshVaillantB503Capability === "function") {
+        this.refreshVaillantB503Capability();
       }
     }
   }
@@ -577,6 +596,10 @@ class PortalShell extends HTMLElement {
         statusEl.textContent = `Gateway ${health.status}`;
       }
       const capabilities = bootstrap.capabilities || {};
+      const gqlEndpoint = bootstrap && bootstrap.endpoints && typeof bootstrap.endpoints.graphql === "string"
+        ? bootstrap.endpoints.graphql
+        : "/graphql";
+      this._graphqlEndpoint = gqlEndpoint;
       this.applyCapabilityState(capabilities);
       const firstEnabled = this.querySelector("[data-nav-target]:not([disabled])");
       if (firstEnabled) {
@@ -760,6 +783,14 @@ class PortalShell extends HTMLElement {
     // Codex P2 on PR #507.
     this.setNavState("l7-catalog", cap.ebus_standard);
     this._capabilityEbusStandard = Boolean(cap.ebus_standard);
+    // Vaillant B503 nav — stays enabled whenever the pane exists so the
+    // operator can navigate in and see an unavailable/placeholder state
+    // surfaced from the GraphQL vaillantCapabilities query. If the whole
+    // vaillant surface is gated by a bootstrap-level flag we honor it;
+    // otherwise default to enabled (the pane itself fails closed).
+    const vaillantFlag = cap.vaillant_b503 === undefined ? true : Boolean(cap.vaillant_b503);
+    this.setNavState("vaillant-b503", vaillantFlag);
+    this._capabilityVaillantB503 = vaillantFlag;
   }
 
   setNavState(name, enabled) {
@@ -2199,6 +2230,7 @@ class PortalShell extends HTMLElement {
             <button data-role="nav-snapshots" data-nav-target="section-snapshots" disabled><span class="nav-bullet"></span> Snapshots</button>
             <button data-role="nav-issue-builder" data-nav-target="section-issue-builder" disabled><span class="nav-bullet"></span> Issue Builder</button>
             <button data-role="nav-l7-catalog" data-nav-target="section-l7-catalog" disabled><span class="nav-bullet"></span> L7 Catalog</button>
+            <button data-role="nav-vaillant-b503" data-nav-target="section-vaillant-b503" disabled><span class="nav-bullet"></span> Vaillant B503</button>
           </aside>
           <main class="main">
             <h1>Portal Overview</h1>
@@ -2445,6 +2477,13 @@ class PortalShell extends HTMLElement {
               <div class="error" data-role="l7-decode-error" style="display:none"></div>
               <pre class="issue-preview" data-role="l7-decode-output"></pre>
             </section>
+            <section id="section-vaillant-b503" class="registry-preview">
+              <h2>Vaillant B503</h2>
+              <p class="muted-inline">Read-only diagnostics over the Vaillant B503 namespace (errors, service, live-monitor). Install-writes are intentionally omitted per plan AD02.</p>
+              <div data-role="vaillant-b503-body">
+                <div class="muted-inline">Loading Vaillant B503 capability...</div>
+              </div>
+            </section>
             <div class="meta" data-role="stream-status">Stream idle</div>
             <div class="meta" data-role="meta">Waiting for bootstrap...</div>
           </main>
@@ -2668,6 +2707,299 @@ class PortalShell extends HTMLElement {
       return `<span class="pill">${escapeHtml(raw)}</span>`;
     }
     return `<span class="pill pill-unknown">unknown</span> <span class="muted-inline">${escapeHtml(raw || "(empty)")}</span>`;
+  }
+
+  // ---------------------------------------------------------------------
+  // M3_PORTAL — Vaillant B503 pane (issue #521)
+  //
+  // Read-only surface over the GraphQL Vaillant B503 queries:
+  //   - vaillantCapabilities      (availability gate)
+  //   - vaillantErrors            (Errors tab: firstActiveError + 5 slots)
+  //   - vaillantServiceCurrent    (Service tab: same shape)
+  //   - vaillantLiveMonitor       (Live-Monitor tab: enable/read/disable)
+  //
+  // Plan invariants enforced in this file:
+  //   AD02 — no install-write UI; this pane never contains 'clear',
+  //          'delete', or 'reset' text. The paired test asserts this.
+  //   AD06 — no feature flag reveals install-writes; the code paths for
+  //          any such affordance are not present.
+  //   AD14 — EXPIRED never surfaces; sanitize via GraphQL resolver maps
+  //          EXPIRED → SESSION_BUSY server-side. We render whatever reason
+  //          the server returns.
+  //
+  // Live-monitor auto-disable: the issuer token is captured on enable and
+  // fired back as a disable call whenever the operator navigates away from
+  // the pane (activateSection hook) or toggles to another tab after the
+  // live-monitor session went active.
+  // ---------------------------------------------------------------------
+
+  async _gqlRequest(query, variables) {
+    const endpoint = this._graphqlEndpoint || "/graphql";
+    const body = JSON.stringify({ query, variables: variables || {} });
+    const resp = await fetch(endpoint, {
+      method: "POST",
+      headers: { "content-type": "application/json", "accept": "application/json" },
+      body,
+    });
+    return resp.json();
+  }
+
+  bindVaillantB503Events() {
+    // The tab bar + inner buttons are rendered dynamically inside the
+    // pane body, so delegation happens in renderVaillantB503Pane which
+    // attaches listeners at render time (querySelector-by-data-role).
+    // Nothing to wire eagerly at boot — the nav click invokes
+    // activateSection → refreshVaillantB503Capability → renderVaillantB503Pane.
+  }
+
+  async refreshVaillantB503Capability() {
+    const body = this.querySelector('[data-role="vaillant-b503-body"]');
+    let reason = "UNKNOWN";
+    try {
+      const env = await this._gqlRequest(
+        "query VaillantB503Cap { vaillantCapabilities { vaillantB503 { available reason } } }",
+        {},
+      );
+      const cap = env && env.data && env.data.vaillantCapabilities
+        && env.data.vaillantCapabilities.vaillantB503;
+      if (cap && typeof cap.reason === "string") {
+        reason = cap.reason;
+      }
+    } catch (err) {
+      // Network failure: render as UNKNOWN. No retry loop; the operator
+      // can click the nav entry again to retry.
+      reason = "UNKNOWN";
+    }
+    this._vaillantB503CapabilityReason = reason;
+    this.renderVaillantB503Pane(reason, body);
+  }
+
+  renderVaillantB503Pane(reason, bodyEl) {
+    const body = bodyEl || this.querySelector('[data-role="vaillant-b503-body"]');
+    if (!body) return;
+    const sanitized = typeof reason === "string" ? reason : "UNKNOWN";
+    if (sanitized === "AVAILABLE") {
+      const activeTab = this._vaillantB503ActiveTab || "errors";
+      body.innerHTML = `
+        <div class="snapshot-controls" data-role="vaillant-b503-tabs">
+          <button class="button" data-role="vaillant-b503-tab-errors" type="button">Errors</button>
+          <button class="button" data-role="vaillant-b503-tab-service" type="button">Service</button>
+          <button class="button" data-role="vaillant-b503-tab-live-monitor" type="button">Live-Monitor</button>
+        </div>
+        <div data-role="vaillant-b503-tab-body">
+          ${this._vaillantB503TabMarkup(activeTab)}
+        </div>
+      `;
+      this._bindVaillantB503TabEvents();
+      this._bindVaillantB503ActiveTabEvents(activeTab);
+    } else if (sanitized === "TRANSPORT_DOWN" || sanitized === "SESSION_BUSY") {
+      body.innerHTML = `
+        <div class="bus-banner bus-state-unavailable">
+          Vaillant B503 temporarily unavailable: ${escapeHtml(sanitized)}
+        </div>
+        <p class="muted-inline">Navigate away and back to retry.</p>
+      `;
+    } else {
+      // NOT_SUPPORTED, UNKNOWN, and any unrecognized reason → safe placeholder.
+      body.innerHTML = `
+        <div class="muted-inline">
+          Vaillant B503 not supported on this device / gateway
+          (<span data-role="vaillant-b503-reason">${escapeHtml(sanitized)}</span>).
+        </div>
+      `;
+    }
+  }
+
+  _vaillantB503TabMarkup(activeTab) {
+    if (activeTab === "service") {
+      return `
+        <div class="snapshot-controls">
+          <button class="button" data-role="vaillant-b503-service-refresh" type="button">Refresh</button>
+        </div>
+        <div data-role="vaillant-b503-service-body">
+          <div class="muted-inline">Click Refresh to load current service counters.</div>
+        </div>
+      `;
+    }
+    if (activeTab === "live-monitor") {
+      return `
+        <div class="snapshot-controls">
+          <button class="button" data-role="vaillant-b503-live-enable" type="button">Enable</button>
+          <button class="button" data-role="vaillant-b503-live-read" type="button">Read</button>
+          <button class="button" data-role="vaillant-b503-live-disable" type="button">Disable</button>
+        </div>
+        <pre class="issue-preview" data-role="vaillant-b503-live-output"></pre>
+        <div class="muted-inline" data-role="vaillant-b503-live-status">Idle.</div>
+      `;
+    }
+    // default: errors
+    return `
+      <div class="snapshot-controls">
+        <button class="button" data-role="vaillant-b503-errors-refresh" type="button">Refresh</button>
+      </div>
+      <div data-role="vaillant-b503-errors-body">
+        <div class="muted-inline">Click Refresh to load current errors.</div>
+      </div>
+    `;
+  }
+
+  _bindVaillantB503TabEvents() {
+    const errorsTab = this.querySelector('[data-role="vaillant-b503-tab-errors"]');
+    const serviceTab = this.querySelector('[data-role="vaillant-b503-tab-service"]');
+    const liveTab = this.querySelector('[data-role="vaillant-b503-tab-live-monitor"]');
+    const swap = (name) => {
+      this._vaillantB503ActiveTab = name;
+      // Re-render the pane body to swap tab contents. The capability
+      // reason is cached on the shell instance, so we don't re-fetch.
+      this.renderVaillantB503Pane(this._vaillantB503CapabilityReason || "AVAILABLE");
+    };
+    if (errorsTab && typeof errorsTab.addEventListener === "function") {
+      errorsTab.addEventListener("click", () => swap("errors"));
+    }
+    if (serviceTab && typeof serviceTab.addEventListener === "function") {
+      serviceTab.addEventListener("click", () => swap("service"));
+    }
+    if (liveTab && typeof liveTab.addEventListener === "function") {
+      liveTab.addEventListener("click", () => swap("live-monitor"));
+    }
+  }
+
+  _bindVaillantB503ActiveTabEvents(activeTab) {
+    if (activeTab === "service") {
+      const refresh = this.querySelector('[data-role="vaillant-b503-service-refresh"]');
+      if (refresh && typeof refresh.addEventListener === "function") {
+        refresh.addEventListener("click", () => this.refreshVaillantServiceCurrent());
+      }
+      return;
+    }
+    if (activeTab === "live-monitor") {
+      const enable = this.querySelector('[data-role="vaillant-b503-live-enable"]');
+      const read = this.querySelector('[data-role="vaillant-b503-live-read"]');
+      const disable = this.querySelector('[data-role="vaillant-b503-live-disable"]');
+      if (enable && typeof enable.addEventListener === "function") {
+        enable.addEventListener("click", () => this.invokeVaillantLiveMonitor("enable"));
+      }
+      if (read && typeof read.addEventListener === "function") {
+        read.addEventListener("click", () => this.invokeVaillantLiveMonitor("read"));
+      }
+      if (disable && typeof disable.addEventListener === "function") {
+        disable.addEventListener("click", () => this.invokeVaillantLiveMonitor("disable"));
+      }
+      return;
+    }
+    // default: errors
+    const refresh = this.querySelector('[data-role="vaillant-b503-errors-refresh"]');
+    if (refresh && typeof refresh.addEventListener === "function") {
+      refresh.addEventListener("click", () => this.refreshVaillantErrors());
+    }
+  }
+
+  _renderB503SlotList(bodyEl, payload) {
+    if (!bodyEl) return;
+    const first = payload && payload.firstActiveError !== undefined && payload.firstActiveError !== null
+      ? String(payload.firstActiveError)
+      : "—";
+    const slots = Array.isArray(payload && payload.slots) ? payload.slots : [];
+    const slotCells = slots.map((slot) => {
+      const cell = slot === null || slot === undefined ? "—" : String(Number(slot));
+      return `<td>${escapeHtml(cell)}</td>`;
+    }).join("");
+    bodyEl.innerHTML = `
+      <dl class="meta-list">
+        <dt>First active error</dt><dd>${escapeHtml(first)}</dd>
+      </dl>
+      <table class="table">
+        <thead><tr><th>Slot 0</th><th>Slot 1</th><th>Slot 2</th><th>Slot 3</th><th>Slot 4</th></tr></thead>
+        <tbody><tr>${slotCells}</tr></tbody>
+      </table>
+    `;
+  }
+
+  async refreshVaillantErrors() {
+    const body = this.querySelector('[data-role="vaillant-b503-errors-body"]');
+    try {
+      const env = await this._gqlRequest(
+        "query VaillantErrors { vaillantErrors { firstActiveError slots } }",
+        {},
+      );
+      if (env && env.errors && env.errors.length) {
+        if (body) body.innerHTML = `<div class="error">${escapeHtml(env.errors[0].message || "error")}</div>`;
+        return;
+      }
+      const payload = env && env.data && env.data.vaillantErrors;
+      this._renderB503SlotList(body, payload || { firstActiveError: null, slots: [] });
+    } catch (err) {
+      if (body) body.innerHTML = `<div class="error">${escapeHtml(String(err))}</div>`;
+    }
+  }
+
+  async refreshVaillantServiceCurrent() {
+    const body = this.querySelector('[data-role="vaillant-b503-service-body"]');
+    try {
+      const env = await this._gqlRequest(
+        "query VaillantServiceCurrent { vaillantServiceCurrent { firstActiveError slots } }",
+        {},
+      );
+      if (env && env.errors && env.errors.length) {
+        if (body) body.innerHTML = `<div class="error">${escapeHtml(env.errors[0].message || "error")}</div>`;
+        return;
+      }
+      const payload = env && env.data && env.data.vaillantServiceCurrent;
+      this._renderB503SlotList(body, payload || { firstActiveError: null, slots: [] });
+    } catch (err) {
+      if (body) body.innerHTML = `<div class="error">${escapeHtml(String(err))}</div>`;
+    }
+  }
+
+  async invokeVaillantLiveMonitor(action) {
+    const status = this.querySelector('[data-role="vaillant-b503-live-status"]');
+    const output = this.querySelector('[data-role="vaillant-b503-live-output"]');
+    const variables = { action: String(action) };
+    if (action === "disable" && this._vaillantB503LiveToken) {
+      variables.issuerToken = this._vaillantB503LiveToken;
+    }
+    try {
+      const env = await this._gqlRequest(
+        "query VaillantLive($action: String!, $issuerToken: String) { vaillantLiveMonitor(action: $action, issuerToken: $issuerToken) { issuerToken rawHex disabled } }",
+        variables,
+      );
+      if (env && env.errors && env.errors.length) {
+        if (status) status.textContent = env.errors[0].message || "error";
+        return;
+      }
+      const payload = env && env.data && env.data.vaillantLiveMonitor;
+      if (!payload) return;
+      if (action === "enable" && typeof payload.issuerToken === "string" && payload.issuerToken !== "") {
+        this._vaillantB503LiveToken = payload.issuerToken;
+        if (status) status.textContent = "Live-monitor session active.";
+      }
+      if (action === "read") {
+        const hex = typeof payload.rawHex === "string" ? payload.rawHex : "";
+        if (output) output.textContent = hex;
+        if (status) status.textContent = hex ? "OK" : "No frame available yet.";
+      }
+      if (action === "disable") {
+        this._vaillantB503LiveToken = null;
+        if (status) status.textContent = "Session disabled.";
+      }
+    } catch (err) {
+      if (status) status.textContent = `Error: ${err}`;
+    }
+  }
+
+  async handleVaillantB503NavAway() {
+    // Auto-disable on nav-away. Only fires if an issuer token is held,
+    // which implies the live-monitor tab entered the Active state. The
+    // disable call is best-effort — failures are swallowed so a stuck
+    // backend does not block nav.
+    if (!this._vaillantB503LiveToken) return;
+    try {
+      await this.invokeVaillantLiveMonitor("disable");
+    } catch {
+      // Fail-open on nav: clear the token anyway so a stale session
+      // cannot be mistaken for a live one.
+      this._vaillantB503LiveToken = null;
+    }
   }
 }
 

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,8 +2,8 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 137692,
-      "sha256": "7cb4f326a253e2758effe677a4f8d1ef67078dd6b5ed702d25c6972a5d038310"
+      "bytes": 138598,
+      "sha256": "69e1bb93641e9ea94f93df3c13008716f5029b34d6232ebbc44656d2f8e1d159"
     },
     "app.css": {
       "bytes": 8115,

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,8 +2,8 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 122588,
-      "sha256": "574743a186f4ab3c36198237d0a3f19a03cfec272178f5f7267c87706b2ceb65"
+      "bytes": 137692,
+      "sha256": "7cb4f326a253e2758effe677a4f8d1ef67078dd6b5ed702d25c6972a5d038310"
     },
     "app.css": {
       "bytes": 8115,

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -378,6 +378,7 @@ class PortalShell extends HTMLElement {
     });
     this.bindExplorerEvents();
     this.bindL7CatalogEvents();
+    this.bindVaillantB503Events();
   }
 
   // bindL7CatalogEvents wires the L7 Standard Catalog section (M5_PORTAL)
@@ -502,6 +503,18 @@ class PortalShell extends HTMLElement {
   }
 
   activateSection(targetID) {
+    // Plan AD02: when navigating AWAY from the Vaillant B503 pane while a
+    // live-monitor issuer token is held, fire an auto-disable so the
+    // session doesn't linger. This runs BEFORE the section swap so any
+    // follow-up render reflects the cleared token state.
+    const previousTarget = this._activeSectionTarget;
+    if (previousTarget === "section-vaillant-b503" && targetID !== "section-vaillant-b503") {
+      if (typeof this.handleVaillantB503NavAway === "function") {
+        this.handleVaillantB503NavAway();
+      }
+    }
+    this._activeSectionTarget = targetID;
+
     const sectionMap = {
       "section-registry": ["section-registry"],
       "section-semantic": ["section-semantic"],
@@ -513,6 +526,7 @@ class PortalShell extends HTMLElement {
       "section-snapshots": ["section-snapshots", "section-snapshot-diff", "section-sessions"],
       "section-issue-builder": ["section-issue-builder"],
       "section-l7-catalog": ["section-l7-catalog"],
+      "section-vaillant-b503": ["section-vaillant-b503"],
     };
     const visible = new Set(sectionMap[targetID] || [targetID]);
     visible.add("section-search");
@@ -540,6 +554,11 @@ class PortalShell extends HTMLElement {
       this._l7CatalogLoaded = true;
       if (typeof this.refreshL7Services === "function") {
         this.refreshL7Services();
+      }
+    }
+    if (targetID === "section-vaillant-b503") {
+      if (typeof this.refreshVaillantB503Capability === "function") {
+        this.refreshVaillantB503Capability();
       }
     }
   }
@@ -576,6 +595,10 @@ class PortalShell extends HTMLElement {
         statusEl.textContent = `Gateway ${health.status}`;
       }
       const capabilities = bootstrap.capabilities || {};
+      const gqlEndpoint = bootstrap && bootstrap.endpoints && typeof bootstrap.endpoints.graphql === "string"
+        ? bootstrap.endpoints.graphql
+        : "/graphql";
+      this._graphqlEndpoint = gqlEndpoint;
       this.applyCapabilityState(capabilities);
       const firstEnabled = this.querySelector("[data-nav-target]:not([disabled])");
       if (firstEnabled) {
@@ -759,6 +782,14 @@ class PortalShell extends HTMLElement {
     // Codex P2 on PR #507.
     this.setNavState("l7-catalog", cap.ebus_standard);
     this._capabilityEbusStandard = Boolean(cap.ebus_standard);
+    // Vaillant B503 nav — stays enabled whenever the pane exists so the
+    // operator can navigate in and see an unavailable/placeholder state
+    // surfaced from the GraphQL vaillantCapabilities query. If the whole
+    // vaillant surface is gated by a bootstrap-level flag we honor it;
+    // otherwise default to enabled (the pane itself fails closed).
+    const vaillantFlag = cap.vaillant_b503 === undefined ? true : Boolean(cap.vaillant_b503);
+    this.setNavState("vaillant-b503", vaillantFlag);
+    this._capabilityVaillantB503 = vaillantFlag;
   }
 
   setNavState(name, enabled) {
@@ -2198,6 +2229,7 @@ class PortalShell extends HTMLElement {
             <button data-role="nav-snapshots" data-nav-target="section-snapshots" disabled><span class="nav-bullet"></span> Snapshots</button>
             <button data-role="nav-issue-builder" data-nav-target="section-issue-builder" disabled><span class="nav-bullet"></span> Issue Builder</button>
             <button data-role="nav-l7-catalog" data-nav-target="section-l7-catalog" disabled><span class="nav-bullet"></span> L7 Catalog</button>
+            <button data-role="nav-vaillant-b503" data-nav-target="section-vaillant-b503" disabled><span class="nav-bullet"></span> Vaillant B503</button>
           </aside>
           <main class="main">
             <h1>Portal Overview</h1>
@@ -2444,6 +2476,13 @@ class PortalShell extends HTMLElement {
               <div class="error" data-role="l7-decode-error" style="display:none"></div>
               <pre class="issue-preview" data-role="l7-decode-output"></pre>
             </section>
+            <section id="section-vaillant-b503" class="registry-preview">
+              <h2>Vaillant B503</h2>
+              <p class="muted-inline">Read-only diagnostics over the Vaillant B503 namespace (errors, service, live-monitor). Install-writes are intentionally omitted per plan AD02.</p>
+              <div data-role="vaillant-b503-body">
+                <div class="muted-inline">Loading Vaillant B503 capability...</div>
+              </div>
+            </section>
             <div class="meta" data-role="stream-status">Stream idle</div>
             <div class="meta" data-role="meta">Waiting for bootstrap...</div>
           </main>
@@ -2667,6 +2706,299 @@ class PortalShell extends HTMLElement {
       return `<span class="pill">${escapeHtml(raw)}</span>`;
     }
     return `<span class="pill pill-unknown">unknown</span> <span class="muted-inline">${escapeHtml(raw || "(empty)")}</span>`;
+  }
+
+  // ---------------------------------------------------------------------
+  // M3_PORTAL — Vaillant B503 pane (issue #521)
+  //
+  // Read-only surface over the GraphQL Vaillant B503 queries:
+  //   - vaillantCapabilities      (availability gate)
+  //   - vaillantErrors            (Errors tab: firstActiveError + 5 slots)
+  //   - vaillantServiceCurrent    (Service tab: same shape)
+  //   - vaillantLiveMonitor       (Live-Monitor tab: enable/read/disable)
+  //
+  // Plan invariants enforced in this file:
+  //   AD02 — no install-write UI; this pane never contains 'clear',
+  //          'delete', or 'reset' text. The paired test asserts this.
+  //   AD06 — no feature flag reveals install-writes; the code paths for
+  //          any such affordance are not present.
+  //   AD14 — EXPIRED never surfaces; sanitize via GraphQL resolver maps
+  //          EXPIRED → SESSION_BUSY server-side. We render whatever reason
+  //          the server returns.
+  //
+  // Live-monitor auto-disable: the issuer token is captured on enable and
+  // fired back as a disable call whenever the operator navigates away from
+  // the pane (activateSection hook) or toggles to another tab after the
+  // live-monitor session went active.
+  // ---------------------------------------------------------------------
+
+  async _gqlRequest(query, variables) {
+    const endpoint = this._graphqlEndpoint || "/graphql";
+    const body = JSON.stringify({ query, variables: variables || {} });
+    const resp = await fetch(endpoint, {
+      method: "POST",
+      headers: { "content-type": "application/json", "accept": "application/json" },
+      body,
+    });
+    return resp.json();
+  }
+
+  bindVaillantB503Events() {
+    // The tab bar + inner buttons are rendered dynamically inside the
+    // pane body, so delegation happens in renderVaillantB503Pane which
+    // attaches listeners at render time (querySelector-by-data-role).
+    // Nothing to wire eagerly at boot — the nav click invokes
+    // activateSection → refreshVaillantB503Capability → renderVaillantB503Pane.
+  }
+
+  async refreshVaillantB503Capability() {
+    const body = this.querySelector('[data-role="vaillant-b503-body"]');
+    let reason = "UNKNOWN";
+    try {
+      const env = await this._gqlRequest(
+        "query VaillantB503Cap { vaillantCapabilities { vaillantB503 { available reason } } }",
+        {},
+      );
+      const cap = env && env.data && env.data.vaillantCapabilities
+        && env.data.vaillantCapabilities.vaillantB503;
+      if (cap && typeof cap.reason === "string") {
+        reason = cap.reason;
+      }
+    } catch (err) {
+      // Network failure: render as UNKNOWN. No retry loop; the operator
+      // can click the nav entry again to retry.
+      reason = "UNKNOWN";
+    }
+    this._vaillantB503CapabilityReason = reason;
+    this.renderVaillantB503Pane(reason, body);
+  }
+
+  renderVaillantB503Pane(reason, bodyEl) {
+    const body = bodyEl || this.querySelector('[data-role="vaillant-b503-body"]');
+    if (!body) return;
+    const sanitized = typeof reason === "string" ? reason : "UNKNOWN";
+    if (sanitized === "AVAILABLE") {
+      const activeTab = this._vaillantB503ActiveTab || "errors";
+      body.innerHTML = `
+        <div class="snapshot-controls" data-role="vaillant-b503-tabs">
+          <button class="button" data-role="vaillant-b503-tab-errors" type="button">Errors</button>
+          <button class="button" data-role="vaillant-b503-tab-service" type="button">Service</button>
+          <button class="button" data-role="vaillant-b503-tab-live-monitor" type="button">Live-Monitor</button>
+        </div>
+        <div data-role="vaillant-b503-tab-body">
+          ${this._vaillantB503TabMarkup(activeTab)}
+        </div>
+      `;
+      this._bindVaillantB503TabEvents();
+      this._bindVaillantB503ActiveTabEvents(activeTab);
+    } else if (sanitized === "TRANSPORT_DOWN" || sanitized === "SESSION_BUSY") {
+      body.innerHTML = `
+        <div class="bus-banner bus-state-unavailable">
+          Vaillant B503 temporarily unavailable: ${escapeHtml(sanitized)}
+        </div>
+        <p class="muted-inline">Navigate away and back to retry.</p>
+      `;
+    } else {
+      // NOT_SUPPORTED, UNKNOWN, and any unrecognized reason → safe placeholder.
+      body.innerHTML = `
+        <div class="muted-inline">
+          Vaillant B503 not supported on this device / gateway
+          (<span data-role="vaillant-b503-reason">${escapeHtml(sanitized)}</span>).
+        </div>
+      `;
+    }
+  }
+
+  _vaillantB503TabMarkup(activeTab) {
+    if (activeTab === "service") {
+      return `
+        <div class="snapshot-controls">
+          <button class="button" data-role="vaillant-b503-service-refresh" type="button">Refresh</button>
+        </div>
+        <div data-role="vaillant-b503-service-body">
+          <div class="muted-inline">Click Refresh to load current service counters.</div>
+        </div>
+      `;
+    }
+    if (activeTab === "live-monitor") {
+      return `
+        <div class="snapshot-controls">
+          <button class="button" data-role="vaillant-b503-live-enable" type="button">Enable</button>
+          <button class="button" data-role="vaillant-b503-live-read" type="button">Read</button>
+          <button class="button" data-role="vaillant-b503-live-disable" type="button">Disable</button>
+        </div>
+        <pre class="issue-preview" data-role="vaillant-b503-live-output"></pre>
+        <div class="muted-inline" data-role="vaillant-b503-live-status">Idle.</div>
+      `;
+    }
+    // default: errors
+    return `
+      <div class="snapshot-controls">
+        <button class="button" data-role="vaillant-b503-errors-refresh" type="button">Refresh</button>
+      </div>
+      <div data-role="vaillant-b503-errors-body">
+        <div class="muted-inline">Click Refresh to load current errors.</div>
+      </div>
+    `;
+  }
+
+  _bindVaillantB503TabEvents() {
+    const errorsTab = this.querySelector('[data-role="vaillant-b503-tab-errors"]');
+    const serviceTab = this.querySelector('[data-role="vaillant-b503-tab-service"]');
+    const liveTab = this.querySelector('[data-role="vaillant-b503-tab-live-monitor"]');
+    const swap = (name) => {
+      this._vaillantB503ActiveTab = name;
+      // Re-render the pane body to swap tab contents. The capability
+      // reason is cached on the shell instance, so we don't re-fetch.
+      this.renderVaillantB503Pane(this._vaillantB503CapabilityReason || "AVAILABLE");
+    };
+    if (errorsTab && typeof errorsTab.addEventListener === "function") {
+      errorsTab.addEventListener("click", () => swap("errors"));
+    }
+    if (serviceTab && typeof serviceTab.addEventListener === "function") {
+      serviceTab.addEventListener("click", () => swap("service"));
+    }
+    if (liveTab && typeof liveTab.addEventListener === "function") {
+      liveTab.addEventListener("click", () => swap("live-monitor"));
+    }
+  }
+
+  _bindVaillantB503ActiveTabEvents(activeTab) {
+    if (activeTab === "service") {
+      const refresh = this.querySelector('[data-role="vaillant-b503-service-refresh"]');
+      if (refresh && typeof refresh.addEventListener === "function") {
+        refresh.addEventListener("click", () => this.refreshVaillantServiceCurrent());
+      }
+      return;
+    }
+    if (activeTab === "live-monitor") {
+      const enable = this.querySelector('[data-role="vaillant-b503-live-enable"]');
+      const read = this.querySelector('[data-role="vaillant-b503-live-read"]');
+      const disable = this.querySelector('[data-role="vaillant-b503-live-disable"]');
+      if (enable && typeof enable.addEventListener === "function") {
+        enable.addEventListener("click", () => this.invokeVaillantLiveMonitor("enable"));
+      }
+      if (read && typeof read.addEventListener === "function") {
+        read.addEventListener("click", () => this.invokeVaillantLiveMonitor("read"));
+      }
+      if (disable && typeof disable.addEventListener === "function") {
+        disable.addEventListener("click", () => this.invokeVaillantLiveMonitor("disable"));
+      }
+      return;
+    }
+    // default: errors
+    const refresh = this.querySelector('[data-role="vaillant-b503-errors-refresh"]');
+    if (refresh && typeof refresh.addEventListener === "function") {
+      refresh.addEventListener("click", () => this.refreshVaillantErrors());
+    }
+  }
+
+  _renderB503SlotList(bodyEl, payload) {
+    if (!bodyEl) return;
+    const first = payload && payload.firstActiveError !== undefined && payload.firstActiveError !== null
+      ? String(payload.firstActiveError)
+      : "—";
+    const slots = Array.isArray(payload && payload.slots) ? payload.slots : [];
+    const slotCells = slots.map((slot) => {
+      const cell = slot === null || slot === undefined ? "—" : String(Number(slot));
+      return `<td>${escapeHtml(cell)}</td>`;
+    }).join("");
+    bodyEl.innerHTML = `
+      <dl class="meta-list">
+        <dt>First active error</dt><dd>${escapeHtml(first)}</dd>
+      </dl>
+      <table class="table">
+        <thead><tr><th>Slot 0</th><th>Slot 1</th><th>Slot 2</th><th>Slot 3</th><th>Slot 4</th></tr></thead>
+        <tbody><tr>${slotCells}</tr></tbody>
+      </table>
+    `;
+  }
+
+  async refreshVaillantErrors() {
+    const body = this.querySelector('[data-role="vaillant-b503-errors-body"]');
+    try {
+      const env = await this._gqlRequest(
+        "query VaillantErrors { vaillantErrors { firstActiveError slots } }",
+        {},
+      );
+      if (env && env.errors && env.errors.length) {
+        if (body) body.innerHTML = `<div class="error">${escapeHtml(env.errors[0].message || "error")}</div>`;
+        return;
+      }
+      const payload = env && env.data && env.data.vaillantErrors;
+      this._renderB503SlotList(body, payload || { firstActiveError: null, slots: [] });
+    } catch (err) {
+      if (body) body.innerHTML = `<div class="error">${escapeHtml(String(err))}</div>`;
+    }
+  }
+
+  async refreshVaillantServiceCurrent() {
+    const body = this.querySelector('[data-role="vaillant-b503-service-body"]');
+    try {
+      const env = await this._gqlRequest(
+        "query VaillantServiceCurrent { vaillantServiceCurrent { firstActiveError slots } }",
+        {},
+      );
+      if (env && env.errors && env.errors.length) {
+        if (body) body.innerHTML = `<div class="error">${escapeHtml(env.errors[0].message || "error")}</div>`;
+        return;
+      }
+      const payload = env && env.data && env.data.vaillantServiceCurrent;
+      this._renderB503SlotList(body, payload || { firstActiveError: null, slots: [] });
+    } catch (err) {
+      if (body) body.innerHTML = `<div class="error">${escapeHtml(String(err))}</div>`;
+    }
+  }
+
+  async invokeVaillantLiveMonitor(action) {
+    const status = this.querySelector('[data-role="vaillant-b503-live-status"]');
+    const output = this.querySelector('[data-role="vaillant-b503-live-output"]');
+    const variables = { action: String(action) };
+    if (action === "disable" && this._vaillantB503LiveToken) {
+      variables.issuerToken = this._vaillantB503LiveToken;
+    }
+    try {
+      const env = await this._gqlRequest(
+        "query VaillantLive($action: String!, $issuerToken: String) { vaillantLiveMonitor(action: $action, issuerToken: $issuerToken) { issuerToken rawHex disabled } }",
+        variables,
+      );
+      if (env && env.errors && env.errors.length) {
+        if (status) status.textContent = env.errors[0].message || "error";
+        return;
+      }
+      const payload = env && env.data && env.data.vaillantLiveMonitor;
+      if (!payload) return;
+      if (action === "enable" && typeof payload.issuerToken === "string" && payload.issuerToken !== "") {
+        this._vaillantB503LiveToken = payload.issuerToken;
+        if (status) status.textContent = "Live-monitor session active.";
+      }
+      if (action === "read") {
+        const hex = typeof payload.rawHex === "string" ? payload.rawHex : "";
+        if (output) output.textContent = hex;
+        if (status) status.textContent = hex ? "OK" : "No frame available yet.";
+      }
+      if (action === "disable") {
+        this._vaillantB503LiveToken = null;
+        if (status) status.textContent = "Session disabled.";
+      }
+    } catch (err) {
+      if (status) status.textContent = `Error: ${err}`;
+    }
+  }
+
+  async handleVaillantB503NavAway() {
+    // Auto-disable on nav-away. Only fires if an issuer token is held,
+    // which implies the live-monitor tab entered the Active state. The
+    // disable call is best-effort — failures are swallowed so a stuck
+    // backend does not block nav.
+    if (!this._vaillantB503LiveToken) return;
+    try {
+      await this.invokeVaillantLiveMonitor("disable");
+    } catch {
+      // Fail-open on nav: clear the token anyway so a stale session
+      // cannot be mistaken for a live one.
+      this._vaillantB503LiveToken = null;
+    }
   }
 }
 

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -2846,7 +2846,21 @@ class PortalShell extends HTMLElement {
     const errorsTab = this.querySelector('[data-role="vaillant-b503-tab-errors"]');
     const serviceTab = this.querySelector('[data-role="vaillant-b503-tab-service"]');
     const liveTab = this.querySelector('[data-role="vaillant-b503-tab-live-monitor"]');
-    const swap = (name) => {
+    const swap = async (name) => {
+      const leavingLive =
+        this._vaillantB503ActiveTab === "live-monitor" &&
+        name !== "live-monitor" &&
+        this._vaillantB503LiveToken;
+      if (leavingLive) {
+        // Fire a best-effort disable before swapping. Matches the
+        // nav-away semantics so clicking Errors/Service while a live
+        // session is held does not leave the token active.
+        try {
+          await this.invokeVaillantLiveMonitor("disable");
+        } catch {
+          this._vaillantB503LiveToken = null;
+        }
+      }
       this._vaillantB503ActiveTab = name;
       // Re-render the pane body to swap tab contents. The capability
       // reason is cached on the shell instance, so we don't re-fetch.
@@ -2964,6 +2978,13 @@ class PortalShell extends HTMLElement {
       );
       if (env && env.errors && env.errors.length) {
         if (status) status.textContent = env.errors[0].message || "error";
+        // For the nav-away / tab-swap cleanup path: a disable that the
+        // backend rejects MUST still surface as an error so the caller
+        // can clear its stale token. Swallowing here caused the
+        // nav-away catch() never to run.
+        if (action === "disable") {
+          throw new Error(env.errors[0].message || "disable failed");
+        }
         return;
       }
       const payload = env && env.data && env.data.vaillantLiveMonitor;

--- a/portal/web/test/vaillant-b503.test.mjs
+++ b/portal/web/test/vaillant-b503.test.mjs
@@ -1,0 +1,387 @@
+// Tests for the M3_PORTAL Vaillant B503 pane (issue #521).
+//
+// Mirrors the FakeDOM + audit-log harness from l7-catalog.test.mjs. The
+// Vaillant B503 pane is read-only over GraphQL; there is NO install-write
+// UI (plan AD02). The live-monitor tab auto-disables on nav-away.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import vm from "node:vm";
+import test from "node:test";
+
+function makeAuditedElement(extra = {}) {
+  const audit = [];
+  let innerHTMLValue = "";
+  let textContentValue = "";
+  const el = {
+    _audit: audit,
+    get innerHTML() {
+      return innerHTMLValue;
+    },
+    set innerHTML(v) {
+      innerHTMLValue = String(v);
+      audit.push({ prop: "innerHTML", value: String(v) });
+    },
+    get textContent() {
+      return textContentValue;
+    },
+    set textContent(v) {
+      textContentValue = String(v);
+      audit.push({ prop: "textContent", value: String(v) });
+    },
+    className: "",
+    style: {},
+    _isConnected: true,
+    get isConnected() {
+      return this._isConnected !== false;
+    },
+    setAttribute() {},
+    ...extra,
+  };
+  return el;
+}
+
+function flush() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+async function loadShellSource() {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const sourcePath = path.resolve(here, "../src/app.js");
+  const source = await readFile(sourcePath, "utf8");
+  return { source, sourcePath };
+}
+
+function buildSandbox({ source, sourcePath, elements, fetchImpl }) {
+  class FakeHTMLElement {
+    constructor() {
+      this._isConnected = true;
+    }
+    get isConnected() {
+      return this._isConnected !== false;
+    }
+  }
+  const fetchRequests = [];
+  const sandbox = {
+    console: { error() {}, log() {}, warn() {} },
+    document: { documentElement: { setAttribute() {} } },
+    customElements: { define() {} },
+    HTMLElement: FakeHTMLElement,
+    localStorage: { getItem: () => null, setItem() {} },
+    setInterval: () => ({}),
+    clearInterval: () => {},
+    setTimeout,
+    clearTimeout,
+    AbortController,
+    URLSearchParams,
+    TextDecoder,
+    fetch: (url, init) => {
+      fetchRequests.push({ url, init });
+      return Promise.resolve(fetchImpl(url, init));
+    },
+  };
+  sandbox.globalThis = sandbox;
+  vm.createContext(sandbox);
+  vm.runInContext(
+    `${source}\n;globalThis.__PortalShell = PortalShell;`,
+    sandbox,
+    { filename: pathToFileURL(sourcePath).href },
+  );
+  const PortalShell = sandbox.__PortalShell;
+  const shell = new PortalShell();
+  shell._isConnected = true;
+  shell.render = () => {};
+  shell.bindEvents = () => {};
+  shell.querySelector = (selector) => elements.get(selector) || null;
+  shell.querySelectorAll = () => [];
+  return { shell, fetchRequests };
+}
+
+// Parse a GraphQL fetch call and return {query, variables} from the init body.
+function parseGqlInit(init) {
+  if (!init || !init.body) return { query: "", variables: {} };
+  try {
+    const body = JSON.parse(String(init.body));
+    return {
+      query: String(body.query || ""),
+      variables: body.variables || {},
+    };
+  } catch {
+    return { query: "", variables: {} };
+  }
+}
+
+// Build a fetchImpl that routes GraphQL POSTs by query-name substring.
+function makeGqlFetchImpl(routes, fallback = { data: {}, errors: null }) {
+  return (url, init) => {
+    const { query, variables } = parseGqlInit(init);
+    for (const route of routes) {
+      if (query.includes(route.match)) {
+        const payload = typeof route.reply === "function"
+          ? route.reply(variables)
+          : route.reply;
+        return { ok: true, status: 200, json: async () => payload };
+      }
+    }
+    return { ok: true, status: 200, json: async () => fallback };
+  };
+}
+
+// ---- 1. Nav item registered ----
+
+test("VaillantB503Pane_NavItemRegistered", async () => {
+  const { source, sourcePath } = await loadShellSource();
+  const { shell } = buildSandbox({
+    source, sourcePath, elements: new Map(),
+    fetchImpl: async () => ({ ok: true, json: async () => ({}) }),
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.render = proto.render;
+  let capturedHTML = "";
+  Object.defineProperty(shell, "innerHTML", {
+    set(v) { capturedHTML = String(v); },
+    get() { return capturedHTML; },
+    configurable: true,
+  });
+  shell.render();
+
+  assert.ok(capturedHTML.includes('data-role="nav-vaillant-b503"'),
+    "render() must emit nav-vaillant-b503 sidebar button");
+  assert.ok(capturedHTML.includes('data-nav-target="section-vaillant-b503"'),
+    "nav button must target section-vaillant-b503");
+  assert.ok(capturedHTML.includes('id="section-vaillant-b503"'),
+    "render() must emit id=section-vaillant-b503");
+});
+
+// ---- 2. Unavailable capability → empty-state placeholder ----
+
+test("VaillantB503Pane_Unavailable_ShowsPlaceholder", async () => {
+  const { source, sourcePath } = await loadShellSource();
+  const paneBody = makeAuditedElement();
+  const elements = new Map([
+    ['[data-role="vaillant-b503-body"]', paneBody],
+  ]);
+  const { shell } = buildSandbox({
+    source, sourcePath, elements,
+    fetchImpl: makeGqlFetchImpl([
+      {
+        match: "vaillantCapabilities",
+        reply: { data: { vaillantCapabilities: { vaillantB503: { available: false, reason: "UNKNOWN" } } } },
+      },
+    ]),
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.renderVaillantB503Pane = proto.renderVaillantB503Pane;
+  shell.refreshVaillantB503Capability = proto.refreshVaillantB503Capability;
+
+  assert.equal(typeof shell.refreshVaillantB503Capability, "function",
+    "refreshVaillantB503Capability must be defined");
+
+  await shell.refreshVaillantB503Capability();
+  await flush();
+
+  const htmlWrites = paneBody._audit.filter((e) => e.prop === "innerHTML");
+  assert.ok(htmlWrites.length >= 1, "pane body should receive rendered HTML");
+  const rendered = htmlWrites.map((e) => e.value).join("\n").toLowerCase();
+  assert.ok(rendered.includes("not supported"),
+    `unavailable state must render a 'not supported' placeholder; got: ${rendered}`);
+});
+
+// ---- 3. Available capability → three tabs ----
+
+test("VaillantB503Pane_Available_ShowsThreeTabs", async () => {
+  const { source, sourcePath } = await loadShellSource();
+  const paneBody = makeAuditedElement();
+  const elements = new Map([
+    ['[data-role="vaillant-b503-body"]', paneBody],
+  ]);
+  const { shell } = buildSandbox({
+    source, sourcePath, elements,
+    fetchImpl: makeGqlFetchImpl([
+      {
+        match: "vaillantCapabilities",
+        reply: { data: { vaillantCapabilities: { vaillantB503: { available: true, reason: "AVAILABLE" } } } },
+      },
+    ]),
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.renderVaillantB503Pane = proto.renderVaillantB503Pane;
+  shell.refreshVaillantB503Capability = proto.refreshVaillantB503Capability;
+
+  await shell.refreshVaillantB503Capability();
+  await flush();
+
+  const htmlWrites = paneBody._audit.filter((e) => e.prop === "innerHTML");
+  const rendered = htmlWrites.map((e) => e.value).join("\n");
+  assert.ok(/data-role="vaillant-b503-tab-errors"/.test(rendered),
+    "errors tab must be rendered");
+  assert.ok(/data-role="vaillant-b503-tab-service"/.test(rendered),
+    "service tab must be rendered");
+  assert.ok(/data-role="vaillant-b503-tab-live-monitor"/.test(rendered),
+    "live-monitor tab must be rendered");
+});
+
+// ---- 4. Errors tab renders slots ----
+
+test("VaillantB503Pane_ErrorsTab_RendersSlots", async () => {
+  const { source, sourcePath } = await loadShellSource();
+  const errorsBody = makeAuditedElement();
+  const elements = new Map([
+    ['[data-role="vaillant-b503-errors-body"]', errorsBody],
+  ]);
+  const { shell } = buildSandbox({
+    source, sourcePath, elements,
+    fetchImpl: makeGqlFetchImpl([
+      {
+        match: "vaillantErrors",
+        reply: {
+          data: {
+            vaillantErrors: {
+              firstActiveError: 281,
+              slots: [281, null, null, null, null],
+            },
+          },
+        },
+      },
+    ]),
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.refreshVaillantErrors = proto.refreshVaillantErrors;
+
+  assert.equal(typeof shell.refreshVaillantErrors, "function",
+    "refreshVaillantErrors must be defined");
+
+  await shell.refreshVaillantErrors();
+  await flush();
+
+  const htmlWrites = errorsBody._audit.filter((e) => e.prop === "innerHTML");
+  assert.ok(htmlWrites.length >= 1, "errors body should render");
+  const rendered = htmlWrites.map((e) => e.value).join("\n");
+  assert.ok(rendered.includes("281"), "firstActiveError 281 must be rendered");
+  // 4 em-dashes for the 4 null slots.
+  const emDashCount = (rendered.match(/—/g) || []).length;
+  assert.ok(emDashCount >= 4,
+    `expected at least 4 em-dashes for null slots; got ${emDashCount} in: ${rendered}`);
+});
+
+// ---- 5. No install-write affordance ----
+
+test("VaillantB503Pane_NoInstallWriteAffordance", async () => {
+  const { source, sourcePath } = await loadShellSource();
+  const { shell } = buildSandbox({
+    source, sourcePath, elements: new Map(),
+    fetchImpl: async () => ({ ok: true, json: async () => ({}) }),
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.render = proto.render;
+  let capturedHTML = "";
+  Object.defineProperty(shell, "innerHTML", {
+    set(v) { capturedHTML = String(v); },
+    get() { return capturedHTML; },
+    configurable: true,
+  });
+  shell.render();
+
+  // Extract the vaillant-b503 pane subtree: from the section open tag until
+  // the matching closing </section>. We do a non-greedy slice — if any of
+  // the forbidden verbs appears inside the pane, fail.
+  const openTag = 'id="section-vaillant-b503"';
+  const start = capturedHTML.indexOf(openTag);
+  assert.ok(start >= 0, "section-vaillant-b503 must exist in rendered HTML");
+  // Search forward for </section> starting from openTag.
+  const end = capturedHTML.indexOf("</section>", start);
+  assert.ok(end > start, "section-vaillant-b503 must have a closing </section>");
+  const paneHTML = capturedHTML.slice(start, end).toLowerCase();
+
+  // If the pane renders its body dynamically (body placeholder), also include
+  // a capability=AVAILABLE dynamic render to audit live-monitor markup.
+  const paneBody = makeAuditedElement();
+  const elements = new Map([
+    ['[data-role="vaillant-b503-body"]', paneBody],
+  ]);
+  const { shell: shell2 } = buildSandbox({
+    source, sourcePath, elements,
+    fetchImpl: (url, init) => {
+      const body = init && init.body ? JSON.parse(String(init.body)) : {};
+      const q = String(body.query || "");
+      if (q.includes("vaillantCapabilities")) {
+        return { ok: true, status: 200, json: async () => ({ data: { vaillantCapabilities: { vaillantB503: { available: true, reason: "AVAILABLE" } } } }) };
+      }
+      return { ok: true, status: 200, json: async () => ({ data: {} }) };
+    },
+  });
+  const proto2 = Object.getPrototypeOf(shell2);
+  shell2.renderVaillantB503Pane = proto2.renderVaillantB503Pane;
+  shell2.refreshVaillantB503Capability = proto2.refreshVaillantB503Capability;
+  await shell2.refreshVaillantB503Capability();
+  await flush();
+
+  const dynamicHTML = paneBody._audit
+    .filter((e) => e.prop === "innerHTML")
+    .map((e) => e.value).join("\n").toLowerCase();
+
+  const combinedHTML = paneHTML + "\n" + dynamicHTML;
+  for (const banned of ["clear", "delete", "reset"]) {
+    assert.ok(!combinedHTML.includes(banned),
+      `vaillant-b503 pane must not contain '${banned}' (install-write forbidden per AD02/AD06). Found in: ${combinedHTML}`);
+  }
+});
+
+// ---- 6. Live-monitor auto-disable on nav leave ----
+
+test("VaillantB503Pane_LiveMonitor_AutoDisableOnLeave", async () => {
+  const { source, sourcePath } = await loadShellSource();
+  const { shell, fetchRequests } = buildSandbox({
+    source, sourcePath, elements: new Map(),
+    fetchImpl: makeGqlFetchImpl([
+      {
+        match: "vaillantLiveMonitor",
+        reply: (vars) => {
+          if (vars && vars.action === "enable") {
+            return { data: { vaillantLiveMonitor: { issuerToken: "tok-xyz-123", rawHex: null, disabled: false } } };
+          }
+          if (vars && vars.action === "disable") {
+            return { data: { vaillantLiveMonitor: { issuerToken: null, rawHex: null, disabled: true } } };
+          }
+          return { data: { vaillantLiveMonitor: { issuerToken: null, rawHex: "aabb", disabled: false } } };
+        },
+      },
+    ]),
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.invokeVaillantLiveMonitor = proto.invokeVaillantLiveMonitor;
+  shell.handleVaillantB503NavAway = proto.handleVaillantB503NavAway;
+
+  assert.equal(typeof shell.invokeVaillantLiveMonitor, "function",
+    "invokeVaillantLiveMonitor must be defined");
+  assert.equal(typeof shell.handleVaillantB503NavAway, "function",
+    "handleVaillantB503NavAway must be defined");
+
+  // Simulate Enable: issuerToken captured into shell state.
+  await shell.invokeVaillantLiveMonitor("enable");
+  await flush();
+  assert.equal(shell._vaillantB503LiveToken, "tok-xyz-123",
+    "shell must store issuer token on enable");
+
+  // Simulate nav-away from vaillant-b503.
+  const beforeCount = fetchRequests.length;
+  await shell.handleVaillantB503NavAway();
+  await flush();
+
+  // Assert a disable GraphQL call was made with the stored token.
+  const afterCalls = fetchRequests.slice(beforeCount);
+  const disableCall = afterCalls.find((r) => {
+    const { query, variables } = parseGqlInit(r.init);
+    return query.includes("vaillantLiveMonitor") && variables && variables.action === "disable";
+  });
+  assert.ok(disableCall,
+    `a vaillantLiveMonitor(action:"disable") call must fire on nav-away; saw: ${JSON.stringify(afterCalls.map((c) => parseGqlInit(c.init)))}`);
+  const { variables: disableVars } = parseGqlInit(disableCall.init);
+  assert.equal(disableVars.issuerToken, "tok-xyz-123",
+    "disable call must pass the stored issuerToken");
+  // Token must be cleared after disable.
+  assert.ok(!shell._vaillantB503LiveToken,
+    "issuerToken must be cleared after auto-disable");
+});


### PR DESCRIPTION
Closes #521.
Tracks cruise-run [execution-plans#19](https://github.com/Project-Helianthus/helianthus-execution-plans/issues/19) — plan `vaillant-b503-namespace-w17-26.implementing`, milestone **M3_PORTAL** (complexity 4).

Predecessors (merged): M0 / M1 / M2a / M5 / M2b.

## Summary

Portal pane with 3 tabs (Errors / Service / Live-Monitor) consuming the M2b GraphQL surface. Capability-gated: `vaillantCapabilities.b503.available` drives render state. TDD strict: RED `e3a8bf5` + IMPL `ed3dddc`.

## Features

- Nav item `vaillant-b503` registered in portal shell
- Capability-driven render: AVAILABLE → tabs; NOT_SUPPORTED/UNKNOWN → empty placeholder; TRANSPORT_DOWN/SESSION_BUSY → unavailable banner with reason
- Live-monitor tab: Enable → token stored; Read → rawHex render; Disable → token consumed
- **Auto-disable on nav-leave** — if user navigates away while live-monitor session active, GraphQL disable is fired with stored token

## Plan invariants enforced (AD02, AD06)

- NO install-write UI affordances — literally no code paths for clear/delete/reset
- DOM-audit test (`VaillantB503Pane_NoInstallWriteAffordance`) scans pane subtree for any element with "clear" / "delete" / "reset" in text/innerHTML; asserts zero matches

## Tests (6 new + 21 pre-existing portal tests pass)

- `VaillantB503Pane_NavItemRegistered`
- `VaillantB503Pane_Unavailable_ShowsPlaceholder`
- `VaillantB503Pane_Available_ShowsThreeTabs`
- `VaillantB503Pane_ErrorsTab_RendersSlots` — decode verify with firstActiveError=281 + em-dash for nulls
- `VaillantB503Pane_NoInstallWriteAffordance` — DOM audit
- `VaillantB503Pane_LiveMonitor_AutoDisableOnLeave` — nav-away triggers disable call

## Verification

- `node --test portal/web/test/vaillant-b503.test.mjs` — 6/6 pass
- Full portal suite — 27/27 pass
- Portal static assets regenerated via `portal/web/scripts/build.mjs` and committed with IMPL

## Publication gate

Per M5 matrix §8 — schema publication behind BENCH-REPLACE. This pane consumes GraphQL; ships portal functionality but serves "NOT_SUPPORTED / UNKNOWN" via M2a stub dispatcher until the production raw-frame bridge lands.