### PR TITLE
fix(adaptermux): pace and gate adapter INFO bootstrap

### DIFF
--- a/cmd/gateway/semantic_vaillant_adapter_info.go
+++ b/cmd/gateway/semantic_vaillant_adapter_info.go
@@ -116,7 +116,10 @@ func (s *vaillantAdapterInfoState) needsIdentityRefresh() bool {
 	if !s.identity.SupportsInfo {
 		return false
 	}
-	return s.hwID == "" || s.hwConfig == ""
+	if s.hwID == "" || s.hwConfig == "" {
+		return true
+	}
+	return s.identity.SupportsInfoID(transport.AdapterInfoResetInfo) && s.restartCount == nil
 }
 
 func (s *vaillantAdapterInfoState) refreshIdentity(ctx context.Context) {
@@ -183,6 +186,25 @@ func (s *vaillantAdapterInfoState) refreshIdentity(ctx context.Context) {
 		s.hwConfig = ""
 	}
 
+	if version.SupportsInfoID(transport.AdapterInfoResetInfo) {
+		if data, err := s.queryInfo(ctx, transport.AdapterInfoResetInfo); err == nil {
+			if info, err := transport.ParseAdapterResetInfo(data); err == nil {
+				s.resetCause = &info.Cause
+				s.resetCode = &info.CauseCode
+				s.restartCount = &info.RestartCount
+				adapterRestartCount.Set(float64(info.RestartCount))
+			} else {
+				log.Printf("adapter_info: reset_info parse failed: %v", err)
+				s.clearResetInfo()
+			}
+		} else {
+			log.Printf("adapter_info: reset_info query failed: %v", err)
+			s.clearResetInfo()
+		}
+	} else {
+		s.clearResetInfo()
+	}
+
 	adapterInfoHealth.Set(boolToInt64(s.hwID != "" && s.hwConfig != ""))
 }
 
@@ -193,7 +215,6 @@ func (s *vaillantAdapterInfoState) refreshTelemetry(ctx context.Context) {
 	if s.identity == nil || !s.identity.SupportsInfo {
 		return
 	}
-	version := s.identity
 	anySuccess := false
 
 	// Temperature (ID 0x03).
@@ -252,52 +273,12 @@ func (s *vaillantAdapterInfoState) refreshTelemetry(ctx context.Context) {
 		adapterBusVoltageMinDV.Set(0)
 	}
 
-	// Reset info (ID 0x06) — gated.
-	if version.SupportsInfoID(transport.AdapterInfoResetInfo) {
-		if data, err := s.queryInfo(ctx, transport.AdapterInfoResetInfo); err == nil {
-			if info, err := transport.ParseAdapterResetInfo(data); err == nil {
-				s.resetCause = &info.Cause
-				s.resetCode = &info.CauseCode
-				s.restartCount = &info.RestartCount
-				adapterRestartCount.Set(float64(info.RestartCount))
-				anySuccess = true
-			}
-		} else if s.shouldRebootstrap(err) {
-			s.invalidateIdentity()
-			adapterInfoHealth.Set(0)
-			return
-		} else {
-			s.resetCause = nil
-			s.resetCode = nil
-			s.restartCount = nil
-			adapterRestartCount.Set(0)
-		}
-	} else {
-		s.resetCause = nil
-		s.resetCode = nil
-		s.restartCount = nil
-	}
+	// Reset info is populated once on the identity/bootstrap path and left
+	// unchanged during periodic telemetry refresh.
 
-	// WiFi RSSI (ID 0x07) — gated.
-	if version.SupportsInfoID(transport.AdapterInfoWiFiRSSI) {
-		if data, err := s.queryInfo(ctx, transport.AdapterInfoWiFiRSSI); err == nil && len(data) >= 1 {
-			v := int(int8(data[0]))
-			if v != 0 {
-				s.wifiRSSI = &v
-				adapterWiFiRSSIDBm.Set(float64(v))
-				anySuccess = true
-			}
-		} else if s.shouldRebootstrap(err) {
-			s.invalidateIdentity()
-			adapterInfoHealth.Set(0)
-			return
-		} else {
-			s.wifiRSSI = nil
-			adapterWiFiRSSIDBm.Set(0)
-		}
-	} else {
-		s.wifiRSSI = nil
-	}
+	// WiFi RSSI is intentionally excluded for this adapter family.
+	s.wifiRSSI = nil
+	adapterWiFiRSSIDBm.Set(0)
 
 	if anySuccess {
 		s.lastTelemetry = time.Now()
@@ -431,6 +412,13 @@ func (s *vaillantAdapterInfoState) clearTelemetry() {
 	adapterBusVoltageMinDV.Set(0)
 	adapterRestartCount.Set(0)
 	adapterWiFiRSSIDBm.Set(0)
+}
+
+func (s *vaillantAdapterInfoState) clearResetInfo() {
+	s.resetCause = nil
+	s.resetCode = nil
+	s.restartCount = nil
+	adapterRestartCount.Set(0)
 }
 
 func boolToInt64(b bool) int64 {

--- a/cmd/gateway/semantic_vaillant_adapter_info_test.go
+++ b/cmd/gateway/semantic_vaillant_adapter_info_test.go
@@ -455,8 +455,8 @@ func TestVaillantAdapterInfoStateUnsupportedTransitionClearsTelemetry(t *testing
 	if info.RestartCount == nil || *info.RestartCount != 0x07 {
 		t.Fatalf("RestartCount after supported refresh = %v; want 0x07", info.RestartCount)
 	}
-	if info.WiFiRSSIDBm == nil || *info.WiFiRSSIDBm != -90 {
-		t.Fatalf("WiFiRSSIDBm after supported refresh = %v; want -90", info.WiFiRSSIDBm)
+	if info.WiFiRSSIDBm != nil {
+		t.Fatalf("WiFiRSSIDBm after supported refresh = %v; want nil", info.WiFiRSSIDBm)
 	}
 	if info.LastTelemetryQuery == nil {
 		t.Fatal("LastTelemetryQuery after supported refresh = nil; want timestamp")
@@ -532,8 +532,159 @@ func TestVaillantAdapterInfoStateUnsupportedTransitionClearsTelemetry(t *testing
 	if got := raw.callCount(transport.AdapterInfoResetInfo); got != 1 {
 		t.Fatalf("AdapterInfoResetInfo call count = %d; want 1", got)
 	}
-	if got := raw.callCount(transport.AdapterInfoWiFiRSSI); got != 1 {
-		t.Fatalf("AdapterInfoWiFiRSSI call count = %d; want 1", got)
+	if got := raw.callCount(transport.AdapterInfoWiFiRSSI); got != 0 {
+		t.Fatalf("AdapterInfoWiFiRSSI call count = %d; want 0", got)
+	}
+}
+
+func TestVaillantAdapterInfoStateResetInfoFailureClearsPreviousState(t *testing.T) {
+	raw := &stubAdapterInfoTransport{
+		responses: map[transport.AdapterInfoID][]adapterInfoResponse{
+			transport.AdapterInfoVersion: {
+				{data: []byte{0x31, 0x01, 0x12, 0x34, 0x18, 0x10, 0xAB, 0xCD}},
+				{data: []byte{0x31, 0x01, 0x12, 0x34, 0x18, 0x10, 0xAB, 0xCD}},
+			},
+			transport.AdapterInfoHardwareID: {
+				{data: []byte{0xDE, 0xAD}},
+				{data: []byte{0xDE, 0xAD}},
+			},
+			transport.AdapterInfoHardwareConf: {
+				{data: []byte{0xBE, 0xEF}},
+				{data: []byte{0xBE, 0xEF}},
+			},
+			transport.AdapterInfoTemperature: {
+				{data: []byte{0x00, 0x19}},
+			},
+			transport.AdapterInfoSupplyVolt: {
+				{data: []byte{0x09, 0xC4}},
+			},
+			transport.AdapterInfoBusVoltage: {
+				{data: []byte{0x96, 0x82}},
+			},
+			transport.AdapterInfoResetInfo: {
+				{data: []byte{0x04, 0x07}},
+				{err: errors.New("transient reset info failure")},
+			},
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := protocol.NewBus(raw, protocol.DefaultBusConfig(), 0)
+	bus.Run(ctx)
+
+	provider := graphql.NewLiveSemanticProvider()
+	state := newVaillantAdapterInfoState(bus, raw, provider)
+	if state == nil {
+		t.Fatal("newVaillantAdapterInfoState() returned nil")
+	}
+
+	state.refreshCycle(ctx)
+	info := provider.AdapterHardwareInfo()
+	if info == nil {
+		t.Fatal("AdapterHardwareInfo() after supported refresh = nil")
+	}
+	if info.ResetCause == nil || *info.ResetCause != "clear" {
+		t.Fatalf("ResetCause after supported refresh = %v; want clear", info.ResetCause)
+	}
+	if info.RestartCount == nil || *info.RestartCount != 0x07 {
+		t.Fatalf("RestartCount after supported refresh = %v; want 0x07", info.RestartCount)
+	}
+	if got := expvarFloatValue(t, "ebus_adapter_restart_count"); got != 7 {
+		t.Fatalf("restart count expvar after supported refresh = %v; want 7", got)
+	}
+
+	state.refreshIdentity(ctx)
+	state.publish()
+
+	info = provider.AdapterHardwareInfo()
+	if info == nil {
+		t.Fatal("AdapterHardwareInfo() after reset_info failure = nil")
+	}
+	if info.ResetCause != nil {
+		t.Fatalf("ResetCause after reset_info failure = %v; want nil", info.ResetCause)
+	}
+	if info.ResetCauseCode != nil {
+		t.Fatalf("ResetCauseCode after reset_info failure = %v; want nil", info.ResetCauseCode)
+	}
+	if info.RestartCount != nil {
+		t.Fatalf("RestartCount after reset_info failure = %v; want nil", info.RestartCount)
+	}
+	if got := expvarFloatValue(t, "ebus_adapter_restart_count"); got != 0 {
+		t.Fatalf("restart count expvar after reset_info failure = %v; want 0", got)
+	}
+}
+
+func TestVaillantAdapterInfoStateRetriesResetInfoAfterTransientFailure(t *testing.T) {
+	raw := &stubAdapterInfoTransport{
+		responses: map[transport.AdapterInfoID][]adapterInfoResponse{
+			transport.AdapterInfoVersion: {
+				{data: []byte{0x31, 0x01, 0x12, 0x34, 0x18, 0x10, 0xAB, 0xCD}},
+				{data: []byte{0x31, 0x01, 0x12, 0x34, 0x18, 0x10, 0xAB, 0xCD}},
+			},
+			transport.AdapterInfoHardwareID: {
+				{data: []byte{0xDE, 0xAD}},
+				{data: []byte{0xDE, 0xAD}},
+			},
+			transport.AdapterInfoHardwareConf: {
+				{data: []byte{0xBE, 0xEF}},
+				{data: []byte{0xBE, 0xEF}},
+			},
+			transport.AdapterInfoTemperature: {
+				{data: []byte{0x00, 0x19}},
+				{data: []byte{0x00, 0x19}},
+			},
+			transport.AdapterInfoSupplyVolt: {
+				{data: []byte{0x09, 0xC4}},
+				{data: []byte{0x09, 0xC4}},
+			},
+			transport.AdapterInfoBusVoltage: {
+				{data: []byte{0x96, 0x82}},
+				{data: []byte{0x96, 0x82}},
+			},
+			transport.AdapterInfoResetInfo: {
+				{err: errors.New("transient reset info failure")},
+				{data: []byte{0x04, 0x08}},
+			},
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := protocol.NewBus(raw, protocol.DefaultBusConfig(), 0)
+	bus.Run(ctx)
+
+	provider := graphql.NewLiveSemanticProvider()
+	state := newVaillantAdapterInfoState(bus, raw, provider)
+	if state == nil {
+		t.Fatal("newVaillantAdapterInfoState() returned nil")
+	}
+
+	state.refreshCycle(ctx)
+	info := provider.AdapterHardwareInfo()
+	if info == nil {
+		t.Fatal("AdapterHardwareInfo() after reset_info failure = nil")
+	}
+	if info.ResetCause != nil {
+		t.Fatalf("ResetCause after reset_info failure = %v; want nil", info.ResetCause)
+	}
+	if got := raw.callCount(transport.AdapterInfoResetInfo); got != 1 {
+		t.Fatalf("AdapterInfoResetInfo call count after failure = %d; want 1", got)
+	}
+
+	state.refreshCycle(ctx)
+	info = provider.AdapterHardwareInfo()
+	if info == nil {
+		t.Fatal("AdapterHardwareInfo() after reset_info retry = nil")
+	}
+	if info.ResetCause == nil || *info.ResetCause != "clear" {
+		t.Fatalf("ResetCause after reset_info retry = %v; want clear", info.ResetCause)
+	}
+	if info.RestartCount == nil || *info.RestartCount != 0x08 {
+		t.Fatalf("RestartCount after reset_info retry = %v; want 0x08", info.RestartCount)
+	}
+	if got := raw.callCount(transport.AdapterInfoResetInfo); got != 2 {
+		t.Fatalf("AdapterInfoResetInfo call count after retry = %d; want 2", got)
 	}
 }
 
@@ -592,8 +743,8 @@ func TestVaillantAdapterInfoStateExpvarTelemetryResetsOnUnsupportedAndInvalidati
 	if got := expvarFloatValue(t, "ebus_adapter_restart_count"); got != 7 {
 		t.Fatalf("restart count expvar before unsupported transition = %v; want 7", got)
 	}
-	if got := expvarFloatValue(t, "ebus_adapter_wifi_rssi_dbm"); got != -90 {
-		t.Fatalf("wifi rssi expvar before unsupported transition = %v; want -90", got)
+	if got := expvarFloatValue(t, "ebus_adapter_wifi_rssi_dbm"); got != 0 {
+		t.Fatalf("wifi rssi expvar before unsupported transition = %v; want 0", got)
 	}
 
 	stateUnsupported.refreshIdentity(ctxUnsupported)
@@ -673,8 +824,8 @@ func TestVaillantAdapterInfoStateExpvarTelemetryResetsOnUnsupportedAndInvalidati
 	if got := expvarFloatValue(t, "ebus_adapter_restart_count"); got != 7 {
 		t.Fatalf("restart count expvar before invalidation = %v; want 7", got)
 	}
-	if got := expvarFloatValue(t, "ebus_adapter_wifi_rssi_dbm"); got != -90 {
-		t.Fatalf("wifi rssi expvar before invalidation = %v; want -90", got)
+	if got := expvarFloatValue(t, "ebus_adapter_wifi_rssi_dbm"); got != 0 {
+		t.Fatalf("wifi rssi expvar before invalidation = %v; want 0", got)
 	}
 
 	stateInvalidated.refreshCycle(ctxInvalidated)

--- a/internal/adaptermux/info_cache_test.go
+++ b/internal/adaptermux/info_cache_test.go
@@ -1,6 +1,7 @@
 package adaptermux
 
 import (
+	"context"
 	"errors"
 	"log"
 	"sync"
@@ -35,6 +36,7 @@ var errUnsupportedInfoID = errors.New("mock: unsupported INFO ID")
 type mockInfoTransport struct {
 	responses map[transport.AdapterInfoID][]byte
 	errors    map[transport.AdapterInfoID]error
+	onRequest func(transport.AdapterInfoID)
 	mu        sync.Mutex
 	calls     []transport.AdapterInfoID // records RequestInfo calls
 }
@@ -48,6 +50,9 @@ func (m *mockInfoTransport) RequestInfo(id transport.AdapterInfoID) ([]byte, err
 	m.mu.Lock()
 	m.calls = append(m.calls, id)
 	m.mu.Unlock()
+	if m.onRequest != nil {
+		m.onRequest(id)
+	}
 
 	if err, ok := m.errors[id]; ok {
 		return nil, err
@@ -88,29 +93,35 @@ func TestPopulateInfoCache(t *testing.T) {
 
 	tr := &mockInfoTransport{
 		responses: map[transport.AdapterInfoID][]byte{
-			transport.AdapterInfoVersion:      {0x23, 0x01},
+			transport.AdapterInfoVersion:      {0x23, 0x01, 0x84, 0x19, 0x3b},
 			transport.AdapterInfoHardwareID:   {0x10, 0x20, 0x30},
 			transport.AdapterInfoHardwareConf: {0x05},
-			transport.AdapterInfoTemperature:  {0x1C}, // volatile — cached as startup snapshot
-			transport.AdapterInfoWiFiRSSI:     {0xE0}, // volatile — cached as startup snapshot
+			transport.AdapterInfoResetInfo:    {0x04, 0x02},
+			transport.AdapterInfoTemperature:  {0x1C},
+			transport.AdapterInfoSupplyVolt:   {0x13, 0x88},
+			transport.AdapterInfoBusVoltage:   {0x18, 0x10},
+			transport.AdapterInfoWiFiRSSI:     {0xE0},
 		},
 	}
 
-	mux.populateInfoCache(tr)
+	if err := mux.populateInfoCache(tr); err != nil {
+		t.Fatalf("populateInfoCache() error = %v", err)
+	}
 
 	mux.infoCacheMu.RLock()
 	defer mux.infoCacheMu.RUnlock()
 
-	// All IDs should be cached including volatile telemetry (startup
-	// snapshots that go stale until reconnect — refreshTelemetry needs
-	// them from the cache to avoid readMu contention).
-	if len(mux.infoCache) != 5 {
-		t.Fatalf("infoCache has %d entries, want 5 (all IDs cached)", len(mux.infoCache))
+	// Startup cache now warms identity/config plus the first telemetry
+	// sample before exposing the transport. This version response is
+	// 5-byte Ethernet (checksum, no bootloader, no WiFi), so reset_info
+	// and wifi_rssi are both gated out.
+	if len(mux.infoCache) != 6 {
+		t.Fatalf("infoCache has %d entries, want 6 (version + 0x02/0x01/0x03/0x04/0x05)", len(mux.infoCache))
 	}
 
 	// Verify version was cached correctly.
-	if got := mux.infoCache[transport.AdapterInfoVersion]; len(got) != 2 || got[0] != 0x23 || got[1] != 0x01 {
-		t.Fatalf("version cache = %v, want [0x23 0x01]", got)
+	if got := mux.infoCache[transport.AdapterInfoVersion]; len(got) != 5 || got[0] != 0x23 || got[1] != 0x01 {
+		t.Fatalf("version cache = %v, want 5-byte version payload", got)
 	}
 
 	// Verify hardware ID was cached.
@@ -118,12 +129,130 @@ func TestPopulateInfoCache(t *testing.T) {
 		t.Fatalf("hardware ID cache = %v, want 3 bytes", got)
 	}
 
-	// Verify volatile IDs ARE cached (startup snapshots).
+	// Telemetry IDs 0x03/0x04/0x05 are now primed during startup.
 	if _, ok := mux.infoCache[transport.AdapterInfoTemperature]; !ok {
-		t.Fatal("AdapterInfoTemperature should be in cache (startup snapshot)")
+		t.Fatal("AdapterInfoTemperature should be in startup cache")
 	}
-	if _, ok := mux.infoCache[transport.AdapterInfoWiFiRSSI]; !ok {
-		t.Fatal("AdapterInfoWiFiRSSI should be in cache (startup snapshot)")
+	if _, ok := mux.infoCache[transport.AdapterInfoSupplyVolt]; !ok {
+		t.Fatal("AdapterInfoSupplyVolt should be in startup cache")
+	}
+	if _, ok := mux.infoCache[transport.AdapterInfoBusVoltage]; !ok {
+		t.Fatal("AdapterInfoBusVoltage should be in startup cache")
+	}
+	if _, ok := mux.infoCache[transport.AdapterInfoResetInfo]; ok {
+		t.Fatal("AdapterInfoResetInfo should not be in startup cache without bootloader support")
+	}
+	if _, ok := mux.infoCache[transport.AdapterInfoWiFiRSSI]; ok {
+		t.Fatal("AdapterInfoWiFiRSSI should not be in startup cache without checksum+WiFi support")
+	}
+}
+
+func TestPopulateInfoCache_GatesQueriesByVersionCapabilities(t *testing.T) {
+	mux := &Mux{
+		logger:    testLogger(t),
+		infoCache: make(map[transport.AdapterInfoID][]byte),
+	}
+
+	tr := &mockInfoTransport{
+		responses: map[transport.AdapterInfoID][]byte{
+			transport.AdapterInfoVersion:      {0x23, 0x01},
+			transport.AdapterInfoHardwareID:   {0x10},
+			transport.AdapterInfoHardwareConf: {0x20},
+			transport.AdapterInfoTemperature:  {0x00, 0x1C},
+			transport.AdapterInfoSupplyVolt:   {0x13, 0x88},
+			transport.AdapterInfoBusVoltage:   {0x18, 0x10},
+			transport.AdapterInfoResetInfo:    {0x04, 0x02},
+			transport.AdapterInfoWiFiRSSI:     {0xE0},
+		},
+	}
+
+	if err := mux.populateInfoCache(tr); err != nil {
+		t.Fatalf("populateInfoCache() error = %v", err)
+	}
+
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+
+	wantCalls := []transport.AdapterInfoID{
+		transport.AdapterInfoVersion,
+		transport.AdapterInfoHardwareConf,
+		transport.AdapterInfoHardwareID,
+		transport.AdapterInfoTemperature,
+		transport.AdapterInfoSupplyVolt,
+		transport.AdapterInfoBusVoltage,
+	}
+	if len(tr.calls) != len(wantCalls) {
+		t.Fatalf("RequestInfo calls = %v, want %v", tr.calls, wantCalls)
+	}
+	for i := range wantCalls {
+		if tr.calls[i] != wantCalls[i] {
+			t.Fatalf("RequestInfo calls = %v, want %v", tr.calls, wantCalls)
+		}
+	}
+}
+
+func TestPopulateInfoCache_NoInfoSupport_CachesVersionOnly(t *testing.T) {
+	mux := &Mux{
+		logger:    testLogger(t),
+		infoCache: make(map[transport.AdapterInfoID][]byte),
+	}
+
+	tr := &mockInfoTransport{
+		responses: map[transport.AdapterInfoID][]byte{
+			transport.AdapterInfoVersion:    {0x23, 0x00},
+			transport.AdapterInfoHardwareID: {0x10},
+		},
+	}
+
+	if err := mux.populateInfoCache(tr); err != nil {
+		t.Fatalf("populateInfoCache() error = %v", err)
+	}
+
+	mux.infoCacheMu.RLock()
+	defer mux.infoCacheMu.RUnlock()
+
+	if len(mux.infoCache) != 1 {
+		t.Fatalf("infoCache has %d entries, want 1 (version only)", len(mux.infoCache))
+	}
+	if _, ok := mux.infoCache[transport.AdapterInfoVersion]; !ok {
+		t.Fatal("AdapterInfoVersion should be cached")
+	}
+
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	if len(tr.calls) != 1 || tr.calls[0] != transport.AdapterInfoVersion {
+		t.Fatalf("RequestInfo calls = %v, want [version]", tr.calls)
+	}
+}
+
+func TestPopulateInfoCache_CachesResetInfoWhenBootloaderSupported(t *testing.T) {
+	mux := &Mux{
+		logger:    testLogger(t),
+		infoCache: make(map[transport.AdapterInfoID][]byte),
+	}
+
+	tr := &mockInfoTransport{
+		responses: map[transport.AdapterInfoID][]byte{
+			transport.AdapterInfoVersion:      {0x23, 0x01, 0x84, 0x19, 0x3b, 0x11, 0x84, 0x7f},
+			transport.AdapterInfoHardwareID:   {0x10},
+			transport.AdapterInfoHardwareConf: {0x20},
+			transport.AdapterInfoResetInfo:    {0x04, 0x02},
+			transport.AdapterInfoWiFiRSSI:     {0xE0},
+		},
+	}
+
+	if err := mux.populateInfoCache(tr); err != nil {
+		t.Fatalf("populateInfoCache() error = %v", err)
+	}
+
+	mux.infoCacheMu.RLock()
+	defer mux.infoCacheMu.RUnlock()
+
+	if _, ok := mux.infoCache[transport.AdapterInfoResetInfo]; !ok {
+		t.Fatal("AdapterInfoResetInfo should be cached when bootloader support is advertised")
+	}
+	if _, ok := mux.infoCache[transport.AdapterInfoWiFiRSSI]; ok {
+		t.Fatal("AdapterInfoWiFiRSSI should remain out of startup cache")
 	}
 }
 
@@ -134,7 +263,9 @@ func TestPopulateInfoCache_NoInfoRequester(t *testing.T) {
 	}
 
 	tr := &mockNoInfoTransport{}
-	mux.populateInfoCache(tr)
+	if err := mux.populateInfoCache(tr); err != nil {
+		t.Fatalf("populateInfoCache() error = %v", err)
+	}
 
 	mux.infoCacheMu.RLock()
 	defer mux.infoCacheMu.RUnlock()
@@ -160,7 +291,9 @@ func TestPopulateInfoCache_VersionFails_SkipsAll(t *testing.T) {
 		},
 	}
 
-	mux.populateInfoCache(tr)
+	if err := mux.populateInfoCache(tr); err != nil {
+		t.Fatalf("populateInfoCache() error = %v", err)
+	}
 
 	mux.infoCacheMu.RLock()
 	defer mux.infoCacheMu.RUnlock()
@@ -169,6 +302,45 @@ func TestPopulateInfoCache_VersionFails_SkipsAll(t *testing.T) {
 	// population is skipped — adapter does not support INFO.
 	if len(mux.infoCache) != 0 {
 		t.Fatalf("infoCache has %d entries, want 0 (version failed = skip all)", len(mux.infoCache))
+	}
+}
+
+func TestPopulateInfoCache_ContextCanceledDuringPacingReturnsError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mux := &Mux{
+		logger:    testLogger(t),
+		ctx:       ctx,
+		infoCache: make(map[transport.AdapterInfoID][]byte),
+	}
+
+	tr := &mockInfoTransport{
+		responses: map[transport.AdapterInfoID][]byte{
+			transport.AdapterInfoVersion:    {0x23, 0x01, 0x84, 0x19, 0x3b},
+			transport.AdapterInfoHardwareID: {0x10, 0x20, 0x30},
+		},
+		errors: map[transport.AdapterInfoID]error{
+			transport.AdapterInfoHardwareConf: errors.New("transient INFO reject"),
+		},
+		onRequest: func(id transport.AdapterInfoID) {
+			if id == transport.AdapterInfoHardwareConf {
+				cancel()
+			}
+		},
+	}
+
+	err := mux.populateInfoCache(tr)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("populateInfoCache() error = %v, want context.Canceled", err)
+	}
+
+	mux.infoCacheMu.RLock()
+	defer mux.infoCacheMu.RUnlock()
+	if _, ok := mux.infoCache[transport.AdapterInfoVersion]; !ok {
+		t.Fatal("partial cache should retain AdapterInfoVersion")
+	}
+	if _, ok := mux.infoCache[transport.AdapterInfoHardwareConf]; ok {
+		t.Fatal("partial cache should not retain failed AdapterInfoHardwareConf")
 	}
 }
 

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"os"
+	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -13,6 +16,13 @@ import (
 	ebuserrors "github.com/Project-Helianthus/helianthus-ebusgo/errors"
 	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
 	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+const infoCacheInterRequestDelay = 200 * time.Millisecond
+
+const (
+	infoBootstrapIDsEnv = "HELIANTHUS_INFO_BOOTSTRAP_IDS"
+	infoDelayMSEnv      = "HELIANTHUS_INFO_DELAY_MS"
 )
 
 // Config configures the adapter multiplexer.
@@ -529,16 +539,17 @@ func (m *Mux) connect() error {
 	}
 
 	// Populate INFO cache with the 2s-timeout transport.
-	m.populateInfoCache(setupTr)
+	if err := m.populateInfoCache(setupTr); err != nil {
+		_ = conn.Close()
+		m.conn = nil     // clear stale reference on ctx cancel
+		m.upstream = nil // clear stale transport on ctx cancel
+		return err
+	}
 
-	// Phase 2: replace with fast-timeout transport for readLoop.
-	// Safety argument for replacing the transport on the same conn:
-	// - readLoop hasn't started (Start calls connect first, then spawns readLoop).
-	// - populateInfoCache is the only reader; INFO responses are complete ENH
-	//   frames, so the parser is fully consumed after each RequestInfo call.
-	// - Bytes arriving during the 500ms stabilization delay buffer in the TCP
-	//   socket (kernel), NOT in the parser. The new transport reads them normally.
-	// - No parser state is lost because setupTr's parser is clean after INFO.
+	// Phase 2: replace with cfg.ReadTimeout transport for readLoop.
+	// RequestInfo needs the longer setup timeout, but steady-state
+	// readLoop timing drives quiet-bus arbitration progress and must
+	// continue honoring cfg.ReadTimeout.
 	m.upstream = newTransport(m.cfg.ReadTimeout)
 
 	return nil
@@ -554,9 +565,8 @@ func (m *Mux) connect() error {
 // does not, the cache is cleared and CachedInfo returns an error.
 //
 // XR_INFO_CACHE_SNAPSHOT / AM29: INFO cache is intentionally a startup
-// snapshot. Volatile telemetry (temp, voltage, RSSI) goes stale after
-// connect — on-demand refresh would require readMu (conflicts with
-// readLoop). The cache is repopulated on each reconnect via connect().
+// snapshot. The cache is repopulated on each reconnect via connect() and is
+// warmed before the adapter is exposed to downstream consumers.
 //
 // Design rationale: the ENH transport's RequestInfo holds readMu
 // exclusively. During normal operation, readLoop also holds readMu to
@@ -566,15 +576,18 @@ func (m *Mux) connect() error {
 // startup-snapshot model accepts stale telemetry in exchange for
 // zero readMu contention during steady state.
 //
-// All INFO IDs (0x00-0x07) are cached, including volatile telemetry
-// (temperature, voltage, RSSI). These are startup snapshots that go
-// stale until reconnect, but refreshTelemetry needs them from the
-// cache to avoid readMu contention with readLoop.
-func (m *Mux) populateInfoCache(tr transport.RawTransport) {
+// INFO version (0x00) is always queried first. The startup cache stores the
+// initial identity/configuration snapshot plus the first telemetry sample
+// (temperature/supply_voltage/bus_voltage) before the transport is handed to
+// consumers. reset_info is fetched once per TCP session when supported.
+// wifi_rssi is intentionally excluded on this adapter family. Startup
+// requests are capability-gated and paced slightly to avoid a tight
+// control-frame burst against fragile adapters.
+func (m *Mux) populateInfoCache(tr transport.RawTransport) error {
 	infoReq, ok := tr.(transport.InfoRequester)
 	if !ok {
 		m.clearInfoCache()
-		return
+		return nil
 	}
 
 	cache := make(map[transport.AdapterInfoID][]byte)
@@ -586,17 +599,51 @@ func (m *Mux) populateInfoCache(tr transport.RawTransport) {
 	if err != nil {
 		m.logger.Printf("adaptermux: INFO not supported by adapter: %v", err)
 		m.clearInfoCache()
-		return
+		return nil
 	}
 	cache[transport.AdapterInfoVersion] = append([]byte(nil), data...)
+	version, err := transport.ParseAdapterVersion(data)
+	if err != nil {
+		m.logger.Printf("adaptermux: INFO version parse failed: %v", err)
+		m.infoCacheMu.Lock()
+		m.infoCache = cache
+		m.infoCacheMu.Unlock()
+		m.logger.Printf("adaptermux: INFO cache populated (%d entries)", len(cache))
+		return nil
+	}
 
-	// Query all remaining IDs (0x01–0x07) including volatile telemetry.
-	for id := transport.AdapterInfoHardwareID; id <= transport.AdapterInfoWiFiRSSI; id++ {
-		data, err := infoReq.RequestInfo(id)
-		if err != nil {
+	bootstrapIDs := []transport.AdapterInfoID{
+		transport.AdapterInfoHardwareConf,
+		transport.AdapterInfoHardwareID,
+		transport.AdapterInfoResetInfo,
+		transport.AdapterInfoTemperature,
+		transport.AdapterInfoSupplyVolt,
+		transport.AdapterInfoBusVoltage,
+	}
+	if overridden, ok := infoBootstrapIDsOverride(); ok {
+		bootstrapIDs = overridden
+	}
+	interRequestDelay := infoCacheInterRequestDelay
+	if overridden, ok := infoBootstrapDelayOverride(); ok {
+		interRequestDelay = overridden
+	}
+	supportedIDs := bootstrapIDs[:0]
+	for _, id := range bootstrapIDs {
+		if !version.SupportsInfoID(id) {
 			continue
 		}
-		cache[id] = append([]byte(nil), data...)
+		supportedIDs = append(supportedIDs, id)
+	}
+	for idx, id := range supportedIDs {
+		data, err := infoReq.RequestInfo(id)
+		if err == nil {
+			cache[id] = append([]byte(nil), data...)
+		}
+		if idx < len(supportedIDs)-1 {
+			if err := m.waitInfoBootstrapDelay(interRequestDelay, cache); err != nil {
+				return err
+			}
+		}
 	}
 
 	m.infoCacheMu.Lock()
@@ -604,6 +651,62 @@ func (m *Mux) populateInfoCache(tr transport.RawTransport) {
 	m.infoCacheMu.Unlock()
 
 	m.logger.Printf("adaptermux: INFO cache populated (%d entries)", len(cache))
+	return nil
+}
+
+func (m *Mux) waitInfoBootstrapDelay(delay time.Duration, cache map[transport.AdapterInfoID][]byte) error {
+	if m.ctx == nil {
+		time.Sleep(delay)
+		return nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-m.ctx.Done():
+		m.infoCacheMu.Lock()
+		m.infoCache = cache
+		m.infoCacheMu.Unlock()
+		m.logger.Printf("adaptermux: INFO cache populated (%d entries)", len(cache))
+		return m.ctx.Err()
+	}
+}
+
+func infoBootstrapIDsOverride() ([]transport.AdapterInfoID, bool) {
+	raw := strings.TrimSpace(os.Getenv(infoBootstrapIDsEnv))
+	if raw == "" {
+		return nil, false
+	}
+	parts := strings.Split(raw, ",")
+	ids := make([]transport.AdapterInfoID, 0, len(parts))
+	for _, part := range parts {
+		token := strings.TrimSpace(part)
+		if token == "" {
+			continue
+		}
+		value, err := strconv.ParseUint(token, 0, 8)
+		if err != nil {
+			continue
+		}
+		ids = append(ids, transport.AdapterInfoID(value))
+	}
+	if len(ids) == 0 {
+		return nil, false
+	}
+	return ids, true
+}
+
+func infoBootstrapDelayOverride() (time.Duration, bool) {
+	raw := strings.TrimSpace(os.Getenv(infoDelayMSEnv))
+	if raw == "" {
+		return 0, false
+	}
+	ms, err := strconv.Atoi(raw)
+	if err != nil || ms < 0 {
+		return 0, false
+	}
+	return time.Duration(ms) * time.Millisecond, true
 }
 
 // clearInfoCache removes all cached INFO entries so that CachedInfo
@@ -870,6 +973,12 @@ func (m *Mux) readLoop() {
 				if m.arb.hasPending() {
 					m.tryGrantAndStart()
 				}
+				continue
+			}
+			if errors.Is(err, ebuserrors.ErrInvalidPayload) {
+				m.logger.Printf("adaptermux: soft parser error (no reconnect): %v", err)
+				firstTimeoutTime = time.Time{}
+				lastDataTime = time.Now()
 				continue
 			}
 			m.logger.Printf("adaptermux: read error: %v", err)


### PR DESCRIPTION
## What

Fix adaptermux INFO bootstrap behavior for fragile ENH/ENS adapters:

- query INFO version first, then capability-gate bootstrap INFO IDs;
- pace bootstrap INFO requests with a 200ms default delay plus temporary env overrides;
- cache identity/config and first telemetry sample before consumers use the transport;
- fetch reset_info once on identity/bootstrap path and stop polling reset_info/wifi_rssi periodically;
- keep steady-state read-loop transport on `cfg.ReadTimeout` after bootstrap;
- treat ENH invalid-payload parser faults as soft read-loop errors instead of reconnect storms.

## Why

On the live adapter, tight INFO bursts caused heap/signal instability. The low-level `RequestInfo` transport behavior already lives in `helianthus-ebusgo`; this PR keeps the operational pacing/cache policy in gateway/adaptermux.

## Validation

Passed:

```bash
go test ./internal/adaptermux ./cmd/gateway -run 'TestPopulateInfoCache|TestActiveTransport_RequestInfo_UsesCache|TestVaillantAdapterInfo'
```

Attempted full local CI:

```bash
./scripts/ci_local.sh
```

It stopped at gofmt on pre-existing B503 files outside this PR diff: `graphql/builder.go`, `graphql/vaillant_b503_test.go`, `mcp/vaillant_b503.go`. Those files are intentionally untouched here.