### PR TITLE
fix(adaptermux): tighten active transaction diagnostics

### DIFF
--- a/internal/adaptermux/active_path.go
+++ b/internal/adaptermux/active_path.go
@@ -150,10 +150,6 @@ func (t *activeTransport) Write(p []byte) (int, error) {
 				return i, err
 			}
 			t.mux.activeTxn.bytesWritten.Add(1)
-			// Shape diag: capture first-N write bytes under stateMu.
-			t.mux.stateMu.Lock()
-			t.mux.recordWritePrefix(b)
-			t.mux.stateMu.Unlock()
 		case <-t.mux.ctx.Done():
 			t.mux.markActiveContextCancel()
 			return i, fmt.Errorf("adaptermux: %w", t.mux.ctx.Err())

--- a/internal/adaptermux/classify_test.go
+++ b/internal/adaptermux/classify_test.go
@@ -120,7 +120,18 @@ func TestTxnClass_SuccessLike(t *testing.T) {
 		t.Fatalf("write err=%v", err)
 	}
 
-	// Feed a non-echo response prefix then a SYN terminator.
+	// Feed back the gateway echo first, then a non-echo response
+	// prefix and a SYN terminator.
+	for _, b := range req {
+		mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: b}
+	}
+	time.Sleep(20 * time.Millisecond)
+	for range req {
+		if _, err := at.ReadByte(); err != nil {
+			t.Fatalf("ReadByte err=%v", err)
+		}
+	}
+
 	resp := []byte{0x10, 0x05, 0x42, 0xCD}
 	for _, b := range resp {
 		mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: b}
@@ -144,6 +155,109 @@ func TestTxnClass_SuccessLike(t *testing.T) {
 	}
 	if snap.NonEcho == 0 || snap.SynMarkers == 0 {
 		t.Errorf("NonEcho=%d SynMarkers=%d, want both >0", snap.NonEcho, snap.SynMarkers)
+	}
+}
+
+// TestTxnClass_SYNTerminatorEchoOnly proves that a trailing SYN after
+// echo-only traffic does not classify as SuccessLike. The transaction
+// lifecycle closed cleanly, but the mux never observed a non-echo
+// response byte from the target.
+func TestTxnClass_SYNTerminatorEchoOnly(t *testing.T) {
+	mux, mock, _, cleanup := newP3TestMux(t)
+	defer cleanup()
+
+	grantGateway(t, mux, mock, 0x71)
+
+	at := mux.ActiveTransport()
+	req := []byte{0x08, 0xB5, 0x09, 0x03, 0x0D, 0x54, 0x00, 0xAA}
+	if _, err := at.Write(req); err != nil {
+		t.Fatalf("write err=%v", err)
+	}
+
+	for _, b := range req {
+		mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: b}
+	}
+	time.Sleep(30 * time.Millisecond)
+	for range req {
+		if _, err := at.ReadByte(); err != nil {
+			t.Fatalf("ReadByte err=%v", err)
+		}
+	}
+
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: protocol.SymbolSyn}
+	time.Sleep(30 * time.Millisecond)
+
+	snap := mux.ActiveTxnSnapshot()
+	if snap.InactiveReason != ReasonSYNTerminator {
+		t.Fatalf("InactiveReason = %q, want %q", snap.InactiveReason, ReasonSYNTerminator)
+	}
+	if snap.TxnClass != TxnClassEchoOnlyTimeout {
+		t.Fatalf("TxnClass = %q, want %q (echo=%d nonEcho=%d syn=%d reads=%d writes=%d)",
+			snap.TxnClass, TxnClassEchoOnlyTimeout,
+			snap.EchoLike, snap.NonEcho, snap.SynMarkers, snap.BytesRead, snap.BytesWritten)
+	}
+	if snap.NonEcho != 0 {
+		t.Errorf("NonEcho = %d, want 0", snap.NonEcho)
+	}
+	if !bytes.Equal(snap.WritePrefix, snap.ReadPrefix) {
+		t.Errorf("WritePrefix = % X ReadPrefix = % X; want identical echo-only prefixes", snap.WritePrefix, snap.ReadPrefix)
+	}
+}
+
+func TestTxnClass_SYNTerminatorUsesWritePrefixBeforeBytesWritten(t *testing.T) {
+	mux, _, _, cleanup := newP3TestMux(t)
+	defer cleanup()
+
+	mux.recordGatewayGrant(0x71, 0)
+	mux.stateMu.Lock()
+	mux.gatewayTxnActive = true
+	mux.recordWritePrefix(0x71)
+	mux.recordReadPrefixAndClassify(0x71)
+	mux.recordReadPrefixAndClassify(0x10)
+	mux.recordReadPrefixAndClassify(protocol.SymbolSyn)
+	mux.gatewayTxnActive = false
+	mux.recordGatewayInactive(ReasonSYNTerminator)
+	mux.stateMu.Unlock()
+
+	snap := mux.ActiveTxnSnapshot()
+	if snap.BytesWritten != 0 {
+		t.Fatalf("BytesWritten = %d, want 0 for pre-writer-counter race", snap.BytesWritten)
+	}
+	if snap.TxnClass != TxnClassSuccessLike {
+		t.Fatalf("TxnClass = %q, want %q when writePrefix exists before BytesWritten increments", snap.TxnClass, TxnClassSuccessLike)
+	}
+}
+
+// TestTxnClass_DelayedEchoAfterLeadingSYNs proves that leading SYN
+// chatter does not permanently misalign echo classification for the
+// next real echoed request byte.
+func TestTxnClass_DelayedEchoAfterLeadingSYNs(t *testing.T) {
+	mux, mock, _, cleanup := newP3TestMux(t)
+	defer cleanup()
+
+	grantGateway(t, mux, mock, 0x71)
+
+	at := mux.ActiveTransport()
+	req := []byte{0x15, 0xB5}
+	if _, err := at.Write(req); err != nil {
+		t.Fatalf("write err=%v", err)
+	}
+
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: protocol.SymbolSyn}
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: protocol.SymbolSyn}
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x15}
+	time.Sleep(30 * time.Millisecond)
+
+	if b, err := at.ReadByte(); err != nil || b != 0x15 {
+		t.Fatalf("ReadByte = (0x%02X,%v), want (0x15,nil)", b, err)
+	}
+
+	snap := mux.ActiveTxnSnapshot()
+	if snap.EchoLike != 1 {
+		t.Fatalf("EchoLike = %d, want 1", snap.EchoLike)
+	}
+	if snap.NonEcho != 0 {
+		t.Fatalf("NonEcho = %d, want 0 for delayed echoed byte", snap.NonEcho)
 	}
 }
 
@@ -212,9 +326,14 @@ func TestTxnClass_SchemaError_OverridesCandidateNoParse(t *testing.T) {
 		t.Fatalf("write err=%v", err)
 	}
 
-	// Feed non-echo bytes AND a SYN — classification at inactive time
-	// becomes SuccessLike (non-echo + syn). Then mark schema error via
-	// the API and ensure snapshot reflects SchemaError.
+	// Feed the echoed write byte, then non-echo bytes and a SYN —
+	// classification at inactive time becomes SuccessLike. Then mark
+	// schema error via the API and ensure snapshot reflects SchemaError.
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x71}
+	time.Sleep(20 * time.Millisecond)
+	if _, err := at.ReadByte(); err != nil {
+		t.Fatalf("ReadByte err=%v", err)
+	}
 	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x10}
 	time.Sleep(20 * time.Millisecond)
 	if _, err := at.ReadByte(); err != nil {

--- a/internal/adaptermux/diag.go
+++ b/internal/adaptermux/diag.go
@@ -111,6 +111,7 @@ type activeTxnDiag struct {
 	writePrefixLen int
 	readPrefix     [txnPrefixCap]byte
 	readPrefixLen  int
+	echoCursor     int
 	// Byte-class counters (atomic; hot-path increments in onReceived
 	// and Write paths).
 	echoLike   atomic.Uint64
@@ -238,6 +239,7 @@ func (m *Mux) recordGatewayGrant(initiator byte, drained int) {
 	// Reset per-txn shape diagnostics.
 	m.activeTxn.writePrefixLen = 0
 	m.activeTxn.readPrefixLen = 0
+	m.activeTxn.echoCursor = 0
 	m.activeTxn.writePrefix = [txnPrefixCap]byte{}
 	m.activeTxn.readPrefix = [txnPrefixCap]byte{}
 	m.activeTxn.echoLike.Store(0)
@@ -326,17 +328,18 @@ func (m *Mux) recordWritePrefix(b byte) {
 func (m *Mux) recordReadPrefixAndClassify(b byte) {
 	if b == protocol.SymbolSyn {
 		m.activeTxn.synMarkers.Add(1)
-	}
-	// Echo detection: position-wise match against writePrefix up to
-	// the smaller of both prefix lengths at insertion time. We compare
-	// the incoming byte against writePrefix[readPrefixLen] when that
-	// slot has been filled by a prior write.
-	pos := m.activeTxn.readPrefixLen
-	echo := pos < m.activeTxn.writePrefixLen && m.activeTxn.writePrefix[pos] == b
-	if echo {
+	} else if m.activeTxn.echoCursor < m.activeTxn.writePrefixLen &&
+		m.activeTxn.writePrefix[m.activeTxn.echoCursor] == b {
+		// Echo matching follows the next expected echoed write byte,
+		// not the absolute read position. Leading SYN chatter must not
+		// permanently misalign a later real echo.
 		m.activeTxn.echoLike.Add(1)
-	} else if b != protocol.SymbolSyn {
+		m.activeTxn.echoCursor++
+	} else {
 		m.activeTxn.nonEcho.Add(1)
+		if m.activeTxn.echoCursor < m.activeTxn.writePrefixLen {
+			m.activeTxn.echoCursor++
+		}
 	}
 	if m.activeTxn.readPrefixLen < txnPrefixCap {
 		m.activeTxn.readPrefix[m.activeTxn.readPrefixLen] = b
@@ -352,8 +355,8 @@ func (m *Mux) recordReadPrefixAndClassify(b byte) {
 //   - SuccessLike: TransactionDone or CmdNACK reason (lifecycle-complete)
 //   - SuccessLike: reads include a SYN marker AND non-echo byte count is
 //     positive AND reads >= writes (plausible response + terminator)
-//   - EchoOnlyTimeout: timeout/abort reason AND reads all matched writes
-//     position-wise (no nonEcho bytes seen)
+//   - EchoOnlyTimeout: no-response shape (including SYN-terminated echo-only
+//     traffic) AND reads all matched writes position-wise (no nonEcho bytes seen)
 //   - NonEchoInvalidFrame: got nonEcho bytes but no SYN and no success
 //     (incoherent bytes on the wire; not a framed response)
 //   - CandidateNoParse: got nonEcho bytes AND a SYN but still timed out
@@ -362,8 +365,7 @@ func (m *Mux) recordReadPrefixAndClassify(b byte) {
 //     caller via classifyTxnWithSchemaError (not computed here)
 //   - Unknown: insufficient signal
 func (m *Mux) classifyTxnLocked(reason ActiveTxnInactiveReason) TxnClass {
-	writes := m.activeTxn.bytesWritten.Load()
-	reads := m.activeTxn.bytesRead.Load()
+	hasWritePrefix := m.activeTxn.writePrefixLen > 0
 	echo := m.activeTxn.echoLike.Load()
 	nonEcho := m.activeTxn.nonEcho.Load()
 	syns := m.activeTxn.synMarkers.Load()
@@ -373,12 +375,12 @@ func (m *Mux) classifyTxnLocked(reason ActiveTxnInactiveReason) TxnClass {
 	// purpose of distinguishing from silent timeouts. (CmdNACK is not
 	// a "successful" read, but the target DID respond — different from
 	// echo-only timeout.)
-	if reason == ReasonTransactionDone || reason == ReasonCmdNACK ||
-		reason == ReasonSYNTerminator {
+	if reason == ReasonTransactionDone || reason == ReasonCmdNACK {
 		return TxnClassSuccessLike
 	}
 
 	isTimeoutLike := reason == ReasonActiveReadTimeout ||
+		reason == ReasonSYNTerminator ||
 		reason == ReasonSYNIdle ||
 		reason == ReasonSYNTimeout ||
 		reason == ReasonMaxOwnership ||
@@ -387,10 +389,11 @@ func (m *Mux) classifyTxnLocked(reason ActiveTxnInactiveReason) TxnClass {
 		reason == ReasonReset ||
 		reason == ReasonReconnect
 
-	// SuccessLike heuristic: saw non-echo response bytes AND a SYN
-	// terminator AND the read count is at least as large as the write
-	// count (response arrived after the echo).
-	if nonEcho > 0 && syns > 0 && reads >= writes && writes > 0 {
+	// SuccessLike heuristic: saw non-echo response bytes and a SYN
+	// terminator after at least part of the gateway write stream was
+	// echoed back. Without an echo signal, stale/foreign traffic can
+	// be incorrectly blessed as the gateway's successful transaction.
+	if nonEcho > 0 && syns > 0 && echo > 0 && hasWritePrefix {
 		return TxnClassSuccessLike
 	}
 
@@ -399,11 +402,11 @@ func (m *Mux) classifyTxnLocked(reason ActiveTxnInactiveReason) TxnClass {
 	}
 
 	// Timeout-like paths past this point.
-	if writes > 0 && nonEcho == 0 && echo >= 1 {
+	if hasWritePrefix && nonEcho == 0 && echo >= 1 {
 		// Every read matched the write prefix position-wise: echo-only.
 		return TxnClassEchoOnlyTimeout
 	}
-	if writes > 0 && reads == 0 {
+	if hasWritePrefix && m.activeTxn.readPrefixLen == 0 {
 		// Didn't even see our own echo back — treat as echo-only
 		// (lowest-confidence class, but still more informative than
 		// "unknown" for an operator triaging the soak log).

--- a/internal/adaptermux/diag_test.go
+++ b/internal/adaptermux/diag_test.go
@@ -39,8 +39,8 @@ func TestActiveTxnDiag_GrantRecorded(t *testing.T) {
 	if snap.GrantsTotal != preSnap.GrantsTotal+1 {
 		t.Fatalf("GrantsTotal = %d, want %d", snap.GrantsTotal, preSnap.GrantsTotal+1)
 	}
-	if !snap.Active {
-		t.Fatal("Active must be true after grant (before end-of-txn SYN)")
+	if snap.Active {
+		t.Fatal("Active must remain false after grant until the gateway performs its first write")
 	}
 	if snap.InactiveReason != ReasonNone {
 		t.Fatalf("InactiveReason must be empty while active, got %q", snap.InactiveReason)
@@ -77,6 +77,10 @@ func TestActiveTxnDiag_ReadCounterIncrements(t *testing.T) {
 	defer cleanup()
 
 	grantGateway(t, mux, mock, 0x71)
+	at := mux.ActiveTransport()
+	if _, err := at.Write([]byte{0x71}); err != nil {
+		t.Fatalf("Write err=%v", err)
+	}
 
 	// Feed response bytes via mock. While gateway txn is active these
 	// are delivered to activeCh and consumed by ReadByte.
@@ -86,7 +90,6 @@ func TestActiveTxnDiag_ReadCounterIncrements(t *testing.T) {
 	}
 	time.Sleep(30 * time.Millisecond)
 
-	at := mux.ActiveTransport()
 	for range bytes {
 		if _, err := at.ReadByte(); err != nil {
 			t.Fatalf("ReadByte err=%v", err)
@@ -145,42 +148,59 @@ func TestActiveTxnDiag_InactiveReason_SYNIdle(t *testing.T) {
 	}
 }
 
-// TestActiveTxnDiag_SYNBeforeRead_DoesNotClear proves the echo_mismatch
-// root-cause fix: a SYN arriving during gateway ownership BEFORE any
-// Write (bytesWritten==0, i.e. the pre-echo window) must NOT terminate
-// the transaction AND must be suppressed from activeCh delivery so it
-// does not race the real echo byte that bus.Send will write.
-//
-// Post-fix gate is bytesWritten (not bytesRead): bytesRead is
-// incremented on CONSUME which lags activeCh delivery, so gating on it
-// would over-suppress legitimate terminators. bytesWritten==0 cleanly
-// identifies the grant-to-first-write window.
+// TestActiveTxnDiag_SYNBeforeRead_DoesNotClear proves that a SYN arriving
+// during gateway ownership BEFORE any Write is ignored for the active
+// path. The transaction has not started yet, so the SYN must neither
+// terminate it nor be counted as active-path traffic.
 func TestActiveTxnDiag_SYNBeforeRead_DoesNotClear(t *testing.T) {
 	mux, mock, _, cleanup := newP3TestMux(t)
 	defer cleanup()
 
 	grantGateway(t, mux, mock, 0x71)
 
-	// NOTE: no Write yet — bytesWritten stays 0, simulating the
-	// grant-to-first-write race window.
+	// NOTE: no Write yet — simulating the grant-to-first-write window.
 	before := mux.ActiveTxnSnapshot().SynSuppressedPreEcho
 
 	// SYN arrives BEFORE any Write. Must NOT clear AND must be
-	// counted as pre-echo suppressed.
+	// ignored by the active path.
 	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: protocol.SymbolSyn}
 	time.Sleep(30 * time.Millisecond)
 
 	snap := mux.ActiveTxnSnapshot()
-	if !snap.Active {
-		t.Fatalf("Active must remain true in pre-echo window (bytesWritten=0); got inactive reason=%q writes=%d reads=%d",
+	if snap.Active {
+		t.Fatalf("Active must remain false before first write; got inactive reason=%q writes=%d reads=%d",
 			snap.InactiveReason, snap.BytesWritten, snap.BytesRead)
 	}
 	if snap.InactiveReason != ReasonNone {
 		t.Fatalf("InactiveReason must be empty, got %q", snap.InactiveReason)
 	}
-	if snap.SynSuppressedPreEcho <= before {
-		t.Fatalf("SynSuppressedPreEcho counter must have incremented (echo_mismatch fix); got %d before=%d",
+	if snap.SynSuppressedPreEcho != before {
+		t.Fatalf("SynSuppressedPreEcho must stay unchanged before first write; got %d before=%d",
 			snap.SynSuppressedPreEcho, before)
+	}
+}
+
+// TestActiveTxnDiag_PreWriteBytesDoNotPolluteTxn proves that bus noise
+// observed while the gateway owns arbitration but has not written the
+// first request byte yet does not contaminate the current txn prefix or
+// non-echo counters.
+func TestActiveTxnDiag_PreWriteBytesDoNotPolluteTxn(t *testing.T) {
+	mux, mock, _, cleanup := newP3TestMux(t)
+	defer cleanup()
+
+	grantGateway(t, mux, mock, 0x71)
+
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0xF1}
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: protocol.SymbolSyn}
+	time.Sleep(30 * time.Millisecond)
+
+	snap := mux.ActiveTxnSnapshot()
+	if snap.NonEcho != 0 || snap.EchoLike != 0 || snap.SynMarkers != 0 {
+		t.Fatalf("pre-write noise polluted txn: echo=%d nonEcho=%d syn=%d",
+			snap.EchoLike, snap.NonEcho, snap.SynMarkers)
+	}
+	if len(snap.ReadPrefix) != 0 {
+		t.Fatalf("ReadPrefix = % X, want empty before first write", snap.ReadPrefix)
 	}
 }
 
@@ -191,6 +211,10 @@ func TestActiveTxnDiag_InactiveReason_Reset(t *testing.T) {
 	defer cleanup()
 
 	grantGateway(t, mux, mock, 0x71)
+	at := mux.ActiveTransport()
+	if _, err := at.Write([]byte{0x71}); err != nil {
+		t.Fatalf("Write err=%v", err)
+	}
 
 	mux.handleReset()
 

--- a/internal/adaptermux/listener.go
+++ b/internal/adaptermux/listener.go
@@ -70,6 +70,9 @@ func (pl *ProxyListener) Close() error {
 	pl.cancel()
 	err := pl.listener.Close()
 	pl.wg.Wait()
+	if errors.Is(err, net.ErrClosed) {
+		return nil
+	}
 	return err
 }
 

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -173,6 +173,7 @@ type Mux struct {
 	busOwned           time.Time          // when current owner acquired the bus
 	pendingStart       *pendingStartState // in-flight START awaiting STARTED/FAILED
 	pendingStartAbsorb int                // stale adapter responses to absorb (FAILED/STARTED from cancelled requests)
+	pendingAbsorbGen   uint64             // generation for stale-response absorb fail-safe timers
 	// Blocking StartArbitration tracking. blockingArbGen is monotonically
 	// increasing (never reset to 0 or reused) — reconnect/handleReset
 	// bump it forward so any stale goroutine's captured gen no longer
@@ -1103,10 +1104,11 @@ func (m *Mux) onReceived(symbol byte) {
 
 	if symbol == protocol.SymbolSyn {
 		// Shape diag: count SYN markers seen during gateway ownership
-		// regardless of whether we deliver (for classification). Must
-		// run BEFORE onSYNLocked so the counter reflects the SYN that
+		// while a gateway transaction is actually active. Pre-write or
+		// post-inactive idle chatter must not contaminate the current txn.
+		// Must run BEFORE onSYNLocked so the counter reflects the SYN that
 		// triggers a possible inactive transition.
-		if hasOwner && ownerID == gatewaySessionID {
+		if hasOwner && ownerID == gatewaySessionID && m.gatewayTxnActive {
 			m.recordReadPrefixAndClassify(symbol)
 		}
 		// Runtime-soak: bus.Send returns BEFORE the trailing SYN (reads
@@ -1115,7 +1117,7 @@ func (m *Mux) onReceived(symbol byte) {
 		// capture AFTER to skip the trailing SYN that has no consumer.
 		var preEchoSuppressed bool
 		passiveEvents, shouldTryGrant, preEchoSuppressed = m.onSYNLocked(phaseEvent, ownerID, hasOwner, now)
-		activeExpects := m.activePathExpectsBytes()
+		activeExpects := m.activePathExpectsByte(symbol)
 		if preEchoSuppressed {
 			// Pre-echo SYN suppression (echo_mismatch root cause fix).
 			// After completeArbitrationGrant, readLoop can read a SYN from
@@ -1191,11 +1193,9 @@ func (m *Mux) onReceived(symbol byte) {
 
 	// Shape diag: capture non-SYN read prefix + echo/non-echo class
 	// while stateMu is held (prefix is a struct field, not atomic).
-	// Restrict to gateway-owned traffic so third-party bytes don't
-	// pollute the per-txn prefix. Includes bytes delivered to activeCh
-	// as well as bytes suppressed — both are "seen" on the wire during
-	// the transaction window.
-	if isGatewayOwned {
+	// Restrict to the live gateway transaction window so pre-write or
+	// post-inactive ownership periods do not pollute the per-txn prefix.
+	if isGatewayOwned && m.gatewayTxnActive {
 		m.recordReadPrefixAndClassify(symbol)
 	}
 
@@ -1219,7 +1219,7 @@ func (m *Mux) onReceived(symbol byte) {
 	// stateMu across the send cannot deadlock.
 	if activeExpects {
 		m.stateMu.Lock()
-		if m.activePathExpectsBytes() {
+		if m.gatewayTxnActive {
 			select {
 			case m.activeCh <- activeEvent{kind: activeEventByte, b: symbol}:
 				// Codex PR #502 P1: count real adapter-originated byte
@@ -1604,6 +1604,24 @@ func (m *Mux) activePathExpectsBytes() bool {
 	return m.gatewayTxnActive
 }
 
+// activePathExpectsByte reports whether a non-SYN byte should be delivered
+// to the active transport. Before the first active byte is delivered, only
+// the next expected echo may pass; stale non-SYN noise must not race the real
+// echo into sendRawWithEcho. After the first delivered byte, the active path
+// owns the transaction stream and response bytes must flow through.
+//
+// Caller must hold stateMu.
+func (m *Mux) activePathExpectsByte(symbol byte) bool {
+	if !m.gatewayTxnActive {
+		return false
+	}
+	if m.activeTxn.bytesDeliveredToActive.Load() > 0 {
+		return true
+	}
+	return m.activeTxn.echoCursor < m.activeTxn.writePrefixLen &&
+		m.activeTxn.writePrefix[m.activeTxn.echoCursor] == symbol
+}
+
 // deliverToActive sends a byte to the active path channel.
 // Logs on overflow instead of silently dropping (CRITICAL-1 fix).
 //
@@ -1668,6 +1686,17 @@ func (m *Mux) tryGrantAndStart() {
 		m.stateMu.Unlock()
 		return
 	}
+	// Do not launch a new START while we still expect at least one stale
+	// STARTED/FAILED from a cancelled or deadline-expired RequestStart.
+	// Gateway requests typically reuse the same initiator (0x71), so once
+	// we have a new pending request there is no reliable way to distinguish
+	// the old STARTED from the new one. Treat pendingStartAbsorb as a real
+	// regrant barrier, not just a best-effort diagnostic counter.
+	if m.pendingStartAbsorb > 0 {
+		m.logger.Printf("adaptermux: tryGrantAndStart skipped — waiting to absorb %d stale arbitration response(s)", m.pendingStartAbsorb)
+		m.stateMu.Unlock()
+		return
+	}
 	// Codex-R5: block regrant while a blocking StartArbitration goroutine
 	// is still in-flight. The deadline may have cleared pendingStart, but
 	// the goroutine is still running on the transport. Starting another
@@ -1697,20 +1726,15 @@ func (m *Mux) tryGrantAndStart() {
 		if m.pendingStart != nil && m.pendingStart.notify == notify {
 			pending := m.pendingStart
 			m.pendingStart = nil
-			m.pendingStartAbsorb++
-			// C2 (PR #502 Copilot): on the blocking path, the
-			// StartArbitration goroutine may still be stuck inside the
-			// transport call. We MUST NOT simply clear blockingArbActive
-			// and re-grant here — that would let a second blocking
-			// goroutine overlap the first on the same transport.
-			// Instead, trigger a transport reconnect: closing m.conn
-			// forces the hung read/write call to return with an I/O
-			// error; readLoop observes the error and invokes reconnect()
-			// which bumps blockingArbGen, clears blockingArbActive, and
-			// fails/re-queues arbitration safely. The hung goroutine's
-			// late return finds a stale gen and skips state mutation.
-			// This yields no overlap AND no queue starvation.
-			needReconnect := pending.blockingArb
+			m.armPendingStartAbsorbLocked("deadline")
+			// Once START times out we no longer trust adapter arbitration
+			// state, even on the non-blocking RequestStart path. A later
+			// STARTED means the adapter granted the old request after we
+			// had already abandoned it; if we simply absorb that event and
+			// launch a new RequestStart, the mux and adapter can stay one
+			// arbitration behind forever. Reconnect is the only reliable
+			// resync boundary for both blocking and non-blocking paths.
+			needReconnect := true
 			m.stateMu.Unlock()
 			m.logger.Printf("adaptermux: pendingStart deadline expired for session %d (AM8)", pending.sessionID)
 			// AM8: guard the send — if another path already delivered a
@@ -1736,10 +1760,6 @@ func (m *Mux) tryGrantAndStart() {
 						m.logger.Printf("adaptermux: deadline triggered transport reconnect to unstick hung StartArbitration (C2)")
 					}
 				}
-			} else if m.arb.hasPending() {
-				// Non-blocking path: no hung goroutine to worry about,
-				// just advance the queue as before.
-				m.tryGrantAndStart()
 			}
 		} else {
 			m.stateMu.Unlock()
@@ -1771,10 +1791,15 @@ func (m *Mux) tryGrantAndStart() {
 				// Since the adapter never received the START, no stale
 				// response will arrive — decrement absorb counter so the
 				// next real arbitration response is not incorrectly consumed.
+				shouldAdvance := false
 				if m.pendingStartAbsorb > 0 {
 					m.pendingStartAbsorb--
+					shouldAdvance = m.pendingStartAbsorb == 0 && m.arb.hasPending()
 				}
 				m.stateMu.Unlock()
+				if shouldAdvance {
+					m.tryGrantAndStart()
+				}
 			}
 			return
 		}
@@ -1993,7 +2018,7 @@ func (m *Mux) completeArbitrationGrant(sessionID uint64, initiator byte, notify 
 			m.logger.Printf("adaptermux: drained %d bytes from activeCh on grant", drained)
 		}
 		m.gatewayEcho.markRequestStart()
-		m.gatewayTxnActive = true
+		m.gatewayTxnActive = false
 		m.recordGatewayGrant(initiator, drained)
 	}
 	m.arb.confirmOwnership(sessionID, initiator)
@@ -2027,12 +2052,29 @@ func (m *Mux) handleArbitrationResponse(started bool, data byte) {
 	// pending request.
 	if m.pendingStartAbsorb > 0 {
 		m.pendingStartAbsorb--
+		shouldAdvance := !started && m.pendingStartAbsorb == 0 && m.pendingStart == nil && m.arb.hasPending()
+		needReconnect := started
 		m.stateMu.Unlock()
 		kind := "FAILED"
 		if started {
 			kind = "STARTED"
 		}
 		m.logger.Printf("adaptermux: absorbed stale %s from cancelled request (data=0x%02X)", kind, data)
+		if needReconnect {
+			m.connMu.Lock()
+			c := m.conn
+			m.connMu.Unlock()
+			if c != nil {
+				if err := c.Close(); err != nil {
+					m.logger.Printf("adaptermux: stale STARTED reconnect close: %v", err)
+				} else {
+					m.logger.Printf("adaptermux: stale STARTED triggered transport reconnect for arbitration resync")
+				}
+			}
+		}
+		if shouldAdvance {
+			m.tryGrantAndStart()
+		}
 		return
 	}
 
@@ -2056,7 +2098,7 @@ func (m *Mux) handleArbitrationResponse(started bool, data byte) {
 			// is no longer tracked. The real response for our pending request
 			// may still arrive — absorb it when it does.
 			m.pendingStart = nil
-			m.pendingStartAbsorb++
+			m.armPendingStartAbsorbLocked("started-mismatch")
 			if pending.deadline != nil {
 				pending.deadline.Stop() // AM8: cancel deadline timer
 			}
@@ -2112,7 +2154,7 @@ func (m *Mux) cancelPendingStart(sessionID uint64) {
 		// The adapter will still send STARTED or FAILED for the cancelled
 		// RequestStart. Increment absorb counter so handleArbitrationResponse
 		// discards that stale response instead of failing a newer request.
-		m.pendingStartAbsorb++
+		m.armPendingStartAbsorbLocked("cancel")
 		// Codex PR #502 P1 (v2 — mirror C2 reconnect pattern): if the
 		// cancelled pending was on the blocking StartArbitration path,
 		// the goroutine may still be hung in the transport call.
@@ -2164,6 +2206,50 @@ func (m *Mux) cancelPendingStart(sessionID uint64) {
 	m.stateMu.Unlock()
 }
 
+// armPendingStartAbsorbLocked records that the mux expects one stale
+// STARTED/FAILED from a cancelled adapter-level START. The hard absorb barrier
+// prevents stale responses from being misapplied to newer requests, but it
+// needs a fail-safe because some adapters may never emit the stale response.
+// On timeout, force a reconnect boundary and clear the barrier so queued STARTs
+// cannot starve forever.
+//
+// Caller must hold stateMu.
+func (m *Mux) armPendingStartAbsorbLocked(reason string) {
+	m.pendingStartAbsorb++
+	m.pendingAbsorbGen++
+	gen := m.pendingAbsorbGen
+	deadline := m.cfg.StartDeadline
+	if deadline <= 0 {
+		deadline = 2 * time.Second
+	}
+	time.AfterFunc(deadline, func() {
+		m.stateMu.Lock()
+		if gen != m.pendingAbsorbGen || m.pendingStartAbsorb == 0 {
+			m.stateMu.Unlock()
+			return
+		}
+		m.logger.Printf("adaptermux: stale arbitration absorb timeout reason=%s count=%d", reason, m.pendingStartAbsorb)
+		m.pendingStartAbsorb = 0
+		m.pendingAbsorbGen++
+		shouldAdvance := m.pendingStart == nil && m.arb.hasPending()
+		m.stateMu.Unlock()
+
+		m.connMu.Lock()
+		c := m.conn
+		m.connMu.Unlock()
+		if c != nil {
+			if err := c.Close(); err != nil {
+				m.logger.Printf("adaptermux: absorb timeout reconnect close: %v", err)
+			} else {
+				m.logger.Printf("adaptermux: absorb timeout triggered transport reconnect for arbitration resync")
+			}
+		}
+		if shouldAdvance {
+			m.tryGrantAndStart()
+		}
+	})
+}
+
 // sendLoop processes send requests from the active path and external sessions.
 func (m *Mux) sendLoop() {
 	defer m.wg.Done()
@@ -2173,6 +2259,18 @@ func (m *Mux) sendLoop() {
 		case <-m.ctx.Done():
 			return
 		case req := <-m.activeSendCh:
+			if req.sessionID == gatewaySessionID {
+				// Arm after sendLoop accepts the request but before doSend
+				// writes to the adapter. That closes the immediate-echo
+				// race without arming transactions that never entered the
+				// mux write path.
+				m.stateMu.Lock()
+				if !m.gatewayTxnActive {
+					m.gatewayTxnActive = true
+				}
+				m.recordWritePrefix(req.data)
+				m.stateMu.Unlock()
+			}
 			err := m.doSend(req.sessionID, req.data)
 			req.result <- err
 		}

--- a/internal/adaptermux/p3_test.go
+++ b/internal/adaptermux/p3_test.go
@@ -400,9 +400,8 @@ func TestArbitrationResponse_SessionDisconnected(t *testing.T) {
 }
 
 // TestRemoveSession_UnblocksNextRequest verifies that RemoveSession
-// calls tryGrantAndStart after clearing the pending START, so the
-// next queued session is serviced immediately without waiting for the
-// adapter's stale response (P3 fix: #3062875632).
+// clears the pending START and advances the next queued session after
+// absorbing the cancelled request's stale adapter response.
 func TestRemoveSession_UnblocksNextRequest(t *testing.T) {
 	mux, mock, _, cleanup := newP3TestMux(t)
 	defer cleanup()
@@ -438,13 +437,74 @@ func TestRemoveSession_UnblocksNextRequest(t *testing.T) {
 	mux.RemoveSession(idA)
 	time.Sleep(50 * time.Millisecond)
 
-	// pendingStart should now be for session B — tryGrantAndStart
-	// was called by RemoveSession and picked up B's queued request.
+	// The cancelled START is still in flight at the adapter. The mux must
+	// wait for and absorb its stale response before issuing B's START,
+	// otherwise the stale STARTED/FAILED cannot be distinguished from B.
+	mux.stateMu.Lock()
+	hasPendingAfterCancel := mux.pendingStart != nil
+	absorbAfterCancel := mux.pendingStartAbsorb
+	mux.stateMu.Unlock()
+	if hasPendingAfterCancel {
+		t.Fatal("pendingStart should be cleared after RemoveSession(A)")
+	}
+	if absorbAfterCancel != 1 {
+		t.Fatalf("pendingStartAbsorb = %d after RemoveSession(A), want 1", absorbAfterCancel)
+	}
+
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventFailed, Data: 0x10}
+	time.Sleep(50 * time.Millisecond)
+
+	// pendingStart should now be for session B — the stale response was
+	// absorbed and tryGrantAndStart picked up B's queued request.
 	mux.stateMu.Lock()
 	hasPendingB := mux.pendingStart != nil && mux.pendingStart.sessionID == idB
+	absorbAfterStale := mux.pendingStartAbsorb
 	mux.stateMu.Unlock()
+	if absorbAfterStale != 0 {
+		t.Fatalf("pendingStartAbsorb = %d after stale FAILED, want 0", absorbAfterStale)
+	}
 	if !hasPendingB {
-		t.Fatal("expected pendingStart to advance to session B after RemoveSession(A)")
+		t.Fatal("expected pendingStart to advance to session B after absorbing stale FAILED")
+	}
+}
+
+func TestPendingStartAbsorbTimeoutUnblocksQueue(t *testing.T) {
+	mux, _, _, cleanup := newP3TestMux(t)
+	defer cleanup()
+	mux.cfg.StartDeadline = 50 * time.Millisecond
+
+	client, server := net.Pipe()
+	defer closeOrLog(t, client, "client")
+	id := mux.AddSession(server)
+	defer mux.RemoveSession(id)
+
+	mux.arb.requestStart(id, 0x66)
+
+	mux.stateMu.Lock()
+	mux.armPendingStartAbsorbLocked("test")
+	mux.stateMu.Unlock()
+
+	deadline := time.Now().Add(300 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		mux.stateMu.Lock()
+		absorb := mux.pendingStartAbsorb
+		hasPending := mux.pendingStart != nil && mux.pendingStart.sessionID == id
+		mux.stateMu.Unlock()
+		if absorb == 0 && hasPending {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	mux.stateMu.Lock()
+	absorb := mux.pendingStartAbsorb
+	hasPending := mux.pendingStart != nil && mux.pendingStart.sessionID == id
+	mux.stateMu.Unlock()
+	if absorb != 0 {
+		t.Fatalf("pendingStartAbsorb = %d after absorb timeout, want 0", absorb)
+	}
+	if !hasPending {
+		t.Fatal("expected queued START to advance after absorb timeout")
 	}
 }
 
@@ -1416,17 +1476,23 @@ func TestHandleArbitrationResponse_StaleFailedIgnored(t *testing.T) {
 	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: protocol.SymbolSyn}
 	time.Sleep(50 * time.Millisecond)
 
-	// Verify pendingStart exists for B.
+	// New invariant: B must NOT start until A's stale response has been
+	// absorbed. The absorb counter is now a real regrant barrier.
 	mux.stateMu.Lock()
 	hasPending = mux.pendingStart != nil
+	starts := mock.getStartRequests()
 	mux.stateMu.Unlock()
-	if !hasPending {
-		t.Fatal("expected pendingStart after SYN for request B")
+	if hasPending {
+		t.Fatal("pendingStart for B must stay nil until stale FAILED is absorbed")
+	}
+	if len(starts) != 1 {
+		t.Fatalf("RequestStart calls before stale FAILED = %d, want 1", len(starts))
 	}
 
 	// --- Phase 4: Inject stale FAILED for A ---
 	// FAILED data=0x10 (the winner of that old arbitration round — irrelevant).
-	// This must be absorbed by the counter, NOT fail request B.
+	// This must be absorbed by the counter, NOT fail request B. After absorb,
+	// tryGrantAndStart should automatically launch B.
 	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventFailed, Data: 0x10}
 	time.Sleep(50 * time.Millisecond)
 
@@ -1438,16 +1504,20 @@ func TestHandleArbitrationResponse_StaleFailedIgnored(t *testing.T) {
 		// Good — stale FAILED was absorbed.
 	}
 
-	// pendingStart must still be set (B's request preserved).
+	// B should now have been started.
 	mux.stateMu.Lock()
 	hasPending = mux.pendingStart != nil
 	absorb = mux.pendingStartAbsorb
 	mux.stateMu.Unlock()
 	if !hasPending {
-		t.Fatal("pendingStart should still be set after stale FAILED")
+		t.Fatal("pendingStart for B should be set after stale FAILED is absorbed")
 	}
 	if absorb != 0 {
 		t.Fatalf("pendingStartAbsorb = %d after absorbing stale FAILED, want 0", absorb)
+	}
+	starts = mock.getStartRequests()
+	if len(starts) != 2 {
+		t.Fatalf("RequestStart calls after stale FAILED = %d, want 2", len(starts))
 	}
 
 	// --- Phase 5: Correct STARTED for B ---
@@ -1477,6 +1547,107 @@ func TestHandleArbitrationResponse_StaleFailedIgnored(t *testing.T) {
 	mux.stateMu.Unlock()
 	if hasPending {
 		t.Fatal("pendingStart should be nil after correct STARTED for B")
+	}
+}
+
+// TestTryGrantAndStart_WaitsForStaleStartedAbsorb verifies the key safety
+// invariant for gateway regrant: after a pending START is cancelled, the mux
+// must NOT issue the next RequestStart until the stale STARTED/FAILED from the
+// cancelled request has been handled. Gateway requests frequently reuse the
+// same initiator (0x71), so launching B before A's stale STARTED arrives makes
+// the response ambiguous and can consume B's valid STARTED as stale.
+//
+// A stale FAILED is safe to absorb and advance past. A stale STARTED is not:
+// on the adapter it means the old request really won arbitration, so the mux
+// must force a reconnect/resync rather than launch the next request inline.
+func TestTryGrantAndStart_WaitsForStaleStartedAbsorb(t *testing.T) {
+	mux, mock, _, cleanup := newP3TestMux(t)
+	defer cleanup()
+
+	// Request A for the gateway and let it reach the adapter.
+	chA := mux.arb.requestStart(gatewaySessionID, 0x71)
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: protocol.SymbolSyn}
+	time.Sleep(50 * time.Millisecond)
+
+	starts := mock.getStartRequests()
+	if len(starts) != 1 || starts[0] != 0x71 {
+		t.Fatalf("RequestStart calls after A = %v, want [0x71]", starts)
+	}
+
+	// Cancel A. This sets the absorb barrier because the adapter can still
+	// emit STARTED/FAILED for that old RequestStart.
+	mux.cancelPendingStart(gatewaySessionID)
+
+	select {
+	case result := <-chA:
+		if result.granted {
+			t.Fatal("cancelled request A should not be granted")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for cancel result on A")
+	}
+
+	mux.stateMu.Lock()
+	absorb := mux.pendingStartAbsorb
+	hasPending := mux.pendingStart != nil
+	mux.stateMu.Unlock()
+	if absorb != 1 {
+		t.Fatalf("pendingStartAbsorb after cancel = %d, want 1", absorb)
+	}
+	if hasPending {
+		t.Fatal("pendingStart should be nil after cancel")
+	}
+
+	// Queue request B with the same initiator and feed another SYN.
+	// The mux must NOT issue RequestStart(B) yet because A's stale response
+	// has not been absorbed.
+	chB := mux.arb.requestStart(gatewaySessionID, 0x71)
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: protocol.SymbolSyn}
+	time.Sleep(50 * time.Millisecond)
+
+	starts = mock.getStartRequests()
+	if len(starts) != 1 {
+		t.Fatalf("RequestStart should be blocked by absorb barrier; got %d calls, want 1", len(starts))
+	}
+
+	mux.stateMu.Lock()
+	hasPending = mux.pendingStart != nil
+	absorb = mux.pendingStartAbsorb
+	mux.stateMu.Unlock()
+	if hasPending {
+		t.Fatal("pendingStart for B must not be created before stale response is absorbed")
+	}
+	if absorb != 1 {
+		t.Fatalf("pendingStartAbsorb before stale STARTED = %d, want 1", absorb)
+	}
+
+	// Deliver stale STARTED for A. The mux must absorb it and keep B blocked:
+	// stale STARTED means the adapter really granted the cancelled request, so
+	// the mux cannot safely launch B inline. Production code forces a reconnect
+	// boundary here; in this unit test there is no real conn, so we just assert
+	// that B is NOT launched spuriously.
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventStarted, Data: 0x71}
+	time.Sleep(50 * time.Millisecond)
+
+	starts = mock.getStartRequests()
+	if len(starts) != 1 {
+		t.Fatalf("RequestStart for B must stay blocked after stale STARTED; got %d calls, want 1", len(starts))
+	}
+
+	mux.stateMu.Lock()
+	hasPending = mux.pendingStart != nil
+	absorb = mux.pendingStartAbsorb
+	mux.stateMu.Unlock()
+	if hasPending {
+		t.Fatal("pendingStart for B must remain nil after stale STARTED; reconnect/resync is required")
+	}
+	if absorb != 0 {
+		t.Fatalf("pendingStartAbsorb after stale STARTED = %d, want 0", absorb)
+	}
+	select {
+	case result := <-chB:
+		t.Fatalf("request B must not resolve inline after stale STARTED: %+v", result)
+	default:
 	}
 }
 

--- a/internal/adaptermux/pr502_review_test.go
+++ b/internal/adaptermux/pr502_review_test.go
@@ -732,28 +732,29 @@ func TestActivePath_RealFlow_NoAccumulationAfterTxnSyn(t *testing.T) {
 	}
 }
 
-// TestActivePath_EarlyAbort_SYNBeforeRead_StaysActive verifies the
-// lifecycle-correctness rule: a SYN arriving during gateway ownership
-// BEFORE any response byte has been read does NOT terminate the
-// transaction as syn_idle. This is a pre-grant stale SYN from the TCP
-// buffer (normal grant-handoff residual).
+// TestActivePath_EarlyAbort_SYNBeforeRead_StaysInactive verifies the
+// lifecycle-correctness rule: a SYN arriving during gateway ownership before
+// the active caller starts Write does not arm or terminate the active
+// transaction. This is a pre-write stale SYN from the TCP buffer (normal
+// grant-handoff residual).
 //
 // Genuine aborts (no writes, no reads) are resolved by MaxOwnershipDuration,
 // ActiveReadTimeout, ActiveWriteError, ctx cancel, reset, or reconnect —
 // NOT by SYN alone.
-func TestActivePath_EarlyAbort_SYNBeforeRead_StaysActive(t *testing.T) {
+func TestActivePath_EarlyAbort_SYNBeforeRead_StaysInactive(t *testing.T) {
 	mux, mock, _, cleanup := newP3TestMux(t)
 	defer cleanup()
 
 	grantGateway(t, mux, mock, 0x71)
 
-	// Pre-grant stale SYN arrives with no reads yet. Must NOT clear.
+	// Pre-write stale SYN arrives with no reads yet. It must not arm the
+	// active path and must not produce an inactive reason.
 	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: protocol.SymbolSyn}
 	time.Sleep(30 * time.Millisecond)
 
 	snap := mux.ActiveTxnSnapshot()
-	if !snap.Active {
-		t.Fatalf("activeTxn must stay active on SYN-before-read; got inactive reason=%q", snap.InactiveReason)
+	if snap.Active {
+		t.Fatalf("activeTxn must stay inactive before first Write; got inactive reason=%q", snap.InactiveReason)
 	}
 	if snap.InactiveReason != ReasonNone {
 		t.Fatalf("InactiveReason must be empty, got %q", snap.InactiveReason)

--- a/internal/adaptermux/syn_diag_test.go
+++ b/internal/adaptermux/syn_diag_test.go
@@ -225,19 +225,11 @@ func TestOnSYNLocked_DeliversTerminatorToActive_WhenBytesReadPositive(t *testing
 }
 
 // TestOnSYNLocked_NoTerminatorDeliveryWhenBytesReadZero documents the
-// pre-grant-stale-SYN semantics we intentionally preserve AND the
-// pre-echo suppression fix (echo_mismatch root cause): a SYN arriving
-// BEFORE any read byte has been consumed must NOT be treated as a
-// terminator (it is almost certainly a TCP-buffered byte from before
-// the grant) AND must NOT be delivered to activeCh (delivering it
-// would race the real echo byte and cause sendRawWithEcho to read 0xAA
-// instead of the expected echo, emitting echo_mismatch — 13,904 events
-// observed in production soak before the fix).
-//
-// gatewayTxnActive stays true (txn is NOT terminated by this SYN); the
-// SYN is swallowed and the synSuppressedPreEcho counter increments.
-// The SYN diag entry records this as gwAfter=true AND synDelivered=false
-// (pre-echo suppression beats the normal deliver path).
+// pre-write stale-SYN semantics: a SYN arriving after grant but before the
+// active caller has started Write must not be treated as a terminator and
+// must not be delivered to activeCh. The active transaction is armed by
+// Write, so this SYN is ignored rather than counted as active pre-echo
+// suppression.
 func TestOnSYNLocked_NoTerminatorDeliveryWhenBytesReadZero(t *testing.T) {
 	mux, mock, _, cleanup := newP3TestMux(t)
 	defer cleanup()
@@ -252,30 +244,29 @@ func TestOnSYNLocked_NoTerminatorDeliveryWhenBytesReadZero(t *testing.T) {
 	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: protocol.SymbolSyn}
 	time.Sleep(50 * time.Millisecond)
 
-	// gatewayTxnActive should still be true (we did NOT clear on this SYN).
+	// gatewayTxnActive has not been armed yet because no Write started.
 	snap := mux.ActiveTxnSnapshot()
-	if !snap.Active {
-		t.Errorf("ActiveTxnSnapshot.Active=false, want true — pre-grant-stale SYN (bytesRead==0) must NOT clear gatewayTxnActive")
+	if snap.Active {
+		t.Errorf("ActiveTxnSnapshot.Active=true, want false before first Write")
 	}
 	if snap.InactiveReason == ReasonSYNTerminator {
 		t.Errorf("InactiveReason=%q — terminator path must NOT fire when bytesRead==0", snap.InactiveReason)
 	}
 
-	// Pre-echo suppression counter must have incremented for this SYN.
-	if snap.SynSuppressedPreEcho <= before {
-		t.Errorf("SynSuppressedPreEcho=%d before=%d, want increment — pre-echo SYN must be counted as suppressed", snap.SynSuppressedPreEcho, before)
+	// The SYN is ignored before Write arms the active transaction.
+	if snap.SynSuppressedPreEcho != before {
+		t.Errorf("SynSuppressedPreEcho=%d before=%d, want unchanged before first Write", snap.SynSuppressedPreEcho, before)
 	}
 
-	// SYN diag entry: gwAfter=true (txn stays active), synDelivered=FALSE
-	// (pre-echo suppression prevents activeCh delivery). Inverted from
-	// the pre-fix assertion which asserted synDelivered=true.
+	// SYN diag entry: no active transaction was armed, and nothing reached
+	// activeCh.
 	entries := mux.SynDiagSnapshot()
 	if len(entries) == 0 {
 		t.Fatalf("SynDiagSnapshot empty, want >=1 entry")
 	}
 	last := entries[len(entries)-1]
-	if !last.GwActiveAfter {
-		t.Errorf("SynDiagEntry.GwActiveAfter=false, want true (pre-grant-stale SYN preserves active state)")
+	if last.GwActiveAfter {
+		t.Errorf("SynDiagEntry.GwActiveAfter=true, want false before first Write")
 	}
 	if last.SynDeliveredToActive {
 		t.Errorf("SynDiagEntry.SynDeliveredToActive=true, want false — pre-echo SYN must be suppressed from activeCh (echo_mismatch fix)")
@@ -316,6 +307,10 @@ func TestEchoMismatch_SYNAfterGrantBeforeFirstEcho(t *testing.T) {
 	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: protocol.SymbolSyn}
 	time.Sleep(20 * time.Millisecond)
 
+	if _, err := at.Write([]byte{0x15}); err != nil {
+		t.Fatalf("Write err=%v", err)
+	}
+
 	// Then inject the real echo byte that bus.Send would expect to read
 	// back (0x15 — source of a scan from 0x15 targeting 0x08).
 	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x15}
@@ -333,10 +328,11 @@ func TestEchoMismatch_SYNAfterGrantBeforeFirstEcho(t *testing.T) {
 		t.Fatalf("ReadByte=0x%02X, want 0x15 (the real echo)", b)
 	}
 
-	// Confirm the suppression counter fired for the stale SYN.
+	// The stale SYN arrived before Write armed the active transaction, so it
+	// is ignored rather than counted as an active pre-echo suppression.
 	after := mux.ActiveTxnSnapshot().SynSuppressedPreEcho
-	if after <= before {
-		t.Errorf("SynSuppressedPreEcho=%d before=%d, want increment — stale SYN should have been counted as suppressed", after, before)
+	if after != before {
+		t.Errorf("SynSuppressedPreEcho=%d before=%d, want unchanged for pre-write SYN", after, before)
 	}
 
 	// Gateway still owns the bus and the txn is still active — the stale


### PR DESCRIPTION
## What

Preserve and isolate the active adaptermux diagnostics work from the local `issue/521-vaillant-b503-portal` branch:

- start the active transaction window on the first gateway write instead of grant;
- avoid contaminating transaction diagnostics with pre-write / post-inactive bus noise;
- classify SYN-terminated echo-only traffic as `echo_only_timeout`, not success;
- keep echo matching aligned when leading SYN chatter precedes echoed request bytes;
- treat pending START absorbs as a regrant barrier and force resync on stale STARTED.

## Why

This came out of the live adaptermux traffic investigation: we saw SYN-only / echo-only paths and stale arbitration responses producing misleading transaction classes and potentially ambiguous regrant behavior. This PR keeps that work separate from the already-merged INFO bootstrap pacing PR.

## Validation

```bash
go test ./internal/adaptermux -run 'TestTxnClass|TestActiveTxnDiag|TestHandleArbitrationResponse_StaleFailedIgnored|TestTryGrantAndStart_WaitsForStaleStartedAbsorb'
```