### PR TITLE
chore: gitignore .claude/ orchestrator-session artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ portal/web/node_modules/
 
 /gateway
 /helianthus-gateway-arm64
+
+# Claude Code orchestrator-session artifacts (per-session tool/skills config, not repo-tracked)
+.claude/


### PR DESCRIPTION
Gitignore Claude Code .claude/ directories (per-session tool/skills config, similar to .vscode/.idea/). Not repo-level infrastructure; workspace-root skills read from filesystem so cross-repo review infra unaffected.

LANE C internal chore. No logic change.