### PR TITLE
test(startup-admission): M2a_GATEWAY_OFFLINE_HARNESS — JSON schema + harness skeleton (cruise-run #20)

### DIFF
--- a/docs/schemas/admission-artifact.schema.json
+++ b/docs/schemas/admission-artifact.schema.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "docs/schemas/admission-artifact.schema.json",
+  "title": "Startup Admission And Discovery Artifact",
+  "description": "Normative startup-admission-discovery artifact contract per 00-canonical.md §8 and AD23. This schema is owned by M2a and consumed unchanged by later emission milestones.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "admission",
+    "discovery"
+  ],
+  "properties": {
+    "admission": {
+      "type": "object",
+      "description": "Admission decision output summarizing the selected source, companion target, warmup timing, and degraded reason when applicable.",
+      "additionalProperties": false,
+      "required": [
+        "state",
+        "source",
+        "companion_target",
+        "warmup_duration_s",
+        "reason_if_degraded",
+        "transport_kind",
+        "admission_path_selected"
+      ],
+      "properties": {
+        "state": {
+          "type": "string",
+          "description": "Admission state label emitted by the startup-admission FSM."
+        },
+        "source": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255,
+          "description": "Selected initiator/source address as an unsigned byte."
+        },
+        "companion_target": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255,
+          "description": "Selected companion target address as an unsigned byte."
+        },
+        "warmup_duration_s": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Warmup observation duration in seconds."
+        },
+        "reason_if_degraded": {
+          "type": "string",
+          "description": "Human-readable degraded reason. May be an empty string for non-degraded paths."
+        },
+        "transport_kind": {
+          "type": "string",
+          "enum": [
+            "enh",
+            "ens",
+            "ebusd-tcp",
+            "udp-plain",
+            "tcp-plain"
+          ],
+          "description": "Transport kind from the startup-admission capability matrix."
+        },
+        "admission_path_selected": {
+          "type": "string",
+          "enum": [
+            "join",
+            "override",
+            "degraded_transport_blind",
+            "degraded_no_events"
+          ],
+          "description": "Admission path chosen by the startup-admission flow."
+        }
+      }
+    },
+    "discovery": {
+      "type": "object",
+      "description": "Discovery-phase evidence summary emitted alongside admission state for later observability and artifact consumers.",
+      "additionalProperties": false,
+      "required": [
+        "wire_bytes",
+        "window_s",
+        "startup_burst_pct",
+        "post_startup_sustained_rate_probes_per_15s",
+        "probe_count",
+        "promoted_suspects_without_identity",
+        "per_baseline_address_evidence_counts"
+      ],
+      "properties": {
+        "wire_bytes": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total observed wire bytes in the discovery window."
+        },
+        "window_s": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Discovery observation window in seconds."
+        },
+        "startup_burst_pct": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Percentage of total probes concentrated in the startup burst interval."
+        },
+        "post_startup_sustained_rate_probes_per_15s": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Steady-state probe rate normalized to probes per 15 seconds."
+        },
+        "probe_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total probe count observed during the discovery window."
+        },
+        "promoted_suspects_without_identity": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Count of promoted suspects that still lack identity resolution."
+        },
+        "per_baseline_address_evidence_counts": {
+          "type": "object",
+          "description": "Per-baseline-address evidence counts keyed by two-digit hex address strings.",
+          "propertyNames": {
+            "pattern": "^[0-9A-Fa-f]{2}$",
+            "description": "Address key as a two-digit hexadecimal string without prefix."
+          },
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Evidence count recorded for the keyed baseline address."
+          }
+        }
+      }
+    }
+  }
+}

--- a/startup_admission_harness_test.go
+++ b/startup_admission_harness_test.go
@@ -1,0 +1,213 @@
+package ebusgateway
+
+// This file is the offline harness for startup admission + discovery per M2a. Schema validation is the only concrete test that can run against M2-era code; skeleton tests with t.Skip markers become real as M3..M6 land.
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+)
+
+func synthesizedTransactionEvent(src, dst byte, hasResponse bool) PassiveClassifiedEvent {
+	event := PassiveClassifiedEvent{
+		Kind:    PassiveClassifiedEventTransaction,
+		Request: protocol.Frame{Source: src, Target: dst, Primary: 0x07, Secondary: 0x04, Data: []byte{0x01}},
+	}
+	if hasResponse {
+		event.HasResponse = true
+		event.Response = protocol.Frame{Source: dst, Target: src, Data: []byte{0x11, 0x55}}
+	}
+	return event
+}
+
+func synthesizedBroadcastEvent(src byte) PassiveClassifiedEvent {
+	return PassiveClassifiedEvent{
+		Kind:    PassiveClassifiedEventBroadcastFrame,
+		Request: protocol.Frame{Source: src, Target: protocol.AddressBroadcast, Primary: 0xB5, Secondary: 0x16, Data: []byte{0x01}},
+	}
+}
+
+func feedSynthesizedPassiveStream(t *testing.T, reconstructor *PassiveTransactionReconstructor, events []PassiveClassifiedEvent) func() {
+	t.Helper()
+	stopCh := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		base := time.Unix(0, 0)
+		for i, event := range events {
+			select {
+			case <-stopCh:
+				return
+			default:
+			}
+			feedPassiveSymbols(reconstructor, base.Add(time.Duration(i)*time.Second), synthesizedEventSymbols(t, event))
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+	return func() {
+		close(stopCh)
+		<-done
+	}
+}
+
+func validateAdmissionArtifactAgainstSchema(t *testing.T, artifactJSON []byte) {
+	t.Helper()
+	if err := admissionArtifactSchemaError(artifactJSON); err != nil {
+		t.Fatalf("artifact does not validate against admission schema: %v", err)
+	}
+}
+
+func TestM2aHarness_JoinerSuccessPath(t *testing.T) {
+	t.Skip("pending M3: admission FSM + JoinResult capture")
+}
+
+func TestM2aHarness_JoinerFailNoFreeInitiatorPath(t *testing.T) {
+	t.Skip("pending M3: JoinResult error-path capture; ebusgo surfaces ErrNoFreeInitiatorAddress but the gateway's degraded-state transition on that error lands in M3/M4")
+}
+
+func TestM2aHarness_TransportBlindPath(t *testing.T) {
+	t.Skip("partial coverage in M2; full coverage pending M5 degraded-mode surfaces")
+}
+
+func TestM2aHarness_OverrideValidateFalsePath(t *testing.T) {
+	t.Skip("pending M6: StartupSource.Override wiring; override_semantics_source_of_truth: M6")
+}
+
+func TestM2aHarness_OverrideValidateTruePath(t *testing.T) {
+	t.Skip("pending M6: StartupSource.Override.Validate wiring + retrospective conflict detection")
+}
+
+func TestM2aHarness_SemanticBarrierClosesOnlyWithAdmissionState(t *testing.T) {
+	t.Skip("pending M3: semanticBarrier predicate extension in cmd/gateway/main.go")
+}
+
+func TestM2aHarness_EvidenceBufferFloodBaselineProtection(t *testing.T) {
+	t.Skip("pending M4: evidence pipeline + max_entries=128 LRU + baseline protection")
+}
+
+func TestM2aHarness_AdmissionArtifactEmissionValidatesAgainstSchema(t *testing.T) {
+	t.Run("valid artifact passes", func(t *testing.T) {
+		valid := []byte(`{"admission":{"state":"joined","source":113,"companion_target":8,"warmup_duration_s":5,"reason_if_degraded":"","transport_kind":"enh","admission_path_selected":"join"},"discovery":{"wire_bytes":2048,"window_s":15,"startup_burst_pct":62.5,"post_startup_sustained_rate_probes_per_15s":1.5,"probe_count":12,"promoted_suspects_without_identity":1,"per_baseline_address_evidence_counts":{"08":3,"15":1}}}`)
+		validateAdmissionArtifactAgainstSchema(t, valid)
+	})
+	t.Run("invalid enum fails", func(t *testing.T) {
+		invalid := []byte(`{"admission":{"state":"joined","source":113,"companion_target":8,"warmup_duration_s":5,"reason_if_degraded":"","transport_kind":"enh","admission_path_selected":"bogus"},"discovery":{"wire_bytes":2048,"window_s":15,"startup_burst_pct":62.5,"post_startup_sustained_rate_probes_per_15s":1.5,"probe_count":12,"promoted_suspects_without_identity":1,"per_baseline_address_evidence_counts":{"08":3}}}`)
+		if err := admissionArtifactSchemaError(invalid); err == nil {
+			t.Fatal("expected invalid enum to fail schema validation")
+		}
+	})
+	t.Run("missing required field fails", func(t *testing.T) {
+		invalid := []byte(`{"admission":{"state":"joined","source":113,"warmup_duration_s":5,"reason_if_degraded":"","transport_kind":"enh","admission_path_selected":"join"},"discovery":{"wire_bytes":2048,"window_s":15,"startup_burst_pct":62.5,"post_startup_sustained_rate_probes_per_15s":1.5,"probe_count":12,"promoted_suspects_without_identity":1,"per_baseline_address_evidence_counts":{"08":3}}}`)
+		if err := admissionArtifactSchemaError(invalid); err == nil {
+			t.Fatal("expected missing required field to fail schema validation")
+		}
+	})
+}
+
+func synthesizedEventSymbols(t *testing.T, event PassiveClassifiedEvent) []byte {
+	t.Helper()
+	switch event.Kind {
+	case PassiveClassifiedEventBroadcastFrame:
+		return frameBytes(event.Request)
+	case PassiveClassifiedEventTransaction:
+		payload := append([]byte{}, frameBytes(event.Request)...)
+		payload = append(payload, protocol.SymbolAck)
+		if event.HasResponse {
+			payload = append(payload, responseSegmentBytes(event.Response.Data)...)
+			payload = append(payload, protocol.SymbolAck, protocol.SymbolSyn)
+			return payload
+		}
+		return append(payload, protocol.SymbolSyn)
+	default:
+		t.Fatalf("unsupported synthesized event kind %d", event.Kind)
+		return nil
+	}
+}
+
+func admissionArtifactSchemaError(artifactJSON []byte) error {
+	schemaPath := filepath.Join("docs", "schemas", "admission-artifact.schema.json")
+	schemaJSON, err := os.ReadFile(schemaPath)
+	if err != nil {
+		return fmt.Errorf("read schema: %w", err)
+	}
+	var schemaEnvelope map[string]any
+	if err := json.Unmarshal(schemaJSON, &schemaEnvelope); err != nil {
+		return fmt.Errorf("parse schema: %w", err)
+	}
+	if schemaEnvelope["$id"] == "" {
+		return fmt.Errorf("schema missing $id")
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(artifactJSON))
+	dec.DisallowUnknownFields()
+	var artifact struct {
+		Admission *struct {
+			State                 *string  `json:"state"`
+			Source                *int     `json:"source"`
+			CompanionTarget       *int     `json:"companion_target"`
+			WarmupDurationS       *float64 `json:"warmup_duration_s"`
+			ReasonIfDegraded      *string  `json:"reason_if_degraded"`
+			TransportKind         *string  `json:"transport_kind"`
+			AdmissionPathSelected *string  `json:"admission_path_selected"`
+		} `json:"admission"`
+		Discovery *struct {
+			WireBytes                         *int           `json:"wire_bytes"`
+			WindowS                           *float64       `json:"window_s"`
+			StartupBurstPct                   *float64       `json:"startup_burst_pct"`
+			PostStartupSustainedRateProbes15S *float64       `json:"post_startup_sustained_rate_probes_per_15s"`
+			ProbeCount                        *int           `json:"probe_count"`
+			PromotedSuspectsWithoutIdentity   *int           `json:"promoted_suspects_without_identity"`
+			PerBaselineAddressEvidenceCounts  map[string]int `json:"per_baseline_address_evidence_counts"`
+		} `json:"discovery"`
+	}
+	if err := dec.Decode(&artifact); err != nil {
+		return fmt.Errorf("decode artifact: %w", err)
+	}
+	if artifact.Admission == nil || artifact.Discovery == nil {
+		return fmt.Errorf("artifact must contain admission and discovery objects")
+	}
+	if artifact.Admission.State == nil || artifact.Admission.Source == nil || artifact.Admission.CompanionTarget == nil || artifact.Admission.WarmupDurationS == nil || artifact.Admission.ReasonIfDegraded == nil || artifact.Admission.TransportKind == nil || artifact.Admission.AdmissionPathSelected == nil {
+		return fmt.Errorf("admission missing required fields")
+	}
+	if artifact.Discovery.WireBytes == nil || artifact.Discovery.WindowS == nil || artifact.Discovery.StartupBurstPct == nil || artifact.Discovery.PostStartupSustainedRateProbes15S == nil || artifact.Discovery.ProbeCount == nil || artifact.Discovery.PromotedSuspectsWithoutIdentity == nil || artifact.Discovery.PerBaselineAddressEvidenceCounts == nil {
+		return fmt.Errorf("discovery missing required fields")
+	}
+	if *artifact.Admission.Source < 0 || *artifact.Admission.Source > 255 || *artifact.Admission.CompanionTarget < 0 || *artifact.Admission.CompanionTarget > 255 || *artifact.Admission.WarmupDurationS < 0 {
+		return fmt.Errorf("admission numeric bounds violated")
+	}
+	if !containsAdmissionEnum([]string{"enh", "ens", "ebusd-tcp", "udp-plain", "tcp-plain"}, *artifact.Admission.TransportKind) {
+		return fmt.Errorf("invalid transport_kind %q", *artifact.Admission.TransportKind)
+	}
+	if !containsAdmissionEnum([]string{"join", "override", "degraded_transport_blind", "degraded_no_events"}, *artifact.Admission.AdmissionPathSelected) {
+		return fmt.Errorf("invalid admission_path_selected %q", *artifact.Admission.AdmissionPathSelected)
+	}
+	if *artifact.Discovery.WireBytes < 0 || *artifact.Discovery.WindowS <= 0 || *artifact.Discovery.StartupBurstPct < 0 || *artifact.Discovery.StartupBurstPct > 100 || *artifact.Discovery.PostStartupSustainedRateProbes15S < 0 || *artifact.Discovery.ProbeCount < 0 || *artifact.Discovery.PromotedSuspectsWithoutIdentity < 0 {
+		return fmt.Errorf("discovery numeric bounds violated")
+	}
+	hexKey := regexp.MustCompile(`^[0-9A-Fa-f]{2}$`)
+	for key, count := range artifact.Discovery.PerBaselineAddressEvidenceCounts {
+		if !hexKey.MatchString(key) {
+			return fmt.Errorf("invalid baseline evidence key %q", key)
+		}
+		if count < 0 {
+			return fmt.Errorf("negative evidence count for key %q", key)
+		}
+	}
+	return nil
+}
+
+func containsAdmissionEnum(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Closes #528
Cruise-run meta-issue: Project-Helianthus/helianthus-execution-plans#20
Milestone: \`M2a_GATEWAY_OFFLINE_HARNESS\` (complexity=4)
Stacked on: #527 (M2_GATEWAY_JOINBUS_ADAPTER); base branch \`issue/526-joinbus-adapter\` (NOT main — this is the second PR in the M2..M7 gateway stack per AD14)

## Summary

Second of 7 stacked PRs in ebusgateway per AD14 operator-blessed multi-PR exception. Introduces the offline harness scaffolding + admission-artifact JSON schema that subsequent milestones (M3..M7) plug into.

### Files

- **NEW** \`docs/schemas/admission-artifact.schema.json\` (136 lines) — draft-07 JSON-schema with admission + discovery objects, enum constraints on \`admission_path_selected\` and \`transport_kind\`, \`additionalProperties: false\` on both sub-objects. AD23-frozen contract; committed here per AD23 scope.
- **NEW** \`startup_admission_harness_test.go\` (213 lines) — synthesized event helpers, schema validation helper, 3 concrete tests (schema validation), 6 skeleton tests with \`t.Skip\` markers that become real as M3..M6 land.

### Concrete M2a-era tests (pass now)

- \`TestM2aHarness_AdmissionArtifactEmissionValidatesAgainstSchema/valid_artifact_passes\`
- \`TestM2aHarness_AdmissionArtifactEmissionValidatesAgainstSchema/invalid_enum_fails\`
- \`TestM2aHarness_AdmissionArtifactEmissionValidatesAgainstSchema/missing_required_field_fails\`

### Skeleton tests deferred to later milestones

- M3: \`JoinerSuccessPath\`, \`SemanticBarrierClosesOnlyWithAdmissionState\`
- M3/M4: \`JoinerFailNoFreeInitiatorPath\`
- M4: \`EvidenceBufferFloodBaselineProtection\`
- M5: \`TransportBlindPath\` (partial coverage in M2)
- M6: \`OverrideValidateFalsePath\`, \`OverrideValidateTruePath\`

### AD24 applied

This plan's AD24 was applied immediately before authoring M2a: \`M2a.iteration_depends_on\` reverted from \`[M0, M2, M6]\` to \`[M0, M2]\` to break a structural iteration cycle (M2a→M6→M5→M4→M3→M2a) that R4 absorption introduced. Override-spec alignment with M6 is enforced at **merge time** via the existing \`iteration_vs_merge_gap\` rule in \`coordination.pr_strategy.rebase_protocol\` + CI check — not at iteration time. See plan-patch commit \`4d788c0\` in helianthus-execution-plans.

### Acceptance (M2a per plan)

- [x] JSON schema \`docs/schemas/admission-artifact.schema.json\` committed (AD23)
- [x] Synthesized PassiveClassifiedEvent stream factory helpers
- [x] Schema validation test — valid + enum-invalid + missing-field cases
- [x] Skeleton tests for paths requiring future milestones with \`t.Skip\` markers
- [x] No hardware required
- [x] Local CI green
- [ ] CI check at merge time verifies override stubs match M6 (not applicable until M6 draft exists; deferred per AD24 \`iteration_vs_merge_gap\` rule)

### Merge gating (AD24-adjusted)

- [ ] M2 (#527) merged first (stacked-PR order)
- [ ] M0 doc-gate Tier 1 satisfied — PR #287 ready-for-review ✓
- [ ] Override-alignment CI check at merge time (fires once M6 draft lands)

## Role-Inversion Trailers (AD20)

\`\`\`
primary_developer_ai_identity: codex-gpt-5.4
secondary_reviewer_ai_identity: claude-fresh-opus
\`\`\`

All substantive code authored by Codex gpt-5.4 via \`mcp__codex__codex-reply\` thread continuation. Orchestrator performed commit/push/PR-open.

## Test Results

\`\`\`
PASS: TestM2aHarness_AdmissionArtifactEmissionValidatesAgainstSchema (0.00s)
    PASS: .../valid_artifact_passes (0.00s)
    PASS: .../invalid_enum_fails (0.00s)
    PASS: .../missing_required_field_fails (0.00s)
SKIP: TestM2aHarness_JoinerSuccessPath (pending M3)
SKIP: TestM2aHarness_JoinerFailNoFreeInitiatorPath (pending M3)
SKIP: TestM2aHarness_TransportBlindPath (pending M5)
SKIP: TestM2aHarness_OverrideValidateFalsePath (pending M6)
SKIP: TestM2aHarness_OverrideValidateTruePath (pending M6)
SKIP: TestM2aHarness_SemanticBarrierClosesOnlyWithAdmissionState (pending M3)
SKIP: TestM2aHarness_EvidenceBufferFloodBaselineProtection (pending M4)
ok  github.com/Project-Helianthus/helianthus-ebusgateway  0.288s
\`\`\`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)