### PR TITLE
feat(evidence,admission): M4 — evidence pipeline + escalation accumulator + rejoin backoff (cruise-run #20)

### DIFF
--- a/admission_escalation.go
+++ b/admission_escalation.go
@@ -1,0 +1,178 @@
+package ebusgateway
+
+import (
+	"sync"
+	"time"
+)
+
+const (
+	StartupAdmissionRejoinBackoffBaseSeconds = 5
+	StartupAdmissionRejoinBackoffMaxSeconds  = 60
+
+	StartupAdmissionEscalationFailureCountThreshold = 5
+	StartupAdmissionEscalationDurationSeconds       = 300
+	StartupAdmissionEscalationWindowSeconds         = 900
+)
+
+// RejoinBackoffSchedule returns the nth attempt's backoff duration:
+// Base * 2^(n-1), capped at Max. attempt=1 → Base; attempt=2 → 2*Base; etc.
+func RejoinBackoffSchedule(attempt int, baseSeconds, maxSeconds int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	secs := baseSeconds
+	for i := 1; i < attempt; i++ {
+		secs *= 2
+		if secs >= maxSeconds {
+			return time.Duration(maxSeconds) * time.Second
+		}
+	}
+	return time.Duration(secs) * time.Second
+}
+
+// DegradedModeAccumulator tracks both consecutive rejoin failures and a
+// rolling-window cumulative degraded-duration counter. Escalation fires
+// when EITHER threshold is reached. Per AD17, the accumulator is
+// in-process only — no restart persistence.
+type DegradedModeAccumulator struct {
+	mu  sync.Mutex
+	now func() time.Time
+
+	consecutiveFailures int
+
+	buckets     [900]uint16
+	bucketIndex int
+	bucketStart time.Time
+
+	inDegradedSince time.Time
+	escalated       bool
+
+	continuousThresholdSeconds int
+	windowSeconds              int
+	failureCountThreshold      int
+}
+
+func NewDegradedModeAccumulator() *DegradedModeAccumulator {
+	return &DegradedModeAccumulator{
+		now:                        time.Now,
+		continuousThresholdSeconds: StartupAdmissionEscalationDurationSeconds,
+		windowSeconds:              StartupAdmissionEscalationWindowSeconds,
+		failureCountThreshold:      StartupAdmissionEscalationFailureCountThreshold,
+	}
+}
+
+// RecordFailure increments the consecutive failure counter and updates the
+// accumulator with the failure moment. Returns true if the accumulator
+// crossed the escalation threshold as a result of this call.
+func (a *DegradedModeAccumulator) RecordFailure() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.consecutiveFailures++
+	now := a.now()
+	if a.inDegradedSince.IsZero() {
+		a.inDegradedSince = now
+		a.bucketStart = now
+		a.bucketIndex = 0
+	}
+	return a.checkEscalationLocked(now)
+}
+
+// RecordDegradedTick advances the cumulative accumulator by one second of
+// degraded-state occupancy. Called by a 1-second ticker in runtime when
+// admission state is degraded. Returns true if the accumulator crossed the
+// escalation threshold.
+func (a *DegradedModeAccumulator) RecordDegradedTick() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	now := a.now()
+	a.advanceBucketsLocked(now)
+	a.buckets[a.bucketIndex] = 1000
+	return a.checkEscalationLocked(now)
+}
+
+// RecordSuccess clears the consecutive failure counter. Does NOT clear the
+// rolling accumulator — flaps remain visible in the window. Latch clears
+// only after state_min_stability_s of continuous active (caller handles
+// the stability window separately).
+func (a *DegradedModeAccumulator) RecordSuccess() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.consecutiveFailures = 0
+	a.inDegradedSince = time.Time{}
+}
+
+// ClearLatch clears the escalated flag after state_min_stability_s of
+// continuous active state. Caller is responsible for the stability timer;
+// this method only flips the flag.
+func (a *DegradedModeAccumulator) ClearLatch() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.escalated = false
+}
+
+// Escalated reports whether the latch is currently set.
+func (a *DegradedModeAccumulator) Escalated() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.escalated
+}
+
+// CumulativeDegradedMs returns the sum of degraded-ms across all buckets in
+// the rolling window.
+func (a *DegradedModeAccumulator) CumulativeDegradedMs() uint64 {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	var sum uint64
+	for _, b := range a.buckets {
+		sum += uint64(b)
+	}
+	return sum
+}
+
+// advanceBucketsLocked rotates the ring buffer forward based on elapsed
+// wall-clock time since the last advance. Zero-fills skipped buckets.
+func (a *DegradedModeAccumulator) advanceBucketsLocked(now time.Time) {
+	if a.bucketStart.IsZero() {
+		a.bucketStart = now
+		a.bucketIndex = 0
+		return
+	}
+	elapsed := now.Sub(a.bucketStart)
+	if elapsed < time.Second {
+		return
+	}
+	secsElapsed := int(elapsed.Seconds())
+	for i := 0; i < secsElapsed; i++ {
+		a.bucketIndex = (a.bucketIndex + 1) % len(a.buckets)
+		a.buckets[a.bucketIndex] = 0
+	}
+	a.bucketStart = a.bucketStart.Add(time.Duration(secsElapsed) * time.Second)
+}
+
+func (a *DegradedModeAccumulator) checkEscalationLocked(now time.Time) bool {
+	if a.escalated {
+		return false
+	}
+	if a.consecutiveFailures >= a.failureCountThreshold {
+		a.escalated = true
+		return true
+	}
+	if !a.inDegradedSince.IsZero() {
+		continuousSeconds := int(now.Sub(a.inDegradedSince).Seconds())
+		if continuousSeconds >= a.continuousThresholdSeconds {
+			a.escalated = true
+			return true
+		}
+	}
+	var cumMs uint64
+	for _, b := range a.buckets {
+		cumMs += uint64(b)
+	}
+	if cumMs >= uint64(a.continuousThresholdSeconds)*1000 {
+		a.escalated = true
+		return true
+	}
+	return false
+}

--- a/admission_escalation_test.go
+++ b/admission_escalation_test.go
@@ -94,3 +94,67 @@ func TestDegradedModeAccumulator_RecordSuccessResetsConsecutiveFailures(t *testi
 		t.Fatal("expected escalation at 5th failure after reset")
 	}
 }
+
+// TestDegradedModeAccumulator_T5min_ContinuousDegradedEscalation drives the
+// continuous-time threshold path (T=5min) using a fake clock. Plan AD17:
+// "escalation fires on EITHER K=5 consecutive rejoin failures OR T=5min
+// cumulative degraded time within rolling 15-min window, whichever fires
+// first." This test covers the T=5min path which K=5 tests do not exercise.
+func TestDegradedModeAccumulator_T5min_ContinuousDegradedEscalation(t *testing.T) {
+	a := NewDegradedModeAccumulator()
+	base := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return base }
+
+	// Initial RecordFailure marks degraded-since=base; not yet escalated
+	// (only 1 consecutive failure).
+	if a.RecordFailure() {
+		t.Fatal("escalated too early on first failure")
+	}
+
+	// Advance to base+299s (just under threshold). Tick degraded each second.
+	// Should not escalate yet.
+	for sec := 1; sec < 300; sec++ {
+		a.now = func() time.Time { return base.Add(time.Duration(sec) * time.Second) }
+		if a.RecordDegradedTick() {
+			t.Fatalf("escalated too early at sec=%d (expected escalation at sec>=300)", sec)
+		}
+	}
+
+	// At base+300s the continuous threshold fires.
+	a.now = func() time.Time { return base.Add(300 * time.Second) }
+	if !a.RecordDegradedTick() {
+		t.Fatal("expected escalation at base+300s continuous degraded duration")
+	}
+	if !a.Escalated() {
+		t.Fatal("latch should be set after T=5min escalation")
+	}
+}
+
+// TestDegradedModeAccumulator_T5min_CumulativeRollingWindow drives the
+// cumulative-buckets path. With state_min_stability_s+continuous_threshold_s
+// frozen at 300, accumulating ≥300000 ms of degraded-state samples in the
+// 900-bucket ring buffer should escalate even without a single continuous
+// degraded-since window of 300s.
+func TestDegradedModeAccumulator_T5min_CumulativeRollingWindow(t *testing.T) {
+	a := NewDegradedModeAccumulator()
+	base := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return base }
+
+	// Walk the bucket index manually by directly setting buckets (simpler
+	// than scripting flap-RecordFailure cycles with intermediate Success).
+	// Fill 300 buckets with 1000ms each = 300000 ms total = exact threshold.
+	a.mu.Lock()
+	for i := 0; i < 300; i++ {
+		a.buckets[i] = 1000
+	}
+	a.mu.Unlock()
+
+	// One observation tick to trigger the cumulative-sum check.
+	a.now = func() time.Time { return base.Add(301 * time.Second) }
+	if !a.RecordDegradedTick() {
+		t.Fatal("expected escalation when cumulative buckets sum reached threshold")
+	}
+	if !a.Escalated() {
+		t.Fatal("latch should be set after cumulative-window escalation")
+	}
+}

--- a/admission_escalation_test.go
+++ b/admission_escalation_test.go
@@ -1,0 +1,96 @@
+package ebusgateway
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRejoinBackoffSchedule(t *testing.T) {
+	cases := []struct {
+		attempt  int
+		base     int
+		max      int
+		wantSecs int
+	}{
+		{1, 5, 60, 5},
+		{2, 5, 60, 10},
+		{3, 5, 60, 20},
+		{4, 5, 60, 40},
+		{5, 5, 60, 60},
+		{10, 5, 60, 60},
+		{0, 5, 60, 5},
+	}
+	for _, tc := range cases {
+		got := RejoinBackoffSchedule(tc.attempt, tc.base, tc.max)
+		wantDur := time.Duration(tc.wantSecs) * time.Second
+		if got != wantDur {
+			t.Errorf("attempt=%d base=%d max=%d: got %v, want %v", tc.attempt, tc.base, tc.max, got, wantDur)
+		}
+	}
+}
+
+func TestDegradedModeAccumulator_K5_FailureCountEscalation(t *testing.T) {
+	a := NewDegradedModeAccumulator()
+	for i := 0; i < 4; i++ {
+		if a.RecordFailure() {
+			t.Fatalf("escalated too early at failure %d", i+1)
+		}
+	}
+	if !a.RecordFailure() {
+		t.Fatal("expected escalation at 5th failure (K=5)")
+	}
+	if !a.Escalated() {
+		t.Fatal("latch should be set after escalation")
+	}
+}
+
+func TestDegradedModeAccumulator_LatchSuppressesFurtherEscalation(t *testing.T) {
+	a := NewDegradedModeAccumulator()
+	for i := 0; i < 5; i++ {
+		a.RecordFailure()
+	}
+	if !a.Escalated() {
+		t.Fatal("should be escalated")
+	}
+	for i := 0; i < 5; i++ {
+		if a.RecordFailure() {
+			t.Errorf("escalation re-fired on failure %d (should latch-suppress)", i+1)
+		}
+	}
+}
+
+func TestDegradedModeAccumulator_ClearLatchOnStabilityWindow(t *testing.T) {
+	a := NewDegradedModeAccumulator()
+	for i := 0; i < 5; i++ {
+		a.RecordFailure()
+	}
+	if !a.Escalated() {
+		t.Fatal("should be escalated")
+	}
+	a.ClearLatch()
+	if a.Escalated() {
+		t.Fatal("latch should be cleared")
+	}
+	a.RecordSuccess()
+	for i := 0; i < 5; i++ {
+		a.RecordFailure()
+	}
+	if !a.Escalated() {
+		t.Fatal("expected re-escalation after latch clear")
+	}
+}
+
+func TestDegradedModeAccumulator_RecordSuccessResetsConsecutiveFailures(t *testing.T) {
+	a := NewDegradedModeAccumulator()
+	a.RecordFailure()
+	a.RecordFailure()
+	a.RecordSuccess()
+	for i := 0; i < 4; i++ {
+		if a.RecordFailure() {
+			t.Fatalf("escalated after reset at failure %d", i+1)
+		}
+	}
+	if !a.RecordFailure() {
+		t.Fatal("expected escalation at 5th failure after reset")
+	}
+}

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mdns"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/portal"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/ui"
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
 	ebusgoTransport "github.com/Project-Helianthus/helianthus-ebusgo/transport"
 	vaillantproviders "github.com/Project-Helianthus/helianthus-ebusreg/providers/vaillant"
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
@@ -107,6 +108,13 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 		log.Printf("warning: --proxy-listen requires adapter-direct transport; proxy endpoint not started")
 	}
 
+	admissionPath, admissionPathErr := ebusgateway.ClassifyTransportAdmission(cfg.TransportConfig.Protocol)
+	if admissionPathErr != nil {
+		log.Printf("startup admission: classifier rejected transport protocol=%q err=%v; falling back to legacy static-source path", cfg.TransportConfig.Protocol, admissionPathErr)
+		admissionPath = ebusgateway.TransportAdmissionStaticFallback
+	}
+	overrideSet := false
+
 	busObservability, deduplicator, err := wireObserveFirstObserversFn(&cfg)
 	if err != nil {
 		return err
@@ -189,15 +197,83 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 		return err
 	}
 
-	startupScanSignals := startDiscoveryScanLoopFn(ctx, cfg, gateway, builder, adapterClassifier)
+	var (
+		listener      *ebusgateway.BroadcastListener
+		reconstructor *ebusgateway.PassiveTransactionReconstructor
+		joinResult    *protocol.JoinResult
+	)
+	attachPassiveObserveFirst := func() error {
+		if reconstructor == nil {
+			return nil
+		}
+		if busObservability != nil {
+			if err := busObservability.AttachReconstructor(ctx, reconstructor); err != nil {
+				return err
+			}
+		}
+		if deduplicator != nil {
+			if err := deduplicator.AttachReconstructor(ctx, reconstructor); err != nil {
+				return err
+			}
+		}
+		if listener == nil {
+			var err error
+			listener, err = startBroadcastListenerWithReconstructorFn(ctx, gateway.Router, reconstructor)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if admissionPath == ebusgateway.TransportAdmissionJoinCapable && !overrideSet && shouldStartPassiveObserveFirst(cfg) {
+		reconstructor, err = startPassiveTransactionReconstructor(ctx, cfg)
+		if err != nil {
+			return err
+		}
+		log.Printf("passive reconstructor started")
+
+		joinBus, err := ebusgateway.NewJoinBusAdapter(reconstructor, "startup_admission_joinbus", false)
+		if err != nil {
+			return fmt.Errorf("m3: new joinbus: %w", err)
+		}
+		joiner := protocol.NewJoiner(joinBus, nil, ebusgateway.DefaultStartupAdmissionJoinConfig())
+
+		log.Printf("joiner warmup begin")
+		warmupCtx, cancel := context.WithTimeout(ctx, 6*time.Second)
+		result, err := joiner.Join(warmupCtx)
+		cancel()
+		if err != nil {
+			log.Printf("startup admission degraded reason=joiner_fail err=%v", err)
+		} else {
+			joinResult = &result
+			log.Printf("startup admission active source=0x%02X companion_target=0x%02X", result.Initiator, result.CompanionTarget)
+		}
+	}
+
+	startupCfg := resolveStartupScanSourceConfig(cfg)
+	startupSourceProvenance := startupScanSourceMode(cfg, startupCfg)
+	if admissionPath == ebusgateway.TransportAdmissionJoinCapable && joinResult != nil {
+		startupCfg.ScanSource = joinResult.Initiator
+		startupCfg.ScanSourceAuto = false
+		startupSourceProvenance = "join_result"
+	}
+
+	log.Printf("startup scan pass")
+	log.Printf("startup_directed_probe_phase begin source=0x%02X provenance=%s", startupCfg.ScanSource, startupSourceProvenance)
+	startupScanSignals := startDiscoveryScanLoopFn(ctx, startupCfg, gateway, builder, adapterClassifier)
 
 	if semanticBarrier != nil {
 		go func() {
 			select {
 			case <-ctx.Done():
+				close(semanticBarrier)
+				return
 			case <-startupScanSignals.semanticBootstrapReady:
 			}
-			close(semanticBarrier)
+			if shouldCloseSemanticBarrier(admissionPath, overrideSet, joinResult != nil) {
+				close(semanticBarrier)
+			}
 		}()
 	}
 
@@ -231,24 +307,12 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 	if err != nil {
 		return err
 	}
-	var listener *ebusgateway.BroadcastListener
-	var reconstructor *ebusgateway.PassiveTransactionReconstructor
 	if shouldStartPassiveObserveFirst(cfg) {
-		waitForStartupScanFirstPass(ctx, cfg, startupScanSignals.firstPassDone)
+		if reconstructor == nil {
+			waitForStartupScanFirstPass(ctx, cfg, startupScanSignals.firstPassDone)
 
-		reconstructor, err = startPassiveTransactionReconstructor(ctx, cfg)
-		if err != nil {
-			if advertiser != nil {
-				_ = advertiser.Close()
-			}
-			if server != nil {
-				_ = server.Close()
-			}
-			return err
-		}
-		if busObservability != nil {
-			if err := busObservability.AttachReconstructor(ctx, reconstructor); err != nil {
-				_ = reconstructor.Close()
+			reconstructor, err = startPassiveTransactionReconstructor(ctx, cfg)
+			if err != nil {
 				if advertiser != nil {
 					_ = advertiser.Close()
 				}
@@ -258,20 +322,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 				return err
 			}
 		}
-		if deduplicator != nil {
-			if err := deduplicator.AttachReconstructor(ctx, reconstructor); err != nil {
-				_ = reconstructor.Close()
-				if advertiser != nil {
-					_ = advertiser.Close()
-				}
-				if server != nil {
-					_ = server.Close()
-				}
-				return err
-			}
-		}
-		listener, err = startBroadcastListenerWithReconstructorFn(ctx, gateway.Router, reconstructor)
-		if err != nil {
+		if err := attachPassiveObserveFirst(); err != nil {
 			_ = reconstructor.Close()
 			if advertiser != nil {
 				_ = advertiser.Close()

--- a/cmd/gateway/main_test.go
+++ b/cmd/gateway/main_test.go
@@ -583,7 +583,7 @@ func TestRun_DefersSemanticBootstrapUntilStartupConfirmationReadyOnPassiveObserv
 		return nil
 	}
 	startPassiveTransactionReconstructor = func(context.Context, ebusgateway.Config) (*ebusgateway.PassiveTransactionReconstructor, error) {
-		return nil, nil
+		return &ebusgateway.PassiveTransactionReconstructor{}, nil
 	}
 	startBroadcastListenerWithReconstructorFn = func(context.Context, *router.BusEventRouter, *ebusgateway.PassiveTransactionReconstructor) (*ebusgateway.BroadcastListener, error) {
 		return nil, nil
@@ -632,8 +632,8 @@ func TestRun_DefersSemanticBootstrapUntilStartupConfirmationReadyOnPassiveObserv
 
 	select {
 	case <-semanticStarted:
-	case <-time.After(2 * time.Second):
-		t.Fatal("semantic bootstrap did not start after semantic barrier readiness")
+		t.Fatal("semantic bootstrap started despite degraded admission without override")
+	case <-time.After(200 * time.Millisecond):
 	}
 
 	cancel()
@@ -722,7 +722,6 @@ func TestRun_WaitsForStartupScanFirstPassBeforePassiveObserveFirst(t *testing.T)
 		startHTTPServerFn = origStartHTTPServerFn
 	})
 
-	firstPassDone := make(chan struct{})
 	passiveStarted := make(chan struct{}, 1)
 
 	wireObserveFirstObserversFn = func(*ebusgateway.Config) (*ebusgateway.BusObservabilityStore, *ebusgateway.ActivePassiveDeduplicator, error) {
@@ -730,7 +729,7 @@ func TestRun_WaitsForStartupScanFirstPassBeforePassiveObserveFirst(t *testing.T)
 	}
 	startDiscoveryScanLoopFn = func(context.Context, ebusgateway.Config, *ebusgateway.Gateway, *graphql.Builder, activeTxnClassifier) startupScanSignals {
 		return startupScanSignals{
-			firstPassDone:          firstPassDone,
+			firstPassDone:          make(chan struct{}),
 			semanticBootstrapReady: make(chan struct{}),
 		}
 	}
@@ -745,7 +744,7 @@ func TestRun_WaitsForStartupScanFirstPassBeforePassiveObserveFirst(t *testing.T)
 		default:
 		}
 		cancel()
-		return nil, nil
+		return &ebusgateway.PassiveTransactionReconstructor{}, nil
 	}
 	startBroadcastListenerWithReconstructorFn = func(context.Context, *router.BusEventRouter, *ebusgateway.PassiveTransactionReconstructor) (*ebusgateway.BroadcastListener, error) {
 		return nil, nil
@@ -763,16 +762,8 @@ func TestRun_WaitsForStartupScanFirstPassBeforePassiveObserveFirst(t *testing.T)
 
 	select {
 	case <-passiveStarted:
-		t.Fatal("passive observe-first started before startup scan first pass completed")
-	case <-time.After(150 * time.Millisecond):
-	}
-
-	close(firstPassDone)
-
-	select {
-	case <-passiveStarted:
 	case <-time.After(2 * time.Second):
-		t.Fatal("passive observe-first did not start after startup scan first pass completed")
+		t.Fatal("passive reconstructor did not start before startup scan on join-capable transport")
 	}
 
 	select {

--- a/cmd/gateway/startup_order.go
+++ b/cmd/gateway/startup_order.go
@@ -1,0 +1,10 @@
+package main
+
+import "github.com/Project-Helianthus/helianthus-ebusgateway"
+
+func shouldCloseSemanticBarrier(admissionPath ebusgateway.TransportAdmissionPath, overrideSet bool, joinResultNotNil bool) bool {
+	if admissionPath != ebusgateway.TransportAdmissionJoinCapable {
+		return true
+	}
+	return overrideSet || joinResultNotNil
+}

--- a/cmd/gateway/startup_order_test.go
+++ b/cmd/gateway/startup_order_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusgateway"
+)
+
+func TestShouldCloseSemanticBarrier(t *testing.T) {
+	cases := []struct {
+		name             string
+		admissionPath    ebusgateway.TransportAdmissionPath
+		overrideSet      bool
+		joinResultNotNil bool
+		wantClose        bool
+	}{
+		{"join-capable + joiner success, override unset -> close", ebusgateway.TransportAdmissionJoinCapable, false, true, true},
+		{"join-capable + no joiner result, override unset -> keep open (DEGRADED)", ebusgateway.TransportAdmissionJoinCapable, false, false, false},
+		{"join-capable + override set (any joiner state) -> close", ebusgateway.TransportAdmissionJoinCapable, true, false, true},
+		{"join-capable + override set + joiner result -> close", ebusgateway.TransportAdmissionJoinCapable, true, true, true},
+		{"static-fallback (ebusd-tcp) -> close (legacy behavior)", ebusgateway.TransportAdmissionStaticFallback, false, false, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldCloseSemanticBarrier(tc.admissionPath, tc.overrideSet, tc.joinResultNotNil)
+			if got != tc.wantClose {
+				t.Errorf("got %v, want %v", got, tc.wantClose)
+			}
+		})
+	}
+}

--- a/config.go
+++ b/config.go
@@ -2,6 +2,8 @@ package ebusgateway
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net"
 	"strings"
 	"time"
@@ -39,7 +41,23 @@ const (
 	DefaultObserveFirstWarmupPostResetWindow       = 5 * time.Second
 	DefaultObserveFirstWarmupPostResetTransactions = 10
 	DefaultObserveFirstWarmupOuterWindow           = 5 * time.Minute
+
+	// Default values for startup-admission escalation thresholds (frozen per
+	// AD17 in startup-admission-discovery-w17-26.locked):
+	//
+	// The continuous_threshold_s value is frozen at 5 minutes (not
+	// operator-tunable). The state_min_stability_s is operator-tunable but
+	// bounded by AD22 invariant: state_min_stability_s * 5 <= continuous_threshold_s.
+	StartupAdmissionContinuousThresholdSeconds      = 300
+	StartupAdmissionStateMinStabilitySecondsDefault = 30
+	StartupAdmissionStateMinStabilitySecondsMin     = 5
+	StartupAdmissionStateMinStabilitySecondsMax     = 60
 )
+
+// ErrStartupAdmissionStabilityInvariant is returned when
+// state_min_stability_s violates the AD22 5:1 invariant against
+// continuous_threshold_s.
+var ErrStartupAdmissionStabilityInvariant = errors.New("startup admission: state_min_stability_s * 5 must be <= continuous_threshold_s (AD22)")
 
 type TransportConfig struct {
 	Protocol     TransportProtocol
@@ -56,21 +74,22 @@ type WatchObserver interface {
 }
 
 type Config struct {
-	Transport              transport.RawTransport
-	PassiveTransport       transport.RawTransport // pre-configured passive transport (adapter-direct mode)
-	ProxyListenAddr        string                 // TCP listen address for ENH proxy clients (empty disables)
-	TransportConfig        TransportConfig
-	BusConfig              protocol.BusConfig
-	QueueCapacity          int
-	Providers              []registry.PlaneProvider
-	ScanOnStart            bool
-	ScanSource             byte
-	ScanSourceAuto         bool
-	ScanTimeout            time.Duration
-	ScanRequestTimeout     time.Duration
-	ScanInterval           time.Duration
-	BackgroundScanInterval time.Duration
-	BootLiveTimeout        time.Duration
+	Transport                transport.RawTransport
+	PassiveTransport         transport.RawTransport // pre-configured passive transport (adapter-direct mode)
+	ProxyListenAddr          string                 // TCP listen address for ENH proxy clients (empty disables)
+	TransportConfig          TransportConfig
+	BusConfig                protocol.BusConfig
+	QueueCapacity            int
+	Providers                []registry.PlaneProvider
+	ScanOnStart              bool
+	ScanSource               byte
+	ScanSourceAuto           bool
+	ScanTimeout              time.Duration
+	ScanRequestTimeout       time.Duration
+	ScanInterval             time.Duration
+	BackgroundScanInterval   time.Duration
+	BootLiveTimeout          time.Duration
+	StateMinStabilitySeconds int
 	// SemanticInterval is a legacy single-interval semantic polling configuration.
 	// Prefer SemanticDiscoveryInterval / SemanticConfigInterval / SemanticStateInterval.
 	SemanticInterval                        time.Duration
@@ -159,6 +178,7 @@ func DefaultConfig() Config {
 		ScanInterval:                            30 * time.Second,
 		BackgroundScanInterval:                  2 * time.Hour,
 		BootLiveTimeout:                         2 * time.Minute,
+		StateMinStabilitySeconds:                StartupAdmissionStateMinStabilitySecondsDefault,
 		SemanticInterval:                        1 * time.Minute,
 		SemanticDiscoveryInterval:               10 * time.Minute,
 		SemanticConfigInterval:                  5 * time.Minute,
@@ -238,6 +258,9 @@ func applyDefaults(cfg Config) Config {
 	}
 	if cfg.BootLiveTimeout == 0 {
 		cfg.BootLiveTimeout = 2 * time.Minute
+	}
+	if cfg.StateMinStabilitySeconds == 0 {
+		cfg.StateMinStabilitySeconds = StartupAdmissionStateMinStabilitySecondsDefault
 	}
 	if cfg.SemanticInterval == 0 {
 		cfg.SemanticInterval = 1 * time.Minute
@@ -416,4 +439,21 @@ func applyDefaults(cfg Config) Config {
 	cfg.PassiveConfigDirectApply = flags.PassiveConfigDirectApply()
 	cfg.ExternalWritePolicy = flags.ExternalWritePolicy()
 	return cfg
+}
+
+// ValidateStartupAdmissionStability enforces AD22.
+func ValidateStartupAdmissionStability(stateMinStabilitySeconds int) error {
+	if stateMinStabilitySeconds < StartupAdmissionStateMinStabilitySecondsMin || stateMinStabilitySeconds > StartupAdmissionStateMinStabilitySecondsMax {
+		return fmt.Errorf("startup admission: state_min_stability_s=%d out of range [%d, %d]",
+			stateMinStabilitySeconds,
+			StartupAdmissionStateMinStabilitySecondsMin,
+			StartupAdmissionStateMinStabilitySecondsMax)
+	}
+	if stateMinStabilitySeconds*5 > StartupAdmissionContinuousThresholdSeconds {
+		return fmt.Errorf("%w: got state_min_stability_s=%d, continuous_threshold_s=%d",
+			ErrStartupAdmissionStabilityInvariant,
+			stateMinStabilitySeconds,
+			StartupAdmissionContinuousThresholdSeconds)
+	}
+	return nil
 }

--- a/docs/schemas/admission-artifact.schema.json
+++ b/docs/schemas/admission-artifact.schema.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "docs/schemas/admission-artifact.schema.json",
+  "title": "Startup Admission And Discovery Artifact",
+  "description": "Normative startup-admission-discovery artifact contract per 00-canonical.md §8 and AD23. This schema is owned by M2a and consumed unchanged by later emission milestones.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "admission",
+    "discovery"
+  ],
+  "properties": {
+    "admission": {
+      "type": "object",
+      "description": "Admission decision output summarizing the selected source, companion target, warmup timing, and degraded reason when applicable.",
+      "additionalProperties": false,
+      "required": [
+        "state",
+        "source",
+        "companion_target",
+        "warmup_duration_s",
+        "reason_if_degraded",
+        "transport_kind",
+        "admission_path_selected"
+      ],
+      "properties": {
+        "state": {
+          "type": "string",
+          "description": "Admission state label emitted by the startup-admission FSM."
+        },
+        "source": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255,
+          "description": "Selected initiator/source address as an unsigned byte."
+        },
+        "companion_target": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255,
+          "description": "Selected companion target address as an unsigned byte."
+        },
+        "warmup_duration_s": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Warmup observation duration in seconds."
+        },
+        "reason_if_degraded": {
+          "type": "string",
+          "description": "Human-readable degraded reason. May be an empty string for non-degraded paths."
+        },
+        "transport_kind": {
+          "type": "string",
+          "enum": [
+            "enh",
+            "ens",
+            "ebusd-tcp",
+            "udp-plain",
+            "tcp-plain"
+          ],
+          "description": "Transport kind from the startup-admission capability matrix."
+        },
+        "admission_path_selected": {
+          "type": "string",
+          "enum": [
+            "join",
+            "override",
+            "degraded_transport_blind",
+            "degraded_no_events"
+          ],
+          "description": "Admission path chosen by the startup-admission flow."
+        }
+      }
+    },
+    "discovery": {
+      "type": "object",
+      "description": "Discovery-phase evidence summary emitted alongside admission state for later observability and artifact consumers.",
+      "additionalProperties": false,
+      "required": [
+        "wire_bytes",
+        "window_s",
+        "startup_burst_pct",
+        "post_startup_sustained_rate_probes_per_15s",
+        "probe_count",
+        "promoted_suspects_without_identity",
+        "per_baseline_address_evidence_counts"
+      ],
+      "properties": {
+        "wire_bytes": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total observed wire bytes in the discovery window."
+        },
+        "window_s": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Discovery observation window in seconds."
+        },
+        "startup_burst_pct": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Percentage of total probes concentrated in the startup burst interval."
+        },
+        "post_startup_sustained_rate_probes_per_15s": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Steady-state probe rate normalized to probes per 15 seconds."
+        },
+        "probe_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total probe count observed during the discovery window."
+        },
+        "promoted_suspects_without_identity": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Count of promoted suspects that still lack identity resolution."
+        },
+        "per_baseline_address_evidence_counts": {
+          "type": "object",
+          "description": "Per-baseline-address evidence counts keyed by two-digit hex address strings.",
+          "propertyNames": {
+            "pattern": "^[0-9A-Fa-f]{2}$",
+            "description": "Address key as a two-digit hexadecimal string without prefix."
+          },
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Evidence count recorded for the keyed baseline address."
+          }
+        }
+      }
+    }
+  }
+}

--- a/evidence_buffer.go
+++ b/evidence_buffer.go
@@ -1,0 +1,165 @@
+package ebusgateway
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+)
+
+// EvidenceStrength classifies an observation's contribution weight toward
+// promoting a suspect to a confirmed-identity candidate.
+type EvidenceStrength uint8
+
+const (
+	EvidenceWeak EvidenceStrength = iota + 1
+	EvidenceStrong
+)
+
+// EvidenceRecord is a single observation for a bus address.
+type EvidenceRecord struct {
+	Address  byte
+	Strength EvidenceStrength
+	Observed time.Time
+	Kind     string
+}
+
+// BaselineTopologySeed is the set of addresses protected from LRU eviction.
+// Vaillant default: {0x08 BAI00, 0x15 BASV2, 0x26 VR_71, 0x04 NETX3-A,
+// 0xF6 NETX3-B, 0xEC SOL00}. Operators MAY override via config; validation
+// enforces slave-range [0x03, 0xFE] excluding 0xAA (SYN) and 0xFE (broadcast).
+var VaillantBaselineTopologySeed = []byte{0x08, 0x15, 0x26, 0x04, 0xF6, 0xEC}
+
+// ValidateBaselineTopologySeed checks the config-provided seed against the
+// slave-address range.
+func ValidateBaselineTopologySeed(seed []byte) error {
+	for _, addr := range seed {
+		if addr < 0x03 || addr >= 0xFE {
+			return fmt.Errorf("evidence: baseline seed 0x%02X out of slave range [0x03, 0xFE]", addr)
+		}
+		if addr == 0xAA {
+			return fmt.Errorf("evidence: baseline seed must not include SYN (0xAA)")
+		}
+	}
+	return nil
+}
+
+// EvidenceBuffer is a bounded, LRU-with-baseline-protection buffer of
+// per-address observations. Its max capacity is max_entries=128 (per AD05).
+// When the buffer is full and a new non-baseline address is observed, the
+// oldest non-baseline entry is evicted. Baseline addresses are NEVER
+// evicted — they may update in place but never leave the buffer.
+type EvidenceBuffer struct {
+	mu         sync.Mutex
+	maxEntries int
+	baseline   map[byte]struct{}
+	entries    map[byte]*addressState
+	tick       uint64
+}
+
+type addressState struct {
+	address      byte
+	observations int
+	strongObs    int
+	lastObserved time.Time
+	touchedAt    uint64
+	promoted     bool
+}
+
+func NewEvidenceBuffer(maxEntries int, baseline []byte) (*EvidenceBuffer, error) {
+	if err := ValidateBaselineTopologySeed(baseline); err != nil {
+		return nil, err
+	}
+	if maxEntries < 32 || maxEntries > 1024 {
+		return nil, fmt.Errorf("evidence: max_entries=%d out of range [32, 1024]", maxEntries)
+	}
+	buf := &EvidenceBuffer{
+		maxEntries: maxEntries,
+		baseline:   make(map[byte]struct{}, len(baseline)),
+		entries:    make(map[byte]*addressState, maxEntries),
+	}
+	for _, addr := range baseline {
+		buf.baseline[addr] = struct{}{}
+	}
+	return buf, nil
+}
+
+// Record adds or updates evidence for an address. Returns whether the address
+// crossed the promotion threshold as a result (≥2 observations OR any strong).
+func (b *EvidenceBuffer) Record(record EvidenceRecord) (promoted bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.tick++
+	state, ok := b.entries[record.Address]
+	if !ok {
+		if len(b.entries) >= b.maxEntries {
+			b.evictOldestNonBaselineLocked()
+		}
+		if len(b.entries) >= b.maxEntries {
+			if _, isBaseline := b.baseline[record.Address]; !isBaseline {
+				return false
+			}
+		}
+		state = &addressState{address: record.Address}
+		b.entries[record.Address] = state
+	}
+
+	state.observations++
+	if record.Strength == EvidenceStrong {
+		state.strongObs++
+	}
+	state.lastObserved = record.Observed
+	state.touchedAt = b.tick
+
+	if !state.promoted && (state.observations >= 2 || state.strongObs >= 1) {
+		state.promoted = true
+		return true
+	}
+	return false
+}
+
+func (b *EvidenceBuffer) evictOldestNonBaselineLocked() {
+	var (
+		victimAddr byte
+		victimTick = ^uint64(0)
+		found      bool
+	)
+	for addr, st := range b.entries {
+		if _, base := b.baseline[addr]; base {
+			continue
+		}
+		if st.touchedAt < victimTick {
+			victimTick = st.touchedAt
+			victimAddr = addr
+			found = true
+		}
+	}
+	if found {
+		delete(b.entries, victimAddr)
+	}
+}
+
+// PromotedAddresses returns the sorted set of addresses that have crossed
+// the promotion threshold. Caller uses this to build the directed probe
+// target list for the ebusreg ScanDirected call.
+func (b *EvidenceBuffer) PromotedAddresses() []byte {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	out := make([]byte, 0)
+	for addr, st := range b.entries {
+		if st.promoted {
+			out = append(out, addr)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+// Len returns the current count of stored entries.
+func (b *EvidenceBuffer) Len() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.entries)
+}

--- a/evidence_buffer_test.go
+++ b/evidence_buffer_test.go
@@ -1,0 +1,116 @@
+package ebusgateway
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEvidenceBuffer_PromotionOnTwoObservations(t *testing.T) {
+	b, err := NewEvidenceBuffer(128, VaillantBaselineTopologySeed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	promoted1 := b.Record(EvidenceRecord{Address: 0x20, Strength: EvidenceWeak, Observed: now})
+	if promoted1 {
+		t.Errorf("promotion on first observation — expected none")
+	}
+	promoted2 := b.Record(EvidenceRecord{Address: 0x20, Strength: EvidenceWeak, Observed: now.Add(time.Second)})
+	if !promoted2 {
+		t.Errorf("expected promotion on second observation")
+	}
+}
+
+func TestEvidenceBuffer_PromotionOnSingleStrongEvidence(t *testing.T) {
+	b, _ := NewEvidenceBuffer(128, VaillantBaselineTopologySeed)
+	promoted := b.Record(EvidenceRecord{Address: 0x20, Strength: EvidenceStrong, Observed: time.Now()})
+	if !promoted {
+		t.Errorf("expected immediate promotion on single strong evidence")
+	}
+}
+
+func TestEvidenceBuffer_FloodWithDefaultSeed_BaselineSurvives(t *testing.T) {
+	b, _ := NewEvidenceBuffer(128, VaillantBaselineTopologySeed)
+	now := time.Now()
+	for _, addr := range VaillantBaselineTopologySeed {
+		b.Record(EvidenceRecord{Address: addr, Strength: EvidenceWeak, Observed: now})
+	}
+	for i := 0; i < 1000; i++ {
+		addr := byte(0x20 + (i % 0xD0))
+		b.Record(EvidenceRecord{Address: addr, Strength: EvidenceWeak, Observed: now.Add(time.Duration(i) * time.Millisecond)})
+	}
+	if b.Len() > 128 {
+		t.Errorf("buffer overflow: len=%d > 128", b.Len())
+	}
+	for _, baseAddr := range VaillantBaselineTopologySeed {
+		promoted := b.PromotedAddresses()
+		found := false
+		for _, p := range promoted {
+			if p == baseAddr {
+				found = true
+				break
+			}
+		}
+		if !found {
+			b.mu.Lock()
+			_, ok := b.entries[baseAddr]
+			b.mu.Unlock()
+			if !ok {
+				t.Errorf("baseline address 0x%02X was evicted — AD05 violation", baseAddr)
+			}
+		}
+	}
+}
+
+func TestEvidenceBuffer_FloodWithNonDefaultSeed_BaselineSurvives(t *testing.T) {
+	customSeed := []byte{0x03, 0x10, 0x50}
+	b, err := NewEvidenceBuffer(128, customSeed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	for _, addr := range customSeed {
+		b.Record(EvidenceRecord{Address: addr, Strength: EvidenceWeak, Observed: now})
+	}
+	for i := 0; i < 1000; i++ {
+		addr := byte(0x60 + (i % 0x90))
+		b.Record(EvidenceRecord{Address: addr, Strength: EvidenceWeak, Observed: now.Add(time.Duration(i) * time.Millisecond)})
+	}
+	if b.Len() > 128 {
+		t.Errorf("buffer overflow: len=%d > 128", b.Len())
+	}
+	for _, baseAddr := range customSeed {
+		b.mu.Lock()
+		_, ok := b.entries[baseAddr]
+		b.mu.Unlock()
+		if !ok {
+			t.Errorf("custom-seed baseline 0x%02X was evicted — AD05 violation", baseAddr)
+		}
+	}
+}
+
+func TestEvidenceBuffer_ValidateBaselineTopologySeed_RejectsOutOfRange(t *testing.T) {
+	cases := [][]byte{
+		{0x00, 0x08},
+		{0x08, 0xFE},
+		{0xAA, 0x08},
+		{0x08, 0xFF},
+	}
+	for i, seed := range cases {
+		if err := ValidateBaselineTopologySeed(seed); err == nil {
+			t.Errorf("case %d: expected error for seed %v", i, seed)
+		}
+	}
+}
+
+func TestEvidenceBuffer_NewRejectsOutOfRangeMaxEntries(t *testing.T) {
+	if _, err := NewEvidenceBuffer(31, VaillantBaselineTopologySeed); err == nil {
+		t.Error("expected error for max_entries=31 (below min 32)")
+	}
+	if _, err := NewEvidenceBuffer(1025, VaillantBaselineTopologySeed); err == nil {
+		t.Error("expected error for max_entries=1025 (above max 1024)")
+	}
+	if _, err := NewEvidenceBuffer(128, VaillantBaselineTopologySeed); err != nil {
+		t.Errorf("expected no error for max_entries=128: %v", err)
+	}
+}

--- a/joinbus.go
+++ b/joinbus.go
@@ -19,6 +19,24 @@ import (
 
 var ErrJoinBusInquiryUnsupported = errors.New("joinbus: inquiry not supported (InquiryEnabled=false)")
 
+// TransportAdmissionPath is the admission-path dispatch decision for a given
+// transport kind per the startup-admission-discovery plan's transport
+// capability matrix (see plan AD11 and
+// helianthus-docs-ebus/architecture/startup-admission-and-discovery.md §10).
+type TransportAdmissionPath uint8
+
+const (
+	// TransportAdmissionJoinCapable denotes a direct transport on which the
+	// gateway runs the Joiner warmup + JoinBus adapter before any
+	// non-override active frame. Applies to ENH, ENS, UDP-plain, TCP-plain.
+	TransportAdmissionJoinCapable TransportAdmissionPath = iota + 1
+
+	// TransportAdmissionStaticFallback denotes the ebusd-tcp path, where the
+	// gateway does NOT instantiate Joiner and uses the configured
+	// ScanSource as admission-fallback per AD13.
+	TransportAdmissionStaticFallback
+)
+
 type joinBusAdapter struct {
 	reconstructor  *PassiveTransactionReconstructor
 	name           string
@@ -88,6 +106,24 @@ func forwardJoinBusEvent(event PassiveClassifiedEvent, onFrame func(protocol.Fra
 
 func (a *joinBusAdapter) InquiryExistence(ctx context.Context) error {
 	return ErrJoinBusInquiryUnsupported
+}
+
+// ClassifyTransportAdmission returns the admission path dispatch for the
+// given TransportProtocol per the startup-admission-discovery plan's
+// transport capability matrix. Unknown or empty values return (zero, error).
+func ClassifyTransportAdmission(kind TransportProtocol) (TransportAdmissionPath, error) {
+	switch kind {
+	case TransportENH, TransportENS, TransportUDPPlain, TransportTCPPlain:
+		return TransportAdmissionJoinCapable, nil
+	case TransportEbusdTCP:
+		return TransportAdmissionStaticFallback, nil
+	case TransportAdapterDirect:
+		return 0, fmt.Errorf("joinbus: adapter-direct is a multiplexer, classify its underlying transport")
+	case "":
+		return 0, fmt.Errorf("joinbus: empty transport protocol")
+	default:
+		return 0, fmt.Errorf("joinbus: unknown transport protocol %q", kind)
+	}
 }
 
 // DefaultStartupAdmissionJoinConfig returns the JoinConfig used by the

--- a/joinbus.go
+++ b/joinbus.go
@@ -1,0 +1,104 @@
+package ebusgateway
+
+// Package-doc continued: JoinBus adapter.
+//
+// This file implements the JoinBus interface from ebusgo/protocol, wired
+// over the PassiveTransactionReconstructor's subscription channel. It is
+// the source-of-truth bridge for startup-admission warmup on join-capable
+// direct transports (ENH, ENS, UDP-plain, TCP-plain). ebusd-tcp does NOT
+// instantiate this adapter per AD13.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+)
+
+var ErrJoinBusInquiryUnsupported = errors.New("joinbus: inquiry not supported (InquiryEnabled=false)")
+
+type joinBusAdapter struct {
+	reconstructor  *PassiveTransactionReconstructor
+	name           string
+	priority       PassiveSubscriberPriority
+	buffer         int
+	inquiryEnabled bool
+}
+
+// NewJoinBusAdapter returns a protocol.JoinBus subscribed to the given
+// reconstructor with priority=NonCritical and default buffer.
+func NewJoinBusAdapter(reconstructor *PassiveTransactionReconstructor, name string, inquiryEnabled bool) (protocol.JoinBus, error) {
+	if reconstructor == nil {
+		return nil, fmt.Errorf("joinbus: reconstructor is nil")
+	}
+	if name == "" {
+		name = "startup_admission_joinbus"
+	}
+	return &joinBusAdapter{
+		reconstructor:  reconstructor,
+		name:           name,
+		priority:       PassiveSubscriberNonCritical,
+		buffer:         0,
+		inquiryEnabled: inquiryEnabled,
+	}, nil
+}
+
+func (a *joinBusAdapter) Listen(ctx context.Context, onFrame func(protocol.Frame)) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	subscription, err := a.reconstructor.Subscribe(a.name, a.priority, a.buffer)
+	if err != nil {
+		return fmt.Errorf("joinbus: subscribe: %w", err)
+	}
+	defer subscription.Close()
+
+	events := subscription.Events()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case event, ok := <-events:
+			if !ok {
+				return nil
+			}
+			forwardJoinBusEvent(event, onFrame)
+		}
+	}
+}
+
+func forwardJoinBusEvent(event PassiveClassifiedEvent, onFrame func(protocol.Frame)) {
+	if onFrame == nil {
+		return
+	}
+
+	switch event.Kind {
+	case PassiveClassifiedEventBroadcastFrame, PassiveClassifiedEventMasterFrame:
+		onFrame(event.Request)
+	case PassiveClassifiedEventTransaction:
+		onFrame(event.Request)
+		if event.HasResponse {
+			onFrame(event.Response)
+		}
+	}
+}
+
+func (a *joinBusAdapter) InquiryExistence(ctx context.Context) error {
+	return ErrJoinBusInquiryUnsupported
+}
+
+// DefaultStartupAdmissionJoinConfig returns the JoinConfig used by the
+// startup-admission-discovery plan for join-capable direct transports.
+// See plan AD01/AD02/AD09 and
+// helianthus-docs-ebus/architecture/startup-admission-and-discovery.md §2.2.3.
+func DefaultStartupAdmissionJoinConfig() protocol.JoinConfig {
+	return protocol.JoinConfig{
+		ListenWarmup:       5 * time.Second,
+		InquiryEnabled:     false,
+		PersistLastGood:    true,
+		PersistLastGoodSet: true,
+	}
+}

--- a/joinbus_transport_test.go
+++ b/joinbus_transport_test.go
@@ -1,0 +1,199 @@
+package ebusgateway
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+)
+
+func TestClassifyTransportAdmission_AllFivePlanMatrixTransports(t *testing.T) {
+	cases := []struct {
+		name   string
+		kind   TransportProtocol
+		expect TransportAdmissionPath
+	}{
+		{"ENH", TransportENH, TransportAdmissionJoinCapable},
+		{"ENS", TransportENS, TransportAdmissionJoinCapable},
+		{"UDP-plain", TransportUDPPlain, TransportAdmissionJoinCapable},
+		{"TCP-plain", TransportTCPPlain, TransportAdmissionJoinCapable},
+		{"ebusd-tcp", TransportEbusdTCP, TransportAdmissionStaticFallback},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ClassifyTransportAdmission(tc.kind)
+			if err != nil {
+				t.Fatalf("unexpected error for %s: %v", tc.kind, err)
+			}
+			if got != tc.expect {
+				t.Errorf("for %s: got %d, want %d", tc.kind, got, tc.expect)
+			}
+		})
+	}
+}
+
+// TestClassifyTransportAdmission_MisclassificationIsTestFailure hardens the
+// plan's M2 acceptance: "Transport classifier is unit-tested against all
+// five transports in the capability matrix {ENH, ENS, ebusd-tcp, UDP-plain,
+// TCP-plain}; misclassification (join-capable routed to static fallback,
+// or ebusd-tcp routed to Joiner) is a test failure."
+func TestClassifyTransportAdmission_MisclassificationIsTestFailure(t *testing.T) {
+	joinCapableTransports := []TransportProtocol{TransportENH, TransportENS, TransportUDPPlain, TransportTCPPlain}
+	for _, kind := range joinCapableTransports {
+		got, err := ClassifyTransportAdmission(kind)
+		if err != nil {
+			t.Fatalf("unexpected error classifying %s: %v", kind, err)
+		}
+		if got == TransportAdmissionStaticFallback {
+			t.Errorf("FAIL: join-capable transport %s misclassified as static fallback", kind)
+		}
+	}
+	got, err := ClassifyTransportAdmission(TransportEbusdTCP)
+	if err != nil {
+		t.Fatalf("unexpected error classifying ebusd-tcp: %v", err)
+	}
+	if got == TransportAdmissionJoinCapable {
+		t.Error("FAIL: ebusd-tcp misclassified as join-capable (AD13 violation)")
+	}
+}
+
+func TestClassifyTransportAdmission_AdapterDirectIsMultiplexer(t *testing.T) {
+	_, err := ClassifyTransportAdmission(TransportAdapterDirect)
+	if err == nil {
+		t.Fatal("expected error for adapter-direct classification (it is a multiplexer)")
+	}
+}
+
+func TestClassifyTransportAdmission_EmptyIsError(t *testing.T) {
+	_, err := ClassifyTransportAdmission("")
+	if err == nil {
+		t.Fatal("expected error for empty transport protocol")
+	}
+}
+
+func TestClassifyTransportAdmission_UnknownIsError(t *testing.T) {
+	_, err := ClassifyTransportAdmission(TransportProtocol("bogus-transport-xyz"))
+	if err == nil {
+		t.Fatal("expected error for unknown transport protocol")
+	}
+	// Also verify the error mentions the bogus value for observability.
+	if !errors.Is(err, nil) && err.Error() == "" {
+		t.Error("expected non-empty error message for unknown transport")
+	}
+}
+
+func TestForwardJoinBusEvent_BroadcastForwardsRequestOnly(t *testing.T) {
+	var captured []protocol.Frame
+	onFrame := func(f protocol.Frame) { captured = append(captured, f) }
+	req := protocol.Frame{Source: 0x71, Target: 0xFE, Primary: 0xB5}
+	forwardJoinBusEvent(PassiveClassifiedEvent{
+		Kind:    PassiveClassifiedEventBroadcastFrame,
+		Request: req,
+	}, onFrame)
+	if len(captured) != 1 || !reflect.DeepEqual(captured[0], req) {
+		t.Fatalf("expected [req], got %v", captured)
+	}
+}
+
+func TestForwardJoinBusEvent_MasterForwardsRequestOnly(t *testing.T) {
+	var captured []protocol.Frame
+	onFrame := func(f protocol.Frame) { captured = append(captured, f) }
+	req := protocol.Frame{Source: 0x71, Target: 0x08, Primary: 0x07, Secondary: 0x04}
+	forwardJoinBusEvent(PassiveClassifiedEvent{
+		Kind:    PassiveClassifiedEventMasterFrame,
+		Request: req,
+	}, onFrame)
+	if len(captured) != 1 || !reflect.DeepEqual(captured[0], req) {
+		t.Fatalf("expected [req], got %v", captured)
+	}
+}
+
+func TestForwardJoinBusEvent_TransactionWithoutResponseForwardsRequestOnly(t *testing.T) {
+	var captured []protocol.Frame
+	onFrame := func(f protocol.Frame) { captured = append(captured, f) }
+	req := protocol.Frame{Source: 0x71, Target: 0x08, Primary: 0x07, Secondary: 0x04}
+	forwardJoinBusEvent(PassiveClassifiedEvent{
+		Kind:        PassiveClassifiedEventTransaction,
+		Request:     req,
+		HasResponse: false,
+	}, onFrame)
+	if len(captured) != 1 || !reflect.DeepEqual(captured[0], req) {
+		t.Fatalf("expected [req], got %v", captured)
+	}
+}
+
+func TestForwardJoinBusEvent_TransactionWithResponseForwardsRequestThenResponse(t *testing.T) {
+	var captured []protocol.Frame
+	onFrame := func(f protocol.Frame) { captured = append(captured, f) }
+	req := protocol.Frame{Source: 0x71, Target: 0x08}
+	resp := protocol.Frame{Source: 0x08, Target: 0x71}
+	forwardJoinBusEvent(PassiveClassifiedEvent{
+		Kind:        PassiveClassifiedEventTransaction,
+		Request:     req,
+		Response:    resp,
+		HasResponse: true,
+	}, onFrame)
+	if len(captured) != 2 {
+		t.Fatalf("expected 2 frames, got %d", len(captured))
+	}
+	if !reflect.DeepEqual(captured[0], req) {
+		t.Errorf("expected frame 0 = req, got %+v", captured[0])
+	}
+	if !reflect.DeepEqual(captured[1], resp) {
+		t.Errorf("expected frame 1 = resp, got %+v", captured[1])
+	}
+}
+
+func TestForwardJoinBusEvent_AbandonedTransactionIsDropped(t *testing.T) {
+	var captured []protocol.Frame
+	onFrame := func(f protocol.Frame) { captured = append(captured, f) }
+	forwardJoinBusEvent(PassiveClassifiedEvent{
+		Kind:    PassiveClassifiedEventAbandonedTransaction,
+		Request: protocol.Frame{Source: 0x71},
+	}, onFrame)
+	if len(captured) != 0 {
+		t.Fatalf("abandoned transaction must not be forwarded (AD01); got %d frames", len(captured))
+	}
+}
+
+func TestForwardJoinBusEvent_DiscontinuityIsDropped(t *testing.T) {
+	var captured []protocol.Frame
+	onFrame := func(f protocol.Frame) { captured = append(captured, f) }
+	forwardJoinBusEvent(PassiveClassifiedEvent{
+		Kind:    PassiveClassifiedEventDiscontinuity,
+		Request: protocol.Frame{Source: 0x71},
+	}, onFrame)
+	if len(captured) != 0 {
+		t.Fatalf("discontinuity must not be forwarded (AD01); got %d frames", len(captured))
+	}
+}
+
+func TestInquiryExistence_AlwaysReturnsSentinel(t *testing.T) {
+	adapterDisabled := &joinBusAdapter{inquiryEnabled: false}
+	adapterEnabled := &joinBusAdapter{inquiryEnabled: true}
+	if err := adapterDisabled.InquiryExistence(context.Background()); err != ErrJoinBusInquiryUnsupported {
+		t.Errorf("disabled: expected ErrJoinBusInquiryUnsupported, got %v", err)
+	}
+	if err := adapterEnabled.InquiryExistence(context.Background()); err != ErrJoinBusInquiryUnsupported {
+		t.Errorf("enabled: expected ErrJoinBusInquiryUnsupported, got %v", err)
+	}
+}
+
+func TestDefaultStartupAdmissionJoinConfig(t *testing.T) {
+	cfg := DefaultStartupAdmissionJoinConfig()
+	if cfg.ListenWarmup != 5*time.Second {
+		t.Errorf("ListenWarmup: got %v, want 5s", cfg.ListenWarmup)
+	}
+	if cfg.InquiryEnabled {
+		t.Error("InquiryEnabled: got true, want false")
+	}
+	if !cfg.PersistLastGood {
+		t.Error("PersistLastGood: got false, want true")
+	}
+	if !cfg.PersistLastGoodSet {
+		t.Error("PersistLastGoodSet: got false, want true")
+	}
+}

--- a/joinbus_transport_test.go
+++ b/joinbus_transport_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -195,5 +196,136 @@ func TestDefaultStartupAdmissionJoinConfig(t *testing.T) {
 	}
 	if !cfg.PersistLastGoodSet {
 		t.Error("PersistLastGoodSet: got false, want true")
+	}
+}
+
+func TestJoinBusAdapter_WarmupObservationForwardsSynthesizedPassiveTraffic(t *testing.T) {
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	joinBus, err := NewJoinBusAdapter(reconstructor, "warmup_test", false)
+	if err != nil {
+		t.Fatalf("NewJoinBusAdapter error = %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	request := protocol.Frame{
+		Source:    0x10,
+		Target:    protocol.AddressBroadcast,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{0x01, 0x02},
+	}
+
+	var (
+		mu       sync.Mutex
+		captured []protocol.Frame
+	)
+	done := make(chan error, 1)
+	gotFrame := make(chan struct{}, 1)
+	go func() {
+		done <- joinBus.Listen(ctx, func(frame protocol.Frame) {
+			mu.Lock()
+			captured = append(captured, frame)
+			mu.Unlock()
+			select {
+			case gotFrame <- struct{}{}:
+			default:
+			}
+			cancel()
+		})
+	}()
+
+	time.Sleep(25 * time.Millisecond)
+	feedPassiveSymbols(reconstructor, time.Unix(0, 0), frameBytes(request))
+
+	select {
+	case <-gotFrame:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for warmup observation to forward a frame")
+	}
+
+	err = <-done
+	if err != context.Canceled && !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+		t.Fatalf("Listen error = %v; want context cancellation/deadline", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(captured) == 0 {
+		t.Fatal("expected at least one forwarded frame")
+	}
+	if !reflect.DeepEqual(captured[0], request) {
+		t.Fatalf("forwarded frame = %+v; want %+v", captured[0], request)
+	}
+}
+
+func TestJoinBusAdapter_WarmupObservationSilentBusForwardsNothing(t *testing.T) {
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	joinBus, err := NewJoinBusAdapter(reconstructor, "silent_bus_test", false)
+	if err != nil {
+		t.Fatalf("NewJoinBusAdapter error = %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var (
+		mu       sync.Mutex
+		captured []protocol.Frame
+	)
+	done := make(chan error, 1)
+	go func() {
+		done <- joinBus.Listen(ctx, func(frame protocol.Frame) {
+			mu.Lock()
+			captured = append(captured, frame)
+			mu.Unlock()
+		})
+	}()
+
+	err = <-done
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Listen error = %v; want context deadline exceeded", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(captured) != 0 {
+		t.Fatalf("expected 0 forwarded frames on silent bus, got %d", len(captured))
+	}
+}
+
+func TestAD22_StateMinStabilityInvariant_ValidValuesAccepted(t *testing.T) {
+	for _, v := range []int{5, 10, 30, 60} {
+		if err := ValidateStartupAdmissionStability(v); err != nil {
+			t.Errorf("valid value %d rejected: %v", v, err)
+		}
+	}
+}
+
+func TestAD22_StateMinStabilityInvariant_RejectsOutOfRange(t *testing.T) {
+	for _, v := range []int{0, 4, 61, 120, 300, -1} {
+		if err := ValidateStartupAdmissionStability(v); err == nil {
+			t.Errorf("out-of-range value %d was not rejected", v)
+		}
+	}
+}
+
+func TestAD22_StateMinStabilityInvariant_Rejects120With300(t *testing.T) {
+	err := ValidateStartupAdmissionStability(120)
+	if err == nil {
+		t.Fatal("expected FATAL error for state_min_stability_s=120 with continuous_threshold_s=300 (AD22 5:1 invariant)")
+	}
+	if !errors.Is(err, ErrStartupAdmissionStabilityInvariant) {
+		t.Logf("rejected by range check rather than invariant check (acceptable); err=%v", err)
+	}
+}
+
+func TestAD22_StateMinStabilityInvariant_DirectViolation(t *testing.T) {
+	if err := ValidateStartupAdmissionStability(60); err != nil {
+		t.Errorf("value 60 (boundary) should be accepted, got %v", err)
+	}
+	if err := ValidateStartupAdmissionStability(61); err == nil {
+		t.Error("value 61 (just over boundary) should be rejected")
 	}
 }

--- a/startup_admission_harness_test.go
+++ b/startup_admission_harness_test.go
@@ -84,10 +84,6 @@ func TestM2aHarness_OverrideValidateTruePath(t *testing.T) {
 	t.Skip("pending M6: StartupSource.Override.Validate wiring + retrospective conflict detection")
 }
 
-func TestM2aHarness_SemanticBarrierClosesOnlyWithAdmissionState(t *testing.T) {
-	t.Skip("pending M3: semanticBarrier predicate extension in cmd/gateway/main.go")
-}
-
 func TestM2aHarness_EvidenceBufferFloodBaselineProtection(t *testing.T) {
 	t.Skip("pending M4: evidence pipeline + max_entries=128 LRU + baseline protection")
 }

--- a/startup_admission_harness_test.go
+++ b/startup_admission_harness_test.go
@@ -85,7 +85,26 @@ func TestM2aHarness_OverrideValidateTruePath(t *testing.T) {
 }
 
 func TestM2aHarness_EvidenceBufferFloodBaselineProtection(t *testing.T) {
-	t.Skip("pending M4: evidence pipeline + max_entries=128 LRU + baseline protection")
+	b, err := NewEvidenceBuffer(128, VaillantBaselineTopologySeed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	for _, addr := range VaillantBaselineTopologySeed {
+		b.Record(EvidenceRecord{Address: addr, Strength: EvidenceWeak, Observed: now})
+	}
+	for i := 0; i < 1000; i++ {
+		addr := byte(0x20 + (i % 0xD0))
+		b.Record(EvidenceRecord{Address: addr, Strength: EvidenceWeak, Observed: now.Add(time.Duration(i) * time.Millisecond)})
+	}
+	for _, addr := range VaillantBaselineTopologySeed {
+		b.mu.Lock()
+		_, ok := b.entries[addr]
+		b.mu.Unlock()
+		if !ok {
+			t.Fatalf("baseline address 0x%02X was evicted", addr)
+		}
+	}
 }
 
 func TestM2aHarness_AdmissionArtifactEmissionValidatesAgainstSchema(t *testing.T) {

--- a/startup_admission_harness_test.go
+++ b/startup_admission_harness_test.go
@@ -1,0 +1,213 @@
+package ebusgateway
+
+// This file is the offline harness for startup admission + discovery per M2a. Schema validation is the only concrete test that can run against M2-era code; skeleton tests with t.Skip markers become real as M3..M6 land.
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+)
+
+func synthesizedTransactionEvent(src, dst byte, hasResponse bool) PassiveClassifiedEvent {
+	event := PassiveClassifiedEvent{
+		Kind:    PassiveClassifiedEventTransaction,
+		Request: protocol.Frame{Source: src, Target: dst, Primary: 0x07, Secondary: 0x04, Data: []byte{0x01}},
+	}
+	if hasResponse {
+		event.HasResponse = true
+		event.Response = protocol.Frame{Source: dst, Target: src, Data: []byte{0x11, 0x55}}
+	}
+	return event
+}
+
+func synthesizedBroadcastEvent(src byte) PassiveClassifiedEvent {
+	return PassiveClassifiedEvent{
+		Kind:    PassiveClassifiedEventBroadcastFrame,
+		Request: protocol.Frame{Source: src, Target: protocol.AddressBroadcast, Primary: 0xB5, Secondary: 0x16, Data: []byte{0x01}},
+	}
+}
+
+func feedSynthesizedPassiveStream(t *testing.T, reconstructor *PassiveTransactionReconstructor, events []PassiveClassifiedEvent) func() {
+	t.Helper()
+	stopCh := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		base := time.Unix(0, 0)
+		for i, event := range events {
+			select {
+			case <-stopCh:
+				return
+			default:
+			}
+			feedPassiveSymbols(reconstructor, base.Add(time.Duration(i)*time.Second), synthesizedEventSymbols(t, event))
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+	return func() {
+		close(stopCh)
+		<-done
+	}
+}
+
+func validateAdmissionArtifactAgainstSchema(t *testing.T, artifactJSON []byte) {
+	t.Helper()
+	if err := admissionArtifactSchemaError(artifactJSON); err != nil {
+		t.Fatalf("artifact does not validate against admission schema: %v", err)
+	}
+}
+
+func TestM2aHarness_JoinerSuccessPath(t *testing.T) {
+	t.Skip("pending M3: admission FSM + JoinResult capture")
+}
+
+func TestM2aHarness_JoinerFailNoFreeInitiatorPath(t *testing.T) {
+	t.Skip("pending M3: JoinResult error-path capture; ebusgo surfaces ErrNoFreeInitiatorAddress but the gateway's degraded-state transition on that error lands in M3/M4")
+}
+
+func TestM2aHarness_TransportBlindPath(t *testing.T) {
+	t.Skip("partial coverage in M2; full coverage pending M5 degraded-mode surfaces")
+}
+
+func TestM2aHarness_OverrideValidateFalsePath(t *testing.T) {
+	t.Skip("pending M6: StartupSource.Override wiring; override_semantics_source_of_truth: M6")
+}
+
+func TestM2aHarness_OverrideValidateTruePath(t *testing.T) {
+	t.Skip("pending M6: StartupSource.Override.Validate wiring + retrospective conflict detection")
+}
+
+func TestM2aHarness_SemanticBarrierClosesOnlyWithAdmissionState(t *testing.T) {
+	t.Skip("pending M3: semanticBarrier predicate extension in cmd/gateway/main.go")
+}
+
+func TestM2aHarness_EvidenceBufferFloodBaselineProtection(t *testing.T) {
+	t.Skip("pending M4: evidence pipeline + max_entries=128 LRU + baseline protection")
+}
+
+func TestM2aHarness_AdmissionArtifactEmissionValidatesAgainstSchema(t *testing.T) {
+	t.Run("valid artifact passes", func(t *testing.T) {
+		valid := []byte(`{"admission":{"state":"joined","source":113,"companion_target":8,"warmup_duration_s":5,"reason_if_degraded":"","transport_kind":"enh","admission_path_selected":"join"},"discovery":{"wire_bytes":2048,"window_s":15,"startup_burst_pct":62.5,"post_startup_sustained_rate_probes_per_15s":1.5,"probe_count":12,"promoted_suspects_without_identity":1,"per_baseline_address_evidence_counts":{"08":3,"15":1}}}`)
+		validateAdmissionArtifactAgainstSchema(t, valid)
+	})
+	t.Run("invalid enum fails", func(t *testing.T) {
+		invalid := []byte(`{"admission":{"state":"joined","source":113,"companion_target":8,"warmup_duration_s":5,"reason_if_degraded":"","transport_kind":"enh","admission_path_selected":"bogus"},"discovery":{"wire_bytes":2048,"window_s":15,"startup_burst_pct":62.5,"post_startup_sustained_rate_probes_per_15s":1.5,"probe_count":12,"promoted_suspects_without_identity":1,"per_baseline_address_evidence_counts":{"08":3}}}`)
+		if err := admissionArtifactSchemaError(invalid); err == nil {
+			t.Fatal("expected invalid enum to fail schema validation")
+		}
+	})
+	t.Run("missing required field fails", func(t *testing.T) {
+		invalid := []byte(`{"admission":{"state":"joined","source":113,"warmup_duration_s":5,"reason_if_degraded":"","transport_kind":"enh","admission_path_selected":"join"},"discovery":{"wire_bytes":2048,"window_s":15,"startup_burst_pct":62.5,"post_startup_sustained_rate_probes_per_15s":1.5,"probe_count":12,"promoted_suspects_without_identity":1,"per_baseline_address_evidence_counts":{"08":3}}}`)
+		if err := admissionArtifactSchemaError(invalid); err == nil {
+			t.Fatal("expected missing required field to fail schema validation")
+		}
+	})
+}
+
+func synthesizedEventSymbols(t *testing.T, event PassiveClassifiedEvent) []byte {
+	t.Helper()
+	switch event.Kind {
+	case PassiveClassifiedEventBroadcastFrame:
+		return frameBytes(event.Request)
+	case PassiveClassifiedEventTransaction:
+		payload := append([]byte{}, frameBytes(event.Request)...)
+		payload = append(payload, protocol.SymbolAck)
+		if event.HasResponse {
+			payload = append(payload, responseSegmentBytes(event.Response.Data)...)
+			payload = append(payload, protocol.SymbolAck, protocol.SymbolSyn)
+			return payload
+		}
+		return append(payload, protocol.SymbolSyn)
+	default:
+		t.Fatalf("unsupported synthesized event kind %d", event.Kind)
+		return nil
+	}
+}
+
+func admissionArtifactSchemaError(artifactJSON []byte) error {
+	schemaPath := filepath.Join("docs", "schemas", "admission-artifact.schema.json")
+	schemaJSON, err := os.ReadFile(schemaPath)
+	if err != nil {
+		return fmt.Errorf("read schema: %w", err)
+	}
+	var schemaEnvelope map[string]any
+	if err := json.Unmarshal(schemaJSON, &schemaEnvelope); err != nil {
+		return fmt.Errorf("parse schema: %w", err)
+	}
+	if schemaEnvelope["$id"] == "" {
+		return fmt.Errorf("schema missing $id")
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(artifactJSON))
+	dec.DisallowUnknownFields()
+	var artifact struct {
+		Admission *struct {
+			State                 *string  `json:"state"`
+			Source                *int     `json:"source"`
+			CompanionTarget       *int     `json:"companion_target"`
+			WarmupDurationS       *float64 `json:"warmup_duration_s"`
+			ReasonIfDegraded      *string  `json:"reason_if_degraded"`
+			TransportKind         *string  `json:"transport_kind"`
+			AdmissionPathSelected *string  `json:"admission_path_selected"`
+		} `json:"admission"`
+		Discovery *struct {
+			WireBytes                         *int           `json:"wire_bytes"`
+			WindowS                           *float64       `json:"window_s"`
+			StartupBurstPct                   *float64       `json:"startup_burst_pct"`
+			PostStartupSustainedRateProbes15S *float64       `json:"post_startup_sustained_rate_probes_per_15s"`
+			ProbeCount                        *int           `json:"probe_count"`
+			PromotedSuspectsWithoutIdentity   *int           `json:"promoted_suspects_without_identity"`
+			PerBaselineAddressEvidenceCounts  map[string]int `json:"per_baseline_address_evidence_counts"`
+		} `json:"discovery"`
+	}
+	if err := dec.Decode(&artifact); err != nil {
+		return fmt.Errorf("decode artifact: %w", err)
+	}
+	if artifact.Admission == nil || artifact.Discovery == nil {
+		return fmt.Errorf("artifact must contain admission and discovery objects")
+	}
+	if artifact.Admission.State == nil || artifact.Admission.Source == nil || artifact.Admission.CompanionTarget == nil || artifact.Admission.WarmupDurationS == nil || artifact.Admission.ReasonIfDegraded == nil || artifact.Admission.TransportKind == nil || artifact.Admission.AdmissionPathSelected == nil {
+		return fmt.Errorf("admission missing required fields")
+	}
+	if artifact.Discovery.WireBytes == nil || artifact.Discovery.WindowS == nil || artifact.Discovery.StartupBurstPct == nil || artifact.Discovery.PostStartupSustainedRateProbes15S == nil || artifact.Discovery.ProbeCount == nil || artifact.Discovery.PromotedSuspectsWithoutIdentity == nil || artifact.Discovery.PerBaselineAddressEvidenceCounts == nil {
+		return fmt.Errorf("discovery missing required fields")
+	}
+	if *artifact.Admission.Source < 0 || *artifact.Admission.Source > 255 || *artifact.Admission.CompanionTarget < 0 || *artifact.Admission.CompanionTarget > 255 || *artifact.Admission.WarmupDurationS < 0 {
+		return fmt.Errorf("admission numeric bounds violated")
+	}
+	if !containsAdmissionEnum([]string{"enh", "ens", "ebusd-tcp", "udp-plain", "tcp-plain"}, *artifact.Admission.TransportKind) {
+		return fmt.Errorf("invalid transport_kind %q", *artifact.Admission.TransportKind)
+	}
+	if !containsAdmissionEnum([]string{"join", "override", "degraded_transport_blind", "degraded_no_events"}, *artifact.Admission.AdmissionPathSelected) {
+		return fmt.Errorf("invalid admission_path_selected %q", *artifact.Admission.AdmissionPathSelected)
+	}
+	if *artifact.Discovery.WireBytes < 0 || *artifact.Discovery.WindowS <= 0 || *artifact.Discovery.StartupBurstPct < 0 || *artifact.Discovery.StartupBurstPct > 100 || *artifact.Discovery.PostStartupSustainedRateProbes15S < 0 || *artifact.Discovery.ProbeCount < 0 || *artifact.Discovery.PromotedSuspectsWithoutIdentity < 0 {
+		return fmt.Errorf("discovery numeric bounds violated")
+	}
+	hexKey := regexp.MustCompile(`^[0-9A-Fa-f]{2}$`)
+	for key, count := range artifact.Discovery.PerBaselineAddressEvidenceCounts {
+		if !hexKey.MatchString(key) {
+			return fmt.Errorf("invalid baseline evidence key %q", key)
+		}
+		if count < 0 {
+			return fmt.Errorf("negative evidence count for key %q", key)
+		}
+	}
+	return nil
+}
+
+func containsAdmissionEnum(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Closes #532. Cruise-run #20. M4 (complexity=6). Stacked on M3 #531. EvidenceBuffer max_entries=128 LRU+baseline-protection, VaillantBaselineTopologySeed. DegradedModeAccumulator K=5/T=5min rolling 15min window, fixed_bucket_1s 900-slot ring (AD17). RejoinBackoffSchedule Base=5s Max=60s exponential. Pure library + tests; no main.go wiring (M7). primary_developer_ai_identity: codex-gpt-5.4; secondary_reviewer_ai_identity: claude-fresh-opus.