### PR TITLE
feat(startup-order): M3 — startup order flip + semanticBarrier predicate (cruise-run #20, re-targeted)

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mdns"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/portal"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/ui"
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
 	ebusgoTransport "github.com/Project-Helianthus/helianthus-ebusgo/transport"
 	vaillantproviders "github.com/Project-Helianthus/helianthus-ebusreg/providers/vaillant"
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
@@ -107,6 +108,13 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 		log.Printf("warning: --proxy-listen requires adapter-direct transport; proxy endpoint not started")
 	}
 
+	admissionPath, admissionPathErr := ebusgateway.ClassifyTransportAdmission(cfg.TransportConfig.Protocol)
+	if admissionPathErr != nil {
+		log.Printf("startup admission: classifier rejected transport protocol=%q err=%v; falling back to legacy static-source path", cfg.TransportConfig.Protocol, admissionPathErr)
+		admissionPath = ebusgateway.TransportAdmissionStaticFallback
+	}
+	overrideSet := false
+
 	busObservability, deduplicator, err := wireObserveFirstObserversFn(&cfg)
 	if err != nil {
 		return err
@@ -189,15 +197,83 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 		return err
 	}
 
-	startupScanSignals := startDiscoveryScanLoopFn(ctx, cfg, gateway, builder, adapterClassifier)
+	var (
+		listener      *ebusgateway.BroadcastListener
+		reconstructor *ebusgateway.PassiveTransactionReconstructor
+		joinResult    *protocol.JoinResult
+	)
+	attachPassiveObserveFirst := func() error {
+		if reconstructor == nil {
+			return nil
+		}
+		if busObservability != nil {
+			if err := busObservability.AttachReconstructor(ctx, reconstructor); err != nil {
+				return err
+			}
+		}
+		if deduplicator != nil {
+			if err := deduplicator.AttachReconstructor(ctx, reconstructor); err != nil {
+				return err
+			}
+		}
+		if listener == nil {
+			var err error
+			listener, err = startBroadcastListenerWithReconstructorFn(ctx, gateway.Router, reconstructor)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if admissionPath == ebusgateway.TransportAdmissionJoinCapable && !overrideSet && shouldStartPassiveObserveFirst(cfg) {
+		reconstructor, err = startPassiveTransactionReconstructor(ctx, cfg)
+		if err != nil {
+			return err
+		}
+		log.Printf("passive reconstructor started")
+
+		joinBus, err := ebusgateway.NewJoinBusAdapter(reconstructor, "startup_admission_joinbus", false)
+		if err != nil {
+			return fmt.Errorf("m3: new joinbus: %w", err)
+		}
+		joiner := protocol.NewJoiner(joinBus, nil, ebusgateway.DefaultStartupAdmissionJoinConfig())
+
+		log.Printf("joiner warmup begin")
+		warmupCtx, cancel := context.WithTimeout(ctx, 6*time.Second)
+		result, err := joiner.Join(warmupCtx)
+		cancel()
+		if err != nil {
+			log.Printf("startup admission degraded reason=joiner_fail err=%v", err)
+		} else {
+			joinResult = &result
+			log.Printf("startup admission active source=0x%02X companion_target=0x%02X", result.Initiator, result.CompanionTarget)
+		}
+	}
+
+	startupCfg := resolveStartupScanSourceConfig(cfg)
+	startupSourceProvenance := startupScanSourceMode(cfg, startupCfg)
+	if admissionPath == ebusgateway.TransportAdmissionJoinCapable && joinResult != nil {
+		startupCfg.ScanSource = joinResult.Initiator
+		startupCfg.ScanSourceAuto = false
+		startupSourceProvenance = "join_result"
+	}
+
+	log.Printf("startup scan pass")
+	log.Printf("startup_directed_probe_phase begin source=0x%02X provenance=%s", startupCfg.ScanSource, startupSourceProvenance)
+	startupScanSignals := startDiscoveryScanLoopFn(ctx, startupCfg, gateway, builder, adapterClassifier)
 
 	if semanticBarrier != nil {
 		go func() {
 			select {
 			case <-ctx.Done():
+				close(semanticBarrier)
+				return
 			case <-startupScanSignals.semanticBootstrapReady:
 			}
-			close(semanticBarrier)
+			if shouldCloseSemanticBarrier(admissionPath, overrideSet, joinResult != nil) {
+				close(semanticBarrier)
+			}
 		}()
 	}
 
@@ -231,24 +307,12 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 	if err != nil {
 		return err
 	}
-	var listener *ebusgateway.BroadcastListener
-	var reconstructor *ebusgateway.PassiveTransactionReconstructor
 	if shouldStartPassiveObserveFirst(cfg) {
-		waitForStartupScanFirstPass(ctx, cfg, startupScanSignals.firstPassDone)
+		if reconstructor == nil {
+			waitForStartupScanFirstPass(ctx, cfg, startupScanSignals.firstPassDone)
 
-		reconstructor, err = startPassiveTransactionReconstructor(ctx, cfg)
-		if err != nil {
-			if advertiser != nil {
-				_ = advertiser.Close()
-			}
-			if server != nil {
-				_ = server.Close()
-			}
-			return err
-		}
-		if busObservability != nil {
-			if err := busObservability.AttachReconstructor(ctx, reconstructor); err != nil {
-				_ = reconstructor.Close()
+			reconstructor, err = startPassiveTransactionReconstructor(ctx, cfg)
+			if err != nil {
 				if advertiser != nil {
 					_ = advertiser.Close()
 				}
@@ -258,20 +322,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 				return err
 			}
 		}
-		if deduplicator != nil {
-			if err := deduplicator.AttachReconstructor(ctx, reconstructor); err != nil {
-				_ = reconstructor.Close()
-				if advertiser != nil {
-					_ = advertiser.Close()
-				}
-				if server != nil {
-					_ = server.Close()
-				}
-				return err
-			}
-		}
-		listener, err = startBroadcastListenerWithReconstructorFn(ctx, gateway.Router, reconstructor)
-		if err != nil {
+		if err := attachPassiveObserveFirst(); err != nil {
 			_ = reconstructor.Close()
 			if advertiser != nil {
 				_ = advertiser.Close()

--- a/cmd/gateway/main_test.go
+++ b/cmd/gateway/main_test.go
@@ -583,7 +583,7 @@ func TestRun_DefersSemanticBootstrapUntilStartupConfirmationReadyOnPassiveObserv
 		return nil
 	}
 	startPassiveTransactionReconstructor = func(context.Context, ebusgateway.Config) (*ebusgateway.PassiveTransactionReconstructor, error) {
-		return nil, nil
+		return &ebusgateway.PassiveTransactionReconstructor{}, nil
 	}
 	startBroadcastListenerWithReconstructorFn = func(context.Context, *router.BusEventRouter, *ebusgateway.PassiveTransactionReconstructor) (*ebusgateway.BroadcastListener, error) {
 		return nil, nil
@@ -632,8 +632,8 @@ func TestRun_DefersSemanticBootstrapUntilStartupConfirmationReadyOnPassiveObserv
 
 	select {
 	case <-semanticStarted:
-	case <-time.After(2 * time.Second):
-		t.Fatal("semantic bootstrap did not start after semantic barrier readiness")
+		t.Fatal("semantic bootstrap started despite degraded admission without override")
+	case <-time.After(200 * time.Millisecond):
 	}
 
 	cancel()
@@ -722,7 +722,6 @@ func TestRun_WaitsForStartupScanFirstPassBeforePassiveObserveFirst(t *testing.T)
 		startHTTPServerFn = origStartHTTPServerFn
 	})
 
-	firstPassDone := make(chan struct{})
 	passiveStarted := make(chan struct{}, 1)
 
 	wireObserveFirstObserversFn = func(*ebusgateway.Config) (*ebusgateway.BusObservabilityStore, *ebusgateway.ActivePassiveDeduplicator, error) {
@@ -730,7 +729,7 @@ func TestRun_WaitsForStartupScanFirstPassBeforePassiveObserveFirst(t *testing.T)
 	}
 	startDiscoveryScanLoopFn = func(context.Context, ebusgateway.Config, *ebusgateway.Gateway, *graphql.Builder, activeTxnClassifier) startupScanSignals {
 		return startupScanSignals{
-			firstPassDone:          firstPassDone,
+			firstPassDone:          make(chan struct{}),
 			semanticBootstrapReady: make(chan struct{}),
 		}
 	}
@@ -745,7 +744,7 @@ func TestRun_WaitsForStartupScanFirstPassBeforePassiveObserveFirst(t *testing.T)
 		default:
 		}
 		cancel()
-		return nil, nil
+		return &ebusgateway.PassiveTransactionReconstructor{}, nil
 	}
 	startBroadcastListenerWithReconstructorFn = func(context.Context, *router.BusEventRouter, *ebusgateway.PassiveTransactionReconstructor) (*ebusgateway.BroadcastListener, error) {
 		return nil, nil
@@ -763,16 +762,8 @@ func TestRun_WaitsForStartupScanFirstPassBeforePassiveObserveFirst(t *testing.T)
 
 	select {
 	case <-passiveStarted:
-		t.Fatal("passive observe-first started before startup scan first pass completed")
-	case <-time.After(150 * time.Millisecond):
-	}
-
-	close(firstPassDone)
-
-	select {
-	case <-passiveStarted:
 	case <-time.After(2 * time.Second):
-		t.Fatal("passive observe-first did not start after startup scan first pass completed")
+		t.Fatal("passive reconstructor did not start before startup scan on join-capable transport")
 	}
 
 	select {

--- a/cmd/gateway/startup_order.go
+++ b/cmd/gateway/startup_order.go
@@ -1,0 +1,10 @@
+package main
+
+import "github.com/Project-Helianthus/helianthus-ebusgateway"
+
+func shouldCloseSemanticBarrier(admissionPath ebusgateway.TransportAdmissionPath, overrideSet bool, joinResultNotNil bool) bool {
+	if admissionPath != ebusgateway.TransportAdmissionJoinCapable {
+		return true
+	}
+	return overrideSet || joinResultNotNil
+}

--- a/cmd/gateway/startup_order_test.go
+++ b/cmd/gateway/startup_order_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusgateway"
+)
+
+func TestShouldCloseSemanticBarrier(t *testing.T) {
+	cases := []struct {
+		name             string
+		admissionPath    ebusgateway.TransportAdmissionPath
+		overrideSet      bool
+		joinResultNotNil bool
+		wantClose        bool
+	}{
+		{"join-capable + joiner success, override unset -> close", ebusgateway.TransportAdmissionJoinCapable, false, true, true},
+		{"join-capable + no joiner result, override unset -> keep open (DEGRADED)", ebusgateway.TransportAdmissionJoinCapable, false, false, false},
+		{"join-capable + override set (any joiner state) -> close", ebusgateway.TransportAdmissionJoinCapable, true, false, true},
+		{"join-capable + override set + joiner result -> close", ebusgateway.TransportAdmissionJoinCapable, true, true, true},
+		{"static-fallback (ebusd-tcp) -> close (legacy behavior)", ebusgateway.TransportAdmissionStaticFallback, false, false, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldCloseSemanticBarrier(tc.admissionPath, tc.overrideSet, tc.joinResultNotNil)
+			if got != tc.wantClose {
+				t.Errorf("got %v, want %v", got, tc.wantClose)
+			}
+		})
+	}
+}

--- a/startup_admission_harness_test.go
+++ b/startup_admission_harness_test.go
@@ -84,10 +84,6 @@ func TestM2aHarness_OverrideValidateTruePath(t *testing.T) {
 	t.Skip("pending M6: StartupSource.Override.Validate wiring + retrospective conflict detection")
 }
 
-func TestM2aHarness_SemanticBarrierClosesOnlyWithAdmissionState(t *testing.T) {
-	t.Skip("pending M3: semanticBarrier predicate extension in cmd/gateway/main.go")
-}
-
 func TestM2aHarness_EvidenceBufferFloodBaselineProtection(t *testing.T) {
 	t.Skip("pending M4: evidence pipeline + max_entries=128 LRU + baseline protection")
 }


### PR DESCRIPTION
Closes #530. Cruise-run #20 milestone M3. Re-opened against main after M2/M2a merged. ebusd-tcp preserved (AD13). semanticBarrier predicate extended (AD16, no poller refactor). Override stub deferred to M6. Replaces #531.