### PR TITLE
feat(evidence,admission): M4 — evidence pipeline + escalation accumulator + rejoin backoff (cruise-run #20)

### DIFF
--- a/admission_escalation.go
+++ b/admission_escalation.go
@@ -1,0 +1,178 @@
+package ebusgateway
+
+import (
+	"sync"
+	"time"
+)
+
+const (
+	StartupAdmissionRejoinBackoffBaseSeconds = 5
+	StartupAdmissionRejoinBackoffMaxSeconds  = 60
+
+	StartupAdmissionEscalationFailureCountThreshold = 5
+	StartupAdmissionEscalationDurationSeconds       = 300
+	StartupAdmissionEscalationWindowSeconds         = 900
+)
+
+// RejoinBackoffSchedule returns the nth attempt's backoff duration:
+// Base * 2^(n-1), capped at Max. attempt=1 → Base; attempt=2 → 2*Base; etc.
+func RejoinBackoffSchedule(attempt int, baseSeconds, maxSeconds int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	secs := baseSeconds
+	for i := 1; i < attempt; i++ {
+		secs *= 2
+		if secs >= maxSeconds {
+			return time.Duration(maxSeconds) * time.Second
+		}
+	}
+	return time.Duration(secs) * time.Second
+}
+
+// DegradedModeAccumulator tracks both consecutive rejoin failures and a
+// rolling-window cumulative degraded-duration counter. Escalation fires
+// when EITHER threshold is reached. Per AD17, the accumulator is
+// in-process only — no restart persistence.
+type DegradedModeAccumulator struct {
+	mu  sync.Mutex
+	now func() time.Time
+
+	consecutiveFailures int
+
+	buckets     [900]uint16
+	bucketIndex int
+	bucketStart time.Time
+
+	inDegradedSince time.Time
+	escalated       bool
+
+	continuousThresholdSeconds int
+	windowSeconds              int
+	failureCountThreshold      int
+}
+
+func NewDegradedModeAccumulator() *DegradedModeAccumulator {
+	return &DegradedModeAccumulator{
+		now:                        time.Now,
+		continuousThresholdSeconds: StartupAdmissionEscalationDurationSeconds,
+		windowSeconds:              StartupAdmissionEscalationWindowSeconds,
+		failureCountThreshold:      StartupAdmissionEscalationFailureCountThreshold,
+	}
+}
+
+// RecordFailure increments the consecutive failure counter and updates the
+// accumulator with the failure moment. Returns true if the accumulator
+// crossed the escalation threshold as a result of this call.
+func (a *DegradedModeAccumulator) RecordFailure() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.consecutiveFailures++
+	now := a.now()
+	if a.inDegradedSince.IsZero() {
+		a.inDegradedSince = now
+		a.bucketStart = now
+		a.bucketIndex = 0
+	}
+	return a.checkEscalationLocked(now)
+}
+
+// RecordDegradedTick advances the cumulative accumulator by one second of
+// degraded-state occupancy. Called by a 1-second ticker in runtime when
+// admission state is degraded. Returns true if the accumulator crossed the
+// escalation threshold.
+func (a *DegradedModeAccumulator) RecordDegradedTick() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	now := a.now()
+	a.advanceBucketsLocked(now)
+	a.buckets[a.bucketIndex] = 1000
+	return a.checkEscalationLocked(now)
+}
+
+// RecordSuccess clears the consecutive failure counter. Does NOT clear the
+// rolling accumulator — flaps remain visible in the window. Latch clears
+// only after state_min_stability_s of continuous active (caller handles
+// the stability window separately).
+func (a *DegradedModeAccumulator) RecordSuccess() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.consecutiveFailures = 0
+	a.inDegradedSince = time.Time{}
+}
+
+// ClearLatch clears the escalated flag after state_min_stability_s of
+// continuous active state. Caller is responsible for the stability timer;
+// this method only flips the flag.
+func (a *DegradedModeAccumulator) ClearLatch() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.escalated = false
+}
+
+// Escalated reports whether the latch is currently set.
+func (a *DegradedModeAccumulator) Escalated() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.escalated
+}
+
+// CumulativeDegradedMs returns the sum of degraded-ms across all buckets in
+// the rolling window.
+func (a *DegradedModeAccumulator) CumulativeDegradedMs() uint64 {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	var sum uint64
+	for _, b := range a.buckets {
+		sum += uint64(b)
+	}
+	return sum
+}
+
+// advanceBucketsLocked rotates the ring buffer forward based on elapsed
+// wall-clock time since the last advance. Zero-fills skipped buckets.
+func (a *DegradedModeAccumulator) advanceBucketsLocked(now time.Time) {
+	if a.bucketStart.IsZero() {
+		a.bucketStart = now
+		a.bucketIndex = 0
+		return
+	}
+	elapsed := now.Sub(a.bucketStart)
+	if elapsed < time.Second {
+		return
+	}
+	secsElapsed := int(elapsed.Seconds())
+	for i := 0; i < secsElapsed; i++ {
+		a.bucketIndex = (a.bucketIndex + 1) % len(a.buckets)
+		a.buckets[a.bucketIndex] = 0
+	}
+	a.bucketStart = a.bucketStart.Add(time.Duration(secsElapsed) * time.Second)
+}
+
+func (a *DegradedModeAccumulator) checkEscalationLocked(now time.Time) bool {
+	if a.escalated {
+		return false
+	}
+	if a.consecutiveFailures >= a.failureCountThreshold {
+		a.escalated = true
+		return true
+	}
+	if !a.inDegradedSince.IsZero() {
+		continuousSeconds := int(now.Sub(a.inDegradedSince).Seconds())
+		if continuousSeconds >= a.continuousThresholdSeconds {
+			a.escalated = true
+			return true
+		}
+	}
+	var cumMs uint64
+	for _, b := range a.buckets {
+		cumMs += uint64(b)
+	}
+	if cumMs >= uint64(a.continuousThresholdSeconds)*1000 {
+		a.escalated = true
+		return true
+	}
+	return false
+}

--- a/admission_escalation_test.go
+++ b/admission_escalation_test.go
@@ -94,3 +94,67 @@ func TestDegradedModeAccumulator_RecordSuccessResetsConsecutiveFailures(t *testi
 		t.Fatal("expected escalation at 5th failure after reset")
 	}
 }
+
+// TestDegradedModeAccumulator_T5min_ContinuousDegradedEscalation drives the
+// continuous-time threshold path (T=5min) using a fake clock. Plan AD17:
+// "escalation fires on EITHER K=5 consecutive rejoin failures OR T=5min
+// cumulative degraded time within rolling 15-min window, whichever fires
+// first." This test covers the T=5min path which K=5 tests do not exercise.
+func TestDegradedModeAccumulator_T5min_ContinuousDegradedEscalation(t *testing.T) {
+	a := NewDegradedModeAccumulator()
+	base := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return base }
+
+	// Initial RecordFailure marks degraded-since=base; not yet escalated
+	// (only 1 consecutive failure).
+	if a.RecordFailure() {
+		t.Fatal("escalated too early on first failure")
+	}
+
+	// Advance to base+299s (just under threshold). Tick degraded each second.
+	// Should not escalate yet.
+	for sec := 1; sec < 300; sec++ {
+		a.now = func() time.Time { return base.Add(time.Duration(sec) * time.Second) }
+		if a.RecordDegradedTick() {
+			t.Fatalf("escalated too early at sec=%d (expected escalation at sec>=300)", sec)
+		}
+	}
+
+	// At base+300s the continuous threshold fires.
+	a.now = func() time.Time { return base.Add(300 * time.Second) }
+	if !a.RecordDegradedTick() {
+		t.Fatal("expected escalation at base+300s continuous degraded duration")
+	}
+	if !a.Escalated() {
+		t.Fatal("latch should be set after T=5min escalation")
+	}
+}
+
+// TestDegradedModeAccumulator_T5min_CumulativeRollingWindow drives the
+// cumulative-buckets path. With state_min_stability_s+continuous_threshold_s
+// frozen at 300, accumulating ≥300000 ms of degraded-state samples in the
+// 900-bucket ring buffer should escalate even without a single continuous
+// degraded-since window of 300s.
+func TestDegradedModeAccumulator_T5min_CumulativeRollingWindow(t *testing.T) {
+	a := NewDegradedModeAccumulator()
+	base := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return base }
+
+	// Walk the bucket index manually by directly setting buckets (simpler
+	// than scripting flap-RecordFailure cycles with intermediate Success).
+	// Fill 300 buckets with 1000ms each = 300000 ms total = exact threshold.
+	a.mu.Lock()
+	for i := 0; i < 300; i++ {
+		a.buckets[i] = 1000
+	}
+	a.mu.Unlock()
+
+	// One observation tick to trigger the cumulative-sum check.
+	a.now = func() time.Time { return base.Add(301 * time.Second) }
+	if !a.RecordDegradedTick() {
+		t.Fatal("expected escalation when cumulative buckets sum reached threshold")
+	}
+	if !a.Escalated() {
+		t.Fatal("latch should be set after cumulative-window escalation")
+	}
+}

--- a/admission_escalation_test.go
+++ b/admission_escalation_test.go
@@ -1,0 +1,96 @@
+package ebusgateway
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRejoinBackoffSchedule(t *testing.T) {
+	cases := []struct {
+		attempt  int
+		base     int
+		max      int
+		wantSecs int
+	}{
+		{1, 5, 60, 5},
+		{2, 5, 60, 10},
+		{3, 5, 60, 20},
+		{4, 5, 60, 40},
+		{5, 5, 60, 60},
+		{10, 5, 60, 60},
+		{0, 5, 60, 5},
+	}
+	for _, tc := range cases {
+		got := RejoinBackoffSchedule(tc.attempt, tc.base, tc.max)
+		wantDur := time.Duration(tc.wantSecs) * time.Second
+		if got != wantDur {
+			t.Errorf("attempt=%d base=%d max=%d: got %v, want %v", tc.attempt, tc.base, tc.max, got, wantDur)
+		}
+	}
+}
+
+func TestDegradedModeAccumulator_K5_FailureCountEscalation(t *testing.T) {
+	a := NewDegradedModeAccumulator()
+	for i := 0; i < 4; i++ {
+		if a.RecordFailure() {
+			t.Fatalf("escalated too early at failure %d", i+1)
+		}
+	}
+	if !a.RecordFailure() {
+		t.Fatal("expected escalation at 5th failure (K=5)")
+	}
+	if !a.Escalated() {
+		t.Fatal("latch should be set after escalation")
+	}
+}
+
+func TestDegradedModeAccumulator_LatchSuppressesFurtherEscalation(t *testing.T) {
+	a := NewDegradedModeAccumulator()
+	for i := 0; i < 5; i++ {
+		a.RecordFailure()
+	}
+	if !a.Escalated() {
+		t.Fatal("should be escalated")
+	}
+	for i := 0; i < 5; i++ {
+		if a.RecordFailure() {
+			t.Errorf("escalation re-fired on failure %d (should latch-suppress)", i+1)
+		}
+	}
+}
+
+func TestDegradedModeAccumulator_ClearLatchOnStabilityWindow(t *testing.T) {
+	a := NewDegradedModeAccumulator()
+	for i := 0; i < 5; i++ {
+		a.RecordFailure()
+	}
+	if !a.Escalated() {
+		t.Fatal("should be escalated")
+	}
+	a.ClearLatch()
+	if a.Escalated() {
+		t.Fatal("latch should be cleared")
+	}
+	a.RecordSuccess()
+	for i := 0; i < 5; i++ {
+		a.RecordFailure()
+	}
+	if !a.Escalated() {
+		t.Fatal("expected re-escalation after latch clear")
+	}
+}
+
+func TestDegradedModeAccumulator_RecordSuccessResetsConsecutiveFailures(t *testing.T) {
+	a := NewDegradedModeAccumulator()
+	a.RecordFailure()
+	a.RecordFailure()
+	a.RecordSuccess()
+	for i := 0; i < 4; i++ {
+		if a.RecordFailure() {
+			t.Fatalf("escalated after reset at failure %d", i+1)
+		}
+	}
+	if !a.RecordFailure() {
+		t.Fatal("expected escalation at 5th failure after reset")
+	}
+}

--- a/evidence_buffer.go
+++ b/evidence_buffer.go
@@ -1,0 +1,165 @@
+package ebusgateway
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+)
+
+// EvidenceStrength classifies an observation's contribution weight toward
+// promoting a suspect to a confirmed-identity candidate.
+type EvidenceStrength uint8
+
+const (
+	EvidenceWeak EvidenceStrength = iota + 1
+	EvidenceStrong
+)
+
+// EvidenceRecord is a single observation for a bus address.
+type EvidenceRecord struct {
+	Address  byte
+	Strength EvidenceStrength
+	Observed time.Time
+	Kind     string
+}
+
+// BaselineTopologySeed is the set of addresses protected from LRU eviction.
+// Vaillant default: {0x08 BAI00, 0x15 BASV2, 0x26 VR_71, 0x04 NETX3-A,
+// 0xF6 NETX3-B, 0xEC SOL00}. Operators MAY override via config; validation
+// enforces slave-range [0x03, 0xFE] excluding 0xAA (SYN) and 0xFE (broadcast).
+var VaillantBaselineTopologySeed = []byte{0x08, 0x15, 0x26, 0x04, 0xF6, 0xEC}
+
+// ValidateBaselineTopologySeed checks the config-provided seed against the
+// slave-address range.
+func ValidateBaselineTopologySeed(seed []byte) error {
+	for _, addr := range seed {
+		if addr < 0x03 || addr >= 0xFE {
+			return fmt.Errorf("evidence: baseline seed 0x%02X out of slave range [0x03, 0xFE]", addr)
+		}
+		if addr == 0xAA {
+			return fmt.Errorf("evidence: baseline seed must not include SYN (0xAA)")
+		}
+	}
+	return nil
+}
+
+// EvidenceBuffer is a bounded, LRU-with-baseline-protection buffer of
+// per-address observations. Its max capacity is max_entries=128 (per AD05).
+// When the buffer is full and a new non-baseline address is observed, the
+// oldest non-baseline entry is evicted. Baseline addresses are NEVER
+// evicted — they may update in place but never leave the buffer.
+type EvidenceBuffer struct {
+	mu         sync.Mutex
+	maxEntries int
+	baseline   map[byte]struct{}
+	entries    map[byte]*addressState
+	tick       uint64
+}
+
+type addressState struct {
+	address      byte
+	observations int
+	strongObs    int
+	lastObserved time.Time
+	touchedAt    uint64
+	promoted     bool
+}
+
+func NewEvidenceBuffer(maxEntries int, baseline []byte) (*EvidenceBuffer, error) {
+	if err := ValidateBaselineTopologySeed(baseline); err != nil {
+		return nil, err
+	}
+	if maxEntries < 32 || maxEntries > 1024 {
+		return nil, fmt.Errorf("evidence: max_entries=%d out of range [32, 1024]", maxEntries)
+	}
+	buf := &EvidenceBuffer{
+		maxEntries: maxEntries,
+		baseline:   make(map[byte]struct{}, len(baseline)),
+		entries:    make(map[byte]*addressState, maxEntries),
+	}
+	for _, addr := range baseline {
+		buf.baseline[addr] = struct{}{}
+	}
+	return buf, nil
+}
+
+// Record adds or updates evidence for an address. Returns whether the address
+// crossed the promotion threshold as a result (≥2 observations OR any strong).
+func (b *EvidenceBuffer) Record(record EvidenceRecord) (promoted bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.tick++
+	state, ok := b.entries[record.Address]
+	if !ok {
+		if len(b.entries) >= b.maxEntries {
+			b.evictOldestNonBaselineLocked()
+		}
+		if len(b.entries) >= b.maxEntries {
+			if _, isBaseline := b.baseline[record.Address]; !isBaseline {
+				return false
+			}
+		}
+		state = &addressState{address: record.Address}
+		b.entries[record.Address] = state
+	}
+
+	state.observations++
+	if record.Strength == EvidenceStrong {
+		state.strongObs++
+	}
+	state.lastObserved = record.Observed
+	state.touchedAt = b.tick
+
+	if !state.promoted && (state.observations >= 2 || state.strongObs >= 1) {
+		state.promoted = true
+		return true
+	}
+	return false
+}
+
+func (b *EvidenceBuffer) evictOldestNonBaselineLocked() {
+	var (
+		victimAddr byte
+		victimTick = ^uint64(0)
+		found      bool
+	)
+	for addr, st := range b.entries {
+		if _, base := b.baseline[addr]; base {
+			continue
+		}
+		if st.touchedAt < victimTick {
+			victimTick = st.touchedAt
+			victimAddr = addr
+			found = true
+		}
+	}
+	if found {
+		delete(b.entries, victimAddr)
+	}
+}
+
+// PromotedAddresses returns the sorted set of addresses that have crossed
+// the promotion threshold. Caller uses this to build the directed probe
+// target list for the ebusreg ScanDirected call.
+func (b *EvidenceBuffer) PromotedAddresses() []byte {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	out := make([]byte, 0)
+	for addr, st := range b.entries {
+		if st.promoted {
+			out = append(out, addr)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+// Len returns the current count of stored entries.
+func (b *EvidenceBuffer) Len() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.entries)
+}

--- a/evidence_buffer_test.go
+++ b/evidence_buffer_test.go
@@ -1,0 +1,116 @@
+package ebusgateway
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEvidenceBuffer_PromotionOnTwoObservations(t *testing.T) {
+	b, err := NewEvidenceBuffer(128, VaillantBaselineTopologySeed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	promoted1 := b.Record(EvidenceRecord{Address: 0x20, Strength: EvidenceWeak, Observed: now})
+	if promoted1 {
+		t.Errorf("promotion on first observation — expected none")
+	}
+	promoted2 := b.Record(EvidenceRecord{Address: 0x20, Strength: EvidenceWeak, Observed: now.Add(time.Second)})
+	if !promoted2 {
+		t.Errorf("expected promotion on second observation")
+	}
+}
+
+func TestEvidenceBuffer_PromotionOnSingleStrongEvidence(t *testing.T) {
+	b, _ := NewEvidenceBuffer(128, VaillantBaselineTopologySeed)
+	promoted := b.Record(EvidenceRecord{Address: 0x20, Strength: EvidenceStrong, Observed: time.Now()})
+	if !promoted {
+		t.Errorf("expected immediate promotion on single strong evidence")
+	}
+}
+
+func TestEvidenceBuffer_FloodWithDefaultSeed_BaselineSurvives(t *testing.T) {
+	b, _ := NewEvidenceBuffer(128, VaillantBaselineTopologySeed)
+	now := time.Now()
+	for _, addr := range VaillantBaselineTopologySeed {
+		b.Record(EvidenceRecord{Address: addr, Strength: EvidenceWeak, Observed: now})
+	}
+	for i := 0; i < 1000; i++ {
+		addr := byte(0x20 + (i % 0xD0))
+		b.Record(EvidenceRecord{Address: addr, Strength: EvidenceWeak, Observed: now.Add(time.Duration(i) * time.Millisecond)})
+	}
+	if b.Len() > 128 {
+		t.Errorf("buffer overflow: len=%d > 128", b.Len())
+	}
+	for _, baseAddr := range VaillantBaselineTopologySeed {
+		promoted := b.PromotedAddresses()
+		found := false
+		for _, p := range promoted {
+			if p == baseAddr {
+				found = true
+				break
+			}
+		}
+		if !found {
+			b.mu.Lock()
+			_, ok := b.entries[baseAddr]
+			b.mu.Unlock()
+			if !ok {
+				t.Errorf("baseline address 0x%02X was evicted — AD05 violation", baseAddr)
+			}
+		}
+	}
+}
+
+func TestEvidenceBuffer_FloodWithNonDefaultSeed_BaselineSurvives(t *testing.T) {
+	customSeed := []byte{0x03, 0x10, 0x50}
+	b, err := NewEvidenceBuffer(128, customSeed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	for _, addr := range customSeed {
+		b.Record(EvidenceRecord{Address: addr, Strength: EvidenceWeak, Observed: now})
+	}
+	for i := 0; i < 1000; i++ {
+		addr := byte(0x60 + (i % 0x90))
+		b.Record(EvidenceRecord{Address: addr, Strength: EvidenceWeak, Observed: now.Add(time.Duration(i) * time.Millisecond)})
+	}
+	if b.Len() > 128 {
+		t.Errorf("buffer overflow: len=%d > 128", b.Len())
+	}
+	for _, baseAddr := range customSeed {
+		b.mu.Lock()
+		_, ok := b.entries[baseAddr]
+		b.mu.Unlock()
+		if !ok {
+			t.Errorf("custom-seed baseline 0x%02X was evicted — AD05 violation", baseAddr)
+		}
+	}
+}
+
+func TestEvidenceBuffer_ValidateBaselineTopologySeed_RejectsOutOfRange(t *testing.T) {
+	cases := [][]byte{
+		{0x00, 0x08},
+		{0x08, 0xFE},
+		{0xAA, 0x08},
+		{0x08, 0xFF},
+	}
+	for i, seed := range cases {
+		if err := ValidateBaselineTopologySeed(seed); err == nil {
+			t.Errorf("case %d: expected error for seed %v", i, seed)
+		}
+	}
+}
+
+func TestEvidenceBuffer_NewRejectsOutOfRangeMaxEntries(t *testing.T) {
+	if _, err := NewEvidenceBuffer(31, VaillantBaselineTopologySeed); err == nil {
+		t.Error("expected error for max_entries=31 (below min 32)")
+	}
+	if _, err := NewEvidenceBuffer(1025, VaillantBaselineTopologySeed); err == nil {
+		t.Error("expected error for max_entries=1025 (above max 1024)")
+	}
+	if _, err := NewEvidenceBuffer(128, VaillantBaselineTopologySeed); err != nil {
+		t.Errorf("expected no error for max_entries=128: %v", err)
+	}
+}

--- a/startup_admission_harness_test.go
+++ b/startup_admission_harness_test.go
@@ -85,7 +85,26 @@ func TestM2aHarness_OverrideValidateTruePath(t *testing.T) {
 }
 
 func TestM2aHarness_EvidenceBufferFloodBaselineProtection(t *testing.T) {
-	t.Skip("pending M4: evidence pipeline + max_entries=128 LRU + baseline protection")
+	b, err := NewEvidenceBuffer(128, VaillantBaselineTopologySeed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	for _, addr := range VaillantBaselineTopologySeed {
+		b.Record(EvidenceRecord{Address: addr, Strength: EvidenceWeak, Observed: now})
+	}
+	for i := 0; i < 1000; i++ {
+		addr := byte(0x20 + (i % 0xD0))
+		b.Record(EvidenceRecord{Address: addr, Strength: EvidenceWeak, Observed: now.Add(time.Duration(i) * time.Millisecond)})
+	}
+	for _, addr := range VaillantBaselineTopologySeed {
+		b.mu.Lock()
+		_, ok := b.entries[addr]
+		b.mu.Unlock()
+		if !ok {
+			t.Fatalf("baseline address 0x%02X was evicted", addr)
+		}
+	}
 }
 
 func TestM2aHarness_AdmissionArtifactEmissionValidatesAgainstSchema(t *testing.T) {


### PR DESCRIPTION
Closes #532. Cruise-run #20 milestone M4. EvidenceBuffer with LRU+baseline-protect (AD05). DegradedModeAccumulator K=5/T=5min rolling 15min (AD17). RejoinBackoffSchedule. Replaces #533.