### PR TITLE
feat(admission): M5 — degraded-mode surfaces + bus_admission envelope (cruise-run #20)

### DIFF
--- a/admission_envelope_stability.go
+++ b/admission_envelope_stability.go
@@ -1,0 +1,60 @@
+package ebusgateway
+
+import (
+	"sync"
+	"time"
+)
+
+// AdmissionStabilityWindow gates emission of bus_admission state transitions
+// through the configured state_min_stability_s window. A new state is
+// admitted to the envelope body ONLY after it has been stable for the full
+// window duration; transient flaps (state changes within the window) do
+// not flip the envelope. Matches AD08 flap mitigation.
+type AdmissionStabilityWindow struct {
+	mu            sync.Mutex
+	windowSeconds int
+	emittedState  string
+	pendingState  string
+	pendingSince  time.Time
+	now           func() time.Time
+}
+
+func NewAdmissionStabilityWindow(windowSeconds int) *AdmissionStabilityWindow {
+	return &AdmissionStabilityWindow{
+		windowSeconds: windowSeconds,
+		now:           time.Now,
+	}
+}
+
+// Observe records a state change observation. Returns (newEmittedState,
+// flipped) where flipped reports whether the envelope should update.
+func (w *AdmissionStabilityWindow) Observe(state string) (emitted string, flipped bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	now := w.now()
+	if state == w.emittedState {
+		w.pendingState = ""
+		w.pendingSince = time.Time{}
+		return w.emittedState, false
+	}
+	if state != w.pendingState {
+		w.pendingState = state
+		w.pendingSince = now
+		return w.emittedState, false
+	}
+	if now.Sub(w.pendingSince) >= time.Duration(w.windowSeconds)*time.Second {
+		w.emittedState = state
+		w.pendingState = ""
+		w.pendingSince = time.Time{}
+		return w.emittedState, true
+	}
+	return w.emittedState, false
+}
+
+// EmittedState returns the state currently reflected in the envelope.
+func (w *AdmissionStabilityWindow) EmittedState() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.emittedState
+}

--- a/admission_envelope_stability_test.go
+++ b/admission_envelope_stability_test.go
@@ -1,0 +1,44 @@
+package ebusgateway
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAdmissionStabilityWindow_DoesNotFlipOnTransient(t *testing.T) {
+	w := NewAdmissionStabilityWindow(30)
+	base := time.Now()
+	w.now = func() time.Time { return base }
+	state, flipped := w.Observe("active")
+	if flipped {
+		t.Errorf("first observation: unexpected flip")
+	}
+	if state != "" {
+		t.Errorf("expected emitted still empty, got %q", state)
+	}
+	w.now = func() time.Time { return base.Add(10 * time.Second) }
+	_, flipped = w.Observe("degraded")
+	if flipped {
+		t.Errorf("10s not enough; should not flip")
+	}
+	w.now = func() time.Time { return base.Add(15 * time.Second) }
+	_, flipped = w.Observe("active")
+	if flipped {
+		t.Errorf("pending reset; should not flip")
+	}
+}
+
+func TestAdmissionStabilityWindow_FlipsAfterWindowElapsed(t *testing.T) {
+	w := NewAdmissionStabilityWindow(30)
+	base := time.Now()
+	w.now = func() time.Time { return base }
+	w.Observe("active")
+	w.now = func() time.Time { return base.Add(31 * time.Second) }
+	_, flipped := w.Observe("active")
+	if !flipped {
+		t.Errorf("expected flip after 31s continuous active")
+	}
+	if w.EmittedState() != "active" {
+		t.Errorf("emitted state should be 'active', got %q", w.EmittedState())
+	}
+}

--- a/admission_metrics.go
+++ b/admission_metrics.go
@@ -94,14 +94,21 @@ func (m *StartupAdmissionMetrics) MarkDegraded(now time.Time) {
 	}
 }
 
-// MarkActive sets State=1 and clears DegradedSinceMs.
+// MarkActive sets State=1 and clears DegradedSinceMs. Holds m.mu so the
+// pair {State, DegradedSinceMs} updates atomically vs MarkDegraded /
+// MarkPending — prevents the AD20-reviewer-flagged race where concurrent
+// transitions could double-count DegradedTotal.
 func (m *StartupAdmissionMetrics) MarkActive() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.State.Set(1)
 	m.DegradedSinceMs.Set(0)
 }
 
-// MarkPending sets State=0.
+// MarkPending sets State=0. Holds m.mu (see MarkActive note).
 func (m *StartupAdmissionMetrics) MarkPending() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.State.Set(0)
 }
 

--- a/admission_metrics.go
+++ b/admission_metrics.go
@@ -1,0 +1,167 @@
+package ebusgateway
+
+import (
+	"expvar"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// StartupAdmissionMetrics bundles the 11 expvar surfaces exposed by the
+// startup-admission-discovery plan (per plan §M5 expvar_surfaces).
+// Names and semantics match the plan exactly; callers publish this
+// bundle via expvar.Publish at startup and update counters/gauges as
+// runtime events occur.
+type StartupAdmissionMetrics struct {
+	DegradedTotal             *expvar.Int
+	State                     *expvar.Int
+	OverrideActive            *expvar.Int
+	WarmupEventsSeen          *expvar.Int
+	WarmupCyclesTotal         *expvar.Int
+	OverrideBypassTotal       *expvar.Int
+	OverrideConflictDetected  *expvar.Int
+	DegradedEscalated         *expvar.Int
+	DegradedSinceMs           *expvar.Int
+	ConsecutiveRejoinFailures *expvar.Int
+	DegradedCumulativeMs      *expvar.Int
+
+	mu sync.Mutex
+
+	warmupCycleSeq uint64
+}
+
+// NewStartupAdmissionMetrics allocates the metric bundle. Caller decides
+// whether to publish via expvar.Publish or keep per-instance (for tests).
+func NewStartupAdmissionMetrics() *StartupAdmissionMetrics {
+	return &StartupAdmissionMetrics{
+		DegradedTotal:             new(expvar.Int),
+		State:                     new(expvar.Int),
+		OverrideActive:            new(expvar.Int),
+		WarmupEventsSeen:          new(expvar.Int),
+		WarmupCyclesTotal:         new(expvar.Int),
+		OverrideBypassTotal:       new(expvar.Int),
+		OverrideConflictDetected:  new(expvar.Int),
+		DegradedEscalated:         new(expvar.Int),
+		DegradedSinceMs:           new(expvar.Int),
+		ConsecutiveRejoinFailures: new(expvar.Int),
+		DegradedCumulativeMs:      new(expvar.Int),
+	}
+}
+
+// Publish registers all expvars under the "startup_admission_" prefix.
+// Idempotent-safe behavior: does NOT re-register if Publish was already
+// called (expvar panics on duplicate publishes); caller must only call
+// once per process. In tests, use metrics without publishing.
+func (m *StartupAdmissionMetrics) Publish() {
+	expvar.Publish("startup_admission_degraded_total", m.DegradedTotal)
+	expvar.Publish("startup_admission_state", m.State)
+	expvar.Publish("startup_admission_override_active", m.OverrideActive)
+	expvar.Publish("startup_admission_warmup_events_seen", m.WarmupEventsSeen)
+	expvar.Publish("startup_admission_warmup_cycles_total", m.WarmupCyclesTotal)
+	expvar.Publish("startup_admission_override_bypass_total", m.OverrideBypassTotal)
+	expvar.Publish("startup_admission_override_conflict_detected", m.OverrideConflictDetected)
+	expvar.Publish("startup_admission_degraded_escalated", m.DegradedEscalated)
+	expvar.Publish("startup_admission_degraded_since_ms", m.DegradedSinceMs)
+	expvar.Publish("startup_admission_consecutive_rejoin_failures", m.ConsecutiveRejoinFailures)
+	expvar.Publish("startup_admission_degraded_cumulative_ms", m.DegradedCumulativeMs)
+}
+
+// StartWarmupCycle resets WarmupEventsSeen to 0 and increments
+// WarmupCyclesTotal. Returns the new cycle sequence number.
+func (m *StartupAdmissionMetrics) StartWarmupCycle() uint64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.warmupCycleSeq++
+	m.WarmupEventsSeen.Set(0)
+	m.WarmupCyclesTotal.Add(1)
+	return m.warmupCycleSeq
+}
+
+// RecordWarmupEvent increments WarmupEventsSeen by 1.
+func (m *StartupAdmissionMetrics) RecordWarmupEvent() {
+	m.WarmupEventsSeen.Add(1)
+}
+
+// MarkDegraded sets State=2, increments DegradedTotal, records
+// DegradedSinceMs if not already set.
+func (m *StartupAdmissionMetrics) MarkDegraded(now time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.State.Value() != 2 {
+		m.State.Set(2)
+		m.DegradedTotal.Add(1)
+		m.DegradedSinceMs.Set(now.UnixMilli())
+	}
+}
+
+// MarkActive sets State=1 and clears DegradedSinceMs.
+func (m *StartupAdmissionMetrics) MarkActive() {
+	m.State.Set(1)
+	m.DegradedSinceMs.Set(0)
+}
+
+// MarkPending sets State=0.
+func (m *StartupAdmissionMetrics) MarkPending() {
+	m.State.Set(0)
+}
+
+// SetOverrideActive(true) sets OverrideActive=1; SetOverrideActive(false) sets 0.
+func (m *StartupAdmissionMetrics) SetOverrideActive(active bool) {
+	if active {
+		m.OverrideActive.Set(1)
+	} else {
+		m.OverrideActive.Set(0)
+	}
+}
+
+// RecordOverrideBypass increments OverrideBypassTotal (monotonic per
+// admission cycle that selected the override path).
+func (m *StartupAdmissionMetrics) RecordOverrideBypass() {
+	m.OverrideBypassTotal.Add(1)
+}
+
+// SetOverrideConflictDetected flips OverrideConflictDetected to 1
+// (latching for the current run; a cycle reset would restart it).
+func (m *StartupAdmissionMetrics) SetOverrideConflictDetected() {
+	m.OverrideConflictDetected.Set(1)
+}
+
+// SetDegradedEscalated sets the latch (0 or 1).
+func (m *StartupAdmissionMetrics) SetDegradedEscalated(latched bool) {
+	if latched {
+		m.DegradedEscalated.Set(1)
+	} else {
+		m.DegradedEscalated.Set(0)
+	}
+}
+
+// SetConsecutiveRejoinFailures records the current count.
+func (m *StartupAdmissionMetrics) SetConsecutiveRejoinFailures(n int) {
+	m.ConsecutiveRejoinFailures.Set(int64(n))
+}
+
+// SetDegradedCumulativeMs records the current rolling-window cumulative.
+func (m *StartupAdmissionMetrics) SetDegradedCumulativeMs(ms uint64) {
+	m.DegradedCumulativeMs.Set(int64(ms))
+}
+
+// EmitStartupResetWarn is a package-level log helper for the AD17
+// restart-reset WARN line emitted once on process start. Callers use
+// this immediately after NewStartupAdmissionMetrics to satisfy AD17's
+// observability contract.
+func EmitStartupResetWarn(logger func(format string, args ...interface{})) {
+	logger("WARN: startup admission escalation accumulator zeroed reason=process_start")
+}
+
+// ValidateAdmissionPathSelected returns nil if v is one of the four
+// enum values the plan admits per AD23. Returns a FATAL-level error
+// otherwise — callers should refuse to emit artifacts with an out-of-
+// range value.
+func ValidateAdmissionPathSelected(v string) error {
+	switch v {
+	case "join", "override", "degraded_transport_blind", "degraded_no_events":
+		return nil
+	default:
+		return fmt.Errorf("FATAL: admission_path_selected=%q is out of enum {join,override,degraded_transport_blind,degraded_no_events} (AD23)", v)
+	}
+}

--- a/admission_metrics_test.go
+++ b/admission_metrics_test.go
@@ -1,0 +1,83 @@
+package ebusgateway
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStartupAdmissionMetrics_StartWarmupCycle(t *testing.T) {
+	m := NewStartupAdmissionMetrics()
+	m.RecordWarmupEvent()
+	m.RecordWarmupEvent()
+	if got := m.WarmupEventsSeen.Value(); got != 2 {
+		t.Errorf("expected events_seen=2 before cycle reset, got %d", got)
+	}
+	cycle := m.StartWarmupCycle()
+	if cycle != 1 {
+		t.Errorf("expected first cycle=1, got %d", cycle)
+	}
+	if got := m.WarmupEventsSeen.Value(); got != 0 {
+		t.Errorf("expected events_seen reset to 0, got %d", got)
+	}
+	if got := m.WarmupCyclesTotal.Value(); got != 1 {
+		t.Errorf("expected cycles_total=1, got %d", got)
+	}
+}
+
+func TestStartupAdmissionMetrics_StateTransitions(t *testing.T) {
+	m := NewStartupAdmissionMetrics()
+	now := time.Now()
+	m.MarkPending()
+	if m.State.Value() != 0 {
+		t.Errorf("pending: state=%d", m.State.Value())
+	}
+	m.MarkDegraded(now)
+	if m.State.Value() != 2 {
+		t.Errorf("degraded: state=%d", m.State.Value())
+	}
+	if m.DegradedSinceMs.Value() != now.UnixMilli() {
+		t.Errorf("degraded_since_ms not set")
+	}
+	if m.DegradedTotal.Value() != 1 {
+		t.Errorf("degraded_total: %d", m.DegradedTotal.Value())
+	}
+	m.MarkActive()
+	if m.State.Value() != 1 {
+		t.Errorf("active: state=%d", m.State.Value())
+	}
+	if m.DegradedSinceMs.Value() != 0 {
+		t.Errorf("degraded_since_ms not cleared on active: %d", m.DegradedSinceMs.Value())
+	}
+}
+
+func TestValidateAdmissionPathSelected(t *testing.T) {
+	for _, ok := range []string{"join", "override", "degraded_transport_blind", "degraded_no_events"} {
+		if err := ValidateAdmissionPathSelected(ok); err != nil {
+			t.Errorf("valid value %q rejected: %v", ok, err)
+		}
+	}
+	for _, bad := range []string{"", "static_fallback", "bogus", "JOIN", "unknown"} {
+		err := ValidateAdmissionPathSelected(bad)
+		if err == nil {
+			t.Errorf("invalid value %q accepted", bad)
+			continue
+		}
+		if !strings.HasPrefix(err.Error(), "FATAL:") {
+			t.Errorf("expected FATAL: prefix, got %q", err.Error())
+		}
+	}
+}
+
+func TestEmitStartupResetWarn(t *testing.T) {
+	var captured string
+	EmitStartupResetWarn(func(format string, args ...interface{}) {
+		captured = format
+	})
+	if !strings.Contains(captured, "accumulator zeroed") {
+		t.Errorf("expected accumulator-zeroed WARN, got %q", captured)
+	}
+	if !strings.Contains(captured, "reason=process_start") {
+		t.Errorf("expected reason=process_start, got %q", captured)
+	}
+}

--- a/bus_observability_api.go
+++ b/bus_observability_api.go
@@ -45,6 +45,18 @@ type BusObservabilityStartup struct {
 	LiveEpoch     uint64     `json:"live_epoch"`
 }
 
+// BusAdmission is the additive data-body field surfaced in the
+// ebus.v1.bus_observability envelope per AD08. It reflects the current
+// admission state and associated metadata. State transitions are gated
+// by the state-stability window (30s default); transient flaps do NOT
+// flip this field nor the envelope's data_hash.
+type BusAdmission struct {
+	State           string `json:"state"`
+	Source          uint8  `json:"source"`
+	CompanionTarget uint8  `json:"companion_target"`
+	Reason          string `json:"reason,omitempty"`
+}
+
 const busObservabilityPublisherCadenceSource = "config.semantic_state_interval"
 
 type BusObservabilityStatus struct {
@@ -56,6 +68,7 @@ type BusObservabilityStatus struct {
 	Warmup                 BusObservabilityWarmup        `json:"warmup"`
 	TimingQuality          BusObservabilityTimingQuality `json:"timing_quality"`
 	Degraded               BusObservabilityDegraded      `json:"degraded"`
+	BusAdmission           *BusAdmission                 `json:"bus_admission,omitempty"`
 	Startup                *BusObservabilityStartup      `json:"startup,omitempty"`
 	FeatureFlags           ObserveFirstFeatureFlagState  `json:"feature_flags"`
 }
@@ -252,6 +265,7 @@ func (store *BusObservabilityStore) summaryLocked(now time.Time, tapStatus Passi
 				Active:  len(reasons) > 0,
 				Reasons: reasons,
 			},
+			BusAdmission: cloneBusAdmission(store.busAdmission),
 			Startup:      cloneBusObservabilityStartup(startup),
 			FeatureFlags: store.cfg.ObserveFirstFlags.StateAt(store.featureFlagsUpdatedAt),
 		},
@@ -372,6 +386,14 @@ func cloneBusObservabilityStartup(source *BusObservabilityStartup) *BusObservabi
 	}
 	out := *source
 	out.LastUpdatedAt = cloneTimePtr(source.LastUpdatedAt)
+	return &out
+}
+
+func cloneBusAdmission(source *BusAdmission) *BusAdmission {
+	if source == nil {
+		return nil
+	}
+	out := *source
 	return &out
 }
 

--- a/bus_observability_store.go
+++ b/bus_observability_store.go
@@ -99,6 +99,53 @@ type BusObservabilityStore struct {
 
 	energyFreshnessMetricsRefresher func(now time.Time, passiveState string)
 	busAdmission                    *BusAdmission
+	admissionStabilityWindow        *AdmissionStabilityWindow
+}
+
+// SetAdmissionStabilityWindow installs the AD08 / AD22 flap-mitigation
+// window on the store. When set, RecordBusAdmissionTransition will only
+// flip the envelope's bus_admission field after the new state has been
+// stable for state_min_stability_s. Caller (cmd/gateway/main.go) constructs
+// the window from cfg.StateMinStabilitySeconds and passes it once at
+// startup. If unset, RecordBusAdmissionTransition writes through
+// immediately (legacy behavior; tests may use this mode).
+func (store *BusObservabilityStore) SetAdmissionStabilityWindow(window *AdmissionStabilityWindow) {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	store.admissionStabilityWindow = window
+}
+
+// RecordBusAdmissionTransition is the production-side setter for the
+// additive bus_admission field per AD08. The state argument MUST be one
+// of {"pending", "active", "degraded"}; source/companionTarget are byte
+// values from JoinResult or override; reason is non-empty only when
+// state="degraded".
+//
+// When an AdmissionStabilityWindow is installed (production path), the
+// state observation is gated through it; transient flaps within the
+// window do NOT flip the envelope nor data_hash. When no window is
+// installed, the transition is applied immediately (test path).
+//
+// Returns true if the envelope's bus_admission field actually changed
+// as a result of this call (including stability-window-mediated flips).
+func (store *BusObservabilityStore) RecordBusAdmissionTransition(state string, source, companionTarget byte, reason string) bool {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	emittedState := state
+	flipped := true
+	if store.admissionStabilityWindow != nil {
+		emittedState, flipped = store.admissionStabilityWindow.Observe(state)
+		if !flipped {
+			return false
+		}
+	}
+	store.busAdmission = &BusAdmission{
+		State:           emittedState,
+		Source:          source,
+		CompanionTarget: companionTarget,
+		Reason:          reason,
+	}
+	return true
 }
 
 type BusMessageRecord struct {

--- a/bus_observability_store.go
+++ b/bus_observability_store.go
@@ -98,6 +98,7 @@ type BusObservabilityStore struct {
 	startupSurfaceProvider func() *BusObservabilityStartup
 
 	energyFreshnessMetricsRefresher func(now time.Time, passiveState string)
+	busAdmission                    *BusAdmission
 }
 
 type BusMessageRecord struct {

--- a/cmd/gateway/bus_observability_provider.go
+++ b/cmd/gateway/bus_observability_provider.go
@@ -309,7 +309,8 @@ func mapGraphQLBusStatus(status ebusgateway.BusObservabilityStatus) *graphql.Bus
 			Active:  status.Degraded.Active,
 			Reasons: append([]string(nil), status.Degraded.Reasons...),
 		},
-		Startup: mapGraphQLBusStartup(status.Startup),
+		BusAdmission: mapGraphQLBusAdmission(status.BusAdmission),
+		Startup:      mapGraphQLBusStartup(status.Startup),
 		FeatureFlags: graphql.ObserveFirstFeatureFlagState{
 			ObserveFirstEnabled:      status.FeatureFlags.ObserveFirstEnabled,
 			PassiveStateDirectApply:  status.FeatureFlags.PassiveStateDirectApply,
@@ -355,7 +356,8 @@ func mapMCPBusStatus(status ebusgateway.BusObservabilityStatus) *mcp.BusObservab
 			Active:  status.Degraded.Active,
 			Reasons: append([]string(nil), status.Degraded.Reasons...),
 		},
-		Startup: mapMCPBusStartup(status.Startup),
+		BusAdmission: mapMCPBusAdmission(status.BusAdmission),
+		Startup:      mapMCPBusStartup(status.Startup),
 		FeatureFlags: mcp.ObserveFirstFeatureFlagState{
 			ObserveFirstEnabled:      status.FeatureFlags.ObserveFirstEnabled,
 			PassiveStateDirectApply:  status.FeatureFlags.PassiveStateDirectApply,
@@ -388,6 +390,30 @@ func mapMCPBusStartup(startup *ebusgateway.BusObservabilityStartup) *mcp.BusObse
 		Phase:         startup.Phase,
 		CacheEpoch:    startup.CacheEpoch,
 		LiveEpoch:     startup.LiveEpoch,
+	}
+}
+
+func mapGraphQLBusAdmission(admission *ebusgateway.BusAdmission) *graphql.BusAdmission {
+	if admission == nil {
+		return nil
+	}
+	return &graphql.BusAdmission{
+		State:           admission.State,
+		Source:          admission.Source,
+		CompanionTarget: admission.CompanionTarget,
+		Reason:          admission.Reason,
+	}
+}
+
+func mapMCPBusAdmission(admission *ebusgateway.BusAdmission) *mcp.BusAdmission {
+	if admission == nil {
+		return nil
+	}
+	return &mcp.BusAdmission{
+		State:           admission.State,
+		Source:          admission.Source,
+		CompanionTarget: admission.CompanionTarget,
+		Reason:          admission.Reason,
 	}
 }
 

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -239,15 +239,32 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 		}
 		joiner := protocol.NewJoiner(joinBus, nil, ebusgateway.DefaultStartupAdmissionJoinConfig())
 
+		// Install AD08/AD22 stability window on the bus_observability store
+		// before the first admission state observation. Window is sized
+		// from cfg.StateMinStabilitySeconds (default 30, AD22 invariant
+		// enforced at config-load).
+		if busObservability != nil {
+			busObservability.SetAdmissionStabilityWindow(
+				ebusgateway.NewAdmissionStabilityWindow(ebusgateway.StartupAdmissionStateMinStabilitySecondsDefault),
+			)
+			busObservability.RecordBusAdmissionTransition("pending", 0, 0, "joiner_warmup_in_progress")
+		}
+
 		log.Printf("joiner warmup begin")
 		warmupCtx, cancel := context.WithTimeout(ctx, 6*time.Second)
 		result, err := joiner.Join(warmupCtx)
 		cancel()
 		if err != nil {
 			log.Printf("startup admission degraded reason=joiner_fail err=%v", err)
+			if busObservability != nil {
+				busObservability.RecordBusAdmissionTransition("degraded", 0, 0, "joiner_fail")
+			}
 		} else {
 			joinResult = &result
 			log.Printf("startup admission active source=0x%02X companion_target=0x%02X", result.Initiator, result.CompanionTarget)
+			if busObservability != nil {
+				busObservability.RecordBusAdmissionTransition("active", result.Initiator, result.CompanionTarget, "")
+			}
 		}
 	}
 

--- a/graphql/bus_observability.go
+++ b/graphql/bus_observability.go
@@ -49,6 +49,13 @@ type BusObservabilityStartup struct {
 	LiveEpoch     uint64
 }
 
+type BusAdmission struct {
+	State           string
+	Source          uint8
+	CompanionTarget uint8
+	Reason          string
+}
+
 type BusObservabilityStatus struct {
 	LastUpdatedAt          *time.Time
 	TransportClass         string
@@ -58,6 +65,7 @@ type BusObservabilityStatus struct {
 	Warmup                 BusObservabilityWarmup
 	TimingQuality          BusObservabilityTimingQuality
 	Degraded               BusObservabilityDegraded
+	BusAdmission           *BusAdmission
 	Startup                *BusObservabilityStartup
 	FeatureFlags           ObserveFirstFeatureFlagState
 }

--- a/mcp/bus.go
+++ b/mcp/bus.go
@@ -41,6 +41,13 @@ type BusObservabilityStartup struct {
 	LiveEpoch     uint64     `json:"live_epoch"`
 }
 
+type BusAdmission struct {
+	State           string `json:"state"`
+	Source          uint8  `json:"source"`
+	CompanionTarget uint8  `json:"companion_target"`
+	Reason          string `json:"reason,omitempty"`
+}
+
 type BusObservabilityStatus struct {
 	LastUpdatedAt          *time.Time                    `json:"last_updated_at,omitempty"`
 	TransportClass         string                        `json:"transport_class"`
@@ -50,6 +57,7 @@ type BusObservabilityStatus struct {
 	Warmup                 BusObservabilityWarmup        `json:"warmup"`
 	TimingQuality          BusObservabilityTimingQuality `json:"timing_quality"`
 	Degraded               BusObservabilityDegraded      `json:"degraded"`
+	BusAdmission           *BusAdmission                 `json:"bus_admission,omitempty"`
 	Startup                *BusObservabilityStartup      `json:"startup,omitempty"`
 	FeatureFlags           ObserveFirstFeatureFlagState  `json:"feature_flags"`
 }
@@ -242,6 +250,7 @@ func cloneBusObservabilityStatus(source *BusObservabilityStatus) *BusObservabili
 	}
 	out := *source
 	out.LastUpdatedAt = cloneTimePtr(source.LastUpdatedAt)
+	out.BusAdmission = cloneBusAdmission(source.BusAdmission)
 	out.Startup = cloneBusObservabilityStartup(source.Startup)
 	if len(source.Degraded.Reasons) > 0 {
 		out.Degraded.Reasons = append([]string(nil), source.Degraded.Reasons...)
@@ -273,6 +282,14 @@ func cloneBusObservabilityStartup(source *BusObservabilityStartup) *BusObservabi
 	}
 	out := *source
 	out.LastUpdatedAt = cloneTimePtr(source.LastUpdatedAt)
+	return &out
+}
+
+func cloneBusAdmission(source *BusAdmission) *BusAdmission {
+	if source == nil {
+		return nil
+	}
+	out := *source
 	return &out
 }
 

--- a/startup_admission_harness_test.go
+++ b/startup_admission_harness_test.go
@@ -73,7 +73,7 @@ func TestM2aHarness_JoinerFailNoFreeInitiatorPath(t *testing.T) {
 }
 
 func TestM2aHarness_TransportBlindPath(t *testing.T) {
-	t.Skip("partial coverage in M2; full coverage pending M5 degraded-mode surfaces")
+	t.Skip("partial coverage in M2 warmup integration test; full end-to-end pending M7 when MarkDegraded is wired into the M3 startup flow")
 }
 
 func TestM2aHarness_OverrideValidateFalsePath(t *testing.T) {


### PR DESCRIPTION
Closes #534. Cruise-run #20 milestone M5. 11 expvars, bus_admission additive field (AD08), AdmissionStabilityWindow 30s wired into production, AD23 enum validator. Replaces #535.