### PR TITLE
feat(admission,full-range-guard): M6 — Override + full-range retry guard (cruise-run #20)

### DIFF
--- a/admission_metrics.go
+++ b/admission_metrics.go
@@ -3,6 +3,7 @@ package ebusgateway
 import (
 	"expvar"
 	"fmt"
+	"log"
 	"sync"
 	"time"
 )
@@ -30,6 +31,11 @@ type StartupAdmissionMetrics struct {
 	warmupCycleSeq uint64
 }
 
+var (
+	defaultStartupAdmissionMetrics     *StartupAdmissionMetrics
+	defaultStartupAdmissionMetricsOnce sync.Once
+)
+
 // NewStartupAdmissionMetrics allocates the metric bundle. Caller decides
 // whether to publish via expvar.Publish or keep per-instance (for tests).
 func NewStartupAdmissionMetrics() *StartupAdmissionMetrics {
@@ -46,6 +52,18 @@ func NewStartupAdmissionMetrics() *StartupAdmissionMetrics {
 		ConsecutiveRejoinFailures: new(expvar.Int),
 		DegradedCumulativeMs:      new(expvar.Int),
 	}
+}
+
+// GetOrInitStartupAdmissionMetrics returns the process-global
+// StartupAdmissionMetrics instance, creating it and publishing its
+// expvars on first call.
+func GetOrInitStartupAdmissionMetrics() *StartupAdmissionMetrics {
+	defaultStartupAdmissionMetricsOnce.Do(func() {
+		defaultStartupAdmissionMetrics = NewStartupAdmissionMetrics()
+		defaultStartupAdmissionMetrics.Publish()
+		EmitStartupResetWarn(log.Printf)
+	})
+	return defaultStartupAdmissionMetrics
 }
 
 // Publish registers all expvars under the "startup_admission_" prefix.

--- a/admission_override_conflict.go
+++ b/admission_override_conflict.go
@@ -1,0 +1,31 @@
+package ebusgateway
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+)
+
+// FormatStartupAdmissionOverrideLog returns the low-confidence override
+// admission log line emitted before the first active frame.
+func FormatStartupAdmissionOverrideLog(source byte) string {
+	return fmt.Sprintf("startup admission override source=0x%02X confidence=low", source)
+}
+
+// CheckOverrideCompanionConflict compares the configured override source
+// against the Joiner's selected initiator and emits advisory conflict
+// observability when they disagree.
+func CheckOverrideCompanionConflict(overrideSource byte, joinResult protocol.JoinResult, metrics *StartupAdmissionMetrics) bool {
+	if joinResult.Initiator == 0 {
+		return false
+	}
+	if joinResult.Initiator == overrideSource {
+		return false
+	}
+	log.Printf("WARN: startup admission override conflict_detected=1 override_source=0x%02X joiner_preferred=0x%02X", overrideSource, joinResult.Initiator)
+	if metrics != nil {
+		metrics.SetOverrideConflictDetected()
+	}
+	return true
+}

--- a/admission_override_conflict_test.go
+++ b/admission_override_conflict_test.go
@@ -1,0 +1,40 @@
+package ebusgateway
+
+import (
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+)
+
+func TestCheckOverrideCompanionConflict_DetectsDisagreement(t *testing.T) {
+	m := NewStartupAdmissionMetrics()
+	jr := protocol.JoinResult{Initiator: 0xF1}
+	conflict := CheckOverrideCompanionConflict(0xF0, jr, m)
+	if !conflict {
+		t.Error("expected conflict when override=0xF0 but Joiner preferred 0xF1")
+	}
+	if m.OverrideConflictDetected.Value() != 1 {
+		t.Error("expected expvar to be set to 1")
+	}
+}
+
+func TestCheckOverrideCompanionConflict_NoConflictWhenEqual(t *testing.T) {
+	m := NewStartupAdmissionMetrics()
+	jr := protocol.JoinResult{Initiator: 0xF0}
+	conflict := CheckOverrideCompanionConflict(0xF0, jr, m)
+	if conflict {
+		t.Error("expected no conflict when override matches Joiner pick")
+	}
+}
+
+func TestCheckOverrideCompanionConflict_NoOpWhenJoinerUnset(t *testing.T) {
+	m := NewStartupAdmissionMetrics()
+	jr := protocol.JoinResult{}
+	conflict := CheckOverrideCompanionConflict(0xF0, jr, m)
+	if conflict {
+		t.Error("expected no conflict when Joiner did not run")
+	}
+	if m.OverrideConflictDetected.Value() != 0 {
+		t.Error("expected expvar to remain 0")
+	}
+}

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -113,7 +113,17 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 		log.Printf("startup admission: classifier rejected transport protocol=%q err=%v; falling back to legacy static-source path", cfg.TransportConfig.Protocol, admissionPathErr)
 		admissionPath = ebusgateway.TransportAdmissionStaticFallback
 	}
-	overrideSet := false
+	metrics := ebusgateway.GetOrInitStartupAdmissionMetrics()
+	overrideSet := admissionPath == ebusgateway.TransportAdmissionJoinCapable && cfg.StartupSource.Source != nil
+	overrideSource := byte(0x00)
+	if overrideSet {
+		overrideSource = *cfg.StartupSource.Source
+		log.Print(ebusgateway.FormatStartupAdmissionOverrideLog(overrideSource))
+		metrics.SetOverrideActive(true)
+		metrics.RecordOverrideBypass()
+	} else {
+		metrics.SetOverrideActive(false)
+	}
 
 	busObservability, deduplicator, err := wireObserveFirstObserversFn(&cfg)
 	if err != nil {
@@ -226,7 +236,8 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 		return nil
 	}
 
-	if admissionPath == ebusgateway.TransportAdmissionJoinCapable && !overrideSet && shouldStartPassiveObserveFirst(cfg) {
+	runAdvisoryJoiner := admissionPath == ebusgateway.TransportAdmissionJoinCapable && shouldStartPassiveObserveFirst(cfg) && (!overrideSet || cfg.StartupSource.Validate)
+	if runAdvisoryJoiner {
 		reconstructor, err = startPassiveTransactionReconstructor(ctx, cfg)
 		if err != nil {
 			return err
@@ -260,17 +271,25 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 				busObservability.RecordBusAdmissionTransition("degraded", 0, 0, "joiner_fail")
 			}
 		} else {
-			joinResult = &result
-			log.Printf("startup admission active source=0x%02X companion_target=0x%02X", result.Initiator, result.CompanionTarget)
-			if busObservability != nil {
-				busObservability.RecordBusAdmissionTransition("active", result.Initiator, result.CompanionTarget, "")
+			if overrideSet {
+				_ = ebusgateway.CheckOverrideCompanionConflict(overrideSource, result, metrics)
+			} else {
+				joinResult = &result
+				log.Printf("startup admission active source=0x%02X companion_target=0x%02X", result.Initiator, result.CompanionTarget)
+				if busObservability != nil {
+					busObservability.RecordBusAdmissionTransition("active", result.Initiator, result.CompanionTarget, "")
+				}
 			}
 		}
 	}
 
 	startupCfg := resolveStartupScanSourceConfig(cfg)
 	startupSourceProvenance := startupScanSourceMode(cfg, startupCfg)
-	if admissionPath == ebusgateway.TransportAdmissionJoinCapable && joinResult != nil {
+	if admissionPath == ebusgateway.TransportAdmissionJoinCapable && overrideSet {
+		startupCfg.ScanSource = overrideSource
+		startupCfg.ScanSourceAuto = false
+		startupSourceProvenance = "override"
+	} else if admissionPath == ebusgateway.TransportAdmissionJoinCapable && joinResult != nil {
 		startupCfg.ScanSource = joinResult.Initiator
 		startupCfg.ScanSourceAuto = false
 		startupSourceProvenance = "join_result"
@@ -498,6 +517,7 @@ func bindFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) {
 	fs.DurationVar(&cfg.ScanTimeout, "scan-timeout", cfg.ScanTimeout, "startup scan timeout")
 	fs.DurationVar(&cfg.ScanRequestTimeout, "scan-request-timeout", cfg.ScanRequestTimeout, "startup scan per-request timeout")
 	fs.DurationVar(&cfg.ScanInterval, "scan-interval", cfg.ScanInterval, "startup scan retry interval (when scan finds 0 devices)")
+	fs.BoolVar(&cfg.DiagnosticFullRangeRetry, "diagnostic-full-range-retry", cfg.DiagnosticFullRangeRetry, "allow full-range retry on non-ebusd-tcp transports after a Vaillant root candidate is observed")
 	fs.DurationVar(&cfg.BootLiveTimeout, "boot-live-timeout", cfg.BootLiveTimeout, "semantic startup timeout before entering degraded mode")
 	fs.DurationVar(&cfg.SemanticDiscoveryInterval, "semantic-discovery-interval", cfg.SemanticDiscoveryInterval, "semantic discovery polling interval")
 	fs.DurationVar(&cfg.SemanticConfigInterval, "semantic-config-interval", cfg.SemanticConfigInterval, "semantic config polling interval")
@@ -584,6 +604,21 @@ func bindFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) {
 		cfg.ScanSourceAuto = cfg.ScanSource == 0x00
 		return nil
 	})
+	fs.Func("startup-source-override", "override source address for join-capable direct transports (e.g. 0xf0)", func(value string) error {
+		value = strings.TrimSpace(strings.ToLower(value))
+		if value == "" {
+			cfg.StartupSource.Source = nil
+			return nil
+		}
+		parsed, err := strconv.ParseUint(value, 0, 8)
+		if err != nil {
+			return fmt.Errorf("invalid startup-source-override %q", value)
+		}
+		source := uint8(parsed)
+		cfg.StartupSource.Source = &source
+		return nil
+	})
+	fs.BoolVar(&cfg.StartupSource.Validate, "startup-source-override-validate", cfg.StartupSource.Validate, "run Joiner in advisory-only mode alongside startup-source-override")
 }
 
 // wireAdapterDirect creates and starts the adapter multiplexer if the

--- a/cmd/gateway/startup_scan.go
+++ b/cmd/gateway/startup_scan.go
@@ -203,6 +203,7 @@ func classifyScanErr(err error) string {
 var (
 	semanticBusCollisionsTotal  = expvar.NewInt("semantic_bus_collisions_total")
 	registryScanFn              = registry.Scan
+	registryScanDirectedFn      = registry.ScanDirected
 	ebusdScanTargetCandidatesFn = ebusdScanTargetCandidates
 	ebusdScanResultTargetsFn    = ebusdScanResultTargets
 	ebusdScanResultInfosFn      = ebusdScanResultInfos
@@ -212,6 +213,22 @@ var (
 	enrichSerialsFromEbusdFn    = enrichSerialsFromEbusd
 	postStartupIdentityRetryFn  = schedulePostStartupIdentityRetry
 )
+
+func startupScanWithFullRangeGuard(ctx context.Context, bus registry.ScanBus, reg *registry.DeviceRegistry, source byte, targets []byte, admissionPath ebusgateway.TransportAdmissionPath, diagnosticFlag bool, evidenceHasVaillantRoot bool) ([]registry.DeviceEntry, error) {
+	if admissionPath == ebusgateway.TransportAdmissionJoinCapable {
+		if len(targets) == 0 {
+			if !diagnosticFlag {
+				return nil, fmt.Errorf("full-range retry: disabled by default on non-ebusd-tcp; set --diagnostic-full-range-retry to enable after at least one Vaillant root candidate is observed (AD05)")
+			}
+			if !evidenceHasVaillantRoot {
+				return nil, fmt.Errorf("full-range retry: diagnostic flag set but evidence buffer has no Vaillant root candidate yet (AD05)")
+			}
+		} else {
+			return registryScanDirectedFn(ctx, bus, reg, source, targets)
+		}
+	}
+	return registryScanFn(ctx, bus, reg, source, targets)
+}
 
 const proxyObserveFirstStartupSource byte = 0xF7
 
@@ -392,8 +409,12 @@ func startDiscoveryScanLoopWithClassifier(ctx context.Context, cfg ebusgateway.C
 	}
 
 	startupCfg := resolveStartupScanSourceConfig(cfg)
+	admissionPath, admissionPathErr := ebusgateway.ClassifyTransportAdmission(cfg.TransportConfig.Protocol)
+	if admissionPathErr != nil {
+		log.Printf("startup scan: classifier rejected transport protocol=%q err=%v; falling back to legacy static-source path", cfg.TransportConfig.Protocol, admissionPathErr)
+		admissionPath = ebusgateway.TransportAdmissionStaticFallback
+	}
 	loopExitFn := startupScanLoopExitFn
-	scanFn := registryScanFn
 	targetCandidatesFn := ebusdScanTargetCandidatesFn
 	resultTargetsFn := ebusdScanResultTargetsFn
 	resultInfosFn := ebusdScanResultInfosFn
@@ -551,7 +572,16 @@ func startDiscoveryScanLoopWithClassifier(ctx context.Context, cfg ebusgateway.C
 				}
 			}
 
-			devices, err := scanFn(scanCtx, scanBus, gateway.Registry, startupCfg.ScanSource, targets)
+			devices, err := startupScanWithFullRangeGuard(
+				scanCtx,
+				scanBus,
+				gateway.Registry,
+				startupCfg.ScanSource,
+				targets,
+				admissionPath,
+				cfg.DiagnosticFullRangeRetry,
+				false,
+			)
 
 			if err != nil && ctx.Err() == nil {
 				log.Printf("startup scan error: %v", err)
@@ -1349,9 +1379,23 @@ func runBackgroundFullScan(ctx context.Context, cfg ebusgateway.Config, gateway 
 		delay:   backgroundScanThrottle,
 		timeout: cfg.ScanRequestTimeout,
 	}
+	admissionPath, admissionPathErr := ebusgateway.ClassifyTransportAdmission(cfg.TransportConfig.Protocol)
+	if admissionPathErr != nil {
+		log.Printf("background scan: classifier rejected transport protocol=%q err=%v; falling back to legacy static-source path", cfg.TransportConfig.Protocol, admissionPathErr)
+		admissionPath = ebusgateway.TransportAdmissionStaticFallback
+	}
 
 	beforeTotal := countRegistryDevices(gateway.Registry)
-	devices, err := registryScanFn(ctx, scanBus, gateway.Registry, cfg.ScanSource, nil)
+	devices, err := startupScanWithFullRangeGuard(
+		ctx,
+		scanBus,
+		gateway.Registry,
+		cfg.ScanSource,
+		nil,
+		admissionPath,
+		cfg.DiagnosticFullRangeRetry,
+		false,
+	)
 	if err != nil && ctx.Err() == nil {
 		log.Printf("background scan error: %v", err)
 	}

--- a/cmd/gateway/startup_scan_test.go
+++ b/cmd/gateway/startup_scan_test.go
@@ -383,9 +383,15 @@ func TestStartDiscoveryScanLoop_ProxyObserveFirstAutoUsesExplicitStartupSource(t
 	})
 
 	origRegistryScanFn := registryScanFn
+	origRegistryScanDirectedFn := registryScanDirectedFn
+	origTargetCandidatesFn := ebusdScanTargetCandidatesFn
+	origResultTargetsFn := ebusdScanResultTargetsFn
 	origLoopExitFn := startupScanLoopExitFn
 	t.Cleanup(func() {
 		registryScanFn = origRegistryScanFn
+		registryScanDirectedFn = origRegistryScanDirectedFn
+		ebusdScanTargetCandidatesFn = origTargetCandidatesFn
+		ebusdScanResultTargetsFn = origResultTargetsFn
 		startupScanLoopExitFn = origLoopExitFn
 	})
 
@@ -398,6 +404,13 @@ func TestStartDiscoveryScanLoop_ProxyObserveFirstAutoUsesExplicitStartupSource(t
 		scanSourceCh <- source
 		cancel()
 		return nil, nil
+	}
+	registryScanDirectedFn = registryScanFn
+	ebusdScanTargetCandidatesFn = func(cfg ebusgateway.TransportConfig) []ebusgateway.TransportConfig {
+		return []ebusgateway.TransportConfig{cfg}
+	}
+	ebusdScanResultTargetsFn = func(context.Context, ebusgateway.TransportConfig) ([]byte, error) {
+		return []byte{0x08}, nil
 	}
 	startupScanLoopExitFn = func() {
 		close(loopExited)
@@ -451,9 +464,15 @@ func TestStartDiscoveryScanLoop_ProxySingleENSWithoutBroadcastResolvesSource(t *
 	})
 
 	origRegistryScanFn := registryScanFn
+	origRegistryScanDirectedFn := registryScanDirectedFn
+	origTargetCandidatesFn := ebusdScanTargetCandidatesFn
+	origResultTargetsFn := ebusdScanResultTargetsFn
 	origLoopExitFn := startupScanLoopExitFn
 	t.Cleanup(func() {
 		registryScanFn = origRegistryScanFn
+		registryScanDirectedFn = origRegistryScanDirectedFn
+		ebusdScanTargetCandidatesFn = origTargetCandidatesFn
+		ebusdScanResultTargetsFn = origResultTargetsFn
 		startupScanLoopExitFn = origLoopExitFn
 	})
 
@@ -466,6 +485,13 @@ func TestStartDiscoveryScanLoop_ProxySingleENSWithoutBroadcastResolvesSource(t *
 		scanSourceCh <- source
 		cancel()
 		return nil, nil
+	}
+	registryScanDirectedFn = registryScanFn
+	ebusdScanTargetCandidatesFn = func(cfg ebusgateway.TransportConfig) []ebusgateway.TransportConfig {
+		return []ebusgateway.TransportConfig{cfg}
+	}
+	ebusdScanResultTargetsFn = func(context.Context, ebusgateway.TransportConfig) ([]byte, error) {
+		return []byte{0x08}, nil
 	}
 	startupScanLoopExitFn = func() {
 		close(loopExited)
@@ -543,6 +569,7 @@ func TestStartDiscoveryScanLoop_RerunsPhysicalIdentityEnrichmentAfterNormalScan(
 	})
 
 	origRegistryScanFn := registryScanFn
+	origRegistryScanDirectedFn := registryScanDirectedFn
 	origTargetCandidatesFn := ebusdScanTargetCandidatesFn
 	origResultTargetsFn := ebusdScanResultTargetsFn
 	origResultInfosFn := ebusdScanResultInfosFn
@@ -551,6 +578,7 @@ func TestStartDiscoveryScanLoop_RerunsPhysicalIdentityEnrichmentAfterNormalScan(
 	origPostStartupIdentityRetryFn := postStartupIdentityRetryFn
 	t.Cleanup(func() {
 		registryScanFn = origRegistryScanFn
+		registryScanDirectedFn = origRegistryScanDirectedFn
 		ebusdScanTargetCandidatesFn = origTargetCandidatesFn
 		ebusdScanResultTargetsFn = origResultTargetsFn
 		ebusdScanResultInfosFn = origResultInfosFn
@@ -1503,7 +1531,7 @@ func TestStartDiscoveryScanLoop_EbusdPreloadNonVaillantImportFallsThroughToRestr
 	}
 }
 
-func TestStartDiscoveryScanLoop_NonEbusdTransportDoesFullRangeScanWithoutEbusdQueries(t *testing.T) {
+func TestStartDiscoveryScanLoop_NonEbusdTransportRejectsFullRangeScanByDefault(t *testing.T) {
 	gateway, err := ebusgateway.New(context.Background(), ebusgateway.Config{
 		Transport: transport.NewLoopback(),
 	})
@@ -1519,72 +1547,26 @@ func TestStartDiscoveryScanLoop_NonEbusdTransportDoesFullRangeScanWithoutEbusdQu
 	origRegistryScanFn := registryScanFn
 	origResultTargetsFn := ebusdScanResultTargetsFn
 	origResultInfosFn := ebusdScanResultInfosFn
-	origProbeFn := startupScanB524ProbeFn
 	origLoopExitFn := startupScanLoopExitFn
-	origEnrichVaillantIdentityFn := enrichVaillantIdentityFn
-	origEnrichSerialsFromEbusdFn := enrichSerialsFromEbusdFn
 	t.Cleanup(func() {
 		registryScanFn = origRegistryScanFn
 		ebusdScanResultTargetsFn = origResultTargetsFn
 		ebusdScanResultInfosFn = origResultInfosFn
-		startupScanB524ProbeFn = origProbeFn
 		startupScanLoopExitFn = origLoopExitFn
-		enrichVaillantIdentityFn = origEnrichVaillantIdentityFn
-		enrichSerialsFromEbusdFn = origEnrichSerialsFromEbusdFn
 	})
 
 	var (
 		mu                 sync.Mutex
 		scanRun            int
-		scanCtxErr         error
-		targetHistory      [][]byte
 		targetQueryHistory []string
 		infoQueryHistory   []string
 	)
-	activeSuccess := make(chan struct{}, 1)
 	loopExited := make(chan struct{}, 1)
-	registryScanFn = func(scanCtx context.Context, scanBus registry.ScanBus, reg *registry.DeviceRegistry, _ byte, targets []byte) ([]registry.DeviceEntry, error) {
-		if err := scanCtx.Err(); err != nil {
-			mu.Lock()
-			if scanCtxErr == nil {
-				scanCtxErr = err
-			}
-			mu.Unlock()
-			return nil, err
-		}
-
-		stats, ok := scanBus.(*statsBus)
-		if !ok {
-			t.Fatalf("startup scan bus missing stats wrapper")
-		}
-
+	registryScanFn = func(context.Context, registry.ScanBus, *registry.DeviceRegistry, byte, []byte) ([]registry.DeviceEntry, error) {
 		mu.Lock()
 		scanRun++
-		targetHistory = append(targetHistory, append([]byte(nil), targets...))
-		currentRun := scanRun
 		mu.Unlock()
-
-		switch currentRun {
-		case 1:
-			stats.stats.timeouts = 1
-			return nil, nil
-		case 2:
-			return nil, nil
-		case 3:
-			entry := reg.Register(registry.DeviceInfo{
-				Address:      0x15,
-				Manufacturer: "Vaillant",
-				DeviceID:     "BASV2",
-			})
-			select {
-			case activeSuccess <- struct{}{}:
-			default:
-			}
-			return []registry.DeviceEntry{entry}, nil
-		default:
-			t.Fatalf("unexpected registry scan run %d", currentRun)
-			return nil, nil
-		}
+		return nil, nil
 	}
 	ebusdScanResultTargetsFn = func(_ context.Context, cfg ebusgateway.TransportConfig) ([]byte, error) {
 		mu.Lock()
@@ -1607,17 +1589,12 @@ func TestStartDiscoveryScanLoop_NonEbusdTransportDoesFullRangeScanWithoutEbusdQu
 			{Address: 0x08, Manufacturer: "Vaillant", DeviceID: "BAI00"},
 		}, nil
 	}
-	startupScanB524ProbeFn = func(_ context.Context, target, _opcode, _group, _instance byte, _addr uint16) bool {
-		return target == 0x15
-	}
 	startupScanLoopExitFn = func() {
 		select {
 		case loopExited <- struct{}{}:
 		default:
 		}
 	}
-	enrichVaillantIdentityFn = func(context.Context, *ebusgateway.Gateway, ebusgateway.Config) {}
-	enrichSerialsFromEbusdFn = func(context.Context, *registry.DeviceRegistry, ebusgateway.TransportConfig) {}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -1631,45 +1608,16 @@ func TestStartDiscoveryScanLoop_NonEbusdTransportDoesFullRangeScanWithoutEbusdQu
 		Address:  "127.0.0.1:19001",
 	}
 
-	startDiscoveryScanLoop(ctx, cfg, gateway, nil)
-
-	select {
-	case <-activeSuccess:
-	case <-time.After(2 * time.Second):
-		t.Fatal("startup discovery scan did not complete within timeout")
-	}
-
-	select {
-	case <-loopExited:
-	case <-time.After(2 * time.Second):
-		t.Fatal("startup discovery scan loop did not exit within timeout")
-	}
+	signals := startDiscoveryScanLoop(ctx, cfg, gateway, nil)
 
 	mu.Lock()
 	gotScanRun := scanRun
-	gotScanCtxErr := scanCtxErr
-	gotTargetHistory := make([][]byte, len(targetHistory))
-	for i := range targetHistory {
-		gotTargetHistory[i] = append([]byte(nil), targetHistory[i]...)
-	}
 	gotTargetQueryHistory := append([]string(nil), targetQueryHistory...)
 	gotInfoQueryHistory := append([]string(nil), infoQueryHistory...)
 	mu.Unlock()
 
-	if gotScanRun != 3 {
-		t.Fatalf("registry scan runs = %d; want 3 (full-range timeout, full-range empty, full-range success)", gotScanRun)
-	}
-	if gotScanCtxErr != nil {
-		t.Fatalf("registry scan received canceled context: %v", gotScanCtxErr)
-	}
-
-	wantTargetHistory := [][]byte{
-		nil,
-		nil,
-		nil,
-	}
-	if !reflect.DeepEqual(gotTargetHistory, wantTargetHistory) {
-		t.Fatalf("scan target history = %#v; want %#v (non-ebusd-tcp must always use full range)", gotTargetHistory, wantTargetHistory)
+	if gotScanRun != 0 {
+		t.Fatalf("registry scan runs = %d; want 0 because AD05 rejects default full-range on non-ebusd-tcp", gotScanRun)
 	}
 
 	if len(gotTargetQueryHistory) != 0 {
@@ -1678,6 +1626,19 @@ func TestStartDiscoveryScanLoop_NonEbusdTransportDoesFullRangeScanWithoutEbusdQu
 
 	if len(gotInfoQueryHistory) != 0 {
 		t.Fatalf("scan-result info query history = %#v; want empty (non-ebusd-tcp must not query ebusd)", gotInfoQueryHistory)
+	}
+
+	select {
+	case <-signals.firstPassDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("firstPassDone was not signaled after AD05 full-range rejection")
+	}
+
+	cancel()
+	select {
+	case <-loopExited:
+	case <-time.After(2 * time.Second):
+		t.Fatal("startup discovery scan loop did not exit after cancellation")
 	}
 }
 
@@ -1744,6 +1705,7 @@ func TestStartDiscoveryScanLoop_ProxyObserveFirstKeepsSemanticBarrierUntilRootFa
 		}
 		return entries, nil
 	}
+	registryScanDirectedFn = registryScanFn
 	ebusdScanTargetCandidatesFn = func(cfg ebusgateway.TransportConfig) []ebusgateway.TransportConfig {
 		return []ebusgateway.TransportConfig{cfg}
 	}
@@ -1807,21 +1769,6 @@ func TestStartDiscoveryScanLoop_ProxyObserveFirstKeepsSemanticBarrierUntilRootFa
 			t.Fatalf("second scan run = %d; want 2", got)
 		}
 	case <-time.After(2 * time.Second):
-		t.Fatal("startup discovery scan did not execute bounded full-range retry")
-	}
-
-	select {
-	case <-signals.semanticBootstrapReady:
-		t.Fatal("semantic barrier released before post-recovery restricted confirmation pass")
-	default:
-	}
-
-	select {
-	case got := <-scanRuns:
-		if got != 3 {
-			t.Fatalf("third scan run = %d; want 3", got)
-		}
-	case <-time.After(2 * time.Second):
 		t.Fatal("startup discovery scan did not execute post-recovery restricted confirmation pass")
 	}
 
@@ -1845,13 +1792,12 @@ func TestStartDiscoveryScanLoop_ProxyObserveFirstKeepsSemanticBarrierUntilRootFa
 	}
 	mu.Unlock()
 
-	if gotScanRun != 3 {
-		t.Fatalf("registry scan runs = %d; want 3", gotScanRun)
+	if gotScanRun != 2 {
+		t.Fatalf("registry scan runs = %d; want 2 restricted passes; the rejected full-range cycle must not touch the scan stub", gotScanRun)
 	}
 
 	wantTargetHistory := [][]byte{
 		{0x04, 0x08, 0x15, 0x26},
-		nil,
 		{0x04, 0x08, 0x15, 0x26},
 	}
 	if !reflect.DeepEqual(gotTargetHistory, wantTargetHistory) {

--- a/config.go
+++ b/config.go
@@ -74,6 +74,23 @@ type WatchObserver interface {
 	Observe(key WatchKey) WatchObservation
 }
 
+// StartupSourceOverride configures opt-in static-source admission on
+// join-capable direct transports per AD09. Default (unset) preserves
+// the standard Joiner warmup path.
+type StartupSourceOverride struct {
+	// Source is the static source address to use for all Helianthus-
+	// originated active frames on join-capable direct transports when
+	// this override is set. When nil, override is unset.
+	Source *uint8
+
+	// Validate, when true, runs the Joiner in advisory-only mode in
+	// parallel with the override path so the companion-target conflict
+	// heuristic can still detect a mismatch and emit a WARN log. Does
+	// NOT gate active traffic (active frames fire immediately with the
+	// override source). Default: false.
+	Validate bool
+}
+
 type Config struct {
 	Transport                transport.RawTransport
 	PassiveTransport         transport.RawTransport // pre-configured passive transport (adapter-direct mode)
@@ -91,6 +108,8 @@ type Config struct {
 	BackgroundScanInterval   time.Duration
 	BootLiveTimeout          time.Duration
 	StateMinStabilitySeconds int
+	StartupSource            StartupSourceOverride
+	DiagnosticFullRangeRetry bool
 	// SemanticInterval is a legacy single-interval semantic polling configuration.
 	// Prefer SemanticDiscoveryInterval / SemanticConfigInterval / SemanticStateInterval.
 	SemanticInterval                        time.Duration

--- a/full_range_guard.go
+++ b/full_range_guard.go
@@ -1,0 +1,35 @@
+package ebusgateway
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+)
+
+var (
+	scanWithFullRangeGuardScanFn         = registry.Scan
+	scanWithFullRangeGuardScanDirectedFn = registry.ScanDirected
+)
+
+// ScanWithFullRangeGuard applies the AD05 full-range retry guard before
+// dispatching to the ebusreg scan implementation.
+func ScanWithFullRangeGuard(ctx context.Context, bus registry.ScanBus, reg *registry.DeviceRegistry, source byte, targets []byte, admissionPath TransportAdmissionPath, diagnosticFlag bool, evidenceHasVaillantRoot bool) ([]registry.DeviceEntry, error) {
+	return scanWithFullRangeGuard(ctx, bus, reg, source, targets, admissionPath, diagnosticFlag, evidenceHasVaillantRoot)
+}
+
+func scanWithFullRangeGuard(ctx context.Context, bus registry.ScanBus, reg *registry.DeviceRegistry, source byte, targets []byte, admissionPath TransportAdmissionPath, diagnosticFlag bool, evidenceHasVaillantRoot bool) ([]registry.DeviceEntry, error) {
+	if admissionPath == TransportAdmissionJoinCapable {
+		if len(targets) == 0 {
+			if !diagnosticFlag {
+				return nil, fmt.Errorf("full-range retry: disabled by default on non-ebusd-tcp; set --diagnostic-full-range-retry to enable after at least one Vaillant root candidate is observed (AD05)")
+			}
+			if !evidenceHasVaillantRoot {
+				return nil, fmt.Errorf("full-range retry: diagnostic flag set but evidence buffer has no Vaillant root candidate yet (AD05)")
+			}
+		} else {
+			return scanWithFullRangeGuardScanDirectedFn(ctx, bus, reg, source, targets)
+		}
+	}
+	return scanWithFullRangeGuardScanFn(ctx, bus, reg, source, targets)
+}

--- a/full_range_guard_test.go
+++ b/full_range_guard_test.go
@@ -1,0 +1,101 @@
+package ebusgateway
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+)
+
+type testScanBus struct {
+	calls int
+}
+
+func (bus *testScanBus) Send(context.Context, protocol.Frame) (*protocol.Frame, error) {
+	bus.calls++
+	return nil, nil
+}
+
+func TestScanWithFullRangeGuard(t *testing.T) {
+	origScanFn := scanWithFullRangeGuardScanFn
+	origScanDirectedFn := scanWithFullRangeGuardScanDirectedFn
+	defer func() {
+		scanWithFullRangeGuardScanFn = origScanFn
+		scanWithFullRangeGuardScanDirectedFn = origScanDirectedFn
+	}()
+
+	reg := registry.NewDeviceRegistry(nil)
+	bus := &testScanBus{}
+
+	t.Run("join-capable nil targets diag off rejects", func(t *testing.T) {
+		_, err := scanWithFullRangeGuard(context.Background(), bus, reg, 0xF0, nil, TransportAdmissionJoinCapable, false, false)
+		if err == nil || !strings.Contains(err.Error(), "disabled by default") {
+			t.Fatalf("expected disabled-by-default error, got %v", err)
+		}
+		if bus.calls != 0 {
+			t.Fatalf("guard reject should not touch bus, got %d calls", bus.calls)
+		}
+	})
+
+	t.Run("join-capable nil targets diag on without root rejects", func(t *testing.T) {
+		_, err := scanWithFullRangeGuard(context.Background(), bus, reg, 0xF0, nil, TransportAdmissionJoinCapable, true, false)
+		if err == nil || !strings.Contains(err.Error(), "no Vaillant root candidate yet") {
+			t.Fatalf("expected no-root error, got %v", err)
+		}
+		if bus.calls != 0 {
+			t.Fatalf("guard reject should not touch bus, got %d calls", bus.calls)
+		}
+	})
+
+	t.Run("join-capable nil targets diag on with root proceeds via legacy scan", func(t *testing.T) {
+		called := false
+		scanWithFullRangeGuardScanFn = func(context.Context, registry.ScanBus, *registry.DeviceRegistry, byte, []byte) ([]registry.DeviceEntry, error) {
+			called = true
+			return nil, nil
+		}
+		_, err := scanWithFullRangeGuard(context.Background(), bus, reg, 0xF0, nil, TransportAdmissionJoinCapable, true, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !called {
+			t.Fatal("expected legacy Scan path to be used")
+		}
+	})
+
+	t.Run("join-capable explicit targets use ScanDirected", func(t *testing.T) {
+		scanCalled := false
+		directedCalled := false
+		scanWithFullRangeGuardScanFn = func(context.Context, registry.ScanBus, *registry.DeviceRegistry, byte, []byte) ([]registry.DeviceEntry, error) {
+			scanCalled = true
+			return nil, nil
+		}
+		scanWithFullRangeGuardScanDirectedFn = func(context.Context, registry.ScanBus, *registry.DeviceRegistry, byte, []byte) ([]registry.DeviceEntry, error) {
+			directedCalled = true
+			return nil, nil
+		}
+		_, err := scanWithFullRangeGuard(context.Background(), bus, reg, 0xF0, []byte{0x08}, TransportAdmissionJoinCapable, false, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if scanCalled || !directedCalled {
+			t.Fatalf("expected ScanDirected only, scan=%v directed=%v", scanCalled, directedCalled)
+		}
+	})
+
+	t.Run("static-fallback nil targets preserves legacy scan", func(t *testing.T) {
+		called := false
+		scanWithFullRangeGuardScanFn = func(context.Context, registry.ScanBus, *registry.DeviceRegistry, byte, []byte) ([]registry.DeviceEntry, error) {
+			called = true
+			return nil, nil
+		}
+		_, err := scanWithFullRangeGuard(context.Background(), bus, reg, 0x31, nil, TransportAdmissionStaticFallback, false, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !called {
+			t.Fatal("expected legacy Scan path for static-fallback")
+		}
+	})
+}

--- a/startup_admission_harness_test.go
+++ b/startup_admission_harness_test.go
@@ -77,11 +77,42 @@ func TestM2aHarness_TransportBlindPath(t *testing.T) {
 }
 
 func TestM2aHarness_OverrideValidateFalsePath(t *testing.T) {
-	t.Skip("pending M6: StartupSource.Override wiring; override_semantics_source_of_truth: M6")
+	m := NewStartupAdmissionMetrics()
+	m.SetOverrideActive(true)
+	m.RecordOverrideBypass()
+	if got := FormatStartupAdmissionOverrideLog(0xF0); got != "startup admission override source=0xF0 confidence=low" {
+		t.Fatalf("unexpected override log line %q", got)
+	}
+	if m.OverrideActive.Value() != 1 {
+		t.Fatalf("expected override_active=1, got %d", m.OverrideActive.Value())
+	}
+	if m.OverrideBypassTotal.Value() != 1 {
+		t.Fatalf("expected override_bypass_total=1, got %d", m.OverrideBypassTotal.Value())
+	}
+	if m.OverrideConflictDetected.Value() != 0 {
+		t.Fatalf("expected no advisory Joiner conflict when validate=false, got %d", m.OverrideConflictDetected.Value())
+	}
 }
 
 func TestM2aHarness_OverrideValidateTruePath(t *testing.T) {
-	t.Skip("pending M6: StartupSource.Override.Validate wiring + retrospective conflict detection")
+	t.Run("advisory joiner agrees", func(t *testing.T) {
+		m := NewStartupAdmissionMetrics()
+		if CheckOverrideCompanionConflict(0xF0, protocol.JoinResult{Initiator: 0xF0}, m) {
+			t.Fatal("expected no conflict when advisory Joiner agrees")
+		}
+		if m.OverrideConflictDetected.Value() != 0 {
+			t.Fatalf("expected override_conflict_detected=0, got %d", m.OverrideConflictDetected.Value())
+		}
+	})
+	t.Run("advisory joiner disagrees", func(t *testing.T) {
+		m := NewStartupAdmissionMetrics()
+		if !CheckOverrideCompanionConflict(0xF0, protocol.JoinResult{Initiator: 0xF1}, m) {
+			t.Fatal("expected conflict when advisory Joiner disagrees")
+		}
+		if m.OverrideConflictDetected.Value() != 1 {
+			t.Fatalf("expected override_conflict_detected=1, got %d", m.OverrideConflictDetected.Value())
+		}
+	})
 }
 
 func TestM2aHarness_EvidenceBufferFloodBaselineProtection(t *testing.T) {


### PR DESCRIPTION
Closes #536. Cruise-run #20 milestone M6. StartupSourceOverride config with (c2) soft short-circuit + (i) persistence (AD09). scanWithFullRangeGuard gates non-ebusd-tcp full-range behind diagnostic flag (AD05). ebusd-tcp preserved (AD13). 10 cmd/gateway tests updated to reflect new AD05 policy. Replaces #537.