### PR TITLE
feat(m7): M7_GATEWAY_INTEGRATION_ACCEPTANCE — admission artifact + evidence scaffold (cruise-run #20)

### DIFF
--- a/admission_artifact.go
+++ b/admission_artifact.go
@@ -1,0 +1,153 @@
+package ebusgateway
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+)
+
+// AdmissionArtifact is the machine-readable summary emitted at the end
+// of the startup admission + discovery window per plan §M7.
+type AdmissionArtifact struct {
+	Admission AdmissionArtifactAdmission `json:"admission"`
+	Discovery AdmissionArtifactDiscovery `json:"discovery"`
+}
+
+type AdmissionArtifactAdmission struct {
+	State                 string  `json:"state"`
+	Source                uint8   `json:"source"`
+	CompanionTarget       uint8   `json:"companion_target"`
+	WarmupDurationS       float64 `json:"warmup_duration_s"`
+	ReasonIfDegraded      string  `json:"reason_if_degraded"`
+	TransportKind         string  `json:"transport_kind"`
+	AdmissionPathSelected string  `json:"admission_path_selected"`
+}
+
+type AdmissionArtifactDiscovery struct {
+	WireBytes                            int            `json:"wire_bytes"`
+	WindowS                              float64        `json:"window_s"`
+	StartupBurstPct                      float64        `json:"startup_burst_pct"`
+	PostStartupSustainedRateProbesPer15s float64        `json:"post_startup_sustained_rate_probes_per_15s"`
+	ProbeCount                           int            `json:"probe_count"`
+	PromotedSuspectsWithoutIdentity      int            `json:"promoted_suspects_without_identity"`
+	PerBaselineAddressEvidenceCounts     map[string]int `json:"per_baseline_address_evidence_counts"`
+}
+
+// AdmissionArtifactBuilder aggregates runtime events over the startup
+// window and produces the final AdmissionArtifact on Emit.
+type AdmissionArtifactBuilder struct {
+	mu        sync.Mutex
+	artifact  AdmissionArtifact
+	startedAt time.Time
+}
+
+func NewAdmissionArtifactBuilder(transportKind string) *AdmissionArtifactBuilder {
+	return &AdmissionArtifactBuilder{
+		startedAt: time.Now(),
+		artifact: AdmissionArtifact{
+			Admission: AdmissionArtifactAdmission{
+				TransportKind:         transportKind,
+				State:                 "pending",
+				AdmissionPathSelected: "degraded_no_events",
+			},
+			Discovery: AdmissionArtifactDiscovery{
+				PerBaselineAddressEvidenceCounts: make(map[string]int),
+			},
+		},
+	}
+}
+
+func (b *AdmissionArtifactBuilder) SetAdmissionPathSelected(v string) error {
+	if err := ValidateAdmissionPathSelected(v); err != nil {
+		return err
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.artifact.Admission.AdmissionPathSelected = v
+	return nil
+}
+
+func (b *AdmissionArtifactBuilder) SetJoinerSelection(source, companionTarget uint8, warmupDuration time.Duration) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.artifact.Admission.Source = source
+	b.artifact.Admission.CompanionTarget = companionTarget
+	b.artifact.Admission.WarmupDurationS = warmupDuration.Seconds()
+	b.artifact.Admission.State = "active"
+}
+
+func (b *AdmissionArtifactBuilder) SetOverrideSource(source uint8) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.artifact.Admission.Source = source
+}
+
+func (b *AdmissionArtifactBuilder) SetDegraded(reason string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.artifact.Admission.State = "degraded"
+	b.artifact.Admission.ReasonIfDegraded = reason
+}
+
+func (b *AdmissionArtifactBuilder) RecordProbe(wireBytes int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.artifact.Discovery.WireBytes += wireBytes
+	b.artifact.Discovery.ProbeCount++
+}
+
+func (b *AdmissionArtifactBuilder) SetPromotedSuspects(n int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.artifact.Discovery.PromotedSuspectsWithoutIdentity = n
+}
+
+func (b *AdmissionArtifactBuilder) SetPostStartupSustainedRateProbesPer15s(rate float64) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.artifact.Discovery.PostStartupSustainedRateProbesPer15s = rate
+}
+
+func (b *AdmissionArtifactBuilder) RecordBaselineEvidence(address uint8, count int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	key := fmt.Sprintf("%02X", address)
+	b.artifact.Discovery.PerBaselineAddressEvidenceCounts[key] = count
+}
+
+func (b *AdmissionArtifactBuilder) Emit() (AdmissionArtifact, []byte, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	windowS := time.Since(b.startedAt).Seconds()
+	if windowS > 0 {
+		b.artifact.Discovery.WindowS = windowS
+		b.artifact.Discovery.StartupBurstPct = float64(b.artifact.Discovery.WireBytes) / (windowS * 240) * 100
+	}
+	data, err := json.MarshalIndent(b.artifact, "", "  ")
+	if err != nil {
+		return AdmissionArtifact{}, nil, err
+	}
+	return b.artifact, data, nil
+}
+
+func (b *AdmissionArtifactBuilder) EmitToFile(path string) error {
+	_, data, err := b.Emit()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dirOf(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+func dirOf(path string) string {
+	for i := len(path) - 1; i >= 0; i-- {
+		if path[i] == '/' {
+			return path[:i]
+		}
+	}
+	return "."
+}

--- a/admission_artifact.go
+++ b/admission_artifact.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -41,6 +43,7 @@ type AdmissionArtifactBuilder struct {
 	mu        sync.Mutex
 	artifact  AdmissionArtifact
 	startedAt time.Time
+	emitOnce  uint32 // CAS guard for EmitToFile
 }
 
 func NewAdmissionArtifactBuilder(transportKind string) *AdmissionArtifactBuilder {
@@ -81,6 +84,20 @@ func (b *AdmissionArtifactBuilder) SetJoinerSelection(source, companionTarget ui
 func (b *AdmissionArtifactBuilder) SetOverrideSource(source uint8) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	b.artifact.Admission.Source = source
+}
+
+// SetActiveOverride flips Admission.State to "active" and records the
+// override Source. Used by the override path (AD09 (c2) soft short-
+// circuit) where the override source is in use from the first active
+// frame regardless of Joiner outcome — so the artifact must reflect
+// state="active", not the default "pending". Found by AD20 second-
+// reviewer M7 pass: the prior code path emitted state=pending on
+// override which was misleading to operators.
+func (b *AdmissionArtifactBuilder) SetActiveOverride(source uint8) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.artifact.Admission.State = "active"
 	b.artifact.Admission.Source = source
 }
 
@@ -132,22 +149,32 @@ func (b *AdmissionArtifactBuilder) Emit() (AdmissionArtifact, []byte, error) {
 	return b.artifact, data, nil
 }
 
+// EmitToFile writes the artifact JSON to the given path. Once a snapshot
+// is emitted (e.g. by the 60s startup-window goroutine), subsequent calls
+// are no-ops via the emitOnce guard — this prevents the AD20-reviewer-
+// flagged race where a defer-on-shutdown emit could overwrite the
+// canonical 60s window snapshot with later state.
+//
+// To re-arm the builder for a new window, call ResetEmitOnce.
 func (b *AdmissionArtifactBuilder) EmitToFile(path string) error {
+	if !atomic.CompareAndSwapUint32(&b.emitOnce, 0, 1) {
+		return nil
+	}
 	_, data, err := b.Emit()
 	if err != nil {
+		// Re-arm so a follow-up call can retry; the file was not written.
+		atomic.StoreUint32(&b.emitOnce, 0)
 		return err
 	}
-	if err := os.MkdirAll(dirOf(path), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		atomic.StoreUint32(&b.emitOnce, 0)
 		return err
 	}
 	return os.WriteFile(path, data, 0o644)
 }
 
-func dirOf(path string) string {
-	for i := len(path) - 1; i >= 0; i-- {
-		if path[i] == '/' {
-			return path[:i]
-		}
-	}
-	return "."
+// ResetEmitOnce re-arms EmitToFile so the next call will write again.
+// Used by tests; production callers should not need this.
+func (b *AdmissionArtifactBuilder) ResetEmitOnce() {
+	atomic.StoreUint32(&b.emitOnce, 0)
 }

--- a/admission_artifact_test.go
+++ b/admission_artifact_test.go
@@ -1,0 +1,72 @@
+package ebusgateway
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAdmissionArtifact_EmitValidatesAgainstSchema(t *testing.T) {
+	builder := NewAdmissionArtifactBuilder("ens")
+	builder.startedAt = time.Now().Add(-60 * time.Second)
+	if err := builder.SetAdmissionPathSelected("join"); err != nil {
+		t.Fatal(err)
+	}
+	builder.SetJoinerSelection(0x71, 0x08, 5*time.Second)
+	builder.RecordProbe(120)
+	builder.RecordProbe(180)
+	builder.SetPostStartupSustainedRateProbesPer15s(1.5)
+	builder.SetPromotedSuspects(2)
+	builder.RecordBaselineEvidence(0x08, 3)
+	builder.RecordBaselineEvidence(0x15, 1)
+
+	artifact, data, err := builder.Emit()
+	if err != nil {
+		t.Fatal(err)
+	}
+	validateAdmissionArtifactAgainstSchema(t, data)
+
+	var reparsed AdmissionArtifact
+	if err := json.Unmarshal(data, &reparsed); err != nil {
+		t.Fatalf("reparse artifact: %v", err)
+	}
+	if reparsed.Admission.AdmissionPathSelected != "join" {
+		t.Fatalf("admission_path_selected=%q", reparsed.Admission.AdmissionPathSelected)
+	}
+	if reparsed.Admission.State != "active" {
+		t.Fatalf("state=%q", reparsed.Admission.State)
+	}
+	if artifact.Discovery.ProbeCount != 2 {
+		t.Fatalf("probe_count=%d", artifact.Discovery.ProbeCount)
+	}
+}
+
+func TestAdmissionArtifact_BadAdmissionPathRejected(t *testing.T) {
+	builder := NewAdmissionArtifactBuilder("enh")
+	err := builder.SetAdmissionPathSelected("bogus")
+	if err == nil {
+		t.Fatal("expected invalid admission_path_selected to fail")
+	}
+	if !strings.HasPrefix(err.Error(), "FATAL:") {
+		t.Fatalf("unexpected error %q", err)
+	}
+}
+
+func TestAdmissionArtifact_WireLoadMath(t *testing.T) {
+	builder := NewAdmissionArtifactBuilder("tcp-plain")
+	builder.startedAt = time.Now().Add(-60 * time.Second)
+	if err := builder.SetAdmissionPathSelected("join"); err != nil {
+		t.Fatal(err)
+	}
+	builder.RecordProbe(100)
+	builder.RecordProbe(200)
+
+	artifact, _, err := builder.Emit()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if artifact.Discovery.StartupBurstPct < 2.07 || artifact.Discovery.StartupBurstPct > 2.10 {
+		t.Fatalf("startup_burst_pct=%f; want approx 2.08", artifact.Discovery.StartupBurstPct)
+	}
+}

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -114,6 +114,8 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 		admissionPath = ebusgateway.TransportAdmissionStaticFallback
 	}
 	metrics := ebusgateway.GetOrInitStartupAdmissionMetrics()
+	artifactBuilder := ebusgateway.NewAdmissionArtifactBuilder(string(cfg.TransportConfig.Protocol))
+	_ = artifactBuilder.SetAdmissionPathSelected("degraded_no_events")
 	overrideSet := admissionPath == ebusgateway.TransportAdmissionJoinCapable && cfg.StartupSource.Source != nil
 	overrideSource := byte(0x00)
 	if overrideSet {
@@ -121,9 +123,29 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 		log.Print(ebusgateway.FormatStartupAdmissionOverrideLog(overrideSource))
 		metrics.SetOverrideActive(true)
 		metrics.RecordOverrideBypass()
+		artifactBuilder.SetOverrideSource(overrideSource)
+		_ = artifactBuilder.SetAdmissionPathSelected("override")
 	} else {
 		metrics.SetOverrideActive(false)
 	}
+	const artifactPath = "/tmp/helianthus-admission-artifact.json"
+	go func() {
+		timer := time.NewTimer(60 * time.Second)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			if err := artifactBuilder.EmitToFile(artifactPath); err != nil {
+				log.Printf("startup admission artifact emit: %v", err)
+			}
+		}
+	}()
+	defer func() {
+		if err := artifactBuilder.EmitToFile(artifactPath); err != nil {
+			log.Printf("startup admission artifact emit: %v", err)
+		}
+	}()
 
 	busObservability, deduplicator, err := wireObserveFirstObserversFn(&cfg)
 	if err != nil {
@@ -263,6 +285,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 
 		log.Printf("joiner warmup begin")
 		warmupCtx, cancel := context.WithTimeout(ctx, 6*time.Second)
+		warmupStartedAt := time.Now()
 		result, err := joiner.Join(warmupCtx)
 		cancel()
 		if err != nil {
@@ -270,11 +293,15 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 			if busObservability != nil {
 				busObservability.RecordBusAdmissionTransition("degraded", 0, 0, "joiner_fail")
 			}
+			artifactBuilder.SetDegraded("joiner_fail")
+			_ = artifactBuilder.SetAdmissionPathSelected("degraded_no_events")
 		} else {
 			if overrideSet {
 				_ = ebusgateway.CheckOverrideCompanionConflict(overrideSource, result, metrics)
 			} else {
 				joinResult = &result
+				artifactBuilder.SetJoinerSelection(result.Initiator, result.CompanionTarget, time.Since(warmupStartedAt))
+				_ = artifactBuilder.SetAdmissionPathSelected("join")
 				log.Printf("startup admission active source=0x%02X companion_target=0x%02X", result.Initiator, result.CompanionTarget)
 				if busObservability != nil {
 					busObservability.RecordBusAdmissionTransition("active", result.Initiator, result.CompanionTarget, "")
@@ -297,6 +324,9 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 
 	log.Printf("startup scan pass")
 	log.Printf("startup_directed_probe_phase begin source=0x%02X provenance=%s", startupCfg.ScanSource, startupSourceProvenance)
+	if overrideSet {
+		artifactBuilder.SetOverrideSource(startupCfg.ScanSource)
+	}
 	startupScanSignals := startDiscoveryScanLoopFn(ctx, startupCfg, gateway, builder, adapterClassifier)
 
 	if semanticBarrier != nil {

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -115,7 +115,9 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 	}
 	metrics := ebusgateway.GetOrInitStartupAdmissionMetrics()
 	artifactBuilder := ebusgateway.NewAdmissionArtifactBuilder(string(cfg.TransportConfig.Protocol))
-	_ = artifactBuilder.SetAdmissionPathSelected("degraded_no_events")
+	if err := artifactBuilder.SetAdmissionPathSelected("degraded_no_events"); err != nil {
+		log.Fatalf("FATAL: AD23 enum violation at startup: %v", err)
+	}
 	overrideSet := admissionPath == ebusgateway.TransportAdmissionJoinCapable && cfg.StartupSource.Source != nil
 	overrideSource := byte(0x00)
 	if overrideSet {
@@ -124,7 +126,14 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 		metrics.SetOverrideActive(true)
 		metrics.RecordOverrideBypass()
 		artifactBuilder.SetOverrideSource(overrideSource)
-		_ = artifactBuilder.SetAdmissionPathSelected("override")
+		if err := artifactBuilder.SetAdmissionPathSelected("override"); err != nil {
+			log.Fatalf("FATAL: AD23 enum violation on override path: %v", err)
+		}
+		// Override is configured: admission state immediately becomes
+		// "active" because the override Initiator is in use from the
+		// first active frame (AD09 (c2) soft short-circuit). Joiner may
+		// still run advisory-only under Validate=true but does not gate.
+		artifactBuilder.SetActiveOverride(overrideSource)
 	} else {
 		metrics.SetOverrideActive(false)
 	}
@@ -294,14 +303,18 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 				busObservability.RecordBusAdmissionTransition("degraded", 0, 0, "joiner_fail")
 			}
 			artifactBuilder.SetDegraded("joiner_fail")
-			_ = artifactBuilder.SetAdmissionPathSelected("degraded_no_events")
+			if perr := artifactBuilder.SetAdmissionPathSelected("degraded_no_events"); perr != nil {
+				log.Fatalf("FATAL: AD23 enum violation on joiner-fail path: %v", perr)
+			}
 		} else {
 			if overrideSet {
 				_ = ebusgateway.CheckOverrideCompanionConflict(overrideSource, result, metrics)
 			} else {
 				joinResult = &result
 				artifactBuilder.SetJoinerSelection(result.Initiator, result.CompanionTarget, time.Since(warmupStartedAt))
-				_ = artifactBuilder.SetAdmissionPathSelected("join")
+				if perr := artifactBuilder.SetAdmissionPathSelected("join"); perr != nil {
+					log.Fatalf("FATAL: AD23 enum violation on join path: %v", perr)
+				}
 				log.Printf("startup admission active source=0x%02X companion_target=0x%02X", result.Initiator, result.CompanionTarget)
 				if busObservability != nil {
 					busObservability.RecordBusAdmissionTransition("active", result.Initiator, result.CompanionTarget, "")

--- a/docs/transport-gate-evidence/README.md
+++ b/docs/transport-gate-evidence/README.md
@@ -1,0 +1,13 @@
+# Transport-Gate Evidence
+
+This directory holds operator-captured evidence for the M7 live-bus acceptance window.
+
+Capture procedure:
+
+1. Run the gateway on real hardware for 5 minutes on the target transport.
+2. Record the final startup-admission expvars and passive event count.
+3. Hash the built gateway binary with `sha256sum`.
+4. Copy `TEMPLATE.yaml` to `docs/transport-gate-evidence/<ISO8601-date>-<transport>.yaml`.
+5. Fill every field and link the committed YAML file in the M7 PR description.
+
+The YAML file is operator-provided evidence. This repo only ships the format and capture procedure.

--- a/docs/transport-gate-evidence/TEMPLATE.yaml
+++ b/docs/transport-gate-evidence/TEMPLATE.yaml
@@ -1,0 +1,20 @@
+# Transport-gate evidence template for M7 acceptance.
+# Operator fills this in after capturing a 5-minute runtime window on
+# real adapter-direct hardware per plan §M7 acceptance criteria.
+#
+# Commit as docs/transport-gate-evidence/<ISO8601-date>-<transport>.yaml
+# and link in the M7 PR description.
+
+transport: ens
+adapter_hw_id: "<e.g., ENH28A1>"
+admission_path_selected: join
+warmup_events_observed: 0
+degraded_escalations: 0
+passive_event_count_5min: 0
+hash_of_gateway_binary_sha256: "<sha256 of the gateway binary>"
+operator_signoff_gh_handle: "<your github handle>"
+timestamp_utc: "2026-04-23T12:00:00Z"
+deployment_seed_exercised_in_ci: [0x08, 0x15, 0x26, 0x04, 0xF6, 0xEC]
+ci_tested_seeds:
+  - default: [0x08, 0x15, 0x26, 0x04, 0xF6, 0xEC]
+  - non_default: [0x03, 0x10, 0x50]

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -34,6 +34,9 @@ go build ./...
 echo "==> go test (race)"
 go test -race -count=1 ./...
 
+echo "==> validating admission-artifact schema coverage"
+go test ./... -run "TestAdmissionArtifact_EmitValidatesAgainstSchema" -count=1
+
 echo "==> python script tests"
 python3 scripts/passive_canary_verifier_test.py
 python3 scripts/transport_gate_test.py

--- a/startup_admission_harness_test.go
+++ b/startup_admission_harness_test.go
@@ -65,7 +65,33 @@ func validateAdmissionArtifactAgainstSchema(t *testing.T, artifactJSON []byte) {
 }
 
 func TestM2aHarness_JoinerSuccessPath(t *testing.T) {
-	t.Skip("pending M3: admission FSM + JoinResult capture")
+	var forwarded []protocol.Frame
+	forwardJoinBusEvent(synthesizedTransactionEvent(0x71, 0x08, true), func(frame protocol.Frame) {
+		forwarded = append(forwarded, frame)
+	})
+	if len(forwarded) == 0 {
+		t.Fatal("expected synthesized passive traffic to forward at least one frame")
+	}
+
+	builder := NewAdmissionArtifactBuilder("ens")
+	builder.startedAt = time.Now().Add(-60 * time.Second)
+	if err := builder.SetAdmissionPathSelected("join"); err != nil {
+		t.Fatal(err)
+	}
+	builder.SetJoinerSelection(0x71, 0x08, 5*time.Second)
+	builder.RecordProbe(120)
+
+	artifact, data, err := builder.Emit()
+	if err != nil {
+		t.Fatal(err)
+	}
+	validateAdmissionArtifactAgainstSchema(t, data)
+	if artifact.Admission.AdmissionPathSelected != "join" {
+		t.Fatalf("admission_path_selected=%q", artifact.Admission.AdmissionPathSelected)
+	}
+	if artifact.Admission.State != "active" {
+		t.Fatalf("state=%q", artifact.Admission.State)
+	}
 }
 
 func TestM2aHarness_JoinerFailNoFreeInitiatorPath(t *testing.T) {


### PR DESCRIPTION
Closes #538. Cruise-run #20 milestone M7. AdmissionArtifactBuilder per AD23 schema; wired into main.go; emit at 60s startup window. docs/transport-gate-evidence/ template. AD23 FATAL enforcement at call sites + dedup emit + override state=active. FINAL milestone of cruise-run #20. Replaces #539.