### PR TITLE
feat(portal/vaillant_b503): M8 — F1..F8 per-target + reason matrix + projection fold-in + session strip + history tab + AD02 banner + tests

### DIFF
--- a/matrix/M6a-vaillant-b503.md
+++ b/matrix/M6a-vaillant-b503.md
@@ -224,3 +224,60 @@ The 5 read selectors + 3 live-monitor lifecycle phases + 1 mixed-traffic regress
 **Cross-reference to §3 RB rows.** §9 production-dispatcher rows do NOT supersede the §3 RB-02 / RB-03 / RB-04 `[~]` markers — those concern B524 baseline non-regression under live load and remain pending BENCH-REPLACE per the §3 honest framing. The two row sets answer different questions: §3 RB asks "does B524 throughput regress under B503 load on real hardware"; §9 VB-BR asks "does the production dispatcher's code path correctly serialise frame envelope, error mapping, lock order, and stale-epoch discipline against the agreed-upon test contract".
 
 **Forward gate.** When M7_BENCH_REPLACE merges with operator-attested capture artefacts, every `[bridge-PASS]` row flips to `[bridge-LIVE-PASS]` and §3 RB-02/03/04 simultaneously flip from `[~]` to `[x]`. That is the only authorised promotion path for the dispatcher rows — flipping any §9 row without the corresponding capture is a defect.
+
+---
+
+## §10 REST shim decision (M8 F7) — locked via cruise-consult
+
+**Decision: B — GraphQL-only, no `/api/v1/vaillant/*` REST shim.**
+
+**Provenance.** Pre-implementation `cruise-consult` dispatched two independent
+consultants (Claude consultant + Codex consultant) on 2026-04-25 prior to M8
+dev start. Consensus reached on consultant decision = B. Artefact:
+[Project-Helianthus/helianthus-execution-plans#19 comment 4320124082](https://github.com/Project-Helianthus/helianthus-execution-plans/issues/19#issuecomment-4320124082).
+
+**Rationale (locked).**
+
+1. **Vendor-namespace boundary.** The Vaillant B503 surface is a vendor namespace
+   (`B5 03`), not part of the `ebus_standard` L7 catalog. The portal's existing
+   `/api/v1/ebus-standard/*` shims expose the *standard* L7 catalog to operator
+   tooling that does not speak GraphQL. B503 has no equivalent standardisation
+   tier — it is firmware-coupled to a specific vendor and family of devices.
+2. **Session-stateful surface.** B503 live-monitor is a session-owned, per-target
+   stateful resource (issuerToken, AD14 epoch semantics, AD16 lock order). REST
+   semantics ("each request idempotent") are a poor fit; GraphQL's
+   session-token + targetAddress arg model is already in place and is the
+   portal's only consumer.
+3. **Zero external consumer.** No external client today requests REST access to
+   B503 reads or live-monitor. Adding shims would expand the public surface
+   area and create a second contract to govern under AD02 / AD14 / AD16
+   invariants without solving any concrete consumer problem.
+4. **Symmetry asymmetry is documented, not erased.** The portal's GraphQL
+   consumer surfaces all B503 reads + live-monitor through the existing
+   `vaillant*` queries. The asymmetry vs `ebus_standard` (which has REST
+   shims) is recorded here AND in
+   `helianthus-docs-ebus/architecture/ebus_standard/09-mcp-envelope.md` (the
+   F7 path-B companion docs PR).
+
+**Re-evaluation trigger.** This decision is re-opened if and only if an
+external consumer requests REST access to B503 reads or live-monitor with a
+documented operational reason. At that point, the cruise-consult cycle
+re-runs and either (a) shims are added with explicit AD14/AD16 mapping
+recorded here, or (b) the rationale in §10 is extended with the new
+evidence. **Adding `/api/v1/vaillant/*` shims without a fresh decision
+artefact is a defect.**
+
+**Mechanical assertion (handler.go behaviour).** Any HTTP request to
+`/api/v1/vaillant/*` MUST return `404 Not Found` (NOT `405 Method Not
+Allowed`, NOT `200 OK`). This is asserted by
+`portal/handler_test.go::TestM8_F7_VaillantRESTShim_Returns404` which probes
+representative paths under `/api/v1/vaillant/*` and asserts the 404
+contract. The contract is preserved by the default-NotFound clause in
+`portal/handler.go::handleAPI` switch — adding a `case "vaillant/..."` arm
+to that switch without a fresh §10 re-evaluation is a defect.
+
+**Companion docs PR (F7 path-B requirement).** `helianthus-docs-ebus`
+gets a new section "Vendor namespaces and portal exposure" added to
+`architecture/ebus_standard/09-mcp-envelope.md` recording the asymmetry.
+That PR is OUT-OF-SCOPE for the M8 gateway PR and is tracked separately
+under the M8 dispatch's docs-companion obligation.

--- a/portal/handler_test.go
+++ b/portal/handler_test.go
@@ -1544,3 +1544,26 @@ func intPtr(value int) *int {
 	v := value
 	return &v
 }
+
+// M8_F7_VaillantRESTShimReturns404 — F7 cruise-consult decision = B
+// (GraphQL-only). matrix/M6a-vaillant-b503.md §10 records the rationale.
+// Any /api/v1/vaillant/* request MUST return 404 (not 405, not 200) so
+// the GraphQL-only contract is mechanically asserted.
+func TestM8_F7_VaillantRESTShim_Returns404(t *testing.T) {
+	h := NewHandler(Options{})
+	paths := []string{
+		"/api/v1/vaillant/errors",
+		"/api/v1/vaillant/service/current",
+		"/api/v1/vaillant/live-monitor",
+		"/api/v1/vaillant/foo/bar",
+	}
+	for _, p := range paths {
+		req := httptest.NewRequest(http.MethodGet, p, nil)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("GET %s status=%d; want 404 (F7 GraphQL-only decision per matrix §10)",
+				p, rec.Code)
+		}
+	}
+}

--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -1862,7 +1862,13 @@ class PortalShell extends HTMLElement {
       // Cap probe is intentionally non-blocking on plane render: a
       // failed probe degrades to "no B503 card" without affecting the
       // existing projection UI.
-      this._probeAndRenderB503Card(device).catch(() => {
+      //
+      // R4 round-1 P2 fix: pass the captured addressRaw + the
+      // lifecycle isActive() callback into the probe so a slow probe
+      // for a previously-selected device cannot append a stale card
+      // after the user switches. The probe re-checks the active
+      // selection BEFORE writing into the host.
+      this._probeAndRenderB503Card(device, addressRaw, isActive).catch(() => {
         // Probe failure → no card. Already a soft-fail in the F3
         // contract (capability=AVAILABLE is the gate; anything else
         // hides the card).
@@ -1882,7 +1888,15 @@ class PortalShell extends HTMLElement {
   // the standard projection UML is rendered. The capability query is
   // target-scoped so a device not implementing B503 returns NOT_SUPPORTED
   // and the card is silently omitted.
-  async _probeAndRenderB503Card(device) {
+  //
+  // `issuedAddressRaw` + `isActive` are captured at probe-issue time
+  // (R4 round-1 P2 fix). Before mutating the host, the probe re-checks
+  // both: (a) the bootstrap lifecycle is still active, and (b) the
+  // currently selected device-select value still matches the issued
+  // address. A late probe for a previously-selected device is dropped
+  // silently — the host has already been cleared and the new device's
+  // own probe (or its absence) is the source of truth.
+  async _probeAndRenderB503Card(device, issuedAddressRaw, isActive) {
     if (!device || device.address === undefined || device.address === null) return;
     let reason = "UNKNOWN";
     try {
@@ -1897,6 +1911,18 @@ class PortalShell extends HTMLElement {
       }
     } catch (err) {
       reason = "UNKNOWN";
+    }
+    // Lifecycle + selection re-check before any DOM mutation.
+    if (typeof isActive === "function" && !isActive()) return;
+    if (issuedAddressRaw !== undefined && issuedAddressRaw !== null) {
+      const sel = this.querySelector('[data-role="projection-device-select"]');
+      const currentRaw = sel ? String(sel.value || "").trim() : "";
+      if (currentRaw !== String(issuedAddressRaw)) {
+        // Stale probe — the user switched targets after the probe was
+        // issued. Do NOT append; the new device's loadAllProjectionPlanes
+        // already cleared the host and runs its own probe.
+        return;
+      }
     }
     await this.renderProjectionB503Card(device, reason);
   }
@@ -3471,7 +3497,13 @@ class PortalShell extends HTMLElement {
   async _dispatchTargetedDisable(target, issuerToken) {
     const variables = { action: "disable", issuerToken };
     const tk = this._vaillantB503TargetKey(target);
-    if (tk !== null) variables.targetAddress = tk;
+    // Only include `targetAddress` when we have an explicit byte
+    // address. The default sentinel (string `<default>`) is a local-
+    // map key — it MUST NOT be sent to GraphQL where parseTargetAddress
+    // expects an Int and would reject the request, leaving the
+    // server-side session active despite local cleanup
+    // (R4 round-1 P2 fix).
+    if (typeof tk === "number") variables.targetAddress = tk;
     try {
       await this._gqlRequest(
         "query VaillantLiveDisable($action: String!, $issuerToken: String, $targetAddress: Int) { vaillantLiveMonitor(action: $action, issuerToken: $issuerToken, targetAddress: $targetAddress) { issuerToken rawHex disabled } }",
@@ -3481,10 +3513,10 @@ class PortalShell extends HTMLElement {
       // Best-effort cleanup; even if the backend rejects, we have
       // already invalidated the local token and will not retry.
     }
-    if (tk !== null) {
-      this._vaillantB503TokenMap().delete(tk);
-      this._setVaillantB503SessionState(tk, "Disabled");
-    }
+    // Local cleanup uses the resolved key (number OR sentinel) so the
+    // map slot the original enable wrote into is the one we delete.
+    this._vaillantB503TokenMap().delete(tk);
+    this._setVaillantB503SessionState(tk, "Disabled");
   }
 
   async handleVaillantB503NavAway() {

--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -2862,10 +2862,23 @@ class PortalShell extends HTMLElement {
   // handler before any state mutation (M8-TGT-04 / R5 A1).
   // -----------------------------------------------------------------
 
+  // Stable sentinel for the unset / default target. The token + state
+  // maps must be readable+writable under this key the same way they
+  // are for explicit byte addresses, otherwise enable/disable on the
+  // default target stores its token under one key and the disable
+  // accessor returns null — the GraphQL provider then rejects the
+  // disable with `issuer_token required` and the local session sticks
+  // (R3 round-1 P2 fix).
+  static _DEFAULT_B503_TARGET_KEY = "<default>";
+
   _vaillantB503TargetKey(addr) {
-    if (addr === null || addr === undefined) return null;
+    if (addr === null || addr === undefined) {
+      return PortalShell._DEFAULT_B503_TARGET_KEY;
+    }
     const n = Number(addr);
-    if (!Number.isFinite(n)) return null;
+    if (!Number.isFinite(n)) {
+      return PortalShell._DEFAULT_B503_TARGET_KEY;
+    }
     return n & 0xff;
   }
 
@@ -2891,15 +2904,17 @@ class PortalShell extends HTMLElement {
   }
 
   vaillantB503LiveTokenForTarget(addr) {
+    // _vaillantB503TargetKey always returns a stable key (number for
+    // explicit byte address, or the DEFAULT sentinel for unset/null
+    // target). Readers must never short-circuit on a null key —
+    // unset target is a valid map slot (R3 round-1 P2 fix).
     const key = this._vaillantB503TargetKey(addr);
-    if (key === null) return null;
     const tok = this._vaillantB503TokenMap().get(key);
     return tok || null;
   }
 
   vaillantB503SessionStateForTarget(addr) {
     const key = this._vaillantB503TargetKey(addr);
-    if (key === null) return "Idle";
     const map = this._vaillantB503SessionStateMap();
     if (map.has(key)) return map.get(key);
     return this._vaillantB503TokenMap().get(key) ? "Active" : "Idle";

--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -2267,6 +2267,11 @@ class PortalShell extends HTMLElement {
               <div class="projection-uml-grid" data-role="projection-uml-grid">
                 <p class="projection-empty">Select a device to view projection planes.</p>
               </div>
+              <!-- M8 F3 — fold-in host for the Vaillant B503 plane card.
+                   renderProjectionB503Card() appends a card per device with
+                   capability=AVAILABLE. Click on the card jumps to the
+                   Vaillant B503 pane with target preselected. -->
+              <div class="uml-grid" data-role="projection-b503-card-host"></div>
             </section>
             <section id="section-explorer" class="registry-preview">
               <h2>Register Explorer</h2>
@@ -2479,7 +2484,22 @@ class PortalShell extends HTMLElement {
             </section>
             <section id="section-vaillant-b503" class="registry-preview">
               <h2>Vaillant B503</h2>
-              <p class="muted-inline">Read-only diagnostics over the Vaillant B503 namespace (errors, service, live-monitor). Install-writes are intentionally omitted per plan AD02.</p>
+              <div class="bus-banner" data-testid="b503-install-writes-banner" role="note">
+                Read-only diagnostics over the Vaillant B503 namespace (errors, service, history, live-monitor). Install-writes are intentionally omitted per plan AD02.
+                <a id="b503-ad02-tooltip-anchor"
+                   class="muted-inline"
+                   href="https://github.com/Project-Helianthus/helianthus-execution-plans/tree/main/vaillant-b503-namespace-w17-26.implementing"
+                   title="Open AD02 install-writes governance — vaillant-b503-namespace-w17-26 plan"
+                   target="_blank"
+                   rel="noopener noreferrer">?</a>
+              </div>
+              <div class="snapshot-controls" data-role="vaillant-b503-target-controls">
+                <label class="explorer-label" for="b503-target-select-input">Target
+                  <select class="select" data-role="b503-target-select" id="b503-target-select-input" aria-label="Vaillant B503 target device">
+                    <option value="">(loading targets...)</option>
+                  </select>
+                </label>
+              </div>
               <div data-role="vaillant-b503-body">
                 <div class="muted-inline">Loading Vaillant B503 capability...</div>
               </div>
@@ -2748,17 +2768,132 @@ class PortalShell extends HTMLElement {
     // The tab bar + inner buttons are rendered dynamically inside the
     // pane body, so delegation happens in renderVaillantB503Pane which
     // attaches listeners at render time (querySelector-by-data-role).
-    // Nothing to wire eagerly at boot — the nav click invokes
-    // activateSection → refreshVaillantB503Capability → renderVaillantB503Pane.
+    // The target selector lives in the static section markup; bind it
+    // here so target switches stay live across re-renders.
+    const targetSelect = this.querySelector('[data-role="b503-target-select"]');
+    if (targetSelect && typeof targetSelect.addEventListener === "function") {
+      targetSelect.addEventListener("change", () => {
+        const raw = targetSelect.value;
+        const num = raw === "" || raw == null ? null : Number(raw);
+        this.setVaillantB503Target(num);
+      });
+    }
+  }
+
+  // -----------------------------------------------------------------
+  // M8 — F1 per-target awareness
+  //
+  // The target selector is fed from `this.projectionDevices` (same
+  // source as section-projection). Each B503 GraphQL query carries
+  // `targetAddress` so capability + read state stays per-device.
+  //
+  // Caching: capability/state is keyed by target address; a switch
+  // does NOT clobber another target's last-known state. In-flight
+  // responses with mismatched target are discarded by the result
+  // handler before any state mutation (M8-TGT-04 / R5 A1).
+  // -----------------------------------------------------------------
+
+  _vaillantB503TargetKey(addr) {
+    if (addr === null || addr === undefined) return null;
+    const n = Number(addr);
+    if (!Number.isFinite(n)) return null;
+    return n & 0xff;
+  }
+
+  _vaillantB503CapabilityMap() {
+    if (!this._vaillantB503CapabilityByTarget) {
+      this._vaillantB503CapabilityByTarget = new Map();
+    }
+    return this._vaillantB503CapabilityByTarget;
+  }
+
+  _vaillantB503TokenMap() {
+    if (!this._vaillantB503LiveTokenByTarget) {
+      this._vaillantB503LiveTokenByTarget = new Map();
+    }
+    return this._vaillantB503LiveTokenByTarget;
+  }
+
+  _vaillantB503SessionStateMap() {
+    if (!this._vaillantB503SessionStateByTarget) {
+      this._vaillantB503SessionStateByTarget = new Map();
+    }
+    return this._vaillantB503SessionStateByTarget;
+  }
+
+  vaillantB503LiveTokenForTarget(addr) {
+    const key = this._vaillantB503TargetKey(addr);
+    if (key === null) return null;
+    const tok = this._vaillantB503TokenMap().get(key);
+    return tok || null;
+  }
+
+  vaillantB503SessionStateForTarget(addr) {
+    const key = this._vaillantB503TargetKey(addr);
+    if (key === null) return "Idle";
+    const map = this._vaillantB503SessionStateMap();
+    if (map.has(key)) return map.get(key);
+    return this._vaillantB503TokenMap().get(key) ? "Active" : "Idle";
+  }
+
+  _setVaillantB503SessionState(addr, state) {
+    const key = this._vaillantB503TargetKey(addr);
+    if (key === null) return;
+    this._vaillantB503SessionStateMap().set(key, state);
+  }
+
+  populateVaillantB503TargetOptions() {
+    const select = this.querySelector('[data-role="b503-target-select"]');
+    if (!select) return;
+    const items = Array.isArray(this.projectionDevices) ? this.projectionDevices : [];
+    if (items.length === 0) {
+      select.innerHTML = '<option value="">(no targets)</option>';
+      select.disabled = true;
+      return;
+    }
+    select.disabled = false;
+    select.innerHTML = items.map((item) => {
+      const addr = String(item.address);
+      const label = item.display_name || item.device_id || formatAddress(item.address);
+      return `<option value="${escapeHtml(addr)}">${escapeHtml(`${label} (${formatAddress(item.address)})`)}</option>`;
+    }).join("");
+    if (this._vaillantB503Target == null && items.length > 0) {
+      this._vaillantB503Target = this._vaillantB503TargetKey(items[0].address);
+    }
+    if (this._vaillantB503Target != null) {
+      select.value = String(this._vaillantB503Target);
+    }
+  }
+
+  async setVaillantB503Target(addr) {
+    const key = this._vaillantB503TargetKey(addr);
+    this._vaillantB503Target = key;
+    // Bump epoch — completions for prior target are rejected by the
+    // result handler when their captured epoch != _vaillantB503Epoch.
+    this._vaillantB503Epoch = (this._vaillantB503Epoch || 0) + 1;
+    const select = this.querySelector('[data-role="b503-target-select"]');
+    if (select && key !== null) {
+      select.value = String(key);
+    }
+    await this.refreshVaillantB503Capability();
+  }
+
+  _vaillantB503TargetVars(extra = {}) {
+    const vars = { ...extra };
+    if (this._vaillantB503Target !== null && this._vaillantB503Target !== undefined) {
+      vars.targetAddress = this._vaillantB503Target;
+    }
+    return vars;
   }
 
   async refreshVaillantB503Capability() {
     const body = this.querySelector('[data-role="vaillant-b503-body"]');
+    this.populateVaillantB503TargetOptions();
     let reason = "UNKNOWN";
     try {
       const env = await this._gqlRequest(
-        "query VaillantB503Cap { vaillantCapabilities { vaillantB503 { available reason } } }",
-        {},
+        "query VaillantB503Cap($targetAddress: Int) { vaillantCapabilities(targetAddress: $targetAddress) { vaillantB503 { available reason } } }",
+        this._vaillantB503TargetVars(),
       );
       const cap = env && env.data && env.data.vaillantCapabilities
         && env.data.vaillantCapabilities.vaillantB503;
@@ -2771,6 +2906,33 @@ class PortalShell extends HTMLElement {
       reason = "UNKNOWN";
     }
     this._vaillantB503CapabilityReason = reason;
+    if (this._vaillantB503Target !== null && this._vaillantB503Target !== undefined) {
+      this._vaillantB503CapabilityMap().set(this._vaillantB503Target, reason);
+    }
+    // F4 epoch-rollover: keep session state in its lifecycle vocabulary
+    // (Idle / Enabling / Active / Disabled). When capability leaves
+    // AVAILABLE for a target while a session was Active or Enabling,
+    // the server-side session epoch implicitly rolled — drop the local
+    // token and demote state to Idle. The strip's UI surfaces the
+    // capability separately.
+    const t = this._vaillantB503Target;
+    if (t !== null && t !== undefined) {
+      const stateMap = this._vaillantB503SessionStateMap();
+      if (reason !== "AVAILABLE") {
+        const cur = stateMap.get(t);
+        if (cur === "Active" || cur === "Enabling") {
+          stateMap.set(t, "Idle");
+          this._vaillantB503TokenMap().delete(t);
+        } else if (!stateMap.has(t)) {
+          stateMap.set(t, "Idle");
+        }
+      } else {
+        // AVAILABLE: idempotent default-Idle for newly-seen targets.
+        if (!stateMap.has(t)) {
+          stateMap.set(t, "Idle");
+        }
+      }
+    }
     this.renderVaillantB503Pane(reason, body);
   }
 
@@ -2778,36 +2940,76 @@ class PortalShell extends HTMLElement {
     const body = bodyEl || this.querySelector('[data-role="vaillant-b503-body"]');
     if (!body) return;
     const sanitized = typeof reason === "string" ? reason : "UNKNOWN";
+    const planRef = "https://github.com/Project-Helianthus/helianthus-execution-plans/tree/main/vaillant-b503-namespace-w17-26.implementing";
     if (sanitized === "AVAILABLE") {
       const activeTab = this._vaillantB503ActiveTab || "errors";
+      const stripHTML = this._vaillantB503SessionStripMarkup();
       body.innerHTML = `
-        <div class="snapshot-controls" data-role="vaillant-b503-tabs">
-          <button class="button" data-role="vaillant-b503-tab-errors" type="button">Errors</button>
-          <button class="button" data-role="vaillant-b503-tab-service" type="button">Service</button>
-          <button class="button" data-role="vaillant-b503-tab-live-monitor" type="button">Live-Monitor</button>
-        </div>
-        <div data-role="vaillant-b503-tab-body">
-          ${this._vaillantB503TabMarkup(activeTab)}
+        <div data-testid="b503-state-available" data-role="vaillant-b503-state-available">
+          ${stripHTML}
+          <div class="snapshot-controls" data-role="vaillant-b503-tabs">
+            <button class="button" data-role="vaillant-b503-tab-errors" type="button">Errors</button>
+            <button class="button" data-role="vaillant-b503-tab-service" type="button">Service</button>
+            <button class="button" data-role="vaillant-b503-tab-history" type="button">History</button>
+            <button class="button" data-role="vaillant-b503-tab-live-monitor" type="button">Live-Monitor</button>
+          </div>
+          <div data-role="vaillant-b503-tab-body">
+            ${this._vaillantB503TabMarkup(activeTab)}
+          </div>
         </div>
       `;
       this._bindVaillantB503TabEvents();
       this._bindVaillantB503ActiveTabEvents(activeTab);
-    } else if (sanitized === "TRANSPORT_DOWN" || sanitized === "SESSION_BUSY") {
+    } else if (sanitized === "NOT_SUPPORTED") {
       body.innerHTML = `
-        <div class="bus-banner bus-state-unavailable">
-          Vaillant B503 temporarily unavailable: ${escapeHtml(sanitized)}
+        <div data-testid="b503-state-not-supported" class="muted-inline">
+          B503 not implemented for this device family. Vendor namespace surface is unavailable on the selected target; this is expected for non-Vaillant or older firmware. (reason=<span data-role="vaillant-b503-reason">${escapeHtml(sanitized)}</span>)
         </div>
-        <p class="muted-inline">Navigate away and back to retry.</p>
+      `;
+    } else if (sanitized === "TRANSPORT_DOWN") {
+      body.innerHTML = `
+        <div data-testid="b503-state-transport-down" class="bus-banner bus-state-unavailable">
+          Transport warning: adapter health is degraded — the gateway cannot reach the bus right now.
+          <span class="muted-inline"> Retry hint: wait for the adapter to reconnect, then navigate away and back to retry.</span>
+        </div>
+      `;
+    } else if (sanitized === "SESSION_BUSY") {
+      body.innerHTML = `
+        <div data-testid="b503-state-session-busy" class="bus-banner bus-state-unavailable">
+          Owner: another client currently holds the live-monitor session — wait for it to be released, then retry.
+        </div>
       `;
     } else {
-      // NOT_SUPPORTED, UNKNOWN, and any unrecognized reason → safe placeholder.
+      // UNKNOWN and any unrecognized reason → probe-failure-hint copy.
       body.innerHTML = `
-        <div class="muted-inline">
-          Vaillant B503 not supported on this device / gateway
-          (<span data-role="vaillant-b503-reason">${escapeHtml(sanitized)}</span>).
+        <div data-testid="b503-state-unknown" class="muted-inline">
+          Probe failure: gateway has not yet completed a successful B503 dispatch on the selected target. Diagnostic suggestion — verify adapter is connected and retry; the capability flips to AVAILABLE on first successful read.
         </div>
       `;
     }
+    // Keep tooltip-anchor referencing the canonical plan even in error
+    // states (the banner is in the static section markup, not body).
+    void planRef;
+  }
+
+  _vaillantB503SessionStripMarkup() {
+    const t = this._vaillantB503Target;
+    const state = this.vaillantB503SessionStateForTarget(t);
+    const cap = (t !== null && t !== undefined)
+      ? this._vaillantB503CapabilityMap().get(t)
+      : this._vaillantB503CapabilityReason;
+    const ownedByOther = cap === "SESSION_BUSY" && !this.vaillantB503LiveTokenForTarget(t);
+    const ownedAffordance = ownedByOther
+      ? `<span class="muted-inline" data-testid="b503-session-owned-by-other">Owned by another client (release required before local enable).</span>`
+      : "";
+    return `
+      <div class="snapshot-controls" data-testid="b503-session-strip" data-role="vaillant-b503-session-strip">
+        <span class="muted-inline">Session:
+          <strong data-testid="b503-session-state-label" data-role="vaillant-b503-session-state">${escapeHtml(state)}</strong>
+        </span>
+        ${ownedAffordance}
+      </div>
+    `;
   }
 
   _vaillantB503TabMarkup(activeTab) {
@@ -2821,12 +3023,26 @@ class PortalShell extends HTMLElement {
         </div>
       `;
     }
-    if (activeTab === "live-monitor") {
+    if (activeTab === "history") {
       return `
         <div class="snapshot-controls">
-          <button class="button" data-role="vaillant-b503-live-enable" type="button">Enable</button>
+          <button class="button" data-role="vaillant-b503-history-refresh" type="button">Refresh</button>
+        </div>
+        <div data-role="vaillant-b503-history-body">
+          <div class="muted-inline">Click Refresh to load error history records.</div>
+        </div>
+      `;
+    }
+    if (activeTab === "live-monitor") {
+      const t = this._vaillantB503Target;
+      const state = this.vaillantB503SessionStateForTarget(t);
+      const enableDisabled = state === "Enabling" ? " disabled" : "";
+      const disableDisabled = state === "Enabling" ? " disabled" : "";
+      return `
+        <div class="snapshot-controls">
+          <button class="button" data-role="vaillant-b503-live-enable" type="button"${enableDisabled}>Enable</button>
           <button class="button" data-role="vaillant-b503-live-read" type="button">Read</button>
-          <button class="button" data-role="vaillant-b503-live-disable" type="button">Disable</button>
+          <button class="button" data-role="vaillant-b503-live-disable" type="button"${disableDisabled}>Disable</button>
         </div>
         <pre class="issue-preview" data-role="vaillant-b503-live-output"></pre>
         <div class="muted-inline" data-role="vaillant-b503-live-status">Idle.</div>
@@ -2846,12 +3062,13 @@ class PortalShell extends HTMLElement {
   _bindVaillantB503TabEvents() {
     const errorsTab = this.querySelector('[data-role="vaillant-b503-tab-errors"]');
     const serviceTab = this.querySelector('[data-role="vaillant-b503-tab-service"]');
+    const historyTab = this.querySelector('[data-role="vaillant-b503-tab-history"]');
     const liveTab = this.querySelector('[data-role="vaillant-b503-tab-live-monitor"]');
     const swap = async (name) => {
       const leavingLive =
         this._vaillantB503ActiveTab === "live-monitor" &&
         name !== "live-monitor" &&
-        this._vaillantB503LiveToken;
+        this.vaillantB503LiveTokenForTarget(this._vaillantB503Target);
       if (leavingLive) {
         // Fire a best-effort disable before swapping. Matches the
         // nav-away semantics so clicking Errors/Service while a live
@@ -2859,7 +3076,8 @@ class PortalShell extends HTMLElement {
         try {
           await this.invokeVaillantLiveMonitor("disable");
         } catch {
-          this._vaillantB503LiveToken = null;
+          // _invokeVaillantLiveMonitor clears the per-target token on
+          // disable failure already; nothing else to do.
         }
       }
       this._vaillantB503ActiveTab = name;
@@ -2873,6 +3091,9 @@ class PortalShell extends HTMLElement {
     if (serviceTab && typeof serviceTab.addEventListener === "function") {
       serviceTab.addEventListener("click", () => swap("service"));
     }
+    if (historyTab && typeof historyTab.addEventListener === "function") {
+      historyTab.addEventListener("click", () => swap("history"));
+    }
     if (liveTab && typeof liveTab.addEventListener === "function") {
       liveTab.addEventListener("click", () => swap("live-monitor"));
     }
@@ -2883,6 +3104,13 @@ class PortalShell extends HTMLElement {
       const refresh = this.querySelector('[data-role="vaillant-b503-service-refresh"]');
       if (refresh && typeof refresh.addEventListener === "function") {
         refresh.addEventListener("click", () => this.refreshVaillantServiceCurrent());
+      }
+      return;
+    }
+    if (activeTab === "history") {
+      const refresh = this.querySelector('[data-role="vaillant-b503-history-refresh"]');
+      if (refresh && typeof refresh.addEventListener === "function") {
+        refresh.addEventListener("click", () => this.refreshVaillantErrorHistory());
       }
       return;
     }
@@ -2933,8 +3161,8 @@ class PortalShell extends HTMLElement {
     const body = this.querySelector('[data-role="vaillant-b503-errors-body"]');
     try {
       const env = await this._gqlRequest(
-        "query VaillantErrors { vaillantErrors { firstActiveError slots } }",
-        {},
+        "query VaillantErrors($targetAddress: Int) { vaillantErrors(targetAddress: $targetAddress) { firstActiveError slots } }",
+        this._vaillantB503TargetVars(),
       );
       if (env && env.errors && env.errors.length) {
         if (body) body.innerHTML = `<div class="error">${escapeHtml(env.errors[0].message || "error")}</div>`;
@@ -2951,8 +3179,8 @@ class PortalShell extends HTMLElement {
     const body = this.querySelector('[data-role="vaillant-b503-service-body"]');
     try {
       const env = await this._gqlRequest(
-        "query VaillantServiceCurrent { vaillantServiceCurrent { firstActiveError slots } }",
-        {},
+        "query VaillantServiceCurrent($targetAddress: Int) { vaillantServiceCurrent(targetAddress: $targetAddress) { firstActiveError slots } }",
+        this._vaillantB503TargetVars(),
       );
       if (env && env.errors && env.errors.length) {
         if (body) body.innerHTML = `<div class="error">${escapeHtml(env.errors[0].message || "error")}</div>`;
@@ -2965,24 +3193,132 @@ class PortalShell extends HTMLElement {
     }
   }
 
+  // M8 F5 — Errors history sub-tab. The History tab renders the most
+  // recent N records via vaillantErrorHistory(targetAddress, index).
+  // Empty-state surfaces an em-dash when no records exist.
+  async refreshVaillantErrorHistory() {
+    const body = this.querySelector('[data-role="vaillant-b503-history-body"]');
+    try {
+      const env = await this._gqlRequest(
+        "query VaillantErrorHistory($targetAddress: Int, $index: Int) { vaillantErrorHistory(targetAddress: $targetAddress, index: $index) { index firstActiveError slots } }",
+        this._vaillantB503TargetVars({ index: 0 }),
+      );
+      if (env && env.errors && env.errors.length) {
+        if (body) body.innerHTML = `<div class="error">${escapeHtml(env.errors[0].message || "error")}</div>`;
+        return;
+      }
+      const payload = env && env.data && env.data.vaillantErrorHistory;
+      if (!body) return;
+      if (!payload || (payload.firstActiveError == null && (!Array.isArray(payload.slots) || payload.slots.length === 0))) {
+        body.innerHTML = `<div class="muted-inline" data-role="vaillant-b503-history-empty">— (no records)</div>`;
+        return;
+      }
+      const first = payload.firstActiveError != null ? String(payload.firstActiveError) : "—";
+      const slots = Array.isArray(payload.slots) ? payload.slots : [];
+      const slotCells = slots.map((slot) => {
+        const cell = slot === null || slot === undefined ? "—" : String(Number(slot));
+        return `<td>${escapeHtml(cell)}</td>`;
+      }).join("");
+      body.innerHTML = `
+        <dl class="meta-list">
+          <dt>Index</dt><dd>${escapeHtml(String(payload.index || 0))}</dd>
+          <dt>First active error</dt><dd>${escapeHtml(first)}</dd>
+        </dl>
+        <table class="table">
+          <thead><tr><th>Slot 0</th><th>Slot 1</th><th>Slot 2</th><th>Slot 3</th><th>Slot 4</th></tr></thead>
+          <tbody><tr>${slotCells || '<td colspan="5">—</td>'}</tr></tbody>
+        </table>
+      `;
+    } catch (err) {
+      if (body) body.innerHTML = `<div class="error">${escapeHtml(String(err))}</div>`;
+    }
+  }
+
+  // M8 F3 — Projection plane card for B503. Rendered into the projection
+  // section (alongside Service / Observability / Debug planes) iff the
+  // device's B503 capability=AVAILABLE for the selected target. Clicking
+  // the card jumps to section-vaillant-b503 with target preselected.
+  async renderProjectionB503Card(device, capabilityState) {
+    if (!device || capabilityState !== "AVAILABLE") return;
+    const host = this.querySelector('[data-role="projection-b503-card-host"]');
+    if (!host) return;
+    const addr = device.address;
+    const hex = formatAddress(addr);
+    const label = device.display_name || device.device_id || hex;
+    const card = `
+      <div class="uml-box" data-role="projection-b503-card" data-b503-target="${escapeHtml(String(addr))}">
+        <div class="uml-header">«Vaillant B503»</div>
+        <div class="muted-inline">${escapeHtml(label)} (${escapeHtml(hex)})</div>
+        <ul class="uml-body">
+          <li class="uml-method">errors</li>
+          <li class="uml-method">service-current</li>
+          <li class="uml-method">service-history</li>
+          <li class="uml-method">live-monitor</li>
+        </ul>
+        <button class="button" data-role="projection-b503-jump" data-b503-target="${escapeHtml(String(addr))}" type="button">Open in Vaillant B503</button>
+      </div>
+    `;
+    // Append (do not replace) — multiple devices may render their own card.
+    const prior = host.innerHTML || "";
+    host.innerHTML = prior + card;
+  }
+
   async invokeVaillantLiveMonitor(action) {
     const status = this.querySelector('[data-role="vaillant-b503-live-status"]');
     const output = this.querySelector('[data-role="vaillant-b503-live-output"]');
+    // Capture the target + epoch at issue-time. The completion path
+    // compares against the captured values BEFORE mutating state so a
+    // late completion on a previous target/epoch never bleeds into the
+    // currently selected target's strip (R5 A1 / M8-TGT-04).
+    const issuedTarget = this._vaillantB503Target;
+    const issuedEpoch = this._vaillantB503Epoch || 0;
     const variables = { action: String(action) };
-    if (action === "disable" && this._vaillantB503LiveToken) {
-      variables.issuerToken = this._vaillantB503LiveToken;
+    if (issuedTarget !== null && issuedTarget !== undefined) {
+      variables.targetAddress = issuedTarget;
+    }
+    if (action === "disable") {
+      const existing = this.vaillantB503LiveTokenForTarget(issuedTarget);
+      if (existing) variables.issuerToken = existing;
+    }
+    if (action === "enable") {
+      this._setVaillantB503SessionState(issuedTarget, "Enabling");
     }
     try {
       const env = await this._gqlRequest(
-        "query VaillantLive($action: String!, $issuerToken: String) { vaillantLiveMonitor(action: $action, issuerToken: $issuerToken) { issuerToken rawHex disabled } }",
+        "query VaillantLive($action: String!, $issuerToken: String, $targetAddress: Int) { vaillantLiveMonitor(action: $action, issuerToken: $issuerToken, targetAddress: $targetAddress) { issuerToken rawHex disabled } }",
         variables,
       );
+      // M8-TGT-04: completion-side discard. If the active target/epoch
+      // has shifted since we issued the request, do NOT mutate any
+      // currently-selected-target state. If the response carries an
+      // issuerToken (i.e. local user actually owns the issued target),
+      // immediately fire a targeted disable so the abandoned session
+      // does not leak.
+      const currentTarget = this._vaillantB503Target;
+      const currentEpoch = this._vaillantB503Epoch || 0;
+      const epochMismatch = issuedEpoch !== currentEpoch
+        || this._vaillantB503TargetKey(issuedTarget) !== this._vaillantB503TargetKey(currentTarget);
+      if (epochMismatch) {
+        const payload = env && env.data && env.data.vaillantLiveMonitor;
+        if (action === "enable" && payload && typeof payload.issuerToken === "string" && payload.issuerToken !== "") {
+          // Stash token under issuedTarget so per-target accessors still
+          // see it (test contract: T1 ownership persists after switch
+          // to T2 if completion arrives post-switch). Fire targeted
+          // disable for issuedTarget without touching current target.
+          this._vaillantB503TokenMap().set(this._vaillantB503TargetKey(issuedTarget), payload.issuerToken);
+          this._setVaillantB503SessionState(issuedTarget, "Active");
+          // Targeted disable: bypass the path that re-reads
+          // _vaillantB503Target so we cannot accidentally touch T2.
+          await this._dispatchTargetedDisable(issuedTarget, payload.issuerToken);
+        }
+        return;
+      }
       if (env && env.errors && env.errors.length) {
         if (status) status.textContent = env.errors[0].message || "error";
-        // For the nav-away / tab-swap cleanup path: a disable that the
-        // backend rejects MUST still surface as an error so the caller
-        // can clear its stale token. Swallowing here caused the
-        // nav-away catch() never to run.
+        if (action === "enable") {
+          // Roll back to last-known state on enable failure.
+          this._setVaillantB503SessionState(issuedTarget, "Idle");
+        }
         if (action === "disable") {
           throw new Error(env.errors[0].message || "disable failed");
         }
@@ -2991,8 +3327,11 @@ class PortalShell extends HTMLElement {
       const payload = env && env.data && env.data.vaillantLiveMonitor;
       if (!payload) return;
       if (action === "enable" && typeof payload.issuerToken === "string" && payload.issuerToken !== "") {
-        this._vaillantB503LiveToken = payload.issuerToken;
+        this._vaillantB503TokenMap().set(this._vaillantB503TargetKey(issuedTarget), payload.issuerToken);
+        this._setVaillantB503SessionState(issuedTarget, "Active");
         if (status) status.textContent = "Live-monitor session active.";
+      } else if (action === "enable") {
+        this._setVaillantB503SessionState(issuedTarget, "Idle");
       }
       if (action === "read") {
         const hex = typeof payload.rawHex === "string" ? payload.rawHex : "";
@@ -3000,26 +3339,55 @@ class PortalShell extends HTMLElement {
         if (status) status.textContent = hex ? "OK" : "No frame available yet.";
       }
       if (action === "disable") {
-        this._vaillantB503LiveToken = null;
+        this._vaillantB503TokenMap().delete(this._vaillantB503TargetKey(issuedTarget));
+        this._setVaillantB503SessionState(issuedTarget, "Idle");
         if (status) status.textContent = "Session disabled.";
       }
     } catch (err) {
       if (status) status.textContent = `Error: ${err}`;
+      if (action === "enable") {
+        // Don't leave the strip stuck in Enabling on a network failure.
+        this._setVaillantB503SessionState(issuedTarget, "Idle");
+      }
+    }
+  }
+
+  // _dispatchTargetedDisable issues a disable for an explicit target +
+  // issuerToken pair, bypassing the active-target accessor so the call
+  // is safe to fire post-target-switch (M8-TGT-04 R5 A1 contract).
+  async _dispatchTargetedDisable(target, issuerToken) {
+    const variables = { action: "disable", issuerToken };
+    const tk = this._vaillantB503TargetKey(target);
+    if (tk !== null) variables.targetAddress = tk;
+    try {
+      await this._gqlRequest(
+        "query VaillantLiveDisable($action: String!, $issuerToken: String, $targetAddress: Int) { vaillantLiveMonitor(action: $action, issuerToken: $issuerToken, targetAddress: $targetAddress) { issuerToken rawHex disabled } }",
+        variables,
+      );
+    } catch {
+      // Best-effort cleanup; even if the backend rejects, we have
+      // already invalidated the local token and will not retry.
+    }
+    if (tk !== null) {
+      this._vaillantB503TokenMap().delete(tk);
+      this._setVaillantB503SessionState(tk, "Disabled");
     }
   }
 
   async handleVaillantB503NavAway() {
-    // Auto-disable on nav-away. Only fires if an issuer token is held,
-    // which implies the live-monitor tab entered the Active state. The
-    // disable call is best-effort — failures are swallowed so a stuck
-    // backend does not block nav.
-    if (!this._vaillantB503LiveToken) return;
-    try {
-      await this.invokeVaillantLiveMonitor("disable");
-    } catch {
-      // Fail-open on nav: clear the token anyway so a stale session
-      // cannot be mistaken for a live one.
-      this._vaillantB503LiveToken = null;
+    // Auto-disable on nav-away. Iterates per-target token map so a
+    // multi-target session set never leaks a live token. Best-effort
+    // (failures swallowed). Falls back to clearing the local map so a
+    // stuck backend cannot mark a stale session as live.
+    const map = this._vaillantB503TokenMap();
+    if (map.size === 0) return;
+    const entries = Array.from(map.entries());
+    for (const [target, token] of entries) {
+      try {
+        await this._dispatchTargetedDisable(target, token);
+      } catch {
+        map.delete(target);
+      }
     }
   }
 }

--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -368,6 +368,28 @@ class PortalShell extends HTMLElement {
         this.loadAllProjectionPlanes();
       });
     }
+    // M8 F3 (R1 round-1 P1 fix): event delegation on the projection
+    // B503 card host so clicks on `data-role="projection-b503-jump"`
+    // navigate to section-vaillant-b503 with the target preselected.
+    const b503CardHost = this.querySelector('[data-role="projection-b503-card-host"]');
+    if (b503CardHost) {
+      b503CardHost.addEventListener("click", (event) => {
+        const button = event.target && event.target.closest
+          ? event.target.closest('[data-role="projection-b503-jump"]')
+          : null;
+        if (!button) return;
+        const raw = button.getAttribute("data-b503-target");
+        const parsed = Number.parseInt(String(raw || ""), 10);
+        if (Number.isFinite(parsed)) {
+          // Pre-set the B503 target before navigating so the pane
+          // renders the correct device on activation.
+          this._vaillantB503Target = parsed;
+          const select = this.querySelector('[data-role="vaillant-b503-target-select"]');
+          if (select) select.value = String(parsed);
+        }
+        this.activateSection("section-vaillant-b503");
+      });
+    }
     this.querySelectorAll("[data-nav-target]").forEach((button) => {
       button.addEventListener("click", () => {
         const targetID = button.getAttribute("data-nav-target");
@@ -1822,6 +1844,21 @@ class PortalShell extends HTMLElement {
         .map((p, i) => ({ plane: p.plane, graph: graphs[i] }))
         .filter((r) => r.graph);
       this.renderProjectionUML(gridEl, device, results);
+      // M8 F3 (R1 round-1 P1 fix): wire renderProjectionB503Card into
+      // the projection load path. Clear stale cards first, then probe
+      // B503 capability per-device and append a card iff AVAILABLE.
+      // Cap probe is intentionally non-blocking on plane render: a
+      // failed probe degrades to "no B503 card" without affecting the
+      // existing projection UI.
+      const cardHost = this.querySelector('[data-role="projection-b503-card-host"]');
+      if (cardHost) {
+        cardHost.innerHTML = "";
+      }
+      this._probeAndRenderB503Card(device).catch(() => {
+        // Probe failure → no card. Already a soft-fail in the F3
+        // contract (capability=AVAILABLE is the gate; anything else
+        // hides the card).
+      });
     } catch (err) {
       if (!isActive()) {
         return false;
@@ -1830,6 +1867,30 @@ class PortalShell extends HTMLElement {
       console.error("projection planes failed", err);
     }
     return true;
+  }
+
+  // M8 F3 — probe per-device B503 capability and render the projection
+  // plane card iff AVAILABLE. Called from loadAllProjectionPlanes after
+  // the standard projection UML is rendered. The capability query is
+  // target-scoped so a device not implementing B503 returns NOT_SUPPORTED
+  // and the card is silently omitted.
+  async _probeAndRenderB503Card(device) {
+    if (!device || device.address === undefined || device.address === null) return;
+    let reason = "UNKNOWN";
+    try {
+      const env = await this._gqlRequest(
+        "query VaillantB503CapForProjection($targetAddress: Int) { vaillantCapabilities(targetAddress: $targetAddress) { vaillantB503 { available reason } } }",
+        { targetAddress: device.address },
+      );
+      const cap = env && env.data && env.data.vaillantCapabilities
+        && env.data.vaillantCapabilities.vaillantB503;
+      if (cap && typeof cap.reason === "string") {
+        reason = cap.reason;
+      }
+    } catch (err) {
+      reason = "UNKNOWN";
+    }
+    await this.renderProjectionB503Card(device, reason);
   }
 
   renderProjectionUML(target, device, planeResults) {
@@ -2889,6 +2950,14 @@ class PortalShell extends HTMLElement {
   async refreshVaillantB503Capability() {
     const body = this.querySelector('[data-role="vaillant-b503-body"]');
     this.populateVaillantB503TargetOptions();
+    // Capture target at query-issue time. The completion path compares
+    // against the current target before mutating cache/UI so a late
+    // response from the previous target cannot bleed into the newly
+    // selected target's state (R1 round-1 P1: M8-TGT-01 invariant
+    // applies to capability queries the same way M8-TGT-04 applies to
+    // live-monitor enable).
+    const issuedTarget = this._vaillantB503Target;
+    const issuedKey = this._vaillantB503TargetKey(issuedTarget);
     let reason = "UNKNOWN";
     try {
       const env = await this._gqlRequest(
@@ -2905,17 +2974,29 @@ class PortalShell extends HTMLElement {
       // can click the nav entry again to retry.
       reason = "UNKNOWN";
     }
-    this._vaillantB503CapabilityReason = reason;
-    if (this._vaillantB503Target !== null && this._vaillantB503Target !== undefined) {
-      this._vaillantB503CapabilityMap().set(this._vaillantB503Target, reason);
+    // R1 round-1 P1 fix: write the capability cache under the
+    // ISSUED target's key, never under the (possibly-shifted) current
+    // target. Then, only render / mutate session state if the issued
+    // target still matches the current selection.
+    if (issuedTarget !== null && issuedTarget !== undefined) {
+      this._vaillantB503CapabilityMap().set(issuedTarget, reason);
     }
+    const currentKey = this._vaillantB503TargetKey(this._vaillantB503Target);
+    if (issuedKey !== currentKey) {
+      // Late response from a previous target. Cache update above is
+      // bound to the issued target so a future re-selection of that
+      // target sees the value; do NOT touch session state or UI for
+      // the currently selected target.
+      return;
+    }
+    this._vaillantB503CapabilityReason = reason;
     // F4 epoch-rollover: keep session state in its lifecycle vocabulary
     // (Idle / Enabling / Active / Disabled). When capability leaves
     // AVAILABLE for a target while a session was Active or Enabling,
     // the server-side session epoch implicitly rolled — drop the local
     // token and demote state to Idle. The strip's UI surfaces the
     // capability separately.
-    const t = this._vaillantB503Target;
+    const t = issuedTarget;
     if (t !== null && t !== undefined) {
       const stateMap = this._vaillantB503SessionStateMap();
       if (reason !== "AVAILABLE") {
@@ -3310,6 +3391,15 @@ class PortalShell extends HTMLElement {
           // Targeted disable: bypass the path that re-reads
           // _vaillantB503Target so we cannot accidentally touch T2.
           await this._dispatchTargetedDisable(issuedTarget, payload.issuerToken);
+        } else if (action === "disable") {
+          // R1 round-1 P2 fix: disable response on a target the user
+          // has switched away from. Backend has already cleared the
+          // session; we MUST clear the local token + demote state for
+          // the issued target so a switch-back later does not falsely
+          // show an active/owned session. Do NOT touch the current
+          // target's state.
+          this._vaillantB503TokenMap().delete(this._vaillantB503TargetKey(issuedTarget));
+          this._setVaillantB503SessionState(issuedTarget, "Idle");
         }
         return;
       }

--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -1805,6 +1805,16 @@ class PortalShell extends HTMLElement {
     const isActive = () => this.isActiveBootstrapLifecycle(lifecycleToken, lifecycleAbort);
     const gridEl = this.querySelector('[data-role="projection-uml-grid"]');
     const deviceSelect = this.querySelector('[data-role="projection-device-select"]');
+    // M8 F3 (R2 round-1 P2 fix): clear the B503 card host AT THE TOP
+    // before any early-return path so a stale card from the previous
+    // device cannot persist when the new selection: (a) lacks
+    // projection planes, (b) is empty, (c) is unknown, or (d) the fetch
+    // path fails. The success path further down will append the new
+    // device's card iff capability=AVAILABLE.
+    const cardHostEarly = this.querySelector('[data-role="projection-b503-card-host"]');
+    if (cardHostEarly) {
+      cardHostEarly.innerHTML = "";
+    }
     if (!gridEl || !deviceSelect) {
       return true;
     }
@@ -1844,16 +1854,14 @@ class PortalShell extends HTMLElement {
         .map((p, i) => ({ plane: p.plane, graph: graphs[i] }))
         .filter((r) => r.graph);
       this.renderProjectionUML(gridEl, device, results);
-      // M8 F3 (R1 round-1 P1 fix): wire renderProjectionB503Card into
-      // the projection load path. Clear stale cards first, then probe
-      // B503 capability per-device and append a card iff AVAILABLE.
+      // M8 F3 (R1 round-1 P1 fix; R2 round-1 P2 follow-up): wire
+      // renderProjectionB503Card into the projection load path. The
+      // host has already been cleared at function entry (so any
+      // early-return branch above also clears it); here we just probe
+      // capability and append the new device's card iff AVAILABLE.
       // Cap probe is intentionally non-blocking on plane render: a
       // failed probe degrades to "no B503 card" without affecting the
       // existing projection UI.
-      const cardHost = this.querySelector('[data-role="projection-b503-card-host"]');
-      if (cardHost) {
-        cardHost.innerHTML = "";
-      }
       this._probeAndRenderB503Card(device).catch(() => {
         // Probe failure → no card. Already a soft-fail in the F3
         // contract (capability=AVAILABLE is the gate; anything else

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,8 +2,8 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 138598,
-      "sha256": "69e1bb93641e9ea94f93df3c13008716f5029b34d6232ebbc44656d2f8e1d159"
+      "bytes": 156793,
+      "sha256": "b251960cb375af09e236f0e25a7d373487316e8d6a371ac715721db19745495f"
     },
     "app.css": {
       "bytes": 8115,

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,8 +2,8 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 156793,
-      "sha256": "b251960cb375af09e236f0e25a7d373487316e8d6a371ac715721db19745495f"
+      "bytes": 161401,
+      "sha256": "b8465da4bcea80c7d094b413ded4d1af9031b1148e6b5325a9af55f2b6513f6d"
     },
     "app.css": {
       "bytes": 8115,

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,8 +2,8 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 161401,
-      "sha256": "b8465da4bcea80c7d094b413ded4d1af9031b1148e6b5325a9af55f2b6513f6d"
+      "bytes": 161928,
+      "sha256": "c7c4fc691953e354c754796799a9af59e56360a898794ec5569844b3e185ecc0"
     },
     "app.css": {
       "bytes": 8115,

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,8 +2,8 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 162708,
-      "sha256": "03bc53dd84867ec5fd83b05cf8e5f052fe6c510c1cb98d57d91004f3027462da"
+      "bytes": 164680,
+      "sha256": "17cc41a2be6c327e2e35c33b4d8760b446940fee957f5379b29fc7b5013513ca"
     },
     "app.css": {
       "bytes": 8115,

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,8 +2,8 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 161928,
-      "sha256": "c7c4fc691953e354c754796799a9af59e56360a898794ec5569844b3e185ecc0"
+      "bytes": 162708,
+      "sha256": "03bc53dd84867ec5fd83b05cf8e5f052fe6c510c1cb98d57d91004f3027462da"
     },
     "app.css": {
       "bytes": 8115,

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -2266,6 +2266,11 @@ class PortalShell extends HTMLElement {
               <div class="projection-uml-grid" data-role="projection-uml-grid">
                 <p class="projection-empty">Select a device to view projection planes.</p>
               </div>
+              <!-- M8 F3 — fold-in host for the Vaillant B503 plane card.
+                   renderProjectionB503Card() appends a card per device with
+                   capability=AVAILABLE. Click on the card jumps to the
+                   Vaillant B503 pane with target preselected. -->
+              <div class="uml-grid" data-role="projection-b503-card-host"></div>
             </section>
             <section id="section-explorer" class="registry-preview">
               <h2>Register Explorer</h2>
@@ -2478,7 +2483,22 @@ class PortalShell extends HTMLElement {
             </section>
             <section id="section-vaillant-b503" class="registry-preview">
               <h2>Vaillant B503</h2>
-              <p class="muted-inline">Read-only diagnostics over the Vaillant B503 namespace (errors, service, live-monitor). Install-writes are intentionally omitted per plan AD02.</p>
+              <div class="bus-banner" data-testid="b503-install-writes-banner" role="note">
+                Read-only diagnostics over the Vaillant B503 namespace (errors, service, history, live-monitor). Install-writes are intentionally omitted per plan AD02.
+                <a id="b503-ad02-tooltip-anchor"
+                   class="muted-inline"
+                   href="https://github.com/Project-Helianthus/helianthus-execution-plans/tree/main/vaillant-b503-namespace-w17-26.implementing"
+                   title="Open AD02 install-writes governance — vaillant-b503-namespace-w17-26 plan"
+                   target="_blank"
+                   rel="noopener noreferrer">?</a>
+              </div>
+              <div class="snapshot-controls" data-role="vaillant-b503-target-controls">
+                <label class="explorer-label" for="b503-target-select-input">Target
+                  <select class="select" data-role="b503-target-select" id="b503-target-select-input" aria-label="Vaillant B503 target device">
+                    <option value="">(loading targets...)</option>
+                  </select>
+                </label>
+              </div>
               <div data-role="vaillant-b503-body">
                 <div class="muted-inline">Loading Vaillant B503 capability...</div>
               </div>
@@ -2747,17 +2767,132 @@ class PortalShell extends HTMLElement {
     // The tab bar + inner buttons are rendered dynamically inside the
     // pane body, so delegation happens in renderVaillantB503Pane which
     // attaches listeners at render time (querySelector-by-data-role).
-    // Nothing to wire eagerly at boot — the nav click invokes
-    // activateSection → refreshVaillantB503Capability → renderVaillantB503Pane.
+    // The target selector lives in the static section markup; bind it
+    // here so target switches stay live across re-renders.
+    const targetSelect = this.querySelector('[data-role="b503-target-select"]');
+    if (targetSelect && typeof targetSelect.addEventListener === "function") {
+      targetSelect.addEventListener("change", () => {
+        const raw = targetSelect.value;
+        const num = raw === "" || raw == null ? null : Number(raw);
+        this.setVaillantB503Target(num);
+      });
+    }
+  }
+
+  // -----------------------------------------------------------------
+  // M8 — F1 per-target awareness
+  //
+  // The target selector is fed from `this.projectionDevices` (same
+  // source as section-projection). Each B503 GraphQL query carries
+  // `targetAddress` so capability + read state stays per-device.
+  //
+  // Caching: capability/state is keyed by target address; a switch
+  // does NOT clobber another target's last-known state. In-flight
+  // responses with mismatched target are discarded by the result
+  // handler before any state mutation (M8-TGT-04 / R5 A1).
+  // -----------------------------------------------------------------
+
+  _vaillantB503TargetKey(addr) {
+    if (addr === null || addr === undefined) return null;
+    const n = Number(addr);
+    if (!Number.isFinite(n)) return null;
+    return n & 0xff;
+  }
+
+  _vaillantB503CapabilityMap() {
+    if (!this._vaillantB503CapabilityByTarget) {
+      this._vaillantB503CapabilityByTarget = new Map();
+    }
+    return this._vaillantB503CapabilityByTarget;
+  }
+
+  _vaillantB503TokenMap() {
+    if (!this._vaillantB503LiveTokenByTarget) {
+      this._vaillantB503LiveTokenByTarget = new Map();
+    }
+    return this._vaillantB503LiveTokenByTarget;
+  }
+
+  _vaillantB503SessionStateMap() {
+    if (!this._vaillantB503SessionStateByTarget) {
+      this._vaillantB503SessionStateByTarget = new Map();
+    }
+    return this._vaillantB503SessionStateByTarget;
+  }
+
+  vaillantB503LiveTokenForTarget(addr) {
+    const key = this._vaillantB503TargetKey(addr);
+    if (key === null) return null;
+    const tok = this._vaillantB503TokenMap().get(key);
+    return tok || null;
+  }
+
+  vaillantB503SessionStateForTarget(addr) {
+    const key = this._vaillantB503TargetKey(addr);
+    if (key === null) return "Idle";
+    const map = this._vaillantB503SessionStateMap();
+    if (map.has(key)) return map.get(key);
+    return this._vaillantB503TokenMap().get(key) ? "Active" : "Idle";
+  }
+
+  _setVaillantB503SessionState(addr, state) {
+    const key = this._vaillantB503TargetKey(addr);
+    if (key === null) return;
+    this._vaillantB503SessionStateMap().set(key, state);
+  }
+
+  populateVaillantB503TargetOptions() {
+    const select = this.querySelector('[data-role="b503-target-select"]');
+    if (!select) return;
+    const items = Array.isArray(this.projectionDevices) ? this.projectionDevices : [];
+    if (items.length === 0) {
+      select.innerHTML = '<option value="">(no targets)</option>';
+      select.disabled = true;
+      return;
+    }
+    select.disabled = false;
+    select.innerHTML = items.map((item) => {
+      const addr = String(item.address);
+      const label = item.display_name || item.device_id || formatAddress(item.address);
+      return `<option value="${escapeHtml(addr)}">${escapeHtml(`${label} (${formatAddress(item.address)})`)}</option>`;
+    }).join("");
+    if (this._vaillantB503Target == null && items.length > 0) {
+      this._vaillantB503Target = this._vaillantB503TargetKey(items[0].address);
+    }
+    if (this._vaillantB503Target != null) {
+      select.value = String(this._vaillantB503Target);
+    }
+  }
+
+  async setVaillantB503Target(addr) {
+    const key = this._vaillantB503TargetKey(addr);
+    this._vaillantB503Target = key;
+    // Bump epoch — completions for prior target are rejected by the
+    // result handler when their captured epoch != _vaillantB503Epoch.
+    this._vaillantB503Epoch = (this._vaillantB503Epoch || 0) + 1;
+    const select = this.querySelector('[data-role="b503-target-select"]');
+    if (select && key !== null) {
+      select.value = String(key);
+    }
+    await this.refreshVaillantB503Capability();
+  }
+
+  _vaillantB503TargetVars(extra = {}) {
+    const vars = { ...extra };
+    if (this._vaillantB503Target !== null && this._vaillantB503Target !== undefined) {
+      vars.targetAddress = this._vaillantB503Target;
+    }
+    return vars;
   }
 
   async refreshVaillantB503Capability() {
     const body = this.querySelector('[data-role="vaillant-b503-body"]');
+    this.populateVaillantB503TargetOptions();
     let reason = "UNKNOWN";
     try {
       const env = await this._gqlRequest(
-        "query VaillantB503Cap { vaillantCapabilities { vaillantB503 { available reason } } }",
-        {},
+        "query VaillantB503Cap($targetAddress: Int) { vaillantCapabilities(targetAddress: $targetAddress) { vaillantB503 { available reason } } }",
+        this._vaillantB503TargetVars(),
       );
       const cap = env && env.data && env.data.vaillantCapabilities
         && env.data.vaillantCapabilities.vaillantB503;
@@ -2770,6 +2905,33 @@ class PortalShell extends HTMLElement {
       reason = "UNKNOWN";
     }
     this._vaillantB503CapabilityReason = reason;
+    if (this._vaillantB503Target !== null && this._vaillantB503Target !== undefined) {
+      this._vaillantB503CapabilityMap().set(this._vaillantB503Target, reason);
+    }
+    // F4 epoch-rollover: keep session state in its lifecycle vocabulary
+    // (Idle / Enabling / Active / Disabled). When capability leaves
+    // AVAILABLE for a target while a session was Active or Enabling,
+    // the server-side session epoch implicitly rolled — drop the local
+    // token and demote state to Idle. The strip's UI surfaces the
+    // capability separately.
+    const t = this._vaillantB503Target;
+    if (t !== null && t !== undefined) {
+      const stateMap = this._vaillantB503SessionStateMap();
+      if (reason !== "AVAILABLE") {
+        const cur = stateMap.get(t);
+        if (cur === "Active" || cur === "Enabling") {
+          stateMap.set(t, "Idle");
+          this._vaillantB503TokenMap().delete(t);
+        } else if (!stateMap.has(t)) {
+          stateMap.set(t, "Idle");
+        }
+      } else {
+        // AVAILABLE: idempotent default-Idle for newly-seen targets.
+        if (!stateMap.has(t)) {
+          stateMap.set(t, "Idle");
+        }
+      }
+    }
     this.renderVaillantB503Pane(reason, body);
   }
 
@@ -2777,36 +2939,76 @@ class PortalShell extends HTMLElement {
     const body = bodyEl || this.querySelector('[data-role="vaillant-b503-body"]');
     if (!body) return;
     const sanitized = typeof reason === "string" ? reason : "UNKNOWN";
+    const planRef = "https://github.com/Project-Helianthus/helianthus-execution-plans/tree/main/vaillant-b503-namespace-w17-26.implementing";
     if (sanitized === "AVAILABLE") {
       const activeTab = this._vaillantB503ActiveTab || "errors";
+      const stripHTML = this._vaillantB503SessionStripMarkup();
       body.innerHTML = `
-        <div class="snapshot-controls" data-role="vaillant-b503-tabs">
-          <button class="button" data-role="vaillant-b503-tab-errors" type="button">Errors</button>
-          <button class="button" data-role="vaillant-b503-tab-service" type="button">Service</button>
-          <button class="button" data-role="vaillant-b503-tab-live-monitor" type="button">Live-Monitor</button>
-        </div>
-        <div data-role="vaillant-b503-tab-body">
-          ${this._vaillantB503TabMarkup(activeTab)}
+        <div data-testid="b503-state-available" data-role="vaillant-b503-state-available">
+          ${stripHTML}
+          <div class="snapshot-controls" data-role="vaillant-b503-tabs">
+            <button class="button" data-role="vaillant-b503-tab-errors" type="button">Errors</button>
+            <button class="button" data-role="vaillant-b503-tab-service" type="button">Service</button>
+            <button class="button" data-role="vaillant-b503-tab-history" type="button">History</button>
+            <button class="button" data-role="vaillant-b503-tab-live-monitor" type="button">Live-Monitor</button>
+          </div>
+          <div data-role="vaillant-b503-tab-body">
+            ${this._vaillantB503TabMarkup(activeTab)}
+          </div>
         </div>
       `;
       this._bindVaillantB503TabEvents();
       this._bindVaillantB503ActiveTabEvents(activeTab);
-    } else if (sanitized === "TRANSPORT_DOWN" || sanitized === "SESSION_BUSY") {
+    } else if (sanitized === "NOT_SUPPORTED") {
       body.innerHTML = `
-        <div class="bus-banner bus-state-unavailable">
-          Vaillant B503 temporarily unavailable: ${escapeHtml(sanitized)}
+        <div data-testid="b503-state-not-supported" class="muted-inline">
+          B503 not implemented for this device family. Vendor namespace surface is unavailable on the selected target; this is expected for non-Vaillant or older firmware. (reason=<span data-role="vaillant-b503-reason">${escapeHtml(sanitized)}</span>)
         </div>
-        <p class="muted-inline">Navigate away and back to retry.</p>
+      `;
+    } else if (sanitized === "TRANSPORT_DOWN") {
+      body.innerHTML = `
+        <div data-testid="b503-state-transport-down" class="bus-banner bus-state-unavailable">
+          Transport warning: adapter health is degraded — the gateway cannot reach the bus right now.
+          <span class="muted-inline"> Retry hint: wait for the adapter to reconnect, then navigate away and back to retry.</span>
+        </div>
+      `;
+    } else if (sanitized === "SESSION_BUSY") {
+      body.innerHTML = `
+        <div data-testid="b503-state-session-busy" class="bus-banner bus-state-unavailable">
+          Owner: another client currently holds the live-monitor session — wait for it to be released, then retry.
+        </div>
       `;
     } else {
-      // NOT_SUPPORTED, UNKNOWN, and any unrecognized reason → safe placeholder.
+      // UNKNOWN and any unrecognized reason → probe-failure-hint copy.
       body.innerHTML = `
-        <div class="muted-inline">
-          Vaillant B503 not supported on this device / gateway
-          (<span data-role="vaillant-b503-reason">${escapeHtml(sanitized)}</span>).
+        <div data-testid="b503-state-unknown" class="muted-inline">
+          Probe failure: gateway has not yet completed a successful B503 dispatch on the selected target. Diagnostic suggestion — verify adapter is connected and retry; the capability flips to AVAILABLE on first successful read.
         </div>
       `;
     }
+    // Keep tooltip-anchor referencing the canonical plan even in error
+    // states (the banner is in the static section markup, not body).
+    void planRef;
+  }
+
+  _vaillantB503SessionStripMarkup() {
+    const t = this._vaillantB503Target;
+    const state = this.vaillantB503SessionStateForTarget(t);
+    const cap = (t !== null && t !== undefined)
+      ? this._vaillantB503CapabilityMap().get(t)
+      : this._vaillantB503CapabilityReason;
+    const ownedByOther = cap === "SESSION_BUSY" && !this.vaillantB503LiveTokenForTarget(t);
+    const ownedAffordance = ownedByOther
+      ? `<span class="muted-inline" data-testid="b503-session-owned-by-other">Owned by another client (release required before local enable).</span>`
+      : "";
+    return `
+      <div class="snapshot-controls" data-testid="b503-session-strip" data-role="vaillant-b503-session-strip">
+        <span class="muted-inline">Session:
+          <strong data-testid="b503-session-state-label" data-role="vaillant-b503-session-state">${escapeHtml(state)}</strong>
+        </span>
+        ${ownedAffordance}
+      </div>
+    `;
   }
 
   _vaillantB503TabMarkup(activeTab) {
@@ -2820,12 +3022,26 @@ class PortalShell extends HTMLElement {
         </div>
       `;
     }
-    if (activeTab === "live-monitor") {
+    if (activeTab === "history") {
       return `
         <div class="snapshot-controls">
-          <button class="button" data-role="vaillant-b503-live-enable" type="button">Enable</button>
+          <button class="button" data-role="vaillant-b503-history-refresh" type="button">Refresh</button>
+        </div>
+        <div data-role="vaillant-b503-history-body">
+          <div class="muted-inline">Click Refresh to load error history records.</div>
+        </div>
+      `;
+    }
+    if (activeTab === "live-monitor") {
+      const t = this._vaillantB503Target;
+      const state = this.vaillantB503SessionStateForTarget(t);
+      const enableDisabled = state === "Enabling" ? " disabled" : "";
+      const disableDisabled = state === "Enabling" ? " disabled" : "";
+      return `
+        <div class="snapshot-controls">
+          <button class="button" data-role="vaillant-b503-live-enable" type="button"${enableDisabled}>Enable</button>
           <button class="button" data-role="vaillant-b503-live-read" type="button">Read</button>
-          <button class="button" data-role="vaillant-b503-live-disable" type="button">Disable</button>
+          <button class="button" data-role="vaillant-b503-live-disable" type="button"${disableDisabled}>Disable</button>
         </div>
         <pre class="issue-preview" data-role="vaillant-b503-live-output"></pre>
         <div class="muted-inline" data-role="vaillant-b503-live-status">Idle.</div>
@@ -2845,12 +3061,13 @@ class PortalShell extends HTMLElement {
   _bindVaillantB503TabEvents() {
     const errorsTab = this.querySelector('[data-role="vaillant-b503-tab-errors"]');
     const serviceTab = this.querySelector('[data-role="vaillant-b503-tab-service"]');
+    const historyTab = this.querySelector('[data-role="vaillant-b503-tab-history"]');
     const liveTab = this.querySelector('[data-role="vaillant-b503-tab-live-monitor"]');
     const swap = async (name) => {
       const leavingLive =
         this._vaillantB503ActiveTab === "live-monitor" &&
         name !== "live-monitor" &&
-        this._vaillantB503LiveToken;
+        this.vaillantB503LiveTokenForTarget(this._vaillantB503Target);
       if (leavingLive) {
         // Fire a best-effort disable before swapping. Matches the
         // nav-away semantics so clicking Errors/Service while a live
@@ -2858,7 +3075,8 @@ class PortalShell extends HTMLElement {
         try {
           await this.invokeVaillantLiveMonitor("disable");
         } catch {
-          this._vaillantB503LiveToken = null;
+          // _invokeVaillantLiveMonitor clears the per-target token on
+          // disable failure already; nothing else to do.
         }
       }
       this._vaillantB503ActiveTab = name;
@@ -2872,6 +3090,9 @@ class PortalShell extends HTMLElement {
     if (serviceTab && typeof serviceTab.addEventListener === "function") {
       serviceTab.addEventListener("click", () => swap("service"));
     }
+    if (historyTab && typeof historyTab.addEventListener === "function") {
+      historyTab.addEventListener("click", () => swap("history"));
+    }
     if (liveTab && typeof liveTab.addEventListener === "function") {
       liveTab.addEventListener("click", () => swap("live-monitor"));
     }
@@ -2882,6 +3103,13 @@ class PortalShell extends HTMLElement {
       const refresh = this.querySelector('[data-role="vaillant-b503-service-refresh"]');
       if (refresh && typeof refresh.addEventListener === "function") {
         refresh.addEventListener("click", () => this.refreshVaillantServiceCurrent());
+      }
+      return;
+    }
+    if (activeTab === "history") {
+      const refresh = this.querySelector('[data-role="vaillant-b503-history-refresh"]');
+      if (refresh && typeof refresh.addEventListener === "function") {
+        refresh.addEventListener("click", () => this.refreshVaillantErrorHistory());
       }
       return;
     }
@@ -2932,8 +3160,8 @@ class PortalShell extends HTMLElement {
     const body = this.querySelector('[data-role="vaillant-b503-errors-body"]');
     try {
       const env = await this._gqlRequest(
-        "query VaillantErrors { vaillantErrors { firstActiveError slots } }",
-        {},
+        "query VaillantErrors($targetAddress: Int) { vaillantErrors(targetAddress: $targetAddress) { firstActiveError slots } }",
+        this._vaillantB503TargetVars(),
       );
       if (env && env.errors && env.errors.length) {
         if (body) body.innerHTML = `<div class="error">${escapeHtml(env.errors[0].message || "error")}</div>`;
@@ -2950,8 +3178,8 @@ class PortalShell extends HTMLElement {
     const body = this.querySelector('[data-role="vaillant-b503-service-body"]');
     try {
       const env = await this._gqlRequest(
-        "query VaillantServiceCurrent { vaillantServiceCurrent { firstActiveError slots } }",
-        {},
+        "query VaillantServiceCurrent($targetAddress: Int) { vaillantServiceCurrent(targetAddress: $targetAddress) { firstActiveError slots } }",
+        this._vaillantB503TargetVars(),
       );
       if (env && env.errors && env.errors.length) {
         if (body) body.innerHTML = `<div class="error">${escapeHtml(env.errors[0].message || "error")}</div>`;
@@ -2964,24 +3192,132 @@ class PortalShell extends HTMLElement {
     }
   }
 
+  // M8 F5 — Errors history sub-tab. The History tab renders the most
+  // recent N records via vaillantErrorHistory(targetAddress, index).
+  // Empty-state surfaces an em-dash when no records exist.
+  async refreshVaillantErrorHistory() {
+    const body = this.querySelector('[data-role="vaillant-b503-history-body"]');
+    try {
+      const env = await this._gqlRequest(
+        "query VaillantErrorHistory($targetAddress: Int, $index: Int) { vaillantErrorHistory(targetAddress: $targetAddress, index: $index) { index firstActiveError slots } }",
+        this._vaillantB503TargetVars({ index: 0 }),
+      );
+      if (env && env.errors && env.errors.length) {
+        if (body) body.innerHTML = `<div class="error">${escapeHtml(env.errors[0].message || "error")}</div>`;
+        return;
+      }
+      const payload = env && env.data && env.data.vaillantErrorHistory;
+      if (!body) return;
+      if (!payload || (payload.firstActiveError == null && (!Array.isArray(payload.slots) || payload.slots.length === 0))) {
+        body.innerHTML = `<div class="muted-inline" data-role="vaillant-b503-history-empty">— (no records)</div>`;
+        return;
+      }
+      const first = payload.firstActiveError != null ? String(payload.firstActiveError) : "—";
+      const slots = Array.isArray(payload.slots) ? payload.slots : [];
+      const slotCells = slots.map((slot) => {
+        const cell = slot === null || slot === undefined ? "—" : String(Number(slot));
+        return `<td>${escapeHtml(cell)}</td>`;
+      }).join("");
+      body.innerHTML = `
+        <dl class="meta-list">
+          <dt>Index</dt><dd>${escapeHtml(String(payload.index || 0))}</dd>
+          <dt>First active error</dt><dd>${escapeHtml(first)}</dd>
+        </dl>
+        <table class="table">
+          <thead><tr><th>Slot 0</th><th>Slot 1</th><th>Slot 2</th><th>Slot 3</th><th>Slot 4</th></tr></thead>
+          <tbody><tr>${slotCells || '<td colspan="5">—</td>'}</tr></tbody>
+        </table>
+      `;
+    } catch (err) {
+      if (body) body.innerHTML = `<div class="error">${escapeHtml(String(err))}</div>`;
+    }
+  }
+
+  // M8 F3 — Projection plane card for B503. Rendered into the projection
+  // section (alongside Service / Observability / Debug planes) iff the
+  // device's B503 capability=AVAILABLE for the selected target. Clicking
+  // the card jumps to section-vaillant-b503 with target preselected.
+  async renderProjectionB503Card(device, capabilityState) {
+    if (!device || capabilityState !== "AVAILABLE") return;
+    const host = this.querySelector('[data-role="projection-b503-card-host"]');
+    if (!host) return;
+    const addr = device.address;
+    const hex = formatAddress(addr);
+    const label = device.display_name || device.device_id || hex;
+    const card = `
+      <div class="uml-box" data-role="projection-b503-card" data-b503-target="${escapeHtml(String(addr))}">
+        <div class="uml-header">«Vaillant B503»</div>
+        <div class="muted-inline">${escapeHtml(label)} (${escapeHtml(hex)})</div>
+        <ul class="uml-body">
+          <li class="uml-method">errors</li>
+          <li class="uml-method">service-current</li>
+          <li class="uml-method">service-history</li>
+          <li class="uml-method">live-monitor</li>
+        </ul>
+        <button class="button" data-role="projection-b503-jump" data-b503-target="${escapeHtml(String(addr))}" type="button">Open in Vaillant B503</button>
+      </div>
+    `;
+    // Append (do not replace) — multiple devices may render their own card.
+    const prior = host.innerHTML || "";
+    host.innerHTML = prior + card;
+  }
+
   async invokeVaillantLiveMonitor(action) {
     const status = this.querySelector('[data-role="vaillant-b503-live-status"]');
     const output = this.querySelector('[data-role="vaillant-b503-live-output"]');
+    // Capture the target + epoch at issue-time. The completion path
+    // compares against the captured values BEFORE mutating state so a
+    // late completion on a previous target/epoch never bleeds into the
+    // currently selected target's strip (R5 A1 / M8-TGT-04).
+    const issuedTarget = this._vaillantB503Target;
+    const issuedEpoch = this._vaillantB503Epoch || 0;
     const variables = { action: String(action) };
-    if (action === "disable" && this._vaillantB503LiveToken) {
-      variables.issuerToken = this._vaillantB503LiveToken;
+    if (issuedTarget !== null && issuedTarget !== undefined) {
+      variables.targetAddress = issuedTarget;
+    }
+    if (action === "disable") {
+      const existing = this.vaillantB503LiveTokenForTarget(issuedTarget);
+      if (existing) variables.issuerToken = existing;
+    }
+    if (action === "enable") {
+      this._setVaillantB503SessionState(issuedTarget, "Enabling");
     }
     try {
       const env = await this._gqlRequest(
-        "query VaillantLive($action: String!, $issuerToken: String) { vaillantLiveMonitor(action: $action, issuerToken: $issuerToken) { issuerToken rawHex disabled } }",
+        "query VaillantLive($action: String!, $issuerToken: String, $targetAddress: Int) { vaillantLiveMonitor(action: $action, issuerToken: $issuerToken, targetAddress: $targetAddress) { issuerToken rawHex disabled } }",
         variables,
       );
+      // M8-TGT-04: completion-side discard. If the active target/epoch
+      // has shifted since we issued the request, do NOT mutate any
+      // currently-selected-target state. If the response carries an
+      // issuerToken (i.e. local user actually owns the issued target),
+      // immediately fire a targeted disable so the abandoned session
+      // does not leak.
+      const currentTarget = this._vaillantB503Target;
+      const currentEpoch = this._vaillantB503Epoch || 0;
+      const epochMismatch = issuedEpoch !== currentEpoch
+        || this._vaillantB503TargetKey(issuedTarget) !== this._vaillantB503TargetKey(currentTarget);
+      if (epochMismatch) {
+        const payload = env && env.data && env.data.vaillantLiveMonitor;
+        if (action === "enable" && payload && typeof payload.issuerToken === "string" && payload.issuerToken !== "") {
+          // Stash token under issuedTarget so per-target accessors still
+          // see it (test contract: T1 ownership persists after switch
+          // to T2 if completion arrives post-switch). Fire targeted
+          // disable for issuedTarget without touching current target.
+          this._vaillantB503TokenMap().set(this._vaillantB503TargetKey(issuedTarget), payload.issuerToken);
+          this._setVaillantB503SessionState(issuedTarget, "Active");
+          // Targeted disable: bypass the path that re-reads
+          // _vaillantB503Target so we cannot accidentally touch T2.
+          await this._dispatchTargetedDisable(issuedTarget, payload.issuerToken);
+        }
+        return;
+      }
       if (env && env.errors && env.errors.length) {
         if (status) status.textContent = env.errors[0].message || "error";
-        // For the nav-away / tab-swap cleanup path: a disable that the
-        // backend rejects MUST still surface as an error so the caller
-        // can clear its stale token. Swallowing here caused the
-        // nav-away catch() never to run.
+        if (action === "enable") {
+          // Roll back to last-known state on enable failure.
+          this._setVaillantB503SessionState(issuedTarget, "Idle");
+        }
         if (action === "disable") {
           throw new Error(env.errors[0].message || "disable failed");
         }
@@ -2990,8 +3326,11 @@ class PortalShell extends HTMLElement {
       const payload = env && env.data && env.data.vaillantLiveMonitor;
       if (!payload) return;
       if (action === "enable" && typeof payload.issuerToken === "string" && payload.issuerToken !== "") {
-        this._vaillantB503LiveToken = payload.issuerToken;
+        this._vaillantB503TokenMap().set(this._vaillantB503TargetKey(issuedTarget), payload.issuerToken);
+        this._setVaillantB503SessionState(issuedTarget, "Active");
         if (status) status.textContent = "Live-monitor session active.";
+      } else if (action === "enable") {
+        this._setVaillantB503SessionState(issuedTarget, "Idle");
       }
       if (action === "read") {
         const hex = typeof payload.rawHex === "string" ? payload.rawHex : "";
@@ -2999,26 +3338,55 @@ class PortalShell extends HTMLElement {
         if (status) status.textContent = hex ? "OK" : "No frame available yet.";
       }
       if (action === "disable") {
-        this._vaillantB503LiveToken = null;
+        this._vaillantB503TokenMap().delete(this._vaillantB503TargetKey(issuedTarget));
+        this._setVaillantB503SessionState(issuedTarget, "Idle");
         if (status) status.textContent = "Session disabled.";
       }
     } catch (err) {
       if (status) status.textContent = `Error: ${err}`;
+      if (action === "enable") {
+        // Don't leave the strip stuck in Enabling on a network failure.
+        this._setVaillantB503SessionState(issuedTarget, "Idle");
+      }
+    }
+  }
+
+  // _dispatchTargetedDisable issues a disable for an explicit target +
+  // issuerToken pair, bypassing the active-target accessor so the call
+  // is safe to fire post-target-switch (M8-TGT-04 R5 A1 contract).
+  async _dispatchTargetedDisable(target, issuerToken) {
+    const variables = { action: "disable", issuerToken };
+    const tk = this._vaillantB503TargetKey(target);
+    if (tk !== null) variables.targetAddress = tk;
+    try {
+      await this._gqlRequest(
+        "query VaillantLiveDisable($action: String!, $issuerToken: String, $targetAddress: Int) { vaillantLiveMonitor(action: $action, issuerToken: $issuerToken, targetAddress: $targetAddress) { issuerToken rawHex disabled } }",
+        variables,
+      );
+    } catch {
+      // Best-effort cleanup; even if the backend rejects, we have
+      // already invalidated the local token and will not retry.
+    }
+    if (tk !== null) {
+      this._vaillantB503TokenMap().delete(tk);
+      this._setVaillantB503SessionState(tk, "Disabled");
     }
   }
 
   async handleVaillantB503NavAway() {
-    // Auto-disable on nav-away. Only fires if an issuer token is held,
-    // which implies the live-monitor tab entered the Active state. The
-    // disable call is best-effort — failures are swallowed so a stuck
-    // backend does not block nav.
-    if (!this._vaillantB503LiveToken) return;
-    try {
-      await this.invokeVaillantLiveMonitor("disable");
-    } catch {
-      // Fail-open on nav: clear the token anyway so a stale session
-      // cannot be mistaken for a live one.
-      this._vaillantB503LiveToken = null;
+    // Auto-disable on nav-away. Iterates per-target token map so a
+    // multi-target session set never leaks a live token. Best-effort
+    // (failures swallowed). Falls back to clearing the local map so a
+    // stuck backend cannot mark a stale session as live.
+    const map = this._vaillantB503TokenMap();
+    if (map.size === 0) return;
+    const entries = Array.from(map.entries());
+    for (const [target, token] of entries) {
+      try {
+        await this._dispatchTargetedDisable(target, token);
+      } catch {
+        map.delete(target);
+      }
     }
   }
 }

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -367,6 +367,28 @@ class PortalShell extends HTMLElement {
         this.loadAllProjectionPlanes();
       });
     }
+    // M8 F3 (R1 round-1 P1 fix): event delegation on the projection
+    // B503 card host so clicks on `data-role="projection-b503-jump"`
+    // navigate to section-vaillant-b503 with the target preselected.
+    const b503CardHost = this.querySelector('[data-role="projection-b503-card-host"]');
+    if (b503CardHost) {
+      b503CardHost.addEventListener("click", (event) => {
+        const button = event.target && event.target.closest
+          ? event.target.closest('[data-role="projection-b503-jump"]')
+          : null;
+        if (!button) return;
+        const raw = button.getAttribute("data-b503-target");
+        const parsed = Number.parseInt(String(raw || ""), 10);
+        if (Number.isFinite(parsed)) {
+          // Pre-set the B503 target before navigating so the pane
+          // renders the correct device on activation.
+          this._vaillantB503Target = parsed;
+          const select = this.querySelector('[data-role="vaillant-b503-target-select"]');
+          if (select) select.value = String(parsed);
+        }
+        this.activateSection("section-vaillant-b503");
+      });
+    }
     this.querySelectorAll("[data-nav-target]").forEach((button) => {
       button.addEventListener("click", () => {
         const targetID = button.getAttribute("data-nav-target");
@@ -1821,6 +1843,21 @@ class PortalShell extends HTMLElement {
         .map((p, i) => ({ plane: p.plane, graph: graphs[i] }))
         .filter((r) => r.graph);
       this.renderProjectionUML(gridEl, device, results);
+      // M8 F3 (R1 round-1 P1 fix): wire renderProjectionB503Card into
+      // the projection load path. Clear stale cards first, then probe
+      // B503 capability per-device and append a card iff AVAILABLE.
+      // Cap probe is intentionally non-blocking on plane render: a
+      // failed probe degrades to "no B503 card" without affecting the
+      // existing projection UI.
+      const cardHost = this.querySelector('[data-role="projection-b503-card-host"]');
+      if (cardHost) {
+        cardHost.innerHTML = "";
+      }
+      this._probeAndRenderB503Card(device).catch(() => {
+        // Probe failure → no card. Already a soft-fail in the F3
+        // contract (capability=AVAILABLE is the gate; anything else
+        // hides the card).
+      });
     } catch (err) {
       if (!isActive()) {
         return false;
@@ -1829,6 +1866,30 @@ class PortalShell extends HTMLElement {
       console.error("projection planes failed", err);
     }
     return true;
+  }
+
+  // M8 F3 — probe per-device B503 capability and render the projection
+  // plane card iff AVAILABLE. Called from loadAllProjectionPlanes after
+  // the standard projection UML is rendered. The capability query is
+  // target-scoped so a device not implementing B503 returns NOT_SUPPORTED
+  // and the card is silently omitted.
+  async _probeAndRenderB503Card(device) {
+    if (!device || device.address === undefined || device.address === null) return;
+    let reason = "UNKNOWN";
+    try {
+      const env = await this._gqlRequest(
+        "query VaillantB503CapForProjection($targetAddress: Int) { vaillantCapabilities(targetAddress: $targetAddress) { vaillantB503 { available reason } } }",
+        { targetAddress: device.address },
+      );
+      const cap = env && env.data && env.data.vaillantCapabilities
+        && env.data.vaillantCapabilities.vaillantB503;
+      if (cap && typeof cap.reason === "string") {
+        reason = cap.reason;
+      }
+    } catch (err) {
+      reason = "UNKNOWN";
+    }
+    await this.renderProjectionB503Card(device, reason);
   }
 
   renderProjectionUML(target, device, planeResults) {
@@ -2888,6 +2949,14 @@ class PortalShell extends HTMLElement {
   async refreshVaillantB503Capability() {
     const body = this.querySelector('[data-role="vaillant-b503-body"]');
     this.populateVaillantB503TargetOptions();
+    // Capture target at query-issue time. The completion path compares
+    // against the current target before mutating cache/UI so a late
+    // response from the previous target cannot bleed into the newly
+    // selected target's state (R1 round-1 P1: M8-TGT-01 invariant
+    // applies to capability queries the same way M8-TGT-04 applies to
+    // live-monitor enable).
+    const issuedTarget = this._vaillantB503Target;
+    const issuedKey = this._vaillantB503TargetKey(issuedTarget);
     let reason = "UNKNOWN";
     try {
       const env = await this._gqlRequest(
@@ -2904,17 +2973,29 @@ class PortalShell extends HTMLElement {
       // can click the nav entry again to retry.
       reason = "UNKNOWN";
     }
-    this._vaillantB503CapabilityReason = reason;
-    if (this._vaillantB503Target !== null && this._vaillantB503Target !== undefined) {
-      this._vaillantB503CapabilityMap().set(this._vaillantB503Target, reason);
+    // R1 round-1 P1 fix: write the capability cache under the
+    // ISSUED target's key, never under the (possibly-shifted) current
+    // target. Then, only render / mutate session state if the issued
+    // target still matches the current selection.
+    if (issuedTarget !== null && issuedTarget !== undefined) {
+      this._vaillantB503CapabilityMap().set(issuedTarget, reason);
     }
+    const currentKey = this._vaillantB503TargetKey(this._vaillantB503Target);
+    if (issuedKey !== currentKey) {
+      // Late response from a previous target. Cache update above is
+      // bound to the issued target so a future re-selection of that
+      // target sees the value; do NOT touch session state or UI for
+      // the currently selected target.
+      return;
+    }
+    this._vaillantB503CapabilityReason = reason;
     // F4 epoch-rollover: keep session state in its lifecycle vocabulary
     // (Idle / Enabling / Active / Disabled). When capability leaves
     // AVAILABLE for a target while a session was Active or Enabling,
     // the server-side session epoch implicitly rolled — drop the local
     // token and demote state to Idle. The strip's UI surfaces the
     // capability separately.
-    const t = this._vaillantB503Target;
+    const t = issuedTarget;
     if (t !== null && t !== undefined) {
       const stateMap = this._vaillantB503SessionStateMap();
       if (reason !== "AVAILABLE") {
@@ -3309,6 +3390,15 @@ class PortalShell extends HTMLElement {
           // Targeted disable: bypass the path that re-reads
           // _vaillantB503Target so we cannot accidentally touch T2.
           await this._dispatchTargetedDisable(issuedTarget, payload.issuerToken);
+        } else if (action === "disable") {
+          // R1 round-1 P2 fix: disable response on a target the user
+          // has switched away from. Backend has already cleared the
+          // session; we MUST clear the local token + demote state for
+          // the issued target so a switch-back later does not falsely
+          // show an active/owned session. Do NOT touch the current
+          // target's state.
+          this._vaillantB503TokenMap().delete(this._vaillantB503TargetKey(issuedTarget));
+          this._setVaillantB503SessionState(issuedTarget, "Idle");
         }
         return;
       }

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -1804,6 +1804,16 @@ class PortalShell extends HTMLElement {
     const isActive = () => this.isActiveBootstrapLifecycle(lifecycleToken, lifecycleAbort);
     const gridEl = this.querySelector('[data-role="projection-uml-grid"]');
     const deviceSelect = this.querySelector('[data-role="projection-device-select"]');
+    // M8 F3 (R2 round-1 P2 fix): clear the B503 card host AT THE TOP
+    // before any early-return path so a stale card from the previous
+    // device cannot persist when the new selection: (a) lacks
+    // projection planes, (b) is empty, (c) is unknown, or (d) the fetch
+    // path fails. The success path further down will append the new
+    // device's card iff capability=AVAILABLE.
+    const cardHostEarly = this.querySelector('[data-role="projection-b503-card-host"]');
+    if (cardHostEarly) {
+      cardHostEarly.innerHTML = "";
+    }
     if (!gridEl || !deviceSelect) {
       return true;
     }
@@ -1843,16 +1853,14 @@ class PortalShell extends HTMLElement {
         .map((p, i) => ({ plane: p.plane, graph: graphs[i] }))
         .filter((r) => r.graph);
       this.renderProjectionUML(gridEl, device, results);
-      // M8 F3 (R1 round-1 P1 fix): wire renderProjectionB503Card into
-      // the projection load path. Clear stale cards first, then probe
-      // B503 capability per-device and append a card iff AVAILABLE.
+      // M8 F3 (R1 round-1 P1 fix; R2 round-1 P2 follow-up): wire
+      // renderProjectionB503Card into the projection load path. The
+      // host has already been cleared at function entry (so any
+      // early-return branch above also clears it); here we just probe
+      // capability and append the new device's card iff AVAILABLE.
       // Cap probe is intentionally non-blocking on plane render: a
       // failed probe degrades to "no B503 card" without affecting the
       // existing projection UI.
-      const cardHost = this.querySelector('[data-role="projection-b503-card-host"]');
-      if (cardHost) {
-        cardHost.innerHTML = "";
-      }
       this._probeAndRenderB503Card(device).catch(() => {
         // Probe failure → no card. Already a soft-fail in the F3
         // contract (capability=AVAILABLE is the gate; anything else

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -1861,7 +1861,13 @@ class PortalShell extends HTMLElement {
       // Cap probe is intentionally non-blocking on plane render: a
       // failed probe degrades to "no B503 card" without affecting the
       // existing projection UI.
-      this._probeAndRenderB503Card(device).catch(() => {
+      //
+      // R4 round-1 P2 fix: pass the captured addressRaw + the
+      // lifecycle isActive() callback into the probe so a slow probe
+      // for a previously-selected device cannot append a stale card
+      // after the user switches. The probe re-checks the active
+      // selection BEFORE writing into the host.
+      this._probeAndRenderB503Card(device, addressRaw, isActive).catch(() => {
         // Probe failure → no card. Already a soft-fail in the F3
         // contract (capability=AVAILABLE is the gate; anything else
         // hides the card).
@@ -1881,7 +1887,15 @@ class PortalShell extends HTMLElement {
   // the standard projection UML is rendered. The capability query is
   // target-scoped so a device not implementing B503 returns NOT_SUPPORTED
   // and the card is silently omitted.
-  async _probeAndRenderB503Card(device) {
+  //
+  // `issuedAddressRaw` + `isActive` are captured at probe-issue time
+  // (R4 round-1 P2 fix). Before mutating the host, the probe re-checks
+  // both: (a) the bootstrap lifecycle is still active, and (b) the
+  // currently selected device-select value still matches the issued
+  // address. A late probe for a previously-selected device is dropped
+  // silently — the host has already been cleared and the new device's
+  // own probe (or its absence) is the source of truth.
+  async _probeAndRenderB503Card(device, issuedAddressRaw, isActive) {
     if (!device || device.address === undefined || device.address === null) return;
     let reason = "UNKNOWN";
     try {
@@ -1896,6 +1910,18 @@ class PortalShell extends HTMLElement {
       }
     } catch (err) {
       reason = "UNKNOWN";
+    }
+    // Lifecycle + selection re-check before any DOM mutation.
+    if (typeof isActive === "function" && !isActive()) return;
+    if (issuedAddressRaw !== undefined && issuedAddressRaw !== null) {
+      const sel = this.querySelector('[data-role="projection-device-select"]');
+      const currentRaw = sel ? String(sel.value || "").trim() : "";
+      if (currentRaw !== String(issuedAddressRaw)) {
+        // Stale probe — the user switched targets after the probe was
+        // issued. Do NOT append; the new device's loadAllProjectionPlanes
+        // already cleared the host and runs its own probe.
+        return;
+      }
     }
     await this.renderProjectionB503Card(device, reason);
   }
@@ -3470,7 +3496,13 @@ class PortalShell extends HTMLElement {
   async _dispatchTargetedDisable(target, issuerToken) {
     const variables = { action: "disable", issuerToken };
     const tk = this._vaillantB503TargetKey(target);
-    if (tk !== null) variables.targetAddress = tk;
+    // Only include `targetAddress` when we have an explicit byte
+    // address. The default sentinel (string `<default>`) is a local-
+    // map key — it MUST NOT be sent to GraphQL where parseTargetAddress
+    // expects an Int and would reject the request, leaving the
+    // server-side session active despite local cleanup
+    // (R4 round-1 P2 fix).
+    if (typeof tk === "number") variables.targetAddress = tk;
     try {
       await this._gqlRequest(
         "query VaillantLiveDisable($action: String!, $issuerToken: String, $targetAddress: Int) { vaillantLiveMonitor(action: $action, issuerToken: $issuerToken, targetAddress: $targetAddress) { issuerToken rawHex disabled } }",
@@ -3480,10 +3512,10 @@ class PortalShell extends HTMLElement {
       // Best-effort cleanup; even if the backend rejects, we have
       // already invalidated the local token and will not retry.
     }
-    if (tk !== null) {
-      this._vaillantB503TokenMap().delete(tk);
-      this._setVaillantB503SessionState(tk, "Disabled");
-    }
+    // Local cleanup uses the resolved key (number OR sentinel) so the
+    // map slot the original enable wrote into is the one we delete.
+    this._vaillantB503TokenMap().delete(tk);
+    this._setVaillantB503SessionState(tk, "Disabled");
   }
 
   async handleVaillantB503NavAway() {

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -2861,10 +2861,23 @@ class PortalShell extends HTMLElement {
   // handler before any state mutation (M8-TGT-04 / R5 A1).
   // -----------------------------------------------------------------
 
+  // Stable sentinel for the unset / default target. The token + state
+  // maps must be readable+writable under this key the same way they
+  // are for explicit byte addresses, otherwise enable/disable on the
+  // default target stores its token under one key and the disable
+  // accessor returns null — the GraphQL provider then rejects the
+  // disable with `issuer_token required` and the local session sticks
+  // (R3 round-1 P2 fix).
+  static _DEFAULT_B503_TARGET_KEY = "<default>";
+
   _vaillantB503TargetKey(addr) {
-    if (addr === null || addr === undefined) return null;
+    if (addr === null || addr === undefined) {
+      return PortalShell._DEFAULT_B503_TARGET_KEY;
+    }
     const n = Number(addr);
-    if (!Number.isFinite(n)) return null;
+    if (!Number.isFinite(n)) {
+      return PortalShell._DEFAULT_B503_TARGET_KEY;
+    }
     return n & 0xff;
   }
 
@@ -2890,15 +2903,17 @@ class PortalShell extends HTMLElement {
   }
 
   vaillantB503LiveTokenForTarget(addr) {
+    // _vaillantB503TargetKey always returns a stable key (number for
+    // explicit byte address, or the DEFAULT sentinel for unset/null
+    // target). Readers must never short-circuit on a null key —
+    // unset target is a valid map slot (R3 round-1 P2 fix).
     const key = this._vaillantB503TargetKey(addr);
-    if (key === null) return null;
     const tok = this._vaillantB503TokenMap().get(key);
     return tok || null;
   }
 
   vaillantB503SessionStateForTarget(addr) {
     const key = this._vaillantB503TargetKey(addr);
-    if (key === null) return "Idle";
     const map = this._vaillantB503SessionStateMap();
     if (map.has(key)) return map.get(key);
     return this._vaillantB503TokenMap().get(key) ? "Active" : "Idle";

--- a/portal/web/test/vaillant-b503.test.mjs
+++ b/portal/web/test/vaillant-b503.test.mjs
@@ -172,6 +172,11 @@ test("VaillantB503Pane_NavItemRegistered", async () => {
 // ---- 2. Unavailable capability → empty-state placeholder ----
 
 test("VaillantB503Pane_Unavailable_ShowsPlaceholder", async () => {
+  // M8 F2 tightened the reason-render contract: NOT_SUPPORTED renders
+  // its own distinct copy (not aliased to UNKNOWN). The M3 baseline
+  // assertion is preserved by mocking NOT_SUPPORTED here; the UNKNOWN
+  // reason now renders a probe-failure hint distinct from
+  // "not supported" (verified by M8_F2_ReasonRender_UNKNOWN).
   const { source, sourcePath } = await loadShellSource();
   const paneBody = makeAuditedElement();
   const elements = new Map([
@@ -182,7 +187,7 @@ test("VaillantB503Pane_Unavailable_ShowsPlaceholder", async () => {
     fetchImpl: makeGqlFetchImpl([
       {
         match: "vaillantCapabilities",
-        reply: { data: { vaillantCapabilities: { vaillantB503: { available: false, reason: "UNKNOWN" } } } },
+        reply: { data: { vaillantCapabilities: { vaillantB503: { available: false, reason: "NOT_SUPPORTED" } } } },
       },
     ]),
   });
@@ -199,8 +204,8 @@ test("VaillantB503Pane_Unavailable_ShowsPlaceholder", async () => {
   const htmlWrites = paneBody._audit.filter((e) => e.prop === "innerHTML");
   assert.ok(htmlWrites.length >= 1, "pane body should receive rendered HTML");
   const rendered = htmlWrites.map((e) => e.value).join("\n").toLowerCase();
-  assert.ok(rendered.includes("not supported"),
-    `unavailable state must render a 'not supported' placeholder; got: ${rendered}`);
+  assert.ok(rendered.includes("not implemented") || rendered.includes("not supported"),
+    `unavailable state must render a 'not supported / not implemented' placeholder; got: ${rendered}`);
 });
 
 // ---- 3. Available capability → three tabs ----
@@ -373,11 +378,23 @@ test("VaillantB503Pane_LiveMonitor_AutoDisableOnLeave", async () => {
   assert.equal(typeof shell.handleVaillantB503NavAway, "function",
     "handleVaillantB503NavAway must be defined");
 
-  // Simulate Enable: issuerToken captured into shell state.
+  // M8 F1: tokens are now per-target. The M3 single-token field
+  // (_vaillantB503LiveToken) is replaced by a per-target Map; the
+  // accessor vaillantB503LiveTokenForTarget(addr) is the supported
+  // surface. The M3 nav-away semantics still hold: an enabled session
+  // must produce a disable GraphQL call on nav-away. We bind the
+  // per-target accessor to keep this test asserting the same contract.
+  shell.vaillantB503LiveTokenForTarget = proto.vaillantB503LiveTokenForTarget;
+  shell.setVaillantB503Target = proto.setVaillantB503Target;
+  shell.refreshVaillantB503Capability = proto.refreshVaillantB503Capability;
+  // Default target = 0 (no projection list provided in this M3 baseline test).
+  shell._vaillantB503Target = 0;
+
+  // Simulate Enable: issuerToken captured into per-target token map.
   await shell.invokeVaillantLiveMonitor("enable");
   await flush();
-  assert.equal(shell._vaillantB503LiveToken, "tok-xyz-123",
-    "shell must store issuer token on enable");
+  assert.equal(shell.vaillantB503LiveTokenForTarget(0), "tok-xyz-123",
+    "shell must store issuer token on enable (per-target map)");
 
   // Simulate nav-away from vaillant-b503.
   const beforeCount = fetchRequests.length;
@@ -396,7 +413,7 @@ test("VaillantB503Pane_LiveMonitor_AutoDisableOnLeave", async () => {
   assert.equal(disableVars.issuerToken, "tok-xyz-123",
     "disable call must pass the stored issuerToken");
   // Token must be cleared after disable.
-  assert.ok(!shell._vaillantB503LiveToken,
+  assert.ok(!shell.vaillantB503LiveTokenForTarget(0),
     "issuerToken must be cleared after auto-disable");
 });
 
@@ -556,10 +573,16 @@ test("M8_F1_TargetSelector_PopulatedFromProjectionDevices", async () => {
   await shell.refreshVaillantB503Capability();
   await flush();
 
+  // Assert the implementation queried the b503-target-select element
+  // (proves wiring to the static section markup) AND populated it with
+  // option entries for every projection device.
+  assert.ok(lazy.map.has('[data-role="b503-target-select"]'),
+    "target selector [data-role=\"b503-target-select\"] must be queried by the implementation");
+  const selectEl = lazy.map.get('[data-role="b503-target-select"]');
   const html = combinedHTML(lazy.map);
   assert.ok(
-    /data-role="b503-target-select"/.test(html),
-    `target selector with data-role="b503-target-select" must be rendered; got: ${html}`,
+    /<option /.test(selectEl.innerHTML || ""),
+    `target selector innerHTML must contain <option> entries; got innerHTML: ${selectEl.innerHTML}`,
   );
   // Selector must list at least the three seeded devices.
   for (const addr of ["8", "21", "16"]) {

--- a/portal/web/test/vaillant-b503.test.mjs
+++ b/portal/web/test/vaillant-b503.test.mjs
@@ -15,8 +15,10 @@ function makeAuditedElement(extra = {}) {
   const audit = [];
   let innerHTMLValue = "";
   let textContentValue = "";
+  const listeners = new Map();
   const el = {
     _audit: audit,
+    _listeners: listeners,
     get innerHTML() {
       return innerHTMLValue;
     },
@@ -33,11 +35,23 @@ function makeAuditedElement(extra = {}) {
     },
     className: "",
     style: {},
+    disabled: false,
+    value: "",
     _isConnected: true,
     get isConnected() {
       return this._isConnected !== false;
     },
     setAttribute() {},
+    addEventListener(name, handler) {
+      if (!listeners.has(name)) listeners.set(name, []);
+      listeners.get(name).push(handler);
+    },
+    dispatch(name, evt = {}) {
+      const arr = listeners.get(name) || [];
+      for (const h of arr) {
+        h(evt);
+      }
+    },
     ...extra,
   };
   return el;
@@ -384,4 +398,771 @@ test("VaillantB503Pane_LiveMonitor_AutoDisableOnLeave", async () => {
   // Token must be cleared after disable.
   assert.ok(!shell._vaillantB503LiveToken,
     "issuerToken must be cleared after auto-disable");
+});
+
+// =====================================================================
+// M8_PORTAL_UX_GAPS — F1..F8 acceptance tests (issue #552)
+//
+// Plan ref: vaillant-b503-namespace-w17-26.implementing/13-amendment-1-dispatcher-portal-ux.md §M8
+// Canonical-SHA256: 86495340799be9340dc191c371a49a958f65c357c76a1e0a2974502c8489b508
+// =====================================================================
+
+// Helper: build an elements-map that lazily creates audited elements as
+// the production code queries selectors it needs. Keeps tests robust to
+// ordering of selector probes inside renderVaillantB503Pane.
+function makeLazyElementMap(prepopulated = {}) {
+  const map = new Map();
+  for (const [k, v] of Object.entries(prepopulated)) {
+    map.set(k, v);
+  }
+  const get = (selector) => {
+    if (!map.has(selector)) {
+      map.set(selector, makeAuditedElement());
+    }
+    return map.get(selector);
+  };
+  return { map, get };
+}
+
+// Helper: install a more permissive shell.querySelector that materialises
+// audited elements on demand AND supports composite-rendered children.
+// The pane body's innerHTML is virtual so child elements don't actually
+// render — but the production code only reads textContent / dispatches
+// click events on selectors it pre-registered, so a lazy map is enough.
+function attachLazyQuerySelector(shell, lazy) {
+  shell.querySelector = (sel) => lazy.get(sel);
+  shell.querySelectorAll = (sel) => {
+    const el = lazy.get(sel);
+    return el ? [el] : [];
+  };
+}
+
+function combinedHTML(elementMap) {
+  const out = [];
+  for (const el of elementMap.values()) {
+    if (!el || !el._audit) continue;
+    for (const e of el._audit) {
+      if (e.prop === "innerHTML" || e.prop === "textContent") {
+        out.push(e.value);
+      }
+    }
+  }
+  return out.join("\n");
+}
+
+// ---- F2 reason-render matrix: 5 separate tests, one per state ------
+// Each state must render its own data-testid AND a state-specific artefact
+// so the UI is matrix-asserted rather than visual-only.
+
+const reasonContract = [
+  {
+    state: "AVAILABLE",
+    testid: "b503-state-available",
+    // available state must render one of the live-data anchors
+    artefactRegex: /vaillant-b503-tab-(errors|service|live-monitor|history)/,
+    artefactName: "live-data tab anchors",
+  },
+  {
+    state: "NOT_SUPPORTED",
+    testid: "b503-state-not-supported",
+    artefactRegex: /b503 not implemented/i,
+    artefactName: "support-limitation copy",
+  },
+  {
+    state: "TRANSPORT_DOWN",
+    testid: "b503-state-transport-down",
+    artefactRegex: /transport|adapter/i,
+    artefactName: "transport warning copy",
+  },
+  {
+    state: "SESSION_BUSY",
+    testid: "b503-state-session-busy",
+    artefactRegex: /owner|another client|release/i,
+    artefactName: "ownership warning copy",
+  },
+  {
+    state: "UNKNOWN",
+    testid: "b503-state-unknown",
+    artefactRegex: /probe|diagnostic|retry/i,
+    artefactName: "probe-failure-hint copy",
+  },
+];
+
+for (const row of reasonContract) {
+  test(`M8_F2_ReasonRender_${row.state}`, async () => {
+    const { source, sourcePath } = await loadShellSource();
+    const paneBody = makeAuditedElement();
+    const elements = new Map([
+      ['[data-role="vaillant-b503-body"]', paneBody],
+    ]);
+    const { shell } = buildSandbox({
+      source, sourcePath, elements,
+      fetchImpl: makeGqlFetchImpl([
+        {
+          match: "vaillantCapabilities",
+          reply: { data: { vaillantCapabilities: { vaillantB503: { available: row.state === "AVAILABLE", reason: row.state } } } },
+        },
+      ]),
+    });
+    const proto = Object.getPrototypeOf(shell);
+    shell.renderVaillantB503Pane = proto.renderVaillantB503Pane;
+    shell.refreshVaillantB503Capability = proto.refreshVaillantB503Capability;
+
+    await shell.refreshVaillantB503Capability();
+    await flush();
+
+    const htmlWrites = paneBody._audit.filter((e) => e.prop === "innerHTML");
+    const rendered = htmlWrites.map((e) => e.value).join("\n");
+    assert.ok(
+      rendered.includes(`data-testid="${row.testid}"`),
+      `${row.state}: required data-testid="${row.testid}" missing in rendered HTML; got: ${rendered}`,
+    );
+    assert.ok(
+      row.artefactRegex.test(rendered),
+      `${row.state}: required artefact (${row.artefactName}) matching ${row.artefactRegex} missing; got: ${rendered}`,
+    );
+  });
+}
+
+// ---- F1 per-target awareness ----------------------------------------
+
+test("M8_F1_TargetSelector_PopulatedFromProjectionDevices", async () => {
+  const { source, sourcePath } = await loadShellSource();
+  const paneBody = makeAuditedElement();
+  const lazy = makeLazyElementMap({
+    '[data-role="vaillant-b503-body"]': paneBody,
+  });
+  const { shell } = buildSandbox({
+    source, sourcePath, elements: lazy.map,
+    fetchImpl: makeGqlFetchImpl([
+      {
+        match: "vaillantCapabilities",
+        reply: { data: { vaillantCapabilities: { vaillantB503: { available: true, reason: "AVAILABLE" } } } },
+      },
+    ]),
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.renderVaillantB503Pane = proto.renderVaillantB503Pane;
+  shell.refreshVaillantB503Capability = proto.refreshVaillantB503Capability;
+  attachLazyQuerySelector(shell, lazy);
+
+  // Seed the projection device list (same source that feeds section-projection).
+  shell.projectionDevices = [
+    { address: 8, display_name: "BAI00", projections: [] },
+    { address: 21, display_name: "BASV2", projections: [] },
+    { address: 16, display_name: "Controller", projections: [] },
+  ];
+
+  await shell.refreshVaillantB503Capability();
+  await flush();
+
+  const html = combinedHTML(lazy.map);
+  assert.ok(
+    /data-role="b503-target-select"/.test(html),
+    `target selector with data-role="b503-target-select" must be rendered; got: ${html}`,
+  );
+  // Selector must list at least the three seeded devices.
+  for (const addr of ["8", "21", "16"]) {
+    assert.ok(
+      html.includes(`value="${addr}"`),
+      `target selector must contain device address ${addr}; got: ${html}`,
+    );
+  }
+});
+
+test("M8-TGT-01_CapabilityInvalidation_PerTargetCacheKeys", async () => {
+  // Threading targetAddress through every B503 GraphQL query: when target
+  // switches, the next capability fetch and downstream queries MUST carry
+  // the new targetAddress.
+  const { source, sourcePath } = await loadShellSource();
+  const paneBody = makeAuditedElement();
+  const lazy = makeLazyElementMap({
+    '[data-role="vaillant-b503-body"]': paneBody,
+  });
+  const { shell, fetchRequests } = buildSandbox({
+    source, sourcePath, elements: lazy.map,
+    fetchImpl: makeGqlFetchImpl([
+      {
+        match: "vaillantCapabilities",
+        reply: { data: { vaillantCapabilities: { vaillantB503: { available: true, reason: "AVAILABLE" } } } },
+      },
+      { match: "vaillantErrors", reply: { data: { vaillantErrors: { firstActiveError: null, slots: [] } } } },
+    ]),
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.renderVaillantB503Pane = proto.renderVaillantB503Pane;
+  shell.refreshVaillantB503Capability = proto.refreshVaillantB503Capability;
+  shell.refreshVaillantErrors = proto.refreshVaillantErrors;
+  shell.setVaillantB503Target = proto.setVaillantB503Target;
+  attachLazyQuerySelector(shell, lazy);
+
+  shell.projectionDevices = [
+    { address: 8, display_name: "BAI00", projections: [] },
+    { address: 21, display_name: "BASV2", projections: [] },
+  ];
+  assert.equal(typeof shell.setVaillantB503Target, "function",
+    "setVaillantB503Target must be defined for F1 target switching");
+
+  await shell.setVaillantB503Target(8);
+  await flush();
+  await shell.refreshVaillantErrors();
+  await flush();
+
+  const beforeSwitch = fetchRequests.length;
+  await shell.setVaillantB503Target(21);
+  await flush();
+  await shell.refreshVaillantErrors();
+  await flush();
+
+  const afterSwitchCalls = fetchRequests.slice(beforeSwitch);
+  const errorsCallsForT2 = afterSwitchCalls.filter((r) => {
+    const { query, variables } = parseGqlInit(r.init);
+    return query.includes("vaillantErrors") && Number(variables.targetAddress) === 21;
+  });
+  assert.ok(
+    errorsCallsForT2.length >= 1,
+    `errors query MUST carry targetAddress=21 after switch; saw: ${JSON.stringify(afterSwitchCalls.map((c) => parseGqlInit(c.init)))}`,
+  );
+});
+
+test("M8-TGT-02_LiveMonitorOwnership_PerTargetIsolation", async () => {
+  // IsOwned()-derived ownership state must be tracked per-target, not globally.
+  const { source, sourcePath } = await loadShellSource();
+  const lazy = makeLazyElementMap();
+  const { shell } = buildSandbox({
+    source, sourcePath, elements: lazy.map,
+    fetchImpl: makeGqlFetchImpl([
+      {
+        match: "vaillantLiveMonitor",
+        reply: (vars) => {
+          if (vars && vars.action === "enable") {
+            return { data: { vaillantLiveMonitor: { issuerToken: `tok-${vars.targetAddress || "x"}`, rawHex: null, disabled: false } } };
+          }
+          return { data: { vaillantLiveMonitor: { issuerToken: null, rawHex: null, disabled: true } } };
+        },
+      },
+    ]),
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.invokeVaillantLiveMonitor = proto.invokeVaillantLiveMonitor;
+  shell.setVaillantB503Target = proto.setVaillantB503Target;
+  shell.vaillantB503LiveTokenForTarget = proto.vaillantB503LiveTokenForTarget;
+  attachLazyQuerySelector(shell, lazy);
+
+  shell.projectionDevices = [
+    { address: 8, display_name: "BAI00" },
+    { address: 21, display_name: "BASV2" },
+  ];
+  assert.equal(typeof shell.vaillantB503LiveTokenForTarget, "function",
+    "vaillantB503LiveTokenForTarget must be defined for per-target ownership");
+
+  await shell.setVaillantB503Target(8);
+  await shell.invokeVaillantLiveMonitor("enable");
+  await flush();
+
+  await shell.setVaillantB503Target(21);
+  await flush();
+  // After switching to T2, the per-target lookup for T1 should still show
+  // the local-user-owned token; T2 starts with no token.
+  assert.equal(shell.vaillantB503LiveTokenForTarget(8), `tok-8`,
+    "T1 ownership must persist after switching to T2");
+  assert.ok(!shell.vaillantB503LiveTokenForTarget(21),
+    "T2 must have no token before its own enable");
+});
+
+test("M8-TGT-03_HistoryInvalidation_PerTargetCache", async () => {
+  const { source, sourcePath } = await loadShellSource();
+  const lazy = makeLazyElementMap();
+  const { shell, fetchRequests } = buildSandbox({
+    source, sourcePath, elements: lazy.map,
+    fetchImpl: makeGqlFetchImpl([
+      {
+        match: "vaillantErrorHistory",
+        reply: (vars) => ({
+          data: { vaillantErrorHistory: { index: vars.index || 0, firstActiveError: 100 + (vars.targetAddress || 0), slots: [] } },
+        }),
+      },
+    ]),
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.refreshVaillantErrorHistory = proto.refreshVaillantErrorHistory;
+  shell.setVaillantB503Target = proto.setVaillantB503Target;
+  attachLazyQuerySelector(shell, lazy);
+
+  shell.projectionDevices = [
+    { address: 8, display_name: "BAI00" },
+    { address: 21, display_name: "BASV2" },
+  ];
+  assert.equal(typeof shell.refreshVaillantErrorHistory, "function",
+    "refreshVaillantErrorHistory must be defined for F5 history sub-tab");
+
+  await shell.setVaillantB503Target(8);
+  await shell.refreshVaillantErrorHistory();
+  await flush();
+
+  const beforeSwitch = fetchRequests.length;
+  await shell.setVaillantB503Target(21);
+  await shell.refreshVaillantErrorHistory();
+  await flush();
+
+  const afterCalls = fetchRequests.slice(beforeSwitch);
+  const t2Call = afterCalls.find((r) => {
+    const { query, variables } = parseGqlInit(r.init);
+    return query.includes("vaillantErrorHistory") && Number(variables.targetAddress) === 21;
+  });
+  assert.ok(t2Call,
+    `history query must carry targetAddress=21 after switch; got: ${JSON.stringify(afterCalls.map((c) => parseGqlInit(c.init)))}`,
+  );
+});
+
+test("M8-TGT-04_TargetSwitchDuringEnableInflight_StaleResponseDiscarded", async () => {
+  // R5 A1 contract: target-switch during live-monitor enable in-flight on T1 with
+  // switch to T2 before completion. T1 enable completion MUST NOT mutate T2 strip
+  // state. If local ownership is obtained on T1 after the switch, the frontend
+  // MUST immediately issue disable for T1.
+  const { source, sourcePath } = await loadShellSource();
+  const lazy = makeLazyElementMap();
+  let releaseT1Enable;
+  const t1EnablePromise = new Promise((resolve) => { releaseT1Enable = resolve; });
+  const { shell, fetchRequests } = buildSandbox({
+    source, sourcePath, elements: lazy.map,
+    fetchImpl: (url, init) => {
+      const { query, variables } = parseGqlInit(init);
+      if (query.includes("vaillantLiveMonitor") && variables.action === "enable" && Number(variables.targetAddress) === 8) {
+        // Hold T1 enable until released by the test.
+        return t1EnablePromise.then(() => ({
+          ok: true, status: 200,
+          json: async () => ({ data: { vaillantLiveMonitor: { issuerToken: "tok-T1", rawHex: null, disabled: false } } }),
+        }));
+      }
+      if (query.includes("vaillantLiveMonitor")) {
+        return Promise.resolve({
+          ok: true, status: 200,
+          json: async () => ({ data: { vaillantLiveMonitor: { issuerToken: null, rawHex: null, disabled: true } } }),
+        });
+      }
+      return Promise.resolve({ ok: true, status: 200, json: async () => ({ data: {} }) });
+    },
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.invokeVaillantLiveMonitor = proto.invokeVaillantLiveMonitor;
+  shell.setVaillantB503Target = proto.setVaillantB503Target;
+  shell.vaillantB503LiveTokenForTarget = proto.vaillantB503LiveTokenForTarget;
+  attachLazyQuerySelector(shell, lazy);
+
+  shell.projectionDevices = [
+    { address: 8, display_name: "BAI00" },
+    { address: 21, display_name: "BASV2" },
+  ];
+
+  await shell.setVaillantB503Target(8);
+  // Kick off enable on T1 but don't await — leave it in flight.
+  const t1EnableP = shell.invokeVaillantLiveMonitor("enable");
+  await flush();
+
+  // Switch to T2 while T1 enable is still pending.
+  await shell.setVaillantB503Target(21);
+  await flush();
+
+  // Release T1 enable response now (post-switch).
+  releaseT1Enable();
+  await t1EnableP.catch(() => {}); // tolerate any propagated state-mutation block
+  await flush();
+  // Allow internal disable-cleanup to fire.
+  await flush();
+  await flush();
+
+  // T2 strip MUST NOT have been mutated by T1 enable completion.
+  assert.ok(!shell.vaillantB503LiveTokenForTarget(21),
+    "T1 enable completion MUST NOT mutate T2 ownership");
+
+  // After switch: an immediate disable for T1 must have fired (preferred per R5 A1).
+  const disableForT1 = fetchRequests.find((r) => {
+    const { query, variables } = parseGqlInit(r.init);
+    return query.includes("vaillantLiveMonitor") && variables.action === "disable" && Number(variables.targetAddress) === 8;
+  });
+  assert.ok(disableForT1,
+    "after target-switch with local-user-owned T1 enable completing, frontend MUST issue disable for T1");
+});
+
+// ---- F4 session-state strip transitions ------------------------------
+
+test("M8_F4_SessionStateStrip_IdleToEnablingToActiveToDisabled", async () => {
+  const { source, sourcePath } = await loadShellSource();
+  const lazy = makeLazyElementMap();
+  let releaseEnable;
+  const enablePromise = new Promise((resolve) => { releaseEnable = resolve; });
+  const { shell } = buildSandbox({
+    source, sourcePath, elements: lazy.map,
+    fetchImpl: (url, init) => {
+      const { query, variables } = parseGqlInit(init);
+      if (query.includes("vaillantLiveMonitor") && variables.action === "enable") {
+        return enablePromise.then(() => ({
+          ok: true, status: 200,
+          json: async () => ({ data: { vaillantLiveMonitor: { issuerToken: "tok-strip", rawHex: null, disabled: false } } }),
+        }));
+      }
+      if (query.includes("vaillantLiveMonitor") && variables.action === "disable") {
+        return Promise.resolve({
+          ok: true, status: 200,
+          json: async () => ({ data: { vaillantLiveMonitor: { issuerToken: null, rawHex: null, disabled: true } } }),
+        });
+      }
+      return Promise.resolve({ ok: true, status: 200, json: async () => ({ data: {} }) });
+    },
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.invokeVaillantLiveMonitor = proto.invokeVaillantLiveMonitor;
+  shell.vaillantB503SessionStateForTarget = proto.vaillantB503SessionStateForTarget;
+  shell.setVaillantB503Target = proto.setVaillantB503Target;
+  attachLazyQuerySelector(shell, lazy);
+
+  assert.equal(typeof shell.vaillantB503SessionStateForTarget, "function",
+    "vaillantB503SessionStateForTarget must be defined for F4 session strip");
+
+  shell.projectionDevices = [{ address: 8, display_name: "BAI00" }];
+  await shell.setVaillantB503Target(8);
+
+  // Idle initially.
+  assert.equal(shell.vaillantB503SessionStateForTarget(8), "Idle");
+
+  // Kick off enable; while pending, state must be Enabling.
+  const enP = shell.invokeVaillantLiveMonitor("enable");
+  await flush();
+  assert.equal(shell.vaillantB503SessionStateForTarget(8), "Enabling",
+    "while enable is in-flight, state must be Enabling");
+
+  // Resolve enable; state Active.
+  releaseEnable();
+  await enP;
+  await flush();
+  assert.equal(shell.vaillantB503SessionStateForTarget(8), "Active",
+    "after enable resolves with token, state must be Active");
+
+  // Disable; state Disabled or Idle.
+  await shell.invokeVaillantLiveMonitor("disable");
+  await flush();
+  const finalState = shell.vaillantB503SessionStateForTarget(8);
+  assert.ok(finalState === "Idle" || finalState === "Disabled",
+    `after disable, state must be Idle or Disabled; got ${finalState}`);
+});
+
+test("M8_F4_SessionStateStrip_OwnedByOther_WhenSessionBusy_NoLocalToken", async () => {
+  // Capability=SESSION_BUSY without a local token implies another client owns
+  // the session. Strip must surface "Owned by another client" affordance.
+  const { source, sourcePath } = await loadShellSource();
+  const paneBody = makeAuditedElement();
+  const lazy = makeLazyElementMap({
+    '[data-role="vaillant-b503-body"]': paneBody,
+  });
+  const { shell } = buildSandbox({
+    source, sourcePath, elements: lazy.map,
+    fetchImpl: makeGqlFetchImpl([
+      {
+        match: "vaillantCapabilities",
+        reply: { data: { vaillantCapabilities: { vaillantB503: { available: false, reason: "SESSION_BUSY" } } } },
+      },
+    ]),
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.renderVaillantB503Pane = proto.renderVaillantB503Pane;
+  shell.refreshVaillantB503Capability = proto.refreshVaillantB503Capability;
+  attachLazyQuerySelector(shell, lazy);
+
+  await shell.refreshVaillantB503Capability();
+  await flush();
+
+  const html = combinedHTML(lazy.map);
+  assert.ok(
+    /b503-state-session-busy/.test(html) && /(another client|owned by other|owner)/i.test(html),
+    `SESSION_BUSY must render owned-by-other affordance; got: ${html}`,
+  );
+});
+
+// ---- F5 history tab loading ------------------------------------------
+
+test("M8_F5_HistoryTab_LoadsAndRendersRecords", async () => {
+  const { source, sourcePath } = await loadShellSource();
+  const historyBody = makeAuditedElement();
+  const lazy = makeLazyElementMap({
+    '[data-role="vaillant-b503-history-body"]': historyBody,
+  });
+  const { shell } = buildSandbox({
+    source, sourcePath, elements: lazy.map,
+    fetchImpl: makeGqlFetchImpl([
+      {
+        match: "vaillantErrorHistory",
+        reply: (vars) => ({
+          data: { vaillantErrorHistory: { index: vars.index || 0, firstActiveError: 281, slots: [281, null, null, null, null] } },
+        }),
+      },
+    ]),
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.refreshVaillantErrorHistory = proto.refreshVaillantErrorHistory;
+  attachLazyQuerySelector(shell, lazy);
+
+  await shell.refreshVaillantErrorHistory();
+  await flush();
+
+  const html = historyBody._audit.filter((e) => e.prop === "innerHTML").map((e) => e.value).join("\n");
+  assert.ok(html.includes("281"), `history must render record value 281; got: ${html}`);
+});
+
+test("M8_F5_HistoryTab_EmptyState", async () => {
+  const { source, sourcePath } = await loadShellSource();
+  const historyBody = makeAuditedElement();
+  const lazy = makeLazyElementMap({
+    '[data-role="vaillant-b503-history-body"]': historyBody,
+  });
+  const { shell } = buildSandbox({
+    source, sourcePath, elements: lazy.map,
+    fetchImpl: makeGqlFetchImpl([
+      {
+        match: "vaillantErrorHistory",
+        reply: { data: { vaillantErrorHistory: { index: 0, firstActiveError: null, slots: [] } } },
+      },
+    ]),
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.refreshVaillantErrorHistory = proto.refreshVaillantErrorHistory;
+  attachLazyQuerySelector(shell, lazy);
+
+  await shell.refreshVaillantErrorHistory();
+  await flush();
+
+  const html = historyBody._audit.filter((e) => e.prop === "innerHTML").map((e) => e.value).join("\n");
+  assert.ok(/—|empty|no records/i.test(html),
+    `empty history must show em-dash or empty-state; got: ${html}`);
+});
+
+test("M8_F5_HistoryTab_RenderedInAvailableState", async () => {
+  // History must appear as a tab in the AVAILABLE state markup.
+  const { source, sourcePath } = await loadShellSource();
+  const paneBody = makeAuditedElement();
+  const lazy = makeLazyElementMap({
+    '[data-role="vaillant-b503-body"]': paneBody,
+  });
+  const { shell } = buildSandbox({
+    source, sourcePath, elements: lazy.map,
+    fetchImpl: makeGqlFetchImpl([
+      {
+        match: "vaillantCapabilities",
+        reply: { data: { vaillantCapabilities: { vaillantB503: { available: true, reason: "AVAILABLE" } } } },
+      },
+    ]),
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.renderVaillantB503Pane = proto.renderVaillantB503Pane;
+  shell.refreshVaillantB503Capability = proto.refreshVaillantB503Capability;
+  attachLazyQuerySelector(shell, lazy);
+
+  await shell.refreshVaillantB503Capability();
+  await flush();
+
+  const html = paneBody._audit.filter((e) => e.prop === "innerHTML").map((e) => e.value).join("\n");
+  assert.ok(/data-role="vaillant-b503-tab-history"/.test(html),
+    `History tab must be rendered alongside Errors / Service / Live-Monitor; got: ${html}`);
+});
+
+// ---- F4 nav-away disable (extends M3 baseline with target awareness) -
+
+test("M8_F4_NavAway_DisableIssuedForOwnedTargets", async () => {
+  // When local user enabled session for T1, navigating away MUST issue a
+  // targeted disable for T1.
+  const { source, sourcePath } = await loadShellSource();
+  const lazy = makeLazyElementMap();
+  const { shell, fetchRequests } = buildSandbox({
+    source, sourcePath, elements: lazy.map,
+    fetchImpl: makeGqlFetchImpl([
+      {
+        match: "vaillantLiveMonitor",
+        reply: (vars) => {
+          if (vars && vars.action === "enable") {
+            return { data: { vaillantLiveMonitor: { issuerToken: `tok-${vars.targetAddress || "x"}`, rawHex: null, disabled: false } } };
+          }
+          return { data: { vaillantLiveMonitor: { issuerToken: null, rawHex: null, disabled: true } } };
+        },
+      },
+    ]),
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.invokeVaillantLiveMonitor = proto.invokeVaillantLiveMonitor;
+  shell.handleVaillantB503NavAway = proto.handleVaillantB503NavAway;
+  shell.setVaillantB503Target = proto.setVaillantB503Target;
+  attachLazyQuerySelector(shell, lazy);
+
+  shell.projectionDevices = [{ address: 8, display_name: "BAI00" }];
+  await shell.setVaillantB503Target(8);
+  await shell.invokeVaillantLiveMonitor("enable");
+  await flush();
+
+  const beforeNav = fetchRequests.length;
+  await shell.handleVaillantB503NavAway();
+  await flush();
+
+  const after = fetchRequests.slice(beforeNav);
+  const disable = after.find((r) => {
+    const { query, variables } = parseGqlInit(r.init);
+    return query.includes("vaillantLiveMonitor") && variables.action === "disable" && Number(variables.targetAddress) === 8;
+  });
+  assert.ok(disable,
+    `nav-away must issue targeted disable for T1=8; saw: ${JSON.stringify(after.map((c) => parseGqlInit(c.init)))}`);
+});
+
+// ---- F6 AD02 install-writes banner ----------------------------------
+
+test("M8_F6_AD02Banner_PresentWithStableSelectors", async () => {
+  const { source, sourcePath } = await loadShellSource();
+  const { shell } = buildSandbox({
+    source, sourcePath, elements: new Map(),
+    fetchImpl: async () => ({ ok: true, json: async () => ({}) }),
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.render = proto.render;
+  let capturedHTML = "";
+  Object.defineProperty(shell, "innerHTML", {
+    set(v) { capturedHTML = String(v); },
+    get() { return capturedHTML; },
+    configurable: true,
+  });
+  shell.render();
+
+  const start = capturedHTML.indexOf('id="section-vaillant-b503"');
+  assert.ok(start >= 0, "section-vaillant-b503 must exist in rendered HTML");
+  const end = capturedHTML.indexOf("</section>", start);
+  const paneHTML = capturedHTML.slice(start, end);
+
+  assert.ok(/data-testid="b503-install-writes-banner"/.test(paneHTML),
+    `banner with data-testid="b503-install-writes-banner" must be in pane; got: ${paneHTML}`);
+  assert.ok(/id="b503-ad02-tooltip-anchor"/.test(paneHTML),
+    `help affordance with id="b503-ad02-tooltip-anchor" must be in pane; got: ${paneHTML}`);
+  // tooltip target must point to canonical plan ref.
+  assert.ok(/vaillant-b503-namespace-w17-26/.test(paneHTML),
+    `tooltip target must reference canonical plan slug; got: ${paneHTML}`);
+});
+
+// ---- F3 projection fold-in ------------------------------------------
+
+test("M8_F3_Projection_B503PlaneCardAppears_WhenAvailable", async () => {
+  const { source, sourcePath } = await loadShellSource();
+  const lazy = makeLazyElementMap();
+  const { shell } = buildSandbox({
+    source, sourcePath, elements: lazy.map,
+    fetchImpl: makeGqlFetchImpl([
+      {
+        match: "vaillantCapabilities",
+        reply: { data: { vaillantCapabilities: { vaillantB503: { available: true, reason: "AVAILABLE" } } } },
+      },
+    ]),
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.renderProjectionB503Card = proto.renderProjectionB503Card;
+  attachLazyQuerySelector(shell, lazy);
+  assert.equal(typeof shell.renderProjectionB503Card, "function",
+    "renderProjectionB503Card must be defined for F3 projection fold-in");
+
+  // Render the B503 plane card for 3 distinct devices that all have
+  // capability=AVAILABLE for B503.
+  for (const addr of [0x08, 0x15, 0x10]) {
+    await shell.renderProjectionB503Card({ address: addr, display_name: `dev-${addr}` }, "AVAILABLE");
+    await flush();
+  }
+  const html = combinedHTML(lazy.map);
+  // The card must be rendered for ≥3 distinct addresses.
+  let count = 0;
+  for (const addr of [0x08, 0x15, 0x10]) {
+    const hex = `0x${addr.toString(16).padStart(2, "0")}`;
+    if (html.includes(`data-role="projection-b503-card"`) && html.includes(hex)) count += 1;
+  }
+  assert.ok(count >= 3,
+    `projection B503 plane card must appear for ≥3 distinct addresses (got ${count}); html: ${html}`);
+});
+
+test("M8_F3_Projection_NoB503CardWhenNotAvailable", async () => {
+  const { source, sourcePath } = await loadShellSource();
+  const lazy = makeLazyElementMap();
+  const { shell } = buildSandbox({
+    source, sourcePath, elements: lazy.map,
+    fetchImpl: async () => ({ ok: true, json: async () => ({}) }),
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.renderProjectionB503Card = proto.renderProjectionB503Card;
+  attachLazyQuerySelector(shell, lazy);
+
+  await shell.renderProjectionB503Card({ address: 0x08, display_name: "BAI" }, "NOT_SUPPORTED");
+  await flush();
+  const html = combinedHTML(lazy.map);
+  assert.ok(!/data-role="projection-b503-card"/.test(html),
+    `B503 plane card must NOT render for capability=NOT_SUPPORTED; html: ${html}`);
+});
+
+// ---- Frontend epoch-rollover composite (F3+F4 R4 A3) ----------------
+
+test("M8_EpochRollover_Composite_4Step", async () => {
+  const { source, sourcePath } = await loadShellSource();
+  const paneBody = makeAuditedElement();
+  const lazy = makeLazyElementMap({
+    '[data-role="vaillant-b503-body"]': paneBody,
+  });
+  let capState = "AVAILABLE";
+  const { shell } = buildSandbox({
+    source, sourcePath, elements: lazy.map,
+    fetchImpl: makeGqlFetchImpl([
+      {
+        match: "vaillantCapabilities",
+        reply: () => ({ data: { vaillantCapabilities: { vaillantB503: { available: capState === "AVAILABLE", reason: capState } } } }),
+      },
+      {
+        match: "vaillantLiveMonitor",
+        reply: (vars) => {
+          if (vars && vars.action === "enable") {
+            return { data: { vaillantLiveMonitor: { issuerToken: "tok-epoch", rawHex: null, disabled: false } } };
+          }
+          return { data: { vaillantLiveMonitor: { issuerToken: null, rawHex: null, disabled: true } } };
+        },
+      },
+    ]),
+  });
+  const proto = Object.getPrototypeOf(shell);
+  shell.renderVaillantB503Pane = proto.renderVaillantB503Pane;
+  shell.refreshVaillantB503Capability = proto.refreshVaillantB503Capability;
+  shell.invokeVaillantLiveMonitor = proto.invokeVaillantLiveMonitor;
+  shell.vaillantB503SessionStateForTarget = proto.vaillantB503SessionStateForTarget;
+  shell.setVaillantB503Target = proto.setVaillantB503Target;
+  attachLazyQuerySelector(shell, lazy);
+
+  shell.projectionDevices = [{ address: 8, display_name: "BAI" }];
+  await shell.setVaillantB503Target(8);
+
+  // Step 1: capability=AVAILABLE, session enabled, State=Active.
+  await shell.refreshVaillantB503Capability();
+  await shell.invokeVaillantLiveMonitor("enable");
+  await flush();
+  assert.equal(shell.vaillantB503SessionStateForTarget(8), "Active",
+    "step 1: post-enable state must be Active");
+
+  // Step 2: transport-down — capability flips to TRANSPORT_DOWN; strip leaves Active.
+  capState = "TRANSPORT_DOWN";
+  await shell.refreshVaillantB503Capability();
+  await flush();
+  const stepTwoState = shell.vaillantB503SessionStateForTarget(8);
+  assert.notEqual(stepTwoState, "Active",
+    `step 2: after capability=TRANSPORT_DOWN, state MUST leave Active immediately; got ${stepTwoState}`);
+
+  // Step 3: reconnect, capability=UNKNOWN — strip must NOT show stale Active.
+  capState = "UNKNOWN";
+  await shell.refreshVaillantB503Capability();
+  await flush();
+  const stepThreeState = shell.vaillantB503SessionStateForTarget(8);
+  assert.notEqual(stepThreeState, "Active",
+    `step 3: capability=UNKNOWN must NOT show stale Active; got ${stepThreeState}`);
+
+  // Step 4: post-reconnect first success → AVAILABLE; strip back to Idle.
+  capState = "AVAILABLE";
+  await shell.refreshVaillantB503Capability();
+  await flush();
+  const stepFourState = shell.vaillantB503SessionStateForTarget(8);
+  assert.ok(stepFourState === "Idle" || stepFourState === "Disabled",
+    `step 4: after first post-reconnect success, state MUST be Idle (NOT Active until user re-enables); got ${stepFourState}`);
 });


### PR DESCRIPTION
## Summary

Closes operator findings F1..F8 on top of the M6 production dispatcher (squashed in #481? — actually M6 squash 25ae909). Pure portal-side change; NO protocol/dispatcher edits. Tracks cruise-run [Project-Helianthus/helianthus-execution-plans#19](https://github.com/Project-Helianthus/helianthus-execution-plans/issues/19) (M8).

- **LANE A — user-visible-breaking; cruise-merge-gate WAIT_OPERATOR mandatory.**
- **F7 decision = B (GraphQL-only)** per cruise-consult [execution-plans#19 comment 4320124082](https://github.com/Project-Helianthus/helianthus-execution-plans/issues/19#issuecomment-4320124082) — locked in `matrix/M6a-vaillant-b503.md` §10. No `/api/v1/vaillant/*` REST shim is added; the portal exposes B503 only via GraphQL.
- **Companion docs PR REQUIRED** in `helianthus-docs-ebus` (`architecture/ebus_standard/09-mcp-envelope.md` adds new section "Vendor namespaces and portal exposure"). That PR is OUT-OF-SCOPE for this gateway PR and is tracked separately under the M8 docs-companion obligation.
- Plan-canonical-SHA256: `86495340799be9340dc191c371a49a958f65c357c76a1e0a2974502c8489b508`

## What changed

| Finding | Surface | Outcome |
|---|---|---|
| F1 | Per-target awareness | `<select data-role="b503-target-select">` populated from `this.projectionDevices`; `targetAddress` threaded through every `vaillant*` GraphQL query; per-target token + state + capability caches; epoch counter on target switch with completion-side discard. |
| F2 | Reason render matrix | 5 distinct `data-testid="b503-state-*"` artefacts: AVAILABLE / NOT_SUPPORTED / TRANSPORT_DOWN / SESSION_BUSY / UNKNOWN. EXPIRED never produced (AD14 invariant; sanitizer at GraphQL layer). |
| F3 | Projection fold-in (AD19) | New `[data-role="projection-b503-card-host"]` in `section-projection`; `renderProjectionB503Card(device, state)` appends a card per device when capability=AVAILABLE. L7 fold-in deferred to follow-up PR per plan §F3 (avoids diff bloat). |
| F4 | Live-monitor session-state strip | `data-testid="b503-session-strip"` with state label; Enable/Disable disabled while State=Enabling; "Owned by another client" affordance when SESSION_BUSY without local token; nav-away iterates per-target token map and issues targeted disable; M8-TGT-04 R5 A1 contract honoured (issued-target+epoch captured at issue-time, completion-side discard, abandoned-session cleanup). |
| F5 | Errors history sub-tab | 4th tab `vaillant-b503-tab-history`; `refreshVaillantErrorHistory` issues `vaillantErrorHistory(targetAddress, index)`; empty-state em-dash. |
| F6 | AD02 install-writes banner | `data-testid="b503-install-writes-banner"` with `id="b503-ad02-tooltip-anchor"` linking the canonical plan slug. |
| F7 | REST-shim decision = B | Matrix §10 + `TestM8_F7_VaillantRESTShim_Returns404` lock in 404 contract. Companion docs PR required separately. |
| F8 | Tests | 20 new jsdom tests + 1 Go handler test (see Test plan). |

## Implementation notes (defence-in-depth)

- **Capability-gated nav preserved.** `applyCapabilityState` / `setNavState` invariants unchanged.
- **XSS hardening preserved.** `textContent` for user-controlled values, `escapeHtml` for catalog-derived strings; no `innerHTML` on raw input.
- **DOM audit preserved.** `section-vaillant-b503` still contains no `clear` / `delete` / `reset` references in any reason state (`VaillantB503Pane_NoInstallWriteAffordance` test green).
- **Per-target query/cache discipline.** All read queries thread `targetAddress`; in-flight responses with mismatched issued target/epoch are discarded by the result handler BEFORE state mutation. Targeted disable for abandoned target uses `_dispatchTargetedDisable(target, token)` which never reads `_vaillantB503Target` so it cannot leak state to the currently-selected target.
- **Frontend epoch-rollover.** `refreshVaillantB503Capability` demotes `Active`/`Enabling` → `Idle` and clears local token when capability leaves AVAILABLE for the selected target (server-side session epoch implicitly rolled per AD14).
- **Two M3 baseline tests adapted, none removed.** `VaillantB503Pane_Unavailable_ShowsPlaceholder` now mocks `NOT_SUPPORTED` (F2 tightened the contract so UNKNOWN → probe-failure-hint, distinct from "not supported"). `VaillantB503Pane_LiveMonitor_AutoDisableOnLeave` now uses the per-target accessor `vaillantB503LiveTokenForTarget(addr)` instead of the removed `_vaillantB503LiveToken` singleton.

## File summary

| File | Change | Lines |
|---|---|---|
| `portal/web/src/app.js` | F1..F6 implementation | +462 / -36 |
| `portal/web/test/vaillant-b503.test.mjs` | F8 tests + 2 baseline updates | +818 / -14 |
| `portal/handler_test.go` | F7 GraphQL-only assertion | +23 / -0 |
| `matrix/M6a-vaillant-b503.md` | §10 REST-shim decision | +57 / -0 |
| `portal/static/assets/app.js` | regenerated by `portal/web/scripts/build.mjs` | +462 / -36 |
| `portal/static/assets/manifest.json` | sha256 update | +2 / -2 |

Total: 2 commits (RED `047c216` + IMPL `f4c723c`).

## Test plan

- [x] `node --test portal/web/test/vaillant-b503.test.mjs` — 26/26 pass (6 baseline + 20 new M8)
- [x] `node --test portal/web/test/l7-catalog.test.mjs` — 19/19 pass
- [x] `node --test portal/web/test/portal-shell.test.mjs` — 2/2 pass
- [x] `go test ./portal/ -count=1` — green
- [x] `go test -race ./portal/ -count=1` — green
- [x] `go test ./graphql/ -run VaillantB503 -count=1` — green
- [x] `go vet ./portal/` + `go build ./...` — clean
- [x] `node portal/web/scripts/build.mjs` — assets rebuilt + manifest sha256 updated
- [ ] Live verification on 192.168.100.4:8080 — deferred until M7 BENCH-REPLACE attestation completes (per plan §M8 constraint).
- [ ] Companion docs PR opened in `helianthus-docs-ebus` (separate, out-of-scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)