### PR TITLE
SAS-03A: migrate gateway admission to source selection

### DIFF
--- a/admission_artifact.go
+++ b/admission_artifact.go
@@ -97,6 +97,11 @@ func (b *AdmissionArtifactBuilder) SetSourceSelection(source, companionTarget ui
 	b.artifact.Admission.Source = source
 	b.artifact.Admission.CompanionTarget = companionTarget
 	b.artifact.Admission.WarmupDurationS = warmupDuration.Seconds()
+}
+
+func (b *AdmissionArtifactBuilder) SetSourceSelectionActive() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	b.artifact.Admission.State = "active"
 }
 

--- a/admission_artifact.go
+++ b/admission_artifact.go
@@ -91,7 +91,7 @@ func (b *AdmissionArtifactBuilder) SetAdmissionPathSelected(v string) error {
 	return nil
 }
 
-func (b *AdmissionArtifactBuilder) SetJoinerSelection(source, companionTarget uint8, warmupDuration time.Duration) {
+func (b *AdmissionArtifactBuilder) SetSourceSelection(source, companionTarget uint8, warmupDuration time.Duration) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.artifact.Admission.Source = source
@@ -109,7 +109,7 @@ func (b *AdmissionArtifactBuilder) SetOverrideSource(source uint8) {
 // SetActiveOverride flips Admission.State to "active" and records the
 // override Source. Used by the override path (AD09 (c2) soft short-
 // circuit) where the override source is in use from the first active
-// frame regardless of Joiner outcome — so the artifact must reflect
+// frame regardless of source-address selector outcome — so the artifact must reflect
 // state="active", not the default "pending". Found by AD20 second-
 // reviewer M7 pass: the prior code path emitted state=pending on
 // override which was misleading to operators.

--- a/admission_artifact_test.go
+++ b/admission_artifact_test.go
@@ -14,6 +14,7 @@ func TestAdmissionArtifact_EmitValidatesAgainstSchema(t *testing.T) {
 		t.Fatal(err)
 	}
 	builder.SetSourceSelection(0x71, 0x08, 5*time.Second)
+	builder.SetSourceSelectionActive()
 	builder.RecordProbe(120)
 	builder.RecordProbe(180)
 	builder.SetPostStartupSustainedRateProbesPer15s(1.5)

--- a/admission_artifact_test.go
+++ b/admission_artifact_test.go
@@ -10,10 +10,10 @@ import (
 func TestAdmissionArtifact_EmitValidatesAgainstSchema(t *testing.T) {
 	builder := NewAdmissionArtifactBuilder("ens")
 	builder.startedAt = time.Now().Add(-60 * time.Second)
-	if err := builder.SetAdmissionPathSelected("join"); err != nil {
+	if err := builder.SetAdmissionPathSelected("source_selection"); err != nil {
 		t.Fatal(err)
 	}
-	builder.SetJoinerSelection(0x71, 0x08, 5*time.Second)
+	builder.SetSourceSelection(0x71, 0x08, 5*time.Second)
 	builder.RecordProbe(120)
 	builder.RecordProbe(180)
 	builder.SetPostStartupSustainedRateProbesPer15s(1.5)
@@ -31,7 +31,7 @@ func TestAdmissionArtifact_EmitValidatesAgainstSchema(t *testing.T) {
 	if err := json.Unmarshal(data, &reparsed); err != nil {
 		t.Fatalf("reparse artifact: %v", err)
 	}
-	if reparsed.Admission.AdmissionPathSelected != "join" {
+	if reparsed.Admission.AdmissionPathSelected != "source_selection" {
 		t.Fatalf("admission_path_selected=%q", reparsed.Admission.AdmissionPathSelected)
 	}
 	if reparsed.Admission.State != "active" {
@@ -56,7 +56,7 @@ func TestAdmissionArtifact_BadAdmissionPathRejected(t *testing.T) {
 func TestAdmissionArtifact_WireLoadMath(t *testing.T) {
 	builder := NewAdmissionArtifactBuilder("tcp-plain")
 	builder.startedAt = time.Now().Add(-60 * time.Second)
-	if err := builder.SetAdmissionPathSelected("join"); err != nil {
+	if err := builder.SetAdmissionPathSelected("source_selection"); err != nil {
 		t.Fatal(err)
 	}
 	builder.RecordProbe(100)

--- a/admission_metrics.go
+++ b/admission_metrics.go
@@ -187,6 +187,6 @@ func ValidateAdmissionPathSelected(v string) error {
 	case "source_selection", "override", "degraded_transport_blind", "degraded_no_events":
 		return nil
 	default:
-		return fmt.Errorf("FATAL: admission_path_selected=%q is out of enum {join,override,degraded_transport_blind,degraded_no_events} (AD23)", v)
+		return fmt.Errorf("FATAL: admission_path_selected=%q is out of enum {source_selection,override,degraded_transport_blind,degraded_no_events} (AD23)", v)
 	}
 }

--- a/admission_metrics.go
+++ b/admission_metrics.go
@@ -184,7 +184,7 @@ func EmitStartupResetWarn(logger func(format string, args ...interface{})) {
 // range value.
 func ValidateAdmissionPathSelected(v string) error {
 	switch v {
-	case "join", "override", "degraded_transport_blind", "degraded_no_events":
+	case "source_selection", "override", "degraded_transport_blind", "degraded_no_events":
 		return nil
 	default:
 		return fmt.Errorf("FATAL: admission_path_selected=%q is out of enum {join,override,degraded_transport_blind,degraded_no_events} (AD23)", v)

--- a/admission_metrics_test.go
+++ b/admission_metrics_test.go
@@ -52,7 +52,7 @@ func TestStartupAdmissionMetrics_StateTransitions(t *testing.T) {
 }
 
 func TestValidateAdmissionPathSelected(t *testing.T) {
-	for _, ok := range []string{"join", "override", "degraded_transport_blind", "degraded_no_events"} {
+	for _, ok := range []string{"source_selection", "override", "degraded_transport_blind", "degraded_no_events"} {
 		if err := ValidateAdmissionPathSelected(ok); err != nil {
 			t.Errorf("valid value %q rejected: %v", ok, err)
 		}

--- a/admission_metrics_test.go
+++ b/admission_metrics_test.go
@@ -57,7 +57,7 @@ func TestValidateAdmissionPathSelected(t *testing.T) {
 			t.Errorf("valid value %q rejected: %v", ok, err)
 		}
 	}
-	for _, bad := range []string{"", "static_fallback", "bogus", "JOIN", "unknown"} {
+	for _, bad := range []string{"", "static_fallback", "bogus", "join", "JOIN", "unknown"} {
 		err := ValidateAdmissionPathSelected(bad)
 		if err == nil {
 			t.Errorf("invalid value %q accepted", bad)
@@ -65,6 +65,9 @@ func TestValidateAdmissionPathSelected(t *testing.T) {
 		}
 		if !strings.HasPrefix(err.Error(), "FATAL:") {
 			t.Errorf("expected FATAL: prefix, got %q", err.Error())
+		}
+		if strings.Contains(err.Error(), "{join,") {
+			t.Errorf("fatal text leaks legacy join enum: %q", err.Error())
 		}
 	}
 }

--- a/admission_override_conflict.go
+++ b/admission_override_conflict.go
@@ -14,16 +14,16 @@ func FormatStartupAdmissionOverrideLog(source byte) string {
 }
 
 // CheckOverrideCompanionConflict compares the configured override source
-// against the Joiner's selected initiator and emits advisory conflict
+// against the selector's selected source and emits advisory conflict
 // observability when they disagree.
-func CheckOverrideCompanionConflict(overrideSource byte, joinResult protocol.JoinResult, metrics *StartupAdmissionMetrics) bool {
-	if joinResult.Initiator == 0 {
+func CheckOverrideCompanionConflict(overrideSource byte, selection *protocol.SourceAddressSelection, metrics *StartupAdmissionMetrics) bool {
+	if selection == nil {
 		return false
 	}
-	if joinResult.Initiator == overrideSource {
+	if selection.Source == overrideSource {
 		return false
 	}
-	log.Printf("WARN: startup admission override conflict_detected=1 override_source=0x%02X joiner_preferred=0x%02X", overrideSource, joinResult.Initiator)
+	log.Printf("WARN: startup admission override conflict_detected=1 override_source=0x%02X selector_preferred=0x%02X", overrideSource, selection.Source)
 	if metrics != nil {
 		metrics.SetOverrideConflictDetected()
 	}

--- a/admission_override_conflict_test.go
+++ b/admission_override_conflict_test.go
@@ -8,10 +8,10 @@ import (
 
 func TestCheckOverrideCompanionConflict_DetectsDisagreement(t *testing.T) {
 	m := NewStartupAdmissionMetrics()
-	jr := protocol.JoinResult{Initiator: 0xF1}
-	conflict := CheckOverrideCompanionConflict(0xF0, jr, m)
+	selection := &protocol.SourceAddressSelection{Source: 0xF1}
+	conflict := CheckOverrideCompanionConflict(0xF0, selection, m)
 	if !conflict {
-		t.Error("expected conflict when override=0xF0 but Joiner preferred 0xF1")
+		t.Error("expected conflict when override=0xF0 but selector preferred 0xF1")
 	}
 	if m.OverrideConflictDetected.Value() != 1 {
 		t.Error("expected expvar to be set to 1")
@@ -20,19 +20,18 @@ func TestCheckOverrideCompanionConflict_DetectsDisagreement(t *testing.T) {
 
 func TestCheckOverrideCompanionConflict_NoConflictWhenEqual(t *testing.T) {
 	m := NewStartupAdmissionMetrics()
-	jr := protocol.JoinResult{Initiator: 0xF0}
-	conflict := CheckOverrideCompanionConflict(0xF0, jr, m)
+	selection := &protocol.SourceAddressSelection{Source: 0xF0}
+	conflict := CheckOverrideCompanionConflict(0xF0, selection, m)
 	if conflict {
-		t.Error("expected no conflict when override matches Joiner pick")
+		t.Error("expected no conflict when override matches selector pick")
 	}
 }
 
-func TestCheckOverrideCompanionConflict_NoOpWhenJoinerUnset(t *testing.T) {
+func TestCheckOverrideCompanionConflict_NoOpWhenSelectionUnset(t *testing.T) {
 	m := NewStartupAdmissionMetrics()
-	jr := protocol.JoinResult{}
-	conflict := CheckOverrideCompanionConflict(0xF0, jr, m)
+	conflict := CheckOverrideCompanionConflict(0xF0, nil, m)
 	if conflict {
-		t.Error("expected no conflict when Joiner did not run")
+		t.Error("expected no conflict when selector did not run")
 	}
 	if m.OverrideConflictDetected.Value() != 0 {
 		t.Error("expected expvar to remain 0")

--- a/bus_observability_store.go
+++ b/bus_observability_store.go
@@ -118,7 +118,7 @@ func (store *BusObservabilityStore) SetAdmissionStabilityWindow(window *Admissio
 // RecordBusAdmissionTransition is the production-side setter for the
 // additive bus_admission field per AD08. The state argument MUST be one
 // of {"pending", "active", "degraded"}; source/companionTarget are byte
-// values from JoinResult or override; reason is non-empty only when
+// values from source-address selection or override; reason is non-empty only when
 // state="degraded".
 //
 // When an AdmissionStabilityWindow is installed (production path), the
@@ -132,8 +132,8 @@ func (store *BusObservabilityStore) RecordBusAdmissionTransition(state string, s
 	store.mu.Lock()
 	defer store.mu.Unlock()
 	emittedState := state
-	flipped := true
 	if store.admissionStabilityWindow != nil {
+		var flipped bool
 		emittedState, flipped = store.admissionStabilityWindow.Observe(state)
 		if !flipped {
 			return false

--- a/cmd/gateway/graphql_bus_observability_integration_test.go
+++ b/cmd/gateway/graphql_bus_observability_integration_test.go
@@ -37,6 +37,7 @@ func TestGraphQLBusObservabilityProviderAdapter_ParityWithMCPAdapter(t *testing.
 			LiveEpoch:     9,
 		}
 	})
+	store.RecordBusAdmissionTransition("active", 0x7F, 0x08, "active_probe_passed")
 
 	if err := store.OnBusEvent(protocol.BusEvent{
 		Kind: protocol.BusEventAttemptComplete,
@@ -116,12 +117,13 @@ func TestRun_WiresBusObservabilityIntoGraphQLQueries(t *testing.T) {
 		if busObservability == nil {
 			t.Fatal("busObservability = nil; want runtime wiring to pass the store")
 		}
+		busObservability.RecordBusAdmissionTransition("active", 0x7F, 0x08, "active_probe_passed")
 		handler, err := graphql.NewInvokeHandler(builder, gateway.Registry, gateway.Router)
 		if err != nil {
 			t.Fatalf("NewInvokeHandler error = %v", err)
 		}
 
-		body := bytes.NewBufferString(`{"query":"{ busSummary { lastUpdatedAt messages { count capacity } status { lastUpdatedAt transportClass publisherCadenceSec publisherCadenceSource capability { activeSupported } startup { lastUpdatedAt phase cacheEpoch liveEpoch } featureFlags { lastUpdatedAt } } } busMessages(limit: 1) { count items { family sourceAddress targetAddress } } }"}`)
+		body := bytes.NewBufferString(`{"query":"{ busSummary { lastUpdatedAt messages { count capacity } status { lastUpdatedAt transportClass publisherCadenceSec publisherCadenceSource capability { activeSupported } busAdmission { state source companionTarget reason } startup { lastUpdatedAt phase cacheEpoch liveEpoch } featureFlags { lastUpdatedAt } } } busMessages(limit: 1) { count items { family sourceAddress targetAddress } } }"}`)
 		req := httptest.NewRequest(http.MethodPost, cfg.GraphQLPath, body)
 		req.Header.Set("Content-Type", "application/json")
 		rec := httptest.NewRecorder()
@@ -147,6 +149,12 @@ func TestRun_WiresBusObservabilityIntoGraphQLQueries(t *testing.T) {
 						Capability             struct {
 							ActiveSupported bool `json:"activeSupported"`
 						} `json:"capability"`
+						BusAdmission struct {
+							State           string `json:"state"`
+							Source          int    `json:"source"`
+							CompanionTarget int    `json:"companionTarget"`
+							Reason          string `json:"reason"`
+						} `json:"busAdmission"`
 						Startup struct {
 							LastUpdatedAt string `json:"lastUpdatedAt"`
 							Phase         string `json:"phase"`
@@ -189,6 +197,12 @@ func TestRun_WiresBusObservabilityIntoGraphQLQueries(t *testing.T) {
 		}
 		if !response.Data.BusSummary.Status.Capability.ActiveSupported {
 			t.Fatal("busSummary.status.capability.activeSupported = false; want true")
+		}
+		if response.Data.BusSummary.Status.BusAdmission.State != "active" ||
+			response.Data.BusSummary.Status.BusAdmission.Source != 0x7F ||
+			response.Data.BusSummary.Status.BusAdmission.CompanionTarget != 0x08 ||
+			response.Data.BusSummary.Status.BusAdmission.Reason != "active_probe_passed" {
+			t.Fatalf("busSummary.status.busAdmission = %+v; want active admitted source", response.Data.BusSummary.Status.BusAdmission)
 		}
 		if response.Data.BusSummary.Status.Startup.Phase != string(graphql.SemanticStartupPhaseBootInit) {
 			t.Fatalf("busSummary.status.startup.phase = %q; want BOOT_INIT", response.Data.BusSummary.Status.Startup.Phase)
@@ -375,6 +389,15 @@ func graphQLStatusToMCP(status *graphql.BusObservabilityStatus) *mcp.BusObservab
 			LiveEpoch:     status.Startup.LiveEpoch,
 		}
 	}
+	var admission *mcp.BusAdmission
+	if status.BusAdmission != nil {
+		admission = &mcp.BusAdmission{
+			State:           status.BusAdmission.State,
+			Source:          status.BusAdmission.Source,
+			CompanionTarget: status.BusAdmission.CompanionTarget,
+			Reason:          status.BusAdmission.Reason,
+		}
+	}
 	return &mcp.BusObservabilityStatus{
 		LastUpdatedAt:          cloneTimePtr(status.LastUpdatedAt),
 		TransportClass:         status.TransportClass,
@@ -408,7 +431,8 @@ func graphQLStatusToMCP(status *graphql.BusObservabilityStatus) *mcp.BusObservab
 			Active:  status.Degraded.Active,
 			Reasons: append([]string(nil), status.Degraded.Reasons...),
 		},
-		Startup: startup,
+		BusAdmission: admission,
+		Startup:      startup,
 		FeatureFlags: mcp.ObserveFirstFeatureFlagState{
 			ObserveFirstEnabled:      status.FeatureFlags.ObserveFirstEnabled,
 			PassiveStateDirectApply:  status.FeatureFlags.PassiveStateDirectApply,

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -856,6 +856,9 @@ func bindFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) {
 			return fmt.Errorf("invalid startup-source-override %q", value)
 		}
 		source := uint8(parsed)
+		if source == 0x00 {
+			return fmt.Errorf("invalid startup-source-override %q: source 0x00 is not a valid active initiator", value)
+		}
 		cfg.StartupSource.Source = &source
 		return nil
 	})

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -246,8 +246,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 	}
 
 	var sourceSelection *protocol.SourceAddressSelection
-	resolvedStartupSource := resolveStartupScanSourceConfig(cfg)
-	if admissionPath == ebusgateway.TransportAdmissionSourceSelectionCapable && !overrideSet && cfg.ScanSourceAuto && resolvedStartupSource.ScanSource == 0x00 && !shouldStartPassiveObserveFirst(cfg) {
+	if admissionPath == ebusgateway.TransportAdmissionSourceSelectionCapable && !overrideSet && cfg.ScanSourceAuto && cfg.ScanSource == 0x00 && !shouldStartPassiveObserveFirst(cfg) {
 		result, err := ebusgateway.SelectDefaultStartupSourceAddress(ctx)
 		if err != nil {
 			log.Printf("startup admission degraded reason=source_selection_default_policy_failed err=%v", err)

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -411,9 +411,15 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 	semanticCfg := resolveStartupScanSourceConfig(cfg)
 	semanticPoller := startVaillantSemanticPollingFn(ctx, semanticCfg, gateway, semanticRuntime.Provider(), hub, semanticBarrier)
 	if semanticPoller != nil {
-		builder.SetSystemConfigWriter(semanticPoller)
-		builder.SetBoilerConfigWriter(semanticPoller)
-		builder.SetScheduleWriter(semanticPoller)
+		gatedGraphQLWriter := admittedGraphQLSemanticWriter{
+			boiler:   semanticPoller,
+			system:   semanticPoller,
+			schedule: semanticPoller,
+			admitted: builder.AdmittedMutationSource,
+		}
+		builder.SetSystemConfigWriter(gatedGraphQLWriter)
+		builder.SetBoilerConfigWriter(gatedGraphQLWriter)
+		builder.SetScheduleWriter(gatedGraphQLWriter)
 		builder.SetWatchSummaryProvider(newGraphQLWatchSummaryProvider(semanticPoller.shadow))
 	}
 	observeFirstFlags := ebusgateway.NormalizeObserveFirstFeatureFlags(
@@ -499,11 +505,17 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 
 	var scheduleWriter mcp.ScheduleWriter
 	if semanticPoller != nil {
-		scheduleWriter = semanticPoller
+		scheduleWriter = admittedMCPScheduleWriter{
+			writer:   semanticPoller,
+			admitted: builder.AdmittedMutationSource,
+		}
 	}
 	var configWriter mcp.ConfigWriter
 	if semanticPoller != nil {
-		configWriter = &mcpConfigWriterAdapter{poller: semanticPoller}
+		configWriter = admittedMCPConfigWriter{
+			writer:   &mcpConfigWriterAdapter{poller: semanticPoller},
+			admitted: builder.AdmittedMutationSource,
+		}
 	}
 	var shadowCache *ebusgateway.ShadowCache
 	if semanticPoller != nil {

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -643,11 +643,20 @@ func admittedMutationSourceForGateway(cfg ebusgateway.Config, admissionPath ebus
 		(admissionPath != ebusgateway.TransportAdmissionSourceSelectionCapable || overrideSet) {
 		return cfg.ScanSource, true
 	}
-	if admissionPath == ebusgateway.TransportAdmissionStaticFallback && cfg.ScanSourceAuto && cfg.ScanSource == 0 {
+	if admissionPath == ebusgateway.TransportAdmissionStaticFallback && isEbusdTransportProtocol(cfg.TransportConfig.Protocol) && cfg.ScanSourceAuto && cfg.ScanSource == 0 {
 		defaultSource := ebusgateway.DefaultConfig().ScanSource
 		return defaultSource, defaultSource != 0
 	}
 	return 0, false
+}
+
+func isEbusdTransportProtocol(protocol ebusgateway.TransportProtocol) bool {
+	switch strings.TrimSpace(strings.ToLower(string(protocol))) {
+	case "ebusd", string(ebusgateway.TransportEbusdTCP):
+		return true
+	default:
+		return false
+	}
 }
 
 func normalizeInstanceGUID(value string) (string, error) {

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"context"
+	"expvar"
 	"flag"
 	"fmt"
 	"log"
 	"net"
-	"expvar"
 	"net/http"
 	"os"
 	"os/signal"
@@ -113,14 +113,14 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 	// special case so all classifier call sites (main.go run(),
 	// startup_scan.go startDiscoveryScanLoop, runBackgroundFullScan) agree
 	// on the dispatch. Adapter-direct multiplexer mode always wraps a
-	// join-capable underlying transport (ENH/ENS), so Joiner runs through
+	// source-selection-capable underlying transport (ENH/ENS), so source-address selector runs through
 	// the shared PassiveTransactionReconstructor regardless of multiplexer
 	// presence. Resolves cruise-run #20 M7 follow-up #1 + validation
 	// finding (admission_path_selected was incorrectly degraded_no_events
 	// on adapter-direct deployments).
 	admissionPath, adapterDirectSpecialCased := ebusgateway.ResolveAdmissionPath(cfg.TransportConfig.Protocol)
 	if adapterDirectSpecialCased {
-		log.Printf("startup admission: adapter-direct multiplexer detected; treating as join-capable (underlying transport is always ENH/ENS)")
+		log.Printf("startup admission: adapter-direct multiplexer detected; treating as source-selection-capable (underlying transport is always ENH/ENS)")
 	} else if admissionPath == ebusgateway.TransportAdmissionStaticFallback && cfg.TransportConfig.Protocol != ebusgateway.TransportEbusdTCP {
 		log.Printf("startup admission: classifier produced static-fallback for transport protocol=%q (unknown/empty); legacy static-source path active", cfg.TransportConfig.Protocol)
 	}
@@ -129,7 +129,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 	if err := artifactBuilder.SetAdmissionPathSelected("degraded_no_events"); err != nil {
 		log.Fatalf("FATAL: AD23 enum violation at startup: %v", err)
 	}
-	overrideSet := admissionPath == ebusgateway.TransportAdmissionJoinCapable && cfg.StartupSource.Source != nil
+	overrideSet := admissionPath == ebusgateway.TransportAdmissionSourceSelectionCapable && cfg.StartupSource.Source != nil
 	overrideSource := byte(0x00)
 	if overrideSet {
 		overrideSource = *cfg.StartupSource.Source
@@ -142,7 +142,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 		}
 		// Override is configured: admission state immediately becomes
 		// "active" because the override Initiator is in use from the
-		// first active frame (AD09 (c2) soft short-circuit). Joiner may
+		// first active frame (AD09 (c2) soft short-circuit). source-address selector may
 		// still run advisory-only under Validate=true but does not gate.
 		artifactBuilder.SetActiveOverride(overrideSource)
 	} else {
@@ -249,6 +249,30 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 		})
 	}
 
+	var sourceSelection *protocol.SourceAddressSelection
+	resolvedStartupSource := resolveStartupScanSourceConfig(cfg)
+	if admissionPath == ebusgateway.TransportAdmissionSourceSelectionCapable && !overrideSet && cfg.ScanSourceAuto && resolvedStartupSource.ScanSource == 0x00 && !shouldStartPassiveObserveFirst(cfg) {
+		result, err := ebusgateway.SelectDefaultStartupSourceAddress(ctx)
+		if err != nil {
+			log.Printf("startup admission degraded reason=source_selection_default_policy_failed err=%v", err)
+			metrics.MarkDegraded(time.Now())
+			artifactBuilder.SetDegraded("source_selection_default_policy_failed")
+		} else {
+			sourceSelection = &result
+			cfg.ScanSource = result.Source
+			cfg.ScanSourceAuto = false
+			artifactBuilder.SetSourceSelection(result.Source, result.Companion, result.Metrics.WarmupDurationActual)
+			if perr := artifactBuilder.SetAdmissionPathSelected("source_selection"); perr != nil {
+				log.Fatalf("FATAL: AD23 enum violation on source-selection default-policy path: %v", perr)
+			}
+			log.Printf("startup admission active source=0x%02X companion_target=0x%02X provenance=source_selection_default_policy", result.Source, result.Companion)
+			if busObservability != nil {
+				busObservability.RecordBusAdmissionTransition("active", result.Source, result.Companion, "")
+			}
+			metrics.MarkActive()
+		}
+	}
+
 	var semanticBarrier chan struct{}
 	if cfg.ScanOnStart && shouldStartPassiveObserveFirst(cfg) {
 		semanticBarrier = make(chan struct{})
@@ -283,7 +307,6 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 	var (
 		listener      *ebusgateway.BroadcastListener
 		reconstructor *ebusgateway.PassiveTransactionReconstructor
-		joinResult    *protocol.JoinResult
 	)
 	attachPassiveObserveFirst := func() error {
 		if reconstructor == nil {
@@ -309,19 +332,19 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 		return nil
 	}
 
-	runAdvisoryJoiner := admissionPath == ebusgateway.TransportAdmissionJoinCapable && shouldStartPassiveObserveFirst(cfg) && (!overrideSet || cfg.StartupSource.Validate)
-	if runAdvisoryJoiner {
+	runAdvisorySourceSelector := admissionPath == ebusgateway.TransportAdmissionSourceSelectionCapable && shouldStartPassiveObserveFirst(cfg) && (!overrideSet || cfg.StartupSource.Validate)
+	if runAdvisorySourceSelector {
 		reconstructor, err = startPassiveTransactionReconstructor(ctx, cfg)
 		if err != nil {
 			return err
 		}
 		log.Printf("passive reconstructor started")
 
-		joinBus, err := ebusgateway.NewJoinBusAdapter(reconstructor, "startup_admission_joinbus", false)
+		selectionBus, err := ebusgateway.NewSourceSelectionBusAdapter(reconstructor, "startup_admission_source_selection_bus", false)
 		if err != nil {
-			return fmt.Errorf("m3: new joinbus: %w", err)
+			return fmt.Errorf("m3: new source address selection bus: %w", err)
 		}
-		joiner := protocol.NewJoiner(joinBus, nil, ebusgateway.DefaultStartupAdmissionJoinConfig())
+		selector := protocol.NewSourceAddressSelector(selectionBus, ebusgateway.DefaultStartupAdmissionSourceSelectionConfig())
 
 		// Install AD08/AD22 stability window on the bus_observability store
 		// before the first admission state observation. Window is sized
@@ -331,49 +354,51 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 			busObservability.SetAdmissionStabilityWindow(
 				ebusgateway.NewAdmissionStabilityWindow(ebusgateway.StartupAdmissionStateMinStabilitySecondsDefault),
 			)
-			busObservability.RecordBusAdmissionTransition("pending", 0, 0, "joiner_warmup_in_progress")
+			busObservability.RecordBusAdmissionTransition("pending", 0, 0, "source_selection_warmup_in_progress")
 		}
 		// Wire M5 expvar surfaces: state pending → warmup cycle starts.
 		// Resolves cruise-run #20 validation finding that the 11
 		// startup_admission_* expvars were defined and Publish()'d via
 		// GetOrInitStartupAdmissionMetrics but never updated by the
-		// runtime — they all stayed at 0 even after Joiner success.
+		// runtime — they all stayed at 0 even after source-address selector success.
 		metrics.MarkPending()
 		metrics.StartWarmupCycle()
 
-		log.Printf("joiner warmup begin")
+		log.Printf("source address selection warmup begin")
 		warmupCtx, cancel := context.WithTimeout(ctx, 6*time.Second)
 		warmupStartedAt := time.Now()
-		result, err := joiner.Join(warmupCtx)
+		result, err := selector.Select(warmupCtx)
 		cancel()
 		if err != nil {
-			log.Printf("startup admission degraded reason=joiner_fail err=%v", err)
+			log.Printf("startup admission degraded reason=source_selection_failed err=%v", err)
 			if busObservability != nil {
-				busObservability.RecordBusAdmissionTransition("degraded", 0, 0, "joiner_fail")
+				busObservability.RecordBusAdmissionTransition("degraded", 0, 0, "source_selection_failed")
 			}
 			metrics.MarkDegraded(time.Now())
-			artifactBuilder.SetDegraded("joiner_fail")
+			artifactBuilder.SetDegraded("source_selection_failed")
 			if perr := artifactBuilder.SetAdmissionPathSelected("degraded_no_events"); perr != nil {
-				log.Fatalf("FATAL: AD23 enum violation on joiner-fail path: %v", perr)
+				log.Fatalf("FATAL: AD23 enum violation on source-address selector-fail path: %v", perr)
 			}
 		} else {
 			if overrideSet {
-				_ = ebusgateway.CheckOverrideCompanionConflict(overrideSource, result, metrics)
+				_ = ebusgateway.CheckOverrideCompanionConflict(overrideSource, &result, metrics)
 			} else {
-				joinResult = &result
-				artifactBuilder.SetJoinerSelection(result.Initiator, result.CompanionTarget, time.Since(warmupStartedAt))
-				if perr := artifactBuilder.SetAdmissionPathSelected("join"); perr != nil {
-					log.Fatalf("FATAL: AD23 enum violation on join path: %v", perr)
+				sourceSelection = &result
+				cfg.StartupProbeTargets = append(cfg.StartupProbeTargets, startupProbeTargetsFromSelection(result)...)
+				artifactBuilder.SetPromotedSuspects(len(startupProbeTargets(cfg)))
+				artifactBuilder.SetSourceSelection(result.Source, result.Companion, time.Since(warmupStartedAt))
+				if perr := artifactBuilder.SetAdmissionPathSelected("source_selection"); perr != nil {
+					log.Fatalf("FATAL: AD23 enum violation on source-selection path: %v", perr)
 				}
-				log.Printf("startup admission active source=0x%02X companion_target=0x%02X", result.Initiator, result.CompanionTarget)
+				log.Printf("startup admission active source=0x%02X companion_target=0x%02X", result.Source, result.Companion)
 				if busObservability != nil {
-					busObservability.RecordBusAdmissionTransition("active", result.Initiator, result.CompanionTarget, "")
+					busObservability.RecordBusAdmissionTransition("active", result.Source, result.Companion, "")
 				}
 				metrics.MarkActive()
-				// Reflect Joiner-observed event count if exposed by ebusgo.
-				// JoinResult does not currently surface a count; the
+				// Reflect selector-observed event count if exposed by ebusgo.
+				// SourceAddressSelection does not currently surface a count; the
 				// warmup_events_seen stays at the per-cycle reset value
-				// of 0 unless the JoinBus adapter is extended to call
+				// of 0 unless the selection bus adapter is extended to call
 				// metrics.RecordWarmupEvent on each forwarded frame.
 				// Tracked as cruise-run #20 follow-up.
 			}
@@ -382,14 +407,14 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 
 	startupCfg := resolveStartupScanSourceConfig(cfg)
 	startupSourceProvenance := startupScanSourceMode(cfg, startupCfg)
-	if admissionPath == ebusgateway.TransportAdmissionJoinCapable && overrideSet {
+	if admissionPath == ebusgateway.TransportAdmissionSourceSelectionCapable && overrideSet {
 		startupCfg.ScanSource = overrideSource
 		startupCfg.ScanSourceAuto = false
 		startupSourceProvenance = "override"
-	} else if admissionPath == ebusgateway.TransportAdmissionJoinCapable && joinResult != nil {
-		startupCfg.ScanSource = joinResult.Initiator
+	} else if admissionPath == ebusgateway.TransportAdmissionSourceSelectionCapable && sourceSelection != nil {
+		startupCfg.ScanSource = sourceSelection.Source
 		startupCfg.ScanSourceAuto = false
-		startupSourceProvenance = "join_result"
+		startupSourceProvenance = "source_selection"
 	}
 
 	log.Printf("startup scan pass")
@@ -407,7 +432,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 				return
 			case <-startupScanSignals.semanticBootstrapReady:
 			}
-			if shouldCloseSemanticBarrier(admissionPath, overrideSet, joinResult != nil) {
+			if shouldCloseSemanticBarrier(admissionPath, overrideSet, sourceSelection != nil) {
 				close(semanticBarrier)
 			}
 		}()
@@ -704,7 +729,15 @@ func bindFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) {
 		cfg.ScanSourceAuto = cfg.ScanSource == 0x00
 		return nil
 	})
-	fs.Func("startup-source-override", "override source address for join-capable direct transports (e.g. 0xf0)", func(value string) error {
+	fs.Func("startup-probe-targets", "comma-separated explicit startup directed-probe targets (e.g. 0x08,0x15)", func(value string) error {
+		targets, err := parseStartupProbeTargets(value)
+		if err != nil {
+			return err
+		}
+		cfg.StartupProbeTargets = targets
+		return nil
+	})
+	fs.Func("startup-source-override", "override source address for source-selection-capable direct transports (e.g. 0xf0)", func(value string) error {
 		value = strings.TrimSpace(strings.ToLower(value))
 		if value == "" {
 			cfg.StartupSource.Source = nil
@@ -718,7 +751,39 @@ func bindFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) {
 		cfg.StartupSource.Source = &source
 		return nil
 	})
-	fs.BoolVar(&cfg.StartupSource.Validate, "startup-source-override-validate", cfg.StartupSource.Validate, "run Joiner in advisory-only mode alongside startup-source-override")
+	fs.BoolVar(&cfg.StartupSource.Validate, "startup-source-override-validate", cfg.StartupSource.Validate, "run source-address selector in advisory-only mode alongside startup-source-override")
+}
+
+func parseStartupProbeTargets(value string) ([]byte, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, nil
+	}
+	parts := strings.FieldsFunc(value, func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\t' || r == '\n'
+	})
+	targets := make([]byte, 0, len(parts))
+	seen := make(map[byte]struct{}, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(strings.ToLower(part))
+		if part == "" {
+			continue
+		}
+		parsed, err := strconv.ParseUint(part, 0, 8)
+		if err != nil {
+			return nil, fmt.Errorf("invalid startup-probe-targets address %q", part)
+		}
+		target := byte(parsed)
+		if target < 0x03 || target >= 0xFE || target == 0xAA {
+			return nil, fmt.Errorf("startup-probe-targets address 0x%02X outside target-capable range", target)
+		}
+		if _, ok := seen[target]; ok {
+			continue
+		}
+		seen[target] = struct{}{}
+		targets = append(targets, target)
+	}
+	return targets, nil
 }
 
 // wireAdapterDirect creates and starts the adapter multiplexer if the

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -70,10 +70,6 @@ func main() {
 	flag.Parse()
 	applyTransportSourcePolicy(&cfg)
 
-	if cfg.ScanSource == 0x31 && !cfg.ScanSourceAuto {
-		log.Printf("warning: source-addr=0x31 is commonly used by ebusd; when running alongside ebusd pick a different source address (e.g. --source-addr=0xf0)")
-	}
-
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
@@ -200,7 +196,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 		artifactBuilder.SetBaselineEvidenceProvider(func() map[string]int {
 			counts := make(map[string]int)
 			for _, addr := range ebusgateway.VaillantBaselineTopologySeed {
-				counts[fmt.Sprintf("0x%02X", addr)] = 0
+				counts[fmt.Sprintf("%02X", addr)] = 0
 			}
 			// RecentMessages returns most recent observations; iterate
 			// and count per baseline address (as either source or
@@ -208,11 +204,11 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 			// enough to capture passive traffic to all baselines on a
 			// healthy bus.
 			for _, msg := range busObservability.RecentMessages(1024) {
-				srcKey := fmt.Sprintf("0x%02X", msg.Source)
+				srcKey := fmt.Sprintf("%02X", msg.Source)
 				if _, ok := counts[srcKey]; ok {
 					counts[srcKey]++
 				}
-				tgtKey := fmt.Sprintf("0x%02X", msg.Target)
+				tgtKey := fmt.Sprintf("%02X", msg.Target)
 				if _, ok := counts[tgtKey]; ok {
 					counts[tgtKey]++
 				}
@@ -261,47 +257,16 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 			sourceSelection = &result
 			cfg.ScanSource = result.Source
 			cfg.ScanSourceAuto = false
+			cfg.StartupCompanionTarget = result.Companion
 			artifactBuilder.SetSourceSelection(result.Source, result.Companion, result.Metrics.WarmupDurationActual)
 			if perr := artifactBuilder.SetAdmissionPathSelected("source_selection"); perr != nil {
 				log.Fatalf("FATAL: AD23 enum violation on source-selection default-policy path: %v", perr)
 			}
-			log.Printf("startup admission active source=0x%02X companion_target=0x%02X provenance=source_selection_default_policy", result.Source, result.Companion)
+			log.Printf("startup admission candidate source=0x%02X companion_target=0x%02X provenance=source_selection_default_policy", result.Source, result.Companion)
 			if busObservability != nil {
-				busObservability.RecordBusAdmissionTransition("active", result.Source, result.Companion, "")
+				busObservability.RecordBusAdmissionTransition("pending", result.Source, result.Companion, "active_probe_pending")
 			}
-			metrics.MarkActive()
 		}
-	}
-
-	var semanticBarrier chan struct{}
-	if cfg.ScanOnStart && shouldStartPassiveObserveFirst(cfg) {
-		semanticBarrier = make(chan struct{})
-	}
-	semanticCfg := resolveStartupScanSourceConfig(cfg)
-	semanticPoller := startVaillantSemanticPollingFn(ctx, semanticCfg, gateway, semanticRuntime.Provider(), hub, semanticBarrier)
-	if semanticPoller != nil {
-		builder.SetSystemConfigWriter(semanticPoller)
-		builder.SetBoilerConfigWriter(semanticPoller)
-		builder.SetScheduleWriter(semanticPoller)
-		builder.SetWatchSummaryProvider(newGraphQLWatchSummaryProvider(semanticPoller.shadow))
-	}
-	observeFirstFlags := ebusgateway.NormalizeObserveFirstFeatureFlags(
-		cfg.ObserveFirstEnabled,
-		cfg.PassiveStateDirectApply,
-		cfg.PassiveConfigDirectApply,
-		cfg.ExternalWritePolicy,
-	)
-	passiveShadowLaneEnabled := observeFirstFlags.PassiveStateDirectApply() ||
-		observeFirstFlags.PassiveConfigDirectApply() ||
-		observeFirstFlags.ExternalWritePolicy() != ebusgateway.ObserveFirstExternalWritePolicyRecordOnly
-	if semanticPoller != nil && deduplicator != nil && observeFirstFlags.ObserveFirstEnabled() && passiveShadowLaneEnabled {
-		if err := attachPassiveShadowProducerFn(semanticPoller, ctx, deduplicator); err != nil {
-			return err
-		}
-	}
-
-	if err := builder.Start(ctx); err != nil {
-		return err
 	}
 
 	var (
@@ -384,17 +349,19 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 				_ = ebusgateway.CheckOverrideCompanionConflict(overrideSource, &result, metrics)
 			} else {
 				sourceSelection = &result
+				cfg.ScanSource = result.Source
+				cfg.ScanSourceAuto = false
+				cfg.StartupCompanionTarget = result.Companion
 				cfg.StartupProbeTargets = append(cfg.StartupProbeTargets, startupProbeTargetsFromSelection(result)...)
 				artifactBuilder.SetPromotedSuspects(len(startupProbeTargets(cfg)))
 				artifactBuilder.SetSourceSelection(result.Source, result.Companion, time.Since(warmupStartedAt))
 				if perr := artifactBuilder.SetAdmissionPathSelected("source_selection"); perr != nil {
 					log.Fatalf("FATAL: AD23 enum violation on source-selection path: %v", perr)
 				}
-				log.Printf("startup admission active source=0x%02X companion_target=0x%02X", result.Source, result.Companion)
+				log.Printf("startup admission candidate source=0x%02X companion_target=0x%02X", result.Source, result.Companion)
 				if busObservability != nil {
-					busObservability.RecordBusAdmissionTransition("active", result.Source, result.Companion, "")
+					busObservability.RecordBusAdmissionTransition("pending", result.Source, result.Companion, "active_probe_pending")
 				}
-				metrics.MarkActive()
 				// Reflect selector-observed event count if exposed by ebusgo.
 				// SourceAddressSelection does not currently surface a count; the
 				// warmup_events_seen stays at the per-cycle reset value
@@ -403,6 +370,50 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 				// Tracked as cruise-run #20 follow-up.
 			}
 		}
+	}
+
+	if admissionPath == ebusgateway.TransportAdmissionSourceSelectionCapable && overrideSet {
+		cfg.ScanSource = overrideSource
+		cfg.ScanSourceAuto = false
+	}
+	builder.SetStatusProvider(newRuntimeStatusProvider(cfg, semanticRuntime.Provider()))
+	if cfg.ScanSource != 0 && !cfg.ScanSourceAuto &&
+		(admissionPath != ebusgateway.TransportAdmissionSourceSelectionCapable || overrideSet) {
+		builder.SetAdmittedMutationSource(cfg.ScanSource)
+	} else {
+		builder.ClearAdmittedMutationSource()
+	}
+
+	sourceSelectionAdmission := admissionPath == ebusgateway.TransportAdmissionSourceSelectionCapable && !overrideSet
+	var semanticBarrier chan struct{}
+	if cfg.ScanOnStart && (shouldStartPassiveObserveFirst(cfg) || sourceSelectionAdmission) {
+		semanticBarrier = make(chan struct{})
+	}
+	semanticCfg := resolveStartupScanSourceConfig(cfg)
+	semanticPoller := startVaillantSemanticPollingFn(ctx, semanticCfg, gateway, semanticRuntime.Provider(), hub, semanticBarrier)
+	if semanticPoller != nil {
+		builder.SetSystemConfigWriter(semanticPoller)
+		builder.SetBoilerConfigWriter(semanticPoller)
+		builder.SetScheduleWriter(semanticPoller)
+		builder.SetWatchSummaryProvider(newGraphQLWatchSummaryProvider(semanticPoller.shadow))
+	}
+	observeFirstFlags := ebusgateway.NormalizeObserveFirstFeatureFlags(
+		cfg.ObserveFirstEnabled,
+		cfg.PassiveStateDirectApply,
+		cfg.PassiveConfigDirectApply,
+		cfg.ExternalWritePolicy,
+	)
+	passiveShadowLaneEnabled := observeFirstFlags.PassiveStateDirectApply() ||
+		observeFirstFlags.PassiveConfigDirectApply() ||
+		observeFirstFlags.ExternalWritePolicy() != ebusgateway.ObserveFirstExternalWritePolicyRecordOnly
+	if semanticPoller != nil && deduplicator != nil && observeFirstFlags.ObserveFirstEnabled() && passiveShadowLaneEnabled {
+		if err := attachPassiveShadowProducerFn(semanticPoller, ctx, deduplicator); err != nil {
+			return err
+		}
+	}
+
+	if err := builder.Start(ctx); err != nil {
+		return err
 	}
 
 	startupCfg := resolveStartupScanSourceConfig(cfg)
@@ -424,21 +435,43 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 	}
 	startupScanSignals := startDiscoveryScanLoopFn(ctx, startupCfg, gateway, builder, adapterClassifier)
 
-	if semanticBarrier != nil {
+	if semanticBarrier != nil || sourceSelection != nil {
 		go func() {
 			select {
 			case <-ctx.Done():
-				close(semanticBarrier)
+				if semanticBarrier != nil {
+					close(semanticBarrier)
+				}
 				return
-			case <-startupScanSignals.semanticBootstrapReady:
+			case <-startupScanSignals.activeProbePassed:
+				if sourceSelection != nil {
+					builder.SetAdmittedMutationSource(sourceSelection.Source)
+					artifactBuilder.SetSourceSelectionActive()
+					metrics.MarkActive()
+					if busObservability != nil {
+						busObservability.RecordBusAdmissionTransition("active", sourceSelection.Source, sourceSelection.Companion, "active_probe_passed")
+					}
+				}
+			case <-startupScanSignals.admissionFailed:
+				if sourceSelection != nil {
+					builder.ClearAdmittedMutationSource()
+					artifactBuilder.SetDegraded("active_probe_failed")
+					metrics.MarkDegraded(time.Now())
+					if busObservability != nil {
+						busObservability.RecordBusAdmissionTransition("degraded", sourceSelection.Source, sourceSelection.Companion, "active_probe_failed")
+					}
+				}
+				return
 			}
 			if shouldCloseSemanticBarrier(admissionPath, overrideSet, sourceSelection != nil) {
-				close(semanticBarrier)
+				if semanticBarrier != nil {
+					close(semanticBarrier)
+				}
 			}
 		}()
 	}
 
-	go startBackgroundFullScanFn(ctx, cfg, gateway, builder, startupScanSignals.semanticBootstrapReady)
+	go startBackgroundFullScanFn(ctx, startupCfg, gateway, builder, startupScanSignals.semanticBootstrapReady)
 
 	var scheduleWriter mcp.ScheduleWriter
 	if semanticPoller != nil {
@@ -593,9 +626,7 @@ func applyTransportSourcePolicy(cfg *ebusgateway.Config) {
 	protocol := strings.TrimSpace(strings.ToLower(string(cfg.TransportConfig.Protocol)))
 	switch protocol {
 	case "ebusd", "ebusd-tcp":
-		if cfg.ScanSourceAuto || cfg.ScanSource == 0xF0 {
-			cfg.ScanSource = 0x31
-		}
+		return
 	default:
 		if cfg.ScanSourceAuto {
 			cfg.ScanSource = 0x00
@@ -774,7 +805,7 @@ func parseStartupProbeTargets(value string) ([]byte, error) {
 			return nil, fmt.Errorf("invalid startup-probe-targets address %q", part)
 		}
 		target := byte(parsed)
-		if target < 0x03 || target >= 0xFE || target == 0xAA {
+		if target < 0x03 || target >= 0xFE || target == 0xAA || target == 0xA9 || isInitiatorCapableAddress(target) {
 			return nil, fmt.Errorf("startup-probe-targets address 0x%02X outside target-capable range", target)
 		}
 		if _, ok := seen[target]; ok {
@@ -976,6 +1007,7 @@ func startHTTPServer(
 	if err != nil {
 		return nil, nil, err
 	}
+	mcpServer.SetAdmittedRPCSourceProvider(builder.AdmittedMutationSource)
 	mcpServer.SetStatusProvider(newMCPRuntimeStatusProvider(cfg, semanticProvider))
 	if busObservability != nil {
 		mcpServer.SetBusObservabilityProvider(newMCPBusObservabilityProvider(busObservability))
@@ -1006,7 +1038,7 @@ func startHTTPServer(
 	// paths use the real session FSM so EXPIRED normalization, session
 	// epochs, and owner-conditional release are all exercised — only the
 	// raw bus dispatch is stubbed.
-	b503rt := installVaillantB503(mcpServer, gateway, &cfg)
+	b503rt := installVaillantB503(mcpServer, gateway, &cfg, builder.AdmittedMutationSource)
 	// M2b_GATEWAY_GRAPHQL (execution-plans#19): wire the GraphQL B503
 	// provider to the same Manager + Dispatcher the MCP surface uses. A
 	// single Manager across both surfaces is mandatory — GraphQL

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -258,6 +258,8 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 			cfg.ScanSource = result.Source
 			cfg.ScanSourceAuto = false
 			cfg.StartupCompanionTarget = result.Companion
+			cfg.StartupProbeTargets = append(cfg.StartupProbeTargets, startupProbeTargetsForSelection(result)...)
+			artifactBuilder.SetPromotedSuspects(len(startupProbeTargets(cfg)))
 			artifactBuilder.SetSourceSelection(result.Source, result.Companion, result.Metrics.WarmupDurationActual)
 			if perr := artifactBuilder.SetAdmissionPathSelected("source_selection"); perr != nil {
 				log.Fatalf("FATAL: AD23 enum violation on source-selection default-policy path: %v", perr)
@@ -352,7 +354,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 				cfg.ScanSource = result.Source
 				cfg.ScanSourceAuto = false
 				cfg.StartupCompanionTarget = result.Companion
-				cfg.StartupProbeTargets = append(cfg.StartupProbeTargets, startupProbeTargetsFromSelection(result)...)
+				cfg.StartupProbeTargets = append(cfg.StartupProbeTargets, startupProbeTargetsForSelection(result)...)
 				artifactBuilder.SetPromotedSuspects(len(startupProbeTargets(cfg)))
 				artifactBuilder.SetSourceSelection(result.Source, result.Companion, time.Since(warmupStartedAt))
 				if perr := artifactBuilder.SetAdmissionPathSelected("source_selection"); perr != nil {

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -377,9 +377,8 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 		cfg.ScanSourceAuto = false
 	}
 	builder.SetStatusProvider(newRuntimeStatusProvider(cfg, semanticRuntime.Provider()))
-	if cfg.ScanSource != 0 && !cfg.ScanSourceAuto &&
-		(admissionPath != ebusgateway.TransportAdmissionSourceSelectionCapable || overrideSet) {
-		builder.SetAdmittedMutationSource(cfg.ScanSource)
+	if source, admitted := admittedMutationSourceForGateway(cfg, admissionPath, overrideSet); admitted {
+		builder.SetAdmittedMutationSource(source)
 	} else {
 		builder.ClearAdmittedMutationSource()
 	}
@@ -459,6 +458,11 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 					metrics.MarkDegraded(time.Now())
 					if busObservability != nil {
 						busObservability.RecordBusAdmissionTransition("degraded", sourceSelection.Source, sourceSelection.Companion, "active_probe_failed")
+					}
+				}
+				if shouldCloseSemanticBarrier(admissionPath, overrideSet, sourceSelection != nil) {
+					if semanticBarrier != nil {
+						close(semanticBarrier)
 					}
 				}
 				return
@@ -632,6 +636,18 @@ func applyTransportSourcePolicy(cfg *ebusgateway.Config) {
 			cfg.ScanSource = 0x00
 		}
 	}
+}
+
+func admittedMutationSourceForGateway(cfg ebusgateway.Config, admissionPath ebusgateway.TransportAdmissionPath, overrideSet bool) (byte, bool) {
+	if cfg.ScanSource != 0 && !cfg.ScanSourceAuto &&
+		(admissionPath != ebusgateway.TransportAdmissionSourceSelectionCapable || overrideSet) {
+		return cfg.ScanSource, true
+	}
+	if admissionPath == ebusgateway.TransportAdmissionStaticFallback && cfg.ScanSourceAuto && cfg.ScanSource == 0 {
+		defaultSource := ebusgateway.DefaultConfig().ScanSource
+		return defaultSource, defaultSource != 0
+	}
+	return 0, false
 }
 
 func normalizeInstanceGUID(value string) (string, error) {

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -270,6 +270,25 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 			}
 		}
 	}
+	if sourceSelection == nil {
+		result, ok := configuredStartupSourceAdmissionCandidate(cfg, admissionPath, overrideSet)
+		if ok {
+			sourceSelection = &result
+			cfg.ScanSource = result.Source
+			cfg.ScanSourceAuto = false
+			cfg.StartupCompanionTarget = result.Companion
+			cfg.StartupProbeTargets = append(cfg.StartupProbeTargets, startupProbeTargetsForSelection(result)...)
+			artifactBuilder.SetPromotedSuspects(len(startupProbeTargets(cfg)))
+			artifactBuilder.SetSourceSelection(result.Source, result.Companion, 0)
+			if perr := artifactBuilder.SetAdmissionPathSelected("source_selection"); perr != nil {
+				log.Fatalf("FATAL: AD23 enum violation on configured source validation path: %v", perr)
+			}
+			log.Printf("startup admission candidate source=0x%02X companion_target=0x%02X provenance=configured_source", result.Source, result.Companion)
+			if busObservability != nil {
+				busObservability.RecordBusAdmissionTransition("pending", result.Source, result.Companion, "active_probe_pending")
+			}
+		}
+	}
 
 	var (
 		listener      *ebusgateway.BroadcastListener
@@ -650,6 +669,26 @@ func admittedMutationSourceForGateway(cfg ebusgateway.Config, admissionPath ebus
 		return defaultSource, defaultSource != 0
 	}
 	return 0, false
+}
+
+func configuredStartupSourceAdmissionCandidate(cfg ebusgateway.Config, admissionPath ebusgateway.TransportAdmissionPath, overrideSet bool) (protocol.SourceAddressSelection, bool) {
+	if admissionPath != ebusgateway.TransportAdmissionSourceSelectionCapable || overrideSet || shouldStartPassiveObserveFirst(cfg) {
+		return protocol.SourceAddressSelection{}, false
+	}
+	if cfg.ScanSourceAuto || cfg.ScanSource == 0x00 {
+		return protocol.SourceAddressSelection{}, false
+	}
+	companion := cfg.StartupCompanionTarget
+	if companion == 0x00 {
+		companion = protocol.CompanionAddressForSource(cfg.ScanSource)
+	}
+	return protocol.SourceAddressSelection{
+		Source:    cfg.ScanSource,
+		Companion: companion,
+		Metrics: protocol.SourceAddressSelectionMetrics{
+			ObservedProbableTargets: append([]byte(nil), cfg.StartupProbeTargets...),
+		},
+	}, true
 }
 
 func isEbusdTransportProtocol(protocol ebusgateway.TransportProtocol) bool {

--- a/cmd/gateway/main_test.go
+++ b/cmd/gateway/main_test.go
@@ -177,6 +177,18 @@ func TestAdmittedMutationSourceForGateway_SourceSelectionWithoutOverrideFailsClo
 	}
 }
 
+func TestAdmittedMutationSourceForGateway_UnknownStaticFallbackAutoFailsClosed(t *testing.T) {
+	cfg := ebusgateway.DefaultConfig()
+	cfg.TransportConfig.Protocol = ebusgateway.TransportProtocol("unknown")
+	cfg.ScanSource = 0x00
+	cfg.ScanSourceAuto = true
+
+	source, admitted := admittedMutationSourceForGateway(cfg, ebusgateway.TransportAdmissionStaticFallback, false)
+	if admitted || source != 0 {
+		t.Fatalf("admitted source = 0x%02X admitted=%v; want fail-closed for unknown static fallback", source, admitted)
+	}
+}
+
 func TestWireObserveFirstObserversWiresDedupSnapshotterIntoObservabilityStore(t *testing.T) {
 	cfg := ebusgateway.DefaultConfig()
 	cfg.BroadcastListen = true

--- a/cmd/gateway/main_test.go
+++ b/cmd/gateway/main_test.go
@@ -668,6 +668,86 @@ func TestRun_DefaultSourceSelectionSeedsStartupProbeTargets(t *testing.T) {
 	}
 }
 
+func TestRun_ConfiguredDirectSourceSeedsStartupProbeTargets(t *testing.T) {
+	origWireObserveFirstObserversFn := wireObserveFirstObserversFn
+	origStartDiscoveryScanLoopFn := startDiscoveryScanLoopFn
+	origStartVaillantSemanticPollingFn := startVaillantSemanticPollingFn
+	origStartHTTPServerFn := startHTTPServerFn
+	t.Cleanup(func() {
+		wireObserveFirstObserversFn = origWireObserveFirstObserversFn
+		startDiscoveryScanLoopFn = origStartDiscoveryScanLoopFn
+		startVaillantSemanticPollingFn = origStartVaillantSemanticPollingFn
+		startHTTPServerFn = origStartHTTPServerFn
+	})
+
+	type startupCapture struct {
+		source  byte
+		auto    bool
+		targets []byte
+	}
+	startupCfg := make(chan startupCapture, 1)
+	wireObserveFirstObserversFn = func(*ebusgateway.Config) (*ebusgateway.BusObservabilityStore, *ebusgateway.ActivePassiveDeduplicator, error) {
+		return nil, nil, nil
+	}
+	startDiscoveryScanLoopFn = func(_ context.Context, cfg ebusgateway.Config, _ *ebusgateway.Gateway, _ *graphql.Builder, _ activeTxnClassifier) startupScanSignals {
+		startupCfg <- startupCapture{
+			source:  cfg.ScanSource,
+			auto:    cfg.ScanSourceAuto,
+			targets: append([]byte(nil), cfg.StartupProbeTargets...),
+		}
+		return startupScanSignals{}
+	}
+	startVaillantSemanticPollingFn = func(context.Context, ebusgateway.Config, *ebusgateway.Gateway, *graphql.LiveSemanticProvider, *graphql.BroadcastHub, <-chan struct{}) *vaillantSemanticPoller {
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	startHTTPServerFn = func(context.Context, ebusgateway.Config, *ebusgateway.Gateway, *graphql.Builder, *graphql.BroadcastHub, graphql.SemanticProvider, mcp.ScheduleWriter, mcp.ConfigWriter, *ebusgateway.BusObservabilityStore, *ebusgateway.ShadowCache) (*http.Server, mdns.Advertiser, error) {
+		cancel()
+		return nil, nil, nil
+	}
+
+	cfg := ebusgateway.DefaultConfig()
+	cfg.Transport = transport.NewLoopback()
+	cfg.TransportConfig.Protocol = ebusgateway.TransportENS
+	cfg.TransportConfig.Network = "tcp"
+	cfg.TransportConfig.Address = "192.0.2.10:9999"
+	cfg.BroadcastListen = false
+	cfg.ScanOnStart = true
+	cfg.ScanSource = 0xF0
+	cfg.ScanSourceAuto = false
+
+	done := make(chan error, 1)
+	go func() {
+		done <- run(ctx, cfg)
+	}()
+
+	select {
+	case got := <-startupCfg:
+		if got.source != 0xF0 {
+			t.Fatalf("startup source = 0x%02X; want configured source 0xF0", got.source)
+		}
+		if got.auto {
+			t.Fatal("startup source remained auto; want configured direct source")
+		}
+		wantTargets := []byte{defaultVaillantTarget}
+		if !reflect.DeepEqual(got.targets, wantTargets) {
+			t.Fatalf("startup probe targets = % X; want % X", got.targets, wantTargets)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("startup scan config was not observed")
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("run() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("run() did not exit after context cancellation")
+	}
+}
+
 func TestRun_DefersSemanticBootstrapUntilStartupConfirmationReadyOnPassiveObserveFirst(t *testing.T) {
 	origWireObserveFirstObserversFn := wireObserveFirstObserversFn
 	origStartDiscoveryScanLoopFn := startDiscoveryScanLoopFn

--- a/cmd/gateway/main_test.go
+++ b/cmd/gateway/main_test.go
@@ -502,7 +502,7 @@ func TestRun_DoesNotAttachPassiveShadowProducerWhenObserveFirstMasterDisabled(t 
 	}
 }
 
-func TestRun_ProxySingleENSAutoUsesSameSemanticSourceAsStartupConfirmation(t *testing.T) {
+func TestRun_ProxySingleENSAutoUsesDefaultSelectionBeforeProxyResolution(t *testing.T) {
 	origWireObserveFirstObserversFn := wireObserveFirstObserversFn
 	origStartDiscoveryScanLoopFn := startDiscoveryScanLoopFn
 	origStartVaillantSemanticPollingFn := startVaillantSemanticPollingFn
@@ -518,6 +518,7 @@ func TestRun_ProxySingleENSAutoUsesSameSemanticSourceAsStartupConfirmation(t *te
 	semanticAuto := make(chan bool, 1)
 	expectedStartupSource := make(chan byte, 1)
 	expectedStartupAuto := make(chan bool, 1)
+	startupTargets := make(chan []byte, 1)
 
 	wireObserveFirstObserversFn = func(*ebusgateway.Config) (*ebusgateway.BusObservabilityStore, *ebusgateway.ActivePassiveDeduplicator, error) {
 		return nil, nil, nil
@@ -526,6 +527,7 @@ func TestRun_ProxySingleENSAutoUsesSameSemanticSourceAsStartupConfirmation(t *te
 		resolved := resolveStartupScanSourceConfig(cfg)
 		expectedStartupSource <- resolved.ScanSource
 		expectedStartupAuto <- resolved.ScanSourceAuto
+		startupTargets <- append([]byte(nil), cfg.StartupProbeTargets...)
 		return startupScanSignals{}
 	}
 	startVaillantSemanticPollingFn = func(_ context.Context, cfg ebusgateway.Config, _ *ebusgateway.Gateway, _ *graphql.LiveSemanticProvider, _ *graphql.BroadcastHub, _ <-chan struct{}) *vaillantSemanticPoller {
@@ -556,14 +558,15 @@ func TestRun_ProxySingleENSAutoUsesSameSemanticSourceAsStartupConfirmation(t *te
 		done <- run(ctx, cfg)
 	}()
 
+	wantSource := byte(0x7F)
 	var gotSemanticSource byte
 	select {
 	case gotSemanticSource = <-semanticSource:
 	case <-time.After(2 * time.Second):
 		t.Fatal("semantic poller was not initialized")
 	}
-	if gotSemanticSource != proxyObserveFirstStartupSource {
-		t.Fatalf("semantic poller source = 0x%02X; want 0x%02X", gotSemanticSource, proxyObserveFirstStartupSource)
+	if gotSemanticSource != wantSource {
+		t.Fatalf("semantic poller source = 0x%02X; want default-selected source 0x%02X", gotSemanticSource, wantSource)
 	}
 
 	select {
@@ -591,6 +594,16 @@ func TestRun_ProxySingleENSAutoUsesSameSemanticSourceAsStartupConfirmation(t *te
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("startup confirmation auto flag was not observed")
+	}
+
+	select {
+	case got := <-startupTargets:
+		want := []byte{defaultVaillantTarget}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("startup probe targets = % X; want % X", got, want)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("startup probe targets were not observed")
 	}
 
 	select {

--- a/cmd/gateway/main_test.go
+++ b/cmd/gateway/main_test.go
@@ -111,7 +111,7 @@ func TestBindFlags_StartupProbeTargetsRejectInvalid(t *testing.T) {
 	}
 }
 
-func TestApplyTransportSourcePolicy_EbusdTCPAutoUsesEbusdSource(t *testing.T) {
+func TestApplyTransportSourcePolicy_EbusdTCPAutoPreservesAutoSource(t *testing.T) {
 	cfg := ebusgateway.DefaultConfig()
 	cfg.TransportConfig.Protocol = ebusgateway.TransportEbusdTCP
 	cfg.ScanSource = 0x00
@@ -119,8 +119,8 @@ func TestApplyTransportSourcePolicy_EbusdTCPAutoUsesEbusdSource(t *testing.T) {
 
 	applyTransportSourcePolicy(&cfg)
 
-	if cfg.ScanSource != 0x31 {
-		t.Fatalf("ScanSource = 0x%02x; want 0x31", cfg.ScanSource)
+	if cfg.ScanSource != 0x00 {
+		t.Fatalf("ScanSource = 0x%02x; want 0x00", cfg.ScanSource)
 	}
 }
 
@@ -137,7 +137,7 @@ func TestApplyTransportSourcePolicy_NonEbusdAutoRemainsDynamic(t *testing.T) {
 	}
 }
 
-func TestApplyTransportSourcePolicy_EbusdTCPDefaultF0PromotesToEbusdSource(t *testing.T) {
+func TestApplyTransportSourcePolicy_EbusdTCPConfiguredSourceIsPreserved(t *testing.T) {
 	cfg := ebusgateway.DefaultConfig()
 	cfg.TransportConfig.Protocol = ebusgateway.TransportEbusdTCP
 	cfg.ScanSource = 0xF0
@@ -145,8 +145,8 @@ func TestApplyTransportSourcePolicy_EbusdTCPDefaultF0PromotesToEbusdSource(t *te
 
 	applyTransportSourcePolicy(&cfg)
 
-	if cfg.ScanSource != 0x31 {
-		t.Fatalf("ScanSource = 0x%02x; want 0x31", cfg.ScanSource)
+	if cfg.ScanSource != 0xF0 {
+		t.Fatalf("ScanSource = 0x%02x; want 0xF0", cfg.ScanSource)
 	}
 }
 
@@ -502,6 +502,7 @@ func TestRun_ProxySingleENSAutoUsesSameSemanticSourceAsStartupConfirmation(t *te
 
 	cfg := ebusgateway.DefaultConfig()
 	cfg.Transport = transport.NewLoopback()
+	cfg.TransportConfig.Protocol = ebusgateway.TransportEbusdTCP
 	cfg.ScanOnStart = true
 	cfg.BroadcastListen = false
 	cfg.ScanSource = 0x00
@@ -708,6 +709,7 @@ func TestRun_DoesNotDeferSemanticBootstrapOutsidePassiveObserveFirst(t *testing.
 
 	cfg := ebusgateway.DefaultConfig()
 	cfg.Transport = transport.NewLoopback()
+	cfg.TransportConfig.Protocol = ebusgateway.TransportEbusdTCP
 	cfg.ScanOnStart = true
 	cfg.BroadcastListen = false
 

--- a/cmd/gateway/main_test.go
+++ b/cmd/gateway/main_test.go
@@ -84,6 +84,33 @@ func TestBindFlags_SourceAddrExplicitDisablesAuto(t *testing.T) {
 	}
 }
 
+func TestBindFlags_StartupProbeTargets(t *testing.T) {
+	cfg := ebusgateway.DefaultConfig()
+	fs := flag.NewFlagSet("gateway-test", flag.ContinueOnError)
+	bindFlags(fs, &cfg)
+	if err := fs.Parse([]string{"-startup-probe-targets", "0x08,0x15 0x08"}); err != nil {
+		t.Fatalf("parse startup-probe-targets: %v", err)
+	}
+	want := []byte{0x08, 0x15}
+	if len(cfg.StartupProbeTargets) != len(want) {
+		t.Fatalf("StartupProbeTargets len = %d; want %d (% X)", len(cfg.StartupProbeTargets), len(want), cfg.StartupProbeTargets)
+	}
+	for i := range want {
+		if cfg.StartupProbeTargets[i] != want[i] {
+			t.Fatalf("StartupProbeTargets = % X; want % X", cfg.StartupProbeTargets, want)
+		}
+	}
+}
+
+func TestBindFlags_StartupProbeTargetsRejectInvalid(t *testing.T) {
+	cfg := ebusgateway.DefaultConfig()
+	fs := flag.NewFlagSet("gateway-test", flag.ContinueOnError)
+	bindFlags(fs, &cfg)
+	if err := fs.Parse([]string{"-startup-probe-targets", "0xFE"}); err == nil {
+		t.Fatal("parse invalid startup-probe-targets error = nil; want error")
+	}
+}
+
 func TestApplyTransportSourcePolicy_EbusdTCPAutoUsesEbusdSource(t *testing.T) {
 	cfg := ebusgateway.DefaultConfig()
 	cfg.TransportConfig.Protocol = ebusgateway.TransportEbusdTCP
@@ -763,7 +790,7 @@ func TestRun_WaitsForStartupScanFirstPassBeforePassiveObserveFirst(t *testing.T)
 	select {
 	case <-passiveStarted:
 	case <-time.After(2 * time.Second):
-		t.Fatal("passive reconstructor did not start before startup scan on join-capable transport")
+		t.Fatal("passive reconstructor did not start before startup scan on source-selection-capable transport")
 	}
 
 	select {

--- a/cmd/gateway/main_test.go
+++ b/cmd/gateway/main_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"net/http"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -590,6 +591,71 @@ func TestRun_ProxySingleENSAutoUsesSameSemanticSourceAsStartupConfirmation(t *te
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("startup confirmation auto flag was not observed")
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("run() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("run() did not exit after context cancellation")
+	}
+}
+
+func TestRun_DefaultSourceSelectionSeedsStartupProbeTargets(t *testing.T) {
+	origWireObserveFirstObserversFn := wireObserveFirstObserversFn
+	origStartDiscoveryScanLoopFn := startDiscoveryScanLoopFn
+	origStartVaillantSemanticPollingFn := startVaillantSemanticPollingFn
+	origStartHTTPServerFn := startHTTPServerFn
+	t.Cleanup(func() {
+		wireObserveFirstObserversFn = origWireObserveFirstObserversFn
+		startDiscoveryScanLoopFn = origStartDiscoveryScanLoopFn
+		startVaillantSemanticPollingFn = origStartVaillantSemanticPollingFn
+		startHTTPServerFn = origStartHTTPServerFn
+	})
+
+	startupTargets := make(chan []byte, 1)
+	wireObserveFirstObserversFn = func(*ebusgateway.Config) (*ebusgateway.BusObservabilityStore, *ebusgateway.ActivePassiveDeduplicator, error) {
+		return nil, nil, nil
+	}
+	startDiscoveryScanLoopFn = func(_ context.Context, cfg ebusgateway.Config, _ *ebusgateway.Gateway, _ *graphql.Builder, _ activeTxnClassifier) startupScanSignals {
+		startupTargets <- append([]byte(nil), cfg.StartupProbeTargets...)
+		return startupScanSignals{}
+	}
+	startVaillantSemanticPollingFn = func(context.Context, ebusgateway.Config, *ebusgateway.Gateway, *graphql.LiveSemanticProvider, *graphql.BroadcastHub, <-chan struct{}) *vaillantSemanticPoller {
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	startHTTPServerFn = func(context.Context, ebusgateway.Config, *ebusgateway.Gateway, *graphql.Builder, *graphql.BroadcastHub, graphql.SemanticProvider, mcp.ScheduleWriter, mcp.ConfigWriter, *ebusgateway.BusObservabilityStore, *ebusgateway.ShadowCache) (*http.Server, mdns.Advertiser, error) {
+		cancel()
+		return nil, nil, nil
+	}
+
+	cfg := ebusgateway.DefaultConfig()
+	cfg.Transport = transport.NewLoopback()
+	cfg.TransportConfig.Protocol = ebusgateway.TransportENS
+	cfg.TransportConfig.Network = "tcp"
+	cfg.TransportConfig.Address = "192.0.2.10:9999"
+	cfg.BroadcastListen = false
+	cfg.ScanOnStart = true
+	cfg.ScanSource = 0x00
+	cfg.ScanSourceAuto = true
+
+	done := make(chan error, 1)
+	go func() {
+		done <- run(ctx, cfg)
+	}()
+
+	select {
+	case got := <-startupTargets:
+		want := []byte{defaultVaillantTarget}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("startup probe targets = % X; want % X", got, want)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("startup scan config was not observed")
 	}
 
 	select {

--- a/cmd/gateway/main_test.go
+++ b/cmd/gateway/main_test.go
@@ -150,6 +150,33 @@ func TestApplyTransportSourcePolicy_EbusdTCPConfiguredSourceIsPreserved(t *testi
 	}
 }
 
+func TestAdmittedMutationSourceForGateway_EbusdTCPAutoUsesDefaultStaticSource(t *testing.T) {
+	cfg := ebusgateway.DefaultConfig()
+	cfg.TransportConfig.Protocol = ebusgateway.TransportEbusdTCP
+	cfg.ScanSource = 0x00
+	cfg.ScanSourceAuto = true
+
+	source, admitted := admittedMutationSourceForGateway(cfg, ebusgateway.TransportAdmissionStaticFallback, false)
+	if !admitted {
+		t.Fatal("admitted = false; want true for ebusd-tcp auto static fallback")
+	}
+	if want := ebusgateway.DefaultConfig().ScanSource; source != want {
+		t.Fatalf("admitted source = 0x%02X; want default static source 0x%02X", source, want)
+	}
+}
+
+func TestAdmittedMutationSourceForGateway_SourceSelectionWithoutOverrideFailsClosed(t *testing.T) {
+	cfg := ebusgateway.DefaultConfig()
+	cfg.TransportConfig.Protocol = ebusgateway.TransportENS
+	cfg.ScanSource = 0x00
+	cfg.ScanSourceAuto = true
+
+	source, admitted := admittedMutationSourceForGateway(cfg, ebusgateway.TransportAdmissionSourceSelectionCapable, false)
+	if admitted || source != 0 {
+		t.Fatalf("admitted source = 0x%02X admitted=%v; want fail-closed before source selection", source, admitted)
+	}
+}
+
 func TestWireObserveFirstObserversWiresDedupSnapshotterIntoObservabilityStore(t *testing.T) {
 	cfg := ebusgateway.DefaultConfig()
 	cfg.BroadcastListen = true
@@ -666,6 +693,97 @@ func TestRun_DefersSemanticBootstrapUntilStartupConfirmationReadyOnPassiveObserv
 
 	cancel()
 
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("run() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("run() did not exit after context cancellation")
+	}
+}
+
+func TestRun_OverrideClosesSemanticBarrierOnAdmissionFailure(t *testing.T) {
+	origWireObserveFirstObserversFn := wireObserveFirstObserversFn
+	origStartDiscoveryScanLoopFn := startDiscoveryScanLoopFn
+	origStartVaillantSemanticPollingFn := startVaillantSemanticPollingFn
+	origStartHTTPServerFn := startHTTPServerFn
+	t.Cleanup(func() {
+		wireObserveFirstObserversFn = origWireObserveFirstObserversFn
+		startDiscoveryScanLoopFn = origStartDiscoveryScanLoopFn
+		startVaillantSemanticPollingFn = origStartVaillantSemanticPollingFn
+		startHTTPServerFn = origStartHTTPServerFn
+	})
+
+	admissionFailed := make(chan struct{})
+	barrierObserved := make(chan bool, 1)
+	semanticStarted := make(chan struct{}, 1)
+
+	wireObserveFirstObserversFn = func(*ebusgateway.Config) (*ebusgateway.BusObservabilityStore, *ebusgateway.ActivePassiveDeduplicator, error) {
+		return nil, nil, nil
+	}
+	startDiscoveryScanLoopFn = func(context.Context, ebusgateway.Config, *ebusgateway.Gateway, *graphql.Builder, activeTxnClassifier) startupScanSignals {
+		return startupScanSignals{
+			firstPassDone:          make(chan struct{}),
+			semanticBootstrapReady: make(chan struct{}),
+			admissionFailed:        admissionFailed,
+		}
+	}
+	startVaillantSemanticPollingFn = func(ctx context.Context, _ ebusgateway.Config, _ *ebusgateway.Gateway, _ *graphql.LiveSemanticProvider, _ *graphql.BroadcastHub, startupBarrier <-chan struct{}) *vaillantSemanticPoller {
+		barrierObserved <- startupBarrier != nil
+		go func() {
+			if startupBarrier == nil {
+				return
+			}
+			select {
+			case <-ctx.Done():
+			case <-startupBarrier:
+				select {
+				case semanticStarted <- struct{}{}:
+				default:
+				}
+			}
+		}()
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	startHTTPServerFn = func(context.Context, ebusgateway.Config, *ebusgateway.Gateway, *graphql.Builder, *graphql.BroadcastHub, graphql.SemanticProvider, mcp.ScheduleWriter, mcp.ConfigWriter, *ebusgateway.BusObservabilityStore, *ebusgateway.ShadowCache) (*http.Server, mdns.Advertiser, error) {
+		return nil, nil, nil
+	}
+
+	overrideSource := uint8(0x7F)
+	cfg := ebusgateway.DefaultConfig()
+	cfg.Transport = transport.NewLoopback()
+	cfg.PassiveTransport = transport.NewLoopback()
+	cfg.BroadcastListen = true
+	cfg.ScanOnStart = true
+	cfg.StartupSource.Source = &overrideSource
+
+	done := make(chan error, 1)
+	go func() {
+		done <- run(ctx, cfg)
+	}()
+
+	select {
+	case observed := <-barrierObserved:
+		if !observed {
+			t.Fatal("semantic startup barrier missing on passive observe-first override path")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("semantic poller was not initialized")
+	}
+
+	close(admissionFailed)
+
+	select {
+	case <-semanticStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("semantic bootstrap did not start after override admission failure")
+	}
+
+	cancel()
 	select {
 	case err := <-done:
 		if err != nil {

--- a/cmd/gateway/main_test.go
+++ b/cmd/gateway/main_test.go
@@ -85,6 +85,18 @@ func TestBindFlags_SourceAddrExplicitDisablesAuto(t *testing.T) {
 	}
 }
 
+func TestBindFlags_StartupSourceOverrideRejectsZero(t *testing.T) {
+	cfg := ebusgateway.DefaultConfig()
+	fs := flag.NewFlagSet("gateway-test", flag.ContinueOnError)
+	bindFlags(fs, &cfg)
+	if err := fs.Parse([]string{"-startup-source-override", "0x00"}); err == nil {
+		t.Fatal("parse startup-source-override 0x00 succeeded; want error")
+	}
+	if cfg.StartupSource.Source != nil {
+		t.Fatalf("StartupSource.Source = %v; want nil after rejected zero override", *cfg.StartupSource.Source)
+	}
+}
+
 func TestBindFlags_StartupProbeTargets(t *testing.T) {
 	cfg := ebusgateway.DefaultConfig()
 	fs := flag.NewFlagSet("gateway-test", flag.ContinueOnError)

--- a/cmd/gateway/semantic_provider.go
+++ b/cmd/gateway/semantic_provider.go
@@ -473,6 +473,115 @@ func cloneFloatPtr(value *float64) *float64 {
 	return &cp
 }
 
+const semanticWriterSourceNotAdmittedError = "source selection not active"
+
+type admittedSourceProvider func() (byte, bool)
+
+func admittedSourceActive(provider admittedSourceProvider) bool {
+	if provider == nil {
+		return false
+	}
+	source, admitted := provider()
+	return admitted && source != 0
+}
+
+type admittedGraphQLSemanticWriter struct {
+	boiler   graphql.BoilerConfigWriter
+	system   graphql.SystemConfigWriter
+	schedule graphql.ScheduleWriter
+	admitted admittedSourceProvider
+}
+
+func (writer admittedGraphQLSemanticWriter) SetBoilerConfig(ctx context.Context, fieldName string, rawValue string) graphql.BoilerConfigMutationResult {
+	if !admittedSourceActive(writer.admitted) {
+		return graphql.BoilerConfigMutationResult{Success: false, Error: semanticWriterSourceNotAdmittedError}
+	}
+	if writer.boiler == nil {
+		return graphql.BoilerConfigMutationResult{Success: false, Error: "boiler config writer unavailable"}
+	}
+	return writer.boiler.SetBoilerConfig(ctx, fieldName, rawValue)
+}
+
+func (writer admittedGraphQLSemanticWriter) SetSystemConfig(ctx context.Context, fieldName string, rawValue string) graphql.ConfigMutationResult {
+	if !admittedSourceActive(writer.admitted) {
+		return graphql.ConfigMutationResult{Success: false, Error: semanticWriterSourceNotAdmittedError}
+	}
+	if writer.system == nil {
+		return graphql.ConfigMutationResult{Success: false, Error: "system config writer unavailable"}
+	}
+	return writer.system.SetSystemConfig(ctx, fieldName, rawValue)
+}
+
+func (writer admittedGraphQLSemanticWriter) SetZoneTimeProgram(ctx context.Context, zone int, weekday int, slots []mcp.TimeProgramSlot) (*mcp.TimeProgramWriteResult, error) {
+	if !admittedSourceActive(writer.admitted) {
+		return &mcp.TimeProgramWriteResult{Success: false, Error: semanticWriterSourceNotAdmittedError}, nil
+	}
+	if writer.schedule == nil {
+		return &mcp.TimeProgramWriteResult{Success: false, Error: "schedule writer unavailable"}, nil
+	}
+	return writer.schedule.SetZoneTimeProgram(ctx, zone, weekday, slots)
+}
+
+func (writer admittedGraphQLSemanticWriter) SetDhwTimeProgram(ctx context.Context, weekday int, slots []mcp.TimeProgramSlot) (*mcp.TimeProgramWriteResult, error) {
+	if !admittedSourceActive(writer.admitted) {
+		return &mcp.TimeProgramWriteResult{Success: false, Error: semanticWriterSourceNotAdmittedError}, nil
+	}
+	if writer.schedule == nil {
+		return &mcp.TimeProgramWriteResult{Success: false, Error: "schedule writer unavailable"}, nil
+	}
+	return writer.schedule.SetDhwTimeProgram(ctx, weekday, slots)
+}
+
+type admittedMCPConfigWriter struct {
+	writer   mcp.ConfigWriter
+	admitted admittedSourceProvider
+}
+
+func (writer admittedMCPConfigWriter) SetSystemConfig(ctx context.Context, field string, value string) mcp.ConfigSetResult {
+	if !admittedSourceActive(writer.admitted) {
+		return mcp.ConfigSetResult{Success: false, Error: semanticWriterSourceNotAdmittedError}
+	}
+	if writer.writer == nil {
+		return mcp.ConfigSetResult{Success: false, Error: "system config writer unavailable"}
+	}
+	return writer.writer.SetSystemConfig(ctx, field, value)
+}
+
+func (writer admittedMCPConfigWriter) SetBoilerConfig(ctx context.Context, field string, value string) mcp.ConfigSetResult {
+	if !admittedSourceActive(writer.admitted) {
+		return mcp.ConfigSetResult{Success: false, Error: semanticWriterSourceNotAdmittedError}
+	}
+	if writer.writer == nil {
+		return mcp.ConfigSetResult{Success: false, Error: "boiler config writer unavailable"}
+	}
+	return writer.writer.SetBoilerConfig(ctx, field, value)
+}
+
+type admittedMCPScheduleWriter struct {
+	writer   mcp.ScheduleWriter
+	admitted admittedSourceProvider
+}
+
+func (writer admittedMCPScheduleWriter) SetZoneTimeProgram(ctx context.Context, zone int, weekday int, slots []mcp.TimeProgramSlot) (*mcp.TimeProgramWriteResult, error) {
+	if !admittedSourceActive(writer.admitted) {
+		return &mcp.TimeProgramWriteResult{Success: false, Error: semanticWriterSourceNotAdmittedError}, nil
+	}
+	if writer.writer == nil {
+		return &mcp.TimeProgramWriteResult{Success: false, Error: "schedule writer unavailable"}, nil
+	}
+	return writer.writer.SetZoneTimeProgram(ctx, zone, weekday, slots)
+}
+
+func (writer admittedMCPScheduleWriter) SetDhwTimeProgram(ctx context.Context, weekday int, slots []mcp.TimeProgramSlot) (*mcp.TimeProgramWriteResult, error) {
+	if !admittedSourceActive(writer.admitted) {
+		return &mcp.TimeProgramWriteResult{Success: false, Error: semanticWriterSourceNotAdmittedError}, nil
+	}
+	if writer.writer == nil {
+		return &mcp.TimeProgramWriteResult{Success: false, Error: "schedule writer unavailable"}, nil
+	}
+	return writer.writer.SetDhwTimeProgram(ctx, weekday, slots)
+}
+
 // mcpConfigWriterAdapter adapts the semantic poller's config write methods
 // to the MCP ConfigWriter interface.
 type mcpConfigWriterAdapter struct {

--- a/cmd/gateway/semantic_provider_test.go
+++ b/cmd/gateway/semantic_provider_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Project-Helianthus/helianthus-ebusgateway/graphql"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
 )
 
 func TestSemanticEnergyAdaptersExposeNeverSeenShapeWithoutPoints(t *testing.T) {
@@ -41,4 +43,101 @@ func TestSemanticEnergyAdaptersExposeNeverSeenShapeWithoutPoints(t *testing.T) {
 	if got := portalTotals.Gas.DHW.TodayMeta.Provenance; got != "none" {
 		t.Fatalf("portal gas.dhw.today_meta.provenance = %q; want none", got)
 	}
+}
+
+type recordingSemanticWriter struct {
+	calls int
+}
+
+func (writer *recordingSemanticWriter) SetBoilerConfig(context.Context, string, string) graphql.BoilerConfigMutationResult {
+	writer.calls++
+	return graphql.BoilerConfigMutationResult{Success: true}
+}
+
+func (writer *recordingSemanticWriter) SetSystemConfig(context.Context, string, string) graphql.ConfigMutationResult {
+	writer.calls++
+	return graphql.ConfigMutationResult{Success: true}
+}
+
+func (writer *recordingSemanticWriter) SetZoneTimeProgram(context.Context, int, int, []mcp.TimeProgramSlot) (*mcp.TimeProgramWriteResult, error) {
+	writer.calls++
+	return &mcp.TimeProgramWriteResult{Success: true}, nil
+}
+
+func (writer *recordingSemanticWriter) SetDhwTimeProgram(context.Context, int, []mcp.TimeProgramSlot) (*mcp.TimeProgramWriteResult, error) {
+	writer.calls++
+	return &mcp.TimeProgramWriteResult{Success: true}, nil
+}
+
+func TestAdmittedSemanticWritersBlockUntilSourceAdmitted(t *testing.T) {
+	admitted := false
+	provider := func() (byte, bool) {
+		if !admitted {
+			return 0, false
+		}
+		return 0x7F, true
+	}
+	underlying := &recordingSemanticWriter{}
+
+	graphWriter := admittedGraphQLSemanticWriter{
+		boiler:   underlying,
+		system:   underlying,
+		schedule: underlying,
+		admitted: provider,
+	}
+	mcpConfigWriter := admittedMCPConfigWriter{
+		writer:   admittedMCPConfigAdapter{writer: underlying},
+		admitted: provider,
+	}
+	mcpScheduleWriter := admittedMCPScheduleWriter{
+		writer:   underlying,
+		admitted: provider,
+	}
+
+	if result := graphWriter.SetSystemConfig(context.Background(), "x", "1"); result.Success || result.Error != semanticWriterSourceNotAdmittedError {
+		t.Fatalf("graph system pre-admission = %+v; want source-not-admitted error", result)
+	}
+	if result := graphWriter.SetBoilerConfig(context.Background(), "x", "1"); result.Success || result.Error != semanticWriterSourceNotAdmittedError {
+		t.Fatalf("graph boiler pre-admission = %+v; want source-not-admitted error", result)
+	}
+	if result, err := graphWriter.SetZoneTimeProgram(context.Background(), 0, 0, []mcp.TimeProgramSlot{{StartHour: 6, EndHour: 7}}); err != nil || result.Success || result.Error != semanticWriterSourceNotAdmittedError {
+		t.Fatalf("graph schedule pre-admission = %+v err=%v; want source-not-admitted error", result, err)
+	}
+	if result := mcpConfigWriter.SetSystemConfig(context.Background(), "x", "1"); result.Success || result.Error != semanticWriterSourceNotAdmittedError {
+		t.Fatalf("mcp config pre-admission = %+v; want source-not-admitted error", result)
+	}
+	if result, err := mcpScheduleWriter.SetDhwTimeProgram(context.Background(), 0, []mcp.TimeProgramSlot{{StartHour: 6, EndHour: 7}}); err != nil || result.Success || result.Error != semanticWriterSourceNotAdmittedError {
+		t.Fatalf("mcp schedule pre-admission = %+v err=%v; want source-not-admitted error", result, err)
+	}
+	if underlying.calls != 0 {
+		t.Fatalf("underlying calls before admission = %d; want 0", underlying.calls)
+	}
+
+	admitted = true
+	if result := graphWriter.SetSystemConfig(context.Background(), "x", "1"); !result.Success {
+		t.Fatalf("graph system after admission = %+v; want success", result)
+	}
+	if result := mcpConfigWriter.SetBoilerConfig(context.Background(), "x", "1"); !result.Success {
+		t.Fatalf("mcp boiler after admission = %+v; want success", result)
+	}
+	if result, err := mcpScheduleWriter.SetZoneTimeProgram(context.Background(), 0, 0, []mcp.TimeProgramSlot{{StartHour: 6, EndHour: 7}}); err != nil || !result.Success {
+		t.Fatalf("mcp schedule after admission = %+v err=%v; want success", result, err)
+	}
+	if underlying.calls != 3 {
+		t.Fatalf("underlying calls after admission = %d; want 3", underlying.calls)
+	}
+}
+
+type admittedMCPConfigAdapter struct {
+	writer *recordingSemanticWriter
+}
+
+func (adapter admittedMCPConfigAdapter) SetSystemConfig(ctx context.Context, field string, value string) mcp.ConfigSetResult {
+	result := adapter.writer.SetSystemConfig(ctx, field, value)
+	return mcp.ConfigSetResult{Success: result.Success, Error: result.Error}
+}
+
+func (adapter admittedMCPConfigAdapter) SetBoilerConfig(ctx context.Context, field string, value string) mcp.ConfigSetResult {
+	result := adapter.writer.SetBoilerConfig(ctx, field, value)
+	return mcp.ConfigSetResult{Success: result.Success, Error: result.Error}
 }

--- a/cmd/gateway/startup_order.go
+++ b/cmd/gateway/startup_order.go
@@ -2,9 +2,9 @@ package main
 
 import "github.com/Project-Helianthus/helianthus-ebusgateway"
 
-func shouldCloseSemanticBarrier(admissionPath ebusgateway.TransportAdmissionPath, overrideSet bool, joinResultNotNil bool) bool {
+func shouldCloseSemanticBarrier(admissionPath ebusgateway.TransportAdmissionPath, overrideSet bool, sourceSelectionReady bool) bool {
 	if admissionPath != ebusgateway.TransportAdmissionSourceSelectionCapable {
 		return true
 	}
-	return overrideSet || joinResultNotNil
+	return overrideSet || sourceSelectionReady
 }

--- a/cmd/gateway/startup_order.go
+++ b/cmd/gateway/startup_order.go
@@ -3,7 +3,7 @@ package main
 import "github.com/Project-Helianthus/helianthus-ebusgateway"
 
 func shouldCloseSemanticBarrier(admissionPath ebusgateway.TransportAdmissionPath, overrideSet bool, joinResultNotNil bool) bool {
-	if admissionPath != ebusgateway.TransportAdmissionJoinCapable {
+	if admissionPath != ebusgateway.TransportAdmissionSourceSelectionCapable {
 		return true
 	}
 	return overrideSet || joinResultNotNil

--- a/cmd/gateway/startup_order_test.go
+++ b/cmd/gateway/startup_order_test.go
@@ -14,10 +14,10 @@ func TestShouldCloseSemanticBarrier(t *testing.T) {
 		joinResultNotNil bool
 		wantClose        bool
 	}{
-		{"join-capable + joiner success, override unset -> close", ebusgateway.TransportAdmissionJoinCapable, false, true, true},
-		{"join-capable + no joiner result, override unset -> keep open (DEGRADED)", ebusgateway.TransportAdmissionJoinCapable, false, false, false},
-		{"join-capable + override set (any joiner state) -> close", ebusgateway.TransportAdmissionJoinCapable, true, false, true},
-		{"join-capable + override set + joiner result -> close", ebusgateway.TransportAdmissionJoinCapable, true, true, true},
+		{"source-selection-capable + source-address selector success, override unset -> close", ebusgateway.TransportAdmissionSourceSelectionCapable, false, true, true},
+		{"source-selection-capable + no source-address selector result, override unset -> keep open (DEGRADED)", ebusgateway.TransportAdmissionSourceSelectionCapable, false, false, false},
+		{"source-selection-capable + override set (any source-address selector state) -> close", ebusgateway.TransportAdmissionSourceSelectionCapable, true, false, true},
+		{"source-selection-capable + override set + source-address selector result -> close", ebusgateway.TransportAdmissionSourceSelectionCapable, true, true, true},
 		{"static-fallback (ebusd-tcp) -> close (legacy behavior)", ebusgateway.TransportAdmissionStaticFallback, false, false, true},
 	}
 

--- a/cmd/gateway/startup_order_test.go
+++ b/cmd/gateway/startup_order_test.go
@@ -8,11 +8,11 @@ import (
 
 func TestShouldCloseSemanticBarrier(t *testing.T) {
 	cases := []struct {
-		name             string
-		admissionPath    ebusgateway.TransportAdmissionPath
-		overrideSet      bool
-		joinResultNotNil bool
-		wantClose        bool
+		name                 string
+		admissionPath        ebusgateway.TransportAdmissionPath
+		overrideSet          bool
+		sourceSelectionReady bool
+		wantClose            bool
 	}{
 		{"source-selection-capable + source-address selector success, override unset -> close", ebusgateway.TransportAdmissionSourceSelectionCapable, false, true, true},
 		{"source-selection-capable + no source-address selector result, override unset -> keep open (DEGRADED)", ebusgateway.TransportAdmissionSourceSelectionCapable, false, false, false},
@@ -23,7 +23,7 @@ func TestShouldCloseSemanticBarrier(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := shouldCloseSemanticBarrier(tc.admissionPath, tc.overrideSet, tc.joinResultNotNil)
+			got := shouldCloseSemanticBarrier(tc.admissionPath, tc.overrideSet, tc.sourceSelectionReady)
 			if got != tc.wantClose {
 				t.Errorf("got %v, want %v", got, tc.wantClose)
 			}

--- a/cmd/gateway/startup_scan.go
+++ b/cmd/gateway/startup_scan.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -201,8 +202,8 @@ func classifyScanErr(err error) string {
 }
 
 var (
-	semanticBusCollisionsTotal  = expvar.NewInt("semantic_bus_collisions_total")
-	registryScanFn              = registry.Scan
+	semanticBusCollisionsTotal = expvar.NewInt("semantic_bus_collisions_total")
+	registryScanFn             = registry.Scan
 
 	// evidenceHasVaillantRootFn reports whether the registry contains at
 	// least one Vaillant root candidate (manufacturer 0xB5 device on a
@@ -210,7 +211,7 @@ var (
 	// a full-range retry under the AD05 diagnostic flag. Tests override
 	// this to skip the AD05 guard for transport-agnostic scan-loop tests.
 	// Resolves cruise-run #20 M6 reviewer-flagged finding (#2).
-	evidenceHasVaillantRootFn = defaultEvidenceHasVaillantRoot
+	evidenceHasVaillantRootFn   = defaultEvidenceHasVaillantRoot
 	registryScanDirectedFn      = registry.ScanDirected
 	ebusdScanTargetCandidatesFn = ebusdScanTargetCandidates
 	ebusdScanResultTargetsFn    = ebusdScanResultTargets
@@ -242,7 +243,7 @@ func defaultEvidenceHasVaillantRoot(reg *registry.DeviceRegistry) bool {
 }
 
 func startupScanWithFullRangeGuard(ctx context.Context, bus registry.ScanBus, reg *registry.DeviceRegistry, source byte, targets []byte, admissionPath ebusgateway.TransportAdmissionPath, diagnosticFlag bool, evidenceHasVaillantRoot bool) ([]registry.DeviceEntry, error) {
-	if admissionPath == ebusgateway.TransportAdmissionJoinCapable {
+	if admissionPath == ebusgateway.TransportAdmissionSourceSelectionCapable {
 		if len(targets) == 0 {
 			if !diagnosticFlag {
 				return nil, fmt.Errorf("full-range retry: disabled by default on non-ebusd-tcp; set --diagnostic-full-range-retry to enable after at least one Vaillant root candidate is observed (AD05)")
@@ -438,7 +439,7 @@ func startDiscoveryScanLoopWithClassifier(ctx context.Context, cfg ebusgateway.C
 	startupCfg := resolveStartupScanSourceConfig(cfg)
 	admissionPath, adapterDirectSpecialCased := ebusgateway.ResolveAdmissionPath(cfg.TransportConfig.Protocol)
 	if adapterDirectSpecialCased {
-		log.Printf("startup scan: adapter-direct multiplexer detected; treating as join-capable (underlying transport is always ENH/ENS)")
+		log.Printf("startup scan: adapter-direct multiplexer detected; treating as source-selection-capable (underlying transport is always ENH/ENS)")
 	}
 	loopExitFn := startupScanLoopExitFn
 	targetCandidatesFn := ebusdScanTargetCandidatesFn
@@ -479,8 +480,8 @@ func startDiscoveryScanLoopWithClassifier(ctx context.Context, cfg ebusgateway.C
 				source:     startupCfg.ScanSource,
 				classifier: classifier,
 			}
-			targets := ([]byte)(nil)
-			targetLabel := ""
+			targets := startupProbeTargets(startupCfg)
+			targetLabel := "startup evidence"
 			var targetConfig *ebusgateway.TransportConfig
 			retryingFullRange := forceFullRangeNextPass
 			forceFullRangeNextPass = false
@@ -491,7 +492,7 @@ func startDiscoveryScanLoopWithClassifier(ctx context.Context, cfg ebusgateway.C
 					targetConfig = &candidateCopy
 				}
 				log.Printf("startup scan: retrying with full target range after partial ebusd inventory")
-			} else {
+			} else if len(targets) == 0 {
 				for _, candidate := range candidates {
 					scanTargets, err := resultTargetsFn(scanCtx, candidate)
 					if err != nil || len(scanTargets) == 0 {
@@ -1023,6 +1024,34 @@ func resolveStartupScanSourceConfig(cfg ebusgateway.Config) ebusgateway.Config {
 	return cfg
 }
 
+func startupProbeTargetsFromSelection(selection protocol.SourceAddressSelection) []byte {
+	return sanitizeStartupProbeTargets(selection.Metrics.ObservedProbableTargets, selection.Source)
+}
+
+func startupProbeTargets(cfg ebusgateway.Config) []byte {
+	return sanitizeStartupProbeTargets(cfg.StartupProbeTargets, cfg.ScanSource)
+}
+
+func sanitizeStartupProbeTargets(candidates []byte, source byte) []byte {
+	if len(candidates) == 0 {
+		return nil
+	}
+	seen := make(map[byte]struct{}, len(candidates))
+	targets := make([]byte, 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate == source || candidate < 0x03 || candidate >= 0xFE || candidate == 0xAA {
+			continue
+		}
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		targets = append(targets, candidate)
+	}
+	sort.Slice(targets, func(i, j int) bool { return targets[i] < targets[j] })
+	return targets
+}
+
 func countRegistryDevices(reg *registry.DeviceRegistry) int {
 	if reg == nil {
 		return 0
@@ -1407,7 +1436,7 @@ func runBackgroundFullScan(ctx context.Context, cfg ebusgateway.Config, gateway 
 	}
 	admissionPath, adapterDirectSpecialCased := ebusgateway.ResolveAdmissionPath(cfg.TransportConfig.Protocol)
 	if adapterDirectSpecialCased {
-		log.Printf("background scan: adapter-direct multiplexer detected; treating as join-capable")
+		log.Printf("background scan: adapter-direct multiplexer detected; treating as source-selection-capable")
 	}
 
 	beforeTotal := countRegistryDevices(gateway.Registry)

--- a/cmd/gateway/startup_scan.go
+++ b/cmd/gateway/startup_scan.go
@@ -1075,6 +1075,14 @@ func startupProbeTargetsFromSelection(selection protocol.SourceAddressSelection)
 	return sanitizeStartupProbeTargets(selection.Metrics.ObservedProbableTargets, selection.Source, selection.Companion)
 }
 
+func startupProbeTargetsForSelection(selection protocol.SourceAddressSelection) []byte {
+	targets := startupProbeTargetsFromSelection(selection)
+	if len(targets) > 0 {
+		return targets
+	}
+	return sanitizeStartupProbeTargets([]byte{defaultVaillantTarget}, selection.Source, selection.Companion)
+}
+
 func startupProbeTargets(cfg ebusgateway.Config) []byte {
 	return sanitizeStartupProbeTargets(cfg.StartupProbeTargets, cfg.ScanSource, cfg.StartupCompanionTarget)
 }

--- a/cmd/gateway/startup_scan.go
+++ b/cmd/gateway/startup_scan.go
@@ -131,6 +131,8 @@ func hexN(b []byte, n int) string {
 type startupScanSignals struct {
 	firstPassDone          <-chan struct{}
 	semanticBootstrapReady <-chan struct{}
+	activeProbePassed      <-chan struct{}
+	admissionFailed        <-chan struct{}
 }
 
 type ebusdScanResultRow struct {
@@ -245,17 +247,18 @@ func defaultEvidenceHasVaillantRoot(reg *registry.DeviceRegistry) bool {
 func startupScanWithFullRangeGuard(ctx context.Context, bus registry.ScanBus, reg *registry.DeviceRegistry, source byte, targets []byte, admissionPath ebusgateway.TransportAdmissionPath, diagnosticFlag bool, evidenceHasVaillantRoot bool) ([]registry.DeviceEntry, error) {
 	if admissionPath == ebusgateway.TransportAdmissionSourceSelectionCapable {
 		if len(targets) == 0 {
-			if !diagnosticFlag {
-				return nil, fmt.Errorf("full-range retry: disabled by default on non-ebusd-tcp; set --diagnostic-full-range-retry to enable after at least one Vaillant root candidate is observed (AD05)")
-			}
-			if !evidenceHasVaillantRoot {
-				return nil, fmt.Errorf("full-range retry: diagnostic flag set but evidence buffer has no Vaillant root candidate yet (AD05)")
-			}
+			_ = diagnosticFlag
+			_ = evidenceHasVaillantRoot
+			return nil, fmt.Errorf("source selection: active probe requires explicit bounded targets")
 		} else {
 			return registryScanDirectedFn(ctx, bus, reg, source, targets)
 		}
 	}
 	return registryScanFn(ctx, bus, reg, source, targets)
+}
+
+func isBoundedTargetsRequiredError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "active probe requires explicit bounded targets")
 }
 
 const proxyObserveFirstStartupSource byte = 0xF7
@@ -423,13 +426,36 @@ func startDiscoveryScanLoopWithClassifier(ctx context.Context, cfg ebusgateway.C
 			close(semanticBootstrapReady)
 		})
 	}
+	activeProbePassed := make(chan struct{})
+	var activeProbePassedOnce sync.Once
+	signalActiveProbePassed := func() {
+		activeProbePassedOnce.Do(func() {
+			close(activeProbePassed)
+		})
+	}
+	admissionFailed := make(chan struct{})
+	var admissionFailedOnce sync.Once
+	signalAdmissionFailed := func() {
+		admissionFailedOnce.Do(func() {
+			close(admissionFailed)
+		})
+	}
 
+	admissionPath, adapterDirectSpecialCased := ebusgateway.ResolveAdmissionPath(cfg.TransportConfig.Protocol)
+	overrideSet := admissionPath == ebusgateway.TransportAdmissionSourceSelectionCapable && cfg.StartupSource.Source != nil
 	if !cfg.ScanOnStart || gateway == nil || gateway.Bus == nil || gateway.Registry == nil {
 		signalFirstPassDone()
+		if admissionPath == ebusgateway.TransportAdmissionSourceSelectionCapable && !overrideSet {
+			signalAdmissionFailed()
+		} else {
+			signalActiveProbePassed()
+		}
 		signalSemanticBootstrapReady()
 		return startupScanSignals{
 			firstPassDone:          firstPassDone,
 			semanticBootstrapReady: semanticBootstrapReady,
+			activeProbePassed:      activeProbePassed,
+			admissionFailed:        admissionFailed,
 		}
 	}
 	if ctx == nil {
@@ -437,7 +463,6 @@ func startDiscoveryScanLoopWithClassifier(ctx context.Context, cfg ebusgateway.C
 	}
 
 	startupCfg := resolveStartupScanSourceConfig(cfg)
-	admissionPath, adapterDirectSpecialCased := ebusgateway.ResolveAdmissionPath(cfg.TransportConfig.Protocol)
 	if adapterDirectSpecialCased {
 		log.Printf("startup scan: adapter-direct multiplexer detected; treating as source-selection-capable (underlying transport is always ENH/ENS)")
 	}
@@ -481,27 +506,31 @@ func startDiscoveryScanLoopWithClassifier(ctx context.Context, cfg ebusgateway.C
 				classifier: classifier,
 			}
 			targets := startupProbeTargets(startupCfg)
-			targetLabel := "startup evidence"
+			targetLabel := "startup probe targets"
 			var targetConfig *ebusgateway.TransportConfig
 			retryingFullRange := forceFullRangeNextPass
 			forceFullRangeNextPass = false
 			candidates := targetCandidatesFn(cfg.TransportConfig)
 			if retryingFullRange {
+				targets = nil
+				targetLabel = "full target range"
 				if len(candidates) > 0 {
 					candidateCopy := candidates[0]
 					targetConfig = &candidateCopy
 				}
 				log.Printf("startup scan: retrying with full target range after partial ebusd inventory")
-			} else if len(targets) == 0 {
+			} else {
 				for _, candidate := range candidates {
 					scanTargets, err := resultTargetsFn(scanCtx, candidate)
 					if err != nil || len(scanTargets) == 0 {
 						continue
 					}
-					targets = scanTargets
-					targetLabel = candidate.Address
 					candidateCopy := candidate
 					targetConfig = &candidateCopy
+					if len(targets) == 0 {
+						targets = scanTargets
+						targetLabel = candidate.Address
+					}
 					break
 				}
 			}
@@ -575,6 +604,11 @@ func startDiscoveryScanLoopWithClassifier(ctx context.Context, cfg ebusgateway.C
 						}
 						continue
 					} else if shouldStopDiscoveryScan(total, confirmationPending, confirmationSatisfied, false) {
+						if confirmationSatisfied {
+							signalActiveProbePassed()
+						} else {
+							signalAdmissionFailed()
+						}
 						signalSemanticBootstrapReady()
 						signalFirstPassDone()
 						cancel()
@@ -612,6 +646,11 @@ func startDiscoveryScanLoopWithClassifier(ctx context.Context, cfg ebusgateway.C
 
 			if err != nil && ctx.Err() == nil {
 				log.Printf("startup scan error: %v", err)
+				if admissionPath == ebusgateway.TransportAdmissionSourceSelectionCapable && isBoundedTargetsRequiredError(err) {
+					signalAdmissionFailed()
+					cancel()
+					return
+				}
 			}
 
 			total := countRegistryDevices(gateway.Registry)
@@ -700,14 +739,11 @@ func startDiscoveryScanLoopWithClassifier(ctx context.Context, cfg ebusgateway.C
 				usedRestrictedTargets &&
 				!retryingFullRange &&
 				restrictedConfirmationAfterRecoveryPending
-			// Direct (non-ebusd-tcp) scans never set usedRestrictedTargets,
-			// so the ebusd-specific fallback path above cannot fire.  The
-			// !usedRestrictedTargets guard below correctly scopes this
-			// counter to direct scans only (adapter-direct, ENH, ENS).
 			// Track consecutive confirmation failures and treat them as
 			// exhausted after two passes to prevent an infinite scan loop
 			// when the B524 coherent-root probe fails under bus contention.
-			if confirmationPending && !confirmationSatisfied && !usedRestrictedTargets && total > 0 {
+			if confirmationPending && !confirmationSatisfied && total > 0 &&
+				(!usedRestrictedTargets || admissionPath == ebusgateway.TransportAdmissionSourceSelectionCapable) {
 				directScanConfirmationRetries++
 				if directScanConfirmationRetries >= 2 {
 					confirmationFallbackExhausted = true
@@ -746,6 +782,11 @@ func startDiscoveryScanLoopWithClassifier(ctx context.Context, cfg ebusgateway.C
 				fullRangeRecoveryAttempted = true
 				restrictedConfirmationAfterRecoveryPending = true
 			} else if shouldStopDiscoveryScan(total, confirmationPending, confirmationSatisfied, confirmationFallbackExhausted) {
+				if confirmationSatisfied {
+					signalActiveProbePassed()
+				} else {
+					signalAdmissionFailed()
+				}
 				signalSemanticBootstrapReady()
 				return
 			}
@@ -762,6 +803,8 @@ func startDiscoveryScanLoopWithClassifier(ctx context.Context, cfg ebusgateway.C
 	return startupScanSignals{
 		firstPassDone:          firstPassDone,
 		semanticBootstrapReady: semanticBootstrapReady,
+		activeProbePassed:      activeProbePassed,
+		admissionFailed:        admissionFailed,
 	}
 }
 
@@ -916,6 +959,10 @@ func shouldRetryDiscoveryWithFullRange(ctx context.Context, cfg ebusgateway.Conf
 	if !usedRestrictedTargets || retryingFullRange || gateway == nil || gateway.Registry == nil {
 		return false
 	}
+	admissionPath, _ := ebusgateway.ResolveAdmissionPath(cfg.TransportConfig.Protocol)
+	if admissionPath == ebusgateway.TransportAdmissionSourceSelectionCapable {
+		return false
+	}
 	if ctx != nil && ctx.Err() != nil {
 		return false
 	}
@@ -1025,21 +1072,24 @@ func resolveStartupScanSourceConfig(cfg ebusgateway.Config) ebusgateway.Config {
 }
 
 func startupProbeTargetsFromSelection(selection protocol.SourceAddressSelection) []byte {
-	return sanitizeStartupProbeTargets(selection.Metrics.ObservedProbableTargets, selection.Source)
+	return sanitizeStartupProbeTargets(selection.Metrics.ObservedProbableTargets, selection.Source, selection.Companion)
 }
 
 func startupProbeTargets(cfg ebusgateway.Config) []byte {
-	return sanitizeStartupProbeTargets(cfg.StartupProbeTargets, cfg.ScanSource)
+	return sanitizeStartupProbeTargets(cfg.StartupProbeTargets, cfg.ScanSource, cfg.StartupCompanionTarget)
 }
 
-func sanitizeStartupProbeTargets(candidates []byte, source byte) []byte {
+func sanitizeStartupProbeTargets(candidates []byte, source byte, companion byte) []byte {
 	if len(candidates) == 0 {
 		return nil
 	}
 	seen := make(map[byte]struct{}, len(candidates))
 	targets := make([]byte, 0, len(candidates))
 	for _, candidate := range candidates {
-		if candidate == source || candidate < 0x03 || candidate >= 0xFE || candidate == 0xAA {
+		if candidate == source || candidate == companion ||
+			candidate < 0x03 || candidate >= 0xFE ||
+			candidate == 0xAA || candidate == 0xA9 ||
+			isInitiatorCapableAddress(candidate) {
 			continue
 		}
 		if _, ok := seen[candidate]; ok {
@@ -1049,7 +1099,23 @@ func sanitizeStartupProbeTargets(candidates []byte, source byte) []byte {
 		targets = append(targets, candidate)
 	}
 	sort.Slice(targets, func(i, j int) bool { return targets[i] < targets[j] })
+	if len(targets) > 3 {
+		targets = targets[:3]
+	}
 	return targets
+}
+
+func isInitiatorCapableAddress(address byte) bool {
+	return isInitiatorCapableNibble(address>>4) && isInitiatorCapableNibble(address&0x0F)
+}
+
+func isInitiatorCapableNibble(nibble byte) bool {
+	switch nibble {
+	case 0x0, 0x1, 0x3, 0x7, 0xF:
+		return true
+	default:
+		return false
+	}
 }
 
 func countRegistryDevices(reg *registry.DeviceRegistry) int {
@@ -1438,6 +1504,11 @@ func runBackgroundFullScan(ctx context.Context, cfg ebusgateway.Config, gateway 
 	if adapterDirectSpecialCased {
 		log.Printf("background scan: adapter-direct multiplexer detected; treating as source-selection-capable")
 	}
+	targets := startupProbeTargets(cfg)
+	if admissionPath == ebusgateway.TransportAdmissionSourceSelectionCapable && len(targets) == 0 {
+		log.Printf("background scan skipped: source selection requires explicit bounded targets")
+		return
+	}
 
 	beforeTotal := countRegistryDevices(gateway.Registry)
 	devices, err := startupScanWithFullRangeGuard(
@@ -1445,7 +1516,7 @@ func runBackgroundFullScan(ctx context.Context, cfg ebusgateway.Config, gateway 
 		scanBus,
 		gateway.Registry,
 		cfg.ScanSource,
-		nil,
+		targets,
 		admissionPath,
 		cfg.DiagnosticFullRangeRetry,
 		evidenceHasVaillantRootFn(gateway.Registry),

--- a/cmd/gateway/startup_scan.go
+++ b/cmd/gateway/startup_scan.go
@@ -1107,9 +1107,6 @@ func sanitizeStartupProbeTargets(candidates []byte, source byte, companion byte)
 		targets = append(targets, candidate)
 	}
 	sort.Slice(targets, func(i, j int) bool { return targets[i] < targets[j] })
-	if len(targets) > 3 {
-		targets = targets[:3]
-	}
 	return targets
 }
 

--- a/cmd/gateway/startup_scan_diag_test.go
+++ b/cmd/gateway/startup_scan_diag_test.go
@@ -39,26 +39,26 @@ func TestStartupScanSourceMode(t *testing.T) {
 			want: "auto-proxy",
 		},
 		{
-			name: "auto kept (auto=true, source=0x71, no proxy change)",
+			name: "auto kept (auto=true, source=0x7F, no proxy change)",
 			original: ebusgateway.Config{
 				ScanSourceAuto: true,
-				ScanSource:     0x71,
+				ScanSource:     0x7F,
 			},
 			resolved: ebusgateway.Config{
 				ScanSourceAuto: true,
-				ScanSource:     0x71,
+				ScanSource:     0x7F,
 			},
 			want: "auto",
 		},
 		{
-			name: "configured (auto=false, source=0x71)",
+			name: "configured (auto=false, source=0x7F)",
 			original: ebusgateway.Config{
 				ScanSourceAuto: false,
-				ScanSource:     0x71,
+				ScanSource:     0x7F,
 			},
 			resolved: ebusgateway.Config{
 				ScanSourceAuto: false,
-				ScanSource:     0x71,
+				ScanSource:     0x7F,
 			},
 			want: "configured",
 		},
@@ -119,12 +119,12 @@ func TestStatsBus_AttemptsBoundedToCap(t *testing.T) {
 	}
 	sb := &statsBus{
 		bus:    &stubBus{errors: errs},
-		source: 0x71,
+		source: 0x7F,
 	}
 
 	var frames []protocol.Frame
 	for i := 0; i < scanAttemptLogCap+20; i++ {
-		frames = append(frames, protocol.Frame{Source: 0x71, Target: byte(0x10 + i)})
+		frames = append(frames, protocol.Frame{Source: 0x7F, Target: byte(0x10 + i)})
 	}
 	for _, f := range frames {
 		_, _ = sb.Send(context.Background(), f)
@@ -154,11 +154,11 @@ func TestStatsBus_AttemptRecordsSourceTargetClass(t *testing.T) {
 			ebuserrors.ErrCRCMismatch,
 			errors.New("unknown protocol error"),
 		}},
-		source: 0x71,
+		source: 0x7F,
 	}
 	targets := []byte{0x08, 0x10, 0x15, 0x26, 0x04, 0x03}
 	for _, tgt := range targets {
-		_, _ = sb.Send(context.Background(), protocol.Frame{Source: 0x71, Target: tgt})
+		_, _ = sb.Send(context.Background(), protocol.Frame{Source: 0x7F, Target: tgt})
 	}
 
 	if len(sb.attempts) != 6 {
@@ -166,8 +166,8 @@ func TestStatsBus_AttemptRecordsSourceTargetClass(t *testing.T) {
 	}
 	wantClasses := []string{"ok", "timeout", "collision", "nack", "crc", "other"}
 	for i, a := range sb.attempts {
-		if a.source != 0x71 {
-			t.Errorf("attempt %d source = 0x%02X, want 0x71", i, a.source)
+		if a.source != 0x7F {
+			t.Errorf("attempt %d source = 0x%02X, want 0x7F", i, a.source)
 		}
 		if a.target != targets[i] {
 			t.Errorf("attempt %d target = 0x%02X, want 0x%02X", i, a.target, targets[i])
@@ -231,12 +231,12 @@ func TestScanAttemptLog_IncludesTxnClass(t *testing.T) {
 	fc := &fakeClassifier{val: "echo_only_timeout"}
 	sb := &statsBus{
 		bus:        &stubBus{errors: []error{ebuserrors.ErrTimeout, nil}},
-		source:     0x71,
+		source:     0x7F,
 		classifier: fc,
 	}
-	_, _ = sb.Send(context.Background(), protocol.Frame{Source: 0x71, Target: 0x08, Primary: 0x07, Secondary: 0x04})
+	_, _ = sb.Send(context.Background(), protocol.Frame{Source: 0x7F, Target: 0x08, Primary: 0x07, Secondary: 0x04})
 	fc.val = "success_like"
-	_, _ = sb.Send(context.Background(), protocol.Frame{Source: 0x71, Target: 0x10, Primary: 0x07, Secondary: 0x04})
+	_, _ = sb.Send(context.Background(), protocol.Frame{Source: 0x7F, Target: 0x10, Primary: 0x07, Secondary: 0x04})
 
 	if len(sb.attempts) != 2 {
 		t.Fatalf("attempts = %d, want 2", len(sb.attempts))
@@ -264,12 +264,12 @@ func TestScanAttemptLog_BoundedWithTxnClass(t *testing.T) {
 	}
 	sb := &statsBus{
 		bus:        &stubBus{errors: errs},
-		source:     0x71,
+		source:     0x7F,
 		classifier: fc,
 	}
 	for i := 0; i < scanAttemptLogCap+10; i++ {
 		_, _ = sb.Send(context.Background(),
-			protocol.Frame{Source: 0x71, Target: byte(0x10 + i), Primary: 0x07, Secondary: 0x04})
+			protocol.Frame{Source: 0x7F, Target: byte(0x10 + i), Primary: 0x07, Secondary: 0x04})
 	}
 	if len(sb.attempts) != scanAttemptLogCap {
 		t.Fatalf("attempts = %d, want %d", len(sb.attempts), scanAttemptLogCap)
@@ -288,10 +288,10 @@ func TestScanAttemptLog_BoundedWithTxnClass(t *testing.T) {
 func TestScanAttemptLog_NoClassifier_EmptyTxnClass(t *testing.T) {
 	sb := &statsBus{
 		bus:    &stubBus{errors: []error{ebuserrors.ErrTimeout}},
-		source: 0x71,
+		source: 0x7F,
 		// classifier: nil (explicit).
 	}
-	_, _ = sb.Send(context.Background(), protocol.Frame{Source: 0x71, Target: 0x08, Primary: 0x07, Secondary: 0x04})
+	_, _ = sb.Send(context.Background(), protocol.Frame{Source: 0x7F, Target: 0x08, Primary: 0x07, Secondary: 0x04})
 	if len(sb.attempts) != 1 {
 		t.Fatalf("attempts = %d, want 1", len(sb.attempts))
 	}
@@ -340,7 +340,7 @@ func (b *shapeCaptureBus) Send(ctx context.Context, frame protocol.Frame) (*prot
 // TestScanRequestShape_AdapterDirect proves the adapter-direct startup
 // scan builds frames with the exact contract expected by a Vaillant bus:
 //
-//	Frame.Source    == configured ScanSource (e.g. 0xF7 proxy or 0x71)
+//	Frame.Source    == configured ScanSource (e.g. 0xF7 proxy or 0x7F)
 //	Frame.Target    ∈ valid scan-target iteration range (0x01..0xFD)
 //	Frame.Primary   == 0x07 (identification)
 //	Frame.Secondary == 0x04
@@ -354,7 +354,7 @@ func TestScanRequestShape_AdapterDirect(t *testing.T) {
 
 	// Use a small explicit target list so the test finishes quickly.
 	targets := []byte{0x08, 0x15, 0x26}
-	const source byte = 0x71
+	const source byte = 0x7F
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
@@ -429,10 +429,10 @@ func TestStatsBus_NonOkPrioritizedOverOk(t *testing.T) {
 	}
 	sb := &statsBus{
 		bus:    &stubBus{errors: errs},
-		source: 0x71,
+		source: 0x7F,
 	}
 	for i := 0; i < len(errs); i++ {
-		_, _ = sb.Send(context.Background(), protocol.Frame{Source: 0x71, Target: byte(0x10 + i)})
+		_, _ = sb.Send(context.Background(), protocol.Frame{Source: 0x7F, Target: byte(0x10 + i)})
 	}
 
 	if len(sb.attempts) != scanAttemptLogCap {
@@ -469,11 +469,11 @@ func TestStatsBus_AllNonOk_NoFurtherEvictions(t *testing.T) {
 	}
 	sb := &statsBus{
 		bus:    &stubBus{errors: errs},
-		source: 0x71,
+		source: 0x7F,
 	}
 	// Send cap+10 timeouts with distinct target bytes.
 	for i := 0; i < len(errs); i++ {
-		_, _ = sb.Send(context.Background(), protocol.Frame{Source: 0x71, Target: byte(0x10 + i)})
+		_, _ = sb.Send(context.Background(), protocol.Frame{Source: 0x7F, Target: byte(0x10 + i)})
 	}
 
 	if len(sb.attempts) != scanAttemptLogCap {
@@ -500,17 +500,17 @@ func TestStartDiscoveryScanLoopWithClassifier_InstanceScoped(t *testing.T) {
 
 	sbA := &statsBus{
 		bus:        &stubBus{errors: []error{ebuserrors.ErrTimeout}},
-		source:     0x71,
+		source:     0x7F,
 		classifier: fcA,
 	}
 	sbB := &statsBus{
 		bus:        &stubBus{errors: []error{ebuserrors.ErrTimeout}},
-		source:     0x71,
+		source:     0x7F,
 		classifier: fcB,
 	}
 
-	_, _ = sbA.Send(context.Background(), protocol.Frame{Source: 0x71, Target: 0x08, Primary: 0x07, Secondary: 0x04})
-	_, _ = sbB.Send(context.Background(), protocol.Frame{Source: 0x71, Target: 0x10, Primary: 0x07, Secondary: 0x04})
+	_, _ = sbA.Send(context.Background(), protocol.Frame{Source: 0x7F, Target: 0x08, Primary: 0x07, Secondary: 0x04})
+	_, _ = sbB.Send(context.Background(), protocol.Frame{Source: 0x7F, Target: 0x10, Primary: 0x07, Secondary: 0x04})
 
 	if len(sbA.attempts) != 1 || sbA.attempts[0].txnClass != "echo_only_timeout" {
 		t.Fatalf("sbA: got %+v, want 1 attempt with txnClass=echo_only_timeout", sbA.attempts)
@@ -540,10 +540,10 @@ func TestStartDiscoveryScanLoop_NoPackageGlobalClassifier(t *testing.T) {
 	// when invoked via the default 4-arg seam (classifier == nil).
 	sb := &statsBus{
 		bus:        &stubBus{errors: []error{ebuserrors.ErrTimeout}},
-		source:     0x71,
+		source:     0x7F,
 		classifier: nil,
 	}
-	_, _ = sb.Send(context.Background(), protocol.Frame{Source: 0x71, Target: 0x08, Primary: 0x07, Secondary: 0x04})
+	_, _ = sb.Send(context.Background(), protocol.Frame{Source: 0x7F, Target: 0x08, Primary: 0x07, Secondary: 0x04})
 	if sb.attempts[0].txnClass != "" {
 		t.Errorf("default entry point leaked a classifier: txnClass=%q", sb.attempts[0].txnClass)
 	}
@@ -566,17 +566,17 @@ func TestWireAdapterDirect_RebindsClassifierPerInstance(t *testing.T) {
 	// run() does after threading `adapterClassifier` as the 5th arg).
 	sb1 := &statsBus{
 		bus:        &stubBus{errors: []error{ebuserrors.ErrTimeout}},
-		source:     0x71,
+		source:     0x7F,
 		classifier: fc1,
 	}
 	sb2 := &statsBus{
 		bus:        &stubBus{errors: []error{ebuserrors.ErrTimeout}},
-		source:     0x71,
+		source:     0x7F,
 		classifier: fc2,
 	}
 
-	_, _ = sb1.Send(context.Background(), protocol.Frame{Source: 0x71, Target: 0x08, Primary: 0x07, Secondary: 0x04})
-	_, _ = sb2.Send(context.Background(), protocol.Frame{Source: 0x71, Target: 0x10, Primary: 0x07, Secondary: 0x04})
+	_, _ = sb1.Send(context.Background(), protocol.Frame{Source: 0x7F, Target: 0x08, Primary: 0x07, Secondary: 0x04})
+	_, _ = sb2.Send(context.Background(), protocol.Frame{Source: 0x7F, Target: 0x10, Primary: 0x07, Secondary: 0x04})
 
 	if sb1.attempts[0].txnClass != "gateway1_class" {
 		t.Fatalf("gateway1 statsBus got txnClass=%q, want gateway1_class — cross-attribution from fc2?", sb1.attempts[0].txnClass)
@@ -630,10 +630,10 @@ func TestScanAttemptLog_TxnIDCorrelation(t *testing.T) {
 	}
 	sb := &statsBus{
 		bus:        &stubBus{errors: []error{nil}},
-		source:     0x71,
+		source:     0x7F,
 		classifier: fs,
 	}
-	_, _ = sb.Send(context.Background(), protocol.Frame{Source: 0x71, Target: 0x08, Primary: 0x07, Secondary: 0x04})
+	_, _ = sb.Send(context.Background(), protocol.Frame{Source: 0x7F, Target: 0x08, Primary: 0x07, Secondary: 0x04})
 
 	if len(sb.attempts) != 1 {
 		t.Fatalf("attempts len=%d, want 1", len(sb.attempts))
@@ -681,12 +681,12 @@ func TestScanAttemptLog_TxnIDAdvancesAcrossAttempts(t *testing.T) {
 			ebuserrors.ErrTimeout,
 			ebuserrors.ErrTimeout,
 		}},
-		source:     0x71,
+		source:     0x7F,
 		classifier: fs,
 	}
 	targets := []byte{0x08, 0x10, 0x15}
 	for _, tgt := range targets {
-		_, _ = sb.Send(context.Background(), protocol.Frame{Source: 0x71, Target: tgt, Primary: 0x07, Secondary: 0x04})
+		_, _ = sb.Send(context.Background(), protocol.Frame{Source: 0x7F, Target: tgt, Primary: 0x07, Secondary: 0x04})
 	}
 
 	if len(sb.attempts) != 3 {
@@ -720,10 +720,10 @@ func TestScanAttemptLog_LegacyClassifierOnly(t *testing.T) {
 	fc := &fakeClassifier{val: "schema_error"}
 	sb := &statsBus{
 		bus:        &stubBus{errors: []error{ebuserrors.ErrTimeout}},
-		source:     0x71,
+		source:     0x7F,
 		classifier: fc,
 	}
-	_, _ = sb.Send(context.Background(), protocol.Frame{Source: 0x71, Target: 0x08, Primary: 0x07, Secondary: 0x04})
+	_, _ = sb.Send(context.Background(), protocol.Frame{Source: 0x7F, Target: 0x08, Primary: 0x07, Secondary: 0x04})
 
 	if len(sb.attempts) != 1 {
 		t.Fatalf("attempts len=%d, want 1", len(sb.attempts))
@@ -790,10 +790,10 @@ func TestStartDiscoveryScanLoopFn_SignatureThreadsClassifier(t *testing.T) {
 	fc := &fakeClassifier{val: "threaded_through_signature"}
 	sb := &statsBus{
 		bus:        &stubBus{errors: []error{ebuserrors.ErrTimeout}},
-		source:     0x71,
+		source:     0x7F,
 		classifier: fc,
 	}
-	_, _ = sb.Send(context.Background(), protocol.Frame{Source: 0x71, Target: 0x08, Primary: 0x07, Secondary: 0x04})
+	_, _ = sb.Send(context.Background(), protocol.Frame{Source: 0x7F, Target: 0x08, Primary: 0x07, Secondary: 0x04})
 	if len(sb.attempts) != 1 {
 		t.Fatalf("expected 1 attempt, got %d", len(sb.attempts))
 	}

--- a/cmd/gateway/startup_scan_test.go
+++ b/cmd/gateway/startup_scan_test.go
@@ -306,6 +306,19 @@ func TestStartupProbeTargetsFromSelection_SanitizesPromotedTargets(t *testing.T)
 	}
 }
 
+func TestStartupProbeTargetsForSelection_DefaultPolicySeedsBoundedTarget(t *testing.T) {
+	t.Parallel()
+
+	targets := startupProbeTargetsForSelection(protocol.SourceAddressSelection{
+		Source:    0x7F,
+		Companion: 0x84,
+	})
+	want := []byte{defaultVaillantTarget}
+	if !reflect.DeepEqual(targets, want) {
+		t.Fatalf("startup probe targets = % X; want % X", targets, want)
+	}
+}
+
 func TestEbusdScanTargetCandidates(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/gateway/startup_scan_test.go
+++ b/cmd/gateway/startup_scan_test.go
@@ -306,6 +306,16 @@ func TestStartupProbeTargetsFromSelection_SanitizesPromotedTargets(t *testing.T)
 	}
 }
 
+func TestSanitizeStartupProbeTargets_PreservesAllConfiguredTargets(t *testing.T) {
+	t.Parallel()
+
+	targets := sanitizeStartupProbeTargets([]byte{0x08, 0x15, 0x26, 0x04}, 0xF0, 0xF5)
+	want := []byte{0x04, 0x08, 0x15, 0x26}
+	if !reflect.DeepEqual(targets, want) {
+		t.Fatalf("startup probe targets = % X; want % X", targets, want)
+	}
+}
+
 func TestStartupProbeTargetsForSelection_DefaultPolicySeedsBoundedTarget(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/gateway/startup_scan_test.go
+++ b/cmd/gateway/startup_scan_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Project-Helianthus/helianthus-ebusgateway"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/graphql"
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
 	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
 )
@@ -285,6 +286,21 @@ func TestResolveStartupScanSourceConfig(t *testing.T) {
 				t.Fatal("resolveStartupScanSourceConfig(...) left ScanSourceAuto=true for explicit proxy startup source")
 			}
 		})
+	}
+}
+
+func TestStartupProbeTargetsFromSelection_SanitizesPromotedTargets(t *testing.T) {
+	t.Parallel()
+
+	targets := startupProbeTargetsFromSelection(protocol.SourceAddressSelection{
+		Source: 0x7F,
+		Metrics: protocol.SourceAddressSelectionMetrics{
+			ObservedProbableTargets: []byte{0x15, 0x08, 0x7F, 0xFE, 0xAA, 0x08, 0x02},
+		},
+	})
+	want := []byte{0x08, 0x15}
+	if !reflect.DeepEqual(targets, want) {
+		t.Fatalf("startup probe targets = % X; want % X", targets, want)
 	}
 }
 

--- a/cmd/gateway/startup_scan_test.go
+++ b/cmd/gateway/startup_scan_test.go
@@ -177,7 +177,9 @@ func TestShouldRetryDiscoveryWithFullRange(t *testing.T) {
 				ctx = canceledCtx
 			}
 
-			got := shouldRetryDiscoveryWithFullRange(ctx, ebusgateway.DefaultConfig(), gateway, test.usedRestricted, test.retryingFullRange)
+			cfg := ebusgateway.DefaultConfig()
+			cfg.TransportConfig.Protocol = ebusgateway.TransportEbusdTCP
+			got := shouldRetryDiscoveryWithFullRange(ctx, cfg, gateway, test.usedRestricted, test.retryingFullRange)
 			if got != test.want {
 				t.Fatalf("shouldRetryDiscoveryWithFullRange(...) = %v; want %v", got, test.want)
 			}
@@ -914,6 +916,7 @@ func TestStartDiscoveryScanLoop_EbusdPreloadKeepsScanningUntilControllerCandidat
 	cfg := ebusgateway.DefaultConfig()
 	cfg.ScanOnStart = true
 	cfg.ScanInterval = 10 * time.Millisecond
+	cfg.ScanRequestTimeout = time.Millisecond
 	cfg.TransportConfig = ebusgateway.TransportConfig{
 		Protocol: ebusgateway.TransportEbusdTCP,
 		Network:  "tcp",
@@ -1094,6 +1097,7 @@ func TestStartDiscoveryScanLoop_EbusdPreloadWithCoherentRootDoesNotRetryFullRang
 	cfg := ebusgateway.DefaultConfig()
 	cfg.ScanOnStart = true
 	cfg.ScanInterval = 10 * time.Millisecond
+	cfg.ScanRequestTimeout = time.Millisecond
 	cfg.TransportConfig = ebusgateway.TransportConfig{
 		Protocol: ebusgateway.TransportEbusdTCP,
 		Network:  "tcp",
@@ -1148,6 +1152,137 @@ func TestStartDiscoveryScanLoop_EbusdPreloadWithCoherentRootDoesNotRetryFullRang
 		t.Fatalf("startup scan readiness probe received canceled context: %v", finalProbeCtxErr)
 	}
 
+}
+
+func TestStartDiscoveryScanLoop_EbusdPreloadRunsWithConfiguredStartupProbeTargets(t *testing.T) {
+	gateway, err := ebusgateway.New(context.Background(), ebusgateway.Config{
+		Transport: transport.NewLoopback(),
+	})
+	if err != nil {
+		t.Fatalf("gateway.New error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := gateway.Close(); err != nil {
+			t.Fatalf("gateway.Close error = %v", err)
+		}
+	})
+
+	origRegistryScanFn := registryScanFn
+	origTargetCandidatesFn := ebusdScanTargetCandidatesFn
+	origResultTargetsFn := ebusdScanResultTargetsFn
+	origResultInfosFn := ebusdScanResultInfosFn
+	origProbeFn := startupScanB524ProbeFn
+	origLoopExitFn := startupScanLoopExitFn
+	origEnrichVaillantIdentityFn := enrichVaillantIdentityFn
+	origEnrichSerialsFromEbusdFn := enrichSerialsFromEbusdFn
+	origPostStartupIdentityRetryFn := postStartupIdentityRetryFn
+	t.Cleanup(func() {
+		registryScanFn = origRegistryScanFn
+		ebusdScanTargetCandidatesFn = origTargetCandidatesFn
+		ebusdScanResultTargetsFn = origResultTargetsFn
+		ebusdScanResultInfosFn = origResultInfosFn
+		startupScanB524ProbeFn = origProbeFn
+		startupScanLoopExitFn = origLoopExitFn
+		enrichVaillantIdentityFn = origEnrichVaillantIdentityFn
+		enrichSerialsFromEbusdFn = origEnrichSerialsFromEbusdFn
+		postStartupIdentityRetryFn = origPostStartupIdentityRetryFn
+	})
+
+	var (
+		mu             sync.Mutex
+		targetLookups  int
+		preloadRuns    int
+		registryScans  int
+		retrySchedules int
+	)
+	registryScanFn = func(context.Context, registry.ScanBus, *registry.DeviceRegistry, byte, []byte) ([]registry.DeviceEntry, error) {
+		mu.Lock()
+		registryScans++
+		mu.Unlock()
+		return nil, nil
+	}
+	ebusdScanTargetCandidatesFn = func(cfg ebusgateway.TransportConfig) []ebusgateway.TransportConfig {
+		return []ebusgateway.TransportConfig{cfg}
+	}
+	ebusdScanResultTargetsFn = func(context.Context, ebusgateway.TransportConfig) ([]byte, error) {
+		mu.Lock()
+		targetLookups++
+		mu.Unlock()
+		return []byte{0x04, 0x08, 0x15}, nil
+	}
+	ebusdScanResultInfosFn = func(context.Context, ebusgateway.TransportConfig) ([]registry.DeviceInfo, error) {
+		mu.Lock()
+		preloadRuns++
+		mu.Unlock()
+		return []registry.DeviceInfo{
+			{Address: 0x04, Manufacturer: "Vaillant", DeviceID: "NETX3"},
+			{Address: 0x08, Manufacturer: "Vaillant", DeviceID: "BAI00"},
+			{Address: 0x15, Manufacturer: "Vaillant", DeviceID: "BASV2"},
+		}, nil
+	}
+	startupScanB524ProbeFn = func(context.Context, byte, byte, byte, byte, uint16) bool {
+		return true
+	}
+	enrichVaillantIdentityFn = func(context.Context, *ebusgateway.Gateway, ebusgateway.Config) {}
+	enrichSerialsFromEbusdFn = func(context.Context, *registry.DeviceRegistry, ebusgateway.TransportConfig) {}
+	postStartupIdentityRetryFn = func(context.Context, *ebusgateway.Gateway, *graphql.Builder, ebusgateway.Config, *ebusgateway.TransportConfig) {
+		mu.Lock()
+		retrySchedules++
+		mu.Unlock()
+	}
+	loopExited := make(chan struct{}, 1)
+	startupScanLoopExitFn = func() {
+		select {
+		case loopExited <- struct{}{}:
+		default:
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := ebusgateway.DefaultConfig()
+	cfg.ScanOnStart = true
+	cfg.ScanInterval = 10 * time.Millisecond
+	cfg.ScanRequestTimeout = time.Millisecond
+	cfg.TransportConfig = ebusgateway.TransportConfig{
+		Protocol: ebusgateway.TransportEbusdTCP,
+		Network:  "tcp",
+		Address:  "127.0.0.1:8888",
+	}
+	cfg.StartupProbeTargets = []byte{0x08}
+
+	signals := startDiscoveryScanLoop(ctx, cfg, gateway, nil)
+	select {
+	case <-signals.semanticBootstrapReady:
+	case <-time.After(2 * time.Second):
+		t.Fatal("semanticBootstrapReady was never signaled")
+	}
+	select {
+	case <-loopExited:
+	case <-time.After(2 * time.Second):
+		t.Fatal("scan loop did not exit after coherent ebusd preload")
+	}
+
+	mu.Lock()
+	gotTargetLookups := targetLookups
+	gotPreloadRuns := preloadRuns
+	gotRegistryScans := registryScans
+	gotRetrySchedules := retrySchedules
+	mu.Unlock()
+
+	if gotTargetLookups != 1 {
+		t.Fatalf("ebusd scan result target lookups = %d; want 1 even with configured startup-probe-targets", gotTargetLookups)
+	}
+	if gotPreloadRuns != 1 {
+		t.Fatalf("ebusd scan preload runs = %d; want 1 even with configured startup-probe-targets", gotPreloadRuns)
+	}
+	if gotRegistryScans != 0 {
+		t.Fatalf("registry scan runs = %d; want 0 after coherent preload stop", gotRegistryScans)
+	}
+	if gotRetrySchedules != 1 {
+		t.Fatalf("identity retry schedules = %d; want 1 from ebusd preload target config", gotRetrySchedules)
+	}
 }
 
 func TestSchedulePostStartupIdentityRetryEnrichesMissingVaillantSerials(t *testing.T) {
@@ -1561,11 +1696,13 @@ func TestStartDiscoveryScanLoop_NonEbusdTransportRejectsFullRangeScanByDefault(t
 	})
 
 	origRegistryScanFn := registryScanFn
+	origRegistryScanDirectedFn := registryScanDirectedFn
 	origResultTargetsFn := ebusdScanResultTargetsFn
 	origResultInfosFn := ebusdScanResultInfosFn
 	origLoopExitFn := startupScanLoopExitFn
 	t.Cleanup(func() {
 		registryScanFn = origRegistryScanFn
+		registryScanDirectedFn = origRegistryScanDirectedFn
 		ebusdScanResultTargetsFn = origResultTargetsFn
 		ebusdScanResultInfosFn = origResultInfosFn
 		startupScanLoopExitFn = origLoopExitFn
@@ -1841,6 +1978,7 @@ func TestStartDiscoveryScanLoop_DirectScanSignalsBootstrapAfterConfirmationRetri
 	})
 
 	origRegistryScanFn := registryScanFn
+	origRegistryScanDirectedFn := registryScanDirectedFn
 	origResultTargetsFn := ebusdScanResultTargetsFn
 	origResultInfosFn := ebusdScanResultInfosFn
 	origProbeFn := startupScanB524ProbeFn
@@ -1855,6 +1993,7 @@ func TestStartDiscoveryScanLoop_DirectScanSignalsBootstrapAfterConfirmationRetri
 	evidenceHasVaillantRootFn = func(*registry.DeviceRegistry) bool { return true }
 	t.Cleanup(func() {
 		registryScanFn = origRegistryScanFn
+		registryScanDirectedFn = origRegistryScanDirectedFn
 		ebusdScanResultTargetsFn = origResultTargetsFn
 		ebusdScanResultInfosFn = origResultInfosFn
 		startupScanB524ProbeFn = origProbeFn
@@ -1893,6 +2032,7 @@ func TestStartDiscoveryScanLoop_DirectScanSignalsBootstrapAfterConfirmationRetri
 		}
 		return entries, nil
 	}
+	registryScanDirectedFn = registryScanFn
 	// Non-ebusd-tcp: these should never be called.
 	ebusdScanResultTargetsFn = func(context.Context, ebusgateway.TransportConfig) ([]byte, error) {
 		t.Fatal("ebusd scan result targets should not be queried for direct transport")
@@ -1928,12 +2068,7 @@ func TestStartDiscoveryScanLoop_DirectScanSignalsBootstrapAfterConfirmationRetri
 		Network:  "tcp",
 		Address:  "127.0.0.1:9999",
 	}
-	// Enable AD05 diagnostic full-range retry: post-cruise-#20, adapter-
-	// direct classifies as JoinCapable so nil-target scans require both
-	// the diag flag AND evidenceHasVaillantRootFn=true (set above in
-	// test setup) to bypass the guard. Without these, the test loop never
-	// runs because the guard rejects.
-	cfg.DiagnosticFullRangeRetry = true
+	cfg.StartupProbeTargets = []byte{0x08, 0x15, 0x26}
 
 	signals := startDiscoveryScanLoop(ctx, cfg, gateway, nil)
 
@@ -1985,6 +2120,7 @@ func TestStartDiscoveryScanLoop_DirectScanTimeoutStillSignalsBootstrap(t *testin
 	})
 
 	origRegistryScanFn := registryScanFn
+	origRegistryScanDirectedFn := registryScanDirectedFn
 	origResultTargetsFn := ebusdScanResultTargetsFn
 	origResultInfosFn := ebusdScanResultInfosFn
 	origProbeFn := startupScanB524ProbeFn
@@ -1999,6 +2135,7 @@ func TestStartDiscoveryScanLoop_DirectScanTimeoutStillSignalsBootstrap(t *testin
 	evidenceHasVaillantRootFn = func(*registry.DeviceRegistry) bool { return true }
 	t.Cleanup(func() {
 		registryScanFn = origRegistryScanFn
+		registryScanDirectedFn = origRegistryScanDirectedFn
 		ebusdScanResultTargetsFn = origResultTargetsFn
 		ebusdScanResultInfosFn = origResultInfosFn
 		startupScanB524ProbeFn = origProbeFn
@@ -2038,6 +2175,7 @@ func TestStartDiscoveryScanLoop_DirectScanTimeoutStillSignalsBootstrap(t *testin
 		// Return nil entries + deadline error, exactly like production.
 		return nil, context.DeadlineExceeded
 	}
+	registryScanDirectedFn = registryScanFn
 	// Non-ebusd-tcp: these should never be called.
 	ebusdScanResultTargetsFn = func(context.Context, ebusgateway.TransportConfig) ([]byte, error) {
 		t.Fatal("ebusd scan result targets should not be queried for direct transport")
@@ -2071,12 +2209,7 @@ func TestStartDiscoveryScanLoop_DirectScanTimeoutStillSignalsBootstrap(t *testin
 		Network:  "tcp",
 		Address:  "127.0.0.1:9999",
 	}
-	// Enable AD05 diagnostic full-range retry: post-cruise-#20, adapter-
-	// direct classifies as JoinCapable so nil-target scans require both
-	// the diag flag AND evidenceHasVaillantRootFn=true (set above in
-	// test setup) to bypass the guard. Without these, the test loop never
-	// runs because the guard rejects.
-	cfg.DiagnosticFullRangeRetry = true
+	cfg.StartupProbeTargets = []byte{0x08, 0x15, 0x26}
 
 	signals := startDiscoveryScanLoop(ctx, cfg, gateway, nil)
 
@@ -2172,6 +2305,7 @@ func TestStartDiscoveryScanLoop_SafetyNetForcesBootstrapAfterMaxUnconfirmedPasse
 		}
 		return nil, context.DeadlineExceeded
 	}
+	registryScanDirectedFn = registryScanFn
 	ebusdScanResultTargetsFn = func(context.Context, ebusgateway.TransportConfig) ([]byte, error) {
 		t.Fatal("ebusd scan result targets should not be queried for direct transport")
 		return nil, nil
@@ -2203,17 +2337,13 @@ func TestStartDiscoveryScanLoop_SafetyNetForcesBootstrapAfterMaxUnconfirmedPasse
 	cfg := ebusgateway.DefaultConfig()
 	cfg.ScanOnStart = true
 	cfg.ScanInterval = 10 * time.Millisecond
+	cfg.ScanRequestTimeout = time.Millisecond
 	cfg.TransportConfig = ebusgateway.TransportConfig{
 		Protocol: ebusgateway.TransportAdapterDirect,
 		Network:  "tcp",
 		Address:  "127.0.0.1:9999",
 	}
-	// Enable AD05 diagnostic full-range retry: post-cruise-#20, adapter-
-	// direct classifies as JoinCapable so nil-target scans require both
-	// the diag flag AND evidenceHasVaillantRootFn=true (set above in
-	// test setup) to bypass the guard. Without these, the test loop never
-	// runs because the guard rejects.
-	cfg.DiagnosticFullRangeRetry = true
+	cfg.StartupProbeTargets = []byte{0x08, 0x15, 0x26}
 
 	signals := startDiscoveryScanLoop(ctx, cfg, gateway, nil)
 

--- a/cmd/gateway/vaillant_b503_dispatcher.go
+++ b/cmd/gateway/vaillant_b503_dispatcher.go
@@ -82,6 +82,9 @@ var (
 	// errRawFrameMisconfigured indicates the dispatcher was constructed
 	// with a nil bus or nil manager.
 	errRawFrameMisconfigured = errors.New("b503dispatcher: misconfigured (nil bus or manager)")
+	// errRawFrameSourceNotAdmitted indicates startup admission has not yet
+	// made a usable source available for gateway-owned B503 traffic.
+	errRawFrameSourceNotAdmitted = errors.New("b503dispatcher: source not admitted")
 )
 
 // rawFrameDispatcher is the production B503 frame routing component.
@@ -95,6 +98,7 @@ var (
 type rawFrameDispatcher struct {
 	bus            b503Bus
 	source         byte
+	sourceProvider func() (byte, bool)
 	readMu         sync.Locker
 	mgr            *b503session.Manager
 	requestTimeout time.Duration
@@ -104,8 +108,8 @@ type rawFrameDispatcher struct {
 //
 //   - bus: the gateway's *protocol.Bus (or a test mock). The single
 //     bus-access primitive — §12.3 / AD16.
-//   - source: the gateway's eBUS initiator address (0x71 per project
-//     convention). Populates Frame.Source.
+//   - source: the gateway's admitted eBUS initiator address. Populates
+//     Frame.Source.
 //   - readMu: the B524 read mutex. Acquired around bus.Send to serialise
 //     B503 frames with B524 polling. May be nil for tests that don't
 //     care about B524 contention. The Manager has already grabbed
@@ -118,9 +122,15 @@ type rawFrameDispatcher struct {
 //     "use ctx as-is"; a positive value bounds bus.Send via a derived
 //     context.
 func newRawFrameDispatcher(bus b503Bus, source byte, readMu sync.Locker, mgr *b503session.Manager, requestTimeout time.Duration) *rawFrameDispatcher {
+	return newRawFrameDispatcherWithSourceProvider(bus, func() (byte, bool) {
+		return source, source != 0
+	}, readMu, mgr, requestTimeout)
+}
+
+func newRawFrameDispatcherWithSourceProvider(bus b503Bus, sourceProvider func() (byte, bool), readMu sync.Locker, mgr *b503session.Manager, requestTimeout time.Duration) *rawFrameDispatcher {
 	return &rawFrameDispatcher{
 		bus:            bus,
-		source:         source,
+		sourceProvider: sourceProvider,
 		readMu:         readMu,
 		mgr:            mgr,
 		requestTimeout: requestTimeout,
@@ -162,6 +172,10 @@ func (d *rawFrameDispatcher) Invoke(ctx context.Context, target byte, payload []
 	if len(payload) >= 2 && payload[0] == b503PrimaryByte && payload[1] == b503SecondaryByte {
 		return nil, errRawFrameMalformedPayload
 	}
+	source, admitted := d.admittedSource()
+	if !admitted || source == 0 {
+		return nil, fmt.Errorf("%w: %w", errRawFrameSourceNotAdmitted, b503session.ErrTransportDown)
+	}
 
 	// Capture the current epoch at issue-time. AD18 + R3 A2 fix: epoch
 	// comparison is request-side metadata, populated when the request
@@ -188,7 +202,7 @@ func (d *rawFrameDispatcher) Invoke(ctx context.Context, target byte, payload []
 		d.readMu.Lock()
 	}
 	frame := protocol.Frame{
-		Source:    d.source,
+		Source:    source,
 		Target:    target,
 		Primary:   b503PrimaryByte,
 		Secondary: b503SecondaryByte,
@@ -225,6 +239,16 @@ func (d *rawFrameDispatcher) Invoke(ctx context.Context, target byte, payload []
 		return nil, fmt.Errorf("%w: nil response frame", errRawFrameUpstreamRPCFailed)
 	}
 	return resp.Data, nil
+}
+
+func (d *rawFrameDispatcher) admittedSource() (byte, bool) {
+	if d == nil {
+		return 0, false
+	}
+	if d.sourceProvider != nil {
+		return d.sourceProvider()
+	}
+	return d.source, d.source != 0
 }
 
 // classifySendErr maps bus.Send errors to dispatcher sentinels per

--- a/cmd/gateway/vaillant_b503_dispatcher_test.go
+++ b/cmd/gateway/vaillant_b503_dispatcher_test.go
@@ -430,37 +430,3 @@ func TestM6Dispatcher_NoStubLiteralInProductionWiring(t *testing.T) {
 		t.Fatalf("M6 acceptance §10: stub-error literal %q still present in production: %v", bad, hits)
 	}
 }
-
-// --- Helpers shared with the truth-table & concurrency suites ---
-
-// installVaillantB503ForTest is a test-only entry point that wires the
-// production dispatcher against a mock bus + readMu. It mirrors the
-// production installVaillantB503 except the bus is a stub. Used by the
-// integration test above and the truth-table tests in
-// vaillant_b503_dispatcher_truthtable_test.go.
-func installVaillantB503ForTest(srv *mcp.Server) *b503Runtime {
-	if srv == nil {
-		return nil
-	}
-	bus := newB503DispatcherMockBus()
-	bus.setResp([2]byte{0x00, 0x01}, []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF})
-	mgr := b503session.New(
-		b503session.TransportKey{AdapterInstanceID: "test", TransportEpoch: 1},
-		30*time.Second,
-		func(ctx context.Context) (b503session.TransportKey, error) {
-			return b503session.TransportKey{}, b503session.ErrTransportDown
-		},
-	)
-	var readMu sync.Mutex
-	disp := newRawFrameDispatcher(bus, gatewaySource, &readMu, mgr, 2*time.Second)
-	mcp.RegisterVaillantB503Tools(srv, mcp.VaillantB503Options{
-		Dispatcher:     disp,
-		SessionManager: mgr,
-		DefaultTarget:  defaultVaillantTarget,
-	})
-	return &b503Runtime{
-		mcpServer:  srv,
-		manager:    mgr,
-		dispatcher: disp,
-	}
-}

--- a/cmd/gateway/vaillant_b503_dispatcher_test.go
+++ b/cmd/gateway/vaillant_b503_dispatcher_test.go
@@ -36,11 +36,9 @@ func gatewayWithMockBus(t *testing.T) *ebusgateway.Gateway {
 	return &ebusgateway.Gateway{Bus: bus}
 }
 
-// gatewaySource is the gateway's eBUS source address. 0x71 per project
-// convention (gateway = 113). Used by the dispatcher to populate
-// Frame.Source. Defined here as test-package-local; production code
-// references its own constant in vaillant_b503_wiring.go after IMPL.
-const gatewaySource byte = 0x71
+// gatewaySource is the admitted eBUS source used by this test dispatcher.
+// Production wiring receives the admitted source from startup admission.
+const gatewaySource byte = 0x7F
 
 // b503DispatcherMockBus implements b503Bus with a programmable response
 // table keyed on the first 2 bytes of the request payload (the §2 family/
@@ -371,6 +369,21 @@ func TestM6Dispatcher_NilManager_ReturnsMisconfigured(t *testing.T) {
 	}
 }
 
+func TestM6Dispatcher_SourceNotAdmitted_FailsClosedBeforeBusSend(t *testing.T) {
+	bus := newB503DispatcherMockBus()
+	mgr := b503session.New(b503session.TransportKey{}, 30*time.Second, nil)
+	disp := newRawFrameDispatcherWithSourceProvider(bus, func() (byte, bool) {
+		return 0, false
+	}, nil, mgr, 0)
+	_, err := disp.Invoke(context.Background(), 0x08, []byte{0x00, 0x01})
+	if err == nil || !errors.Is(err, errRawFrameSourceNotAdmitted) {
+		t.Fatalf("Invoke before admission = %v; want errRawFrameSourceNotAdmitted", err)
+	}
+	if bus.callCount() != 0 {
+		t.Fatalf("bus.Send calls = %d; want 0 before source admission", bus.callCount())
+	}
+}
+
 // --- Integration: production installVaillantB503 must inject the real dispatcher ---
 
 // TestM6Dispatcher_InstallVaillantB503_InjectsProductionDispatcher exercises
@@ -384,8 +397,8 @@ func TestM6Dispatcher_InstallVaillantB503_InjectsProductionDispatcher(t *testing
 		t.Fatalf("mcp.NewServer = %v", err)
 	}
 	gw := gatewayWithMockBus(t)
-	cfg := &ebusgateway.Config{}
-	rt := installVaillantB503(srv, gw, cfg)
+	cfg := &ebusgateway.Config{ScanSource: 0x7F}
+	rt := installVaillantB503(srv, gw, cfg, func() (byte, bool) { return 0x7F, true })
 	if rt == nil {
 		t.Fatalf("installVaillantB503 returned nil")
 	}

--- a/cmd/gateway/vaillant_b503_wiring.go
+++ b/cmd/gateway/vaillant_b503_wiring.go
@@ -25,11 +25,6 @@ import (
 // per existing gateway precedent (semantic_vaillant.go).
 const defaultVaillantTarget byte = 0x08
 
-// vaillantGatewaySource is the gateway's eBUS source address (113 / 0x71)
-// per project convention. Populates protocol.Frame.Source on every B503
-// request emitted by the production dispatcher.
-const vaillantGatewaySource byte = 0x71
-
 // b503DispatcherRequestTimeout bounds each individual B503 dispatch.
 // Mirrors the ~2s timeout used by writeB555Frame in semantic_vaillant.go;
 // production live-monitor latency on adapter-direct typically completes
@@ -85,12 +80,10 @@ type b503Runtime struct {
 // falls back to b503StubDispatcher — every Invoke surfaces
 // UPSTREAM_RPC_FAILED, but the FSM and capability signal still operate
 // so consumer envelopes are correctly populated.
-func installVaillantB503(s *mcp.Server, gw *ebusgateway.Gateway, cfg *ebusgateway.Config) *b503Runtime {
+func installVaillantB503(s *mcp.Server, gw *ebusgateway.Gateway, cfg *ebusgateway.Config, sourceProvider func() (byte, bool)) *b503Runtime {
 	if s == nil {
 		return nil
 	}
-	_ = cfg // reserved for future config-driven default-target override
-
 	initialTK := b503session.TransportKey{
 		AdapterInstanceID: "gateway",
 		TransportEpoch:    0,
@@ -99,18 +92,28 @@ func installVaillantB503(s *mcp.Server, gw *ebusgateway.Gateway, cfg *ebusgatewa
 
 	var disp mcp.RPCDispatcher
 	if gw != nil && gw.Bus != nil {
-		// Production path: route through the gateway's *protocol.Bus.
-		// readMu is a fresh sync.Mutex dedicated to the B503 dispatcher
-		// — it is NOT the per-poller readMu inside vaillantSemanticPoller
-		// because that field is package-private. Sharing the mutex with
-		// the poller would require either a public accessor or moving
-		// the poller into the same package; both are out of scope for
-		// M6. The dedicated mutex still serialises B503 dispatches with
-		// each other (the M6-CONC-* tests assert this); B524 vs B503
-		// concurrency is governed at the bus.Send level (the bus
-		// arbitrates per-frame serially regardless).
-		readMu := &sync.Mutex{}
-		disp = newRawFrameDispatcher(gw.Bus, vaillantGatewaySource, readMu, mgr, b503DispatcherRequestTimeout)
+		if sourceProvider == nil && cfg != nil && !cfg.ScanSourceAuto && cfg.ScanSource != 0 {
+			source := cfg.ScanSource
+			sourceProvider = func() (byte, bool) {
+				return source, true
+			}
+		}
+		if sourceProvider == nil {
+			disp = b503StubDispatcher{}
+		} else {
+			// Production path: route through the gateway's *protocol.Bus.
+			// readMu is a fresh sync.Mutex dedicated to the B503 dispatcher
+			// — it is NOT the per-poller readMu inside vaillantSemanticPoller
+			// because that field is package-private. Sharing the mutex with
+			// the poller would require either a public accessor or moving
+			// the poller into the same package; both are out of scope for
+			// M6. The dedicated mutex still serialises B503 dispatches with
+			// each other (the M6-CONC-* tests assert this); B524 vs B503
+			// concurrency is governed at the bus.Send level (the bus
+			// arbitrates per-frame serially regardless).
+			readMu := &sync.Mutex{}
+			disp = newRawFrameDispatcherWithSourceProvider(gw.Bus, sourceProvider, readMu, mgr, b503DispatcherRequestTimeout)
+		}
 	} else {
 		disp = b503StubDispatcher{}
 	}

--- a/config.go
+++ b/config.go
@@ -103,6 +103,7 @@ type Config struct {
 	ScanSource               byte
 	ScanSourceAuto           bool
 	StartupProbeTargets      []byte
+	StartupCompanionTarget   byte
 	ScanTimeout              time.Duration
 	ScanRequestTimeout       time.Duration
 	ScanInterval             time.Duration

--- a/config.go
+++ b/config.go
@@ -75,15 +75,15 @@ type WatchObserver interface {
 }
 
 // StartupSourceOverride configures opt-in static-source admission on
-// join-capable direct transports per AD09. Default (unset) preserves
-// the standard Joiner warmup path.
+// source-selection-capable direct transports per AD09. Default (unset) preserves
+// the standard source-address selector warmup path.
 type StartupSourceOverride struct {
 	// Source is the static source address to use for all Helianthus-
-	// originated active frames on join-capable direct transports when
+	// originated active frames on source-selection-capable direct transports when
 	// this override is set. When nil, override is unset.
 	Source *uint8
 
-	// Validate, when true, runs the Joiner in advisory-only mode in
+	// Validate, when true, runs the source-address selector in advisory-only mode in
 	// parallel with the override path so the companion-target conflict
 	// heuristic can still detect a mismatch and emit a WARN log. Does
 	// NOT gate active traffic (active frames fire immediately with the
@@ -102,6 +102,7 @@ type Config struct {
 	ScanOnStart              bool
 	ScanSource               byte
 	ScanSourceAuto           bool
+	StartupProbeTargets      []byte
 	ScanTimeout              time.Duration
 	ScanRequestTimeout       time.Duration
 	ScanInterval             time.Duration

--- a/docs/schemas/admission-artifact.schema.json
+++ b/docs/schemas/admission-artifact.schema.json
@@ -59,12 +59,12 @@
             "tcp-plain",
             "adapter-direct"
           ],
-          "description": "Transport kind from the startup-admission capability matrix. 'adapter-direct' is the multiplexer mode that wraps an underlying ENH/ENS adapter; semantically equivalent to a join-capable transport (main.go special-cases it to admissionPath=JoinCapable)."
+          "description": "Transport kind from the startup-admission capability matrix. 'adapter-direct' is the multiplexer mode that wraps an underlying ENH/ENS adapter; semantically equivalent to a source-selection-capable transport (main.go special-cases it to admissionPath=SourceSelectionCapable)."
         },
         "admission_path_selected": {
           "type": "string",
           "enum": [
-            "join",
+            "source_selection",
             "override",
             "degraded_transport_blind",
             "degraded_no_events"

--- a/evidence_buffer.go
+++ b/evidence_buffer.go
@@ -27,15 +27,15 @@ type EvidenceRecord struct {
 // BaselineTopologySeed is the set of addresses protected from LRU eviction.
 // Vaillant default: {0x08 BAI00, 0x15 BASV2, 0x26 VR_71, 0x04 NETX3-A,
 // 0xF6 NETX3-B, 0xEC SOL00}. Operators MAY override via config; validation
-// enforces slave-range [0x03, 0xFE] excluding 0xAA (SYN) and 0xFE (broadcast).
+// enforces responder-range [0x03, 0xFE] excluding 0xAA (SYN) and 0xFE (broadcast).
 var VaillantBaselineTopologySeed = []byte{0x08, 0x15, 0x26, 0x04, 0xF6, 0xEC}
 
 // ValidateBaselineTopologySeed checks the config-provided seed against the
-// slave-address range.
+// responder-address range.
 func ValidateBaselineTopologySeed(seed []byte) error {
 	for _, addr := range seed {
 		if addr < 0x03 || addr >= 0xFE {
-			return fmt.Errorf("evidence: baseline seed 0x%02X out of slave range [0x03, 0xFE]", addr)
+			return fmt.Errorf("evidence: baseline seed 0x%02X out of responder range [0x03, 0xFE]", addr)
 		}
 		if addr == 0xAA {
 			return fmt.Errorf("evidence: baseline seed must not include SYN (0xAA)")

--- a/full_range_guard.go
+++ b/full_range_guard.go
@@ -21,12 +21,9 @@ func ScanWithFullRangeGuard(ctx context.Context, bus registry.ScanBus, reg *regi
 func scanWithFullRangeGuard(ctx context.Context, bus registry.ScanBus, reg *registry.DeviceRegistry, source byte, targets []byte, admissionPath TransportAdmissionPath, diagnosticFlag bool, evidenceHasVaillantRoot bool) ([]registry.DeviceEntry, error) {
 	if admissionPath == TransportAdmissionSourceSelectionCapable {
 		if len(targets) == 0 {
-			if !diagnosticFlag {
-				return nil, fmt.Errorf("full-range retry: disabled by default on non-ebusd-tcp; set --diagnostic-full-range-retry to enable after at least one Vaillant root candidate is observed (AD05)")
-			}
-			if !evidenceHasVaillantRoot {
-				return nil, fmt.Errorf("full-range retry: diagnostic flag set but evidence buffer has no Vaillant root candidate yet (AD05)")
-			}
+			_ = diagnosticFlag
+			_ = evidenceHasVaillantRoot
+			return nil, fmt.Errorf("source selection: active probe requires explicit bounded targets")
 		} else {
 			return scanWithFullRangeGuardScanDirectedFn(ctx, bus, reg, source, targets)
 		}

--- a/full_range_guard.go
+++ b/full_range_guard.go
@@ -19,7 +19,7 @@ func ScanWithFullRangeGuard(ctx context.Context, bus registry.ScanBus, reg *regi
 }
 
 func scanWithFullRangeGuard(ctx context.Context, bus registry.ScanBus, reg *registry.DeviceRegistry, source byte, targets []byte, admissionPath TransportAdmissionPath, diagnosticFlag bool, evidenceHasVaillantRoot bool) ([]registry.DeviceEntry, error) {
-	if admissionPath == TransportAdmissionJoinCapable {
+	if admissionPath == TransportAdmissionSourceSelectionCapable {
 		if len(targets) == 0 {
 			if !diagnosticFlag {
 				return nil, fmt.Errorf("full-range retry: disabled by default on non-ebusd-tcp; set --diagnostic-full-range-retry to enable after at least one Vaillant root candidate is observed (AD05)")

--- a/full_range_guard_test.go
+++ b/full_range_guard_test.go
@@ -29,8 +29,8 @@ func TestScanWithFullRangeGuard(t *testing.T) {
 	reg := registry.NewDeviceRegistry(nil)
 	bus := &testScanBus{}
 
-	t.Run("join-capable nil targets diag off rejects", func(t *testing.T) {
-		_, err := scanWithFullRangeGuard(context.Background(), bus, reg, 0xF0, nil, TransportAdmissionJoinCapable, false, false)
+	t.Run("source-selection-capable nil targets source zero diag off rejects", func(t *testing.T) {
+		_, err := scanWithFullRangeGuard(context.Background(), bus, reg, 0x00, nil, TransportAdmissionSourceSelectionCapable, false, false)
 		if err == nil || !strings.Contains(err.Error(), "disabled by default") {
 			t.Fatalf("expected disabled-by-default error, got %v", err)
 		}
@@ -39,8 +39,8 @@ func TestScanWithFullRangeGuard(t *testing.T) {
 		}
 	})
 
-	t.Run("join-capable nil targets diag on without root rejects", func(t *testing.T) {
-		_, err := scanWithFullRangeGuard(context.Background(), bus, reg, 0xF0, nil, TransportAdmissionJoinCapable, true, false)
+	t.Run("source-selection-capable nil targets diag on without root rejects", func(t *testing.T) {
+		_, err := scanWithFullRangeGuard(context.Background(), bus, reg, 0x00, nil, TransportAdmissionSourceSelectionCapable, true, false)
 		if err == nil || !strings.Contains(err.Error(), "no Vaillant root candidate yet") {
 			t.Fatalf("expected no-root error, got %v", err)
 		}
@@ -49,13 +49,13 @@ func TestScanWithFullRangeGuard(t *testing.T) {
 		}
 	})
 
-	t.Run("join-capable nil targets diag on with root proceeds via legacy scan", func(t *testing.T) {
+	t.Run("source-selection-capable nil targets diag on with root proceeds via legacy scan", func(t *testing.T) {
 		called := false
 		scanWithFullRangeGuardScanFn = func(context.Context, registry.ScanBus, *registry.DeviceRegistry, byte, []byte) ([]registry.DeviceEntry, error) {
 			called = true
 			return nil, nil
 		}
-		_, err := scanWithFullRangeGuard(context.Background(), bus, reg, 0xF0, nil, TransportAdmissionJoinCapable, true, true)
+		_, err := scanWithFullRangeGuard(context.Background(), bus, reg, 0x00, nil, TransportAdmissionSourceSelectionCapable, true, true)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -64,7 +64,7 @@ func TestScanWithFullRangeGuard(t *testing.T) {
 		}
 	})
 
-	t.Run("join-capable explicit targets use ScanDirected", func(t *testing.T) {
+	t.Run("source-selection-capable explicit targets use ScanDirected", func(t *testing.T) {
 		scanCalled := false
 		directedCalled := false
 		scanWithFullRangeGuardScanFn = func(context.Context, registry.ScanBus, *registry.DeviceRegistry, byte, []byte) ([]registry.DeviceEntry, error) {
@@ -75,7 +75,7 @@ func TestScanWithFullRangeGuard(t *testing.T) {
 			directedCalled = true
 			return nil, nil
 		}
-		_, err := scanWithFullRangeGuard(context.Background(), bus, reg, 0xF0, []byte{0x08}, TransportAdmissionJoinCapable, false, false)
+		_, err := scanWithFullRangeGuard(context.Background(), bus, reg, 0xF0, []byte{0x08}, TransportAdmissionSourceSelectionCapable, false, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/full_range_guard_test.go
+++ b/full_range_guard_test.go
@@ -31,8 +31,8 @@ func TestScanWithFullRangeGuard(t *testing.T) {
 
 	t.Run("source-selection-capable nil targets source zero diag off rejects", func(t *testing.T) {
 		_, err := scanWithFullRangeGuard(context.Background(), bus, reg, 0x00, nil, TransportAdmissionSourceSelectionCapable, false, false)
-		if err == nil || !strings.Contains(err.Error(), "disabled by default") {
-			t.Fatalf("expected disabled-by-default error, got %v", err)
+		if err == nil || !strings.Contains(err.Error(), "active probe requires explicit bounded targets") {
+			t.Fatalf("expected bounded-target error, got %v", err)
 		}
 		if bus.calls != 0 {
 			t.Fatalf("guard reject should not touch bus, got %d calls", bus.calls)
@@ -41,26 +41,26 @@ func TestScanWithFullRangeGuard(t *testing.T) {
 
 	t.Run("source-selection-capable nil targets diag on without root rejects", func(t *testing.T) {
 		_, err := scanWithFullRangeGuard(context.Background(), bus, reg, 0x00, nil, TransportAdmissionSourceSelectionCapable, true, false)
-		if err == nil || !strings.Contains(err.Error(), "no Vaillant root candidate yet") {
-			t.Fatalf("expected no-root error, got %v", err)
+		if err == nil || !strings.Contains(err.Error(), "active probe requires explicit bounded targets") {
+			t.Fatalf("expected bounded-target error, got %v", err)
 		}
 		if bus.calls != 0 {
 			t.Fatalf("guard reject should not touch bus, got %d calls", bus.calls)
 		}
 	})
 
-	t.Run("source-selection-capable nil targets diag on with root proceeds via legacy scan", func(t *testing.T) {
+	t.Run("source-selection-capable nil targets diag on with root still rejects", func(t *testing.T) {
 		called := false
 		scanWithFullRangeGuardScanFn = func(context.Context, registry.ScanBus, *registry.DeviceRegistry, byte, []byte) ([]registry.DeviceEntry, error) {
 			called = true
 			return nil, nil
 		}
 		_, err := scanWithFullRangeGuard(context.Background(), bus, reg, 0x00, nil, TransportAdmissionSourceSelectionCapable, true, true)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+		if err == nil || !strings.Contains(err.Error(), "active probe requires explicit bounded targets") {
+			t.Fatalf("expected bounded-target error, got %v", err)
 		}
-		if !called {
-			t.Fatal("expected legacy Scan path to be used")
+		if called {
+			t.Fatal("source-selection path must not fall back to legacy full-range Scan")
 		}
 	})
 
@@ -90,7 +90,7 @@ func TestScanWithFullRangeGuard(t *testing.T) {
 			called = true
 			return nil, nil
 		}
-		_, err := scanWithFullRangeGuard(context.Background(), bus, reg, 0x31, nil, TransportAdmissionStaticFallback, false, false)
+		_, err := scanWithFullRangeGuard(context.Background(), bus, reg, 0x7F, nil, TransportAdmissionStaticFallback, false, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260505120935-8083eedd15ee
-	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260419103431-30aa69a099ec
+	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260505121944-06c9f875761f
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Project-Helianthus/helianthus-ebusgateway
 go 1.22
 
 require (
-	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260422202142-5491494d667c
+	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260505120935-8083eedd15ee
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260419103431-30aa69a099ec
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260422202142-5491494d667c h1:TR9LfKzlnfDm0T3MLOhC0rIqu0ox8CSbEEMAKnEiWH8=
-github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260422202142-5491494d667c/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
+github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260505120935-8083eedd15ee h1:2Ze+bphuP+/GYKg/mnFqlcDwQp6mXWvas7xjS4+p1ac=
+github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260505120935-8083eedd15ee/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260419103431-30aa69a099ec h1:l0DzHLH41AmijBTb/an+j98JfTImJMlpgKZ19Eeb7G8=
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260419103431-30aa69a099ec/go.mod h1:ux6qvwEyyK+LUfseHKpTTS4i5O6slZHVZ+f4orOtFm4=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260505120935-8083eedd15ee h1:2Ze+bphuP+/GYKg/mnFqlcDwQp6mXWvas7xjS4+p1ac=
 github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260505120935-8083eedd15ee/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260419103431-30aa69a099ec h1:l0DzHLH41AmijBTb/an+j98JfTImJMlpgKZ19Eeb7G8=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260419103431-30aa69a099ec/go.mod h1:ux6qvwEyyK+LUfseHKpTTS4i5O6slZHVZ+f4orOtFm4=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260505121944-06c9f875761f h1:19h6QUOZ7ugyag30Ku5vtHIfE/au/VFNCDAMxRZY2zI=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260505121944-06c9f875761f/go.mod h1:ux6qvwEyyK+LUfseHKpTTS4i5O6slZHVZ+f4orOtFm4=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=

--- a/graphql/builder.go
+++ b/graphql/builder.go
@@ -6,16 +6,16 @@ import (
 )
 
 type Builder struct {
-	registry Registry
-	changes  <-chan struct{}
-	status   StatusProvider
-	identity GatewayIdentityProvider
-	semantic SemanticProvider
-	bus      BusObservabilityProvider
-	watch    WatchSummaryProvider
-	boiler   BoilerConfigWriter
-	system   SystemConfigWriter
-	schedule ScheduleWriter
+	registry     Registry
+	changes      <-chan struct{}
+	status       StatusProvider
+	identity     GatewayIdentityProvider
+	semantic     SemanticProvider
+	bus          BusObservabilityProvider
+	watch        WatchSummaryProvider
+	boiler       BoilerConfigWriter
+	system       SystemConfigWriter
+	schedule     ScheduleWriter
 	vaillantB503 VaillantB503Provider
 
 	mu       sync.RWMutex

--- a/graphql/builder.go
+++ b/graphql/builder.go
@@ -6,17 +6,19 @@ import (
 )
 
 type Builder struct {
-	registry     Registry
-	changes      <-chan struct{}
-	status       StatusProvider
-	identity     GatewayIdentityProvider
-	semantic     SemanticProvider
-	bus          BusObservabilityProvider
-	watch        WatchSummaryProvider
-	boiler       BoilerConfigWriter
-	system       SystemConfigWriter
-	schedule     ScheduleWriter
-	vaillantB503 VaillantB503Provider
+	registry               Registry
+	changes                <-chan struct{}
+	status                 StatusProvider
+	identity               GatewayIdentityProvider
+	semantic               SemanticProvider
+	bus                    BusObservabilityProvider
+	watch                  WatchSummaryProvider
+	boiler                 BoilerConfigWriter
+	system                 SystemConfigWriter
+	schedule               ScheduleWriter
+	vaillantB503           VaillantB503Provider
+	mutationSource         byte
+	mutationSourceAdmitted bool
 
 	mu       sync.RWMutex
 	schema   Schema
@@ -256,6 +258,41 @@ func (b *Builder) SetSystemConfigWriter(writer SystemConfigWriter) {
 	b.mu.Lock()
 	b.system = writer
 	b.mu.Unlock()
+}
+
+func (b *Builder) SetAdmittedMutationSource(source byte) {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	b.mutationSource = source
+	b.mutationSourceAdmitted = source != 0
+	b.mu.Unlock()
+}
+
+func (b *Builder) ClearAdmittedMutationSource() {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	b.mutationSource = 0
+	b.mutationSourceAdmitted = false
+	b.mu.Unlock()
+}
+
+func (b *Builder) admittedMutationSource() (byte, bool) {
+	if b == nil {
+		return 0, false
+	}
+	b.mu.RLock()
+	source := b.mutationSource
+	admitted := b.mutationSourceAdmitted
+	b.mu.RUnlock()
+	return source, admitted
+}
+
+func (b *Builder) AdmittedMutationSource() (byte, bool) {
+	return b.admittedMutationSource()
 }
 
 func (b *Builder) systemConfigWriter() SystemConfigWriter {

--- a/graphql/bus_observability.go
+++ b/graphql/bus_observability.go
@@ -708,6 +708,52 @@ func buildBusObservabilityTypes() (*graphqlgo.Object, *graphqlgo.Object, *graphq
 		},
 	})
 
+	busAdmissionType := graphqlgo.NewObject(graphqlgo.ObjectConfig{
+		Name: "BusAdmission",
+		Fields: graphqlgo.Fields{
+			"state": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.String),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					admission, ok := busAdmissionFromSource(params.Source)
+					if !ok {
+						return "", nil
+					}
+					return admission.State, nil
+				},
+			},
+			"source": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Int),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					admission, ok := busAdmissionFromSource(params.Source)
+					if !ok {
+						return 0, nil
+					}
+					return int(admission.Source), nil
+				},
+			},
+			"companionTarget": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Int),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					admission, ok := busAdmissionFromSource(params.Source)
+					if !ok {
+						return 0, nil
+					}
+					return int(admission.CompanionTarget), nil
+				},
+			},
+			"reason": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					admission, ok := busAdmissionFromSource(params.Source)
+					if !ok || admission.Reason == "" {
+						return nil, nil
+					}
+					return admission.Reason, nil
+				},
+			},
+		},
+	})
+
 	statusType := graphqlgo.NewObject(graphqlgo.ObjectConfig{
 		Name: "BusObservabilityStatus",
 		Fields: graphqlgo.Fields{
@@ -807,6 +853,20 @@ func buildBusObservabilityTypes() (*graphqlgo.Object, *graphqlgo.Object, *graphq
 						return BusObservabilityDegraded{}, nil
 					}
 					return value.Degraded, nil
+				},
+			},
+			"busAdmission": &graphqlgo.Field{
+				Type: busAdmissionType,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					status, ok := params.Source.(*BusObservabilityStatus)
+					if ok && status != nil {
+						return status.BusAdmission, nil
+					}
+					value, ok := params.Source.(BusObservabilityStatus)
+					if !ok {
+						return nil, nil
+					}
+					return value.BusAdmission, nil
 				},
 			},
 			"startup": &graphqlgo.Field{
@@ -1430,4 +1490,18 @@ func resolveBusPeriodicity(builder *Builder, rootValue any, limit int) *BusPerio
 	result.Count = len(snapshot.Periodicity)
 	result.Capacity = len(snapshot.Periodicity)
 	return result
+}
+
+func busAdmissionFromSource(source any) (BusAdmission, bool) {
+	switch admission := source.(type) {
+	case BusAdmission:
+		return admission, true
+	case *BusAdmission:
+		if admission == nil {
+			return BusAdmission{}, false
+		}
+		return *admission, true
+	default:
+		return BusAdmission{}, false
+	}
 }

--- a/graphql/mutations.go
+++ b/graphql/mutations.go
@@ -96,7 +96,6 @@ type configFieldSpec struct {
 
 const (
 	mutationControllerFallbackAddr = byte(0x15)
-	mutationSourceAddr             = byte(0x31)
 	mutationB524OpcodeLocal        = byte(0x02)
 	mutationSystemPlane            = "system"
 	mutationSetExtRegisterMethod   = "set_ext_register"
@@ -153,7 +152,7 @@ func NewSchema(builder *Builder, registry InvokeRegistry, invoker Invoker, hub *
 
 	var mutationType *graphqlgo.Object
 	if registry != nil && invoker != nil {
-		mutationType = buildMutationType(registry, invoker, builder.boilerConfigWriter(), builder.systemConfigWriter(), builder.scheduleWriter())
+		mutationType = buildMutationType(registry, invoker, builder.boilerConfigWriter(), builder.systemConfigWriter(), builder.scheduleWriter(), builder.admittedMutationSource)
 	}
 
 	var subscriptionType *graphqlgo.Object
@@ -184,7 +183,10 @@ func NewInvokeHandler(builder *Builder, registry InvokeRegistry, invoker Invoker
 	}), nil
 }
 
-func buildMutationType(registry InvokeRegistry, invoker Invoker, boilerWriter BoilerConfigWriter, systemWriter SystemConfigWriter, scheduleWriter ScheduleWriter) *graphqlgo.Object {
+func buildMutationType(registry InvokeRegistry, invoker Invoker, boilerWriter BoilerConfigWriter, systemWriter SystemConfigWriter, scheduleWriter ScheduleWriter, mutationSourceProvider func() (byte, bool)) *graphqlgo.Object {
+	if mutationSourceProvider == nil {
+		mutationSourceProvider = func() (byte, bool) { return 0, false }
+	}
 	jsonScalar := jsonScalarType()
 	errorType := graphqlgo.NewObject(graphqlgo.ObjectConfig{
 		Name: "InvokeError",
@@ -404,7 +406,8 @@ func buildMutationType(registry InvokeRegistry, invoker Invoker, boilerWriter Bo
 					"params":  &graphqlgo.ArgumentConfig{Type: jsonScalar},
 				},
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
-					result, err := invokeResolve(params, registry, invoker)
+					source, admitted := mutationSourceProvider()
+					result, err := invokeResolve(params, registry, invoker, source, admitted)
 					if err != nil {
 						return InvokeResult{
 							Ok:    false,
@@ -452,7 +455,8 @@ func buildMutationType(registry InvokeRegistry, invoker Invoker, boilerWriter Bo
 					"value": &graphqlgo.ArgumentConfig{Type: graphqlgo.NewNonNull(graphqlgo.String)},
 				},
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
-					return setCircuitConfigResolve(params, registry, invoker), nil
+					mutationSource, mutationSourceAdmitted := mutationSourceProvider()
+					return setCircuitConfigResolve(params, registry, invoker, mutationSource, mutationSourceAdmitted), nil
 				},
 			},
 			"set_circuit_config": &graphqlgo.Field{
@@ -463,7 +467,8 @@ func buildMutationType(registry InvokeRegistry, invoker Invoker, boilerWriter Bo
 					"value": &graphqlgo.ArgumentConfig{Type: graphqlgo.NewNonNull(graphqlgo.String)},
 				},
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
-					return setCircuitConfigResolve(params, registry, invoker), nil
+					mutationSource, mutationSourceAdmitted := mutationSourceProvider()
+					return setCircuitConfigResolve(params, registry, invoker, mutationSource, mutationSourceAdmitted), nil
 				},
 			},
 			"setSystemConfig": &graphqlgo.Field{
@@ -473,7 +478,8 @@ func buildMutationType(registry InvokeRegistry, invoker Invoker, boilerWriter Bo
 					"value": &graphqlgo.ArgumentConfig{Type: graphqlgo.NewNonNull(graphqlgo.String)},
 				},
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
-					return setSystemConfigResolve(params, registry, invoker, systemWriter), nil
+					mutationSource, mutationSourceAdmitted := mutationSourceProvider()
+					return setSystemConfigResolve(params, registry, invoker, systemWriter, mutationSource, mutationSourceAdmitted), nil
 				},
 			},
 			"set_system_config": &graphqlgo.Field{
@@ -483,7 +489,8 @@ func buildMutationType(registry InvokeRegistry, invoker Invoker, boilerWriter Bo
 					"value": &graphqlgo.ArgumentConfig{Type: graphqlgo.NewNonNull(graphqlgo.String)},
 				},
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
-					return setSystemConfigResolve(params, registry, invoker, systemWriter), nil
+					mutationSource, mutationSourceAdmitted := mutationSourceProvider()
+					return setSystemConfigResolve(params, registry, invoker, systemWriter, mutationSource, mutationSourceAdmitted), nil
 				},
 			},
 			"setZoneConfig": &graphqlgo.Field{
@@ -494,7 +501,8 @@ func buildMutationType(registry InvokeRegistry, invoker Invoker, boilerWriter Bo
 					"value": &graphqlgo.ArgumentConfig{Type: graphqlgo.NewNonNull(graphqlgo.String)},
 				},
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
-					return setZoneConfigResolve(params, registry, invoker), nil
+					mutationSource, mutationSourceAdmitted := mutationSourceProvider()
+					return setZoneConfigResolve(params, registry, invoker, mutationSource, mutationSourceAdmitted), nil
 				},
 			},
 			"set_zone_config": &graphqlgo.Field{
@@ -505,7 +513,8 @@ func buildMutationType(registry InvokeRegistry, invoker Invoker, boilerWriter Bo
 					"value": &graphqlgo.ArgumentConfig{Type: graphqlgo.NewNonNull(graphqlgo.String)},
 				},
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
-					return setZoneConfigResolve(params, registry, invoker), nil
+					mutationSource, mutationSourceAdmitted := mutationSourceProvider()
+					return setZoneConfigResolve(params, registry, invoker, mutationSource, mutationSourceAdmitted), nil
 				},
 			},
 			"setZoneTimeProgram": &graphqlgo.Field{
@@ -561,7 +570,7 @@ func boilerConfigUnsupportedResult() BoilerConfigMutationResult {
 	}
 }
 
-func setCircuitConfigResolve(params graphqlgo.ResolveParams, registry InvokeRegistry, invoker Invoker) ConfigMutationResult {
+func setCircuitConfigResolve(params graphqlgo.ResolveParams, registry InvokeRegistry, invoker Invoker, mutationSource byte, mutationSourceAdmitted bool) ConfigMutationResult {
 	instance, err := parseConfigInstance(params.Args["index"])
 	if err != nil {
 		return configMutationError(err)
@@ -572,10 +581,10 @@ func setCircuitConfigResolve(params graphqlgo.ResolveParams, registry InvokeRegi
 	if err != nil {
 		return configMutationError(err)
 	}
-	return applyConfigMutation(params.Context, registry, invoker, spec, instance, fieldValue)
+	return applyConfigMutation(params.Context, registry, invoker, mutationSource, mutationSourceAdmitted, spec, instance, fieldValue)
 }
 
-func setSystemConfigResolve(params graphqlgo.ResolveParams, registry InvokeRegistry, invoker Invoker, systemWriter SystemConfigWriter) ConfigMutationResult {
+func setSystemConfigResolve(params graphqlgo.ResolveParams, registry InvokeRegistry, invoker Invoker, systemWriter SystemConfigWriter, mutationSource byte, mutationSourceAdmitted bool) ConfigMutationResult {
 	fieldName, _ := params.Args["field"].(string)
 	fieldValue, _ := params.Args["value"].(string)
 	if systemWriter != nil {
@@ -589,10 +598,10 @@ func setSystemConfigResolve(params graphqlgo.ResolveParams, registry InvokeRegis
 	if err != nil {
 		return configMutationError(err)
 	}
-	return applyConfigMutation(params.Context, registry, invoker, spec, 0x00, fieldValue)
+	return applyConfigMutation(params.Context, registry, invoker, mutationSource, mutationSourceAdmitted, spec, 0x00, fieldValue)
 }
 
-func setZoneConfigResolve(params graphqlgo.ResolveParams, registry InvokeRegistry, invoker Invoker) ConfigMutationResult {
+func setZoneConfigResolve(params graphqlgo.ResolveParams, registry InvokeRegistry, invoker Invoker, mutationSource byte, mutationSourceAdmitted bool) ConfigMutationResult {
 	instance, err := parseConfigInstance(params.Args["index"])
 	if err != nil {
 		return configMutationError(err)
@@ -603,7 +612,7 @@ func setZoneConfigResolve(params graphqlgo.ResolveParams, registry InvokeRegistr
 	if err != nil {
 		return configMutationError(err)
 	}
-	return applyConfigMutation(params.Context, registry, invoker, spec, instance, fieldValue)
+	return applyConfigMutation(params.Context, registry, invoker, mutationSource, mutationSourceAdmitted, spec, instance, fieldValue)
 }
 
 func setZoneTimeProgramResolve(params graphqlgo.ResolveParams, scheduleWriter ScheduleWriter) *mcp.TimeProgramWriteResult {
@@ -670,9 +679,12 @@ func setDhwTimeProgramResolve(params graphqlgo.ResolveParams, scheduleWriter Sch
 	return result
 }
 
-func applyConfigMutation(ctx context.Context, registry InvokeRegistry, invoker Invoker, spec configFieldSpec, instance byte, rawValue string) ConfigMutationResult {
+func applyConfigMutation(ctx context.Context, registry InvokeRegistry, invoker Invoker, source byte, sourceAdmitted bool, spec configFieldSpec, instance byte, rawValue string) ConfigMutationResult {
 	if registry == nil || invoker == nil {
 		return configMutationError(fmt.Errorf("config mutation missing dependencies: %w", ebuserrors.ErrInvalidPayload))
+	}
+	if !sourceAdmitted || source == 0 {
+		return configMutationError(fmt.Errorf("source selection not active: %w", ebuserrors.ErrInvalidPayload))
 	}
 
 	data, err := encodeConfigValue(spec, rawValue)
@@ -690,7 +702,7 @@ func applyConfigMutation(ctx context.Context, registry InvokeRegistry, invoker I
 	}
 
 	writeParams := map[string]any{
-		"source":   mutationSourceAddr,
+		"source":   source,
 		"opcode":   mutationB524OpcodeLocal,
 		"group":    spec.group,
 		"instance": instance,
@@ -702,7 +714,7 @@ func applyConfigMutation(ctx context.Context, registry InvokeRegistry, invoker I
 	}
 
 	readParams := map[string]any{
-		"source":   mutationSourceAddr,
+		"source":   source,
 		"opcode":   mutationB524OpcodeLocal,
 		"group":    spec.group,
 		"instance": instance,
@@ -837,12 +849,12 @@ func scheduleWriteMutationError(err error) *mcp.TimeProgramWriteResult {
 }
 
 // ApplyConfigMutation performs a B524 set_ext_register write with read-back verification.
-func ApplyConfigMutation(ctx context.Context, registry InvokeRegistry, invoker Invoker, fieldName string, rawValue string, specs map[string]configFieldSpec) ConfigMutationResult {
+func ApplyConfigMutation(ctx context.Context, registry InvokeRegistry, invoker Invoker, source byte, sourceAdmitted bool, fieldName string, rawValue string, specs map[string]configFieldSpec) ConfigMutationResult {
 	spec, err := resolveConfigFieldSpec("system", fieldName, specs)
 	if err != nil {
 		return configMutationError(err)
 	}
-	return applyConfigMutation(ctx, registry, invoker, spec, 0x00, rawValue)
+	return applyConfigMutation(ctx, registry, invoker, source, sourceAdmitted, spec, 0x00, rawValue)
 }
 
 // SystemConfigFieldSpecs returns a copy of the system config field specs map.
@@ -1258,9 +1270,12 @@ func decodePayloadUint16(payload []byte) (uint16, bool) {
 	return binary.LittleEndian.Uint16(payload[:2]), true
 }
 
-func invokeResolve(params graphqlgo.ResolveParams, registry InvokeRegistry, invoker Invoker) (InvokeResult, error) {
+func invokeResolve(params graphqlgo.ResolveParams, registry InvokeRegistry, invoker Invoker, source byte, sourceAdmitted bool) (InvokeResult, error) {
 	if registry == nil || invoker == nil {
 		return InvokeResult{}, fmt.Errorf("graphql invoke missing dependencies: %w", ebuserrors.ErrInvalidPayload)
+	}
+	if !sourceAdmitted || source == 0 {
+		return InvokeResult{}, fmt.Errorf("source selection not active: %w", ebuserrors.ErrInvalidPayload)
 	}
 
 	address, err := parseAddress(params.Args["address"])
@@ -1273,6 +1288,9 @@ func invokeResolve(params graphqlgo.ResolveParams, registry InvokeRegistry, invo
 	paramMap, err := parseParams(params.Args["params"])
 	if err != nil {
 		return InvokeResult{}, err
+	}
+	if _, ok := paramMap["source"]; ok {
+		return InvokeResult{}, fmt.Errorf("graphql invoke field %q unsupported: %w", "source", ebuserrors.ErrInvalidPayload)
 	}
 
 	entry, ok := registry.Lookup(address)
@@ -1299,6 +1317,7 @@ func invokeResolve(params graphqlgo.ResolveParams, registry InvokeRegistry, invo
 	if err != nil {
 		return InvokeResult{}, err
 	}
+	normalizedParams["source"] = source
 
 	ctx := params.Context
 	if ctx == nil {

--- a/graphql/mutations_integration_test.go
+++ b/graphql/mutations_integration_test.go
@@ -2,6 +2,7 @@ package graphql
 
 import (
 	"context"
+	"net/http/httptest"
 	"sync"
 	"testing"
 
@@ -12,8 +13,8 @@ import (
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
 	"github.com/Project-Helianthus/helianthus-ebusreg/router"
 	"github.com/Project-Helianthus/helianthus-ebusreg/schema"
+	graphqlgo "github.com/graphql-go/graphql"
 	graphqlclient "github.com/machinebox/graphql"
-	"net/http/httptest"
 )
 
 type invokeTemplate struct {
@@ -241,6 +242,7 @@ func TestInvokeMutation_Integration(t *testing.T) {
 	gateway.Start(ctx)
 
 	builder := NewBuilder(gateway.Registry, nil)
+	builder.SetAdmittedMutationSource(plane.source)
 	if err := builder.Start(context.Background()); err != nil {
 		t.Fatalf("builder.Start error = %v", err)
 	}
@@ -303,6 +305,59 @@ func TestInvokeMutation_Integration(t *testing.T) {
 		t.Fatalf("transport write missing")
 	} else if !equalBytes(got[:len(expectedWrite)], expectedWrite) {
 		t.Fatalf("transport write prefix = %v; want %v", got[:len(expectedWrite)], expectedWrite)
+	}
+}
+
+func TestInvokeMutation_FailsClosedBeforeSourceAdmission(t *testing.T) {
+	method := mockMethod{
+		name:     "set_level",
+		readOnly: false,
+		template: invokeTemplate{
+			primary:   0xB5,
+			secondary: 0x05,
+			params: schema.Schema{
+				Fields: []schema.SchemaField{
+					{Name: "level", Type: types.DATA1b{}},
+				},
+			},
+		},
+	}
+	plane := &invokePlane{
+		name:            "heating",
+		source:          0x10,
+		target:          0x08,
+		hardwareVersion: "7603",
+		methods:         []registry.Method{method},
+	}
+	reg := mutationTestRegistry{
+		entries: map[byte]registry.DeviceEntry{
+			plane.target: mockEntry{
+				info: registry.DeviceInfo{
+					Address:         plane.target,
+					Manufacturer:    "vaillant",
+					DeviceID:        "device-a",
+					HardwareVersion: plane.hardwareVersion,
+				},
+				planes: []registry.Plane{plane},
+			},
+		},
+		order: []byte{plane.target},
+	}
+	invoker := &mutationTestInvoker{}
+
+	_, err := invokeResolve(graphqlgo.ResolveParams{
+		Args: map[string]any{
+			"address": int(plane.target),
+			"plane":   "heating",
+			"method":  "set_level",
+			"params":  map[string]any{"level": 5},
+		},
+	}, reg, invoker, 0, false)
+	if err == nil {
+		t.Fatal("invokeResolve before source admission = nil; want fail-closed error")
+	}
+	if len(invoker.calls) != 0 {
+		t.Fatalf("invoker calls = %d; want 0 before source admission", len(invoker.calls))
 	}
 }
 

--- a/graphql/mutations_unit_test.go
+++ b/graphql/mutations_unit_test.go
@@ -259,7 +259,7 @@ func TestSetBoilerConfigMutation_UnsupportedInReducedProfile(t *testing.T) {
 			"noop": &graphqlgo.Field{Type: graphqlgo.String},
 		},
 	})
-	mutationType := buildMutationType(nil, nil, nil, nil, nil)
+	mutationType := buildMutationType(nil, nil, nil, nil, nil, func() (byte, bool) { return 0, false })
 	schema, err := graphqlgo.NewSchema(graphqlgo.SchemaConfig{
 		Query:    queryType,
 		Mutation: mutationType,
@@ -351,8 +351,8 @@ func TestSetCircuitConfigMutation_Success(t *testing.T) {
 	if got := first.Params["opcode"]; got != byte(0x02) {
 		t.Fatalf("first call opcode = %#v; want 0x02", got)
 	}
-	if got := first.Params["source"]; got != byte(0x31) {
-		t.Fatalf("first call source = %#v; want 0x31", got)
+	if got := first.Params["source"]; got != byte(0x7F) {
+		t.Fatalf("first call source = %#v; want 0x7F", got)
 	}
 	dataBytes, ok := first.Params["data"].([]byte)
 	if !ok || !bytes.Equal(dataBytes, []byte{0x00, 0x00, 0xC0, 0x3F}) {
@@ -365,6 +365,61 @@ func TestSetCircuitConfigMutation_Success(t *testing.T) {
 	}
 	if _, ok := second.Params["data"]; ok {
 		t.Fatalf("second call unexpectedly has data param: %#v", second.Params["data"])
+	}
+}
+
+func TestSetCircuitConfigMutation_FailsClosedBeforeSourceAdmission(t *testing.T) {
+	registry := mutationTestRegistry{
+		entries: map[byte]registry.DeviceEntry{
+			0x15: testControllerEntryWithMethods(mutationSetExtRegisterMethod, mutationGetExtRegisterMethod),
+		},
+		order: []byte{0x15},
+	}
+	invoker := &mutationTestInvoker{}
+
+	data := executeMutation(t, buildMutationSchemaWithSourceProvider(t, registry, invoker, nil, nil, func() (byte, bool) {
+		return 0, false
+	}), `mutation {
+		setCircuitConfig(index: 1, field: "heatingCurve", value: "1.5") {
+			success
+			error
+		}
+	}`)
+
+	payload, ok := data["setCircuitConfig"].(map[string]any)
+	if !ok {
+		t.Fatalf("setCircuitConfig payload type = %T; want map", data["setCircuitConfig"])
+	}
+	if got, _ := payload["success"].(bool); got {
+		t.Fatalf("setCircuitConfig success = %v; want false", got)
+	}
+	errMessage, _ := payload["error"].(string)
+	if !strings.Contains(errMessage, "source selection not active") {
+		t.Fatalf("setCircuitConfig error = %q; want source selection not active", errMessage)
+	}
+	if len(invoker.calls) != 0 {
+		t.Fatalf("invoker calls = %d; want 0 before source admission", len(invoker.calls))
+	}
+}
+
+func TestApplyConfigMutation_FailsClosedBeforeSourceAdmission(t *testing.T) {
+	registry := mutationTestRegistry{
+		entries: map[byte]registry.DeviceEntry{
+			0x15: testControllerEntryWithMethods(mutationSetExtRegisterMethod, mutationGetExtRegisterMethod),
+		},
+		order: []byte{0x15},
+	}
+	invoker := &mutationTestInvoker{}
+
+	result := ApplyConfigMutation(context.Background(), registry, invoker, 0, false, "heatingCurve", "1.5", circuitConfigFieldSpecs)
+	if result.Success {
+		t.Fatalf("ApplyConfigMutation success = true; want false")
+	}
+	if !strings.Contains(result.Error, "source selection not active") {
+		t.Fatalf("ApplyConfigMutation error = %q; want source selection not active", result.Error)
+	}
+	if len(invoker.calls) != 0 {
+		t.Fatalf("invoker calls = %d; want 0 before source admission", len(invoker.calls))
 	}
 }
 
@@ -812,6 +867,10 @@ func TestSetZoneTimeProgramMutation_InvalidJSON(t *testing.T) {
 }
 
 func buildMutationSchema(t *testing.T, registry InvokeRegistry, invoker Invoker, boilerWriter BoilerConfigWriter, scheduleWriter ScheduleWriter) graphqlgo.Schema {
+	return buildMutationSchemaWithSourceProvider(t, registry, invoker, boilerWriter, scheduleWriter, func() (byte, bool) { return 0x7F, true })
+}
+
+func buildMutationSchemaWithSourceProvider(t *testing.T, registry InvokeRegistry, invoker Invoker, boilerWriter BoilerConfigWriter, scheduleWriter ScheduleWriter, sourceProvider func() (byte, bool)) graphqlgo.Schema {
 	t.Helper()
 	queryType := graphqlgo.NewObject(graphqlgo.ObjectConfig{
 		Name: "Query",
@@ -819,7 +878,7 @@ func buildMutationSchema(t *testing.T, registry InvokeRegistry, invoker Invoker,
 			"noop": &graphqlgo.Field{Type: graphqlgo.String},
 		},
 	})
-	mutationType := buildMutationType(registry, invoker, boilerWriter, nil, scheduleWriter)
+	mutationType := buildMutationType(registry, invoker, boilerWriter, nil, scheduleWriter, sourceProvider)
 	schema, err := graphqlgo.NewSchema(graphqlgo.SchemaConfig{
 		Query:    queryType,
 		Mutation: mutationType,

--- a/graphql/vaillant_b503_test.go
+++ b/graphql/vaillant_b503_test.go
@@ -120,12 +120,12 @@ func TestVaillantB503GraphQL_ErrorsGet_Schema(t *testing.T) {
 	// Confirm types present.
 	types, _ := sch["types"].([]any)
 	neededTypes := map[string]bool{
-		"B503Availability":             false,
-		"VaillantB503Errors":           false,
-		"VaillantB503HistoryRecord":    false,
-		"VaillantB503LiveMonitor":      false,
-		"VaillantB503Capability":       false,
-		"VaillantCapabilities":         false,
+		"B503Availability":          false,
+		"VaillantB503Errors":        false,
+		"VaillantB503HistoryRecord": false,
+		"VaillantB503LiveMonitor":   false,
+		"VaillantB503Capability":    false,
+		"VaillantCapabilities":      false,
 	}
 	for _, tEntry := range types {
 		m, _ := tEntry.(map[string]any)

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -1688,10 +1688,10 @@ func (m *Mux) tryGrantAndStart() {
 	}
 	// Do not launch a new START while we still expect at least one stale
 	// STARTED/FAILED from a cancelled or deadline-expired RequestStart.
-	// Gateway requests typically reuse the same initiator (0x71), so once
-	// we have a new pending request there is no reliable way to distinguish
-	// the old STARTED from the new one. Treat pendingStartAbsorb as a real
-	// regrant barrier, not just a best-effort diagnostic counter.
+	// A client often reuses the same initiator, so once we have a new
+	// pending request there is no reliable way to distinguish the old
+	// STARTED from the new one. Treat pendingStartAbsorb as a real regrant
+	// barrier, not just a best-effort diagnostic counter.
 	if m.pendingStartAbsorb > 0 {
 		m.logger.Printf("adaptermux: tryGrantAndStart skipped — waiting to absorb %d stale arbitration response(s)", m.pendingStartAbsorb)
 		m.stateMu.Unlock()

--- a/internal/matrix/runner.go
+++ b/internal/matrix/runner.go
@@ -544,7 +544,8 @@ func inferInfraReasonFromLog(logFilePath string) string {
 		return ""
 	}
 	lower := strings.ToLower(string(data))
-	if strings.Contains(lower, "adapter preflight failed: ebus signal is not acquired") {
+	if strings.Contains(lower, "adapter preflight failed: ebus signal is not acquired") ||
+		strings.Contains(lower, "adapter preflight failed: ebus initial signal is not acquired") {
 		return infraReasonAdapterNoSignal
 	}
 	if strings.Contains(lower, "adapter reports ebus signal: no signal") {

--- a/internal/matrix/runner_test.go
+++ b/internal/matrix/runner_test.go
@@ -198,7 +198,7 @@ func TestRunnerExecuteClassifiesBlockedInfra(t *testing.T) {
 		Target:       "local",
 		IncludeIDs:   []string{"T01"},
 		Execute:      true,
-		StartGateway: "printf 'adapter preflight failed: eBUS signal is not acquired\\n'; exit 1",
+		StartGateway: "printf 'adapter preflight failed: eBUS initial signal is not acquired\\n'; exit 1",
 		StopGateway:  "echo gateway-stop",
 		SmokeCommand: "echo smoke-ok",
 	})
@@ -234,7 +234,7 @@ func TestRunnerExecuteClassifiesExpectedFailure(t *testing.T) {
 		OutputDir:        filepath.Join(tempDir, "results"),
 		Target:           "local",
 		IncludeIDs:       []string{"T01"},
-		ExpectedFailures: map[string]string{"t01": "gentle-join unavailable via ebusd-tcp"},
+		ExpectedFailures: map[string]string{"t01": "source selection unavailable via ebusd-tcp"},
 		Execute:          true,
 		StartGateway:     "echo gateway-start",
 		StopGateway:      "echo gateway-stop",
@@ -262,7 +262,7 @@ func TestRunnerExecuteClassifiesExpectedFailure(t *testing.T) {
 	if verdict.Expected != "fail" {
 		t.Fatalf("verdict expected = %q; want fail", verdict.Expected)
 	}
-	if verdict.Expectation != "gentle-join unavailable via ebusd-tcp" {
+	if verdict.Expectation != "source selection unavailable via ebusd-tcp" {
 		t.Fatalf("verdict expectation = %q", verdict.Expectation)
 	}
 }

--- a/internal/nm_runtime/nm_runtime.go
+++ b/internal/nm_runtime/nm_runtime.go
@@ -66,12 +66,11 @@ var declaredEmitEvents = map[EmitEvent]struct{}{
 var ErrEmitterRequired = errors.New("nm_runtime: emitter is required")
 
 // Emitter is the transport-facing interface used by the NM runtime to push
-// catalog-driven frames onto the bus. Implementations MUST use the gateway
-// initiator source (rpc_source.Gateway).
+// catalog-driven frames onto the bus. Implementations receive the admitted
+// gateway source chosen by startup admission.
 type Emitter interface {
 	// EmitBroadcast sends a broadcast frame with PB/SB and payload from
-	// the gateway initiator source. The implementation MUST call
-	// rpc_source.Enforce on the source byte it uses.
+	// the admitted gateway initiator source.
 	EmitBroadcast(ctx context.Context, source, pb, sb byte, payload []byte) error
 }
 
@@ -81,6 +80,7 @@ type Emitter interface {
 type Runtime struct {
 	catalog ebusstd.Catalog
 	emitter Emitter
+	source  byte
 }
 
 // NewRuntime constructs a runtime bound to the catalog and emitter. It
@@ -88,19 +88,22 @@ type Runtime struct {
 // valid mode of operation without a transport, and lazy-failing at the
 // first Emit call would only surface the wiring bug much later (and as a
 // nil-pointer panic). Fail-fast at construction per operator preference.
-func NewRuntime(cat ebusstd.Catalog, emitter Emitter) (*Runtime, error) {
+func NewRuntime(cat ebusstd.Catalog, emitter Emitter, source byte) (*Runtime, error) {
 	if emitter == nil {
 		return nil, ErrEmitterRequired
 	}
-	return &Runtime{catalog: cat, emitter: emitter}, nil
+	if err := rpc_source.Enforce(source); err != nil {
+		return nil, err
+	}
+	return &Runtime{catalog: cat, emitter: emitter, source: source}, nil
 }
 
 // Emit dispatches the named NM emit event through the catalog + policy
 // gate. The policy gate is consulted with caller=system_nm_runtime so the
 // compile-time whitelist in execution_policy applies.
 func (r *Runtime) Emit(ctx context.Context, event EmitEvent, payload []byte) error {
-	if err := rpc_source.Enforce(rpc_source.Gateway); err != nil {
-		return err // defensive: Gateway is const, never non-113
+	if err := rpc_source.Enforce(r.source); err != nil {
+		return err
 	}
 	if _, declared := declaredEmitEvents[event]; !declared {
 		return fmt.Errorf("event=%q: %w", event, ErrUnknownEmitEvent)
@@ -114,7 +117,7 @@ func (r *Runtime) Emit(ctx context.Context, event EmitEvent, payload []byte) err
 	}
 	pb := cmd.Identity.PBValue()
 	sb := cmd.Identity.SBValue()
-	return r.emitter.EmitBroadcast(ctx, rpc_source.Gateway, pb, sb, payload)
+	return r.emitter.EmitBroadcast(ctx, r.source, pb, sb, payload)
 }
 
 // findEmit selects the catalog command matching the broadcast emit event.

--- a/internal/nm_runtime/nm_runtime_catalog_integration_test.go
+++ b/internal/nm_runtime/nm_runtime_catalog_integration_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/nm_runtime"
-	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/rpc_source"
 	ebusstd "github.com/Project-Helianthus/helianthus-ebusreg/catalog/ebus_standard"
 )
 
@@ -34,7 +33,7 @@ func TestEmit_AgainstEmbeddedCatalog(t *testing.T) {
 		tc := tc
 		t.Run(string(tc.event), func(t *testing.T) {
 			em := &recordingEmitter{}
-			rt, err := nm_runtime.NewRuntime(cat, em)
+			rt, err := nm_runtime.NewRuntime(cat, em, testRuntimeSource)
 			if err != nil {
 				t.Fatalf("NewRuntime err: %v", err)
 			}
@@ -45,8 +44,8 @@ func TestEmit_AgainstEmbeddedCatalog(t *testing.T) {
 				t.Fatalf("emit %q: want 1 emit call, got %d", tc.event, len(em.calls))
 			}
 			c := em.calls[0]
-			if c.src != rpc_source.Gateway {
-				t.Fatalf("emit %q: source = 0x%02X, want 0x71", tc.event, c.src)
+			if c.src != testRuntimeSource {
+				t.Fatalf("emit %q: source = 0x%02X, want 0x%02X", tc.event, c.src, testRuntimeSource)
 			}
 			if c.pb != tc.wantPB || c.sb != tc.wantSB {
 				t.Fatalf("emit %q: pb/sb = 0x%02X/0x%02X, want 0x%02X/0x%02X",

--- a/internal/nm_runtime/nm_runtime_test.go
+++ b/internal/nm_runtime/nm_runtime_test.go
@@ -11,6 +11,8 @@ import (
 	ebusstd "github.com/Project-Helianthus/helianthus-ebusreg/catalog/ebus_standard"
 )
 
+const testRuntimeSource byte = 0x7F
+
 type recordingEmitter struct {
 	calls []struct {
 		src, pb, sb byte
@@ -74,7 +76,7 @@ func syntheticCatalog() ebusstd.Catalog {
 
 func TestRuntime_Emit_ResetStatus_PassesPolicyAndEmits(t *testing.T) {
 	em := &recordingEmitter{}
-	rt, err := nm_runtime.NewRuntime(syntheticCatalog(), em)
+	rt, err := nm_runtime.NewRuntime(syntheticCatalog(), em, testRuntimeSource)
 	if err != nil {
 		t.Fatalf("NewRuntime err: %v", err)
 	}
@@ -85,8 +87,8 @@ func TestRuntime_Emit_ResetStatus_PassesPolicyAndEmits(t *testing.T) {
 		t.Fatalf("want 1 emit call, got %d", len(em.calls))
 	}
 	c := em.calls[0]
-	if c.src != rpc_source.Gateway {
-		t.Fatalf("emit source = 0x%02X, want 0x71", c.src)
+	if c.src != testRuntimeSource {
+		t.Fatalf("emit source = 0x%02X, want 0x%02X", c.src, testRuntimeSource)
 	}
 	if c.pb != 0xFF || c.sb != 0x00 {
 		t.Fatalf("emit pb/sb = 0x%02X/0x%02X, want FF/00", c.pb, c.sb)
@@ -95,7 +97,7 @@ func TestRuntime_Emit_ResetStatus_PassesPolicyAndEmits(t *testing.T) {
 
 func TestRuntime_Emit_FailureBroadcast(t *testing.T) {
 	em := &recordingEmitter{}
-	rt, err := nm_runtime.NewRuntime(syntheticCatalog(), em)
+	rt, err := nm_runtime.NewRuntime(syntheticCatalog(), em, testRuntimeSource)
 	if err != nil {
 		t.Fatalf("NewRuntime err: %v", err)
 	}
@@ -109,7 +111,7 @@ func TestRuntime_Emit_FailureBroadcast(t *testing.T) {
 
 func TestRuntime_Emit_RefusesIfCatalogMissing(t *testing.T) {
 	em := &recordingEmitter{}
-	rt, err := nm_runtime.NewRuntime(ebusstd.Catalog{Namespace: "ebus_standard"}, em)
+	rt, err := nm_runtime.NewRuntime(ebusstd.Catalog{Namespace: "ebus_standard"}, em, testRuntimeSource)
 	if err != nil {
 		t.Fatalf("NewRuntime err: %v", err)
 	}
@@ -124,7 +126,7 @@ func TestRuntime_Emit_RefusesIfCatalogMissing(t *testing.T) {
 // nil-panic on the first Emit call; now construction must reject it with
 // ErrEmitterRequired.
 func TestNewRuntime_RejectsNilEmitter(t *testing.T) {
-	rt, err := nm_runtime.NewRuntime(syntheticCatalog(), nil)
+	rt, err := nm_runtime.NewRuntime(syntheticCatalog(), nil, testRuntimeSource)
 	if err == nil {
 		t.Fatal("NewRuntime(nil emitter) must return error")
 	}
@@ -145,7 +147,7 @@ func TestNewRuntime_RejectsNilEmitter(t *testing.T) {
 // approval.
 func TestRuntime_Emit_RejectsUndeclaredEvent(t *testing.T) {
 	em := &recordingEmitter{}
-	rt, err := nm_runtime.NewRuntime(syntheticCatalog(), em)
+	rt, err := nm_runtime.NewRuntime(syntheticCatalog(), em, testRuntimeSource)
 	if err != nil {
 		t.Fatalf("NewRuntime err: %v", err)
 	}
@@ -166,7 +168,7 @@ func TestRuntime_Emit_RejectsUndeclaredEvent(t *testing.T) {
 // findEmit and policy.
 func TestRuntime_Emit_DeclaredEventContinuesToCatalog(t *testing.T) {
 	em := &recordingEmitter{}
-	rt, err := nm_runtime.NewRuntime(syntheticCatalog(), em)
+	rt, err := nm_runtime.NewRuntime(syntheticCatalog(), em, testRuntimeSource)
 	if err != nil {
 		t.Fatalf("NewRuntime err: %v", err)
 	}
@@ -198,7 +200,7 @@ func TestRuntime_Emit_PolicyDeniesWhenWhitelistMismatch(t *testing.T) {
 	// policy layer (no emit, policy not consulted). The "policy denies"
 	// path is covered by internal/execution_policy own tests.
 	em := &recordingEmitter{}
-	rt, err := nm_runtime.NewRuntime(syntheticCatalog(), em)
+	rt, err := nm_runtime.NewRuntime(syntheticCatalog(), em, testRuntimeSource)
 	if err != nil {
 		t.Fatalf("NewRuntime err: %v", err)
 	}

--- a/internal/rpc_source/source.go
+++ b/internal/rpc_source/source.go
@@ -1,9 +1,8 @@
-// Package rpc_source centralises the gateway's RPC initiator source byte.
+// Package rpc_source contains shared validation for caller-supplied RPC source
+// bytes.
 //
-// Per project invariant (MEMORY.md): every gateway rpc.invoke call MUST use
-// source=113 (0x71). Non-113 sources are a programming error and MUST
-// surface as compile-time OR sentinel-error failures, not silent traffic
-// under the wrong initiator address.
+// Gateway-owned callers must pass the admitted source selected during startup.
+// This package intentionally does not define a fixed gateway initiator address.
 package rpc_source
 
 import (
@@ -11,28 +10,26 @@ import (
 	"fmt"
 )
 
-// Gateway is the gateway's fixed initiator source byte. Compile-time
-// constant — changing it is a locked-plan decision, not a code change.
-const Gateway byte = 0x71
+// ErrInvalidSource is the sentinel returned when an RPC-invoke call site
+// attempts to use an invalid source byte.
+var ErrInvalidSource = errors.New("rpc_source: source byte is invalid")
 
-// ErrNon113Source is the sentinel returned when an RPC-invoke call site
-// attempts to use a source byte other than Gateway (0x71).
-var ErrNon113Source = errors.New("rpc_source: source byte is not gateway (0x71)")
-
-// Enforce validates that the supplied source byte is the gateway source. It
-// returns a non-nil error wrapping ErrNon113Source when src != Gateway.
+// Enforce validates that the supplied source byte is usable as an active
+// initiator source. It returns a non-nil error wrapping ErrInvalidSource for
+// source zero, which is not a valid admitted active source.
 //
-// Callers SHOULD embed this check at every rpc.invoke call-site. The
-// returned error carries the attempted source byte for audit purposes.
+// Callers SHOULD embed this check at rpc.invoke call-sites that receive a
+// source from startup admission or an explicit user override. The returned
+// error carries the attempted source byte for audit purposes.
 func Enforce(src byte) error {
-	if src == Gateway {
-		return nil
+	if src == 0 {
+		return fmt.Errorf("got 0x%02X: %w", src, ErrInvalidSource)
 	}
-	return fmt.Errorf("got 0x%02X, want 0x%02X: %w", src, Gateway, ErrNon113Source)
+	return nil
 }
 
-// Require panics when src != Gateway. Use in tests or startup-time
-// invariant guards where a non-gateway source is unrecoverable.
+// Require panics when src is not a valid active source. Use in tests or
+// startup-time invariant guards where an invalid source is unrecoverable.
 func Require(src byte) {
 	if err := Enforce(src); err != nil {
 		panic(err)

--- a/internal/rpc_source/source_test.go
+++ b/internal/rpc_source/source_test.go
@@ -7,35 +7,29 @@ import (
 	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/rpc_source"
 )
 
-func TestGateway_IsConstant113(t *testing.T) {
-	if rpc_source.Gateway != 0x71 {
-		t.Fatalf("Gateway = 0x%02X, want 0x71 (113)", rpc_source.Gateway)
-	}
-}
-
-func TestEnforce_AcceptsGateway(t *testing.T) {
-	if err := rpc_source.Enforce(0x71); err != nil {
-		t.Fatalf("Enforce(0x71) = %v, want nil", err)
-	}
-}
-
-func TestEnforce_RejectsNon113(t *testing.T) {
-	for _, src := range []byte{0x00, 0x03, 0x08, 0x70, 0x72, 0xFF} {
-		err := rpc_source.Enforce(src)
-		if err == nil {
-			t.Fatalf("Enforce(0x%02X) = nil, want ErrNon113Source", src)
-		}
-		if !errors.Is(err, rpc_source.ErrNon113Source) {
-			t.Fatalf("Enforce(0x%02X) = %v, want errors.Is ErrNon113Source", src, err)
+func TestEnforce_AcceptsNonZeroSource(t *testing.T) {
+	for _, src := range []byte{0x03, 0x08, 0x70, 0x72, 0x7F, 0xFF} {
+		if err := rpc_source.Enforce(src); err != nil {
+			t.Fatalf("Enforce(0x%02X) = %v, want nil", src, err)
 		}
 	}
 }
 
-func TestRequire_PanicsOnNon113(t *testing.T) {
+func TestEnforce_RejectsZeroSource(t *testing.T) {
+	err := rpc_source.Enforce(0x00)
+	if err == nil {
+		t.Fatal("Enforce(0x00) = nil, want ErrInvalidSource")
+	}
+	if !errors.Is(err, rpc_source.ErrInvalidSource) {
+		t.Fatalf("Enforce(0x00) = %v, want errors.Is ErrInvalidSource", err)
+	}
+}
+
+func TestRequire_PanicsOnZeroSource(t *testing.T) {
 	defer func() {
 		if recover() == nil {
-			t.Fatal("Require(0x08) must panic")
+			t.Fatal("Require(0x00) must panic")
 		}
 	}()
-	rpc_source.Require(0x08)
+	rpc_source.Require(0x00)
 }

--- a/joinbus.go
+++ b/joinbus.go
@@ -1,12 +1,12 @@
 package ebusgateway
 
-// Package-doc continued: JoinBus adapter.
+// Package-doc continued: startup source-address selection bus adapter.
 //
-// This file implements the JoinBus interface from ebusgo/protocol, wired
-// over the PassiveTransactionReconstructor's subscription channel. It is
-// the source-of-truth bridge for startup-admission warmup on join-capable
-// direct transports (ENH, ENS, UDP-plain, TCP-plain). ebusd-tcp does NOT
-// instantiate this adapter per AD13.
+// This file implements the SourceAddressSelectionBus interface from
+// ebusgo/protocol, wired over the PassiveTransactionReconstructor's
+// subscription channel. It is the source-of-truth bridge for startup-admission
+// warmup on source-selection-capable direct transports (ENH, ENS, UDP-plain, TCP-plain).
+// ebusd-tcp does NOT instantiate this adapter per AD13.
 
 import (
 	"context"
@@ -17,7 +17,7 @@ import (
 	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
 )
 
-var ErrJoinBusInquiryUnsupported = errors.New("joinbus: inquiry not supported (InquiryEnabled=false)")
+var ErrSourceSelectionBusInquiryUnsupported = errors.New("source address selection: inquiry not supported (InquiryEnabled=false)")
 
 // TransportAdmissionPath is the admission-path dispatch decision for a given
 // transport kind per the startup-admission-discovery plan's transport
@@ -26,18 +26,18 @@ var ErrJoinBusInquiryUnsupported = errors.New("joinbus: inquiry not supported (I
 type TransportAdmissionPath uint8
 
 const (
-	// TransportAdmissionJoinCapable denotes a direct transport on which the
-	// gateway runs the Joiner warmup + JoinBus adapter before any
+	// TransportAdmissionSourceSelectionCapable denotes a direct transport on which the
+	// gateway runs the source-address selector warmup before any
 	// non-override active frame. Applies to ENH, ENS, UDP-plain, TCP-plain.
-	TransportAdmissionJoinCapable TransportAdmissionPath = iota + 1
+	TransportAdmissionSourceSelectionCapable TransportAdmissionPath = iota + 1
 
 	// TransportAdmissionStaticFallback denotes the ebusd-tcp path, where the
-	// gateway does NOT instantiate Joiner and uses the configured
+	// gateway does NOT instantiate source-address selection and uses the configured
 	// ScanSource as admission-fallback per AD13.
 	TransportAdmissionStaticFallback
 )
 
-type joinBusAdapter struct {
+type sourceSelectionBusAdapter struct {
 	reconstructor  *PassiveTransactionReconstructor
 	name           string
 	priority       PassiveSubscriberPriority
@@ -45,16 +45,16 @@ type joinBusAdapter struct {
 	inquiryEnabled bool
 }
 
-// NewJoinBusAdapter returns a protocol.JoinBus subscribed to the given
-// reconstructor with priority=NonCritical and default buffer.
-func NewJoinBusAdapter(reconstructor *PassiveTransactionReconstructor, name string, inquiryEnabled bool) (protocol.JoinBus, error) {
+// NewSourceSelectionBusAdapter returns a protocol.SourceAddressSelectionBus subscribed to
+// the given reconstructor with priority=NonCritical and default buffer.
+func NewSourceSelectionBusAdapter(reconstructor *PassiveTransactionReconstructor, name string, inquiryEnabled bool) (protocol.SourceAddressSelectionBus, error) {
 	if reconstructor == nil {
-		return nil, fmt.Errorf("joinbus: reconstructor is nil")
+		return nil, fmt.Errorf("source address selection: reconstructor is nil")
 	}
 	if name == "" {
-		name = "startup_admission_joinbus"
+		name = "startup_admission_source_selection_bus"
 	}
-	return &joinBusAdapter{
+	return &sourceSelectionBusAdapter{
 		reconstructor:  reconstructor,
 		name:           name,
 		priority:       PassiveSubscriberNonCritical,
@@ -63,14 +63,14 @@ func NewJoinBusAdapter(reconstructor *PassiveTransactionReconstructor, name stri
 	}, nil
 }
 
-func (a *joinBusAdapter) Listen(ctx context.Context, onFrame func(protocol.Frame)) error {
+func (a *sourceSelectionBusAdapter) Listen(ctx context.Context, onFrame func(protocol.Frame)) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 
 	subscription, err := a.reconstructor.Subscribe(a.name, a.priority, a.buffer)
 	if err != nil {
-		return fmt.Errorf("joinbus: subscribe: %w", err)
+		return fmt.Errorf("source address selection: subscribe: %w", err)
 	}
 	defer subscription.Close()
 
@@ -83,12 +83,12 @@ func (a *joinBusAdapter) Listen(ctx context.Context, onFrame func(protocol.Frame
 			if !ok {
 				return nil
 			}
-			forwardJoinBusEvent(event, onFrame)
+			forwardSourceSelectionBusEvent(event, onFrame)
 		}
 	}
 }
 
-func forwardJoinBusEvent(event PassiveClassifiedEvent, onFrame func(protocol.Frame)) {
+func forwardSourceSelectionBusEvent(event PassiveClassifiedEvent, onFrame func(protocol.Frame)) {
 	if onFrame == nil {
 		return
 	}
@@ -104,8 +104,8 @@ func forwardJoinBusEvent(event PassiveClassifiedEvent, onFrame func(protocol.Fra
 	}
 }
 
-func (a *joinBusAdapter) InquiryExistence(ctx context.Context) error {
-	return ErrJoinBusInquiryUnsupported
+func (a *sourceSelectionBusAdapter) InquiryExistence(ctx context.Context) error {
+	return ErrSourceSelectionBusInquiryUnsupported
 }
 
 // ClassifyTransportAdmission returns the admission path dispatch for the
@@ -114,24 +114,26 @@ func (a *joinBusAdapter) InquiryExistence(ctx context.Context) error {
 func ClassifyTransportAdmission(kind TransportProtocol) (TransportAdmissionPath, error) {
 	switch kind {
 	case TransportENH, TransportENS, TransportUDPPlain, TransportTCPPlain:
-		return TransportAdmissionJoinCapable, nil
+		return TransportAdmissionSourceSelectionCapable, nil
 	case TransportEbusdTCP:
 		return TransportAdmissionStaticFallback, nil
 	case TransportAdapterDirect:
-		return 0, fmt.Errorf("joinbus: adapter-direct is a multiplexer, classify its underlying transport")
+		return 0, fmt.Errorf("source-selection bus: adapter-direct is a multiplexer, classify its underlying transport")
 	case "":
-		return 0, fmt.Errorf("joinbus: empty transport protocol")
+		return 0, fmt.Errorf("source-selection bus: empty transport protocol")
 	default:
-		return 0, fmt.Errorf("joinbus: unknown transport protocol %q", kind)
+		return 0, fmt.Errorf("source-selection bus: unknown transport protocol %q", kind)
 	}
 }
 
 // ResolveAdmissionPath returns the admission-path dispatch with adapter-direct
 // special-cased to JoinCapable. Adapter-direct multiplexer mode always wraps a
-// join-capable underlying transport (ENH or ENS in practice; UDP/TCP-plain are
-// not configurations the multiplexer is built for). The JoinBus adapter
+// source-selection-capable underlying transport (ENH or ENS in practice; UDP/TCP-plain are
+// not configurations the multiplexer is built for). The source-address
+// selection bus adapter
 // subscribes to the same PassiveTransactionReconstructor regardless of
-// multiplexer presence, so adapter-direct deployments MUST run Joiner.
+// multiplexer presence, so adapter-direct deployments MUST run source-address
+// selection.
 //
 // This helper exists because ClassifyTransportAdmission is intentionally pure
 // (one transport at a time, no multiplexer-context awareness) and rejects
@@ -150,7 +152,7 @@ func ClassifyTransportAdmission(kind TransportProtocol) (TransportAdmissionPath,
 // logic here keeps all call sites in agreement.
 func ResolveAdmissionPath(kind TransportProtocol) (path TransportAdmissionPath, adapterDirectSpecialCase bool) {
 	if kind == TransportAdapterDirect {
-		return TransportAdmissionJoinCapable, true
+		return TransportAdmissionSourceSelectionCapable, true
 	}
 	resolved, err := ClassifyTransportAdmission(kind)
 	if err != nil {
@@ -159,15 +161,36 @@ func ResolveAdmissionPath(kind TransportProtocol) (path TransportAdmissionPath, 
 	return resolved, false
 }
 
-// DefaultStartupAdmissionJoinConfig returns the JoinConfig used by the
-// startup-admission-discovery plan for join-capable direct transports.
+// DefaultStartupAdmissionSourceSelectionConfig returns the SourceAddressSelectionConfig
+// used by the startup-admission-discovery plan for source-selection-capable direct
+// transports.
 // See plan AD01/AD02/AD09 and
 // helianthus-docs-ebus/architecture/startup-admission-and-discovery.md §2.2.3.
-func DefaultStartupAdmissionJoinConfig() protocol.JoinConfig {
-	return protocol.JoinConfig{
-		ListenWarmup:       5 * time.Second,
-		InquiryEnabled:     false,
-		PersistLastGood:    true,
-		PersistLastGoodSet: true,
+func DefaultStartupAdmissionSourceSelectionConfig() protocol.SourceAddressSelectionConfig {
+	return protocol.SourceAddressSelectionConfig{
+		ListenWarmup:   5 * time.Second,
+		InquiryEnabled: false,
 	}
+}
+
+type noObservationSourceSelectionBus struct{}
+
+func (noObservationSourceSelectionBus) Listen(context.Context, func(protocol.Frame)) error {
+	return nil
+}
+
+func (noObservationSourceSelectionBus) InquiryExistence(context.Context) error {
+	return ErrSourceSelectionBusInquiryUnsupported
+}
+
+// SelectDefaultStartupSourceAddress applies the docs-backed Helianthus
+// source-selection policy without passive observations. This covers transports
+// that cannot expose an observe-first lane: "auto" still means source
+// selection, not source 0x00.
+func SelectDefaultStartupSourceAddress(ctx context.Context) (protocol.SourceAddressSelection, error) {
+	cfg := DefaultStartupAdmissionSourceSelectionConfig()
+	cfg.ListenWarmup = time.Nanosecond
+	cfg.InquiryEnabled = false
+	selector := protocol.NewSourceAddressSelector(noObservationSourceSelectionBus{}, cfg)
+	return selector.Select(ctx)
 }

--- a/joinbus_transport_test.go
+++ b/joinbus_transport_test.go
@@ -17,10 +17,10 @@ func TestClassifyTransportAdmission_AllFivePlanMatrixTransports(t *testing.T) {
 		kind   TransportProtocol
 		expect TransportAdmissionPath
 	}{
-		{"ENH", TransportENH, TransportAdmissionJoinCapable},
-		{"ENS", TransportENS, TransportAdmissionJoinCapable},
-		{"UDP-plain", TransportUDPPlain, TransportAdmissionJoinCapable},
-		{"TCP-plain", TransportTCPPlain, TransportAdmissionJoinCapable},
+		{"ENH", TransportENH, TransportAdmissionSourceSelectionCapable},
+		{"ENS", TransportENS, TransportAdmissionSourceSelectionCapable},
+		{"UDP-plain", TransportUDPPlain, TransportAdmissionSourceSelectionCapable},
+		{"TCP-plain", TransportTCPPlain, TransportAdmissionSourceSelectionCapable},
 		{"ebusd-tcp", TransportEbusdTCP, TransportAdmissionStaticFallback},
 	}
 	for _, tc := range cases {
@@ -39,8 +39,8 @@ func TestClassifyTransportAdmission_AllFivePlanMatrixTransports(t *testing.T) {
 // TestClassifyTransportAdmission_MisclassificationIsTestFailure hardens the
 // plan's M2 acceptance: "Transport classifier is unit-tested against all
 // five transports in the capability matrix {ENH, ENS, ebusd-tcp, UDP-plain,
-// TCP-plain}; misclassification (join-capable routed to static fallback,
-// or ebusd-tcp routed to Joiner) is a test failure."
+// TCP-plain}; misclassification (source-selection-capable routed to static fallback,
+// or ebusd-tcp routed to source-address selector) is a test failure."
 func TestClassifyTransportAdmission_MisclassificationIsTestFailure(t *testing.T) {
 	joinCapableTransports := []TransportProtocol{TransportENH, TransportENS, TransportUDPPlain, TransportTCPPlain}
 	for _, kind := range joinCapableTransports {
@@ -49,15 +49,15 @@ func TestClassifyTransportAdmission_MisclassificationIsTestFailure(t *testing.T)
 			t.Fatalf("unexpected error classifying %s: %v", kind, err)
 		}
 		if got == TransportAdmissionStaticFallback {
-			t.Errorf("FAIL: join-capable transport %s misclassified as static fallback", kind)
+			t.Errorf("FAIL: source-selection-capable transport %s misclassified as static fallback", kind)
 		}
 	}
 	got, err := ClassifyTransportAdmission(TransportEbusdTCP)
 	if err != nil {
 		t.Fatalf("unexpected error classifying ebusd-tcp: %v", err)
 	}
-	if got == TransportAdmissionJoinCapable {
-		t.Error("FAIL: ebusd-tcp misclassified as join-capable (AD13 violation)")
+	if got == TransportAdmissionSourceSelectionCapable {
+		t.Error("FAIL: ebusd-tcp misclassified as source-selection-capable (AD13 violation)")
 	}
 }
 
@@ -86,11 +86,27 @@ func TestClassifyTransportAdmission_UnknownIsError(t *testing.T) {
 	}
 }
 
-func TestForwardJoinBusEvent_BroadcastForwardsRequestOnly(t *testing.T) {
+func TestSelectDefaultStartupSourceAddress_UsesPolicyWithoutObservations(t *testing.T) {
+	result, err := SelectDefaultStartupSourceAddress(context.Background())
+	if err != nil {
+		t.Fatalf("SelectDefaultStartupSourceAddress() error = %v", err)
+	}
+	if result.Source != 0x7F {
+		t.Fatalf("default selected source = 0x%02X; want 0x7F", result.Source)
+	}
+	if result.Companion != 0x84 {
+		t.Fatalf("default companion = 0x%02X; want 0x84", result.Companion)
+	}
+	if !reflect.DeepEqual(result.Metrics.CandidatesConsidered, []byte{0xFF, 0x7F}) {
+		t.Fatalf("candidates considered = % X; want FF 7F", result.Metrics.CandidatesConsidered)
+	}
+}
+
+func TestForwardSourceSelectionBusEvent_BroadcastForwardsRequestOnly(t *testing.T) {
 	var captured []protocol.Frame
 	onFrame := func(f protocol.Frame) { captured = append(captured, f) }
 	req := protocol.Frame{Source: 0x71, Target: 0xFE, Primary: 0xB5}
-	forwardJoinBusEvent(PassiveClassifiedEvent{
+	forwardSourceSelectionBusEvent(PassiveClassifiedEvent{
 		Kind:    PassiveClassifiedEventBroadcastFrame,
 		Request: req,
 	}, onFrame)
@@ -99,11 +115,11 @@ func TestForwardJoinBusEvent_BroadcastForwardsRequestOnly(t *testing.T) {
 	}
 }
 
-func TestForwardJoinBusEvent_MasterForwardsRequestOnly(t *testing.T) {
+func TestForwardSourceSelectionBusEvent_MasterForwardsRequestOnly(t *testing.T) {
 	var captured []protocol.Frame
 	onFrame := func(f protocol.Frame) { captured = append(captured, f) }
 	req := protocol.Frame{Source: 0x71, Target: 0x08, Primary: 0x07, Secondary: 0x04}
-	forwardJoinBusEvent(PassiveClassifiedEvent{
+	forwardSourceSelectionBusEvent(PassiveClassifiedEvent{
 		Kind:    PassiveClassifiedEventMasterFrame,
 		Request: req,
 	}, onFrame)
@@ -112,11 +128,11 @@ func TestForwardJoinBusEvent_MasterForwardsRequestOnly(t *testing.T) {
 	}
 }
 
-func TestForwardJoinBusEvent_TransactionWithoutResponseForwardsRequestOnly(t *testing.T) {
+func TestForwardSourceSelectionBusEvent_TransactionWithoutResponseForwardsRequestOnly(t *testing.T) {
 	var captured []protocol.Frame
 	onFrame := func(f protocol.Frame) { captured = append(captured, f) }
 	req := protocol.Frame{Source: 0x71, Target: 0x08, Primary: 0x07, Secondary: 0x04}
-	forwardJoinBusEvent(PassiveClassifiedEvent{
+	forwardSourceSelectionBusEvent(PassiveClassifiedEvent{
 		Kind:        PassiveClassifiedEventTransaction,
 		Request:     req,
 		HasResponse: false,
@@ -126,12 +142,12 @@ func TestForwardJoinBusEvent_TransactionWithoutResponseForwardsRequestOnly(t *te
 	}
 }
 
-func TestForwardJoinBusEvent_TransactionWithResponseForwardsRequestThenResponse(t *testing.T) {
+func TestForwardSourceSelectionBusEvent_TransactionWithResponseForwardsRequestThenResponse(t *testing.T) {
 	var captured []protocol.Frame
 	onFrame := func(f protocol.Frame) { captured = append(captured, f) }
 	req := protocol.Frame{Source: 0x71, Target: 0x08}
 	resp := protocol.Frame{Source: 0x08, Target: 0x71}
-	forwardJoinBusEvent(PassiveClassifiedEvent{
+	forwardSourceSelectionBusEvent(PassiveClassifiedEvent{
 		Kind:        PassiveClassifiedEventTransaction,
 		Request:     req,
 		Response:    resp,
@@ -148,10 +164,10 @@ func TestForwardJoinBusEvent_TransactionWithResponseForwardsRequestThenResponse(
 	}
 }
 
-func TestForwardJoinBusEvent_AbandonedTransactionIsDropped(t *testing.T) {
+func TestForwardSourceSelectionBusEvent_AbandonedTransactionIsDropped(t *testing.T) {
 	var captured []protocol.Frame
 	onFrame := func(f protocol.Frame) { captured = append(captured, f) }
-	forwardJoinBusEvent(PassiveClassifiedEvent{
+	forwardSourceSelectionBusEvent(PassiveClassifiedEvent{
 		Kind:    PassiveClassifiedEventAbandonedTransaction,
 		Request: protocol.Frame{Source: 0x71},
 	}, onFrame)
@@ -160,10 +176,10 @@ func TestForwardJoinBusEvent_AbandonedTransactionIsDropped(t *testing.T) {
 	}
 }
 
-func TestForwardJoinBusEvent_DiscontinuityIsDropped(t *testing.T) {
+func TestForwardSourceSelectionBusEvent_DiscontinuityIsDropped(t *testing.T) {
 	var captured []protocol.Frame
 	onFrame := func(f protocol.Frame) { captured = append(captured, f) }
-	forwardJoinBusEvent(PassiveClassifiedEvent{
+	forwardSourceSelectionBusEvent(PassiveClassifiedEvent{
 		Kind:    PassiveClassifiedEventDiscontinuity,
 		Request: protocol.Frame{Source: 0x71},
 	}, onFrame)
@@ -173,37 +189,31 @@ func TestForwardJoinBusEvent_DiscontinuityIsDropped(t *testing.T) {
 }
 
 func TestInquiryExistence_AlwaysReturnsSentinel(t *testing.T) {
-	adapterDisabled := &joinBusAdapter{inquiryEnabled: false}
-	adapterEnabled := &joinBusAdapter{inquiryEnabled: true}
-	if err := adapterDisabled.InquiryExistence(context.Background()); err != ErrJoinBusInquiryUnsupported {
-		t.Errorf("disabled: expected ErrJoinBusInquiryUnsupported, got %v", err)
+	adapterDisabled := &sourceSelectionBusAdapter{inquiryEnabled: false}
+	adapterEnabled := &sourceSelectionBusAdapter{inquiryEnabled: true}
+	if err := adapterDisabled.InquiryExistence(context.Background()); err != ErrSourceSelectionBusInquiryUnsupported {
+		t.Errorf("disabled: expected ErrSourceSelectionBusInquiryUnsupported, got %v", err)
 	}
-	if err := adapterEnabled.InquiryExistence(context.Background()); err != ErrJoinBusInquiryUnsupported {
-		t.Errorf("enabled: expected ErrJoinBusInquiryUnsupported, got %v", err)
+	if err := adapterEnabled.InquiryExistence(context.Background()); err != ErrSourceSelectionBusInquiryUnsupported {
+		t.Errorf("enabled: expected ErrSourceSelectionBusInquiryUnsupported, got %v", err)
 	}
 }
 
-func TestDefaultStartupAdmissionJoinConfig(t *testing.T) {
-	cfg := DefaultStartupAdmissionJoinConfig()
+func TestDefaultStartupAdmissionSourceSelectionConfig(t *testing.T) {
+	cfg := DefaultStartupAdmissionSourceSelectionConfig()
 	if cfg.ListenWarmup != 5*time.Second {
 		t.Errorf("ListenWarmup: got %v, want 5s", cfg.ListenWarmup)
 	}
 	if cfg.InquiryEnabled {
 		t.Error("InquiryEnabled: got true, want false")
 	}
-	if !cfg.PersistLastGood {
-		t.Error("PersistLastGood: got false, want true")
-	}
-	if !cfg.PersistLastGoodSet {
-		t.Error("PersistLastGoodSet: got false, want true")
-	}
 }
 
-func TestJoinBusAdapter_WarmupObservationForwardsSynthesizedPassiveTraffic(t *testing.T) {
+func TestSourceSelectionBusAdapter_WarmupObservationForwardsSynthesizedPassiveTraffic(t *testing.T) {
 	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
-	joinBus, err := NewJoinBusAdapter(reconstructor, "warmup_test", false)
+	joinBus, err := NewSourceSelectionBusAdapter(reconstructor, "warmup_test", false)
 	if err != nil {
-		t.Fatalf("NewJoinBusAdapter error = %v", err)
+		t.Fatalf("NewSourceSelectionBusAdapter error = %v", err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -277,11 +287,11 @@ func TestJoinBusAdapter_WarmupObservationForwardsSynthesizedPassiveTraffic(t *te
 	}
 }
 
-func TestJoinBusAdapter_WarmupObservationSilentBusForwardsNothing(t *testing.T) {
+func TestSourceSelectionBusAdapter_WarmupObservationSilentBusForwardsNothing(t *testing.T) {
 	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
-	joinBus, err := NewJoinBusAdapter(reconstructor, "silent_bus_test", false)
+	joinBus, err := NewSourceSelectionBusAdapter(reconstructor, "silent_bus_test", false)
 	if err != nil {
-		t.Fatalf("NewJoinBusAdapter error = %v", err)
+		t.Fatalf("NewSourceSelectionBusAdapter error = %v", err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/mcp/parity_contract_test.go
+++ b/mcp/parity_contract_test.go
@@ -134,6 +134,7 @@ func TestParityMatrixReadAndInvoke(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewServer error = %v", err)
 	}
+	server.SetAdmittedRPCSource(0x7F)
 	server.SetStatusProvider(testStatusProvider{daemon: ServiceStatus{Status: "running"}, adapter: ServiceStatus{Status: "connected"}})
 	server.SetSemanticProvider(testSemanticProvider{
 		zones:    []Zone{{ID: "zone-a", Name: "Living", Config: ZoneConfig{OperatingMode: "AUTO", Preset: "COMFORT"}}},

--- a/mcp/rpc_source_guard.go
+++ b/mcp/rpc_source_guard.go
@@ -1,65 +1,71 @@
 package mcp
 
 import (
+	"errors"
 	"fmt"
 	"math"
 
 	rpcsource "github.com/Project-Helianthus/helianthus-ebusgateway/internal/rpc_source"
 )
 
+var errSourceSelectionNotActive = errors.New("source selection not active")
+
 // enforceRPCSourceParam is the rpc.invoke call-site guard enforcing the
-// MEMORY.md invariant "All rpc.invoke MUST use source: 113". If params
-// carries an explicit "source", it MUST be 113 (0x71). If absent (or if
-// the params map itself is nil), the canonical value is injected so
-// downstream transport layers cannot silently use a different initiator.
+// admitted-source invariant. If params omits "source", the startup-admitted
+// source is injected. If params carries an explicit "source", it is treated as
+// a user-requested override and only validated as a byte-shaped source.
 //
 // Note: a nil input map cannot be mutated, so nil is treated as "no
 // params provided and no way to attach a source" — callers that accept
 // absent-params must use enforceRPCSourceOnArgs which operates on the
 // enclosing args envelope and can create a fresh params map.
 //
-// The guard wraps rpc_source.ErrNon113Source; callers classify via
-// errors.Is(err, rpc_source.ErrNon113Source).
-func enforceRPCSourceParam(params map[string]any) error {
+// Invalid explicit source values wrap rpc_source.ErrInvalidSource.
+func enforceRPCSourceParam(params map[string]any, admittedSource byte, admitted bool) error {
 	if params == nil {
 		return nil
 	}
 	raw, ok := params["source"]
 	if !ok {
-		params["source"] = int(rpcsource.Gateway)
+		if !admitted || admittedSource == 0 {
+			return errSourceSelectionNotActive
+		}
+		params["source"] = int(admittedSource)
 		return nil
 	}
-	src, err := toByteSource(raw)
+	source, err := toByteSource(raw)
 	if err != nil {
 		return fmt.Errorf("params.source: %w", err)
 	}
-	if err := rpcsource.Enforce(src); err != nil {
-		return err
+	if err := rpcsource.Enforce(source); err != nil {
+		return fmt.Errorf("params.source: %w", err)
 	}
+	params["source"] = int(source)
 	return nil
 }
 
-// enforceRPCSourceOnArgs enforces the source=113 invariant on the
+// enforceRPCSourceOnArgs enforces the admitted-source invariant on the
 // enclosing rpc.invoke args envelope. Unlike enforceRPCSourceParam it
 // handles the case where args["params"] is absent, nil, or not a map —
-// in which case a fresh params map is materialised with
-// source=rpc_source.Gateway, so the invariant holds regardless of input
-// shape.
+// in which case a fresh params map is materialised with the admitted source.
 //
 // Returns the resolved params map (never nil on success) so callers can
 // use the injected value directly instead of re-reading args["params"].
-func enforceRPCSourceOnArgs(args map[string]any) (map[string]any, error) {
+func enforceRPCSourceOnArgs(args map[string]any, admittedSource byte, admitted bool) (map[string]any, error) {
 	if args == nil {
 		// No envelope to attach params to; caller must handle.
 		return nil, nil
 	}
 	params, _ := args["params"].(map[string]any)
 	if params == nil {
-		params = map[string]any{"source": int(rpcsource.Gateway)}
+		if !admitted || admittedSource == 0 {
+			return nil, errSourceSelectionNotActive
+		}
+		params = map[string]any{"source": int(admittedSource)}
 		args["params"] = params
 		return params, nil
 	}
-	if err := enforceRPCSourceParam(params); err != nil {
+	if err := enforceRPCSourceParam(params, admittedSource, admitted); err != nil {
 		return params, err
 	}
 	return params, nil
@@ -68,7 +74,7 @@ func enforceRPCSourceOnArgs(args map[string]any) (map[string]any, error) {
 // toByteSource coerces a JSON-decoded value into an 8-bit source byte.
 //
 // It returns a non-nil error in two distinguishable cases — both wrap
-// rpc_source.ErrNon113Source so the outer classifier (classifyToolError)
+// rpc_source.ErrInvalidSource so the outer classifier (classifyToolError)
 // still maps them to INVALID_ARGUMENT:
 //
 //   - unsupported type (e.g. bool, string, map, slice, nil): the caller
@@ -82,36 +88,34 @@ func enforceRPCSourceOnArgs(args map[string]any) (map[string]any, error) {
 func toByteSource(v any) (byte, error) {
 	switch x := v.(type) {
 	case byte:
-		// byte is an alias for uint8, always in [0,255] by type;
-		// no range check needed. Accepts rpc_source.Gateway directly
-		// for in-process callers that build params maps
-		// programmatically with the typed constant.
+		// byte is an alias for uint8, always in [0,255] by type; no
+		// range check needed for in-process callers that build params maps
+		// programmatically.
 		return x, nil
 	case int:
 		if x < 0 || x > 255 {
-			return 0, fmt.Errorf("invalid value %d (int out of byte range [0,255]): %w", x, rpcsource.ErrNon113Source)
+			return 0, fmt.Errorf("invalid value %d (int out of byte range [0,255]): %w", x, rpcsource.ErrInvalidSource)
 		}
 		return byte(x), nil
 	case int64:
 		if x < 0 || x > 255 {
-			return 0, fmt.Errorf("invalid value %d (int64 out of byte range [0,255]): %w", x, rpcsource.ErrNon113Source)
+			return 0, fmt.Errorf("invalid value %d (int64 out of byte range [0,255]): %w", x, rpcsource.ErrInvalidSource)
 		}
 		return byte(x), nil
 	case float64:
 		// The underlying transport emits an 8-bit source byte;
-		// byte(113.9) silently truncates to 113 and would bypass the
-		// Enforce check for any near-match fractional value. Only
-		// accept whole-number float64s in range.
+		// byte(127.9) silently truncates to 127. Only accept
+		// whole-number float64s in range.
 		if math.IsNaN(x) || math.IsInf(x, 0) {
-			return 0, fmt.Errorf("invalid value %v (NaN or Inf): %w", x, rpcsource.ErrNon113Source)
+			return 0, fmt.Errorf("invalid value %v (NaN or Inf): %w", x, rpcsource.ErrInvalidSource)
 		}
 		if math.Trunc(x) != x {
-			return 0, fmt.Errorf("invalid value %v (fractional float64, expected whole number): %w", x, rpcsource.ErrNon113Source)
+			return 0, fmt.Errorf("invalid value %v (fractional float64, expected whole number): %w", x, rpcsource.ErrInvalidSource)
 		}
 		if x < 0 || x > 255 {
-			return 0, fmt.Errorf("invalid value %v (float64 out of byte range [0,255]): %w", x, rpcsource.ErrNon113Source)
+			return 0, fmt.Errorf("invalid value %v (float64 out of byte range [0,255]): %w", x, rpcsource.ErrInvalidSource)
 		}
 		return byte(x), nil
 	}
-	return 0, fmt.Errorf("unsupported type %T: %w", v, rpcsource.ErrNon113Source)
+	return 0, fmt.Errorf("unsupported type %T: %w", v, rpcsource.ErrInvalidSource)
 }

--- a/mcp/rpc_source_guard_test.go
+++ b/mcp/rpc_source_guard_test.go
@@ -7,85 +7,96 @@ import (
 	rpcsource "github.com/Project-Helianthus/helianthus-ebusgateway/internal/rpc_source"
 )
 
+const admittedTestSource byte = 0x7F
+
 func TestEnforceRPCSourceParam_InjectsGatewayWhenMissing(t *testing.T) {
 	params := map[string]any{}
-	if err := enforceRPCSourceParam(params); err != nil {
+	if err := enforceRPCSourceParam(params, admittedTestSource, true); err != nil {
 		t.Fatalf("expected nil err, got %v", err)
 	}
 	src, ok := params["source"]
 	if !ok {
 		t.Fatal("expected injected source key")
 	}
-	if src != int(rpcsource.Gateway) {
-		t.Fatalf("injected source = %v, want 0x71", src)
+	if src != int(admittedTestSource) {
+		t.Fatalf("injected source = %v, want 0x%02X", src, admittedTestSource)
 	}
 }
 
-func TestEnforceRPCSourceParam_AcceptsExplicit113(t *testing.T) {
-	for _, v := range []any{int(0x71), float64(0x71), int64(113)} {
+func TestEnforceRPCSourceParam_AcceptsExplicitByteOverride(t *testing.T) {
+	for _, v := range []any{int(0x71), float64(0x7F), int64(0x08)} {
 		params := map[string]any{"source": v}
-		if err := enforceRPCSourceParam(params); err != nil {
+		if err := enforceRPCSourceParam(params, admittedTestSource, true); err != nil {
 			t.Fatalf("source=%v: %v", v, err)
 		}
 	}
 }
 
-func TestEnforceRPCSourceParam_RejectsNon113(t *testing.T) {
+func TestEnforceRPCSourceParam_AcceptsExplicitNonAdmittedOverride(t *testing.T) {
 	for _, v := range []any{int(0x03), int(0x08), float64(0x26), 0xFF} {
 		params := map[string]any{"source": v}
-		err := enforceRPCSourceParam(params)
-		if err == nil {
-			t.Fatalf("source=%v must be rejected", v)
+		if err := enforceRPCSourceParam(params, admittedTestSource, true); err != nil {
+			t.Fatalf("source=%v explicit MCP override should be accepted: %v", v, err)
 		}
-		if !errors.Is(err, rpcsource.ErrNon113Source) {
-			t.Fatalf("source=%v: want errors.Is ErrNon113Source, got %v", v, err)
+	}
+}
+
+func TestEnforceRPCSourceParam_RejectsExplicitZeroOverride(t *testing.T) {
+	for _, v := range []any{int(0), float64(0), int64(0), byte(0)} {
+		params := map[string]any{"source": v}
+		err := enforceRPCSourceParam(params, admittedTestSource, true)
+		if err == nil {
+			t.Fatalf("source=%v explicit MCP override must reject zero", v)
+		}
+		if !errors.Is(err, rpcsource.ErrInvalidSource) {
+			t.Fatalf("source=%v: want ErrInvalidSource, got %v", v, err)
 		}
 	}
 }
 
 func TestEnforceRPCSourceParam_RejectsUnsupportedType(t *testing.T) {
 	params := map[string]any{"source": "0x71"}
-	err := enforceRPCSourceParam(params)
+	err := enforceRPCSourceParam(params, admittedTestSource, true)
 	if err == nil {
 		t.Fatal("string source must be rejected")
 	}
-	if !errors.Is(err, rpcsource.ErrNon113Source) {
-		t.Fatalf("want errors.Is ErrNon113Source, got %v", err)
+	if !errors.Is(err, rpcsource.ErrInvalidSource) {
+		t.Fatalf("want errors.Is ErrInvalidSource, got %v", err)
 	}
 }
 
 func TestEnforceRPCSourceParam_NilMapNoop(t *testing.T) {
-	if err := enforceRPCSourceParam(nil); err != nil {
+	if err := enforceRPCSourceParam(nil, admittedTestSource, true); err != nil {
 		t.Fatalf("nil map: %v", err)
 	}
 }
 
 // TestEnforceRPCSourceParam_RejectsFractionalFloat64 pins the invariant
-// that non-integer float64 "source" values are rejected before the
-// byte() truncation would mask a near-match fractional value
-// (e.g. 113.9 → 113). Regression for PR #505 comment id=3106729474.
+// that non-integer float64 "source" values are rejected before the byte()
+// truncation would mask a near-match fractional value. Regression for PR #505
+// comment id=3106729474.
 func TestEnforceRPCSourceParam_RejectsFractionalFloat64(t *testing.T) {
-	for _, v := range []float64{113.9, 113.0001, 112.5, -0.5} {
+	for _, v := range []float64{127.9, 127.0001, 126.5, -0.5} {
 		params := map[string]any{"source": v}
-		err := enforceRPCSourceParam(params)
+		err := enforceRPCSourceParam(params, admittedTestSource, true)
 		if err == nil {
 			t.Fatalf("fractional source=%v must be rejected", v)
 		}
-		if !errors.Is(err, rpcsource.ErrNon113Source) {
-			t.Fatalf("source=%v: want ErrNon113Source, got %v", v, err)
+		if !errors.Is(err, rpcsource.ErrInvalidSource) {
+			t.Fatalf("source=%v: want ErrInvalidSource, got %v", v, err)
 		}
 	}
 }
 
-func TestEnforceRPCSourceParam_AcceptsWholeFloat64_113(t *testing.T) {
-	params := map[string]any{"source": float64(113.0)}
-	if err := enforceRPCSourceParam(params); err != nil {
-		t.Fatalf("113.0 must be accepted, got %v", err)
+func TestEnforceRPCSourceParam_AcceptsWholeFloat64(t *testing.T) {
+	params := map[string]any{"source": float64(admittedTestSource)}
+	if err := enforceRPCSourceParam(params, admittedTestSource, true); err != nil {
+		t.Fatalf("whole float64 source must be accepted, got %v", err)
 	}
 }
 
 // TestEnforceRPCSourceOnArgs_InjectsParamsWhenAbsent pins the invariant
-// that rpc.invoke calls with no "params" field still get source=113
+// that rpc.invoke calls with no "params" field still get the admitted source
 // materialised. Regression for PR #505 comment id=3106729473.
 func TestEnforceRPCSourceOnArgs_InjectsParamsWhenAbsent(t *testing.T) {
 	args := map[string]any{
@@ -94,15 +105,15 @@ func TestEnforceRPCSourceOnArgs_InjectsParamsWhenAbsent(t *testing.T) {
 		"method":  "some.method",
 		// no "params" at all
 	}
-	params, err := enforceRPCSourceOnArgs(args)
+	params, err := enforceRPCSourceOnArgs(args, admittedTestSource, true)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 	if params == nil {
 		t.Fatal("params must be materialised, got nil")
 	}
-	if src := params["source"]; src != int(rpcsource.Gateway) {
-		t.Fatalf("source = %v, want %d", src, int(rpcsource.Gateway))
+	if src := params["source"]; src != int(admittedTestSource) {
+		t.Fatalf("source = %v, want %d", src, int(admittedTestSource))
 	}
 	// args must also have the params written back so downstream call
 	// sites observe the same map.
@@ -110,7 +121,7 @@ func TestEnforceRPCSourceOnArgs_InjectsParamsWhenAbsent(t *testing.T) {
 	if !ok {
 		t.Fatalf("args[params] not materialised: %T", args["params"])
 	}
-	if attached["source"] != int(rpcsource.Gateway) {
+	if attached["source"] != int(admittedTestSource) {
 		t.Fatalf("attached.source = %v", attached["source"])
 	}
 }
@@ -118,20 +129,20 @@ func TestEnforceRPCSourceOnArgs_InjectsParamsWhenAbsent(t *testing.T) {
 func TestEnforceRPCSourceOnArgs_InjectsWhenParamsNilMap(t *testing.T) {
 	var nilParams map[string]any
 	args := map[string]any{"params": nilParams}
-	params, err := enforceRPCSourceOnArgs(args)
+	params, err := enforceRPCSourceOnArgs(args, admittedTestSource, true)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if params["source"] != int(rpcsource.Gateway) {
+	if params["source"] != int(admittedTestSource) {
 		t.Fatalf("source = %v", params["source"])
 	}
 }
 
-func TestEnforceRPCSourceOnArgs_PreservesExplicit113(t *testing.T) {
+func TestEnforceRPCSourceOnArgs_PreservesExplicitOverride(t *testing.T) {
 	args := map[string]any{
-		"params": map[string]any{"source": int(0x71), "foo": "bar"},
+		"params": map[string]any{"source": int(0x08), "foo": "bar"},
 	}
-	params, err := enforceRPCSourceOnArgs(args)
+	params, err := enforceRPCSourceOnArgs(args, admittedTestSource, true)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -140,55 +151,53 @@ func TestEnforceRPCSourceOnArgs_PreservesExplicit113(t *testing.T) {
 	}
 }
 
-// TestEnforceRPCSourceParam_AcceptsByteTypedGateway pins the invariant
-// that in-process callers passing the canonical rpc_source.Gateway
-// constant directly (type byte/uint8) are accepted without being
-// rejected as "unsupported type". Regression for PR #505 comment
+// TestEnforceRPCSourceParam_AcceptsByteTypedSource pins the invariant that
+// in-process callers passing a byte/uint8 source directly are accepted without
+// being rejected as "unsupported type". Regression for PR #505 comment
 // id=3106887656.
-func TestEnforceRPCSourceParam_AcceptsByteTypedGateway(t *testing.T) {
-	params := map[string]any{"source": rpcsource.Gateway}
-	if err := enforceRPCSourceParam(params); err != nil {
-		t.Fatalf("byte-typed Gateway must be accepted, got %v", err)
+func TestEnforceRPCSourceParam_AcceptsByteTypedSource(t *testing.T) {
+	params := map[string]any{"source": admittedTestSource}
+	if err := enforceRPCSourceParam(params, admittedTestSource, true); err != nil {
+		t.Fatalf("byte-typed source must be accepted, got %v", err)
 	}
 }
 
-func TestEnforceRPCSourceParam_AcceptsByteLiteral113(t *testing.T) {
-	params := map[string]any{"source": byte(0x71)}
-	if err := enforceRPCSourceParam(params); err != nil {
-		t.Fatalf("byte(0x71) must be accepted, got %v", err)
+func TestEnforceRPCSourceParam_AcceptsByteLiteralOverride(t *testing.T) {
+	params := map[string]any{"source": byte(0x08)}
+	if err := enforceRPCSourceParam(params, admittedTestSource, true); err != nil {
+		t.Fatalf("byte override source must be accepted, got %v", err)
 	}
 }
 
-func TestEnforceRPCSourceParam_RejectsNon113Byte(t *testing.T) {
+func TestEnforceRPCSourceParam_AcceptsNonAdmittedByteOverride(t *testing.T) {
 	params := map[string]any{"source": byte(114)}
-	err := enforceRPCSourceParam(params)
-	if err == nil {
-		t.Fatal("byte(114) must be rejected")
-	}
-	if !errors.Is(err, rpcsource.ErrNon113Source) {
-		t.Fatalf("want ErrNon113Source, got %v", err)
+	if err := enforceRPCSourceParam(params, admittedTestSource, true); err != nil {
+		t.Fatalf("byte(114) explicit MCP override should be accepted: %v", err)
 	}
 }
 
 func TestToByteSource_ByteInRange(t *testing.T) {
-	got, err := toByteSource(byte(0x71))
+	got, err := toByteSource(admittedTestSource)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if got != 113 {
-		t.Fatalf("got %d, want 113", got)
+	if got != admittedTestSource {
+		t.Fatalf("got %d, want %d", got, admittedTestSource)
 	}
 }
 
-func TestEnforceRPCSourceOnArgs_RejectsNon113(t *testing.T) {
+func TestEnforceRPCSourceOnArgs_AcceptsExplicitOverride(t *testing.T) {
 	args := map[string]any{
 		"params": map[string]any{"source": int(0x08)},
 	}
-	_, err := enforceRPCSourceOnArgs(args)
-	if err == nil {
-		t.Fatal("non-113 source must be rejected")
+	if _, err := enforceRPCSourceOnArgs(args, admittedTestSource, true); err != nil {
+		t.Fatalf("explicit MCP override should be accepted: %v", err)
 	}
-	if !errors.Is(err, rpcsource.ErrNon113Source) {
-		t.Fatalf("want ErrNon113Source, got %v", err)
+}
+
+func TestEnforceRPCSourceOnArgs_FailsClosedBeforeAdmission(t *testing.T) {
+	args := map[string]any{"params": map[string]any{}}
+	if _, err := enforceRPCSourceOnArgs(args, 0, false); err == nil {
+		t.Fatal("rpc.invoke must fail closed before source admission")
 	}
 }

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -413,18 +413,21 @@ type SemanticProvider interface {
 }
 
 type Server struct {
-	registry       Registry
-	invoker        Invoker
-	statusProvider StatusProvider
-	bus            BusObservabilityProvider
-	watch          WatchSummaryProvider
-	semantic       SemanticProvider
-	scheduleWriter ScheduleWriter
-	configWriter   ConfigWriter
-	idempotencyMu  sync.Mutex
-	idempotency    map[string]idempotencyEntry
-	snapshotMu     sync.RWMutex
-	snapshots      map[string]snapshotState
+	registry          Registry
+	invoker           Invoker
+	statusProvider    StatusProvider
+	bus               BusObservabilityProvider
+	watch             WatchSummaryProvider
+	semantic          SemanticProvider
+	scheduleWriter    ScheduleWriter
+	configWriter      ConfigWriter
+	rpcSource         byte
+	rpcSourceAdmitted bool
+	rpcSourceProvider func() (byte, bool)
+	idempotencyMu     sync.Mutex
+	idempotency       map[string]idempotencyEntry
+	snapshotMu        sync.RWMutex
+	snapshots         map[string]snapshotState
 
 	tools []Tool
 
@@ -1171,6 +1174,31 @@ func (s *Server) SetConfigWriter(writer ConfigWriter) {
 	s.configWriter = writer
 }
 
+func (s *Server) SetAdmittedRPCSource(source byte) {
+	if s == nil {
+		return
+	}
+	s.rpcSource = source
+	s.rpcSourceAdmitted = source != 0
+}
+
+func (s *Server) SetAdmittedRPCSourceProvider(provider func() (byte, bool)) {
+	if s == nil {
+		return
+	}
+	s.rpcSourceProvider = provider
+}
+
+func (s *Server) admittedRPCSource() (byte, bool) {
+	if s == nil {
+		return 0, false
+	}
+	if s.rpcSourceProvider != nil {
+		return s.rpcSourceProvider()
+	}
+	return s.rpcSource, s.rpcSourceAdmitted
+}
+
 func (s *Server) Handler() http.Handler {
 	return http.HandlerFunc(s.ServeHTTP)
 }
@@ -1531,14 +1559,15 @@ func (s *Server) handleToolsCall(ctx context.Context, params json.RawMessage) (a
 		if err != nil {
 			return callToolResultText(mustJSON(newToolEnvelope(nil, err)), true), nil
 		}
-		// Normalize rpc source (inject canonical 113 if omitted) BEFORE
+		// Normalize rpc source (inject admitted source if omitted) BEFORE
 		// computing the idempotency signature, so caller-variance on
-		// params.source (omitted vs. explicit 113) produces identical
+		// params.source (omitted vs. explicit admitted source) produces identical
 		// signatures and thus identical cache keys. Without this, two
 		// semantically identical MUTATE requests would hash differently
 		// and the second would be rejected as "idempotency key reused
 		// with different payload". See PR #505 r3106812547.
-		if _, err := enforceRPCSourceOnArgs(call.Arguments); err != nil {
+		rpcSource, rpcSourceAdmitted := s.admittedRPCSource()
+		if _, err := enforceRPCSourceOnArgs(call.Arguments, rpcSource, rpcSourceAdmitted); err != nil {
 			return callToolResultText(mustJSON(newToolEnvelope(nil, err)), true), nil
 		}
 		signature := ""
@@ -2037,10 +2066,12 @@ func classifyToolError(err error) (code string, retriable bool, sourceLayer stri
 		return "CONFLICT", false, "gateway"
 	case errors.Is(err, errSnapshotNotFound):
 		return "NOT_FOUND", false, "gateway"
-	case errors.Is(err, rpcsource.ErrNon113Source):
-		// Client supplied params.source != 113 (or an unsupported type /
-		// fractional float that cannot be safely narrowed to the gateway
-		// source byte). This is a client input error, not a server fault.
+	case errors.Is(err, errSourceSelectionNotActive):
+		return "INVALID_ARGUMENT", false, "gateway"
+	case errors.Is(err, rpcsource.ErrInvalidSource):
+		// Client supplied an unsupported source type or a numeric value
+		// that cannot be safely narrowed to a nonzero source byte. This is
+		// a client input error, not a server fault.
 		return "INVALID_ARGUMENT", false, "gateway"
 	case errors.Is(err, ebuserrors.ErrInvalidPayload):
 		return "INVALID_ARGUMENT", false, "ebusreg"
@@ -3678,12 +3709,11 @@ func (s *Server) invoke(ctx context.Context, args map[string]any) (any, error) {
 	if methodName == "" {
 		return nil, fmt.Errorf("missing method: %w", ebuserrors.ErrInvalidPayload)
 	}
-	// RPC source byte MUST be the gateway initiator (0x71 == 113). If the
-	// caller supplies an explicit params.source, enforce it; if it is
-	// absent — or if params itself is absent — inject the canonical value
-	// and materialise params so downstream code cannot use a different
-	// initiator by accident. See internal/rpc_source.
-	params, err := enforceRPCSourceOnArgs(args)
+	// Gateway-owned rpc.invoke calls default to the admitted startup source.
+	// An explicit params.source is accepted as the user override path after
+	// byte-shape validation.
+	rpcSource, rpcSourceAdmitted := s.admittedRPCSource()
+	params, err := enforceRPCSourceOnArgs(args, rpcSource, rpcSourceAdmitted)
 	if err != nil {
 		return nil, err
 	}

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -610,6 +610,7 @@ func TestServer_ToolsCallDevicesAndInvoke(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewServer error = %v", err)
 	}
+	server.SetAdmittedRPCSource(0x7F)
 
 	res := doRPC(t, server.Handler(), rpcRequest{
 		JSONRPC: "2.0",
@@ -2159,6 +2160,7 @@ func TestServer_ToolsCallLegacyAliases(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewServer error = %v", err)
 	}
+	server.SetAdmittedRPCSource(0x7F)
 
 	res := doRPC(t, server.Handler(), rpcRequest{
 		JSONRPC: "2.0",
@@ -2211,6 +2213,7 @@ func TestServer_ToolsCallInvokeErrorEnvelope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewServer error = %v", err)
 	}
+	server.SetAdmittedRPCSource(0x7F)
 
 	res := doRPC(t, server.Handler(), rpcRequest{
 		JSONRPC: "2.0",
@@ -2283,6 +2286,7 @@ func TestServer_ToolsCallInvokeV1SafetyGuards(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewServer error = %v", err)
 	}
+	server.SetAdmittedRPCSource(0x7F)
 
 	t.Run("missing intent", func(t *testing.T) {
 		res := doRPC(t, server.Handler(), rpcRequest{
@@ -2345,6 +2349,7 @@ func TestServer_ToolsCallInvokeV1Idempotency(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewServer error = %v", err)
 	}
+	server.SetAdmittedRPCSource(0x7F)
 
 	first := doRPC(t, server.Handler(), rpcRequest{
 		JSONRPC: "2.0",
@@ -2380,7 +2385,7 @@ func TestServer_ToolsCallInvokeV1Idempotency(t *testing.T) {
 
 // Regression test for PR #505 r3106812547: source normalization must run
 // BEFORE idempotency signature is computed, so caller-variance on
-// params.source (omitted vs explicit 113) produces identical cache keys.
+// params.source (omitted vs explicit admitted source) produces identical cache keys.
 // Before the fix, the second call hashed differently and was rejected
 // with "idempotency key reused with different payload" / CONFLICT.
 func TestServer_ToolsCallInvokeV1IdempotencySourceNormalization(t *testing.T) {
@@ -2413,8 +2418,9 @@ func TestServer_ToolsCallInvokeV1IdempotencySourceNormalization(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewServer error = %v", err)
 	}
+	server.SetAdmittedRPCSource(0x7F)
 
-	// First call: params.source omitted — guard injects 113.
+	// First call: params.source omitted, so the guard injects the admitted source.
 	first := doRPC(t, server.Handler(), rpcRequest{
 		JSONRPC: "2.0",
 		ID:      1,
@@ -2426,19 +2432,19 @@ func TestServer_ToolsCallInvokeV1IdempotencySourceNormalization(t *testing.T) {
 	}
 
 	// Second call: same idempotency_key, same payload semantics, but
-	// caller explicitly sets params.source=113. Must be treated as
-	// identical to the first and return the cached result (no CONFLICT).
+	// caller explicitly sets params.source to the admitted source. Must be
+	// treated as identical to the first and return the cached result (no CONFLICT).
 	second := doRPC(t, server.Handler(), rpcRequest{
 		JSONRPC: "2.0",
 		ID:      2,
 		Method:  "tools/call",
-		Params:  json.RawMessage(`{"name":"ebus.v1.rpc.invoke","arguments":{"address":8,"plane":"heating","method":"set_target","params":{"target_c":21.5,"source":113},"intent":"MUTATE","allow_dangerous":true,"idempotency_key":"srckey"}}`),
+		Params:  json.RawMessage(`{"name":"ebus.v1.rpc.invoke","arguments":{"address":8,"plane":"heating","method":"set_target","params":{"target_c":21.5,"source":127},"intent":"MUTATE","allow_dangerous":true,"idempotency_key":"srckey"}}`),
 	})
 	if second.Error != nil {
 		t.Fatalf("second invoke rpc error = %+v", second.Error)
 	}
 	// Without the fix, the second call hashes differently (explicit
-	// source=113 is present in the signature, the first call had source
+	// admitted source is present in the signature, the first call had source
 	// absent) and lookupIdempotency returns a CONFLICT error envelope
 	// (isError=true). With the fix, source is normalized before the
 	// signature is computed, so signatures match and the cached result
@@ -2455,11 +2461,11 @@ func TestServer_ToolsCallInvokeV1IdempotencySourceNormalization(t *testing.T) {
 				text, _ = item["text"].(string)
 			}
 		}
-		t.Fatalf("second call returned isError=true (signature mismatch across omitted vs explicit source=113): %s", text)
+		t.Fatalf("second call returned isError=true (signature mismatch across omitted vs explicit admitted source): %s", text)
 	}
 	// And the invoker MUST NOT be dispatched a second time (cache hit).
 	if len(invoker.calls) != 1 {
-		t.Fatalf("invoker calls = %d; want 1 (dedup across omitted vs explicit source=113)", len(invoker.calls))
+		t.Fatalf("invoker calls = %d; want 1 (dedup across omitted vs explicit admitted source)", len(invoker.calls))
 	}
 }
 
@@ -2493,6 +2499,7 @@ func TestServer_ToolsCallInvokeV1Timeout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewServer error = %v", err)
 	}
+	server.SetAdmittedRPCSource(0x7F)
 
 	res := doRPC(t, server.Handler(), rpcRequest{
 		JSONRPC: "2.0",
@@ -2524,14 +2531,15 @@ func TestClassifyToolError_KnownMappings(t *testing.T) {
 		{name: "deadline exceeded", err: context.DeadlineExceeded, code: "TIMEOUT", retriable: true, sourceLayer: "gateway"},
 		{name: "idempotency conflict", err: errInvokeIdempotencyConflict, code: "CONFLICT", retriable: false, sourceLayer: "gateway"},
 		{name: "snapshot not found", err: errSnapshotNotFound, code: "NOT_FOUND", retriable: false, sourceLayer: "gateway"},
-		// Issue #505 r3106859308: non-113 source / unsupported-type /
+		{name: "source selection not active", err: errSourceSelectionNotActive, code: "INVALID_ARGUMENT", retriable: false, sourceLayer: "gateway"},
+		// Issue #505 r3106859308: invalid source / unsupported-type /
 		// fractional-float at rpc.invoke is a client input error, not a
 		// server fault. classifyToolError must surface it as
 		// INVALID_ARGUMENT (via errors.Is unwrap through wrapped
 		// fmt.Errorf chains).
-		{name: "rpc source non-113 direct", err: rpcsource.ErrNon113Source, code: "INVALID_ARGUMENT", retriable: false, sourceLayer: "gateway"},
-		{name: "rpc source non-113 wrapped", err: fmt.Errorf("got 0x72, want 0x71: %w", rpcsource.ErrNon113Source), code: "INVALID_ARGUMENT", retriable: false, sourceLayer: "gateway"},
-		{name: "rpc source fractional float", err: fmt.Errorf("params.source has unsupported type float64: %w", rpcsource.ErrNon113Source), code: "INVALID_ARGUMENT", retriable: false, sourceLayer: "gateway"},
+		{name: "rpc source invalid direct", err: rpcsource.ErrInvalidSource, code: "INVALID_ARGUMENT", retriable: false, sourceLayer: "gateway"},
+		{name: "rpc source invalid wrapped", err: fmt.Errorf("got 0x00: %w", rpcsource.ErrInvalidSource), code: "INVALID_ARGUMENT", retriable: false, sourceLayer: "gateway"},
+		{name: "rpc source fractional float", err: fmt.Errorf("params.source has unsupported type float64: %w", rpcsource.ErrInvalidSource), code: "INVALID_ARGUMENT", retriable: false, sourceLayer: "gateway"},
 	}
 
 	for _, tc := range cases {

--- a/mcp/vaillant_b503.go
+++ b/mcp/vaillant_b503.go
@@ -238,77 +238,77 @@ func historyIndex(args map[string]any) (byte, bool, error) {
 func (st *b503State) handleErrorsGet(ctx context.Context, args map[string]any) map[string]any {
 	target, err := st.target(args)
 	if err != nil {
-		return st.errEnvelope(ctx,err)
+		return st.errEnvelope(ctx, err)
 	}
 	resp, err := st.opts.Dispatcher.Invoke(ctx, target, b503.EncodeCurrentError())
 	if err != nil {
-		return st.errEnvelope(ctx,fmt.Errorf("%w: %v", errUpstreamRPCFailed, err))
+		return st.errEnvelope(ctx, fmt.Errorf("%w: %v", errUpstreamRPCFailed, err))
 	}
 	slots, err := b503.DecodeCurrentError(resp)
 	if err != nil {
-		return st.errEnvelope(ctx,fmt.Errorf("%w: %v", errDecodeFailed, err))
+		return st.errEnvelope(ctx, fmt.Errorf("%w: %v", errDecodeFailed, err))
 	}
-	return st.okEnvelope(ctx,slotsToMap(slots))
+	return st.okEnvelope(ctx, slotsToMap(slots))
 }
 
 func (st *b503State) handleServiceCurrentGet(ctx context.Context, args map[string]any) map[string]any {
 	target, err := st.target(args)
 	if err != nil {
-		return st.errEnvelope(ctx,err)
+		return st.errEnvelope(ctx, err)
 	}
 	resp, err := st.opts.Dispatcher.Invoke(ctx, target, b503.EncodeCurrentService())
 	if err != nil {
-		return st.errEnvelope(ctx,fmt.Errorf("%w: %v", errUpstreamRPCFailed, err))
+		return st.errEnvelope(ctx, fmt.Errorf("%w: %v", errUpstreamRPCFailed, err))
 	}
 	slots, err := b503.DecodeCurrentService(resp)
 	if err != nil {
-		return st.errEnvelope(ctx,fmt.Errorf("%w: %v", errDecodeFailed, err))
+		return st.errEnvelope(ctx, fmt.Errorf("%w: %v", errDecodeFailed, err))
 	}
-	return st.okEnvelope(ctx,slotsToMap(slots))
+	return st.okEnvelope(ctx, slotsToMap(slots))
 }
 
 func (st *b503State) handleErrorsHistoryGet(ctx context.Context, args map[string]any) map[string]any {
 	target, err := st.target(args)
 	if err != nil {
-		return st.errEnvelope(ctx,err)
+		return st.errEnvelope(ctx, err)
 	}
 	payload := b503.EncodeErrorHistory()
 	if idx, present, err := historyIndex(args); err != nil {
-		return st.errEnvelope(ctx,err)
+		return st.errEnvelope(ctx, err)
 	} else if present {
 		payload = append(payload, idx)
 	}
 	resp, err := st.opts.Dispatcher.Invoke(ctx, target, payload)
 	if err != nil {
-		return st.errEnvelope(ctx,fmt.Errorf("%w: %v", errUpstreamRPCFailed, err))
+		return st.errEnvelope(ctx, fmt.Errorf("%w: %v", errUpstreamRPCFailed, err))
 	}
 	rec, err := b503.DecodeErrorHistory(resp)
 	if err != nil {
-		return st.errEnvelope(ctx,fmt.Errorf("%w: %v", errDecodeFailed, err))
+		return st.errEnvelope(ctx, fmt.Errorf("%w: %v", errDecodeFailed, err))
 	}
-	return st.okEnvelope(ctx,historyToMap(rec))
+	return st.okEnvelope(ctx, historyToMap(rec))
 }
 
 func (st *b503State) handleServiceHistoryGet(ctx context.Context, args map[string]any) map[string]any {
 	target, err := st.target(args)
 	if err != nil {
-		return st.errEnvelope(ctx,err)
+		return st.errEnvelope(ctx, err)
 	}
 	payload := b503.EncodeServiceHistory()
 	if idx, present, err := historyIndex(args); err != nil {
-		return st.errEnvelope(ctx,err)
+		return st.errEnvelope(ctx, err)
 	} else if present {
 		payload = append(payload, idx)
 	}
 	resp, err := st.opts.Dispatcher.Invoke(ctx, target, payload)
 	if err != nil {
-		return st.errEnvelope(ctx,fmt.Errorf("%w: %v", errUpstreamRPCFailed, err))
+		return st.errEnvelope(ctx, fmt.Errorf("%w: %v", errUpstreamRPCFailed, err))
 	}
 	rec, err := b503.DecodeServiceHistory(resp)
 	if err != nil {
-		return st.errEnvelope(ctx,fmt.Errorf("%w: %v", errDecodeFailed, err))
+		return st.errEnvelope(ctx, fmt.Errorf("%w: %v", errDecodeFailed, err))
 	}
-	return st.okEnvelope(ctx,historyToMap(rec))
+	return st.okEnvelope(ctx, historyToMap(rec))
 }
 
 func (st *b503State) handleLiveMonitor(ctx context.Context, args map[string]any) map[string]any {
@@ -318,32 +318,32 @@ func (st *b503State) handleLiveMonitor(ctx context.Context, args map[string]any)
 	// refresh the idle timer and prolong SESSION_BUSY for other clients.
 	raw, present := args["action"]
 	if !present {
-		return st.errEnvelope(ctx,fmt.Errorf("%w: action is required (enable|read|disable)", errInvalidArgument))
+		return st.errEnvelope(ctx, fmt.Errorf("%w: action is required (enable|read|disable)", errInvalidArgument))
 	}
 	action, ok := raw.(string)
 	if !ok {
-		return st.errEnvelope(ctx,fmt.Errorf("%w: action must be a string (enable|read|disable)", errInvalidArgument))
+		return st.errEnvelope(ctx, fmt.Errorf("%w: action must be a string (enable|read|disable)", errInvalidArgument))
 	}
 	switch action {
 	case "enable", "read", "disable":
 		// valid
 	default:
-		return st.errEnvelope(ctx,fmt.Errorf("%w: action must be one of enable|read|disable, got %q", errInvalidArgument, action))
+		return st.errEnvelope(ctx, fmt.Errorf("%w: action must be one of enable|read|disable, got %q", errInvalidArgument, action))
 	}
 	mgr := st.opts.SessionManager
 	if mgr == nil {
-		return st.errEnvelope(ctx,errNotSupported)
+		return st.errEnvelope(ctx, errNotSupported)
 	}
 
 	switch action {
 	case "enable":
 		target, err := st.target(args)
 		if err != nil {
-			return st.errEnvelope(ctx,err)
+			return st.errEnvelope(ctx, err)
 		}
 		key, err := mgr.Enable(ctx)
 		if err != nil {
-			return st.errEnvelope(ctx,normalizeSessionErr(err))
+			return st.errEnvelope(ctx, normalizeSessionErr(err))
 		}
 		// Emit the request so the device acknowledges live-monitor
 		// activation. Bound by SERVICE_WRITE safety class.
@@ -360,10 +360,10 @@ func (st *b503State) handleLiveMonitor(ctx context.Context, args map[string]any)
 				IssuerToken: key.IssuerToken,
 			}
 			_ = mgr.Disable(rebuilt)
-			return st.errEnvelope(ctx,fmt.Errorf("%w: %v", errUpstreamRPCFailed, err))
+			return st.errEnvelope(ctx, fmt.Errorf("%w: %v", errUpstreamRPCFailed, err))
 		}
 		data := map[string]any{"issuer_token": key.IssuerToken}
-		return st.okEnvelope(ctx,data)
+		return st.okEnvelope(ctx, data)
 
 	case "read":
 		// Resolver per spec §8 / plan AD14: surface the current FSM outcome
@@ -376,21 +376,21 @@ func (st *b503State) handleLiveMonitor(ctx context.Context, args map[string]any)
 		// clients) only to then fail with INVALID_ARGUMENT.
 		target, err := st.target(args)
 		if err != nil {
-			return st.errEnvelope(ctx,err)
+			return st.errEnvelope(ctx, err)
 		}
 		if mgr.LastRefreshTransportDown() {
-			return st.errEnvelope(ctx,errTransportDown)
+			return st.errEnvelope(ctx, errTransportDown)
 		}
 		transport := mgr.TransportKey()
 		if err := mgr.Read(transport); err != nil {
-			return st.errEnvelope(ctx,normalizeSessionErr(err))
+			return st.errEnvelope(ctx, normalizeSessionErr(err))
 		}
 		resp, err := st.opts.Dispatcher.Invoke(ctx, target, b503.EncodeLiveMonitorMain())
 		if err != nil {
-			return st.errEnvelope(ctx,fmt.Errorf("%w: %v", errUpstreamRPCFailed, err))
+			return st.errEnvelope(ctx, fmt.Errorf("%w: %v", errUpstreamRPCFailed, err))
 		}
 		data := map[string]any{"raw_hex": hexString(resp)}
-		return st.okEnvelope(ctx,data)
+		return st.okEnvelope(ctx, data)
 
 	case "disable":
 		// issuer_token is mandatory for disable. Silently treating a missing
@@ -416,7 +416,7 @@ func (st *b503State) handleLiveMonitor(ctx context.Context, args map[string]any)
 		}
 		return st.okEnvelope(ctx, map[string]any{"disabled": true})
 	}
-	return st.errEnvelope(ctx,fmt.Errorf("%w: unknown action %q", errInvalidToken, action))
+	return st.errEnvelope(ctx, fmt.Errorf("%w: unknown action %q", errInvalidToken, action))
 }
 
 func slotsToMap(s b503.ErrorSlots) map[string]any {
@@ -575,15 +575,15 @@ func (s *Server) VaillantB503Availability() B503Availability {
 // derived under the same deadline as the response itself.
 //
 // Probe ordering (first match wins):
-//   1. Manager reports LastRefreshTransportDown → TRANSPORT_DOWN.
-//   2. Manager.State() ∈ {Enabling, Active} → SESSION_BUSY (a second
-//      action=enable would fail with SESSION_BUSY; publishing
-//      AVAILABLE here would contradict the error code clients receive).
-//   3. Probe succeeds → AVAILABLE.
-//   4. Probe returns ErrTransportDown → TRANSPORT_DOWN.
-//   5. Any other probe error → UNKNOWN (conservative — cannot
-//      distinguish "not supported" from "transient failure" or
-//      dispatcher-stub).
+//  1. Manager reports LastRefreshTransportDown → TRANSPORT_DOWN.
+//  2. Manager.State() ∈ {Enabling, Active} → SESSION_BUSY (a second
+//     action=enable would fail with SESSION_BUSY; publishing
+//     AVAILABLE here would contradict the error code clients receive).
+//  3. Probe succeeds → AVAILABLE.
+//  4. Probe returns ErrTransportDown → TRANSPORT_DOWN.
+//  5. Any other probe error → UNKNOWN (conservative — cannot
+//     distinguish "not supported" from "transient failure" or
+//     dispatcher-stub).
 func (s *Server) VaillantB503AvailabilityCtx(ctx context.Context) B503Availability {
 	st, ok := b503StateFor(s)
 	if !ok || st == nil {

--- a/scripts/passive_matrix_case_ha.sh
+++ b/scripts/passive_matrix_case_ha.sh
@@ -200,6 +200,19 @@ build_observe_first_cli_flags() {
   printf '%s\n' "${flags[*]}"
 }
 
+build_startup_probe_cli_flags() {
+  local targets
+  targets="$(printf '%s' "${MATRIX_STARTUP_PROBE_TARGETS:-}" | xargs)"
+  if [[ -z "${targets}" && "${MATRIX_PASSIVE_MODE:-}" == "required" ]]; then
+    targets="${MATRIX_REQUIRED_PASSIVE_STARTUP_PROBE_TARGETS:-0x08,0x15,0x26,0x04}"
+  fi
+  if [[ -z "${targets}" ]]; then
+    printf '\n'
+    return 0
+  fi
+  printf '%s\n' "--startup-probe-targets '${targets}'"
+}
+
 select_ebusd_config_src() {
   if [[ -n "${EBUSD_CONFIG_SRC:-}" ]]; then
     printf '%s\n' "${EBUSD_CONFIG_SRC}"
@@ -329,9 +342,11 @@ restart_gateway_with_passive_mode() {
   local gateway_log_path="${1:-${MATRIX_GATEWAY_LOG_PATH:-${remote_case_dir}/logs/gateway.log}}"
   local protocol network address
   local observe_first_flags=""
+  local startup_probe_flags=""
   enforce_gw15_proof_flag_state
   IFS=';' read -r protocol network address < <(gateway_connection)
   observe_first_flags="$(build_observe_first_cli_flags)"
+  startup_probe_flags="$(build_startup_probe_cli_flags)"
 
   remote_exec "mkdir -p '${remote_case_dir}/state' '${remote_case_dir}/logs'"
   remote_exec "if [ -f '${remote_case_dir}/state/gateway.pid' ]; then kill \$(cat '${remote_case_dir}/state/gateway.pid') >/dev/null 2>&1 || true; rm -f '${remote_case_dir}/state/gateway.pid'; fi"
@@ -344,6 +359,7 @@ restart_gateway_with_passive_mode() {
     --semantic-discovery-interval 5m --semantic-config-interval 5m --semantic-state-interval 1m --semantic-request-timeout 2s \
     --semantic-cache-path '${remote_case_dir}/state/semantic_cache.json' \
     ${observe_first_flags} \
+    ${startup_probe_flags} \
     --http-addr ':${gateway_http_port}' --mdns=false --broadcast=true \
     > '${gateway_log_path}' 2>&1 & echo \$! > '${remote_case_dir}/state/gateway.pid'"
   remote_exec "for i in \$(seq 1 60); do kill -0 \$(cat '${remote_case_dir}/state/gateway.pid') || exit 2; ss -ltn '( sport = :${gateway_http_port} )' | grep -q LISTEN && exit 0; sleep 1; done; exit 1"

--- a/scripts/passive_smoke_check.sh
+++ b/scripts/passive_smoke_check.sh
@@ -276,7 +276,10 @@ except json.JSONDecodeError as exc:
     raise SystemExit(1)
 
 devices = ((graphql.get("data") or {}).get("devices")) or []
-if not isinstance(devices, list) or len(devices) == 0:
+if not isinstance(devices, list):
+    print(f"{case_id}: devices payload is not a list", file=sys.stderr)
+    raise SystemExit(1)
+if passive_mode == "required" and len(devices) == 0:
     print(f"{case_id}: devices list is empty", file=sys.stderr)
     raise SystemExit(1)
 

--- a/startup_admission_harness_test.go
+++ b/startup_admission_harness_test.go
@@ -27,36 +27,6 @@ func synthesizedTransactionEvent(src, dst byte, hasResponse bool) PassiveClassif
 	return event
 }
 
-func synthesizedBroadcastEvent(src byte) PassiveClassifiedEvent {
-	return PassiveClassifiedEvent{
-		Kind:    PassiveClassifiedEventBroadcastFrame,
-		Request: protocol.Frame{Source: src, Target: protocol.AddressBroadcast, Primary: 0xB5, Secondary: 0x16, Data: []byte{0x01}},
-	}
-}
-
-func feedSynthesizedPassiveStream(t *testing.T, reconstructor *PassiveTransactionReconstructor, events []PassiveClassifiedEvent) func() {
-	t.Helper()
-	stopCh := make(chan struct{})
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		base := time.Unix(0, 0)
-		for i, event := range events {
-			select {
-			case <-stopCh:
-				return
-			default:
-			}
-			feedPassiveSymbols(reconstructor, base.Add(time.Duration(i)*time.Second), synthesizedEventSymbols(t, event))
-			time.Sleep(10 * time.Millisecond)
-		}
-	}()
-	return func() {
-		close(stopCh)
-		<-done
-	}
-}
-
 func validateAdmissionArtifactAgainstSchema(t *testing.T, artifactJSON []byte) {
 	t.Helper()
 	if err := admissionArtifactSchemaError(artifactJSON); err != nil {
@@ -64,9 +34,9 @@ func validateAdmissionArtifactAgainstSchema(t *testing.T, artifactJSON []byte) {
 	}
 }
 
-func TestM2aHarness_JoinerSuccessPath(t *testing.T) {
+func TestM2aHarness_SourceSelectionSuccessPath(t *testing.T) {
 	var forwarded []protocol.Frame
-	forwardJoinBusEvent(synthesizedTransactionEvent(0x71, 0x08, true), func(frame protocol.Frame) {
+	forwardSourceSelectionBusEvent(synthesizedTransactionEvent(0x71, 0x08, true), func(frame protocol.Frame) {
 		forwarded = append(forwarded, frame)
 	})
 	if len(forwarded) == 0 {
@@ -75,10 +45,10 @@ func TestM2aHarness_JoinerSuccessPath(t *testing.T) {
 
 	builder := NewAdmissionArtifactBuilder("ens")
 	builder.startedAt = time.Now().Add(-60 * time.Second)
-	if err := builder.SetAdmissionPathSelected("join"); err != nil {
+	if err := builder.SetAdmissionPathSelected("source_selection"); err != nil {
 		t.Fatal(err)
 	}
-	builder.SetJoinerSelection(0x71, 0x08, 5*time.Second)
+	builder.SetSourceSelection(0x71, 0x08, 5*time.Second)
 	builder.RecordProbe(120)
 
 	artifact, data, err := builder.Emit()
@@ -86,7 +56,7 @@ func TestM2aHarness_JoinerSuccessPath(t *testing.T) {
 		t.Fatal(err)
 	}
 	validateAdmissionArtifactAgainstSchema(t, data)
-	if artifact.Admission.AdmissionPathSelected != "join" {
+	if artifact.Admission.AdmissionPathSelected != "source_selection" {
 		t.Fatalf("admission_path_selected=%q", artifact.Admission.AdmissionPathSelected)
 	}
 	if artifact.Admission.State != "active" {
@@ -94,8 +64,8 @@ func TestM2aHarness_JoinerSuccessPath(t *testing.T) {
 	}
 }
 
-func TestM2aHarness_JoinerFailNoFreeInitiatorPath(t *testing.T) {
-	t.Skip("pending M3: JoinResult error-path capture; ebusgo surfaces ErrNoFreeInitiatorAddress but the gateway's degraded-state transition on that error lands in M3/M4")
+func TestM2aHarness_SourceSelectionFailNoFreeInitiatorPath(t *testing.T) {
+	t.Skip("pending M3: source-address selection error-path capture; ebusgo surfaces no-available-source errors but the gateway's degraded-state transition on that error lands in M3/M4")
 }
 
 func TestM2aHarness_TransportBlindPath(t *testing.T) {
@@ -116,24 +86,24 @@ func TestM2aHarness_OverrideValidateFalsePath(t *testing.T) {
 		t.Fatalf("expected override_bypass_total=1, got %d", m.OverrideBypassTotal.Value())
 	}
 	if m.OverrideConflictDetected.Value() != 0 {
-		t.Fatalf("expected no advisory Joiner conflict when validate=false, got %d", m.OverrideConflictDetected.Value())
+		t.Fatalf("expected no advisory source-address selector conflict when validate=false, got %d", m.OverrideConflictDetected.Value())
 	}
 }
 
 func TestM2aHarness_OverrideValidateTruePath(t *testing.T) {
-	t.Run("advisory joiner agrees", func(t *testing.T) {
+	t.Run("advisory source-address selector agrees", func(t *testing.T) {
 		m := NewStartupAdmissionMetrics()
-		if CheckOverrideCompanionConflict(0xF0, protocol.JoinResult{Initiator: 0xF0}, m) {
-			t.Fatal("expected no conflict when advisory Joiner agrees")
+		if CheckOverrideCompanionConflict(0xF0, &protocol.SourceAddressSelection{Source: 0xF0}, m) {
+			t.Fatal("expected no conflict when advisory selector agrees")
 		}
 		if m.OverrideConflictDetected.Value() != 0 {
 			t.Fatalf("expected override_conflict_detected=0, got %d", m.OverrideConflictDetected.Value())
 		}
 	})
-	t.Run("advisory joiner disagrees", func(t *testing.T) {
+	t.Run("advisory source-address selector disagrees", func(t *testing.T) {
 		m := NewStartupAdmissionMetrics()
-		if !CheckOverrideCompanionConflict(0xF0, protocol.JoinResult{Initiator: 0xF1}, m) {
-			t.Fatal("expected conflict when advisory Joiner disagrees")
+		if !CheckOverrideCompanionConflict(0xF0, &protocol.SourceAddressSelection{Source: 0xF1}, m) {
+			t.Fatal("expected conflict when advisory selector disagrees")
 		}
 		if m.OverrideConflictDetected.Value() != 1 {
 			t.Fatalf("expected override_conflict_detected=1, got %d", m.OverrideConflictDetected.Value())
@@ -166,7 +136,7 @@ func TestM2aHarness_EvidenceBufferFloodBaselineProtection(t *testing.T) {
 
 func TestM2aHarness_AdmissionArtifactEmissionValidatesAgainstSchema(t *testing.T) {
 	t.Run("valid artifact passes", func(t *testing.T) {
-		valid := []byte(`{"admission":{"state":"joined","source":113,"companion_target":8,"warmup_duration_s":5,"reason_if_degraded":"","transport_kind":"enh","admission_path_selected":"join"},"discovery":{"wire_bytes":2048,"window_s":15,"startup_burst_pct":62.5,"post_startup_sustained_rate_probes_per_15s":1.5,"probe_count":12,"promoted_suspects_without_identity":1,"per_baseline_address_evidence_counts":{"08":3,"15":1}}}`)
+		valid := []byte(`{"admission":{"state":"joined","source":113,"companion_target":8,"warmup_duration_s":5,"reason_if_degraded":"","transport_kind":"enh","admission_path_selected":"source_selection"},"discovery":{"wire_bytes":2048,"window_s":15,"startup_burst_pct":62.5,"post_startup_sustained_rate_probes_per_15s":1.5,"probe_count":12,"promoted_suspects_without_identity":1,"per_baseline_address_evidence_counts":{"08":3,"15":1}}}`)
 		validateAdmissionArtifactAgainstSchema(t, valid)
 	})
 	t.Run("invalid enum fails", func(t *testing.T) {
@@ -176,31 +146,11 @@ func TestM2aHarness_AdmissionArtifactEmissionValidatesAgainstSchema(t *testing.T
 		}
 	})
 	t.Run("missing required field fails", func(t *testing.T) {
-		invalid := []byte(`{"admission":{"state":"joined","source":113,"warmup_duration_s":5,"reason_if_degraded":"","transport_kind":"enh","admission_path_selected":"join"},"discovery":{"wire_bytes":2048,"window_s":15,"startup_burst_pct":62.5,"post_startup_sustained_rate_probes_per_15s":1.5,"probe_count":12,"promoted_suspects_without_identity":1,"per_baseline_address_evidence_counts":{"08":3}}}`)
+		invalid := []byte(`{"admission":{"state":"joined","source":113,"warmup_duration_s":5,"reason_if_degraded":"","transport_kind":"enh","admission_path_selected":"source_selection"},"discovery":{"wire_bytes":2048,"window_s":15,"startup_burst_pct":62.5,"post_startup_sustained_rate_probes_per_15s":1.5,"probe_count":12,"promoted_suspects_without_identity":1,"per_baseline_address_evidence_counts":{"08":3}}}`)
 		if err := admissionArtifactSchemaError(invalid); err == nil {
 			t.Fatal("expected missing required field to fail schema validation")
 		}
 	})
-}
-
-func synthesizedEventSymbols(t *testing.T, event PassiveClassifiedEvent) []byte {
-	t.Helper()
-	switch event.Kind {
-	case PassiveClassifiedEventBroadcastFrame:
-		return frameBytes(event.Request)
-	case PassiveClassifiedEventTransaction:
-		payload := append([]byte{}, frameBytes(event.Request)...)
-		payload = append(payload, protocol.SymbolAck)
-		if event.HasResponse {
-			payload = append(payload, responseSegmentBytes(event.Response.Data)...)
-			payload = append(payload, protocol.SymbolAck, protocol.SymbolSyn)
-			return payload
-		}
-		return append(payload, protocol.SymbolSyn)
-	default:
-		t.Fatalf("unsupported synthesized event kind %d", event.Kind)
-		return nil
-	}
 }
 
 func admissionArtifactSchemaError(artifactJSON []byte) error {
@@ -257,7 +207,7 @@ func admissionArtifactSchemaError(artifactJSON []byte) error {
 	if !containsAdmissionEnum([]string{"enh", "ens", "ebusd-tcp", "udp-plain", "tcp-plain", "adapter-direct"}, *artifact.Admission.TransportKind) {
 		return fmt.Errorf("invalid transport_kind %q", *artifact.Admission.TransportKind)
 	}
-	if !containsAdmissionEnum([]string{"join", "override", "degraded_transport_blind", "degraded_no_events"}, *artifact.Admission.AdmissionPathSelected) {
+	if !containsAdmissionEnum([]string{"source_selection", "override", "degraded_transport_blind", "degraded_no_events"}, *artifact.Admission.AdmissionPathSelected) {
 		return fmt.Errorf("invalid admission_path_selected %q", *artifact.Admission.AdmissionPathSelected)
 	}
 	if *artifact.Discovery.WireBytes < 0 || *artifact.Discovery.WindowS <= 0 || *artifact.Discovery.StartupBurstPct < 0 || *artifact.Discovery.StartupBurstPct > 100 || *artifact.Discovery.PostStartupSustainedRateProbes15S < 0 || *artifact.Discovery.ProbeCount < 0 || *artifact.Discovery.PromotedSuspectsWithoutIdentity < 0 {

--- a/startup_admission_harness_test.go
+++ b/startup_admission_harness_test.go
@@ -49,6 +49,7 @@ func TestM2aHarness_SourceSelectionSuccessPath(t *testing.T) {
 		t.Fatal(err)
 	}
 	builder.SetSourceSelection(0x71, 0x08, 5*time.Second)
+	builder.SetSourceSelectionActive()
 	builder.RecordProbe(120)
 
 	artifact, data, err := builder.Emit()


### PR DESCRIPTION
## What
Migrate gateway startup admission from legacy join/gentlejoin naming and API usage to the SAS source-address selection contract.

## Why
This implements SAS-03A from Project-Helianthus/helianthus-execution-plans#22 after SAS-01 docs, SAS-02 ebusgo, and SAS-02A add-on were merged. The gateway must consume the new ebusgo source-selection API and stop exposing/depending on legacy join-era admission vocabulary.

## Changes
- Replace gateway Joiner/JoinBus/JoinResult usage with SourceAddressSelector/SourceSelectionBusAdapter terminology and ebusgo API.
- Map `--source-addr auto` direct startup to the ebusgo default source-selection policy instead of unusable source 0x00.
- Keep source-selection-capable startup scans protocol-correct: no selected-source full-range scan escape; directed startup probes require explicit targets or passive promoted suspects.
- Add `--startup-probe-targets` for lab/runtime configured directed probes and wire HA passive matrix required cases to the known lab target set.
- Rename admission artifact enum from `join` to `source_selection` and update tests/schema.
- Adjust passive smoke semantics so unsupported/misconfigured passive cases may pass with an empty device list, while required passive cases still require devices.
- Bump helianthus-ebusgo to merged SAS-02 commit `8083eedd15ee`.

## Validation
- `go test ./...`
- `golangci-lint run ./...` (`0 issues`)
- `bash -n scripts/passive_matrix_case_ha.sh scripts/passive_smoke_check.sh`
- `python3 scripts/passive_canary_verifier_test.py PassiveSmokeCanaryVerdictGateTests.test_smoke_hold_zero_waits_for_first_interval_when_interval_phase_is_required`
- `TRANSPORT_MATRIX_REPORT="results-matrix-ha/20260504T183356Z-sas02-ebusgo-c9a4697-full88-correct-adapter-signal/index.json" PASSIVE_SMOKE_REPORT="results-matrix-ha/20260505T134601Z-sas03a-gateway-passive-p01-p06-combined-pass/index.json" ./scripts/ci_local.sh`

## Live Evidence
- Transport gate baseline: `results-matrix-ha/20260504T183356Z-sas02-ebusgo-c9a4697-full88-correct-adapter-signal/index.json` (`pass=46`, `xfail=7`, `blocked=35`, `xpass=0`, `total=88`)
- Passive full run: `results-matrix-ha/20260505T134110Z-sas03a-gateway-passive-p01-p06-configured-targets`
- Passive P02 rerun after transient ENH adapter init failure: `results-matrix-ha/20260505T134601Z-sas03a-gateway-passive-p02-rerun`
- Passive combined gate input: `results-matrix-ha/20260505T134601Z-sas03a-gateway-passive-p01-p06-combined-pass/index.json` (`pass=6`)

## Notes
- The configured passive matrix target set is harness/lab configuration, not a gateway hardcoded source address. Normal gateway bus-reaching operations use the selected/admitted source unless an explicit transport-specific MCP/proxy client override path is used.
- Docs gate for the source-selection contract was satisfied by Project-Helianthus/helianthus-docs-ebus#291 and companion add-on docs by #292.

Refs Project-Helianthus/helianthus-execution-plans#22.