### PR TITLE
SAS-03B: GraphQL source selection admission parity

### DIFF
--- a/bus_observability_api.go
+++ b/bus_observability_api.go
@@ -51,10 +51,40 @@ type BusObservabilityStartup struct {
 // by the state-stability window (30s default); transient flaps do NOT
 // flip this field nor the envelope's data_hash.
 type BusAdmission struct {
-	State           string `json:"state"`
-	Source          uint8  `json:"source"`
-	CompanionTarget uint8  `json:"companion_target"`
-	Reason          string `json:"reason,omitempty"`
+	State           string                       `json:"state"`
+	Source          uint8                        `json:"source"`
+	CompanionTarget uint8                        `json:"companion_target"`
+	Reason          string                       `json:"reason,omitempty"`
+	SourceSelection *BusAdmissionSourceSelection `json:"source_selection,omitempty"`
+}
+
+type BusAdmissionSourceSelection struct {
+	State                   string                          `json:"state"`
+	Mode                    string                          `json:"mode,omitempty"`
+	Outcome                 string                          `json:"outcome,omitempty"`
+	Reason                  string                          `json:"reason,omitempty"`
+	SelectedSource          *uint8                          `json:"selected_source,omitempty"`
+	FailedSource            *uint8                          `json:"failed_source,omitempty"`
+	CompanionTarget         *uint8                          `json:"companion_target,omitempty"`
+	ActiveProbe             *BusAdmissionActiveProbe        `json:"active_probe,omitempty"`
+	Retryable               bool                            `json:"retryable"`
+	NextAction              string                          `json:"next_action,omitempty"`
+	LastSuccessfulSource    *uint8                          `json:"last_successful_source,omitempty"`
+	AutomaticRetryScheduled bool                            `json:"automatic_retry_scheduled"`
+	RejectedCandidates      []BusAdmissionRejectedCandidate `json:"rejected_candidates,omitempty"`
+}
+
+type BusAdmissionActiveProbe struct {
+	Target *uint8 `json:"target,omitempty"`
+	Opcode string `json:"opcode,omitempty"`
+	Status string `json:"status,omitempty"`
+}
+
+type BusAdmissionRejectedCandidate struct {
+	Source             uint8  `json:"source"`
+	Reason             string `json:"reason,omitempty"`
+	OccupancyState     string `json:"occupancy_state,omitempty"`
+	EvidenceProvenance string `json:"evidence_provenance,omitempty"`
 }
 
 const busObservabilityPublisherCadenceSource = "config.semantic_state_interval"
@@ -394,7 +424,36 @@ func cloneBusAdmission(source *BusAdmission) *BusAdmission {
 		return nil
 	}
 	out := *source
+	out.SourceSelection = cloneBusAdmissionSourceSelection(source.SourceSelection)
 	return &out
+}
+
+func cloneBusAdmissionSourceSelection(source *BusAdmissionSourceSelection) *BusAdmissionSourceSelection {
+	if source == nil {
+		return nil
+	}
+	out := *source
+	out.SelectedSource = cloneUint8Ptr(source.SelectedSource)
+	out.FailedSource = cloneUint8Ptr(source.FailedSource)
+	out.CompanionTarget = cloneUint8Ptr(source.CompanionTarget)
+	out.LastSuccessfulSource = cloneUint8Ptr(source.LastSuccessfulSource)
+	if source.ActiveProbe != nil {
+		activeProbe := *source.ActiveProbe
+		activeProbe.Target = cloneUint8Ptr(source.ActiveProbe.Target)
+		out.ActiveProbe = &activeProbe
+	}
+	if len(source.RejectedCandidates) > 0 {
+		out.RejectedCandidates = append([]BusAdmissionRejectedCandidate(nil), source.RejectedCandidates...)
+	}
+	return &out
+}
+
+func cloneUint8Ptr(source *uint8) *uint8 {
+	if source == nil {
+		return nil
+	}
+	value := *source
+	return &value
 }
 
 func (store *BusObservabilityStore) specimenFamilyCountLocked() int {

--- a/bus_observability_store.go
+++ b/bus_observability_store.go
@@ -135,7 +135,7 @@ func (store *BusObservabilityStore) RecordBusAdmissionTransition(state string, s
 	if store.admissionStabilityWindow != nil {
 		var flipped bool
 		emittedState, flipped = store.admissionStabilityWindow.Observe(state)
-		if !flipped {
+		if !flipped && (emittedState == "" || emittedState != state) {
 			return false
 		}
 	}
@@ -144,8 +144,70 @@ func (store *BusObservabilityStore) RecordBusAdmissionTransition(state string, s
 		Source:          source,
 		CompanionTarget: companionTarget,
 		Reason:          reason,
+		SourceSelection: busAdmissionSourceSelectionFromTransition(emittedState, source, companionTarget, reason),
 	}
 	return true
+}
+
+func busAdmissionSourceSelectionFromTransition(state string, source, companionTarget uint8, reason string) *BusAdmissionSourceSelection {
+	selection := &BusAdmissionSourceSelection{
+		State:   state,
+		Outcome: busAdmissionSourceSelectionOutcome(state, reason),
+		Reason:  reason,
+	}
+	if source != 0 {
+		if state == "degraded" {
+			selection.FailedSource = uint8Ptr(source)
+		} else {
+			selection.SelectedSource = uint8Ptr(source)
+		}
+		if state == "active" {
+			selection.LastSuccessfulSource = uint8Ptr(source)
+		}
+	}
+	if companionTarget != 0 {
+		selection.CompanionTarget = uint8Ptr(companionTarget)
+	}
+	if status := busAdmissionActiveProbeStatus(state, reason); status != "" {
+		selection.ActiveProbe = &BusAdmissionActiveProbe{
+			Target: selection.CompanionTarget,
+			Status: status,
+		}
+	}
+	return selection
+}
+
+func busAdmissionSourceSelectionOutcome(state, reason string) string {
+	switch reason {
+	case "active_probe_pending":
+		return "not_started"
+	case "active_probe_passed":
+		return "active_probe_passed"
+	case "source_selection_warmup_in_progress":
+		return "not_started"
+	}
+	if state == "active" {
+		return "active_probe_passed"
+	}
+	if state == "degraded" {
+		return "operator_action_required"
+	}
+	return "not_started"
+}
+
+func busAdmissionActiveProbeStatus(state, reason string) string {
+	switch reason {
+	case "active_probe_pending", "active_probe_passed", "active_probe_failed":
+		return reason
+	}
+	if state == "active" {
+		return "active_probe_passed"
+	}
+	return ""
+}
+
+func uint8Ptr(value uint8) *uint8 {
+	return &value
 }
 
 type BusMessageRecord struct {

--- a/bus_observability_store_test.go
+++ b/bus_observability_store_test.go
@@ -71,6 +71,111 @@ func TestBusObservabilityStoreRecentRingEvictsOldestButCountersAdvance(t *testin
 	}
 }
 
+func TestBusObservabilityStoreRecordsSourceSelectionAdmissionStatus(t *testing.T) {
+	store := NewBusObservabilityStore(DefaultConfig())
+
+	if changed := store.RecordBusAdmissionTransition("active", 0x7F, 0x08, "active_probe_passed"); !changed {
+		t.Fatal("RecordBusAdmissionTransition changed = false; want true")
+	}
+
+	snapshot := store.Snapshot()
+	admission := snapshot.Summary.Status.BusAdmission
+	if admission == nil {
+		t.Fatal("BusAdmission = nil; want active admission")
+	}
+	if admission.State != "active" || admission.Source != 0x7F || admission.CompanionTarget != 0x08 || admission.Reason != "active_probe_passed" {
+		t.Fatalf("BusAdmission = %+v; want active 0x7F/0x08 active_probe_passed", admission)
+	}
+	selection := admission.SourceSelection
+	if selection == nil {
+		t.Fatal("BusAdmission.SourceSelection = nil; want nested source-selection status")
+	}
+	if selection.State != "active" ||
+		selection.Outcome != "active_probe_passed" ||
+		selection.SelectedSource == nil ||
+		*selection.SelectedSource != 0x7F ||
+		selection.CompanionTarget == nil ||
+		*selection.CompanionTarget != 0x08 ||
+		selection.ActiveProbe == nil ||
+		selection.ActiveProbe.Target == nil ||
+		*selection.ActiveProbe.Target != 0x08 ||
+		selection.ActiveProbe.Status != "active_probe_passed" ||
+		selection.Retryable ||
+		selection.AutomaticRetryScheduled {
+		t.Fatalf("SourceSelection = %+v; want active admitted source-selection status", selection)
+	}
+}
+
+func TestBusObservabilityStoreRefreshesAdmissionMetadataForStableState(t *testing.T) {
+	store := NewBusObservabilityStore(DefaultConfig())
+	window := NewAdmissionStabilityWindow(30)
+	base := time.Now().UTC()
+	window.now = func() time.Time { return base }
+	store.SetAdmissionStabilityWindow(window)
+
+	if changed := store.RecordBusAdmissionTransition("pending", 0x00, 0x00, "source_selection_warmup_in_progress"); changed {
+		t.Fatal("first pending observation changed = true; want stability window to hold emission")
+	}
+	if admission := store.Snapshot().Summary.Status.BusAdmission; admission != nil {
+		t.Fatalf("BusAdmission = %+v; want nil before pending state is stable", admission)
+	}
+
+	window.now = func() time.Time { return base.Add(31 * time.Second) }
+	if changed := store.RecordBusAdmissionTransition("pending", 0x00, 0x00, "source_selection_warmup_in_progress"); !changed {
+		t.Fatal("stable pending observation changed = false; want emitted pending state")
+	}
+
+	window.now = func() time.Time { return base.Add(32 * time.Second) }
+	if changed := store.RecordBusAdmissionTransition("pending", 0x7F, 0x08, "active_probe_pending"); !changed {
+		t.Fatal("same-state metadata refresh changed = false; want source-selection details refreshed")
+	}
+
+	admission := store.Snapshot().Summary.Status.BusAdmission
+	if admission == nil || admission.State != "pending" || admission.Source != 0x7F || admission.CompanionTarget != 0x08 || admission.Reason != "active_probe_pending" {
+		t.Fatalf("BusAdmission after metadata refresh = %+v; want pending 0x7F/0x08 active_probe_pending", admission)
+	}
+	selection := admission.SourceSelection
+	if selection == nil ||
+		selection.State != "pending" ||
+		selection.Outcome != "not_started" ||
+		selection.SelectedSource == nil ||
+		*selection.SelectedSource != 0x7F ||
+		selection.CompanionTarget == nil ||
+		*selection.CompanionTarget != 0x08 ||
+		selection.ActiveProbe == nil ||
+		selection.ActiveProbe.Target == nil ||
+		*selection.ActiveProbe.Target != 0x08 ||
+		selection.ActiveProbe.Status != "active_probe_pending" {
+		t.Fatalf("SourceSelection after metadata refresh = %+v; want pending source/companion active probe metadata", selection)
+	}
+}
+
+func TestBusObservabilityStoreRecordsDegradedSourceSelectionWithoutInventedRetry(t *testing.T) {
+	store := NewBusObservabilityStore(DefaultConfig())
+
+	if changed := store.RecordBusAdmissionTransition("degraded", 0xF7, 0xFC, "active_probe_failed"); !changed {
+		t.Fatal("RecordBusAdmissionTransition changed = false; want degraded admission")
+	}
+
+	admission := store.Snapshot().Summary.Status.BusAdmission
+	if admission == nil || admission.State != "degraded" || admission.Source != 0xF7 || admission.CompanionTarget != 0xFC || admission.Reason != "active_probe_failed" {
+		t.Fatalf("BusAdmission = %+v; want degraded 0xF7/0xFC active_probe_failed", admission)
+	}
+	selection := admission.SourceSelection
+	if selection == nil ||
+		selection.State != "degraded" ||
+		selection.Outcome != "operator_action_required" ||
+		selection.FailedSource == nil ||
+		*selection.FailedSource != 0xF7 ||
+		selection.SelectedSource != nil ||
+		selection.CompanionTarget == nil ||
+		*selection.CompanionTarget != 0xFC ||
+		selection.Retryable ||
+		selection.NextAction != "" {
+		t.Fatalf("SourceSelection = %+v; want degraded failure without invented retry semantics", selection)
+	}
+}
+
 func TestBusObservabilityStorePeriodicityBudgetEvictsLRU(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.BroadcastListen = true

--- a/cmd/gateway/bus_observability_provider.go
+++ b/cmd/gateway/bus_observability_provider.go
@@ -402,6 +402,7 @@ func mapGraphQLBusAdmission(admission *ebusgateway.BusAdmission) *graphql.BusAdm
 		Source:          admission.Source,
 		CompanionTarget: admission.CompanionTarget,
 		Reason:          admission.Reason,
+		SourceSelection: mapGraphQLBusAdmissionSourceSelection(admission.SourceSelection),
 	}
 }
 
@@ -415,6 +416,44 @@ func mapMCPBusAdmission(admission *ebusgateway.BusAdmission) *mcp.BusAdmission {
 		CompanionTarget: admission.CompanionTarget,
 		Reason:          admission.Reason,
 	}
+}
+
+func mapGraphQLBusAdmissionSourceSelection(selection *ebusgateway.BusAdmissionSourceSelection) *graphql.BusAdmissionSourceSelection {
+	if selection == nil {
+		return nil
+	}
+	out := &graphql.BusAdmissionSourceSelection{
+		State:                   selection.State,
+		Mode:                    selection.Mode,
+		Outcome:                 selection.Outcome,
+		Reason:                  selection.Reason,
+		SelectedSource:          cloneAdmissionUint8Ptr(selection.SelectedSource),
+		FailedSource:            cloneAdmissionUint8Ptr(selection.FailedSource),
+		CompanionTarget:         cloneAdmissionUint8Ptr(selection.CompanionTarget),
+		Retryable:               selection.Retryable,
+		NextAction:              selection.NextAction,
+		LastSuccessfulSource:    cloneAdmissionUint8Ptr(selection.LastSuccessfulSource),
+		AutomaticRetryScheduled: selection.AutomaticRetryScheduled,
+	}
+	if selection.ActiveProbe != nil {
+		out.ActiveProbe = &graphql.BusAdmissionActiveProbe{
+			Target: cloneAdmissionUint8Ptr(selection.ActiveProbe.Target),
+			Opcode: selection.ActiveProbe.Opcode,
+			Status: selection.ActiveProbe.Status,
+		}
+	}
+	if len(selection.RejectedCandidates) > 0 {
+		out.RejectedCandidates = make([]graphql.BusAdmissionRejectedCandidate, 0, len(selection.RejectedCandidates))
+		for _, candidate := range selection.RejectedCandidates {
+			out.RejectedCandidates = append(out.RejectedCandidates, graphql.BusAdmissionRejectedCandidate{
+				Source:             candidate.Source,
+				Reason:             candidate.Reason,
+				OccupancyState:     candidate.OccupancyState,
+				EvidenceProvenance: candidate.EvidenceProvenance,
+			})
+		}
+	}
+	return out
 }
 
 func mapGraphQLBusMessages(records []ebusgateway.BusMessageRecord) []graphql.BusMessage {
@@ -524,6 +563,14 @@ func cloneTimePtr(source *time.Time) *time.Time {
 	}
 	updatedAt := source.UTC()
 	return &updatedAt
+}
+
+func cloneAdmissionUint8Ptr(source *uint8) *uint8 {
+	if source == nil {
+		return nil
+	}
+	value := *source
+	return &value
 }
 
 func durationString(value time.Duration) string {

--- a/cmd/gateway/graphql_bus_observability_integration_test.go
+++ b/cmd/gateway/graphql_bus_observability_integration_test.go
@@ -149,28 +149,28 @@ func TestRun_WiresBusObservabilityIntoGraphQLQueries(t *testing.T) {
 						Capability             struct {
 							ActiveSupported bool `json:"activeSupported"`
 						} `json:"capability"`
-							BusAdmission struct {
+						BusAdmission struct {
+							State           string `json:"state"`
+							Source          int    `json:"source"`
+							CompanionTarget int    `json:"companionTarget"`
+							Reason          string `json:"reason"`
+						} `json:"busAdmission"`
+						BusAdmissionSnake struct {
+							SourceSelection struct {
 								State           string `json:"state"`
-								Source          int    `json:"source"`
-								CompanionTarget int    `json:"companionTarget"`
+								Outcome         string `json:"outcome"`
+								SelectedSource  int    `json:"selected_source"`
+								CompanionTarget int    `json:"companion_target"`
 								Reason          string `json:"reason"`
-							} `json:"busAdmission"`
-							BusAdmissionSnake struct {
-								SourceSelection struct {
-									State           string `json:"state"`
-									Outcome         string `json:"outcome"`
-									SelectedSource  int    `json:"selected_source"`
-									CompanionTarget int    `json:"companion_target"`
-									Reason          string `json:"reason"`
-									ActiveProbe     struct {
-										Target int    `json:"target"`
-										Status string `json:"status"`
-									} `json:"active_probe"`
-									Retryable                bool   `json:"retryable"`
-									AutomaticRetryScheduled  bool   `json:"automatic_retry_scheduled"`
-									NextAction               string `json:"next_action"`
-								} `json:"source_selection"`
-							} `json:"bus_admission"`
+								ActiveProbe     struct {
+									Target int    `json:"target"`
+									Status string `json:"status"`
+								} `json:"active_probe"`
+								Retryable               bool   `json:"retryable"`
+								AutomaticRetryScheduled bool   `json:"automatic_retry_scheduled"`
+								NextAction              string `json:"next_action"`
+							} `json:"source_selection"`
+						} `json:"bus_admission"`
 						Startup struct {
 							LastUpdatedAt string `json:"lastUpdatedAt"`
 							Phase         string `json:"phase"`
@@ -214,25 +214,25 @@ func TestRun_WiresBusObservabilityIntoGraphQLQueries(t *testing.T) {
 		if !response.Data.BusSummary.Status.Capability.ActiveSupported {
 			t.Fatal("busSummary.status.capability.activeSupported = false; want true")
 		}
-			if response.Data.BusSummary.Status.BusAdmission.State != "active" ||
-				response.Data.BusSummary.Status.BusAdmission.Source != 0x7F ||
-				response.Data.BusSummary.Status.BusAdmission.CompanionTarget != 0x08 ||
-				response.Data.BusSummary.Status.BusAdmission.Reason != "active_probe_passed" {
-				t.Fatalf("busSummary.status.busAdmission = %+v; want active admitted source", response.Data.BusSummary.Status.BusAdmission)
-			}
-			sourceSelection := response.Data.BusSummary.Status.BusAdmissionSnake.SourceSelection
-			if sourceSelection.State != "active" ||
-				sourceSelection.Outcome != "active_probe_passed" ||
-				sourceSelection.SelectedSource != 0x7F ||
-				sourceSelection.CompanionTarget != 0x08 ||
-				sourceSelection.Reason != "active_probe_passed" ||
-				sourceSelection.ActiveProbe.Target != 0x08 ||
-				sourceSelection.ActiveProbe.Status != "active_probe_passed" ||
-				sourceSelection.Retryable ||
-				sourceSelection.AutomaticRetryScheduled ||
-				sourceSelection.NextAction != "" {
-				t.Fatalf("busSummary.status.bus_admission.source_selection = %+v; want active admitted source-selection parity", sourceSelection)
-			}
+		if response.Data.BusSummary.Status.BusAdmission.State != "active" ||
+			response.Data.BusSummary.Status.BusAdmission.Source != 0x7F ||
+			response.Data.BusSummary.Status.BusAdmission.CompanionTarget != 0x08 ||
+			response.Data.BusSummary.Status.BusAdmission.Reason != "active_probe_passed" {
+			t.Fatalf("busSummary.status.busAdmission = %+v; want active admitted source", response.Data.BusSummary.Status.BusAdmission)
+		}
+		sourceSelection := response.Data.BusSummary.Status.BusAdmissionSnake.SourceSelection
+		if sourceSelection.State != "active" ||
+			sourceSelection.Outcome != "active_probe_passed" ||
+			sourceSelection.SelectedSource != 0x7F ||
+			sourceSelection.CompanionTarget != 0x08 ||
+			sourceSelection.Reason != "active_probe_passed" ||
+			sourceSelection.ActiveProbe.Target != 0x08 ||
+			sourceSelection.ActiveProbe.Status != "active_probe_passed" ||
+			sourceSelection.Retryable ||
+			sourceSelection.AutomaticRetryScheduled ||
+			sourceSelection.NextAction != "" {
+			t.Fatalf("busSummary.status.bus_admission.source_selection = %+v; want active admitted source-selection parity", sourceSelection)
+		}
 		if response.Data.BusSummary.Status.Startup.Phase != string(graphql.SemanticStartupPhaseBootInit) {
 			t.Fatalf("busSummary.status.startup.phase = %q; want BOOT_INIT", response.Data.BusSummary.Status.Startup.Phase)
 		}

--- a/cmd/gateway/graphql_bus_observability_integration_test.go
+++ b/cmd/gateway/graphql_bus_observability_integration_test.go
@@ -123,7 +123,7 @@ func TestRun_WiresBusObservabilityIntoGraphQLQueries(t *testing.T) {
 			t.Fatalf("NewInvokeHandler error = %v", err)
 		}
 
-		body := bytes.NewBufferString(`{"query":"{ busSummary { lastUpdatedAt messages { count capacity } status { lastUpdatedAt transportClass publisherCadenceSec publisherCadenceSource capability { activeSupported } busAdmission { state source companionTarget reason } startup { lastUpdatedAt phase cacheEpoch liveEpoch } featureFlags { lastUpdatedAt } } } busMessages(limit: 1) { count items { family sourceAddress targetAddress } } }"}`)
+		body := bytes.NewBufferString(`{"query":"{ busSummary { lastUpdatedAt messages { count capacity } status { lastUpdatedAt transportClass publisherCadenceSec publisherCadenceSource capability { activeSupported } busAdmission { state source companionTarget reason } bus_admission { source_selection { state outcome selected_source companion_target reason active_probe { target status } retryable automatic_retry_scheduled next_action } } startup { lastUpdatedAt phase cacheEpoch liveEpoch } featureFlags { lastUpdatedAt } } } busMessages(limit: 1) { count items { family sourceAddress targetAddress } } }"}`)
 		req := httptest.NewRequest(http.MethodPost, cfg.GraphQLPath, body)
 		req.Header.Set("Content-Type", "application/json")
 		rec := httptest.NewRecorder()
@@ -149,12 +149,28 @@ func TestRun_WiresBusObservabilityIntoGraphQLQueries(t *testing.T) {
 						Capability             struct {
 							ActiveSupported bool `json:"activeSupported"`
 						} `json:"capability"`
-						BusAdmission struct {
-							State           string `json:"state"`
-							Source          int    `json:"source"`
-							CompanionTarget int    `json:"companionTarget"`
-							Reason          string `json:"reason"`
-						} `json:"busAdmission"`
+							BusAdmission struct {
+								State           string `json:"state"`
+								Source          int    `json:"source"`
+								CompanionTarget int    `json:"companionTarget"`
+								Reason          string `json:"reason"`
+							} `json:"busAdmission"`
+							BusAdmissionSnake struct {
+								SourceSelection struct {
+									State           string `json:"state"`
+									Outcome         string `json:"outcome"`
+									SelectedSource  int    `json:"selected_source"`
+									CompanionTarget int    `json:"companion_target"`
+									Reason          string `json:"reason"`
+									ActiveProbe     struct {
+										Target int    `json:"target"`
+										Status string `json:"status"`
+									} `json:"active_probe"`
+									Retryable                bool   `json:"retryable"`
+									AutomaticRetryScheduled  bool   `json:"automatic_retry_scheduled"`
+									NextAction               string `json:"next_action"`
+								} `json:"source_selection"`
+							} `json:"bus_admission"`
 						Startup struct {
 							LastUpdatedAt string `json:"lastUpdatedAt"`
 							Phase         string `json:"phase"`
@@ -198,12 +214,25 @@ func TestRun_WiresBusObservabilityIntoGraphQLQueries(t *testing.T) {
 		if !response.Data.BusSummary.Status.Capability.ActiveSupported {
 			t.Fatal("busSummary.status.capability.activeSupported = false; want true")
 		}
-		if response.Data.BusSummary.Status.BusAdmission.State != "active" ||
-			response.Data.BusSummary.Status.BusAdmission.Source != 0x7F ||
-			response.Data.BusSummary.Status.BusAdmission.CompanionTarget != 0x08 ||
-			response.Data.BusSummary.Status.BusAdmission.Reason != "active_probe_passed" {
-			t.Fatalf("busSummary.status.busAdmission = %+v; want active admitted source", response.Data.BusSummary.Status.BusAdmission)
-		}
+			if response.Data.BusSummary.Status.BusAdmission.State != "active" ||
+				response.Data.BusSummary.Status.BusAdmission.Source != 0x7F ||
+				response.Data.BusSummary.Status.BusAdmission.CompanionTarget != 0x08 ||
+				response.Data.BusSummary.Status.BusAdmission.Reason != "active_probe_passed" {
+				t.Fatalf("busSummary.status.busAdmission = %+v; want active admitted source", response.Data.BusSummary.Status.BusAdmission)
+			}
+			sourceSelection := response.Data.BusSummary.Status.BusAdmissionSnake.SourceSelection
+			if sourceSelection.State != "active" ||
+				sourceSelection.Outcome != "active_probe_passed" ||
+				sourceSelection.SelectedSource != 0x7F ||
+				sourceSelection.CompanionTarget != 0x08 ||
+				sourceSelection.Reason != "active_probe_passed" ||
+				sourceSelection.ActiveProbe.Target != 0x08 ||
+				sourceSelection.ActiveProbe.Status != "active_probe_passed" ||
+				sourceSelection.Retryable ||
+				sourceSelection.AutomaticRetryScheduled ||
+				sourceSelection.NextAction != "" {
+				t.Fatalf("busSummary.status.bus_admission.source_selection = %+v; want active admitted source-selection parity", sourceSelection)
+			}
 		if response.Data.BusSummary.Status.Startup.Phase != string(graphql.SemanticStartupPhaseBootInit) {
 			t.Fatalf("busSummary.status.startup.phase = %q; want BOOT_INIT", response.Data.BusSummary.Status.Startup.Phase)
 		}

--- a/docs/schemas/source-selection-admission.graphql
+++ b/docs/schemas/source-selection-admission.graphql
@@ -1,0 +1,44 @@
+type Query {
+  busSummary: BusSummary
+}
+
+type BusSummary {
+  status: BusObservabilityStatus
+}
+
+type BusObservabilityStatus {
+  bus_admission: BusAdmission
+}
+
+type BusAdmission {
+  source_selection: BusAdmissionSourceSelection
+}
+
+type BusAdmissionSourceSelection {
+  state: String!
+  mode: String
+  outcome: String
+  reason: String
+  selected_source: Int
+  failed_source: Int
+  companion_target: Int
+  active_probe: BusAdmissionActiveProbe
+  retryable: Boolean!
+  next_action: String
+  last_successful_source: Int
+  automatic_retry_scheduled: Boolean!
+  rejected_candidates: [BusAdmissionRejectedCandidate!]
+}
+
+type BusAdmissionActiveProbe {
+  target: Int
+  opcode: String
+  status: String
+}
+
+type BusAdmissionRejectedCandidate {
+  source: Int!
+  reason: String
+  occupancy_state: String
+  evidence_provenance: String
+}

--- a/docs/schemas/source-selection-admission.schema.json
+++ b/docs/schemas/source-selection-admission.schema.json
@@ -1,0 +1,206 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "docs/schemas/source-selection-admission.schema.json",
+  "title": "GraphQL Source Selection Admission Status",
+  "description": "HA-consumable schema artifact for busSummary.status.bus_admission.source_selection.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "busSummary"
+  ],
+  "properties": {
+    "busSummary": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "status"
+      ],
+      "properties": {
+        "status": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": [
+            "bus_admission"
+          ],
+          "properties": {
+            "bus_admission": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": true,
+              "properties": {
+                "source_selection": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false,
+                  "required": [
+                    "state",
+                    "retryable",
+                    "automatic_retry_scheduled"
+                  ],
+                  "properties": {
+                    "state": {
+                      "type": "string",
+                      "enum": [
+                        "pending",
+                        "active",
+                        "degraded"
+                      ]
+                    },
+                    "mode": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "enum": [
+                        "default_policy",
+                        "source_description_constrained_policy",
+                        "priority_filtered_default_policy",
+                        "explicit_validate_only",
+                        null
+                      ]
+                    },
+                    "outcome": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "enum": [
+                        "not_started",
+                        "active_probe_passed",
+                        "candidate_quarantined",
+                        "all_candidates_failed",
+                        "operator_action_required",
+                        null
+                      ]
+                    },
+                    "reason": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "selected_source": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 0,
+                      "maximum": 255
+                    },
+                    "failed_source": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 0,
+                      "maximum": 255
+                    },
+                    "companion_target": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 0,
+                      "maximum": 255
+                    },
+                    "active_probe": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "additionalProperties": false,
+                      "properties": {
+                        "target": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
+                          "minimum": 0,
+                          "maximum": 255
+                        },
+                        "opcode": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "status": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    },
+                    "retryable": {
+                      "type": "boolean"
+                    },
+                    "next_action": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "last_successful_source": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 0,
+                      "maximum": 255
+                    },
+                    "automatic_retry_scheduled": {
+                      "type": "boolean"
+                    },
+                    "rejected_candidates": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                          "source"
+                        ],
+                        "properties": {
+                          "source": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 255
+                          },
+                          "reason": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "occupancy_state": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "evidence_provenance": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/graphql/bus_observability.go
+++ b/graphql/bus_observability.go
@@ -54,6 +54,36 @@ type BusAdmission struct {
 	Source          uint8
 	CompanionTarget uint8
 	Reason          string
+	SourceSelection *BusAdmissionSourceSelection
+}
+
+type BusAdmissionSourceSelection struct {
+	State                   string
+	Mode                    string
+	Outcome                 string
+	Reason                  string
+	SelectedSource          *uint8
+	FailedSource            *uint8
+	CompanionTarget         *uint8
+	ActiveProbe             *BusAdmissionActiveProbe
+	Retryable               bool
+	NextAction              string
+	LastSuccessfulSource    *uint8
+	AutomaticRetryScheduled bool
+	RejectedCandidates      []BusAdmissionRejectedCandidate
+}
+
+type BusAdmissionActiveProbe struct {
+	Target *uint8
+	Opcode string
+	Status string
+}
+
+type BusAdmissionRejectedCandidate struct {
+	Source             uint8
+	Reason             string
+	OccupancyState     string
+	EvidenceProvenance string
 }
 
 type BusObservabilityStatus struct {
@@ -270,6 +300,7 @@ func cloneBusObservabilityStatus(source *BusObservabilityStatus) *BusObservabili
 	}
 	out := *source
 	out.LastUpdatedAt = cloneTimePtr(source.LastUpdatedAt)
+	out.BusAdmission = cloneBusAdmission(source.BusAdmission)
 	out.Startup = cloneBusObservabilityStartup(source.Startup)
 	if len(source.Degraded.Reasons) > 0 {
 		out.Degraded.Reasons = append([]string(nil), source.Degraded.Reasons...)
@@ -296,12 +327,49 @@ func cloneObserveFirstFeatureFlagState(source ObserveFirstFeatureFlagState) Obse
 	return out
 }
 
+func cloneBusAdmission(source *BusAdmission) *BusAdmission {
+	if source == nil {
+		return nil
+	}
+	out := *source
+	out.SourceSelection = cloneBusAdmissionSourceSelection(source.SourceSelection)
+	return &out
+}
+
+func cloneBusAdmissionSourceSelection(source *BusAdmissionSourceSelection) *BusAdmissionSourceSelection {
+	if source == nil {
+		return nil
+	}
+	out := *source
+	out.SelectedSource = cloneUint8Ptr(source.SelectedSource)
+	out.FailedSource = cloneUint8Ptr(source.FailedSource)
+	out.CompanionTarget = cloneUint8Ptr(source.CompanionTarget)
+	out.LastSuccessfulSource = cloneUint8Ptr(source.LastSuccessfulSource)
+	if source.ActiveProbe != nil {
+		activeProbe := *source.ActiveProbe
+		activeProbe.Target = cloneUint8Ptr(source.ActiveProbe.Target)
+		out.ActiveProbe = &activeProbe
+	}
+	if len(source.RejectedCandidates) > 0 {
+		out.RejectedCandidates = append([]BusAdmissionRejectedCandidate(nil), source.RejectedCandidates...)
+	}
+	return &out
+}
+
 func cloneTimePtr(source *time.Time) *time.Time {
 	if source == nil {
 		return nil
 	}
 	updatedAt := source.UTC()
 	return &updatedAt
+}
+
+func cloneUint8Ptr(source *uint8) *uint8 {
+	if source == nil {
+		return nil
+	}
+	value := *source
+	return &value
 }
 
 func graphqlTimeString(source *time.Time) any {
@@ -708,9 +776,237 @@ func buildBusObservabilityTypes() (*graphqlgo.Object, *graphqlgo.Object, *graphq
 		},
 	})
 
+	busAdmissionActiveProbeType := graphqlgo.NewObject(graphqlgo.ObjectConfig{
+		Name: "BusAdmissionActiveProbe",
+		Fields: graphqlgo.Fields{
+			"target": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					probe, ok := busAdmissionActiveProbeFromSource(params.Source)
+					if !ok || probe.Target == nil {
+						return nil, nil
+					}
+					return int(*probe.Target), nil
+				},
+			},
+			"opcode": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					probe, ok := busAdmissionActiveProbeFromSource(params.Source)
+					if !ok || probe.Opcode == "" {
+						return nil, nil
+					}
+					return probe.Opcode, nil
+				},
+			},
+			"status": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					probe, ok := busAdmissionActiveProbeFromSource(params.Source)
+					if !ok || probe.Status == "" {
+						return nil, nil
+					}
+					return probe.Status, nil
+				},
+			},
+		},
+	})
+
+	busAdmissionRejectedCandidateType := graphqlgo.NewObject(graphqlgo.ObjectConfig{
+		Name: "BusAdmissionRejectedCandidate",
+		Fields: graphqlgo.Fields{
+			"source": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Int),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					candidate, ok := busAdmissionRejectedCandidateFromSource(params.Source)
+					if !ok {
+						return 0, nil
+					}
+					return int(candidate.Source), nil
+				},
+			},
+			"reason": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					candidate, ok := busAdmissionRejectedCandidateFromSource(params.Source)
+					if !ok || candidate.Reason == "" {
+						return nil, nil
+					}
+					return candidate.Reason, nil
+				},
+			},
+			"occupancy_state": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					candidate, ok := busAdmissionRejectedCandidateFromSource(params.Source)
+					if !ok || candidate.OccupancyState == "" {
+						return nil, nil
+					}
+					return candidate.OccupancyState, nil
+				},
+			},
+			"evidence_provenance": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					candidate, ok := busAdmissionRejectedCandidateFromSource(params.Source)
+					if !ok || candidate.EvidenceProvenance == "" {
+						return nil, nil
+					}
+					return candidate.EvidenceProvenance, nil
+				},
+			},
+		},
+	})
+
+	busAdmissionSourceSelectionType := graphqlgo.NewObject(graphqlgo.ObjectConfig{
+		Name: "BusAdmissionSourceSelection",
+		Fields: graphqlgo.Fields{
+			"state": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.String),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					selection, ok := busAdmissionSourceSelectionFromSource(params.Source)
+					if !ok {
+						return "", nil
+					}
+					return selection.State, nil
+				},
+			},
+			"mode": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					selection, ok := busAdmissionSourceSelectionFromSource(params.Source)
+					if !ok || selection.Mode == "" {
+						return nil, nil
+					}
+					return selection.Mode, nil
+				},
+			},
+			"outcome": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					selection, ok := busAdmissionSourceSelectionFromSource(params.Source)
+					if !ok || selection.Outcome == "" {
+						return nil, nil
+					}
+					return selection.Outcome, nil
+				},
+			},
+			"reason": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					selection, ok := busAdmissionSourceSelectionFromSource(params.Source)
+					if !ok || selection.Reason == "" {
+						return nil, nil
+					}
+					return selection.Reason, nil
+				},
+			},
+			"selected_source": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					selection, ok := busAdmissionSourceSelectionFromSource(params.Source)
+					if !ok || selection.SelectedSource == nil {
+						return nil, nil
+					}
+					return int(*selection.SelectedSource), nil
+				},
+			},
+			"failed_source": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					selection, ok := busAdmissionSourceSelectionFromSource(params.Source)
+					if !ok || selection.FailedSource == nil {
+						return nil, nil
+					}
+					return int(*selection.FailedSource), nil
+				},
+			},
+			"companion_target": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					selection, ok := busAdmissionSourceSelectionFromSource(params.Source)
+					if !ok || selection.CompanionTarget == nil {
+						return nil, nil
+					}
+					return int(*selection.CompanionTarget), nil
+				},
+			},
+			"active_probe": &graphqlgo.Field{
+				Type: busAdmissionActiveProbeType,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					selection, ok := busAdmissionSourceSelectionFromSource(params.Source)
+					if !ok {
+						return nil, nil
+					}
+					return selection.ActiveProbe, nil
+				},
+			},
+			"retryable": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Boolean),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					selection, ok := busAdmissionSourceSelectionFromSource(params.Source)
+					if !ok {
+						return false, nil
+					}
+					return selection.Retryable, nil
+				},
+			},
+			"next_action": &graphqlgo.Field{
+				Type: graphqlgo.String,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					selection, ok := busAdmissionSourceSelectionFromSource(params.Source)
+					if !ok || selection.NextAction == "" {
+						return nil, nil
+					}
+					return selection.NextAction, nil
+				},
+			},
+			"last_successful_source": &graphqlgo.Field{
+				Type: graphqlgo.Int,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					selection, ok := busAdmissionSourceSelectionFromSource(params.Source)
+					if !ok || selection.LastSuccessfulSource == nil {
+						return nil, nil
+					}
+					return int(*selection.LastSuccessfulSource), nil
+				},
+			},
+			"automatic_retry_scheduled": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Boolean),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					selection, ok := busAdmissionSourceSelectionFromSource(params.Source)
+					if !ok {
+						return false, nil
+					}
+					return selection.AutomaticRetryScheduled, nil
+				},
+			},
+			"rejected_candidates": &graphqlgo.Field{
+				Type: graphqlgo.NewList(graphqlgo.NewNonNull(busAdmissionRejectedCandidateType)),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					selection, ok := busAdmissionSourceSelectionFromSource(params.Source)
+					if !ok {
+						return nil, nil
+					}
+					return selection.RejectedCandidates, nil
+				},
+			},
+		},
+	})
+
 	busAdmissionType := graphqlgo.NewObject(graphqlgo.ObjectConfig{
 		Name: "BusAdmission",
 		Fields: graphqlgo.Fields{
+			"source_selection": &graphqlgo.Field{
+				Type: busAdmissionSourceSelectionType,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					admission, ok := busAdmissionFromSource(params.Source)
+					if !ok {
+						return nil, nil
+					}
+					return admission.SourceSelection, nil
+				},
+			},
 			"state": &graphqlgo.Field{
 				Type: graphqlgo.NewNonNull(graphqlgo.String),
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
@@ -856,6 +1152,20 @@ func buildBusObservabilityTypes() (*graphqlgo.Object, *graphqlgo.Object, *graphq
 				},
 			},
 			"busAdmission": &graphqlgo.Field{
+				Type: busAdmissionType,
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					status, ok := params.Source.(*BusObservabilityStatus)
+					if ok && status != nil {
+						return status.BusAdmission, nil
+					}
+					value, ok := params.Source.(BusObservabilityStatus)
+					if !ok {
+						return nil, nil
+					}
+					return value.BusAdmission, nil
+				},
+			},
+			"bus_admission": &graphqlgo.Field{
 				Type: busAdmissionType,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					status, ok := params.Source.(*BusObservabilityStatus)
@@ -1503,5 +1813,47 @@ func busAdmissionFromSource(source any) (BusAdmission, bool) {
 		return *admission, true
 	default:
 		return BusAdmission{}, false
+	}
+}
+
+func busAdmissionSourceSelectionFromSource(source any) (BusAdmissionSourceSelection, bool) {
+	switch selection := source.(type) {
+	case BusAdmissionSourceSelection:
+		return selection, true
+	case *BusAdmissionSourceSelection:
+		if selection == nil {
+			return BusAdmissionSourceSelection{}, false
+		}
+		return *selection, true
+	default:
+		return BusAdmissionSourceSelection{}, false
+	}
+}
+
+func busAdmissionActiveProbeFromSource(source any) (BusAdmissionActiveProbe, bool) {
+	switch probe := source.(type) {
+	case BusAdmissionActiveProbe:
+		return probe, true
+	case *BusAdmissionActiveProbe:
+		if probe == nil {
+			return BusAdmissionActiveProbe{}, false
+		}
+		return *probe, true
+	default:
+		return BusAdmissionActiveProbe{}, false
+	}
+}
+
+func busAdmissionRejectedCandidateFromSource(source any) (BusAdmissionRejectedCandidate, bool) {
+	switch candidate := source.(type) {
+	case BusAdmissionRejectedCandidate:
+		return candidate, true
+	case *BusAdmissionRejectedCandidate:
+		if candidate == nil {
+			return BusAdmissionRejectedCandidate{}, false
+		}
+		return *candidate, true
+	default:
+		return BusAdmissionRejectedCandidate{}, false
 	}
 }

--- a/graphql/queries_test.go
+++ b/graphql/queries_test.go
@@ -158,6 +158,8 @@ func TestQueryResolvers_Integration(t *testing.T) {
 	semantic := NewLiveSemanticProvider()
 	builder.SetSemanticProvider(semantic)
 	updatedAt := time.Date(2026, time.March, 12, 18, 30, 0, 0, time.UTC)
+	selectedSource := uint8(0x7F)
+	companionTarget := uint8(0x08)
 	builder.SetBusObservabilityProvider(testBusObservabilityProvider{
 		snapshot: BusObservabilitySnapshot{
 			Summary: &BusSummary{
@@ -200,6 +202,22 @@ func TestQueryResolvers_Integration(t *testing.T) {
 					Degraded: BusObservabilityDegraded{
 						Active:  true,
 						Reasons: []string{"unsupported_or_misconfigured", "dedup_degraded"},
+					},
+					BusAdmission: &BusAdmission{
+						State:           "active",
+						Source:          selectedSource,
+						CompanionTarget: companionTarget,
+						Reason:          "active_probe_passed",
+						SourceSelection: &BusAdmissionSourceSelection{
+							State:                   "active",
+							Outcome:                 "active_probe_passed",
+							Reason:                  "active_probe_passed",
+							SelectedSource:          &selectedSource,
+							CompanionTarget:         &companionTarget,
+							ActiveProbe:             &BusAdmissionActiveProbe{Target: &companionTarget, Status: "active_probe_passed"},
+							LastSuccessfulSource:    &selectedSource,
+							AutomaticRetryScheduled: false,
+						},
 					},
 					FeatureFlags: ObserveFirstFeatureFlagState{
 						ObserveFirstEnabled:      true,
@@ -563,12 +581,34 @@ func TestQueryResolvers_Integration(t *testing.T) {
 							busy
 							periodicity
 						}
-						degraded {
-							active
-							reasons
-						}
-						featureFlags {
-							lastUpdatedAt
+							degraded {
+								active
+								reasons
+							}
+							busAdmission {
+								state
+								source
+								companionTarget
+								reason
+							}
+							bus_admission {
+								source_selection {
+									state
+									outcome
+									reason
+									selected_source
+									companion_target
+										active_probe {
+											target
+											status
+										}
+									retryable
+									last_successful_source
+									automatic_retry_scheduled
+								}
+							}
+							featureFlags {
+								lastUpdatedAt
 							observeFirstEnabled
 							passiveStateDirectApply
 							passiveConfigDirectApply
@@ -677,6 +717,28 @@ func TestQueryResolvers_Integration(t *testing.T) {
 						Active  bool     `json:"active"`
 						Reasons []string `json:"reasons"`
 					} `json:"degraded"`
+					BusAdmission struct {
+						State           string `json:"state"`
+						Source          int    `json:"source"`
+						CompanionTarget int    `json:"companionTarget"`
+						Reason          string `json:"reason"`
+					} `json:"busAdmission"`
+					BusAdmissionSnake struct {
+						SourceSelection struct {
+							State           string `json:"state"`
+							Outcome         string `json:"outcome"`
+							Reason          string `json:"reason"`
+							SelectedSource  int    `json:"selected_source"`
+							CompanionTarget int    `json:"companion_target"`
+							ActiveProbe     struct {
+								Target int    `json:"target"`
+								Status string `json:"status"`
+							} `json:"active_probe"`
+							Retryable               bool `json:"retryable"`
+							LastSuccessfulSource    int  `json:"last_successful_source"`
+							AutomaticRetryScheduled bool `json:"automatic_retry_scheduled"`
+						} `json:"source_selection"`
+					} `json:"bus_admission"`
 					FeatureFlags struct {
 						LastUpdatedAt            string   `json:"lastUpdatedAt"`
 						ObserveFirstEnabled      bool     `json:"observeFirstEnabled"`
@@ -760,6 +822,25 @@ func TestQueryResolvers_Integration(t *testing.T) {
 		}
 		if !response.BusSummary.Status.Degraded.Active || len(response.BusSummary.Status.Degraded.Reasons) != 2 {
 			t.Fatalf("degraded = %+v; want active with 2 reasons", response.BusSummary.Status.Degraded)
+		}
+		if response.BusSummary.Status.BusAdmission.State != "active" ||
+			response.BusSummary.Status.BusAdmission.Source != 0x7F ||
+			response.BusSummary.Status.BusAdmission.CompanionTarget != 0x08 ||
+			response.BusSummary.Status.BusAdmission.Reason != "active_probe_passed" {
+			t.Fatalf("busAdmission = %+v; want legacy active admission mirror", response.BusSummary.Status.BusAdmission)
+		}
+		sourceSelection := response.BusSummary.Status.BusAdmissionSnake.SourceSelection
+		if sourceSelection.State != "active" ||
+			sourceSelection.Outcome != "active_probe_passed" ||
+			sourceSelection.Reason != "active_probe_passed" ||
+			sourceSelection.SelectedSource != 0x7F ||
+			sourceSelection.CompanionTarget != 0x08 ||
+			sourceSelection.ActiveProbe.Target != 0x08 ||
+			sourceSelection.ActiveProbe.Status != "active_probe_passed" ||
+			sourceSelection.Retryable ||
+			sourceSelection.LastSuccessfulSource != 0x7F ||
+			sourceSelection.AutomaticRetryScheduled {
+			t.Fatalf("bus_admission.source_selection = %+v; want GraphQL parity admission status", sourceSelection)
 		}
 		if response.BusSummary.Status.FeatureFlags.ExternalWritePolicy != "record_only" {
 			t.Fatalf("featureFlags.externalWritePolicy = %q; want record_only", response.BusSummary.Status.FeatureFlags.ExternalWritePolicy)


### PR DESCRIPTION
## What
Adds SAS-03B GraphQL parity for the source-selection admission status contract.

## Why
M3a froze the MCP/artifact admission behavior. M3b exposes the HA-consumable GraphQL parity path required by the locked source-address-selection-admission plan before HA M6 can develop against a pinned schema artifact.

## Changes
- Adds `busSummary.status.bus_admission.source_selection` as an additive GraphQL snake_case path.
- Preserves existing GraphQL `busAdmission` until M4 legacy/public API cleanup.
- Keeps MCP M3a shape frozen: `status.bus_admission` remains flat on MCP.
- Adds HA-consumable schema artifacts:
  - `docs/schemas/source-selection-admission.graphql`
  - `docs/schemas/source-selection-admission.schema.json`
- Refreshes same-state source-selection metadata through the admission stability window without inventing retry/opcode semantics.

## Verification
- RED commit: `5414474 test: cover GraphQL source-selection admission parity`
- GREEN commit: `6d0dbca feat: expose GraphQL source selection admission parity`
- `go test ./...`
- `go test ./graphql -run '^TestQueryResolvers_Integration/bus_observability$' -count=1`
- `go test ./cmd/gateway -run '^TestRun_WiresBusObservabilityIntoGraphQLQueries$' -count=1`
- `go test . -run '^TestBusObservabilityStore(RecordsSourceSelectionAdmissionStatus|RefreshesAdmissionMetadataForStableState|RecordsDegradedSourceSelectionWithoutInventedRetry)$' -count=1`
- Two fresh adversarial reviewers returned `NO FINDINGS` after fixes.

## Dependencies
- Depends on merged SAS-03A gateway PR #555.
