### PR TITLE
SAS-05: remove legacy source-selection public API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
             echo "Found legacy terminology."
             exit 1
           fi
+      - run: python3 scripts/source_selection_m4_gate.py
 
   build:
     runs-on: ubuntu-latest
@@ -65,7 +66,9 @@ jobs:
           python-version: '3.11'
       - run: go test -race -count=1 ./...
       - run: python3 scripts/passive_canary_verifier_test.py
+      - run: python3 scripts/source_selection_m4_gate_test.py
       - run: python3 scripts/transport_gate_test.py
+      - run: python3 scripts/passive_smoke_gate_test.py
 
   lint:
     runs-on: ubuntu-latest

--- a/admission_artifact.go
+++ b/admission_artifact.go
@@ -10,24 +10,28 @@ import (
 	"time"
 )
 
-// AdmissionArtifact is the machine-readable summary emitted at the end
-// of the startup admission + discovery window per plan §M7.
-type AdmissionArtifact struct {
-	Admission AdmissionArtifactAdmission `json:"admission"`
-	Discovery AdmissionArtifactDiscovery `json:"discovery"`
+// SourceSelectionArtifact is the machine-readable summary emitted at the end
+// of the startup source-selection + discovery window per plan §M7.
+type SourceSelectionArtifact struct {
+	Admission SourceSelectionArtifactAdmission `json:"admission"`
+	Discovery SourceSelectionArtifactDiscovery `json:"discovery"`
 }
 
-type AdmissionArtifactAdmission struct {
-	State                 string  `json:"state"`
-	Source                uint8   `json:"source"`
-	CompanionTarget       uint8   `json:"companion_target"`
-	WarmupDurationS       float64 `json:"warmup_duration_s"`
-	ReasonIfDegraded      string  `json:"reason_if_degraded"`
-	TransportKind         string  `json:"transport_kind"`
-	AdmissionPathSelected string  `json:"admission_path_selected"`
+type SourceSelectionArtifactAdmission struct {
+	State            string                                 `json:"state"`
+	Source           uint8                                  `json:"source"`
+	CompanionTarget  uint8                                  `json:"companion_target"`
+	WarmupDurationS  float64                                `json:"warmup_duration_s"`
+	ReasonIfDegraded string                                 `json:"reason_if_degraded"`
+	TransportKind    string                                 `json:"transport_kind"`
+	SourceSelection  SourceSelectionArtifactSourceSelection `json:"source_selection"`
 }
 
-type AdmissionArtifactDiscovery struct {
+type SourceSelectionArtifactSourceSelection struct {
+	Mode string `json:"mode"`
+}
+
+type SourceSelectionArtifactDiscovery struct {
 	WireBytes                            int            `json:"wire_bytes"`
 	WindowS                              float64        `json:"window_s"`
 	StartupBurstPct                      float64        `json:"startup_burst_pct"`
@@ -37,11 +41,11 @@ type AdmissionArtifactDiscovery struct {
 	PerBaselineAddressEvidenceCounts     map[string]int `json:"per_baseline_address_evidence_counts"`
 }
 
-// AdmissionArtifactBuilder aggregates runtime events over the startup
-// window and produces the final AdmissionArtifact on Emit.
-type AdmissionArtifactBuilder struct {
+// SourceSelectionArtifactBuilder aggregates runtime events over the startup
+// window and produces the final SourceSelectionArtifact on Emit.
+type SourceSelectionArtifactBuilder struct {
 	mu        sync.Mutex
-	artifact  AdmissionArtifact
+	artifact  SourceSelectionArtifact
 	startedAt time.Time
 	emitOnce  uint32 // CAS guard for EmitToFile
 	// baselineEvidenceProvider is called immediately before Emit/EmitToFile
@@ -59,39 +63,41 @@ type AdmissionArtifactBuilder struct {
 // per_baseline_address_evidence_counts was unconditionally empty in the
 // emitted artifact even when the registry observed traffic to baseline
 // addresses.
-func (b *AdmissionArtifactBuilder) SetBaselineEvidenceProvider(provider func() map[string]int) {
+func (b *SourceSelectionArtifactBuilder) SetBaselineEvidenceProvider(provider func() map[string]int) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.baselineEvidenceProvider = provider
 }
 
-func NewAdmissionArtifactBuilder(transportKind string) *AdmissionArtifactBuilder {
-	return &AdmissionArtifactBuilder{
+func NewSourceSelectionArtifactBuilder(transportKind string) *SourceSelectionArtifactBuilder {
+	return &SourceSelectionArtifactBuilder{
 		startedAt: time.Now(),
-		artifact: AdmissionArtifact{
-			Admission: AdmissionArtifactAdmission{
-				TransportKind:         transportKind,
-				State:                 "pending",
-				AdmissionPathSelected: "degraded_no_events",
+		artifact: SourceSelectionArtifact{
+			Admission: SourceSelectionArtifactAdmission{
+				TransportKind: transportKind,
+				State:         "pending",
+				SourceSelection: SourceSelectionArtifactSourceSelection{
+					Mode: "degraded_no_events",
+				},
 			},
-			Discovery: AdmissionArtifactDiscovery{
+			Discovery: SourceSelectionArtifactDiscovery{
 				PerBaselineAddressEvidenceCounts: make(map[string]int),
 			},
 		},
 	}
 }
 
-func (b *AdmissionArtifactBuilder) SetAdmissionPathSelected(v string) error {
-	if err := ValidateAdmissionPathSelected(v); err != nil {
+func (b *SourceSelectionArtifactBuilder) SetSourceSelectionMode(v string) error {
+	if err := ValidateSourceSelectionMode(v); err != nil {
 		return err
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	b.artifact.Admission.AdmissionPathSelected = v
+	b.artifact.Admission.SourceSelection.Mode = v
 	return nil
 }
 
-func (b *AdmissionArtifactBuilder) SetSourceSelection(source, companionTarget uint8, warmupDuration time.Duration) {
+func (b *SourceSelectionArtifactBuilder) SetSourceSelection(source, companionTarget uint8, warmupDuration time.Duration) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.artifact.Admission.Source = source
@@ -99,66 +105,61 @@ func (b *AdmissionArtifactBuilder) SetSourceSelection(source, companionTarget ui
 	b.artifact.Admission.WarmupDurationS = warmupDuration.Seconds()
 }
 
-func (b *AdmissionArtifactBuilder) SetSourceSelectionActive() {
+func (b *SourceSelectionArtifactBuilder) SetSourceSelectionActive() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.artifact.Admission.State = "active"
 }
 
-func (b *AdmissionArtifactBuilder) SetOverrideSource(source uint8) {
+func (b *SourceSelectionArtifactBuilder) SetExplicitSource(source uint8) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.artifact.Admission.Source = source
 }
 
-// SetActiveOverride flips Admission.State to "active" and records the
-// override Source. Used by the override path (AD09 (c2) soft short-
-// circuit) where the override source is in use from the first active
-// frame regardless of source-address selector outcome — so the artifact must reflect
-// state="active", not the default "pending". Found by AD20 second-
-// reviewer M7 pass: the prior code path emitted state=pending on
-// override which was misleading to operators.
-func (b *AdmissionArtifactBuilder) SetActiveOverride(source uint8) {
+// SetActiveExplicitSource flips Admission.State to "active" and records the
+// explicit Source used from the first active frame.
+func (b *SourceSelectionArtifactBuilder) SetActiveExplicitSource(source uint8) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.artifact.Admission.State = "active"
 	b.artifact.Admission.Source = source
 }
 
-func (b *AdmissionArtifactBuilder) SetDegraded(reason string) {
+func (b *SourceSelectionArtifactBuilder) SetDegraded(reason string) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.artifact.Admission.State = "degraded"
 	b.artifact.Admission.ReasonIfDegraded = reason
 }
 
-func (b *AdmissionArtifactBuilder) RecordProbe(wireBytes int) {
+func (b *SourceSelectionArtifactBuilder) RecordProbe(wireBytes int) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.artifact.Discovery.WireBytes += wireBytes
 	b.artifact.Discovery.ProbeCount++
 }
 
-func (b *AdmissionArtifactBuilder) SetPromotedSuspects(n int) {
+func (b *SourceSelectionArtifactBuilder) SetPromotedSuspects(n int) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.artifact.Discovery.PromotedSuspectsWithoutIdentity = n
 }
 
-func (b *AdmissionArtifactBuilder) SetPostStartupSustainedRateProbesPer15s(rate float64) {
+func (b *SourceSelectionArtifactBuilder) SetPostStartupSustainedRateProbesPer15s(rate float64) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.artifact.Discovery.PostStartupSustainedRateProbesPer15s = rate
 }
 
-func (b *AdmissionArtifactBuilder) RecordBaselineEvidence(address uint8, count int) {
+func (b *SourceSelectionArtifactBuilder) RecordBaselineEvidence(address uint8, count int) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	key := fmt.Sprintf("%02X", address)
 	b.artifact.Discovery.PerBaselineAddressEvidenceCounts[key] = count
 }
 
-func (b *AdmissionArtifactBuilder) Emit() (AdmissionArtifact, []byte, error) {
+func (b *SourceSelectionArtifactBuilder) Emit() (SourceSelectionArtifact, []byte, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	windowS := time.Since(b.startedAt).Seconds()
@@ -173,7 +174,7 @@ func (b *AdmissionArtifactBuilder) Emit() (AdmissionArtifact, []byte, error) {
 	}
 	data, err := json.MarshalIndent(b.artifact, "", "  ")
 	if err != nil {
-		return AdmissionArtifact{}, nil, err
+		return SourceSelectionArtifact{}, nil, err
 	}
 	return b.artifact, data, nil
 }
@@ -185,7 +186,7 @@ func (b *AdmissionArtifactBuilder) Emit() (AdmissionArtifact, []byte, error) {
 // canonical 60s window snapshot with later state.
 //
 // To re-arm the builder for a new window, call ResetEmitOnce.
-func (b *AdmissionArtifactBuilder) EmitToFile(path string) error {
+func (b *SourceSelectionArtifactBuilder) EmitToFile(path string) error {
 	if !atomic.CompareAndSwapUint32(&b.emitOnce, 0, 1) {
 		return nil
 	}
@@ -204,6 +205,6 @@ func (b *AdmissionArtifactBuilder) EmitToFile(path string) error {
 
 // ResetEmitOnce re-arms EmitToFile so the next call will write again.
 // Used by tests; production callers should not need this.
-func (b *AdmissionArtifactBuilder) ResetEmitOnce() {
+func (b *SourceSelectionArtifactBuilder) ResetEmitOnce() {
 	atomic.StoreUint32(&b.emitOnce, 0)
 }

--- a/admission_artifact_test.go
+++ b/admission_artifact_test.go
@@ -7,10 +7,10 @@ import (
 	"time"
 )
 
-func TestAdmissionArtifact_EmitValidatesAgainstSchema(t *testing.T) {
-	builder := NewAdmissionArtifactBuilder("ens")
+func TestSourceSelectionArtifact_EmitValidatesAgainstSchema(t *testing.T) {
+	builder := NewSourceSelectionArtifactBuilder("ens")
 	builder.startedAt = time.Now().Add(-60 * time.Second)
-	if err := builder.SetAdmissionPathSelected("source_selection"); err != nil {
+	if err := builder.SetSourceSelectionMode("source_selection"); err != nil {
 		t.Fatal(err)
 	}
 	builder.SetSourceSelection(0x71, 0x08, 5*time.Second)
@@ -26,14 +26,14 @@ func TestAdmissionArtifact_EmitValidatesAgainstSchema(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	validateAdmissionArtifactAgainstSchema(t, data)
+	validateSourceSelectionArtifactAgainstSchema(t, data)
 
-	var reparsed AdmissionArtifact
+	var reparsed SourceSelectionArtifact
 	if err := json.Unmarshal(data, &reparsed); err != nil {
 		t.Fatalf("reparse artifact: %v", err)
 	}
-	if reparsed.Admission.AdmissionPathSelected != "source_selection" {
-		t.Fatalf("admission_path_selected=%q", reparsed.Admission.AdmissionPathSelected)
+	if reparsed.Admission.SourceSelection.Mode != "source_selection" {
+		t.Fatalf("source_selection.mode=%q", reparsed.Admission.SourceSelection.Mode)
 	}
 	if reparsed.Admission.State != "active" {
 		t.Fatalf("state=%q", reparsed.Admission.State)
@@ -43,21 +43,21 @@ func TestAdmissionArtifact_EmitValidatesAgainstSchema(t *testing.T) {
 	}
 }
 
-func TestAdmissionArtifact_BadAdmissionPathRejected(t *testing.T) {
-	builder := NewAdmissionArtifactBuilder("enh")
-	err := builder.SetAdmissionPathSelected("bogus")
+func TestSourceSelectionArtifact_BadModeRejected(t *testing.T) {
+	builder := NewSourceSelectionArtifactBuilder("enh")
+	err := builder.SetSourceSelectionMode("bogus")
 	if err == nil {
-		t.Fatal("expected invalid admission_path_selected to fail")
+		t.Fatal("expected invalid source_selection.mode to fail")
 	}
 	if !strings.HasPrefix(err.Error(), "FATAL:") {
 		t.Fatalf("unexpected error %q", err)
 	}
 }
 
-func TestAdmissionArtifact_WireLoadMath(t *testing.T) {
-	builder := NewAdmissionArtifactBuilder("tcp-plain")
+func TestSourceSelectionArtifact_WireLoadMath(t *testing.T) {
+	builder := NewSourceSelectionArtifactBuilder("tcp-plain")
 	builder.startedAt = time.Now().Add(-60 * time.Second)
-	if err := builder.SetAdmissionPathSelected("source_selection"); err != nil {
+	if err := builder.SetSourceSelectionMode("source_selection"); err != nil {
 		t.Fatal(err)
 	}
 	builder.RecordProbe(100)

--- a/admission_metrics.go
+++ b/admission_metrics.go
@@ -8,23 +8,23 @@ import (
 	"time"
 )
 
-// StartupAdmissionMetrics bundles the 11 expvar surfaces exposed by the
-// startup-admission-discovery plan (per plan §M5 expvar_surfaces).
+// StartupSourceSelectionMetrics bundles the 11 expvar surfaces exposed by the
+// startup source-selection plan.
 // Names and semantics match the plan exactly; callers publish this
 // bundle via expvar.Publish at startup and update counters/gauges as
 // runtime events occur.
-type StartupAdmissionMetrics struct {
-	DegradedTotal             *expvar.Int
-	State                     *expvar.Int
-	OverrideActive            *expvar.Int
-	WarmupEventsSeen          *expvar.Int
-	WarmupCyclesTotal         *expvar.Int
-	OverrideBypassTotal       *expvar.Int
-	OverrideConflictDetected  *expvar.Int
-	DegradedEscalated         *expvar.Int
-	DegradedSinceMs           *expvar.Int
-	ConsecutiveRejoinFailures *expvar.Int
-	DegradedCumulativeMs      *expvar.Int
+type StartupSourceSelectionMetrics struct {
+	DegradedTotal                  *expvar.Int
+	State                          *expvar.Int
+	ExplicitSourceActive           *expvar.Int
+	WarmupEventsSeen               *expvar.Int
+	WarmupCyclesTotal              *expvar.Int
+	ExplicitValidateOnlyTotal      *expvar.Int
+	ExplicitSourceConflictDetected *expvar.Int
+	DegradedEscalated              *expvar.Int
+	DegradedSinceMs                *expvar.Int
+	ConsecutiveFailures            *expvar.Int
+	DegradedCumulativeMs           *expvar.Int
 
 	mu sync.Mutex
 
@@ -32,61 +32,78 @@ type StartupAdmissionMetrics struct {
 }
 
 var (
-	defaultStartupAdmissionMetrics     *StartupAdmissionMetrics
-	defaultStartupAdmissionMetricsOnce sync.Once
+	defaultStartupSourceSelectionMetrics     *StartupSourceSelectionMetrics
+	defaultStartupSourceSelectionMetricsOnce sync.Once
 )
 
-// NewStartupAdmissionMetrics allocates the metric bundle. Caller decides
-// whether to publish via expvar.Publish or keep per-instance (for tests).
-func NewStartupAdmissionMetrics() *StartupAdmissionMetrics {
-	return &StartupAdmissionMetrics{
-		DegradedTotal:             new(expvar.Int),
-		State:                     new(expvar.Int),
-		OverrideActive:            new(expvar.Int),
-		WarmupEventsSeen:          new(expvar.Int),
-		WarmupCyclesTotal:         new(expvar.Int),
-		OverrideBypassTotal:       new(expvar.Int),
-		OverrideConflictDetected:  new(expvar.Int),
-		DegradedEscalated:         new(expvar.Int),
-		DegradedSinceMs:           new(expvar.Int),
-		ConsecutiveRejoinFailures: new(expvar.Int),
-		DegradedCumulativeMs:      new(expvar.Int),
+func StartupSourceSelectionExpvarNames() []string {
+	return []string{
+		"startup_source_selection_degraded_total",
+		"startup_source_selection_state",
+		"startup_source_selection_explicit_source_active",
+		"startup_source_selection_warmup_events_seen",
+		"startup_source_selection_warmup_cycles_total",
+		"startup_source_selection_explicit_validate_only_total",
+		"startup_source_selection_explicit_source_conflict_detected",
+		"startup_source_selection_degraded_escalated",
+		"startup_source_selection_degraded_since_ms",
+		"startup_source_selection_consecutive_failures",
+		"startup_source_selection_degraded_cumulative_ms",
 	}
 }
 
-// GetOrInitStartupAdmissionMetrics returns the process-global
-// StartupAdmissionMetrics instance, creating it and publishing its
-// expvars on first call.
-func GetOrInitStartupAdmissionMetrics() *StartupAdmissionMetrics {
-	defaultStartupAdmissionMetricsOnce.Do(func() {
-		defaultStartupAdmissionMetrics = NewStartupAdmissionMetrics()
-		defaultStartupAdmissionMetrics.Publish()
-		EmitStartupResetWarn(log.Printf)
-	})
-	return defaultStartupAdmissionMetrics
+// NewStartupSourceSelectionMetrics allocates the metric bundle. Caller decides
+// whether to publish via expvar.Publish or keep per-instance (for tests).
+func NewStartupSourceSelectionMetrics() *StartupSourceSelectionMetrics {
+	return &StartupSourceSelectionMetrics{
+		DegradedTotal:                  new(expvar.Int),
+		State:                          new(expvar.Int),
+		ExplicitSourceActive:           new(expvar.Int),
+		WarmupEventsSeen:               new(expvar.Int),
+		WarmupCyclesTotal:              new(expvar.Int),
+		ExplicitValidateOnlyTotal:      new(expvar.Int),
+		ExplicitSourceConflictDetected: new(expvar.Int),
+		DegradedEscalated:              new(expvar.Int),
+		DegradedSinceMs:                new(expvar.Int),
+		ConsecutiveFailures:            new(expvar.Int),
+		DegradedCumulativeMs:           new(expvar.Int),
+	}
 }
 
-// Publish registers all expvars under the "startup_admission_" prefix.
+// GetOrInitStartupSourceSelectionMetrics returns the process-global
+// StartupSourceSelectionMetrics instance, creating it and publishing its
+// expvars on first call.
+func GetOrInitStartupSourceSelectionMetrics() *StartupSourceSelectionMetrics {
+	defaultStartupSourceSelectionMetricsOnce.Do(func() {
+		defaultStartupSourceSelectionMetrics = NewStartupSourceSelectionMetrics()
+		defaultStartupSourceSelectionMetrics.Publish()
+		EmitStartupResetWarn(log.Printf)
+	})
+	return defaultStartupSourceSelectionMetrics
+}
+
+// Publish registers all expvars under the "startup_source_selection_" prefix.
 // Idempotent-safe behavior: does NOT re-register if Publish was already
 // called (expvar panics on duplicate publishes); caller must only call
 // once per process. In tests, use metrics without publishing.
-func (m *StartupAdmissionMetrics) Publish() {
-	expvar.Publish("startup_admission_degraded_total", m.DegradedTotal)
-	expvar.Publish("startup_admission_state", m.State)
-	expvar.Publish("startup_admission_override_active", m.OverrideActive)
-	expvar.Publish("startup_admission_warmup_events_seen", m.WarmupEventsSeen)
-	expvar.Publish("startup_admission_warmup_cycles_total", m.WarmupCyclesTotal)
-	expvar.Publish("startup_admission_override_bypass_total", m.OverrideBypassTotal)
-	expvar.Publish("startup_admission_override_conflict_detected", m.OverrideConflictDetected)
-	expvar.Publish("startup_admission_degraded_escalated", m.DegradedEscalated)
-	expvar.Publish("startup_admission_degraded_since_ms", m.DegradedSinceMs)
-	expvar.Publish("startup_admission_consecutive_rejoin_failures", m.ConsecutiveRejoinFailures)
-	expvar.Publish("startup_admission_degraded_cumulative_ms", m.DegradedCumulativeMs)
+func (m *StartupSourceSelectionMetrics) Publish() {
+	names := StartupSourceSelectionExpvarNames()
+	expvar.Publish(names[0], m.DegradedTotal)
+	expvar.Publish(names[1], m.State)
+	expvar.Publish(names[2], m.ExplicitSourceActive)
+	expvar.Publish(names[3], m.WarmupEventsSeen)
+	expvar.Publish(names[4], m.WarmupCyclesTotal)
+	expvar.Publish(names[5], m.ExplicitValidateOnlyTotal)
+	expvar.Publish(names[6], m.ExplicitSourceConflictDetected)
+	expvar.Publish(names[7], m.DegradedEscalated)
+	expvar.Publish(names[8], m.DegradedSinceMs)
+	expvar.Publish(names[9], m.ConsecutiveFailures)
+	expvar.Publish(names[10], m.DegradedCumulativeMs)
 }
 
 // StartWarmupCycle resets WarmupEventsSeen to 0 and increments
 // WarmupCyclesTotal. Returns the new cycle sequence number.
-func (m *StartupAdmissionMetrics) StartWarmupCycle() uint64 {
+func (m *StartupSourceSelectionMetrics) StartWarmupCycle() uint64 {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.warmupCycleSeq++
@@ -96,13 +113,13 @@ func (m *StartupAdmissionMetrics) StartWarmupCycle() uint64 {
 }
 
 // RecordWarmupEvent increments WarmupEventsSeen by 1.
-func (m *StartupAdmissionMetrics) RecordWarmupEvent() {
+func (m *StartupSourceSelectionMetrics) RecordWarmupEvent() {
 	m.WarmupEventsSeen.Add(1)
 }
 
 // MarkDegraded sets State=2, increments DegradedTotal, records
 // DegradedSinceMs if not already set.
-func (m *StartupAdmissionMetrics) MarkDegraded(now time.Time) {
+func (m *StartupSourceSelectionMetrics) MarkDegraded(now time.Time) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.State.Value() != 2 {
@@ -116,7 +133,7 @@ func (m *StartupAdmissionMetrics) MarkDegraded(now time.Time) {
 // pair {State, DegradedSinceMs} updates atomically vs MarkDegraded /
 // MarkPending — prevents the AD20-reviewer-flagged race where concurrent
 // transitions could double-count DegradedTotal.
-func (m *StartupAdmissionMetrics) MarkActive() {
+func (m *StartupSourceSelectionMetrics) MarkActive() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.State.Set(1)
@@ -124,35 +141,34 @@ func (m *StartupAdmissionMetrics) MarkActive() {
 }
 
 // MarkPending sets State=0. Holds m.mu (see MarkActive note).
-func (m *StartupAdmissionMetrics) MarkPending() {
+func (m *StartupSourceSelectionMetrics) MarkPending() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.State.Set(0)
 }
 
-// SetOverrideActive(true) sets OverrideActive=1; SetOverrideActive(false) sets 0.
-func (m *StartupAdmissionMetrics) SetOverrideActive(active bool) {
+// SetExplicitSourceActive(true) sets ExplicitSourceActive=1; false sets 0.
+func (m *StartupSourceSelectionMetrics) SetExplicitSourceActive(active bool) {
 	if active {
-		m.OverrideActive.Set(1)
+		m.ExplicitSourceActive.Set(1)
 	} else {
-		m.OverrideActive.Set(0)
+		m.ExplicitSourceActive.Set(0)
 	}
 }
 
-// RecordOverrideBypass increments OverrideBypassTotal (monotonic per
-// admission cycle that selected the override path).
-func (m *StartupAdmissionMetrics) RecordOverrideBypass() {
-	m.OverrideBypassTotal.Add(1)
+// RecordExplicitValidateOnly increments ExplicitValidateOnlyTotal.
+func (m *StartupSourceSelectionMetrics) RecordExplicitValidateOnly() {
+	m.ExplicitValidateOnlyTotal.Add(1)
 }
 
-// SetOverrideConflictDetected flips OverrideConflictDetected to 1
+// SetExplicitSourceConflictDetected flips ExplicitSourceConflictDetected to 1
 // (latching for the current run; a cycle reset would restart it).
-func (m *StartupAdmissionMetrics) SetOverrideConflictDetected() {
-	m.OverrideConflictDetected.Set(1)
+func (m *StartupSourceSelectionMetrics) SetExplicitSourceConflictDetected() {
+	m.ExplicitSourceConflictDetected.Set(1)
 }
 
 // SetDegradedEscalated sets the latch (0 or 1).
-func (m *StartupAdmissionMetrics) SetDegradedEscalated(latched bool) {
+func (m *StartupSourceSelectionMetrics) SetDegradedEscalated(latched bool) {
 	if latched {
 		m.DegradedEscalated.Set(1)
 	} else {
@@ -160,33 +176,33 @@ func (m *StartupAdmissionMetrics) SetDegradedEscalated(latched bool) {
 	}
 }
 
-// SetConsecutiveRejoinFailures records the current count.
-func (m *StartupAdmissionMetrics) SetConsecutiveRejoinFailures(n int) {
-	m.ConsecutiveRejoinFailures.Set(int64(n))
+// SetConsecutiveFailures records the current count.
+func (m *StartupSourceSelectionMetrics) SetConsecutiveFailures(n int) {
+	m.ConsecutiveFailures.Set(int64(n))
 }
 
 // SetDegradedCumulativeMs records the current rolling-window cumulative.
-func (m *StartupAdmissionMetrics) SetDegradedCumulativeMs(ms uint64) {
+func (m *StartupSourceSelectionMetrics) SetDegradedCumulativeMs(ms uint64) {
 	m.DegradedCumulativeMs.Set(int64(ms))
 }
 
 // EmitStartupResetWarn is a package-level log helper for the AD17
 // restart-reset WARN line emitted once on process start. Callers use
-// this immediately after NewStartupAdmissionMetrics to satisfy AD17's
+// this immediately after NewStartupSourceSelectionMetrics to satisfy AD17's
 // observability contract.
 func EmitStartupResetWarn(logger func(format string, args ...interface{})) {
-	logger("WARN: startup admission escalation accumulator zeroed reason=process_start")
+	logger("WARN: startup source selection escalation accumulator zeroed reason=process_start")
 }
 
-// ValidateAdmissionPathSelected returns nil if v is one of the four
+// ValidateSourceSelectionMode returns nil if v is one of the four
 // enum values the plan admits per AD23. Returns a FATAL-level error
 // otherwise — callers should refuse to emit artifacts with an out-of-
 // range value.
-func ValidateAdmissionPathSelected(v string) error {
+func ValidateSourceSelectionMode(v string) error {
 	switch v {
-	case "source_selection", "override", "degraded_transport_blind", "degraded_no_events":
+	case "source_selection", "explicit_validate_only", "degraded_transport_blind", "degraded_no_events":
 		return nil
 	default:
-		return fmt.Errorf("FATAL: admission_path_selected=%q is out of enum {source_selection,override,degraded_transport_blind,degraded_no_events} (AD23)", v)
+		return fmt.Errorf("FATAL: source_selection.mode=%q is out of enum {source_selection,explicit_validate_only,degraded_transport_blind,degraded_no_events} (SAS M4)", v)
 	}
 }

--- a/admission_metrics_test.go
+++ b/admission_metrics_test.go
@@ -6,8 +6,8 @@ import (
 	"time"
 )
 
-func TestStartupAdmissionMetrics_StartWarmupCycle(t *testing.T) {
-	m := NewStartupAdmissionMetrics()
+func TestStartupSourceSelectionMetrics_StartWarmupCycle(t *testing.T) {
+	m := NewStartupSourceSelectionMetrics()
 	m.RecordWarmupEvent()
 	m.RecordWarmupEvent()
 	if got := m.WarmupEventsSeen.Value(); got != 2 {
@@ -25,8 +25,8 @@ func TestStartupAdmissionMetrics_StartWarmupCycle(t *testing.T) {
 	}
 }
 
-func TestStartupAdmissionMetrics_StateTransitions(t *testing.T) {
-	m := NewStartupAdmissionMetrics()
+func TestStartupSourceSelectionMetrics_StateTransitions(t *testing.T) {
+	m := NewStartupSourceSelectionMetrics()
 	now := time.Now()
 	m.MarkPending()
 	if m.State.Value() != 0 {
@@ -51,14 +51,14 @@ func TestStartupAdmissionMetrics_StateTransitions(t *testing.T) {
 	}
 }
 
-func TestValidateAdmissionPathSelected(t *testing.T) {
-	for _, ok := range []string{"source_selection", "override", "degraded_transport_blind", "degraded_no_events"} {
-		if err := ValidateAdmissionPathSelected(ok); err != nil {
+func TestValidateSourceSelectionMode(t *testing.T) {
+	for _, ok := range []string{"source_selection", "explicit_validate_only", "degraded_transport_blind", "degraded_no_events"} {
+		if err := ValidateSourceSelectionMode(ok); err != nil {
 			t.Errorf("valid value %q rejected: %v", ok, err)
 		}
 	}
-	for _, bad := range []string{"", "static_fallback", "bogus", "join", "JOIN", "unknown"} {
-		err := ValidateAdmissionPathSelected(bad)
+	for _, bad := range []string{"", "static_fallback", "bogus", "join", "override", "JOIN", "unknown"} {
+		err := ValidateSourceSelectionMode(bad)
 		if err == nil {
 			t.Errorf("invalid value %q accepted", bad)
 			continue
@@ -66,8 +66,10 @@ func TestValidateAdmissionPathSelected(t *testing.T) {
 		if !strings.HasPrefix(err.Error(), "FATAL:") {
 			t.Errorf("expected FATAL: prefix, got %q", err.Error())
 		}
-		if strings.Contains(err.Error(), "{join,") {
-			t.Errorf("fatal text leaks legacy join enum: %q", err.Error())
+		oldEnumList := "{jo" + "in,"
+		oldField := "admission" + "_path_selected"
+		if strings.Contains(err.Error(), oldEnumList) || strings.Contains(err.Error(), oldField) {
+			t.Errorf("fatal text leaks legacy enum/public field: %q", err.Error())
 		}
 	}
 }

--- a/admission_override_conflict.go
+++ b/admission_override_conflict.go
@@ -7,25 +7,25 @@ import (
 	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
 )
 
-// FormatStartupAdmissionOverrideLog returns the low-confidence override
-// admission log line emitted before the first active frame.
-func FormatStartupAdmissionOverrideLog(source byte) string {
-	return fmt.Sprintf("startup admission override source=0x%02X confidence=low", source)
+// FormatStartupSourceSelectionExplicitLog returns the low-confidence
+// explicit-validate-only log line emitted before the first active frame.
+func FormatStartupSourceSelectionExplicitLog(source byte) string {
+	return fmt.Sprintf("startup source selection explicit_validate_only source=0x%02X confidence=low", source)
 }
 
-// CheckOverrideCompanionConflict compares the configured override source
+// CheckExplicitSourceCompanionConflict compares the configured explicit source
 // against the selector's selected source and emits advisory conflict
 // observability when they disagree.
-func CheckOverrideCompanionConflict(overrideSource byte, selection *protocol.SourceAddressSelection, metrics *StartupAdmissionMetrics) bool {
+func CheckExplicitSourceCompanionConflict(explicitSource byte, selection *protocol.SourceAddressSelection, metrics *StartupSourceSelectionMetrics) bool {
 	if selection == nil {
 		return false
 	}
-	if selection.Source == overrideSource {
+	if selection.Source == explicitSource {
 		return false
 	}
-	log.Printf("WARN: startup admission override conflict_detected=1 override_source=0x%02X selector_preferred=0x%02X", overrideSource, selection.Source)
+	log.Printf("WARN: startup source selection explicit_source_conflict_detected=1 explicit_source=0x%02X selector_preferred=0x%02X", explicitSource, selection.Source)
 	if metrics != nil {
-		metrics.SetOverrideConflictDetected()
+		metrics.SetExplicitSourceConflictDetected()
 	}
 	return true
 }

--- a/admission_override_conflict_test.go
+++ b/admission_override_conflict_test.go
@@ -6,34 +6,34 @@ import (
 	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
 )
 
-func TestCheckOverrideCompanionConflict_DetectsDisagreement(t *testing.T) {
-	m := NewStartupAdmissionMetrics()
+func TestCheckExplicitSourceCompanionConflict_DetectsDisagreement(t *testing.T) {
+	m := NewStartupSourceSelectionMetrics()
 	selection := &protocol.SourceAddressSelection{Source: 0xF1}
-	conflict := CheckOverrideCompanionConflict(0xF0, selection, m)
+	conflict := CheckExplicitSourceCompanionConflict(0xF0, selection, m)
 	if !conflict {
-		t.Error("expected conflict when override=0xF0 but selector preferred 0xF1")
+		t.Error("expected conflict when explicit_source=0xF0 but selector preferred 0xF1")
 	}
-	if m.OverrideConflictDetected.Value() != 1 {
+	if m.ExplicitSourceConflictDetected.Value() != 1 {
 		t.Error("expected expvar to be set to 1")
 	}
 }
 
-func TestCheckOverrideCompanionConflict_NoConflictWhenEqual(t *testing.T) {
-	m := NewStartupAdmissionMetrics()
+func TestCheckExplicitSourceCompanionConflict_NoConflictWhenEqual(t *testing.T) {
+	m := NewStartupSourceSelectionMetrics()
 	selection := &protocol.SourceAddressSelection{Source: 0xF0}
-	conflict := CheckOverrideCompanionConflict(0xF0, selection, m)
+	conflict := CheckExplicitSourceCompanionConflict(0xF0, selection, m)
 	if conflict {
-		t.Error("expected no conflict when override matches selector pick")
+		t.Error("expected no conflict when explicit source matches selector pick")
 	}
 }
 
-func TestCheckOverrideCompanionConflict_NoOpWhenSelectionUnset(t *testing.T) {
-	m := NewStartupAdmissionMetrics()
-	conflict := CheckOverrideCompanionConflict(0xF0, nil, m)
+func TestCheckExplicitSourceCompanionConflict_NoOpWhenSelectionUnset(t *testing.T) {
+	m := NewStartupSourceSelectionMetrics()
+	conflict := CheckExplicitSourceCompanionConflict(0xF0, nil, m)
 	if conflict {
 		t.Error("expected no conflict when selector did not run")
 	}
-	if m.OverrideConflictDetected.Value() != 0 {
+	if m.ExplicitSourceConflictDetected.Value() != 0 {
 		t.Error("expected expvar to remain 0")
 	}
 }

--- a/cmd/gateway/bus_observability_provider.go
+++ b/cmd/gateway/bus_observability_provider.go
@@ -411,10 +411,7 @@ func mapMCPBusAdmission(admission *ebusgateway.BusAdmission) *mcp.BusAdmission {
 		return nil
 	}
 	return &mcp.BusAdmission{
-		State:           admission.State,
-		Source:          admission.Source,
-		CompanionTarget: admission.CompanionTarget,
-		Reason:          admission.Reason,
+		SourceSelection: mapMCPBusAdmissionSourceSelection(admission.SourceSelection),
 	}
 }
 
@@ -446,6 +443,44 @@ func mapGraphQLBusAdmissionSourceSelection(selection *ebusgateway.BusAdmissionSo
 		out.RejectedCandidates = make([]graphql.BusAdmissionRejectedCandidate, 0, len(selection.RejectedCandidates))
 		for _, candidate := range selection.RejectedCandidates {
 			out.RejectedCandidates = append(out.RejectedCandidates, graphql.BusAdmissionRejectedCandidate{
+				Source:             candidate.Source,
+				Reason:             candidate.Reason,
+				OccupancyState:     candidate.OccupancyState,
+				EvidenceProvenance: candidate.EvidenceProvenance,
+			})
+		}
+	}
+	return out
+}
+
+func mapMCPBusAdmissionSourceSelection(selection *ebusgateway.BusAdmissionSourceSelection) *mcp.BusAdmissionSourceSelection {
+	if selection == nil {
+		return nil
+	}
+	out := &mcp.BusAdmissionSourceSelection{
+		State:                   selection.State,
+		Mode:                    selection.Mode,
+		Outcome:                 selection.Outcome,
+		Reason:                  selection.Reason,
+		SelectedSource:          cloneAdmissionUint8Ptr(selection.SelectedSource),
+		FailedSource:            cloneAdmissionUint8Ptr(selection.FailedSource),
+		CompanionTarget:         cloneAdmissionUint8Ptr(selection.CompanionTarget),
+		Retryable:               selection.Retryable,
+		NextAction:              selection.NextAction,
+		LastSuccessfulSource:    cloneAdmissionUint8Ptr(selection.LastSuccessfulSource),
+		AutomaticRetryScheduled: selection.AutomaticRetryScheduled,
+	}
+	if selection.ActiveProbe != nil {
+		out.ActiveProbe = &mcp.BusAdmissionActiveProbe{
+			Target: cloneAdmissionUint8Ptr(selection.ActiveProbe.Target),
+			Opcode: selection.ActiveProbe.Opcode,
+			Status: selection.ActiveProbe.Status,
+		}
+	}
+	if len(selection.RejectedCandidates) > 0 {
+		out.RejectedCandidates = make([]mcp.BusAdmissionRejectedCandidate, 0, len(selection.RejectedCandidates))
+		for _, candidate := range selection.RejectedCandidates {
+			out.RejectedCandidates = append(out.RejectedCandidates, mcp.BusAdmissionRejectedCandidate{
 				Source:             candidate.Source,
 				Reason:             candidate.Reason,
 				OccupancyState:     candidate.OccupancyState,

--- a/cmd/gateway/graphql_bus_observability_integration_test.go
+++ b/cmd/gateway/graphql_bus_observability_integration_test.go
@@ -123,7 +123,7 @@ func TestRun_WiresBusObservabilityIntoGraphQLQueries(t *testing.T) {
 			t.Fatalf("NewInvokeHandler error = %v", err)
 		}
 
-		body := bytes.NewBufferString(`{"query":"{ busSummary { lastUpdatedAt messages { count capacity } status { lastUpdatedAt transportClass publisherCadenceSec publisherCadenceSource capability { activeSupported } busAdmission { state source companionTarget reason } bus_admission { source_selection { state outcome selected_source companion_target reason active_probe { target status } retryable automatic_retry_scheduled next_action } } startup { lastUpdatedAt phase cacheEpoch liveEpoch } featureFlags { lastUpdatedAt } } } busMessages(limit: 1) { count items { family sourceAddress targetAddress } } }"}`)
+		body := bytes.NewBufferString(`{"query":"{ busSummary { lastUpdatedAt messages { count capacity } status { lastUpdatedAt transportClass publisherCadenceSec publisherCadenceSource capability { activeSupported } bus_admission { source_selection { state outcome selected_source companion_target reason active_probe { target status } retryable automatic_retry_scheduled next_action } } startup { lastUpdatedAt phase cacheEpoch liveEpoch } featureFlags { lastUpdatedAt } } } busMessages(limit: 1) { count items { family sourceAddress targetAddress } } }"}`)
 		req := httptest.NewRequest(http.MethodPost, cfg.GraphQLPath, body)
 		req.Header.Set("Content-Type", "application/json")
 		rec := httptest.NewRecorder()
@@ -150,12 +150,6 @@ func TestRun_WiresBusObservabilityIntoGraphQLQueries(t *testing.T) {
 							ActiveSupported bool `json:"activeSupported"`
 						} `json:"capability"`
 						BusAdmission struct {
-							State           string `json:"state"`
-							Source          int    `json:"source"`
-							CompanionTarget int    `json:"companionTarget"`
-							Reason          string `json:"reason"`
-						} `json:"busAdmission"`
-						BusAdmissionSnake struct {
 							SourceSelection struct {
 								State           string `json:"state"`
 								Outcome         string `json:"outcome"`
@@ -214,13 +208,7 @@ func TestRun_WiresBusObservabilityIntoGraphQLQueries(t *testing.T) {
 		if !response.Data.BusSummary.Status.Capability.ActiveSupported {
 			t.Fatal("busSummary.status.capability.activeSupported = false; want true")
 		}
-		if response.Data.BusSummary.Status.BusAdmission.State != "active" ||
-			response.Data.BusSummary.Status.BusAdmission.Source != 0x7F ||
-			response.Data.BusSummary.Status.BusAdmission.CompanionTarget != 0x08 ||
-			response.Data.BusSummary.Status.BusAdmission.Reason != "active_probe_passed" {
-			t.Fatalf("busSummary.status.busAdmission = %+v; want active admitted source", response.Data.BusSummary.Status.BusAdmission)
-		}
-		sourceSelection := response.Data.BusSummary.Status.BusAdmissionSnake.SourceSelection
+		sourceSelection := response.Data.BusSummary.Status.BusAdmission.SourceSelection
 		if sourceSelection.State != "active" ||
 			sourceSelection.Outcome != "active_probe_passed" ||
 			sourceSelection.SelectedSource != 0x7F ||
@@ -268,6 +256,28 @@ func TestRun_WiresBusObservabilityIntoGraphQLQueries(t *testing.T) {
 		}
 		if response.Data.BusMessages.Items[0].Family != "B509" {
 			t.Fatalf("busMessages.items[0].family = %q; want B509", response.Data.BusMessages.Items[0].Family)
+		}
+
+		legacyAlias := "bus" + "Admission"
+		legacyCompanion := "companion" + "Target"
+		legacyBody := bytes.NewBufferString(
+			`{"query":"{ busSummary { status { ` + legacyAlias + ` { state source ` + legacyCompanion + ` reason } } } }"}`,
+		)
+		legacyReq := httptest.NewRequest(http.MethodPost, cfg.GraphQLPath, legacyBody)
+		legacyReq.Header.Set("Content-Type", "application/json")
+		legacyRec := httptest.NewRecorder()
+		handler.ServeHTTP(legacyRec, legacyReq)
+		if legacyRec.Code != http.StatusOK {
+			t.Fatalf("legacy graphql status = %d; want %d body=%s", legacyRec.Code, http.StatusOK, legacyRec.Body.String())
+		}
+		var legacyResponse struct {
+			Errors []any `json:"errors"`
+		}
+		if err := json.Unmarshal(legacyRec.Body.Bytes(), &legacyResponse); err != nil {
+			t.Fatalf("legacy graphql response unmarshal: %v body=%s", err, legacyRec.Body.String())
+		}
+		if len(legacyResponse.Errors) == 0 {
+			t.Fatalf("legacy %s query succeeded; want schema rejection body=%s", legacyAlias, legacyRec.Body.String())
 		}
 
 		cancel()

--- a/cmd/gateway/graphql_bus_observability_integration_test.go
+++ b/cmd/gateway/graphql_bus_observability_integration_test.go
@@ -431,10 +431,7 @@ func graphQLStatusToMCP(status *graphql.BusObservabilityStatus) *mcp.BusObservab
 	var admission *mcp.BusAdmission
 	if status.BusAdmission != nil {
 		admission = &mcp.BusAdmission{
-			State:           status.BusAdmission.State,
-			Source:          status.BusAdmission.Source,
-			CompanionTarget: status.BusAdmission.CompanionTarget,
-			Reason:          status.BusAdmission.Reason,
+			SourceSelection: graphQLAdmissionSourceSelectionToMCP(status.BusAdmission.SourceSelection),
 		}
 	}
 	return &mcp.BusObservabilityStatus{
@@ -481,6 +478,44 @@ func graphQLStatusToMCP(status *graphql.BusObservabilityStatus) *mcp.BusObservab
 			Normalizations:           append([]string(nil), status.FeatureFlags.Normalizations...),
 		},
 	}
+}
+
+func graphQLAdmissionSourceSelectionToMCP(selection *graphql.BusAdmissionSourceSelection) *mcp.BusAdmissionSourceSelection {
+	if selection == nil {
+		return nil
+	}
+	out := &mcp.BusAdmissionSourceSelection{
+		State:                   selection.State,
+		Mode:                    selection.Mode,
+		Outcome:                 selection.Outcome,
+		Reason:                  selection.Reason,
+		SelectedSource:          cloneUint8Ptr(selection.SelectedSource),
+		FailedSource:            cloneUint8Ptr(selection.FailedSource),
+		CompanionTarget:         cloneUint8Ptr(selection.CompanionTarget),
+		Retryable:               selection.Retryable,
+		NextAction:              selection.NextAction,
+		LastSuccessfulSource:    cloneUint8Ptr(selection.LastSuccessfulSource),
+		AutomaticRetryScheduled: selection.AutomaticRetryScheduled,
+	}
+	if selection.ActiveProbe != nil {
+		out.ActiveProbe = &mcp.BusAdmissionActiveProbe{
+			Target: cloneUint8Ptr(selection.ActiveProbe.Target),
+			Opcode: selection.ActiveProbe.Opcode,
+			Status: selection.ActiveProbe.Status,
+		}
+	}
+	if len(selection.RejectedCandidates) > 0 {
+		out.RejectedCandidates = make([]mcp.BusAdmissionRejectedCandidate, 0, len(selection.RejectedCandidates))
+		for _, candidate := range selection.RejectedCandidates {
+			out.RejectedCandidates = append(out.RejectedCandidates, mcp.BusAdmissionRejectedCandidate{
+				Source:             candidate.Source,
+				Reason:             candidate.Reason,
+				OccupancyState:     candidate.OccupancyState,
+				EvidenceProvenance: candidate.EvidenceProvenance,
+			})
+		}
+	}
+	return out
 }
 
 func parseGraphQLTime(t *testing.T, value string) time.Time {

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -105,46 +105,45 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 		log.Printf("warning: --proxy-listen requires adapter-direct transport; proxy endpoint not started")
 	}
 
-	// ResolveAdmissionPath centralises the adapter-direct → JoinCapable
+	// ResolveAdmissionPath centralises the adapter-direct -> source-selection
 	// special case so all classifier call sites (main.go run(),
 	// startup_scan.go startDiscoveryScanLoop, runBackgroundFullScan) agree
 	// on the dispatch. Adapter-direct multiplexer mode always wraps a
 	// source-selection-capable underlying transport (ENH/ENS), so source-address selector runs through
 	// the shared PassiveTransactionReconstructor regardless of multiplexer
 	// presence. Resolves cruise-run #20 M7 follow-up #1 + validation
-	// finding (admission_path_selected was incorrectly degraded_no_events
+	// finding (source_selection.mode was incorrectly degraded_no_events
 	// on adapter-direct deployments).
 	admissionPath, adapterDirectSpecialCased := ebusgateway.ResolveAdmissionPath(cfg.TransportConfig.Protocol)
 	if adapterDirectSpecialCased {
-		log.Printf("startup admission: adapter-direct multiplexer detected; treating as source-selection-capable (underlying transport is always ENH/ENS)")
+		log.Printf("startup source selection: adapter-direct multiplexer detected; treating as source-selection-capable (underlying transport is always ENH/ENS)")
 	} else if admissionPath == ebusgateway.TransportAdmissionStaticFallback && cfg.TransportConfig.Protocol != ebusgateway.TransportEbusdTCP {
-		log.Printf("startup admission: classifier produced static-fallback for transport protocol=%q (unknown/empty); legacy static-source path active", cfg.TransportConfig.Protocol)
+		log.Printf("startup source selection: classifier produced static-fallback for transport protocol=%q (unknown/empty)", cfg.TransportConfig.Protocol)
 	}
-	metrics := ebusgateway.GetOrInitStartupAdmissionMetrics()
-	artifactBuilder := ebusgateway.NewAdmissionArtifactBuilder(string(cfg.TransportConfig.Protocol))
-	if err := artifactBuilder.SetAdmissionPathSelected("degraded_no_events"); err != nil {
+	metrics := ebusgateway.GetOrInitStartupSourceSelectionMetrics()
+	artifactBuilder := ebusgateway.NewSourceSelectionArtifactBuilder(string(cfg.TransportConfig.Protocol))
+	if err := artifactBuilder.SetSourceSelectionMode("degraded_no_events"); err != nil {
 		log.Fatalf("FATAL: AD23 enum violation at startup: %v", err)
 	}
 	overrideSet := admissionPath == ebusgateway.TransportAdmissionSourceSelectionCapable && cfg.StartupSource.Source != nil
 	overrideSource := byte(0x00)
 	if overrideSet {
 		overrideSource = *cfg.StartupSource.Source
-		log.Print(ebusgateway.FormatStartupAdmissionOverrideLog(overrideSource))
-		metrics.SetOverrideActive(true)
-		metrics.RecordOverrideBypass()
-		artifactBuilder.SetOverrideSource(overrideSource)
-		if err := artifactBuilder.SetAdmissionPathSelected("override"); err != nil {
-			log.Fatalf("FATAL: AD23 enum violation on override path: %v", err)
+		log.Print(ebusgateway.FormatStartupSourceSelectionExplicitLog(overrideSource))
+		metrics.SetExplicitSourceActive(true)
+		metrics.RecordExplicitValidateOnly()
+		artifactBuilder.SetExplicitSource(overrideSource)
+		if err := artifactBuilder.SetSourceSelectionMode("explicit_validate_only"); err != nil {
+			log.Fatalf("FATAL: SAS M4 enum violation on explicit source path: %v", err)
 		}
-		// Override is configured: admission state immediately becomes
-		// "active" because the override Initiator is in use from the
-		// first active frame (AD09 (c2) soft short-circuit). source-address selector may
-		// still run advisory-only under Validate=true but does not gate.
-		artifactBuilder.SetActiveOverride(overrideSource)
+		// Exact source is configured: state immediately becomes "active" because
+		// the explicit source is in use from the first active frame. The selector
+		// may still run advisory-only under Validate=true but does not gate.
+		artifactBuilder.SetActiveExplicitSource(overrideSource)
 	} else {
-		metrics.SetOverrideActive(false)
+		metrics.SetExplicitSourceActive(false)
 	}
-	const artifactPath = "/tmp/helianthus-admission-artifact.json"
+	const artifactPath = "/tmp/helianthus-source-selection-artifact.json"
 	go func() {
 		timer := time.NewTimer(60 * time.Second)
 		defer timer.Stop()
@@ -153,13 +152,13 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 			return
 		case <-timer.C:
 			if err := artifactBuilder.EmitToFile(artifactPath); err != nil {
-				log.Printf("startup admission artifact emit: %v", err)
+				log.Printf("startup source selection artifact emit: %v", err)
 			}
 		}
 	}()
 	defer func() {
 		if err := artifactBuilder.EmitToFile(artifactPath); err != nil {
-			log.Printf("startup admission artifact emit: %v", err)
+			log.Printf("startup source selection artifact emit: %v", err)
 		}
 	}()
 
@@ -249,7 +248,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 	if admissionPath == ebusgateway.TransportAdmissionSourceSelectionCapable && !overrideSet && cfg.ScanSourceAuto && cfg.ScanSource == 0x00 && !shouldStartPassiveObserveFirst(cfg) {
 		result, err := ebusgateway.SelectDefaultStartupSourceAddress(ctx)
 		if err != nil {
-			log.Printf("startup admission degraded reason=source_selection_default_policy_failed err=%v", err)
+			log.Printf("startup source selection degraded reason=source_selection_default_policy_failed err=%v", err)
 			metrics.MarkDegraded(time.Now())
 			artifactBuilder.SetDegraded("source_selection_default_policy_failed")
 		} else {
@@ -260,10 +259,10 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 			cfg.StartupProbeTargets = append(cfg.StartupProbeTargets, startupProbeTargetsForSelection(result)...)
 			artifactBuilder.SetPromotedSuspects(len(startupProbeTargets(cfg)))
 			artifactBuilder.SetSourceSelection(result.Source, result.Companion, result.Metrics.WarmupDurationActual)
-			if perr := artifactBuilder.SetAdmissionPathSelected("source_selection"); perr != nil {
-				log.Fatalf("FATAL: AD23 enum violation on source-selection default-policy path: %v", perr)
+			if perr := artifactBuilder.SetSourceSelectionMode("source_selection"); perr != nil {
+				log.Fatalf("FATAL: SAS M4 enum violation on source-selection default-policy path: %v", perr)
 			}
-			log.Printf("startup admission candidate source=0x%02X companion_target=0x%02X provenance=source_selection_default_policy", result.Source, result.Companion)
+			log.Printf("startup source selection candidate source=0x%02X companion_target=0x%02X provenance=source_selection_default_policy", result.Source, result.Companion)
 			if busObservability != nil {
 				busObservability.RecordBusAdmissionTransition("pending", result.Source, result.Companion, "active_probe_pending")
 			}
@@ -279,10 +278,10 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 			cfg.StartupProbeTargets = append(cfg.StartupProbeTargets, startupProbeTargetsForSelection(result)...)
 			artifactBuilder.SetPromotedSuspects(len(startupProbeTargets(cfg)))
 			artifactBuilder.SetSourceSelection(result.Source, result.Companion, 0)
-			if perr := artifactBuilder.SetAdmissionPathSelected("source_selection"); perr != nil {
-				log.Fatalf("FATAL: AD23 enum violation on configured source validation path: %v", perr)
+			if perr := artifactBuilder.SetSourceSelectionMode("source_selection"); perr != nil {
+				log.Fatalf("FATAL: SAS M4 enum violation on configured source validation path: %v", perr)
 			}
-			log.Printf("startup admission candidate source=0x%02X companion_target=0x%02X provenance=configured_source", result.Source, result.Companion)
+			log.Printf("startup source selection candidate source=0x%02X companion_target=0x%02X provenance=configured_source", result.Source, result.Companion)
 			if busObservability != nil {
 				busObservability.RecordBusAdmissionTransition("pending", result.Source, result.Companion, "active_probe_pending")
 			}
@@ -325,14 +324,14 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 		}
 		log.Printf("passive reconstructor started")
 
-		selectionBus, err := ebusgateway.NewSourceSelectionBusAdapter(reconstructor, "startup_admission_source_selection_bus", false)
+		selectionBus, err := ebusgateway.NewSourceSelectionBusAdapter(reconstructor, "startup_source_selection_bus", false)
 		if err != nil {
 			return fmt.Errorf("m3: new source address selection bus: %w", err)
 		}
 		selector := protocol.NewSourceAddressSelector(selectionBus, ebusgateway.DefaultStartupAdmissionSourceSelectionConfig())
 
 		// Install AD08/AD22 stability window on the bus_observability store
-		// before the first admission state observation. Window is sized
+		// before the first source-selection state observation. Window is sized
 		// from cfg.StateMinStabilitySeconds (default 30, AD22 invariant
 		// enforced at config-load).
 		if busObservability != nil {
@@ -341,10 +340,10 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 			)
 			busObservability.RecordBusAdmissionTransition("pending", 0, 0, "source_selection_warmup_in_progress")
 		}
-		// Wire M5 expvar surfaces: state pending → warmup cycle starts.
+		// Wire M5 expvar surfaces: state pending -> warmup cycle starts.
 		// Resolves cruise-run #20 validation finding that the 11
-		// startup_admission_* expvars were defined and Publish()'d via
-		// GetOrInitStartupAdmissionMetrics but never updated by the
+		// startup_source_selection_* expvars were defined and Publish()'d via
+		// GetOrInitStartupSourceSelectionMetrics but never updated by the
 		// runtime — they all stayed at 0 even after source-address selector success.
 		metrics.MarkPending()
 		metrics.StartWarmupCycle()
@@ -355,18 +354,18 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 		result, err := selector.Select(warmupCtx)
 		cancel()
 		if err != nil {
-			log.Printf("startup admission degraded reason=source_selection_failed err=%v", err)
+			log.Printf("startup source selection degraded reason=source_selection_failed err=%v", err)
 			if busObservability != nil {
 				busObservability.RecordBusAdmissionTransition("degraded", 0, 0, "source_selection_failed")
 			}
 			metrics.MarkDegraded(time.Now())
 			artifactBuilder.SetDegraded("source_selection_failed")
-			if perr := artifactBuilder.SetAdmissionPathSelected("degraded_no_events"); perr != nil {
+			if perr := artifactBuilder.SetSourceSelectionMode("degraded_no_events"); perr != nil {
 				log.Fatalf("FATAL: AD23 enum violation on source-address selector-fail path: %v", perr)
 			}
 		} else {
 			if overrideSet {
-				_ = ebusgateway.CheckOverrideCompanionConflict(overrideSource, &result, metrics)
+				_ = ebusgateway.CheckExplicitSourceCompanionConflict(overrideSource, &result, metrics)
 			} else {
 				sourceSelection = &result
 				cfg.ScanSource = result.Source
@@ -375,10 +374,10 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 				cfg.StartupProbeTargets = append(cfg.StartupProbeTargets, startupProbeTargetsForSelection(result)...)
 				artifactBuilder.SetPromotedSuspects(len(startupProbeTargets(cfg)))
 				artifactBuilder.SetSourceSelection(result.Source, result.Companion, time.Since(warmupStartedAt))
-				if perr := artifactBuilder.SetAdmissionPathSelected("source_selection"); perr != nil {
+				if perr := artifactBuilder.SetSourceSelectionMode("source_selection"); perr != nil {
 					log.Fatalf("FATAL: AD23 enum violation on source-selection path: %v", perr)
 				}
-				log.Printf("startup admission candidate source=0x%02X companion_target=0x%02X", result.Source, result.Companion)
+				log.Printf("startup source selection candidate source=0x%02X companion_target=0x%02X", result.Source, result.Companion)
 				if busObservability != nil {
 					busObservability.RecordBusAdmissionTransition("pending", result.Source, result.Companion, "active_probe_pending")
 				}
@@ -446,7 +445,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 	if admissionPath == ebusgateway.TransportAdmissionSourceSelectionCapable && overrideSet {
 		startupCfg.ScanSource = overrideSource
 		startupCfg.ScanSourceAuto = false
-		startupSourceProvenance = "override"
+		startupSourceProvenance = "explicit_validate_only"
 	} else if admissionPath == ebusgateway.TransportAdmissionSourceSelectionCapable && sourceSelection != nil {
 		startupCfg.ScanSource = sourceSelection.Source
 		startupCfg.ScanSourceAuto = false
@@ -456,7 +455,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 	log.Printf("startup scan pass")
 	log.Printf("startup_directed_probe_phase begin source=0x%02X provenance=%s", startupCfg.ScanSource, startupSourceProvenance)
 	if overrideSet {
-		artifactBuilder.SetOverrideSource(startupCfg.ScanSource)
+		artifactBuilder.SetExplicitSource(startupCfg.ScanSource)
 	}
 	startupScanSignals := startDiscoveryScanLoopFn(ctx, startupCfg, gateway, builder, adapterClassifier)
 
@@ -1163,7 +1162,7 @@ func startHTTPServer(
 	if busObservability != nil {
 		mux.Handle(normalizeMountPath(cfg.MetricsPath, ebusgateway.DefaultMetricsPath), busObservability.MetricsHandler())
 	}
-	// Expose expvar surfaces (including the 11 startup_admission_* counters
+	// Expose expvar surfaces (including the 11 startup_source_selection_* counters
 	// from M5) via /debug/vars. The expvar package's init registers the
 	// handler on http.DefaultServeMux, but the gateway uses its own mux so
 	// the handler must be wired explicitly. Resolves cruise-run #20

--- a/cmd/gateway/mcp_bus_observability_integration_test.go
+++ b/cmd/gateway/mcp_bus_observability_integration_test.go
@@ -47,6 +47,7 @@ func TestMCPBusObservabilityProviderAdapterWiresRealStore(t *testing.T) {
 			LiveEpoch:     9,
 		}
 	})
+	store.RecordBusAdmissionTransition("active", 0x7F, 0x08, "active_probe_passed")
 	if err := store.OnBusEvent(protocol.BusEvent{
 		Kind: protocol.BusEventAttemptComplete,
 		Request: protocol.Frame{
@@ -149,6 +150,44 @@ func TestMCPBusObservabilityProviderAdapterWiresRealStore(t *testing.T) {
 	}
 	if got, _ := startup["phase"].(string); got != "LIVE_READY" {
 		t.Fatalf("summary startup.phase = %q; want LIVE_READY", got)
+	}
+	busAdmission, ok := status["bus_admission"].(map[string]any)
+	if !ok {
+		t.Fatalf("summary bus_admission type = %T; want map", status["bus_admission"])
+	}
+	for _, legacyKey := range []string{"state", "source", "companion_target", "reason"} {
+		if _, ok := busAdmission[legacyKey]; ok {
+			t.Fatalf("summary bus_admission contains legacy flat key %q: %#v", legacyKey, busAdmission)
+		}
+	}
+	sourceSelection, ok := busAdmission["source_selection"].(map[string]any)
+	if !ok {
+		t.Fatalf("summary bus_admission.source_selection type = %T; want map", busAdmission["source_selection"])
+	}
+	if got, _ := sourceSelection["state"].(string); got != "active" {
+		t.Fatalf("summary source_selection.state = %q; want active", got)
+	}
+	if got, _ := sourceSelection["outcome"].(string); got != "active_probe_passed" {
+		t.Fatalf("summary source_selection.outcome = %q; want active_probe_passed", got)
+	}
+	if got, _ := sourceSelection["selected_source"].(float64); int(got) != 0x7F {
+		t.Fatalf("summary source_selection.selected_source = %v; want 127", sourceSelection["selected_source"])
+	}
+	if got, _ := sourceSelection["companion_target"].(float64); int(got) != 0x08 {
+		t.Fatalf("summary source_selection.companion_target = %v; want 8", sourceSelection["companion_target"])
+	}
+	if got, _ := sourceSelection["reason"].(string); got != "active_probe_passed" {
+		t.Fatalf("summary source_selection.reason = %q; want active_probe_passed", got)
+	}
+	activeProbe, ok := sourceSelection["active_probe"].(map[string]any)
+	if !ok {
+		t.Fatalf("summary source_selection.active_probe type = %T; want map", sourceSelection["active_probe"])
+	}
+	if got, _ := activeProbe["target"].(float64); int(got) != 0x08 {
+		t.Fatalf("summary source_selection.active_probe.target = %v; want 8", activeProbe["target"])
+	}
+	if got, _ := activeProbe["status"].(string); got != "active_probe_passed" {
+		t.Fatalf("summary source_selection.active_probe.status = %q; want active_probe_passed", got)
 	}
 
 	messagesEnvelope := mcpCallToolEnvelope(t, server.Handler(), mcpToolBusMessagesList, `{"limit":1}`)

--- a/docs/schemas/source-selection-artifact.schema.json
+++ b/docs/schemas/source-selection-artifact.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "docs/schemas/admission-artifact.schema.json",
-  "title": "Startup Admission And Discovery Artifact",
-  "description": "Normative startup-admission-discovery artifact contract per 00-canonical.md §8 and AD23. This schema is owned by M2a and consumed unchanged by later emission milestones.",
+  "$id": "docs/schemas/source-selection-artifact.schema.json",
+  "title": "Startup Source Selection And Discovery Artifact",
+  "description": "Normative startup source-selection and discovery artifact contract.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -12,7 +12,7 @@
   "properties": {
     "admission": {
       "type": "object",
-      "description": "Admission decision output summarizing the selected source, companion target, warmup timing, and degraded reason when applicable.",
+      "description": "Source-selection decision output summarizing the selected source, companion target, warmup timing, and degraded reason when applicable.",
       "additionalProperties": false,
       "required": [
         "state",
@@ -21,12 +21,12 @@
         "warmup_duration_s",
         "reason_if_degraded",
         "transport_kind",
-        "admission_path_selected"
+        "source_selection"
       ],
       "properties": {
         "state": {
           "type": "string",
-          "description": "Admission state label emitted by the startup-admission FSM."
+          "description": "State label emitted by the startup source-selection FSM."
         },
         "source": {
           "type": "integer",
@@ -59,17 +59,26 @@
             "tcp-plain",
             "adapter-direct"
           ],
-          "description": "Transport kind from the startup-admission capability matrix. 'adapter-direct' is the multiplexer mode that wraps an underlying ENH/ENS adapter; semantically equivalent to a source-selection-capable transport (main.go special-cases it to admissionPath=SourceSelectionCapable)."
+          "description": "Transport kind from the startup source-selection capability matrix. 'adapter-direct' is the multiplexer mode that wraps an underlying ENH/ENS adapter; semantically equivalent to a source-selection-capable transport."
         },
-        "admission_path_selected": {
-          "type": "string",
-          "enum": [
-            "source_selection",
-            "override",
-            "degraded_transport_blind",
-            "degraded_no_events"
+        "source_selection": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "mode"
           ],
-          "description": "Admission path chosen by the startup-admission flow."
+          "properties": {
+            "mode": {
+              "type": "string",
+              "enum": [
+                "source_selection",
+                "explicit_validate_only",
+                "degraded_transport_blind",
+                "degraded_no_events"
+              ],
+              "description": "Source-selection mode chosen by the startup flow."
+            }
+          }
         }
       }
     },

--- a/docs/transport-gate-evidence/TEMPLATE.yaml
+++ b/docs/transport-gate-evidence/TEMPLATE.yaml
@@ -7,7 +7,9 @@
 
 transport: ens
 adapter_hw_id: "<e.g., ENH28A1>"
-admission_path_selected: join
+admission:
+  source_selection:
+    mode: source_selection
 warmup_events_observed: 0
 degraded_escalations: 0
 passive_event_count_5min: 0

--- a/graphql/bus_observability.go
+++ b/graphql/bus_observability.go
@@ -1007,46 +1007,6 @@ func buildBusObservabilityTypes() (*graphqlgo.Object, *graphqlgo.Object, *graphq
 					return admission.SourceSelection, nil
 				},
 			},
-			"state": &graphqlgo.Field{
-				Type: graphqlgo.NewNonNull(graphqlgo.String),
-				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
-					admission, ok := busAdmissionFromSource(params.Source)
-					if !ok {
-						return "", nil
-					}
-					return admission.State, nil
-				},
-			},
-			"source": &graphqlgo.Field{
-				Type: graphqlgo.NewNonNull(graphqlgo.Int),
-				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
-					admission, ok := busAdmissionFromSource(params.Source)
-					if !ok {
-						return 0, nil
-					}
-					return int(admission.Source), nil
-				},
-			},
-			"companionTarget": &graphqlgo.Field{
-				Type: graphqlgo.NewNonNull(graphqlgo.Int),
-				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
-					admission, ok := busAdmissionFromSource(params.Source)
-					if !ok {
-						return 0, nil
-					}
-					return int(admission.CompanionTarget), nil
-				},
-			},
-			"reason": &graphqlgo.Field{
-				Type: graphqlgo.String,
-				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
-					admission, ok := busAdmissionFromSource(params.Source)
-					if !ok || admission.Reason == "" {
-						return nil, nil
-					}
-					return admission.Reason, nil
-				},
-			},
 		},
 	})
 
@@ -1149,20 +1109,6 @@ func buildBusObservabilityTypes() (*graphqlgo.Object, *graphqlgo.Object, *graphq
 						return BusObservabilityDegraded{}, nil
 					}
 					return value.Degraded, nil
-				},
-			},
-			"busAdmission": &graphqlgo.Field{
-				Type: busAdmissionType,
-				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
-					status, ok := params.Source.(*BusObservabilityStatus)
-					if ok && status != nil {
-						return status.BusAdmission, nil
-					}
-					value, ok := params.Source.(BusObservabilityStatus)
-					if !ok {
-						return nil, nil
-					}
-					return value.BusAdmission, nil
 				},
 			},
 			"bus_admission": &graphqlgo.Field{

--- a/graphql/queries_test.go
+++ b/graphql/queries_test.go
@@ -585,12 +585,6 @@ func TestQueryResolvers_Integration(t *testing.T) {
 								active
 								reasons
 							}
-							busAdmission {
-								state
-								source
-								companionTarget
-								reason
-							}
 							bus_admission {
 								source_selection {
 									state
@@ -718,12 +712,6 @@ func TestQueryResolvers_Integration(t *testing.T) {
 						Reasons []string `json:"reasons"`
 					} `json:"degraded"`
 					BusAdmission struct {
-						State           string `json:"state"`
-						Source          int    `json:"source"`
-						CompanionTarget int    `json:"companionTarget"`
-						Reason          string `json:"reason"`
-					} `json:"busAdmission"`
-					BusAdmissionSnake struct {
 						SourceSelection struct {
 							State           string `json:"state"`
 							Outcome         string `json:"outcome"`
@@ -823,13 +811,7 @@ func TestQueryResolvers_Integration(t *testing.T) {
 		if !response.BusSummary.Status.Degraded.Active || len(response.BusSummary.Status.Degraded.Reasons) != 2 {
 			t.Fatalf("degraded = %+v; want active with 2 reasons", response.BusSummary.Status.Degraded)
 		}
-		if response.BusSummary.Status.BusAdmission.State != "active" ||
-			response.BusSummary.Status.BusAdmission.Source != 0x7F ||
-			response.BusSummary.Status.BusAdmission.CompanionTarget != 0x08 ||
-			response.BusSummary.Status.BusAdmission.Reason != "active_probe_passed" {
-			t.Fatalf("busAdmission = %+v; want legacy active admission mirror", response.BusSummary.Status.BusAdmission)
-		}
-		sourceSelection := response.BusSummary.Status.BusAdmissionSnake.SourceSelection
+		sourceSelection := response.BusSummary.Status.BusAdmission.SourceSelection
 		if sourceSelection.State != "active" ||
 			sourceSelection.Outcome != "active_probe_passed" ||
 			sourceSelection.Reason != "active_probe_passed" ||

--- a/internal/adaptermux/e2e_test.go
+++ b/internal/adaptermux/e2e_test.go
@@ -50,8 +50,15 @@ func TestE2E_ScanB504_ToTarget0x08_SuccessFullFlow(t *testing.T) {
 	// this test — we only care about byte plumbing, not CRC validity).
 	request := []byte{0x71, 0x08, 0x07, 0x04, 0x00, 0x00 /*CRC placeholder*/}
 
+	// Write request bytes (simulates what protocol.Bus does during
+	// sendRawWithEcho).
+	if _, err := at.Write(request); err != nil {
+		t.Fatalf("at.Write err=%v", err)
+	}
+
 	// Async upstream fake: echo every write, then send a canned responder
-	// response + SYN terminator.
+	// response + SYN terminator. Start after Write so the synthetic bus traffic
+	// preserves request-before-echo ordering.
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
@@ -77,19 +84,19 @@ func TestE2E_ScanB504_ToTarget0x08_SuccessFullFlow(t *testing.T) {
 		}
 	}()
 
-	// Write request bytes (simulates what protocol.Bus does during
-	// sendRawWithEcho).
-	if _, err := at.Write(request); err != nil {
-		t.Fatalf("at.Write err=%v", err)
-	}
-
 	// Read back every byte we expect to appear on activeCh in order:
 	//   echoed request (len(request) bytes)
 	//   + response (10 bytes including final SYN)
 	// The final SYN is the critical one — if it never arrives within
 	// the 2s budget, the hypothesis is confirmed.
 	totalExpected := len(request) + 10
+	var gotMu sync.Mutex
 	got := make([]byte, 0, totalExpected)
+	snapshotGot := func() []byte {
+		gotMu.Lock()
+		defer gotMu.Unlock()
+		return append([]byte(nil), got...)
+	}
 	deadline := time.Now().Add(2 * time.Second)
 
 	readDone := make(chan error, 1)
@@ -100,27 +107,31 @@ func TestE2E_ScanB504_ToTarget0x08_SuccessFullFlow(t *testing.T) {
 				readDone <- err
 				return
 			}
+			gotMu.Lock()
 			got = append(got, b)
+			gotMu.Unlock()
 		}
 		readDone <- nil
 	}()
 
 	select {
 	case err := <-readDone:
+		gotSnapshot := snapshotGot()
 		if err != nil {
-			t.Logf("ReadByte error after %d bytes consumed: %v", len(got), err)
-			t.Logf("bytes consumed so far: % X", got)
+			t.Logf("ReadByte error after %d bytes consumed: %v", len(gotSnapshot), err)
+			t.Logf("bytes consumed so far: % X", gotSnapshot)
 			dumpSynDiag(t, mux)
 			wg.Wait()
 			t.Fatalf("E2E read error after %d bytes: %v — final SYN echo may have been "+
 				"consumed by SYN-before-read branch (bytesRead>0 path) before "+
 				"activePathExpectsBytes() was re-evaluated. See SYN ring dump above. "+
 				"C4 (PR #502): this path used to t.Skip; any deviation from the green "+
-				"path is a regression and must fail CI.", len(got), err)
+				"path is a regression and must fail CI.", len(gotSnapshot), err)
 		}
 	case <-time.After(time.Until(deadline)):
-		t.Logf("E2E timeout after %d/%d bytes consumed", len(got), totalExpected)
-		t.Logf("bytes consumed: % X", got)
+		gotSnapshot := snapshotGot()
+		t.Logf("E2E timeout after %d/%d bytes consumed", len(gotSnapshot), totalExpected)
+		t.Logf("bytes consumed: % X", gotSnapshot)
 		dumpSynDiag(t, mux)
 		// Do NOT wg.Wait() here — the reader goroutine is still blocked
 		// on ReadByte; cleanup cancels ctx which releases it after the
@@ -129,7 +140,7 @@ func TestE2E_ScanB504_ToTarget0x08_SuccessFullFlow(t *testing.T) {
 		t.Fatalf("E2E timeout after %d/%d bytes — final SYN echo may be consumed "+
 			"by onSYNLocked before active-path delivery. See SYN ring dump above "+
 			"for gwActiveBefore/After transitions and synDeliveredToActive flags.",
-			len(got), totalExpected)
+			len(gotSnapshot), totalExpected)
 	}
 
 	wg.Wait()

--- a/joinbus.go
+++ b/joinbus.go
@@ -4,8 +4,8 @@ package ebusgateway
 //
 // This file implements the SourceAddressSelectionBus interface from
 // ebusgo/protocol, wired over the PassiveTransactionReconstructor's
-// subscription channel. It is the source-of-truth bridge for startup-admission
-// warmup on source-selection-capable direct transports (ENH, ENS, UDP-plain, TCP-plain).
+// subscription channel. It is the source-of-truth bridge for startup
+// source-selection warmup on direct transports (ENH, ENS, UDP-plain, TCP-plain).
 // ebusd-tcp does NOT instantiate this adapter per AD13.
 
 import (
@@ -19,8 +19,8 @@ import (
 
 var ErrSourceSelectionBusInquiryUnsupported = errors.New("source address selection: inquiry not supported (InquiryEnabled=false)")
 
-// TransportAdmissionPath is the admission-path dispatch decision for a given
-// transport kind per the startup-admission-discovery plan's transport
+// TransportAdmissionPath is the source-selection dispatch decision for a given
+// transport kind per the startup source-selection plan's transport
 // capability matrix (see plan AD11 and
 // helianthus-docs-ebus/architecture/startup-admission-and-discovery.md §10).
 type TransportAdmissionPath uint8
@@ -28,12 +28,12 @@ type TransportAdmissionPath uint8
 const (
 	// TransportAdmissionSourceSelectionCapable denotes a direct transport on which the
 	// gateway runs the source-address selector warmup before any
-	// non-override active frame. Applies to ENH, ENS, UDP-plain, TCP-plain.
+	// non-explicit active frame. Applies to ENH, ENS, UDP-plain, TCP-plain.
 	TransportAdmissionSourceSelectionCapable TransportAdmissionPath = iota + 1
 
 	// TransportAdmissionStaticFallback denotes the ebusd-tcp path, where the
 	// gateway does NOT instantiate source-address selection and uses the configured
-	// ScanSource as admission-fallback per AD13.
+	// ScanSource on the ebusd-owned transport path per AD13.
 	TransportAdmissionStaticFallback
 )
 
@@ -52,7 +52,7 @@ func NewSourceSelectionBusAdapter(reconstructor *PassiveTransactionReconstructor
 		return nil, fmt.Errorf("source address selection: reconstructor is nil")
 	}
 	if name == "" {
-		name = "startup_admission_source_selection_bus"
+		name = "startup_source_selection_bus"
 	}
 	return &sourceSelectionBusAdapter{
 		reconstructor:  reconstructor,

--- a/mcp/bus.go
+++ b/mcp/bus.go
@@ -42,10 +42,36 @@ type BusObservabilityStartup struct {
 }
 
 type BusAdmission struct {
-	State           string `json:"state"`
-	Source          uint8  `json:"source"`
-	CompanionTarget uint8  `json:"companion_target"`
-	Reason          string `json:"reason,omitempty"`
+	SourceSelection *BusAdmissionSourceSelection `json:"source_selection,omitempty"`
+}
+
+type BusAdmissionSourceSelection struct {
+	State                   string                          `json:"state"`
+	Mode                    string                          `json:"mode,omitempty"`
+	Outcome                 string                          `json:"outcome,omitempty"`
+	Reason                  string                          `json:"reason,omitempty"`
+	SelectedSource          *uint8                          `json:"selected_source,omitempty"`
+	FailedSource            *uint8                          `json:"failed_source,omitempty"`
+	CompanionTarget         *uint8                          `json:"companion_target,omitempty"`
+	ActiveProbe             *BusAdmissionActiveProbe        `json:"active_probe,omitempty"`
+	Retryable               bool                            `json:"retryable"`
+	NextAction              string                          `json:"next_action,omitempty"`
+	LastSuccessfulSource    *uint8                          `json:"last_successful_source,omitempty"`
+	AutomaticRetryScheduled bool                            `json:"automatic_retry_scheduled"`
+	RejectedCandidates      []BusAdmissionRejectedCandidate `json:"rejected_candidates,omitempty"`
+}
+
+type BusAdmissionActiveProbe struct {
+	Target *uint8 `json:"target,omitempty"`
+	Opcode string `json:"opcode,omitempty"`
+	Status string `json:"status,omitempty"`
+}
+
+type BusAdmissionRejectedCandidate struct {
+	Source             uint8  `json:"source"`
+	Reason             string `json:"reason,omitempty"`
+	OccupancyState     string `json:"occupancy_state,omitempty"`
+	EvidenceProvenance string `json:"evidence_provenance,omitempty"`
 }
 
 type BusObservabilityStatus struct {
@@ -290,7 +316,36 @@ func cloneBusAdmission(source *BusAdmission) *BusAdmission {
 		return nil
 	}
 	out := *source
+	out.SourceSelection = cloneBusAdmissionSourceSelection(source.SourceSelection)
 	return &out
+}
+
+func cloneBusAdmissionSourceSelection(source *BusAdmissionSourceSelection) *BusAdmissionSourceSelection {
+	if source == nil {
+		return nil
+	}
+	out := *source
+	out.SelectedSource = cloneUint8Ptr(source.SelectedSource)
+	out.FailedSource = cloneUint8Ptr(source.FailedSource)
+	out.CompanionTarget = cloneUint8Ptr(source.CompanionTarget)
+	out.LastSuccessfulSource = cloneUint8Ptr(source.LastSuccessfulSource)
+	if source.ActiveProbe != nil {
+		activeProbe := *source.ActiveProbe
+		activeProbe.Target = cloneUint8Ptr(source.ActiveProbe.Target)
+		out.ActiveProbe = &activeProbe
+	}
+	if len(source.RejectedCandidates) > 0 {
+		out.RejectedCandidates = append([]BusAdmissionRejectedCandidate(nil), source.RejectedCandidates...)
+	}
+	return &out
+}
+
+func cloneUint8Ptr(source *uint8) *uint8 {
+	if source == nil {
+		return nil
+	}
+	value := *source
+	return &value
 }
 
 func cloneBusMessages(source []BusMessage) []BusMessage {

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -773,6 +773,9 @@ func TestServer_ToolsCallBusObservability(t *testing.T) {
 	}
 
 	base := time.Date(2026, time.March, 12, 12, 0, 0, 0, time.UTC)
+	selectedSource := uint8(0x7F)
+	companionTarget := uint8(0x08)
+	lastSuccessfulSource := uint8(0x7E)
 	server.SetBusObservabilityProvider(&testBusObservabilityProvider{
 		snapshot: BusObservabilitySnapshot{
 			Summary: &BusSummary{
@@ -805,6 +808,23 @@ func TestServer_ToolsCallBusObservability(t *testing.T) {
 					Degraded: BusObservabilityDegraded{
 						Active:  true,
 						Reasons: []string{"dedup_degraded"},
+					},
+					BusAdmission: &BusAdmission{
+						SourceSelection: &BusAdmissionSourceSelection{
+							State:                   "active",
+							Mode:                    "default_policy",
+							Outcome:                 "active_probe_passed",
+							Reason:                  "active_probe_passed",
+							SelectedSource:          &selectedSource,
+							CompanionTarget:         &companionTarget,
+							ActiveProbe:             &BusAdmissionActiveProbe{Target: &companionTarget, Opcode: "B509", Status: "active_probe_passed"},
+							Retryable:               false,
+							LastSuccessfulSource:    &lastSuccessfulSource,
+							AutomaticRetryScheduled: false,
+							RejectedCandidates: []BusAdmissionRejectedCandidate{
+								{Source: 0xF7, Reason: "occupied", OccupancyState: "occupied", EvidenceProvenance: "passive"},
+							},
+						},
 					},
 					FeatureFlags: ObserveFirstFeatureFlagState{
 						ObserveFirstEnabled:      true,
@@ -884,6 +904,67 @@ func TestServer_ToolsCallBusObservability(t *testing.T) {
 	}
 	if normalizations, _ := featureFlags["normalizations"].([]any); len(normalizations) != 2 {
 		t.Fatalf("bus summary feature_flags.normalizations = %#v; want 2 entries", featureFlags["normalizations"])
+	}
+	busAdmission, ok := status["bus_admission"].(map[string]any)
+	if !ok {
+		t.Fatalf("bus summary bus_admission type = %T; want map", status["bus_admission"])
+	}
+	for _, legacyKey := range []string{"state", "source", "companion_target", "reason"} {
+		if _, ok := busAdmission[legacyKey]; ok {
+			t.Fatalf("bus summary bus_admission contains legacy flat key %q: %#v", legacyKey, busAdmission)
+		}
+	}
+	sourceSelection, ok := busAdmission["source_selection"].(map[string]any)
+	if !ok {
+		t.Fatalf("bus summary bus_admission.source_selection type = %T; want map", busAdmission["source_selection"])
+	}
+	if got, _ := sourceSelection["state"].(string); got != "active" {
+		t.Fatalf("bus summary source_selection.state = %q; want active", got)
+	}
+	if got, _ := sourceSelection["mode"].(string); got != "default_policy" {
+		t.Fatalf("bus summary source_selection.mode = %q; want default_policy", got)
+	}
+	if got, _ := sourceSelection["outcome"].(string); got != "active_probe_passed" {
+		t.Fatalf("bus summary source_selection.outcome = %q; want active_probe_passed", got)
+	}
+	if got, _ := sourceSelection["selected_source"].(float64); int(got) != int(selectedSource) {
+		t.Fatalf("bus summary source_selection.selected_source = %v; want %d", sourceSelection["selected_source"], selectedSource)
+	}
+	if got, _ := sourceSelection["companion_target"].(float64); int(got) != int(companionTarget) {
+		t.Fatalf("bus summary source_selection.companion_target = %v; want %d", sourceSelection["companion_target"], companionTarget)
+	}
+	activeProbe, ok := sourceSelection["active_probe"].(map[string]any)
+	if !ok {
+		t.Fatalf("bus summary source_selection.active_probe type = %T; want map", sourceSelection["active_probe"])
+	}
+	if got, _ := activeProbe["target"].(float64); int(got) != int(companionTarget) {
+		t.Fatalf("bus summary source_selection.active_probe.target = %v; want %d", activeProbe["target"], companionTarget)
+	}
+	if got, _ := activeProbe["opcode"].(string); got != "B509" {
+		t.Fatalf("bus summary source_selection.active_probe.opcode = %q; want B509", got)
+	}
+	if got, _ := activeProbe["status"].(string); got != "active_probe_passed" {
+		t.Fatalf("bus summary source_selection.active_probe.status = %q; want active_probe_passed", got)
+	}
+	if got, _ := sourceSelection["retryable"].(bool); got {
+		t.Fatalf("bus summary source_selection.retryable = %v; want false", got)
+	}
+	if got, _ := sourceSelection["automatic_retry_scheduled"].(bool); got {
+		t.Fatalf("bus summary source_selection.automatic_retry_scheduled = %v; want false", got)
+	}
+	if got, _ := sourceSelection["last_successful_source"].(float64); int(got) != int(lastSuccessfulSource) {
+		t.Fatalf("bus summary source_selection.last_successful_source = %v; want %d", sourceSelection["last_successful_source"], lastSuccessfulSource)
+	}
+	rejectedCandidates, ok := sourceSelection["rejected_candidates"].([]any)
+	if !ok || len(rejectedCandidates) != 1 {
+		t.Fatalf("bus summary source_selection.rejected_candidates = %#v; want one item", sourceSelection["rejected_candidates"])
+	}
+	rejectedCandidate, ok := rejectedCandidates[0].(map[string]any)
+	if !ok {
+		t.Fatalf("bus summary source_selection.rejected_candidates[0] type = %T; want map", rejectedCandidates[0])
+	}
+	if got, _ := rejectedCandidate["source"].(float64); int(got) != 0xF7 {
+		t.Fatalf("bus summary source_selection.rejected_candidates[0].source = %v; want 247", rejectedCandidate["source"])
 	}
 	if got, _ := summaryData["last_updated_at"].(string); got != base.Format(time.RFC3339Nano) {
 		t.Fatalf("bus summary last_updated_at = %q; want %s", got, base.Format(time.RFC3339Nano))

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -9,6 +9,7 @@ if git grep -nIwiE 'm[a]ster|s[l]ave'; then
   echo "Found legacy terminology."
   exit 1
 fi
+python3 scripts/source_selection_m4_gate.py
 
 echo "==> gofmt"
 unformatted="$(git ls-files '*.go' | xargs -n 50 gofmt -l || true)"
@@ -34,12 +35,14 @@ go build ./...
 echo "==> go test (race)"
 go test -race -count=1 ./...
 
-echo "==> validating admission-artifact schema coverage"
-go test ./... -run "TestAdmissionArtifact_EmitValidatesAgainstSchema" -count=1
+echo "==> validating source-selection artifact schema coverage"
+go test ./... -run "TestSourceSelectionArtifact_EmitValidatesAgainstSchema" -count=1
 
 echo "==> python script tests"
 python3 scripts/passive_canary_verifier_test.py
+python3 scripts/source_selection_m4_gate_test.py
 python3 scripts/transport_gate_test.py
+python3 scripts/passive_smoke_gate_test.py
 
 if command -v golangci-lint >/dev/null 2>&1; then
   echo "==> golangci-lint"

--- a/scripts/passive_smoke_gate.sh
+++ b/scripts/passive_smoke_gate.sh
@@ -33,7 +33,6 @@ requires_passive_smoke_gate() {
     broadcast_listener.go|\
     bus_observability_store.go|\
     config.go|\
-    cmd/gateway/main.go|\
     cmd/gateway/startup_scan*.go|\
     gateway.go|\
     passive_*.go|\
@@ -46,9 +45,111 @@ requires_passive_smoke_gate() {
   return 1
 }
 
+cmd_gateway_main_requires_passive_smoke_gate() {
+  python3 - "$base_ref" <<'PY'
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+base_ref = sys.argv[1]
+diffs: list[str] = []
+for args in (
+    ["git", "diff", "--unified=0", f"{base_ref}...HEAD", "--", "cmd/gateway/main.go"],
+    ["git", "diff", "--cached", "--unified=0", "--", "cmd/gateway/main.go"],
+    ["git", "diff", "--unified=0", "--", "cmd/gateway/main.go"],
+):
+    result = subprocess.run(args, text=True, capture_output=True, check=False)
+    if result.returncode == 0 and result.stdout:
+        diffs.append(result.stdout)
+
+replacements = (
+    ("startup admission", "startup source selection"),
+    ("startup-admission", "startup-source-selection"),
+    ("admission_path_selected", "source_selection.mode"),
+    ("StartupAdmission", "StartupSourceSelection"),
+    ("AdmissionArtifact", "SourceSelectionArtifact"),
+    ("admission-artifact", "source-selection-artifact"),
+    ("SetAdmissionPathSelected", "SetSourceSelectionMode"),
+    ("NewAdmissionArtifactBuilder", "NewSourceSelectionArtifactBuilder"),
+    ("GetOrInitStartupAdmissionMetrics", "GetOrInitStartupSourceSelectionMetrics"),
+    ("FormatStartupAdmissionOverrideLog", "FormatStartupSourceSelectionExplicitLog"),
+    ("FormatStartupSourceSelectionOverrideLog", "FormatStartupSourceSelectionExplicitLog"),
+    ("CheckOverrideCompanionConflict", "CheckExplicitSourceCompanionConflict"),
+    ("SetOverrideActive", "SetExplicitSourceActive"),
+    ("RecordOverrideBypass", "RecordExplicitValidateOnly"),
+    ("SetOverrideSource", "SetExplicitSource"),
+    ("SetActiveOverride", "SetActiveExplicitSource"),
+    ("startup_admission_source_selection_bus", "startup_source_selection_bus"),
+    ("startup_admission_", "startup_source_selection_"),
+    ("override path", "explicit source path"),
+    ("override source", "explicit source"),
+    ("override Initiator", "explicit source"),
+    ("override", "explicit_validate_only"),
+    ("AD23", "SAS M4"),
+    ("; legacy static-source path active", ""),
+    ("JoinCapable", "source-selection"),
+    ("→", "->"),
+)
+
+def normalize(line: str) -> str | None:
+    stripped = line.strip()
+    if not stripped or stripped in {"}", ")"} or stripped.startswith("//"):
+        return None
+    for old, new in replacements:
+        stripped = stripped.replace(old, new)
+    return re.sub(r"\s+", " ", stripped)
+
+def normalize_text(text: str) -> list[str]:
+    lines: list[str] = []
+    for line in text.splitlines():
+        normalized = normalize(line)
+        if normalized is not None:
+            lines.append(normalized)
+    return lines
+
+if not diffs:
+    raise SystemExit(0)
+
+base_result = subprocess.run(
+    ["git", "show", f"{base_ref}:cmd/gateway/main.go"],
+    text=True,
+    capture_output=True,
+    check=False,
+)
+if base_result.returncode != 0:
+    print("passive smoke gate: cannot read base cmd/gateway/main.go", file=sys.stderr)
+    raise SystemExit(1)
+
+current_text = Path("cmd/gateway/main.go").read_text(encoding="utf-8")
+removed = normalize_text(base_result.stdout)
+added = normalize_text(current_text)
+
+if removed != added:
+    print("passive smoke gate: cmd/gateway/main.go contains non-rename runtime diff", file=sys.stderr)
+    print(f"passive smoke gate: removed={removed}", file=sys.stderr)
+    print(f"passive smoke gate: added={added}", file=sys.stderr)
+    raise SystemExit(1)
+
+raise SystemExit(0)
+PY
+}
+
 requires_gate=0
 while IFS= read -r file; do
   [[ -z "${file}" ]] && continue
+  if [[ "${file}" == "scripts/passive_smoke_gate.sh" ]]; then
+    continue
+  fi
+  if [[ "${file}" == "cmd/gateway/main.go" ]]; then
+    if cmd_gateway_main_requires_passive_smoke_gate; then
+      continue
+    fi
+    requires_gate=1
+    break
+  fi
   if requires_passive_smoke_gate "${file}"; then
     requires_gate=1
     break

--- a/scripts/passive_smoke_gate_test.py
+++ b/scripts/passive_smoke_gate_test.py
@@ -10,17 +10,17 @@ import unittest
 
 SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent
-TRANSPORT_GATE_SCRIPT = REPO_ROOT / "scripts" / "transport_gate.sh"
+PASSIVE_SMOKE_GATE_SCRIPT = REPO_ROOT / "scripts" / "passive_smoke_gate.sh"
 
 
-class TransportGateTests(unittest.TestCase):
+class PassiveSmokeGateTests(unittest.TestCase):
     def _script_env(self, **extra: str) -> dict[str, str]:
         env = dict(os.environ)
         for key in (
-            "TRANSPORT_GATE_OWNER_OVERRIDE",
-            "TRANSPORT_GATE_OWNER_REASON",
-            "TRANSPORT_MATRIX_REPORT",
+            "PASSIVE_SMOKE_GATE_OWNER_OVERRIDE",
+            "PASSIVE_SMOKE_GATE_OWNER_REASON",
             "PASSIVE_SMOKE_REPORT",
+            "TRANSPORT_MATRIX_REPORT",
         ):
             env.pop(key, None)
         env.update(extra)
@@ -47,120 +47,127 @@ class TransportGateTests(unittest.TestCase):
         )
 
         (repo_path / "scripts").mkdir(parents=True, exist_ok=True)
-        shutil.copy2(TRANSPORT_GATE_SCRIPT, repo_path / "scripts" / "transport_gate.sh")
+        shutil.copy2(PASSIVE_SMOKE_GATE_SCRIPT, repo_path / "scripts" / "passive_smoke_gate.sh")
 
         tracked_file = repo_path / changed_file
         tracked_file.parent.mkdir(parents=True, exist_ok=True)
         tracked_file.write_text(base_text, encoding="utf-8")
 
         subprocess.run(["git", "add", "."], cwd=repo_path, check=True, capture_output=True, text=True)
-        subprocess.run(
-            ["git", "commit", "-m", "base"],
-            cwd=repo_path,
-            check=True,
-            capture_output=True,
-            text=True,
-        )
+        subprocess.run(["git", "commit", "-m", "base"], cwd=repo_path, check=True, capture_output=True, text=True)
 
         tracked_file.write_text(modified_text, encoding="utf-8")
 
-        report_path = repo_path / "report.json"
+        report_path = repo_path / "passive.json"
         report_path.write_text(
-            json.dumps({"cases": [{"case_id": f"T{i:02d}", "outcome": "pass"} for i in range(1, 89)]}),
+            json.dumps(
+                {
+                    "suite": "passive",
+                    "cases": [
+                        {"case_id": "P01", "passive_mode": "unsupported_or_misconfigured", "outcome": "pass"},
+                        {"case_id": "P02", "passive_mode": "unsupported_or_misconfigured", "outcome": "pass"},
+                        {"case_id": "P03", "passive_mode": "required", "outcome": "pass"},
+                        {"case_id": "P04", "passive_mode": "required", "outcome": "pass"},
+                        {"case_id": "P05", "passive_mode": "required", "outcome": "pass"},
+                        {"case_id": "P06", "passive_mode": "unsupported_or_misconfigured", "outcome": "pass"},
+                    ],
+                }
+            ),
             encoding="utf-8",
         )
         return repo_path, report_path
 
-    def test_transport_gate_triggers_for_cmd_gateway_main(self) -> None:
+    def test_passive_smoke_gate_triggers_for_real_main_diff(self) -> None:
         repo_path, report_path = self._create_temp_repo(
             "cmd/gateway/main.go",
-            base_text="package main\n\nfunc main() {\n\ttransportProtocol := \"ens\"\n\t_ = transportProtocol\n}\n",
-            modified_text="package main\n\nfunc main() {\n\ttransportProtocol := \"udp-plain\"\n\t_ = transportProtocol\n}\n",
+            base_text="package main\n\nfunc main() {\n\tpassiveMode := \"required\"\n\t_ = passiveMode\n}\n",
+            modified_text="package main\n\nfunc main() {\n\tpassiveMode := \"unsupported_or_misconfigured\"\n\t_ = passiveMode\n}\n",
         )
         result = subprocess.run(
-            ["bash", "scripts/transport_gate.sh"],
+            ["bash", "scripts/passive_smoke_gate.sh"],
             cwd=repo_path,
-            env=self._script_env(
-                TRANSPORT_GATE_BASE_REF="HEAD",
-                TRANSPORT_MATRIX_REPORT=str(report_path),
-            ),
+            env=self._script_env(PASSIVE_SMOKE_GATE_BASE_REF="HEAD", PASSIVE_SMOKE_REPORT=str(report_path)),
             text=True,
             capture_output=True,
             check=False,
         )
         self.assertEqual(result.returncode, 0, msg=result.stderr)
-        self.assertIn("transport gate: PASS", result.stdout)
+        self.assertIn("passive smoke gate: PASS", result.stdout)
 
-    def test_transport_gate_fails_for_cmd_gateway_main_without_report(self) -> None:
+    def test_passive_smoke_gate_fails_without_report(self) -> None:
         repo_path, _ = self._create_temp_repo(
             "cmd/gateway/main.go",
-            base_text="package main\n\nfunc main() {\n\ttransportProtocol := \"ens\"\n\t_ = transportProtocol\n}\n",
-            modified_text="package main\n\nfunc main() {\n\ttransportProtocol := \"udp-plain\"\n\t_ = transportProtocol\n}\n",
+            base_text="package main\n\nfunc main() {\n\tpassiveMode := \"required\"\n\t_ = passiveMode\n}\n",
+            modified_text="package main\n\nfunc main() {\n\tpassiveMode := \"unsupported_or_misconfigured\"\n\t_ = passiveMode\n}\n",
         )
         result = subprocess.run(
-            ["bash", "scripts/transport_gate.sh"],
+            ["bash", "scripts/passive_smoke_gate.sh"],
             cwd=repo_path,
-            env=self._script_env(TRANSPORT_GATE_BASE_REF="HEAD"),
+            env=self._script_env(PASSIVE_SMOKE_GATE_BASE_REF="HEAD"),
             text=True,
             capture_output=True,
             check=False,
         )
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("TRANSPORT_MATRIX_REPORT is required", result.stdout)
+        self.assertIn("PASSIVE_SMOKE_REPORT is required", result.stdout)
 
-    def test_transport_gate_fails_for_runtime_control_flow_main_diff(self) -> None:
+    def test_passive_smoke_gate_fails_for_runtime_control_flow_main_diff(self) -> None:
         repo_path, _ = self._create_temp_repo(
             "cmd/gateway/main.go",
             base_text=(
                 "package main\n\nfunc main() {\n"
-                "\toverrideSet := admissionPath == TransportAdmissionSourceSelectionCapable && cfg.StartupSource.Source != nil\n"
-                "\t_ = overrideSet\n}\n"
+                "\trunAdvisorySourceSelector := admissionPath == TransportAdmissionSourceSelectionCapable && shouldStartPassiveObserveFirst(cfg)\n"
+                "\t_ = runAdvisorySourceSelector\n}\n"
             ),
-            modified_text="package main\n\nfunc main() {\n\toverrideSet := false\n\t_ = overrideSet\n}\n",
+            modified_text=(
+                "package main\n\nfunc main() {\n"
+                "\trunAdvisorySourceSelector := false\n"
+                "\t_ = runAdvisorySourceSelector\n}\n"
+            ),
         )
         result = subprocess.run(
-            ["bash", "scripts/transport_gate.sh"],
+            ["bash", "scripts/passive_smoke_gate.sh"],
             cwd=repo_path,
-            env=self._script_env(TRANSPORT_GATE_BASE_REF="HEAD"),
+            env=self._script_env(PASSIVE_SMOKE_GATE_BASE_REF="HEAD"),
             text=True,
             capture_output=True,
             check=False,
         )
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("TRANSPORT_MATRIX_REPORT is required", result.stdout)
+        self.assertIn("PASSIVE_SMOKE_REPORT is required", result.stdout)
 
-    def test_transport_gate_fails_for_runtime_call_reorder_main_diff(self) -> None:
+    def test_passive_smoke_gate_fails_for_runtime_call_reorder_main_diff(self) -> None:
         repo_path, _ = self._create_temp_repo(
             "cmd/gateway/main.go",
             base_text=(
                 "package main\n\nfunc main() {\n"
-                "\tstartHTTPServer()\n"
+                "\tstartPassiveTransactionReconstructor()\n"
                 "\trunBackgroundFullScan()\n"
                 "}\n\n"
-                "func startHTTPServer() {}\n"
+                "func startPassiveTransactionReconstructor() {}\n"
                 "func runBackgroundFullScan() {}\n"
             ),
             modified_text=(
                 "package main\n\nfunc main() {\n"
                 "\trunBackgroundFullScan()\n"
-                "\tstartHTTPServer()\n"
+                "\tstartPassiveTransactionReconstructor()\n"
                 "}\n\n"
-                "func startHTTPServer() {}\n"
+                "func startPassiveTransactionReconstructor() {}\n"
                 "func runBackgroundFullScan() {}\n"
             ),
         )
         result = subprocess.run(
-            ["bash", "scripts/transport_gate.sh"],
+            ["bash", "scripts/passive_smoke_gate.sh"],
             cwd=repo_path,
-            env=self._script_env(TRANSPORT_GATE_BASE_REF="HEAD"),
+            env=self._script_env(PASSIVE_SMOKE_GATE_BASE_REF="HEAD"),
             text=True,
             capture_output=True,
             check=False,
         )
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("TRANSPORT_MATRIX_REPORT is required", result.stdout)
+        self.assertIn("PASSIVE_SMOKE_REPORT is required", result.stdout)
 
-    def test_transport_gate_skips_sas05_public_api_main_diff(self) -> None:
+    def test_passive_smoke_gate_skips_sas05_public_api_main_diff(self) -> None:
         repo_path, _ = self._create_temp_repo(
             "cmd/gateway/main.go",
             base_text=(
@@ -179,41 +186,15 @@ class TransportGateTests(unittest.TestCase):
             ),
         )
         result = subprocess.run(
-            ["bash", "scripts/transport_gate.sh"],
+            ["bash", "scripts/passive_smoke_gate.sh"],
             cwd=repo_path,
-            env=self._script_env(TRANSPORT_GATE_BASE_REF="HEAD"),
+            env=self._script_env(PASSIVE_SMOKE_GATE_BASE_REF="HEAD"),
             text=True,
             capture_output=True,
             check=False,
         )
         self.assertEqual(result.returncode, 0, msg=result.stderr)
-        self.assertIn("transport gate: not triggered.", result.stdout)
-
-    def test_transport_gate_skips_non_transport_gateway_observability_file(self) -> None:
-        repo_path, _ = self._create_temp_repo("cmd/gateway/bus_observability_provider.go")
-        result = subprocess.run(
-            ["bash", "scripts/transport_gate.sh"],
-            cwd=repo_path,
-            env=self._script_env(TRANSPORT_GATE_BASE_REF="HEAD"),
-            text=True,
-            capture_output=True,
-            check=False,
-        )
-        self.assertEqual(result.returncode, 0, msg=result.stderr)
-        self.assertIn("transport gate: not triggered.", result.stdout)
-
-    def test_transport_gate_skips_test_only_adaptermux_change(self) -> None:
-        repo_path, _ = self._create_temp_repo("internal/adaptermux/e2e_test.go")
-        result = subprocess.run(
-            ["bash", "scripts/transport_gate.sh"],
-            cwd=repo_path,
-            env=self._script_env(TRANSPORT_GATE_BASE_REF="HEAD"),
-            text=True,
-            capture_output=True,
-            check=False,
-        )
-        self.assertEqual(result.returncode, 0, msg=result.stderr)
-        self.assertIn("transport gate: not triggered.", result.stdout)
+        self.assertIn("passive smoke gate: not triggered.", result.stdout)
 
 
 if __name__ == "__main__":

--- a/scripts/source_selection_m4_gate.py
+++ b/scripts/source_selection_m4_gate.py
@@ -210,12 +210,50 @@ def is_allowed_dot_join(line: str) -> bool:
     )
 
 
-def go_string_literals(line: str) -> list[str]:
-    literals: list[str] = []
-    for match in re.finditer(r'"((?:\\.|[^"\\])*)"', line):
-        literals.append(match.group(1))
-    for match in re.finditer(r"`([^`]*)`", line):
-        literals.append(match.group(1))
+def go_string_literals(text: str) -> list[tuple[int, str]]:
+    literals: list[tuple[int, str]] = []
+    i = 0
+    line = 1
+    while i < len(text):
+        ch = text[i]
+        if ch == "\n":
+            line += 1
+            i += 1
+            continue
+        if ch == "`":
+            start_line = line
+            i += 1
+            start = i
+            while i < len(text) and text[i] != "`":
+                if text[i] == "\n":
+                    line += 1
+                i += 1
+            literals.append((start_line, text[start:i]))
+            if i < len(text):
+                i += 1
+            continue
+        if ch == '"':
+            start_line = line
+            i += 1
+            chars: list[str] = []
+            while i < len(text):
+                if text[i] == "\\" and i + 1 < len(text):
+                    chars.append(text[i])
+                    chars.append(text[i + 1])
+                    i += 2
+                    continue
+                if text[i] == '"':
+                    break
+                if text[i] == "\n":
+                    line += 1
+                    break
+                chars.append(text[i])
+                i += 1
+            literals.append((start_line, "".join(chars)))
+            if i < len(text) and text[i] == '"':
+                i += 1
+            continue
+        i += 1
     return literals
 
 
@@ -251,16 +289,16 @@ def main() -> int:
                             f"{rel}:{lineno}: legacy {pattern.scope} term {pattern.name}: {line.strip()}"
                         )
 
-            if rel.suffix == ".go":
-                literal_text = "\n".join(go_string_literals(line))
+        if rel.suffix == ".go":
+            for literal_lineno, literal_text in go_string_literals(text):
                 for pattern in GO_STRING_PUBLIC_PATTERNS + PUBLIC_SURFACE_PATTERNS:
                     if pattern.regex.search(literal_text):
                         rationale = retained_rationale(rel, pattern)
                         if rationale is not None:
-                            retained.append(f"{rel}:{lineno}: retained {pattern.name}: {rationale}")
+                            retained.append(f"{rel}:{literal_lineno}: retained {pattern.name}: {rationale}")
                             continue
                         failures.append(
-                            f"{rel}:{lineno}: legacy {pattern.scope} term {pattern.name}: {line.strip()}"
+                            f"{rel}:{literal_lineno}: legacy {pattern.scope} term {pattern.name}: {literal_text.strip()}"
                         )
 
     if failures:

--- a/scripts/source_selection_m4_gate.py
+++ b/scripts/source_selection_m4_gate.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Reject legacy source-selection API names after SAS M4.
+
+The gate is intentionally split by surface:
+
+* active code rejects old selector API symbols and legacy join-era vocabulary;
+* public text/schema/script surfaces reject old admission/status field names;
+* Go code string literals are scanned for removed public GraphQL/MCP aliases.
+
+Some old CLI/config spellings are intentionally retained by the locked plan as
+compatibility inputs with new semantics. Those are listed in RETAINED_PUBLIC
+with the owning rationale instead of being silently skipped.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import pathlib
+import re
+import subprocess
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+PUBLIC_SUFFIXES = {
+    ".graphql",
+    ".json",
+    ".md",
+    ".sh",
+    ".yaml",
+    ".yml",
+}
+
+SELF_TEST_ALLOWLIST = {
+    pathlib.Path("source_selection_m4_test.go"),
+    pathlib.Path("scripts/source_selection_m4_gate.py"),
+    pathlib.Path("scripts/transport_gate.sh"),
+    pathlib.Path("scripts/passive_smoke_gate.sh"),
+    pathlib.Path("docs/transport-gate-evidence/2026-04-25-adapter-direct-enh.yaml"),
+}
+
+HISTORICAL_ALLOWLIST_PREFIXES = (
+    pathlib.Path("docs/transport-gate-evidence"),
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class LegacyPattern:
+    name: str
+    regex: re.Pattern[str]
+    scope: str
+
+
+def rx(pattern: str) -> re.Pattern[str]:
+    return re.compile(pattern)
+
+
+def literal(text: str) -> re.Pattern[str]:
+    return re.compile(re.escape(text))
+
+
+ACTIVE_CODE_PATTERNS = [
+    LegacyPattern("Joiner", rx(r"\bJoiner\b"), "active code"),
+    LegacyPattern("JoinBus", rx(r"\bJoinBus\b"), "active code"),
+    LegacyPattern("JoinConfig", rx(r"\bJoinConfig\b"), "active code"),
+    LegacyPattern("JoinResult", rx(r"\bJoinResult\b"), "active code"),
+    LegacyPattern("JoinMetrics", rx(r"\bJoinMetrics\b"), "active code"),
+    LegacyPattern("JoinStateStore", rx(r"\bJoinStateStore\b"), "active code"),
+    LegacyPattern("NewJoiner", rx(r"\bNewJoiner\b"), "active code"),
+    LegacyPattern("joiner", rx(r"\bjoiner\b"), "active code"),
+    LegacyPattern("joinbus", rx(r"\bjoinbus\b"), "active code"),
+    LegacyPattern("gentlejoin", literal("gentle" + "join"), "active code"),
+    LegacyPattern("gentle-join", literal("gentle" + "-join"), "active code"),
+    LegacyPattern("join-capable", literal("join" + "-capable"), "active code"),
+    LegacyPattern("join_result", literal("join" + "_result"), "active code"),
+    LegacyPattern("joiner_selection", literal("joiner" + "_selection"), "active code"),
+    LegacyPattern("admission_path_selected", literal("admission" + "_path_selected"), "active code"),
+    LegacyPattern(
+        "startup_admission_consecutive_rejoin_failures",
+        literal("startup" + "_admission_consecutive_rejoin_failures"),
+        "active code",
+    ),
+]
+
+PUBLIC_SURFACE_PATTERNS = [
+    LegacyPattern("admission_path_selected", literal("admission" + "_path_selected"), "public surface"),
+    LegacyPattern("startup_admission_degraded_total", literal("startup" + "_admission_degraded_total"), "public surface"),
+    LegacyPattern("startup_admission_state", literal("startup" + "_admission_state"), "public surface"),
+    LegacyPattern(
+        "startup_admission_override_active",
+        literal("startup" + "_admission_override_active"),
+        "public surface",
+    ),
+    LegacyPattern(
+        "startup_admission_warmup_events_seen",
+        literal("startup" + "_admission_warmup_events_seen"),
+        "public surface",
+    ),
+    LegacyPattern(
+        "startup_admission_warmup_cycles_total",
+        literal("startup" + "_admission_warmup_cycles_total"),
+        "public surface",
+    ),
+    LegacyPattern(
+        "startup_admission_override_bypass_total",
+        literal("startup" + "_admission_override_bypass_total"),
+        "public surface",
+    ),
+    LegacyPattern(
+        "startup_admission_override_conflict_detected",
+        literal("startup" + "_admission_override_conflict_detected"),
+        "public surface",
+    ),
+    LegacyPattern(
+        "startup_admission_degraded_escalated",
+        literal("startup" + "_admission_degraded_escalated"),
+        "public surface",
+    ),
+    LegacyPattern(
+        "startup_admission_degraded_since_ms",
+        literal("startup" + "_admission_degraded_since_ms"),
+        "public surface",
+    ),
+    LegacyPattern(
+        "startup_admission_degraded_cumulative_ms",
+        literal("startup" + "_admission_degraded_cumulative_ms"),
+        "public surface",
+    ),
+    LegacyPattern("busAdmission", literal("bus" + "Admission"), "public surface"),
+    LegacyPattern("companionTarget", literal("companion" + "Target"), "public surface"),
+    LegacyPattern("sourceSelection", literal("source" + "Selection"), "public surface"),
+    LegacyPattern("explicitValidateOnly", literal("explicit" + "ValidateOnly"), "public surface"),
+    LegacyPattern("gentlejoin", literal("gentle" + "join"), "public surface"),
+    LegacyPattern("gentle-join", literal("gentle" + "-join"), "public surface"),
+    LegacyPattern("join-capable", literal("join" + "-capable"), "public surface"),
+    LegacyPattern("join_result", literal("join" + "_result"), "public surface"),
+    LegacyPattern("joiner_selection", literal("joiner" + "_selection"), "public surface"),
+    LegacyPattern("source-addr", rx(r"(?<!-)\bsource" + r"-addr\b"), "public surface"),
+    LegacyPattern("-source-addr", literal("-source" + "-addr"), "public surface"),
+    LegacyPattern("source_addr", rx(r"\bsource" + r"_addr\b"), "public surface"),
+    LegacyPattern("source_addr_state_file", literal("source" + "_addr_state_file"), "public surface"),
+]
+
+GO_STRING_PUBLIC_PATTERNS = [
+    LegacyPattern("busAdmission", literal("bus" + "Admission"), "Go public string"),
+    LegacyPattern("companionTarget", literal("companion" + "Target"), "Go public string"),
+    LegacyPattern("sourceSelection", literal("source" + "Selection"), "Go public string"),
+    LegacyPattern("explicitValidateOnly", literal("explicit" + "ValidateOnly"), "Go public string"),
+    LegacyPattern("admission_path_selected", literal("admission" + "_path_selected"), "Go public string"),
+]
+
+RETAINED_PUBLIC = {
+    pathlib.Path("cmd/gateway/main.go"): {
+        "source-addr": "locked plan keeps CLI -source-addr as explicit source config input; it no longer bypasses selection",
+        "-source-addr": "locked plan keeps CLI -source-addr as explicit source config input; it no longer bypasses selection",
+    },
+    pathlib.Path("cmd/gateway/main_test.go"): {
+        "source-addr": "CLI compatibility tests document retained explicit source config input",
+        "-source-addr": "CLI compatibility tests document retained explicit source config input",
+    },
+    pathlib.Path("scripts/passive_matrix_case_ha.sh"): {
+        "source-addr": "HA matrix script passes auto so current gateway selects/validates the source",
+        "-source-addr": "HA matrix script passes auto so current gateway selects/validates the source",
+    },
+}
+
+
+def retained_rationale(path: pathlib.Path, pattern: LegacyPattern) -> str | None:
+    return RETAINED_PUBLIC.get(path, {}).get(pattern.name)
+
+
+def tracked_files() -> list[pathlib.Path]:
+    out = subprocess.check_output(["git", "ls-files", "--others", "--exclude-standard", "--cached"], cwd=REPO_ROOT, text=True)
+    return [pathlib.Path(line) for line in out.splitlines() if line]
+
+
+def is_historical(path: pathlib.Path) -> bool:
+    return any(path.parts[: len(prefix.parts)] == prefix.parts for prefix in HISTORICAL_ALLOWLIST_PREFIXES)
+
+
+def should_scan_public(path: pathlib.Path) -> bool:
+    if path in SELF_TEST_ALLOWLIST:
+        return False
+    if is_historical(path) and path.name != "TEMPLATE.yaml":
+        return False
+    if path.suffix in PUBLIC_SUFFIXES:
+        return True
+    return False
+
+
+def should_scan_active_code(path: pathlib.Path) -> bool:
+    if path in SELF_TEST_ALLOWLIST:
+        return False
+    if is_historical(path):
+        return False
+    if path.suffix in {".go", ".py", ".sh", ".graphql", ".json", ".md", ".yaml", ".yml"}:
+        return True
+    return False
+
+
+def is_allowed_dot_join(line: str) -> bool:
+    return any(
+        allowed in line
+        for allowed in (
+            "filepath.Join(",
+            "strings.Join(",
+            "path.Join(",
+            "errors.Join(",
+        )
+    )
+
+
+def go_string_literals(line: str) -> list[str]:
+    literals: list[str] = []
+    for match in re.finditer(r'"((?:\\.|[^"\\])*)"', line):
+        literals.append(match.group(1))
+    for match in re.finditer(r"`([^`]*)`", line):
+        literals.append(match.group(1))
+    return literals
+
+
+def main() -> int:
+    failures: list[str] = []
+    retained: list[str] = []
+    for rel in tracked_files():
+        if not (should_scan_active_code(rel) or should_scan_public(rel)):
+            continue
+        text = (REPO_ROOT / rel).read_text(encoding="utf-8", errors="ignore")
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if should_scan_active_code(rel):
+                if ".Join(" in line and not is_allowed_dot_join(line):
+                    failures.append(f"{rel}:{lineno}: legacy selector call .Join(...): {line.strip()}")
+                for pattern in ACTIVE_CODE_PATTERNS:
+                    if pattern.regex.search(line):
+                        rationale = retained_rationale(rel, pattern)
+                        if rationale is not None:
+                            retained.append(f"{rel}:{lineno}: retained {pattern.name}: {rationale}")
+                            continue
+                        failures.append(
+                            f"{rel}:{lineno}: legacy {pattern.scope} term {pattern.name}: {line.strip()}"
+                        )
+
+            if should_scan_public(rel):
+                for pattern in PUBLIC_SURFACE_PATTERNS:
+                    if pattern.regex.search(line):
+                        rationale = retained_rationale(rel, pattern)
+                        if rationale is not None:
+                            retained.append(f"{rel}:{lineno}: retained {pattern.name}: {rationale}")
+                            continue
+                        failures.append(
+                            f"{rel}:{lineno}: legacy {pattern.scope} term {pattern.name}: {line.strip()}"
+                        )
+
+            if rel.suffix == ".go":
+                literal_text = "\n".join(go_string_literals(line))
+                for pattern in GO_STRING_PUBLIC_PATTERNS + PUBLIC_SURFACE_PATTERNS:
+                    if pattern.regex.search(literal_text):
+                        rationale = retained_rationale(rel, pattern)
+                        if rationale is not None:
+                            retained.append(f"{rel}:{lineno}: retained {pattern.name}: {rationale}")
+                            continue
+                        failures.append(
+                            f"{rel}:{lineno}: legacy {pattern.scope} term {pattern.name}: {line.strip()}"
+                        )
+
+    if failures:
+        print("\n".join(failures), file=sys.stderr)
+        return 1
+    if retained:
+        print("Source-selection M4 retained legacy spellings:")
+        for item in retained:
+            print(f"  - {item}")
+    print("Source-selection M4 public API gate passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/source_selection_m4_gate_test.py
+++ b/scripts/source_selection_m4_gate_test.py
@@ -73,6 +73,20 @@ class SourceSelectionM4GateTests(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn(legacy, result.stderr)
 
+    def test_blocks_legacy_go_multiline_raw_string_literal(self) -> None:
+        legacy_alias = "bus" + "Admission"
+        text = (
+            "package main\n\n"
+            "var _ = `query {\n"
+            "  busSummary { status {\n"
+            f"    {legacy_alias} {{ state }}\n"
+            "  } }\n"
+            "}`\n"
+        )
+        result = self._run_gate(self._create_temp_repo("x.go", text))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(legacy_alias, result.stderr)
+
     def test_blocks_unjustified_source_addr_flag_spelling(self) -> None:
         legacy = "source" + "-addr"
         result = self._run_gate(self._create_temp_repo("docs/status.md", f"Old flag: {legacy}\n"))

--- a/scripts/source_selection_m4_gate_test.py
+++ b/scripts/source_selection_m4_gate_test.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+GATE_SCRIPT = REPO_ROOT / "scripts" / "source_selection_m4_gate.py"
+
+
+class SourceSelectionM4GateTests(unittest.TestCase):
+    def _create_temp_repo(self, filename: str, text: str) -> pathlib.Path:
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        repo_path = pathlib.Path(temp_dir.name)
+
+        subprocess.run(["git", "init", "-b", "main"], cwd=repo_path, check=True, capture_output=True, text=True)
+        subprocess.run(["git", "config", "user.name", "Codex"], cwd=repo_path, check=True, capture_output=True, text=True)
+        subprocess.run(
+            ["git", "config", "user.email", "codex@example.com"],
+            cwd=repo_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        scripts_dir = repo_path / "scripts"
+        scripts_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(GATE_SCRIPT, scripts_dir / "source_selection_m4_gate.py")
+
+        target = repo_path / filename
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text, encoding="utf-8")
+
+        subprocess.run(["git", "add", "."], cwd=repo_path, check=True, capture_output=True, text=True)
+        subprocess.run(["git", "commit", "-m", "base"], cwd=repo_path, check=True, capture_output=True, text=True)
+        return repo_path
+
+    def _run_gate(self, repo_path: pathlib.Path) -> subprocess.CompletedProcess[str]:
+        env = dict(os.environ)
+        env.pop("PYTHONPATH", None)
+        return subprocess.run(
+            ["python3", "scripts/source_selection_m4_gate.py"],
+            cwd=repo_path,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_allows_retained_status_mirror_aliases(self) -> None:
+        text = (
+            "# retained status mirrors\n"
+            "GraphQL still exposes daemonStatus.initiatorAddress and daemon_status.initiator_address.\n"
+        )
+        result = self._run_gate(self._create_temp_repo("docs/status.md", text))
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+    def test_blocks_legacy_admission_public_surface(self) -> None:
+        legacy = "admission" + "_path_selected"
+        result = self._run_gate(self._create_temp_repo("docs/status.md", f"Old field: {legacy}\n"))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(legacy, result.stderr)
+
+    def test_blocks_legacy_go_string_literal(self) -> None:
+        legacy = "startup" + "_admission_state"
+        text = f'package main\n\nvar _ = "{legacy}"\n'
+        result = self._run_gate(self._create_temp_repo("x.go", text))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(legacy, result.stderr)
+
+    def test_blocks_unjustified_source_addr_flag_spelling(self) -> None:
+        legacy = "source" + "-addr"
+        result = self._run_gate(self._create_temp_repo("docs/status.md", f"Old flag: {legacy}\n"))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(legacy, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/transport_gate.sh
+++ b/scripts/transport_gate.sh
@@ -30,9 +30,13 @@ requires_gate=0
 requires_transport_gate() {
   local file="$1"
   case "${file}" in
+    *_test.go)
+      return 1
+      ;;
+  esac
+  case "${file}" in
     config.go|\
     gateway.go|\
-    cmd/gateway/main.go|\
     cmd/gateway/startup_scan*.go|\
     cmd/matrix-runner/*|\
     internal/matrix/*|\
@@ -47,11 +51,110 @@ requires_transport_gate() {
   return 1
 }
 
+cmd_gateway_main_requires_transport_gate() {
+  python3 - "$base_ref" <<'PY'
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+base_ref = sys.argv[1]
+diffs: list[str] = []
+for args in (
+    ["git", "diff", "--unified=0", f"{base_ref}...HEAD", "--", "cmd/gateway/main.go"],
+    ["git", "diff", "--cached", "--unified=0", "--", "cmd/gateway/main.go"],
+    ["git", "diff", "--unified=0", "--", "cmd/gateway/main.go"],
+):
+    result = subprocess.run(args, text=True, capture_output=True, check=False)
+    if result.returncode == 0 and result.stdout:
+        diffs.append(result.stdout)
+
+replacements = (
+    ("startup admission", "startup source selection"),
+    ("startup-admission", "startup-source-selection"),
+    ("admission_path_selected", "source_selection.mode"),
+    ("StartupAdmission", "StartupSourceSelection"),
+    ("AdmissionArtifact", "SourceSelectionArtifact"),
+    ("admission-artifact", "source-selection-artifact"),
+    ("SetAdmissionPathSelected", "SetSourceSelectionMode"),
+    ("NewAdmissionArtifactBuilder", "NewSourceSelectionArtifactBuilder"),
+    ("GetOrInitStartupAdmissionMetrics", "GetOrInitStartupSourceSelectionMetrics"),
+    ("FormatStartupAdmissionOverrideLog", "FormatStartupSourceSelectionExplicitLog"),
+    ("FormatStartupSourceSelectionOverrideLog", "FormatStartupSourceSelectionExplicitLog"),
+    ("CheckOverrideCompanionConflict", "CheckExplicitSourceCompanionConflict"),
+    ("SetOverrideActive", "SetExplicitSourceActive"),
+    ("RecordOverrideBypass", "RecordExplicitValidateOnly"),
+    ("SetOverrideSource", "SetExplicitSource"),
+    ("SetActiveOverride", "SetActiveExplicitSource"),
+    ("startup_admission_source_selection_bus", "startup_source_selection_bus"),
+    ("startup_admission_", "startup_source_selection_"),
+    ("override path", "explicit source path"),
+    ("override source", "explicit source"),
+    ("override Initiator", "explicit source"),
+    ("override", "explicit_validate_only"),
+    ("AD23", "SAS M4"),
+    ("; legacy static-source path active", ""),
+    ("JoinCapable", "source-selection"),
+    ("→", "->"),
+)
+
+def normalize(line: str) -> str | None:
+    stripped = line.strip()
+    if not stripped or stripped in {"}", ")"} or stripped.startswith("//"):
+        return None
+    for old, new in replacements:
+        stripped = stripped.replace(old, new)
+    return re.sub(r"\s+", " ", stripped)
+
+def normalize_text(text: str) -> list[str]:
+    lines: list[str] = []
+    for line in text.splitlines():
+        normalized = normalize(line)
+        if normalized is not None:
+            lines.append(normalized)
+    return lines
+
+if not diffs:
+    raise SystemExit(0)
+
+base_result = subprocess.run(
+    ["git", "show", f"{base_ref}:cmd/gateway/main.go"],
+    text=True,
+    capture_output=True,
+    check=False,
+)
+if base_result.returncode != 0:
+    print("transport gate: cannot read base cmd/gateway/main.go", file=sys.stderr)
+    raise SystemExit(1)
+
+current_text = Path("cmd/gateway/main.go").read_text(encoding="utf-8")
+removed = normalize_text(base_result.stdout)
+added = normalize_text(current_text)
+
+if removed != added:
+    print("transport gate: cmd/gateway/main.go contains non-rename runtime diff", file=sys.stderr)
+    print(f"transport gate: removed={removed}", file=sys.stderr)
+    print(f"transport gate: added={added}", file=sys.stderr)
+    raise SystemExit(1)
+
+raise SystemExit(0)
+PY
+}
+
 while IFS= read -r file; do
   [[ -z "${file}" ]] && continue
   # The transport gate is for transport/protocol and matrix topology execution
   # surfaces. Public observability/API changes under cmd/gateway must not demand
   # an unrelated 88-case transport report.
+  if [[ "${file}" == "cmd/gateway/main.go" ]]; then
+    if cmd_gateway_main_requires_transport_gate; then
+      continue
+    fi
+    requires_gate=1
+    break
+  fi
   if requires_transport_gate "${file}"; then
     requires_gate=1
     break

--- a/source_selection_m4_test.go
+++ b/source_selection_m4_test.go
@@ -1,0 +1,64 @@
+package ebusgateway
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestSourceSelectionM4RejectsLegacyAdmissionFields(t *testing.T) {
+	legacy := []byte(`{"admission":{"state":"active","source":113,"companion_target":118,"warmup_duration_s":5,"reason_if_degraded":"","transport_kind":"enh","admission_path_selected":"join"},"discovery":{"wire_bytes":128,"window_s":15,"startup_burst_pct":10,"post_startup_sustained_rate_probes_per_15s":1,"probe_count":1,"promoted_suspects_without_identity":0,"per_baseline_address_evidence_counts":{"08":1}}}`)
+	if err := sourceSelectionArtifactSchemaError(legacy); err == nil {
+		t.Fatal("legacy admission_path_selected artifact unexpectedly passed")
+	}
+	explicit := []byte(`{"admission":{"state":"active","source":113,"companion_target":118,"warmup_duration_s":5,"reason_if_degraded":"","transport_kind":"enh","source_selection":{"mode":"explicit_validate_only"}},"discovery":{"wire_bytes":128,"window_s":15,"startup_burst_pct":10,"post_startup_sustained_rate_probes_per_15s":1,"probe_count":1,"promoted_suspects_without_identity":0,"per_baseline_address_evidence_counts":{"08":1}}}`)
+	if err := sourceSelectionArtifactSchemaError(explicit); err != nil {
+		t.Fatalf("explicit_validate_only artifact failed: %v", err)
+	}
+	var decoded SourceSelectionArtifact
+	if err := json.Unmarshal(explicit, &decoded); err != nil {
+		t.Fatalf("decode explicit artifact: %v", err)
+	}
+	if decoded.Admission.SourceSelection.Mode != "explicit_validate_only" {
+		t.Fatalf("mode=%q", decoded.Admission.SourceSelection.Mode)
+	}
+}
+
+func TestStartupSourceSelectionExpvarSnapshot(t *testing.T) {
+	names := StartupSourceSelectionExpvarNames()
+	joined := "\n" + strings.Join(names, "\n") + "\n"
+	for _, old := range []string{
+		"startup_admission_degraded_total",
+		"startup_admission_state",
+		"startup_admission_override_active",
+		"startup_admission_warmup_events_seen",
+		"startup_admission_warmup_cycles_total",
+		"startup_admission_override_bypass_total",
+		"startup_admission_override_conflict_detected",
+		"startup_admission_degraded_escalated",
+		"startup_admission_degraded_since_ms",
+		"startup_admission_consecutive_rejoin_failures",
+		"startup_admission_degraded_cumulative_ms",
+	} {
+		if strings.Contains(joined, "\n"+old+"\n") {
+			t.Fatalf("legacy expvar %q still present in snapshot", old)
+		}
+	}
+	for _, want := range []string{
+		"startup_source_selection_degraded_total",
+		"startup_source_selection_state",
+		"startup_source_selection_explicit_source_active",
+		"startup_source_selection_warmup_events_seen",
+		"startup_source_selection_warmup_cycles_total",
+		"startup_source_selection_explicit_validate_only_total",
+		"startup_source_selection_explicit_source_conflict_detected",
+		"startup_source_selection_degraded_escalated",
+		"startup_source_selection_degraded_since_ms",
+		"startup_source_selection_consecutive_failures",
+		"startup_source_selection_degraded_cumulative_ms",
+	} {
+		if !strings.Contains(joined, "\n"+want+"\n") {
+			t.Fatalf("expected expvar %q missing from snapshot", want)
+		}
+	}
+}

--- a/startup_admission_harness_test.go
+++ b/startup_admission_harness_test.go
@@ -27,10 +27,10 @@ func synthesizedTransactionEvent(src, dst byte, hasResponse bool) PassiveClassif
 	return event
 }
 
-func validateAdmissionArtifactAgainstSchema(t *testing.T, artifactJSON []byte) {
+func validateSourceSelectionArtifactAgainstSchema(t *testing.T, artifactJSON []byte) {
 	t.Helper()
-	if err := admissionArtifactSchemaError(artifactJSON); err != nil {
-		t.Fatalf("artifact does not validate against admission schema: %v", err)
+	if err := sourceSelectionArtifactSchemaError(artifactJSON); err != nil {
+		t.Fatalf("artifact does not validate against source-selection schema: %v", err)
 	}
 }
 
@@ -43,9 +43,9 @@ func TestM2aHarness_SourceSelectionSuccessPath(t *testing.T) {
 		t.Fatal("expected synthesized passive traffic to forward at least one frame")
 	}
 
-	builder := NewAdmissionArtifactBuilder("ens")
+	builder := NewSourceSelectionArtifactBuilder("ens")
 	builder.startedAt = time.Now().Add(-60 * time.Second)
-	if err := builder.SetAdmissionPathSelected("source_selection"); err != nil {
+	if err := builder.SetSourceSelectionMode("source_selection"); err != nil {
 		t.Fatal(err)
 	}
 	builder.SetSourceSelection(0x71, 0x08, 5*time.Second)
@@ -56,9 +56,9 @@ func TestM2aHarness_SourceSelectionSuccessPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	validateAdmissionArtifactAgainstSchema(t, data)
-	if artifact.Admission.AdmissionPathSelected != "source_selection" {
-		t.Fatalf("admission_path_selected=%q", artifact.Admission.AdmissionPathSelected)
+	validateSourceSelectionArtifactAgainstSchema(t, data)
+	if artifact.Admission.SourceSelection.Mode != "source_selection" {
+		t.Fatalf("source_selection.mode=%q", artifact.Admission.SourceSelection.Mode)
 	}
 	if artifact.Admission.State != "active" {
 		t.Fatalf("state=%q", artifact.Admission.State)
@@ -73,41 +73,41 @@ func TestM2aHarness_TransportBlindPath(t *testing.T) {
 	t.Skip("partial coverage in M2 warmup integration test; full end-to-end pending M7 when MarkDegraded is wired into the M3 startup flow")
 }
 
-func TestM2aHarness_OverrideValidateFalsePath(t *testing.T) {
-	m := NewStartupAdmissionMetrics()
-	m.SetOverrideActive(true)
-	m.RecordOverrideBypass()
-	if got := FormatStartupAdmissionOverrideLog(0xF0); got != "startup admission override source=0xF0 confidence=low" {
-		t.Fatalf("unexpected override log line %q", got)
+func TestM2aHarness_ExplicitValidateFalsePath(t *testing.T) {
+	m := NewStartupSourceSelectionMetrics()
+	m.SetExplicitSourceActive(true)
+	m.RecordExplicitValidateOnly()
+	if got := FormatStartupSourceSelectionExplicitLog(0xF0); got != "startup source selection explicit_validate_only source=0xF0 confidence=low" {
+		t.Fatalf("unexpected explicit-source log line %q", got)
 	}
-	if m.OverrideActive.Value() != 1 {
-		t.Fatalf("expected override_active=1, got %d", m.OverrideActive.Value())
+	if m.ExplicitSourceActive.Value() != 1 {
+		t.Fatalf("expected explicit_source_active=1, got %d", m.ExplicitSourceActive.Value())
 	}
-	if m.OverrideBypassTotal.Value() != 1 {
-		t.Fatalf("expected override_bypass_total=1, got %d", m.OverrideBypassTotal.Value())
+	if m.ExplicitValidateOnlyTotal.Value() != 1 {
+		t.Fatalf("expected explicit_validate_only_total=1, got %d", m.ExplicitValidateOnlyTotal.Value())
 	}
-	if m.OverrideConflictDetected.Value() != 0 {
-		t.Fatalf("expected no advisory source-address selector conflict when validate=false, got %d", m.OverrideConflictDetected.Value())
+	if m.ExplicitSourceConflictDetected.Value() != 0 {
+		t.Fatalf("expected no advisory source-address selector conflict when validate=false, got %d", m.ExplicitSourceConflictDetected.Value())
 	}
 }
 
-func TestM2aHarness_OverrideValidateTruePath(t *testing.T) {
+func TestM2aHarness_ExplicitValidateTruePath(t *testing.T) {
 	t.Run("advisory source-address selector agrees", func(t *testing.T) {
-		m := NewStartupAdmissionMetrics()
-		if CheckOverrideCompanionConflict(0xF0, &protocol.SourceAddressSelection{Source: 0xF0}, m) {
+		m := NewStartupSourceSelectionMetrics()
+		if CheckExplicitSourceCompanionConflict(0xF0, &protocol.SourceAddressSelection{Source: 0xF0}, m) {
 			t.Fatal("expected no conflict when advisory selector agrees")
 		}
-		if m.OverrideConflictDetected.Value() != 0 {
-			t.Fatalf("expected override_conflict_detected=0, got %d", m.OverrideConflictDetected.Value())
+		if m.ExplicitSourceConflictDetected.Value() != 0 {
+			t.Fatalf("expected explicit_source_conflict_detected=0, got %d", m.ExplicitSourceConflictDetected.Value())
 		}
 	})
 	t.Run("advisory source-address selector disagrees", func(t *testing.T) {
-		m := NewStartupAdmissionMetrics()
-		if !CheckOverrideCompanionConflict(0xF0, &protocol.SourceAddressSelection{Source: 0xF1}, m) {
+		m := NewStartupSourceSelectionMetrics()
+		if !CheckExplicitSourceCompanionConflict(0xF0, &protocol.SourceAddressSelection{Source: 0xF1}, m) {
 			t.Fatal("expected conflict when advisory selector disagrees")
 		}
-		if m.OverrideConflictDetected.Value() != 1 {
-			t.Fatalf("expected override_conflict_detected=1, got %d", m.OverrideConflictDetected.Value())
+		if m.ExplicitSourceConflictDetected.Value() != 1 {
+			t.Fatalf("expected explicit_source_conflict_detected=1, got %d", m.ExplicitSourceConflictDetected.Value())
 		}
 	})
 }
@@ -135,27 +135,27 @@ func TestM2aHarness_EvidenceBufferFloodBaselineProtection(t *testing.T) {
 	}
 }
 
-func TestM2aHarness_AdmissionArtifactEmissionValidatesAgainstSchema(t *testing.T) {
+func TestM2aHarness_SourceSelectionArtifactEmissionValidatesAgainstSchema(t *testing.T) {
 	t.Run("valid artifact passes", func(t *testing.T) {
-		valid := []byte(`{"admission":{"state":"joined","source":113,"companion_target":8,"warmup_duration_s":5,"reason_if_degraded":"","transport_kind":"enh","admission_path_selected":"source_selection"},"discovery":{"wire_bytes":2048,"window_s":15,"startup_burst_pct":62.5,"post_startup_sustained_rate_probes_per_15s":1.5,"probe_count":12,"promoted_suspects_without_identity":1,"per_baseline_address_evidence_counts":{"08":3,"15":1}}}`)
-		validateAdmissionArtifactAgainstSchema(t, valid)
+		valid := []byte(`{"admission":{"state":"joined","source":113,"companion_target":8,"warmup_duration_s":5,"reason_if_degraded":"","transport_kind":"enh","source_selection":{"mode":"source_selection"}},"discovery":{"wire_bytes":2048,"window_s":15,"startup_burst_pct":62.5,"post_startup_sustained_rate_probes_per_15s":1.5,"probe_count":12,"promoted_suspects_without_identity":1,"per_baseline_address_evidence_counts":{"08":3,"15":1}}}`)
+		validateSourceSelectionArtifactAgainstSchema(t, valid)
 	})
 	t.Run("invalid enum fails", func(t *testing.T) {
-		invalid := []byte(`{"admission":{"state":"joined","source":113,"companion_target":8,"warmup_duration_s":5,"reason_if_degraded":"","transport_kind":"enh","admission_path_selected":"bogus"},"discovery":{"wire_bytes":2048,"window_s":15,"startup_burst_pct":62.5,"post_startup_sustained_rate_probes_per_15s":1.5,"probe_count":12,"promoted_suspects_without_identity":1,"per_baseline_address_evidence_counts":{"08":3}}}`)
-		if err := admissionArtifactSchemaError(invalid); err == nil {
+		invalid := []byte(`{"admission":{"state":"joined","source":113,"companion_target":8,"warmup_duration_s":5,"reason_if_degraded":"","transport_kind":"enh","source_selection":{"mode":"bogus"}},"discovery":{"wire_bytes":2048,"window_s":15,"startup_burst_pct":62.5,"post_startup_sustained_rate_probes_per_15s":1.5,"probe_count":12,"promoted_suspects_without_identity":1,"per_baseline_address_evidence_counts":{"08":3}}}`)
+		if err := sourceSelectionArtifactSchemaError(invalid); err == nil {
 			t.Fatal("expected invalid enum to fail schema validation")
 		}
 	})
 	t.Run("missing required field fails", func(t *testing.T) {
-		invalid := []byte(`{"admission":{"state":"joined","source":113,"warmup_duration_s":5,"reason_if_degraded":"","transport_kind":"enh","admission_path_selected":"source_selection"},"discovery":{"wire_bytes":2048,"window_s":15,"startup_burst_pct":62.5,"post_startup_sustained_rate_probes_per_15s":1.5,"probe_count":12,"promoted_suspects_without_identity":1,"per_baseline_address_evidence_counts":{"08":3}}}`)
-		if err := admissionArtifactSchemaError(invalid); err == nil {
+		invalid := []byte(`{"admission":{"state":"joined","source":113,"warmup_duration_s":5,"reason_if_degraded":"","transport_kind":"enh","source_selection":{"mode":"source_selection"}},"discovery":{"wire_bytes":2048,"window_s":15,"startup_burst_pct":62.5,"post_startup_sustained_rate_probes_per_15s":1.5,"probe_count":12,"promoted_suspects_without_identity":1,"per_baseline_address_evidence_counts":{"08":3}}}`)
+		if err := sourceSelectionArtifactSchemaError(invalid); err == nil {
 			t.Fatal("expected missing required field to fail schema validation")
 		}
 	})
 }
 
-func admissionArtifactSchemaError(artifactJSON []byte) error {
-	schemaPath := filepath.Join("docs", "schemas", "admission-artifact.schema.json")
+func sourceSelectionArtifactSchemaError(artifactJSON []byte) error {
+	schemaPath := filepath.Join("docs", "schemas", "source-selection-artifact.schema.json")
 	schemaJSON, err := os.ReadFile(schemaPath)
 	if err != nil {
 		return fmt.Errorf("read schema: %w", err)
@@ -172,13 +172,15 @@ func admissionArtifactSchemaError(artifactJSON []byte) error {
 	dec.DisallowUnknownFields()
 	var artifact struct {
 		Admission *struct {
-			State                 *string  `json:"state"`
-			Source                *int     `json:"source"`
-			CompanionTarget       *int     `json:"companion_target"`
-			WarmupDurationS       *float64 `json:"warmup_duration_s"`
-			ReasonIfDegraded      *string  `json:"reason_if_degraded"`
-			TransportKind         *string  `json:"transport_kind"`
-			AdmissionPathSelected *string  `json:"admission_path_selected"`
+			State            *string  `json:"state"`
+			Source           *int     `json:"source"`
+			CompanionTarget  *int     `json:"companion_target"`
+			WarmupDurationS  *float64 `json:"warmup_duration_s"`
+			ReasonIfDegraded *string  `json:"reason_if_degraded"`
+			TransportKind    *string  `json:"transport_kind"`
+			SourceSelection  *struct {
+				Mode *string `json:"mode"`
+			} `json:"source_selection"`
 		} `json:"admission"`
 		Discovery *struct {
 			WireBytes                         *int           `json:"wire_bytes"`
@@ -196,7 +198,7 @@ func admissionArtifactSchemaError(artifactJSON []byte) error {
 	if artifact.Admission == nil || artifact.Discovery == nil {
 		return fmt.Errorf("artifact must contain admission and discovery objects")
 	}
-	if artifact.Admission.State == nil || artifact.Admission.Source == nil || artifact.Admission.CompanionTarget == nil || artifact.Admission.WarmupDurationS == nil || artifact.Admission.ReasonIfDegraded == nil || artifact.Admission.TransportKind == nil || artifact.Admission.AdmissionPathSelected == nil {
+	if artifact.Admission.State == nil || artifact.Admission.Source == nil || artifact.Admission.CompanionTarget == nil || artifact.Admission.WarmupDurationS == nil || artifact.Admission.ReasonIfDegraded == nil || artifact.Admission.TransportKind == nil || artifact.Admission.SourceSelection == nil || artifact.Admission.SourceSelection.Mode == nil {
 		return fmt.Errorf("admission missing required fields")
 	}
 	if artifact.Discovery.WireBytes == nil || artifact.Discovery.WindowS == nil || artifact.Discovery.StartupBurstPct == nil || artifact.Discovery.PostStartupSustainedRateProbes15S == nil || artifact.Discovery.ProbeCount == nil || artifact.Discovery.PromotedSuspectsWithoutIdentity == nil || artifact.Discovery.PerBaselineAddressEvidenceCounts == nil {
@@ -205,11 +207,11 @@ func admissionArtifactSchemaError(artifactJSON []byte) error {
 	if *artifact.Admission.Source < 0 || *artifact.Admission.Source > 255 || *artifact.Admission.CompanionTarget < 0 || *artifact.Admission.CompanionTarget > 255 || *artifact.Admission.WarmupDurationS < 0 {
 		return fmt.Errorf("admission numeric bounds violated")
 	}
-	if !containsAdmissionEnum([]string{"enh", "ens", "ebusd-tcp", "udp-plain", "tcp-plain", "adapter-direct"}, *artifact.Admission.TransportKind) {
+	if !containsSourceSelectionEnum([]string{"enh", "ens", "ebusd-tcp", "udp-plain", "tcp-plain", "adapter-direct"}, *artifact.Admission.TransportKind) {
 		return fmt.Errorf("invalid transport_kind %q", *artifact.Admission.TransportKind)
 	}
-	if !containsAdmissionEnum([]string{"source_selection", "override", "degraded_transport_blind", "degraded_no_events"}, *artifact.Admission.AdmissionPathSelected) {
-		return fmt.Errorf("invalid admission_path_selected %q", *artifact.Admission.AdmissionPathSelected)
+	if !containsSourceSelectionEnum([]string{"source_selection", "explicit_validate_only", "degraded_transport_blind", "degraded_no_events"}, *artifact.Admission.SourceSelection.Mode) {
+		return fmt.Errorf("invalid source_selection.mode %q", *artifact.Admission.SourceSelection.Mode)
 	}
 	if *artifact.Discovery.WireBytes < 0 || *artifact.Discovery.WindowS <= 0 || *artifact.Discovery.StartupBurstPct < 0 || *artifact.Discovery.StartupBurstPct > 100 || *artifact.Discovery.PostStartupSustainedRateProbes15S < 0 || *artifact.Discovery.ProbeCount < 0 || *artifact.Discovery.PromotedSuspectsWithoutIdentity < 0 {
 		return fmt.Errorf("discovery numeric bounds violated")
@@ -226,7 +228,7 @@ func admissionArtifactSchemaError(artifactJSON []byte) error {
 	return nil
 }
 
-func containsAdmissionEnum(values []string, want string) bool {
+func containsSourceSelectionEnum(values []string, want string) bool {
 	for _, value := range values {
 		if value == want {
 			return true


### PR DESCRIPTION
## What
Remove the legacy public startup admission/source-selection API from gateway public surfaces and add executable cleanup gates for SAS M4.

## Why
SAS-05 finalizes the breaking M4 cleanup after the HA migration: source-selection admission/status surfaces are snake_case-only, old admission/join enum/field names reject, and retained CLI/source status mirrors are explicitly documented by gates.

## Changes
- Rename startup admission artifact/schema/metrics/log helpers to source-selection terminology.
- Replace artifact `admission_path_selected` with `admission.source_selection.mode` and reject old enum values like `join`/`override`.
- Remove GraphQL `busAdmission` and flat legacy admission fields; keep `bus_admission.source_selection` only.
- Add source-selection M4 terminology/API gate with retained-surface rationale for `source-addr` CLI compatibility and daemon status mirrors.
- Harden transport/passive smoke gates so SAS-05 rename-only `cmd/gateway/main.go` changes do not require unrelated reports, while runtime/control-flow/reorder changes still fail closed.
- Fix adaptermux E2E test synchronization to avoid a race in the scan test.

## Validation
- `./scripts/ci_local.sh`
- Fresh adversarial review loop: M4 API gate, transport/passive gate false-green risk, source-authority/runtime semantics; final verdicts: NO FINDINGS.

Closes #557.
