### PR TITLE
SAS-10: publish source admission after rollout

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -40,6 +40,7 @@ var (
 	startPassiveTransactionReconstructor      = ebusgateway.StartPassiveTransactionReconstructor
 	startBroadcastListenerWithReconstructorFn = ebusgateway.StartBroadcastListenerWithReconstructor
 	startHTTPServerFn                         = startHTTPServer
+	admissionStabilityRefreshDelay            = time.Duration(ebusgateway.StartupAdmissionStateMinStabilitySecondsDefault)*time.Second + 200*time.Millisecond
 	instanceGUIDPattern                       = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
 )
 
@@ -76,6 +77,28 @@ func main() {
 	if err := run(ctx, cfg); err != nil {
 		log.Fatalf("gateway: %v", err)
 	}
+}
+
+func recordBusAdmissionTransitionWithStabilityRefresh(ctx context.Context, store *ebusgateway.BusObservabilityStore, state string, source, companionTarget byte, reason string) {
+	if store == nil {
+		return
+	}
+	if store.RecordBusAdmissionTransition(state, source, companionTarget, reason) {
+		return
+	}
+	if state != "active" && state != "degraded" {
+		return
+	}
+	go func() {
+		timer := time.NewTimer(admissionStabilityRefreshDelay)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			store.RecordBusAdmissionTransition(state, source, companionTarget, reason)
+		}
+	}()
 }
 
 func run(ctx context.Context, cfg ebusgateway.Config) error {
@@ -263,9 +286,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 				log.Fatalf("FATAL: SAS M4 enum violation on source-selection default-policy path: %v", perr)
 			}
 			log.Printf("startup source selection candidate source=0x%02X companion_target=0x%02X provenance=source_selection_default_policy", result.Source, result.Companion)
-			if busObservability != nil {
-				busObservability.RecordBusAdmissionTransition("pending", result.Source, result.Companion, "active_probe_pending")
-			}
+			recordBusAdmissionTransitionWithStabilityRefresh(ctx, busObservability, "pending", result.Source, result.Companion, "active_probe_pending")
 		}
 	}
 	if sourceSelection == nil {
@@ -282,9 +303,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 				log.Fatalf("FATAL: SAS M4 enum violation on configured source validation path: %v", perr)
 			}
 			log.Printf("startup source selection candidate source=0x%02X companion_target=0x%02X provenance=configured_source", result.Source, result.Companion)
-			if busObservability != nil {
-				busObservability.RecordBusAdmissionTransition("pending", result.Source, result.Companion, "active_probe_pending")
-			}
+			recordBusAdmissionTransitionWithStabilityRefresh(ctx, busObservability, "pending", result.Source, result.Companion, "active_probe_pending")
 		}
 	}
 
@@ -338,7 +357,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 			busObservability.SetAdmissionStabilityWindow(
 				ebusgateway.NewAdmissionStabilityWindow(ebusgateway.StartupAdmissionStateMinStabilitySecondsDefault),
 			)
-			busObservability.RecordBusAdmissionTransition("pending", 0, 0, "source_selection_warmup_in_progress")
+			recordBusAdmissionTransitionWithStabilityRefresh(ctx, busObservability, "pending", 0, 0, "source_selection_warmup_in_progress")
 		}
 		// Wire M5 expvar surfaces: state pending -> warmup cycle starts.
 		// Resolves cruise-run #20 validation finding that the 11
@@ -355,9 +374,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 		cancel()
 		if err != nil {
 			log.Printf("startup source selection degraded reason=source_selection_failed err=%v", err)
-			if busObservability != nil {
-				busObservability.RecordBusAdmissionTransition("degraded", 0, 0, "source_selection_failed")
-			}
+			recordBusAdmissionTransitionWithStabilityRefresh(ctx, busObservability, "degraded", 0, 0, "source_selection_failed")
 			metrics.MarkDegraded(time.Now())
 			artifactBuilder.SetDegraded("source_selection_failed")
 			if perr := artifactBuilder.SetSourceSelectionMode("degraded_no_events"); perr != nil {
@@ -378,9 +395,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 					log.Fatalf("FATAL: AD23 enum violation on source-selection path: %v", perr)
 				}
 				log.Printf("startup source selection candidate source=0x%02X companion_target=0x%02X", result.Source, result.Companion)
-				if busObservability != nil {
-					busObservability.RecordBusAdmissionTransition("pending", result.Source, result.Companion, "active_probe_pending")
-				}
+				recordBusAdmissionTransitionWithStabilityRefresh(ctx, busObservability, "pending", result.Source, result.Companion, "active_probe_pending")
 				// Reflect selector-observed event count if exposed by ebusgo.
 				// SourceAddressSelection does not currently surface a count; the
 				// warmup_events_seen stays at the per-cycle reset value
@@ -472,18 +487,14 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 					builder.SetAdmittedMutationSource(sourceSelection.Source)
 					artifactBuilder.SetSourceSelectionActive()
 					metrics.MarkActive()
-					if busObservability != nil {
-						busObservability.RecordBusAdmissionTransition("active", sourceSelection.Source, sourceSelection.Companion, "active_probe_passed")
-					}
+					recordBusAdmissionTransitionWithStabilityRefresh(ctx, busObservability, "active", sourceSelection.Source, sourceSelection.Companion, "active_probe_passed")
 				}
 			case <-startupScanSignals.admissionFailed:
 				if sourceSelection != nil {
 					builder.ClearAdmittedMutationSource()
 					artifactBuilder.SetDegraded("active_probe_failed")
 					metrics.MarkDegraded(time.Now())
-					if busObservability != nil {
-						busObservability.RecordBusAdmissionTransition("degraded", sourceSelection.Source, sourceSelection.Companion, "active_probe_failed")
-					}
+					recordBusAdmissionTransitionWithStabilityRefresh(ctx, busObservability, "degraded", sourceSelection.Source, sourceSelection.Companion, "active_probe_failed")
 				}
 				if shouldCloseSemanticBarrier(admissionPath, overrideSet, sourceSelection != nil) {
 					if semanticBarrier != nil {

--- a/cmd/gateway/main_test.go
+++ b/cmd/gateway/main_test.go
@@ -202,6 +202,42 @@ func TestAdmittedMutationSourceForGateway_UnknownStaticFallbackAutoFailsClosed(t
 	}
 }
 
+func TestRecordBusAdmissionTransitionWithStabilityRefreshPublishesOneShotActive(t *testing.T) {
+	origDelay := admissionStabilityRefreshDelay
+	admissionStabilityRefreshDelay = 1100 * time.Millisecond
+	t.Cleanup(func() {
+		admissionStabilityRefreshDelay = origDelay
+	})
+
+	store := ebusgateway.NewBusObservabilityStore(ebusgateway.DefaultConfig())
+	store.SetAdmissionStabilityWindow(ebusgateway.NewAdmissionStabilityWindow(1))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	recordBusAdmissionTransitionWithStabilityRefresh(ctx, store, "active", 0x7F, 0x84, "active_probe_passed")
+	if admission := store.Snapshot().Summary.Status.BusAdmission; admission != nil {
+		t.Fatalf("BusAdmission before stability refresh = %+v; want nil", admission)
+	}
+
+	deadline := time.After(2 * time.Second)
+	for {
+		admission := store.Snapshot().Summary.Status.BusAdmission
+		if admission != nil {
+			if admission.State != "active" || admission.Source != 0x7F || admission.CompanionTarget != 0x84 || admission.Reason != "active_probe_passed" {
+				t.Fatalf("BusAdmission = %+v; want active 0x7F/0x84 active_probe_passed", admission)
+			}
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("BusAdmission stayed nil after stability refresh")
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+}
+
 func TestWireObserveFirstObserversWiresDedupSnapshotterIntoObservabilityStore(t *testing.T) {
 	cfg := ebusgateway.DefaultConfig()
 	cfg.BroadcastListen = true

--- a/cmd/gateway/startup_scan.go
+++ b/cmd/gateway/startup_scan.go
@@ -463,6 +463,9 @@ func startDiscoveryScanLoopWithClassifier(ctx context.Context, cfg ebusgateway.C
 	}
 
 	startupCfg := resolveStartupScanSourceConfig(cfg)
+	sourceSelectionActiveAdmission := admissionPath == ebusgateway.TransportAdmissionSourceSelectionCapable &&
+		!overrideSet &&
+		startupCfg.StartupCompanionTarget != 0
 	if adapterDirectSpecialCased {
 		log.Printf("startup scan: adapter-direct multiplexer detected; treating as source-selection-capable (underlying transport is always ENH/ENS)")
 	}
@@ -603,8 +606,8 @@ func startDiscoveryScanLoopWithClassifier(ctx context.Context, cfg ebusgateway.C
 						case <-timer.C:
 						}
 						continue
-					} else if shouldStopDiscoveryScan(total, confirmationPending, confirmationSatisfied, false) {
-						if confirmationSatisfied {
+					} else if shouldStopSourceAdmissionScan(sourceSelectionActiveAdmission, false, total, confirmationPending, confirmationSatisfied, false) {
+						if sourceAdmissionProbeSatisfied(sourceSelectionActiveAdmission, false, confirmationSatisfied) {
 							signalActiveProbePassed()
 						} else {
 							signalAdmissionFailed()
@@ -781,8 +784,8 @@ func startDiscoveryScanLoopWithClassifier(ctx context.Context, cfg ebusgateway.C
 				forceFullRangeNextPass = true
 				fullRangeRecoveryAttempted = true
 				restrictedConfirmationAfterRecoveryPending = true
-			} else if shouldStopDiscoveryScan(total, confirmationPending, confirmationSatisfied, confirmationFallbackExhausted) {
-				if confirmationSatisfied {
+			} else if shouldStopSourceAdmissionScan(sourceSelectionActiveAdmission, activeConfirmed, total, confirmationPending, confirmationSatisfied, confirmationFallbackExhausted) {
+				if sourceAdmissionProbeSatisfied(sourceSelectionActiveAdmission, activeConfirmed, confirmationSatisfied) {
 					signalActiveProbePassed()
 				} else {
 					signalAdmissionFailed()
@@ -933,6 +936,20 @@ func shouldStopDiscoveryScan(total int, confirmationPending bool, confirmationSa
 		return false
 	}
 	return true
+}
+
+func sourceAdmissionProbeSatisfied(sourceSelectionActiveAdmission bool, activeConfirmed bool, confirmationSatisfied bool) bool {
+	if confirmationSatisfied {
+		return true
+	}
+	return sourceSelectionActiveAdmission && activeConfirmed
+}
+
+func shouldStopSourceAdmissionScan(sourceSelectionActiveAdmission bool, activeConfirmed bool, total int, confirmationPending bool, confirmationSatisfied bool, confirmationFallbackExhausted bool) bool {
+	if sourceAdmissionProbeSatisfied(sourceSelectionActiveAdmission, activeConfirmed, confirmationSatisfied) {
+		return true
+	}
+	return shouldStopDiscoveryScan(total, confirmationPending, confirmationSatisfied, confirmationFallbackExhausted)
 }
 
 func startupScanConfirmationSatisfied(ctx context.Context, cfg ebusgateway.Config, gateway *ebusgateway.Gateway, total int, activeConfirmation bool) bool {

--- a/cmd/gateway/startup_scan_test.go
+++ b/cmd/gateway/startup_scan_test.go
@@ -51,6 +51,124 @@ func TestShouldStopDiscoveryScan(t *testing.T) {
 	}
 }
 
+func TestSourceAdmissionProbeSatisfied(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                  string
+		sourceSelectionActive bool
+		activeConfirmed       bool
+		confirmationSatisfied bool
+		want                  bool
+	}{
+		{
+			name:                  "semantic confirmation passes",
+			confirmationSatisfied: true,
+			want:                  true,
+		},
+		{
+			name:                  "source selection active probe passes independently of semantic root confirmation",
+			sourceSelectionActive: true,
+			activeConfirmed:       true,
+			want:                  true,
+		},
+		{
+			name:            "non admission scan cannot use active probe alone",
+			activeConfirmed: true,
+			want:            false,
+		},
+		{
+			name:                  "source selection without active evidence fails",
+			sourceSelectionActive: true,
+			want:                  false,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := sourceAdmissionProbeSatisfied(test.sourceSelectionActive, test.activeConfirmed, test.confirmationSatisfied); got != test.want {
+				t.Fatalf("sourceAdmissionProbeSatisfied(source_selection_active=%v, active=%v, confirmation=%v) = %v; want %v",
+					test.sourceSelectionActive, test.activeConfirmed, test.confirmationSatisfied, got, test.want)
+			}
+		})
+	}
+}
+
+func TestShouldStopSourceAdmissionScan(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                          string
+		sourceSelectionActive         bool
+		activeConfirmed               bool
+		total                         int
+		confirmationPending           bool
+		confirmationSatisfied         bool
+		confirmationFallbackExhausted bool
+		want                          bool
+	}{
+		{
+			name:                  "source selection active probe stops before semantic confirmation resolves",
+			sourceSelectionActive: true,
+			activeConfirmed:       true,
+			total:                 1,
+			confirmationPending:   true,
+			want:                  true,
+		},
+		{
+			name:                "semantic-only scan still waits for pending semantic confirmation",
+			activeConfirmed:     true,
+			total:               1,
+			confirmationPending: true,
+			want:                false,
+		},
+		{
+			name:                  "semantic confirmation still stops any path",
+			total:                 1,
+			confirmationPending:   true,
+			confirmationSatisfied: true,
+			want:                  true,
+		},
+		{
+			name:                          "fallback exhaustion still stops source selection without active evidence",
+			sourceSelectionActive:         true,
+			total:                         1,
+			confirmationPending:           true,
+			confirmationFallbackExhausted: true,
+			want:                          true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := shouldStopSourceAdmissionScan(
+				test.sourceSelectionActive,
+				test.activeConfirmed,
+				test.total,
+				test.confirmationPending,
+				test.confirmationSatisfied,
+				test.confirmationFallbackExhausted,
+			)
+			if got != test.want {
+				t.Fatalf("shouldStopSourceAdmissionScan(source_selection_active=%v, active=%v, total=%d, pending=%v, satisfied=%v, exhausted=%v) = %v; want %v",
+					test.sourceSelectionActive,
+					test.activeConfirmed,
+					test.total,
+					test.confirmationPending,
+					test.confirmationSatisfied,
+					test.confirmationFallbackExhausted,
+					got,
+					test.want,
+				)
+			}
+		})
+	}
+}
+
 func TestShouldRetryDiscoveryWithFullRange(t *testing.T) {
 	origProbeFn := startupScanB524ProbeFn
 	t.Cleanup(func() { startupScanB524ProbeFn = origProbeFn })


### PR DESCRIPTION
## What
Fixes two M7 rollout blockers found during live HA validation of source-address selection admission.

## Why
The rollout reached active bus traffic with source `0x7F` and companion target `0x84`, but GraphQL `bus_admission` stayed null. Root cause was twofold:

- one-shot `active_probe_passed` could be suppressed by the admission stability window without a later refresh
- source-selection admission was tied to Vaillant semantic/root confirmation instead of the bounded active source probe

Source admission should become active when the selected source passes the directed active probe. Vaillant semantic bootstrap/root confirmation remains a separate semantic readiness concern.

## Acceptance Criteria
- [x] `active_probe_passed` is republished after the admission stability window when the first event is suppressed
- [x] source-selection-capable admission treats active probe evidence as sufficient even when semantic root confirmation is incomplete
- [x] unit tests cover both behaviors
- [x] live HA rollout shows `bus_admission.source_selection.state = active`, `selected_source = 127`, `companion_target = 132`
- [x] proxy listener disabled during direct-path rollout; no `:19001`, `:7624`, or `:8888` listeners observed
- [x] CI green locally

## Validation
- `go test ./cmd/gateway -run '^(TestRecordBusAdmissionTransitionWithStabilityRefreshPublishesOneShotActive|TestSourceAdmissionProbeSatisfied|TestShouldStopDiscoveryScan)$' -count=1`
- `go test ./... -run 'Test(BusObservabilityStore|GraphQLBusObservability|Run_WiresBusObservability|RecordBusAdmissionTransition|SourceAdmissionProbe|ShouldStopDiscoveryScan|StartupScan)' -count=1`
- `TRANSPORT_MATRIX_REPORT=results-matrix-ha/20260504T183356Z-sas02-ebusgo-c9a4697-full88-correct-adapter-signal/index.json PASSIVE_SMOKE_REPORT=results-matrix-ha/20260505T134601Z-sas03a-gateway-passive-p01-p06-combined-pass/index.json ./scripts/ci_local.sh`
  - transport gate: `PASS (pass=46, xfail=7, xpass=0, blocked=35, total=88)`
  - passive smoke gate: `PASS (6 passive cases, all pass)`

## Live Evidence
- HA binary override built from this branch and deployed to `local_helianthus`
- GraphQL `busSummary.status.bus_admission.source_selection`:
  - `state: active`
  - `outcome: active_probe_passed`
  - `selected_source: 127`
  - `companion_target: 132`
  - `reason: active_probe_passed`
  - `active_probe.status: active_probe_passed`
  - `degraded.active: false`
- expvar:
  - `startup_source_selection_state: 1`
  - `startup_source_selection_degraded_total: 0`
  - `startup_source_selection_warmup_cycles_total: 1`
- Portal `/portal/` returned HTTP 200

## Dependencies
- Depends on source-address-selection-admission M4 PRs already merged.
