### PR TITLE
fix(discovery): structural Vaillant target seed + B524 root augmentation

### DIFF
--- a/cmd/gateway/main_test.go
+++ b/cmd/gateway/main_test.go
@@ -646,7 +646,11 @@ func TestRun_ProxySingleENSAutoUsesDefaultSelectionBeforeProxyResolution(t *test
 
 	select {
 	case got := <-startupTargets:
-		want := []byte{defaultVaillantTarget}
+		// Structural fallback: when source-selection's passive warmup
+		// observed no probable targets, the startup probe seed is the
+		// bounded Vaillant structural set so 0x15 (regulator) and 0x26
+		// (primary controller) enter discovery — not the boiler alone.
+		want := []byte{0x08, 0x15, 0x26}
 		if !reflect.DeepEqual(got, want) {
 			t.Fatalf("startup probe targets = % X; want % X", got, want)
 		}
@@ -711,7 +715,10 @@ func TestRun_DefaultSourceSelectionSeedsStartupProbeTargets(t *testing.T) {
 
 	select {
 	case got := <-startupTargets:
-		want := []byte{defaultVaillantTarget}
+		// Structural fallback: passive warmup on the direct adapter
+		// observed no probable targets in the test harness, so the
+		// startup probe seeds the bounded Vaillant structural set.
+		want := []byte{0x08, 0x15, 0x26}
 		if !reflect.DeepEqual(got, want) {
 			t.Fatalf("startup probe targets = % X; want % X", got, want)
 		}
@@ -791,7 +798,10 @@ func TestRun_ConfiguredDirectSourceSeedsStartupProbeTargets(t *testing.T) {
 		if got.auto {
 			t.Fatal("startup source remained auto; want configured direct source")
 		}
-		wantTargets := []byte{defaultVaillantTarget}
+		// Structural fallback: configured-direct path with no observed
+		// probable targets seeds the bounded Vaillant structural set
+		// (sanitized vs source/companion) — not the boiler alone.
+		wantTargets := []byte{0x08, 0x15, 0x26}
 		if !reflect.DeepEqual(got.targets, wantTargets) {
 			t.Fatalf("startup probe targets = % X; want % X", got.targets, wantTargets)
 		}

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -339,6 +339,7 @@ type vaillantSemanticPoller struct {
 	refreshFromEbusdGrabFn func(context.Context) (map[byte]bool, bool)
 	b524ProbeFn            func(ctx context.Context, target, opcode, group, instance byte, addr uint16) bool
 	sendFrameFn            func(ctx context.Context, frame protocol.Frame) (*protocol.Frame, error)
+	routerPlanesRefreshFn  func()
 	nowFn                  func() time.Time
 }
 
@@ -706,6 +707,7 @@ func newVaillantSemanticPoller(cfg ebusgateway.Config, gateway *ebusgateway.Gate
 		OnSuppressed:       poller.onSemanticReadBreakerSuppressed,
 	})
 	poller.adapterInfo = newVaillantAdapterInfoState(gateway.Bus, gateway.Transport, provider)
+	poller.routerPlanesRefreshFn = func() { _ = gateway.RefreshRouterPlanes() }
 	return poller
 }
 
@@ -1657,6 +1659,16 @@ func (p *vaillantSemanticPoller) refreshDiscovery(ctx context.Context) {
 		p.refreshFM5Semantic(ctx)
 		return
 	}
+
+	// When B524 root discovery converges via the structural-fallback
+	// path, the controller address may not yet be in the registry —
+	// the directed startup probe that would normally register it
+	// either has not run for this address (e.g. the regulator missed
+	// the startup window) or did not yield enrichment. Register a
+	// minimal Vaillant entry so GraphQL devices and the router plane
+	// reflect the regulator. Registry de-dupes on address, so a
+	// no-op when the controller is already known.
+	p.registerStructuralControllerIfMissing(controller)
 
 	if enrichment := p.enrichRegulatorIdentity(controller); enrichment != nil {
 		log.Printf("semantic_controller_enrichment address=0x%02x family=%s device=%s",
@@ -6586,10 +6598,49 @@ func (p *vaillantSemanticPoller) probeB524Register(ctx context.Context, target, 
 	return false
 }
 
-// discoverB524Root finds the B524 semantic root by probing candidates with
-// multi-register coherency checks. Iterates D1-ordered: 0x15 first (common
-// regulator address), then ascending. Stops at first coherent candidate.
+// b524DiscoveryOptions controls how discoverB524RootWithOptions builds its
+// candidate set. The default zero value (augmentStructural=false) is the
+// registry-health-check semantic — answers "does the existing registry
+// contain a coherent B524 root?" without probing addresses outside the
+// registry. Set augmentStructural=true for the production discovery
+// path used by refreshDiscovery, which unconditionally probes the
+// bounded Vaillant structural target set even when the registry has
+// not yet learned about the regulator.
+type b524DiscoveryOptions struct {
+	augmentStructural bool
+}
+
+// discoverB524Root is the production discovery path. It augments the
+// registry-derived candidate list with the bounded Vaillant structural
+// target set {0x08, 0x15, 0x26}, probes D1-ordered (0x15 first), and
+// stops at the first coherent candidate.
+//
+// Structural augmentation is unconditional and idempotent: the dedup
+// map collapses overlap, and the structural set is bounded to three
+// non-broadcast unicast targets. The alternative — gating on registry
+// size — has a hostile-registry hole where any stray non-Vaillant
+// entry (e.g. {0x08 boiler, 0xEC passive-only responder}) suppresses
+// the fallback exactly when it is needed.
+//
+// Probing structural addresses that are not yet in the registry is
+// safe: the unicast probe either elicits a coherent response (in
+// which case refreshDiscovery registers the controller post-
+// discovery via registerStructuralControllerIfMissing) or it does
+// not. Source-address invariant is upheld — the probe uses the
+// existing admitted source via probeFn.
 func (p *vaillantSemanticPoller) discoverB524Root(ctx context.Context) (byte, error) {
+	return p.discoverB524RootWithOptions(ctx, b524DiscoveryOptions{augmentStructural: true})
+}
+
+// discoverB524RootInRegistry is the registry-health-check path. It
+// considers ONLY candidates already in the registry. Used by startup
+// scan helpers to ask "is the existing registry coherent?", which is
+// a distinct question from "where is the regulator?".
+func (p *vaillantSemanticPoller) discoverB524RootInRegistry(ctx context.Context) (byte, error) {
+	return p.discoverB524RootWithOptions(ctx, b524DiscoveryOptions{augmentStructural: false})
+}
+
+func (p *vaillantSemanticPoller) discoverB524RootWithOptions(ctx context.Context, opts b524DiscoveryOptions) (byte, error) {
 	if p == nil || p.reg == nil {
 		return 0, fmt.Errorf("gateway.discoverB524Root: nil poller or registry")
 	}
@@ -6599,28 +6650,37 @@ func (p *vaillantSemanticPoller) discoverB524Root(ctx context.Context) (byte, er
 		probeFn = p.probeB524Register
 	}
 
+	candidateSet := make(map[byte]struct{})
 	var candidates []byte
-	has0x15 := false
 	p.reg.Iterate(func(entry registry.DeviceEntry) bool {
 		if entry == nil {
 			return true
 		}
 		addr := entry.Address()
-		if addr == 0x15 {
-			has0x15 = true
+		if _, dup := candidateSet[addr]; !dup {
+			candidateSet[addr] = struct{}{}
+			candidates = append(candidates, addr)
 		}
-		candidates = append(candidates, addr)
 		return true
 	})
+
+	if opts.augmentStructural {
+		for _, addr := range ebusgateway.VaillantStructuralStartupProbeTargets {
+			if _, dup := candidateSet[addr]; dup {
+				continue
+			}
+			candidateSet[addr] = struct{}{}
+			candidates = append(candidates, addr)
+		}
+	}
 
 	if len(candidates) == 0 {
 		return 0, fmt.Errorf("gateway.discoverB524Root: no devices in registry")
 	}
 
 	slices.Sort(candidates)
-	candidates = slices.Compact(candidates)
 
-	if has0x15 {
+	if _, has0x15 := candidateSet[0x15]; has0x15 {
 		ordered := make([]byte, 0, len(candidates))
 		ordered = append(ordered, 0x15)
 		for _, c := range candidates {
@@ -6650,6 +6710,45 @@ func (p *vaillantSemanticPoller) discoverB524Root(ctx context.Context) (byte, er
 		addrs[i] = fmt.Sprintf("0x%02x", c)
 	}
 	return 0, fmt.Errorf("gateway.discoverB524Root: no coherent responder among [%s]", strings.Join(addrs, ", "))
+}
+
+// registerStructuralControllerIfMissing registers a minimal Vaillant
+// device entry for a B524-coherent controller address that is not yet
+// in the registry. This closes the gap where discoverB524Root converges
+// via the structural-fallback path (probing 0x15 / 0x26 even when they
+// are absent from the registry) — the address must surface in
+// GraphQL devices and on the router plane after discovery.
+//
+// The minimal entry is safe: the address has just satisfied the B524
+// multi-register coherency check, which is strong evidence of a
+// Vaillant regulator. Registry de-dupes on address, so this is a
+// no-op for already-known controllers. Manufacturer is the only
+// identity field set; richer fields (DeviceID, SerialNumber,
+// SoftwareVersion) are populated naturally by subsequent identity
+// reads or by the discovery promotion pipeline once that lands.
+func (p *vaillantSemanticPoller) registerStructuralControllerIfMissing(controller byte) {
+	if p == nil || p.reg == nil || controller == 0 {
+		return
+	}
+	already := false
+	p.reg.Iterate(func(e registry.DeviceEntry) bool {
+		if e != nil && e.Address() == controller {
+			already = true
+			return false
+		}
+		return true
+	})
+	if already {
+		return
+	}
+	p.reg.Register(registry.DeviceInfo{
+		Address:      controller,
+		Manufacturer: "Vaillant",
+	})
+	log.Printf("semantic_controller_registry_register address=0x%02x source=b524_structural_fallback", controller)
+	if p.routerPlanesRefreshFn != nil {
+		p.routerPlanesRefreshFn()
+	}
 }
 
 // enrichRegulatorIdentity returns enrichment metadata for the B524 root device.

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -289,6 +289,7 @@ type vaillantSemanticPoller struct {
 	watchEfficiency ebusgateway.WatchEfficiencyObserver
 
 	source                   byte
+	companion                byte
 	requestTimeout           time.Duration
 	discoveryInterval        time.Duration
 	configInterval           time.Duration
@@ -648,6 +649,7 @@ func newVaillantSemanticPoller(cfg ebusgateway.Config, gateway *ebusgateway.Gate
 		watchObserver:   cfg.WatchObserver,
 		watchEfficiency: cfg.WatchEfficiencyObserver,
 		source:          cfg.ScanSource,
+		companion:       cfg.StartupCompanionTarget,
 
 		requestTimeout:           cfg.SemanticRequestTimeout,
 		discoveryInterval:        cfg.SemanticDiscoveryInterval,
@@ -1668,11 +1670,24 @@ func (p *vaillantSemanticPoller) refreshDiscovery(ctx context.Context) {
 	// minimal Vaillant entry so GraphQL devices and the router plane
 	// reflect the regulator. Registry de-dupes on address, so a
 	// no-op when the controller is already known.
-	p.registerStructuralControllerIfMissing(controller)
+	registered := p.registerStructuralControllerIfMissing(controller)
 
 	if enrichment := p.enrichRegulatorIdentity(controller); enrichment != nil {
 		log.Printf("semantic_controller_enrichment address=0x%02x family=%s device=%s",
 			controller, enrichment.family, enrichment.deviceID)
+	}
+
+	// Recompute regulator capability after structural registration:
+	// the registry just gained a new Vaillant entry, so the
+	// capability lookup must run against the post-registration
+	// inventory. Without this recompute, p.regulatorCapability
+	// stays at the pre-registration value (typically ControllerNone
+	// when the registry held only the boiler) until the next
+	// regulatorRecheckInterval tick — leaving status surfaces
+	// reporting "no regulator" while semantic discovery already
+	// has one.
+	if registered {
+		regCap = p.findRegulatorCapability()
 	}
 
 	p.mu.Lock()
@@ -6669,16 +6684,23 @@ func (p *vaillantSemanticPoller) discoverB524RootWithOptions(ctx context.Context
 			if _, dup := candidateSet[addr]; dup {
 				continue
 			}
-			// Source-address invariant: a structural target that
+			// Source/companion invariant: a structural target that
 			// matches the admitted source would produce a self-
 			// directed unicast probe (probeB524Register builds a
 			// frame with Source=p.source, Target=addr). When an
 			// explicit source configuration admits 0x15 (or the
 			// source-selection result lands on 0x15), the regulator
-			// must not be self-probed. The startup probe path
-			// sanitizes via sanitizeStartupProbeTargets; this path
-			// is a separate entry point and must apply the same guard.
+			// must not be self-probed. Likewise the admitted
+			// companion target — under source-selection a companion
+			// of 0x26 is reserved for the gateway; probing it would
+			// pre-empt the source-selection arbitration partner.
+			// The startup probe path sanitizes via
+			// sanitizeStartupProbeTargets(... source, companion);
+			// this entry point must apply the same guard.
 			if addr == p.source {
+				continue
+			}
+			if p.companion != 0 && addr == p.companion {
 				continue
 			}
 			candidateSet[addr] = struct{}{}
@@ -6738,9 +6760,14 @@ func (p *vaillantSemanticPoller) discoverB524RootWithOptions(ctx context.Context
 // identity field set; richer fields (DeviceID, SerialNumber,
 // SoftwareVersion) are populated naturally by subsequent identity
 // reads or by the discovery promotion pipeline once that lands.
-func (p *vaillantSemanticPoller) registerStructuralControllerIfMissing(controller byte) {
+// registerStructuralControllerIfMissing returns true iff the registry
+// gained a new entry as a result of this call (false when the
+// controller was already known, was zero, or the poller was nil).
+// Callers use the return value to decide whether downstream caches
+// (e.g. regulator capability) need recomputation.
+func (p *vaillantSemanticPoller) registerStructuralControllerIfMissing(controller byte) bool {
 	if p == nil || p.reg == nil || controller == 0 {
-		return
+		return false
 	}
 	already := false
 	p.reg.Iterate(func(e registry.DeviceEntry) bool {
@@ -6751,7 +6778,7 @@ func (p *vaillantSemanticPoller) registerStructuralControllerIfMissing(controlle
 		return true
 	})
 	if already {
-		return
+		return false
 	}
 	p.reg.Register(registry.DeviceInfo{
 		Address:      controller,
@@ -6761,6 +6788,7 @@ func (p *vaillantSemanticPoller) registerStructuralControllerIfMissing(controlle
 	if p.routerPlanesRefreshFn != nil {
 		p.routerPlanesRefreshFn()
 	}
+	return true
 }
 
 // enrichRegulatorIdentity returns enrichment metadata for the B524 root device.

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -6672,12 +6672,12 @@ func (p *vaillantSemanticPoller) discoverB524RootWithOptions(ctx context.Context
 			// Source-address invariant: a structural target that
 			// matches the admitted source would produce a self-
 			// directed unicast probe (probeB524Register builds a
-			// frame with Source=p.source, Target=addr). Operators
-			// running with `-source-addr 0x15` (or a source-selection
-			// result that lands on 0x15) must not have the regulator
-			// self-probed. The startup probe path sanitizes via
-			// sanitizeStartupProbeTargets; this path is a separate
-			// entry point and must apply the same guard.
+			// frame with Source=p.source, Target=addr). When an
+			// explicit source configuration admits 0x15 (or the
+			// source-selection result lands on 0x15), the regulator
+			// must not be self-probed. The startup probe path
+			// sanitizes via sanitizeStartupProbeTargets; this path
+			// is a separate entry point and must apply the same guard.
 			if addr == p.source {
 				continue
 			}

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -6665,6 +6665,25 @@ func (p *vaillantSemanticPoller) discoverB524RootWithOptions(ctx context.Context
 		probeFn = p.probeB524Register
 	}
 
+	// Source-address invariant applies uniformly across both
+	// candidate entry points (registry iteration AND structural
+	// fallback). A configured source / companion target that happens
+	// to be already present in the registry — e.g. an ebusd preload
+	// imports 0x26 before semantic discovery runs, or a prior
+	// session left the companion address registered — would otherwise
+	// bypass the structural-augmentation guard via the dedup map and
+	// be probed unicast. The shared filter ensures any candidate
+	// matching the admitted source or companion is dropped regardless
+	// of how it entered the candidate set.
+	skipReservedSourceCompanion := func(addr byte) bool {
+		if addr == p.source {
+			return true
+		}
+		if p.companion != 0 && addr == p.companion {
+			return true
+		}
+		return false
+	}
 	candidateSet := make(map[byte]struct{})
 	var candidates []byte
 	p.reg.Iterate(func(entry registry.DeviceEntry) bool {
@@ -6672,6 +6691,9 @@ func (p *vaillantSemanticPoller) discoverB524RootWithOptions(ctx context.Context
 			return true
 		}
 		addr := entry.Address()
+		if skipReservedSourceCompanion(addr) {
+			return true
+		}
 		if _, dup := candidateSet[addr]; !dup {
 			candidateSet[addr] = struct{}{}
 			candidates = append(candidates, addr)
@@ -6684,23 +6706,7 @@ func (p *vaillantSemanticPoller) discoverB524RootWithOptions(ctx context.Context
 			if _, dup := candidateSet[addr]; dup {
 				continue
 			}
-			// Source/companion invariant: a structural target that
-			// matches the admitted source would produce a self-
-			// directed unicast probe (probeB524Register builds a
-			// frame with Source=p.source, Target=addr). When an
-			// explicit source configuration admits 0x15 (or the
-			// source-selection result lands on 0x15), the regulator
-			// must not be self-probed. Likewise the admitted
-			// companion target — under source-selection a companion
-			// of 0x26 is reserved for the gateway; probing it would
-			// pre-empt the source-selection arbitration partner.
-			// The startup probe path sanitizes via
-			// sanitizeStartupProbeTargets(... source, companion);
-			// this entry point must apply the same guard.
-			if addr == p.source {
-				continue
-			}
-			if p.companion != 0 && addr == p.companion {
+			if skipReservedSourceCompanion(addr) {
 				continue
 			}
 			candidateSet[addr] = struct{}{}

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -6669,6 +6669,18 @@ func (p *vaillantSemanticPoller) discoverB524RootWithOptions(ctx context.Context
 			if _, dup := candidateSet[addr]; dup {
 				continue
 			}
+			// Source-address invariant: a structural target that
+			// matches the admitted source would produce a self-
+			// directed unicast probe (probeB524Register builds a
+			// frame with Source=p.source, Target=addr). Operators
+			// running with `-source-addr 0x15` (or a source-selection
+			// result that lands on 0x15) must not have the regulator
+			// self-probed. The startup probe path sanitizes via
+			// sanitizeStartupProbeTargets; this path is a separate
+			// entry point and must apply the same guard.
+			if addr == p.source {
+				continue
+			}
 			candidateSet[addr] = struct{}{}
 			candidates = append(candidates, addr)
 		}

--- a/cmd/gateway/semantic_vaillant_test.go
+++ b/cmd/gateway/semantic_vaillant_test.go
@@ -5095,10 +5095,10 @@ func TestRefreshDiscovery_StructuralFallbackRegistersControllerInRegistry(t *tes
 // TestCapabilityFirstDiscovery_StructuralFallbackSkipsAdmittedSource closes
 // the source-address invariant hole found during Codex adversarial review
 // (PR #560 P2): when the admitted semantic source equals one of the
-// structural targets (operator runs with `-source-addr 0x15` or a
-// source-selection result lands on 0x15), the structural augmentation
-// must NOT add that address to the probe candidates — probeB524Register
-// would issue Source=0x15 / Target=0x15, a self-directed unicast probe.
+// structural targets (e.g. configured source 0x15, or a source-selection
+// result lands on 0x15), the structural augmentation must NOT add that
+// address to the probe candidates — probeB524Register would issue
+// Source=0x15 / Target=0x15, a self-directed unicast probe.
 func TestCapabilityFirstDiscovery_StructuralFallbackSkipsAdmittedSource(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/gateway/semantic_vaillant_test.go
+++ b/cmd/gateway/semantic_vaillant_test.go
@@ -5163,6 +5163,69 @@ func TestCapabilityFirstDiscovery_StructuralFallbackSkipsAdmittedCompanion(t *te
 	}
 }
 
+// TestCapabilityFirstDiscovery_DropsAdmittedSourceFromRegistryCandidates closes
+// Codex PR #560 P2 finding: when the admitted source is already in the
+// registry (e.g. preload imported it), the registry-iteration pass would
+// add it to candidates and bypass the structural-augmentation guard.
+// The unified filter must drop it regardless of how it entered.
+func TestCapabilityFirstDiscovery_DropsAdmittedSourceFromRegistryCandidates(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.NewDeviceRegistry(nil)
+	// Preload contains the configured source address.
+	reg.Register(registry.DeviceInfo{Address: 0x15, Manufacturer: "Vaillant", DeviceID: "BASV2"})
+	reg.Register(registry.DeviceInfo{Address: 0x08, Manufacturer: "Vaillant", DeviceID: "BAI00"})
+
+	var probed []byte
+	poller := newTestPoller(reg)
+	poller.source = 0x15
+	poller.b524ProbeFn = mockB524Probe(map[byte]bool{0x08: true, 0x15: true}, &probed)
+
+	addr, err := poller.discoverB524Root(context.Background())
+	if err != nil {
+		t.Fatalf("discoverB524Root error = %v", err)
+	}
+	if addr != 0x08 {
+		t.Fatalf("discoverB524Root = 0x%02x; want 0x08 (0x15 dropped — admitted source)", addr)
+	}
+	for _, p := range probed {
+		if p == 0x15 {
+			t.Fatalf("self-directed probe issued via registry-derived candidate: 0x15 was probed but is admitted source. probed=%v", probed)
+		}
+	}
+}
+
+// TestCapabilityFirstDiscovery_DropsAdmittedCompanionFromRegistryCandidates
+// closes the registry-side companion guard hole identified by Codex.
+func TestCapabilityFirstDiscovery_DropsAdmittedCompanionFromRegistryCandidates(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.NewDeviceRegistry(nil)
+	// Registry preload includes the companion target.
+	reg.Register(registry.DeviceInfo{Address: 0x26, Manufacturer: "Vaillant", DeviceID: "VR_71"})
+	reg.Register(registry.DeviceInfo{Address: 0x15, Manufacturer: "Vaillant", DeviceID: "BASV2"})
+
+	var probed []byte
+	poller := newTestPoller(reg)
+	poller.source = 0x7F
+	poller.companion = 0x26 // companion reserved for the gateway
+
+	poller.b524ProbeFn = mockB524Probe(map[byte]bool{0x15: true, 0x26: true}, &probed)
+
+	addr, err := poller.discoverB524Root(context.Background())
+	if err != nil {
+		t.Fatalf("discoverB524Root error = %v", err)
+	}
+	if addr != 0x15 {
+		t.Fatalf("discoverB524Root = 0x%02x; want 0x15 (0x26 dropped — admitted companion)", addr)
+	}
+	for _, p := range probed {
+		if p == 0x26 {
+			t.Fatalf("companion-targeted probe issued via registry-derived candidate: 0x26 was probed. probed=%v", probed)
+		}
+	}
+}
+
 // TestRefreshDiscovery_RecomputesRegulatorCapabilityAfterStructuralRegistration
 // pins the capability-recompute fix (Codex PR #560 P2 re-review): when
 // refreshDiscovery's discoverB524Root succeeds via the structural-

--- a/cmd/gateway/semantic_vaillant_test.go
+++ b/cmd/gateway/semantic_vaillant_test.go
@@ -5127,6 +5127,79 @@ func TestCapabilityFirstDiscovery_StructuralFallbackSkipsAdmittedSource(t *testi
 	}
 }
 
+// TestCapabilityFirstDiscovery_StructuralFallbackSkipsAdmittedCompanion closes
+// the source-address invariant on the companion side (Codex PR #560 P2
+// re-review): under source-selection, a configured / source-selected
+// companion target reserved for the gateway must NOT be probed by the
+// runtime semantic-discovery entry point. The startup probe path
+// sanitizes via sanitizeStartupProbeTargets(... source, companion);
+// discoverB524Root must apply the same guard.
+func TestCapabilityFirstDiscovery_StructuralFallbackSkipsAdmittedCompanion(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.NewDeviceRegistry(nil)
+	reg.Register(registry.DeviceInfo{Address: 0x08, Manufacturer: "Vaillant", DeviceID: "BAI00"})
+
+	var probed []byte
+	poller := newTestPoller(reg)
+	poller.source = 0x7F
+	poller.companion = 0x26 // companion reserved for the gateway
+
+	// Only 0x15 is coherent. Without the companion guard, 0x26 would
+	// be probed as a structural target (it's in the structural set).
+	poller.b524ProbeFn = mockB524Probe(map[byte]bool{0x08: false, 0x15: true, 0x26: true}, &probed)
+
+	addr, err := poller.discoverB524Root(context.Background())
+	if err != nil {
+		t.Fatalf("discoverB524Root error = %v", err)
+	}
+	if addr != 0x15 {
+		t.Fatalf("discoverB524Root = 0x%02x; want 0x15", addr)
+	}
+	for _, p := range probed {
+		if p == 0x26 {
+			t.Fatalf("admitted companion 0x26 was probed; source-address invariant violated. probed=%v", probed)
+		}
+	}
+}
+
+// TestRefreshDiscovery_RecomputesRegulatorCapabilityAfterStructuralRegistration
+// pins the capability-recompute fix (Codex PR #560 P2 re-review): when
+// refreshDiscovery's discoverB524Root succeeds via the structural-
+// fallback path and registers the controller as a side effect, the
+// regulator capability lookup must run against the post-registration
+// inventory. Otherwise p.regulatorCapability stays at ControllerNone
+// until the next regulator-recheck tick.
+func TestRefreshDiscovery_RecomputesRegulatorCapabilityAfterStructuralRegistration(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.NewDeviceRegistry(nil)
+	reg.Register(registry.DeviceInfo{Address: 0x08, Manufacturer: "Vaillant", DeviceID: "BAI00"})
+
+	poller := newTestPoller(reg)
+	// Initial capability is ControllerNone (registry has only boiler).
+	if cap := poller.findRegulatorCapability(); cap == productids.ControllerPresent {
+		t.Fatalf("test setup invalid: pre-registration capability already %v", cap)
+	}
+
+	// Discover 0x15 via structural fallback, then register it.
+	poller.b524ProbeFn = mockB524Probe(map[byte]bool{0x08: false, 0x15: true, 0x26: false}, nil)
+	controller, err := poller.discoverB524Root(context.Background())
+	if err != nil {
+		t.Fatalf("discoverB524Root error = %v", err)
+	}
+	registered := poller.registerStructuralControllerIfMissing(controller)
+	if !registered {
+		t.Fatal("registerStructuralControllerIfMissing returned false; expected true for newly-discovered 0x15")
+	}
+
+	// findRegulatorCapability must now reflect the new inventory.
+	postCap := poller.findRegulatorCapability()
+	if postCap == productids.ControllerNone {
+		t.Fatalf("post-registration capability = %v; want non-ControllerNone (registry now contains 0x15 Vaillant)", postCap)
+	}
+}
+
 // TestRegisterStructuralControllerIfMissing_NoOpWhenAlreadyRegistered pins
 // the idempotence contract: repeated structural-fallback calls for an
 // already-registered controller must not duplicate registry entries or

--- a/cmd/gateway/semantic_vaillant_test.go
+++ b/cmd/gateway/semantic_vaillant_test.go
@@ -4939,6 +4939,214 @@ func TestCapabilityFirstDiscovery_SkipsNonCoherentDevice(t *testing.T) {
 	}
 }
 
+// TestCapabilityFirstDiscovery_StructuralFallbackWhenRegistryHasOnlyBoiler
+// reproduces the post-source-selection regression where startup admission
+// completes with only the boiler in the registry. discoverB524Root must
+// augment its candidate list with the bounded Vaillant structural target
+// set so the regulator (0x15) can be probed even before it appears in
+// the registry.
+func TestCapabilityFirstDiscovery_StructuralFallbackWhenRegistryHasOnlyBoiler(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.NewDeviceRegistry(nil)
+	reg.Register(registry.DeviceInfo{Address: 0x08, Manufacturer: "Vaillant", DeviceID: "BAI00"})
+
+	var probed []byte
+	// Only 0x15 is coherent. Without structural fallback, 0x15 is not in
+	// the registry and discoverB524Root would return "no coherent
+	// responder among [0x08]".
+	poller := newTestPoller(reg)
+	poller.b524ProbeFn = mockB524Probe(map[byte]bool{0x08: false, 0x15: true, 0x26: false}, &probed)
+
+	addr, err := poller.discoverB524Root(context.Background())
+	if err != nil {
+		t.Fatalf("discoverB524Root error = %v; structural fallback must add 0x15/0x26 to candidates", err)
+	}
+	if addr != 0x15 {
+		t.Fatalf("discoverB524Root = 0x%02x; want 0x15 (structural fallback regulator)", addr)
+	}
+	if len(probed) == 0 || probed[0] != 0x15 {
+		t.Fatalf("probed = %v; want 0x15 first per D1 ordering", probed)
+	}
+}
+
+// TestCapabilityFirstDiscovery_RichRegistryStopsAt0x15CoherentRoot pins the
+// stop-at-first-coherent invariant when the registry already contains the
+// regulator. Structural augmentation is now unconditional (idempotent — see
+// the hostile-registry rationale in the next test) but D1 ordering must
+// still terminate on the first coherent candidate. With 0x15 coherent,
+// 0x26 must never be probed.
+func TestCapabilityFirstDiscovery_RichRegistryStopsAt0x15CoherentRoot(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.NewDeviceRegistry(nil)
+	reg.Register(registry.DeviceInfo{Address: 0x08, Manufacturer: "Vaillant", DeviceID: "BAI00"})
+	reg.Register(registry.DeviceInfo{Address: 0x15, Manufacturer: "Vaillant", DeviceID: "BASV2"})
+
+	var probed []byte
+	poller := newTestPoller(reg)
+	poller.b524ProbeFn = mockB524Probe(map[byte]bool{0x08: false, 0x15: true, 0x26: true}, &probed)
+
+	addr, err := poller.discoverB524Root(context.Background())
+	if err != nil {
+		t.Fatalf("discoverB524Root error = %v", err)
+	}
+	if addr != 0x15 {
+		t.Fatalf("discoverB524Root = 0x%02x; want 0x15", addr)
+	}
+	for _, p := range probed {
+		if p == 0x26 {
+			t.Fatalf("D1 stop-at-first violated: probed includes 0x26 after 0x15 coherent: %v", probed)
+		}
+	}
+}
+
+// TestCapabilityFirstDiscovery_HostileRegistryWithStaleSlaveStillProbesRegulator
+// closes the post-source-selection regression hole identified during
+// adversarial review: a registry containing the boiler plus any stray
+// non-Vaillant entry (e.g. 0xEC SOL00 from passive observation, or a
+// phantom from a prior process) must NOT suppress the structural
+// fallback. Always-augment guarantees 0x15 enters the candidate list
+// regardless of registry size.
+func TestCapabilityFirstDiscovery_HostileRegistryWithStaleSlaveStillProbesRegulator(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.NewDeviceRegistry(nil)
+	reg.Register(registry.DeviceInfo{Address: 0x08, Manufacturer: "Vaillant", DeviceID: "BAI00"})
+	// Stale passive-only-responder entry from prior session — never
+	// responds to active B524 probes.
+	reg.Register(registry.DeviceInfo{Address: 0xEC, Manufacturer: "", DeviceID: ""})
+
+	var probed []byte
+	poller := newTestPoller(reg)
+	poller.b524ProbeFn = mockB524Probe(map[byte]bool{0x08: false, 0xEC: false, 0x15: true, 0x26: false}, &probed)
+
+	addr, err := poller.discoverB524Root(context.Background())
+	if err != nil {
+		t.Fatalf("discoverB524Root error = %v; structural fallback must still fire when registry contains stray passive-only entries", err)
+	}
+	if addr != 0x15 {
+		t.Fatalf("discoverB524Root = 0x%02x; want 0x15", addr)
+	}
+	if len(probed) == 0 || probed[0] != 0x15 {
+		t.Fatalf("probed = %v; want 0x15 first per D1 ordering", probed)
+	}
+}
+
+// TestRefreshDiscovery_StructuralFallbackRegistersControllerInRegistry
+// locks the live-evidence claim: when discoverB524Root converges on 0x15
+// via the structural-fallback path (i.e. 0x15 was NOT in the registry
+// when discovery started), refreshDiscovery must register 0x15 so the
+// regulator surfaces in GraphQL devices and on the router plane.
+// Without this side-effect the user-visible "GraphQL devices includes
+// regulator 0x15" outcome is unattainable from the gateway-side fix.
+func TestRefreshDiscovery_StructuralFallbackRegistersControllerInRegistry(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.NewDeviceRegistry(nil)
+	reg.Register(registry.DeviceInfo{Address: 0x08, Manufacturer: "Vaillant", DeviceID: "BAI00"})
+
+	poller := newTestPoller(reg)
+	poller.b524ProbeFn = mockB524Probe(map[byte]bool{0x08: false, 0x15: true, 0x26: false}, nil)
+
+	addr, err := poller.discoverB524Root(context.Background())
+	if err != nil {
+		t.Fatalf("discoverB524Root error = %v", err)
+	}
+	if addr != 0x15 {
+		t.Fatalf("discoverB524Root = 0x%02x; want 0x15", addr)
+	}
+
+	// Pre-condition: 0x15 not in registry.
+	var has0x15Before bool
+	reg.Iterate(func(e registry.DeviceEntry) bool {
+		if e != nil && e.Address() == 0x15 {
+			has0x15Before = true
+			return false
+		}
+		return true
+	})
+	if has0x15Before {
+		t.Fatal("test setup invalid: 0x15 already in registry before structural-fallback registration")
+	}
+
+	// Trigger the registration helper directly. (refreshDiscovery wraps
+	// this with snapshot rebuilds we don't need to exercise here.)
+	poller.registerStructuralControllerIfMissing(addr)
+
+	var has0x15After bool
+	var manufacturer string
+	reg.Iterate(func(e registry.DeviceEntry) bool {
+		if e != nil && e.Address() == 0x15 {
+			has0x15After = true
+			manufacturer = e.Manufacturer()
+			return false
+		}
+		return true
+	})
+	if !has0x15After {
+		t.Fatal("registry missing 0x15 after structural-fallback registration; GraphQL devices will not surface the regulator")
+	}
+	if manufacturer != "Vaillant" {
+		t.Fatalf("registered 0x15 manufacturer = %q; want %q", manufacturer, "Vaillant")
+	}
+}
+
+// TestRegisterStructuralControllerIfMissing_NoOpWhenAlreadyRegistered pins
+// the idempotence contract: repeated structural-fallback calls for an
+// already-registered controller must not duplicate registry entries or
+// thrash the router plane.
+func TestRegisterStructuralControllerIfMissing_NoOpWhenAlreadyRegistered(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.NewDeviceRegistry(nil)
+	reg.Register(registry.DeviceInfo{Address: 0x15, Manufacturer: "Vaillant", DeviceID: "BASV2"})
+
+	poller := newTestPoller(reg)
+
+	refreshCount := 0
+	poller.routerPlanesRefreshFn = func() { refreshCount++ }
+
+	poller.registerStructuralControllerIfMissing(0x15)
+
+	if refreshCount != 0 {
+		t.Fatalf("router plane refreshed %d times for already-registered controller; want 0", refreshCount)
+	}
+
+	count := 0
+	reg.Iterate(func(e registry.DeviceEntry) bool {
+		if e != nil && e.Address() == 0x15 {
+			count++
+		}
+		return true
+	})
+	if count != 1 {
+		t.Fatalf("registry has %d entries for 0x15; want 1 (idempotent)", count)
+	}
+}
+
+// TestCapabilityFirstDiscovery_StructuralFallbackEmptyRegistry covers the
+// degenerate case where registry is empty — structural fallback alone
+// must permit discovery to attempt the structural set rather than
+// returning "no devices in registry".
+func TestCapabilityFirstDiscovery_StructuralFallbackEmptyRegistry(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.NewDeviceRegistry(nil)
+
+	var probed []byte
+	poller := newTestPoller(reg)
+	poller.b524ProbeFn = mockB524Probe(map[byte]bool{0x15: true}, &probed)
+
+	addr, err := poller.discoverB524Root(context.Background())
+	if err != nil {
+		t.Fatalf("discoverB524Root error = %v; want structural fallback to attempt 0x15", err)
+	}
+	if addr != 0x15 {
+		t.Fatalf("discoverB524Root = 0x%02x; want 0x15", addr)
+	}
+}
+
 func TestEnrichRegulatorIdentity(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/gateway/semantic_vaillant_test.go
+++ b/cmd/gateway/semantic_vaillant_test.go
@@ -5092,6 +5092,41 @@ func TestRefreshDiscovery_StructuralFallbackRegistersControllerInRegistry(t *tes
 	}
 }
 
+// TestCapabilityFirstDiscovery_StructuralFallbackSkipsAdmittedSource closes
+// the source-address invariant hole found during Codex adversarial review
+// (PR #560 P2): when the admitted semantic source equals one of the
+// structural targets (operator runs with `-source-addr 0x15` or a
+// source-selection result lands on 0x15), the structural augmentation
+// must NOT add that address to the probe candidates — probeB524Register
+// would issue Source=0x15 / Target=0x15, a self-directed unicast probe.
+func TestCapabilityFirstDiscovery_StructuralFallbackSkipsAdmittedSource(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.NewDeviceRegistry(nil)
+	reg.Register(registry.DeviceInfo{Address: 0x08, Manufacturer: "Vaillant", DeviceID: "BAI00"})
+
+	var probed []byte
+	poller := newTestPoller(reg)
+	poller.source = 0x15
+	// 0x26 is the only coherent structural target left after 0x15 is
+	// dropped (admitted source). 0x08 stays in candidates from the
+	// registry but is non-coherent.
+	poller.b524ProbeFn = mockB524Probe(map[byte]bool{0x08: false, 0x15: true, 0x26: true}, &probed)
+
+	addr, err := poller.discoverB524Root(context.Background())
+	if err != nil {
+		t.Fatalf("discoverB524Root error = %v", err)
+	}
+	if addr != 0x26 {
+		t.Fatalf("discoverB524Root = 0x%02x; want 0x26 (0x15 dropped because it equals admitted source)", addr)
+	}
+	for _, p := range probed {
+		if p == 0x15 {
+			t.Fatalf("self-directed probe issued: 0x15 was probed but is admitted source. probed=%v", probed)
+		}
+	}
+}
+
 // TestRegisterStructuralControllerIfMissing_NoOpWhenAlreadyRegistered pins
 // the idempotence contract: repeated structural-fallback calls for an
 // already-registered controller must not duplicate registry entries or

--- a/cmd/gateway/startup_scan.go
+++ b/cmd/gateway/startup_scan.go
@@ -1046,6 +1046,16 @@ func startupScanHasCoherentVaillantRoot(ctx context.Context, cfg ebusgateway.Con
 		reg:            gateway.Registry,
 		bus:            gateway.Bus,
 		source:         cfg.ScanSource,
+		// Companion is plumbed for the same source-address invariant
+		// the runtime path enforces: when source-selection has
+		// reserved a companion (e.g. StartupCompanionTarget=0x26)
+		// and that address is already in the registry from an ebusd
+		// preload, the registry-only health check must NOT treat
+		// the reserved companion as a coherent root candidate.
+		// discoverB524RootInRegistry filters companion via
+		// p.companion; without setting it here, that guard is a
+		// no-op for this entry point.
+		companion:      cfg.StartupCompanionTarget,
 		requestTimeout: cfg.SemanticRequestTimeout,
 	}
 	if startupScanB524ProbeFn != nil {

--- a/cmd/gateway/startup_scan.go
+++ b/cmd/gateway/startup_scan.go
@@ -1051,7 +1051,13 @@ func startupScanHasCoherentVaillantRoot(ctx context.Context, cfg ebusgateway.Con
 	if startupScanB524ProbeFn != nil {
 		poller.b524ProbeFn = startupScanB524ProbeFn
 	}
-	_, err := poller.discoverB524Root(probeCtx)
+	// Registry-only flavor: this is a "is the existing registry
+	// coherent?" health check, not a discovery attempt. The recovery
+	// scan flow (shouldRetryDiscoveryWithFullRange) depends on this
+	// returning false when the regulator is not yet in the registry,
+	// even though discoverB524Root's structural-augmentation path
+	// would converge by probing 0x15 directly.
+	_, err := poller.discoverB524RootInRegistry(probeCtx)
 	return err == nil
 }
 
@@ -1097,7 +1103,19 @@ func startupProbeTargetsForSelection(selection protocol.SourceAddressSelection) 
 	if len(targets) > 0 {
 		return targets
 	}
-	return sanitizeStartupProbeTargets([]byte{defaultVaillantTarget}, selection.Source, selection.Companion)
+	// Source-selection passive warmup observed no probable targets.
+	// Falling back to {0x08} alone leaves the regulator (0x15) and
+	// primary controller (0x26) undiscovered — semantic B524 root
+	// discovery cannot converge against a registry that contains
+	// only the boiler. Seed with the bounded Vaillant structural
+	// target set so the directed startup probe registers any of the
+	// three structural devices that respond to identity. Source
+	// remains the admitted selection.Source.
+	return sanitizeStartupProbeTargets(
+		ebusgateway.VaillantStructuralStartupProbeTargets,
+		selection.Source,
+		selection.Companion,
+	)
 }
 
 func startupProbeTargets(cfg ebusgateway.Config) []byte {

--- a/cmd/gateway/startup_scan_test.go
+++ b/cmd/gateway/startup_scan_test.go
@@ -2618,3 +2618,55 @@ func TestCoherentVaillantRootProbeTimeoutScalesWithCandidates(t *testing.T) {
 		t.Fatal("startupScanHasCoherentVaillantRoot returned false; want true — probe timeout should scale with candidate count")
 	}
 }
+
+// TestCoherentVaillantRootSkipsAdmittedCompanion closes Codex PR #560 P2
+// finding: when source-selection has reserved a companion (e.g.
+// StartupCompanionTarget=0x26) and that address is already in the
+// registry from an ebusd preload, the registry-only health check must
+// NOT probe the reserved companion. Without plumbing
+// cfg.StartupCompanionTarget into the temporary poller, the
+// p.companion-based filter in discoverB524RootInRegistry would be a
+// no-op for this entry point.
+func TestCoherentVaillantRootSkipsAdmittedCompanion(t *testing.T) {
+	gateway, err := ebusgateway.New(context.Background(), ebusgateway.Config{
+		Transport: transport.NewLoopback(),
+	})
+	if err != nil {
+		t.Fatalf("gateway.New error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := gateway.Close(); err != nil {
+			t.Fatalf("gateway.Close error = %v", err)
+		}
+	})
+
+	origProbeFn := startupScanB524ProbeFn
+	t.Cleanup(func() { startupScanB524ProbeFn = origProbeFn })
+
+	// Registry preload includes the companion address (0x26) plus the
+	// boiler. Neither 0x15 nor any other coherent root is registered.
+	gateway.Registry.Register(registry.DeviceInfo{Address: 0x08, Manufacturer: "Vaillant", DeviceID: "BAI00"})
+	gateway.Registry.Register(registry.DeviceInfo{Address: 0x26, Manufacturer: "Vaillant", DeviceID: "VR_71"})
+
+	probedCompanion := false
+	startupScanB524ProbeFn = func(_ context.Context, target, _opcode, _group, _instance byte, _addr uint16) bool {
+		if target == 0x26 {
+			probedCompanion = true
+		}
+		return target == 0x26 // would otherwise pass coherency
+	}
+
+	cfg := ebusgateway.DefaultConfig()
+	cfg.ScanSource = 0x7F
+	cfg.StartupCompanionTarget = 0x26
+	cfg.SemanticRequestTimeout = 100 * time.Millisecond
+	cfg.ScanRequestTimeout = 50 * time.Millisecond
+
+	result := startupScanHasCoherentVaillantRoot(context.Background(), cfg, gateway)
+	if probedCompanion {
+		t.Fatal("startupScanHasCoherentVaillantRoot probed reserved companion 0x26; companion guard not propagated to registry-only health check")
+	}
+	if result {
+		t.Fatal("startupScanHasCoherentVaillantRoot returned true; companion was the only coherent target and it must not count as a coherent root")
+	}
+}

--- a/cmd/gateway/startup_scan_test.go
+++ b/cmd/gateway/startup_scan_test.go
@@ -434,14 +434,56 @@ func TestSanitizeStartupProbeTargets_PreservesAllConfiguredTargets(t *testing.T)
 	}
 }
 
-func TestStartupProbeTargetsForSelection_DefaultPolicySeedsBoundedTarget(t *testing.T) {
+func TestStartupProbeTargetsForSelection_DefaultPolicySeedsStructuralVaillantSet(t *testing.T) {
 	t.Parallel()
 
+	// When source-address selection observes no probable targets, the
+	// fallback MUST seed the bounded Vaillant structural set (boiler,
+	// regulator, primary controller) — not the boiler alone. Otherwise
+	// the regulator (0x15) and VR_71 (0x26) never enter discovery and
+	// the post-source-selection regression of an empty regulator
+	// surface reproduces.
 	targets := startupProbeTargetsForSelection(protocol.SourceAddressSelection{
 		Source:    0x7F,
 		Companion: 0x84,
 	})
-	want := []byte{defaultVaillantTarget}
+	want := []byte{0x08, 0x15, 0x26}
+	if !reflect.DeepEqual(targets, want) {
+		t.Fatalf("startup probe targets = % X; want % X", targets, want)
+	}
+}
+
+func TestStartupProbeTargetsForSelection_StructuralFallbackRespectsSourceAndCompanion(t *testing.T) {
+	t.Parallel()
+
+	// Sanitization must continue to drop any structural-set entry that
+	// collides with the admitted source or its companion target. This
+	// guards against accidentally probing our own admitted source as
+	// a target.
+	targets := startupProbeTargetsForSelection(protocol.SourceAddressSelection{
+		Source:    0x15, // regulator address used as source — drops 0x15 from targets
+		Companion: 0x26, // VR_71 used as companion — drops 0x26 from targets
+	})
+	want := []byte{0x08}
+	if !reflect.DeepEqual(targets, want) {
+		t.Fatalf("startup probe targets = % X; want % X", targets, want)
+	}
+}
+
+func TestStartupProbeTargetsForSelection_PrefersObservedTargetsWhenAvailable(t *testing.T) {
+	t.Parallel()
+
+	// When passive warmup observed probable targets, the structural
+	// fallback must NOT replace them. Observed evidence > structural
+	// guess.
+	targets := startupProbeTargetsForSelection(protocol.SourceAddressSelection{
+		Source:    0x7F,
+		Companion: 0x84,
+		Metrics: protocol.SourceAddressSelectionMetrics{
+			ObservedProbableTargets: []byte{0x08, 0x15},
+		},
+	})
+	want := []byte{0x08, 0x15}
 	if !reflect.DeepEqual(targets, want) {
 		t.Fatalf("startup probe targets = % X; want % X", targets, want)
 	}

--- a/evidence_buffer.go
+++ b/evidence_buffer.go
@@ -30,6 +30,19 @@ type EvidenceRecord struct {
 // enforces responder-range [0x03, 0xFE] excluding 0xAA (SYN) and 0xFE (broadcast).
 var VaillantBaselineTopologySeed = []byte{0x08, 0x15, 0x26, 0x04, 0xF6, 0xEC}
 
+// VaillantStructuralStartupProbeTargets is the bounded set of Vaillant
+// device targets used as the structural startup-probe fallback when the
+// source-address selector's passive warmup observed no probable targets.
+//
+// Why this is narrower than VaillantBaselineTopologySeed: stealth slaves
+// (0x04/0xF6 NETX3, 0xEC SOL00) are passive-only and do not respond to
+// directed identity probes. The structural set is the active-probable
+// subset {boiler, regulator, primary controller}.
+//
+// These are TARGETS for active probes from the admitted source —
+// never source addresses themselves.
+var VaillantStructuralStartupProbeTargets = []byte{0x08, 0x15, 0x26}
+
 // ValidateBaselineTopologySeed checks the config-provided seed against the
 // responder-address range.
 func ValidateBaselineTopologySeed(seed []byte) error {


### PR DESCRIPTION
## Summary

Restores regulator-area discovery on adapter-direct after the source-selection rollout. Live evidence prior to fix: `zones=[]`, `dhw=null`, `radioDevices=[]`, `semantic_regulator_state=ABSENT`, gateway log repeating `no coherent responder among [0x08]`.

Two surgical fixes:

- **Startup probe fallback** — `startupProbeTargetsForSelection` now seeds the bounded Vaillant structural set `{0x08, 0x15, 0x26}` when source-selection's passive warmup observed no probable targets, instead of the boiler alone. Sanitization vs admitted source/companion is preserved. These are TARGETS, never sources.
- **B524 root discovery** — `discoverB524Root` unconditionally unions the structural target set into the registry-derived candidate list (idempotent, bounded ≤3 extra probes), avoiding the hostile-registry hole where any stray non-Vaillant entry would suppress a registry-size threshold. Split into:
  - `discoverB524Root` (production, augmented) — used by `refreshDiscovery`
  - `discoverB524RootInRegistry` (registry-only) — used by the registry-health-check `startupScanHasCoherentVaillantRoot`. Preserves recovery-scan trigger semantics.
- **Post-discovery controller registration** — when discovery converges via the structural-fallback path, the controller is registered in the device registry and router planes are refreshed so the regulator surfaces in GraphQL devices.

## Adversarial-review history (pre-PR)

This PR went through one Claude angry-tester adversarial pass before opening; its two BLOCKERS were both addressed:
- **B1 (hostile registry threshold)**: dropped `< 2` gate; always-augment is idempotent.
- **B2 (live-evidence claim)**: added `registerStructuralControllerIfMissing` so 0x15 lands in the registry when discovery converges via structural fallback.

Codex adversarial review still pending on this PR per cruise-control protocol.

## Test plan

- [x] `go test ./... -count=1 -race` passes (full gateway suite).
- [x] New regression tests cover: structural-set seed; sanitize-vs-source/companion; preferred-observed-targets-when-available; D1 stop-at-first; hostile-registry recovery (boiler + stray passive-only entry); empty-registry structural fallback; structural-fallback-registers-controller; idempotent-re-registration.
- [x] Local CI green with documented owner overrides on transport-gate and passive-smoke-gate (rationale: discovery-candidate-only change, no transport.go / protocol / adaptermux / matrix-runner / passive-observability edits).
- [ ] Live HA validation post-merge: confirm GraphQL devices includes 0x15; confirm `semantic_regulator_state` not ABSENT; confirm zones/dhw/radioDevices/system populate; confirm `bus_admission.source_selection` remains active and `selected_source` unchanged.

## Out of scope

- Runtime promotion of late-arrival regulators via passive evidence (Bug 2 in the goal description). Tracked separately — needed when the regulator boots after the gateway. This PR fixes the steady-state regression where the regulator is on the bus but startup observed no probable targets.

## Source-address invariant

Confirmed: structural addresses {0x08, 0x15, 0x26} are TARGETS for unicast active probes. The admitted source remains the source-selection result (typically 0x7F). No hardcoding of 0x71/0x31 or any other source address. `sanitizeStartupProbeTargets` continues to drop any structural address that collides with the admitted source or companion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)