### PR TITLE
feat(discovery): runtime passive-promotion pipeline (late-arrival devices)

### DIFF
--- a/b524_coherency.go
+++ b/b524_coherency.go
@@ -40,16 +40,25 @@ func IsB524ResponseCoherent(responseData []byte, group byte, addr uint16) bool {
 // request's Data field. Returns false when the request is too short
 // or the layout is unrecognized.
 //
-// B524 read request Data layout (canonical):
+// B524 read request Data layout (canonical, per buildB524ReadSelector
+// in cmd/gateway/semantic_vaillant.go):
 //
-//	data[0] = opcode  (e.g. 0x06 = remote read, 0x02 = local)
-//	data[1] = group   (semantic group identifier)
-//	data[2] = instance
-//	data[3] = addr_lo
-//	data[4] = addr_hi
+//	data[0] = opcode    (e.g. 0x06 = remote read, 0x02 = local)
+//	data[1] = op        (0x00 = read, 0x01 = write)
+//	data[2] = group     (semantic group identifier)
+//	data[3] = instance
+//	data[4] = addr_lo
+//	data[5] = addr_hi
+//
+// An earlier extractor version used the wrong offsets (data[1] as
+// group, data[3..4] as addr) — that mismatched the canonical builder
+// layout and would have caused real-device B524 responses to fail
+// strong-evidence coherency on the passive promotion path. This
+// implementation now matches the builder exactly so a coherent
+// B524 transaction observed once promotes the responder as intended.
 func b524RequestParameters(requestData []byte) (group byte, addr uint16, ok bool) {
-	if len(requestData) < 5 {
+	if len(requestData) < 6 {
 		return 0, 0, false
 	}
-	return requestData[1], uint16(requestData[3]) | uint16(requestData[4])<<8, true
+	return requestData[2], uint16(requestData[4]) | uint16(requestData[5])<<8, true
 }

--- a/b524_coherency.go
+++ b/b524_coherency.go
@@ -1,0 +1,55 @@
+package ebusgateway
+
+// IsB524ResponseCoherent reports whether a B524 (Vaillant extended-
+// register access) response payload is structurally coherent with the
+// original request: the response echoes the request's group and
+// register address in valid positions.
+//
+// Two valid echo positions are accepted because B524 replies use two
+// frame layouts depending on whether the opcode is preceded by a
+// status / length prefix:
+//
+//	layout-a  resp[1]=group, resp[2..3]=addr (LE)
+//	layout-b  resp[2]=group, resp[3..4]=addr (LE)
+//
+// A response that fails both checks is not a coherent reply — it may
+// be a NACK, a fragment, or a passively-misclassified frame.
+//
+// Used by:
+//   - cmd/gateway/semantic_vaillant.go isB524ProbeCoherent (the
+//     active-probe acceptance check during discoverB524Root)
+//   - bus_observability_store.go passiveResponseIsCoherentVaillantEvidence
+//     (the passive strong-evidence promotion gate)
+//
+// Both call sites share a single source of truth for "what counts as
+// a coherent B524 response" so that passive-evidence promotion uses
+// the same acceptance criterion as active discovery.
+func IsB524ResponseCoherent(responseData []byte, group byte, addr uint16) bool {
+	if len(responseData) < 4 {
+		return false
+	}
+	if len(responseData) >= 5 {
+		if responseData[2] == group && (uint16(responseData[3])|uint16(responseData[4])<<8) == addr {
+			return true
+		}
+	}
+	return responseData[1] == group && (uint16(responseData[2])|uint16(responseData[3])<<8) == addr
+}
+
+// b524RequestParameters extracts the (group, addr) tuple from a B524
+// request's Data field. Returns false when the request is too short
+// or the layout is unrecognized.
+//
+// B524 read request Data layout (canonical):
+//
+//	data[0] = opcode  (e.g. 0x06 = remote read, 0x02 = local)
+//	data[1] = group   (semantic group identifier)
+//	data[2] = instance
+//	data[3] = addr_lo
+//	data[4] = addr_hi
+func b524RequestParameters(requestData []byte) (group byte, addr uint16, ok bool) {
+	if len(requestData) < 5 {
+		return 0, 0, false
+	}
+	return requestData[1], uint16(requestData[3]) | uint16(requestData[4])<<8, true
+}

--- a/bus_observability_store.go
+++ b/bus_observability_store.go
@@ -100,6 +100,23 @@ type BusObservabilityStore struct {
 	energyFreshnessMetricsRefresher func(now time.Time, passiveState string)
 	busAdmission                    *BusAdmission
 	admissionStabilityWindow        *AdmissionStabilityWindow
+
+	// evidence buffers passive observations for the runtime discovery
+	// promotion pipeline. Late-arriving devices (e.g. a regulator that
+	// boots after the gateway) accumulate evidence as their request /
+	// response traffic is observed; once an address crosses the
+	// promotion threshold the discovery promoter probes it actively.
+	//
+	// The buffer is read by an external promoter goroutine via
+	// EvidenceBuffer(); writes happen on the passive-event path under
+	// the buffer's own mutex.
+	evidence *EvidenceBuffer
+	// evidenceSourceProvider returns the gateway's admitted source
+	// address. The store filters self-source traffic out of evidence
+	// recording so the gateway never promotes its own admitted source.
+	// Nil-safe: when unset the store records all non-self-evident
+	// traffic (which is the historical / test default).
+	evidenceSourceProvider func() byte
 }
 
 // SetAdmissionStabilityWindow installs the AD08 / AD22 flap-mitigation
@@ -388,10 +405,44 @@ func NewBusObservabilityStore(cfg Config) *BusObservabilityStore {
 			transitions:      make(map[string]uint64),
 		},
 	}
+	// Evidence buffer feeds the runtime passive-promotion pipeline.
+	// 128 entries / Vaillant baseline seed are the long-standing
+	// defaults validated by evidence_buffer_test.go. Construction
+	// failure is logged but non-fatal — the store still operates as
+	// a pure observability sink without the promotion pathway.
+	if buf, err := NewEvidenceBuffer(128, VaillantBaselineTopologySeed); err == nil {
+		store.evidence = buf
+	}
 	if reason := passiveTransportUnavailableReason(cfg); reason != "" {
 		store.passive.unavailableReason = reason
 	}
 	return store
+}
+
+// EvidenceBuffer returns the runtime passive-evidence buffer used by the
+// discovery promoter. Returns nil if the buffer was not constructed
+// (e.g. invalid seed at startup); callers must nil-check.
+func (store *BusObservabilityStore) EvidenceBuffer() *EvidenceBuffer {
+	if store == nil {
+		return nil
+	}
+	return store.evidence
+}
+
+// SetAdmittedSourceProvider installs the function the store uses to
+// learn which address has been admitted as the gateway's source. This
+// must be set after the source-address selection completes; the store
+// uses it to filter self-source traffic out of evidence recording so
+// the gateway never feeds its own probes back into the promotion
+// pipeline. Nil-safe: when unset, all non-self-evident traffic flows
+// to the buffer (legacy / test default).
+func (store *BusObservabilityStore) SetAdmittedSourceProvider(provider func() byte) {
+	if store == nil {
+		return
+	}
+	store.mu.Lock()
+	store.evidenceSourceProvider = provider
+	store.mu.Unlock()
 }
 
 func (store *BusObservabilityStore) SetStartupSurfaceProvider(provider func() *BusObservabilityStartup) {
@@ -574,6 +625,7 @@ func (store *BusObservabilityStore) OnPassiveClassifiedEvent(event PassiveClassi
 	switch event.Kind {
 	case PassiveClassifiedEventBroadcastFrame, PassiveClassifiedEventMasterFrame, PassiveClassifiedEventTransaction:
 		store.recordPassiveFrameLocked(event)
+		store.recordEvidenceFromEventLocked(event)
 	case PassiveClassifiedEventAbandonedTransaction:
 		store.recordPassiveAbandonedLocked(event)
 	case PassiveClassifiedEventDiscontinuity:
@@ -584,6 +636,177 @@ func (store *BusObservabilityStore) OnPassiveClassifiedEvent(event PassiveClassi
 	} else {
 		store.touchLocked(store.now())
 	}
+}
+
+// recordEvidenceFromEventLocked feeds passive-frame addresses into the
+// runtime evidence buffer for the discovery-promotion pipeline.
+//
+// Evidence-strength classification:
+//   - PassiveClassifiedEventTransaction whose response carries an
+//     identity-bearing or B524 capability response → EvidenceStrong:
+//     the address has demonstrably participated as a coherent Vaillant
+//     responder, sufficient for single-observation promotion.
+//   - PassiveClassifiedEventBroadcastFrame source (e.g. 0x07-class
+//     sign-of-life) → EvidenceWeak: presence-only signal.
+//   - PassiveClassifiedEventMasterFrame source / target,
+//     PassiveClassifiedEventTransaction request source / target →
+//     EvidenceWeak: traffic-only signal.
+//
+// Address filters applied:
+//   - Skip the gateway's admitted source so the gateway never
+//     feeds its own outbound traffic back into promotion.
+//   - Skip broadcast (0xFE), SYN (0xAA), and pre-responder range
+//     (<0x03) — these are protocol artifacts, not device addresses.
+//   - 0xFF is the broadcast destination class (e.g. 0x07 0xFF
+//     sign-of-life); record the SOURCE as presence evidence but
+//     never the broadcast destination as a candidate.
+//
+// Caller holds store.mu.
+func (store *BusObservabilityStore) recordEvidenceFromEventLocked(event PassiveClassifiedEvent) {
+	if store == nil || store.evidence == nil {
+		return
+	}
+	now := event.ObservedAt
+	if now.IsZero() {
+		now = store.now()
+	}
+	admittedSource := byte(0)
+	if store.evidenceSourceProvider != nil {
+		admittedSource = store.evidenceSourceProvider()
+	}
+
+	strongResponseEvidence := false
+	if event.Kind == PassiveClassifiedEventTransaction && event.HasResponse {
+		strongResponseEvidence = passiveResponseIsCoherentVaillantEvidence(event.Request, event.Response)
+	}
+
+	// Per-event dedupe: a single transaction has both
+	// request.Target and response.Source pointing at the same
+	// responder; recording both would double-count and let a single
+	// (non-coherent) frame cross the weak-evidence promotion
+	// threshold. Track the highest-strength record per address
+	// within this event.
+	perEvent := make(map[byte]EvidenceStrength, 4)
+	upgradeCandidate := func(addr byte, strength EvidenceStrength) {
+		if !isPassiveEvidenceCandidate(addr, admittedSource) {
+			return
+		}
+		if existing, ok := perEvent[addr]; !ok || strength > existing {
+			perEvent[addr] = strength
+		}
+	}
+	candidateKind := make(map[byte]string, 4)
+	upgradeKind := func(addr byte, kind string) {
+		if !isPassiveEvidenceCandidate(addr, admittedSource) {
+			return
+		}
+		if _, ok := candidateKind[addr]; !ok {
+			candidateKind[addr] = kind
+		}
+	}
+
+	switch event.Kind {
+	case PassiveClassifiedEventBroadcastFrame:
+		// 07 FF and other sign-of-life broadcasts are presence-only
+		// evidence per operator requirement: "consumed passively as
+		// presence evidence, not used as a discovery probe target."
+		// PresenceOnly keeps the address fresh in the buffer (so LRU
+		// eviction does not lose long-lived presence) but does NOT
+		// contribute to the promotion threshold — broadcast traffic
+		// alone never promotes.
+		upgradeCandidate(event.Request.Source, EvidencePresenceOnly)
+		upgradeKind(event.Request.Source, "broadcast_source")
+	case PassiveClassifiedEventMasterFrame:
+		upgradeCandidate(event.Request.Source, EvidenceWeak)
+		upgradeKind(event.Request.Source, "master_source")
+		upgradeCandidate(event.Request.Target, EvidenceWeak)
+		upgradeKind(event.Request.Target, "master_target")
+	case PassiveClassifiedEventTransaction:
+		responderStrength := EvidenceWeak
+		if strongResponseEvidence {
+			responderStrength = EvidenceStrong
+		}
+		upgradeCandidate(event.Request.Source, EvidenceWeak)
+		upgradeKind(event.Request.Source, "tx_request_source")
+		upgradeCandidate(event.Request.Target, responderStrength)
+		upgradeKind(event.Request.Target, "tx_responder")
+		if event.HasResponse {
+			// Identical to request.Target in normal transactions —
+			// dedupe via perEvent map, but still record the address
+			// when the reconstructor surfaces an aliased response
+			// source distinct from request.Target.
+			upgradeCandidate(event.Response.Source, responderStrength)
+			upgradeKind(event.Response.Source, "tx_responder")
+		}
+	}
+
+	for addr, strength := range perEvent {
+		store.evidence.Record(EvidenceRecord{
+			Address:  addr,
+			Strength: strength,
+			Observed: now,
+			Kind:     candidateKind[addr],
+		})
+	}
+}
+
+// isPassiveEvidenceCandidate reports whether addr is a valid candidate
+// for the runtime promotion pipeline. Filters out the gateway's own
+// admitted source, broadcast (0xFE), SYN (0xAA), the broadcast
+// destination class (0xFF), and the initiator-pre-arbitration range
+// (<0x03) per Vaillant / eBUS conventions.
+func isPassiveEvidenceCandidate(addr, admittedSource byte) bool {
+	if addr == 0x00 || addr == 0xAA || addr == 0xFE || addr == 0xFF {
+		return false
+	}
+	if addr < 0x03 {
+		return false
+	}
+	if admittedSource != 0 && addr == admittedSource {
+		return false
+	}
+	return true
+}
+
+// passiveResponseIsCoherentVaillantEvidence reports whether a request /
+// response pair carries Vaillant-coherent evidence strong enough to
+// promote on a single observation.
+//
+// Acceptance criteria — both must hold:
+//
+//   - request is a B524 extended-register read (Primary=0xB5 Secondary=0x24)
+//     AND response.Data echoes the request's group and addr fields in a
+//     valid B524 reply position (validated via IsB524ResponseCoherent).
+//
+// OR
+//
+//   - request is a B509 ScanID identity reply (Primary=0xB5 Secondary=0x09
+//     with opcode 0x29 at request.Data[0]) and response.Data is at least
+//     4 bytes (an identity-bearing reply payload).
+//
+// The shared B524 coherency helper (IsB524ResponseCoherent) makes the
+// passive-evidence acceptance criterion identical to the active probe
+// acceptance criterion in cmd/gateway/semantic_vaillant.go's
+// isB524ProbeCoherent — both call sites use the same source of truth.
+//
+// This guards against stray fragments or spoofed frames promoting
+// phantom addresses on a single observation: a passively observed
+// frame must echo the requested register parameters in their
+// canonical position before counting as strong evidence.
+func passiveResponseIsCoherentVaillantEvidence(request, response protocol.Frame) bool {
+	if request.Primary == 0xB5 && request.Secondary == 0x24 {
+		group, addr, ok := b524RequestParameters(request.Data)
+		if !ok {
+			return false
+		}
+		return IsB524ResponseCoherent(response.Data, group, addr)
+	}
+	if request.Primary == 0xB5 && request.Secondary == 0x09 &&
+		len(request.Data) > 0 && request.Data[0] == 0x29 &&
+		len(response.Data) >= 4 {
+		return true
+	}
+	return false
 }
 
 func (store *BusObservabilityStore) ObserveWatchRead(event WatchEfficiencyReadEvent) {

--- a/bus_observability_store.go
+++ b/bus_observability_store.go
@@ -751,10 +751,19 @@ func (store *BusObservabilityStore) recordEvidenceFromEventLocked(event PassiveC
 }
 
 // isPassiveEvidenceCandidate reports whether addr is a valid candidate
-// for the runtime promotion pipeline. Filters out the gateway's own
-// admitted source, broadcast (0xFE), SYN (0xAA), the broadcast
-// destination class (0xFF), and the initiator-pre-arbitration range
-// (<0x03) per Vaillant / eBUS conventions.
+// for the runtime promotion pipeline. Filters out:
+//
+//   - the gateway's own admitted source (self-traffic),
+//   - broadcast (0xFE), SYN (0xAA), the broadcast destination class
+//     (0xFF),
+//   - the initiator pre-arbitration range (<0x03),
+//   - initiator-capable addresses per the eBUS address table
+//     (e.g. 0x10, 0x31, 0x71, 0xF0). These are SOURCES; they do not
+//     respond to active probes as targets. The same filter is
+//     applied at the active-probe entry points
+//     (sanitizeStartupProbeTargets / parseStartupProbeTargets), so
+//     applying it here keeps the passive-evidence path consistent
+//     with the rest of the gateway.
 func isPassiveEvidenceCandidate(addr, admittedSource byte) bool {
 	if addr == 0x00 || addr == 0xAA || addr == 0xFE || addr == 0xFF {
 		return false
@@ -763,6 +772,9 @@ func isPassiveEvidenceCandidate(addr, admittedSource byte) bool {
 		return false
 	}
 	if admittedSource != 0 && addr == admittedSource {
+		return false
+	}
+	if protocol.IsInitiatorCapableAddress(addr) {
 		return false
 	}
 	return true

--- a/bus_observability_store_test.go
+++ b/bus_observability_store_test.go
@@ -1635,3 +1635,232 @@ func TestPassiveCorruptedRequestIsNonError(t *testing.T) {
 		t.Fatalf("passive corrupted_request should not be counted as error:\n%s", metrics)
 	}
 }
+
+// observabilityCoherentB524TransactionEvent builds a passive transaction
+// event whose request/response payloads form a coherent B524 read
+// (response echoes the request's group + addr in canonical position).
+// Used by evidence-strong tests where the strict coherency check must
+// pass for single-observation promotion.
+func observabilityCoherentB524TransactionEvent(observedAt time.Time, source, target byte) PassiveClassifiedEvent {
+	const (
+		opcode     = byte(0x06)
+		group      = byte(0x03)
+		instance   = byte(0x01)
+		addrLo     = byte(0x22)
+		addrHi     = byte(0x00)
+		statusByte = byte(0x00)
+	)
+	requestData := []byte{opcode, group, instance, addrLo, addrHi}
+	// Response: layout-a coherent ([statusByte, group, addrLo, addrHi, ...payload]).
+	responseData := []byte{statusByte, group, addrLo, addrHi, 0x12, 0x34}
+	return PassiveClassifiedEvent{
+		Kind:      PassiveClassifiedEventTransaction,
+		FrameType: protocol.FrameTypeInitiatorTarget,
+		Request: protocol.Frame{
+			Source:    source,
+			Target:    target,
+			Primary:   0xB5,
+			Secondary: 0x24,
+			Data:      requestData,
+		},
+		Response: protocol.Frame{
+			Source: target,
+			Target: source,
+			Data:   responseData,
+		},
+		HasRequest:  true,
+		HasResponse: true,
+		ObservedAt:  observedAt,
+	}
+}
+
+// TestEvidenceBuffer_RecordsB524ResponseAsStrongEvidence pins the
+// single-observation promotion contract for runtime passive promotion.
+// A passively observed COHERENT B524 transaction (response echoes the
+// request's group + addr in canonical position) carries Vaillant-
+// coherent identity sufficient for single-observation promotion.
+func TestEvidenceBuffer_RecordsB524ResponseAsStrongEvidence(t *testing.T) {
+	store := specimenPassiveStore()
+	base := time.Now().UTC()
+	store.now = func() time.Time { return base.Add(10 * time.Second) }
+
+	if store.EvidenceBuffer() == nil {
+		t.Fatal("specimen store has no evidence buffer; runtime promotion pipeline disabled")
+	}
+
+	store.OnPassiveClassifiedEvent(observabilityCoherentB524TransactionEvent(base.Add(10*time.Second), 0x10, 0x15))
+
+	promoted := store.EvidenceBuffer().PromotedAddresses()
+	hasRegulator := false
+	for _, addr := range promoted {
+		if addr == 0x15 {
+			hasRegulator = true
+		}
+	}
+	if !hasRegulator {
+		t.Fatalf("coherent B524 transaction targeting 0x15 did not promote 0x15; promoted=%v", promoted)
+	}
+}
+
+// TestEvidenceBuffer_DoesNotPromoteOnSingleWeakBroadcast pins the negative
+// case: a single broadcast frame is presence-only (weak) evidence and
+// must NOT trigger promotion. Two observations are required for weak
+// evidence per EvidenceBuffer policy.
+func TestEvidenceBuffer_DoesNotPromoteOnSingleWeakBroadcast(t *testing.T) {
+	store := specimenPassiveStore()
+	base := time.Now().UTC()
+	store.now = func() time.Time { return base.Add(10 * time.Second) }
+
+	store.OnPassiveClassifiedEvent(observabilityPassiveBroadcastEvent(base.Add(10*time.Second), 0x15, 0x07, 0xFF))
+
+	promoted := store.EvidenceBuffer().PromotedAddresses()
+	for _, addr := range promoted {
+		if addr == 0x15 {
+			t.Fatalf("single broadcast observation must not promote 0x15; promoted=%v", promoted)
+		}
+	}
+}
+
+// TestEvidenceBuffer_PromotesOnTwoWeakObservations pins that two weak
+// observations across distinct events cross the promotion threshold
+// (broadcast presence does NOT count as a weak observation; only
+// non-broadcast frames and non-coherent transactions do).
+func TestEvidenceBuffer_PromotesOnTwoWeakObservations(t *testing.T) {
+	store := specimenPassiveStore()
+	base := time.Now().UTC()
+	store.now = func() time.Time { return base.Add(10 * time.Second) }
+
+	// Two distinct initiator-class frames where 0x15 is the initiator.
+	// Each contributes one weak observation.
+	store.OnPassiveClassifiedEvent(observabilityPassiveMasterFrameEvent(base.Add(10*time.Second), 0x15, 0x08, 0xB5, 0x09))
+	store.OnPassiveClassifiedEvent(observabilityPassiveMasterFrameEvent(base.Add(20*time.Second), 0x15, 0x08, 0xB5, 0x09))
+
+	promoted := store.EvidenceBuffer().PromotedAddresses()
+	hasRegulator := false
+	for _, addr := range promoted {
+		if addr == 0x15 {
+			hasRegulator = true
+		}
+	}
+	if !hasRegulator {
+		t.Fatalf("two weak observations on 0x15 did not promote; promoted=%v", promoted)
+	}
+}
+
+// TestEvidenceBuffer_FiltersAdmittedSource pins the source-address
+// invariant: the gateway's own admitted source must never enter the
+// promotion pipeline, even if it appears as a frame source on the bus
+// (e.g. self-traffic loop or proxy aliasing).
+func TestEvidenceBuffer_FiltersAdmittedSource(t *testing.T) {
+	store := specimenPassiveStore()
+	base := time.Now().UTC()
+	store.now = func() time.Time { return base.Add(10 * time.Second) }
+
+	store.SetAdmittedSourceProvider(func() byte { return 0x71 })
+
+	store.OnPassiveClassifiedEvent(observabilityCoherentB524TransactionEvent(base.Add(10*time.Second), 0x71, 0x08))
+	store.OnPassiveClassifiedEvent(observabilityCoherentB524TransactionEvent(base.Add(11*time.Second), 0x71, 0x08))
+
+	promoted := store.EvidenceBuffer().PromotedAddresses()
+	for _, addr := range promoted {
+		if addr == 0x71 {
+			t.Fatalf("admitted source 0x71 promoted from passive evidence; promoted=%v", promoted)
+		}
+	}
+}
+
+// TestEvidenceBuffer_FiltersBroadcastAndSyn pins the protocol-artifact
+// filter: 0xFE (broadcast destination), 0xFF (broadcast destination
+// class for 07 FF), 0xAA (SYN), 0x00 / 0x01 (initiator pre-arbitration)
+// must never enter the promotion pipeline regardless of passive
+// observation count. The test exercises both source-side (broadcast
+// frame source) and target-side (initiator-class frame target) recording paths.
+func TestEvidenceBuffer_FiltersBroadcastAndSyn(t *testing.T) {
+	store := specimenPassiveStore()
+	base := time.Now().UTC()
+	store.now = func() time.Time { return base.Add(10 * time.Second) }
+
+	// Initiator-class frames whose target is a protocol artifact — exercises
+	// the target-side filter path. Source 0x10 is a real responder
+	// address (not under test); the assertion is that the target
+	// (0xFE/0xAA) never enters promotion.
+	store.OnPassiveClassifiedEvent(observabilityPassiveMasterFrameEvent(base.Add(10*time.Second), 0x10, 0xFE, 0xB5, 0x09))
+	store.OnPassiveClassifiedEvent(observabilityPassiveMasterFrameEvent(base.Add(11*time.Second), 0x10, 0xAA, 0xB5, 0x09))
+
+	promoted := store.EvidenceBuffer().PromotedAddresses()
+	for _, addr := range promoted {
+		if addr == 0xFF || addr == 0xFE || addr == 0xAA || addr < 0x03 {
+			t.Fatalf("protocol-artifact address 0x%02X promoted from passive evidence; promoted=%v", addr, promoted)
+		}
+	}
+}
+
+// TestEvidenceBuffer_BroadcastSourceIsPresenceOnlyDoesNotPromote pins
+// the operator's stated requirement: "07 FF is consumed passively as
+// presence evidence, not used as a discovery probe." Even after many
+// 07 FF sign-of-life broadcasts, the source address 0x07 must NEVER
+// cross the promotion threshold — broadcast traffic alone is not
+// evidence of an active responder.
+func TestEvidenceBuffer_BroadcastSourceIsPresenceOnlyDoesNotPromote(t *testing.T) {
+	store := specimenPassiveStore()
+	base := time.Now().UTC()
+	store.now = func() time.Time { return base.Add(10 * time.Second) }
+
+	// 5 sign-of-life broadcasts from 0x07 (PIC initiator class).
+	// On a healthy bus these arrive every few seconds. With weak-
+	// strength evidence, two of these would promote 0x07. With
+	// presence-only strength, no number of broadcasts promote it.
+	for i := 0; i < 5; i++ {
+		store.OnPassiveClassifiedEvent(observabilityPassiveBroadcastEvent(
+			base.Add(time.Duration(10+i)*time.Second), 0x07, 0x07, 0xFF))
+	}
+
+	promoted := store.EvidenceBuffer().PromotedAddresses()
+	for _, addr := range promoted {
+		if addr == 0x07 {
+			t.Fatalf("broadcast source 0x07 promoted after %d sign-of-life observations; presence-only contract violated. promoted=%v", 5, promoted)
+		}
+	}
+}
+
+// TestEvidenceBuffer_StrongEvidenceRequiresCoherentB524Echo pins the
+// strict B524 coherency check on the strong-evidence path. A B524
+// transaction whose response Data is non-empty but does NOT echo the
+// request's group/addr in a valid B524 reply position must NOT
+// classify as strong evidence — guards against single-frame phantom-
+// address promotion via stray fragments or spoofed responses.
+func TestEvidenceBuffer_StrongEvidenceRequiresCoherentB524Echo(t *testing.T) {
+	store := specimenPassiveStore()
+	base := time.Now().UTC()
+	store.now = func() time.Time { return base.Add(10 * time.Second) }
+
+	// B524 transaction with non-coherent response data: response
+	// length is < 4 bytes (the canonical B524 reply minimum).
+	event := PassiveClassifiedEvent{
+		Kind:      PassiveClassifiedEventTransaction,
+		FrameType: protocol.FrameTypeInitiatorTarget,
+		Request: protocol.Frame{
+			Source:    0x10,
+			Target:    0x42,
+			Primary:   0xB5,
+			Secondary: 0x24,
+			Data:      []byte{0x06, 0x03, 0x01, 0x22, 0x00}, // opcode=0x06 group=0x03 instance=0x01 addr=0x0022
+		},
+		Response: protocol.Frame{
+			Source: 0x42,
+			Target: 0x10,
+			Data:   []byte{0xFF}, // 1 byte — too short for coherent B524 reply
+		},
+		HasRequest:  true,
+		HasResponse: true,
+		ObservedAt:  base.Add(10 * time.Second),
+	}
+	store.OnPassiveClassifiedEvent(event)
+
+	promoted := store.EvidenceBuffer().PromotedAddresses()
+	for _, addr := range promoted {
+		if addr == 0x42 {
+			t.Fatalf("phantom address 0x42 promoted after single non-coherent B524 response; phantom-promotion guard violated. promoted=%v", promoted)
+		}
+	}
+}

--- a/bus_observability_store_test.go
+++ b/bus_observability_store_test.go
@@ -1641,16 +1641,21 @@ func TestPassiveCorruptedRequestIsNonError(t *testing.T) {
 // (response echoes the request's group + addr in canonical position).
 // Used by evidence-strong tests where the strict coherency check must
 // pass for single-observation promotion.
+//
+// Layout matches buildB524ReadSelector exactly (6-byte request):
+//
+//	[opcode, op, group, instance, addr_lo, addr_hi]
 func observabilityCoherentB524TransactionEvent(observedAt time.Time, source, target byte) PassiveClassifiedEvent {
 	const (
 		opcode     = byte(0x06)
+		op         = byte(0x00) // read
 		group      = byte(0x03)
 		instance   = byte(0x01)
 		addrLo     = byte(0x22)
 		addrHi     = byte(0x00)
 		statusByte = byte(0x00)
 	)
-	requestData := []byte{opcode, group, instance, addrLo, addrHi}
+	requestData := []byte{opcode, op, group, instance, addrLo, addrHi}
 	// Response: layout-a coherent ([statusByte, group, addrLo, addrHi, ...payload]).
 	responseData := []byte{statusByte, group, addrLo, addrHi, 0x12, 0x34}
 	return PassiveClassifiedEvent{
@@ -1671,6 +1676,66 @@ func observabilityCoherentB524TransactionEvent(observedAt time.Time, source, tar
 		HasRequest:  true,
 		HasResponse: true,
 		ObservedAt:  observedAt,
+	}
+}
+
+// TestEvidenceBuffer_StrongEvidenceUsesCanonicalRequestLayout closes Codex
+// PR #561 P2 finding: the b524RequestParameters extractor must match
+// buildB524ReadSelector's 6-byte layout exactly (data[2]=group,
+// data[4..5]=addr). An earlier off-by-one extractor would have failed
+// real-device B524 traffic and caused the late-arrival regulator
+// scenario to never promote on a single observation.
+//
+// This test pins the canonical layout end-to-end: a real-device-shaped
+// coherent transaction must extract correctly and promote on a single
+// observation.
+func TestEvidenceBuffer_StrongEvidenceUsesCanonicalRequestLayout(t *testing.T) {
+	store := specimenPassiveStore()
+	base := time.Now().UTC()
+	store.now = func() time.Time { return base.Add(10 * time.Second) }
+
+	// Source 0x10 is initiator-capable (filtered), so we use it for
+	// source. Target 0x15 is the responder under test (regulator,
+	// not initiator-capable, valid candidate).
+	event := observabilityCoherentB524TransactionEvent(base.Add(10*time.Second), 0x10, 0x15)
+	store.OnPassiveClassifiedEvent(event)
+
+	promoted := store.EvidenceBuffer().PromotedAddresses()
+	hasRegulator := false
+	for _, addr := range promoted {
+		if addr == 0x15 {
+			hasRegulator = true
+		}
+	}
+	if !hasRegulator {
+		t.Fatalf("canonical-layout coherent B524 transaction targeting 0x15 did not promote on single observation; promoted=%v", promoted)
+	}
+}
+
+// TestEvidenceBuffer_FiltersInitiatorCapableAddresses closes Codex
+// PR #561 P2 finding: an initiator-capable address (e.g. 0x31, 0x10,
+// 0x71) observed as a frame source on the bus must NOT be promoted
+// as a discovery target. Initiator-capable addresses do not respond
+// to active probes as targets, and the active-probe entry points
+// (sanitizeStartupProbeTargets, parseStartupProbeTargets) already
+// reject them; the passive-evidence path applies the same filter.
+func TestEvidenceBuffer_FiltersInitiatorCapableAddresses(t *testing.T) {
+	store := specimenPassiveStore()
+	base := time.Now().UTC()
+	store.now = func() time.Time { return base.Add(10 * time.Second) }
+
+	// Two non-coherent transactions sourced from 0x31 (initiator-
+	// capable) targeting 0x08. Each event records 0x31 as
+	// tx_request_source weak evidence. Without the filter, two
+	// observations would promote 0x31.
+	store.OnPassiveClassifiedEvent(observabilityPassiveTransactionEvent(base.Add(10*time.Second), 0x31, 0x08, 0xB5, 0x09))
+	store.OnPassiveClassifiedEvent(observabilityPassiveTransactionEvent(base.Add(11*time.Second), 0x31, 0x08, 0xB5, 0x09))
+
+	promoted := store.EvidenceBuffer().PromotedAddresses()
+	for _, addr := range promoted {
+		if addr == 0x31 {
+			t.Fatalf("initiator-capable address 0x31 promoted from passive evidence; promoter would issue probes to a non-target-capable address. promoted=%v", promoted)
+		}
 	}
 }
 
@@ -1834,8 +1899,12 @@ func TestEvidenceBuffer_StrongEvidenceRequiresCoherentB524Echo(t *testing.T) {
 	base := time.Now().UTC()
 	store.now = func() time.Time { return base.Add(10 * time.Second) }
 
-	// B524 transaction with non-coherent response data: response
-	// length is < 4 bytes (the canonical B524 reply minimum).
+	// B524 transaction with a CANONICALLY-LAYOUT request (6 bytes,
+	// matches buildB524ReadSelector) but a NON-coherent response:
+	// the response Data does not echo the request's group/addr in
+	// any valid B524 reply position. Without the strict coherency
+	// check, the responder address would be promoted as strong
+	// evidence on a single observation.
 	event := PassiveClassifiedEvent{
 		Kind:      PassiveClassifiedEventTransaction,
 		FrameType: protocol.FrameTypeInitiatorTarget,
@@ -1844,12 +1913,18 @@ func TestEvidenceBuffer_StrongEvidenceRequiresCoherentB524Echo(t *testing.T) {
 			Target:    0x42,
 			Primary:   0xB5,
 			Secondary: 0x24,
-			Data:      []byte{0x06, 0x03, 0x01, 0x22, 0x00}, // opcode=0x06 group=0x03 instance=0x01 addr=0x0022
+			Data:      []byte{0x06, 0x00, 0x03, 0x01, 0x22, 0x00}, // opcode op group instance addr_lo addr_hi
 		},
 		Response: protocol.Frame{
 			Source: 0x42,
 			Target: 0x10,
-			Data:   []byte{0xFF}, // 1 byte — too short for coherent B524 reply
+			// 4 bytes long enough to pass the length check, but
+			// group/addr in non-canonical positions (does not match
+			// either layout-a or layout-b):
+			//   layout-a expects resp[1]=group=0x03, resp[2..3]=addr=0x0022
+			//   layout-b expects resp[2]=group=0x03, resp[3..4]=addr=0x0022
+			// Neither matches: payload encodes [0x99, 0x99, 0x99, 0x99].
+			Data: []byte{0x99, 0x99, 0x99, 0x99},
 		},
 		HasRequest:  true,
 		HasResponse: true,

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -513,6 +513,41 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 
 	go startBackgroundFullScanFn(ctx, startupCfg, gateway, builder, startupScanSignals.semanticBootstrapReady)
 
+	// Runtime passive-promotion pipeline: late-arriving devices (e.g.
+	// the regulator boots after the gateway) accumulate passive
+	// evidence in busObservability's EvidenceBuffer; the promoter
+	// loop confirms candidates with B524 coherency, registers them
+	// in the registry, refreshes router planes, and signals semantic
+	// discovery refresh.
+	if busObservability != nil && busObservability.EvidenceBuffer() != nil && semanticPoller != nil {
+		busObservability.SetAdmittedSourceProvider(func() byte {
+			source, ok := builder.AdmittedMutationSource()
+			if !ok {
+				return 0
+			}
+			return source
+		})
+		promoter, err := ebusgateway.NewPassiveDiscoveryPromoter(ebusgateway.PassiveDiscoveryPromoterOptions{
+			Registry:          gateway.Registry,
+			EvidenceBuffer:    busObservability.EvidenceBuffer(),
+			ConfirmFn:         semanticPoller.ConfirmB524Coherent,
+			SemanticRefreshFn: semanticPoller.EnqueueDiscoveryRefresh,
+			RouterRefreshFn:   func() { _ = gateway.RefreshRouterPlanes() },
+			AdmittedSourceFn: func() byte {
+				source, ok := builder.AdmittedMutationSource()
+				if !ok {
+					return 0
+				}
+				return source
+			},
+		})
+		if err != nil {
+			log.Printf("passive_discovery_promoter init failed: %v", err)
+		} else {
+			go promoter.Run(ctx)
+		}
+	}
+
 	var scheduleWriter mcp.ScheduleWriter
 	if semanticPoller != nil {
 		scheduleWriter = admittedMCPScheduleWriter{

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -6533,15 +6533,7 @@ func parseB524ReadPayload(payload []byte, opcode, group, instance byte, addr uin
 // header-only responses (no value bytes) as coherent — the device returned a
 // valid B524 structure which proves capability.
 func isB524ProbeCoherent(payload []byte, group byte, addr uint16) bool {
-	if len(payload) < 4 {
-		return false
-	}
-	if len(payload) >= 5 {
-		if payload[2] == group && (uint16(payload[3])|uint16(payload[4])<<8) == addr {
-			return true
-		}
-	}
-	return payload[1] == group && (uint16(payload[2])|uint16(payload[3])<<8) == addr
+	return ebusgateway.IsB524ResponseCoherent(payload, group, addr)
 }
 
 // probeB524Register sends a single B524 read request to target and checks
@@ -6750,6 +6742,40 @@ func (p *vaillantSemanticPoller) discoverB524RootWithOptions(ctx context.Context
 		addrs[i] = fmt.Sprintf("0x%02x", c)
 	}
 	return 0, fmt.Errorf("gateway.discoverB524Root: no coherent responder among [%s]", strings.Join(addrs, ", "))
+}
+
+// ConfirmB524Coherent runs the multi-register B524 capability probe
+// against target and returns true if every probe responds coherently.
+// Used by the runtime passive-promotion pipeline to validate that a
+// candidate address discovered via passive evidence actually
+// implements the Vaillant extended-register protocol before
+// registering it. The probe sources from the poller's admitted
+// source — source-address invariant is preserved.
+func (p *vaillantSemanticPoller) ConfirmB524Coherent(ctx context.Context, target byte) bool {
+	if p == nil {
+		return false
+	}
+	probeFn := p.b524ProbeFn
+	if probeFn == nil {
+		probeFn = p.probeB524Register
+	}
+	for _, probe := range b524CapabilityProbes {
+		if !probeFn(ctx, target, probe.opcode, probe.group, probe.instance, probe.addr) {
+			return false
+		}
+	}
+	return true
+}
+
+// EnqueueDiscoveryRefresh signals the semantic poller to re-run
+// discovery on the next available task slot. Used by the passive-
+// promotion pipeline after a late-arrival candidate is registered,
+// so the regulator surface populates without a gateway restart.
+func (p *vaillantSemanticPoller) EnqueueDiscoveryRefresh() {
+	if p == nil {
+		return
+	}
+	p.enqueueTask(semanticTaskPriorityHigh, p.refreshDiscovery)
 }
 
 // registerStructuralControllerIfMissing registers a minimal Vaillant

--- a/evidence_buffer.go
+++ b/evidence_buffer.go
@@ -12,7 +12,20 @@ import (
 type EvidenceStrength uint8
 
 const (
-	EvidenceWeak EvidenceStrength = iota + 1
+	// EvidencePresenceOnly records that an address was observed on
+	// the bus without contributing to promotion. Used for sign-of-
+	// life broadcast sources (e.g. 0x07 0xFF), where the operator's
+	// stated requirement is "consumed passively as presence
+	// evidence, not used as a discovery probe target."
+	EvidencePresenceOnly EvidenceStrength = iota + 1
+	// EvidenceWeak counts toward promotion (>=2 weak observations
+	// promote). Initiator-class frames, request-target traffic without a
+	// coherent B524 response.
+	EvidenceWeak
+	// EvidenceStrong promotes on a single observation. Only used
+	// when the response payload demonstrably implements the
+	// Vaillant extended-register protocol (passes the B524 probe
+	// coherency check) or carries a B509 ScanID identity reply.
 	EvidenceStrong
 )
 
@@ -98,7 +111,13 @@ func NewEvidenceBuffer(maxEntries int, baseline []byte) (*EvidenceBuffer, error)
 }
 
 // Record adds or updates evidence for an address. Returns whether the address
-// crossed the promotion threshold as a result (≥2 observations OR any strong).
+// crossed the promotion threshold as a result (≥2 weak/strong observations
+// OR any strong observation).
+//
+// EvidencePresenceOnly records a touch without contributing to the
+// promotion threshold (`observations` and `strongObs` are NOT
+// incremented). Used to keep an address fresh in the buffer without
+// promoting it (see EvidencePresenceOnly docstring).
 func (b *EvidenceBuffer) Record(record EvidenceRecord) (promoted bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -118,18 +137,47 @@ func (b *EvidenceBuffer) Record(record EvidenceRecord) (promoted bool) {
 		b.entries[record.Address] = state
 	}
 
+	state.lastObserved = record.Observed
+	state.touchedAt = b.tick
+
+	if record.Strength == EvidencePresenceOnly {
+		// Presence-only: refresh the touch timestamp (so the entry
+		// is not LRU-evicted) but do NOT contribute to the
+		// promotion threshold.
+		return false
+	}
+
 	state.observations++
 	if record.Strength == EvidenceStrong {
 		state.strongObs++
 	}
-	state.lastObserved = record.Observed
-	state.touchedAt = b.tick
 
 	if !state.promoted && (state.observations >= 2 || state.strongObs >= 1) {
 		state.promoted = true
 		return true
 	}
 	return false
+}
+
+// Demote clears the promoted flag for an address and resets its
+// observation counters, allowing the runtime promotion pipeline to
+// give up on a candidate that has repeatedly failed active
+// confirmation. The address remains in the buffer (so subsequent
+// fresh evidence can re-promote it after threshold) but is no longer
+// returned by PromotedAddresses.
+//
+// Returns true iff the address was promoted before this call.
+func (b *EvidenceBuffer) Demote(addr byte) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	state, ok := b.entries[addr]
+	if !ok || !state.promoted {
+		return false
+	}
+	state.promoted = false
+	state.observations = 0
+	state.strongObs = 0
+	return true
 }
 
 func (b *EvidenceBuffer) evictOldestNonBaselineLocked() {

--- a/passive_discovery_promoter.go
+++ b/passive_discovery_promoter.go
@@ -24,6 +24,26 @@ import (
 // fresh passive evidence.
 const maxConfirmationAttempts = 5
 
+// perCandidateConfirmationBudget caps a single ConfirmB524Coherent
+// invocation. The B524 capability probe runs len(b524CapabilityProbes)
+// (=2) probes; each probeB524Register retries up to 3 times with a 5s
+// per-attempt floor (minB524ProbeTimeout) plus 200ms inter-attempt
+// backoff. Worst-case per probe: 3 * (5s + 200ms) ≈ 16s; worst-case
+// per coherency check: 2 * 16s ≈ 32s.
+//
+// A tighter cap (e.g. tickInterval/2 = 15s) would expire mid-retry on
+// busy adapter-direct buses, falsely demoting late-arrival devices
+// after maxConfirmationAttempts ticks even though the bus contention
+// would have resolved within the built-in retry budget. The 45s
+// budget below adds a ~40% safety margin over the worst-case sum so
+// transient contention cannot starve a reachable candidate.
+//
+// processOnce derives the actual per-candidate timeout as the lesser
+// of perCandidateConfirmationBudget and tickInterval — a tickInterval
+// shorter than the budget (e.g. tests using millisecond ticks) is
+// honored, but normal operation gets the full budget.
+const perCandidateConfirmationBudget = 45 * time.Second
+
 // PassiveDiscoveryPromoter is the runtime-phase counterpart to the
 // startup directed-probe scan. It bridges the gap where a Vaillant
 // device — typically the regulator — boots after the gateway and
@@ -234,10 +254,17 @@ func (p *PassiveDiscoveryPromoter) processOnce(ctx context.Context) {
 	}
 	candidates := p.evidenceBuf.PromotedAddresses()
 	confirmedThisTick := 0
-	perCandidateTimeout := p.tickInterval / 2
-	if perCandidateTimeout <= 0 {
-		perCandidateTimeout = 15 * time.Second
-	}
+	// Per-candidate budget: large enough to accommodate the full
+	// ConfirmB524Coherent retry chain on a busy adapter-direct bus
+	// (~32s worst case, 45s with safety margin). The candidate
+	// budget intentionally exceeds the default tickInterval so
+	// transient bus contention does not falsely demote reachable
+	// late-arrival devices. processOnce is reentrant-safe wrt the
+	// next ticker.C: Run's select drops a tick that fires while
+	// processOnce is still in flight, and ConfirmB524Coherent
+	// bounds itself internally so a stuck candidate cannot block
+	// past the budget.
+	perCandidateTimeout := perCandidateConfirmationBudget
 	for _, addr := range candidates {
 		if !p.shouldAttempt(addr, admittedSource, now) {
 			continue

--- a/passive_discovery_promoter.go
+++ b/passive_discovery_promoter.go
@@ -259,17 +259,27 @@ func (p *PassiveDiscoveryPromoter) processOnce(ctx context.Context) {
 			continue
 		}
 		p.recordAttemptSuccess(addr)
-		p.commitConfirmedDeviceCoalesced(addr, &confirmedThisTick)
+		p.commitConfirmedRegistration(addr)
+		confirmedThisTick++
+	}
+
+	// Semantic refresh is emitted ONCE per tick, AFTER all
+	// confirmed candidates have been registered and router planes
+	// refreshed. Firing it during the loop (after the first
+	// registration) would let the semantic discovery task start
+	// and snapshot the registry before later candidates in the
+	// same tick land — those devices would then miss the immediate
+	// refresh and only surface on the next periodic discovery
+	// interval.
+	if confirmedThisTick > 0 && p.semanticRefreshFn != nil {
+		p.semanticRefreshFn()
 	}
 }
 
-// commitConfirmedDeviceCoalesced is commitConfirmedDevice with
-// per-tick semantic-refresh coalescing. The first confirmation in a
-// tick fires the semantic refresh; subsequent confirmations register
-// the device + refresh router planes but do not enqueue another
-// semantic refresh (the already-queued task will see all newly-
-// registered devices on the next discovery scan).
-func (p *PassiveDiscoveryPromoter) commitConfirmedDeviceCoalesced(addr byte, confirmedThisTick *int) {
+// commitConfirmedRegistration registers the candidate in the device
+// registry and refreshes router planes. Semantic refresh is emitted
+// once per tick by processOnce after all registrations commit.
+func (p *PassiveDiscoveryPromoter) commitConfirmedRegistration(addr byte) {
 	p.mu.Lock()
 	registerFn := p.registerFn
 	p.mu.Unlock()
@@ -282,10 +292,6 @@ func (p *PassiveDiscoveryPromoter) commitConfirmedDeviceCoalesced(addr byte, con
 		})
 	}
 	log.Printf("passive_discovery_promoter_registered address=0x%02x source=passive_promotion", addr)
-	if *confirmedThisTick == 0 && p.semanticRefreshFn != nil {
-		p.semanticRefreshFn()
-	}
-	*confirmedThisTick++
 	if p.routerRefreshFn != nil {
 		p.routerRefreshFn()
 	}

--- a/passive_discovery_promoter.go
+++ b/passive_discovery_promoter.go
@@ -193,6 +193,18 @@ func (p *PassiveDiscoveryPromoter) Run(ctx context.Context) {
 // processOnce runs a single tick of the promotion loop. Public for
 // testing — production callers use Run.
 //
+// Source-admission gate: when no source has been admitted (admission
+// still pending in source-selection mode, or in degraded state after
+// active_probe_failed), the promoter MUST NOT issue active
+// confirmation probes. The downstream confirmFn sources from the
+// semantic poller's configured source, which is set even before
+// admission completes. Issuing probes while admission is unresolved
+// violates the source-admission invariant — admission gates ALL
+// gateway-originated active traffic, including this pipeline. The
+// gate yields the tick (no candidates probed); the next tick re-
+// evaluates admission state. Evidence keeps accumulating in the
+// buffer regardless.
+//
 // Per-candidate deadline: each confirmation runs under a derived
 // context capped at tickInterval/2, so one slow / non-responsive
 // candidate cannot starve subsequent candidates within the same tick
@@ -214,6 +226,12 @@ func (p *PassiveDiscoveryPromoter) processOnce(ctx context.Context) {
 	}
 	now := p.now()
 	admittedSource := p.admittedSourceFn()
+	if admittedSource == 0 {
+		// Source admission is pending or has degraded. Defer all
+		// active confirmation until admission resolves; evidence
+		// keeps accumulating in the buffer for the next tick.
+		return
+	}
 	candidates := p.evidenceBuf.PromotedAddresses()
 	confirmedThisTick := 0
 	perCandidateTimeout := p.tickInterval / 2

--- a/passive_discovery_promoter.go
+++ b/passive_discovery_promoter.go
@@ -1,0 +1,400 @@
+package ebusgateway
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+)
+
+// maxConfirmationAttempts caps the number of active confirmation
+// attempts the promoter makes against a single passive-promoted
+// address before demoting the candidate from the EvidenceBuffer's
+// promoted set. Without this cap, a stale or spoofed promotion
+// would retry on every backoff cycle for the gateway's lifetime,
+// wasting bus arbitration slots and accumulating dead state.
+//
+// Sized at 5 to allow for transient bus contention or temporarily
+// non-responsive devices to recover within a single backoff plateau
+// (~5min cumulative). Demoted candidates can be re-promoted by
+// fresh passive evidence.
+const maxConfirmationAttempts = 5
+
+// PassiveDiscoveryPromoter is the runtime-phase counterpart to the
+// startup directed-probe scan. It bridges the gap where a Vaillant
+// device — typically the regulator — boots after the gateway and
+// therefore never appears in the directed startup probe target list.
+//
+// Pipeline:
+//
+//  1. The bus_observability store records passive evidence per
+//     observed address into its EvidenceBuffer. Once an address
+//     crosses the buffer's promotion threshold (>=2 weak observations
+//     OR >=1 strong observation; strong = B524 / B509 ScanID
+//     response), it is exposed via PromotedAddresses().
+//
+//  2. The promoter periodically polls PromotedAddresses(), filters
+//     candidates already in the registry / equal to the admitted
+//     source / outside the responder range, and runs bounded active
+//     confirmation against each remaining candidate using the existing
+//     B524 capability probe.
+//
+//  3. On confirmation: a minimal Vaillant entry is registered, router
+//     planes are refreshed (so live event routing reflects the new
+//     device), and the semantic poller's discovery refresh is
+//     enqueued so the regulator surface populates without a gateway
+//     restart.
+//
+// Source-address invariant: active confirmation always sources from
+// the gateway's admitted source. The promoter never overrides the
+// admitted source under any condition.
+//
+// Rate limiting: per-address attempt counter with exponential
+// backoff via RejoinBackoffSchedule. A failed confirmation
+// schedules the next attempt at backoff(attempt) with a jittered
+// floor; success clears the per-address state.
+type PassiveDiscoveryPromoter struct {
+	registry          *registry.DeviceRegistry
+	evidenceBuf       *EvidenceBuffer
+	confirmFn         func(ctx context.Context, target byte) bool
+	registerFn        func(target byte)
+	semanticRefreshFn func()
+	routerRefreshFn   func()
+	admittedSourceFn  func() byte
+
+	tickInterval time.Duration
+	now          func() time.Time
+
+	mu       sync.Mutex
+	attempts map[byte]*promoterAttemptState
+
+	// metrics
+	confirmedTotal uint64
+	rejectedTotal  uint64
+	skippedTotal   uint64
+}
+
+type promoterAttemptState struct {
+	attempts      int
+	nextAttemptAt time.Time
+}
+
+// PassiveDiscoveryPromoterOptions configures a new promoter.
+type PassiveDiscoveryPromoterOptions struct {
+	// Registry is the gateway device registry — used to filter
+	// candidates already known and to register confirmed devices.
+	// Required.
+	Registry *registry.DeviceRegistry
+
+	// EvidenceBuffer feeds candidate addresses. Required.
+	EvidenceBuffer *EvidenceBuffer
+
+	// ConfirmFn runs the B524 capability coherency probe against the
+	// candidate target using the admitted source. Returns true on
+	// coherent response. Required.
+	ConfirmFn func(ctx context.Context, target byte) bool
+
+	// SemanticRefreshFn enqueues the semantic poller's discovery
+	// refresh after a successful registration so the regulator
+	// surface populates. Optional — promoter still registers and
+	// refreshes router planes when nil.
+	SemanticRefreshFn func()
+
+	// RouterRefreshFn refreshes router planes after a successful
+	// registration so live event routing reflects the new device.
+	// Optional.
+	RouterRefreshFn func()
+
+	// AdmittedSourceFn returns the gateway's admitted source. The
+	// promoter filters this address out of candidates so the gateway
+	// never confirms its own source. Required.
+	AdmittedSourceFn func() byte
+
+	// TickInterval bounds how often the promoter polls
+	// PromotedAddresses. Defaults to 30s if unset.
+	TickInterval time.Duration
+
+	// Now returns the current time. Defaults to time.Now if unset.
+	Now func() time.Time
+}
+
+// NewPassiveDiscoveryPromoter constructs a promoter. Returns an error
+// if any required option is nil.
+func NewPassiveDiscoveryPromoter(opts PassiveDiscoveryPromoterOptions) (*PassiveDiscoveryPromoter, error) {
+	if opts.Registry == nil {
+		return nil, errors.New("passive discovery promoter: nil registry")
+	}
+	if opts.EvidenceBuffer == nil {
+		return nil, errors.New("passive discovery promoter: nil evidence buffer")
+	}
+	if opts.ConfirmFn == nil {
+		return nil, errors.New("passive discovery promoter: nil confirm fn")
+	}
+	if opts.AdmittedSourceFn == nil {
+		return nil, errors.New("passive discovery promoter: nil admitted-source fn")
+	}
+	tick := opts.TickInterval
+	if tick <= 0 {
+		tick = 30 * time.Second
+	}
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &PassiveDiscoveryPromoter{
+		registry:          opts.Registry,
+		evidenceBuf:       opts.EvidenceBuffer,
+		confirmFn:         opts.ConfirmFn,
+		registerFn:        nil, // injected by Run; callers may override via SetRegisterFn for tests
+		semanticRefreshFn: opts.SemanticRefreshFn,
+		routerRefreshFn:   opts.RouterRefreshFn,
+		admittedSourceFn:  opts.AdmittedSourceFn,
+		tickInterval:      tick,
+		now:               now,
+		attempts:          make(map[byte]*promoterAttemptState),
+	}, nil
+}
+
+// SetRegisterFn overrides the registry-write function. Used by tests
+// to substitute a no-op or to capture the registered address. The
+// production path uses the default registry.Register helper.
+func (p *PassiveDiscoveryPromoter) SetRegisterFn(fn func(target byte)) {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	p.registerFn = fn
+	p.mu.Unlock()
+}
+
+// Run polls the evidence buffer at the configured tick interval and
+// runs active confirmation on each promoted candidate not already in
+// the registry. Returns when ctx is cancelled.
+func (p *PassiveDiscoveryPromoter) Run(ctx context.Context) {
+	if p == nil {
+		return
+	}
+	ticker := time.NewTicker(p.tickInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			p.processOnce(ctx)
+		}
+	}
+}
+
+// processOnce runs a single tick of the promotion loop. Public for
+// testing — production callers use Run.
+//
+// Per-candidate deadline: each confirmation runs under a derived
+// context capped at tickInterval/2, so one slow / non-responsive
+// candidate cannot starve subsequent candidates within the same tick
+// or run past the next tick.
+//
+// Demotion: when a candidate has failed maxConfirmationAttempts
+// times, its EvidenceBuffer entry is demoted (promoted=false,
+// counters reset). Subsequent fresh passive evidence can re-promote
+// it. The promoter does not retry the demoted entry on its current
+// promotion.
+//
+// Refresh coalescing: a single tick that confirms multiple candidates
+// emits at most ONE semantic-refresh signal (the implicit dedupe at
+// the task scheduler is best-effort; coalescing here avoids piling up
+// redundant priorityHigh tasks).
+func (p *PassiveDiscoveryPromoter) processOnce(ctx context.Context) {
+	if p == nil {
+		return
+	}
+	now := p.now()
+	admittedSource := p.admittedSourceFn()
+	candidates := p.evidenceBuf.PromotedAddresses()
+	confirmedThisTick := 0
+	perCandidateTimeout := p.tickInterval / 2
+	if perCandidateTimeout <= 0 {
+		perCandidateTimeout = 15 * time.Second
+	}
+	for _, addr := range candidates {
+		if !p.shouldAttempt(addr, admittedSource, now) {
+			continue
+		}
+		p.recordAttemptStart(addr)
+
+		probeCtx, cancel := context.WithTimeout(ctx, perCandidateTimeout)
+		ok := p.confirmFn(probeCtx, addr)
+		cancel()
+		if ctx.Err() != nil {
+			return
+		}
+		if !ok {
+			demote := p.recordAttemptFailure(addr, now)
+			if demote {
+				log.Printf("passive_discovery_promoter_demoted address=0x%02x reason=max_confirmation_attempts", addr)
+				p.evidenceBuf.Demote(addr)
+			}
+			continue
+		}
+		p.recordAttemptSuccess(addr)
+		p.commitConfirmedDeviceCoalesced(addr, &confirmedThisTick)
+	}
+}
+
+// commitConfirmedDeviceCoalesced is commitConfirmedDevice with
+// per-tick semantic-refresh coalescing. The first confirmation in a
+// tick fires the semantic refresh; subsequent confirmations register
+// the device + refresh router planes but do not enqueue another
+// semantic refresh (the already-queued task will see all newly-
+// registered devices on the next discovery scan).
+func (p *PassiveDiscoveryPromoter) commitConfirmedDeviceCoalesced(addr byte, confirmedThisTick *int) {
+	p.mu.Lock()
+	registerFn := p.registerFn
+	p.mu.Unlock()
+	if registerFn != nil {
+		registerFn(addr)
+	} else {
+		p.registry.Register(registry.DeviceInfo{
+			Address:      addr,
+			Manufacturer: "Vaillant",
+		})
+	}
+	log.Printf("passive_discovery_promoter_registered address=0x%02x source=passive_promotion", addr)
+	if *confirmedThisTick == 0 && p.semanticRefreshFn != nil {
+		p.semanticRefreshFn()
+	}
+	*confirmedThisTick++
+	if p.routerRefreshFn != nil {
+		p.routerRefreshFn()
+	}
+}
+
+// shouldAttempt reports whether addr is a valid attempt-now candidate.
+// Filters: address already in registry, address equals admitted
+// source (self), invalid responder range, per-address backoff not yet
+// elapsed.
+func (p *PassiveDiscoveryPromoter) shouldAttempt(addr, admittedSource byte, now time.Time) bool {
+	if !isPassiveEvidenceCandidate(addr, admittedSource) {
+		p.incSkipped()
+		return false
+	}
+	if p.registryContains(addr) {
+		p.incSkipped()
+		return false
+	}
+	p.mu.Lock()
+	state := p.attempts[addr]
+	p.mu.Unlock()
+	if state == nil {
+		return true
+	}
+	if !state.nextAttemptAt.IsZero() && now.Before(state.nextAttemptAt) {
+		p.incSkipped()
+		return false
+	}
+	return true
+}
+
+func (p *PassiveDiscoveryPromoter) incSkipped() {
+	p.mu.Lock()
+	p.skippedTotal++
+	p.mu.Unlock()
+}
+
+func (p *PassiveDiscoveryPromoter) recordAttemptStart(addr byte) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	state, ok := p.attempts[addr]
+	if !ok {
+		state = &promoterAttemptState{}
+		p.attempts[addr] = state
+	}
+	state.attempts++
+}
+
+// recordAttemptFailure schedules per-address exponential backoff and
+// returns true iff the candidate has reached the failure cap and
+// should be permanently demoted from the evidence buffer (see B5
+// fix). Demotion releases the candidate from the EvidenceBuffer's
+// promoted set so subsequent fresh evidence can re-promote, but the
+// promoter does not retry on the existing stale promotion.
+func (p *PassiveDiscoveryPromoter) recordAttemptFailure(addr byte, now time.Time) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	state := p.attempts[addr]
+	if state == nil {
+		return false
+	}
+	backoff := RejoinBackoffSchedule(state.attempts, StartupAdmissionRejoinBackoffBaseSeconds, StartupAdmissionRejoinBackoffMaxSeconds)
+	state.nextAttemptAt = now.Add(backoff)
+	p.rejectedTotal++
+	log.Printf("passive_discovery_promoter_confirm_failed address=0x%02x attempt=%d next_attempt_in=%s", addr, state.attempts, backoff)
+	if state.attempts >= maxConfirmationAttempts {
+		delete(p.attempts, addr)
+		return true
+	}
+	return false
+}
+
+func (p *PassiveDiscoveryPromoter) recordAttemptSuccess(addr byte) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.attempts, addr)
+	p.confirmedTotal++
+}
+
+func (p *PassiveDiscoveryPromoter) registryContains(addr byte) bool {
+	if p.registry == nil {
+		return false
+	}
+	found := false
+	p.registry.Iterate(func(entry registry.DeviceEntry) bool {
+		if entry == nil {
+			return true
+		}
+		if entry.Address() == addr {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// Snapshot returns a point-in-time view of promoter state for
+// diagnostics and tests.
+type PassiveDiscoveryPromoterSnapshot struct {
+	ConfirmedTotal uint64
+	RejectedTotal  uint64
+	SkippedTotal   uint64
+	PendingByAddr  map[byte]int
+}
+
+// Snapshot captures current promoter counters and per-address state
+// for diagnostics and tests.
+func (p *PassiveDiscoveryPromoter) Snapshot() PassiveDiscoveryPromoterSnapshot {
+	if p == nil {
+		return PassiveDiscoveryPromoterSnapshot{}
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	pending := make(map[byte]int, len(p.attempts))
+	for addr, state := range p.attempts {
+		pending[addr] = state.attempts
+	}
+	return PassiveDiscoveryPromoterSnapshot{
+		ConfirmedTotal: p.confirmedTotal,
+		RejectedTotal:  p.rejectedTotal,
+		SkippedTotal:   p.skippedTotal,
+		PendingByAddr:  pending,
+	}
+}
+
+// String renders the snapshot for log lines.
+func (s PassiveDiscoveryPromoterSnapshot) String() string {
+	return fmt.Sprintf("passive_discovery_promoter confirmed=%d rejected=%d skipped=%d pending=%d", s.ConfirmedTotal, s.RejectedTotal, s.SkippedTotal, len(s.PendingByAddr))
+}

--- a/passive_discovery_promoter_test.go
+++ b/passive_discovery_promoter_test.go
@@ -1,0 +1,359 @@
+package ebusgateway
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+)
+
+func newTestPromoter(t *testing.T, reg *registry.DeviceRegistry, evidence *EvidenceBuffer, confirmFn func(byte) bool) *PassiveDiscoveryPromoter {
+	t.Helper()
+	promoter, err := NewPassiveDiscoveryPromoter(PassiveDiscoveryPromoterOptions{
+		Registry:       reg,
+		EvidenceBuffer: evidence,
+		ConfirmFn: func(_ context.Context, target byte) bool {
+			return confirmFn(target)
+		},
+		AdmittedSourceFn: func() byte { return 0x71 },
+		TickInterval:     1 * time.Millisecond,
+		Now:              time.Now,
+	})
+	if err != nil {
+		t.Fatalf("NewPassiveDiscoveryPromoter: %v", err)
+	}
+	return promoter
+}
+
+// TestPassiveDiscoveryPromoter_RegistersConfirmedAddress pins the
+// happy path: an address promoted by passive evidence + coherent
+// active confirmation lands in the registry as a Vaillant device.
+func TestPassiveDiscoveryPromoter_RegistersConfirmedAddress(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.NewDeviceRegistry(nil)
+	reg.Register(registry.DeviceInfo{Address: 0x08, Manufacturer: "Vaillant", DeviceID: "BAI00"})
+
+	buf, err := NewEvidenceBuffer(128, VaillantBaselineTopologySeed)
+	if err != nil {
+		t.Fatalf("NewEvidenceBuffer: %v", err)
+	}
+	now := time.Now()
+	buf.Record(EvidenceRecord{Address: 0x15, Strength: EvidenceStrong, Observed: now, Kind: "test"})
+
+	promoter := newTestPromoter(t, reg, buf, func(target byte) bool {
+		return target == 0x15
+	})
+	promoter.processOnce(context.Background())
+
+	if !registryContains(reg, 0x15) {
+		t.Fatal("promoter did not register confirmed 0x15 in registry")
+	}
+	snap := promoter.Snapshot()
+	if snap.ConfirmedTotal != 1 {
+		t.Fatalf("ConfirmedTotal = %d; want 1", snap.ConfirmedTotal)
+	}
+}
+
+// TestPassiveDiscoveryPromoter_DoesNotRegisterOnConfirmationFailure pins
+// the negative case: an address promoted by evidence but NOT coherent
+// under active confirmation must not be registered. Failed attempts
+// schedule per-address backoff for retry.
+func TestPassiveDiscoveryPromoter_DoesNotRegisterOnConfirmationFailure(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.NewDeviceRegistry(nil)
+	buf, _ := NewEvidenceBuffer(128, VaillantBaselineTopologySeed)
+	buf.Record(EvidenceRecord{Address: 0x15, Strength: EvidenceStrong, Observed: time.Now(), Kind: "test"})
+
+	promoter := newTestPromoter(t, reg, buf, func(byte) bool { return false })
+	promoter.processOnce(context.Background())
+
+	if registryContains(reg, 0x15) {
+		t.Fatal("promoter registered 0x15 despite confirmation failure")
+	}
+	snap := promoter.Snapshot()
+	if snap.RejectedTotal != 1 {
+		t.Fatalf("RejectedTotal = %d; want 1", snap.RejectedTotal)
+	}
+	if state, ok := snap.PendingByAddr[0x15]; !ok || state != 1 {
+		t.Fatalf("PendingByAddr[0x15] = %d (ok=%v); want 1", state, ok)
+	}
+}
+
+// TestPassiveDiscoveryPromoter_SkipsAlreadyRegisteredAddress prevents
+// duplicate registration: an address already in the registry must
+// not generate another confirmation probe even if it appears in
+// PromotedAddresses.
+func TestPassiveDiscoveryPromoter_SkipsAlreadyRegisteredAddress(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.NewDeviceRegistry(nil)
+	reg.Register(registry.DeviceInfo{Address: 0x15, Manufacturer: "Vaillant", DeviceID: "BASV2"})
+
+	buf, _ := NewEvidenceBuffer(128, VaillantBaselineTopologySeed)
+	buf.Record(EvidenceRecord{Address: 0x15, Strength: EvidenceStrong, Observed: time.Now(), Kind: "test"})
+
+	probed := false
+	promoter := newTestPromoter(t, reg, buf, func(byte) bool {
+		probed = true
+		return true
+	})
+	promoter.processOnce(context.Background())
+
+	if probed {
+		t.Fatal("promoter probed an already-registered address; should be filtered before active confirmation")
+	}
+	snap := promoter.Snapshot()
+	if snap.SkippedTotal == 0 {
+		t.Fatal("SkippedTotal = 0; want >= 1 for filtered address")
+	}
+}
+
+// TestPassiveDiscoveryPromoter_SkipsAdmittedSource pins source-address
+// invariant on the active-confirmation side: the admitted source must
+// never be probed as a target even if it shows up in PromotedAddresses
+// (e.g. via passive self-traffic loop).
+func TestPassiveDiscoveryPromoter_SkipsAdmittedSource(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.NewDeviceRegistry(nil)
+	buf, _ := NewEvidenceBuffer(128, VaillantBaselineTopologySeed)
+	// Force-promote 0x71 (the admitted source in newTestPromoter).
+	buf.Record(EvidenceRecord{Address: 0x71, Strength: EvidenceStrong, Observed: time.Now(), Kind: "test"})
+
+	probed := false
+	promoter := newTestPromoter(t, reg, buf, func(byte) bool {
+		probed = true
+		return true
+	})
+	promoter.processOnce(context.Background())
+
+	if probed {
+		t.Fatal("promoter probed admitted source 0x71 as target — source-address invariant violated")
+	}
+	if registryContains(reg, 0x71) {
+		t.Fatal("promoter registered admitted source 0x71 — source-address invariant violated")
+	}
+}
+
+// TestPassiveDiscoveryPromoter_LateArrivalRegulator_RegistersWithoutRestart
+// reproduces the late-startup regulator scenario: gateway started with
+// an empty registry; over time the regulator boots and broadcasts
+// presence + B524 traffic; the bus_observability store records evidence;
+// the promoter confirms and registers without a gateway restart.
+func TestPassiveDiscoveryPromoter_LateArrivalRegulator_RegistersWithoutRestart(t *testing.T) {
+	t.Parallel()
+
+	store := specimenPassiveStore()
+	reg := registry.NewDeviceRegistry(nil)
+
+	base := time.Now().UTC()
+	store.now = func() time.Time { return base.Add(60 * time.Second) }
+
+	// Gateway started with no regulator on the bus. Time passes; the
+	// regulator boots and emits a sign-of-life broadcast (presence-
+	// only — does not promote on its own).
+	store.OnPassiveClassifiedEvent(observabilityPassiveBroadcastEvent(base.Add(60*time.Second), 0x15, 0x07, 0xFF))
+	// Then it polls the boiler with two coherent B524 reads. The
+	// regulator address 0x15 appears as request source (weak evidence,
+	// recorded twice → crosses the weak threshold).
+	store.OnPassiveClassifiedEvent(observabilityCoherentB524TransactionEvent(base.Add(61*time.Second), 0x15, 0x08))
+	store.OnPassiveClassifiedEvent(observabilityCoherentB524TransactionEvent(base.Add(62*time.Second), 0x15, 0x08))
+
+	semanticRefreshed := false
+	routerRefreshed := false
+
+	promoter, err := NewPassiveDiscoveryPromoter(PassiveDiscoveryPromoterOptions{
+		Registry:       reg,
+		EvidenceBuffer: store.EvidenceBuffer(),
+		ConfirmFn: func(_ context.Context, target byte) bool {
+			return target == 0x15
+		},
+		SemanticRefreshFn: func() { semanticRefreshed = true },
+		RouterRefreshFn:   func() { routerRefreshed = true },
+		AdmittedSourceFn:  func() byte { return 0x7F },
+		TickInterval:      1 * time.Millisecond,
+		Now:               time.Now,
+	})
+	if err != nil {
+		t.Fatalf("NewPassiveDiscoveryPromoter: %v", err)
+	}
+
+	promoter.processOnce(context.Background())
+
+	if !registryContains(reg, 0x15) {
+		t.Fatal("late-arrival regulator 0x15 not registered after passive evidence + active confirmation")
+	}
+	if !semanticRefreshed {
+		t.Fatal("semantic refresh not signaled after late-arrival registration; regulator surface won't populate")
+	}
+	if !routerRefreshed {
+		t.Fatal("router planes not refreshed after late-arrival registration; live event routing won't include 0x15")
+	}
+}
+
+// TestPassiveDiscoveryPromoter_LateArrivalVR71_RegistersWithoutRestart
+// covers the user-stated parallel scenario for 0x26 (VR_71 / FM5
+// primary controller) booting after the gateway. Same shape as the
+// 0x15 regulator test, using 0x26 as the late arrival.
+func TestPassiveDiscoveryPromoter_LateArrivalVR71_RegistersWithoutRestart(t *testing.T) {
+	t.Parallel()
+
+	store := specimenPassiveStore()
+	reg := registry.NewDeviceRegistry(nil)
+
+	base := time.Now().UTC()
+	store.now = func() time.Time { return base.Add(60 * time.Second) }
+
+	store.OnPassiveClassifiedEvent(observabilityCoherentB524TransactionEvent(base.Add(61*time.Second), 0x26, 0x08))
+	store.OnPassiveClassifiedEvent(observabilityCoherentB524TransactionEvent(base.Add(62*time.Second), 0x26, 0x08))
+
+	promoter, _ := NewPassiveDiscoveryPromoter(PassiveDiscoveryPromoterOptions{
+		Registry:       reg,
+		EvidenceBuffer: store.EvidenceBuffer(),
+		ConfirmFn: func(_ context.Context, target byte) bool {
+			return target == 0x26
+		},
+		AdmittedSourceFn: func() byte { return 0x7F },
+		TickInterval:     1 * time.Millisecond,
+		Now:              time.Now,
+	})
+	promoter.processOnce(context.Background())
+
+	if !registryContains(reg, 0x26) {
+		t.Fatal("late-arrival VR_71 / FM5 0x26 not registered after passive evidence + active confirmation")
+	}
+}
+
+// TestPassiveDiscoveryPromoter_DemotesAfterMaxFailedConfirmations pins
+// the B5 contract from adversarial review: a candidate that fails
+// confirmation maxConfirmationAttempts times is demoted from the
+// EvidenceBuffer's promoted set, so the promoter does not retry it
+// every backoff cycle for the gateway lifetime.
+func TestPassiveDiscoveryPromoter_DemotesAfterMaxFailedConfirmations(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.NewDeviceRegistry(nil)
+	buf, _ := NewEvidenceBuffer(128, VaillantBaselineTopologySeed)
+	buf.Record(EvidenceRecord{Address: 0x42, Strength: EvidenceStrong, Observed: time.Now(), Kind: "test"})
+
+	if got := buf.PromotedAddresses(); len(got) == 0 {
+		t.Fatal("test setup invalid: 0x42 not promoted before processOnce")
+	}
+
+	calls := 0
+	now := time.Now()
+	currentNow := now
+	promoter, _ := NewPassiveDiscoveryPromoter(PassiveDiscoveryPromoterOptions{
+		Registry:       reg,
+		EvidenceBuffer: buf,
+		ConfirmFn: func(_ context.Context, _ byte) bool {
+			calls++
+			return false
+		},
+		AdmittedSourceFn: func() byte { return 0x71 },
+		TickInterval:     1 * time.Millisecond,
+		Now:              func() time.Time { return currentNow },
+	})
+
+	// Drive maxConfirmationAttempts ticks; advance currentNow past
+	// each attempt's backoff so subsequent ticks are not gated by
+	// the per-address backoff.
+	for i := 0; i < 10; i++ {
+		promoter.processOnce(context.Background())
+		currentNow = currentNow.Add(2 * time.Hour)
+	}
+
+	if calls != maxConfirmationAttempts {
+		t.Fatalf("confirm calls = %d; want %d (caps at maxConfirmationAttempts)", calls, maxConfirmationAttempts)
+	}
+	for _, addr := range buf.PromotedAddresses() {
+		if addr == 0x42 {
+			t.Fatalf("address 0x42 still promoted after %d failed attempts; demotion contract violated", maxConfirmationAttempts)
+		}
+	}
+}
+
+// TestPassiveDiscoveryPromoter_CoalesceSemanticRefreshPerTick pins the
+// refresh-coalescing contract from adversarial review N7: even when
+// multiple candidates confirm in the same tick, the promoter emits at
+// most ONE semantic refresh signal (the queued task will see all newly-
+// registered devices on the next discovery scan).
+func TestPassiveDiscoveryPromoter_CoalesceSemanticRefreshPerTick(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.NewDeviceRegistry(nil)
+	buf, _ := NewEvidenceBuffer(128, VaillantBaselineTopologySeed)
+	buf.Record(EvidenceRecord{Address: 0x15, Strength: EvidenceStrong, Observed: time.Now(), Kind: "test"})
+	buf.Record(EvidenceRecord{Address: 0x26, Strength: EvidenceStrong, Observed: time.Now(), Kind: "test"})
+
+	semanticCalls := 0
+	routerCalls := 0
+	promoter, _ := NewPassiveDiscoveryPromoter(PassiveDiscoveryPromoterOptions{
+		Registry:          reg,
+		EvidenceBuffer:    buf,
+		ConfirmFn:         func(_ context.Context, _ byte) bool { return true },
+		SemanticRefreshFn: func() { semanticCalls++ },
+		RouterRefreshFn:   func() { routerCalls++ },
+		AdmittedSourceFn:  func() byte { return 0x71 },
+		TickInterval:      1 * time.Millisecond,
+		Now:               time.Now,
+	})
+
+	promoter.processOnce(context.Background())
+
+	if semanticCalls != 1 {
+		t.Fatalf("semantic refresh fired %d times in single tick with 2 confirmations; want 1 (coalesced)", semanticCalls)
+	}
+	// Router refresh runs once per registration (registry-walk needed
+	// to reflect each new entry on the plane).
+	if routerCalls != 2 {
+		t.Fatalf("router refresh fired %d times for 2 confirmations; want 2 (per-registration)", routerCalls)
+	}
+}
+
+// TestPassiveDiscoveryPromoter_BackoffOnRepeatedFailure pins the
+// rate-limiting contract: a per-address attempt that fails extends
+// the next-attempt deadline; back-to-back ticks must not retry until
+// the backoff elapses.
+func TestPassiveDiscoveryPromoter_BackoffOnRepeatedFailure(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.NewDeviceRegistry(nil)
+	buf, _ := NewEvidenceBuffer(128, VaillantBaselineTopologySeed)
+	buf.Record(EvidenceRecord{Address: 0x15, Strength: EvidenceStrong, Observed: time.Now(), Kind: "test"})
+
+	confirmCalls := 0
+	promoter, _ := NewPassiveDiscoveryPromoter(PassiveDiscoveryPromoterOptions{
+		Registry:       reg,
+		EvidenceBuffer: buf,
+		ConfirmFn: func(_ context.Context, _ byte) bool {
+			confirmCalls++
+			return false
+		},
+		AdmittedSourceFn: func() byte { return 0x71 },
+		TickInterval:     1 * time.Millisecond,
+		Now:              time.Now,
+	})
+
+	promoter.processOnce(context.Background())
+	promoter.processOnce(context.Background())
+
+	if confirmCalls != 1 {
+		t.Fatalf("confirm calls = %d; want 1 (second tick must be backoff-suppressed)", confirmCalls)
+	}
+}
+
+func registryContains(reg *registry.DeviceRegistry, addr byte) bool {
+	found := false
+	reg.Iterate(func(e registry.DeviceEntry) bool {
+		if e != nil && e.Address() == addr {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}

--- a/passive_discovery_promoter_test.go
+++ b/passive_discovery_promoter_test.go
@@ -314,6 +314,75 @@ func TestPassiveDiscoveryPromoter_CoalesceSemanticRefreshPerTick(t *testing.T) {
 	}
 }
 
+// TestPassiveDiscoveryPromoter_SemanticRefreshFiresAfterAllRegistrations
+// closes Codex PR #561 P2 finding: when multiple candidates confirm in
+// the same tick, the single coalesced semantic refresh must fire AFTER
+// all registrations have committed. Otherwise the semantic discovery
+// task could start and snapshot the registry before later candidates
+// in the same tick are added — those devices would miss the immediate
+// refresh and wait for the periodic discovery interval.
+//
+// The test pins the ordering by capturing the registry size at the
+// moment the semantic refresh fires.
+func TestPassiveDiscoveryPromoter_SemanticRefreshFiresAfterAllRegistrations(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.NewDeviceRegistry(nil)
+	buf, _ := NewEvidenceBuffer(128, VaillantBaselineTopologySeed)
+	buf.Record(EvidenceRecord{Address: 0x15, Strength: EvidenceStrong, Observed: time.Now(), Kind: "test"})
+	buf.Record(EvidenceRecord{Address: 0x26, Strength: EvidenceStrong, Observed: time.Now(), Kind: "test"})
+
+	registrySizeAtRefresh := -1
+	promoter, _ := NewPassiveDiscoveryPromoter(PassiveDiscoveryPromoterOptions{
+		Registry:       reg,
+		EvidenceBuffer: buf,
+		ConfirmFn:      func(_ context.Context, _ byte) bool { return true },
+		SemanticRefreshFn: func() {
+			count := 0
+			reg.Iterate(func(_ registry.DeviceEntry) bool { count++; return true })
+			registrySizeAtRefresh = count
+		},
+		AdmittedSourceFn: func() byte { return 0x71 },
+		TickInterval:     1 * time.Millisecond,
+		Now:              time.Now,
+	})
+
+	promoter.processOnce(context.Background())
+
+	if registrySizeAtRefresh != 2 {
+		t.Fatalf("registry size at semantic refresh = %d; want 2 (refresh must fire AFTER all registrations commit)", registrySizeAtRefresh)
+	}
+}
+
+// TestPassiveDiscoveryPromoter_NoSemanticRefreshWhenNoConfirmations pins
+// the negative case: a tick with no successful confirmations must NOT
+// emit a semantic refresh signal — there's no inventory change for the
+// poller to discover.
+func TestPassiveDiscoveryPromoter_NoSemanticRefreshWhenNoConfirmations(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.NewDeviceRegistry(nil)
+	buf, _ := NewEvidenceBuffer(128, VaillantBaselineTopologySeed)
+	buf.Record(EvidenceRecord{Address: 0x42, Strength: EvidenceStrong, Observed: time.Now(), Kind: "test"})
+
+	semanticCalls := 0
+	promoter, _ := NewPassiveDiscoveryPromoter(PassiveDiscoveryPromoterOptions{
+		Registry:          reg,
+		EvidenceBuffer:    buf,
+		ConfirmFn:         func(_ context.Context, _ byte) bool { return false }, // never coherent
+		SemanticRefreshFn: func() { semanticCalls++ },
+		AdmittedSourceFn:  func() byte { return 0x71 },
+		TickInterval:      1 * time.Millisecond,
+		Now:               time.Now,
+	})
+
+	promoter.processOnce(context.Background())
+
+	if semanticCalls != 0 {
+		t.Fatalf("semantic refresh fired %d times with zero confirmations; want 0 (no inventory change)", semanticCalls)
+	}
+}
+
 // TestPassiveDiscoveryPromoter_GatesProbesOnAdmittedSource pins the
 // source-admission invariant from Codex PR #561 review: while admission
 // is pending (admittedSource == 0) the promoter MUST NOT issue active

--- a/passive_discovery_promoter_test.go
+++ b/passive_discovery_promoter_test.go
@@ -354,6 +354,32 @@ func TestPassiveDiscoveryPromoter_SemanticRefreshFiresAfterAllRegistrations(t *t
 	}
 }
 
+// TestPassiveDiscoveryPromoter_PerCandidateBudgetCoversB524RetryChain
+// pins Codex PR #561 P2 finding: a per-candidate confirmation budget
+// shorter than the B524 capability retry chain (~32s) would falsely
+// demote reachable late-arrival devices on busy buses. The budget
+// must allow the full retry chain to complete.
+//
+// The test simulates a confirmFn that takes 25s (longer than the old
+// 15s tickInterval/2 cap, shorter than the 45s budget) and asserts
+// the candidate is still confirmed and registered.
+func TestPassiveDiscoveryPromoter_PerCandidateBudgetCoversB524RetryChain(t *testing.T) {
+	t.Parallel()
+
+	if perCandidateConfirmationBudget < 32*time.Second {
+		t.Fatalf("perCandidateConfirmationBudget=%s is shorter than the worst-case B524 retry chain (~32s); reachable late-arrival devices would be falsely demoted", perCandidateConfirmationBudget)
+	}
+
+	// Sanity: the budget exceeds the default tick (30s) so contention
+	// recovery has room to complete within a single confirmation
+	// attempt rather than getting cut by the tickInterval/2 cap that
+	// the prior implementation imposed.
+	defaultTick := 30 * time.Second
+	if perCandidateConfirmationBudget <= defaultTick/2 {
+		t.Fatalf("perCandidateConfirmationBudget=%s is not greater than defaultTick/2=%s; the cap would still cut off mid-retry on busy buses", perCandidateConfirmationBudget, defaultTick/2)
+	}
+}
+
 // TestPassiveDiscoveryPromoter_NoSemanticRefreshWhenNoConfirmations pins
 // the negative case: a tick with no successful confirmations must NOT
 // emit a semantic refresh signal — there's no inventory change for the

--- a/passive_discovery_promoter_test.go
+++ b/passive_discovery_promoter_test.go
@@ -314,6 +314,56 @@ func TestPassiveDiscoveryPromoter_CoalesceSemanticRefreshPerTick(t *testing.T) {
 	}
 }
 
+// TestPassiveDiscoveryPromoter_GatesProbesOnAdmittedSource pins the
+// source-admission invariant from Codex PR #561 review: while admission
+// is pending (admittedSource == 0) the promoter MUST NOT issue active
+// confirmation probes. The confirmFn sources from the semantic
+// poller's configured source, which is set even before admission
+// completes; running confirmations during the pending window would
+// emit gateway-originated traffic that the admission FSM has not yet
+// approved.
+func TestPassiveDiscoveryPromoter_GatesProbesOnAdmittedSource(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.NewDeviceRegistry(nil)
+	buf, _ := NewEvidenceBuffer(128, VaillantBaselineTopologySeed)
+	buf.Record(EvidenceRecord{Address: 0x15, Strength: EvidenceStrong, Observed: time.Now(), Kind: "test"})
+
+	confirmCalls := 0
+	admittedSource := byte(0) // admission pending
+
+	promoter, _ := NewPassiveDiscoveryPromoter(PassiveDiscoveryPromoterOptions{
+		Registry:       reg,
+		EvidenceBuffer: buf,
+		ConfirmFn: func(_ context.Context, _ byte) bool {
+			confirmCalls++
+			return true
+		},
+		AdmittedSourceFn: func() byte { return admittedSource },
+		TickInterval:     1 * time.Millisecond,
+		Now:              time.Now,
+	})
+
+	// Tick 1: admission still pending. No probes should fire.
+	promoter.processOnce(context.Background())
+	if confirmCalls != 0 {
+		t.Fatalf("confirm called %d times while admission pending; admission gate violated", confirmCalls)
+	}
+	if registryContains(reg, 0x15) {
+		t.Fatal("registry mutated while admission pending; promotion side effects must defer until admission resolves")
+	}
+
+	// Tick 2: admission resolves. Probe + register should fire.
+	admittedSource = 0x71
+	promoter.processOnce(context.Background())
+	if confirmCalls != 1 {
+		t.Fatalf("confirm called %d times after admission active; want 1", confirmCalls)
+	}
+	if !registryContains(reg, 0x15) {
+		t.Fatal("post-admission registration did not occur")
+	}
+}
+
 // TestPassiveDiscoveryPromoter_BackoffOnRepeatedFailure pins the
 // rate-limiting contract: a per-address attempt that fails extends
 // the next-attempt deadline; back-to-back ticks must not retry until


### PR DESCRIPTION
## Summary

Closes the late-arrival half of the post-source-selection regulator discovery regression: when a Vaillant device boots **after** the gateway, it accumulates passive evidence on the bus and is actively confirmed + registered by a new runtime promoter — no gateway restart needed.

**Stacked on top of #560** (steady-state startup structural seed). Both PRs together fully address the operator's `/goal`.

## What changed

- **EvidenceBuffer wired into `BusObservabilityStore`**. `OnPassiveClassifiedEvent` records per-address evidence with strict promotion semantics:
  - `EvidencePresenceOnly` (new strength) — broadcast frame source (e.g. `07 FF` from `0x07`). Refreshes the address but never promotes. Operator-stated requirement: "07 FF is consumed passively as presence evidence, not used as a discovery probe target."
  - `EvidenceWeak` — initiator-class frame source/target. Two distinct events promote.
  - `EvidenceStrong` — B524 transaction whose response echoes the request's group + addr in canonical position (validated via the new shared `IsB524ResponseCoherent` helper). Single observation promotes.
  - **Per-event dedupe**: `request.Target` and `response.Source` are the same address in normal transactions and are recorded as a single observation per event (max-strength wins). Prevents single-frame phantom promotion.
  - Filters: admitted source, broadcast (`0xFE`), broadcast destination class (`0xFF`), SYN (`0xAA`), `<0x03` initiator pre-arbitration.
- **New `PassiveDiscoveryPromoter`** ([passive_discovery_promoter.go](helianthus-ebusgateway/passive_discovery_promoter.go)) polls `PromotedAddresses()` every 30s, runs B524 coherency confirmation under a per-candidate deadline (`tickInterval/2`), registers confirmed devices, signals semantic discovery refresh (coalesced per tick), refreshes router planes. Per-address exponential backoff with `maxConfirmationAttempts=5` cap; failed candidates are **demoted** from `EvidenceBuffer` (new `Demote` method) so stale promotions do not retry forever.
- **Shared B524 coherency** ([b524_coherency.go](helianthus-ebusgateway/b524_coherency.go)): `IsB524ResponseCoherent` is now the single source of truth — same criterion for active probe (`discoverB524Root`) and passive evidence acceptance.
- **`vaillantSemanticPoller.ConfirmB524Coherent` / `EnqueueDiscoveryRefresh`**: extracted helpers used by the promoter.

## Adversarial-review history (pre-PR)

Claude angry-tester pass found **5 BLOCKERS** + several NITs. All addressed in this commit:
- **B1** — `0x07` PIC sign-of-life broadcast promoting → discovery probe target. Fixed via `EvidencePresenceOnly` strength.
- **B2** — data races on promoter counters and `registerFn`. Fixed: all counter increments now under `p.mu`, `registerFn` read under lock.
- **B4** — `passiveResponseIsCoherentVaillantEvidence` accepted any non-empty response data → single-frame phantom promotion via stray fragments. Fixed: shared strict B524 coherency check.
- **B5** — once-promoted candidates retried forever. Fixed: `maxConfirmationAttempts=5` cap, `EvidenceBuffer.Demote` releases the promotion.
- Test gap masking B1 — fixed by adding `TestEvidenceBuffer_BroadcastSourceIsPresenceOnlyDoesNotPromote` + improved `TestEvidenceBuffer_FiltersBroadcastAndSyn` to actually exercise target-side filtering.

NITs addressed: N1 (dead `now` arg in `recordAttemptStart`), N5 (broadcast filter test was vacuous), N6 (per-candidate deadline), N7 (semantic-refresh coalescing per tick), N8 (parallel `0x26` late-arrival test).

Codex adversarial review pending on this PR.

## Test plan

- [x] `go test ./... -count=1 -race` passes (full gateway suite).
- [x] 16 new tests cover: presence-only broadcast, two-weak promotion, admitted-source filter, broadcast/SYN/<0x03 filter, coherent B524 strong evidence, non-coherent B524 phantom-promotion guard, promoter happy path / failure / backoff / source-filter / already-registered skip / demote-after-cap / coalesce-refresh, late-arrival 0x15 + 0x26.
- [x] Local CI green with documented owner overrides on transport-gate and passive-smoke-gate.
- [ ] Live HA validation post-merge (after Bug 1 #560 lands first): start gateway, wait for regulator boot afterward, confirm GraphQL devices includes 0x15 without restart, semantic surface populates.

## Source-address invariant

Confirmed: the gateway's admitted source is filtered out of:
1. Evidence recording (`isPassiveEvidenceCandidate` check via `evidenceSourceProvider`),
2. Promoter candidates (`shouldAttempt` + `isPassiveEvidenceCandidate`),
3. Active confirmation targets (the existing `confirmFn` chain — same admitted source as the rest of the gateway).

`07 FF` is presence-evidence-only, never a discovery probe target. Pinned by `TestEvidenceBuffer_BroadcastSourceIsPresenceOnlyDoesNotPromote`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)