### PR TITLE
feat(gateway): M0B + M2A + M3 + M4 — observation correlator + address-table insertion + companion corroboration (RED→GREEN)

### DIFF
--- a/address_table.go
+++ b/address_table.go
@@ -33,9 +33,47 @@ func (t *AddressTable) Lookup(addr byte) (*AddressSlot, bool) {
 	if t == nil {
 		return nil, false
 	}
-	slot, ok := t.slots[addr]
-	if !ok || slot == nil {
-		return nil, false
+	if slot, ok := t.slots[addr]; ok && slot != nil {
+		return slot, true
 	}
-	return slot, true
+	// Consult the wrapped registry so static seeds and active-discovered
+	// devices are visible here, preventing maybeInsert from rewriting
+	// their metadata (Codex P2: preserve-existing-registry-slots).
+	if t.reg != nil {
+		if regSlot, ok := t.reg.LookupSlot(addr); ok && regSlot != nil {
+			role := ""
+			switch regSlot.Role {
+			case registry.SlotRoleMaster:
+				role = "initiator"
+			case registry.SlotRoleSlave:
+				role = "target"
+			}
+			discovery := ""
+			switch regSlot.DiscoverySource {
+			case registry.DiscoverySourcePassiveObserved:
+				discovery = "passive_observed"
+			case registry.DiscoverySourceStaticSeed:
+				discovery = "static_seed"
+			case registry.DiscoverySourceActiveConfirmed:
+				discovery = "active_confirmed"
+			}
+			verification := ""
+			switch regSlot.VerificationState {
+			case registry.VerificationStateCandidate:
+				verification = "candidate"
+			case registry.VerificationStateCorroborated:
+				verification = "corroborated_pending"
+			case registry.VerificationStateIdentityConfirmed:
+				verification = "identity_confirmed"
+			}
+			return &AddressSlot{
+				Addr:              addr,
+				Role:              role,
+				DiscoverySource:   discovery,
+				VerificationState: verification,
+				RegistrySlot:      regSlot,
+			}, true
+		}
+	}
+	return nil, false
 }

--- a/address_table.go
+++ b/address_table.go
@@ -1,0 +1,41 @@
+package ebusgateway
+
+import "github.com/Project-Helianthus/helianthus-ebusreg/registry"
+
+type AddressSlot struct {
+	Addr              byte
+	Role              string
+	DiscoverySource   string
+	VerificationState string
+	RegistrySlot      *registry.AddressSlot
+}
+
+type AddressTable struct {
+	reg   *registry.DeviceRegistry
+	slots map[byte]*AddressSlot
+}
+
+func NewAddressTable(regs ...*registry.DeviceRegistry) *AddressTable {
+	var reg *registry.DeviceRegistry
+	if len(regs) > 0 {
+		reg = regs[0]
+	}
+	if reg == nil {
+		reg = registry.NewDeviceRegistry(nil)
+	}
+	return &AddressTable{
+		reg:   reg,
+		slots: make(map[byte]*AddressSlot),
+	}
+}
+
+func (t *AddressTable) Lookup(addr byte) (*AddressSlot, bool) {
+	if t == nil {
+		return nil, false
+	}
+	slot, ok := t.slots[addr]
+	if !ok || slot == nil {
+		return nil, false
+	}
+	return slot, true
+}

--- a/address_table_inserter.go
+++ b/address_table_inserter.go
@@ -1,0 +1,114 @@
+package ebusgateway
+
+import (
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+)
+
+type AddressObservation struct {
+	PositiveACKCount int
+}
+
+type AddressTableInserter struct {
+	table              *AddressTable
+	cfg                Config
+	observationsByAddr map[byte]AddressObservation
+}
+
+func NewAddressTableInserter(table *AddressTable, cfg Config) *AddressTableInserter {
+	return &AddressTableInserter{
+		table:              table,
+		cfg:                cfg,
+		observationsByAddr: make(map[byte]AddressObservation),
+	}
+}
+
+func (i *AddressTableInserter) OnPassiveClassifiedEvent(event PassiveClassifiedEvent) {
+	if i == nil || !event.ACKCorrelation.CompleteRequest || event.ACKCorrelation.Correlator != PassiveACKCorrelatorM2A {
+		return
+	}
+	corr := event.ACKCorrelation
+	if corr.Position != PassiveACKPositionRequestACK {
+		return
+	}
+
+	srcAddr := event.Request.Source
+	dstAddr := event.Request.Target
+	admittedSrc := i.admittedSource()
+
+	if corr.Byte == protocol.SymbolNack {
+		return
+	}
+	if corr.Byte != protocol.SymbolAck {
+		return
+	}
+
+	if srcAddr == 0xFF {
+		i.maybeInsert(0xFF, "master", admittedSrc, event.ObservedAt)
+		return
+	}
+	if srcAddr == admittedSrc {
+		return
+	}
+
+	i.maybeInsert(dstAddr, "slave", admittedSrc, event.ObservedAt)
+	observation := i.observationsByAddr[srcAddr]
+	observation.PositiveACKCount++
+	i.observationsByAddr[srcAddr] = observation
+
+	if observation.PositiveACKCount < 2 {
+		return
+	}
+	if companion, ok := protocol.Companion(srcAddr); ok {
+		i.maybeInsert(companion, "slave", admittedSrc, event.ObservedAt)
+	}
+}
+
+func (i *AddressTableInserter) admittedSource() byte {
+	if i == nil {
+		return 0
+	}
+	if i.cfg.AdmittedSource != nil {
+		return i.cfg.AdmittedSource()
+	}
+	return i.cfg.ScanSource
+}
+
+func (i *AddressTableInserter) maybeInsert(addr byte, role string, admittedSrc byte, observedAt time.Time) {
+	if i == nil || i.table == nil || i.table.reg == nil {
+		return
+	}
+	if addr == admittedSrc || addr == 0xFE {
+		return
+	}
+	if _, exists := i.table.Lookup(addr); exists {
+		return
+	}
+
+	i.table.reg.Register(registry.DeviceInfo{Address: addr})
+	registrySlot, _ := i.table.reg.LookupSlot(addr)
+	if registrySlot != nil {
+		registrySlot.DiscoverySource = registry.DiscoverySourcePassiveObserved
+		registrySlot.VerificationState = registry.VerificationStateCorroborated
+		switch role {
+		case "master":
+			registrySlot.Role = registry.SlotRoleMaster
+		case "slave":
+			registrySlot.Role = registry.SlotRoleSlave
+		}
+		if registrySlot.FirstObservedAt.IsZero() {
+			registrySlot.FirstObservedAt = observedAt
+		}
+		registrySlot.LastObservedAt = observedAt
+	}
+
+	i.table.slots[addr] = &AddressSlot{
+		Addr:              addr,
+		Role:              role,
+		DiscoverySource:   "passive_observed",
+		VerificationState: "corroborated_pending",
+		RegistrySlot:      registrySlot,
+	}
+}

--- a/address_table_inserter.go
+++ b/address_table_inserter.go
@@ -46,14 +46,14 @@ func (i *AddressTableInserter) OnPassiveClassifiedEvent(event PassiveClassifiedE
 	}
 
 	if srcAddr == 0xFF {
-		i.maybeInsert(0xFF, "master", admittedSrc, event.ObservedAt)
+		i.maybeInsert(0xFF, "initiator", admittedSrc, event.ObservedAt)
 		return
 	}
 	if srcAddr == admittedSrc {
 		return
 	}
 
-	i.maybeInsert(dstAddr, "slave", admittedSrc, event.ObservedAt)
+	i.maybeInsert(dstAddr, "target", admittedSrc, event.ObservedAt)
 	observation := i.observationsByAddr[srcAddr]
 	observation.PositiveACKCount++
 	i.observationsByAddr[srcAddr] = observation
@@ -62,7 +62,7 @@ func (i *AddressTableInserter) OnPassiveClassifiedEvent(event PassiveClassifiedE
 		return
 	}
 	if companion, ok := protocol.Companion(srcAddr); ok {
-		i.maybeInsert(companion, "slave", admittedSrc, event.ObservedAt)
+		i.maybeInsert(companion, "target", admittedSrc, event.ObservedAt)
 	}
 }
 
@@ -93,9 +93,9 @@ func (i *AddressTableInserter) maybeInsert(addr byte, role string, admittedSrc b
 		registrySlot.DiscoverySource = registry.DiscoverySourcePassiveObserved
 		registrySlot.VerificationState = registry.VerificationStateCorroborated
 		switch role {
-		case "master":
+		case "initiator":
 			registrySlot.Role = registry.SlotRoleMaster
-		case "slave":
+		case "target":
 			registrySlot.Role = registry.SlotRoleSlave
 		}
 		if registrySlot.FirstObservedAt.IsZero() {

--- a/address_table_insertion_test.go
+++ b/address_table_insertion_test.go
@@ -1,0 +1,119 @@
+// RED tests for cruise plan address-table-registry-w19-26 M0B/gateway — references M3/M4 + M2A + M1 + M2 symbols that intentionally don't exist yet.
+package ebusgateway
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+)
+
+func TestFirstObservation_PositiveACKOnly(t *testing.T) {
+	table, inserter := newATRInsertionHarness(t, DefaultConfig())
+
+	event := atrPassiveTransactionEvent(time.Now().UTC(), 0x10, 0x99, protocol.SymbolAck)
+	inserter.OnPassiveClassifiedEvent(event)
+
+	slot := requireATRSlot(t, table, 0x99)
+	if slot.VerificationState != "corroborated_pending" {
+		t.Fatalf("slot[0x99].VerificationState = %q; want corroborated_pending", slot.VerificationState)
+	}
+}
+
+func TestFirstObservation_NoNACKInsertion(t *testing.T) {
+	table, inserter := newATRInsertionHarness(t, DefaultConfig())
+
+	event := atrPassiveTransactionEvent(time.Now().UTC(), 0x10, 0x99, protocol.SymbolNack)
+	inserter.OnPassiveClassifiedEvent(event)
+
+	assertATRSlotAbsent(t, table, 0x99)
+}
+
+func TestFirstObservation_SelfSourceExcluded(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.AdmittedSource = func() byte { return 0x7F }
+	table, inserter := newATRInsertionHarness(t, cfg)
+
+	admittedSource := cfg.AdmittedSource()
+	event := atrPassiveTransactionEvent(time.Now().UTC(), admittedSource, 0x88, protocol.SymbolAck)
+	inserter.OnPassiveClassifiedEvent(event)
+
+	assertATRSlotAbsent(t, table, admittedSource)
+}
+
+func TestCompanionInsert_RequiresCorroboration(t *testing.T) {
+	table, inserter := newATRInsertionHarness(t, DefaultConfig())
+	base := time.Now().UTC()
+
+	first := atrPassiveTransactionEvent(base, 0xF1, 0x99, protocol.SymbolAck)
+	inserter.OnPassiveClassifiedEvent(first)
+	if got := inserter.observationsByAddr[0xF1].PositiveACKCount; got != 1 {
+		t.Fatalf("observationsByAddr[0xF1].PositiveACKCount after first observation = %d; want 1", got)
+	}
+	assertATRSlotAbsent(t, table, 0xF6)
+
+	second := atrPassiveTransactionEvent(base.Add(2*time.Second), 0xF1, 0x99, protocol.SymbolAck)
+	inserter.OnPassiveClassifiedEvent(second)
+	if got := inserter.observationsByAddr[0xF1].PositiveACKCount; got != 2 {
+		t.Fatalf("observationsByAddr[0xF1].PositiveACKCount after second observation = %d; want 2", got)
+	}
+	requireATRSlot(t, table, 0xF6)
+}
+
+func TestFFDisambiguation_FrameStartVsACKPosition(t *testing.T) {
+	table, inserter := newATRInsertionHarness(t, DefaultConfig())
+	base := time.Now().UTC()
+
+	frameStartFF := atrPassiveTransactionEvent(base, 0xFF, 0x04, protocol.SymbolAck)
+	inserter.OnPassiveClassifiedEvent(frameStartFF)
+	before := requireATRSlot(t, table, 0xFF)
+
+	nackPositionFF := atrPassiveTransactionEvent(base.Add(time.Second), 0x10, 0x99, protocol.SymbolNack)
+	inserter.OnPassiveClassifiedEvent(nackPositionFF)
+	after := requireATRSlot(t, table, 0xFF)
+
+	if after.VerificationState != before.VerificationState {
+		t.Fatalf("slot[0xFF].VerificationState changed after NACK-position 0xFF: got %q; want %q", after.VerificationState, before.VerificationState)
+	}
+}
+
+func newATRInsertionHarness(t *testing.T, cfg Config) (*AddressTable, *AddressTableInserter) {
+	t.Helper()
+
+	table := NewAddressTable()
+	inserter := NewAddressTableInserter(table, cfg)
+	return table, inserter
+}
+
+func atrPassiveTransactionEvent(observedAt time.Time, source, target, ack byte) PassiveClassifiedEvent {
+	event := observabilityPassiveTransactionEvent(observedAt, source, target, 0xB5, 0x24)
+	event.ACKCorrelation = PassiveACKCorrelation{
+		Byte:            ack,
+		Position:        PassiveACKPositionRequestACK,
+		CompleteRequest: true,
+		Correlator:      PassiveACKCorrelatorM2A,
+	}
+	return event
+}
+
+func requireATRSlot(t *testing.T, table *AddressTable, address byte) *AddressSlot {
+	t.Helper()
+
+	slot, ok := table.Lookup(address)
+	if !ok {
+		t.Fatalf("AddressTable.Lookup(0x%02X) ok = false; want true", address)
+	}
+	if slot == nil {
+		t.Fatalf("AddressTable.Lookup(0x%02X) slot = nil; want AddressSlot", address)
+	}
+	return slot
+}
+
+func assertATRSlotAbsent(t *testing.T, table *AddressTable, address byte) {
+	t.Helper()
+
+	slot, ok := table.Lookup(address)
+	if ok || slot != nil {
+		t.Fatalf("AddressTable.Lookup(0x%02X) = (%+v, %v); want (nil, false)", address, slot, ok)
+	}
+}

--- a/config.go
+++ b/config.go
@@ -143,6 +143,7 @@ type Config struct {
 	PassiveDedupRecoveryHysteresis          time.Duration
 	PassiveDedupRecoveryEventThreshold      int
 	LocalAddressSnapshotter                 LocalBusAddressSnapshotter
+	AdmittedSource                          func() byte
 	WatchObserver                           WatchObserver
 	WatchEfficiencyObserver                 WatchEfficiencyObserver
 	HTTPAddr                                string

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/Project-Helianthus/helianthus-ebusgateway
 go 1.22
 
 require (
-	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260505120935-8083eedd15ee
-	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260505121944-06c9f875761f
+	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260506144445-5ab7ab6cdb1e
+	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260506144832-b7e69997181f
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260505120935-8083eedd15ee h1:2Ze+bphuP+/GYKg/mnFqlcDwQp6mXWvas7xjS4+p1ac=
-github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260505120935-8083eedd15ee/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260505121944-06c9f875761f h1:19h6QUOZ7ugyag30Ku5vtHIfE/au/VFNCDAMxRZY2zI=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260505121944-06c9f875761f/go.mod h1:ux6qvwEyyK+LUfseHKpTTS4i5O6slZHVZ+f4orOtFm4=
+github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260506144445-5ab7ab6cdb1e h1:AOLYUOvKdzSAAu9t1aXjqpZptHb7+3U2fMY/T6TVSZA=
+github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260506144445-5ab7ab6cdb1e/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260506144832-b7e69997181f h1:/u/itWUzNSd/fUKfkdm/4hvzQdkmZ6Lfdy1Oj/wyaD4=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260506144832-b7e69997181f/go.mod h1:ux6qvwEyyK+LUfseHKpTTS4i5O6slZHVZ+f4orOtFm4=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=

--- a/passive_transaction_reconstructor.go
+++ b/passive_transaction_reconstructor.go
@@ -73,6 +73,20 @@ type PassiveTimingMarkers struct {
 	Terminal      time.Time
 }
 
+type PassiveACKPosition = protocol.ACKPosition
+
+const (
+	PassiveACKPositionRequestACK = protocol.ACKPositionRequestACK
+)
+
+type PassiveACKCorrelator = protocol.ACKCorrelator
+
+const (
+	PassiveACKCorrelatorM2A = protocol.ACKCorrelatorM2A
+)
+
+type PassiveACKCorrelation = protocol.ACKCorrelation
+
 type PassiveClassifiedEvent struct {
 	Kind                PassiveClassifiedEventKind
 	FrameType           protocol.FrameType
@@ -84,6 +98,7 @@ type PassiveClassifiedEvent struct {
 	ObservedAt          time.Time
 	AbandonReason       PassiveAbandonReason
 	DiscontinuityReason PassiveDiscontinuityReason
+	ACKCorrelation      PassiveACKCorrelation
 	Err                 error
 	Subscriber          string
 }
@@ -138,6 +153,7 @@ type passiveTransactionState struct {
 	response            protocol.Frame
 	responseExpectedLen int
 	responseCRCValid    bool
+	ackCorrelation      PassiveACKCorrelation
 	frameType           protocol.FrameType
 	timing              PassiveTimingMarkers
 	lastProgressAt      time.Time
@@ -404,6 +420,7 @@ func (reconstructor *PassiveTransactionReconstructor) startRequestLocked(symbol 
 	reconstructor.state.response = protocol.Frame{}
 	reconstructor.state.responseExpectedLen = 0
 	reconstructor.state.responseCRCValid = false
+	reconstructor.state.ackCorrelation = PassiveACKCorrelation{}
 	reconstructor.state.frameType = protocol.FrameTypeUnknown
 	reconstructor.state.timing = PassiveTimingMarkers{RequestStart: observedAt}
 	reconstructor.state.lastProgressAt = observedAt
@@ -533,6 +550,7 @@ func (reconstructor *PassiveTransactionReconstructor) handleACKSymbolLocked(even
 	switch symbol {
 	case protocol.SymbolAck:
 		reconstructor.state.lastProgressAt = observedAt
+		reconstructor.state.ackCorrelation = m2aRequestACKCorrelation(symbol)
 		if reconstructor.state.frameType == protocol.FrameTypeInitiatorInitiator {
 			reconstructor.state.phase = passivePhaseWaitTerminal
 			return events
@@ -543,6 +561,7 @@ func (reconstructor *PassiveTransactionReconstructor) handleACKSymbolLocked(even
 		reconstructor.state.responseCRCValid = false
 		return events
 	case protocol.SymbolNack:
+		reconstructor.state.ackCorrelation = m2aRequestACKCorrelation(symbol)
 		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonNACK, observedAt, ebuserrors.ErrNACK))
 		reconstructor.resetStateLocked()
 		return events
@@ -640,24 +659,26 @@ func (reconstructor *PassiveTransactionReconstructor) handleTerminalSymbolLocked
 	case protocol.FrameTypeInitiatorInitiator:
 		reconstructor.recordRecoveryLocked()
 		events = append(events, PassiveClassifiedEvent{
-			Kind:       PassiveClassifiedEventMasterFrame,
-			FrameType:  reconstructor.state.frameType,
-			Request:    reconstructor.state.request,
-			HasRequest: true,
-			Timing:     timing,
-			ObservedAt: observedAt,
+			Kind:           PassiveClassifiedEventMasterFrame,
+			FrameType:      reconstructor.state.frameType,
+			Request:        reconstructor.state.request,
+			HasRequest:     true,
+			Timing:         timing,
+			ObservedAt:     observedAt,
+			ACKCorrelation: reconstructor.state.ackCorrelation,
 		})
 	case protocol.FrameTypeInitiatorTarget:
 		reconstructor.recordRecoveryLocked()
 		events = append(events, PassiveClassifiedEvent{
-			Kind:        PassiveClassifiedEventTransaction,
-			FrameType:   reconstructor.state.frameType,
-			Request:     reconstructor.state.request,
-			Response:    reconstructor.state.response,
-			HasRequest:  true,
-			HasResponse: true,
-			Timing:      timing,
-			ObservedAt:  observedAt,
+			Kind:           PassiveClassifiedEventTransaction,
+			FrameType:      reconstructor.state.frameType,
+			Request:        reconstructor.state.request,
+			Response:       reconstructor.state.response,
+			HasRequest:     true,
+			HasResponse:    true,
+			Timing:         timing,
+			ObservedAt:     observedAt,
+			ACKCorrelation: reconstructor.state.ackCorrelation,
 		})
 	default:
 		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonUnexpectedSymbol, observedAt, ebuserrors.ErrInvalidPayload))
@@ -670,16 +691,17 @@ func (reconstructor *PassiveTransactionReconstructor) abandonLocked(reason Passi
 	hasRequest := reconstructor.state.frameType != protocol.FrameTypeUnknown
 	hasResponse := reconstructor.state.responseExpectedLen > 0
 	event := PassiveClassifiedEvent{
-		Kind:          PassiveClassifiedEventAbandonedTransaction,
-		FrameType:     reconstructor.state.frameType,
-		Request:       reconstructor.state.request,
-		Response:      reconstructor.state.response,
-		HasRequest:    hasRequest,
-		HasResponse:   hasResponse,
-		Timing:        reconstructor.state.timing,
-		ObservedAt:    observedAt,
-		AbandonReason: reason,
-		Err:           err,
+		Kind:           PassiveClassifiedEventAbandonedTransaction,
+		FrameType:      reconstructor.state.frameType,
+		Request:        reconstructor.state.request,
+		Response:       reconstructor.state.response,
+		HasRequest:     hasRequest,
+		HasResponse:    hasResponse,
+		Timing:         reconstructor.state.timing,
+		ObservedAt:     observedAt,
+		AbandonReason:  reason,
+		ACKCorrelation: reconstructor.state.ackCorrelation,
+		Err:            err,
 	}
 	event.Timing.Terminal = observedAt
 	return event
@@ -693,9 +715,19 @@ func (reconstructor *PassiveTransactionReconstructor) resetStateLocked() {
 	reconstructor.state.response = protocol.Frame{}
 	reconstructor.state.responseExpectedLen = 0
 	reconstructor.state.responseCRCValid = false
+	reconstructor.state.ackCorrelation = PassiveACKCorrelation{}
 	reconstructor.state.frameType = protocol.FrameTypeUnknown
 	reconstructor.state.timing = PassiveTimingMarkers{}
 	reconstructor.state.lastProgressAt = time.Time{}
+}
+
+func m2aRequestACKCorrelation(symbol byte) PassiveACKCorrelation {
+	return PassiveACKCorrelation{
+		Byte:            symbol,
+		Position:        PassiveACKPositionRequestACK,
+		CompleteRequest: true,
+		Correlator:      PassiveACKCorrelatorM2A,
+	}
 }
 
 func parsePassiveResponse(request protocol.Frame, raw []byte) (protocol.Frame, bool) {


### PR DESCRIPTION
## Summary

M0B_TDD_GATE/gateway of cruise plan [`address-table-registry-w19-26.locked`](https://github.com/Project-Helianthus/helianthus-execution-plans/tree/main/address-table-registry-w19-26.locked) (meta-issue [helianthus-execution-plans#23](https://github.com/Project-Helianthus/helianthus-execution-plans/issues/23)).

Last of the M0B per-repo wave (after [docs-ebus#295](https://github.com/Project-Helianthus/helianthus-docs-ebus/pull/295), [ebusgateway#563](https://github.com/Project-Helianthus/helianthus-ebusgateway/pull/563), [ebusreg#131](https://github.com/Project-Helianthus/helianthus-ebusreg/pull/131), [ebusgo#148](https://github.com/Project-Helianthus/helianthus-ebusgo/pull/148)).

Adds intentionally-failing tests pinning M3/M4 acceptance criteria. **DO NOT MERGE** until M3/M4 + supporting milestones turn GREEN.

## RED state

`go test ./...` fails with multiple `undefined` errors:
- `cfg.AdmittedSource undefined`
- `undefined: AddressTable`
- `undefined: AddressTableInserter`
- `undefined: NewAddressTable`
- `undefined: NewAddressTableInserter`
- `event.ACKCorrelation undefined`
- `undefined: AddressSlot`

These reference M3, M2A, and M1 symbols that don't exist yet.

## Tests authored

- `TestFirstObservation_PositiveACKOnly`: positive-ACK insertion fires
- `TestFirstObservation_NoNACKInsertion`: NACK does NOT insert
- `TestFirstObservation_SelfSourceExcluded`: admitted source filtered
- `TestCompanionInsert_RequiresCorroboration`: companion needs second observation
- `TestFFDisambiguation_FrameStartVsACKPosition`: 0xFF as master vs NACK byte

Cross-references AD03, AD04, AD05, AD09, AD15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)