### PR TITLE
fix(gateway): Phase A.6 — insert request src on positive ACK (AD05 spec compliance, P1 close)

### DIFF
--- a/address_table_inserter.go
+++ b/address_table_inserter.go
@@ -53,6 +53,13 @@ func (i *AddressTableInserter) OnPassiveClassifiedEvent(event PassiveClassifiedE
 		return
 	}
 
+	// Insert request src as initiator (AD05 Address Eligibility:
+	// "request src MAY create a slot if it is not the gateway's own
+	// admitted source"). PR #564 missed this — observed-only initiators
+	// like NETX3 0xF1 never landed in the registry passively
+	// even though their traffic was seen on the bus.
+	i.maybeInsert(srcAddr, "initiator", admittedSrc, event.ObservedAt)
+
 	i.maybeInsert(dstAddr, "target", admittedSrc, event.ObservedAt)
 	observation := i.observationsByAddr[srcAddr]
 	observation.PositiveACKCount++

--- a/address_table_insertion_test.go
+++ b/address_table_insertion_test.go
@@ -65,11 +65,11 @@ func TestCompanionInsert_RequiresCorroboration(t *testing.T) {
 // just the target. Per architecture/atr/03-ack-nack-insertion-rules.md
 // "Address Eligibility":
 //
-//   "request `src` MAY create a slot if it is not the gateway's own admitted source"
+//	"request `src` MAY create a slot if it is not the gateway's own admitted source"
 //
 // PR #564 implemented dst insertion + companion-after-corroboration but
-// missed src insertion, so addresses like NETX3 master 0xF1 never landed
-// in the registry passively even though their traffic was observed.
+// missed src insertion, so initiator addresses like NETX3 0xF1 never
+// landed in the registry passively even though their traffic was observed.
 func TestFirstObservation_SourceInserted(t *testing.T) {
 	table, inserter := newATRInsertionHarness(t, DefaultConfig())
 

--- a/address_table_insertion_test.go
+++ b/address_table_insertion_test.go
@@ -60,6 +60,39 @@ func TestCompanionInsert_RequiresCorroboration(t *testing.T) {
 	requireATRSlot(t, table, 0xF6)
 }
 
+// TestFirstObservation_SourceInserted asserts that on a positive ACK the
+// initiator address (request src) is inserted as an "initiator" slot — not
+// just the target. Per architecture/atr/03-ack-nack-insertion-rules.md
+// "Address Eligibility":
+//
+//   "request `src` MAY create a slot if it is not the gateway's own admitted source"
+//
+// PR #564 implemented dst insertion + companion-after-corroboration but
+// missed src insertion, so addresses like NETX3 master 0xF1 never landed
+// in the registry passively even though their traffic was observed.
+func TestFirstObservation_SourceInserted(t *testing.T) {
+	table, inserter := newATRInsertionHarness(t, DefaultConfig())
+
+	event := atrPassiveTransactionEvent(time.Now().UTC(), 0xF1, 0x99, protocol.SymbolAck)
+	inserter.OnPassiveClassifiedEvent(event)
+
+	srcSlot := requireATRSlot(t, table, 0xF1)
+	if srcSlot.Role != "initiator" {
+		t.Fatalf("slot[0xF1].Role = %q; want initiator", srcSlot.Role)
+	}
+	if srcSlot.DiscoverySource != "passive_observed" {
+		t.Fatalf("slot[0xF1].DiscoverySource = %q; want passive_observed", srcSlot.DiscoverySource)
+	}
+	if srcSlot.VerificationState != "corroborated_pending" {
+		t.Fatalf("slot[0xF1].VerificationState = %q; want corroborated_pending", srcSlot.VerificationState)
+	}
+
+	dstSlot := requireATRSlot(t, table, 0x99)
+	if dstSlot.Role != "target" {
+		t.Fatalf("slot[0x99].Role = %q; want target", dstSlot.Role)
+	}
+}
+
 func TestFFDisambiguation_FrameStartVsACKPosition(t *testing.T) {
 	table, inserter := newATRInsertionHarness(t, DefaultConfig())
 	base := time.Now().UTC()


### PR DESCRIPTION
## Summary

Operator-confirmed regression in PR #564 (M3+M4): the inserter inserts dst on positive ACK and companion(src) after 2× corroboration, but never inserts the request src itself. Per the locked plan's normative spec at \`architecture/atr/03-ack-nack-insertion-rules.md\` "Address Eligibility":

> request \`src\` MAY create a slot if it is not the gateway's own admitted source

Live evidence on HA after Phase A.5 deploy: \`bus_messages_list\` shows 1× passive frame with \`source=0xF1 target=0x15 outcome=success\`, but neither 0xF1 nor 0xF6 (companion of 0xF1) landed in the registry. The frame was correctly classified by the reconstructor and reached the inserter (verified by deployed binary checksum match), but the inserter dropped src on the floor.

Fix: add \`maybeInsert(srcAddr, "initiator", admittedSrc, observedAt)\` between the self-source filter and the dst insertion in \`address_table_inserter.go\`. The 0xFF and self-source guards above already cover the spec's negative assertions; passing those means srcAddr is eligible per AD05.

After this change a single positive ACK from \`0xF1 → any-target\` inserts both 0xF1 (initiator) and the target. The companion-pair corroboration gate (\`observationsByAddr[srcAddr] >= 2\`) still governs companion(srcAddr) insertion (i.e. 0xF6) — that semantic is unchanged.

## Test plan

- [x] RED test \`TestFirstObservation_SourceInserted\` fails at HEAD before fix
- [x] GREEN: passes after fix; existing tests \`TestFirstObservation_PositiveACKOnly\`, \`TestFirstObservation_NoNACKInsertion\`, \`TestFirstObservation_SelfSourceExcluded\`, \`TestCompanionInsert_RequiresCorroboration\`, \`TestFFDisambiguation_FrameStartVsACKPosition\` all still PASS
- [x] \`go test -race ./... -timeout 8m\` — green
- [x] Local \`scripts/ci_local.sh\` — exit 0 with documented owner overrides (no transport/protocol changes; only inserter rule expanded)
- [ ] Live re-validation post-deploy: 0xF1 + 0xF6 visible after first organic 0xF1 ACK / second F1 ACK respectively

## Plan reference

- Plan: \`address-table-registry-w19-26.locked\` Phase A.6 (post-deploy spec-compliance fix)
- Closes P1 from M8 live validation: 0xF6 visible passively + 0xF1 visible directly
- Companion to merged PRs: gateway #564 #565, ebusgo #148, ebusreg #131, docs-ebus #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)