### PR TITLE
fix(gateway): A.7b — alias canonical-pair addresses on insert

### DIFF
--- a/address_table_inserter.go
+++ b/address_table_inserter.go
@@ -91,6 +91,11 @@ func (i *AddressTableInserter) maybeInsert(addr byte, role string, admittedSrc b
 		return
 	}
 	if _, exists := i.table.Lookup(addr); exists {
+		// Already in registry (active scan, prior passive observation,
+		// or static seed) — but still attempt canonical-pair aliasing
+		// in case the companion was registered separately and never
+		// went through the new-insert alias path. Idempotent.
+		i.maybeAliasCanonicalCompanion(addr)
 		return
 	}
 
@@ -118,4 +123,29 @@ func (i *AddressTableInserter) maybeInsert(addr byte, role string, admittedSrc b
 		VerificationState: "corroborated_pending",
 		RegistrySlot:      registrySlot,
 	}
+
+	// A.7b — canonical-pair aliasing. If addr is one half of a canonical
+	// pair from the docs-owned eBUS standard table (sourceAddressTableV1)
+	// and the other half is already in the registry, alias them into a
+	// single DeviceEntry so MCP/GraphQL queries return one device with
+	// two addresses. Aliasing only fires for the 25 canonical pairs;
+	// non-canonical neighbours (e.g. 0x26 / 0xEC) are never aliased here.
+	i.maybeAliasCanonicalCompanion(addr)
+}
+
+// maybeAliasCanonicalCompanion calls registry.AliasAddresses(addr, companion)
+// when addr is one half of a canonical eBUS source/companion pair AND the
+// other half is already present in the wrapped registry. Idempotent.
+func (i *AddressTableInserter) maybeAliasCanonicalCompanion(addr byte) {
+	if i == nil || i.table == nil || i.table.reg == nil {
+		return
+	}
+	companion, ok := protocol.Companion(addr)
+	if !ok {
+		return
+	}
+	if _, exists := i.table.reg.Lookup(companion); !exists {
+		return
+	}
+	_ = i.table.reg.AliasAddresses(addr, companion)
 }

--- a/address_table_insertion_test.go
+++ b/address_table_insertion_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
 )
 
 func TestFirstObservation_PositiveACKOnly(t *testing.T) {
@@ -126,7 +127,8 @@ func TestCanonicalAliasing_SourceCompanionPair_AfterBothObserved(t *testing.T) {
 	requireATRSlot(t, table, 0x15)
 
 	// Step 3: assert canonical aliasing — both addresses resolve to the
-	// same DeviceEntry in the wrapped registry.
+	// same DeviceEntry in the wrapped registry, and the entry exposes
+	// both addresses via Addresses().
 	entryA, okA := table.reg.Lookup(0x10)
 	entryB, okB := table.reg.Lookup(0x15)
 	if !okA || !okB {
@@ -135,6 +137,73 @@ func TestCanonicalAliasing_SourceCompanionPair_AfterBothObserved(t *testing.T) {
 	if entryA.Address() != entryB.Address() {
 		t.Fatalf("canonical pair 0x10 ↔ 0x15 not aliased: 0x10 entry primary=0x%02X, 0x15 entry primary=0x%02X; want same primary", entryA.Address(), entryB.Address())
 	}
+	addrs := entryA.Addresses()
+	hasMaster, hasCompanion := false, false
+	for _, a := range addrs {
+		if a == 0x10 {
+			hasMaster = true
+		}
+		if a == 0x15 {
+			hasCompanion = true
+		}
+	}
+	if !hasMaster || !hasCompanion {
+		t.Fatalf("DeviceEntry.Addresses() = %v; want both 0x10 and 0x15", addrs)
+	}
+}
+
+// TestCanonicalAliasing_FFAndZeroFour_BothDirections asserts the wrap-pair
+// aliasing for 0xFF ↔ 0x04. NETX3 publishes a target at 0x04 whose canonical
+// source is 0xFF (per architecture/ebus_standard/12-source-address-table.md
+// row 25, with byte-modulo arithmetic 0xFF + 0x05 = 0x04). Tests both
+// orderings: 0xFF first then 0x04 (forward) and 0x04 first then 0xFF
+// (reverse).
+func TestCanonicalAliasing_FFAndZeroFour_BothDirections(t *testing.T) {
+	t.Parallel()
+
+	t.Run("FF_then_04", func(t *testing.T) {
+		table, inserter := newATRInsertionHarness(t, DefaultConfig())
+		base := time.Now().UTC()
+
+		// 0xFF as src (frame-start, not NACK byte) → inserts 0xFF.
+		ff := atrPassiveTransactionEvent(base, 0xFF, 0x99, protocol.SymbolAck)
+		inserter.OnPassiveClassifiedEvent(ff)
+		requireATRSlot(t, table, 0xFF)
+
+		// Some-source → 0x04 with positive ACK → inserts 0x04.
+		zero4 := atrPassiveTransactionEvent(base.Add(time.Second), 0x10, 0x04, protocol.SymbolAck)
+		inserter.OnPassiveClassifiedEvent(zero4)
+		requireATRSlot(t, table, 0x04)
+
+		entryFF, okFF := table.reg.Lookup(0xFF)
+		entry04, ok04 := table.reg.Lookup(0x04)
+		if !okFF || !ok04 {
+			t.Fatalf("registry.Lookup ok: 0xFF=%v 0x04=%v", okFF, ok04)
+		}
+		if entryFF.Address() != entry04.Address() {
+			t.Fatalf("0xFF ↔ 0x04 wrap-pair not aliased: 0xFF primary=0x%02X, 0x04 primary=0x%02X", entryFF.Address(), entry04.Address())
+		}
+	})
+
+	t.Run("04_then_FF", func(t *testing.T) {
+		table, inserter := newATRInsertionHarness(t, DefaultConfig())
+		base := time.Now().UTC()
+
+		// Reverse ordering: 0x04 inserted first via dst observation.
+		zero4 := atrPassiveTransactionEvent(base, 0x10, 0x04, protocol.SymbolAck)
+		inserter.OnPassiveClassifiedEvent(zero4)
+		requireATRSlot(t, table, 0x04)
+
+		ff := atrPassiveTransactionEvent(base.Add(time.Second), 0xFF, 0x99, protocol.SymbolAck)
+		inserter.OnPassiveClassifiedEvent(ff)
+		requireATRSlot(t, table, 0xFF)
+
+		entryFF, _ := table.reg.Lookup(0xFF)
+		entry04, _ := table.reg.Lookup(0x04)
+		if entryFF.Address() != entry04.Address() {
+			t.Fatalf("0xFF ↔ 0x04 wrap-pair (reverse order) not aliased: 0xFF primary=0x%02X, 0x04 primary=0x%02X", entryFF.Address(), entry04.Address())
+		}
+	})
 }
 
 // TestCanonicalAliasing_NonCanonicalAddresses_NotAliased asserts that
@@ -146,14 +215,14 @@ func TestCanonicalAliasing_NonCanonicalAddresses_NotAliased(t *testing.T) {
 	table, inserter := newATRInsertionHarness(t, DefaultConfig())
 	base := time.Now().UTC()
 
-	// 0x26 (VR_71 slave) is observed as target. Its hypothetical
+	// 0x26 (VR_71 target-only address) is observed as target. Its hypothetical
 	// "companion" via math 0x21 is not in the canonical table, and the
 	// canonical-table-backed lookup correctly rejects it.
 	first := atrPassiveTransactionEvent(base, 0x10, 0x26, protocol.SymbolAck)
 	inserter.OnPassiveClassifiedEvent(first)
 	requireATRSlot(t, table, 0x26)
 
-	// 0xEC (SOL00 slave) is observed as target. Same situation.
+	// 0xEC (SOL00 target-only address) is observed as target. Same situation.
 	second := atrPassiveTransactionEvent(base.Add(time.Second), 0x10, 0xEC, protocol.SymbolAck)
 	inserter.OnPassiveClassifiedEvent(second)
 	requireATRSlot(t, table, 0xEC)
@@ -166,6 +235,40 @@ func TestCanonicalAliasing_NonCanonicalAddresses_NotAliased(t *testing.T) {
 	}
 	if entryA.Address() == entryB.Address() {
 		t.Fatalf("non-canonical addresses 0x26 and 0xEC unexpectedly aliased to primary 0x%02X", entryA.Address())
+	}
+}
+
+// TestCanonicalAliasing_BothPreRegistered_AliasOnObservation asserts that
+// when both halves of a canonical pair were registered BEFORE the inserter
+// runs (e.g. via startup active scan or static seed), a subsequent passive
+// observation of either half still triggers the alias merge. Without this,
+// devices that the active scan picks up as separate entries (the common
+// case for 0x10/0x15 BASV2 controller pair) would never become aliased.
+func TestCanonicalAliasing_BothPreRegistered_AliasOnObservation(t *testing.T) {
+	table, inserter := newATRInsertionHarness(t, DefaultConfig())
+
+	// Pre-register both 0x10 and 0x15 as if startup active scan had
+	// discovered them as separate entries. Force them apart by giving
+	// each a distinct identity so registry.Register doesn't auto-merge.
+	table.reg.Register(registry.DeviceInfo{Address: 0x10, Manufacturer: "Vaillant", DeviceID: "VRC700", SerialNumber: "SN-VRC"})
+	table.reg.Register(registry.DeviceInfo{Address: 0x15, Manufacturer: "Vaillant", DeviceID: "BASV2", SerialNumber: "SN-BASV2"})
+
+	entry10Pre, _ := table.reg.Lookup(0x10)
+	entry15Pre, _ := table.reg.Lookup(0x15)
+	if entry10Pre.Address() == entry15Pre.Address() {
+		t.Fatalf("test setup: 0x10 and 0x15 unexpectedly share primary 0x%02X (Register auto-merged)", entry10Pre.Address())
+	}
+
+	// Observe passive traffic with 0x10 as src. Inserter sees 0x10 in
+	// table.Lookup → existing → MUST still attempt alias of 0x10's
+	// canonical companion 0x15.
+	event := atrPassiveTransactionEvent(time.Now().UTC(), 0x10, 0x99, protocol.SymbolAck)
+	inserter.OnPassiveClassifiedEvent(event)
+
+	entry10, _ := table.reg.Lookup(0x10)
+	entry15, _ := table.reg.Lookup(0x15)
+	if entry10.Address() != entry15.Address() {
+		t.Fatalf("pre-registered canonical pair 0x10 ↔ 0x15 not aliased after passive observation: 0x10 primary=0x%02X, 0x15 primary=0x%02X", entry10.Address(), entry15.Address())
 	}
 }
 

--- a/address_table_insertion_test.go
+++ b/address_table_insertion_test.go
@@ -93,6 +93,82 @@ func TestFirstObservation_SourceInserted(t *testing.T) {
 	}
 }
 
+// TestCanonicalAliasing_SourceCompanionPair_AfterSecondCorroboration asserts
+// that when both a canonical source AND its canonical companion land in the
+// registry, the inserter aliases them as a single device — so MCP/GraphQL
+// queries return one device with two addresses, not two unrelated entries.
+//
+// Per architecture/ebus_standard/12-source-address-table.md, 0x10 ↔ 0x15 is
+// the canonical Heating regulator pair. After the inserter sees:
+//  1. positive ACK from 0x10 → some-target  (inserts 0x10 as initiator)
+//  2. positive ACK from some-source → 0x15  (inserts 0x15 as target — but
+//     the companion-pair gate requires 2 observations of source for
+//     companion(source) insertion; here 0x15 is inserted as direct dst)
+//
+// At the moment both 0x10 and 0x15 are present in the table, the inserter
+// MUST call AliasAddresses(0x10, 0x15) so registry.Lookup(0x10) and
+// registry.Lookup(0x15) return the same DeviceEntry.
+func TestCanonicalAliasing_SourceCompanionPair_AfterBothObserved(t *testing.T) {
+	table, inserter := newATRInsertionHarness(t, DefaultConfig())
+	base := time.Now().UTC()
+
+	// Step 1: observe 0x10 → 0x33-style-target (positive ACK) → inserts
+	// 0x10 as initiator + the target as target.
+	first := atrPassiveTransactionEvent(base, 0x10, 0x99, protocol.SymbolAck)
+	inserter.OnPassiveClassifiedEvent(first)
+	requireATRSlot(t, table, 0x10)
+
+	// Step 2: observe a different source emitting to 0x15 (canonical
+	// companion of 0x10) with positive ACK → inserts 0x15 as target.
+	// Now both 0x10 and 0x15 are present — the inserter MUST alias them.
+	second := atrPassiveTransactionEvent(base.Add(time.Second), 0x71, 0x15, protocol.SymbolAck)
+	inserter.OnPassiveClassifiedEvent(second)
+	requireATRSlot(t, table, 0x15)
+
+	// Step 3: assert canonical aliasing — both addresses resolve to the
+	// same DeviceEntry in the wrapped registry.
+	entryA, okA := table.reg.Lookup(0x10)
+	entryB, okB := table.reg.Lookup(0x15)
+	if !okA || !okB {
+		t.Fatalf("registry.Lookup ok values: 0x10=%v 0x15=%v; want both true", okA, okB)
+	}
+	if entryA.Address() != entryB.Address() {
+		t.Fatalf("canonical pair 0x10 ↔ 0x15 not aliased: 0x10 entry primary=0x%02X, 0x15 entry primary=0x%02X; want same primary", entryA.Address(), entryB.Address())
+	}
+}
+
+// TestCanonicalAliasing_NonCanonicalAddresses_NotAliased asserts that
+// non-canonical companions (e.g. real but non-table addresses 0x26 / 0xEC
+// for VR_71 / SOL00) are NOT aliased even if they appear in the registry
+// alongside other addresses. Aliasing only fires for the 25 canonical
+// pairs from sourceAddressTableV1.
+func TestCanonicalAliasing_NonCanonicalAddresses_NotAliased(t *testing.T) {
+	table, inserter := newATRInsertionHarness(t, DefaultConfig())
+	base := time.Now().UTC()
+
+	// 0x26 (VR_71 slave) is observed as target. Its hypothetical
+	// "companion" via math 0x21 is not in the canonical table, and the
+	// canonical-table-backed lookup correctly rejects it.
+	first := atrPassiveTransactionEvent(base, 0x10, 0x26, protocol.SymbolAck)
+	inserter.OnPassiveClassifiedEvent(first)
+	requireATRSlot(t, table, 0x26)
+
+	// 0xEC (SOL00 slave) is observed as target. Same situation.
+	second := atrPassiveTransactionEvent(base.Add(time.Second), 0x10, 0xEC, protocol.SymbolAck)
+	inserter.OnPassiveClassifiedEvent(second)
+	requireATRSlot(t, table, 0xEC)
+
+	// 0x26 and 0xEC must remain separate device entries.
+	entryA, okA := table.reg.Lookup(0x26)
+	entryB, okB := table.reg.Lookup(0xEC)
+	if !okA || !okB {
+		t.Fatalf("registry.Lookup ok: 0x26=%v 0xEC=%v; want both true", okA, okB)
+	}
+	if entryA.Address() == entryB.Address() {
+		t.Fatalf("non-canonical addresses 0x26 and 0xEC unexpectedly aliased to primary 0x%02X", entryA.Address())
+	}
+}
+
 func TestFFDisambiguation_FrameStartVsACKPosition(t *testing.T) {
 	table, inserter := newATRInsertionHarness(t, DefaultConfig())
 	base := time.Now().UTC()

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Project-Helianthus/helianthus-ebusgateway
 go 1.22
 
 require (
-	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260506144445-5ab7ab6cdb1e
+	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260506212127-c2b8efb55579
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260506144832-b7e69997181f
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260506144445-5ab7ab6cdb1e h1:AOLYUOvKdzSAAu9t1aXjqpZptHb7+3U2fMY/T6TVSZA=
 github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260506144445-5ab7ab6cdb1e/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
+github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260506212127-c2b8efb55579 h1:Xf06i1rQ6dUWeeOqmxWfgVqc+Qw7Gq5FKv39OKHjSCw=
+github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260506212127-c2b8efb55579/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260506144832-b7e69997181f h1:/u/itWUzNSd/fUKfkdm/4hvzQdkmZ6Lfdy1Oj/wyaD4=
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260506144832-b7e69997181f/go.mod h1:ux6qvwEyyK+LUfseHKpTTS4i5O6slZHVZ+f4orOtFm4=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -2459,8 +2459,14 @@ func cloneDeviceInfoList(source []deviceInfo) []deviceInfo {
 	}
 	out := make([]deviceInfo, len(source))
 	for i, device := range source {
+		var aliases []int
+		if len(device.Addresses) > 0 {
+			aliases = make([]int, len(device.Addresses))
+			copy(aliases, device.Addresses)
+		}
 		out[i] = deviceInfo{
 			Address:         device.Address,
+			Addresses:       aliases,
 			Manufacturer:    device.Manufacturer,
 			DeviceID:        device.DeviceID,
 			SoftwareVersion: device.SoftwareVersion,
@@ -2472,9 +2478,20 @@ func cloneDeviceInfoList(source []deviceInfo) []deviceInfo {
 }
 
 func findDeviceInfoByAddress(devices []deviceInfo, address byte) (deviceInfo, bool) {
+	target := int(address)
 	for _, device := range devices {
-		if device.Address == int(address) {
+		if device.Address == target {
 			return device, true
+		}
+		// A.7b — canonical-pair aliasing collapses paired addresses
+		// (e.g. 0x10/0x15) into one DeviceEntry whose Address() is the
+		// primary; aliased addresses are exposed via Addresses(). The
+		// snapshot must respect that or queries by alias address would
+		// return "unknown device" when live registry would resolve.
+		for _, alias := range device.Addresses {
+			if alias == target {
+				return device, true
+			}
 		}
 	}
 	return deviceInfo{}, false
@@ -2482,6 +2499,7 @@ func findDeviceInfoByAddress(devices []deviceInfo, address byte) (deviceInfo, bo
 
 type deviceInfo struct {
 	Address         int         `json:"address"`
+	Addresses       []int       `json:"addresses,omitempty"`
 	Manufacturer    string      `json:"manufacturer"`
 	DeviceID        string      `json:"device_id"`
 	SoftwareVersion string      `json:"software_version"`
@@ -3523,8 +3541,25 @@ func cloneEnergySeries(series EnergySeries) EnergySeries {
 }
 
 func buildDeviceInfo(entry registry.DeviceEntry) deviceInfo {
+	primary := entry.Address()
+	all := entry.Addresses()
+	// Surface the complete address set (primary + aliases) to match the
+	// GraphQL `addresses` semantics in graphql/schema.go. Snapshot
+	// consumers (findDeviceInfoByAddress) check this list to resolve
+	// canonical-pair queries regardless of which half the caller asked
+	// for. MCP↔GraphQL parity contract requires identical list contents.
+	var aliases []int
+	if len(all) > 0 {
+		aliases = make([]int, 0, len(all))
+		for _, a := range all {
+			aliases = append(aliases, int(a))
+		}
+	} else {
+		aliases = []int{int(primary)}
+	}
 	return deviceInfo{
-		Address:         int(entry.Address()),
+		Address:         int(primary),
+		Addresses:       aliases,
 		Manufacturer:    entry.Manufacturer(),
 		DeviceID:        entry.DeviceID(),
 		SoftwareVersion: entry.SoftwareVersion(),


### PR DESCRIPTION
## Summary

A.7b in cruise plan address-table-registry-w19-26 follow-up. When the inserter sees both members of a canonical eBUS source/companion pair (per `architecture/ebus_standard/12-source-address-table.md`), it now calls `registry.AliasAddresses(addr, companion)` so MCP/GraphQL queries return one DeviceEntry with two addresses, not two unrelated entries.

Operator-confirmed regression on live HA: registry contained 0x10 (VRC master) and 0x15 (BASV2 regulator) as **separate** entries despite being a canonical pair from the eBUS standard table. Same gap for 0x03/0x08 (BAI), 0xF1/0xF6 (NETX3 main), 0xFF/0x04 (NETX3 wrap pair).

## Implementation

New helper `maybeAliasCanonicalCompanion(addr)` called at the end of `maybeInsert` after the new slot is registered. Uses `protocol.Companion` (rebased on the docs-owned table in helianthus-ebusgo PR #149) — only returns true for the 25 canonical pairs.

Non-canonical addresses (real but non-table 0x26 / 0xEC for VR_71 / SOL00) are correctly NOT auto-aliased; same-device grouping for those will land via M6 enrichment merge.

Bumps `helianthus-ebusgo` to `v0.5.1-0.20260506212127-c2b8efb55579` (A.7a merged commit `c2b8efb`).

## Test plan

- [x] RED test `TestCanonicalAliasing_SourceCompanionPair_AfterBothObserved` fails at HEAD (assertion: 0x10 + 0x15 not aliased) → passes after fix.
- [x] Negative test `TestCanonicalAliasing_NonCanonicalAddresses_NotAliased` (0x26 + 0xEC stay separate) — passes both before and after.
- [x] All existing AD04/AD05 tests still pass.
- [x] Local `scripts/ci_local.sh` exit 0 with documented owner overrides.
- [ ] 20-min live test on Helianthus after A.7c+d+e land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)