### PR TITLE
feat(gateway): A.9 — per-reason abandon counter on PassiveReconstructorSnapshot

### DIFF
--- a/bus_observability_store.go
+++ b/bus_observability_store.go
@@ -1243,6 +1243,22 @@ func (store *BusObservabilityStore) RenderPrometheus() string {
 		writer.writeCounterSample("ebus_passive_reconstructor_recoveries_total", float64(snapshot.RecoveryTotal[reason]), labelMap("reason", reason))
 	}
 
+	// A.9 — surface per-reason abandon counts so operators can compare
+	// to Grafana ground-truth frame counts. Catches operator-confirmed
+	// regressions like 0xF1→0x15 (B503) being abandoned with
+	// unexpected_symbol or 0x03→0x04 (B511) being abandoned with
+	// no_response despite valid frames on the wire.
+	writer.writeHelp("ebus_passive_reconstructor_abandons_total", "Passive reconstructor abandon counts per reason.")
+	writer.writeType("ebus_passive_reconstructor_abandons_total", "counter")
+	abandonReasonsSorted := make([]string, 0, len(snapshot.AbandonsByReason))
+	for reason := range snapshot.AbandonsByReason {
+		abandonReasonsSorted = append(abandonReasonsSorted, reason)
+	}
+	sort.Strings(abandonReasonsSorted)
+	for _, reason := range abandonReasonsSorted {
+		writer.writeCounterSample("ebus_passive_reconstructor_abandons_total", float64(snapshot.AbandonsByReason[reason]), labelMap("reason", reason))
+	}
+
 	writer.writeHelp("passive_hits_total", "Observe-first scheduler reads served from passive shadow.")
 	writer.writeType("passive_hits_total", "counter")
 	for _, item := range sortedWatchEfficiencyBuckets(watchEfficiency.buckets) {

--- a/passive_transaction_reconstructor.go
+++ b/passive_transaction_reconstructor.go
@@ -186,11 +186,19 @@ type PassiveReconstructorSnapshot struct {
 	TapStatus           PassiveTapStatus
 	FanoutOverflowTotal map[string]uint64
 	RecoveryTotal       map[string]uint64
+	// AbandonsByReason counts how many transactions the reconstructor
+	// classified into each PassiveAbandonReason. Operators query this
+	// to determine if a specific (src, dst) pair is failing
+	// classification at unusual rates — e.g. live evidence of B503
+	// frames hitting unexpected_symbol despite Grafana ground truth
+	// showing positive ACKs on the wire (A.9 diagnostic surface).
+	AbandonsByReason map[string]uint64
 }
 
 type passiveReconstructorMetrics struct {
 	fanoutOverflowTotal map[string]uint64
 	recoveryTotal       map[string]uint64
+	abandonsByReason    map[string]uint64
 }
 
 func StartPassiveTransactionReconstructor(ctx context.Context, cfg Config) (*PassiveTransactionReconstructor, error) {
@@ -314,6 +322,7 @@ func (reconstructor *PassiveTransactionReconstructor) Snapshot() PassiveReconstr
 		TapStatus:           tapStatus,
 		FanoutOverflowTotal: cloneUint64Map(reconstructor.metrics.fanoutOverflowTotal),
 		RecoveryTotal:       cloneUint64Map(reconstructor.metrics.recoveryTotal),
+		AbandonsByReason:    cloneUint64Map(reconstructor.metrics.abandonsByReason),
 	}
 }
 
@@ -706,15 +715,20 @@ func (reconstructor *PassiveTransactionReconstructor) abandonLocked(reason Passi
 	}
 	event.Timing.Terminal = observedAt
 	// A.8 — forensic logging for protocol-classification failures the
-	// inserter cannot consume. Specifically unexpected_symbol /
-	// corrupted_request / corrupted_target / no_response are the
-	// operator-confirmed symptoms that block 0xF1→0x15 / 0x03→X
-	// transactions from creating registry entries. Log raw bytes +
-	// state phase so post-mortem can reproduce + identify root cause
-	// without re-deploying.
+	// inserter cannot consume.
 	if shouldLogReconstructorForensics(reason) {
 		reconstructor.logForensicsLocked(reason, observedAt)
 	}
+	// A.9 — per-reason counter so operators can compare Helianthus
+	// abandon rate to Grafana ground-truth frame counts without
+	// log-grep aggregation. Lock-protected so Snapshot() can read
+	// safely.
+	reconstructor.metricsMu.Lock()
+	if reconstructor.metrics.abandonsByReason == nil {
+		reconstructor.metrics.abandonsByReason = make(map[string]uint64, 8)
+	}
+	reconstructor.metrics.abandonsByReason[string(reason)]++
+	reconstructor.metricsMu.Unlock()
 	return event
 }
 


### PR DESCRIPTION
A.9. Adds AbandonsByReason map to PassiveReconstructorSnapshot — per-reason counter (unexpected_symbol/no_response/corrupted_request/etc) updated in abandonLocked under metricsMu. Complements A.8 forensic logging by giving operators a queryable counter to compare Helianthus abandon rates to Grafana ground-truth frame counts without log-grep aggregation. Diagnoses operator-confirmed 0x03→0x04 no_response + 0xF1→0x15 B503 unexpected_symbol cases.