### PR TITLE
fix(gateway): switch inserter from direct slot mutation to MarkSlotPassiveObserved API (M6.1 use site)

### DIFF
--- a/address_table_inserter.go
+++ b/address_table_inserter.go
@@ -101,21 +101,19 @@ func (i *AddressTableInserter) maybeInsert(addr byte, role string, admittedSrc b
 	}
 
 	i.table.reg.Register(registry.DeviceInfo{Address: addr})
-	registrySlot, _ := i.table.reg.LookupSlot(addr)
-	if registrySlot != nil {
-		registrySlot.DiscoverySource = registry.DiscoverySourcePassiveObserved
-		registrySlot.VerificationState = registry.VerificationStateCorroborated
-		switch role {
-		case "initiator":
-			registrySlot.Role = registry.SlotRoleMaster
-		case "target":
-			registrySlot.Role = registry.SlotRoleSlave
-		}
-		if registrySlot.FirstObservedAt.IsZero() {
-			registrySlot.FirstObservedAt = observedAt
-		}
-		registrySlot.LastObservedAt = observedAt
+	// A.7+M6.1 — use the thread-safe MarkSlotPassiveObserved API
+	// instead of mutating the slot pointer directly. The previous
+	// direct-mutation pattern was racy with concurrent readers via
+	// LookupSlot / Lookup (Codex P2 follow-up from PR #565).
+	var slotRole registry.SlotRole
+	switch role {
+	case "initiator":
+		slotRole = registry.SlotRoleMaster
+	case "target":
+		slotRole = registry.SlotRoleSlave
 	}
+	i.table.reg.MarkSlotPassiveObserved(addr, slotRole, observedAt)
+	registrySlot, _ := i.table.reg.LookupSlot(addr)
 
 	tier, free := canonicalSlotMetadata(addr)
 	i.table.slots[addr] = &AddressSlot{

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260506212127-c2b8efb55579
-	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260506144832-b7e69997181f
+	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260506235755-856f3a19368d
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260506212127-c2b8efb5
 github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260506212127-c2b8efb55579/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260506144832-b7e69997181f h1:/u/itWUzNSd/fUKfkdm/4hvzQdkmZ6Lfdy1Oj/wyaD4=
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260506144832-b7e69997181f/go.mod h1:ux6qvwEyyK+LUfseHKpTTS4i5O6slZHVZ+f4orOtFm4=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260506235755-856f3a19368d h1:YPh6uCcC80cgwCahxpRSLdLE/r4SVkohNNJBRa5VdeU=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260506235755-856f3a19368d/go.mod h1:ux6qvwEyyK+LUfseHKpTTS4i5O6slZHVZ+f4orOtFm4=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=


### PR DESCRIPTION
M6.1 use site. Replaces inserter's direct *AddressSlot field mutation with the new MarkSlotPassiveObserved API (helianthus-ebusreg #132 b3f2f1a). Closes the pre-existing race surface flagged on PR #565 (Codex P2). Bumps ebusreg to commit 856f3a1. Race + full test suite pass.