### PR TITLE
fix(gateway): Phase C M-C6b — migrate 33 entry.Address() callers to PrimaryDisplayAddress

### DIFF
--- a/address_table_inserter.go
+++ b/address_table_inserter.go
@@ -191,7 +191,7 @@ func (i *AddressTableInserter) maybeAliasCanonicalCompanion(addr byte) {
 	// distinct DeviceEntries; otherwise it's already aliased and we
 	// don't need to log noise on every observation of the pair.
 	primaryAddr, primaryOk := i.table.reg.Lookup(addr)
-	if primaryOk && primaryAddr.Address() == entryAddr.Address() {
+	if primaryOk && primaryAddr.PrimaryDisplayAddress() == entryAddr.PrimaryDisplayAddress() {
 		return
 	}
 	if err := i.table.reg.AliasAddresses(addr, companion); err != nil {

--- a/address_table_insertion_test.go
+++ b/address_table_insertion_test.go
@@ -134,8 +134,8 @@ func TestCanonicalAliasing_SourceCompanionPair_AfterBothObserved(t *testing.T) {
 	if !okA || !okB {
 		t.Fatalf("registry.Lookup ok values: 0x10=%v 0x15=%v; want both true", okA, okB)
 	}
-	if entryA.Address() != entryB.Address() {
-		t.Fatalf("canonical pair 0x10 ↔ 0x15 not aliased: 0x10 entry primary=0x%02X, 0x15 entry primary=0x%02X; want same primary", entryA.Address(), entryB.Address())
+	if entryA.PrimaryDisplayAddress() != entryB.PrimaryDisplayAddress() {
+		t.Fatalf("canonical pair 0x10 ↔ 0x15 not aliased: 0x10 entry primary=0x%02X, 0x15 entry primary=0x%02X; want same primary", entryA.PrimaryDisplayAddress(), entryB.PrimaryDisplayAddress())
 	}
 	addrs := entryA.Addresses()
 	hasMaster, hasCompanion := false, false
@@ -180,8 +180,8 @@ func TestCanonicalAliasing_FFAndZeroFour_BothDirections(t *testing.T) {
 		if !okFF || !ok04 {
 			t.Fatalf("registry.Lookup ok: 0xFF=%v 0x04=%v", okFF, ok04)
 		}
-		if entryFF.Address() != entry04.Address() {
-			t.Fatalf("0xFF ↔ 0x04 wrap-pair not aliased: 0xFF primary=0x%02X, 0x04 primary=0x%02X", entryFF.Address(), entry04.Address())
+		if entryFF.PrimaryDisplayAddress() != entry04.PrimaryDisplayAddress() {
+			t.Fatalf("0xFF ↔ 0x04 wrap-pair not aliased: 0xFF primary=0x%02X, 0x04 primary=0x%02X", entryFF.PrimaryDisplayAddress(), entry04.PrimaryDisplayAddress())
 		}
 	})
 
@@ -200,8 +200,8 @@ func TestCanonicalAliasing_FFAndZeroFour_BothDirections(t *testing.T) {
 
 		entryFF, _ := table.reg.Lookup(0xFF)
 		entry04, _ := table.reg.Lookup(0x04)
-		if entryFF.Address() != entry04.Address() {
-			t.Fatalf("0xFF ↔ 0x04 wrap-pair (reverse order) not aliased: 0xFF primary=0x%02X, 0x04 primary=0x%02X", entryFF.Address(), entry04.Address())
+		if entryFF.PrimaryDisplayAddress() != entry04.PrimaryDisplayAddress() {
+			t.Fatalf("0xFF ↔ 0x04 wrap-pair (reverse order) not aliased: 0xFF primary=0x%02X, 0x04 primary=0x%02X", entryFF.PrimaryDisplayAddress(), entry04.PrimaryDisplayAddress())
 		}
 	})
 }
@@ -233,8 +233,8 @@ func TestCanonicalAliasing_NonCanonicalAddresses_NotAliased(t *testing.T) {
 	if !okA || !okB {
 		t.Fatalf("registry.Lookup ok: 0x26=%v 0xEC=%v; want both true", okA, okB)
 	}
-	if entryA.Address() == entryB.Address() {
-		t.Fatalf("non-canonical addresses 0x26 and 0xEC unexpectedly aliased to primary 0x%02X", entryA.Address())
+	if entryA.PrimaryDisplayAddress() == entryB.PrimaryDisplayAddress() {
+		t.Fatalf("non-canonical addresses 0x26 and 0xEC unexpectedly aliased to primary 0x%02X", entryA.PrimaryDisplayAddress())
 	}
 }
 
@@ -359,8 +359,8 @@ func TestCanonicalAliasing_BothPreRegistered_AliasOnObservation(t *testing.T) {
 
 	entry10Pre, _ := table.reg.Lookup(0x10)
 	entry15Pre, _ := table.reg.Lookup(0x15)
-	if entry10Pre.Address() == entry15Pre.Address() {
-		t.Fatalf("test setup: 0x10 and 0x15 unexpectedly share primary 0x%02X (Register auto-merged)", entry10Pre.Address())
+	if entry10Pre.PrimaryDisplayAddress() == entry15Pre.PrimaryDisplayAddress() {
+		t.Fatalf("test setup: 0x10 and 0x15 unexpectedly share primary 0x%02X (Register auto-merged)", entry10Pre.PrimaryDisplayAddress())
 	}
 
 	// Observe passive traffic with 0x10 as src. Inserter sees 0x10 in
@@ -371,8 +371,8 @@ func TestCanonicalAliasing_BothPreRegistered_AliasOnObservation(t *testing.T) {
 
 	entry10, _ := table.reg.Lookup(0x10)
 	entry15, _ := table.reg.Lookup(0x15)
-	if entry10.Address() != entry15.Address() {
-		t.Fatalf("pre-registered canonical pair 0x10 ↔ 0x15 not aliased after passive observation: 0x10 primary=0x%02X, 0x15 primary=0x%02X", entry10.Address(), entry15.Address())
+	if entry10.PrimaryDisplayAddress() != entry15.PrimaryDisplayAddress() {
+		t.Fatalf("pre-registered canonical pair 0x10 ↔ 0x15 not aliased after passive observation: 0x10 primary=0x%02X, 0x15 primary=0x%02X", entry10.PrimaryDisplayAddress(), entry15.PrimaryDisplayAddress())
 	}
 }
 

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -1367,7 +1367,7 @@ func startHTTPServer(
 						intAddrs[i] = int(a)
 					}
 					device := portal.RegistryDevice{
-						Address:      int(entry.Address()),
+						Address:      int(entry.PrimaryDisplayAddress()),
 						Addresses:    intAddrs,
 						Manufacturer: entry.Manufacturer(),
 						DeviceID:     entry.DeviceID(),
@@ -1376,7 +1376,7 @@ func startHTTPServer(
 						Hardware:     entry.HardwareVersion(),
 						Planes:       make([]portal.RegistryPlane, 0),
 					}
-					if sd, ok := schemaByAddr[entry.Address()]; ok {
+					if sd, ok := schemaByAddr[entry.PrimaryDisplayAddress()]; ok {
 						device.DisplayName = sd.DisplayName
 						device.Role = sd.Role
 					}

--- a/cmd/gateway/main_address_table_wireup_test.go
+++ b/cmd/gateway/main_address_table_wireup_test.go
@@ -177,7 +177,7 @@ func assertPassiveObservedDeviceEntry(t *testing.T, reg *registry.DeviceRegistry
 
 	deadline := time.Now().Add(2 * time.Second)
 	for {
-		if entry, ok := reg.Lookup(address); ok && entry != nil && entry.Address() == address {
+		if entry, ok := reg.Lookup(address); ok && entry != nil && entry.PrimaryDisplayAddress() == address {
 			return
 		}
 		if time.Now().After(deadline) {

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -5186,12 +5186,20 @@ func (p *vaillantSemanticPoller) findBoilerAddress() byte {
 		return 0
 	}
 
+	// Phase C M-C6b: select the routing target byte for B5.09
+	// boiler reads/writes. An aliased canonical pair (e.g. BAI
+	// 0x03↔0x08) whose display is the initiator side (0x03) must
+	// resolve to 0x08 here, otherwise refreshBoilerStatusB509
+	// builds frames with Target: 0x03 and the read/write fails.
+	// TargetAddressForRouting prefers AddressByRole(SlotRoleSlave)
+	// and falls back to PrimaryDisplayAddress when no target-role
+	// face exists.
 	selected := byte(0)
 	p.reg.Iterate(func(entry registry.DeviceEntry) bool {
 		if entry == nil || !isBoilerDeviceCandidate(entry) {
 			return true
 		}
-		addr := entry.PrimaryDisplayAddress()
+		addr := ebusgateway.TargetAddressForRouting(entry)
 		if addr == 0x08 {
 			selected = addr
 			return false
@@ -6682,7 +6690,12 @@ func (p *vaillantSemanticPoller) discoverB524RootWithOptions(ctx context.Context
 		if entry == nil {
 			return true
 		}
-		addr := entry.PrimaryDisplayAddress()
+		// Phase C M-C6b: B524 candidates are routing targets, not
+		// display addresses. An aliased regulator entry (e.g.
+		// 0x10↔0x15 displayed as 0x10) must be probed at 0x15
+		// where the responder lives — probing 0x10 misses the
+		// coherent responder and reports no B524 root.
+		addr := ebusgateway.TargetAddressForRouting(entry)
 		if skipReservedSourceCompanion(addr) {
 			return true
 		}
@@ -6801,9 +6814,16 @@ func (p *vaillantSemanticPoller) registerStructuralControllerIfMissing(controlle
 	if p == nil || p.reg == nil || controller == 0 {
 		return false
 	}
+	// Phase C M-C6b: containment must check the full address set,
+	// not just PrimaryDisplayAddress. A controller (e.g. 0x15) that
+	// is already an alias face on a registered entry (e.g. an
+	// aliased 0x10↔0x15 regulator displayed as 0x10) must be
+	// treated as already-known, otherwise the function violates
+	// its idempotence contract and re-registers + re-refreshes
+	// router planes on every discovery cycle.
 	already := false
 	p.reg.Iterate(func(e registry.DeviceEntry) bool {
-		if e != nil && e.PrimaryDisplayAddress() == controller {
+		if ebusgateway.EntryContainsAddress(e, controller) {
 			already = true
 			return false
 		}

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -4340,7 +4340,7 @@ func preserveExistingRegistryMetadata(reg *registry.DeviceRegistry, info registr
 		return info
 	}
 	reg.Iterate(func(entry registry.DeviceEntry) bool {
-		if entry == nil || entry.Address() != info.Address {
+		if entry == nil || entry.PrimaryDisplayAddress() != info.Address {
 			return true
 		}
 		if info.Manufacturer == "" {
@@ -5191,7 +5191,7 @@ func (p *vaillantSemanticPoller) findBoilerAddress() byte {
 		if entry == nil || !isBoilerDeviceCandidate(entry) {
 			return true
 		}
-		addr := entry.Address()
+		addr := entry.PrimaryDisplayAddress()
 		if addr == 0x08 {
 			selected = addr
 			return false
@@ -6682,7 +6682,7 @@ func (p *vaillantSemanticPoller) discoverB524RootWithOptions(ctx context.Context
 		if entry == nil {
 			return true
 		}
-		addr := entry.Address()
+		addr := entry.PrimaryDisplayAddress()
 		if skipReservedSourceCompanion(addr) {
 			return true
 		}
@@ -6803,7 +6803,7 @@ func (p *vaillantSemanticPoller) registerStructuralControllerIfMissing(controlle
 	}
 	already := false
 	p.reg.Iterate(func(e registry.DeviceEntry) bool {
-		if e != nil && e.Address() == controller {
+		if e != nil && e.PrimaryDisplayAddress() == controller {
 			already = true
 			return false
 		}
@@ -6832,7 +6832,7 @@ func (p *vaillantSemanticPoller) enrichRegulatorIdentity(addr byte) *regulatorEn
 
 	var entry registry.DeviceEntry
 	p.reg.Iterate(func(e registry.DeviceEntry) bool {
-		if e != nil && e.Address() == addr {
+		if e != nil && e.PrimaryDisplayAddress() == addr {
 			entry = e
 			return false
 		}

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -6850,9 +6850,15 @@ func (p *vaillantSemanticPoller) enrichRegulatorIdentity(addr byte) *regulatorEn
 		return nil
 	}
 
+	// Phase C M-C6b: discoverB524Root returns the routed controller
+	// face (e.g. 0x15 for an aliased 0x10↔0x15 regulator). The
+	// existing entry is displayed as 0x10, so matching only
+	// PrimaryDisplayAddress would miss it and the enrichment
+	// metadata/logging would be lost for the aliased path. Use the
+	// full address-set membership check instead.
 	var entry registry.DeviceEntry
 	p.reg.Iterate(func(e registry.DeviceEntry) bool {
-		if e != nil && e.PrimaryDisplayAddress() == addr {
+		if ebusgateway.EntryContainsAddress(e, addr) {
 			entry = e
 			return false
 		}

--- a/cmd/gateway/semantic_vaillant_test.go
+++ b/cmd/gateway/semantic_vaillant_test.go
@@ -5060,7 +5060,7 @@ func TestRefreshDiscovery_StructuralFallbackRegistersControllerInRegistry(t *tes
 	// Pre-condition: 0x15 not in registry.
 	var has0x15Before bool
 	reg.Iterate(func(e registry.DeviceEntry) bool {
-		if e != nil && e.Address() == 0x15 {
+		if e != nil && e.PrimaryDisplayAddress() == 0x15 {
 			has0x15Before = true
 			return false
 		}
@@ -5077,7 +5077,7 @@ func TestRefreshDiscovery_StructuralFallbackRegistersControllerInRegistry(t *tes
 	var has0x15After bool
 	var manufacturer string
 	reg.Iterate(func(e registry.DeviceEntry) bool {
-		if e != nil && e.Address() == 0x15 {
+		if e != nil && e.PrimaryDisplayAddress() == 0x15 {
 			has0x15After = true
 			manufacturer = e.Manufacturer()
 			return false
@@ -5286,7 +5286,7 @@ func TestRegisterStructuralControllerIfMissing_NoOpWhenAlreadyRegistered(t *test
 
 	count := 0
 	reg.Iterate(func(e registry.DeviceEntry) bool {
-		if e != nil && e.Address() == 0x15 {
+		if e != nil && e.PrimaryDisplayAddress() == 0x15 {
 			count++
 		}
 		return true

--- a/cmd/gateway/startup_scan.go
+++ b/cmd/gateway/startup_scan.go
@@ -1339,7 +1339,7 @@ func enrichVaillantIdentity(ctx context.Context, gw *ebusgateway.Gateway, cfg eb
 			return true
 		}
 		candidates = append(candidates, candidate{
-			address:      entry.Address(),
+			address:      entry.PrimaryDisplayAddress(),
 			manufacturer: entry.Manufacturer(),
 			deviceID:     entry.DeviceID(),
 			swVersion:    entry.SoftwareVersion(),
@@ -1428,7 +1428,7 @@ func enrichSerialsFromEbusd(ctx context.Context, reg *registry.DeviceRegistry, c
 		if entry.SerialNumber() != "" {
 			return true
 		}
-		row, ok := ebusdByAddr[entry.Address()]
+		row, ok := ebusdByAddr[entry.PrimaryDisplayAddress()]
 		if !ok {
 			return true
 		}
@@ -1441,7 +1441,7 @@ func enrichSerialsFromEbusd(ctx context.Context, reg *registry.DeviceRegistry, c
 			return true
 		}
 		candidates = append(candidates, candidate{
-			address:      entry.Address(),
+			address:      entry.PrimaryDisplayAddress(),
 			manufacturer: entry.Manufacturer(),
 			deviceID:     entry.DeviceID(),
 			swVersion:    entry.SoftwareVersion(),

--- a/cmd/gateway/startup_scan.go
+++ b/cmd/gateway/startup_scan.go
@@ -1338,8 +1338,12 @@ func enrichVaillantIdentity(ctx context.Context, gw *ebusgateway.Gateway, cfg eb
 		if !strings.EqualFold(entry.Manufacturer(), "Vaillant") {
 			return true
 		}
+		// B5.09 ScanID is M2S; route to the target slot. For an aliased
+		// canonical pair (e.g. BAI 0x03↔0x08), PrimaryDisplayAddress
+		// may be the initiator side; TargetAddressForRouting selects
+		// the target-role face that answers the read. Phase C M-C6b.
 		candidates = append(candidates, candidate{
-			address:      entry.PrimaryDisplayAddress(),
+			address:      ebusgateway.TargetAddressForRouting(entry),
 			manufacturer: entry.Manufacturer(),
 			deviceID:     entry.DeviceID(),
 			swVersion:    entry.SoftwareVersion(),

--- a/cmd/gateway/startup_scan.go
+++ b/cmd/gateway/startup_scan.go
@@ -1432,8 +1432,26 @@ func enrichSerialsFromEbusd(ctx context.Context, reg *registry.DeviceRegistry, c
 		if entry.SerialNumber() != "" {
 			return true
 		}
-		row, ok := ebusdByAddr[entry.PrimaryDisplayAddress()]
-		if !ok {
+		// Phase C M-C6b: ebusd's scan result may report the
+		// companion/target face of an aliased device (e.g. BASV2
+		// at 0x15 while the registry entry displays 0x10). Match
+		// against the full address set, not just the display
+		// address; otherwise the fallback enrichment skips the
+		// device even though the row is present.
+		var (
+			row     ebusdScanResultRow
+			matched bool
+			matchAt byte
+		)
+		for _, a := range entry.Addresses() {
+			if r, ok := ebusdByAddr[a]; ok {
+				row = r
+				matched = true
+				matchAt = a
+				break
+			}
+		}
+		if !matched {
 			return true
 		}
 		// Verify identity fields match to prevent stale cache misassignment.
@@ -1445,7 +1463,7 @@ func enrichSerialsFromEbusd(ctx context.Context, reg *registry.DeviceRegistry, c
 			return true
 		}
 		candidates = append(candidates, candidate{
-			address:      entry.PrimaryDisplayAddress(),
+			address:      matchAt,
 			manufacturer: entry.Manufacturer(),
 			deviceID:     entry.DeviceID(),
 			swVersion:    entry.SoftwareVersion(),

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/Project-Helianthus/helianthus-ebusgateway
 go 1.22
 
 require (
-	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260506212127-c2b8efb55579
-	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260506235755-856f3a19368d
+	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260507140006-4dfa4a22cec3
+	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260507141830-fb0d67836ec7
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,5 @@
-github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260506144445-5ab7ab6cdb1e h1:AOLYUOvKdzSAAu9t1aXjqpZptHb7+3U2fMY/T6TVSZA=
-github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260506144445-5ab7ab6cdb1e/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
-github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260506212127-c2b8efb55579 h1:Xf06i1rQ6dUWeeOqmxWfgVqc+Qw7Gq5FKv39OKHjSCw=
-github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260506212127-c2b8efb55579/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
 github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260507140006-4dfa4a22cec3 h1:U90kuV7LhIkiwnD1iZFGV29Vpd87S119DXDcso4cCp8=
 github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260507140006-4dfa4a22cec3/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260506144832-b7e69997181f h1:/u/itWUzNSd/fUKfkdm/4hvzQdkmZ6Lfdy1Oj/wyaD4=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260506144832-b7e69997181f/go.mod h1:ux6qvwEyyK+LUfseHKpTTS4i5O6slZHVZ+f4orOtFm4=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260506235755-856f3a19368d h1:YPh6uCcC80cgwCahxpRSLdLE/r4SVkohNNJBRa5VdeU=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260506235755-856f3a19368d/go.mod h1:ux6qvwEyyK+LUfseHKpTTS4i5O6slZHVZ+f4orOtFm4=
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260507141830-fb0d67836ec7 h1:zaToWPlTVT0FabXkq74TVkFWGqrfRCeDjZ4Ea3iHet0=
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260507141830-fb0d67836ec7/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,14 @@ github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260506144445-5ab7ab6c
 github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260506144445-5ab7ab6cdb1e/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
 github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260506212127-c2b8efb55579 h1:Xf06i1rQ6dUWeeOqmxWfgVqc+Qw7Gq5FKv39OKHjSCw=
 github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260506212127-c2b8efb55579/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
+github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260507140006-4dfa4a22cec3 h1:U90kuV7LhIkiwnD1iZFGV29Vpd87S119DXDcso4cCp8=
+github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260507140006-4dfa4a22cec3/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260506144832-b7e69997181f h1:/u/itWUzNSd/fUKfkdm/4hvzQdkmZ6Lfdy1Oj/wyaD4=
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260506144832-b7e69997181f/go.mod h1:ux6qvwEyyK+LUfseHKpTTS4i5O6slZHVZ+f4orOtFm4=
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260506235755-856f3a19368d h1:YPh6uCcC80cgwCahxpRSLdLE/r4SVkohNNJBRa5VdeU=
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260506235755-856f3a19368d/go.mod h1:ux6qvwEyyK+LUfseHKpTTS4i5O6slZHVZ+f4orOtFm4=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260507141830-fb0d67836ec7 h1:zaToWPlTVT0FabXkq74TVkFWGqrfRCeDjZ4Ea3iHet0=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260507141830-fb0d67836ec7/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=

--- a/graphql/builder_test.go
+++ b/graphql/builder_test.go
@@ -461,6 +461,14 @@ func (entry mockEntry) Address() byte {
 	return entry.info.Address
 }
 
+func (entry mockEntry) PrimaryDisplayAddress() byte {
+	return entry.info.Address
+}
+
+func (entry mockEntry) AddressByRole(registry.SlotRole) (byte, bool) {
+	return entry.info.Address, true
+}
+
 func (entry mockEntry) Addresses() []byte {
 	if len(entry.addresses) == 0 {
 		return []byte{entry.info.Address}

--- a/graphql/schema.go
+++ b/graphql/schema.go
@@ -104,8 +104,8 @@ func BuildSchema(reg Registry) (Schema, error) {
 		}
 
 		device := Device{
-			Address:         entry.Address(),
-			Addresses:       normalizeDeviceAddresses(entry.Address(), entry.Addresses()),
+			Address:         entry.PrimaryDisplayAddress(),
+			Addresses:       normalizeDeviceAddresses(entry.PrimaryDisplayAddress(), entry.Addresses()),
 			Manufacturer:    entry.Manufacturer(),
 			DeviceID:        entry.DeviceID(),
 			SerialNumber:    entry.SerialNumber(),
@@ -367,7 +367,7 @@ func selectResponseSchema(entry registry.DeviceEntry, selector schema.SchemaSele
 		return ResponseSchema{}, fmt.Errorf("graphql schema build missing device: %w", ebuserrors.ErrInvalidPayload)
 	}
 
-	selected := selector.Select(entry.Address(), entry.HardwareVersion())
+	selected := selector.Select(entry.PrimaryDisplayAddress(), entry.HardwareVersion())
 	fields := make([]Field, 0, len(selected.Fields))
 	for _, field := range selected.Fields {
 		if field.Type == nil {

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -3541,7 +3541,7 @@ func cloneEnergySeries(series EnergySeries) EnergySeries {
 }
 
 func buildDeviceInfo(entry registry.DeviceEntry) deviceInfo {
-	primary := entry.Address()
+	primary := entry.PrimaryDisplayAddress()
 	all := entry.Addresses()
 	// Surface the complete address set (primary + aliases) to match the
 	// GraphQL `addresses` semantics in graphql/schema.go. Snapshot

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -45,15 +45,17 @@ type testEntry struct {
 	planes []registry.Plane
 }
 
-func (e testEntry) Address() byte            { return e.info.Address }
-func (e testEntry) Addresses() []byte        { return []byte{e.info.Address} }
-func (e testEntry) Manufacturer() string     { return e.info.Manufacturer }
-func (e testEntry) DeviceID() string         { return e.info.DeviceID }
-func (e testEntry) SerialNumber() string     { return e.info.SerialNumber }
-func (e testEntry) MacAddress() string       { return e.info.MacAddress }
-func (e testEntry) SoftwareVersion() string  { return e.info.SoftwareVersion }
-func (e testEntry) HardwareVersion() string  { return e.info.HardwareVersion }
-func (e testEntry) Planes() []registry.Plane { return e.planes }
+func (e testEntry) Address() byte                                { return e.info.Address }
+func (e testEntry) PrimaryDisplayAddress() byte                  { return e.info.Address }
+func (e testEntry) AddressByRole(registry.SlotRole) (byte, bool) { return e.info.Address, true }
+func (e testEntry) Addresses() []byte                            { return []byte{e.info.Address} }
+func (e testEntry) Manufacturer() string                         { return e.info.Manufacturer }
+func (e testEntry) DeviceID() string                             { return e.info.DeviceID }
+func (e testEntry) SerialNumber() string                         { return e.info.SerialNumber }
+func (e testEntry) MacAddress() string                           { return e.info.MacAddress }
+func (e testEntry) SoftwareVersion() string                      { return e.info.SoftwareVersion }
+func (e testEntry) HardwareVersion() string                      { return e.info.HardwareVersion }
+func (e testEntry) Planes() []registry.Plane                     { return e.planes }
 func (e testEntry) Projections() []registry.Projection {
 	return nil
 }

--- a/passive_discovery_promoter.go
+++ b/passive_discovery_promoter.go
@@ -407,7 +407,7 @@ func (p *PassiveDiscoveryPromoter) registryContains(addr byte) bool {
 		if entry == nil {
 			return true
 		}
-		if entry.Address() == addr {
+		if entry.PrimaryDisplayAddress() == addr {
 			found = true
 			return false
 		}

--- a/passive_discovery_promoter.go
+++ b/passive_discovery_promoter.go
@@ -402,12 +402,16 @@ func (p *PassiveDiscoveryPromoter) registryContains(addr byte) bool {
 	if p.registry == nil {
 		return false
 	}
+	// Phase C M-C6b: scan the full address set on each entry, not just
+	// PrimaryDisplayAddress. A promoted address that is already an
+	// alias face on a registered entry (e.g. 0x08 on an aliased BAI
+	// 0x03↔0x08 whose display is 0x03) must be treated as already
+	// registered, otherwise the promoter actively re-confirms and
+	// re-commits it on every cycle, producing redundant bus probes
+	// and router/semantic refreshes.
 	found := false
 	p.registry.Iterate(func(entry registry.DeviceEntry) bool {
-		if entry == nil {
-			return true
-		}
-		if entry.PrimaryDisplayAddress() == addr {
+		if EntryContainsAddress(entry, addr) {
 			found = true
 			return false
 		}

--- a/passive_discovery_promoter_test.go
+++ b/passive_discovery_promoter_test.go
@@ -494,7 +494,7 @@ func TestPassiveDiscoveryPromoter_BackoffOnRepeatedFailure(t *testing.T) {
 func registryContains(reg *registry.DeviceRegistry, addr byte) bool {
 	found := false
 	reg.Iterate(func(e registry.DeviceEntry) bool {
-		if e != nil && e.Address() == addr {
+		if e != nil && e.PrimaryDisplayAddress() == addr {
 			found = true
 			return false
 		}

--- a/register_dump.go
+++ b/register_dump.go
@@ -363,7 +363,7 @@ func runRegisterProbe(ctx context.Context, cfg smokeConfig, gateway *Gateway, sy
 
 func findEntryByAddress(entries []registry.DeviceEntry, target byte) registry.DeviceEntry {
 	for _, entry := range entries {
-		if entry != nil && entry.Address() == target {
+		if entry != nil && entry.PrimaryDisplayAddress() == target {
 			return entry
 		}
 	}

--- a/register_dump.go
+++ b/register_dump.go
@@ -362,8 +362,14 @@ func runRegisterProbe(ctx context.Context, cfg smokeConfig, gateway *Gateway, sy
 }
 
 func findEntryByAddress(entries []registry.DeviceEntry, target byte) registry.DeviceEntry {
+	// Phase C M-C6b: match the full address set (display + aliases) so
+	// that a register-dump request naming the companion side of an
+	// aliased canonical pair (e.g. 0x08 on a BAI 0x03↔0x08 entry) still
+	// resolves to the entry. Matching only PrimaryDisplayAddress would
+	// drop the lookup with "target not found in scan results" even
+	// though the requested address is a real face on the entry.
 	for _, entry := range entries {
-		if entry != nil && entry.PrimaryDisplayAddress() == target {
+		if EntryContainsAddress(entry, target) {
 			return entry
 		}
 	}

--- a/smoke.go
+++ b/smoke.go
@@ -847,7 +847,13 @@ func (p *smokePlane) DecodeResponse(method registry.Method, response protocol.Fr
 		return nil, fmt.Errorf("smoke decode response missing data: %w", ebuserrors.ErrInvalidPayload)
 	}
 	selector := method.ResponseSchema()
-	schemaValue := selector.Select(p.entry.PrimaryDisplayAddress(), p.entry.HardwareVersion())
+	// Phase C M-C6b: BuildRequest sends to TargetAddressForRouting,
+	// so the schema selector must use the SAME byte to look up the
+	// per-target schema branch. For an aliased canonical pair (e.g.
+	// 0x03↔0x08) BuildRequest routes to 0x08 — selecting the schema
+	// with 0x03 (PrimaryDisplay) decodes the 0x08 response with the
+	// wrong schema and produces incorrect smoke data.
+	schemaValue := selector.Select(TargetAddressForRouting(p.entry), p.entry.HardwareVersion())
 	return schemaValue.Decode(response.Data)
 }
 

--- a/smoke.go
+++ b/smoke.go
@@ -364,9 +364,9 @@ func RunSmoke(ctx context.Context, cfg smokeConfig, opts SmokeOptions) (runErr e
 	for _, entry := range entries {
 		planes := entry.Planes()
 		if len(planes) == 0 {
-			logger.Printf("device 0x%02x has no planes; running identify", entry.Address())
+			logger.Printf("device 0x%02x has no planes; running identify", entry.PrimaryDisplayAddress())
 			if err := invokeIdentify(ctx, gateway.Router, entry, source, time.Duration(cfg.Smoke.MethodTimeoutSec)*time.Second, logger); err != nil {
-				invokeErrors = append(invokeErrors, fmt.Sprintf("device 0x%02x identify: %v", entry.Address(), err))
+				invokeErrors = append(invokeErrors, fmt.Sprintf("device 0x%02x identify: %v", entry.PrimaryDisplayAddress(), err))
 			}
 			continue
 		}
@@ -384,7 +384,7 @@ func RunSmoke(ctx context.Context, cfg smokeConfig, opts SmokeOptions) (runErr e
 				params, ok := smokeParams(entry, invokePlane.Name(), method.Name(), source)
 				if !ok {
 					if smokeMethodNeedsParams(method) {
-						logger.Printf("device 0x%02x plane %s method %s skipped: cannot determine params", entry.Address(), invokePlane.Name(), method.Name())
+						logger.Printf("device 0x%02x plane %s method %s skipped: cannot determine params", entry.PrimaryDisplayAddress(), invokePlane.Name(), method.Name())
 						continue
 					}
 					params = map[string]any{}
@@ -410,21 +410,21 @@ func RunSmoke(ctx context.Context, cfg smokeConfig, opts SmokeOptions) (runErr e
 				invoked = true
 				if err != nil {
 					if errors.Is(err, ebuserrors.ErrInvalidPayload) {
-						logger.Printf("device 0x%02x plane %s method %s skipped: %v", entry.Address(), invokePlane.Name(), method.Name(), err)
+						logger.Printf("device 0x%02x plane %s method %s skipped: %v", entry.PrimaryDisplayAddress(), invokePlane.Name(), method.Name(), err)
 						continue
 					}
-					invokeErrors = append(invokeErrors, fmt.Sprintf("device 0x%02x plane %s method %s: %v", entry.Address(), invokePlane.Name(), method.Name(), err))
+					invokeErrors = append(invokeErrors, fmt.Sprintf("device 0x%02x plane %s method %s: %v", entry.PrimaryDisplayAddress(), invokePlane.Name(), method.Name(), err))
 					break
 				}
-				logger.Printf("device 0x%02x plane %s method %s ok: %+v", entry.Address(), invokePlane.Name(), method.Name(), result)
+				logger.Printf("device 0x%02x plane %s method %s ok: %+v", entry.PrimaryDisplayAddress(), invokePlane.Name(), method.Name(), result)
 				break
 			}
 			if !hasReadOnly {
-				logger.Printf("device 0x%02x plane %s has no read-only methods", entry.Address(), invokePlane.Name())
+				logger.Printf("device 0x%02x plane %s has no read-only methods", entry.PrimaryDisplayAddress(), invokePlane.Name())
 				continue
 			}
 			if !invoked {
-				logger.Printf("device 0x%02x plane %s has no invokable read-only methods", entry.Address(), invokePlane.Name())
+				logger.Printf("device 0x%02x plane %s has no invokable read-only methods", entry.PrimaryDisplayAddress(), invokePlane.Name())
 				continue
 			}
 		}
@@ -450,7 +450,7 @@ func invokeIdentify(ctx context.Context, router *router.BusEventRouter, entry re
 		return err
 	}
 	if logger != nil {
-		logger.Printf("device 0x%02x identify ok: %+v", entry.Address(), result)
+		logger.Printf("device 0x%02x identify ok: %+v", entry.PrimaryDisplayAddress(), result)
 	}
 	return nil
 }
@@ -507,7 +507,7 @@ func defaultSmokeProviders() []registry.PlaneProvider {
 func logDeviceInfo(logger *log.Logger, entries []registry.DeviceEntry) {
 	for _, entry := range entries {
 		logger.Printf("device 0x%02x: manufacturer=%s device=%s sw=%s hw=%s",
-			entry.Address(),
+			entry.PrimaryDisplayAddress(),
 			entry.Manufacturer(),
 			entry.DeviceID(),
 			entry.SoftwareVersion(),
@@ -526,7 +526,7 @@ func logExpectedDevices(logger *log.Logger, expected []expectedDevice, entries [
 	}
 	found := make(map[byte]registry.DeviceEntry, len(entries))
 	for _, entry := range entries {
-		found[entry.Address()] = entry
+		found[entry.PrimaryDisplayAddress()] = entry
 	}
 
 	var missing []string
@@ -835,7 +835,7 @@ func (p *smokePlane) BuildRequest(method registry.Method, params map[string]any)
 
 	return protocol.Frame{
 		Source:    p.source,
-		Target:    p.entry.Address(),
+		Target:    targetAddressForRouting(p.entry),
 		Primary:   template.Primary(),
 		Secondary: template.Secondary(),
 		Data:      data,
@@ -847,7 +847,7 @@ func (p *smokePlane) DecodeResponse(method registry.Method, response protocol.Fr
 		return nil, fmt.Errorf("smoke decode response missing data: %w", ebuserrors.ErrInvalidPayload)
 	}
 	selector := method.ResponseSchema()
-	schemaValue := selector.Select(p.entry.Address(), p.entry.HardwareVersion())
+	schemaValue := selector.Select(p.entry.PrimaryDisplayAddress(), p.entry.HardwareVersion())
 	return schemaValue.Decode(response.Data)
 }
 
@@ -879,7 +879,7 @@ func (p *identifyPlane) OnBroadcast(protocol.Frame) error {
 func (p *identifyPlane) BuildRequest(registry.Method, map[string]any) (protocol.Frame, error) {
 	return protocol.Frame{
 		Source:    p.source,
-		Target:    p.entry.Address(),
+		Target:    targetAddressForRouting(p.entry),
 		Primary:   0x07,
 		Secondary: 0x04,
 	}, nil

--- a/smoke.go
+++ b/smoke.go
@@ -835,7 +835,7 @@ func (p *smokePlane) BuildRequest(method registry.Method, params map[string]any)
 
 	return protocol.Frame{
 		Source:    p.source,
-		Target:    targetAddressForRouting(p.entry),
+		Target:    TargetAddressForRouting(p.entry),
 		Primary:   template.Primary(),
 		Secondary: template.Secondary(),
 		Data:      data,
@@ -879,7 +879,7 @@ func (p *identifyPlane) OnBroadcast(protocol.Frame) error {
 func (p *identifyPlane) BuildRequest(registry.Method, map[string]any) (protocol.Frame, error) {
 	return protocol.Frame{
 		Source:    p.source,
-		Target:    targetAddressForRouting(p.entry),
+		Target:    TargetAddressForRouting(p.entry),
 		Primary:   0x07,
 		Secondary: 0x04,
 	}, nil

--- a/smoke_test.go
+++ b/smoke_test.go
@@ -46,15 +46,17 @@ type testEntry struct {
 	planes []registry.Plane
 }
 
-func (e testEntry) Address() byte            { return e.info.Address }
-func (e testEntry) Addresses() []byte        { return []byte{e.info.Address} }
-func (e testEntry) Manufacturer() string     { return e.info.Manufacturer }
-func (e testEntry) DeviceID() string         { return e.info.DeviceID }
-func (e testEntry) SerialNumber() string     { return e.info.SerialNumber }
-func (e testEntry) MacAddress() string       { return e.info.MacAddress }
-func (e testEntry) SoftwareVersion() string  { return e.info.SoftwareVersion }
-func (e testEntry) HardwareVersion() string  { return e.info.HardwareVersion }
-func (e testEntry) Planes() []registry.Plane { return e.planes }
+func (e testEntry) Address() byte                                { return e.info.Address }
+func (e testEntry) PrimaryDisplayAddress() byte                  { return e.info.Address }
+func (e testEntry) AddressByRole(registry.SlotRole) (byte, bool) { return e.info.Address, true }
+func (e testEntry) Addresses() []byte                            { return []byte{e.info.Address} }
+func (e testEntry) Manufacturer() string                         { return e.info.Manufacturer }
+func (e testEntry) DeviceID() string                             { return e.info.DeviceID }
+func (e testEntry) SerialNumber() string                         { return e.info.SerialNumber }
+func (e testEntry) MacAddress() string                           { return e.info.MacAddress }
+func (e testEntry) SoftwareVersion() string                      { return e.info.SoftwareVersion }
+func (e testEntry) HardwareVersion() string                      { return e.info.HardwareVersion }
+func (e testEntry) Planes() []registry.Plane                     { return e.planes }
 func (e testEntry) Projections() []registry.Projection {
 	return nil
 }

--- a/target_address.go
+++ b/target_address.go
@@ -2,18 +2,18 @@ package ebusgateway
 
 import "github.com/Project-Helianthus/helianthus-ebusreg/registry"
 
-// targetAddressForRouting returns the routing-correct target byte for
+// TargetAddressForRouting returns the routing-correct target byte for
 // an M2S write. Prefers AddressByRole(SlotRoleSlave) so an aliased
-// canonical pair (e.g. BAI 0x03↔0x08) returns the slave byte 0x08
+// canonical pair (e.g. BAI 0x03↔0x08) returns the target byte 0x08
 // rather than the alias-primary which may be the initiator. Falls
-// back to PrimaryDisplayAddress only when no slave-role face exists
-// (single-master device, or a face with SlotRoleUnknown that the
+// back to PrimaryDisplayAddress only when no target-role face exists
+// (single-initiator device, or a face with SlotRoleUnknown that the
 // AddressClass-fallback in registry.AddressByRole cannot classify).
 //
 // Phase C M-C6b helper. M-C7 will replace these per-callsite usages
 // with explicit Frame.FrameType + Frame.Validate flow at the
 // semantic API boundary.
-func targetAddressForRouting(entry registry.DeviceEntry) byte {
+func TargetAddressForRouting(entry registry.DeviceEntry) byte {
 	if entry == nil {
 		return 0
 	}
@@ -21,4 +21,24 @@ func targetAddressForRouting(entry registry.DeviceEntry) byte {
 		return addr
 	}
 	return entry.PrimaryDisplayAddress()
+}
+
+// EntryContainsAddress reports whether the entry's full address set
+// (including aliases) contains addr. Use this for membership/lookup
+// checks where any face on the entry should match — e.g. register
+// dump target resolution and registry containment filters in passive
+// discovery — instead of comparing only PrimaryDisplayAddress, which
+// would miss the non-display side of an aliased canonical pair.
+//
+// Phase C M-C6b helper.
+func EntryContainsAddress(entry registry.DeviceEntry, addr byte) bool {
+	if entry == nil {
+		return false
+	}
+	for _, a := range entry.Addresses() {
+		if a == addr {
+			return true
+		}
+	}
+	return false
 }

--- a/target_address.go
+++ b/target_address.go
@@ -1,0 +1,24 @@
+package ebusgateway
+
+import "github.com/Project-Helianthus/helianthus-ebusreg/registry"
+
+// targetAddressForRouting returns the routing-correct target byte for
+// an M2S write. Prefers AddressByRole(SlotRoleSlave) so an aliased
+// canonical pair (e.g. BAI 0x03↔0x08) returns the slave byte 0x08
+// rather than the alias-primary which may be the initiator. Falls
+// back to PrimaryDisplayAddress only when no slave-role face exists
+// (single-master device, or a face with SlotRoleUnknown that the
+// AddressClass-fallback in registry.AddressByRole cannot classify).
+//
+// Phase C M-C6b helper. M-C7 will replace these per-callsite usages
+// with explicit Frame.FrameType + Frame.Validate flow at the
+// semantic API boundary.
+func targetAddressForRouting(entry registry.DeviceEntry) byte {
+	if entry == nil {
+		return 0
+	}
+	if addr, ok := entry.AddressByRole(registry.SlotRoleSlave); ok {
+		return addr
+	}
+	return entry.PrimaryDisplayAddress()
+}

--- a/unknown_device_dump.go
+++ b/unknown_device_dump.go
@@ -158,7 +158,7 @@ func dumpUnknownDevice(ctx context.Context, bus DumpBus, entry registry.DeviceEn
 		traffic = append(traffic, record)
 	}
 
-	target := targetAddressForRouting(entry)
+	target := TargetAddressForRouting(entry)
 	identify := runIdentifyDump(ctx, bus, target, opts.SourceAddress, opts, recordTraffic)
 	b509 := runB509Dump(ctx, bus, target, opts.SourceAddress, opts, recordTraffic)
 	b524 := runB524Dump(ctx, bus, target, opts.SourceAddress, opts, recordTraffic)

--- a/unknown_device_dump.go
+++ b/unknown_device_dump.go
@@ -133,7 +133,7 @@ func filterUnknownEntries(entries []registry.DeviceEntry) []registry.DeviceEntry
 
 func dumpUnknownDevice(ctx context.Context, bus DumpBus, entry registry.DeviceEntry, opts UnknownDeviceDumpOptions) UnknownDeviceDumpResult {
 	result := UnknownDeviceDumpResult{
-		Address: entry.Address(),
+		Address: entry.PrimaryDisplayAddress(),
 	}
 	logger := opts.Logger
 	if logger == nil {
@@ -142,7 +142,7 @@ func dumpUnknownDevice(ctx context.Context, bus DumpBus, entry registry.DeviceEn
 
 	bundleID := newBundleID()
 	createdAt := opts.Now().UTC()
-	deviceLabel := fmt.Sprintf("0x%02x", entry.Address())
+	deviceLabel := fmt.Sprintf("0x%02x", entry.PrimaryDisplayAddress())
 	tempDir, err := os.MkdirTemp(opts.OutputDir, "bundle-"+strings.TrimPrefix(deviceLabel, "0x")+"-")
 	if err != nil {
 		result.Error = err.Error()
@@ -158,9 +158,10 @@ func dumpUnknownDevice(ctx context.Context, bus DumpBus, entry registry.DeviceEn
 		traffic = append(traffic, record)
 	}
 
-	identify := runIdentifyDump(ctx, bus, entry.Address(), opts.SourceAddress, opts, recordTraffic)
-	b509 := runB509Dump(ctx, bus, entry.Address(), opts.SourceAddress, opts, recordTraffic)
-	b524 := runB524Dump(ctx, bus, entry.Address(), opts.SourceAddress, opts, recordTraffic)
+	target := targetAddressForRouting(entry)
+	identify := runIdentifyDump(ctx, bus, target, opts.SourceAddress, opts, recordTraffic)
+	b509 := runB509Dump(ctx, bus, target, opts.SourceAddress, opts, recordTraffic)
+	b524 := runB524Dump(ctx, bus, target, opts.SourceAddress, opts, recordTraffic)
 
 	files := make([]dumpFileInfo, 0, 4)
 
@@ -572,7 +573,7 @@ type captureSummary struct {
 
 func buildManifest(entry registry.DeviceEntry, bundleID string, createdAt time.Time, opts UnknownDeviceDumpOptions, identify identifyDump, b509 registerDump, b524 registerDump, traffic []trafficFrame, files []dumpFileInfo) dumpManifest {
 	device := manifestDevice{
-		Address:         fmt.Sprintf("0x%02x", entry.Address()),
+		Address:         fmt.Sprintf("0x%02x", entry.PrimaryDisplayAddress()),
 		Manufacturer:    entry.Manufacturer(),
 		DeviceID:        entry.DeviceID(),
 		SerialNumber:    entry.SerialNumber(),

--- a/unknown_device_dump_test.go
+++ b/unknown_device_dump_test.go
@@ -23,12 +23,14 @@ type testDumpEntry struct {
 	planes []registry.Plane
 }
 
-func (e testDumpEntry) Address() byte        { return e.info.Address }
-func (e testDumpEntry) Addresses() []byte    { return []byte{e.info.Address} }
-func (e testDumpEntry) Manufacturer() string { return e.info.Manufacturer }
-func (e testDumpEntry) DeviceID() string     { return e.info.DeviceID }
-func (e testDumpEntry) SerialNumber() string { return e.info.SerialNumber }
-func (e testDumpEntry) MacAddress() string   { return e.info.MacAddress }
+func (e testDumpEntry) Address() byte                                { return e.info.Address }
+func (e testDumpEntry) PrimaryDisplayAddress() byte                  { return e.info.Address }
+func (e testDumpEntry) AddressByRole(registry.SlotRole) (byte, bool) { return e.info.Address, true }
+func (e testDumpEntry) Addresses() []byte                            { return []byte{e.info.Address} }
+func (e testDumpEntry) Manufacturer() string                         { return e.info.Manufacturer }
+func (e testDumpEntry) DeviceID() string                             { return e.info.DeviceID }
+func (e testDumpEntry) SerialNumber() string                         { return e.info.SerialNumber }
+func (e testDumpEntry) MacAddress() string                           { return e.info.MacAddress }
 func (e testDumpEntry) SoftwareVersion() string {
 	return e.info.SoftwareVersion
 }


### PR DESCRIPTION
Pre-removal pure rename. Migrates 33 callers across 11 files in helianthus-ebusgateway (incl. MCP, GraphQL, semantic poller, startup scan, smoke, dumps) from registry.DeviceEntry.Address() to PrimaryDisplayAddress() (new display alias from M-C6a). M2S routing-correct lookups via AddressByRole(SlotRoleSlave) land in M-C7 per-API-site enrichment. Bumps ebusreg to fb0d678. Test mocks get PrimaryDisplayAddress + AddressByRole stubs.