### PR TITLE
chore(gateway): Phase C M-C6d — bump helianthus-ebusreg to post-M-C6c (Address() removed)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260507140006-4dfa4a22cec3
-	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260507141830-fb0d67836ec7
+	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260507193239-77b56516dbb5
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260507140006-4dfa4a22cec3 h1:U90kuV7LhIkiwnD1iZFGV29Vpd87S119DXDcso4cCp8=
 github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260507140006-4dfa4a22cec3/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260507141830-fb0d67836ec7 h1:zaToWPlTVT0FabXkq74TVkFWGqrfRCeDjZ4Ea3iHet0=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260507141830-fb0d67836ec7/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260507193239-77b56516dbb5 h1:uW6OKijnbyGI9zFu/DCGcBlJJRjFztIyUL7QeavXiHQ=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260507193239-77b56516dbb5/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=


### PR DESCRIPTION
## Summary

Phase C M-C6d. Bumps helianthus-ebusreg to v0.0.0-20260507193239-77b56516dbb5, the post-M-C6c version where \`DeviceEntry.Address()\` has been REMOVED.

This is the **build-break safety net activation**: the entire helianthus-ebusgateway repository is now built against an ebusreg with no \`Address()\` method. CI passing here proves M-C6b's caller migration (PR #576) was exhaustive — any missed caller would fail compilation.

## What changes

\`\`\`diff
- github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260507141830-fb0d67836ec7 (M-C6a)
+ github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260507193239-77b56516dbb5 (M-C6c)
\`\`\`

## Test plan

- [x] go build ./... — clean
- [x] go vet ./... — clean
- [x] go test -race -count=1 ./... — full suite green
- [x] scripts/ci_local.sh — exit 0
- [ ] GH Actions all green (will populate when CI runs)

## References

- helianthus-ebusreg PR #135 (M-C6c, merged 77b56516)
- helianthus-ebusgateway PR #576 (M-C6b, merged 2f37e402)
- Phase C plan: address-table-registry-w19-26.locked / 14-phase-c-frame-type-transport.md, M-C6d

🤖 Generated with [Claude Code](https://claude.com/claude-code)