### PR TITLE
fix(gateway): P1+P1.5 — drop abandon-events from inserter + strip stale ACK

### DIFF
--- a/address_table_inserter.go
+++ b/address_table_inserter.go
@@ -47,7 +47,21 @@ func (i *AddressTableInserter) SetEnrichmentRefreshFn(fn func()) {
 }
 
 func (i *AddressTableInserter) OnPassiveClassifiedEvent(event PassiveClassifiedEvent) {
-	if i == nil || !event.ACKCorrelation.CompleteRequest || event.ACKCorrelation.Correlator != PassiveACKCorrelatorM2A {
+	// P1 (post-Phase-C live validation 2026-05-08): only fully-
+	// completed M-T transactions create registry slots. Abandoned
+	// transactions in any phase — particularly phase-3 no_response
+	// abandons that retain a populated ACKCorrelation from the prior
+	// successful ACK observation — must NOT promote their src/dst
+	// into the registry. Live evidence: NETX3's identity-scan probes
+	// (e.g. 0xF1 → 0x07/0x04 → 0x24 ACKed but no response) were
+	// inserting phantom 0x24, 0x84, etc. as registry entries.
+	//
+	// This aligns with BusObservabilityStore.recordEvidenceFromEvent-
+	// Locked which already excludes AbandonedTransaction events.
+	if i == nil || event.Kind != PassiveClassifiedEventTransaction {
+		return
+	}
+	if !event.ACKCorrelation.CompleteRequest || event.ACKCorrelation.Correlator != PassiveACKCorrelatorM2A {
 		return
 	}
 	corr := event.ACKCorrelation

--- a/cmd/gateway/main_address_table_wireup_test.go
+++ b/cmd/gateway/main_address_table_wireup_test.go
@@ -158,7 +158,17 @@ func feedGatewayAddressTablePassiveObservation(ctx context.Context, reconstructo
 		Secondary: 0x24,
 		Data:      []byte{0x01},
 	}
-	symbols := append(gatewayWireupFrameBytes(request), protocol.SymbolAck, protocol.SymbolSyn)
+	// Post-Phase-C P1: the inserter now requires a fully-completed
+	// M-T transaction (PassiveClassifiedEventTransaction). Build the
+	// proper wire flow:  request bytes  + ACK + response segment
+	//   + ACK + SYN   so the reconstructor classifies as Transaction
+	// (was previously: request + ACK + SYN, which produced a phase-3
+	// no_response abandon — the inserter accepted those pre-P1, but
+	// that was the bug that produced phantom registry entries from
+	// NETX3's identity scans).
+	symbols := append(gatewayWireupFrameBytes(request), protocol.SymbolAck)
+	symbols = append(symbols, gatewayWireupResponseSegmentBytes([]byte{0x11, 0x55})...)
+	symbols = append(symbols, protocol.SymbolAck, protocol.SymbolSyn)
 
 	ticker := time.NewTicker(10 * time.Millisecond)
 	defer ticker.Stop()
@@ -170,6 +180,14 @@ func feedGatewayAddressTablePassiveObservation(ctx context.Context, reconstructo
 		case <-ticker.C:
 		}
 	}
+}
+
+func gatewayWireupResponseSegmentBytes(data []byte) []byte {
+	raw := make([]byte, 0, 2+len(data))
+	raw = append(raw, byte(len(data)))
+	raw = append(raw, data...)
+	raw = append(raw, protocol.CRC(raw))
+	return raw
 }
 
 func assertPassiveObservedDeviceEntry(t *testing.T, reg *registry.DeviceRegistry, address byte) {

--- a/passive_transaction_reconstructor.go
+++ b/passive_transaction_reconstructor.go
@@ -712,8 +712,15 @@ func (reconstructor *PassiveTransactionReconstructor) abandonLocked(reason Passi
 	ackCorrelation := reconstructor.state.ackCorrelation
 	switch reason {
 	case PassiveAbandonReasonNoResponse,
+		PassiveAbandonReasonNoProgress,
 		PassiveAbandonReasonAmbiguousRetransmit,
 		PassiveAbandonReasonCRCMismatch:
+		// NoProgress is the watchdog/read-timeout sibling of
+		// NoResponse: request was ACK'd, then the bus/tap went silent
+		// without a SYN. Same stale-ACK hazard — strip the
+		// correlation so downstream consumers don't treat it as a
+		// completed transaction. (Codex P2 follow-up on PR #579,
+		// 2026-05-08.)
 		ackCorrelation = PassiveACKCorrelation{}
 	}
 	event := PassiveClassifiedEvent{

--- a/passive_transaction_reconstructor.go
+++ b/passive_transaction_reconstructor.go
@@ -700,6 +700,22 @@ func (reconstructor *PassiveTransactionReconstructor) handleTerminalSymbolLocked
 func (reconstructor *PassiveTransactionReconstructor) abandonLocked(reason PassiveAbandonReason, observedAt time.Time, err error) PassiveClassifiedEvent {
 	hasRequest := reconstructor.state.frameType != protocol.FrameTypeUnknown
 	hasResponse := reconstructor.state.responseExpectedLen > 0
+	// P1.5 (post-Phase-C live validation 2026-05-08): strip stale
+	// ACKCorrelation for failure reasons that invalidate the prior
+	// ACK as evidence of a completed transaction. Phase-3 no_response
+	// means responder went silent after ACKing the request; carrying
+	// the ACK forward as if the transaction completed is a
+	// misclassification. Defense-in-depth alongside P1 inserter
+	// kind-filter — if any future consumer relies on ACKCorrelation
+	// from abandoned events, they get an empty correlation rather
+	// than a stale positive ACK from a doomed transaction.
+	ackCorrelation := reconstructor.state.ackCorrelation
+	switch reason {
+	case PassiveAbandonReasonNoResponse,
+		PassiveAbandonReasonAmbiguousRetransmit,
+		PassiveAbandonReasonCRCMismatch:
+		ackCorrelation = PassiveACKCorrelation{}
+	}
 	event := PassiveClassifiedEvent{
 		Kind:           PassiveClassifiedEventAbandonedTransaction,
 		FrameType:      reconstructor.state.frameType,
@@ -710,7 +726,7 @@ func (reconstructor *PassiveTransactionReconstructor) abandonLocked(reason Passi
 		Timing:         reconstructor.state.timing,
 		ObservedAt:     observedAt,
 		AbandonReason:  reason,
-		ACKCorrelation: reconstructor.state.ackCorrelation,
+		ACKCorrelation: ackCorrelation,
 		Err:            err,
 	}
 	event.Timing.Terminal = observedAt


### PR DESCRIPTION
## Summary

Post-Phase-C P1+P1.5 from the live HA validation report (2026-05-08). Closes the **false-positive registry insertion** regression: NETX3's identity-scan probes (0x07/0x04 to addresses with no device behind them) ACK then go silent, the reconstructor abandons the transaction with reason \`no_response\` carrying a positive ACKCorrelation, the inserter accepts it, and a phantom registry entry lands.

## Live evidence (from the M-C8 deployment investigation)

\`\`\`
07:43:44 passive_reconstructor abandon reason=no_response phase=3 src=0xF1 dst=0x24 prim=0x07 sec=0x04
07:43:44 address_table_inserter insert addr=0xF1 role=initiator
07:43:44 address_table_inserter insert addr=0x24 role=target    ← phantom
\`\`\`

Same pattern produced phantom 0x84 (and previous deploys' 0x44, 0x64, 0x75, 0xA0 — different transient subset of NETX3's scan target list at gateway-startup time).

## Fix

### P1 — \`address_table_inserter.go:OnPassiveClassifiedEvent\`

Add at the top of the guard chain:
\`\`\`go
if event.Kind != PassiveClassifiedEventTransaction {
    return
}
\`\`\`
Only fully-completed M-T transactions promote slots into the registry. Aligns with \`BusObservabilityStore.recordEvidenceFromEventLocked\` (line 626) which already excludes \`AbandonedTransaction\` events.

### P1.5 — \`passive_transaction_reconstructor.go:abandonLocked\` (defense-in-depth)

Strip stale \`ACKCorrelation\` for failure reasons that invalidate the prior ACK as evidence: \`NoResponse\`, \`AmbiguousRetransmit\`, \`CRCMismatch\`. Future event consumers that inspect ACKCorrelation get an empty correlation rather than a positive ACK from a doomed transaction.

### Test fixup

\`TestRun_AddressTableInserterWiresThroughPassiveReconstructor\` previously fed \`request + ACK + SYN\` (phase-3 no_response abandon). Updated to feed a complete M-T transaction: \`request + ACK + responseSegment + ACK + SYN\`, mirroring the canonical \`TestPassiveTransactionReconstructor_ClassifiesDirectTransaction\` format.

## Test plan

- [x] \`go test -race -count=1 ./...\` — clean (full suite + race-detector)
- [x] \`scripts/ci_local.sh\` — exit 0 with documented owner overrides
- [x] Fixed wireup test now feeds a complete transaction and passes
- [ ] Live verify post-deploy: 0x24 / 0x84 should NOT appear in registry after gateway restart on the same bus
- [x] BusObservabilityStore tests untouched (already on the right path)

## References

- Phase C M-C8 live validation: phantom 0x24 + 0x84 registry entries
- Codex investigation agent root-cause analysis (2026-05-08)
- Cruise plan: post-Phase-C P1 + P1.5 of 6-item batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)