### PR TITLE
feat(gateway): P3 — wire LoadSeedTable into startup registry

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -30,6 +30,7 @@ import (
 	ebusgoTransport "github.com/Project-Helianthus/helianthus-ebusgo/transport"
 	vaillantproviders "github.com/Project-Helianthus/helianthus-ebusreg/providers/vaillant"
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+	"github.com/Project-Helianthus/helianthus-ebusreg/vaillant/productids"
 )
 
 var (
@@ -204,6 +205,18 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 	}()
 
 	gateway.Start(ctx)
+
+	// P3 (post-Phase-C live validation 2026-05-08): when enabled,
+	// plant the productids static seed entries into the registry at
+	// startup. Surfaces Vaillant addresses that don't respond to
+	// active scan (NETX3 0x04, SOL00 0xEC) so they're visible from
+	// MCP/GraphQL/portal even before passive observation produces
+	// corroborated evidence. Identity (Manufacturer, DeviceID) is
+	// authoritative from the seed table; serial/sw/hw versions
+	// remain empty until enrichment populates them.
+	if cfg.EnableStaticSeedTable {
+		applyStaticSeedTable(gateway.Registry)
+	}
 
 	builder := graphql.NewBuilder(gateway.Registry, nil)
 
@@ -951,6 +964,7 @@ func bindFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) {
 	fs.StringVar(&cfg.DumpOutputDir, "dump-output-dir", cfg.DumpOutputDir, "unknown device dump output dir")
 	fs.StringVar(&cfg.DumpUploadURL, "dump-upload-url", cfg.DumpUploadURL, "unknown device dump upload url (internal)")
 	fs.BoolVar(&cfg.DumpIncludePII, "dump-include-pii", cfg.DumpIncludePII, "include identifiers in unknown device dumps")
+	fs.BoolVar(&cfg.EnableStaticSeedTable, "enable-static-seed-table", cfg.EnableStaticSeedTable, "plant productids static seed entries (NETX3 0x04 / 0xF1 / 0xF6, BASV2 0x15 / 0xEC) into registry at startup; default false")
 	fs.BoolVar(&cfg.ObserveFirstEnabled, "observe-first-enabled", cfg.ObserveFirstEnabled, "enable observe-first runtime behavior gates")
 	fs.BoolVar(&cfg.PassiveStateDirectApply, "passive-state-direct-apply", cfg.PassiveStateDirectApply, "allow passive state direct-apply when observe-first is enabled")
 	fs.BoolVar(&cfg.PassiveConfigDirectApply, "passive-config-direct-apply", cfg.PassiveConfigDirectApply, "allow passive config direct-apply when state direct-apply is enabled")
@@ -2038,4 +2052,44 @@ func buildResponderCapabilityProvider(cfg ebusgateway.Config, actualTransport eb
 		Transports: transports,
 	}
 	return func() ebus_standard.ResponderCapability { return cap }
+}
+
+// applyStaticSeedTable plants the productids static seed entries
+// into the registry. Each seed entry contributes one DeviceInfo per
+// address with full Vaillant identity (Manufacturer + DeviceID),
+// allowing the registry's identity-merge contract to collapse
+// canonical-pair faces into a single entry. SerialNumber and
+// version fields are intentionally empty — they will be populated
+// by subsequent active enrichment (P5 follow-up) or remain empty
+// for seed-only addresses (e.g. NETX3 broadcast face 0x04 which
+// does not respond to active probes).
+//
+// Phase post-C P3 (live validation 2026-05-08): NETX3's 0x04
+// face was absent from the registry entirely because broadcast-
+// source frames never carry an ACKCorrelation that would feed
+// the inserter. Static seed bypasses that gate at startup.
+//
+// Roles in productids.SeedAddressEntry are strings ("initiator",
+// "target"); we map them to registry.SlotRole indirectly via
+// Register's identity-merge invariant — the SlotRole on the
+// resulting AddressSlot is set by the registry's alias-aware
+// face-syncing logic.
+func applyStaticSeedTable(reg *registry.DeviceRegistry) {
+	seeds := productids.LoadSeedTable(true)
+	if len(seeds) == 0 {
+		return
+	}
+	count := 0
+	for _, seed := range seeds {
+		for _, addr := range seed.Addresses {
+			info := registry.DeviceInfo{
+				Address:      addr.Addr,
+				Manufacturer: seed.Manufacturer,
+				DeviceID:     seed.DeviceID,
+			}
+			reg.Register(info)
+			count++
+		}
+	}
+	log.Printf("static seed table: planted %d address(es) across %d device(s) at startup (source=productids.LoadSeedTable)", count, len(seeds))
 }

--- a/config.go
+++ b/config.go
@@ -175,6 +175,20 @@ type Config struct {
 	ObserveFirstWarmupPostResetWindow       time.Duration
 	ObserveFirstWarmupPostResetTransactions int
 	ObserveFirstWarmupOuterWindow           time.Duration
+
+	// EnableStaticSeedTable, when true, plants the
+	// helianthus-ebusreg/vaillant/productids static seed entries
+	// into the registry at gateway startup. Used to deterministically
+	// surface Vaillant addresses that don't respond to active scan
+	// (e.g. NETX3 broadcast face 0x04 / 0xFF, SOL00 0xEC). Default
+	// false to preserve the strict observe-first AD05 contract;
+	// operators opt in via the addon config / CLI flag.
+	//
+	// Phase post-C P3 (live validation 2026-05-08): NETX3's 0x04
+	// face was absent from the registry because broadcast-source
+	// frames never carry an ACKCorrelation that would flow through
+	// the inserter. Static seed bypasses that gate.
+	EnableStaticSeedTable bool
 }
 
 func DefaultConfig() Config {


### PR DESCRIPTION
## Summary

Post-Phase-C P3 from the live HA validation report (2026-05-08). Plants the helianthus-ebusreg/vaillant/productids static seed entries into the registry at gateway startup when \`EnableStaticSeedTable=true\`.

Surfaces Vaillant addresses that don't respond to active scan (NETX3 broadcast face 0x04, SOL00 0xEC) so they're visible from MCP/GraphQL/portal even before passive observation produces corroborated evidence.

## Pre-fix state

\`productids.LoadSeedTable\` was implemented + tested in helianthus-ebusreg M5A (PR #131) but had **zero non-test callers** in the workspace. The "EnableStaticSeedTable=false" wording in the plan-status was misleading — the flag was never plumbed through, so the feature was strictly on-paper.

## Changes

- \`config.go\`: add \`EnableStaticSeedTable bool\` field
- \`cmd/gateway/main.go\`:
  - import \`productids\`
  - add CLI flag \`-enable-static-seed-table\` (default false to preserve strict AD05 observe-first contract)
  - \`applyStaticSeedTable(reg)\` at startup, after \`gateway.Start\`
  - log planted address + device count for operator audit

Seed contents:
- NETX3 (Vaillant): 0xF1 (initiator), 0xF6 (target), 0x04 (target)
- BASV2 (Vaillant): 0x15 (target), 0xEC (target)

## Composition with P0 + P2

When P0 (#136 ebusreg \`absorbIdentityLocked\`) + P2 (#580 gateway canonical-pair alias on scan) + this PR + P3 addon (separate) all land:

- 0xF6 ↔ 0xF1 grouped at boot under one entry, mfr="Vaillant" devID="NETX3"
- 0x04 also grouped (Companion(0x04)=0xFF, but 0xFF won't be in registry until P4 broadcast path)
- BASV2 0x15 ↔ 0x10 grouped (P2 from scan), 0xEC also seeded (no canonical companion)

## Test plan

- [x] go build/vet/test ./... — clean
- [x] scripts/ci_local.sh — exit 0 with documented owner overrides
- [ ] Live verify post-deploy with \`enable_static_seed_table=true\`: registry shows 0xF6+0xF1+0x04 (NETX3) and 0x15+0xEC (BASV2) at boot

## Companion PRs

- helianthus-ha-addon: \`feat/p3-static-seed-table\` (PR follows)
- Depends on this PR for the \`-enable-static-seed-table\` CLI flag to exist on the gateway binary

## References

- Phase C live validation 2026-05-08: NETX3 0x04 absent
- helianthus-ebusreg M5A (PR #131): seed table API
- Cruise plan: post-Phase-C P3 of 6-item batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)