### PR TITLE
feat(gateway): P5 — per-address identity probe after passive insert

### DIFF
--- a/address_table_inserter.go
+++ b/address_table_inserter.go
@@ -62,26 +62,38 @@ func (i *AddressTableInserter) SetEnrichmentRefreshFn(fn func()) {
 // manufacturer / deviceID / serialNumber forever, which prevents
 // identity-merge from grouping aliased faces.
 //
-// Backfill (P5 round-2 follow-up, Codex P2): if any addresses
-// were inserted before this hook was wired (e.g. subscription
-// firing during the activeProbePassed startup window), iterate
-// the registry's existing entries and probe any address that
-// looks unidentified (manufacturer empty OR (Vaillant + serial
-// empty)). This closes the race where a passive observation
-// during the gateway's startup-admission window would land in
-// the registry without ever getting an identity probe.
+// This setter is fire-only: it installs the fn pointer and returns
+// without invoking it. Callers that need to backfill addresses
+// inserted before the hook was wired should call
+// BackfillUnidentifiedAddresses AFTER the gateway's startup barrier
+// (semantic scheduler readiness) clears — see main.go for the wiring.
 func (i *AddressTableInserter) SetEnrichmentIdentityProbeFn(fn func(addr byte)) {
 	if i == nil {
 		return
 	}
 	i.enrichmentIdentityProbeFn = fn
-	if fn == nil || i.table == nil || i.table.reg == nil {
+}
+
+// BackfillUnidentifiedAddresses iterates the registry's existing
+// entries and invokes the wired enrichmentIdentityProbeFn for any
+// address that looks unidentified (manufacturer empty OR Vaillant +
+// serial empty). Used to close the race where a passive observation
+// during the gateway's startup-admission window lands in the
+// registry before SetEnrichmentIdentityProbeFn was wired.
+//
+// Callers MUST defer the invocation until the gateway's startup
+// barrier (admittedSource finalization) has closed — otherwise the
+// probe submissions will race the startup directed scan and emit
+// bus traffic during the admission validation window. See P5
+// round-3 finding (Codex P2 on PR #583, 2026-05-08).
+//
+// The probe fn is idempotent (per-address sync.Map in
+// EnqueueAddressIdentityProbe), so repeat calls are harmless.
+func (i *AddressTableInserter) BackfillUnidentifiedAddresses() {
+	if i == nil || i.enrichmentIdentityProbeFn == nil || i.table == nil || i.table.reg == nil {
 		return
 	}
-	// Backfill probe for any address already in the registry that
-	// looks unidentified. The fn implementation is idempotent (per-
-	// address sync.Map in EnqueueAddressIdentityProbe), so repeats
-	// for already-probed addresses are harmless.
+	fn := i.enrichmentIdentityProbeFn
 	i.table.reg.Iterate(func(entry registry.DeviceEntry) bool {
 		if entry == nil {
 			return true

--- a/address_table_inserter.go
+++ b/address_table_inserter.go
@@ -324,11 +324,27 @@ func (i *AddressTableInserter) maybeInsert(addr byte, role string, admittedSrc b
 		i.enrichmentRefreshFn()
 	}
 
+	// A.7b — canonical-pair aliasing. If addr is one half of a canonical
+	// pair from the docs-owned eBUS standard table (sourceAddressTableV1)
+	// and the other half is already in the registry, alias them into a
+	// single DeviceEntry so MCP/GraphQL queries return one device with
+	// two addresses. Aliasing only fires for the 25 canonical pairs;
+	// non-canonical neighbours (e.g. 0x26 / 0xEC) are never aliased here.
+	i.maybeAliasCanonicalCompanion(addr)
+
 	// P5 (post-Phase-C live validation 2026-05-08): per-address
 	// identity probe of the just-inserted slot. Triggers a
-	// 0x07/0x04 + B5.09 ScanID read against `addr`; on success the
-	// registry's M6 identity-merge path collapses canonical pairs
-	// that share identity into a single DeviceEntry.
+	// 0x07/0x04 + B5.09 ScanID read against the responder face;
+	// on success the registry's M6 identity-merge path collapses
+	// canonical pairs that share identity into a single DeviceEntry.
+	//
+	// MUST run AFTER maybeAliasCanonicalCompanion so that when the
+	// just-inserted address has a canonical companion already in
+	// the registry, the alias merge happens first and the
+	// EnqueueAddressIdentityProbe lookup sees the merged entry
+	// (with its target-role face) — not a fresh initiator-only
+	// entry that would resolve to no_responder_face. (Codex P2
+	// round-7 finding 2026-05-08 on PR #583.)
 	//
 	// Without this hook, passive-observed entries (e.g. NETX3
 	// 0xF1↔0xF6) stay at empty manufacturer / deviceID /
@@ -339,14 +355,6 @@ func (i *AddressTableInserter) maybeInsert(addr byte, role string, admittedSrc b
 	if i.enrichmentIdentityProbeFn != nil {
 		i.enrichmentIdentityProbeFn(addr)
 	}
-
-	// A.7b — canonical-pair aliasing. If addr is one half of a canonical
-	// pair from the docs-owned eBUS standard table (sourceAddressTableV1)
-	// and the other half is already in the registry, alias them into a
-	// single DeviceEntry so MCP/GraphQL queries return one device with
-	// two addresses. Aliasing only fires for the 25 canonical pairs;
-	// non-canonical neighbours (e.g. 0x26 / 0xEC) are never aliased here.
-	i.maybeAliasCanonicalCompanion(addr)
 }
 
 // maybeAliasCanonicalCompanion calls registry.AliasAddresses(addr, companion)

--- a/address_table_inserter.go
+++ b/address_table_inserter.go
@@ -18,14 +18,21 @@ type AddressTableInserter struct {
 	observationsByAddr map[byte]AddressObservation
 	// enrichmentRefreshFn is called once per new passive slot insertion.
 	// Wired to semanticPoller.EnqueueDiscoveryRefresh in production: the
-	// next discovery cycle probes B509 ScanID + B524 identity for the
-	// newly-observed address, then re-Registers with full identity
-	// (Manufacturer + DeviceID + SerialNumber). That triggers M6
-	// identity-merge in helianthus-ebusreg, grouping addresses with
-	// matching identity into a single DeviceEntry (e.g. NETX3 0xF1 +
-	// 0xF6 + 0x04 + 0xFF all collapse into one device once enrichment
-	// runs). Nil-safe: skipped when not wired (unit tests, etc.).
+	// next discovery cycle re-runs B524 root coherency on the controller.
+	// Nil-safe: skipped when not wired (unit tests, etc.).
 	enrichmentRefreshFn func()
+	// enrichmentIdentityProbeFn is called once per new passive slot
+	// insertion with the inserted address. Wired to
+	// semanticPoller.EnqueueAddressIdentityProbe in production: probes
+	// the new address with 0x07/0x04 + B5.09 ScanID and re-Registers
+	// with full identity (Manufacturer + DeviceID + SerialNumber).
+	// That triggers M6 identity-merge in helianthus-ebusreg, grouping
+	// addresses with matching identity into a single DeviceEntry
+	// (e.g. NETX3 0xF1 + 0xF6 + 0x04 + 0xFF all collapse into one
+	// device once enrichment runs). Phase post-C P5 (live validation
+	// 2026-05-08): without this hook, passive-observed entries stay
+	// at empty manufacturer indefinitely. Nil-safe.
+	enrichmentIdentityProbeFn func(addr byte)
 }
 
 func NewAddressTableInserter(table *AddressTable, cfg Config) *AddressTableInserter {
@@ -36,14 +43,29 @@ func NewAddressTableInserter(table *AddressTable, cfg Config) *AddressTableInser
 	}
 }
 
-// SetEnrichmentRefreshFn wires the post-insertion enrichment trigger so
-// new passive slots get probed for identity by the semantic poller. See
-// AddressTableInserter.enrichmentRefreshFn for semantics.
+// SetEnrichmentRefreshFn wires the post-insertion B524 root re-discovery
+// trigger so the regulator surface populates without a gateway restart.
+// See AddressTableInserter.enrichmentRefreshFn for semantics.
 func (i *AddressTableInserter) SetEnrichmentRefreshFn(fn func()) {
 	if i == nil {
 		return
 	}
 	i.enrichmentRefreshFn = fn
+}
+
+// SetEnrichmentIdentityProbeFn wires the post-insertion per-address
+// identity probe so new passive slots get a 0x07/0x04 + B5.09 ScanID
+// read against them. See AddressTableInserter.enrichmentIdentityProbeFn.
+//
+// Phase post-C P5 (live validation 2026-05-08): without this hook
+// passive-observed entries (e.g. NETX3 0xF1↔0xF6) stay at empty
+// manufacturer / deviceID / serialNumber forever, which prevents
+// identity-merge from grouping aliased faces.
+func (i *AddressTableInserter) SetEnrichmentIdentityProbeFn(fn func(addr byte)) {
+	if i == nil {
+		return
+	}
+	i.enrichmentIdentityProbeFn = fn
 }
 
 func (i *AddressTableInserter) OnPassiveClassifiedEvent(event PassiveClassifiedEvent) {
@@ -251,12 +273,28 @@ func (i *AddressTableInserter) maybeInsert(addr byte, role string, admittedSrc b
 		addr, role, admittedSrc, observedAt.Format(time.RFC3339Nano))
 
 	// M6 enrichment trigger — schedule a semantic-poller discovery
-	// refresh so the newly-inserted slot gets probed for identity. Once
-	// SerialNumber + Manufacturer are populated via Register, the
-	// registry's M6 identity-merge path collapses canonical pairs that
-	// share identity into a single DeviceEntry.
+	// refresh so the regulator surface populates without a gateway
+	// restart. Note: this is a B524-root coherency re-run, NOT an
+	// identity probe of the just-inserted address (see
+	// enrichmentIdentityProbeFn below for the latter).
 	if i.enrichmentRefreshFn != nil {
 		i.enrichmentRefreshFn()
+	}
+
+	// P5 (post-Phase-C live validation 2026-05-08): per-address
+	// identity probe of the just-inserted slot. Triggers a
+	// 0x07/0x04 + B5.09 ScanID read against `addr`; on success the
+	// registry's M6 identity-merge path collapses canonical pairs
+	// that share identity into a single DeviceEntry.
+	//
+	// Without this hook, passive-observed entries (e.g. NETX3
+	// 0xF1↔0xF6) stay at empty manufacturer / deviceID /
+	// serialNumber forever, which prevents identity-merge from
+	// grouping aliased faces. The probe is bounded + idempotent
+	// per the wired implementation (see semanticPoller.
+	// EnqueueAddressIdentityProbe).
+	if i.enrichmentIdentityProbeFn != nil {
+		i.enrichmentIdentityProbeFn(addr)
 	}
 
 	// A.7b — canonical-pair aliasing. If addr is one half of a canonical

--- a/address_table_inserter.go
+++ b/address_table_inserter.go
@@ -61,11 +61,42 @@ func (i *AddressTableInserter) SetEnrichmentRefreshFn(fn func()) {
 // passive-observed entries (e.g. NETX3 0xF1↔0xF6) stay at empty
 // manufacturer / deviceID / serialNumber forever, which prevents
 // identity-merge from grouping aliased faces.
+//
+// Backfill (P5 round-2 follow-up, Codex P2): if any addresses
+// were inserted before this hook was wired (e.g. subscription
+// firing during the activeProbePassed startup window), iterate
+// the registry's existing entries and probe any address that
+// looks unidentified (manufacturer empty OR (Vaillant + serial
+// empty)). This closes the race where a passive observation
+// during the gateway's startup-admission window would land in
+// the registry without ever getting an identity probe.
 func (i *AddressTableInserter) SetEnrichmentIdentityProbeFn(fn func(addr byte)) {
 	if i == nil {
 		return
 	}
 	i.enrichmentIdentityProbeFn = fn
+	if fn == nil || i.table == nil || i.table.reg == nil {
+		return
+	}
+	// Backfill probe for any address already in the registry that
+	// looks unidentified. The fn implementation is idempotent (per-
+	// address sync.Map in EnqueueAddressIdentityProbe), so repeats
+	// for already-probed addresses are harmless.
+	i.table.reg.Iterate(func(entry registry.DeviceEntry) bool {
+		if entry == nil {
+			return true
+		}
+		manufacturer := entry.Manufacturer()
+		serial := entry.SerialNumber()
+		needsProbe := manufacturer == "" || (manufacturer == "Vaillant" && serial == "")
+		if !needsProbe {
+			return true
+		}
+		for _, addr := range entry.Addresses() {
+			fn(addr)
+		}
+		return true
+	})
 }
 
 func (i *AddressTableInserter) OnPassiveClassifiedEvent(event PassiveClassifiedEvent) {

--- a/address_table_inserter.go
+++ b/address_table_inserter.go
@@ -278,6 +278,18 @@ func (i *AddressTableInserter) maybeInsert(addr byte, role string, admittedSrc b
 		// in case the companion was registered separately and never
 		// went through the new-insert alias path. Idempotent.
 		i.maybeAliasCanonicalCompanion(addr)
+		// P5 round-9 (Codex P2 follow-up 2026-05-08): also re-fire
+		// the identity probe on the existing-address path. The
+		// probe fn is idempotent via sync.Map; this matters when a
+		// previous probe attempt was rolled back due to queue
+		// overload (EnqueueAddressIdentityProbe.Delete on submit
+		// failure). Without this, a passive slot that hits the
+		// queue-overload window stays anonymous until a gateway
+		// restart, even though later passive observations of the
+		// same address keep arriving.
+		if i.enrichmentIdentityProbeFn != nil {
+			i.enrichmentIdentityProbeFn(addr)
+		}
 		return
 	}
 

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -666,23 +666,42 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 		// ScanID probe and re-Register with full identity. Bounded
 		// + idempotent (probes each address at most once per
 		// gateway lifetime).
-		addressTableInserter.SetEnrichmentIdentityProbeFn(semanticPoller.EnqueueAddressIdentityProbe)
+		//
+		// P5 round-5 (Codex P2 follow-up 2026-05-08): gate per-
+		// insert probes on the startup admission barrier. Without
+		// the gate, a passive slot inserted before semanticBarrier
+		// closes would call EnqueueAddressIdentityProbe immediately
+		// and the task scheduler (already running) would emit
+		// ScanDirected bus traffic during the admission validation
+		// window — racing the startup directed scan. When the
+		// gate drops a probe call during admission, the post-
+		// barrier BackfillUnidentifiedAddresses catches up: it
+		// iterates the registry's existing entries and re-fires
+		// the probe for any unidentified address.
+		var probeReady atomic.Bool
+		if semanticBarrier == nil {
+			probeReady.Store(true)
+		}
+		addressTableInserter.SetEnrichmentIdentityProbeFn(func(addr byte) {
+			if !probeReady.Load() {
+				return
+			}
+			semanticPoller.EnqueueAddressIdentityProbe(addr)
+		})
 
-		// P5 round-3 (Codex P2 follow-up 2026-05-08): backfill
-		// identity probes for any addresses that were inserted
-		// before SetEnrichmentIdentityProbeFn wired the hook (early
-		// subscription in subscribeAddressTableInserter at line 401
-		// can fire during the activeProbePassed window). MUST defer
-		// until the semanticBarrier closes, otherwise the probes
-		// race the startup directed scan and emit bus traffic during
-		// admission validation. When semanticBarrier is nil (no
-		// startup barrier configured), backfill inline.
+		// Backfill identity probes for any addresses that were
+		// inserted before the hook was wired (early subscription
+		// in subscribeAddressTableInserter can fire during the
+		// activeProbePassed window) OR while the barrier was open.
+		// Defer until semanticBarrier closes to avoid racing the
+		// startup directed scan.
 		if semanticBarrier != nil {
 			go func() {
 				select {
 				case <-ctx.Done():
 					return
 				case <-semanticBarrier:
+					probeReady.Store(true)
 					addressTableInserter.BackfillUnidentifiedAddresses()
 				}
 			}()

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -667,6 +667,28 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 		// + idempotent (probes each address at most once per
 		// gateway lifetime).
 		addressTableInserter.SetEnrichmentIdentityProbeFn(semanticPoller.EnqueueAddressIdentityProbe)
+
+		// P5 round-3 (Codex P2 follow-up 2026-05-08): backfill
+		// identity probes for any addresses that were inserted
+		// before SetEnrichmentIdentityProbeFn wired the hook (early
+		// subscription in subscribeAddressTableInserter at line 401
+		// can fire during the activeProbePassed window). MUST defer
+		// until the semanticBarrier closes, otherwise the probes
+		// race the startup directed scan and emit bus traffic during
+		// admission validation. When semanticBarrier is nil (no
+		// startup barrier configured), backfill inline.
+		if semanticBarrier != nil {
+			go func() {
+				select {
+				case <-ctx.Done():
+					return
+				case <-semanticBarrier:
+					addressTableInserter.BackfillUnidentifiedAddresses()
+				}
+			}()
+		} else {
+			addressTableInserter.BackfillUnidentifiedAddresses()
+		}
 	}
 
 	var scheduleWriter mcp.ScheduleWriter

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -660,6 +660,13 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 	// into a single DeviceEntry.
 	if semanticPoller != nil {
 		addressTableInserter.SetEnrichmentRefreshFn(semanticPoller.EnqueueDiscoveryRefresh)
+		// P5 (post-Phase-C live validation 2026-05-08): per-address
+		// identity probe wired so passive-observed slots (e.g.
+		// NETX3 0xF1↔0xF6, BASV2 0x10) get a 0x07/0x04 + B5.09
+		// ScanID probe and re-Register with full identity. Bounded
+		// + idempotent (probes each address at most once per
+		// gateway lifetime).
+		addressTableInserter.SetEnrichmentIdentityProbeFn(semanticPoller.EnqueueAddressIdentityProbe)
 	}
 
 	var scheduleWriter mcp.ScheduleWriter

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -6825,19 +6825,60 @@ func (p *vaillantSemanticPoller) EnqueueAddressIdentityProbe(addr byte) {
 	if addr == 0 || addr == 0xFE || addr == 0xAA {
 		return
 	}
-	if _, alreadyProbed := p.identityProbedAddresses.LoadOrStore(addr, struct{}{}); alreadyProbed {
+	// P5 round-6 (Codex P2 follow-up 2026-05-08): resolve the input
+	// address to its responder/target byte before probing. Active
+	// identity reads (0x07/0x04 + B5.09 ScanID) must be addressed
+	// to the responder face — sending them to an initiator/source
+	// byte (e.g. BASV2 0x10, NETX3 0xF1) produces no response and
+	// just times out. The existing startup scan path filters
+	// initiator-capable addresses out of target lists for the same
+	// reason.
+	//
+	// Resolution order:
+	// 1. If addr is non-initiator-capable, it IS already a
+	//    responder/target — probe directly.
+	// 2. Otherwise, look up the entry containing addr and use
+	//    TargetAddressForRouting (prefers SlotRoleSlave, falls
+	//    back to PrimaryDisplayAddress when no target-role face
+	//    exists).
+	// 3. If neither yields a valid target, skip — initiator-only
+	//    devices have no probable identity face.
+	probeAddr := addr
+	if protocol.IsInitiatorCapableAddress(addr) {
+		var resolvedTarget byte
+		p.reg.Iterate(func(entry registry.DeviceEntry) bool {
+			if entry == nil {
+				return true
+			}
+			for _, a := range entry.Addresses() {
+				if a == addr {
+					resolvedTarget = ebusgateway.TargetAddressForRouting(entry)
+					return false
+				}
+			}
+			return true
+		})
+		if resolvedTarget == 0 || protocol.IsInitiatorCapableAddress(resolvedTarget) {
+			// No target-role face on the entry, OR the entry's
+			// only addresses are initiator-capable — skip.
+			log.Printf("semantic_address_identity_probe address=0x%02X status=skipped reason=no_responder_face", addr)
+			return
+		}
+		probeAddr = resolvedTarget
+	}
+	if _, alreadyProbed := p.identityProbedAddresses.LoadOrStore(probeAddr, struct{}{}); alreadyProbed {
 		return
 	}
 	scheduler := p.tasks
 	probeFn := func(ctx context.Context) {
 		probeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
-		_, err := registry.ScanDirected(probeCtx, p.bus, p.reg, p.source, []byte{addr})
+		_, err := registry.ScanDirected(probeCtx, p.bus, p.reg, p.source, []byte{probeAddr})
 		if err != nil {
-			log.Printf("semantic_address_identity_probe address=0x%02X status=fail err=%v", addr, err)
+			log.Printf("semantic_address_identity_probe address=0x%02X status=fail err=%v", probeAddr, err)
 			return
 		}
-		log.Printf("semantic_address_identity_probe address=0x%02X status=ok", addr)
+		log.Printf("semantic_address_identity_probe address=0x%02X status=ok", probeAddr)
 	}
 	if scheduler == nil {
 		// No scheduler wired (unit tests, etc.) — run inline.
@@ -6855,13 +6896,13 @@ func (p *vaillantSemanticPoller) EnqueueAddressIdentityProbe(addr byte) {
 		p.withPollLock(taskCtx, probeFn)
 	})
 	if err != nil {
-		// Rollback so the address is eligible for retry.
-		p.identityProbedAddresses.Delete(addr)
+		// Rollback so the (resolved) address is eligible for retry.
+		p.identityProbedAddresses.Delete(probeAddr)
 		if errors.Is(err, errSemanticTaskQueueOverloaded) {
-			log.Printf("semantic_address_identity_probe address=0x%02X status=enqueue_dropped reason=queue_overloaded", addr)
+			log.Printf("semantic_address_identity_probe address=0x%02X status=enqueue_dropped reason=queue_overloaded", probeAddr)
 			return
 		}
-		log.Printf("semantic_address_identity_probe address=0x%02X status=enqueue_failed err=%v", addr, err)
+		log.Printf("semantic_address_identity_probe address=0x%02X status=enqueue_failed err=%v", probeAddr, err)
 	}
 }
 

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -6825,6 +6825,18 @@ func (p *vaillantSemanticPoller) EnqueueAddressIdentityProbe(addr byte) {
 	if addr == 0 || addr == 0xFE || addr == 0xAA {
 		return
 	}
+	// P5 round-8 (Codex P2 follow-up 2026-05-08): skip the gateway's
+	// own admitted source + companion. The existing
+	// discoverB524RootInRegistry candidate path explicitly drops
+	// these (skipReservedSourceCompanion); this probe path must
+	// honor the same protection so we don't emit identity traffic
+	// to our own admitted address (or its companion).
+	if addr == p.source {
+		return
+	}
+	if p.companion != 0 && addr == p.companion {
+		return
+	}
 	// P5 round-6 (Codex P2 follow-up 2026-05-08): resolve the input
 	// address to its responder/target byte before probing. Active
 	// identity reads (0x07/0x04 + B5.09 ScanID) must be addressed

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -307,6 +307,11 @@ type vaillantSemanticPoller struct {
 	pollMu sync.Mutex
 	readMu sync.Mutex
 
+	// identityProbedAddresses tracks per-address probe attempts for
+	// EnqueueAddressIdentityProbe (P5). Each address is probed at
+	// most once per gateway lifetime; failures are not retried.
+	identityProbedAddresses sync.Map // map[byte]struct{}
+
 	catalog    productids.Catalog
 	catalogErr error
 
@@ -6793,6 +6798,46 @@ func (p *vaillantSemanticPoller) EnqueueDiscoveryRefresh() {
 		return
 	}
 	p.enqueueTask(semanticTaskPriorityHigh, p.refreshDiscovery)
+}
+
+// EnqueueAddressIdentityProbe schedules a per-address identity
+// probe for the given address. Runs registry.Scan against just
+// that address using the gateway's current scan source — on
+// success, the registry's M6 identity-merge path collapses
+// canonical pairs that share identity into a single DeviceEntry.
+//
+// Phase post-C P5 (live validation 2026-05-08): closes the gap
+// where passive-observed addresses (e.g. NETX3 0xF1, 0xF6, BASV2
+// 0x10) sit in the registry forever with empty manufacturer /
+// deviceID / serialNumber because no path probes them for
+// identity post-insertion.
+//
+// Bounded + idempotent: probes each address at most once per
+// gateway lifetime via p.identityProbedAddresses (sync.Map).
+// Probes that fail (timeout, NACK, etc.) are NOT retried — the
+// next gateway restart re-attempts. This is intentional: NETX3's
+// 0x04 broadcast face does not respond to active probes by spec,
+// so retry would just spam the bus.
+func (p *vaillantSemanticPoller) EnqueueAddressIdentityProbe(addr byte) {
+	if p == nil || p.bus == nil || p.reg == nil {
+		return
+	}
+	if addr == 0 || addr == 0xFE || addr == 0xAA {
+		return
+	}
+	if _, alreadyProbed := p.identityProbedAddresses.LoadOrStore(addr, struct{}{}); alreadyProbed {
+		return
+	}
+	p.enqueueTask(semanticTaskPriorityLow, func(ctx context.Context) {
+		probeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+		_, err := registry.ScanDirected(probeCtx, p.bus, p.reg, p.source, []byte{addr})
+		if err != nil {
+			log.Printf("semantic_address_identity_probe address=0x%02X status=fail err=%v", addr, err)
+			return
+		}
+		log.Printf("semantic_address_identity_probe address=0x%02X status=ok", addr)
+	})
 }
 
 // registerStructuralControllerIfMissing registers a minimal Vaillant

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -6828,7 +6828,8 @@ func (p *vaillantSemanticPoller) EnqueueAddressIdentityProbe(addr byte) {
 	if _, alreadyProbed := p.identityProbedAddresses.LoadOrStore(addr, struct{}{}); alreadyProbed {
 		return
 	}
-	p.enqueueTask(semanticTaskPriorityLow, func(ctx context.Context) {
+	scheduler := p.tasks
+	probeFn := func(ctx context.Context) {
 		probeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
 		_, err := registry.ScanDirected(probeCtx, p.bus, p.reg, p.source, []byte{addr})
@@ -6837,7 +6838,31 @@ func (p *vaillantSemanticPoller) EnqueueAddressIdentityProbe(addr byte) {
 			return
 		}
 		log.Printf("semantic_address_identity_probe address=0x%02X status=ok", addr)
+	}
+	if scheduler == nil {
+		// No scheduler wired (unit tests, etc.) — run inline.
+		probeFn(context.Background())
+		return
+	}
+	// Codex P2 follow-up on PR #583 (2026-05-08): submit BEFORE
+	// committing the per-address probed marker. If the task queue
+	// is overloaded and submit fails, roll back the sync.Map entry
+	// so the address remains eligible for retry on the next passive
+	// observation. Without rollback, an overloaded queue at startup
+	// permanently blocks identity enrichment for the dropped
+	// addresses until the next gateway restart.
+	err := scheduler.submit(semanticTaskPriorityLow, func(taskCtx context.Context) {
+		p.withPollLock(taskCtx, probeFn)
 	})
+	if err != nil {
+		// Rollback so the address is eligible for retry.
+		p.identityProbedAddresses.Delete(addr)
+		if errors.Is(err, errSemanticTaskQueueOverloaded) {
+			log.Printf("semantic_address_identity_probe address=0x%02X status=enqueue_dropped reason=queue_overloaded", addr)
+			return
+		}
+		log.Printf("semantic_address_identity_probe address=0x%02X status=enqueue_failed err=%v", addr, err)
+	}
 }
 
 // registerStructuralControllerIfMissing registers a minimal Vaillant


### PR DESCRIPTION
## Summary

Post-Phase-C P5 from the live HA validation report. Closes the gap where passive-observed entries (e.g. NETX3 0xF1↔0xF6, BASV2 0x10) sit in the registry forever with empty manufacturer / deviceID / serialNumber. The pre-existing \`enrichmentRefreshFn\` was wired to \`EnqueueDiscoveryRefresh\` which only re-runs B524 root coherency on the controller — it does NOT probe arbitrary new addresses for identity. The comment-vs-impl mismatch was the root cause.

## Mechanism

- New \`EnqueueAddressIdentityProbe(addr byte)\` method on \`vaillantSemanticPoller\` schedules a low-priority semantic task to call \`registry.ScanDirected\` against just that address.
- New callback \`enrichmentIdentityProbeFn func(addr byte)\` on \`AddressTableInserter\`, paired with \`SetEnrichmentIdentityProbeFn\` setter.
- Inserter's \`maybeInsert\` calls both the existing refresh hook AND the new identity probe hook after committing a slot.
- main.go wires the new callback to the poller.

## Bounded + idempotent

- Per-address \`sync.Map\` (\`identityProbedAddresses\`) ensures each address is probed **at most once per gateway lifetime**. Probes that fail (timeout, NACK, no responder) are **not retried** — next gateway restart re-attempts.
- 10s timeout per probe so a non-responding target doesn't stall the semantic task scheduler.
- Skips reserved bytes (0, 0xFE, 0xAA).

## Composition with cruise items

| Item | Effect |
|------|--------|
| P0 (#136) | AliasAddresses preserves identity at merge → probe-acquired identity propagates across aliases |
| P1 (#579) | Kind-filter ensures no phantom slots reach the probe path |
| P2 (#580) | Already aliases canonical pairs from active scan; this fills post-passive-insert case |
| P3 (#581 + addon #124) | Static seed plants 0x04 / 0xEC at boot; their identity probes don't respond (passive-only devices), but one-shot semantics avoid bus spam |
| P4 (#582) | Broadcast insertion captures 0xFF; this PR triggers identity probe for it |
| **P5 (this PR)** | Closes the identity-population loop |

## Test plan

- [x] go build/vet/test ./... — clean
- [x] scripts/ci_local.sh — exit 0 with documented owner overrides
- [ ] Live verify: NETX3 0xF1+0xF6 register with mfr="Vaillant" devID="NETX3" within seconds of first observation; BASV2 0x10+0x15 same

## References

- Phase C live validation 2026-05-08: pairs aliased but anonymous
- Codex P5 investigation (2026-05-08): comment-vs-impl mismatch
- Cruise plan: post-Phase-C P5 of 6-item batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)