### PR TITLE
chore(gateway): P0-bump — helianthus-ebusreg to post-P0 (identity preservation)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260507140006-4dfa4a22cec3
-	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260507193239-77b56516dbb5
+	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260508165100-6557307c3c98
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260507140006-4dfa4a22cec3 h1:U90kuV7LhIkiwnD1iZFGV29Vpd87S119DXDcso4cCp8=
 github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260507140006-4dfa4a22cec3/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260507193239-77b56516dbb5 h1:uW6OKijnbyGI9zFu/DCGcBlJJRjFztIyUL7QeavXiHQ=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260507193239-77b56516dbb5/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260508165100-6557307c3c98 h1:nQpzdmxK2UG6XN9FmwWWxWNso8xU/fQ6kpt2iSQ3LFM=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260508165100-6557307c3c98/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=


### PR DESCRIPTION
Post-Phase-C P0-bump. Bumps helianthus-ebusreg to v0.0.0-20260508165100-6557307c3c98 (post-P0 #136 squash 6557307c).

Pairs with PR #580 (P2 canonical-pair alias on scan completion): P2 calls reg.AliasAddresses(companion, addr) and the live behavior is now correct (manufacturer/deviceID/serialNumber preserved across the merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)