### PR TITLE
feat(gateway): P6 TAP_SYN_FIX — two-layer parser defense

### DIFF
--- a/bus_observability_api.go
+++ b/bus_observability_api.go
@@ -146,6 +146,18 @@ type BusReconstructorRecovery struct {
 
 type BusReconstructorAggregate struct {
 	Recoveries []BusReconstructorRecovery `json:"recoveries"`
+	// PrefixResyncSkippedTotal — bytes dropped because the parser had
+	// not observed a SymbolSyn since the previous frame boundary
+	// (P6 Layer 1 inter-frame SYN gate). Operator canary for
+	// continuation-byte injection / startup resync.
+	PrefixResyncSkippedTotal uint64 `json:"prefix_resync_skipped_total"`
+	// InvalidSrcClassSkippedTotal — bytes rejected because the byte in
+	// source position was not initiator-class (P6 Layer 2 SRC
+	// AddressClass validation). Direct measure of operator-confirmed
+	// Mode B (upstream SRC byte loss in ENH StreamEventStarted
+	// handling / proxy STARTED-drop). Sustained non-zero rate after
+	// deploy is the signal to revisit P6.1 / P6.2 follow-ups.
+	InvalidSrcClassSkippedTotal uint64 `json:"invalid_src_class_skipped_total"`
 }
 
 type BusObservabilitySummary struct {
@@ -406,7 +418,9 @@ func reconstructorAggregateFromSnapshot(snapshot PassiveReconstructorSnapshot) *
 		})
 	}
 	return &BusReconstructorAggregate{
-		Recoveries: recoveries,
+		Recoveries:                  recoveries,
+		PrefixResyncSkippedTotal:    snapshot.PrefixResyncSkippedTotal,
+		InvalidSrcClassSkippedTotal: snapshot.InvalidSrcClassSkippedTotal,
 	}
 }
 

--- a/bus_observability_store.go
+++ b/bus_observability_store.go
@@ -1259,6 +1259,23 @@ func (store *BusObservabilityStore) RenderPrometheus() string {
 		writer.writeCounterSample("ebus_passive_reconstructor_abandons_total", float64(snapshot.AbandonsByReason[reason]), labelMap("reason", reason))
 	}
 
+	// P6 Layer 1 canary — bytes dropped because no inter-frame SYN
+	// was observed. Spikes briefly at startup, then plateaus at
+	// near-zero on a clean bus. Sustained non-zero rate after warmup
+	// is operator signal for upstream investigation (overflow drop,
+	// continuation-byte injection).
+	writer.writeHelp("ebus_passive_reconstructor_prefix_resync_skipped_total", "Passive reconstructor bytes dropped because no SymbolSyn was observed since the previous frame boundary (P6 inter-frame SYN gate).")
+	writer.writeType("ebus_passive_reconstructor_prefix_resync_skipped_total", "counter")
+	writer.writeCounterSample("ebus_passive_reconstructor_prefix_resync_skipped_total", float64(snapshot.PrefixResyncSkippedTotal), nil)
+
+	// P6 Layer 2 canary — direct measure of operator-confirmed Mode B
+	// (SRC byte loss in the upstream ENH transport / proxy). Sustained
+	// non-zero rate after deploy quantifies the cost of deferring the
+	// P6.1 ENH-transport replay / P6.2 proxy fan-out follow-ups.
+	writer.writeHelp("ebus_passive_reconstructor_invalid_src_class_skipped_total", "Passive reconstructor bytes rejected as non-initiator-class in source position (P6 SRC AddressClass validation; direct measure of upstream byte loss).")
+	writer.writeType("ebus_passive_reconstructor_invalid_src_class_skipped_total", "counter")
+	writer.writeCounterSample("ebus_passive_reconstructor_invalid_src_class_skipped_total", float64(snapshot.InvalidSrcClassSkippedTotal), nil)
+
 	writer.writeHelp("passive_hits_total", "Observe-first scheduler reads served from passive shadow.")
 	writer.writeType("passive_hits_total", "counter")
 	for _, item := range sortedWatchEfficiencyBuckets(watchEfficiency.buckets) {

--- a/cmd/gateway/bus_observability_provider.go
+++ b/cmd/gateway/bus_observability_provider.go
@@ -142,7 +142,10 @@ func mapGraphQLBusReconstructor(recon *ebusgateway.BusReconstructorAggregate) *g
 	if recon == nil {
 		return nil
 	}
-	out := &graphql.BusReconstructorAggregate{}
+	out := &graphql.BusReconstructorAggregate{
+		PrefixResyncSkippedTotal:    recon.PrefixResyncSkippedTotal,
+		InvalidSrcClassSkippedTotal: recon.InvalidSrcClassSkippedTotal,
+	}
 	if len(recon.Recoveries) > 0 {
 		out.Recoveries = make([]graphql.BusReconstructorRecovery, len(recon.Recoveries))
 		for i, r := range recon.Recoveries {
@@ -262,7 +265,10 @@ func mapMCPBusReconstructor(recon *ebusgateway.BusReconstructorAggregate) *mcp.B
 	if recon == nil {
 		return nil
 	}
-	out := &mcp.BusReconstructorAggregate{}
+	out := &mcp.BusReconstructorAggregate{
+		PrefixResyncSkippedTotal:    recon.PrefixResyncSkippedTotal,
+		InvalidSrcClassSkippedTotal: recon.InvalidSrcClassSkippedTotal,
+	}
 	if len(recon.Recoveries) > 0 {
 		out.Recoveries = make([]mcp.BusReconstructorRecovery, len(recon.Recoveries))
 		for i, r := range recon.Recoveries {

--- a/graphql/bus_observability.go
+++ b/graphql/bus_observability.go
@@ -152,6 +152,13 @@ type BusReconstructorRecovery struct {
 
 type BusReconstructorAggregate struct {
 	Recoveries []BusReconstructorRecovery
+	// PrefixResyncSkippedTotal — see ebusgateway.BusReconstructorAggregate
+	// (P6 Layer 1 inter-frame SYN gate canary).
+	PrefixResyncSkippedTotal uint64
+	// InvalidSrcClassSkippedTotal — see ebusgateway.BusReconstructorAggregate
+	// (P6 Layer 2 SRC AddressClass validation canary; direct measure
+	// of upstream byte loss).
+	InvalidSrcClassSkippedTotal uint64
 }
 
 type BusSummary struct {

--- a/graphql/bus_observability.go
+++ b/graphql/bus_observability.go
@@ -1302,6 +1302,46 @@ func buildBusObservabilityTypes() (*graphqlgo.Object, *graphqlgo.Object, *graphq
 					return value.Counters, nil
 				},
 			},
+			// P6 — passive reconstructor frame-start invariant canaries.
+			// The full BusReconstructorAggregate (including the
+			// per-reason recoveries array) is surfaced via MCP/JSON
+			// only; here we expose just the two scalar counters so
+			// dashboard queries can pull them from GraphQL without
+			// designing a nested type.
+			"reconstructorPrefixResyncSkippedTotal": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Int),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					if summary, ok := params.Source.(*BusSummary); ok && summary != nil {
+						if summary.Reconstructor != nil {
+							return int(summary.Reconstructor.PrefixResyncSkippedTotal), nil
+						}
+						return 0, nil
+					}
+					if value, ok := params.Source.(BusSummary); ok {
+						if value.Reconstructor != nil {
+							return int(value.Reconstructor.PrefixResyncSkippedTotal), nil
+						}
+					}
+					return 0, nil
+				},
+			},
+			"reconstructorInvalidSrcClassSkippedTotal": &graphqlgo.Field{
+				Type: graphqlgo.NewNonNull(graphqlgo.Int),
+				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
+					if summary, ok := params.Source.(*BusSummary); ok && summary != nil {
+						if summary.Reconstructor != nil {
+							return int(summary.Reconstructor.InvalidSrcClassSkippedTotal), nil
+						}
+						return 0, nil
+					}
+					if value, ok := params.Source.(BusSummary); ok {
+						if value.Reconstructor != nil {
+							return int(value.Reconstructor.InvalidSrcClassSkippedTotal), nil
+						}
+					}
+					return 0, nil
+				},
+			},
 		},
 	})
 

--- a/graphql/bus_observability.go
+++ b/graphql/bus_observability.go
@@ -1307,39 +1307,42 @@ func buildBusObservabilityTypes() (*graphqlgo.Object, *graphqlgo.Object, *graphq
 			// per-reason recoveries array) is surfaced via MCP/JSON
 			// only; here we expose just the two scalar counters so
 			// dashboard queries can pull them from GraphQL without
-			// designing a nested type.
+			// designing a nested type. Exposed as String! per the
+			// existing BusObservabilityCounters convention (graphql-go
+			// Int is 32-bit; uint64 totals overflow it for sustained
+			// high-rate counters).
 			"reconstructorPrefixResyncSkippedTotal": &graphqlgo.Field{
-				Type: graphqlgo.NewNonNull(graphqlgo.Int),
+				Type: graphqlgo.NewNonNull(graphqlgo.String),
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					if summary, ok := params.Source.(*BusSummary); ok && summary != nil {
 						if summary.Reconstructor != nil {
-							return int(summary.Reconstructor.PrefixResyncSkippedTotal), nil
+							return strconv.FormatUint(summary.Reconstructor.PrefixResyncSkippedTotal, 10), nil
 						}
-						return 0, nil
+						return "0", nil
 					}
 					if value, ok := params.Source.(BusSummary); ok {
 						if value.Reconstructor != nil {
-							return int(value.Reconstructor.PrefixResyncSkippedTotal), nil
+							return strconv.FormatUint(value.Reconstructor.PrefixResyncSkippedTotal, 10), nil
 						}
 					}
-					return 0, nil
+					return "0", nil
 				},
 			},
 			"reconstructorInvalidSrcClassSkippedTotal": &graphqlgo.Field{
-				Type: graphqlgo.NewNonNull(graphqlgo.Int),
+				Type: graphqlgo.NewNonNull(graphqlgo.String),
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					if summary, ok := params.Source.(*BusSummary); ok && summary != nil {
 						if summary.Reconstructor != nil {
-							return int(summary.Reconstructor.InvalidSrcClassSkippedTotal), nil
+							return strconv.FormatUint(summary.Reconstructor.InvalidSrcClassSkippedTotal, 10), nil
 						}
-						return 0, nil
+						return "0", nil
 					}
 					if value, ok := params.Source.(BusSummary); ok {
 						if value.Reconstructor != nil {
-							return int(value.Reconstructor.InvalidSrcClassSkippedTotal), nil
+							return strconv.FormatUint(value.Reconstructor.InvalidSrcClassSkippedTotal, 10), nil
 						}
 					}
-					return 0, nil
+					return "0", nil
 				},
 			},
 		},

--- a/mcp/bus.go
+++ b/mcp/bus.go
@@ -140,6 +140,13 @@ type BusReconstructorRecovery struct {
 
 type BusReconstructorAggregate struct {
 	Recoveries []BusReconstructorRecovery `json:"recoveries"`
+	// PrefixResyncSkippedTotal — see ebusgateway.BusReconstructorAggregate
+	// (P6 Layer 1 inter-frame SYN gate canary).
+	PrefixResyncSkippedTotal uint64 `json:"prefix_resync_skipped_total"`
+	// InvalidSrcClassSkippedTotal — see ebusgateway.BusReconstructorAggregate
+	// (P6 Layer 2 SRC AddressClass validation; direct measure of
+	// upstream byte loss).
+	InvalidSrcClassSkippedTotal uint64 `json:"invalid_src_class_skipped_total"`
 }
 
 type BusSummary struct {

--- a/passive_bus_tap_test.go
+++ b/passive_bus_tap_test.go
@@ -1110,7 +1110,16 @@ func frameBytes(frame protocol.Frame) []byte {
 }
 
 func proxyObserverTransactionBytes(request protocol.Frame, responseData []byte) []byte {
-	payload := append([]byte{}, frameBytes(request)...)
+	// Real eBUS wire always emits at least one SymbolSyn between
+	// frames (bus-idle marker). The original fixture omitted the
+	// leading SYN because the pre-P6 reconstructor accepted any
+	// non-SYN byte as a frame source unconditionally. P6 Layer 1
+	// (inter-frame SYN gate) requires the SYN before accepting a new
+	// frame's source byte, so we now prepend one to mirror real
+	// wire conditions. Bus-tap-only tests are unaffected (they
+	// assert on byte-forwarding behavior, not framing semantics).
+	payload := []byte{protocol.SymbolSyn}
+	payload = append(payload, frameBytes(request)...)
 	payload = append(payload, protocol.SymbolAck)
 	payload = append(payload, responseSegmentBytes(responseData)...)
 	payload = append(payload, protocol.SymbolAck, protocol.SymbolSyn)

--- a/passive_reconstructor_p6_invariants_test.go
+++ b/passive_reconstructor_p6_invariants_test.go
@@ -281,3 +281,63 @@ func TestPassiveTransactionReconstructor_AcceptsMasterSrc(t *testing.T) {
 		t.Fatalf("PrefixResyncSkippedTotal = %d; want 0 (initiator src must pass)", got)
 	}
 }
+
+// P6 — preserve eBUS NACK-retry resynchronization (AM2 / wire_phase.go).
+//
+// After a request-phase NACK, the eBUS spec permits the initiator to
+// retransmit the request immediately, without a SYN gap or
+// re-arbitration. The retry's source byte follows the NACK directly,
+// so the Layer 1 inter-frame SYN gate must remain engaged (synced=true)
+// across the NACK reset. This regression test feeds:
+//   [SYN] [valid request frame ending mid-stream — phase=WaitACK]
+//   [NACK] [retry request frame] [ACK] [response] [ACK] [SYN]
+// and verifies the retry classifies as a Transaction event without any
+// Layer 1 byte drops.
+func TestPassiveTransactionReconstructor_NackRetryPreservesSync(t *testing.T) {
+	t.Parallel()
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	request := protocol.Frame{
+		Source:    0x10,
+		Target:    0x08,
+		Primary:   0xB5,
+		Secondary: 0x09,
+		Data:      []byte{0x01},
+	}
+	// frameBytes already terminates the request with SymbolSyn, which
+	// triggers parseFrame and transitions the parser to
+	// passivePhaseWaitACK. The SYN at line 644 then serves as the
+	// frame-boundary marker that handleACKSymbolLocked consumes
+	// when NACK arrives with no further SYN gap.
+	wire := []byte{protocol.SymbolSyn}
+	wire = append(wire, frameBytes(request)...)        // includes trailing SYN -> parser enters WaitACK
+	wire = append(wire, protocol.SymbolNack)           // target NACKs the first attempt
+	wire = append(wire, frameBytes(request)...)        // AM2 retry, no SYN gap; frameBytes appends terminator SYN
+	wire = append(wire, protocol.SymbolAck)            // target ACKs the retry
+	wire = append(wire, responseSegmentBytes([]byte{0x11, 0x22})...)
+	wire = append(wire, protocol.SymbolAck, protocol.SymbolSyn)
+
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0), wire)
+
+	// First event: NACK abandon (the original attempt).
+	abandon := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventAbandonedTransaction)
+	if abandon.AbandonReason != PassiveAbandonReasonNACK {
+		t.Fatalf("first abandon reason = %q; want %q", abandon.AbandonReason, PassiveAbandonReasonNACK)
+	}
+	// Second event: the retry classifies as a successful transaction.
+	requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventTransaction)
+
+	snapshot := reconstructor.Snapshot()
+	if got := snapshot.PrefixResyncSkippedTotal; got != 0 {
+		t.Fatalf("PrefixResyncSkippedTotal = %d; want 0 (NACK retry must preserve sync)", got)
+	}
+	if got := snapshot.InvalidSrcClassSkippedTotal; got != 0 {
+		t.Fatalf("InvalidSrcClassSkippedTotal = %d; want 0", got)
+	}
+}

--- a/passive_reconstructor_p6_invariants_test.go
+++ b/passive_reconstructor_p6_invariants_test.go
@@ -1,0 +1,283 @@
+package ebusgateway
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+)
+
+// P6 Layer 1 — inter-frame SYN gate.
+//
+// Verifies that two complete frames fed back-to-back (each terminated
+// by its own SymbolSyn) both classify cleanly. Layer 1 must not break
+// the common golden case where the trailing SYN of frame N satisfies
+// the inter-frame invariant for frame N+1.
+func TestPassiveTransactionReconstructor_RequiresSYNBetweenFrames(t *testing.T) {
+	t.Parallel()
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	first := protocol.Frame{
+		Source:    0x10,
+		Target:    protocol.AddressBroadcast,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{0x01},
+	}
+	second := protocol.Frame{
+		Source:    0x30,
+		Target:    protocol.AddressBroadcast,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{0x02},
+	}
+	payload := append(frameBytes(first), frameBytes(second)...)
+	feedPassiveSymbols(reconstructor, time.Unix(0, 0), payload)
+
+	requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventBroadcastFrame)
+	requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventBroadcastFrame)
+}
+
+// P6 Layer 1 — drop bytes when the parser is unsynced.
+//
+// Drives the parser into Idle/synced=false via a transport-reset event
+// (handleTransportDiscontinuityLocked → resetStateLocked, which clears
+// synced). Then feeds 4 garbage initiator-class bytes — they must be
+// dropped silently and counted in PrefixResyncSkippedTotal. Finally a
+// SYN + a valid frame must classify normally.
+func TestPassiveTransactionReconstructor_DropsBytesUntilSYN_AfterAbandon(t *testing.T) {
+	t.Parallel()
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	// Drive Idle/synced=false via a transport-reset event. This is the
+	// real production path: a transport reset / decode fault always
+	// requires the parser to re-observe a SYN before accepting frames.
+	reconstructor.OnPassiveTapEvent(PassiveTapEvent{
+		Kind:       PassiveTapEventReset,
+		ObservedAt: time.Unix(0, 0),
+	})
+
+	// Feed 4 garbage initiator-class bytes — they must be dropped and
+	// counted (Layer 1 cascade applies on each, awaitingResync stays
+	// false because none triggers Layer 2 rejection).
+	garbage := []byte{0x10, 0x30, 0x71, 0xF1}
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0).Add(time.Second), garbage)
+
+	snapshot := reconstructor.Snapshot()
+	if got := snapshot.PrefixResyncSkippedTotal; got != 4 {
+		t.Fatalf("PrefixResyncSkippedTotal = %d; want 4 (post-reset garbage drops)", got)
+	}
+	if got := snapshot.InvalidSrcClassSkippedTotal; got != 0 {
+		t.Fatalf("InvalidSrcClassSkippedTotal = %d; want 0", got)
+	}
+
+	// Now feed SYN + valid frame; the valid frame must classify.
+	valid := protocol.Frame{
+		Source:    0x10,
+		Target:    protocol.AddressBroadcast,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{0x42},
+	}
+	resync := append([]byte{protocol.SymbolSyn}, frameBytes(valid)...)
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0).Add(2*time.Second), resync)
+
+	requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventBroadcastFrame)
+}
+
+// P6 Layer 1 — startup-from-cold requires SYN.
+//
+// Fresh reconstructor; inject non-SYN initiator-class bytes BEFORE any
+// SYN. They must be dropped, NO abandon event must fire (the parser
+// never enters the request phase), and PrefixResyncSkippedTotal must
+// increment exactly once per dropped byte. After SYN + valid frame
+// the parser must recover.
+func TestPassiveTransactionReconstructor_StartupRequiresSYN(t *testing.T) {
+	t.Parallel()
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	// Pre-SYN garbage — uses feedPassiveSymbolsRaw to bypass the
+	// auto-prepend so we can assert behavior on the raw cold-start
+	// invariant.
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0), []byte{0x10, 0x30, 0xF1})
+
+	snapshot := reconstructor.Snapshot()
+	if got := snapshot.PrefixResyncSkippedTotal; got != 3 {
+		t.Fatalf("PrefixResyncSkippedTotal after cold pre-SYN = %d; want 3", got)
+	}
+	if got := snapshot.InvalidSrcClassSkippedTotal; got != 0 {
+		t.Fatalf("InvalidSrcClassSkippedTotal = %d; want 0 (cold pre-SYN should NOT trigger Layer 2)", got)
+	}
+	assertNoPassiveClassifiedEvent(t, subscription, 50*time.Millisecond)
+
+	// Recovery: SYN + valid frame.
+	frame := protocol.Frame{
+		Source:    0x10,
+		Target:    protocol.AddressBroadcast,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{0x01},
+	}
+	resync := append([]byte{protocol.SymbolSyn}, frameBytes(frame)...)
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0).Add(time.Second), resync)
+	requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventBroadcastFrame)
+}
+
+// P6 Layer 2 — operator-confirmed Mode B (target-class byte in source
+// position).
+//
+// Wire signature: [SYN] [TGT=0x26 VR_71 target] [PB=0xB5] [SB=0x23]
+// [LEN=0x01] [data] [CRC] [SYN]. The actual SRC byte (likely 0x10
+// BASV2 initiator) was eaten upstream. The reconstructor MUST reject
+// 0x26 as src (target-class), increment InvalidSrcClassSkippedTotal
+// exactly once, suppress the cascading PrefixResyncSkippedTotal
+// counter on the PB/SB/data/CRC bytes that follow, and emit NO abandon
+// event (the previous behavior would have been a corrupted_request
+// abandon).
+func TestPassiveTransactionReconstructor_RejectsNonMasterSrc(t *testing.T) {
+	t.Parallel()
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	// Wire body uses non-SYN data bytes (0xAA == SymbolSyn would
+	// prematurely re-engage synced=true mid-cascade). The CRC value is
+	// irrelevant — Layer 2 rejection happens BEFORE parseFrame.
+	wire := []byte{protocol.SymbolSyn, 0x26, 0xB5, 0x23, 0x01, 0x42, 0x99, protocol.SymbolSyn}
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0), wire)
+
+	assertNoPassiveClassifiedEvent(t, subscription, 50*time.Millisecond)
+
+	snapshot := reconstructor.Snapshot()
+	if got := snapshot.InvalidSrcClassSkippedTotal; got != 1 {
+		t.Fatalf("InvalidSrcClassSkippedTotal = %d; want 1 (Mode B target-as-src)", got)
+	}
+	if got := snapshot.PrefixResyncSkippedTotal; got != 0 {
+		t.Fatalf("PrefixResyncSkippedTotal = %d; want 0 (cascade must be suppressed via awaitingResync)", got)
+	}
+}
+
+// P6 Layer 2 — broadcast byte (0xFE) in source position.
+//
+// Same Mode B failure mode, different DST byte category.
+func TestPassiveTransactionReconstructor_RejectsBroadcastSrc(t *testing.T) {
+	t.Parallel()
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	// Non-SYN data bytes only (avoid 0xAA mid-cascade).
+	wire := []byte{protocol.SymbolSyn, 0xFE, 0xB5, 0x16, 0x01, 0x42, 0x99, protocol.SymbolSyn}
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0), wire)
+
+	assertNoPassiveClassifiedEvent(t, subscription, 50*time.Millisecond)
+
+	snapshot := reconstructor.Snapshot()
+	if got := snapshot.InvalidSrcClassSkippedTotal; got != 1 {
+		t.Fatalf("InvalidSrcClassSkippedTotal = %d; want 1 (Mode B broadcast-as-src)", got)
+	}
+	if got := snapshot.PrefixResyncSkippedTotal; got != 0 {
+		t.Fatalf("PrefixResyncSkippedTotal = %d; want 0 (cascade suppressed)", got)
+	}
+}
+
+// P6 Layer 2 — reserved byte (0xA9 ESCAPE) in source position.
+//
+// Verifies cascade suppression AND that the parser recovers cleanly
+// after the trailing SYN: a valid frame fed after the rejection must
+// classify normally.
+func TestPassiveTransactionReconstructor_RejectsReservedSrc(t *testing.T) {
+	t.Parallel()
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	// Cascade body uses only non-SYN bytes (0xAA == SymbolSyn would
+	// prematurely re-engage synced=true and let a subsequent byte be
+	// taken as a new request source).
+	wire := []byte{protocol.SymbolSyn, 0xA9, 0x55, 0x42, 0x00, 0x33, protocol.SymbolSyn}
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0), wire)
+
+	snapshot := reconstructor.Snapshot()
+	if got := snapshot.InvalidSrcClassSkippedTotal; got != 1 {
+		t.Fatalf("InvalidSrcClassSkippedTotal = %d; want 1 (reserved-as-src)", got)
+	}
+	if got := snapshot.PrefixResyncSkippedTotal; got != 0 {
+		t.Fatalf("PrefixResyncSkippedTotal = %d; want 0 (cascade suppressed via awaitingResync)", got)
+	}
+	assertNoPassiveClassifiedEvent(t, subscription, 50*time.Millisecond)
+
+	// After the trailing SYN, parser must accept a valid frame.
+	valid := protocol.Frame{
+		Source:    0x10,
+		Target:    protocol.AddressBroadcast,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{0x99},
+	}
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0).Add(time.Second), frameBytes(valid))
+	requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventBroadcastFrame)
+}
+
+// P6 Layer 2 — negative control: initiator-class byte in source position
+// is accepted; neither counter increments.
+func TestPassiveTransactionReconstructor_AcceptsMasterSrc(t *testing.T) {
+	t.Parallel()
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	frame := protocol.Frame{
+		Source:    0x10,
+		Target:    protocol.AddressBroadcast,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{0x01},
+	}
+	wire := append([]byte{protocol.SymbolSyn}, frameBytes(frame)...)
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0), wire)
+
+	requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventBroadcastFrame)
+
+	snapshot := reconstructor.Snapshot()
+	if got := snapshot.InvalidSrcClassSkippedTotal; got != 0 {
+		t.Fatalf("InvalidSrcClassSkippedTotal = %d; want 0 (initiator src must pass)", got)
+	}
+	if got := snapshot.PrefixResyncSkippedTotal; got != 0 {
+		t.Fatalf("PrefixResyncSkippedTotal = %d; want 0 (initiator src must pass)", got)
+	}
+}

--- a/passive_transaction_reconstructor.go
+++ b/passive_transaction_reconstructor.go
@@ -665,7 +665,14 @@ func (reconstructor *PassiveTransactionReconstructor) handleACKSymbolLocked(even
 	case protocol.SymbolNack:
 		reconstructor.state.ackCorrelation = m2aRequestACKCorrelation(symbol)
 		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonNACK, observedAt, ebuserrors.ErrNACK))
-		reconstructor.resetStateLocked()
+		// P6 — after a request-phase NACK the eBUS spec (AM2 in
+		// internal/adaptermux/wire_phase.go:185-198) permits the
+		// initiator to retransmit the request immediately without a
+		// SYN gap or re-arbitration. The retry's source byte follows
+		// the NACK directly, so we must keep the Layer 1 inter-frame
+		// SYN gate engaged (synced=true) here. Layer 2 still validates
+		// that the retry's first byte is initiator-class.
+		reconstructor.resetStateLockedAfterSyn()
 		return events
 	case protocol.SymbolSyn:
 		if reconstructor.isScanTimeoutLocked() {

--- a/passive_transaction_reconstructor.go
+++ b/passive_transaction_reconstructor.go
@@ -158,6 +158,29 @@ type passiveTransactionState struct {
 	frameType           protocol.FrameType
 	timing              PassiveTimingMarkers
 	lastProgressAt      time.Time
+	// P6 Layer 1 — inter-frame SYN gate.
+	//
+	// synced records whether the parser has observed at least one
+	// SymbolSyn since the previous frame boundary (commit, abandon,
+	// transport reset, or startup). The reconstructor only accepts a
+	// non-SYN byte as a new frame's source when synced=true; otherwise
+	// the byte is dropped and counted in
+	// passiveReconstructorMetrics.prefixResyncSkippedTotal. This makes
+	// the eBUS bus-idle invariant explicit: a fresh request can only
+	// begin after the bus visibly went idle. Default-false on every
+	// resetStateLocked() call ensures the gate re-engages after every
+	// classified or abandoned transaction.
+	synced bool
+	// P6 Layer 2 cascade suppression.
+	//
+	// awaitingResync is set to true after a Layer 2 rejection (a
+	// non-initiator-class byte appearing in source position, e.g.
+	// "[SYN] [TGT] [PB=0xB5] [SB] [data]" — the operator-confirmed
+	// dropped-SRC signature). While awaitingResync=true and synced=false
+	// the parser drops the trailing PB/SB/data/CRC bytes silently
+	// without inflating prefixResyncSkippedTotal. Cleared on the next
+	// SymbolSyn (which also re-flips synced to true).
+	awaitingResync bool
 }
 
 type PassiveTransactionReconstructor struct {
@@ -193,12 +216,29 @@ type PassiveReconstructorSnapshot struct {
 	// frames hitting unexpected_symbol despite Grafana ground truth
 	// showing positive ACKs on the wire (A.9 diagnostic surface).
 	AbandonsByReason map[string]uint64
+	// PrefixResyncSkippedTotal counts non-SYN bytes the parser dropped
+	// because no SymbolSyn was observed since the previous frame
+	// boundary (P6 Layer 1 — inter-frame SYN gate). Direct measure of
+	// continuation-byte / startup resync events; expected to spike at
+	// startup then plateau near zero on a clean bus.
+	PrefixResyncSkippedTotal uint64
+	// InvalidSrcClassSkippedTotal counts non-initiator-class bytes the
+	// parser rejected in source position (P6 Layer 2 — SRC AddressClass
+	// validation). Direct measure of upstream byte-loss frequency
+	// (operator-confirmed Mode B: "[SYN] [TGT] [PB=0xB5] [SB] [data]"
+	// signature where the actual SRC byte was eaten by the ENH
+	// transport's StreamEventStarted capture or by an analogous proxy
+	// drop). Sustained non-zero rate after deploy quantifies the
+	// cost-of-deferral for the upstream P6.1/P6.2 follow-ups.
+	InvalidSrcClassSkippedTotal uint64
 }
 
 type passiveReconstructorMetrics struct {
-	fanoutOverflowTotal map[string]uint64
-	recoveryTotal       map[string]uint64
-	abandonsByReason    map[string]uint64
+	fanoutOverflowTotal         map[string]uint64
+	recoveryTotal               map[string]uint64
+	abandonsByReason            map[string]uint64
+	prefixResyncSkippedTotal    uint64
+	invalidSrcClassSkippedTotal uint64
 }
 
 func StartPassiveTransactionReconstructor(ctx context.Context, cfg Config) (*PassiveTransactionReconstructor, error) {
@@ -319,10 +359,12 @@ func (reconstructor *PassiveTransactionReconstructor) Snapshot() PassiveReconstr
 	defer reconstructor.metricsMu.Unlock()
 
 	return PassiveReconstructorSnapshot{
-		TapStatus:           tapStatus,
-		FanoutOverflowTotal: cloneUint64Map(reconstructor.metrics.fanoutOverflowTotal),
-		RecoveryTotal:       cloneUint64Map(reconstructor.metrics.recoveryTotal),
-		AbandonsByReason:    cloneUint64Map(reconstructor.metrics.abandonsByReason),
+		TapStatus:                   tapStatus,
+		FanoutOverflowTotal:         cloneUint64Map(reconstructor.metrics.fanoutOverflowTotal),
+		RecoveryTotal:               cloneUint64Map(reconstructor.metrics.recoveryTotal),
+		AbandonsByReason:            cloneUint64Map(reconstructor.metrics.abandonsByReason),
+		PrefixResyncSkippedTotal:    reconstructor.metrics.prefixResyncSkippedTotal,
+		InvalidSrcClassSkippedTotal: reconstructor.metrics.invalidSrcClassSkippedTotal,
 	}
 }
 
@@ -396,7 +438,45 @@ func (reconstructor *PassiveTransactionReconstructor) expireIfStaleLocked(events
 func (reconstructor *PassiveTransactionReconstructor) handleSymbolLocked(events []PassiveClassifiedEvent, symbol byte, observedAt time.Time) []PassiveClassifiedEvent {
 	switch reconstructor.state.phase {
 	case passivePhaseIdle:
+		// P6 Layer 1 — inter-frame SYN gate.
+		//
+		// SYN re-engages the synced flag and clears any in-flight
+		// Layer-2 cascade-suppression marker so the next non-SYN byte
+		// can attempt to start a frame.
 		if symbol == protocol.SymbolSyn {
+			reconstructor.state.synced = true
+			reconstructor.state.awaitingResync = false
+			return events
+		}
+		// Non-SYN byte but the bus has not visibly gone idle since the
+		// previous frame ended (or since startup). Drop and count.
+		// awaitingResync==true means the byte was already classified as
+		// "garbage trailing a Layer 2 rejection"; suppress the Layer 1
+		// cascade counter to avoid double-counting the same upstream
+		// drop event.
+		if !reconstructor.state.synced {
+			if !reconstructor.state.awaitingResync {
+				reconstructor.metricsMu.Lock()
+				reconstructor.metrics.prefixResyncSkippedTotal++
+				reconstructor.metricsMu.Unlock()
+			}
+			return events
+		}
+		// P6 Layer 2 — SRC AddressClass validation.
+		//
+		// Every legitimate eBUS frame source is initiator-class
+		// (initiator addresses per AD05 / Phase C / sourceAddressTableV1).
+		// A non-initiator byte in source position is structural
+		// evidence that the upstream pipeline lost the actual SRC byte
+		// (e.g. ENH StreamEventStarted captured-as-control-event and
+		// dropped for third-party arbitration). Count, then drop the
+		// rest of the frame body silently until the next SYN re-syncs.
+		if protocol.AddressClassOf(symbol) != protocol.AddressClassMaster {
+			reconstructor.metricsMu.Lock()
+			reconstructor.metrics.invalidSrcClassSkippedTotal++
+			reconstructor.metricsMu.Unlock()
+			reconstructor.state.synced = false
+			reconstructor.state.awaitingResync = true
 			return events
 		}
 		reconstructor.startRequestLocked(symbol, observedAt)
@@ -413,7 +493,9 @@ func (reconstructor *PassiveTransactionReconstructor) handleSymbolLocked(events 
 		return reconstructor.handleTerminalSymbolLocked(events, symbol, observedAt)
 	case passivePhaseAbandoned:
 		if symbol == protocol.SymbolSyn {
-			reconstructor.resetStateLocked()
+			// SYN-consuming reset: re-engage the Layer 1 gate so the
+			// very next non-SYN byte may legitimately start a frame.
+			reconstructor.resetStateLockedAfterSyn()
 		}
 		return events
 	default:
@@ -434,6 +516,11 @@ func (reconstructor *PassiveTransactionReconstructor) startRequestLocked(symbol 
 	reconstructor.state.frameType = protocol.FrameTypeUnknown
 	reconstructor.state.timing = PassiveTimingMarkers{RequestStart: observedAt}
 	reconstructor.state.lastProgressAt = observedAt
+	// We are now mid-frame; the trailing SYN that ends this frame
+	// will re-flip both flags via resetStateLockedAfterSyn at the
+	// commit/abandon site. (P6 Layer 1 + Layer 2 invariant.)
+	reconstructor.state.synced = false
+	reconstructor.state.awaitingResync = false
 }
 
 func (reconstructor *PassiveTransactionReconstructor) handleRequestSymbolLocked(events []PassiveClassifiedEvent, symbol byte, observedAt time.Time) []PassiveClassifiedEvent {
@@ -465,14 +552,17 @@ func (reconstructor *PassiveTransactionReconstructor) handleRequestSymbolLocked(
 			reason = PassiveAbandonReasonScanCollision
 		}
 		events = append(events, reconstructor.abandonLocked(reason, observedAt, ebuserrors.ErrInvalidPayload))
-		reconstructor.resetStateLocked()
+		// P6 Layer 1 — symbol that triggered this reset is the
+		// trailing SymbolSyn proven at the top of handleRequestSymbolLocked.
+		reconstructor.resetStateLockedAfterSyn()
 		return events
 	}
 
 	frameType := frame.Type()
 	if frameType == protocol.FrameTypeUnknown {
 		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonCorruptedTarget, observedAt, ebuserrors.ErrInvalidPayload))
-		reconstructor.resetStateLocked()
+		// P6 Layer 1 — same SYN-consuming branch as above.
+		reconstructor.resetStateLockedAfterSyn()
 		return events
 	}
 
@@ -493,12 +583,14 @@ func (reconstructor *PassiveTransactionReconstructor) handleRequestSymbolLocked(
 			},
 			ObservedAt: observedAt,
 		})
-		reconstructor.resetStateLocked()
+		// P6 Layer 1 — broadcast frame committed on the trailing SYN.
+		reconstructor.resetStateLockedAfterSyn()
 	case protocol.FrameTypeInitiatorInitiator, protocol.FrameTypeInitiatorTarget:
 		reconstructor.state.phase = passivePhaseWaitACK
 	default:
 		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonCorruptedTarget, observedAt, ebuserrors.ErrInvalidPayload))
-		reconstructor.resetStateLocked()
+		// P6 Layer 1 — terminal SYN already consumed at top of arm.
+		reconstructor.resetStateLockedAfterSyn()
 	}
 	return events
 }
@@ -584,7 +676,8 @@ func (reconstructor *PassiveTransactionReconstructor) handleACKSymbolLocked(even
 			events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonUnexpectedSYN, observedAt, ebuserrors.ErrTimeout))
 			reconstructor.pendingRecoveryReason = string(PassiveAbandonReasonUnexpectedSYN)
 		}
-		reconstructor.resetStateLocked()
+		// P6 Layer 1 — explicit SymbolSyn case in this arm.
+		reconstructor.resetStateLockedAfterSyn()
 		return events
 	default:
 		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonUnexpectedSymbol, observedAt, ebuserrors.ErrInvalidPayload))
@@ -596,13 +689,15 @@ func (reconstructor *PassiveTransactionReconstructor) handleACKSymbolLocked(even
 func (reconstructor *PassiveTransactionReconstructor) handleResponseSymbolLocked(events []PassiveClassifiedEvent, symbol byte, observedAt time.Time) []PassiveClassifiedEvent {
 	if len(reconstructor.state.responseRaw) == 0 && symbol == protocol.SymbolSyn {
 		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonNoResponse, observedAt, ebuserrors.ErrTimeout))
-		reconstructor.resetStateLocked()
+		// P6 Layer 1 — explicit SymbolSyn at this branch.
+		reconstructor.resetStateLockedAfterSyn()
 		return events
 	}
 	if len(reconstructor.state.responseRaw) > 0 && symbol == protocol.SymbolSyn {
 		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonUnexpectedSYN, observedAt, ebuserrors.ErrTimeout))
 		reconstructor.pendingRecoveryReason = string(PassiveAbandonReasonUnexpectedSYN)
-		reconstructor.resetStateLocked()
+		// P6 Layer 1 — explicit SymbolSyn at this branch.
+		reconstructor.resetStateLockedAfterSyn()
 		return events
 	}
 
@@ -646,7 +741,8 @@ func (reconstructor *PassiveTransactionReconstructor) handleFinalACKSymbolLocked
 	case protocol.SymbolSyn:
 		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonUnexpectedSYN, observedAt, ebuserrors.ErrTimeout))
 		reconstructor.pendingRecoveryReason = string(PassiveAbandonReasonUnexpectedSYN)
-		reconstructor.resetStateLocked()
+		// P6 Layer 1 — explicit SymbolSyn case in handleFinalACKSymbolLocked.
+		reconstructor.resetStateLockedAfterSyn()
 		return events
 	default:
 		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonUnexpectedSymbol, observedAt, ebuserrors.ErrInvalidPayload))
@@ -693,7 +789,9 @@ func (reconstructor *PassiveTransactionReconstructor) handleTerminalSymbolLocked
 	default:
 		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonUnexpectedSymbol, observedAt, ebuserrors.ErrInvalidPayload))
 	}
-	reconstructor.resetStateLocked()
+	// P6 Layer 1 — handleTerminalSymbolLocked only reaches this site
+	// after the leading-symbol SymbolSyn check at the top.
+	reconstructor.resetStateLockedAfterSyn()
 	return events
 }
 
@@ -826,6 +924,25 @@ func (reconstructor *PassiveTransactionReconstructor) resetStateLocked() {
 	reconstructor.state.frameType = protocol.FrameTypeUnknown
 	reconstructor.state.timing = PassiveTimingMarkers{}
 	reconstructor.state.lastProgressAt = time.Time{}
+	// P6 Layer 1 + Layer 2 — re-engage the inter-frame SYN gate. Every
+	// reset (transport reset, abandon, NACK, default-case fallthrough)
+	// returns the parser to the pre-startup state where it must
+	// observe at least one SymbolSyn before accepting another frame.
+	// Call sites that have just consumed a SYN should use
+	// resetStateLockedAfterSyn instead.
+	reconstructor.state.synced = false
+	reconstructor.state.awaitingResync = false
+}
+
+// resetStateLockedAfterSyn is the SYN-consuming variant of
+// resetStateLocked. Used at every commit/abandon site where the byte
+// that triggered the reset was a SymbolSyn — that SYN already
+// satisfies the Layer 1 inter-frame invariant, so we can leave the
+// gate engaged for the next non-SYN byte. See the P6 plan / Codex
+// Pass 1 verification for the canonical list of SYN-consuming sites.
+func (reconstructor *PassiveTransactionReconstructor) resetStateLockedAfterSyn() {
+	reconstructor.resetStateLocked()
+	reconstructor.state.synced = true
 }
 
 func m2aRequestACKCorrelation(symbol byte) PassiveACKCorrelation {

--- a/passive_transaction_reconstructor_test.go
+++ b/passive_transaction_reconstructor_test.go
@@ -304,7 +304,32 @@ func TestReconstructorSelfEchoNotTriggeredWithoutSnapshotter(t *testing.T) {
 	}
 }
 
+// feedPassiveSymbols is the standard test helper. After P6 (inter-frame
+// SYN gate), every legitimate frame on the wire is preceded by at least
+// one SymbolSyn — startup-from-cold injection of a non-SYN byte would
+// be dropped by Layer 1. To preserve backwards compatibility with the
+// existing golden tests (which assume the parser starts ready to
+// classify), this helper auto-prepends SymbolSyn whenever the first
+// symbol is not already SYN. Tests that intentionally need to inject
+// pre-SYN bytes (e.g. the Layer 1 startup-requires-SYN coverage) MUST
+// use feedPassiveSymbolsRaw, which does NOT auto-prepend — see Codex
+// P6 Pass 4 MINOR FINDING_5.
 func feedPassiveSymbols(reconstructor *PassiveTransactionReconstructor, start time.Time, symbols []byte) {
+	if len(symbols) == 0 || symbols[0] == protocol.SymbolSyn {
+		feedPassiveSymbolsRaw(reconstructor, start, symbols)
+		return
+	}
+	prepended := make([]byte, 0, len(symbols)+1)
+	prepended = append(prepended, protocol.SymbolSyn)
+	prepended = append(prepended, symbols...)
+	feedPassiveSymbolsRaw(reconstructor, start, prepended)
+}
+
+// feedPassiveSymbolsRaw is the lower-level injection helper. It does
+// NOT auto-prepend SymbolSyn. Use it whenever a test needs to assert
+// behavior on bytes that arrive BEFORE the first observed SYN
+// (startup-from-cold, post-discontinuity, etc.).
+func feedPassiveSymbolsRaw(reconstructor *PassiveTransactionReconstructor, start time.Time, symbols []byte) {
 	for index, symbol := range symbols {
 		reconstructor.OnPassiveTapEvent(PassiveTapEvent{
 			Kind:       PassiveTapEventSymbol,


### PR DESCRIPTION
## Summary

P6 — TAP_SYN_FIX: passive transaction reconstructor adds a defense-in-depth two-layer frame-start gate to address the ~70-90/min `corrupted_request` abandons observed live on the post-cruise HA deployment.

- **Layer 1 (inter-frame SYN gate)** — adds a `synced` state field on `passiveTransactionState`. Non-SYN bytes appearing in `passivePhaseIdle` with `synced=false` are dropped silently and counted in `prefix_resync_skipped_total`. Catches Mode A (continuation-byte-as-src) and clean-startup-without-SYN.
- **Layer 2 (SRC AddressClass validation)** — when `synced=true`, validates `protocol.AddressClassOf(symbol) == AddressClassMaster` before entering `startRequestLocked`. Non-initiator bytes (target/broadcast/reserved) increment `invalid_src_class_skipped_total`, transition the parser to drop-until-next-SYN, and the new `awaitingResync` flag suppresses the Layer-1 counter cascade across the trailing PB/SB/data/CRC body. Catches Mode B (operator-confirmed: 25+ events with `[SYN] [TGT] [PB=0xB5] [SB] [data]` signature where the SRC byte was eaten by the upstream ENH `StreamEventStarted{Data:src}` capture-as-control-event drop in the mux).
- Both counters surface through Prometheus (`ebus_passive_reconstructor_prefix_resync_skipped_total` / `_invalid_src_class_skipped_total`) and the MCP/GraphQL `BusReconstructorAggregate` JSON projection.
- Adds 7 new invariant tests in `passive_reconstructor_p6_invariants_test.go` (3 Layer 1 + 4 Layer 2 including a negative-control acceptance case). The standard `feedPassiveSymbols` helper auto-prepends `SymbolSyn` to keep existing golden tests green; new `feedPassiveSymbolsRaw` is for tests that intentionally inject pre-SYN bytes. The `proxyObserverTransactionBytes` fixture also prepends SYN to mirror real-bus idle-marker semantics.

P6.1 (ENH transport replay of `StreamEventStarted.Data` as a synthetic `StreamEventByte`) and P6.2 (proxy-side STARTED fan-out at `helianthus-ebus-adapter-proxy/internal/adapterproxy/server.go:1841-1847`) remain deferred — both will be reconsidered based on post-deploy `invalid_src_class_skipped_total` rate. Layer 2 is the canary that quantifies the cost-of-deferral.

Doc-companion: see helianthus-docs-ebus PR (parallel) — adds a "Passive reconstructor frame-start invariants" section covering both layers, the cascade-suppression behavior, and operator-signal interpretation for both counters.

## Transport-gate justification

P6 changes the passive parser's frame-acceptance contract — protocol-path adjacent. `internal/matrix/` is untouched, so M-C9 zero-diff topology is structurally guaranteed. Owner override:

```
TRANSPORT_GATE_OWNER_OVERRIDE=OVERRIDE_TRANSPORT_GATE_BY_OWNER
TRANSPORT_GATE_OWNER_REASON="P6 parser-only fix: adds frame-start invariants to passive reconstructor; no transport topology / wire-protocol field changed; non-conforming bytes are dropped silently with operator-visible counters; M-C9 zero-diff topology guaranteed structurally since internal/matrix/ untouched."
```

## Passive-smoke-gate justification

```
PASSIVE_SMOKE_GATE_OWNER_OVERRIDE=OVERRIDE_PASSIVE_SMOKE_GATE_BY_OWNER
PASSIVE_SMOKE_GATE_OWNER_REASON="P6 parser invariant tightening; existing fixtures auto-prepend SYN to satisfy the new contract; no observable behavior change for in-protocol traffic."
```

## Test plan

- [x] `go test -race -count=1 ./...` — all packages pass
- [x] `go vet ./...`, `go build ./...` — clean
- [x] `scripts/ci_local.sh` — green (terminology gate, gofmt, portal, vet, build, race tests, source-selection schema, golangci-lint, transport gate "not triggered", passive-smoke-gate with owner override)
- [ ] Post-deploy on HA: `corrupted_request` rate drops from ~70-90/min to <5/min within 30 min
- [ ] Post-deploy: `prefix_resync_skipped_total` plateaus <5/min after warmup
- [ ] Post-deploy: `invalid_src_class_skipped_total` ≤25/min sustained (quantitative target for P6.1/P6.2 follow-ups)
- [ ] Post-deploy: NETX3 four faces (0xF1, 0xF6, 0xFF, 0x04) appear in `ebus.v1.registry.devices.list` within ~5 min
- [ ] Post-deploy: Phase C invariant — gateway sends to `0x03/0x10` remain 0