### PR TITLE
feat(gateway): P7 — LEN-based request completion (Mode C fix)

### DIFF
--- a/cmd/gateway/main_address_table_wireup_test.go
+++ b/cmd/gateway/main_address_table_wireup_test.go
@@ -215,10 +215,14 @@ func feedGatewayWireupSymbols(reconstructor *ebusgateway.PassiveTransactionRecon
 	}
 }
 
+// gatewayWireupFrameBytes returns the wire bytes for an M2T request
+// (SRC..CRC) WITHOUT a trailing SymbolSyn — matches real eBUS wire
+// shape (Spec_Prot_7 §3, P7). Caller appends ACK + response segment
+// + ACK + SYN for a full transaction, mirroring real wire.
 func gatewayWireupFrameBytes(frame protocol.Frame) []byte {
-	raw := make([]byte, 0, 7+len(frame.Data))
+	raw := make([]byte, 0, 6+len(frame.Data))
 	raw = append(raw, frame.Source, frame.Target, frame.Primary, frame.Secondary, byte(len(frame.Data)))
 	raw = append(raw, frame.Data...)
-	raw = append(raw, protocol.CRC(raw), protocol.SymbolSyn)
+	raw = append(raw, protocol.CRC(raw))
 	return raw
 }

--- a/passive_bus_tap_test.go
+++ b/passive_bus_tap_test.go
@@ -1101,25 +1101,49 @@ func enhReceivedBytes(values []byte) []byte {
 	return out
 }
 
-func frameBytes(frame protocol.Frame) []byte {
-	raw := make([]byte, 0, 7+len(frame.Data))
+// requestFrameBytes returns the wire bytes for a single eBUS request
+// frame (`SRC DST PB SB LEN [data×LEN] CRC`) WITHOUT a trailing
+// SymbolSyn. This matches the real-wire shape for M2I (initiator/
+// initiator) and M2T (initiator/target) transactions, where the
+// transaction continues with target ACK + (optional) response phase
+// before the trailing SYN — there is NO SYN between the command CRC
+// and the target's ACK byte (Spec_Prot_7 §3, P7).
+//
+// Use frameBytes (with trailing SYN) for broadcast wire tests where
+// the SYN immediately after CRC matches actual broadcast wire shape.
+func requestFrameBytes(frame protocol.Frame) []byte {
+	raw := make([]byte, 0, 6+len(frame.Data))
 	raw = append(raw, frame.Source, frame.Target, frame.Primary, frame.Secondary, byte(len(frame.Data)))
 	raw = append(raw, frame.Data...)
-	raw = append(raw, protocol.CRC(raw), protocol.SymbolSyn)
+	raw = append(raw, protocol.CRC(raw))
 	return raw
 }
 
+// frameBytes returns a request frame with a trailing SymbolSyn — the
+// real-wire shape for broadcast transactions (which have no ACK or
+// response phase, so SYN immediately follows CRC). Most M2I/M2T tests
+// should use requestFrameBytes instead.
+func frameBytes(frame protocol.Frame) []byte {
+	return append(requestFrameBytes(frame), protocol.SymbolSyn)
+}
+
 func proxyObserverTransactionBytes(request protocol.Frame, responseData []byte) []byte {
-	// Real eBUS wire always emits at least one SymbolSyn between
-	// frames (bus-idle marker). The original fixture omitted the
-	// leading SYN because the pre-P6 reconstructor accepted any
-	// non-SYN byte as a frame source unconditionally. P6 Layer 1
-	// (inter-frame SYN gate) requires the SYN before accepting a new
-	// frame's source byte, so we now prepend one to mirror real
-	// wire conditions. Bus-tap-only tests are unaffected (they
-	// assert on byte-forwarding behavior, not framing semantics).
+	// Real eBUS wire (Spec_Prot_7 §3) for an M2T transaction:
+	//
+	//     [SYN]  (bus-idle marker between frames — P6 Layer 1)
+	//     SRC DST PB SB LEN data CRC
+	//     ACK    (target acks command — NO SYN before this byte, P7)
+	//     RESP_LEN resp_data RESP_CRC
+	//     ACK    (initiator acks response)
+	//     SYN    (transaction terminator)
+	//
+	// Pre-P6 fixture lacked the leading SYN; pre-P7 fixture (legacy
+	// frameBytes with trailing SYN) injected a spurious SYN between
+	// command CRC and target ACK that does not exist on real wire.
+	// requestFrameBytes returns SRC..CRC without a trailing SYN, so
+	// the wire shape now matches Spec_Prot_7 exactly.
 	payload := []byte{protocol.SymbolSyn}
-	payload = append(payload, frameBytes(request)...)
+	payload = append(payload, requestFrameBytes(request)...)
 	payload = append(payload, protocol.SymbolAck)
 	payload = append(payload, responseSegmentBytes(responseData)...)
 	payload = append(payload, protocol.SymbolAck, protocol.SymbolSyn)

--- a/passive_reconstructor_p6_invariants_test.go
+++ b/passive_reconstructor_p6_invariants_test.go
@@ -312,16 +312,24 @@ func TestPassiveTransactionReconstructor_NackRetryPreservesSync(t *testing.T) {
 		Secondary: 0x09,
 		Data:      []byte{0x01},
 	}
-	// frameBytes already terminates the request with SymbolSyn, which
-	// triggers parseFrame and transitions the parser to
-	// passivePhaseWaitACK. The SYN at line 644 then serves as the
-	// frame-boundary marker that handleACKSymbolLocked consumes
-	// when NACK arrives with no further SYN gap.
+	// Real eBUS M2T wire shape for AM2 NACK retry (Spec_Prot_7 §3 +
+	// internal/adaptermux/wire_phase.go:185-198):
+	//
+	//   [SYN]                           (Layer 1 idle marker)
+	//   SRC DST PB SB LEN data CRC      (request, no trailing SYN)
+	//   NACK                            (target NACKs first attempt)
+	//   SRC DST PB SB LEN data CRC      (immediate retry, no SYN gap)
+	//   ACK                             (target ACKs retry)
+	//   RESP_LEN resp_data RESP_CRC     (response)
+	//   ACK SYN                         (initiator ACKs + transaction end)
+	//
+	// requestFrameBytes returns SRC..CRC without the trailing SYN
+	// that the legacy frameBytes helper appended (Mode C / P7 fix).
 	wire := []byte{protocol.SymbolSyn}
-	wire = append(wire, frameBytes(request)...) // includes trailing SYN -> parser enters WaitACK
-	wire = append(wire, protocol.SymbolNack)    // target NACKs the first attempt
-	wire = append(wire, frameBytes(request)...) // AM2 retry, no SYN gap; frameBytes appends terminator SYN
-	wire = append(wire, protocol.SymbolAck)     // target ACKs the retry
+	wire = append(wire, requestFrameBytes(request)...) // request
+	wire = append(wire, protocol.SymbolNack)           // target NACKs the first attempt
+	wire = append(wire, requestFrameBytes(request)...) // AM2 retry, immediate, no SYN gap
+	wire = append(wire, protocol.SymbolAck)            // target ACKs the retry
 	wire = append(wire, responseSegmentBytes([]byte{0x11, 0x22})...)
 	wire = append(wire, protocol.SymbolAck, protocol.SymbolSyn)
 

--- a/passive_reconstructor_p7_lenbased_test.go
+++ b/passive_reconstructor_p7_lenbased_test.go
@@ -93,12 +93,15 @@ func TestPassiveTransactionReconstructor_M2I_RealWireShape(t *testing.T) {
 }
 
 // TestPassiveTransactionReconstructor_BroadcastStillWorksAtLENBoundary
-// verifies that broadcast frames continue to work after the P7 fix.
-// Broadcast wire IS [request_bytes][SYN] — no ACK or response phase —
-// so the parser hits LEN+CRC at len(requestRaw) == 6 + LEN_byte, the
-// LEN-based early-transition emits the BroadcastFrame event and resets
-// to Idle, and the trailing SYN re-engages Layer 1 via the
-// passivePhaseIdle handler.
+// verifies that broadcast frames continue to classify correctly after
+// the P7 fix. Per Codex P7 review pass 3, the LEN-based path now
+// DEFERS broadcast classification to the trailing SYN (so timing
+// observables match real wire and truncated [SYN] SRC..CRC does not
+// classify as a complete broadcast). This test feeds a complete
+// broadcast wire `[SYN] SRC..CRC SYN` and asserts the BroadcastFrame
+// event is emitted via the SYN-triggered path. The
+// BroadcastDefersToSYNTrigger test below proves the no-trailing-SYN
+// case explicitly.
 func TestPassiveTransactionReconstructor_BroadcastStillWorksAtLENBoundary(t *testing.T) {
 	t.Parallel()
 

--- a/passive_reconstructor_p7_lenbased_test.go
+++ b/passive_reconstructor_p7_lenbased_test.go
@@ -1,0 +1,226 @@
+package ebusgateway
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+)
+
+// P7 — LEN-based request completion invariant.
+//
+// Real eBUS wire (Spec_Prot_7 §3) for an M2T transaction has NO SYN
+// between command CRC and target ACK. The parser must detect request
+// completion at LEN+CRC reach (len(requestRaw) == 6 + LEN_byte) and
+// transition to passivePhaseWaitACK proactively, instead of waiting
+// for a trailing SYN that doesn't arrive until the entire transaction
+// is over.
+//
+// This regression suite locks in the post-Mode-C behavior.
+
+// TestPassiveTransactionReconstructor_M2T_RealWireShape verifies that
+// the reconstructor classifies a real-wire M2T transaction (no SYN
+// between command CRC and target ACK) as a successful Transaction
+// event. Pre-P7 this case abandoned with corrupted_request because
+// the parser kept accumulating ACK + response bytes into requestRaw
+// until the trailing SYN, then parseFrame failed on length mismatch.
+func TestPassiveTransactionReconstructor_M2T_RealWireShape(t *testing.T) {
+	t.Parallel()
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	request := protocol.Frame{
+		Source:    0x10,
+		Target:    0x08,
+		Primary:   0xB5,
+		Secondary: 0x09,
+		Data:      []byte{0x01},
+	}
+	// Real wire: SRC DST PB SB LEN data CRC ACK RESP_LEN data RESP_CRC
+	// ACK SYN. requestFrameBytes appends nothing past CRC.
+	wire := append([]byte{protocol.SymbolSyn}, requestFrameBytes(request)...)
+	wire = append(wire, protocol.SymbolAck)
+	wire = append(wire, responseSegmentBytes([]byte{0x11, 0x55})...)
+	wire = append(wire, protocol.SymbolAck, protocol.SymbolSyn)
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0), wire)
+
+	event := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventTransaction)
+	if event.FrameType != protocol.FrameTypeInitiatorTarget {
+		t.Errorf("frame type = %v; want FrameTypeInitiatorTarget", event.FrameType)
+	}
+	if !event.HasResponse {
+		t.Errorf("HasResponse = false; want true")
+	}
+	if got, want := len(event.Response.Data), 2; got != want {
+		t.Errorf("response data len = %d; want %d", got, want)
+	}
+}
+
+// TestPassiveTransactionReconstructor_M2I_RealWireShape verifies the
+// real-wire shape for M2I (initiator/initiator) transactions, which
+// have NO SYN between command CRC and the target's ACK and have NO
+// response phase — wire is SRC DST PB SB LEN data CRC ACK SYN.
+func TestPassiveTransactionReconstructor_M2I_RealWireShape(t *testing.T) {
+	t.Parallel()
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	frame := protocol.Frame{
+		Source:    0x30,
+		Target:    0x10,
+		Primary:   0x01,
+		Secondary: 0x02,
+		Data:      []byte{0x03},
+	}
+	wire := append([]byte{protocol.SymbolSyn}, requestFrameBytes(frame)...)
+	wire = append(wire, protocol.SymbolAck, protocol.SymbolSyn)
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0), wire)
+
+	event := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventMasterFrame)
+	if event.FrameType != protocol.FrameTypeInitiatorInitiator {
+		t.Errorf("frame type = %v; want FrameTypeInitiatorInitiator", event.FrameType)
+	}
+}
+
+// TestPassiveTransactionReconstructor_BroadcastStillWorksAtLENBoundary
+// verifies that broadcast frames continue to work after the P7 fix.
+// Broadcast wire IS [request_bytes][SYN] — no ACK or response phase —
+// so the parser hits LEN+CRC at len(requestRaw) == 6 + LEN_byte, the
+// LEN-based early-transition emits the BroadcastFrame event and resets
+// to Idle, and the trailing SYN re-engages Layer 1 via the
+// passivePhaseIdle handler.
+func TestPassiveTransactionReconstructor_BroadcastStillWorksAtLENBoundary(t *testing.T) {
+	t.Parallel()
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	frame := protocol.Frame{
+		Source:    0x10,
+		Target:    protocol.AddressBroadcast,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{0x42, 0x99},
+	}
+	// Broadcast wire shape: SRC DST PB SB LEN data CRC SYN.
+	wire := append([]byte{protocol.SymbolSyn}, frameBytes(frame)...)
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0), wire)
+
+	event := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventBroadcastFrame)
+	if event.FrameType != protocol.FrameTypeBroadcast {
+		t.Errorf("frame type = %v; want FrameTypeBroadcast", event.FrameType)
+	}
+	if got, want := len(event.Request.Data), 2; got != want {
+		t.Errorf("request data len = %d; want %d", got, want)
+	}
+}
+
+// TestPassiveTransactionReconstructor_M2T_BackToBack verifies that two
+// consecutive M2T transactions (with NO inter-frame SYN gap inside
+// each transaction, but a SYN between transactions per real wire) both
+// classify as Transaction events.
+func TestPassiveTransactionReconstructor_M2T_BackToBack(t *testing.T) {
+	t.Parallel()
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	first := protocol.Frame{
+		Source:    0x10,
+		Target:    0x08,
+		Primary:   0xB5,
+		Secondary: 0x09,
+		Data:      []byte{0x01},
+	}
+	second := protocol.Frame{
+		Source:    0xF1,
+		Target:    0x15,
+		Primary:   0xB5,
+		Secondary: 0x24,
+		Data:      []byte{0x06, 0x02, 0x00, 0x03, 0x01, 0x14},
+	}
+
+	wire := []byte{protocol.SymbolSyn}
+	wire = append(wire, requestFrameBytes(first)...)
+	wire = append(wire, protocol.SymbolAck)
+	// Response data avoids 0xAA — see P7.1 follow-up note in
+	// handleRequestSymbolLocked: the parser still treats logical 0xAA
+	// in data as SYN until escape-vs-wire metadata is propagated
+	// through PassiveTapEvent.
+	wire = append(wire, responseSegmentBytes([]byte{0x42})...)
+	wire = append(wire, protocol.SymbolAck, protocol.SymbolSyn)
+	// Inter-transaction idle marker. Real wire emits ≥1 SYN here.
+	wire = append(wire, protocol.SymbolSyn)
+	wire = append(wire, requestFrameBytes(second)...)
+	wire = append(wire, protocol.SymbolAck)
+	wire = append(wire, responseSegmentBytes([]byte{0x42, 0x99})...)
+	wire = append(wire, protocol.SymbolAck, protocol.SymbolSyn)
+
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0), wire)
+
+	requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventTransaction)
+	requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventTransaction)
+
+	snapshot := reconstructor.Snapshot()
+	if got := snapshot.AbandonsByReason["corrupted_request"]; got != 0 {
+		t.Errorf("AbandonsByReason[corrupted_request] = %d; want 0 (real-wire M2T must not abandon)", got)
+	}
+}
+
+// TestPassiveTransactionReconstructor_M2T_CRCMismatchAtLENBoundary
+// covers the parseFrame-failure path inside the LEN-based early
+// transition. When LEN+CRC is reached but parseFrame fails (bad CRC),
+// the parser MUST keep accumulating bytes — the trailing SYN path
+// then classifies the abandon, preserving the pre-P7 corrupted_request
+// classification for genuinely corrupt frames.
+func TestPassiveTransactionReconstructor_M2T_CRCMismatchAtLENBoundary(t *testing.T) {
+	t.Parallel()
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	request := protocol.Frame{
+		Source:    0x10,
+		Target:    0x08,
+		Primary:   0xB5,
+		Secondary: 0x09,
+		Data:      []byte{0x01},
+	}
+	// Build the request with a deliberately wrong CRC byte.
+	requestRaw := requestFrameBytes(request)
+	requestRaw[len(requestRaw)-1] ^= 0xFF // corrupt CRC
+
+	wire := append([]byte{protocol.SymbolSyn}, requestRaw...)
+	// Append more wire bytes; eventual trailing SYN triggers abandon.
+	wire = append(wire, protocol.SymbolAck)
+	wire = append(wire, 0x02, 0x11, 0x22)
+	wire = append(wire, protocol.SymbolSyn)
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0), wire)
+
+	event := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventAbandonedTransaction)
+	if event.AbandonReason != PassiveAbandonReasonCorruptedRequest {
+		t.Errorf("abandon reason = %q; want %q", event.AbandonReason, PassiveAbandonReasonCorruptedRequest)
+	}
+}

--- a/passive_reconstructor_p7_lenbased_test.go
+++ b/passive_reconstructor_p7_lenbased_test.go
@@ -185,6 +185,58 @@ func TestPassiveTransactionReconstructor_M2T_BackToBack(t *testing.T) {
 	}
 }
 
+// TestPassiveTransactionReconstructor_BroadcastDefersToSYNTrigger covers
+// the Codex P7 review pass 3 contract: broadcast frames whose request
+// bytes structurally complete at LEN+CRC reach MUST NOT be classified
+// before the trailing SYN arrives. Real broadcast wire is
+// [SRC..CRC][SYN] and the broadcast event's timing observables
+// (RequestEnd, Terminal, ObservedAt) must reflect the SYN timestamp.
+//
+// Feeds [SYN] SRC DST=0xFE PB SB LEN data CRC <gap> SYN with a delay
+// before SYN; asserts the BroadcastFrame event is emitted at the SYN
+// timestamp, NOT at the CRC byte's timestamp. Also asserts that a
+// TRUNCATED broadcast (CRC reached but no trailing SYN, then transport
+// reset) does NOT produce a spurious BroadcastFrame event before the
+// SYN.
+func TestPassiveTransactionReconstructor_BroadcastDefersToSYNTrigger(t *testing.T) {
+	t.Parallel()
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	frame := protocol.Frame{
+		Source:    0x10,
+		Target:    protocol.AddressBroadcast,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{0x01, 0x02},
+	}
+
+	// Feed leading SYN + request bytes WITHOUT trailing SYN. At
+	// LEN+CRC reach, commitRequestFrameLocked sees frameType=Broadcast
+	// and returns ok=false (defers to SYN path). No event yet.
+	requestBytes := requestFrameBytes(frame)
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0), append([]byte{protocol.SymbolSyn}, requestBytes...))
+	assertNoPassiveClassifiedEvent(t, subscription, 50*time.Millisecond)
+
+	// Now feed the trailing SYN at a LATER timestamp; expect the
+	// BroadcastFrame event to use THIS timestamp (not the CRC byte's).
+	synTimestamp := time.Unix(0, 0).Add(500 * time.Millisecond)
+	feedPassiveSymbolsRaw(reconstructor, synTimestamp, []byte{protocol.SymbolSyn})
+
+	event := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventBroadcastFrame)
+	if !event.ObservedAt.Equal(synTimestamp) {
+		t.Errorf("event.ObservedAt = %v; want %v (broadcast must be timestamped at trailing SYN, not CRC byte)", event.ObservedAt, synTimestamp)
+	}
+	if !event.Timing.Terminal.Equal(synTimestamp) {
+		t.Errorf("event.Timing.Terminal = %v; want %v", event.Timing.Terminal, synTimestamp)
+	}
+}
+
 // TestPassiveTransactionReconstructor_M2T_CRCMismatchAtLENBoundary
 // covers the parseFrame-failure path inside the LEN-based early
 // transition. When LEN+CRC is reached but parseFrame fails (bad CRC),

--- a/passive_transaction_reconstructor.go
+++ b/passive_transaction_reconstructor.go
@@ -674,7 +674,18 @@ func (reconstructor *PassiveTransactionReconstructor) dispatchParsedRequestLocke
 		reset = reconstructor.resetStateLockedAfterSyn
 	}
 
+	// FrameTypeUnknown: abandon before mutating any frame state so
+	// the abandon event observes an EMPTY state.request and an
+	// untouched state.timing.RequestEnd / lastProgressAt — matches
+	// the pre-refactor SYN path AND pre-refactor LEN path observable
+	// behavior (Codex P7 review pass 2 FINDING_1).
 	frameType := frame.Type()
+	if frameType == protocol.FrameTypeUnknown {
+		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonCorruptedTarget, observedAt, ebuserrors.ErrInvalidPayload))
+		reset()
+		return events
+	}
+
 	reconstructor.state.timing.RequestEnd = observedAt
 	reconstructor.state.lastProgressAt = observedAt
 	reconstructor.state.request = frame
@@ -699,6 +710,11 @@ func (reconstructor *PassiveTransactionReconstructor) dispatchParsedRequestLocke
 	case protocol.FrameTypeInitiatorInitiator, protocol.FrameTypeInitiatorTarget:
 		reconstructor.state.phase = passivePhaseWaitACK
 	default:
+		// protocol.FrameType enum has only Unknown / M2I / M2T /
+		// Broadcast today; this branch is defensive against future
+		// enum extensions. State has already been populated above
+		// (matches the pre-refactor SYN-path default branch which
+		// also wrote state.request before abandon).
 		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonCorruptedTarget, observedAt, ebuserrors.ErrInvalidPayload))
 		reset()
 	}

--- a/passive_transaction_reconstructor.go
+++ b/passive_transaction_reconstructor.go
@@ -632,24 +632,44 @@ func (reconstructor *PassiveTransactionReconstructor) handleRequestSymbolLocked(
 
 // commitRequestFrameLocked is the LEN-based early-transition entry
 // point used by handleRequestSymbolLocked while still accumulating
-// non-SYN bytes (Mode C / P7). Returns the possibly-extended events
-// slice and ok=true when parseFrame succeeded (regardless of whether
-// the frame was committed cleanly or routed to abandon via the
-// corrupted_target branch); ok=false means parseFrame itself failed
-// and the caller should keep accumulating until the trailing SYN
-// triggers the legacy abandon-classification path.
+// non-SYN bytes (Mode C / P7).
+//
+// Returns ok=true when the frame was handled (M2I/M2T transitioned
+// to passivePhaseWaitACK without waiting for the SYN that doesn't
+// arrive on real wire). Returns ok=false in two cases:
+//
+//   1. parseFrame itself failed — caller keeps accumulating; the
+//      trailing SYN path classifies the abandon (corrupted_request /
+//      arbitration_fragment / self_echo / scan_collision).
+//
+//   2. Frame parsed cleanly but its frameType is Broadcast or Unknown.
+//      Codex P7 review pass 3 FINDING_1: real broadcast wire IS
+//      [SRC..CRC][SYN] — the trailing SYN is the canonical commit
+//      boundary, and broadcast timing observables (RequestEnd,
+//      Terminal, ObservedAt) must reflect that SYN's timestamp, not
+//      the CRC byte's. Truncated [SYN] SRC..CRC without the trailing
+//      SYN must NOT classify as a complete broadcast. So broadcast
+//      and Unknown fall through to the SYN-triggered path.
 //
 // Caller MUST hold stateMu and MUST have populated requestRaw with
-// the candidate request bytes. The post-commit reset uses
-// resetStateLocked (NOT AfterSyn) because no SYN has been consumed
-// at LEN+CRC reach — the trailing wire SYN re-engages Layer 1 via
-// the passivePhaseIdle handler.
+// the candidate request bytes. When ok=true, the post-commit reset
+// uses resetStateLocked (NOT AfterSyn) because no SYN has been
+// consumed at LEN+CRC reach — the trailing wire SYN re-engages
+// Layer 1 via the passivePhaseIdle handler.
 func (reconstructor *PassiveTransactionReconstructor) commitRequestFrameLocked(events []PassiveClassifiedEvent, observedAt time.Time) ([]PassiveClassifiedEvent, bool) {
 	frame, ok := parseFrame(reconstructor.state.requestRaw)
 	if !ok {
 		return events, false
 	}
-	return reconstructor.dispatchParsedRequestLocked(events, frame, observedAt, false /*afterSyn*/), true
+	switch frame.Type() {
+	case protocol.FrameTypeInitiatorInitiator, protocol.FrameTypeInitiatorTarget:
+		return reconstructor.dispatchParsedRequestLocked(events, frame, observedAt, false /*afterSyn*/), true
+	default:
+		// Broadcast / Unknown: defer to SYN-triggered path so the
+		// terminal SYN provides canonical timing for broadcast and
+		// classification for Unknown.
+		return events, false
+	}
 }
 
 // dispatchParsedRequestLocked is the post-parse-success dispatch used

--- a/passive_transaction_reconstructor.go
+++ b/passive_transaction_reconstructor.go
@@ -534,6 +534,71 @@ func (reconstructor *PassiveTransactionReconstructor) handleRequestSymbolLocked(
 			}
 			events = append(events, reconstructor.abandonLocked(reason, observedAt, ebuserrors.ErrInvalidPayload))
 			reconstructor.state.phase = passivePhaseAbandoned
+			return events
+		}
+
+		// P7 — LEN-based request completion (Mode C fix).
+		//
+		// eBUS protocol fact (Spec_Prot_7 §3, mirrored in
+		// helianthus-docs-ebus protocols/ebus-services/ebus-overview.md
+		// §"Frame Sequence"): for M2I (initiator/initiator) and M2T
+		// (initiator/target) transactions, there is NO SYN between the
+		// command's CRC byte and the target's ACK byte. The wire is
+		//
+		//     I -> T: SRC DST PB SB LEN [data×LEN] CRC
+		//     T -> I: ACK
+		//     [M2T only] T -> I: RESP_LEN [data×RESP_LEN] RESP_CRC
+		//     [M2T only] I -> T: ACK
+		//     I -> T: SYN  (only at the very end of the transaction)
+		//
+		// Without this early-transition, the parser keeps accumulating
+		// post-CRC bytes (ACK + response + final ACK) into requestRaw
+		// until the trailing SYN. parseFrame then rejects the buffer
+		// because len != 6 + LEN, abandoning every M2I/M2T transaction
+		// on real wire as `corrupted_request` — the dominant failure
+		// mode left after P6 (live-validated 2026-05-09: 0/min Layer 1,
+		// ~4/min Layer 2, ~68/min uncategorised — this fix targets that
+		// remainder).
+		//
+		// As soon as `requestRaw` reaches the structurally-complete
+		// length 6 + LEN_byte AND parseFrame succeeds, transition to
+		// the appropriate phase based on frameType:
+		//
+		//   * Broadcast: emit the BroadcastFrame event immediately and
+		//     reset to Idle (synced=false; the next observed SYN will
+		//     re-engage the Layer 1 gate). Real broadcast wire IS
+		//     [request_bytes][SYN] so the SYN that follows is consumed
+		//     cleanly by the Idle handler.
+		//
+		//   * M2I / M2T: transition to passivePhaseWaitACK so the next
+		//     wire byte (the target's ACK or NACK) is processed by
+		//     handleACKSymbolLocked.
+		//
+		// parseFrame failure at LEN reach (e.g. CRC mismatch) does NOT
+		// abandon here — keeps accumulating. The trailing SYN path
+		// below preserves the existing abandon classification (and
+		// matches the historical behavior for genuinely corrupt
+		// frames).
+		//
+		// CAVEAT (P7.1 follow-up): the passive-tap escape decoder
+		// produces a logical 0xAA when the wire carried the escape
+		// sequence 0xA9 0x01 (a logical data byte 0xAA). The current
+		// non-SYN-branch entry condition treats that logical 0xAA as
+		// SYN, so frames whose data region contains a logical 0xAA
+		// still abandon at the SYN branch below before reaching this
+		// LEN-completion check. Tracking raw-vs-logical metadata
+		// through PassiveTapEvent (or making the SYN check
+		// frame-state-aware) is a separate change — see the deferred
+		// follow-ups in the post-cruise plan.
+		if len(reconstructor.state.requestRaw) >= 5 {
+			expectedLen := 6 + int(reconstructor.state.requestRaw[4])
+			if len(reconstructor.state.requestRaw) == expectedLen {
+				if events, ok := reconstructor.commitRequestFrameLocked(events, observedAt); ok {
+					return events
+				}
+				// parseFrame failed: keep accumulating and let the
+				// SYN-triggered path classify the abandon below.
+			}
 		}
 		return events
 	}
@@ -593,6 +658,66 @@ func (reconstructor *PassiveTransactionReconstructor) handleRequestSymbolLocked(
 		reconstructor.resetStateLockedAfterSyn()
 	}
 	return events
+}
+
+// commitRequestFrameLocked is the shared body that validates and
+// dispatches a structurally-complete request frame. Used by both the
+// P7 LEN-based early-transition path (entered while still accumulating
+// non-SYN bytes) and the legacy SYN-triggered parse path. Returns the
+// possibly-extended events slice and ok=true when parseFrame succeeded
+// (regardless of whether the frame was committed cleanly or routed to
+// abandon via the corrupted_target branch); ok=false means parseFrame
+// itself failed and the caller should keep accumulating.
+//
+// Caller MUST hold stateMu and MUST have populated requestRaw with the
+// candidate request bytes. Caller is responsible for unlocking, for
+// recording any post-event state transitions handled outside this
+// helper, and for the SYN-vs-non-SYN trigger context.
+func (reconstructor *PassiveTransactionReconstructor) commitRequestFrameLocked(events []PassiveClassifiedEvent, observedAt time.Time) ([]PassiveClassifiedEvent, bool) {
+	frame, ok := parseFrame(reconstructor.state.requestRaw)
+	if !ok {
+		return events, false
+	}
+	frameType := frame.Type()
+	if frameType == protocol.FrameTypeUnknown {
+		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonCorruptedTarget, observedAt, ebuserrors.ErrInvalidPayload))
+		// We have not consumed a SYN here (LEN-based path), so the
+		// inter-frame Layer 1 gate stays disengaged until the trailing
+		// SYN re-engages it via the passivePhaseAbandoned arm.
+		reconstructor.resetStateLocked()
+		return events, true
+	}
+
+	reconstructor.state.timing.RequestEnd = observedAt
+	reconstructor.state.lastProgressAt = observedAt
+	reconstructor.state.request = frame
+	reconstructor.state.frameType = frameType
+	switch frameType {
+	case protocol.FrameTypeBroadcast:
+		reconstructor.recordRecoveryLocked()
+		events = append(events, PassiveClassifiedEvent{
+			Kind:       PassiveClassifiedEventBroadcastFrame,
+			FrameType:  frameType,
+			Request:    frame,
+			HasRequest: true,
+			Timing: PassiveTimingMarkers{
+				RequestStart: reconstructor.state.timing.RequestStart,
+				RequestEnd:   observedAt,
+				Terminal:     observedAt,
+			},
+			ObservedAt: observedAt,
+		})
+		// LEN-based path: the trailing wire SYN has not arrived yet.
+		// Reset to Idle with synced=false; the next observed SYN
+		// re-engages Layer 1 via the passivePhaseIdle handler.
+		reconstructor.resetStateLocked()
+	case protocol.FrameTypeInitiatorInitiator, protocol.FrameTypeInitiatorTarget:
+		reconstructor.state.phase = passivePhaseWaitACK
+	default:
+		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonCorruptedTarget, observedAt, ebuserrors.ErrInvalidPayload))
+		reconstructor.resetStateLocked()
+	}
+	return events, true
 }
 
 // isScanProbeRaw checks raw request bytes for a 0704 device identity query

--- a/passive_transaction_reconstructor.go
+++ b/passive_transaction_reconstructor.go
@@ -623,75 +623,63 @@ func (reconstructor *PassiveTransactionReconstructor) handleRequestSymbolLocked(
 		return events
 	}
 
-	frameType := frame.Type()
-	if frameType == protocol.FrameTypeUnknown {
-		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonCorruptedTarget, observedAt, ebuserrors.ErrInvalidPayload))
-		// P6 Layer 1 — same SYN-consuming branch as above.
-		reconstructor.resetStateLockedAfterSyn()
-		return events
-	}
-
-	reconstructor.state.request = frame
-	reconstructor.state.frameType = frameType
-	switch frameType {
-	case protocol.FrameTypeBroadcast:
-		reconstructor.recordRecoveryLocked()
-		events = append(events, PassiveClassifiedEvent{
-			Kind:       PassiveClassifiedEventBroadcastFrame,
-			FrameType:  frameType,
-			Request:    frame,
-			HasRequest: true,
-			Timing: PassiveTimingMarkers{
-				RequestStart: reconstructor.state.timing.RequestStart,
-				RequestEnd:   observedAt,
-				Terminal:     observedAt,
-			},
-			ObservedAt: observedAt,
-		})
-		// P6 Layer 1 — broadcast frame committed on the trailing SYN.
-		reconstructor.resetStateLockedAfterSyn()
-	case protocol.FrameTypeInitiatorInitiator, protocol.FrameTypeInitiatorTarget:
-		reconstructor.state.phase = passivePhaseWaitACK
-	default:
-		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonCorruptedTarget, observedAt, ebuserrors.ErrInvalidPayload))
-		// P6 Layer 1 — terminal SYN already consumed at top of arm.
-		reconstructor.resetStateLockedAfterSyn()
-	}
-	return events
+	// Successful parse: dispatch via the shared helper. The trailing
+	// SYN consumed this frame so the post-commit reset MUST use the
+	// AfterSyn variant to keep Layer 1's synced flag engaged for the
+	// next frame. Codex P7 review pass 1 NIT FINDING_1.
+	return reconstructor.dispatchParsedRequestLocked(events, frame, observedAt, true /*afterSyn*/)
 }
 
-// commitRequestFrameLocked is the shared body that validates and
-// dispatches a structurally-complete request frame. Used by both the
-// P7 LEN-based early-transition path (entered while still accumulating
-// non-SYN bytes) and the legacy SYN-triggered parse path. Returns the
-// possibly-extended events slice and ok=true when parseFrame succeeded
-// (regardless of whether the frame was committed cleanly or routed to
-// abandon via the corrupted_target branch); ok=false means parseFrame
-// itself failed and the caller should keep accumulating.
+// commitRequestFrameLocked is the LEN-based early-transition entry
+// point used by handleRequestSymbolLocked while still accumulating
+// non-SYN bytes (Mode C / P7). Returns the possibly-extended events
+// slice and ok=true when parseFrame succeeded (regardless of whether
+// the frame was committed cleanly or routed to abandon via the
+// corrupted_target branch); ok=false means parseFrame itself failed
+// and the caller should keep accumulating until the trailing SYN
+// triggers the legacy abandon-classification path.
 //
-// Caller MUST hold stateMu and MUST have populated requestRaw with the
-// candidate request bytes. Caller is responsible for unlocking, for
-// recording any post-event state transitions handled outside this
-// helper, and for the SYN-vs-non-SYN trigger context.
+// Caller MUST hold stateMu and MUST have populated requestRaw with
+// the candidate request bytes. The post-commit reset uses
+// resetStateLocked (NOT AfterSyn) because no SYN has been consumed
+// at LEN+CRC reach — the trailing wire SYN re-engages Layer 1 via
+// the passivePhaseIdle handler.
 func (reconstructor *PassiveTransactionReconstructor) commitRequestFrameLocked(events []PassiveClassifiedEvent, observedAt time.Time) ([]PassiveClassifiedEvent, bool) {
 	frame, ok := parseFrame(reconstructor.state.requestRaw)
 	if !ok {
 		return events, false
 	}
-	frameType := frame.Type()
-	if frameType == protocol.FrameTypeUnknown {
-		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonCorruptedTarget, observedAt, ebuserrors.ErrInvalidPayload))
-		// We have not consumed a SYN here (LEN-based path), so the
-		// inter-frame Layer 1 gate stays disengaged until the trailing
-		// SYN re-engages it via the passivePhaseAbandoned arm.
-		reconstructor.resetStateLocked()
-		return events, true
+	return reconstructor.dispatchParsedRequestLocked(events, frame, observedAt, false /*afterSyn*/), true
+}
+
+// dispatchParsedRequestLocked is the post-parse-success dispatch used
+// by BOTH the LEN-based early-transition path
+// (commitRequestFrameLocked, afterSyn=false) AND the legacy SYN-
+// triggered path (handleRequestSymbolLocked's SYN branch,
+// afterSyn=true). Centralising the frameType switch + Faces / event
+// emission / reset here prevents the two entry points from drifting
+// (Codex P7 review pass 1 NIT FINDING_1).
+//
+// afterSyn selects the post-commit reset variant. The SYN-triggered
+// path consumes a SymbolSyn so the reset re-engages Layer 1's synced
+// flag (resetStateLockedAfterSyn). The LEN-based path has not yet
+// consumed a SYN; the trailing wire SYN re-engages Layer 1 via the
+// passivePhaseIdle handler (resetStateLocked).
+//
+// The FrameTypeUnknown case folds into the default branch (corrupted
+// target abandon), so callers do not need to pre-filter Unknown.
+func (reconstructor *PassiveTransactionReconstructor) dispatchParsedRequestLocked(events []PassiveClassifiedEvent, frame protocol.Frame, observedAt time.Time, afterSyn bool) []PassiveClassifiedEvent {
+	reset := reconstructor.resetStateLocked
+	if afterSyn {
+		reset = reconstructor.resetStateLockedAfterSyn
 	}
 
+	frameType := frame.Type()
 	reconstructor.state.timing.RequestEnd = observedAt
 	reconstructor.state.lastProgressAt = observedAt
 	reconstructor.state.request = frame
 	reconstructor.state.frameType = frameType
+
 	switch frameType {
 	case protocol.FrameTypeBroadcast:
 		reconstructor.recordRecoveryLocked()
@@ -707,17 +695,14 @@ func (reconstructor *PassiveTransactionReconstructor) commitRequestFrameLocked(e
 			},
 			ObservedAt: observedAt,
 		})
-		// LEN-based path: the trailing wire SYN has not arrived yet.
-		// Reset to Idle with synced=false; the next observed SYN
-		// re-engages Layer 1 via the passivePhaseIdle handler.
-		reconstructor.resetStateLocked()
+		reset()
 	case protocol.FrameTypeInitiatorInitiator, protocol.FrameTypeInitiatorTarget:
 		reconstructor.state.phase = passivePhaseWaitACK
 	default:
 		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonCorruptedTarget, observedAt, ebuserrors.ErrInvalidPayload))
-		reconstructor.resetStateLocked()
+		reset()
 	}
-	return events, true
+	return events
 }
 
 // isScanProbeRaw checks raw request bytes for a 0704 device identity query

--- a/passive_transaction_reconstructor_bench_test.go
+++ b/passive_transaction_reconstructor_bench_test.go
@@ -33,7 +33,8 @@ func BenchmarkPassiveTransactionReconstructorRetainedTransaction(b *testing.B) {
 		Secondary: 0x09,
 		Data:      []byte{0x01},
 	}
-	payload := append(frameBytes(request), protocol.SymbolAck)
+	// M2T wire shape (P7 — no SYN between command CRC and target ACK).
+	payload := append(requestFrameBytes(request), protocol.SymbolAck)
 	payload = append(payload, responseSegmentBytes([]byte{0x11, 0x55})...)
 	payload = append(payload, protocol.SymbolAck, protocol.SymbolSyn)
 	base := time.Unix(0, 0)

--- a/passive_transaction_reconstructor_test.go
+++ b/passive_transaction_reconstructor_test.go
@@ -53,7 +53,10 @@ func TestPassiveTransactionReconstructor_ClassifiesMasterMaster(t *testing.T) {
 		Secondary: 0x02,
 		Data:      []byte{0x03},
 	}
-	payload := append(frameBytes(frame), protocol.SymbolAck, protocol.SymbolSyn)
+	// M2I (FrameTypeInitiatorInitiator) wire: SRC DST PB SB LEN data
+	// CRC ACK SYN — no SYN between command CRC and the target's ACK
+	// (Spec_Prot_7 §3, P7).
+	payload := append(requestFrameBytes(frame), protocol.SymbolAck, protocol.SymbolSyn)
 	feedPassiveSymbols(reconstructor, time.Unix(0, 0), payload)
 
 	event := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventMasterFrame)
@@ -79,7 +82,10 @@ func TestPassiveTransactionReconstructor_ClassifiesDirectTransaction(t *testing.
 		Secondary: 0x09,
 		Data:      []byte{0x01},
 	}
-	payload := append(frameBytes(request), protocol.SymbolAck)
+	// M2T wire: SRC DST PB SB LEN data CRC ACK RESP_LEN resp_data
+	// RESP_CRC ACK SYN — no SYN between command CRC and the target's
+	// ACK (Spec_Prot_7 §3, P7).
+	payload := append(requestFrameBytes(request), protocol.SymbolAck)
 	payload = append(payload, responseSegmentBytes([]byte{0x11, 0x55})...)
 	payload = append(payload, protocol.SymbolAck, protocol.SymbolSyn)
 	feedPassiveSymbols(reconstructor, time.Unix(0, 0), payload)
@@ -113,7 +119,10 @@ func TestPassiveTransactionReconstructor_NoResponseBecomesAbandoned(t *testing.T
 		Secondary: 0x09,
 		Data:      []byte{0x01},
 	}
-	payload := append(frameBytes(request), protocol.SymbolAck, protocol.SymbolSyn)
+	// M2T no-response wire: SRC DST PB SB LEN data CRC ACK SYN — no
+	// SYN between command CRC and the target's ACK; the trailing SYN
+	// (with empty response phase) signals no_response (P7).
+	payload := append(requestFrameBytes(request), protocol.SymbolAck, protocol.SymbolSyn)
 	feedPassiveSymbols(reconstructor, time.Unix(0, 0), payload)
 
 	event := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventAbandonedTransaction)
@@ -140,7 +149,7 @@ func TestPassiveTransactionReconstructor_ResetAbandonsInFlight(t *testing.T) {
 		Data:      []byte{0x01},
 	}
 	base := time.Unix(0, 0)
-	feedPassiveSymbols(reconstructor, base, append(frameBytes(request), protocol.SymbolAck))
+	feedPassiveSymbols(reconstructor, base, append(requestFrameBytes(request), protocol.SymbolAck))
 	reconstructor.OnPassiveTapEvent(PassiveTapEvent{
 		Kind:       PassiveTapEventReset,
 		ObservedAt: base.Add(100 * time.Millisecond),
@@ -176,7 +185,7 @@ func TestPassiveTransactionReconstructor_ReadTimeoutHonorsWatchdog(t *testing.T)
 		Data:      []byte{0x01},
 	}
 	base := time.Unix(0, 0)
-	feedPassiveSymbols(reconstructor, base, append(frameBytes(request), protocol.SymbolAck))
+	feedPassiveSymbols(reconstructor, base, append(requestFrameBytes(request), protocol.SymbolAck))
 
 	reconstructor.OnPassiveTapEvent(PassiveTapEvent{
 		Kind:       PassiveTapEventReadTimeout,
@@ -271,9 +280,12 @@ func TestReconstructorSelfEchoACKPhase(t *testing.T) {
 		Secondary: 0x09,
 		Data:      []byte{0x01},
 	}
-	// frameBytes includes the trailing SYN which transitions to ACK wait phase.
-	// Then send another SYN to trigger the unexpected_syn/self_echo path.
-	payload := append(frameBytes(request), protocol.SymbolSyn)
+	// requestFrameBytes is the M2T-shape (no trailing SYN), matching
+	// real wire. The parser hits LEN+CRC, transitions to WaitACK
+	// (P7), then the SYN below is processed as an unexpected SYN
+	// during ACK wait → self_echo classification because src matches
+	// the local snapshotter address.
+	payload := append(requestFrameBytes(request), protocol.SymbolSyn)
 	feedPassiveSymbols(reconstructor, time.Unix(0, 0), payload)
 
 	event := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventAbandonedTransaction)

--- a/timing_reference_artifact_test.go
+++ b/timing_reference_artifact_test.go
@@ -569,7 +569,8 @@ func TestBuildWireTimingReferenceArtifactFailsOnMalformedSessionSendLine(t *test
 }
 
 func transactionPayload(request protocol.Frame, responseData []byte) []byte {
-	payload := append([]byte{}, frameBytes(request)...)
+	// M2T wire shape (P7 — no SYN between command CRC and target ACK).
+	payload := append([]byte{}, requestFrameBytes(request)...)
 	payload = append(payload, protocol.SymbolAck)
 	payload = append(payload, responseSegmentBytes(responseData)...)
 	payload = append(payload, protocol.SymbolAck, protocol.SymbolSyn)
@@ -580,8 +581,12 @@ func proxyLogLinesForTransaction(at time.Time, request protocol.Frame, responseD
 	lines := make([]string, 0, 32)
 	prefix := at.UTC().Format(proxyLogTimestampLayout)
 	lines = append(lines, fmt.Sprintf("%s session=1 start initiator=0x%02X", prefix, request.Source))
-	sendSymbols := frameBytes(request)
-	sendSymbols = append(sendSymbols[1:len(sendSymbols)-1], protocol.SymbolAck, protocol.SymbolSyn)
+	// proxy "send" log line: source byte is consumed by the
+	// `start initiator=...` event, so the first byte is dropped.
+	// requestFrameBytes returns SRC..CRC (no trailing SYN); skip the
+	// SRC byte and append ACK + SYN to mirror the proxy's outbound
+	// log shape.
+	sendSymbols := append(requestFrameBytes(request)[1:], protocol.SymbolAck, protocol.SymbolSyn)
 	for _, symbol := range sendSymbols {
 		lines = append(lines, fmt.Sprintf("%s session=1 send symbol=0x%02X", prefix, symbol))
 	}


### PR DESCRIPTION
## Summary

Post-P6 live observation (2026-05-09 cruise) revealed that the dominant `corrupted_request` failure mode (~68/min, ~95% of total) was NOT addressed by P6's two-layer SYN gate / SRC AddressClass validation. Live `/metrics` post-P6:

- `prefix_resync_skipped_total`: 0/min (Layer 1 — Mode A not happening)
- `invalid_src_class_skipped_total`: ~4/min (Layer 2 — Mode B caught)
- `corrupted_request`: ~72/min (Mode C — uncategorized, dominant)
- `ebus_frames_observed_total{scope="passive"}`: ZERO successful M2I/M2T classifications; only `frame_type="broadcast"` worked.

## Root cause (Mode C — Codex consultant validated)

`handleRequestSymbolLocked` only transitions out of `passivePhaseRequest` on a `SymbolSyn`. eBUS protocol (Spec_Prot_7 §3, mirrored in [`docs/protocols/ebus-services/ebus-overview.md`](https://github.com/Project-Helianthus/helianthus-docs-ebus/blob/main/protocols/ebus-services/ebus-overview.md)) says M2I/M2T wire is:

```
I -> T: SRC DST PB SB LEN data CRC
T -> I: ACK
[M2T only] T -> I: RESP_LEN data RESP_CRC
[M2T only] I -> T: ACK
I -> T: SYN  (only at the very end of the transaction)
```

There is **NO SYN between command CRC and target ACK**. The parser keeps accumulating ACK + response bytes into `requestRaw` until the trailing SYN, then `parseFrame` rejects on length mismatch — abandoning every M2I/M2T transaction on real wire.

Existing tests passed because `frameBytes` test helper injected a spurious SYN-after-CRC that doesn't exist on real wire, masking the bug since day 1.

## Fix

- LEN-driven early-transition: after appending each non-SYN byte, if `len(requestRaw) == 6 + requestRaw[4]` (LEN byte structural completion) and `parseFrame` succeeds, transition immediately:
  - M2I / M2T → `passivePhaseWaitACK` (next wire byte is target ACK)
  - Broadcast → emit `BroadcastFrame` event, reset to Idle (next byte is trailing SYN, re-engages Layer 1)
  - `parseFrame` failure → keep accumulating; trailing SYN path preserves existing `corrupted_request` classification
- Factored `commitRequestFrameLocked` shared helper used by both the LEN-based path and the legacy SYN-triggered path
- Test fixture split: `requestFrameBytes` (M2I/M2T, no SYN) vs `frameBytes` (broadcast, with SYN); all M2I/M2T fixtures updated
- New invariant suite: M2T_RealWireShape, M2I_RealWireShape, BroadcastStillWorksAtLENBoundary, M2T_BackToBack, M2T_CRCMismatchAtLENBoundary

## P7.1 follow-up (deferred)

Adapter-direct mux's escape decoder emits logical `0xAA` when wire was `0xA9 0x01`. Parser's SYN check at top of `handleSymbolLocked` / `handleRequestSymbolLocked` treats that logical `0xAA` as SYN, so frames with a logical `0xAA` in data still abandon at the SYN branch. Tracking raw-vs-logical metadata through `PassiveTapEvent` is a separate change. Most B524/B523/B5xx data does not contain logical `0xAA`, so live impact is bounded.

## Transport-gate justification

```
TRANSPORT_GATE_OWNER_OVERRIDE=OVERRIDE_TRANSPORT_GATE_BY_OWNER
TRANSPORT_GATE_OWNER_REASON="P7 Mode C fix: parser detects request completion at LEN+CRC reach instead of waiting for SYN. Matches Spec_Prot_7 §3 wire shape. Parser-only; no transport topology / wire-protocol field changed. internal/matrix/ untouched, M-C9 zero-diff guaranteed."
```

## Passive-smoke-gate justification

```
PASSIVE_SMOKE_GATE_OWNER_OVERRIDE=OVERRIDE_PASSIVE_SMOKE_GATE_BY_OWNER
PASSIVE_SMOKE_GATE_OWNER_REASON="P7 parser-completion semantics tightening; existing fixtures updated to match real-wire shape; corrupted_request rate is expected to drop substantially."
```

## Test plan

- [x] `go test -race -count=1 ./...` — all packages green
- [x] `scripts/ci_local.sh` — clean (terminology, gofmt, vet, build, race tests, schema validation, golangci-lint, transport gate, passive smoke gate)
- [x] 5 new P7 invariant tests pass; all existing tests pass after fixture migration
- [ ] **Post-deploy on HA** (success criteria, repeated from the P6+P3.5 plan now actually achievable):
  - `corrupted_request` rate drops from ~72/min to <5/min within 30 min
  - `ebus_frames_observed_total{scope="passive"}` shows non-zero `frame_type="initiator_target"` and `frame_type="initiator_initiator"` counts
  - NETX3 four faces (0xF1, 0xF6, 0xFF, 0x04) appear in `ebus.v1.registry.devices.list` within ~5 min
  - Phase C invariant unchanged: gateway sends to `0x03/0x10` remain 0