### PR TITLE
P7.1 — disambiguate escape-decoded 0xAA from wire SYN

### DIFF
--- a/passive_reconstructor_p71_escape_test.go
+++ b/passive_reconstructor_p71_escape_test.go
@@ -1,0 +1,380 @@
+package ebusgateway
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+)
+
+// P7.1 — escape-decoded 0xAA disambiguation.
+//
+// The passive bus tap's escape decoder converts wire `0xA9 0x01` into
+// logical `protocol.SymbolSyn` (0xAA). Pre-P7.1, the reconstructor's
+// SYN checks could not distinguish a real wire-SYN frame terminator
+// from a logical 0xAA data byte, so frames whose data or CRC region
+// contained a logical 0xAA were abandoned at the SYN branch. P7.1
+// adds length-aware predicates (isMidRequestFrame / isMidResponseFrame)
+// that route SYN-valued bytes through the data-accumulation path while
+// the buffer is structurally below the LEN-declared length.
+//
+// This regression suite locks in the post-P7.1 behavior.
+
+// TestPassiveReconstructor_P71_M2T_RequestData0xAA_Classified verifies
+// that an M2T transaction whose request data contains a logical 0xAA
+// byte (mid-frame, between LEN and CRC) classifies as a Transaction
+// event instead of abandoning at the SYN branch.
+func TestPassiveReconstructor_P71_M2T_RequestData0xAA_Classified(t *testing.T) {
+	t.Parallel()
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	// Request data carries a logical 0xAA byte. requestFrameBytes
+	// stamps SRC DST PB SB LEN data CRC; CRC is whatever the helper
+	// computes — that's covered by the natural CRC validation path.
+	request := protocol.Frame{
+		Source:    0x10,
+		Target:    0x08,
+		Primary:   0xB5,
+		Secondary: 0x09,
+		Data:      []byte{0x01, 0xAA, 0x02},
+	}
+	wire := append([]byte{protocol.SymbolSyn}, requestFrameBytes(request)...)
+	wire = append(wire, protocol.SymbolAck)
+	// Response data MUST NOT contain 0xAA in this test (avoids
+	// commingling with the response-side fix; that's covered by the
+	// _M2T_ResponseData0xAA_Classified test below).
+	wire = append(wire, responseSegmentBytes([]byte{0x11, 0x55})...)
+	wire = append(wire, protocol.SymbolAck, protocol.SymbolSyn)
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0), wire)
+
+	event := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventTransaction)
+	if event.FrameType != protocol.FrameTypeInitiatorTarget {
+		t.Errorf("frame type = %v; want FrameTypeInitiatorTarget", event.FrameType)
+	}
+	if got, want := len(event.Request.Data), 3; got != want {
+		t.Errorf("request data len = %d; want %d", got, want)
+	}
+	if event.Request.Data[1] != 0xAA {
+		t.Errorf("request.Data[1] = 0x%02X; want 0xAA (mid-frame logical 0xAA)", event.Request.Data[1])
+	}
+
+	snapshot := reconstructor.Snapshot()
+	if got := snapshot.AbandonsByReason["corrupted_request"]; got != 0 {
+		t.Errorf("AbandonsByReason[corrupted_request] = %d; want 0 (request data 0xAA must not abandon)", got)
+	}
+}
+
+// TestPassiveReconstructor_P71_M2T_ResponseData0xAA_Classified verifies
+// the symmetric response-side case: an M2T transaction whose response
+// data contains a logical 0xAA byte classifies cleanly. Pre-P7.1 the
+// SYN-valued byte mid-response would have been treated as
+// unexpected_syn and abandoned.
+func TestPassiveReconstructor_P71_M2T_ResponseData0xAA_Classified(t *testing.T) {
+	t.Parallel()
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	request := protocol.Frame{
+		Source:    0x10,
+		Target:    0x08,
+		Primary:   0xB5,
+		Secondary: 0x09,
+		Data:      []byte{0x01},
+	}
+	wire := append([]byte{protocol.SymbolSyn}, requestFrameBytes(request)...)
+	wire = append(wire, protocol.SymbolAck)
+	// Response data carries a logical 0xAA byte.
+	wire = append(wire, responseSegmentBytes([]byte{0x11, 0xAA, 0x55})...)
+	wire = append(wire, protocol.SymbolAck, protocol.SymbolSyn)
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0), wire)
+
+	event := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventTransaction)
+	if !event.HasResponse {
+		t.Errorf("HasResponse = false; want true")
+	}
+	if got, want := len(event.Response.Data), 3; got != want {
+		t.Errorf("response data len = %d; want %d", got, want)
+	}
+	if event.Response.Data[1] != 0xAA {
+		t.Errorf("response.Data[1] = 0x%02X; want 0xAA (mid-response logical 0xAA)", event.Response.Data[1])
+	}
+
+	snapshot := reconstructor.Snapshot()
+	if got := snapshot.AbandonsByReason["unexpected_syn"]; got != 0 {
+		t.Errorf("AbandonsByReason[unexpected_syn] = %d; want 0 (response data 0xAA must not abandon)", got)
+	}
+}
+
+// TestPassiveReconstructor_P71_Broadcast_Data0xAA_Classified verifies
+// the broadcast-frame case — pre-P7.1, a broadcast whose data contained
+// 0xAA would have abandoned at the SYN branch (since broadcast commit
+// defers to the trailing wire SYN per Codex P7 Pass 3). With P7.1 the
+// 0xAA byte is treated as data and the trailing SYN reaches the
+// LEN-based commit cleanly.
+func TestPassiveReconstructor_P71_Broadcast_Data0xAA_Classified(t *testing.T) {
+	t.Parallel()
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	frame := protocol.Frame{
+		Source:    0x10,
+		Target:    protocol.AddressBroadcast,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{0x42, 0xAA, 0x99},
+	}
+	wire := append([]byte{protocol.SymbolSyn}, frameBytes(frame)...)
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0), wire)
+
+	event := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventBroadcastFrame)
+	if event.FrameType != protocol.FrameTypeBroadcast {
+		t.Errorf("frame type = %v; want FrameTypeBroadcast", event.FrameType)
+	}
+	if got, want := len(event.Request.Data), 3; got != want {
+		t.Errorf("request data len = %d; want %d", got, want)
+	}
+	if event.Request.Data[1] != 0xAA {
+		t.Errorf("request.Data[1] = 0x%02X; want 0xAA (broadcast data 0xAA)", event.Request.Data[1])
+	}
+
+	snapshot := reconstructor.Snapshot()
+	if got := snapshot.AbandonsByReason["corrupted_request"]; got != 0 {
+		t.Errorf("AbandonsByReason[corrupted_request] = %d; want 0 (broadcast data 0xAA must not abandon)", got)
+	}
+}
+
+// TestPassiveReconstructor_P71_RequestCRC0xAA_Commits constructs a
+// request frame whose CRC byte (terminal byte at position 6+LEN-1)
+// equals 0xAA. Verifies that the LEN-based commit at line 593-602
+// fires correctly: the 0xAA byte is appended as data (because
+// isMidRequestFrame returns true at that position), then the next-cycle
+// length check `len(requestRaw) == 6+LEN` triggers commit.
+func TestPassiveReconstructor_P71_RequestCRC0xAA_Commits(t *testing.T) {
+	t.Parallel()
+
+	// Brute-force a payload whose CRC is exactly 0xAA. The first
+	// 5-byte data combination that produces CRC=0xAA wins.
+	var data []byte
+	for i := 0; i < 256 && data == nil; i++ {
+		candidateData := []byte{byte(i)}
+		header := []byte{0x10, 0x08, 0xB5, 0x09, byte(len(candidateData))}
+		full := append(header, candidateData...)
+		if protocol.CRC(full) == 0xAA {
+			data = candidateData
+			break
+		}
+	}
+	if data == nil {
+		// Fallback: single-byte search exhausted; widen to 2 bytes.
+		for i := 0; i < 256 && data == nil; i++ {
+			for j := 0; j < 256 && data == nil; j++ {
+				candidateData := []byte{byte(i), byte(j)}
+				header := []byte{0x10, 0x08, 0xB5, 0x09, byte(len(candidateData))}
+				full := append(header, candidateData...)
+				if protocol.CRC(full) == 0xAA {
+					data = candidateData
+					break
+				}
+			}
+		}
+	}
+	if data == nil {
+		t.Fatal("could not synthesise a payload with CRC=0xAA in 1- or 2-byte space")
+	}
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	request := protocol.Frame{
+		Source:    0x10,
+		Target:    0x08,
+		Primary:   0xB5,
+		Secondary: 0x09,
+		Data:      data,
+	}
+	requestBytes := requestFrameBytes(request)
+	if requestBytes[len(requestBytes)-1] != 0xAA {
+		t.Fatalf("synthesised request CRC = 0x%02X; want 0xAA", requestBytes[len(requestBytes)-1])
+	}
+
+	wire := append([]byte{protocol.SymbolSyn}, requestBytes...)
+	wire = append(wire, protocol.SymbolAck)
+	wire = append(wire, responseSegmentBytes([]byte{0x42})...)
+	wire = append(wire, protocol.SymbolAck, protocol.SymbolSyn)
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0), wire)
+
+	event := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventTransaction)
+	if event.FrameType != protocol.FrameTypeInitiatorTarget {
+		t.Errorf("frame type = %v; want FrameTypeInitiatorTarget", event.FrameType)
+	}
+
+	snapshot := reconstructor.Snapshot()
+	if got := snapshot.AbandonsByReason["corrupted_request"]; got != 0 {
+		t.Errorf("AbandonsByReason[corrupted_request] = %d; want 0 (CRC=0xAA must commit)", got)
+	}
+}
+
+// TestPassiveReconstructor_P71_ResponseCRC0xAA_Commits is the
+// response-region symmetric of RequestCRC0xAA — Codex P7.1 review
+// addition. Synthesises a response payload whose response CRC equals
+// 0xAA and verifies the transaction classifies cleanly.
+func TestPassiveReconstructor_P71_ResponseCRC0xAA_Commits(t *testing.T) {
+	t.Parallel()
+
+	// Brute-force a response payload whose CRC is 0xAA. Response CRC
+	// scope is `[RESP_LEN, RESP_DATA…]`.
+	var responseData []byte
+	for i := 0; i < 256 && responseData == nil; i++ {
+		candidate := []byte{byte(i)}
+		hdr := []byte{byte(len(candidate))}
+		full := append(hdr, candidate...)
+		if protocol.CRC(full) == 0xAA {
+			responseData = candidate
+			break
+		}
+	}
+	if responseData == nil {
+		for i := 0; i < 256 && responseData == nil; i++ {
+			for j := 0; j < 256 && responseData == nil; j++ {
+				candidate := []byte{byte(i), byte(j)}
+				hdr := []byte{byte(len(candidate))}
+				full := append(hdr, candidate...)
+				if protocol.CRC(full) == 0xAA {
+					responseData = candidate
+					break
+				}
+			}
+		}
+	}
+	if responseData == nil {
+		t.Fatal("could not synthesise a response with CRC=0xAA in 1- or 2-byte space")
+	}
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	request := protocol.Frame{
+		Source:    0x10,
+		Target:    0x08,
+		Primary:   0xB5,
+		Secondary: 0x09,
+		Data:      []byte{0x01},
+	}
+	wire := append([]byte{protocol.SymbolSyn}, requestFrameBytes(request)...)
+	wire = append(wire, protocol.SymbolAck)
+	respBytes := responseSegmentBytes(responseData)
+	if respBytes[len(respBytes)-1] != 0xAA {
+		t.Fatalf("synthesised response CRC = 0x%02X; want 0xAA", respBytes[len(respBytes)-1])
+	}
+	wire = append(wire, respBytes...)
+	wire = append(wire, protocol.SymbolAck, protocol.SymbolSyn)
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0), wire)
+
+	event := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventTransaction)
+	if !event.HasResponse {
+		t.Errorf("HasResponse = false; want true")
+	}
+
+	snapshot := reconstructor.Snapshot()
+	if got := snapshot.AbandonsByReason["unexpected_syn"]; got != 0 {
+		t.Errorf("AbandonsByReason[unexpected_syn] = %d; want 0 (response CRC=0xAA must commit)", got)
+	}
+}
+
+// TestPassiveReconstructor_P71_WireSYNBeforeLENStillAbandons proves the
+// negative case: a SYN-valued byte arriving while requestRaw is below
+// 5 bytes (LEN byte not yet observed) is still treated as a wire SYN
+// and abandons. This covers the "isMidRequestFrame returns false when
+// len < 5" branch and ensures the fix does not silently mask
+// genuinely-corrupt arbitration fragments.
+func TestPassiveReconstructor_P71_WireSYNBeforeLENStillAbandons(t *testing.T) {
+	t.Parallel()
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	// Wire: SYN (gates Layer 1) + master-class src + DST + PB + SB + SYN.
+	// 4 bytes accumulated when the SYN arrives — still below LEN
+	// position (5). isMidRequestFrame returns false → SYN-handling path
+	// → abandon. requestRaw len > 3 disqualifies the
+	// arbitration_fragment classification, so the abandon reason is
+	// corrupted_request — proving the predicate didn't silently swallow
+	// the premature SYN as data.
+	wire := []byte{
+		protocol.SymbolSyn, // gate
+		0x10,               // master src (BASV2-master)
+		0x08,               // DST (BAI)
+		0xB5,               // PB
+		0x09,               // SB
+		protocol.SymbolSyn, // structurally-impossible SYN at LEN position
+	}
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0), wire)
+
+	event := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventAbandonedTransaction)
+	if event.AbandonReason != PassiveAbandonReasonCorruptedRequest {
+		t.Errorf("AbandonReason = %v; want corrupted_request (premature SYN must still abandon)", event.AbandonReason)
+	}
+}
+
+// TestPassiveReconstructor_P71_M2I_RequestData0xAA_Classified covers
+// the M2I (initiator/initiator) request-only path with a 0xAA in data.
+func TestPassiveReconstructor_P71_M2I_RequestData0xAA_Classified(t *testing.T) {
+	t.Parallel()
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	frame := protocol.Frame{
+		Source:    0x30,
+		Target:    0x10,
+		Primary:   0x01,
+		Secondary: 0x02,
+		Data:      []byte{0x03, 0xAA, 0x04},
+	}
+	wire := append([]byte{protocol.SymbolSyn}, requestFrameBytes(frame)...)
+	wire = append(wire, protocol.SymbolAck, protocol.SymbolSyn)
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0), wire)
+
+	event := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventMasterFrame)
+	if event.FrameType != protocol.FrameTypeInitiatorInitiator {
+		t.Errorf("frame type = %v; want FrameTypeInitiatorInitiator", event.FrameType)
+	}
+	if got, want := len(event.Request.Data), 3; got != want {
+		t.Errorf("request data len = %d; want %d", got, want)
+	}
+	if event.Request.Data[1] != 0xAA {
+		t.Errorf("request.Data[1] = 0x%02X; want 0xAA", event.Request.Data[1])
+	}
+}

--- a/passive_transaction_reconstructor.go
+++ b/passive_transaction_reconstructor.go
@@ -20,6 +20,17 @@ const (
 	minPassiveTransactionWatchdog             = 250 * time.Millisecond
 	maxPassiveTransactionWatchdog             = 5 * time.Second
 	maxPassiveRequestBytes                    = 512
+
+	// maxPassiveDataLen is the eBUS spec-mandated upper bound on the LEN
+	// byte (Spec_Prot_7 §3.1: a single service frame carries up to 16
+	// payload bytes). Used by isMidRequestFrame / isMidResponseFrame
+	// (P7.1) to refuse to absorb wire-SYN bytes as data when the
+	// declared LEN is structurally impossible — i.e. the parser is
+	// almost certainly looking at a misclassified byte (e.g. an
+	// arbitrary bus byte admitted as an initiator-class source after a
+	// prior abandon). Bounding the predicate here prevents a single bad
+	// position from cascading into watchdog-bounded byte absorption.
+	maxPassiveDataLen = 16
 )
 
 type PassiveClassifiedEventKind uint8
@@ -523,8 +534,79 @@ func (reconstructor *PassiveTransactionReconstructor) startRequestLocked(symbol 
 	reconstructor.state.awaitingResync = false
 }
 
+// isMidRequestFrame reports whether requestRaw is structurally
+// mid-frame: the LEN byte (position 4) is observed and the buffer is
+// shorter than the LEN-declared full-frame length 6+LEN. P7.1 uses
+// this predicate to disambiguate a logical 0xAA byte (escape-decoded
+// from wire 0xA9 0x01) from a real wire-SYN frame terminator: in
+// mid-frame state the byte must structurally be data, regardless of
+// whether the upstream tap reported it via the escape decoder or as a
+// raw symbol.
+//
+// SCOPE / DEFERRED: this predicate only disambiguates positions
+// strictly after the LEN byte (positions 5 .. 6+LEN-1, i.e. data and
+// CRC). Logical 0xAA bytes at positions 0..4 (SRC, DST, PB, SB, LEN)
+// remain ambiguous under this approach because the reconstructor
+// hasn't yet learnt the structural length. In practice on the eBUS
+// wire those positions are either statically constrained (SRC must be
+// initiator-class, never 0xAA — Layer 2 rejects; DST must be target
+// or broadcast, never 0xAA — frame would abandon either way) or
+// extremely unlikely (PB/SB=0xAA is not a catalogued opcode for
+// Vaillant traffic; LEN=0xAA = 170 bytes would exceed any service
+// payload bound). Full disambiguation would require plumbing a
+// per-byte WasEscaped flag through transport.StreamEvent →
+// PassiveEvent → PassiveTapEvent (Approach A in the P7.1 consult);
+// deferred until live captures justify the cross-repo change.
+//
+// SAFETY BOUND: the predicate also returns false when the declared
+// LEN exceeds maxPassiveDataLen (eBUS spec §3.1 limit, 16 bytes). An
+// out-of-spec LEN means the parser is almost certainly mid-state on a
+// misclassified byte sequence (e.g. an arbitrary byte was admitted as
+// an initiator-class source after a previous abandon). Refusing to
+// absorb wire-SYNs in that state lets the SYN reach the existing
+// abandon/resync path instead of cascading into a watchdog-bounded
+// byte-absorption window.
+func (reconstructor *PassiveTransactionReconstructor) isMidRequestFrame() bool {
+	if len(reconstructor.state.requestRaw) < 5 {
+		return false
+	}
+	declaredLen := int(reconstructor.state.requestRaw[4])
+	if declaredLen > maxPassiveDataLen {
+		return false
+	}
+	return len(reconstructor.state.requestRaw) < 6+declaredLen
+}
+
+// isMidResponseFrame reports whether responseRaw is structurally
+// mid-frame: the response LEN byte (position 0) is observed and the
+// buffer is shorter than responseExpectedLen (= LEN+2 to include the
+// trailing CRC). Mirrors isMidRequestFrame's role for the response
+// region — see that doc-comment for scope/deferred notes. Also bounds
+// by maxPassiveDataLen for the same safety reason.
+func (reconstructor *PassiveTransactionReconstructor) isMidResponseFrame() bool {
+	if len(reconstructor.state.responseRaw) == 0 {
+		return false
+	}
+	if reconstructor.state.responseExpectedLen > maxPassiveDataLen+2 {
+		return false
+	}
+	return len(reconstructor.state.responseRaw) < reconstructor.state.responseExpectedLen
+}
+
 func (reconstructor *PassiveTransactionReconstructor) handleRequestSymbolLocked(events []PassiveClassifiedEvent, symbol byte, observedAt time.Time) []PassiveClassifiedEvent {
-	if symbol != protocol.SymbolSyn {
+	// P7.1 — escape-decoded 0xAA disambiguation.
+	//
+	// The passive bus tap's escape decoder produces logical 0xAA when
+	// the wire carried the 2-byte sequence 0xA9 0x01. A naive `symbol
+	// == SymbolSyn` check at this entry treats that logical 0xAA as a
+	// frame-end SYN, abandoning every M2I/M2T/Broadcast frame whose
+	// data or CRC region contains a 0xAA byte. With the LEN byte
+	// already in `requestRaw` (positions 0..4 buffered), the structural
+	// length is known; an SYN-valued byte arriving while
+	// len(requestRaw) < 6+LEN must be data (escape-decoded), not a wire
+	// SYN. Treat it as data and fall through to the data-accumulation
+	// path. See isMidRequestFrame for scope and deferred edge cases.
+	if symbol != protocol.SymbolSyn || reconstructor.isMidRequestFrame() {
 		reconstructor.state.requestRaw = append(reconstructor.state.requestRaw, symbol)
 		reconstructor.state.lastProgressAt = observedAt
 		if len(reconstructor.state.requestRaw) > maxPassiveRequestBytes {
@@ -580,16 +662,12 @@ func (reconstructor *PassiveTransactionReconstructor) handleRequestSymbolLocked(
 		// matches the historical behavior for genuinely corrupt
 		// frames).
 		//
-		// CAVEAT (P7.1 follow-up): the passive-tap escape decoder
-		// produces a logical 0xAA when the wire carried the escape
-		// sequence 0xA9 0x01 (a logical data byte 0xAA). The current
-		// non-SYN-branch entry condition treats that logical 0xAA as
-		// SYN, so frames whose data region contains a logical 0xAA
-		// still abandon at the SYN branch below before reaching this
-		// LEN-completion check. Tracking raw-vs-logical metadata
-		// through PassiveTapEvent (or making the SYN check
-		// frame-state-aware) is a separate change — see the deferred
-		// follow-ups in the post-cruise plan.
+		// P7.1 — the entry condition above (`symbol != SymbolSyn ||
+		// isMidRequestFrame()`) routes logical 0xAA bytes (escape-
+		// decoded from wire 0xA9 0x01) appearing at positions 5 ..
+		// 6+LEN-1 into the data-accumulation path. They reach this
+		// LEN-completion check naturally and frames whose data /
+		// CRC region contains 0xAA now classify cleanly.
 		if len(reconstructor.state.requestRaw) >= 5 {
 			expectedLen := 6 + int(reconstructor.state.requestRaw[4])
 			if len(reconstructor.state.requestRaw) == expectedLen {
@@ -638,18 +716,18 @@ func (reconstructor *PassiveTransactionReconstructor) handleRequestSymbolLocked(
 // to passivePhaseWaitACK without waiting for the SYN that doesn't
 // arrive on real wire). Returns ok=false in two cases:
 //
-//   1. parseFrame itself failed — caller keeps accumulating; the
-//      trailing SYN path classifies the abandon (corrupted_request /
-//      arbitration_fragment / self_echo / scan_collision).
+//  1. parseFrame itself failed — caller keeps accumulating; the
+//     trailing SYN path classifies the abandon (corrupted_request /
+//     arbitration_fragment / self_echo / scan_collision).
 //
-//   2. Frame parsed cleanly but its frameType is Broadcast or Unknown.
-//      Codex P7 review pass 3 FINDING_1: real broadcast wire IS
-//      [SRC..CRC][SYN] — the trailing SYN is the canonical commit
-//      boundary, and broadcast timing observables (RequestEnd,
-//      Terminal, ObservedAt) must reflect that SYN's timestamp, not
-//      the CRC byte's. Truncated [SYN] SRC..CRC without the trailing
-//      SYN must NOT classify as a complete broadcast. So broadcast
-//      and Unknown fall through to the SYN-triggered path.
+//  2. Frame parsed cleanly but its frameType is Broadcast or Unknown.
+//     Codex P7 review pass 3 FINDING_1: real broadcast wire IS
+//     [SRC..CRC][SYN] — the trailing SYN is the canonical commit
+//     boundary, and broadcast timing observables (RequestEnd,
+//     Terminal, ObservedAt) must reflect that SYN's timestamp, not
+//     the CRC byte's. Truncated [SYN] SRC..CRC without the trailing
+//     SYN must NOT classify as a complete broadcast. So broadcast
+//     and Unknown fall through to the SYN-triggered path.
 //
 // Caller MUST hold stateMu and MUST have populated requestRaw with
 // the candidate request bytes. When ok=true, the post-commit reset
@@ -846,7 +924,12 @@ func (reconstructor *PassiveTransactionReconstructor) handleResponseSymbolLocked
 		reconstructor.resetStateLockedAfterSyn()
 		return events
 	}
-	if len(reconstructor.state.responseRaw) > 0 && symbol == protocol.SymbolSyn {
+	if len(reconstructor.state.responseRaw) > 0 && symbol == protocol.SymbolSyn && !reconstructor.isMidResponseFrame() {
+		// P7.1 — only treat a SYN-valued byte as a wire SYN when we are
+		// past the structurally-required response length (LEN+2,
+		// including CRC). Mid-response 0xAA bytes (escape-decoded from
+		// wire 0xA9 0x01) fall through to the data-accumulation path
+		// below and reach the LEN-completion check.
 		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonUnexpectedSYN, observedAt, ebuserrors.ErrTimeout))
 		reconstructor.pendingRecoveryReason = string(PassiveAbandonReasonUnexpectedSYN)
 		// P6 Layer 1 — explicit SymbolSyn at this branch.


### PR DESCRIPTION
## Summary

- The passive bus tap escape decoder converts wire `0xA9 0x01` into logical `SymbolSyn` (0xAA). Pre-P7.1 the reconstructor's SYN checks could not tell a real wire-SYN apart from a logical 0xAA data byte, abandoning frames whose data/CRC region contained 0xAA.
- Adds two structural-length predicates (`isMidRequestFrame`, `isMidResponseFrame`) bounded by `maxPassiveDataLen` (16, eBUS §3.1). When mid-frame, a SYN-valued byte routes to data-accumulation; otherwise it stays a wire SYN.
- New invariant suite `passive_reconstructor_p71_escape_test.go` covers M2T/M2I/broadcast data 0xAA, request CRC 0xAA, response CRC 0xAA (Codex addition), and a negative case proving premature SYN still abandons.

Codex consult (gpt-5.5) recommended Approach B+ (this implementation) over the deeper StreamEvent `WasEscaped`-plumbing approach, citing single-repo scope and the structural guarantee LEN provides post-byte-4. Approach A remains a deferred follow-up if PB/SB/LEN=0xAA traffic ever appears in live captures.

## Test plan

- [x] `go test -race -count=1 ./...` (gateway full suite — 168 tests in main pkg pass)
- [x] `./scripts/ci_local.sh` (passive smoke gate run with documented owner override)
- [x] New tests cover both fix sites (request region 527, response region 849)
- [x] Negative case: WireSYNBeforeLENStillAbandons proves predicate returns false when LEN unknown
- [x] Regression caught: TestBroadcastListener_RoutesBroadcastFramesViaPassiveTap caught a cascade where a misclassified byte made LEN=0xB5; safety bound (LEN ≤ 16) prevents the cascade

## Owner override gate trailer

`PASSIVE_SMOKE_GATE_OWNER_REASON="P7.1 parser-only fix: structural-length disambiguation"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)