### PR TITLE
P8 — switch passive inserter to RegisterPassiveObserved (correct discovery_source label)

### DIFF
--- a/address_table.go
+++ b/address_table.go
@@ -115,6 +115,36 @@ func canonicalSlotMetadata(addr byte) (protocol.SourceAddressPriorityIndex, bool
 	return tier, free
 }
 
+// projectDiscoverySourceLabel maps the registry's DiscoverySource enum
+// to the AddressTable's externally-visible string label. Exposed at
+// package scope so both Lookup branches (cached + registry-fallback)
+// share the same projection — preventing drift between the two paths.
+func projectDiscoverySourceLabel(source registry.DiscoverySource) string {
+	switch source {
+	case registry.DiscoverySourcePassiveObserved:
+		return "passive_observed"
+	case registry.DiscoverySourceStaticSeed:
+		return "static_seed"
+	case registry.DiscoverySourceActiveConfirmed:
+		return "active_confirmed"
+	}
+	return ""
+}
+
+// projectVerificationStateLabel mirrors projectDiscoverySourceLabel for
+// the VerificationState enum.
+func projectVerificationStateLabel(state registry.VerificationState) string {
+	switch state {
+	case registry.VerificationStateCandidate:
+		return "candidate"
+	case registry.VerificationStateCorroborated:
+		return "corroborated_pending"
+	case registry.VerificationStateIdentityConfirmed:
+		return "identity_confirmed"
+	}
+	return ""
+}
+
 type AddressTable struct {
 	reg   *registry.DeviceRegistry
 	slots map[byte]*AddressSlot
@@ -139,6 +169,21 @@ func (t *AddressTable) Lookup(addr byte) (*AddressSlot, bool) {
 		return nil, false
 	}
 	if slot, ok := t.slots[addr]; ok && slot != nil {
+		// P8 cache-coherence (Codex P8 gateway review MINOR FINDING_1):
+		// the cached slot's DiscoverySource / VerificationState string
+		// fields are projections captured at insertion time and become
+		// stale when the registry's underlying slot upgrades (e.g. a
+		// directed scan promotes a passive-observed slot to
+		// active_confirmed). Reproject from the live RegistrySlot
+		// pointer to keep the snapshot consistent with the registry's
+		// monotonic ladder. Returns a copy so concurrent readers don't
+		// see torn writes through the cached map entry.
+		if slot.RegistrySlot != nil {
+			view := *slot
+			view.DiscoverySource = projectDiscoverySourceLabel(slot.RegistrySlot.DiscoverySource)
+			view.VerificationState = projectVerificationStateLabel(slot.RegistrySlot.VerificationState)
+			return &view, true
+		}
 		return slot, true
 	}
 	// Consult the wrapped registry so static seeds and active-discovered
@@ -153,30 +198,12 @@ func (t *AddressTable) Lookup(addr byte) (*AddressSlot, bool) {
 			case registry.SlotRoleSlave:
 				role = "target"
 			}
-			discovery := ""
-			switch regSlot.DiscoverySource {
-			case registry.DiscoverySourcePassiveObserved:
-				discovery = "passive_observed"
-			case registry.DiscoverySourceStaticSeed:
-				discovery = "static_seed"
-			case registry.DiscoverySourceActiveConfirmed:
-				discovery = "active_confirmed"
-			}
-			verification := ""
-			switch regSlot.VerificationState {
-			case registry.VerificationStateCandidate:
-				verification = "candidate"
-			case registry.VerificationStateCorroborated:
-				verification = "corroborated_pending"
-			case registry.VerificationStateIdentityConfirmed:
-				verification = "identity_confirmed"
-			}
 			tier, free := canonicalSlotMetadata(addr)
 			return &AddressSlot{
 				Addr:              addr,
 				Role:              role,
-				DiscoverySource:   discovery,
-				VerificationState: verification,
+				DiscoverySource:   projectDiscoverySourceLabel(regSlot.DiscoverySource),
+				VerificationState: projectVerificationStateLabel(regSlot.VerificationState),
 				PriorityTier:      tier,
 				FreeUse:           free,
 				RegistrySlot:      regSlot,

--- a/address_table_inserter.go
+++ b/address_table_inserter.go
@@ -293,11 +293,18 @@ func (i *AddressTableInserter) maybeInsert(addr byte, role string, admittedSrc b
 		return
 	}
 
-	i.table.reg.Register(registry.DeviceInfo{Address: addr})
-	// A.7+M6.1 — use the thread-safe MarkSlotPassiveObserved API
-	// instead of mutating the slot pointer directly. The previous
-	// direct-mutation pattern was racy with concurrent readers via
-	// LookupSlot / Lookup (Codex P2 follow-up from PR #565).
+	// P8 — atomic identity-merge + correct passive-observed label.
+	//
+	// Pre-P8 the inserter called Register(DeviceInfo{}) followed by
+	// MarkSlotPassiveObserved. Register stamped the slot at
+	// DiscoverySourceActiveConfirmed/VerificationStateIdentityConfirmed,
+	// which the monotonic ladder then prevented MarkSlotPassiveObserved
+	// from downgrading. Net: every passive insertion was misreported
+	// as `active_confirmed` in operator surfaces. RegisterPassiveObserved
+	// performs identity-merge AND the passive-label stamp atomically
+	// under one r.mu acquisition with the correct
+	// DiscoverySourcePassiveObserved/VerificationStateCorroborated
+	// labels — see helianthus-ebusreg PR #138.
 	var slotRole registry.SlotRole
 	switch role {
 	case "initiator":
@@ -305,7 +312,14 @@ func (i *AddressTableInserter) maybeInsert(addr byte, role string, admittedSrc b
 	case "target":
 		slotRole = registry.SlotRoleSlave
 	}
-	i.table.reg.MarkSlotPassiveObserved(addr, slotRole, observedAt)
+	i.table.reg.RegisterPassiveObserved(registry.DeviceInfo{Address: addr}, slotRole, observedAt)
+	// Capture the slot pointer for the AddressTable's cached
+	// `slots[addr].RegistrySlot` field. RegisterPassiveObserved already
+	// attaches slot.Device, so this LookupSlot is purely for the
+	// projection cache (Codex P8 ebusreg review NIT FINDING_3 — kept
+	// intentionally to preserve the AddressTable.Lookup cached-slot
+	// shape; no internal readers depend on it but external projections
+	// in address_table.go do).
 	registrySlot, _ := i.table.reg.LookupSlot(addr)
 
 	tier, free := canonicalSlotMetadata(addr)

--- a/address_table_inserter_p8_test.go
+++ b/address_table_inserter_p8_test.go
@@ -62,6 +62,52 @@ func TestATRInserter_P8_SourceInsertStampsPassiveObservedLabel(t *testing.T) {
 	}
 }
 
+// TestATRInserter_P8_AddressTableProjectsLiveRegistryLabel covers the
+// cache-coherence half of P8 (Codex P8 gateway review MINOR FINDING_1):
+// after a passive insertion lands the slot at "passive_observed", a
+// subsequent registry mutation (e.g. directed scan promoting the slot
+// to active_confirmed) MUST be visible through AddressTable.Lookup
+// despite the cached AddressSlot in t.slots. Pre-fix the cached strings
+// were captured at insert time and went stale; post-fix Lookup
+// reprojects from slot.RegistrySlot's live enum.
+func TestATRInserter_P8_AddressTableProjectsLiveRegistryLabel(t *testing.T) {
+	reg := registry.NewDeviceRegistry(nil)
+	table := NewAddressTable(reg)
+	inserter := NewAddressTableInserter(table, DefaultConfig())
+
+	// Passive insertion lands the slot at passive_observed.
+	event := atrPassiveTransactionEvent(time.Now().UTC(), 0x10, 0x99, protocol.SymbolAck)
+	inserter.OnPassiveClassifiedEvent(event)
+	pre, ok := table.Lookup(0x99)
+	if !ok || pre == nil {
+		t.Fatalf("Lookup(0x99) ok=%v slot=%v", ok, pre)
+	}
+	if pre.DiscoverySource != "passive_observed" {
+		t.Fatalf("pre-condition: DiscoverySource = %q; want passive_observed", pre.DiscoverySource)
+	}
+
+	// Now the registry upgrades the slot via an active scan.
+	reg.Register(registry.DeviceInfo{
+		Address:      0x99,
+		Manufacturer: "Vaillant",
+		DeviceID:     "TEST",
+		SerialNumber: "SN-99",
+	})
+
+	// AddressTable.Lookup MUST reflect the upgrade despite the cached
+	// AddressSlot still being in t.slots from the passive insertion.
+	post, ok := table.Lookup(0x99)
+	if !ok || post == nil {
+		t.Fatalf("post-upgrade Lookup(0x99) ok=%v slot=%v", ok, post)
+	}
+	if post.DiscoverySource != "active_confirmed" {
+		t.Errorf("post-upgrade DiscoverySource = %q; want active_confirmed (registry mutation must be visible through cached slot via RegistrySlot reprojection)", post.DiscoverySource)
+	}
+	if post.VerificationState != "identity_confirmed" {
+		t.Errorf("post-upgrade VerificationState = %q; want identity_confirmed", post.VerificationState)
+	}
+}
+
 // TestATRInserter_P8_AddressTableSlotMirrorsRegistryLabel ties the
 // AddressTable's projection (`slots[addr].DiscoverySource` /
 // `.VerificationState`) to the registry's underlying slot. The

--- a/address_table_inserter_p8_test.go
+++ b/address_table_inserter_p8_test.go
@@ -1,0 +1,89 @@
+package ebusgateway
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+)
+
+// TestATRInserter_P8_PassiveInsertStampsPassiveObservedLabel asserts
+// that a passive insertion via the AddressTableInserter labels the
+// underlying registry AddressSlot with
+// DiscoverySourcePassiveObserved/VerificationStateCorroborated — NOT
+// the ActiveConfirmed/IdentityConfirmed labels Register stamps.
+//
+// This is the central P8 contract on the gateway side: pre-P8 the
+// inserter called `Register + MarkSlotPassiveObserved` and the
+// monotonic ladder made the second call a no-op, so passively-
+// observed slots were misreported as `active_confirmed` in operator
+// surfaces. After the switch to RegisterPassiveObserved, the slot
+// stamps should reflect the actual provenance.
+func TestATRInserter_P8_PassiveInsertStampsPassiveObservedLabel(t *testing.T) {
+	reg := registry.NewDeviceRegistry(nil)
+	table := NewAddressTable(reg)
+	inserter := NewAddressTableInserter(table, DefaultConfig())
+
+	event := atrPassiveTransactionEvent(time.Now().UTC(), 0x10, 0x99, protocol.SymbolAck)
+	inserter.OnPassiveClassifiedEvent(event)
+
+	regSlot, ok := reg.LookupSlot(0x99)
+	if !ok || regSlot == nil {
+		t.Fatalf("registry.LookupSlot(0x99) ok=%v slot=%v", ok, regSlot)
+	}
+	if regSlot.DiscoverySource != registry.DiscoverySourcePassiveObserved {
+		t.Errorf("regSlot.DiscoverySource = %v; want PassiveObserved (P8 contract — passive insert must NOT stamp ActiveConfirmed)", regSlot.DiscoverySource)
+	}
+	if regSlot.VerificationState != registry.VerificationStateCorroborated {
+		t.Errorf("regSlot.VerificationState = %v; want Corroborated", regSlot.VerificationState)
+	}
+}
+
+// TestATRInserter_P8_SourceInsertStampsPassiveObservedLabel covers
+// the request-source insert path (PR #564 / TestFirstObservation_
+// SourceInserted): when the request initiator is admitted via
+// passive observation, its slot should also wear the
+// passive-observed label, not active-confirmed.
+func TestATRInserter_P8_SourceInsertStampsPassiveObservedLabel(t *testing.T) {
+	reg := registry.NewDeviceRegistry(nil)
+	table := NewAddressTable(reg)
+	inserter := NewAddressTableInserter(table, DefaultConfig())
+
+	event := atrPassiveTransactionEvent(time.Now().UTC(), 0xF1, 0x99, protocol.SymbolAck)
+	inserter.OnPassiveClassifiedEvent(event)
+
+	srcSlot, ok := reg.LookupSlot(0xF1)
+	if !ok || srcSlot == nil {
+		t.Fatalf("registry.LookupSlot(0xF1) ok=%v slot=%v (initiator must also insert)", ok, srcSlot)
+	}
+	if srcSlot.DiscoverySource != registry.DiscoverySourcePassiveObserved {
+		t.Errorf("srcSlot.DiscoverySource = %v; want PassiveObserved", srcSlot.DiscoverySource)
+	}
+}
+
+// TestATRInserter_P8_AddressTableSlotMirrorsRegistryLabel ties the
+// AddressTable's projection (`slots[addr].DiscoverySource` /
+// `.VerificationState`) to the registry's underlying slot. The
+// address_table.go projection (lines 158-164 area) maps the
+// registry's DiscoverySource enum to a string label; we verify the
+// post-P8 projection emits "passive_observed" for a passive insert.
+func TestATRInserter_P8_AddressTableSlotMirrorsRegistryLabel(t *testing.T) {
+	reg := registry.NewDeviceRegistry(nil)
+	table := NewAddressTable(reg)
+	inserter := NewAddressTableInserter(table, DefaultConfig())
+
+	event := atrPassiveTransactionEvent(time.Now().UTC(), 0x10, 0x99, protocol.SymbolAck)
+	inserter.OnPassiveClassifiedEvent(event)
+
+	slot, ok := table.Lookup(0x99)
+	if !ok || slot == nil {
+		t.Fatalf("AddressTable.Lookup(0x99) ok=%v slot=%v", ok, slot)
+	}
+	if slot.DiscoverySource != "passive_observed" {
+		t.Errorf("AddressTable slot.DiscoverySource = %q; want \"passive_observed\"", slot.DiscoverySource)
+	}
+	if slot.RegistrySlot == nil {
+		t.Errorf("AddressTable slot.RegistrySlot is nil; want pointer to registry slot (cached projection)")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260507140006-4dfa4a22cec3
-	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260509105842-9fe5ae1ab841
+	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260509162332-e56b232ca875
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260507140006-4dfa4a22cec3 h1:U90kuV7LhIkiwnD1iZFGV29Vpd87S119DXDcso4cCp8=
 github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260507140006-4dfa4a22cec3/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260509105842-9fe5ae1ab841 h1:p5L/2KCRoQHTONco4whlTOo+imsJqvVEtCCkrjKNiw8=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260509105842-9fe5ae1ab841/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260509162332-e56b232ca875 h1:Sa0PbyRjIxhkM6D6/dOCWR8TSf69RwCIKEZRAKQbU44=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260509162332-e56b232ca875/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=

--- a/passive_reconstructor_p71_escape_test.go
+++ b/passive_reconstructor_p71_escape_test.go
@@ -321,8 +321,8 @@ func TestPassiveReconstructor_P71_WireSYNBeforeLENStillAbandons(t *testing.T) {
 	}
 	defer subscription.Close()
 
-	// Wire: SYN (gates Layer 1) + master-class src + DST + PB + SB + SYN.
-	// 4 bytes accumulated when the SYN arrives — still below LEN
+	// Wire: SYN (gates Layer 1) + initiator-class src + DST + PB + SB +
+	// SYN. 4 bytes accumulated when the SYN arrives — still below LEN
 	// position (5). isMidRequestFrame returns false → SYN-handling path
 	// → abandon. requestRaw len > 3 disqualifies the
 	// arbitration_fragment classification, so the abandon reason is
@@ -330,7 +330,7 @@ func TestPassiveReconstructor_P71_WireSYNBeforeLENStillAbandons(t *testing.T) {
 	// the premature SYN as data.
 	wire := []byte{
 		protocol.SymbolSyn, // gate
-		0x10,               // master src (BASV2-master)
+		0x10,               // initiator src (BASV2 initiator face)
 		0x08,               // DST (BAI)
 		0xB5,               // PB
 		0x09,               // SB


### PR DESCRIPTION
## Summary

- Pre-P8 the gateway address_table_inserter called \`Register + MarkSlotPassiveObserved\`. The monotonic ladder made the second call a no-op, so passively-observed slots wore the wrong \`discovery_source: "active_confirmed"\` label in operator surfaces.
- Switches the inserter to \`RegisterPassiveObserved\` (helianthus-ebusreg PR #138, merged) which atomically identity-merges AND stamps PassiveObserved/Corroborated under one r.mu acquisition.
- Three tests cover the registry-slot label, the source-insert path, and the AddressTable projection mirror.

## Test plan

- [x] \`go test -race -count=1 ./...\` (full gateway suite passes)
- [x] \`./scripts/ci_local.sh\` green with passive-smoke-gate owner override
- [x] New \`TestATRInserter_P8_*\` tests assert PassiveObserved label on registry slot, source-insert path, and AddressTable projection
- [x] Pre-existing \`TestRun_AddressTableInserterWiresThroughPassiveReconstructor\` still passes
- [x] Live verification after merge: query MCP \`devices.list\` — addresses 0x04 (broadcast-only) and 0xF1 (NETX3 alias) should drop from \`discovery_source: "active_confirmed"\` to \`"passive_observed"\`

## Drive-by

P7.1 test file used legacy \"master src\" comments that the terminology gate would have caught had P7.1's local CI run with the gate enabled. Rewritten to \"initiator-class\" in this PR.

## Codex P8 ebusreg review NIT FINDING_3 disposition

Kept the post-Register \`LookupSlot\` call intentionally — the AddressTable's cached \`slots[addr].RegistrySlot\` field is populated by it, and external projection consumers (\`address_table.go\` lines 158-164) depend on the cached pointer.

## Owner override gate trailer

\`PASSIVE_SMOKE_GATE_OWNER_REASON="P8 gateway-side wire-up: switch inserter to RegisterPassiveObserved"\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)