### PR TITLE
P8.1 — switch AddressTable.Lookup to LookupSlotSnapshot (race-free reads)

### DIFF
--- a/address_table.go
+++ b/address_table.go
@@ -168,21 +168,26 @@ func (t *AddressTable) Lookup(addr byte) (*AddressSlot, bool) {
 	if t == nil {
 		return nil, false
 	}
+	// P8.1 — race-free reprojection via LookupSlotSnapshot.
+	//
+	// Both branches below project DiscoverySource / VerificationState
+	// from a value-typed AddressSlotSnapshot taken under r.mu.RLock.
+	// Pre-P8.1 these fields were read lock-free through a live
+	// AddressSlot pointer (worked in practice because the underlying
+	// enums are int-typed and atomic on Go's supported architectures,
+	// but the race detector flags it under sufficient contention).
+	// LookupSlotSnapshot's lock-protected value copy eliminates that
+	// race surface — registry writers must acquire r.mu.Lock() which
+	// blocks behind LookupSlotSnapshot's RLock before mutating slot
+	// fields.
 	if slot, ok := t.slots[addr]; ok && slot != nil {
-		// P8 cache-coherence (Codex P8 gateway review MINOR FINDING_1):
-		// the cached slot's DiscoverySource / VerificationState string
-		// fields are projections captured at insertion time and become
-		// stale when the registry's underlying slot upgrades (e.g. a
-		// directed scan promotes a passive-observed slot to
-		// active_confirmed). Reproject from the live RegistrySlot
-		// pointer to keep the snapshot consistent with the registry's
-		// monotonic ladder. Returns a copy so concurrent readers don't
-		// see torn writes through the cached map entry.
-		if slot.RegistrySlot != nil {
-			view := *slot
-			view.DiscoverySource = projectDiscoverySourceLabel(slot.RegistrySlot.DiscoverySource)
-			view.VerificationState = projectVerificationStateLabel(slot.RegistrySlot.VerificationState)
-			return &view, true
+		if t.reg != nil {
+			if snap, snapOK := t.reg.LookupSlotSnapshot(addr); snapOK {
+				view := *slot
+				view.DiscoverySource = projectDiscoverySourceLabel(snap.DiscoverySource)
+				view.VerificationState = projectVerificationStateLabel(snap.VerificationState)
+				return &view, true
+			}
 		}
 		return slot, true
 	}
@@ -190,20 +195,32 @@ func (t *AddressTable) Lookup(addr byte) (*AddressSlot, bool) {
 	// devices are visible here, preventing maybeInsert from rewriting
 	// their metadata (Codex P2: preserve-existing-registry-slots).
 	if t.reg != nil {
-		if regSlot, ok := t.reg.LookupSlot(addr); ok && regSlot != nil {
+		if snap, ok := t.reg.LookupSlotSnapshot(addr); ok {
 			role := ""
-			switch regSlot.Role {
+			switch snap.Role {
 			case registry.SlotRoleMaster:
 				role = "initiator"
 			case registry.SlotRoleSlave:
 				role = "target"
 			}
 			tier, free := canonicalSlotMetadata(addr)
+			// RegistrySlot pointer is still surfaced for fields not
+			// covered by the snapshot (e.g. FirstObservedAt /
+			// LastObservedAt are in the snapshot, but external
+			// projection consumers may walk to slot.Device for
+			// identity). Use LookupSlot (not LookupSlotSnapshot
+			// alone) because the AddressSlot field expects a
+			// pointer; the snapshot already protected the
+			// race-prone enum reads.
+			var regSlot *registry.AddressSlot
+			if liveSlot, ok := t.reg.LookupSlot(addr); ok {
+				regSlot = liveSlot
+			}
 			return &AddressSlot{
 				Addr:              addr,
 				Role:              role,
-				DiscoverySource:   projectDiscoverySourceLabel(regSlot.DiscoverySource),
-				VerificationState: projectVerificationStateLabel(regSlot.VerificationState),
+				DiscoverySource:   projectDiscoverySourceLabel(snap.DiscoverySource),
+				VerificationState: projectVerificationStateLabel(snap.VerificationState),
 				PriorityTier:      tier,
 				FreeUse:           free,
 				RegistrySlot:      regSlot,

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260507140006-4dfa4a22cec3
-	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260509162332-e56b232ca875
+	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260509165653-c3bef59ee848
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260507140006-4dfa4a22cec3 h1:U90kuV7LhIkiwnD1iZFGV29Vpd87S119DXDcso4cCp8=
 github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260507140006-4dfa4a22cec3/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260509162332-e56b232ca875 h1:Sa0PbyRjIxhkM6D6/dOCWR8TSf69RwCIKEZRAKQbU44=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260509162332-e56b232ca875/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260509165653-c3bef59ee848 h1:si6UKr2oUahl2vLxwsV2DsWRcR9v5gw/V9FYglwR+as=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260509165653-c3bef59ee848/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=


### PR DESCRIPTION
## Summary

- Both branches of \`AddressTable.Lookup\` (cached + registry-fallback) now read \`DiscoverySource\` / \`VerificationState\` via \`LookupSlotSnapshot\` (helianthus-ebusreg PR #139, merged).
- Eliminates the lock-free read pattern that the GitHub Codex bot flagged on PR #589 (deferred there as P8.1 follow-up).
- Concurrent registry writes (Register, RegisterPassiveObserved, MarkSlot*) take \`r.mu.Lock()\` which blocks behind the snapshot's \`RLock\` — torn read window closed.

## Test plan

- [x] \`go test -race -count=1 ./...\` passes (all P8 inserter tests + pre-existing tests pass)
- [x] \`./scripts/ci_local.sh\` green
- [x] LookupSlotSnapshot itself has 4 tests in ebusreg PR #139 including a race-free assertion under concurrent writes

## RegistrySlot field disposition

The \`AddressSlot.RegistrySlot\` pointer is still surfaced via the fallback path (re-fetched via LookupSlot) for projection consumers that need \`FirstObservedAt\` / Device-walk access. The race-prone enum reads no longer go through that pointer; they go through the snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)