### PR TITLE
P8.2 — add AddressTable.slotsMu RWMutex (close concurrent-map-access race)

### DIFF
--- a/address_table.go
+++ b/address_table.go
@@ -1,6 +1,8 @@
 package ebusgateway
 
 import (
+	"sync"
+
 	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
 )
@@ -146,8 +148,19 @@ func projectVerificationStateLabel(state registry.VerificationState) string {
 }
 
 type AddressTable struct {
-	reg   *registry.DeviceRegistry
-	slots map[byte]*AddressSlot
+	reg *registry.DeviceRegistry
+
+	// slotsMu guards the slots map for concurrent access between the
+	// AddressTableInserter (which writes via OnPassiveClassifiedEvent
+	// from the passive reconstructor's goroutine) and Lookup readers
+	// (MCP / GraphQL / address-table snapshot consumers, all on
+	// distinct goroutines). P8.2 — close the pre-existing
+	// concurrent-map-access surface flagged by Codex on PR #590.
+	// RWMutex over plain Mutex because reads dominate writes (passive
+	// inserts are bounded by new-address-discovery rate; Lookup runs
+	// per MCP query / GraphQL request).
+	slotsMu sync.RWMutex
+	slots   map[byte]*AddressSlot
 }
 
 func NewAddressTable(regs ...*registry.DeviceRegistry) *AddressTable {
@@ -168,6 +181,17 @@ func (t *AddressTable) Lookup(addr byte) (*AddressSlot, bool) {
 	if t == nil {
 		return nil, false
 	}
+	// P8.2 — slotsMu RLock guards the t.slots map read against the
+	// inserter's concurrent map write at address_table_inserter.go.
+	// Pre-P8.2 these reads were unsynced — Go's runtime detects
+	// concurrent map writes (panic) but read+write produces a torn
+	// read that the race detector also flags. The cached slot's
+	// label fields are then reprojected from a registry snapshot
+	// (P8.1) outside the local lock.
+	t.slotsMu.RLock()
+	cached, hit := t.slots[addr]
+	t.slotsMu.RUnlock()
+
 	// P8.1 — race-free reprojection via LookupSlotSnapshot.
 	//
 	// Both branches below project DiscoverySource / VerificationState
@@ -180,16 +204,16 @@ func (t *AddressTable) Lookup(addr byte) (*AddressSlot, bool) {
 	// race surface — registry writers must acquire r.mu.Lock() which
 	// blocks behind LookupSlotSnapshot's RLock before mutating slot
 	// fields.
-	if slot, ok := t.slots[addr]; ok && slot != nil {
+	if hit && cached != nil {
 		if t.reg != nil {
 			if snap, snapOK := t.reg.LookupSlotSnapshot(addr); snapOK {
-				view := *slot
+				view := *cached
 				view.DiscoverySource = projectDiscoverySourceLabel(snap.DiscoverySource)
 				view.VerificationState = projectVerificationStateLabel(snap.VerificationState)
 				return &view, true
 			}
 		}
-		return slot, true
+		return cached, true
 	}
 	// Consult the wrapped registry so static seeds and active-discovered
 	// devices are visible here, preventing maybeInsert from rewriting

--- a/address_table_inserter.go
+++ b/address_table_inserter.go
@@ -323,6 +323,11 @@ func (i *AddressTableInserter) maybeInsert(addr byte, role string, admittedSrc b
 	registrySlot, _ := i.table.reg.LookupSlot(addr)
 
 	tier, free := canonicalSlotMetadata(addr)
+	// P8.2 — guard the slots map mutation with the AddressTable's
+	// slotsMu so concurrent Lookup readers don't observe a partially-
+	// constructed map state. Closes the pre-existing concurrent-map-
+	// access surface flagged by Codex on PR #590.
+	i.table.slotsMu.Lock()
 	i.table.slots[addr] = &AddressSlot{
 		Addr:              addr,
 		Role:              role,
@@ -332,6 +337,7 @@ func (i *AddressTableInserter) maybeInsert(addr byte, role string, admittedSrc b
 		FreeUse:           free,
 		RegistrySlot:      registrySlot,
 	}
+	i.table.slotsMu.Unlock()
 
 	// A.7c — runtime audit trail. Every passive insertion is logged at
 	// INFO with addr/role/admitted-source/observation-time so operator

--- a/address_table_inserter_p82_test.go
+++ b/address_table_inserter_p82_test.go
@@ -45,16 +45,17 @@ func TestATRInserter_P82_ConcurrentLookupAndInsertRaceFree(t *testing.T) {
 	var slotWrites uint64
 	stop := make(chan struct{})
 
-	var wg sync.WaitGroup
+	var writerWg sync.WaitGroup
+	var readerWg sync.WaitGroup
 
 	// Writer goroutine: directly hammer t.slots under slotsMu Lock,
 	// using a rotating pool of addresses. Each iteration is a real
 	// map mutation (not gated by the inserter's existence-check
 	// short-circuit), so the slotWrites counter accurately reflects
 	// the number of map assignments.
-	wg.Add(1)
+	writerWg.Add(1)
 	go func() {
-		defer wg.Done()
+		defer writerWg.Done()
 		i := 0
 		for {
 			select {
@@ -77,12 +78,13 @@ func TestATRInserter_P82_ConcurrentLookupAndInsertRaceFree(t *testing.T) {
 	}()
 
 	// Start barrier — wait for at least one slot write before
-	// kicking the readers.
+	// kicking the readers (proves the writer is producing real map
+	// mutations before reads begin).
 	deadline := time.Now().Add(2 * time.Second)
 	for atomic.LoadUint64(&slotWrites) == 0 {
 		if time.Now().After(deadline) {
 			close(stop)
-			wg.Wait()
+			writerWg.Wait()
 			t.Fatal("writer goroutine produced no slot writes within 2s — start barrier exceeded")
 		}
 		time.Sleep(time.Microsecond)
@@ -90,12 +92,16 @@ func TestATRInserter_P82_ConcurrentLookupAndInsertRaceFree(t *testing.T) {
 
 	startWrites := atomic.LoadUint64(&slotWrites)
 
-	// 4 reader goroutines hammering Lookup.
+	// 4 reader goroutines hammering Lookup. Tracked in a separate
+	// WaitGroup so we can join them BEFORE stopping the writer —
+	// Codex P8.2 pass 2 MINOR: closing stop immediately after
+	// spawning readers would let the writer exit before the readers
+	// actually execute map reads, defeating the overlap test.
 	const numReaders = 4
 	for r := 0; r < numReaders; r++ {
-		wg.Add(1)
+		readerWg.Add(1)
 		go func() {
-			defer wg.Done()
+			defer readerWg.Done()
 			for j := 0; j < 1000; j++ {
 				addr := byte(0x10 + (j % writeAddrPool))
 				if slot, ok := table.Lookup(addr); ok && slot != nil {
@@ -107,17 +113,23 @@ func TestATRInserter_P82_ConcurrentLookupAndInsertRaceFree(t *testing.T) {
 		}()
 	}
 
-	// Stop the writer; wg.Wait joins everyone.
-	close(stop)
-	wg.Wait()
-
-	// End-of-phase assertion: at least some writer iterations ran
-	// during the reader phase. The threshold is intentionally low —
-	// the test goal is the race detector exercising any overlap, and
-	// goroutine scheduling can starve the writer when readers
-	// dominate the runqueue. A non-zero advance proves overlap; the
-	// race detector is the authoritative correctness gate.
+	// Wait for readers FIRST — writer keeps producing map writes
+	// throughout the reader phase, ensuring real overlap.
+	readerWg.Wait()
+	// End-of-phase write counter sample: must have advanced during
+	// the reader phase (proves the writer kept producing map
+	// mutations while readers ran, not just before they spawned).
 	endWrites := atomic.LoadUint64(&slotWrites)
+
+	// Now stop the writer.
+	close(stop)
+	writerWg.Wait()
+
+	// The threshold is intentionally low — goroutine scheduling can
+	// starve the writer when readers dominate the runqueue, but the
+	// reader-then-writer join order ensures the writer was running
+	// for the full reader phase. A non-zero advance proves overlap;
+	// the race detector is the authoritative correctness gate.
 	if endWrites-startWrites < 1 {
 		t.Errorf("writer produced 0 slot writes during reader phase; want >= 1 (race window not exercised)")
 	}
@@ -136,10 +148,12 @@ func TestATRInserter_P82_ConcurrentLookupAndInserterEndToEnd(t *testing.T) {
 	stop := make(chan struct{})
 	var inserterCalls uint64
 
-	var wg sync.WaitGroup
-	wg.Add(1)
+	var writerWg sync.WaitGroup
+	var readerWg sync.WaitGroup
+
+	writerWg.Add(1)
 	go func() {
-		defer wg.Done()
+		defer writerWg.Done()
 		i := 0
 		for {
 			select {
@@ -166,7 +180,7 @@ func TestATRInserter_P82_ConcurrentLookupAndInserterEndToEnd(t *testing.T) {
 	for atomic.LoadUint64(&inserterCalls) == 0 {
 		if time.Now().After(deadline) {
 			close(stop)
-			wg.Wait()
+			writerWg.Wait()
 			t.Fatal("inserter goroutine made no calls within 2s")
 		}
 		time.Sleep(time.Microsecond)
@@ -174,9 +188,9 @@ func TestATRInserter_P82_ConcurrentLookupAndInserterEndToEnd(t *testing.T) {
 
 	const numReaders = 4
 	for r := 0; r < numReaders; r++ {
-		wg.Add(1)
+		readerWg.Add(1)
 		go func() {
-			defer wg.Done()
+			defer readerWg.Done()
 			for j := 0; j < 500; j++ {
 				addr := byte(0x10 + byte(j%240))
 				_, _ = table.Lookup(addr)
@@ -184,8 +198,12 @@ func TestATRInserter_P82_ConcurrentLookupAndInserterEndToEnd(t *testing.T) {
 		}()
 	}
 
+	// Codex P8.2 pass 2 MINOR — wait for readers to complete BEFORE
+	// stopping the writer. Closing stop too early would let the
+	// writer exit before the reader phase actually runs.
+	readerWg.Wait()
 	close(stop)
-	wg.Wait()
+	writerWg.Wait()
 }
 
 // TestATRInserter_P82_LookupAfterInsertSeesUpdatedMap is a sanity

--- a/address_table_inserter_p82_test.go
+++ b/address_table_inserter_p82_test.go
@@ -18,27 +18,40 @@ import (
 // mutex, so concurrent map writes can panic Go's runtime and
 // concurrent read+write trips the race detector.
 //
-// Methodology: a writer goroutine drives passive insertions across a
-// rotating address pool while reader goroutines hammer
-// AddressTable.Lookup. Race detector (-race) is the authoritative
-// gate — a torn map read or any concurrent map access would fail.
+// Methodology: a writer goroutine directly mutates t.slots (under
+// the new slotsMu Lock) and reader goroutines hammer
+// AddressTable.Lookup (which takes RLock). Race detector (-race) is
+// the authoritative gate — any unsynced map access would fail.
 //
-// The test also asserts the reader sees a consistent slot value —
-// the cached AddressSlot's label fields are projected from the
-// registry snapshot (P8.1) so the read is doubly guarded: t.slotsMu
-// for the map access, then registry.r.mu for the enum reads.
+// Why bypass the inserter (Codex P8.2 review MINOR FINDING_1): the
+// inserter's maybeInsert short-circuits via `if _, exists :=
+// table.Lookup(addr); exists { return }` once an address has been
+// registered, so a writer cycling a small address pool only mutates
+// the map on the FIRST pass. End-of-phase counters tracking
+// OnPassiveClassifiedEvent calls thus over-count actual writes, and
+// the test could appear to pass while only exercising a tiny race
+// window. Driving the map mutations directly here ensures every
+// iteration of the writer goroutine produces a real
+// `t.slots[addr] = ...` assignment that overlaps with the reader
+// goroutines' map reads.
+//
+// We still go through the slotsMu lock so the test exercises the
+// same locking path the inserter uses in production.
 func TestATRInserter_P82_ConcurrentLookupAndInsertRaceFree(t *testing.T) {
 	reg := registry.NewDeviceRegistry(nil)
 	table := NewAddressTable(reg)
-	inserter := NewAddressTableInserter(table, DefaultConfig())
 
 	const writeAddrPool = 16
-	var writes uint64
+	var slotWrites uint64
 	stop := make(chan struct{})
 
 	var wg sync.WaitGroup
 
-	// Writer goroutine: cycle through addresses 0x10..0x1F.
+	// Writer goroutine: directly hammer t.slots under slotsMu Lock,
+	// using a rotating pool of addresses. Each iteration is a real
+	// map mutation (not gated by the inserter's existence-check
+	// short-circuit), so the slotWrites counter accurately reflects
+	// the number of map assignments.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -50,27 +63,35 @@ func TestATRInserter_P82_ConcurrentLookupAndInsertRaceFree(t *testing.T) {
 			default:
 			}
 			addr := byte(0x10 + (i % writeAddrPool))
-			event := atrPassiveTransactionEvent(time.Now().UTC(), 0xF1, addr, protocol.SymbolAck)
-			inserter.OnPassiveClassifiedEvent(event)
-			atomic.AddUint64(&writes, 1)
+			table.slotsMu.Lock()
+			table.slots[addr] = &AddressSlot{
+				Addr:              addr,
+				Role:              "target",
+				DiscoverySource:   "passive_observed",
+				VerificationState: "corroborated_pending",
+			}
+			table.slotsMu.Unlock()
+			atomic.AddUint64(&slotWrites, 1)
 			i++
 		}
 	}()
 
-	// Start barrier — wait for at least one write before reads.
+	// Start barrier — wait for at least one slot write before
+	// kicking the readers.
 	deadline := time.Now().Add(2 * time.Second)
-	for atomic.LoadUint64(&writes) == 0 {
+	for atomic.LoadUint64(&slotWrites) == 0 {
 		if time.Now().After(deadline) {
 			close(stop)
 			wg.Wait()
-			t.Fatal("writer goroutine produced no writes within 2s — start barrier exceeded")
+			t.Fatal("writer goroutine produced no slot writes within 2s — start barrier exceeded")
 		}
 		time.Sleep(time.Microsecond)
 	}
 
+	startWrites := atomic.LoadUint64(&slotWrites)
+
 	// 4 reader goroutines hammering Lookup.
 	const numReaders = 4
-	startWrites := atomic.LoadUint64(&writes)
 	for r := 0; r < numReaders; r++ {
 		wg.Add(1)
 		go func() {
@@ -78,8 +99,6 @@ func TestATRInserter_P82_ConcurrentLookupAndInsertRaceFree(t *testing.T) {
 			for j := 0; j < 1000; j++ {
 				addr := byte(0x10 + (j % writeAddrPool))
 				if slot, ok := table.Lookup(addr); ok && slot != nil {
-					// Read each label field (these are race-free per
-					// P8.1: snapshot copy under registry RLock).
 					_ = slot.DiscoverySource
 					_ = slot.VerificationState
 					_ = slot.Role
@@ -88,18 +107,85 @@ func TestATRInserter_P82_ConcurrentLookupAndInsertRaceFree(t *testing.T) {
 		}()
 	}
 
-	// Stop the writer; wg.Wait joins both the writer and the reader
-	// goroutines (each reader has a fixed 1000-iteration loop and
-	// exits naturally; the writer exits on stop).
+	// Stop the writer; wg.Wait joins everyone.
 	close(stop)
 	wg.Wait()
 
-	// End-of-phase assertion: writes counter advanced sufficiently
-	// during the test.
-	endWrites := atomic.LoadUint64(&writes)
-	if endWrites <= startWrites {
-		t.Errorf("writer produced %d writes after start barrier; want > 0 (race window not exercised)", endWrites-startWrites)
+	// End-of-phase assertion: at least some writer iterations ran
+	// during the reader phase. The threshold is intentionally low —
+	// the test goal is the race detector exercising any overlap, and
+	// goroutine scheduling can starve the writer when readers
+	// dominate the runqueue. A non-zero advance proves overlap; the
+	// race detector is the authoritative correctness gate.
+	endWrites := atomic.LoadUint64(&slotWrites)
+	if endWrites-startWrites < 1 {
+		t.Errorf("writer produced 0 slot writes during reader phase; want >= 1 (race window not exercised)")
 	}
+}
+
+// TestATRInserter_P82_ConcurrentLookupAndInserterEndToEnd is the
+// end-to-end variant: the writer goes through the actual inserter,
+// which exercises the inserter's call site of slotsMu.Lock. Limited
+// race-window exposure (the inserter short-circuits after first-pass
+// admission), but proves the lock IS taken on the production path.
+func TestATRInserter_P82_ConcurrentLookupAndInserterEndToEnd(t *testing.T) {
+	reg := registry.NewDeviceRegistry(nil)
+	table := NewAddressTable(reg)
+	inserter := NewAddressTableInserter(table, DefaultConfig())
+
+	stop := make(chan struct{})
+	var inserterCalls uint64
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		i := 0
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			// Cycle distinct addresses so each call MAY produce a
+			// real map write the first time it's seen. After all
+			// 240 candidate addresses have been admitted the
+			// inserter starts short-circuiting — that's fine; this
+			// test focuses on proving the mutex is taken, not on
+			// long-running overlap.
+			addr := byte(0x10 + byte(i%240))
+			event := atrPassiveTransactionEvent(time.Now().UTC(), 0xF1, addr, protocol.SymbolAck)
+			inserter.OnPassiveClassifiedEvent(event)
+			atomic.AddUint64(&inserterCalls, 1)
+			i++
+		}
+	}()
+
+	// Wait for at least one inserter call.
+	deadline := time.Now().Add(2 * time.Second)
+	for atomic.LoadUint64(&inserterCalls) == 0 {
+		if time.Now().After(deadline) {
+			close(stop)
+			wg.Wait()
+			t.Fatal("inserter goroutine made no calls within 2s")
+		}
+		time.Sleep(time.Microsecond)
+	}
+
+	const numReaders = 4
+	for r := 0; r < numReaders; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 500; j++ {
+				addr := byte(0x10 + byte(j%240))
+				_, _ = table.Lookup(addr)
+			}
+		}()
+	}
+
+	close(stop)
+	wg.Wait()
 }
 
 // TestATRInserter_P82_LookupAfterInsertSeesUpdatedMap is a sanity

--- a/address_table_inserter_p82_test.go
+++ b/address_table_inserter_p82_test.go
@@ -1,0 +1,124 @@
+package ebusgateway
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+)
+
+// TestATRInserter_P82_ConcurrentLookupAndInsertRaceFree closes the
+// pre-existing concurrent-map-access bug flagged by Codex on PR #590:
+// the AddressTable's `slots` map was written by the inserter (passive
+// reconstructor goroutine) and read by Lookup callers (MCP / GraphQL
+// / snapshot consumers, distinct goroutines). Pre-P8.2 there was no
+// mutex, so concurrent map writes can panic Go's runtime and
+// concurrent read+write trips the race detector.
+//
+// Methodology: a writer goroutine drives passive insertions across a
+// rotating address pool while reader goroutines hammer
+// AddressTable.Lookup. Race detector (-race) is the authoritative
+// gate — a torn map read or any concurrent map access would fail.
+//
+// The test also asserts the reader sees a consistent slot value —
+// the cached AddressSlot's label fields are projected from the
+// registry snapshot (P8.1) so the read is doubly guarded: t.slotsMu
+// for the map access, then registry.r.mu for the enum reads.
+func TestATRInserter_P82_ConcurrentLookupAndInsertRaceFree(t *testing.T) {
+	reg := registry.NewDeviceRegistry(nil)
+	table := NewAddressTable(reg)
+	inserter := NewAddressTableInserter(table, DefaultConfig())
+
+	const writeAddrPool = 16
+	var writes uint64
+	stop := make(chan struct{})
+
+	var wg sync.WaitGroup
+
+	// Writer goroutine: cycle through addresses 0x10..0x1F.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		i := 0
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			addr := byte(0x10 + (i % writeAddrPool))
+			event := atrPassiveTransactionEvent(time.Now().UTC(), 0xF1, addr, protocol.SymbolAck)
+			inserter.OnPassiveClassifiedEvent(event)
+			atomic.AddUint64(&writes, 1)
+			i++
+		}
+	}()
+
+	// Start barrier — wait for at least one write before reads.
+	deadline := time.Now().Add(2 * time.Second)
+	for atomic.LoadUint64(&writes) == 0 {
+		if time.Now().After(deadline) {
+			close(stop)
+			wg.Wait()
+			t.Fatal("writer goroutine produced no writes within 2s — start barrier exceeded")
+		}
+		time.Sleep(time.Microsecond)
+	}
+
+	// 4 reader goroutines hammering Lookup.
+	const numReaders = 4
+	startWrites := atomic.LoadUint64(&writes)
+	for r := 0; r < numReaders; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 1000; j++ {
+				addr := byte(0x10 + (j % writeAddrPool))
+				if slot, ok := table.Lookup(addr); ok && slot != nil {
+					// Read each label field (these are race-free per
+					// P8.1: snapshot copy under registry RLock).
+					_ = slot.DiscoverySource
+					_ = slot.VerificationState
+					_ = slot.Role
+				}
+			}
+		}()
+	}
+
+	// Stop the writer; wg.Wait joins both the writer and the reader
+	// goroutines (each reader has a fixed 1000-iteration loop and
+	// exits naturally; the writer exits on stop).
+	close(stop)
+	wg.Wait()
+
+	// End-of-phase assertion: writes counter advanced sufficiently
+	// during the test.
+	endWrites := atomic.LoadUint64(&writes)
+	if endWrites <= startWrites {
+		t.Errorf("writer produced %d writes after start barrier; want > 0 (race window not exercised)", endWrites-startWrites)
+	}
+}
+
+// TestATRInserter_P82_LookupAfterInsertSeesUpdatedMap is a sanity
+// check that the mutex doesn't accidentally hide writes from
+// readers. Single-goroutine: insert then immediately Lookup. The
+// reader MUST see the inserted slot.
+func TestATRInserter_P82_LookupAfterInsertSeesUpdatedMap(t *testing.T) {
+	reg := registry.NewDeviceRegistry(nil)
+	table := NewAddressTable(reg)
+	inserter := NewAddressTableInserter(table, DefaultConfig())
+
+	event := atrPassiveTransactionEvent(time.Now().UTC(), 0xF1, 0x99, protocol.SymbolAck)
+	inserter.OnPassiveClassifiedEvent(event)
+
+	slot, ok := table.Lookup(0x99)
+	if !ok || slot == nil {
+		t.Fatalf("Lookup(0x99) ok=%v slot=%v after passive insert; want hit", ok, slot)
+	}
+	if slot.DiscoverySource != "passive_observed" {
+		t.Errorf("slot.DiscoverySource = %q; want passive_observed", slot.DiscoverySource)
+	}
+}


### PR DESCRIPTION
## Summary

- Pre-P8.2 the AddressTable.slots map was written by the inserter (passive reconstructor goroutine) and read by Lookup callers (MCP / GraphQL / snapshot consumers, distinct goroutines) without any mutex.
- Codex P8.1 review explicitly noted this pre-existing race and deferred it as a P8.2 follow-up.
- Adds \`sync.RWMutex\` (RWMutex over Mutex because reads dominate writes); inserter takes Lock for the single map mutation, Lookup takes RLock for the read.

## Test plan

- [x] \`go test -race -count=5 ./...\` passes (5 iterations to surface flaky-race scenarios)
- [x] New \`TestATRInserter_P82_ConcurrentLookupAndInsertRaceFree\`: 4 reader goroutines hammer Lookup against a writer cycling 16 addresses; race detector is authoritative
- [x] Sanity test \`TestATRInserter_P82_LookupAfterInsertSeesUpdatedMap\` confirms the mutex doesn't hide writes from readers
- [x] \`./scripts/ci_local.sh\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)