### PR TITLE
P8.3 — MCP lookupDiscoveryLabels uses LookupSlotSnapshot (race-free enum reads)

### DIFF
--- a/cmd/gateway/mcp_bus_observability_integration_test.go
+++ b/cmd/gateway/mcp_bus_observability_integration_test.go
@@ -35,6 +35,12 @@ func (emptyMCPRegistry) LookupSlot(byte) (*registry.AddressSlot, bool) {
 	return nil, false
 }
 
+// LookupSlotSnapshot satisfies mcp.Registry (added in P8.3 — value-typed
+// snapshot for race-free enum reads). Empty test fake.
+func (emptyMCPRegistry) LookupSlotSnapshot(byte) (registry.AddressSlotSnapshot, bool) {
+	return registry.AddressSlotSnapshot{}, false
+}
+
 func TestMCPBusObservabilityProviderAdapterWiresRealStore(t *testing.T) {
 	cfg := ebusgateway.DefaultConfig()
 	cfg.BroadcastListen = true

--- a/mcp/lookup_discovery_labels_p83_test.go
+++ b/mcp/lookup_discovery_labels_p83_test.go
@@ -1,0 +1,148 @@
+package mcp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+)
+
+// P8.3 — lookupDiscoveryLabels uses LookupSlotSnapshot.
+//
+// Pre-P8.3 lookupDiscoveryLabels called LookupSlot (live pointer)
+// and read slot.DiscoverySource / .VerificationState lock-free —
+// race-prone with concurrent Register / RegisterPassiveObserved /
+// MarkSlot* writers. Switched to LookupSlotSnapshot (value copy
+// under registry RLock).
+
+// trackingRegistry is a Registry implementation that counts which
+// methods were called. Used to prove lookupDiscoveryLabels does NOT
+// fall back to LookupSlot for the enum reads.
+type trackingRegistry struct {
+	lookupSlotCalls         int
+	lookupSlotSnapshotCalls int
+	snap                    registry.AddressSlotSnapshot
+	hasSnap                 bool
+}
+
+func (t *trackingRegistry) Iterate(func(registry.DeviceEntry) bool) {}
+
+func (t *trackingRegistry) Lookup(byte) (registry.DeviceEntry, bool) { return nil, false }
+
+func (t *trackingRegistry) LookupSlot(byte) (*registry.AddressSlot, bool) {
+	t.lookupSlotCalls++
+	return nil, false
+}
+
+func (t *trackingRegistry) LookupSlotSnapshot(byte) (registry.AddressSlotSnapshot, bool) {
+	t.lookupSlotSnapshotCalls++
+	if t.hasSnap {
+		return t.snap, true
+	}
+	return registry.AddressSlotSnapshot{}, false
+}
+
+func TestLookupDiscoveryLabels_UsesSnapshotPath(t *testing.T) {
+	t.Parallel()
+
+	reg := &trackingRegistry{
+		hasSnap: true,
+		snap: registry.AddressSlotSnapshot{
+			Addr:              0x10,
+			Role:              registry.SlotRoleMaster,
+			DiscoverySource:   registry.DiscoverySourcePassiveObserved,
+			VerificationState: registry.VerificationStateCorroborated,
+			FirstObservedAt:   time.Now(),
+			LastObservedAt:    time.Now(),
+			DeviceAttached:    true,
+		},
+	}
+
+	discovery, verification := lookupDiscoveryLabels(reg, 0x10)
+
+	if reg.lookupSlotSnapshotCalls != 1 {
+		t.Errorf("LookupSlotSnapshot called %d times; want 1 (P8.3 contract: snapshot path is the primary)", reg.lookupSlotSnapshotCalls)
+	}
+	if reg.lookupSlotCalls != 0 {
+		t.Errorf("LookupSlot called %d times; want 0 (P8.3 contract: live-pointer path is no longer used for label reads)", reg.lookupSlotCalls)
+	}
+	if discovery != "passive_observed" {
+		t.Errorf("discovery = %q; want passive_observed", discovery)
+	}
+	if verification != "corroborated_pending" {
+		t.Errorf("verification = %q; want corroborated_pending", verification)
+	}
+}
+
+func TestLookupDiscoveryLabels_AbsentSnapshotReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	reg := &trackingRegistry{hasSnap: false}
+
+	discovery, verification := lookupDiscoveryLabels(reg, 0x99)
+	if discovery != "" || verification != "" {
+		t.Errorf("absent slot: discovery=%q verification=%q; want both empty", discovery, verification)
+	}
+	if reg.lookupSlotSnapshotCalls != 1 {
+		t.Errorf("LookupSlotSnapshot called %d times; want 1", reg.lookupSlotSnapshotCalls)
+	}
+	if reg.lookupSlotCalls != 0 {
+		t.Errorf("LookupSlot called %d times; want 0 (no fallback to live pointer)", reg.lookupSlotCalls)
+	}
+}
+
+func TestLookupDiscoveryLabels_NilRegistryReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	discovery, verification := lookupDiscoveryLabels(nil, 0x10)
+	if discovery != "" || verification != "" {
+		t.Errorf("nil registry: discovery=%q verification=%q; want both empty", discovery, verification)
+	}
+}
+
+func TestLookupDiscoveryLabels_StaticSeedAndActiveConfirmedProjections(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		discovery        registry.DiscoverySource
+		verification     registry.VerificationState
+		wantDiscovery    string
+		wantVerification string
+	}{
+		{
+			name:             "static_seed_candidate",
+			discovery:        registry.DiscoverySourceStaticSeed,
+			verification:     registry.VerificationStateCandidate,
+			wantDiscovery:    "static_seed",
+			wantVerification: "candidate",
+		},
+		{
+			name:             "active_confirmed_identity",
+			discovery:        registry.DiscoverySourceActiveConfirmed,
+			verification:     registry.VerificationStateIdentityConfirmed,
+			wantDiscovery:    "active_confirmed",
+			wantVerification: "identity_confirmed",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := &trackingRegistry{
+				hasSnap: true,
+				snap: registry.AddressSlotSnapshot{
+					Addr:              0x10,
+					DiscoverySource:   tc.discovery,
+					VerificationState: tc.verification,
+				},
+			}
+			discovery, verification := lookupDiscoveryLabels(reg, 0x10)
+			if discovery != tc.wantDiscovery {
+				t.Errorf("discovery = %q; want %q", discovery, tc.wantDiscovery)
+			}
+			if verification != tc.wantVerification {
+				t.Errorf("verification = %q; want %q", verification, tc.wantVerification)
+			}
+		})
+	}
+}

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -30,7 +30,21 @@ type Registry interface {
 	// can project discovery_source / verification_state into
 	// JSON-serializable strings (P3.5). Mirrors the same method on
 	// *registry.DeviceRegistry.
+	//
+	// DEPRECATED for label projection: prefer LookupSlotSnapshot for
+	// any code that reads `slot.DiscoverySource` / `.VerificationState`
+	// outside the registry's lock. The live pointer can be mutated
+	// concurrently by Register / RegisterPassiveObserved / MarkSlot*
+	// callers; reading the int-typed enums is atomic in practice on
+	// supported architectures but the race detector flags it under
+	// contention. Retained for callers that need a stable pointer
+	// for FirstObservedAt walks or device-attached probes.
 	LookupSlot(address byte) (*registry.AddressSlot, bool)
+	// LookupSlotSnapshot returns a value-typed snapshot of the slot
+	// taken under the registry's RLock. Callers can read snapshot
+	// fields without race risk (P8.1 / P8.3). Mirrors the same
+	// method on *registry.DeviceRegistry.
+	LookupSlotSnapshot(address byte) (registry.AddressSlotSnapshot, bool)
 }
 
 type Invoker interface {
@@ -3690,15 +3704,21 @@ func (s *Server) snapshotAddressSlots() map[byte]addressSlotLabels {
 // address_table.go so MCP and the address-table snapshot agree on
 // label spellings. Returns ("", "") when reg is nil or the slot is
 // missing.
+//
+// P8.3: switched from LookupSlot (live pointer) to LookupSlotSnapshot
+// (value copy under registry RLock) so the enum reads are race-free
+// with concurrent registry writers (Register / RegisterPassiveObserved
+// / MarkSlot*). The race detector flags the live-pointer pattern
+// under contention; the snapshot eliminates that race surface.
 func lookupDiscoveryLabels(reg Registry, addr byte) (discovery string, verification string) {
 	if reg == nil {
 		return "", ""
 	}
-	slot, ok := reg.LookupSlot(addr)
-	if !ok || slot == nil {
+	snap, ok := reg.LookupSlotSnapshot(addr)
+	if !ok {
 		return "", ""
 	}
-	switch slot.DiscoverySource {
+	switch snap.DiscoverySource {
 	case registry.DiscoverySourcePassiveObserved:
 		discovery = "passive_observed"
 	case registry.DiscoverySourceStaticSeed:
@@ -3706,7 +3726,7 @@ func lookupDiscoveryLabels(reg Registry, addr byte) (discovery string, verificat
 	case registry.DiscoverySourceActiveConfirmed:
 		discovery = "active_confirmed"
 	}
-	switch slot.VerificationState {
+	switch snap.VerificationState {
 	case registry.VerificationStateCandidate:
 		verification = "candidate"
 	case registry.VerificationStateCorroborated:

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -48,6 +48,13 @@ func (r *testRegistry) LookupSlot(byte) (*registry.AddressSlot, bool) {
 	return nil, false
 }
 
+// LookupSlotSnapshot satisfies mcp.Registry (added in P8.3 — value-typed
+// snapshot used by lookupDiscoveryLabels for race-free enum reads).
+// The test fake holds no slots.
+func (r *testRegistry) LookupSlotSnapshot(byte) (registry.AddressSlotSnapshot, bool) {
+	return registry.AddressSlotSnapshot{}, false
+}
+
 type testEntry struct {
 	info   registry.DeviceInfo
 	planes []registry.Plane


### PR DESCRIPTION
## Summary

- Last gateway-side caller of \`LookupSlot\`'s live-pointer pattern for label reads. Codex post-P8.2 next-finding consult ranked this as the #1 remaining race surface.
- Switches \`mcp/server.go:lookupDiscoveryLabels\` from \`LookupSlot\` to \`LookupSlotSnapshot\` (helianthus-ebusreg P8.1, PR #139). Snapshot is value-typed and taken under the registry's RLock — race-free by construction.
- Extends \`mcp.Registry\` interface with \`LookupSlotSnapshot\`. Both test mocks updated.

## Test plan

- [x] \`go test -race -count=1 ./...\` passes
- [x] 4 new tests in \`lookup_discovery_labels_p83_test.go\`: UsesSnapshotPath (proves snapshot is the primary path AND LookupSlot is not used), absent slot, nil registry, all DiscoverySource/VerificationState projections
- [x] \`./scripts/ci_local.sh\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)