### PR TITLE
P9 — MCP snapshotAddressSlots uses IterateSnapshots (race-free)

### DIFF
--- a/cmd/gateway/mcp_bus_observability_integration_test.go
+++ b/cmd/gateway/mcp_bus_observability_integration_test.go
@@ -41,6 +41,14 @@ func (emptyMCPRegistry) LookupSlotSnapshot(byte) (registry.AddressSlotSnapshot, 
 	return registry.AddressSlotSnapshot{}, false
 }
 
+// IterateSnapshots satisfies mcp.Registry (added in P9). Empty fake.
+func (emptyMCPRegistry) IterateSnapshots(func(registry.DeviceEntrySnapshot) bool) {}
+
+// LookupEntrySnapshot satisfies mcp.Registry (added in P9). Empty fake.
+func (emptyMCPRegistry) LookupEntrySnapshot(byte) (registry.DeviceEntrySnapshot, bool) {
+	return registry.DeviceEntrySnapshot{}, false
+}
+
 func TestMCPBusObservabilityProviderAdapterWiresRealStore(t *testing.T) {
 	cfg := ebusgateway.DefaultConfig()
 	cfg.BroadcastListen = true

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260507140006-4dfa4a22cec3
-	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260509165653-c3bef59ee848
+	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260509181158-2a12133252d1
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260507140006-4dfa4a22cec3 h1:U90kuV7LhIkiwnD1iZFGV29Vpd87S119DXDcso4cCp8=
 github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260507140006-4dfa4a22cec3/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260509165653-c3bef59ee848 h1:si6UKr2oUahl2vLxwsV2DsWRcR9v5gw/V9FYglwR+as=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260509165653-c3bef59ee848/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260509181158-2a12133252d1 h1:hB2AH1usRux5lBCSiYugfrt5XGmJxCkPfbwnD+QF81M=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260509181158-2a12133252d1/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=

--- a/mcp/lookup_discovery_labels_p83_test.go
+++ b/mcp/lookup_discovery_labels_p83_test.go
@@ -42,6 +42,12 @@ func (t *trackingRegistry) LookupSlotSnapshot(byte) (registry.AddressSlotSnapsho
 	return registry.AddressSlotSnapshot{}, false
 }
 
+func (t *trackingRegistry) IterateSnapshots(func(registry.DeviceEntrySnapshot) bool) {}
+
+func (t *trackingRegistry) LookupEntrySnapshot(byte) (registry.DeviceEntrySnapshot, bool) {
+	return registry.DeviceEntrySnapshot{}, false
+}
+
 func TestLookupDiscoveryLabels_UsesSnapshotPath(t *testing.T) {
 	t.Parallel()
 

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -26,6 +26,19 @@ import (
 type Registry interface {
 	Iterate(func(registry.DeviceEntry) bool)
 	Lookup(address byte) (registry.DeviceEntry, bool)
+	// IterateSnapshots is the value-typed counterpart to Iterate
+	// (added in helianthus-ebusreg P9). Each callback invocation
+	// receives a DeviceEntrySnapshot taken under the registry's
+	// RLock; the lock is released before the callback runs.
+	// Race-free reads of identity fields without lock-free
+	// dereferencing of live *deviceEntry pointers.
+	IterateSnapshots(func(registry.DeviceEntrySnapshot) bool)
+	// LookupEntrySnapshot is the value-typed counterpart to Lookup
+	// (added in helianthus-ebusreg P9). Returns a value copy of the
+	// entry's identity fields under the registry's RLock; race-free
+	// for callers that don't need the live pointer or Planes /
+	// Projections.
+	LookupEntrySnapshot(address byte) (registry.DeviceEntrySnapshot, bool)
 	// LookupSlot exposes the AddressSlot enum state so MCP responses
 	// can project discovery_source / verification_state into
 	// JSON-serializable strings (P3.5). Mirrors the same method on
@@ -3677,12 +3690,20 @@ func buildDeviceInfo(entry registry.DeviceEntry, reg Registry, preferredAddr byt
 // slot state instead of falling back to the cached deviceInfo's
 // primary-address labels (Codex P3.5 review pass 4).
 //
+// P9 — uses IterateSnapshots / LookupSlotSnapshot so the iteration
+// reads are race-free with concurrent registry writers (Register /
+// RegisterPassiveObserved / MarkSlot*). The previous Iterate path
+// dereferenced live entry pointers outside the registry's lock.
+//
 // Iterates the registry's known device entries and projects each
 // alias address. Empty when the registry has no entries.
 func (s *Server) snapshotAddressSlots() map[byte]addressSlotLabels {
 	out := make(map[byte]addressSlotLabels)
-	s.registry.Iterate(func(entry registry.DeviceEntry) bool {
-		for _, addr := range entry.Addresses() {
+	if s.registry == nil {
+		return nil
+	}
+	s.registry.IterateSnapshots(func(snap registry.DeviceEntrySnapshot) bool {
+		for _, addr := range snap.Addresses {
 			discovery, verification := lookupDiscoveryLabels(s.registry, addr)
 			if discovery == "" && verification == "" {
 				continue

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -2605,10 +2605,16 @@ func (s *Server) listDevices(snapshot *snapshotState) []deviceInfo {
 		return cloneDeviceInfoList(snapshot.devices)
 	}
 	out := make([]deviceInfo, 0)
-	s.registry.Iterate(func(entry registry.DeviceEntry) bool {
+	// P9 — race-free identity-field reads via IterateSnapshots. Each
+	// callback receives a value-typed DeviceEntrySnapshot built under
+	// the registry's RLock; the lock is released before the callback
+	// runs. Planes are still fetched via a separate Lookup (residual
+	// race surface for the Planes interface tree — deferred to a
+	// Plane-aware ebusreg snapshot API; documented in the PR body).
+	s.registry.IterateSnapshots(func(snap registry.DeviceEntrySnapshot) bool {
 		// list view: project the primary address's slot state.
 		// Per-alias detail is reachable via devices.get(address=alias).
-		out = append(out, buildDeviceInfo(entry, s.registry, entry.PrimaryDisplayAddress()))
+		out = append(out, buildDeviceInfoFromSnapshot(snap, s.registry, snap.PrimaryDisplayAddress()))
 		return true
 	})
 	sort.Slice(out, func(i, j int) bool {
@@ -3650,6 +3656,56 @@ func cloneEnergySeries(series EnergySeries) EnergySeries {
 //
 // preferredAddr=0 is treated as "use the primary"; this keeps existing
 // internal callers that do not need per-alias precision working.
+// buildDeviceInfoFromSnapshot is the race-free counterpart of
+// buildDeviceInfo. Identity fields (Manufacturer / DeviceID / version
+// strings / Addresses) come from the value-typed snapshot, which is
+// disconnected from registry storage and immune to concurrent
+// Register writes.
+//
+// Planes are still fetched via a live registry.Lookup of the primary
+// address. The Planes interface tree is NOT included in the
+// DeviceEntrySnapshot (P9 SCOPE note in helianthus-ebusreg), so this
+// path retains the live-pointer read for Planes ONLY. The race
+// surface for Planes is much narrower than the full identity-field
+// surface — tracked as P9.1+ residual.
+func buildDeviceInfoFromSnapshot(snap registry.DeviceEntrySnapshot, reg Registry, preferredAddr byte) deviceInfo {
+	primary := snap.PrimaryDisplayAddress()
+	if preferredAddr == 0 {
+		preferredAddr = primary
+	}
+	all := snap.Addresses
+	var aliases []int
+	if len(all) > 0 {
+		aliases = make([]int, 0, len(all))
+		for _, a := range all {
+			aliases = append(aliases, int(a))
+		}
+	} else {
+		aliases = []int{int(primary)}
+	}
+	discovery, verification := lookupDiscoveryLabels(reg, preferredAddr)
+	// Plane data: P9.1+ residual — DeviceEntrySnapshot doesn't
+	// include Planes (interface tree). Fetch via live Lookup; the
+	// Planes() read is still race-prone with concurrent Register.
+	var planes []planeInfo
+	if reg != nil {
+		if entry, ok := reg.Lookup(primary); ok && entry != nil {
+			planes = buildPlaneInfoList(entry.Planes())
+		}
+	}
+	return deviceInfo{
+		Address:           int(primary),
+		Addresses:         aliases,
+		Manufacturer:      snap.Manufacturer,
+		DeviceID:          snap.DeviceID,
+		SoftwareVersion:   snap.SoftwareVersion,
+		HardwareVersion:   snap.HardwareVersion,
+		Planes:            planes,
+		DiscoverySource:   discovery,
+		VerificationState: verification,
+	}
+}
+
 func buildDeviceInfo(entry registry.DeviceEntry, reg Registry, preferredAddr byte) deviceInfo {
 	primary := entry.PrimaryDisplayAddress()
 	if preferredAddr == 0 {

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -55,6 +55,39 @@ func (r *testRegistry) LookupSlotSnapshot(byte) (registry.AddressSlotSnapshot, b
 	return registry.AddressSlotSnapshot{}, false
 }
 
+// IterateSnapshots satisfies mcp.Registry (added in P9). The test fake
+// has no notion of snapshots; iterate the existing entries map and
+// emit a minimal snapshot per entry so tests that exercise the
+// snapshot-iteration path still work.
+func (r *testRegistry) IterateSnapshots(fn func(registry.DeviceEntrySnapshot) bool) {
+	for _, entry := range r.entries {
+		snap := registry.DeviceEntrySnapshot{
+			PrimaryAddress: entry.PrimaryDisplayAddress(),
+			Addresses:      entry.Addresses(),
+			Manufacturer:   entry.Manufacturer(),
+			DeviceID:       entry.DeviceID(),
+		}
+		if !fn(snap) {
+			return
+		}
+	}
+}
+
+// LookupEntrySnapshot satisfies mcp.Registry (added in P9). Builds a
+// minimal snapshot from the test fake's entries map.
+func (r *testRegistry) LookupEntrySnapshot(addr byte) (registry.DeviceEntrySnapshot, bool) {
+	entry, ok := r.entries[addr]
+	if !ok {
+		return registry.DeviceEntrySnapshot{}, false
+	}
+	return registry.DeviceEntrySnapshot{
+		PrimaryAddress: entry.PrimaryDisplayAddress(),
+		Addresses:      entry.Addresses(),
+		Manufacturer:   entry.Manufacturer(),
+		DeviceID:       entry.DeviceID(),
+	}, true
+}
+
 type testEntry struct {
 	info   registry.DeviceInfo
 	planes []registry.Plane

--- a/mcp/snapshot_address_slots_p9_test.go
+++ b/mcp/snapshot_address_slots_p9_test.go
@@ -1,0 +1,118 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+)
+
+// P9 — snapshotAddressSlots uses IterateSnapshots / LookupSlotSnapshot.
+
+// iterateTrackingRegistry counts which iteration API was called.
+type iterateTrackingRegistry struct {
+	iterateCalls         int
+	iterateSnapshotCalls int
+	snapshots            []registry.DeviceEntrySnapshot
+	slotSnapshots        map[byte]registry.AddressSlotSnapshot
+}
+
+func (r *iterateTrackingRegistry) Iterate(fn func(registry.DeviceEntry) bool) {
+	r.iterateCalls++
+	// Should NOT be called by snapshotAddressSlots after P9.
+}
+
+func (r *iterateTrackingRegistry) Lookup(byte) (registry.DeviceEntry, bool) {
+	return nil, false
+}
+
+func (r *iterateTrackingRegistry) LookupSlot(byte) (*registry.AddressSlot, bool) {
+	return nil, false
+}
+
+func (r *iterateTrackingRegistry) LookupSlotSnapshot(addr byte) (registry.AddressSlotSnapshot, bool) {
+	if snap, ok := r.slotSnapshots[addr]; ok {
+		return snap, true
+	}
+	return registry.AddressSlotSnapshot{}, false
+}
+
+func (r *iterateTrackingRegistry) IterateSnapshots(fn func(registry.DeviceEntrySnapshot) bool) {
+	r.iterateSnapshotCalls++
+	for _, snap := range r.snapshots {
+		if !fn(snap) {
+			return
+		}
+	}
+}
+
+func (r *iterateTrackingRegistry) LookupEntrySnapshot(byte) (registry.DeviceEntrySnapshot, bool) {
+	return registry.DeviceEntrySnapshot{}, false
+}
+
+// TestSnapshotAddressSlots_UsesIterateSnapshots proves the P9 contract:
+// snapshotAddressSlots iterates via IterateSnapshots (race-free) and
+// no longer calls Iterate (which dereferences live entry pointers
+// outside the registry's lock).
+func TestSnapshotAddressSlots_UsesIterateSnapshots(t *testing.T) {
+	t.Parallel()
+
+	reg := &iterateTrackingRegistry{
+		snapshots: []registry.DeviceEntrySnapshot{
+			{
+				PrimaryAddress: 0x10,
+				Addresses:      []byte{0x10, 0x15},
+				Manufacturer:   "Vaillant",
+			},
+		},
+		slotSnapshots: map[byte]registry.AddressSlotSnapshot{
+			0x10: {
+				DiscoverySource:   registry.DiscoverySourcePassiveObserved,
+				VerificationState: registry.VerificationStateCorroborated,
+			},
+			0x15: {
+				DiscoverySource:   registry.DiscoverySourcePassiveObserved,
+				VerificationState: registry.VerificationStateCorroborated,
+			},
+		},
+	}
+
+	server := &Server{registry: reg}
+	out := server.snapshotAddressSlots()
+
+	if reg.iterateSnapshotCalls != 1 {
+		t.Errorf("IterateSnapshots called %d times; want 1", reg.iterateSnapshotCalls)
+	}
+	if reg.iterateCalls != 0 {
+		t.Errorf("Iterate called %d times; want 0 (P9 contract: snapshot iteration only)", reg.iterateCalls)
+	}
+	if len(out) != 2 {
+		t.Errorf("output map size = %d; want 2 (both 0x10 and 0x15)", len(out))
+	}
+	if out[0x10].discovery != "passive_observed" {
+		t.Errorf("out[0x10].discovery = %q; want passive_observed", out[0x10].discovery)
+	}
+	if out[0x15].discovery != "passive_observed" {
+		t.Errorf("out[0x15].discovery = %q; want passive_observed", out[0x15].discovery)
+	}
+}
+
+// TestSnapshotAddressSlots_NilRegistryReturnsNil verifies the early
+// nil-guard.
+func TestSnapshotAddressSlots_NilRegistryReturnsNil(t *testing.T) {
+	t.Parallel()
+	server := &Server{registry: nil}
+	if got := server.snapshotAddressSlots(); got != nil {
+		t.Errorf("snapshotAddressSlots() = %v; want nil for nil registry", got)
+	}
+}
+
+// TestSnapshotAddressSlots_EmptyRegistryReturnsNil verifies that an
+// empty registry produces nil (not an empty map).
+func TestSnapshotAddressSlots_EmptyRegistryReturnsNil(t *testing.T) {
+	t.Parallel()
+	reg := &iterateTrackingRegistry{}
+	server := &Server{registry: reg}
+	if got := server.snapshotAddressSlots(); got != nil {
+		t.Errorf("snapshotAddressSlots() = %v; want nil for empty registry", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Migrates the MCP server's \`snapshotAddressSlots\` AND \`listDevices\` from \`Iterate\`+live entry pointers to \`IterateSnapshots\` (helianthus-ebusreg P9, PR #140).
- Introduces \`buildDeviceInfoFromSnapshot\` as the race-free counterpart of \`buildDeviceInfo\`. Identity fields (Manufacturer / DeviceID / version strings / Addresses) read from the value-typed snapshot; only \`Planes()\` still goes through a live \`Lookup\` (residual race surface narrowed from 6+ string fields to just the Planes interface tree).
- Extends \`mcp.Registry\` interface with \`IterateSnapshots\` + \`LookupEntrySnapshot\`. Three test mocks updated.

## Test plan

- [x] \`go test -race -count=1 ./...\` passes (full gateway suite, 168+ tests)
- [x] 3 new tests in \`snapshot_address_slots_p9_test.go\` (IterateSnapshots is called, Iterate is never called)
- [x] \`./scripts/ci_local.sh\` green

## Race surface delta

**Closed**: identity-field reads in \`devices.list\` and \`bus.summary.get\` slot-label projection. Concurrent Register writes against the registry no longer produce torn reads of \`entry.info\` strings via these paths.

**Residual (P9.1+)**: \`Planes()\` still read live via \`Lookup\`. The Planes interface tree isn't covered by \`DeviceEntrySnapshot\` (it requires its own snapshot strategy — Codex SCOPE note in P9 ebusreg). Other consumers (devices.get, devices.info, GraphQL surfaces, BusObservabilityStore, smoke.go) still use the live-pointer \`Lookup\` API. These will migrate in subsequent PRs as the snapshot pattern propagates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)