### PR TITLE
P9.1 — MCP getDevice uses LookupEntrySnapshot + drop unused buildDeviceInfo

### DIFF
--- a/mcp/get_device_p91_test.go
+++ b/mcp/get_device_p91_test.go
@@ -1,0 +1,119 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+)
+
+// P9.1 — getDevice uses LookupEntrySnapshot (race-free identity).
+
+// getDeviceTrackingRegistry counts which lookup API was called by
+// getDevice. Pre-P9.1 the call routed through Lookup (live entry);
+// post-P9.1 it routes through LookupEntrySnapshot.
+type getDeviceTrackingRegistry struct {
+	lookupCalls         int
+	lookupSnapshotCalls int
+	snapshot            registry.DeviceEntrySnapshot
+	hasSnapshot         bool
+	slotSnap            registry.AddressSlotSnapshot
+	hasSlotSnap         bool
+}
+
+func (r *getDeviceTrackingRegistry) Iterate(func(registry.DeviceEntry) bool) {}
+
+func (r *getDeviceTrackingRegistry) Lookup(byte) (registry.DeviceEntry, bool) {
+	r.lookupCalls++
+	return nil, false
+}
+
+func (r *getDeviceTrackingRegistry) LookupSlot(byte) (*registry.AddressSlot, bool) {
+	return nil, false
+}
+
+func (r *getDeviceTrackingRegistry) LookupSlotSnapshot(byte) (registry.AddressSlotSnapshot, bool) {
+	if r.hasSlotSnap {
+		return r.slotSnap, true
+	}
+	return registry.AddressSlotSnapshot{}, false
+}
+
+func (r *getDeviceTrackingRegistry) IterateSnapshots(func(registry.DeviceEntrySnapshot) bool) {
+}
+
+func (r *getDeviceTrackingRegistry) LookupEntrySnapshot(byte) (registry.DeviceEntrySnapshot, bool) {
+	r.lookupSnapshotCalls++
+	if r.hasSnapshot {
+		return r.snapshot, true
+	}
+	return registry.DeviceEntrySnapshot{}, false
+}
+
+// TestGetDevice_UsesLookupEntrySnapshot proves the P9.1 contract:
+// getDevice calls LookupEntrySnapshot for identity fields and does
+// NOT use the live-pointer Lookup path.
+//
+// NOTE: getDevice's buildDeviceInfoFromSnapshot helper still calls
+// reg.Lookup to fetch Planes (residual surface, P9.2+ follow-up).
+// This test asserts the PRIMARY identity-read path uses the snapshot
+// API by counting LookupEntrySnapshot vs Lookup calls.
+func TestGetDevice_UsesLookupEntrySnapshot(t *testing.T) {
+	t.Parallel()
+
+	reg := &getDeviceTrackingRegistry{
+		hasSnapshot: true,
+		snapshot: registry.DeviceEntrySnapshot{
+			PrimaryAddress: 0x10,
+			Addresses:      []byte{0x10, 0x15},
+			Manufacturer:   "Vaillant",
+			DeviceID:       "BASV2",
+		},
+		hasSlotSnap: true,
+		slotSnap: registry.AddressSlotSnapshot{
+			DiscoverySource:   registry.DiscoverySourcePassiveObserved,
+			VerificationState: registry.VerificationStateCorroborated,
+		},
+	}
+
+	server := &Server{registry: reg}
+	dev, err := server.getDevice(map[string]any{"address": float64(0x10)}, nil)
+	if err != nil {
+		t.Fatalf("getDevice error = %v", err)
+	}
+
+	if reg.lookupSnapshotCalls != 1 {
+		t.Errorf("LookupEntrySnapshot called %d times; want 1 (P9.1 contract: primary identity-read path)", reg.lookupSnapshotCalls)
+	}
+	// reg.lookupCalls is permitted to be 1 (Planes fetch from
+	// buildDeviceInfoFromSnapshot's residual). Strictly assert it
+	// wasn't called more than the Plane fetch.
+	if reg.lookupCalls > 1 {
+		t.Errorf("Lookup called %d times; want at most 1 (Planes residual)", reg.lookupCalls)
+	}
+
+	if dev.Manufacturer != "Vaillant" {
+		t.Errorf("Manufacturer = %q; want Vaillant", dev.Manufacturer)
+	}
+	if dev.DeviceID != "BASV2" {
+		t.Errorf("DeviceID = %q; want BASV2", dev.DeviceID)
+	}
+	if dev.DiscoverySource != "passive_observed" {
+		t.Errorf("DiscoverySource = %q; want passive_observed", dev.DiscoverySource)
+	}
+}
+
+// TestGetDevice_AbsentEntryReturnsError verifies the error path
+// (LookupEntrySnapshot returns false → ErrNoSuchDevice).
+func TestGetDevice_AbsentEntryReturnsError(t *testing.T) {
+	t.Parallel()
+
+	reg := &getDeviceTrackingRegistry{hasSnapshot: false}
+	server := &Server{registry: reg}
+	_, err := server.getDevice(map[string]any{"address": float64(0x42)}, nil)
+	if err == nil {
+		t.Error("getDevice for absent entry: err=nil; want ErrNoSuchDevice")
+	}
+	if reg.lookupSnapshotCalls != 1 {
+		t.Errorf("LookupEntrySnapshot called %d times; want 1", reg.lookupSnapshotCalls)
+	}
+}

--- a/mcp/get_device_p91_test.go
+++ b/mcp/get_device_p91_test.go
@@ -1,8 +1,10 @@
 package mcp
 
 import (
+	"errors"
 	"testing"
 
+	ebuserrors "github.com/Project-Helianthus/helianthus-ebusgo/errors"
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
 )
 
@@ -51,12 +53,14 @@ func (r *getDeviceTrackingRegistry) LookupEntrySnapshot(byte) (registry.DeviceEn
 
 // TestGetDevice_UsesLookupEntrySnapshot proves the P9.1 contract:
 // getDevice calls LookupEntrySnapshot for identity fields and does
-// NOT use the live-pointer Lookup path.
+// NOT use the live-pointer Lookup path FOR IDENTITY FIELDS.
 //
 // NOTE: getDevice's buildDeviceInfoFromSnapshot helper still calls
-// reg.Lookup to fetch Planes (residual surface, P9.2+ follow-up).
-// This test asserts the PRIMARY identity-read path uses the snapshot
-// API by counting LookupEntrySnapshot vs Lookup calls.
+// reg.Lookup ONCE to fetch Planes (residual surface, P9.2+
+// follow-up). The assertion `lookupCalls <= 1` accommodates that
+// expected residual; tightening the assertion to `lookupCalls == 0`
+// would be a regression because the Plane fetch is the documented
+// behavior, not a leftover live-pointer identity read.
 func TestGetDevice_UsesLookupEntrySnapshot(t *testing.T) {
 	t.Parallel()
 
@@ -104,6 +108,14 @@ func TestGetDevice_UsesLookupEntrySnapshot(t *testing.T) {
 
 // TestGetDevice_AbsentEntryReturnsError verifies the error path
 // (LookupEntrySnapshot returns false → ErrNoSuchDevice).
+//
+// Locks down two contracts:
+//   - The error wraps ebuserrors.ErrNoSuchDevice (operator-visible
+//     contract — MCP returns a specific error code for unknown
+//     addresses).
+//   - The live-pointer Lookup path is NEVER consulted on snapshot
+//     miss (P9.1 contract — no fallback that would reintroduce the
+//     race surface).
 func TestGetDevice_AbsentEntryReturnsError(t *testing.T) {
 	t.Parallel()
 
@@ -111,9 +123,15 @@ func TestGetDevice_AbsentEntryReturnsError(t *testing.T) {
 	server := &Server{registry: reg}
 	_, err := server.getDevice(map[string]any{"address": float64(0x42)}, nil)
 	if err == nil {
-		t.Error("getDevice for absent entry: err=nil; want ErrNoSuchDevice")
+		t.Fatal("getDevice for absent entry: err=nil; want ErrNoSuchDevice")
+	}
+	if !errors.Is(err, ebuserrors.ErrNoSuchDevice) {
+		t.Errorf("err = %v; want errors.Is(err, ErrNoSuchDevice)", err)
 	}
 	if reg.lookupSnapshotCalls != 1 {
 		t.Errorf("LookupEntrySnapshot called %d times; want 1", reg.lookupSnapshotCalls)
+	}
+	if reg.lookupCalls != 0 {
+		t.Errorf("Lookup called %d times; want 0 (P9.1 contract: snapshot miss must NOT fall back to live Lookup)", reg.lookupCalls)
 	}
 }

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -2650,7 +2650,11 @@ func (s *Server) getDevice(args map[string]any, snapshot *snapshotState) (device
 		}
 		return device, nil
 	}
-	entry, ok := s.registry.Lookup(address)
+	// P9.1 — race-free identity-field reads via LookupEntrySnapshot.
+	// Identity fields come from the value-typed snapshot; Planes are
+	// fetched via a live Lookup inside buildDeviceInfoFromSnapshot
+	// (residual race surface: Planes interface tree only).
+	snap, ok := s.registry.LookupEntrySnapshot(address)
 	if !ok {
 		return deviceInfo{}, fmt.Errorf("unknown device 0x%02x: %w", address, ebuserrors.ErrNoSuchDevice)
 	}
@@ -2659,7 +2663,7 @@ func (s *Server) getDevice(args map[string]any, snapshot *snapshotState) (device
 	// aliases at different DiscoverySource levels, the operator gets
 	// the slot they asked about — not the primary's potentially-
 	// different label.
-	return buildDeviceInfo(entry, s.registry, address), nil
+	return buildDeviceInfoFromSnapshot(snap, s.registry, address), nil
 }
 
 func (s *Server) listPlanes(args map[string]any, snapshot *snapshotState) ([]planeInfo, error) {
@@ -3639,7 +3643,8 @@ func cloneEnergySeries(series EnergySeries) EnergySeries {
 	return series
 }
 
-// buildDeviceInfo materialises the JSON view of a device entry.
+// buildDeviceInfoFromSnapshot materialises the JSON view of a device
+// entry from a value-typed DeviceEntrySnapshot.
 //
 // preferredAddr selects which AddressSlot is consulted for the
 // top-level discovery_source/verification_state projection. For
@@ -3656,18 +3661,19 @@ func cloneEnergySeries(series EnergySeries) EnergySeries {
 //
 // preferredAddr=0 is treated as "use the primary"; this keeps existing
 // internal callers that do not need per-alias precision working.
-// buildDeviceInfoFromSnapshot is the race-free counterpart of
-// buildDeviceInfo. Identity fields (Manufacturer / DeviceID / version
-// strings / Addresses) come from the value-typed snapshot, which is
-// disconnected from registry storage and immune to concurrent
-// Register writes.
+//
+// Race-free counterpart of the legacy buildDeviceInfo (P9.1 — that
+// helper was removed because all known callers migrated). Identity
+// fields (Manufacturer / DeviceID / version strings / Addresses)
+// come from the value-typed snapshot, which is disconnected from
+// registry storage and immune to concurrent Register writes.
 //
 // Planes are still fetched via a live registry.Lookup of the primary
 // address. The Planes interface tree is NOT included in the
 // DeviceEntrySnapshot (P9 SCOPE note in helianthus-ebusreg), so this
 // path retains the live-pointer read for Planes ONLY. The race
 // surface for Planes is much narrower than the full identity-field
-// surface — tracked as P9.1+ residual.
+// surface — tracked as P9.2+ residual.
 func buildDeviceInfoFromSnapshot(snap registry.DeviceEntrySnapshot, reg Registry, preferredAddr byte) deviceInfo {
 	primary := snap.PrimaryDisplayAddress()
 	if preferredAddr == 0 {
@@ -3701,40 +3707,6 @@ func buildDeviceInfoFromSnapshot(snap registry.DeviceEntrySnapshot, reg Registry
 		SoftwareVersion:   snap.SoftwareVersion,
 		HardwareVersion:   snap.HardwareVersion,
 		Planes:            planes,
-		DiscoverySource:   discovery,
-		VerificationState: verification,
-	}
-}
-
-func buildDeviceInfo(entry registry.DeviceEntry, reg Registry, preferredAddr byte) deviceInfo {
-	primary := entry.PrimaryDisplayAddress()
-	if preferredAddr == 0 {
-		preferredAddr = primary
-	}
-	all := entry.Addresses()
-	// Surface the complete address set (primary + aliases) to match the
-	// GraphQL `addresses` semantics in graphql/schema.go. Snapshot
-	// consumers (findDeviceInfoByAddress) check this list to resolve
-	// canonical-pair queries regardless of which half the caller asked
-	// for. MCP↔GraphQL parity contract requires identical list contents.
-	var aliases []int
-	if len(all) > 0 {
-		aliases = make([]int, 0, len(all))
-		for _, a := range all {
-			aliases = append(aliases, int(a))
-		}
-	} else {
-		aliases = []int{int(primary)}
-	}
-	discovery, verification := lookupDiscoveryLabels(reg, preferredAddr)
-	return deviceInfo{
-		Address:           int(primary),
-		Addresses:         aliases,
-		Manufacturer:      entry.Manufacturer(),
-		DeviceID:          entry.DeviceID(),
-		SoftwareVersion:   entry.SoftwareVersion(),
-		HardwareVersion:   entry.HardwareVersion(),
-		Planes:            buildPlaneInfoList(entry.Planes()),
 		DiscoverySource:   discovery,
 		VerificationState: verification,
 	}


### PR DESCRIPTION
## Summary

- Migrates \`getDevice\` (backing \`ebus.v1.registry.devices.get\`) from \`Lookup\` (live entry pointer) to \`LookupEntrySnapshot\` (value-typed snapshot under registry RLock).
- Drops the legacy \`buildDeviceInfo\` helper now that all callers use \`buildDeviceInfoFromSnapshot\` (golangci-lint flagged unused).
- Race surface delta: identity-field reads in devices.get are now race-free. Planes() residual (live Lookup inside buildDeviceInfoFromSnapshot) remains, documented as P9.2+.

## Test plan

- [x] \`go test -race -count=1 ./...\` passes
- [x] 2 new tests prove the contract (LookupEntrySnapshot called for identity, Lookup at most once for Planes residual)
- [x] \`./scripts/ci_local.sh\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)