### PR TITLE
P9.2 — passive_discovery_promoter uses IterateSnapshots + SnapshotContainsAddress helper

### DIFF
--- a/passive_discovery_promoter.go
+++ b/passive_discovery_promoter.go
@@ -409,9 +409,16 @@ func (p *PassiveDiscoveryPromoter) registryContains(addr byte) bool {
 	// registered, otherwise the promoter actively re-confirms and
 	// re-commits it on every cycle, producing redundant bus probes
 	// and router/semantic refreshes.
+	//
+	// P9.2 — uses IterateSnapshots so the address-list reads are
+	// race-free with concurrent registry writers (Register /
+	// RegisterPassiveObserved / AliasAddresses). The promoter runs
+	// on its own goroutine and the registry is mutated by other
+	// goroutines (passive inserter, startup scan); the previous
+	// Iterate path read entry.Addresses() lock-free.
 	found := false
-	p.registry.Iterate(func(entry registry.DeviceEntry) bool {
-		if EntryContainsAddress(entry, addr) {
+	p.registry.IterateSnapshots(func(snap registry.DeviceEntrySnapshot) bool {
+		if SnapshotContainsAddress(snap, addr) {
 			found = true
 			return false
 		}

--- a/snapshot_contains_address_p92_test.go
+++ b/snapshot_contains_address_p92_test.go
@@ -95,16 +95,40 @@ func TestSnapshotContainsAddress_AliasResolutionParity(t *testing.T) {
 		t.Fatalf("AliasAddresses error = %v", err)
 	}
 
-	// Build a snapshot of the merged entry; verify both addresses
-	// are visible in the snapshot's Addresses slice.
-	snap, ok := reg.LookupEntrySnapshot(0x10)
-	if !ok {
+	// Take both views of the same entry: live pointer (used by
+	// EntryContainsAddress) and snapshot (used by
+	// SnapshotContainsAddress). Both APIs must agree for every test
+	// address — that's the parity the P9.2 promoter migration depends
+	// on.
+	entry, entryOK := reg.Lookup(0x10)
+	if !entryOK {
+		t.Fatalf("Lookup(0x10) ok=false")
+	}
+	snap, snapOK := reg.LookupEntrySnapshot(0x10)
+	if !snapOK {
 		t.Fatalf("LookupEntrySnapshot(0x10) ok=false")
 	}
-	if !SnapshotContainsAddress(snap, 0x10) {
-		t.Errorf("SnapshotContainsAddress(snap, 0x10) = false; want true")
+
+	cases := []struct {
+		addr byte
+		want bool
+		desc string
+	}{
+		{0x10, true, "primary"},
+		{0x15, true, "alias"},
+		{0x42, false, "miss"},
 	}
-	if !SnapshotContainsAddress(snap, 0x15) {
-		t.Errorf("SnapshotContainsAddress(snap, 0x15) = false; want true (alias)")
+	for _, tc := range cases {
+		gotEntry := EntryContainsAddress(entry, tc.addr)
+		gotSnap := SnapshotContainsAddress(snap, tc.addr)
+		if gotEntry != tc.want {
+			t.Errorf("%s: EntryContainsAddress(entry, 0x%02X) = %v; want %v", tc.desc, tc.addr, gotEntry, tc.want)
+		}
+		if gotSnap != tc.want {
+			t.Errorf("%s: SnapshotContainsAddress(snap, 0x%02X) = %v; want %v", tc.desc, tc.addr, gotSnap, tc.want)
+		}
+		if gotEntry != gotSnap {
+			t.Errorf("%s: EntryContainsAddress=%v != SnapshotContainsAddress=%v for 0x%02X (parity violation — promoter migration would change behavior)", tc.desc, gotEntry, gotSnap, tc.addr)
+		}
 	}
 }

--- a/snapshot_contains_address_p92_test.go
+++ b/snapshot_contains_address_p92_test.go
@@ -64,18 +64,28 @@ func TestSnapshotContainsAddress_EmptySliceReturnsFalse(t *testing.T) {
 	}
 }
 
-// TestPassiveDiscoveryPromoter_RegistryContainsUsesIterateSnapshots
-// is a partial integration check: register an entry, call the
-// promoter's registryContains via reflection or a public proxy. The
-// promoter's registryContains is private; use an alias-aware
-// registry to verify the address-membership semantics still hold
-// post-migration.
+// TestSnapshotContainsAddress_AliasResolutionParity verifies the
+// behavior-equivalence contract between EntryContainsAddress (live
+// pointer) and SnapshotContainsAddress (snapshot) on an aliased
+// canonical pair. The promoter's registryContains migration depends
+// on this parity: both APIs must report the same membership truth on
+// the same registry state, otherwise the migration would change
+// observable behaviour.
 //
-// We use the real *registry.DeviceRegistry (not a tracking mock)
-// because registryContains is unexported. The race-detector run as
-// part of `go test -race ./...` already covers the migration's
-// correctness against concurrent writers.
-func TestPassiveDiscoveryPromoter_RegistryContains_PostP92(t *testing.T) {
+// NOTE (Codex P9.2 review pass 1 NIT FINDING_2): this is NOT a
+// regression test for the promoter's specific IterateSnapshots vs
+// Iterate routing — registryContains is unexported and the promoter
+// uses *registry.DeviceRegistry (concrete type, not interface) so a
+// counter-tracking mock isn't substitutable without refactoring the
+// promoter to take a Registry interface. The migration's correctness
+// is verified by:
+//
+//  1. Code inspection of the diff (one-line API swap at
+//     passive_discovery_promoter.go:420 — Iterate → IterateSnapshots,
+//     EntryContainsAddress → SnapshotContainsAddress).
+//  2. This behavior-parity test on the underlying helpers.
+//  3. -race ./... on the full suite (race detector authoritative).
+func TestSnapshotContainsAddress_AliasResolutionParity(t *testing.T) {
 	t.Parallel()
 
 	reg := registry.NewDeviceRegistry(nil)

--- a/snapshot_contains_address_p92_test.go
+++ b/snapshot_contains_address_p92_test.go
@@ -1,0 +1,100 @@
+package ebusgateway
+
+import (
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+)
+
+// P9.2 — SnapshotContainsAddress helper.
+//
+// Race-free counterpart of EntryContainsAddress for callers that
+// have already taken a DeviceEntrySnapshot. Reads from the
+// snapshot's Addresses slice (a value-typed copy taken under the
+// registry's RLock) — disconnected from registry storage and
+// immune to concurrent Register / RegisterPassiveObserved /
+// AliasAddresses writes.
+
+func TestSnapshotContainsAddress_HitsPrimary(t *testing.T) {
+	t.Parallel()
+
+	snap := registry.DeviceEntrySnapshot{
+		PrimaryAddress: 0x10,
+		Addresses:      []byte{0x10, 0x15},
+	}
+
+	if !SnapshotContainsAddress(snap, 0x10) {
+		t.Errorf("SnapshotContainsAddress(snap, 0x10) = false; want true (primary in Addresses)")
+	}
+}
+
+func TestSnapshotContainsAddress_HitsAlias(t *testing.T) {
+	t.Parallel()
+
+	snap := registry.DeviceEntrySnapshot{
+		PrimaryAddress: 0x10,
+		Addresses:      []byte{0x10, 0x15},
+	}
+
+	if !SnapshotContainsAddress(snap, 0x15) {
+		t.Errorf("SnapshotContainsAddress(snap, 0x15) = false; want true (alias in Addresses)")
+	}
+}
+
+func TestSnapshotContainsAddress_MissReturnsFalse(t *testing.T) {
+	t.Parallel()
+
+	snap := registry.DeviceEntrySnapshot{
+		PrimaryAddress: 0x10,
+		Addresses:      []byte{0x10, 0x15},
+	}
+
+	if SnapshotContainsAddress(snap, 0x42) {
+		t.Errorf("SnapshotContainsAddress(snap, 0x42) = true; want false")
+	}
+}
+
+func TestSnapshotContainsAddress_EmptySliceReturnsFalse(t *testing.T) {
+	t.Parallel()
+
+	snap := registry.DeviceEntrySnapshot{}
+
+	if SnapshotContainsAddress(snap, 0x10) {
+		t.Errorf("SnapshotContainsAddress(empty, 0x10) = true; want false")
+	}
+}
+
+// TestPassiveDiscoveryPromoter_RegistryContainsUsesIterateSnapshots
+// is a partial integration check: register an entry, call the
+// promoter's registryContains via reflection or a public proxy. The
+// promoter's registryContains is private; use an alias-aware
+// registry to verify the address-membership semantics still hold
+// post-migration.
+//
+// We use the real *registry.DeviceRegistry (not a tracking mock)
+// because registryContains is unexported. The race-detector run as
+// part of `go test -race ./...` already covers the migration's
+// correctness against concurrent writers.
+func TestPassiveDiscoveryPromoter_RegistryContains_PostP92(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.NewDeviceRegistry(nil)
+	reg.Register(registry.DeviceInfo{Address: 0x10, SerialNumber: "SN-X"})
+	reg.Register(registry.DeviceInfo{Address: 0x15, SerialNumber: "SN-Y"})
+	if err := reg.AliasAddresses(0x10, 0x15); err != nil {
+		t.Fatalf("AliasAddresses error = %v", err)
+	}
+
+	// Build a snapshot of the merged entry; verify both addresses
+	// are visible in the snapshot's Addresses slice.
+	snap, ok := reg.LookupEntrySnapshot(0x10)
+	if !ok {
+		t.Fatalf("LookupEntrySnapshot(0x10) ok=false")
+	}
+	if !SnapshotContainsAddress(snap, 0x10) {
+		t.Errorf("SnapshotContainsAddress(snap, 0x10) = false; want true")
+	}
+	if !SnapshotContainsAddress(snap, 0x15) {
+		t.Errorf("SnapshotContainsAddress(snap, 0x15) = false; want true (alias)")
+	}
+}

--- a/target_address.go
+++ b/target_address.go
@@ -42,3 +42,21 @@ func EntryContainsAddress(entry registry.DeviceEntry, addr byte) bool {
 	}
 	return false
 }
+
+// SnapshotContainsAddress is the value-typed counterpart of
+// EntryContainsAddress for callers that have already taken a
+// DeviceEntrySnapshot via LookupEntrySnapshot / IterateSnapshots.
+//
+// P9.2 — race-free address-membership check. Pre-P9.2 callers had to
+// take an EntryContainsAddress(entry, addr) on a live *deviceEntry
+// pointer (entry.Addresses() reads through to mutable storage); this
+// helper reads the snapshot's Addresses slice (already a value-typed
+// copy taken under the registry's RLock).
+func SnapshotContainsAddress(snap registry.DeviceEntrySnapshot, addr byte) bool {
+	for _, a := range snap.Addresses {
+		if a == addr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

- Migrates \`PassiveDiscoveryPromoter.registryContains\` from \`Iterate\` (live entry pointer) to \`IterateSnapshots\` (value-typed snapshot under registry RLock).
- Adds \`SnapshotContainsAddress\` helper — value-typed counterpart of \`EntryContainsAddress\` for snapshot consumers.
- Closes the race surface where the promoter's address-membership check could observe torn reads of \`entry.addresses\` under concurrent Register / RegisterPassiveObserved / AliasAddresses writes.

## Test plan

- [x] \`go test -race -count=1 ./...\` passes
- [x] 5 new tests in \`snapshot_contains_address_p92_test.go\` (hit primary, hit alias, miss, empty, post-migration alias resolution)
- [x] \`./scripts/ci_local.sh\` green

## Out-of-scope

Other EntryContainsAddress callers (register_dump, startup_scan, semantic_vaillant, smoke) are NOT migrated — single-goroutine paths or one-shot operations with negligible concurrent-write surface. Will migrate opportunistically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)