### PR TITLE
refactor(gateway): P9.5 — controller detection by canonical regulator target addresses (identifier-free)

### DIFF
--- a/graphql/find_controller_entry_p95_test.go
+++ b/graphql/find_controller_entry_p95_test.go
@@ -1,100 +1,66 @@
 package graphql
 
 import (
-	"strings"
+	"errors"
 	"testing"
 
+	ebuserrors "github.com/Project-Helianthus/helianthus-ebusgo/errors"
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
 )
 
-// P9.5 — findControllerEntry uses IterateSnapshots for DeviceID scan.
+// P9.5 (operator-directed pivot 2026-05-09) — findControllerEntry
+// uses canonical regulator target addresses, not BASV-prefix scan.
 //
-// Pre-P9.5 the iteration read entry.DeviceID() lock-free; Post-P9.5
-// it reads from a value-typed snapshot. This test pins the snapshot
-// path with a tracking mock that counts which iteration API was
-// called. Codex P9.5 review pass 1 NIT FINDING_2 noted that
-// existing mutationTestRegistry only implements Iterate (not
-// IterateSnapshots), so without this test the new path isn't
-// directly exercised in regression.
+// The previous BASV-prefix DeviceID scan silently skipped non-BASV
+// controllers (CTLV*/CTLS*/CTLR*/BASS*/future identifiers) and was
+// also race-prone with concurrent Register writes. The new algorithm
+// looks up canonical eBUS regulator target addresses in priority
+// order; the first registered entry is the controller.
 
-type findControllerTrackingRegistry struct {
-	iterateCalls         int
-	iterateSnapshotCalls int
-	lookupCalls          int
-	lookupSnapCalls      int
-	snapshots            []registry.DeviceEntrySnapshot
-	entries              map[byte]registry.DeviceEntry
-	snapByAddr           map[byte]registry.DeviceEntrySnapshot
+// findControllerCanonicalLookupRegistry is a minimal Registry mock
+// that only implements Lookup. Used to verify findControllerEntry's
+// canonical-address-iteration contract: each canonical address gets
+// looked up in priority order until one returns a registered entry.
+type findControllerCanonicalLookupRegistry struct {
+	lookups []byte // ordered list of addresses queried
+	entries map[byte]registry.DeviceEntry
 }
 
-func (r *findControllerTrackingRegistry) Lookup(addr byte) (registry.DeviceEntry, bool) {
-	r.lookupCalls++
+func (r *findControllerCanonicalLookupRegistry) Lookup(addr byte) (registry.DeviceEntry, bool) {
+	r.lookups = append(r.lookups, addr)
 	entry, ok := r.entries[addr]
 	return entry, ok
 }
 
-func (r *findControllerTrackingRegistry) Iterate(fn func(registry.DeviceEntry) bool) {
-	r.iterateCalls++
-}
-
-func (r *findControllerTrackingRegistry) IterateSnapshots(fn func(registry.DeviceEntrySnapshot) bool) {
-	r.iterateSnapshotCalls++
-	for _, snap := range r.snapshots {
-		if !fn(snap) {
-			return
-		}
-	}
-}
-
-func (r *findControllerTrackingRegistry) LookupEntrySnapshot(addr byte) (registry.DeviceEntrySnapshot, bool) {
-	r.lookupSnapCalls++
-	if snap, ok := r.snapByAddr[addr]; ok {
-		return snap, true
-	}
-	return registry.DeviceEntrySnapshot{}, false
-}
-
-// trackingControllerEntry is a minimal DeviceEntry implementation
-// returned by the mock's Lookup. Only methods exercised by
-// findControllerEntry's caller pattern are implemented (Manufacturer,
-// DeviceID, Planes — return safe values).
-type trackingControllerEntry struct {
+// minimalEntry is a stub DeviceEntry returned by the mock's Lookup.
+type minimalEntry struct {
 	primaryAddress byte
 	deviceID       string
 }
 
-func (e *trackingControllerEntry) AddressByRole(registry.SlotRole) (byte, bool) {
-	return e.primaryAddress, true
-}
-func (e *trackingControllerEntry) PrimaryDisplayAddress() byte { return e.primaryAddress }
-func (e *trackingControllerEntry) Addresses() []byte           { return []byte{e.primaryAddress} }
-func (e *trackingControllerEntry) Manufacturer() string        { return "Vaillant" }
-func (e *trackingControllerEntry) DeviceID() string            { return e.deviceID }
-func (e *trackingControllerEntry) SerialNumber() string        { return "" }
-func (e *trackingControllerEntry) MacAddress() string          { return "" }
-func (e *trackingControllerEntry) SoftwareVersion() string     { return "" }
-func (e *trackingControllerEntry) HardwareVersion() string     { return "" }
-func (e *trackingControllerEntry) Planes() []registry.Plane    { return nil }
-func (e *trackingControllerEntry) Projections() []registry.Projection {
-	return nil
-}
+func (e *minimalEntry) AddressByRole(registry.SlotRole) (byte, bool) { return e.primaryAddress, true }
+func (e *minimalEntry) PrimaryDisplayAddress() byte                  { return e.primaryAddress }
+func (e *minimalEntry) Addresses() []byte                            { return []byte{e.primaryAddress} }
+func (e *minimalEntry) Manufacturer() string                         { return "Vaillant" }
+func (e *minimalEntry) DeviceID() string                             { return e.deviceID }
+func (e *minimalEntry) SerialNumber() string                         { return "" }
+func (e *minimalEntry) MacAddress() string                           { return "" }
+func (e *minimalEntry) SoftwareVersion() string                      { return "" }
+func (e *minimalEntry) HardwareVersion() string                      { return "" }
+func (e *minimalEntry) Planes() []registry.Plane                     { return nil }
+func (e *minimalEntry) Projections() []registry.Projection           { return nil }
 
-// TestFindControllerEntry_UsesSnapshotIteration proves the P9.5
-// contract: findControllerEntry calls IterateSnapshots (NOT Iterate)
-// for the BASV2 DeviceID prefix scan.
-func TestFindControllerEntry_UsesSnapshotIteration(t *testing.T) {
+// TestFindControllerEntry_FindsRegulatorAtPrimaryCanonicalAddress
+// verifies the primary canonical regulator target address (0x15) is
+// the FIRST address tried, and the entry there is returned without
+// further Lookup calls.
+func TestFindControllerEntry_FindsRegulatorAtPrimaryCanonicalAddress(t *testing.T) {
 	t.Parallel()
 
-	basvEntry := &trackingControllerEntry{primaryAddress: 0x10, deviceID: "BASV2X"}
-	reg := &findControllerTrackingRegistry{
-		snapshots: []registry.DeviceEntrySnapshot{
-			{PrimaryAddress: 0x10, DeviceID: "BASV2X"},
-		},
+	primaryRegulator := &minimalEntry{primaryAddress: 0x15, deviceID: "BASV2X"}
+	reg := &findControllerCanonicalLookupRegistry{
 		entries: map[byte]registry.DeviceEntry{
-			0x10: basvEntry,
-		},
-		snapByAddr: map[byte]registry.DeviceEntrySnapshot{
-			0x10: {PrimaryAddress: 0x10, DeviceID: "BASV2X"},
+			0x15: primaryRegulator,
 		},
 	}
 
@@ -102,45 +68,26 @@ func TestFindControllerEntry_UsesSnapshotIteration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("findControllerEntry error = %v", err)
 	}
-	if got != basvEntry {
-		t.Errorf("returned entry = %v; want the BASV2 entry at 0x10", got)
+	if got != primaryRegulator {
+		t.Errorf("returned entry = %v; want primary regulator at 0x15", got)
 	}
-
-	if reg.iterateSnapshotCalls != 1 {
-		t.Errorf("IterateSnapshots called %d times; want 1 (P9.5 contract)", reg.iterateSnapshotCalls)
-	}
-	if reg.iterateCalls != 0 {
-		t.Errorf("Iterate called %d times; want 0 (P9.5 contract: snapshot path is primary)", reg.iterateCalls)
-	}
-	if reg.lookupSnapCalls != 1 {
-		t.Errorf("LookupEntrySnapshot called %d times; want 1 (TOCTOU re-validation)", reg.lookupSnapCalls)
+	if len(reg.lookups) != 1 || reg.lookups[0] != 0x15 {
+		t.Errorf("lookups = %v; want [0x15] (primary canonical address only)", reg.lookups)
 	}
 }
 
-// TestFindControllerEntry_TOCTOUFallsBackOnRevalidationFailure
-// proves the Codex P9.5 pass 1 MINOR FINDING_1 fix: when the
-// snapshot iteration finds a BASV2 candidate at addr but a
-// concurrent Register has since swapped the entry (LookupEntrySnapshot
-// at the same addr no longer reports BASV-prefixed DeviceID), the
-// function falls back to the canonical-address Lookup instead of
-// returning a non-BASV entry's Planes.
-func TestFindControllerEntry_TOCTOUFallsBackOnRevalidationFailure(t *testing.T) {
+// TestFindControllerEntry_FallsThroughToAlternateCanonicalAddresses
+// verifies that when 0x15 has no registered entry, the function
+// tries the alternate canonical regulator target addresses in the
+// documented priority order: 0x15, 0x35, 0x75, 0xF5, 0x76, 0xF6.
+func TestFindControllerEntry_FallsThroughToAlternateCanonicalAddresses(t *testing.T) {
 	t.Parallel()
 
-	basvEntry := &trackingControllerEntry{primaryAddress: 0x10, deviceID: "BASV2X"}
-	fallbackEntry := &trackingControllerEntry{primaryAddress: mutationControllerFallbackAddr, deviceID: "BASV2-FALLBACK"}
-	reg := &findControllerTrackingRegistry{
-		snapshots: []registry.DeviceEntrySnapshot{
-			// IterateSnapshots reports BASV at 0x10
-			{PrimaryAddress: 0x10, DeviceID: "BASV2X"},
-		},
+	// Register a regulator only at 0x35 (P0 Heating circuit reg. 1).
+	circuitReg1 := &minimalEntry{primaryAddress: 0x35, deviceID: "CTLV2X"}
+	reg := &findControllerCanonicalLookupRegistry{
 		entries: map[byte]registry.DeviceEntry{
-			0x10:                            basvEntry,
-			mutationControllerFallbackAddr:  fallbackEntry,
-		},
-		snapByAddr: map[byte]registry.DeviceEntrySnapshot{
-			// Re-validation: 0x10 has been swapped to a non-BASV entry.
-			0x10: {PrimaryAddress: 0x10, DeviceID: "OTHER-DEVICE"},
+			0x35: circuitReg1,
 		},
 	}
 
@@ -148,46 +95,89 @@ func TestFindControllerEntry_TOCTOUFallsBackOnRevalidationFailure(t *testing.T) 
 	if err != nil {
 		t.Fatalf("findControllerEntry error = %v", err)
 	}
-	// On re-validation failure we must NOT return the original BASV
-	// entry — we must use the fallback path.
-	if got == basvEntry {
-		t.Errorf("returned the snapshot-found entry despite TOCTOU re-validation failure; should have used fallback")
+	if got != circuitReg1 {
+		t.Errorf("returned entry = %v; want circuit regulator at 0x35", got)
 	}
-	if got != fallbackEntry {
-		t.Errorf("returned entry = %v; want the fallback entry at 0x%02X", got, mutationControllerFallbackAddr)
+	want := []byte{0x15, 0x35}
+	if len(reg.lookups) != len(want) {
+		t.Fatalf("lookups = %v; want exactly [0x15, 0x35] (stops on first hit)", reg.lookups)
 	}
-	if reg.lookupSnapCalls != 1 {
-		t.Errorf("LookupEntrySnapshot called %d times; want 1 (re-validation step)", reg.lookupSnapCalls)
-	}
-	deviceID := strings.ToUpper(strings.TrimSpace(got.DeviceID()))
-	if !strings.HasPrefix(deviceID, "BASV") {
-		t.Errorf("returned entry DeviceID = %q; want BASV-prefixed (fallback should be canonical BASV2 address)", deviceID)
+	for i, addr := range want {
+		if reg.lookups[i] != addr {
+			t.Errorf("lookups[%d] = 0x%02X; want 0x%02X", i, reg.lookups[i], addr)
+		}
 	}
 }
 
-// TestFindControllerEntry_AbsentBASVUsesFallback proves the
-// existing fallback path: when no BASV entry exists in the
-// registry, the function returns the entry at
-// mutationControllerFallbackAddr.
-func TestFindControllerEntry_AbsentBASVUsesFallback(t *testing.T) {
+// TestFindControllerEntry_AcceptsNonBASVDeviceIDs verifies the
+// operator-directed core contract: a regulator at 0x15 with a NON-BASV
+// DeviceID (e.g. CTLV2X, CTLS3, CTLR9, BASS4, or a hypothetical
+// future identifier) is STILL returned as the controller. The
+// previous DeviceID-prefix scan would have silently skipped this
+// device.
+func TestFindControllerEntry_AcceptsNonBASVDeviceIDs(t *testing.T) {
 	t.Parallel()
 
-	fallbackEntry := &trackingControllerEntry{primaryAddress: mutationControllerFallbackAddr, deviceID: "BASV2-FALLBACK"}
-	reg := &findControllerTrackingRegistry{
-		snapshots: []registry.DeviceEntrySnapshot{
-			{PrimaryAddress: 0x20, DeviceID: "OTHER"},
-		},
-		entries: map[byte]registry.DeviceEntry{
-			mutationControllerFallbackAddr: fallbackEntry,
-		},
-		snapByAddr: map[byte]registry.DeviceEntrySnapshot{},
+	cases := []struct {
+		name     string
+		deviceID string
+	}{
+		{name: "CTLV", deviceID: "CTLV2X"},
+		{name: "CTLS", deviceID: "CTLS3Y"},
+		{name: "CTLR", deviceID: "CTLR9Z"},
+		{name: "BASS", deviceID: "BASS4Q"},
+		{name: "future identifier", deviceID: "FUTURE99"},
 	}
 
-	got, err := findControllerEntry(reg)
-	if err != nil {
-		t.Fatalf("findControllerEntry error = %v", err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := &minimalEntry{primaryAddress: 0x15, deviceID: tc.deviceID}
+			reg := &findControllerCanonicalLookupRegistry{
+				entries: map[byte]registry.DeviceEntry{
+					0x15: entry,
+				},
+			}
+
+			got, err := findControllerEntry(reg)
+			if err != nil {
+				t.Fatalf("findControllerEntry(%s) error = %v", tc.deviceID, err)
+			}
+			if got != entry {
+				t.Errorf("returned entry = %v; want regulator at 0x15 (DeviceID=%q)", got, tc.deviceID)
+			}
+		})
 	}
-	if got != fallbackEntry {
-		t.Errorf("returned entry = %v; want the fallback entry", got)
+}
+
+// TestFindControllerEntry_ReturnsErrorWhenNoCanonicalRegulator
+// verifies the new error path: when none of the canonical regulator
+// target addresses has a registered entry, the function returns an
+// error wrapping ErrInvalidPayload (not just a hardcoded fallback).
+func TestFindControllerEntry_ReturnsErrorWhenNoCanonicalRegulator(t *testing.T) {
+	t.Parallel()
+
+	reg := &findControllerCanonicalLookupRegistry{
+		entries: map[byte]registry.DeviceEntry{
+			// Only an off-canonical entry — should NOT match.
+			0x42: &minimalEntry{primaryAddress: 0x42, deviceID: "BASV2X"},
+		},
+	}
+
+	_, err := findControllerEntry(reg)
+	if err == nil {
+		t.Fatal("findControllerEntry: err=nil; want error when no canonical regulator")
+	}
+	if !errors.Is(err, ebuserrors.ErrInvalidPayload) {
+		t.Errorf("err = %v; want errors.Is(err, ErrInvalidPayload)", err)
+	}
+	// Verify it tried EVERY canonical address before giving up.
+	want := []byte{0x15, 0x35, 0x75, 0xF5, 0x76, 0xF6}
+	if len(reg.lookups) != len(want) {
+		t.Fatalf("lookups = %v; want all %d canonical addresses tried", reg.lookups, len(want))
+	}
+	for i, addr := range want {
+		if reg.lookups[i] != addr {
+			t.Errorf("lookups[%d] = 0x%02X; want 0x%02X (priority order)", i, reg.lookups[i], addr)
+		}
 	}
 }

--- a/graphql/find_controller_entry_p95_test.go
+++ b/graphql/find_controller_entry_p95_test.go
@@ -1,0 +1,193 @@
+package graphql
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+)
+
+// P9.5 — findControllerEntry uses IterateSnapshots for DeviceID scan.
+//
+// Pre-P9.5 the iteration read entry.DeviceID() lock-free; Post-P9.5
+// it reads from a value-typed snapshot. This test pins the snapshot
+// path with a tracking mock that counts which iteration API was
+// called. Codex P9.5 review pass 1 NIT FINDING_2 noted that
+// existing mutationTestRegistry only implements Iterate (not
+// IterateSnapshots), so without this test the new path isn't
+// directly exercised in regression.
+
+type findControllerTrackingRegistry struct {
+	iterateCalls         int
+	iterateSnapshotCalls int
+	lookupCalls          int
+	lookupSnapCalls      int
+	snapshots            []registry.DeviceEntrySnapshot
+	entries              map[byte]registry.DeviceEntry
+	snapByAddr           map[byte]registry.DeviceEntrySnapshot
+}
+
+func (r *findControllerTrackingRegistry) Lookup(addr byte) (registry.DeviceEntry, bool) {
+	r.lookupCalls++
+	entry, ok := r.entries[addr]
+	return entry, ok
+}
+
+func (r *findControllerTrackingRegistry) Iterate(fn func(registry.DeviceEntry) bool) {
+	r.iterateCalls++
+}
+
+func (r *findControllerTrackingRegistry) IterateSnapshots(fn func(registry.DeviceEntrySnapshot) bool) {
+	r.iterateSnapshotCalls++
+	for _, snap := range r.snapshots {
+		if !fn(snap) {
+			return
+		}
+	}
+}
+
+func (r *findControllerTrackingRegistry) LookupEntrySnapshot(addr byte) (registry.DeviceEntrySnapshot, bool) {
+	r.lookupSnapCalls++
+	if snap, ok := r.snapByAddr[addr]; ok {
+		return snap, true
+	}
+	return registry.DeviceEntrySnapshot{}, false
+}
+
+// trackingControllerEntry is a minimal DeviceEntry implementation
+// returned by the mock's Lookup. Only methods exercised by
+// findControllerEntry's caller pattern are implemented (Manufacturer,
+// DeviceID, Planes — return safe values).
+type trackingControllerEntry struct {
+	primaryAddress byte
+	deviceID       string
+}
+
+func (e *trackingControllerEntry) AddressByRole(registry.SlotRole) (byte, bool) {
+	return e.primaryAddress, true
+}
+func (e *trackingControllerEntry) PrimaryDisplayAddress() byte { return e.primaryAddress }
+func (e *trackingControllerEntry) Addresses() []byte           { return []byte{e.primaryAddress} }
+func (e *trackingControllerEntry) Manufacturer() string        { return "Vaillant" }
+func (e *trackingControllerEntry) DeviceID() string            { return e.deviceID }
+func (e *trackingControllerEntry) SerialNumber() string        { return "" }
+func (e *trackingControllerEntry) MacAddress() string          { return "" }
+func (e *trackingControllerEntry) SoftwareVersion() string     { return "" }
+func (e *trackingControllerEntry) HardwareVersion() string     { return "" }
+func (e *trackingControllerEntry) Planes() []registry.Plane    { return nil }
+func (e *trackingControllerEntry) Projections() []registry.Projection {
+	return nil
+}
+
+// TestFindControllerEntry_UsesSnapshotIteration proves the P9.5
+// contract: findControllerEntry calls IterateSnapshots (NOT Iterate)
+// for the BASV2 DeviceID prefix scan.
+func TestFindControllerEntry_UsesSnapshotIteration(t *testing.T) {
+	t.Parallel()
+
+	basvEntry := &trackingControllerEntry{primaryAddress: 0x10, deviceID: "BASV2X"}
+	reg := &findControllerTrackingRegistry{
+		snapshots: []registry.DeviceEntrySnapshot{
+			{PrimaryAddress: 0x10, DeviceID: "BASV2X"},
+		},
+		entries: map[byte]registry.DeviceEntry{
+			0x10: basvEntry,
+		},
+		snapByAddr: map[byte]registry.DeviceEntrySnapshot{
+			0x10: {PrimaryAddress: 0x10, DeviceID: "BASV2X"},
+		},
+	}
+
+	got, err := findControllerEntry(reg)
+	if err != nil {
+		t.Fatalf("findControllerEntry error = %v", err)
+	}
+	if got != basvEntry {
+		t.Errorf("returned entry = %v; want the BASV2 entry at 0x10", got)
+	}
+
+	if reg.iterateSnapshotCalls != 1 {
+		t.Errorf("IterateSnapshots called %d times; want 1 (P9.5 contract)", reg.iterateSnapshotCalls)
+	}
+	if reg.iterateCalls != 0 {
+		t.Errorf("Iterate called %d times; want 0 (P9.5 contract: snapshot path is primary)", reg.iterateCalls)
+	}
+	if reg.lookupSnapCalls != 1 {
+		t.Errorf("LookupEntrySnapshot called %d times; want 1 (TOCTOU re-validation)", reg.lookupSnapCalls)
+	}
+}
+
+// TestFindControllerEntry_TOCTOUFallsBackOnRevalidationFailure
+// proves the Codex P9.5 pass 1 MINOR FINDING_1 fix: when the
+// snapshot iteration finds a BASV2 candidate at addr but a
+// concurrent Register has since swapped the entry (LookupEntrySnapshot
+// at the same addr no longer reports BASV-prefixed DeviceID), the
+// function falls back to the canonical-address Lookup instead of
+// returning a non-BASV entry's Planes.
+func TestFindControllerEntry_TOCTOUFallsBackOnRevalidationFailure(t *testing.T) {
+	t.Parallel()
+
+	basvEntry := &trackingControllerEntry{primaryAddress: 0x10, deviceID: "BASV2X"}
+	fallbackEntry := &trackingControllerEntry{primaryAddress: mutationControllerFallbackAddr, deviceID: "BASV2-FALLBACK"}
+	reg := &findControllerTrackingRegistry{
+		snapshots: []registry.DeviceEntrySnapshot{
+			// IterateSnapshots reports BASV at 0x10
+			{PrimaryAddress: 0x10, DeviceID: "BASV2X"},
+		},
+		entries: map[byte]registry.DeviceEntry{
+			0x10:                            basvEntry,
+			mutationControllerFallbackAddr:  fallbackEntry,
+		},
+		snapByAddr: map[byte]registry.DeviceEntrySnapshot{
+			// Re-validation: 0x10 has been swapped to a non-BASV entry.
+			0x10: {PrimaryAddress: 0x10, DeviceID: "OTHER-DEVICE"},
+		},
+	}
+
+	got, err := findControllerEntry(reg)
+	if err != nil {
+		t.Fatalf("findControllerEntry error = %v", err)
+	}
+	// On re-validation failure we must NOT return the original BASV
+	// entry — we must use the fallback path.
+	if got == basvEntry {
+		t.Errorf("returned the snapshot-found entry despite TOCTOU re-validation failure; should have used fallback")
+	}
+	if got != fallbackEntry {
+		t.Errorf("returned entry = %v; want the fallback entry at 0x%02X", got, mutationControllerFallbackAddr)
+	}
+	if reg.lookupSnapCalls != 1 {
+		t.Errorf("LookupEntrySnapshot called %d times; want 1 (re-validation step)", reg.lookupSnapCalls)
+	}
+	deviceID := strings.ToUpper(strings.TrimSpace(got.DeviceID()))
+	if !strings.HasPrefix(deviceID, "BASV") {
+		t.Errorf("returned entry DeviceID = %q; want BASV-prefixed (fallback should be canonical BASV2 address)", deviceID)
+	}
+}
+
+// TestFindControllerEntry_AbsentBASVUsesFallback proves the
+// existing fallback path: when no BASV entry exists in the
+// registry, the function returns the entry at
+// mutationControllerFallbackAddr.
+func TestFindControllerEntry_AbsentBASVUsesFallback(t *testing.T) {
+	t.Parallel()
+
+	fallbackEntry := &trackingControllerEntry{primaryAddress: mutationControllerFallbackAddr, deviceID: "BASV2-FALLBACK"}
+	reg := &findControllerTrackingRegistry{
+		snapshots: []registry.DeviceEntrySnapshot{
+			{PrimaryAddress: 0x20, DeviceID: "OTHER"},
+		},
+		entries: map[byte]registry.DeviceEntry{
+			mutationControllerFallbackAddr: fallbackEntry,
+		},
+		snapByAddr: map[byte]registry.DeviceEntrySnapshot{},
+	}
+
+	got, err := findControllerEntry(reg)
+	if err != nil {
+		t.Fatalf("findControllerEntry error = %v", err)
+	}
+	if got != fallbackEntry {
+		t.Errorf("returned entry = %v; want the fallback entry", got)
+	}
+}

--- a/graphql/mutations.go
+++ b/graphql/mutations.go
@@ -1083,6 +1083,9 @@ func findControllerEntry(reg InvokeRegistry) (registry.DeviceEntry, error) {
 	type snapshotIterativeRegistry interface {
 		IterateSnapshots(func(registry.DeviceEntrySnapshot) bool)
 	}
+	type snapshotLookupRegistry interface {
+		LookupEntrySnapshot(byte) (registry.DeviceEntrySnapshot, bool)
+	}
 	if iter, ok := reg.(snapshotIterativeRegistry); ok {
 		var controllerAddr byte
 		var found bool
@@ -1095,6 +1098,27 @@ func findControllerEntry(reg InvokeRegistry) (registry.DeviceEntry, error) {
 			return true
 		})
 		if found {
+			// Codex P9.5 review pass 1 MINOR FINDING_1 — TOCTOU
+			// re-validation: between IterateSnapshots and Lookup,
+			// Register can replace r.entries[addr] on identity/model
+			// conflict. Re-validate via a second snapshot read at
+			// controllerAddr before returning the live entry. If the
+			// re-validation snapshot's DeviceID no longer matches
+			// "BASV", the entry has been swapped out — fall through
+			// to the fallback Lookup so we don't return a non-BASV
+			// entry's Planes for controller-mutation routing.
+			if snapReg, ok := reg.(snapshotLookupRegistry); ok {
+				revalidate, ok := snapReg.LookupEntrySnapshot(controllerAddr)
+				if !ok || !strings.HasPrefix(strings.ToUpper(strings.TrimSpace(revalidate.DeviceID)), "BASV") {
+					// Entry at controllerAddr no longer BASV (race);
+					// skip to fallback.
+					controller, ok := reg.Lookup(mutationControllerFallbackAddr)
+					if ok && controller != nil {
+						return controller, nil
+					}
+					return nil, fmt.Errorf("controller BASV2 not found: %w", ebuserrors.ErrInvalidPayload)
+				}
+			}
 			if controller, ok := reg.Lookup(controllerAddr); ok && controller != nil {
 				return controller, nil
 			}

--- a/graphql/mutations.go
+++ b/graphql/mutations.go
@@ -1065,23 +1065,39 @@ func findControllerEntry(reg InvokeRegistry) (registry.DeviceEntry, error) {
 		return nil, fmt.Errorf("registry missing: %w", ebuserrors.ErrInvalidPayload)
 	}
 
-	type iterativeRegistry interface {
-		Iterate(func(registry.DeviceEntry) bool)
+	// P9.5 — race-free DeviceID prefix scan via IterateSnapshots
+	// (added in helianthus-ebusreg P9). Pre-P9.5 the iteration read
+	// entry.DeviceID() lock-free on a live *deviceEntry pointer
+	// concurrent with Register / RegisterPassiveObserved writes that
+	// can mutate entry.info.DeviceID. The snapshot path reads the
+	// DeviceID from a value-typed copy taken under the registry's
+	// RLock.
+	//
+	// The function still returns a live registry.DeviceEntry because
+	// the caller needs entry.Planes() — Planes are NOT in the P9
+	// snapshot (interface tree, separate Plane-aware snapshot
+	// surface tracked as P9.x follow-up). After identifying the
+	// controller's primary address via the snapshot we re-fetch the
+	// live entry via Lookup; the Planes-tree race window is reduced
+	// to a single point-of-use rather than the iteration loop.
+	type snapshotIterativeRegistry interface {
+		IterateSnapshots(func(registry.DeviceEntrySnapshot) bool)
 	}
-	if iter, ok := reg.(iterativeRegistry); ok {
-		var controller registry.DeviceEntry
-		iter.Iterate(func(entry registry.DeviceEntry) bool {
-			if entry == nil {
-				return true
-			}
-			if strings.HasPrefix(strings.ToUpper(strings.TrimSpace(entry.DeviceID())), "BASV") {
-				controller = entry
+	if iter, ok := reg.(snapshotIterativeRegistry); ok {
+		var controllerAddr byte
+		var found bool
+		iter.IterateSnapshots(func(snap registry.DeviceEntrySnapshot) bool {
+			if strings.HasPrefix(strings.ToUpper(strings.TrimSpace(snap.DeviceID)), "BASV") {
+				controllerAddr = snap.PrimaryAddress
+				found = true
 				return false
 			}
 			return true
 		})
-		if controller != nil {
-			return controller, nil
+		if found {
+			if controller, ok := reg.Lookup(controllerAddr); ok && controller != nil {
+				return controller, nil
+			}
 		}
 	}
 

--- a/graphql/mutations.go
+++ b/graphql/mutations.go
@@ -102,6 +102,33 @@ const (
 	mutationGetExtRegisterMethod   = "get_ext_register"
 )
 
+// canonicalRegulatorTargetAddresses lists the eBUS standard target
+// (companion) addresses for heating-regulator-class sources. Per the
+// docs-owned source-address table (helianthus-ebusgo
+// protocol/source_address_selection.go), each entry is a Companion
+// byte from a P0/P1 row whose canonical description names "Heating
+// regulator" or "Heating circuit regulator":
+//
+//	0x15 — companion of 0x10 (P0 Heating regulator)        [Vaillant primary]
+//	0x35 — companion of 0x30 (P0 Heating circuit reg. 1)
+//	0x75 — companion of 0x70 (P0 Heating circuit reg. 2)
+//	0xF5 — companion of 0xF0 (P0 Heating circuit reg. 3)
+//	0x76 — companion of 0x71 (P1 Heating controller)
+//	0xF6 — companion of 0xF1 (P1 Heating controller)
+//
+// Listed in priority order: Vaillant's primary regulator (BASV2 family
+// and successors CTLV*/CTLS*/CTLR*/BASS*) lives at 0x15. P0/P1
+// alternates handle multi-regulator setups and competing vendors.
+//
+// This identifier-free detection replaces the previous BASV-prefix
+// DeviceID scan (PR #598 review pivot 2026-05-09): the prefix check
+// would silently skip any non-BASV controller (CTLV*/CTLS*/CTLR*/
+// BASS*/future identifiers), and even with TOCTOU re-validation the
+// scan was racy with concurrent registry mutation. Looking up by
+// canonical address is atomic per Lookup call and identifier-
+// agnostic.
+var canonicalRegulatorTargetAddresses = []byte{0x15, 0x35, 0x75, 0xF5, 0x76, 0xF6}
+
 var circuitConfigFieldSpecs = map[string]configFieldSpec{
 	"heatingCurve":    {group: 0x02, addr: 0x000F, valueType: configValueFloat32, min: 0.1, max: 4.0},
 	"flowTempMaxC":    {group: 0x02, addr: 0x0010, valueType: configValueFloat32, min: 15.0, max: 80.0},
@@ -1065,70 +1092,45 @@ func findControllerEntry(reg InvokeRegistry) (registry.DeviceEntry, error) {
 		return nil, fmt.Errorf("registry missing: %w", ebuserrors.ErrInvalidPayload)
 	}
 
-	// P9.5 — race-free DeviceID prefix scan via IterateSnapshots
-	// (added in helianthus-ebusreg P9). Pre-P9.5 the iteration read
-	// entry.DeviceID() lock-free on a live *deviceEntry pointer
-	// concurrent with Register / RegisterPassiveObserved writes that
-	// can mutate entry.info.DeviceID. The snapshot path reads the
-	// DeviceID from a value-typed copy taken under the registry's
-	// RLock.
+	// P9.5 (operator-directed pivot 2026-05-09) — identifier-free
+	// controller detection.
 	//
-	// The function still returns a live registry.DeviceEntry because
-	// the caller needs entry.Planes() — Planes are NOT in the P9
-	// snapshot (interface tree, separate Plane-aware snapshot
-	// surface tracked as P9.x follow-up). After identifying the
-	// controller's primary address via the snapshot we re-fetch the
-	// live entry via Lookup; the Planes-tree race window is reduced
-	// to a single point-of-use rather than the iteration loop.
-	type snapshotIterativeRegistry interface {
-		IterateSnapshots(func(registry.DeviceEntrySnapshot) bool)
-	}
-	type snapshotLookupRegistry interface {
-		LookupEntrySnapshot(byte) (registry.DeviceEntrySnapshot, bool)
-	}
-	if iter, ok := reg.(snapshotIterativeRegistry); ok {
-		var controllerAddr byte
-		var found bool
-		iter.IterateSnapshots(func(snap registry.DeviceEntrySnapshot) bool {
-			if strings.HasPrefix(strings.ToUpper(strings.TrimSpace(snap.DeviceID)), "BASV") {
-				controllerAddr = snap.PrimaryAddress
-				found = true
-				return false
-			}
-			return true
-		})
-		if found {
-			// Codex P9.5 review pass 1 MINOR FINDING_1 — TOCTOU
-			// re-validation: between IterateSnapshots and Lookup,
-			// Register can replace r.entries[addr] on identity/model
-			// conflict. Re-validate via a second snapshot read at
-			// controllerAddr before returning the live entry. If the
-			// re-validation snapshot's DeviceID no longer matches
-			// "BASV", the entry has been swapped out — fall through
-			// to the fallback Lookup so we don't return a non-BASV
-			// entry's Planes for controller-mutation routing.
-			if snapReg, ok := reg.(snapshotLookupRegistry); ok {
-				revalidate, ok := snapReg.LookupEntrySnapshot(controllerAddr)
-				if !ok || !strings.HasPrefix(strings.ToUpper(strings.TrimSpace(revalidate.DeviceID)), "BASV") {
-					// Entry at controllerAddr no longer BASV (race);
-					// skip to fallback.
-					controller, ok := reg.Lookup(mutationControllerFallbackAddr)
-					if ok && controller != nil {
-						return controller, nil
-					}
-					return nil, fmt.Errorf("controller BASV2 not found: %w", ebuserrors.ErrInvalidPayload)
-				}
-			}
-			if controller, ok := reg.Lookup(controllerAddr); ok && controller != nil {
-				return controller, nil
-			}
+	// The previous algorithm scanned the registry for any entry
+	// whose DeviceID started with "BASV" and returned that as the
+	// controller. Two problems made it brittle:
+	//
+	//  1. Identifier coupling: only Vaillant BASV2 controllers
+	//     matched. Successor and sibling families (CTLV*, CTLS*,
+	//     CTLR*, BASS*) and any future controller identifier got
+	//     silently skipped, falling through to a hardcoded address
+	//     fallback that may or may not be correct.
+	//
+	//  2. TOCTOU race with concurrent Register: the iteration's
+	//     DeviceID read was lock-free, and even with snapshot-based
+	//     re-validation (P9.5 pass 2 finding) a Register call between
+	//     the snapshot identity-check and the live Lookup could swap
+	//     the entry, returning a non-controller's Planes for
+	//     mutation routing.
+	//
+	// New algorithm: try canonical regulator target addresses (eBUS
+	// standard heating-regulator/heating-circuit-regulator companion
+	// bytes) in priority order via plain Lookup. Each Lookup is
+	// atomic under the registry RLock, so no TOCTOU window exists.
+	// The first registered entry at one of these canonical addresses
+	// is the controller — by construction the device sitting on the
+	// bus at a regulator target address IS the regulator, regardless
+	// of what identifier string the product-id catalog assigns to it.
+	//
+	// `mutationControllerFallbackAddr` (0x15) is the first address
+	// in the canonical list, so the previous fallback behavior is
+	// preserved as a no-op semantic when no other regulator is
+	// registered.
+	for _, addr := range canonicalRegulatorTargetAddresses {
+		if entry, ok := reg.Lookup(addr); ok && entry != nil {
+			return entry, nil
 		}
 	}
-
-	if fallback, ok := reg.Lookup(mutationControllerFallbackAddr); ok && fallback != nil {
-		return fallback, nil
-	}
-	return nil, fmt.Errorf("controller BASV2 not found: %w", ebuserrors.ErrInvalidPayload)
+	return nil, fmt.Errorf("no heating regulator at canonical eBUS target addresses: %w", ebuserrors.ErrInvalidPayload)
 }
 
 func extractExtRegisterValue(result any) ([]byte, error) {

--- a/graphql/mutations_unit_test.go
+++ b/graphql/mutations_unit_test.go
@@ -642,8 +642,11 @@ func TestSetSystemConfigMutation_FailureScenarios(t *testing.T) {
 		if got, _ := payload["success"].(bool); got {
 			t.Fatalf("setSystemConfig success = %v; want false", got)
 		}
-		if errMessage, _ := payload["error"].(string); !strings.Contains(errMessage, "controller BASV2 not found") {
-			t.Fatalf("setSystemConfig error = %q; want missing controller", errMessage)
+		// P9.5 pivot — error message changed from "controller BASV2
+		// not found" (identifier-coupled) to "no heating regulator at
+		// canonical eBUS target addresses" (identifier-free).
+		if errMessage, _ := payload["error"].(string); !strings.Contains(errMessage, "no heating regulator at canonical eBUS target addresses") {
+			t.Fatalf("setSystemConfig error = %q; want missing-regulator error", errMessage)
 		}
 	})
 


### PR DESCRIPTION
## Summary

**Pivot from prior approach** (Codex P9.5 pass 2 + operator directive):

Previous: scan registry for entries whose DeviceID starts with \"BASV\". Two problems:

1. **Identifier coupling** — silently skips successor families (CTLV*/CTLS*/CTLR*/BASS*) and any future controller identifier.
2. **Recursive TOCTOU** — even with snapshot re-validation, a concurrent Register between identity check and live Lookup could swap the entry, returning a non-controller's Planes for mutation routing.

New: detect by canonical regulator TARGET address per the eBUS standard heating-regulator companion table (helianthus-ebusgo source_address_selection.go).

\`canonicalRegulatorTargetAddresses\` (priority-ordered):
- 0x15 — companion of 0x10 (P0 Heating regulator) [Vaillant primary]
- 0x35, 0x75, 0xF5 — companions of P0 heating circuit regulators 1/2/3
- 0x76, 0xF6 — companions of P1 heating controllers

\`findControllerEntry\` Lookups each canonical address in order and returns the first registered entry. Each Lookup is atomic under registry RLock — no TOCTOU window. Identifier-agnostic — works for any product family at a canonical regulator address.

## Test plan

- [x] \`go test -race -count=1 ./...\` passes
- [x] 4 new tests in \`find_controller_entry_p95_test.go\`:
  - \`FindsRegulatorAtPrimaryCanonicalAddress\` — single Lookup at 0x15
  - \`FallsThroughToAlternateCanonicalAddresses\` — priority order
  - \`AcceptsNonBASVDeviceIDs\` — CTLV/CTLS/CTLR/BASS/future (operator's core directive)
  - \`ReturnsErrorWhenNoCanonicalRegulator\` — error path with off-canonical entries
- [x] Updated existing \`missing controller\` test message expectation to identifier-free string
- [x] \`./scripts/ci_local.sh\` green

## Behavior delta

- Vaillant systems with BASV2 controller at 0x15: unchanged (still returns the entry at 0x15).
- Vaillant systems with successor controller (CTLV/CTLS/CTLR/BASS/future) at 0x15: now correctly returned (was silently skipped).
- Multi-regulator systems with controller at 0x35/0x75/etc: now correctly returned via fallthrough (was using 0x15 fallback even when no entry at 0x15).
- Systems with no regulator at any canonical address: now returns explicit error (was returning the 0x15 fallback or nil).

🤖 Generated with [Claude Code](https://claude.com/claude-code)