### PR TITLE
P10.2: suppress mid-write SYN as echo_mismatch noise

### DIFF
--- a/internal/adaptermux/diag.go
+++ b/internal/adaptermux/diag.go
@@ -98,16 +98,23 @@ type activeTxnDiag struct {
 	// real echo byte and cause sendRawWithEcho to observe SYN (0xAA)
 	// in place of the expected echo, emitting echo_mismatch.
 	//
-	// P10.2 — the gate now uses `gatewayEcho.peekNextExpected()`:
+	// P10.2 — the gate now uses `gatewayEcho.peekNextExpected()` to
+	// classify SYNs that arrive during an active gateway txn:
 	//   - hasPending=true && nextExpected==SymbolSyn → legitimate
 	//     terminator (bus.Send wrote SYN, awaiting its echo); NOT
 	//     suppressed.
-	//   - hasPending=true && nextExpected!=SymbolSyn → mid-frame
-	//     noise (gateway awaiting echo of a non-SYN data byte);
+	//   - hasPending=true && nextExpected!=SymbolSyn → mid-write
+	//     noise (gateway awaiting echo of a non-SYN body byte);
 	//     SUPPRESSED.
-	//   - hasPending=false → response-read phase (gateway has no
-	//     pending writes, so this SYN cannot be a terminator);
-	//     SUPPRESSED.
+	//   - hasPending=false (queue empty): the gate is OPEN —
+	//     `midWriteSyn=false`, so the terminator branch fires per
+	//     the legacy PR #502 contract whenever
+	//     bytesDeliveredToActive>0 (the gateway has consumed all its
+	//     echoes — typical end-of-frame shape, including tests that
+	//     omit the explicit terminator-write step). The pre-first-
+	//     echo branch (separate gate, bytesDeliveredToActive==0)
+	//     suppresses queue-empty SYNs that arrive before the first
+	//     adapter byte has been delivered to activeCh.
 	//
 	// Original semantics (P0): pre-first-echo case where
 	// bytesDeliveredToActive==0. P10.2 generalizes — that case still

--- a/internal/adaptermux/diag.go
+++ b/internal/adaptermux/diag.go
@@ -92,17 +92,33 @@ type activeTxnDiag struct {
 	terminatorDropOnFullCh atomic.Uint64
 
 	// synSuppressedPreEcho counts SYN bytes that arrived during gateway
-	// ownership with gatewayTxnActive=true but bytesRead==0 (i.e. BEFORE
-	// the first real echo byte). These SYNs are pre-echo noise (buffered
-	// in the TCP/ENH pipeline from before bus.Send's first Write reached
-	// the adapter) and MUST NOT be delivered to activeCh — doing so would
-	// race the real echo byte and cause sendRawWithEcho to observe SYN
-	// (0xAA) in place of the expected echo, emitting echo_mismatch
-	// (13,904 events observed in production soak before this fix).
-	// Expected to be non-zero under normal adapter-direct operation (one
-	// or two suppressed SYNs per transaction is common); a persistent
-	// zero after deploy would indicate the readLoop is no longer racing
-	// bus.Send on the grant boundary.
+	// ownership with gatewayTxnActive=true and were classified as
+	// non-terminator noise (NOT a legitimate frame-end SYN echo). These
+	// SYNs MUST NOT be delivered to activeCh — doing so would race the
+	// real echo byte and cause sendRawWithEcho to observe SYN (0xAA)
+	// in place of the expected echo, emitting echo_mismatch.
+	//
+	// P10.2 — the gate now uses `gatewayEcho.peekNextExpected()`:
+	//   - hasPending=true && nextExpected==SymbolSyn → legitimate
+	//     terminator (bus.Send wrote SYN, awaiting its echo); NOT
+	//     suppressed.
+	//   - hasPending=true && nextExpected!=SymbolSyn → mid-frame
+	//     noise (gateway awaiting echo of a non-SYN data byte);
+	//     SUPPRESSED.
+	//   - hasPending=false → response-read phase (gateway has no
+	//     pending writes, so this SYN cannot be a terminator);
+	//     SUPPRESSED.
+	//
+	// Original semantics (P0): pre-first-echo case where
+	// bytesDeliveredToActive==0. P10.2 generalizes — that case still
+	// suppresses (no echoes yet, so any pending entry is non-SYN by
+	// construction in normal request flow), but additionally suppresses
+	// late mid-frame SYN races and response-phase noise. 671 pre_echo_syn
+	// events observed pre-P10.2 (~16% of all echo_mismatch); expected to
+	// drop to floor (single-digit per hour) after deploy.
+	//
+	// Expected to be non-zero under normal adapter-direct operation
+	// (typically 1–3 suppressed SYNs per transaction).
 	synSuppressedPreEcho atomic.Uint64
 
 	// --- Transaction-shape diagnostics (bounded) ---

--- a/internal/adaptermux/echo_tracker.go
+++ b/internal/adaptermux/echo_tracker.go
@@ -160,6 +160,20 @@ func (t *echoTracker) hasPendingEchoes() bool {
 	return len(t.expectedEchoes) > 0
 }
 
+// peekNextExpected returns the byte at the head of the expected-echo
+// queue and a boolean indicating whether the queue is non-empty. Used by
+// the mux to discriminate legitimate terminator-SYN echoes (next expected
+// is a SYN that the gateway just wrote) from mid-frame SYN noise (next
+// expected is a non-SYN data byte) and from response-phase SYN noise
+// (queue empty — gateway is reading the target's response and has no
+// pending writes). Read-only; does NOT consume the queue head. P10.2.
+func (t *echoTracker) peekNextExpected() (byte, bool) {
+	if len(t.expectedEchoes) == 0 {
+		return 0, false
+	}
+	return t.expectedEchoes[0], true
+}
+
 // reset clears all tracking state.
 func (t *echoTracker) reset() {
 	t.expectedEchoes = t.expectedEchoes[:0]

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -1292,11 +1292,52 @@ func (m *Mux) onSYNLocked(phaseEvent wirePhaseEvent, ownerID uint64, hasOwner bo
 	wasGatewayOwned := hasOwner && ownerID == gatewaySessionID
 	gwActiveBefore := m.gatewayTxnActive
 
+	// P10.2 — peek the gateway echo tracker BEFORE flushOnSYN clears it.
+	// The next-expected-echo byte discriminates the *only* unsafe case
+	// (mid-write race) from all the legitimate ones. Using the queue
+	// head as the discriminator preserves backward-compat with the
+	// pre-P10.2 terminator semantics for the common shape (queue empty
+	// at SYN time — gateway between writes or in response-read) while
+	// closing the specific bug where a buffered/colliding SYN arrives
+	// while the gateway is still awaiting the echo of a non-SYN body
+	// byte:
+	//
+	//   - hasPending=true  && nextExpected == SymbolSyn: bus.Send just
+	//     wrote the terminator SYN (sendEndOfMessage path); the wire
+	//     echo IS the legitimate terminator. Allow terminator gate.
+	//   - hasPending=false: queue is empty. Either the gateway has
+	//     consumed all its echoes (between request and response, or
+	//     during response read), or it has never written. A SYN here
+	//     was the assumed-terminator under pre-P10.2 semantics. Allow
+	//     terminator gate (preserves all existing tests / lifecycle
+	//     contracts; legacy behavior from PR #502).
+	//   - hasPending=true  && nextExpected != SymbolSyn: gateway is
+	//     mid-write (waiting for echo of a request body byte). This
+	//     wire SYN CANNOT be a terminator — eBUS protocol guarantees
+	//     no foreign SYN appears mid-frame after arbitration. SUPPRESS
+	//     activeCh delivery, idle release, and flushOnSYN. This is the
+	//     P10.2-specific behavior change that closes the 671
+	//     pre_echo_syn events observed in production.
+	//
+	// Codex P10.2 review: idle release MUST be gated on the suppression
+	// decision — otherwise a mid-frame noise SYN that arrives after
+	// IdleReleaseGrace elapses (slow txn) would still abort the
+	// legitimate transaction even though we suppressed activeCh delivery.
+	nextExpectedEcho, hasPendingEcho := m.gatewayEcho.peekNextExpected()
+	midWriteSyn := hasPendingEcho && nextExpectedEcho != protocol.SymbolSyn
+
 	// Flush gateway echo tracker at SYN boundary. Flushed bytes are
 	// confirmed gateway self-traffic — do NOT emit to passive path
 	// (passive is third-party only). They are delivered to external
 	// sessions via deliverSYNToSessions + deliverToSessions elsewhere.
-	m.gatewayEcho.flushOnSYN()
+	//
+	// P10.2: skip flush when this SYN is mid-write noise. The expected-
+	// echo queue must survive so the next real echo of the pending
+	// non-SYN byte still matches.
+	preEchoMidFrameSuppress := wasGatewayOwned && m.gatewayTxnActive && midWriteSyn
+	if !preEchoMidFrameSuppress {
+		m.gatewayEcho.flushOnSYN()
+	}
 
 	// Runtime-soak P0 + lifecycle correctness + Codex PR #502 P1:
 	// clear gatewayTxnActive on SYN during gateway ownership ONLY if
@@ -1348,9 +1389,22 @@ func (m *Mux) onSYNLocked(phaseEvent wirePhaseEvent, ownerID uint64, hasOwner bo
 	// Use ReasonSYNTerminator (not ReasonSYNIdle) to distinguish a
 	// successful terminator delivery from the abandoned-grant SYN-idle
 	// path in onSYNLocked's idle-release branch below.
+	// P10.2: terminator gate gains an additional guard `!midWriteSyn`.
+	// Without this guard, mid-write SYNs (stale buffered SYN from before
+	// grant interleaved into mid-frame echo flow, wire collision,
+	// foreign-initiator glitch) would be delivered to activeCh while
+	// bus.Send is waiting for echo of a non-SYN data byte → 0xAA in
+	// echo position → echo_mismatch with subclass=pre_echo_syn (671
+	// events observed in production soak before this fix; ~16% of all
+	// echo_mismatch). The legacy "queue empty → assume terminator"
+	// branch (pre-P10.2 default) still fires for the bytesDeliveredToActive>0
+	// case where the gateway has consumed all its echoes — that
+	// preserves the lifecycle contract and existing tests. Only the
+	// specific mid-write race (queue head is a non-SYN byte) is closed.
 	terminatorDelivered := false
 	if hasOwner && ownerID == gatewaySessionID && m.gatewayTxnActive &&
-		m.activeTxn.bytesDeliveredToActive.Load() > 0 {
+		m.activeTxn.bytesDeliveredToActive.Load() > 0 &&
+		!midWriteSyn {
 		select {
 		case m.activeCh <- activeEvent{kind: activeEventByte, b: protocol.SymbolSyn}:
 			terminatorDelivered = true
@@ -1380,7 +1434,22 @@ func (m *Mux) onSYNLocked(phaseEvent wirePhaseEvent, ownerID uint64, hasOwner bo
 	}
 
 	// Release ownership on idle SYN after grace period.
-	if phaseEvent == wirePhaseEventSYNIdle && hasOwner {
+	//
+	// P10.2 — gate idle release ONLY for live mid-frame races, NOT for
+	// stuck-write timeouts. The distinguishing signal:
+	//   - bytesDeliveredToActive > 0 + preEchoMidFrameSuppress: the
+	//     gateway has live echo activity AND a noise SYN arrived
+	//     mid-write. Aborting the txn would discard real progress.
+	//     Suppress idle release.
+	//   - bytesDeliveredToActive == 0 + preEchoMidFrameSuppress: the
+	//     gateway wrote bytes but NO echo ever arrived. The bus is
+	//     stuck/unresponsive. The IdleReleaseGrace mechanism is exactly
+	//     designed to bail out here. Allow idle release. (Used by
+	//     TestRegression_StartedButNoResponse to model production
+	//     unresponsive-target scenarios.)
+	suppressIdleRelease := preEchoMidFrameSuppress &&
+		m.activeTxn.bytesDeliveredToActive.Load() > 0
+	if phaseEvent == wirePhaseEventSYNIdle && hasOwner && !suppressIdleRelease {
 		if time.Since(m.busOwned) > m.cfg.IdleReleaseGrace {
 			m.logger.Printf("adaptermux: ownership released for session %d (idle grace expired) (AM6)", ownerID)
 			m.arb.releaseOwnership(ownerID)
@@ -1403,29 +1472,24 @@ func (m *Mux) onSYNLocked(phaseEvent wirePhaseEvent, ownerID uint64, hasOwner bo
 	})
 
 	// Pre-echo SYN suppression decision (echo_mismatch fix).
-	// Computed AFTER the terminator/idle branches so that a gwActive flag
-	// that was just cleared by those branches does not incorrectly trigger
-	// suppression. The pre-echo case is: gateway still owns, gatewayTxnActive
-	// still true, and no real adapter byte has been enqueued on activeCh
-	// yet for this txn — i.e. the mux has not yet observed post-grant
-	// traffic on the active path. A SYN observed in this window is buffer
-	// noise that pre-dates the grant's first Write and must not race the
-	// real echo on activeCh. See onReceived for the counter increment and
-	// activeExpects gating.
 	//
-	// Codex PR #502 P1: the gate here is complementary to the terminator
-	// gate above — one single signal (bytesDeliveredToActive) governs
-	// both branches. See the terminator comment block for the full
-	// rationale on why bytesDeliveredToActive beats bytesRead (lags,
-	// consumer side) and bytesWritten (leads, initiator side before echo
-	// returns). The critical win on busy/idle-chatter links: bytesWritten
-	// flips to ≥1 the moment Write returns, so a buffered idle SYN in the
-	// window between Write and echo-enqueue would falsely pass the
-	// terminator gate and deliver 0xAA to sendRawWithEcho; with
-	// bytesDeliveredToActive, that same SYN is correctly classified as
-	// pre-echo and suppressed.
-	preEchoSuppressed := hasOwner && ownerID == gatewaySessionID &&
+	// P10.2 — combines the original "pre-first-echo" suppression
+	// (bytesDeliveredToActive == 0 — buffered idle SYN that pre-dates
+	// any post-grant byte) with the new "mid-write-race" suppression
+	// (gateway owns + txn active + queue head is non-SYN). Both cases
+	// describe a SYN that cannot be a legitimate terminator and that
+	// would corrupt sendRawWithEcho if delivered to activeCh.
+	//
+	// Codex PR #502 P1 originally defined the pre-first-echo gate using
+	// bytesDeliveredToActive (chosen for its precise mid-point semantics
+	// between bytesWritten leading and bytesRead lagging). P10.2 keeps
+	// that branch and adds the mid-write branch as an OR.
+	//
+	// Counter (synSuppressedPreEcho) preserved for backward-compat with
+	// existing diag tests; semantically it now covers a superset.
+	preFirstEchoSyn := hasOwner && ownerID == gatewaySessionID &&
 		m.gatewayTxnActive && m.activeTxn.bytesDeliveredToActive.Load() == 0
+	preEchoSuppressed := preFirstEchoSyn || preEchoMidFrameSuppress
 	if preEchoSuppressed {
 		m.activeTxn.synSuppressedPreEcho.Add(1)
 	}

--- a/internal/adaptermux/pre_echo_syn_p102_test.go
+++ b/internal/adaptermux/pre_echo_syn_p102_test.go
@@ -236,12 +236,13 @@ func TestPreEchoSyn_StuckWrite_IdleReleaseStillFires(t *testing.T) {
 	if snap.Active {
 		t.Errorf("Active=true after idle-grace expiry — idle release was suppressed by P10.2 mid-write gate (regression)")
 	}
+	// Codex P10.2 review LOW: require ReasonSYNIdle ONLY. Accepting
+	// ReasonSYNTerminator here would hide the regression this test is
+	// meant to catch — in this scenario bytesDeliveredToActive==0 and
+	// the queue head is non-SYN (mid-write), so a terminator
+	// classification would mean we falsely treated the wire SYN as a
+	// frame terminator instead of a stuck-write idle bail-out.
 	if snap.InactiveReason != ReasonSYNIdle {
-		// SYN-terminator is acceptable too if the test fixture happened
-		// to deliver the SYN as terminator, but for this scenario the
-		// canonical reason is idle release.
-		if snap.InactiveReason != ReasonSYNTerminator {
-			t.Errorf("InactiveReason=%q, want %q (or ReasonSYNTerminator)", snap.InactiveReason, ReasonSYNIdle)
-		}
+		t.Errorf("InactiveReason=%q, want %q (stuck-write must terminate via idle release, NOT terminator)", snap.InactiveReason, ReasonSYNIdle)
 	}
 }

--- a/internal/adaptermux/pre_echo_syn_p102_test.go
+++ b/internal/adaptermux/pre_echo_syn_p102_test.go
@@ -1,0 +1,247 @@
+package adaptermux
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+// P10.2 — verify that a wire SYN arriving while the gateway is mid-write
+// (waiting for the echo of a non-SYN body byte) is suppressed and NOT
+// delivered to activeCh, NOT classified as terminator, and does NOT
+// abort the live transaction via idle release.
+//
+// Production motivation: 671 echo_mismatch events with subclass
+// `pre_echo_syn` were observed in the live HA gateway soak. Live byte:
+// 0xAA (SYN). Path: bus.Send.sendRawWithEcho writes byte N, gates on
+// echo, the mux's terminator branch (pre-P10.2) delivered an
+// interleaved buffered/colliding SYN to activeCh as if it were the
+// terminator, and bus.Send saw 0xAA in echo position.
+//
+// Scenario covered:
+//
+//  1. Grant gateway (initiator 0x71).
+//  2. Gateway writes byte 0x71 (the source) — gatewayEcho.expectedEchoes
+//     = [0x71]. Echo delivered + consumed → bytesDeliveredToActive=1,
+//     expectedEchoes empty.
+//  3. Gateway writes byte 0x08 (target) — expectedEchoes = [0x08].
+//     Echo NOT yet fed.
+//  4. A noise wire SYN arrives BEFORE the echo of 0x08.
+//
+// Pre-P10.2 result: terminator gate fires (bytesDeliveredToActive>0 &&
+// gatewayTxnActive=true) → SYN delivered to activeCh → bus.Send
+// reading echo expects 0x08, gets 0xAA → echo_mismatch, subclass
+// pre_echo_syn.
+//
+// P10.2 result: peekNextExpected returns (0x08, true). nextExpected !=
+// SymbolSyn → midWriteSyn=true → preEchoMidFrameSuppress=true:
+//   - terminator gate does NOT fire (gated on `!midWriteSyn`)
+//   - flushOnSYN does NOT fire (queue [0x08] preserved)
+//   - idle release does NOT fire (bytesDeliveredToActive>0)
+//   - synSuppressedPreEcho counter increments
+//   - the txn stays live; the next echo (0x08) still matches.
+func TestPreEchoSyn_MidWriteSyn_Suppressed(t *testing.T) {
+	mux, mock, _, cleanup := newP3TestMux(t)
+	defer cleanup()
+
+	grantGateway(t, mux, mock, 0x71)
+	at := mux.ActiveTransport()
+
+	// Step 2: write source byte and let it echo+consume so we leave the
+	// pre-first-echo window (bytesDeliveredToActive>=1).
+	if _, err := at.Write([]byte{0x71}); err != nil {
+		t.Fatalf("Write(0x71) err=%v", err)
+	}
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x71}
+	if b, err := at.ReadByte(); err != nil || b != 0x71 {
+		t.Fatalf("ReadByte (echo of 0x71) = (0x%02X, %v), want (0x71, nil)", b, err)
+	}
+
+	mid := mux.ActiveTxnSnapshot()
+	if mid.BytesDeliveredToActive == 0 {
+		t.Fatalf("BytesDeliveredToActive=0 after first echo, want >=1 — test precondition")
+	}
+	suppressedBefore := mid.SynSuppressedPreEcho
+
+	// Step 3: write the target byte 0x08 — DO NOT feed its echo. The
+	// gateway is now mid-write with expectedEchoes head = 0x08.
+	if _, err := at.Write([]byte{0x08}); err != nil {
+		t.Fatalf("Write(0x08) err=%v", err)
+	}
+	// Allow sendLoop's recordSent(0x08) to populate the queue before the
+	// noise SYN arrives (sendLoop holds stateMu so the inbound SYN's
+	// onSYNLocked critical section will serialize after recordSent;
+	// nevertheless yield so the goroutine is scheduled).
+	time.Sleep(20 * time.Millisecond)
+
+	// Step 4: inject the noise SYN.
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: protocol.SymbolSyn}
+	time.Sleep(50 * time.Millisecond)
+
+	snap := mux.ActiveTxnSnapshot()
+
+	// Assertion (a): synSuppressedPreEcho incremented (P10.2 mid-write
+	// branch fired).
+	if snap.SynSuppressedPreEcho <= suppressedBefore {
+		t.Errorf("SynSuppressedPreEcho=%d, suppressedBefore=%d, want increment — mid-write SYN must be classified as noise (P10.2)",
+			snap.SynSuppressedPreEcho, suppressedBefore)
+	}
+
+	// Assertion (b): txn is STILL active. The mid-write SYN must not
+	// have aborted the transaction via terminator OR idle release.
+	if !snap.Active {
+		t.Errorf("ActiveTxnSnapshot.Active=false, want true — mid-write SYN must not abort live txn")
+	}
+	if snap.InactiveReason == ReasonSYNTerminator {
+		t.Errorf("InactiveReason=ReasonSYNTerminator — pre-P10.2 bug: terminator path fired on mid-write SYN")
+	}
+	if snap.InactiveReason == ReasonSYNIdle {
+		t.Errorf("InactiveReason=ReasonSYNIdle — idle release fired on mid-write SYN despite bytesDeliveredToActive>0")
+	}
+
+	// Assertion (c): the echo of 0x08 still matches after the noise SYN
+	// (queue [0x08] was preserved by skipping flushOnSYN). Feeding the
+	// echo now must succeed without echo_mismatch and ReadByte returns
+	// 0x08 to the bus.Send consumer.
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x08}
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		b, err := at.ReadByte()
+		if err == nil && b == 0x08 {
+			return // success
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Errorf("did not receive 0x08 echo after noise SYN — gatewayEcho queue corrupted by flushOnSYN")
+}
+
+// P10.2 negative control — verify that the legitimate frame terminator
+// (bus.Send wrote SYN itself, queue head IS SYN) still fires the
+// terminator path. This guards against an over-aggressive suppression
+// regression.
+func TestPreEchoSyn_LegitimateTerminator_Delivered(t *testing.T) {
+	mux, mock, _, cleanup := newP3TestMux(t)
+	defer cleanup()
+
+	grantGateway(t, mux, mock, 0x71)
+	at := mux.ActiveTransport()
+
+	// Write source byte, feed echo, consume.
+	if _, err := at.Write([]byte{0x71}); err != nil {
+		t.Fatalf("Write err=%v", err)
+	}
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x71}
+	if _, err := at.ReadByte(); err != nil {
+		t.Fatalf("ReadByte err=%v", err)
+	}
+
+	// Gateway writes the terminator SYN itself (sendEndOfMessage path).
+	// expectedEchoes head is now SYN.
+	go func() { _, _ = at.Write([]byte{protocol.SymbolSyn}) }()
+	time.Sleep(20 * time.Millisecond)
+
+	// Wire echoes the SYN. The gate must let it through as terminator.
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: protocol.SymbolSyn}
+
+	deadline := time.Now().Add(1 * time.Second)
+	delivered := false
+	for time.Now().Before(deadline) {
+		b, err := at.ReadByte()
+		if err == nil && b == protocol.SymbolSyn {
+			delivered = true
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !delivered {
+		t.Fatalf("legitimate terminator SYN was not delivered to activeCh — over-aggressive P10.2 suppression regression")
+	}
+
+	time.Sleep(20 * time.Millisecond)
+	snap := mux.ActiveTxnSnapshot()
+	if snap.Active {
+		t.Errorf("Active=true after legitimate terminator, want false")
+	}
+	if snap.InactiveReason != ReasonSYNTerminator {
+		t.Errorf("InactiveReason=%q, want %q", snap.InactiveReason, ReasonSYNTerminator)
+	}
+}
+
+// P10.2 — verify the response-phase / between-writes case (queue
+// empty, bytesDeliveredToActive>0) still fires terminator path. This
+// preserves the pre-P10.2 lifecycle contract for tests that simulate
+// "gateway wrote, got echo, then SYN" without the explicit
+// sendEndOfMessage step (legacy contract per PR #502).
+func TestPreEchoSyn_QueueEmpty_TerminatorFiresAsBefore(t *testing.T) {
+	mux, mock, _, cleanup := newP3TestMux(t)
+	defer cleanup()
+
+	grantGateway(t, mux, mock, 0x71)
+	at := mux.ActiveTransport()
+
+	// Write+echo+consume so queue is empty AND bytesDeliveredToActive>=1.
+	if _, err := at.Write([]byte{0x71}); err != nil {
+		t.Fatalf("Write err=%v", err)
+	}
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x71}
+	if _, err := at.ReadByte(); err != nil {
+		t.Fatalf("ReadByte err=%v", err)
+	}
+
+	// Inject SYN — queue is empty, so peekNextExpected returns
+	// (0, false). midWriteSyn=false. Terminator gate fires (legacy
+	// PR #502 semantics retained).
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: protocol.SymbolSyn}
+
+	deadline := time.Now().Add(1 * time.Second)
+	delivered := false
+	for time.Now().Before(deadline) {
+		b, err := at.ReadByte()
+		if err == nil && b == protocol.SymbolSyn {
+			delivered = true
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !delivered {
+		t.Fatalf("legacy terminator (queue empty) was not delivered — backward-compat regression")
+	}
+}
+
+// P10.2 — verify that an unresponsive-target stuck-write scenario still
+// terminates via idle release. This guards the
+// `!suppressIdleRelease` carve-out: when bytesDeliveredToActive == 0
+// and the gateway has pending writes that never echoed, idle release
+// MUST fire so the transaction does not pin ownership forever.
+func TestPreEchoSyn_StuckWrite_IdleReleaseStillFires(t *testing.T) {
+	mux, mock, _, cleanup := newP3TestMux(t)
+	defer cleanup()
+
+	grantGateway(t, mux, mock, 0x71)
+	at := mux.ActiveTransport()
+
+	// Write 7 bytes; do NOT feed any echoes (simulates unresponsive
+	// target — TestRegression_StartedButNoResponse production shape).
+	go func() { _, _ = at.Write([]byte{0x08, 0xB5, 0x04, 0x01, 0x00, 0x00, 0xCD}) }()
+	time.Sleep(20 * time.Millisecond)
+
+	// Wait past IdleReleaseGrace and inject an idle SYN.
+	time.Sleep(220 * time.Millisecond)
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: protocol.SymbolSyn}
+	time.Sleep(50 * time.Millisecond)
+
+	snap := mux.ActiveTxnSnapshot()
+	if snap.Active {
+		t.Errorf("Active=true after idle-grace expiry — idle release was suppressed by P10.2 mid-write gate (regression)")
+	}
+	if snap.InactiveReason != ReasonSYNIdle {
+		// SYN-terminator is acceptable too if the test fixture happened
+		// to deliver the SYN as terminator, but for this scenario the
+		// canonical reason is idle release.
+		if snap.InactiveReason != ReasonSYNTerminator {
+			t.Errorf("InactiveReason=%q, want %q (or ReasonSYNTerminator)", snap.InactiveReason, ReasonSYNIdle)
+		}
+	}
+}

--- a/internal/adaptermux/syn_diag_test.go
+++ b/internal/adaptermux/syn_diag_test.go
@@ -28,6 +28,14 @@ import (
 // records synDeliveredToActive=true and the reason is ReasonSYNTerminator
 // (distinct from ReasonSYNIdle which is reserved for abandoned-grant
 // idle-release).
+//
+// P10.2: this scenario remains a legitimate terminator under the new
+// gate. After ReadByte consumes the echo, gatewayEcho.expectedEchoes is
+// empty, so peekNextExpected returns hasPending=false → midWriteSyn=false
+// → terminator branch fires as before. The mid-write race the new gate
+// closes is the *different* scenario where queue head is a non-SYN byte
+// (gateway awaiting echo of body byte at SYN arrival) — exercised by
+// the new TestPreEchoSyn_MidWriteSyn_Suppressed test.
 func TestSynDiag_RecordsOwnershipTransition(t *testing.T) {
 	mux, mock, _, cleanup := newP3TestMux(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary

Production soak observed **671 echo_mismatch events** with subclass=`pre_echo_syn` (~16% of all 4182 echo_mismatch). Root cause: the mux's terminator gate at `onSYNLocked` fired unconditionally once `bytesDeliveredToActive>0`, delivering interleaved buffered or wire-collision SYN bytes to `activeCh` as if they were the legitimate frame terminator. `bus.Send.sendRawWithEcho` — still mid-frame, awaiting echo of a non-SYN body byte — saw `0xAA` in echo position and emitted `echo_mismatch`.

## Fix

Use `gatewayEcho.expectedEchoes` queue head as a discriminator:

| Queue state | Old behavior | New behavior |
|-------------|--------------|--------------|
| `hasPending=true && head == SymbolSyn` (gateway just wrote terminator) | terminator fires | **terminator fires** ✓ |
| `hasPending=false` (queue empty — between writes / response-read) | terminator fires | **terminator fires** (legacy PR #502 contract preserved) |
| `hasPending=true && head != SymbolSyn` (mid-write race) | terminator fires → echo_mismatch | **SUPPRESS** ← P10.2 change |

Mid-write suppression also gates `flushOnSYN` (preserve queue so the next echo of the pending non-SYN byte still matches) and `idle release` (when `bytesDeliveredToActive>0`, i.e. live txn — would otherwise abort a slow legitimate txn). Idle release for stuck-write scenarios (`bytesDeliveredToActive==0`, target unresponsive) still fires via the `!suppressIdleRelease` carve-out so `TestRegression_StartedButNoResponse` and production unresponsive-target paths continue to bail out cleanly.

## Codex pass 1 findings

1. **flushOnSYN ordering** — addressed: gated on `!preEchoMidFrameSuppress`.
2. **Idle release** — addressed via the `bytesDeliveredToActive>0` carve-out (`suppressIdleRelease`).
3. **expectedEchoes ordering** — confirmed authoritative: `recordSent` runs in `sendLoop` under `stateMu` BEFORE `doSend`, so any echo arrives strictly after the queue update.

## Test plan

- [x] `go test -race -count=1 ./...` PASS (incl. 4 new `TestPreEchoSyn_*` tests in `pre_echo_syn_p102_test.go`)
- [x] `scripts/ci_local.sh` PASS (terminology gate, gofmt, vet, build, full race tests, golangci-lint, transport gate via owner override, AD gate via documented skip, passive smoke gate)
- [ ] Post-deploy: `ebus_active_echo_mismatch_subclass_total{subclass="pre_echo_syn"}` rate drops from ~2.8/min to floor (single-digit per hour or zero).
- [ ] Post-deploy: total `echo_mismatch` rate drops by ~16% (671/4182 share).
- [ ] Post-deploy: no regression in `synSuppressedPreEcho` semantics (counter still increments under live load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)