### PR TITLE
P9.x: graphql.BuildSchema uses IterateSnapshots (race-free)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260507140006-4dfa4a22cec3
-	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260509181158-2a12133252d1
+	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510061749-3b9b2d2ae4c5
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260507140006-4dfa4a22cec3 h1:U90kuV7LhIkiwnD1iZFGV29Vpd87S119DXDcso4cCp8=
 github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260507140006-4dfa4a22cec3/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260509181158-2a12133252d1 h1:hB2AH1usRux5lBCSiYugfrt5XGmJxCkPfbwnD+QF81M=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260509181158-2a12133252d1/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510061749-3b9b2d2ae4c5 h1:gHQV7gIi3tAaVrsDcLRQQhMeJvdQhSfX+CnWPLFl7qU=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510061749-3b9b2d2ae4c5/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=

--- a/graphql/builder_test.go
+++ b/graphql/builder_test.go
@@ -428,6 +428,17 @@ func (reg mockRegistry) Iterate(fn func(registry.DeviceEntry) bool) {
 	}
 }
 
+// IterateSnapshots — P9.x. Synthesizes a DeviceEntrySnapshot from each
+// stored DeviceEntry so the test fixture continues to drive
+// BuildSchema after the migration to snapshot-based iteration.
+func (reg mockRegistry) IterateSnapshots(fn func(registry.DeviceEntrySnapshot) bool) {
+	for _, entry := range reg.entries {
+		if !fn(snapshotFromTestEntry(entry)) {
+			return
+		}
+	}
+}
+
 type mutableRegistry struct {
 	mu      sync.RWMutex
 	entries []registry.DeviceEntry
@@ -441,6 +452,41 @@ func (reg *mutableRegistry) Iterate(fn func(registry.DeviceEntry) bool) {
 		if !fn(entry) {
 			return
 		}
+	}
+}
+
+// IterateSnapshots — P9.x companion of Iterate (see mockRegistry).
+func (reg *mutableRegistry) IterateSnapshots(fn func(registry.DeviceEntrySnapshot) bool) {
+	reg.mu.RLock()
+	entries := append([]registry.DeviceEntry(nil), reg.entries...)
+	reg.mu.RUnlock()
+	for _, entry := range entries {
+		if !fn(snapshotFromTestEntry(entry)) {
+			return
+		}
+	}
+}
+
+// snapshotFromTestEntry converts a test fixture's DeviceEntry into a
+// DeviceEntrySnapshot. Production builds snapshots inside the
+// registry under RLock; tests don't need that lock discipline since
+// fixtures are single-threaded. Method/Plane/Projection slices are
+// passed through (they are immutable after fixture construction).
+func snapshotFromTestEntry(entry registry.DeviceEntry) registry.DeviceEntrySnapshot {
+	if entry == nil {
+		return registry.DeviceEntrySnapshot{}
+	}
+	return registry.DeviceEntrySnapshot{
+		PrimaryAddress:  entry.PrimaryDisplayAddress(),
+		Addresses:       entry.Addresses(),
+		Manufacturer:    entry.Manufacturer(),
+		DeviceID:        entry.DeviceID(),
+		SerialNumber:    entry.SerialNumber(),
+		MacAddress:      entry.MacAddress(),
+		SoftwareVersion: entry.SoftwareVersion(),
+		HardwareVersion: entry.HardwareVersion(),
+		Planes:          entry.Planes(),
+		Projections:     entry.Projections(),
 	}
 }
 

--- a/graphql/schema.go
+++ b/graphql/schema.go
@@ -75,7 +75,12 @@ type ProjectionEdge struct {
 }
 
 type Registry interface {
-	Iterate(func(registry.DeviceEntry) bool)
+	// IterateSnapshots visits each device as a value-typed snapshot
+	// (P9.x — graphql/BuildSchema is race-free against concurrent
+	// registry mutations because the snapshot's slice headers are
+	// captured under RLock and Plane wrappers ensure Methods()
+	// returns snapshot-owned storage).
+	IterateSnapshots(func(registry.DeviceEntrySnapshot) bool)
 }
 
 func BuildSchema(reg Registry) (Schema, error) {
@@ -89,29 +94,29 @@ func BuildSchema(reg Registry) (Schema, error) {
 	var buildErr error
 	catalog, catalogErr := productids.LoadCatalog()
 
-	reg.Iterate(func(entry registry.DeviceEntry) bool {
+	reg.IterateSnapshots(func(snap registry.DeviceEntrySnapshot) bool {
 		partNumber := ""
 		displayName := ""
 		family := ""
 		model := ""
 		role := ""
-		if strings.EqualFold(entry.Manufacturer(), "Vaillant") {
-			partNumber = extractVaillantPartNumber(entry.SerialNumber())
+		if strings.EqualFold(snap.Manufacturer, "Vaillant") {
+			partNumber = extractVaillantPartNumber(snap.SerialNumber)
 			displayName, family, model, role = resolveVaillantProduct(partNumber, catalog, catalogErr)
 			if displayName == "" && family == "" && model == "" && role == "" {
-				displayName, family, model, role = fallbackVaillantIdentity(entry.DeviceID())
+				displayName, family, model, role = fallbackVaillantIdentity(snap.DeviceID)
 			}
 		}
 
 		device := Device{
-			Address:         entry.PrimaryDisplayAddress(),
-			Addresses:       normalizeDeviceAddresses(entry.PrimaryDisplayAddress(), entry.Addresses()),
-			Manufacturer:    entry.Manufacturer(),
-			DeviceID:        entry.DeviceID(),
-			SerialNumber:    entry.SerialNumber(),
-			MacAddress:      entry.MacAddress(),
-			SoftwareVersion: entry.SoftwareVersion(),
-			HardwareVersion: entry.HardwareVersion(),
+			Address:         snap.PrimaryDisplayAddress(),
+			Addresses:       normalizeDeviceAddresses(snap.PrimaryDisplayAddress(), snap.Addresses),
+			Manufacturer:    snap.Manufacturer,
+			DeviceID:        snap.DeviceID,
+			SerialNumber:    snap.SerialNumber,
+			MacAddress:      snap.MacAddress,
+			SoftwareVersion: snap.SoftwareVersion,
+			HardwareVersion: snap.HardwareVersion,
 			DisplayName:     displayName,
 			ProductFamily:   family,
 			ProductModel:    model,
@@ -121,7 +126,7 @@ func BuildSchema(reg Registry) (Schema, error) {
 			Projections:     make([]Projection, 0),
 		}
 
-		for _, plane := range entry.Planes() {
+		for _, plane := range snap.Planes {
 			methods := make([]Method, 0, len(plane.Methods()))
 			for _, method := range plane.Methods() {
 				template := method.Template()
@@ -130,7 +135,7 @@ func BuildSchema(reg Registry) (Schema, error) {
 					return false
 				}
 
-				response, err := selectResponseSchema(entry, method.ResponseSchema())
+				response, err := selectResponseSchemaFromSnapshot(snap, method.ResponseSchema())
 				if err != nil {
 					buildErr = err
 					return false
@@ -151,7 +156,7 @@ func BuildSchema(reg Registry) (Schema, error) {
 			})
 		}
 
-		for _, projection := range entry.Projections() {
+		for _, projection := range snap.Projections {
 			if err := projection.Validate(); err != nil {
 				buildErr = fmt.Errorf("graphql schema build projection %q invalid: %w", projection.Plane, err)
 				return false
@@ -362,12 +367,12 @@ func isDigits(value string) bool {
 	return true
 }
 
-func selectResponseSchema(entry registry.DeviceEntry, selector schema.SchemaSelector) (ResponseSchema, error) {
-	if entry == nil {
-		return ResponseSchema{}, fmt.Errorf("graphql schema build missing device: %w", ebuserrors.ErrInvalidPayload)
-	}
-
-	selected := selector.Select(entry.PrimaryDisplayAddress(), entry.HardwareVersion())
+// selectResponseSchemaFromSnapshot operates on a value-typed
+// DeviceEntrySnapshot. Used by BuildSchema (P9.x) so the schema build
+// path no longer has to dereference live *deviceEntry pointer fields
+// after the registry RLock has been released.
+func selectResponseSchemaFromSnapshot(snap registry.DeviceEntrySnapshot, selector schema.SchemaSelector) (ResponseSchema, error) {
+	selected := selector.Select(snap.PrimaryDisplayAddress(), snap.HardwareVersion)
 	fields := make([]Field, 0, len(selected.Fields))
 	for _, field := range selected.Fields {
 		if field.Type == nil {

--- a/graphql/subscriptions_integration_test.go
+++ b/graphql/subscriptions_integration_test.go
@@ -21,6 +21,9 @@ type emptyRegistry struct{}
 
 func (emptyRegistry) Iterate(func(registry.DeviceEntry) bool) {}
 
+// IterateSnapshots — P9.x. No-op for empty registry.
+func (emptyRegistry) IterateSnapshots(func(registry.DeviceEntrySnapshot) bool) {}
+
 type noopBus struct{}
 
 func (noopBus) Send(context.Context, protocol.Frame) (*protocol.Frame, error) {


### PR DESCRIPTION
## Summary

Companion to ebusreg PR #141 (P9.x DeviceEntrySnapshot.Planes/Projections). Migrates `graphql.BuildSchema` from the live-pointer `Iterate` to the value-typed `IterateSnapshots`, closing the long-standing race where `mergeEntries` could rebind `entry.planes` / `entry.projections` while BuildSchema iterated.

## Changes

- `graphql.Registry` interface: `Iterate` → `IterateSnapshots`
- BuildSchema body: `entry.Manufacturer()` → `snap.Manufacturer` (and analogous for the other identity fields); `snap.Planes` / `snap.Projections` used directly
- `selectResponseSchema` (live-pointer) replaced by `selectResponseSchemaFromSnapshot` (value-typed)
- Test fixtures (`mockRegistry`, `mutableRegistry`, `emptyRegistry`) gain `IterateSnapshots` methods that synthesize snapshots from their fixture DeviceEntry values via `snapshotFromTestEntry` helper
- `go.mod` bumped to ebusreg `v0.0.0-20260510061749-3b9b2d2ae4c5`

## Test plan

- [x] `go test -race -count=1 ./...` PASS
- [x] `scripts/ci_local.sh` PASS (transport gate + AD gate via documented owner override; golangci-lint clean)
- [ ] Post-deploy: BuildSchema continues to produce consistent schemas (no torn-string regressions in GraphQL responses observed under concurrent device-merge load)

🤖 Generated with [Claude Code](https://claude.com/claude-code)