### PR TITLE
P10.2.1: echoTracker overflow reset + operator counter

### DIFF
--- a/internal/adaptermux/diag.go
+++ b/internal/adaptermux/diag.go
@@ -168,6 +168,13 @@ type ActiveTxnSnapshot struct {
 	TerminatorDropOnFullCh uint64
 	// SynSuppressedPreEcho mirrors activeTxnDiag.synSuppressedPreEcho.
 	SynSuppressedPreEcho uint64
+	// EchoQueueOverflowResets mirrors gatewayEcho.totalOverflowResets
+	// (P10.2.1). Non-zero indicates the gateway-write loop produced
+	// more than 256 unacknowledged writes, triggering a queue reset.
+	// Real eBUS frames are <30 bytes; reaching 256 implies a
+	// pathological condition (TCP backpressure, paused readLoop,
+	// runaway write loop) and warrants operator investigation.
+	EchoQueueOverflowResets uint64
 	// BytesDeliveredToActive mirrors activeTxnDiag.bytesDeliveredToActive.
 	BytesDeliveredToActive uint64
 
@@ -201,29 +208,30 @@ func (m *Mux) ActiveTxnSnapshot() ActiveTxnSnapshot {
 	rp := make([]byte, m.activeTxn.readPrefixLen)
 	copy(rp, m.activeTxn.readPrefix[:m.activeTxn.readPrefixLen])
 	return ActiveTxnSnapshot{
-		ID:                     m.activeTxn.id,
-		Initiator:              m.activeTxn.initiator,
-		GrantedAt:              m.activeTxn.grantedAt,
-		InactiveAt:             m.activeTxn.inactiveAt,
-		InactiveReason:         m.activeTxn.inactiveReas,
-		DrainedOnGrant:         m.activeTxn.drainedOnGrant,
-		Active:                 m.gatewayTxnActive,
-		BytesWritten:           m.activeTxn.bytesWritten.Load(),
-		BytesRead:              m.activeTxn.bytesRead.Load(),
-		GrantsTotal:            m.activeTxn.grantsTotal.Load(),
-		WriteErrTotal:          m.activeTxn.writeErrTotal.Load(),
-		ReadTimeoutTot:         m.activeTxn.readTimeoutTot.Load(),
-		AfterInactive:          m.activeTxn.afterInactive.Load(),
-		TerminatorDropOnFullCh: m.activeTxn.terminatorDropOnFullCh.Load(),
-		SynSuppressedPreEcho:   m.activeTxn.synSuppressedPreEcho.Load(),
-		BytesDeliveredToActive: m.activeTxn.bytesDeliveredToActive.Load(),
-		WritePrefix:            wp,
-		ReadPrefix:             rp,
-		EchoLike:               m.activeTxn.echoLike.Load(),
-		NonEcho:                m.activeTxn.nonEcho.Load(),
-		SynMarkers:             m.activeTxn.synMarkers.Load(),
-		TxnClass:               m.activeTxn.txnClass,
-		LastTxnClass:           m.activeTxn.lastClass,
+		ID:                      m.activeTxn.id,
+		Initiator:               m.activeTxn.initiator,
+		GrantedAt:               m.activeTxn.grantedAt,
+		InactiveAt:              m.activeTxn.inactiveAt,
+		InactiveReason:          m.activeTxn.inactiveReas,
+		DrainedOnGrant:          m.activeTxn.drainedOnGrant,
+		Active:                  m.gatewayTxnActive,
+		BytesWritten:            m.activeTxn.bytesWritten.Load(),
+		BytesRead:               m.activeTxn.bytesRead.Load(),
+		GrantsTotal:             m.activeTxn.grantsTotal.Load(),
+		WriteErrTotal:           m.activeTxn.writeErrTotal.Load(),
+		ReadTimeoutTot:          m.activeTxn.readTimeoutTot.Load(),
+		AfterInactive:           m.activeTxn.afterInactive.Load(),
+		TerminatorDropOnFullCh:  m.activeTxn.terminatorDropOnFullCh.Load(),
+		SynSuppressedPreEcho:    m.activeTxn.synSuppressedPreEcho.Load(),
+		EchoQueueOverflowResets: m.gatewayEcho.overflowResets(),
+		BytesDeliveredToActive:  m.activeTxn.bytesDeliveredToActive.Load(),
+		WritePrefix:             wp,
+		ReadPrefix:              rp,
+		EchoLike:                m.activeTxn.echoLike.Load(),
+		NonEcho:                 m.activeTxn.nonEcho.Load(),
+		SynMarkers:              m.activeTxn.synMarkers.Load(),
+		TxnClass:                m.activeTxn.txnClass,
+		LastTxnClass:            m.activeTxn.lastClass,
 	}
 }
 

--- a/internal/adaptermux/echo_tracker.go
+++ b/internal/adaptermux/echo_tracker.go
@@ -39,6 +39,18 @@ type echoTracker struct {
 	// Stats.
 	totalSuppressed uint64
 	totalMismatches uint64
+
+	// totalOverflowResets counts how many times recordSent reset the
+	// expectedEchoes queue because it would have exceeded
+	// maxPendingEchoes. Pre-P10.2 the queue silently dropped its oldest
+	// entry on overflow (FIFO); under sustained mid-write SYN noise
+	// (P10.2 keeps the queue across suppressed SYNs) that silent drop
+	// would desync subsequent matchEcho calls — every comparison would
+	// be against a wrong head, producing a cascading echo_mismatch
+	// storm hard to diagnose. Reset semantics make the failure noisy
+	// (next received byte won't match an empty queue → echoMatchNone)
+	// and operator-visible via this counter (P10.2.1).
+	totalOverflowResets uint64
 }
 
 // newEchoTracker creates a fresh echo tracker.
@@ -51,10 +63,24 @@ func newEchoTracker() *echoTracker {
 
 // recordSent records a byte that the session is sending to the adapter.
 // We expect the adapter to echo this byte back as ENHResReceived.
+//
+// Overflow handling (P10.2.1 — replaces the AM16 silent FIFO drop):
+// at the cap (maxPendingEchoes=256) the queue is RESET, NOT shifted.
+// FIFO drop preserved length but silently rotated the head, which
+// post-P10.2 (mid-write SYN now keeps the queue rather than flushing
+// it on SYN) would desynchronize subsequent matchEcho calls — every
+// comparison would be against the wrong head, producing a cascading
+// echo_mismatch storm hard to diagnose. Reset semantics make the
+// failure noisy (echoMatchNone on the next byte; bus.Send will see
+// the lost-echo timeout and retry the txn) and the
+// `totalOverflowResets` counter exposes the regression for
+// operators. Real eBUS frames are <30 bytes; reaching 256 implies a
+// pathological condition (TCP backpressure, paused readLoop, runaway
+// gateway write loop) where loud failure is preferable to drift.
 func (t *echoTracker) recordSent(data byte) {
-	// AM16: drop oldest if queue is at capacity.
 	if len(t.expectedEchoes) >= maxPendingEchoes {
-		t.expectedEchoes = t.expectedEchoes[1:]
+		t.expectedEchoes = t.expectedEchoes[:0]
+		t.totalOverflowResets++
 	}
 	t.expectedEchoes = append(t.expectedEchoes, data)
 }
@@ -184,4 +210,13 @@ func (t *echoTracker) reset() {
 // stats returns echo tracking statistics.
 func (t *echoTracker) stats() (suppressed, mismatches uint64) {
 	return t.totalSuppressed, t.totalMismatches
+}
+
+// overflowResets returns the number of times recordSent reset the
+// expectedEchoes queue because it was about to exceed
+// maxPendingEchoes. Non-zero means the gateway-write loop produced
+// more than 256 unacknowledged writes — a pathological condition
+// that matters as a tripwire for operator visibility (P10.2.1).
+func (t *echoTracker) overflowResets() uint64 {
+	return t.totalOverflowResets
 }

--- a/internal/adaptermux/echo_tracker_test.go
+++ b/internal/adaptermux/echo_tracker_test.go
@@ -154,3 +154,61 @@ func TestEchoTracker_EmptyTracker(t *testing.T) {
 		t.Fatalf("empty flush: len = %d, want 0", len(flushed))
 	}
 }
+
+// TestEchoTracker_OverflowReset (P10.2.1) — exceeding maxPendingEchoes
+// must RESET the queue rather than silently FIFO-drop the head. P10.2's
+// flushOnSYN-skip-on-mid-write would compound the silent FIFO drop into
+// a cascading echo_mismatch storm; reset semantics make the failure
+// noisy (next byte returns echoMatchNone, bus.Send observes timeout +
+// retry) and the totalOverflowResets counter exposes the regression.
+func TestEchoTracker_OverflowReset(t *testing.T) {
+	tracker := newEchoTracker()
+
+	// Fill queue to capacity with sentinel byte 0x71.
+	for i := 0; i < maxPendingEchoes; i++ {
+		tracker.recordSent(0x71)
+	}
+	if got := len(tracker.expectedEchoes); got != maxPendingEchoes {
+		t.Fatalf("queue len at cap = %d; want %d", got, maxPendingEchoes)
+	}
+	if got := tracker.overflowResets(); got != 0 {
+		t.Fatalf("overflowResets pre-overflow = %d; want 0", got)
+	}
+
+	// One more recordSent triggers the overflow path: queue must be
+	// reset to a single entry with the new byte (NOT FIFO-shifted).
+	tracker.recordSent(0x08)
+	if got := len(tracker.expectedEchoes); got != 1 {
+		t.Fatalf("queue len after overflow = %d; want 1 (reset semantics)", got)
+	}
+	if got := tracker.expectedEchoes[0]; got != 0x08 {
+		t.Errorf("queue head after overflow = 0x%02X; want 0x08 (latest write)", got)
+	}
+	if got := tracker.overflowResets(); got != 1 {
+		t.Errorf("overflowResets after overflow = %d; want 1", got)
+	}
+
+	// matchEcho against the latest write 0x08 succeeds — the post-reset
+	// queue head IS 0x08 (the only entry).
+	result, _ := tracker.matchEcho(0x08)
+	if result != echoMatchSuppressed {
+		t.Errorf("matchEcho(0x08) = %v; want Suppressed (post-reset head)", result)
+	}
+
+	// All later stale echoes (the original 256 sentinels still buffered
+	// upstream) now fail to match. Pre-P10.2.1 (FIFO drop) the queue
+	// would have kept [byte_2 ... byte_257] — first mismatch flushes
+	// the queue; downstream echoes are then treated as observer
+	// traffic. Reset semantics produce the same downstream behavior
+	// but expose the regression via overflowResets, which is the
+	// operator tripwire. Verify queue is empty and subsequent stale
+	// echoes return echoMatchNone (NOT echoMatchSuppressed — the
+	// gateway no longer claims them).
+	if got := len(tracker.expectedEchoes); got != 0 {
+		t.Errorf("queue len after consuming 0x08 = %d; want 0", got)
+	}
+	result, _ = tracker.matchEcho(0x71)
+	if result != echoMatchNone {
+		t.Errorf("stale echo of 0x71 post-overflow = %v; want echoMatchNone (queue empty after consume)", result)
+	}
+}


### PR DESCRIPTION
## Summary

Angry-tester adversarial review of [P10.2 (#601)](https://github.com/Project-Helianthus/helianthus-ebusgateway/pull/601) flagged a MEDIUM regression: P10.2 preserves `expectedEchoes` across mid-write SYNs (skip `flushOnSYN`) so the queue can grow unboundedly under sustained noise. The pre-existing AM16 cap (256) silently FIFO-dropped the head, which post-P10.2 would desync subsequent `matchEcho` calls against the wrong head — producing a cascading echo_mismatch storm hard to diagnose.

Replace silent FIFO drop with explicit reset + operator-visible counter:

- `recordSent` at cap → reset queue to single entry (the new byte) + increment `totalOverflowResets`
- `EchoQueueOverflowResets` surfaced in `ActiveTxnSnapshot` for operator diagnostics
- Loud failure + counter preferable to silent drift

Real eBUS frames are <30 bytes; reaching 256 implies a pathological condition (TCP backpressure, paused readLoop, runaway write loop).

## Test plan

- [x] `TestEchoTracker_OverflowReset` covers cap + reset semantics + counter increment
- [x] `go test -race -count=1 ./...` PASS
- [x] `scripts/ci_local.sh` PASS
- [ ] Post-deploy: `EchoQueueOverflowResets` should remain 0 under normal load

🤖 Generated with [Claude Code](https://claude.com/claude-code)