### PR TITLE
Bump ebusreg for 4-face NETX3 seed (0xFF)

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -1012,7 +1012,7 @@ func bindFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) {
 	fs.StringVar(&cfg.DumpOutputDir, "dump-output-dir", cfg.DumpOutputDir, "unknown device dump output dir")
 	fs.StringVar(&cfg.DumpUploadURL, "dump-upload-url", cfg.DumpUploadURL, "unknown device dump upload url (internal)")
 	fs.BoolVar(&cfg.DumpIncludePII, "dump-include-pii", cfg.DumpIncludePII, "include identifiers in unknown device dumps")
-	fs.BoolVar(&cfg.EnableStaticSeedTable, "enable-static-seed-table", cfg.EnableStaticSeedTable, "plant productids static seed entries (NETX3 0x04 / 0xF1 / 0xF6, BASV2 0x15 / 0xEC) into registry at startup; default false")
+	fs.BoolVar(&cfg.EnableStaticSeedTable, "enable-static-seed-table", cfg.EnableStaticSeedTable, "plant productids static seed entries (NETX3 0xF1 / 0xF6 / 0x04 / 0xFF, BASV2 0x15 / 0xEC) into registry at startup; default false")
 	fs.BoolVar(&cfg.ObserveFirstEnabled, "observe-first-enabled", cfg.ObserveFirstEnabled, "enable observe-first runtime behavior gates")
 	fs.BoolVar(&cfg.PassiveStateDirectApply, "passive-state-direct-apply", cfg.PassiveStateDirectApply, "allow passive state direct-apply when observe-first is enabled")
 	fs.BoolVar(&cfg.PassiveConfigDirectApply, "passive-config-direct-apply", cfg.PassiveConfigDirectApply, "allow passive config direct-apply when state direct-apply is enabled")

--- a/cmd/gateway/static_seed_table_test.go
+++ b/cmd/gateway/static_seed_table_test.go
@@ -40,7 +40,9 @@ func TestApplyStaticSeedTable_StampsStaticSeedLabel(t *testing.T) {
 	applyStaticSeedTable(reg)
 
 	// Each NETX3 face + each BASV2 face from productids.LoadSeedTable(true).
-	expectedAddresses := []byte{0xF1, 0xF6, 0x04, 0x15, 0xEC}
+	// NETX3 has four faces (operator observation 2026-05-10): 0xF1
+	// initiator, 0xF6 target, 0x04+0xFF target/broadcast pair.
+	expectedAddresses := []byte{0xF1, 0xF6, 0x04, 0xFF, 0x15, 0xEC}
 	for _, addr := range expectedAddresses {
 		slot, ok := reg.LookupSlot(addr)
 		if !ok || slot == nil {
@@ -139,8 +141,9 @@ func TestApplyStaticSeedTable_MCPDeviceListProjection(t *testing.T) {
 	for _, d := range envelope.Data {
 		byAddr[d.Address] = struct{ discovery, verification string }{d.DiscoverySource, d.VerificationState}
 	}
-	// All 5 productids seed addresses must appear with static_seed/candidate.
-	for _, addr := range []int{0xF1, 0xF6, 0x04, 0x15, 0xEC} {
+	// All 6 productids seed addresses must appear with static_seed/candidate
+	// (NETX3 0xF1/0xF6/0x04/0xFF + BASV2 0x15/0xEC).
+	for _, addr := range []int{0xF1, 0xF6, 0x04, 0xFF, 0x15, 0xEC} {
 		got, ok := byAddr[addr]
 		if !ok {
 			// Some seeded faces may share an entry (canonical pair

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260507140006-4dfa4a22cec3
-	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510061749-3b9b2d2ae4c5
+	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260507140006-4dfa4a22cec3 h1:U90kuV7LhIkiwnD1iZFGV29Vpd87S119DXDcso4cCp8=
 github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260507140006-4dfa4a22cec3/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510061749-3b9b2d2ae4c5 h1:gHQV7gIi3tAaVrsDcLRQQhMeJvdQhSfX+CnWPLFl7qU=
-github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510061749-3b9b2d2ae4c5/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2 h1:6VFOfwe5L0GQkVRMcjdjCjnfBWcDoelnmoP1wIflrKM=
+github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=


### PR DESCRIPTION
## Summary

Bumps `helianthus-ebusreg` to e7b3e38 ([Project-Helianthus/helianthus-ebusreg#142](https://github.com/Project-Helianthus/helianthus-ebusreg/pull/142)). Operator observation 2026-05-10: NETX3 exposes four faces on the wire — 0xF1 master, 0xF6 slave, 0x04 + 0xFF target/broadcast pair. Without 0xFF in the seed, NETX3's 0xFF broadcasts land in a separate unidentified registry entry that never gets enriched (NETX3 does not respond to identify probes on 0xFF or 0xF6 — confirmed live: 0xF6 probe timed out at 10s).

Net registry state pre-fix:
- 0x04 entry: identified Vaillant/NETX3
- 0xF6/0xF1 entry: unidentified (probe failed)
- 0xFF: not in registry at all

Post-fix (with `enable_static_seed_table=true`): single NETX3 entry with [0xF1, 0xF6, 0x04, 0xFF].

## Changes

- `go.mod` / `go.sum`: bump ebusreg pseudo-version
- `cmd/gateway/main.go`: update `-enable-static-seed-table` help text (3-face → 4-face address list)
- `cmd/gateway/static_seed_table_test.go`: update expected addresses to include 0xFF

## Follow-up

The HA addon's run script does not yet pass `-enable-static-seed-table`. A follow-up PR in `helianthus-ha-addon` will expose `enable_static_seed_table` as a config option and forward it to the gateway.

## Test plan

- [x] `go test -race -count=1 ./...` PASS
- [x] `scripts/ci_local.sh` PASS (transport gate + passive smoke gate via owner override)
- [ ] Post-deploy with `-enable-static-seed-table=true`: registry shows single NETX3 entry with all 4 addresses + BASV2 entry with 2 addresses

🤖 Generated with [Claude Code](https://claude.com/claude-code)