### PR TITLE
P11: mid-write stale-byte filter + PR #603 P2 overflow rollback

### DIFF
--- a/internal/adaptermux/classify_test.go
+++ b/internal/adaptermux/classify_test.go
@@ -78,16 +78,16 @@ func TestTxnClass_NonEchoInvalidFrame(t *testing.T) {
 	}
 
 	// Feed back bytes that do NOT match the write prefix. No SYN.
+	// P11 — these bytes are now FILTERED from activeCh (mid-write
+	// non-match), but they still reach recordReadPrefixAndClassify
+	// before the filter and contribute to the nonEcho counter for
+	// classification purposes. Do not attempt to ReadByte — those
+	// reads would time out under the P11 filter.
 	noise := []byte{0x11, 0x22, 0x33}
 	for _, b := range noise {
 		mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: b}
 	}
 	time.Sleep(50 * time.Millisecond)
-	for range noise {
-		if _, err := at.ReadByte(); err != nil {
-			t.Fatalf("ReadByte err=%v", err)
-		}
-	}
 
 	mux.markActiveReadTimeout()
 
@@ -282,15 +282,14 @@ func TestTxnClass_BoundedWriteReadCapture(t *testing.T) {
 
 	// Feed 20 bytes back (non-echo, distinct values) — read prefix
 	// must also cap at 8.
+	// P11 — these are filtered from activeCh (mid-write non-match)
+	// but recordReadPrefixAndClassify runs BEFORE the filter, so
+	// readPrefix is still populated. Don't attempt ReadByte (would
+	// timeout under the P11 filter).
 	for i := 0; i < 20; i++ {
 		mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: byte(0x80 + i)}
 	}
 	time.Sleep(60 * time.Millisecond)
-	for i := 0; i < 20; i++ {
-		if _, err := at.ReadByte(); err != nil {
-			t.Fatalf("ReadByte err=%v", err)
-		}
-	}
 
 	snap := mux.ActiveTxnSnapshot()
 	if len(snap.WritePrefix) != txnPrefixCap {
@@ -370,11 +369,11 @@ func TestLastTxnClass_AfterTerminal(t *testing.T) {
 	at := mux.ActiveTransport()
 	_, _ = at.Write([]byte{0xAA})
 	// Feed mismatched byte, no SYN → NonEchoInvalidFrame on timeout.
+	// P11 — 0x55 is filtered from activeCh (mid-write, doesn't match
+	// 0xAA), but recordReadPrefixAndClassify counts it as nonEcho
+	// before the filter, which is what classifies the txn.
 	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x55}
 	time.Sleep(20 * time.Millisecond)
-	if _, err := at.ReadByte(); err != nil {
-		t.Fatalf("ReadByte err=%v", err)
-	}
 	mux.markActiveReadTimeout()
 
 	if got := mux.LastTxnClass(); got != string(TxnClassNonEchoInvalidFrame) {

--- a/internal/adaptermux/diag_test.go
+++ b/internal/adaptermux/diag_test.go
@@ -82,8 +82,19 @@ func TestActiveTxnDiag_ReadCounterIncrements(t *testing.T) {
 		t.Fatalf("Write err=%v", err)
 	}
 
-	// Feed response bytes via mock. While gateway txn is active these
-	// are delivered to activeCh and consumed by ReadByte.
+	// P11 — feed the source-byte echo first to leave mid-write phase
+	// (echoCursor catches up to writePrefixLen). Without this, the new
+	// per-byte filter rejects subsequent bytes that don't match
+	// writePrefix[echoCursor]. Pre-P11 the bulk filter let any byte
+	// flow through during ownership; the new filter requires
+	// protocol-correctness (echo first, then response bytes).
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x71}
+	if _, err := at.ReadByte(); err != nil {
+		t.Fatalf("ReadByte echo err=%v", err)
+	}
+
+	// Feed response bytes via mock. Now in response phase
+	// (echoCursor == writePrefixLen), so any byte is delivered.
 	bytes := []byte{0x10, 0x08, 0xB5}
 	for _, b := range bytes {
 		mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: b}
@@ -97,8 +108,8 @@ func TestActiveTxnDiag_ReadCounterIncrements(t *testing.T) {
 	}
 
 	snap := mux.ActiveTxnSnapshot()
-	if snap.BytesRead < 3 {
-		t.Fatalf("BytesRead = %d, want >= 3", snap.BytesRead)
+	if snap.BytesRead < 4 {
+		t.Fatalf("BytesRead = %d, want >= 4 (1 echo + 3 response)", snap.BytesRead)
 	}
 }
 
@@ -125,7 +136,14 @@ func TestActiveTxnDiag_InactiveReason_SYNIdle(t *testing.T) {
 		t.Fatalf("at.Write err=%v", err)
 	}
 
-	// Simulate a response read (bytesRead > 0 too, for realism).
+	// P11 — feed echo of 0x71 first so we leave mid-write phase.
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x71}
+	time.Sleep(20 * time.Millisecond)
+	if _, err := at.ReadByte(); err != nil {
+		t.Fatalf("ReadByte echo err=%v", err)
+	}
+
+	// Simulate a response read (response phase open, any byte ok).
 	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x10}
 	time.Sleep(20 * time.Millisecond)
 	if _, err := at.ReadByte(); err != nil {
@@ -240,6 +258,12 @@ func TestActiveTxnDiag_InactiveReason_Idempotent(t *testing.T) {
 	// is treated as the frame terminator, not pre-echo suppressed.
 	if _, err := at.Write([]byte{0x71}); err != nil {
 		t.Fatalf("Write err=%v", err)
+	}
+	// P11 — feed echo of 0x71 first to leave mid-write phase.
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x71}
+	time.Sleep(20 * time.Millisecond)
+	if _, err := at.ReadByte(); err != nil {
+		t.Fatalf("ReadByte echo err=%v", err)
 	}
 	// Also feed + consume a response byte for realism.
 	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x10}
@@ -418,8 +442,14 @@ func TestActiveTxnDiag_DrainedOnGrant_ZeroInSteadyState(t *testing.T) {
 	if _, err := at.Write([]byte{0x71}); err != nil {
 		t.Fatalf("Write err=%v", err)
 	}
+	// P11 — feed echo of 0x71 first to leave mid-write phase.
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x71}
+	time.Sleep(20 * time.Millisecond)
+	if _, err := at.ReadByte(); err != nil {
+		t.Fatalf("ReadByte echo err=%v", err)
+	}
 	// Feed response byte + consume via activeTransport so bytesRead > 0
-	// (for realism; the clear is gated on bytesWritten, not bytesRead).
+	// (response phase is open after first echo).
 	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x10}
 	time.Sleep(20 * time.Millisecond)
 	if _, err := at.ReadByte(); err != nil {
@@ -493,6 +523,12 @@ func TestActiveTxnDiag_AfterInactive_Counter(t *testing.T) {
 	// SYN is treated as terminator, not pre-echo suppressed.
 	if _, err := at.Write([]byte{0x71}); err != nil {
 		t.Fatalf("Write err=%v", err)
+	}
+	// P11 — feed echo of 0x71 first to leave mid-write phase.
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x71}
+	time.Sleep(20 * time.Millisecond)
+	if _, err := at.ReadByte(); err != nil {
+		t.Fatalf("ReadByte echo err=%v", err)
 	}
 	// Simulate a completed transaction read.
 	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x10}

--- a/internal/adaptermux/echo_tracker.go
+++ b/internal/adaptermux/echo_tracker.go
@@ -51,6 +51,19 @@ type echoTracker struct {
 	// (next received byte won't match an empty queue → echoMatchNone)
 	// and operator-visible via this counter (P10.2.1).
 	totalOverflowResets uint64
+
+	// preOverflowEchoes captures the queue contents IMMEDIATELY BEFORE
+	// the most recent overflow-reset-triggering recordSent call.
+	// rollbackSent restores from this snapshot to guarantee the cap
+	// behavior is transactional with the adapter Write that follows
+	// recordSent (Codex PR #603 P2). nil if the most recent recordSent
+	// did NOT trigger an overflow reset.
+	//
+	// Invariant: at most one snapshot is retained; subsequent successful
+	// recordSent calls (no overflow) clear it. This matches the doSend
+	// call sequence (recordSent → Write → maybe rollbackSent) where the
+	// snapshot is only valid for the duration of a single doSend.
+	preOverflowEchoes []byte
 }
 
 // newEchoTracker creates a fresh echo tracker.
@@ -77,16 +90,48 @@ func newEchoTracker() *echoTracker {
 // operators. Real eBUS frames are <30 bytes; reaching 256 implies a
 // pathological condition (TCP backpressure, paused readLoop, runaway
 // gateway write loop) where loud failure is preferable to drift.
+//
+// Codex PR #603 P2 follow-up: the reset is now TRANSACTIONAL with the
+// adapter Write that follows in doSend. preOverflowEchoes snapshots
+// the prior queue so rollbackSent (called when Write fails) can
+// restore the 256 prior expectations and revert the counter
+// increment. Without this, a Write-fails-at-cap path would lose all
+// prior echo expectations even though the adapter never accepted the
+// new byte — subsequent real echoes would all return echoMatchNone.
 func (t *echoTracker) recordSent(data byte) {
 	if len(t.expectedEchoes) >= maxPendingEchoes {
+		t.preOverflowEchoes = make([]byte, len(t.expectedEchoes))
+		copy(t.preOverflowEchoes, t.expectedEchoes)
 		t.expectedEchoes = t.expectedEchoes[:0]
 		t.totalOverflowResets++
+	} else {
+		// Successful append without overflow: clear any stale
+		// snapshot from a prior overflow that was never rolled back
+		// (the adapter Write succeeded; the reset is now committed).
+		t.preOverflowEchoes = nil
 	}
 	t.expectedEchoes = append(t.expectedEchoes, data)
 }
 
 // rollbackSent removes the last recorded sent byte (e.g., on SEND error).
+//
+// Codex PR #603 P2 follow-up: when the prior recordSent triggered an
+// overflow reset, rollbackSent restores the pre-overflow queue and
+// reverts the counter increment. The adapter Write failed so byte 257
+// never reached the wire AND the 256 prior expectations are still
+// awaiting their echoes — restore them.
 func (t *echoTracker) rollbackSent() {
+	if t.preOverflowEchoes != nil {
+		// Overflow path: restore prior 256 + drop counter increment.
+		// The new byte was appended after the reset; it never reached
+		// the adapter, so we fully revert.
+		t.expectedEchoes = t.preOverflowEchoes
+		t.preOverflowEchoes = nil
+		if t.totalOverflowResets > 0 {
+			t.totalOverflowResets--
+		}
+		return
+	}
 	if len(t.expectedEchoes) > 0 {
 		t.expectedEchoes = t.expectedEchoes[:len(t.expectedEchoes)-1]
 	}
@@ -123,6 +168,11 @@ func (t *echoTracker) matchEcho(received byte) (result echoMatchResult, flushedB
 	if len(t.expectedEchoes) == 0 {
 		return echoMatchNone, nil
 	}
+
+	// Codex PR #603 P2 invariant: any matchEcho commits the prior
+	// recordSent (the adapter actually replied to it), so the
+	// preOverflowEchoes snapshot is no longer eligible for rollback.
+	t.preOverflowEchoes = nil
 
 	if received == t.expectedEchoes[0] {
 		// Match: consume from expected, accumulate in seen.
@@ -168,6 +218,10 @@ func (t *echoTracker) flushOnSYN() (flushedBytes []byte, wasAtStart bool) {
 
 	// Clear expected echoes at SYN boundary.
 	t.expectedEchoes = t.expectedEchoes[:0]
+	// Codex PR #603 P2 invariant: a SYN boundary commits any
+	// in-flight overflow reset. preOverflowEchoes no longer eligible
+	// for rollback.
+	t.preOverflowEchoes = nil
 
 	return flushedBytes, wasAtStart
 }
@@ -178,6 +232,9 @@ func (t *echoTracker) markRequestStart() {
 	t.atRequestStart = true
 	t.seenEchoes = t.seenEchoes[:0]
 	t.expectedEchoes = t.expectedEchoes[:0]
+	// Codex PR #603 P2 invariant: a new request boundary invalidates
+	// any pending overflow snapshot.
+	t.preOverflowEchoes = nil
 }
 
 // hasPendingEchoes reports whether there are expected echoes that
@@ -205,6 +262,7 @@ func (t *echoTracker) reset() {
 	t.expectedEchoes = t.expectedEchoes[:0]
 	t.seenEchoes = t.seenEchoes[:0]
 	t.atRequestStart = false
+	t.preOverflowEchoes = nil
 }
 
 // stats returns echo tracking statistics.

--- a/internal/adaptermux/echo_tracker_test.go
+++ b/internal/adaptermux/echo_tracker_test.go
@@ -212,3 +212,79 @@ func TestEchoTracker_OverflowReset(t *testing.T) {
 		t.Errorf("stale echo of 0x71 post-overflow = %v; want echoMatchNone (queue empty after consume)", result)
 	}
 }
+
+// TestEchoTracker_OverflowRollbackRestoresQueue (Codex PR #603 P2) —
+// when recordSent triggers an overflow reset and the subsequent
+// adapter Write fails, rollbackSent must restore the prior 256
+// expectations and revert the counter increment. Pre-fix the prior
+// queue was lost forever and incoming real echoes mismatched.
+func TestEchoTracker_OverflowRollbackRestoresQueue(t *testing.T) {
+	tracker := newEchoTracker()
+
+	// Fill queue to capacity with distinct sentinels so we can verify
+	// the exact pre-overflow contents are restored.
+	for i := 0; i < maxPendingEchoes; i++ {
+		tracker.recordSent(byte(i % 256))
+	}
+
+	// Trigger overflow + immediate rollback (simulates Write failure).
+	tracker.recordSent(0xFE)
+	if got := tracker.overflowResets(); got != 1 {
+		t.Fatalf("overflowResets after overflow = %d; want 1", got)
+	}
+	if got := len(tracker.expectedEchoes); got != 1 {
+		t.Fatalf("queue len after overflow = %d; want 1", got)
+	}
+
+	tracker.rollbackSent()
+
+	// Counter reverted.
+	if got := tracker.overflowResets(); got != 0 {
+		t.Errorf("overflowResets after rollback = %d; want 0 (must revert)", got)
+	}
+	// Queue restored to the original 256 expectations.
+	if got := len(tracker.expectedEchoes); got != maxPendingEchoes {
+		t.Fatalf("queue len after rollback = %d; want %d (must restore)", got, maxPendingEchoes)
+	}
+	for i := 0; i < maxPendingEchoes; i++ {
+		want := byte(i % 256)
+		if got := tracker.expectedEchoes[i]; got != want {
+			t.Errorf("expectedEchoes[%d] post-rollback = 0x%02X; want 0x%02X", i, got, want)
+		}
+	}
+
+	// Real echoes (e.g. of byte 0) now match correctly — pre-fix they
+	// would have all returned echoMatchNone because the prior queue
+	// was destroyed.
+	result, _ := tracker.matchEcho(0)
+	if result != echoMatchSuppressed {
+		t.Errorf("matchEcho(0) post-rollback = %v; want Suppressed (restored queue head)", result)
+	}
+}
+
+// TestEchoTracker_OverflowSnapshotInvalidatedByMatch (Codex PR #603 P2
+// invariant) — once any echo matches, the prior recordSent is
+// considered committed; a subsequent rollbackSent must NOT restore the
+// snapshot. Otherwise: overflow recordSent → match → rollback would
+// resurrect a stale 256-element queue + drop the counter, both wrong.
+func TestEchoTracker_OverflowSnapshotInvalidatedByMatch(t *testing.T) {
+	tracker := newEchoTracker()
+
+	for i := 0; i < maxPendingEchoes; i++ {
+		tracker.recordSent(0x71)
+	}
+	tracker.recordSent(0x08) // overflow → snapshot stored
+
+	// matchEcho commits → snapshot must be cleared.
+	tracker.matchEcho(0x08)
+
+	// Now rollback must NOT restore the prior 256 entries (we already
+	// committed the overflow by consuming the post-reset head).
+	tracker.rollbackSent()
+	if got := len(tracker.expectedEchoes); got != 0 {
+		t.Errorf("queue len after match+rollback = %d; want 0 (snapshot invalidated)", got)
+	}
+	if got := tracker.overflowResets(); got != 1 {
+		t.Errorf("overflowResets after match+rollback = %d; want 1 (counter NOT reverted)", got)
+	}
+}

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -2407,8 +2407,23 @@ func (m *Mux) doSend(sessionID uint64, data byte) error {
 	_, err := tr.Write([]byte{data})
 	if err != nil {
 		// Rollback echo expectation on send failure.
+		//
+		// P11 round-4 (Codex pass-3 P1): clear gatewayTxnActive in the
+		// SAME stateMu critical section as the rollback. Pre-round-4 the
+		// rollback ran under stateMu, then doSend returned err, then the
+		// caller's activeTransport.Write fired markActiveWriteError to
+		// clear gatewayTxnActive — leaving a window where stateMu was
+		// released with gatewayTxnActive=true and gatewayEcho queue
+		// empty. onReceived in that window would read response-phase
+		// open and deliver stale bytes. recordGatewayInactive is
+		// idempotent so the activeTransport.Write call site's
+		// markActiveWriteError remains safe (no double-clear).
 		if sessionID == gatewaySessionID {
 			m.stateMu.Lock()
+			if m.gatewayTxnActive {
+				m.gatewayTxnActive = false
+				m.recordGatewayInactive(ReasonActiveWriteError)
+			}
 			m.gatewayEcho.rollbackSent()
 			m.stateMu.Unlock()
 		} else {

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -1175,23 +1175,52 @@ func (m *Mux) onReceived(symbol byte) {
 	// The echo tracker still runs for internal state tracking, but its
 	// result is not used for passive filtering — we suppress everything.
 	isGatewayOwned := hasOwner && ownerID == gatewaySessionID
-	if isGatewayOwned {
+	// P11 round-2 (Codex P1 findings on PR #606) — capture the echo
+	// queue head BEFORE matchEcho consumes a matching byte. The filter
+	// uses the PRE-MATCH queue head as the protocol-accurate "what byte
+	// is bus.Send currently waiting for" signal.
+	//
+	// Why not echoCursor / writePrefix:
+	//   - writePrefix is capped at txnPrefixCap=8 (diagnostic). Frames
+	//     longer than 8 bytes would have echoCursor==writePrefixLen
+	//     forever after byte 8, opening response phase prematurely.
+	//   - recordReadPrefixAndClassify advances echoCursor on a NON-match
+	//     too (diagnostic side effect). A single mid-write stale byte
+	//     would advance the cursor past the missing echo, and a second
+	//     stale byte before the real echo would slip through.
+	//
+	// gatewayEcho.expectedEchoes is the authoritative protocol state:
+	// every byte bus.Send writes is recorded; matchEcho only consumes
+	// on actual match. Uncapped, mismatch-resistant.
+	preMatchHead, hadPendingEcho := m.gatewayEcho.peekNextExpected()
+	// P11 round-2 cascade fix: only call matchEcho when it will MATCH
+	// (or when the queue is empty — then it's a no-op). matchEcho's
+	// mismatch branch CLEARS the queue, which would destroy our filter
+	// state for cascading stale bytes (a single mid-write stale byte
+	// would clear the queue and the second stale byte would slip
+	// through as response-phase). By gating the call on a match check
+	// we preserve the queue across stale bytes.
+	matchWouldHit := !hadPendingEcho || (hadPendingEcho && symbol == preMatchHead)
+	if isGatewayOwned && matchWouldHit {
 		m.gatewayEcho.matchEcho(symbol) // track echo state internally
 	}
-	// Soak fix: gate activeCh delivery to periods when the active path
-	// is expecting bytes. Non-SYN bytes during third-party traffic
-	// should not accumulate on activeCh.
+	// P11 — gate activeCh delivery: mid-write requires queue-head match;
+	// response phase (no pending writes) accepts any byte.
 	//
-	// P11 — use the per-byte filter (activePathExpectsByte) instead of
-	// the bulk filter (activePathExpectsBytes). The per-byte filter
-	// rejects mid-write stale bytes (e.g. 0x00 ACK from BASV2's just-
-	// finished 0704 scan still sitting in TCP/ENH pipeline) when
-	// echoCursor < writePrefixLen and the byte does not match the
-	// expected echo. Pre-P11 the non-SYN path used the bulk filter
-	// (just gatewayTxnActive), so any byte during ownership flowed
-	// through and post_grant_ack accounted for ~52% of all
-	// echo_mismatch.
-	activeExpects := m.activePathExpectsByte(symbol)
+	// Pre-P11 the non-SYN path used the bulk filter
+	// (activePathExpectsBytes — just gatewayTxnActive), so any byte
+	// during ownership flowed through and post_grant_ack accounted for
+	// ~52% of all echo_mismatch. P11 round-1 used echoCursor /
+	// writePrefix as the gate but those are capped diagnostic state;
+	// P11 round-2 uses gatewayEcho's pre-match queue head, which is
+	// protocol-accurate and uncapped.
+	activeExpects := m.gatewayTxnActive
+	if activeExpects && hadPendingEcho {
+		// Mid-write: only the next expected echo passes.
+		activeExpects = symbol == preMatchHead
+	}
+	// hadPendingEcho == false: response phase open, activeExpects
+	// stays as gatewayTxnActive (true) — any byte delivered.
 	// Codex P2: regression signal — if a non-SYN byte arrives while
 	// gateway still owns the bus but gatewayTxnActive is already false
 	// (post-SYN window before ownership is released), we skipped
@@ -1668,43 +1697,18 @@ func (m *Mux) resetAllSessionEchoes() {
 // embodied by activePathExpectsByte's mid-write/response phase
 // branches).
 
-// activePathExpectsByte reports whether a non-SYN byte should be delivered
-// to the active transport.
-//
-// P11 — symmetric mid-write filter. The byte must satisfy ONE of:
-//
-//   - Mid-write phase (echoCursor < writePrefixLen): byte must equal
-//     writePrefix[echoCursor], i.e. exactly the next expected echo.
-//     Stale third-party tail bytes from a prior frame still sitting
-//     in the TCP/ENH pipeline (e.g. a 0x00 ACK from BASV2's just-
-//     finished 0704 scan) would otherwise leak into activeCh and
-//     race the real echo. bus.Send sees 0x00 in echo position →
-//     echo_mismatch with subclass=post_grant_ack (52% of all
-//     echo_mismatch in production soak before this fix).
-//
-//   - Response phase (echoCursor == writePrefixLen): all writes have
-//     been echoed, the gateway is now reading the target's response.
-//     Accept any byte; bus.Send will surface invalid framing as a
-//     downstream frame error rather than echo_mismatch.
-//
-// Pre-P11 the gate was looser: once `bytesDeliveredToActive > 0`,
-// every byte passed (including mid-write stale bytes). The current
-// gate uses echoCursor as the precise mid-write/response phase
-// boundary, replacing the bytesDeliveredToActive>0 floodgate. This
-// catches the post_grant_ack pattern (~52% of echo_mismatch) without
-// breaking response-phase delivery.
-//
-// Caller must hold stateMu.
+// activePathExpectsByte — REMOVED in P11 round-2. The per-byte gate
+// is now inlined in onReceived using gatewayEcho's pre-match queue
+// head (protocol-accurate; uncapped). The previous round used
+// echoCursor/writePrefix which were capped at txnPrefixCap=8 AND
+// advanced on non-match — both broken signals (Codex P1 findings on
+// PR #606). The SYN-path call site (line 1120) still uses the legacy
+// helper; preserved as a stub returning the same gatewayTxnActive
+// signal the SYN handler expects (the SYN-specific suppression logic
+// lives in onSYNLocked's preEchoMidFrameSuppress / midWriteSyn —
+// independent of this byte-level filter).
 func (m *Mux) activePathExpectsByte(symbol byte) bool {
-	if !m.gatewayTxnActive {
-		return false
-	}
-	if m.activeTxn.echoCursor < m.activeTxn.writePrefixLen {
-		// Mid-write: only the expected echo passes.
-		return m.activeTxn.writePrefix[m.activeTxn.echoCursor] == symbol
-	}
-	// Response phase: all writes echoed, accept anything.
-	return true
+	return m.gatewayTxnActive
 }
 
 // deliverToActive sends a byte to the active path channel.

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -2353,11 +2353,20 @@ func (m *Mux) sendLoop() {
 				// writes to the adapter. That closes the immediate-echo
 				// race without arming transactions that never entered the
 				// mux write path.
+				//
+				// P11 round-3 (Codex pass-2 P1): record the echo expectation
+				// in the SAME critical section as gatewayTxnActive flip +
+				// recordWritePrefix. Pre-round-3 recordSent ran in doSend
+				// AFTER stateMu was released, leaving a state-ordering race
+				// where gatewayTxnActive=true && gatewayEcho empty: stale
+				// bytes leaked through as response-phase. Hoisting the call
+				// closes the gap.
 				m.stateMu.Lock()
 				if !m.gatewayTxnActive {
 					m.gatewayTxnActive = true
 				}
 				m.recordWritePrefix(req.data)
+				m.gatewayEcho.recordSent(req.data)
 				m.stateMu.Unlock()
 			}
 			err := m.doSend(req.sessionID, req.data)
@@ -2381,11 +2390,13 @@ func (m *Mux) doSend(sessionID uint64, data byte) error {
 	}
 
 	// Record echo expectation.
-	if sessionID == gatewaySessionID {
-		m.stateMu.Lock()
-		m.gatewayEcho.recordSent(data)
-		m.stateMu.Unlock()
-	} else {
+	//
+	// P11 round-3: gateway session's recordSent is hoisted into sendLoop
+	// (same critical section as gatewayTxnActive flip) to close the
+	// state-ordering race where gatewayTxnActive=true but gatewayEcho
+	// queue is still empty. External sessions still record here — they
+	// don't gate the active-path filter.
+	if sessionID != gatewaySessionID {
 		m.sessionsMu.Lock()
 		if sess, ok := m.sessions[sessionID]; ok {
 			sess.echoTracker.recordSent(data)

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -2376,7 +2376,31 @@ func (m *Mux) sendLoop() {
 }
 
 // doSend writes a byte to the adapter for the given session.
+//
+// P11 round-5 (Codex P2 finding on PR #606): every error path —
+// errNotBusOwner / errNotConnected / tr.Write failure — must roll
+// back gateway echo state (the byte never reached the wire) AND
+// clear gatewayTxnActive in the SAME stateMu critical section. The
+// pre-write returns previously skipped both, leaving phantom echo
+// expectations and a stuck gatewayTxnActive=true state until the
+// next SYN/grant reset. The deferred rollback below handles all
+// failure exits uniformly.
 func (m *Mux) doSend(sessionID uint64, data byte) error {
+	isGateway := sessionID == gatewaySessionID
+	sendOK := false
+	defer func() {
+		if !isGateway || sendOK {
+			return
+		}
+		m.stateMu.Lock()
+		if m.gatewayTxnActive {
+			m.gatewayTxnActive = false
+			m.recordGatewayInactive(ReasonActiveWriteError)
+		}
+		m.gatewayEcho.rollbackSent()
+		m.stateMu.Unlock()
+	}()
+
 	if !m.arb.isOwner(sessionID) {
 		return errNotBusOwner
 	}
@@ -2396,7 +2420,7 @@ func (m *Mux) doSend(sessionID uint64, data byte) error {
 	// state-ordering race where gatewayTxnActive=true but gatewayEcho
 	// queue is still empty. External sessions still record here — they
 	// don't gate the active-path filter.
-	if sessionID != gatewaySessionID {
+	if !isGateway {
 		m.sessionsMu.Lock()
 		if sess, ok := m.sessions[sessionID]; ok {
 			sess.echoTracker.recordSent(data)
@@ -2406,27 +2430,9 @@ func (m *Mux) doSend(sessionID uint64, data byte) error {
 
 	_, err := tr.Write([]byte{data})
 	if err != nil {
-		// Rollback echo expectation on send failure.
-		//
-		// P11 round-4 (Codex pass-3 P1): clear gatewayTxnActive in the
-		// SAME stateMu critical section as the rollback. Pre-round-4 the
-		// rollback ran under stateMu, then doSend returned err, then the
-		// caller's activeTransport.Write fired markActiveWriteError to
-		// clear gatewayTxnActive — leaving a window where stateMu was
-		// released with gatewayTxnActive=true and gatewayEcho queue
-		// empty. onReceived in that window would read response-phase
-		// open and deliver stale bytes. recordGatewayInactive is
-		// idempotent so the activeTransport.Write call site's
-		// markActiveWriteError remains safe (no double-clear).
-		if sessionID == gatewaySessionID {
-			m.stateMu.Lock()
-			if m.gatewayTxnActive {
-				m.gatewayTxnActive = false
-				m.recordGatewayInactive(ReasonActiveWriteError)
-			}
-			m.gatewayEcho.rollbackSent()
-			m.stateMu.Unlock()
-		} else {
+		if !isGateway {
+			// External session rollback (gateway handled by deferred
+			// rollback above).
 			m.sessionsMu.Lock()
 			if sess, ok := m.sessions[sessionID]; ok {
 				sess.echoTracker.rollbackSent()
@@ -2436,6 +2442,7 @@ func (m *Mux) doSend(sessionID uint64, data byte) error {
 		return fmt.Errorf("%w: %v", errAdapterWrite, err)
 	}
 
+	sendOK = true
 	return nil
 }
 

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -1181,7 +1181,17 @@ func (m *Mux) onReceived(symbol byte) {
 	// Soak fix: gate activeCh delivery to periods when the active path
 	// is expecting bytes. Non-SYN bytes during third-party traffic
 	// should not accumulate on activeCh.
-	activeExpects := m.activePathExpectsBytes()
+	//
+	// P11 — use the per-byte filter (activePathExpectsByte) instead of
+	// the bulk filter (activePathExpectsBytes). The per-byte filter
+	// rejects mid-write stale bytes (e.g. 0x00 ACK from BASV2's just-
+	// finished 0704 scan still sitting in TCP/ENH pipeline) when
+	// echoCursor < writePrefixLen and the byte does not match the
+	// expected echo. Pre-P11 the non-SYN path used the bulk filter
+	// (just gatewayTxnActive), so any byte during ownership flowed
+	// through and post_grant_ack accounted for ~52% of all
+	// echo_mismatch.
+	activeExpects := m.activePathExpectsByte(symbol)
 	// Codex P2: regression signal — if a non-SYN byte arrives while
 	// gateway still owns the bus but gatewayTxnActive is already false
 	// (post-SYN window before ownership is released), we skipped
@@ -1649,41 +1659,52 @@ func (m *Mux) resetAllSessionEchoes() {
 	}
 }
 
-// activePathExpectsBytes reports whether bus.Send is CURRENTLY consuming
-// activeCh for a gateway transaction. Ownership alone is insufficient:
-// after a transaction completes or aborts, ownership can linger up to
-// IdleReleaseGrace while bus.Send has already returned. Third-party
-// bytes in that idle window must NOT accumulate on activeCh.
-//
-// Policy (runtime soak fix):
-//   - gatewayTxnActive: true iff bus.Send was granted and has not yet
-//     released (set in completeArbitrationGrant, cleared on ownership
-//     release via SYN timeout/idle grace, NACK, or TransactionDone).
-//   - Do NOT deliver idle SYN bursts (no active txn → no consumer).
-//   - Do NOT use activeCh as a passive backlog — passive traffic goes
-//     through the passive path and external sessions, not activeCh.
-//
-// Caller must hold stateMu.
-func (m *Mux) activePathExpectsBytes() bool {
-	return m.gatewayTxnActive
-}
+// activePathExpectsBytes — REMOVED in P11. Pre-P11 the non-SYN
+// delivery path used this bulk filter (just gatewayTxnActive); P11
+// switched to the per-byte filter activePathExpectsByte(symbol) which
+// is symmetric across pre/post-first-echo and rejects mid-write stale
+// bytes. The function's comments still appear historically in
+// onSYNLocked (referring to the gating semantics, which are now
+// embodied by activePathExpectsByte's mid-write/response phase
+// branches).
 
 // activePathExpectsByte reports whether a non-SYN byte should be delivered
-// to the active transport. Before the first active byte is delivered, only
-// the next expected echo may pass; stale non-SYN noise must not race the real
-// echo into sendRawWithEcho. After the first delivered byte, the active path
-// owns the transaction stream and response bytes must flow through.
+// to the active transport.
+//
+// P11 — symmetric mid-write filter. The byte must satisfy ONE of:
+//
+//   - Mid-write phase (echoCursor < writePrefixLen): byte must equal
+//     writePrefix[echoCursor], i.e. exactly the next expected echo.
+//     Stale third-party tail bytes from a prior frame still sitting
+//     in the TCP/ENH pipeline (e.g. a 0x00 ACK from BASV2's just-
+//     finished 0704 scan) would otherwise leak into activeCh and
+//     race the real echo. bus.Send sees 0x00 in echo position →
+//     echo_mismatch with subclass=post_grant_ack (52% of all
+//     echo_mismatch in production soak before this fix).
+//
+//   - Response phase (echoCursor == writePrefixLen): all writes have
+//     been echoed, the gateway is now reading the target's response.
+//     Accept any byte; bus.Send will surface invalid framing as a
+//     downstream frame error rather than echo_mismatch.
+//
+// Pre-P11 the gate was looser: once `bytesDeliveredToActive > 0`,
+// every byte passed (including mid-write stale bytes). The current
+// gate uses echoCursor as the precise mid-write/response phase
+// boundary, replacing the bytesDeliveredToActive>0 floodgate. This
+// catches the post_grant_ack pattern (~52% of echo_mismatch) without
+// breaking response-phase delivery.
 //
 // Caller must hold stateMu.
 func (m *Mux) activePathExpectsByte(symbol byte) bool {
 	if !m.gatewayTxnActive {
 		return false
 	}
-	if m.activeTxn.bytesDeliveredToActive.Load() > 0 {
-		return true
+	if m.activeTxn.echoCursor < m.activeTxn.writePrefixLen {
+		// Mid-write: only the expected echo passes.
+		return m.activeTxn.writePrefix[m.activeTxn.echoCursor] == symbol
 	}
-	return m.activeTxn.echoCursor < m.activeTxn.writePrefixLen &&
-		m.activeTxn.writePrefix[m.activeTxn.echoCursor] == symbol
+	// Response phase: all writes echoed, accept anything.
+	return true
 }
 
 // deliverToActive sends a byte to the active path channel.

--- a/internal/adaptermux/p11_mid_write_filter_test.go
+++ b/internal/adaptermux/p11_mid_write_filter_test.go
@@ -1,0 +1,115 @@
+package adaptermux
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+// P11 — verify activePathExpectsByte rejects stale third-party tail
+// bytes that arrive mid-write (echoCursor < writePrefixLen).
+//
+// Production motivation: post_grant_ack accounted for ~52% of all
+// echo_mismatch events (312/600 in the 2026-05-10 soak window). Live
+// pattern: BASV2 (0x10) finishes a 0704 scan probe, the adapter has
+// the trailing 0x00 ACK byte buffered in the TCP/ENH pipeline; the
+// gateway wins arbitration immediately, writes its source byte (e.g.
+// 0x71), the adapter echoes 0x71 back; while bus.Send is mid-write
+// awaiting echo of byte 2 (e.g. 0x15 target), the buffered 0x00
+// finally pops out of the pipeline. Pre-P11 the gate
+// `bytesDeliveredToActive>0 → return true` let it through; bus.Send
+// read 0x00 in echo position → echo_mismatch (subclass=post_grant_ack).
+//
+// P11 fix: the gate uses echoCursor as the mid-write/response phase
+// boundary. While echoCursor < writePrefixLen, only writePrefix[
+// echoCursor] passes; everything else routes to passive. Once all
+// writes echo, the gate opens for response-phase delivery.
+func TestP11_MidWriteStaleByteRejected(t *testing.T) {
+	mux, mock, _, cleanup := newP3TestMux(t)
+	defer cleanup()
+
+	grantGateway(t, mux, mock, 0x71)
+	at := mux.ActiveTransport()
+
+	// Step 1: write source byte 0x71, echo arrives, consume.
+	if _, err := at.Write([]byte{0x71}); err != nil {
+		t.Fatalf("Write(0x71) err=%v", err)
+	}
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x71}
+	if b, err := at.ReadByte(); err != nil || b != 0x71 {
+		t.Fatalf("ReadByte echo of 0x71 = (0x%02X, %v); want (0x71, nil)", b, err)
+	}
+
+	// Step 2: write target byte 0x15. expectedEchoes = [0x15],
+	// writePrefixLen = 2, echoCursor = 1 (matched 0x71). Mid-write
+	// state is now established.
+	if _, err := at.Write([]byte{0x15}); err != nil {
+		t.Fatalf("Write(0x15) err=%v", err)
+	}
+	// Yield for sendLoop to record the prefix.
+	time.Sleep(20 * time.Millisecond)
+
+	// Step 3: simulate stale 0x00 from BASV2's prior frame tail
+	// arriving BEFORE the real echo of 0x15. Pre-P11 this would have
+	// reached activeCh and bus.Send.ReadByte would return 0x00.
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x00}
+
+	// Step 4: now feed the legitimate echo of 0x15.
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x15}
+
+	// Step 5: bus.Send.ReadByte should observe 0x15 (the real echo),
+	// NOT 0x00 (the stale byte). P11 filter rejects 0x00 because
+	// writePrefix[echoCursor] == 0x15 != 0x00.
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		b, err := at.ReadByte()
+		if err == nil {
+			if b == 0x00 {
+				t.Fatalf("ReadByte returned stale 0x00 — P11 filter regressed (post_grant_ack would fire)")
+			}
+			if b == 0x15 {
+				return // success
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("did not observe legitimate 0x15 echo within 1s")
+}
+
+// P11 — once all writes have been echoed (echoCursor == writePrefixLen),
+// the response-phase gate opens. ANY byte (even 0x00) reaches
+// bus.Send for downstream interpretation. Guards against an
+// over-aggressive filter regression that would block legitimate
+// target ACK bytes.
+func TestP11_ResponsePhaseAcceptsAnyByte(t *testing.T) {
+	mux, mock, _, cleanup := newP3TestMux(t)
+	defer cleanup()
+
+	grantGateway(t, mux, mock, 0x71)
+	at := mux.ActiveTransport()
+
+	// Write + echo + consume so we leave the mid-write phase
+	// (echoCursor == writePrefixLen).
+	if _, err := at.Write([]byte{0x71}); err != nil {
+		t.Fatalf("Write err=%v", err)
+	}
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x71}
+	if _, err := at.ReadByte(); err != nil {
+		t.Fatalf("ReadByte echo err=%v", err)
+	}
+
+	// Now in response phase. Inject 0x00 (target ACK) — must be
+	// delivered.
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x00}
+
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		b, err := at.ReadByte()
+		if err == nil && b == 0x00 {
+			return // success
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("response-phase 0x00 was filtered — P11 over-aggressive (target ACK delivery broken)")
+}

--- a/internal/adaptermux/p11_mid_write_filter_test.go
+++ b/internal/adaptermux/p11_mid_write_filter_test.go
@@ -77,6 +77,152 @@ func TestP11_MidWriteStaleByteRejected(t *testing.T) {
 	t.Fatalf("did not observe legitimate 0x15 echo within 1s")
 }
 
+// P11 round-2 — Codex P1 finding 1 cascade: multiple stale mid-write
+// bytes in succession must ALL be rejected, not just the first.
+// Pre-round-2 the filter used echoCursor (advanced on non-match by
+// recordReadPrefixAndClassify); after the first stale byte rejected
+// the cursor advanced past the missing echo, opening response phase
+// → second stale byte slipped through. Round-2 uses gatewayEcho's
+// queue head (consumed only on match), so the cascade is caught.
+func TestP11_MidWriteCascadeStaleBytesAllRejected(t *testing.T) {
+	mux, mock, _, cleanup := newP3TestMux(t)
+	defer cleanup()
+
+	grantGateway(t, mux, mock, 0x71)
+	at := mux.ActiveTransport()
+
+	// Step 1: source byte echoes, consumed.
+	if _, err := at.Write([]byte{0x71}); err != nil {
+		t.Fatalf("Write(0x71) err=%v", err)
+	}
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x71}
+	if b, err := at.ReadByte(); err != nil || b != 0x71 {
+		t.Fatalf("ReadByte echo of 0x71 = (0x%02X, %v); want (0x71, nil)", b, err)
+	}
+
+	// Step 2: write target byte. Mid-write expecting 0x15 echo.
+	if _, err := at.Write([]byte{0x15}); err != nil {
+		t.Fatalf("Write(0x15) err=%v", err)
+	}
+	time.Sleep(20 * time.Millisecond)
+
+	// Step 3: feed 3 stale bytes BEFORE the real echo. All must be
+	// filtered. Pre-round-2 only the first was filtered; bytes 2-3
+	// would have reached activeCh.
+	for _, stale := range []byte{0x00, 0xFF, 0xA9} {
+		mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: stale}
+	}
+
+	// Step 4: real 0x15 echo.
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x15}
+
+	// bus.Send.ReadByte must observe 0x15. If any stale byte slipped
+	// through, ReadByte returns it instead.
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		b, err := at.ReadByte()
+		if err == nil {
+			if b != 0x15 {
+				t.Fatalf("ReadByte=0x%02X (stale leaked); want 0x15 — P11 cascade filter regressed", b)
+			}
+			return // success
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("did not observe legitimate 0x15 echo within 1s")
+}
+
+// P11 round-2 — Codex P1 finding 2 long-frame: filter must work for
+// frames >8 bytes (writePrefix capped at txnPrefixCap=8 was the bug).
+// gatewayEcho.expectedEchoes is uncapped, so the round-2 filter
+// stays correct for any frame length.
+func TestP11_LongFrameFilterCorrectness(t *testing.T) {
+	mux, mock, _, cleanup := newP3TestMux(t)
+	defer cleanup()
+
+	grantGateway(t, mux, mock, 0x71)
+	at := mux.ActiveTransport()
+
+	// Write 12 bytes (longer than txnPrefixCap=8). Each gets echoed.
+	frame := []byte{0x71, 0x15, 0xB5, 0x09, 0x03, 0x0D, 0x18, 0x00, 0x3F, 0x42, 0x99, 0xC1}
+	for i, b := range frame {
+		if _, err := at.Write([]byte{b}); err != nil {
+			t.Fatalf("byte %d Write(0x%02X) err=%v", i, b, err)
+		}
+		mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: b}
+		got, err := at.ReadByte()
+		if err != nil || got != b {
+			t.Fatalf("byte %d: ReadByte=(0x%02X,%v); want (0x%02X, nil)", i, got, err, b)
+		}
+	}
+
+	// At this point we've written 12 bytes and consumed 12 echoes.
+	// gatewayEcho queue is empty → response phase. Inject any stale
+	// byte, must reach activeCh (response phase open).
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x00}
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		b, err := at.ReadByte()
+		if err == nil && b == 0x00 {
+			return // success — response phase delivers
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("response-phase byte did not reach activeCh after 12-byte frame — P11 long-frame regression")
+}
+
+// P11 round-2 — Codex P1 finding 2 mid-write past byte 8: a stale
+// byte arriving during mid-write of byte 9+ must STILL be rejected.
+// Pre-round-2 the writePrefix-based filter capped at txnPrefixCap=8;
+// after byte 8 echoCursor==writePrefixLen=8 forever, opening response
+// phase. Round-2 uses gatewayEcho (uncapped), so byte 9 mid-write
+// stale bytes are rejected.
+func TestP11_LongFrameMidWriteStaleRejected(t *testing.T) {
+	mux, mock, _, cleanup := newP3TestMux(t)
+	defer cleanup()
+
+	grantGateway(t, mux, mock, 0x71)
+	at := mux.ActiveTransport()
+
+	// Write + echo + consume bytes 1..8 to fully load txnPrefixCap.
+	for i, b := range []byte{0x71, 0x15, 0xB5, 0x09, 0x03, 0x0D, 0x18, 0x00} {
+		if _, err := at.Write([]byte{b}); err != nil {
+			t.Fatalf("byte %d Write err=%v", i, err)
+		}
+		mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: b}
+		got, err := at.ReadByte()
+		if err != nil || got != b {
+			t.Fatalf("byte %d ReadByte=(0x%02X,%v); want (0x%02X,nil)", i, got, err, b)
+		}
+	}
+
+	// Now write byte 9 (0x3F) — past the writePrefix cap. Mid-write
+	// expecting 0x3F echo. gatewayEcho queue head = 0x3F.
+	if _, err := at.Write([]byte{0x3F}); err != nil {
+		t.Fatalf("Write byte 9 err=%v", err)
+	}
+	time.Sleep(20 * time.Millisecond)
+
+	// Inject stale 0x42 BEFORE the real 0x3F echo.
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x42}
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x3F}
+
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		b, err := at.ReadByte()
+		if err == nil {
+			if b == 0x42 {
+				t.Fatalf("stale 0x42 leaked into activeCh past byte 8 — P11 long-frame mid-write filter regressed")
+			}
+			if b == 0x3F {
+				return // success
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("did not observe legitimate 0x3F echo within 1s")
+}
+
 // P11 — once all writes have been echoed (echoCursor == writePrefixLen),
 // the response-phase gate opens. ANY byte (even 0x00) reaches
 // bus.Send for downstream interpretation. Guards against an


### PR DESCRIPTION
## Summary

**P11** tightens the non-SYN active-path filter from `activePathExpectsBytes()` (bulk) to `activePathExpectsByte(symbol)` (per-byte). Symmetric semantics: while mid-write (echoCursor < writePrefixLen), only `writePrefix[echoCursor]` passes; once all writes echo (response phase), any byte is delivered.

Pre-P11 the bulk filter let any byte through after the first echo, so stale third-party tail bytes (e.g. 0x00 ACK from BASV2's just-finished 0704 scan still buffered in TCP/ENH pipeline) reached bus.Send mid-write and triggered `echo_mismatch` with `subclass=post_grant_ack` — **~52% of all echo_mismatch (312/600 in 1h45m soak)**.

**Bundled**: addresses [Codex bot P2 finding on PR #603](https://github.com/Project-Helianthus/helianthus-ebusgateway/pull/603#discussion_r) — `recordSent` overflow reset + `rollbackSent` failed to restore the pre-overflow queue + counter. Now snapshots are taken at reset and restored on rollback; matchEcho/flushOnSYN/markRequestStart/reset all invalidate the snapshot.

## Test plan

- [x] `TestP11_MidWriteStaleByteRejected` (new)
- [x] `TestP11_ResponsePhaseAcceptsAnyByte` (new)
- [x] `TestEchoTracker_OverflowRollbackRestoresQueue` (new)
- [x] `TestEchoTracker_OverflowSnapshotInvalidatedByMatch` (new)
- [x] 7 existing diag/classify tests updated for protocol-correct echo feed
- [x] `go test -race -count=1 ./...` PASS
- [x] `scripts/ci_local.sh` PASS (transport + passive-smoke + AD gates via owner overrides)
- [ ] Post-deploy: `ebus_active_echo_mismatch_subclass_total{subclass="post_grant_ack"}` drops from ~3/min to single-digit per hour

🤖 Generated with [Claude Code](https://claude.com/claude-code)