### PR TITLE
P12: drain stale activeCh in inter-write window

### DIFF
--- a/internal/adaptermux/diag.go
+++ b/internal/adaptermux/diag.go
@@ -91,6 +91,18 @@ type activeTxnDiag struct {
 	// promptly during bus.Send). Non-zero indicates runtime backpressure.
 	terminatorDropOnFullCh atomic.Uint64
 
+	// interWriteDrainTotal counts bytes drained from activeCh in
+	// sendLoop's pre-recordSent critical section (P12). Each drained
+	// byte was a stale entry sitting in activeCh during the inter-write
+	// queue-empty window — i.e., between matchEcho consuming byte K's
+	// echo and sendLoop arming byte K+1. Without the drain those bytes
+	// would have been read by bus.Send.sendRawWithEcho on the next
+	// write and fired echo_mismatch (post_grant_ack on stale 0x00,
+	// pre_echo_syn on stale 0xAA). Non-zero is normal under busy bus
+	// load; persistent zero post-deploy means the upstream pipeline
+	// is fully drained between writes (clean).
+	interWriteDrainTotal atomic.Uint64
+
 	// synSuppressedPreEcho counts SYN bytes that arrived during gateway
 	// ownership with gatewayTxnActive=true and were classified as
 	// non-terminator noise (NOT a legitimate frame-end SYN echo). These
@@ -168,6 +180,11 @@ type ActiveTxnSnapshot struct {
 	TerminatorDropOnFullCh uint64
 	// SynSuppressedPreEcho mirrors activeTxnDiag.synSuppressedPreEcho.
 	SynSuppressedPreEcho uint64
+	// InterWriteDrainTotal mirrors activeTxnDiag.interWriteDrainTotal
+	// (P12). Bytes drained from activeCh in sendLoop's pre-recordSent
+	// section. Non-zero is normal; persistent zero indicates the
+	// upstream pipeline is fully drained between writes.
+	InterWriteDrainTotal uint64
 	// EchoQueueOverflowResets mirrors gatewayEcho.totalOverflowResets
 	// (P10.2.1). Non-zero indicates the gateway-write loop produced
 	// more than 256 unacknowledged writes, triggering a queue reset.
@@ -223,6 +240,7 @@ func (m *Mux) ActiveTxnSnapshot() ActiveTxnSnapshot {
 		AfterInactive:           m.activeTxn.afterInactive.Load(),
 		TerminatorDropOnFullCh:  m.activeTxn.terminatorDropOnFullCh.Load(),
 		SynSuppressedPreEcho:    m.activeTxn.synSuppressedPreEcho.Load(),
+		InterWriteDrainTotal:    m.activeTxn.interWriteDrainTotal.Load(),
 		EchoQueueOverflowResets: m.gatewayEcho.overflowResets(),
 		BytesDeliveredToActive:  m.activeTxn.bytesDeliveredToActive.Load(),
 		WritePrefix:             wp,

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -1663,6 +1663,45 @@ func (m *Mux) drainActiveCh() int {
 	}
 }
 
+// drainActiveChBytesOnly discards only byte events (activeEventByte)
+// from the active channel, preserving lifecycle events (activeEventError
+// — reset / disconnect boundaries). Codex P12 review pass-1 P1: the
+// inter-write drain must NOT swallow reset boundary signals; bus.Send
+// needs to see them to abort cleanly. Re-enqueues any preserved error
+// event back onto activeCh in order.
+//
+// Returns the number of byte events drained.
+//
+// Caller must hold stateMu (we're racing onReceived which also writes
+// to activeCh under stateMu — peer-of-equals discipline).
+func (m *Mux) drainActiveChBytesOnly() int {
+	n := 0
+	var preserved []activeEvent
+	for {
+		select {
+		case ev := <-m.activeCh:
+			if ev.kind == activeEventByte {
+				n++
+				continue
+			}
+			preserved = append(preserved, ev)
+		default:
+			// Re-enqueue preserved lifecycle events in order. Non-
+			// blocking — if activeCh is full (capacity 4096), log
+			// and continue (the lifecycle event was already in the
+			// channel pre-drain so this is a no-regression path).
+			for _, ev := range preserved {
+				select {
+				case m.activeCh <- ev:
+				default:
+					m.logger.Printf("adaptermux: drain re-enqueue full, lifecycle event dropped: kind=%d err=%v", ev.kind, ev.err)
+				}
+			}
+			return n
+		}
+	}
+}
+
 // flushSessionEchoTrackers flushes echo trackers for all external sessions
 // at a SYN boundary. The flushed bytes are discarded — they were already
 // delivered live to passive consumers in onReceived. This call only resets
@@ -2378,8 +2417,23 @@ func (m *Mux) sendLoop() {
 				// stateMu is held throughout drain+arm+recordSent so
 				// onReceived (which also acquires stateMu) cannot
 				// interleave a new stale byte between drain and arm.
+				//
+				// CONTRACT (Codex P12 pass-1 P1): drainActiveChBytesOnly
+				// preserves lifecycle (activeEventError) events for
+				// bus.Send abort path. Drain is byte-only.
+				//
+				// CONTRACT (Codex P12 pass-1 P2): bus.sendRawWithEcho calls
+				// activeTransport.Write with single-byte slices and reads
+				// each echo before issuing the next write — so by the
+				// time sendLoop receives a new request, the prior echo
+				// has already been consumed by bus.Send.ReadByte and is
+				// no longer in activeCh. Multi-byte gateway writes would
+				// risk draining a legitimate prior echo; the API
+				// supports them but no production caller uses them.
+				// Tests that use multi-byte Write sequence echoes after
+				// Write returns, so the drain is still safe in practice.
 				m.stateMu.Lock()
-				drained := m.drainActiveCh()
+				drained := m.drainActiveChBytesOnly()
 				if drained > 0 {
 					m.activeTxn.interWriteDrainTotal.Add(uint64(drained))
 				}

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -2361,7 +2361,28 @@ func (m *Mux) sendLoop() {
 				// where gatewayTxnActive=true && gatewayEcho empty: stale
 				// bytes leaked through as response-phase. Hoisting the call
 				// closes the gap.
+				//
+				// P12 (echo_mismatch deep-dive 2026-05-10): drain activeCh
+				// of any stale bytes BEFORE arming the next write. The
+				// inter-byte queue-empty window (between matchEcho
+				// consuming byte K's echo and sendLoop recording byte K+1)
+				// briefly opens response-phase delivery in
+				// activePathExpectsByte. Stale bytes that landed in that
+				// window must be discarded before we arm gatewayTxnActive
+				// on the next write — otherwise bus.Send.sendRawWithEcho
+				// would read them in echo position and fire
+				// echo_mismatch (post_grant_ack on stale 0x00,
+				// pre_echo_syn on stale 0xAA). Both subclasses share this
+				// root cause; agent deep-dive 2026-05-10 confirmed.
+				//
+				// stateMu is held throughout drain+arm+recordSent so
+				// onReceived (which also acquires stateMu) cannot
+				// interleave a new stale byte between drain and arm.
 				m.stateMu.Lock()
+				drained := m.drainActiveCh()
+				if drained > 0 {
+					m.activeTxn.interWriteDrainTotal.Add(uint64(drained))
+				}
 				if !m.gatewayTxnActive {
 					m.gatewayTxnActive = true
 				}

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -1151,7 +1151,29 @@ func (m *Mux) onReceived(symbol byte) {
 			// the gateway owns the bus with gatewayTxnActive=true — count
 			// this enqueue so bytesDeliveredToActive reflects real
 			// adapter-originated bytes delivered during this grant.
-			m.deliverToActive(symbol, true)
+			//
+			// P12 pass-2 (Codex P1): re-acquire stateMu and re-validate
+			// gatewayTxnActive before delivering. Mirrors the non-SYN
+			// path at line ~1220. Pre-pass-2 sendLoop could drain+arm
+			// for byte K+1 between stateMu.Unlock above and this
+			// deliverToActive call — landing the SYN in activeCh AFTER
+			// the drain, where bus.Send.sendRawWithEcho on byte K+1
+			// reads it as 0xAA → echo_mismatch (pre_echo_syn). With
+			// re-acquisition, P12's drain-then-arm under stateMu is
+			// genuinely atomic with this enqueue.
+			m.stateMu.Lock()
+			if m.gatewayTxnActive {
+				select {
+				case m.activeCh <- activeEvent{kind: activeEventByte, b: symbol}:
+					m.activeTxn.bytesDeliveredToActive.Add(1)
+				default:
+					m.activeTxn.terminatorDropOnFullCh.Add(1)
+					m.logger.Printf("adaptermux: active channel full, dropping SYN 0x%02X", symbol)
+				}
+			} else if hasOwner && ownerID == gatewaySessionID {
+				m.activeTxn.afterInactive.Add(1)
+			}
+			m.stateMu.Unlock()
 		}
 		for _, pe := range passiveEvents {
 			m.emitPassive(pe)
@@ -1761,6 +1783,15 @@ func (m *Mux) activePathExpectsByte(symbol byte) bool {
 // active-path delivery under gateway ownership (decided under stateMu
 // via activePathExpectsBytes); pass false for shutdown/reset events or
 // for non-gateway-owned passthrough.
+//
+// P12 pass-2 (Codex P1): both call sites now perform their own
+// stateMu.Lock + revalidation around the enqueue (mirror of the non-SYN
+// path at mux.go:1220-1239). This helper is kept for callers that need
+// the standalone non-blocking send semantics; currently unused at
+// compile time but retained for the documented "shutdown/reset
+// passthrough" use case.
+//
+//nolint:unused // retained for future shutdown/reset callers per godoc
 func (m *Mux) deliverToActive(symbol byte, countAsDelivered bool) {
 	select {
 	case m.activeCh <- activeEvent{kind: activeEventByte, b: symbol}:

--- a/internal/adaptermux/p11_mid_write_filter_test.go
+++ b/internal/adaptermux/p11_mid_write_filter_test.go
@@ -223,6 +223,76 @@ func TestP11_LongFrameMidWriteStaleRejected(t *testing.T) {
 	t.Fatalf("did not observe legitimate 0x3F echo within 1s")
 }
 
+// P12 — sendLoop drains stale activeCh bytes BEFORE recordSent. The
+// inter-write queue-empty window (between matchEcho consuming byte
+// K's echo and sendLoop arming byte K+1) briefly opens response-phase
+// delivery. Stale bytes that landed in that window must be discarded
+// before bus.Send.sendRawWithEcho on byte K+1 reads from activeCh.
+// Pre-P12 a stale 0x00 here fired post_grant_ack; a stale 0xAA fired
+// pre_echo_syn. Both subclasses share this root cause per agent
+// deep-dive 2026-05-10.
+func TestP12_InterWriteDrainStale(t *testing.T) {
+	mux, mock, _, cleanup := newP3TestMux(t)
+	defer cleanup()
+
+	grantGateway(t, mux, mock, 0x71)
+	at := mux.ActiveTransport()
+
+	// Step 1: source byte echoes, consumed. Queue now empty.
+	if _, err := at.Write([]byte{0x71}); err != nil {
+		t.Fatalf("Write(0x71) err=%v", err)
+	}
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x71}
+	if b, err := at.ReadByte(); err != nil || b != 0x71 {
+		t.Fatalf("ReadByte echo of 0x71 = (0x%02X, %v); want (0x71, nil)", b, err)
+	}
+
+	// Step 2: stale 0x00 arrives DURING the inter-write window.
+	// activePathExpectsByte (queue empty → response phase open) lets
+	// it through to activeCh. Pre-P12 this would be read by bus.Send
+	// on the next Write's echo readback.
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x00}
+	time.Sleep(20 * time.Millisecond)
+
+	preDrain := mux.ActiveTxnSnapshot().InterWriteDrainTotal
+
+	// Step 3: write the next byte. P12's sendLoop drain MUST clear
+	// the stale 0x00 BEFORE arming the next write.
+	if _, err := at.Write([]byte{0x15}); err != nil {
+		t.Fatalf("Write(0x15) err=%v", err)
+	}
+	time.Sleep(20 * time.Millisecond)
+
+	// Step 4: feed the legitimate 0x15 echo.
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x15}
+
+	// Step 5: bus.Send.ReadByte must observe 0x15 (the real echo),
+	// NOT 0x00 (the stale byte that should have been drained).
+	deadline := time.Now().Add(1 * time.Second)
+	got15 := false
+	for time.Now().Before(deadline) {
+		b, err := at.ReadByte()
+		if err == nil {
+			if b == 0x00 {
+				t.Fatalf("ReadByte returned stale 0x00 — P12 inter-write drain regressed (post_grant_ack would fire)")
+			}
+			if b == 0x15 {
+				got15 = true
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !got15 {
+		t.Fatalf("did not observe legitimate 0x15 echo within 1s")
+	}
+
+	postDrain := mux.ActiveTxnSnapshot().InterWriteDrainTotal
+	if postDrain <= preDrain {
+		t.Errorf("InterWriteDrainTotal = %d (pre=%d); want increment after stale 0x00 was drained", postDrain, preDrain)
+	}
+}
+
 // P11 — once all writes have been echoed (echoCursor == writePrefixLen),
 // the response-phase gate opens. ANY byte (even 0x00) reaches
 // bus.Send for downstream interpretation. Guards against an

--- a/internal/adaptermux/p11_mid_write_filter_test.go
+++ b/internal/adaptermux/p11_mid_write_filter_test.go
@@ -1,6 +1,7 @@
 package adaptermux
 
 import (
+	"io"
 	"testing"
 	"time"
 
@@ -221,6 +222,50 @@ func TestP11_LongFrameMidWriteStaleRejected(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("did not observe legitimate 0x3F echo within 1s")
+}
+
+// TestP12_DrainPreservesErrorEvents (Codex P12 pass-1 P1) — the
+// inter-write drain must NOT discard activeEventError lifecycle
+// events. handleReset / reconnect / mux shutdown enqueue these to
+// signal bus.Send abort boundaries. Pre-fix drainActiveCh nuked
+// everything; post-fix drainActiveChBytesOnly re-enqueues errors.
+func TestP12_DrainPreservesErrorEvents(t *testing.T) {
+	mux, _, _, cleanup := newP3TestMux(t)
+	defer cleanup()
+
+	// Inject a mix: 2 stale bytes + 1 lifecycle error + 1 stale byte.
+	mux.activeCh <- activeEvent{kind: activeEventByte, b: 0x00}
+	mux.activeCh <- activeEvent{kind: activeEventByte, b: 0xAA}
+	mux.activeCh <- activeEvent{kind: activeEventError, err: io.EOF}
+	mux.activeCh <- activeEvent{kind: activeEventByte, b: 0xFF}
+
+	mux.stateMu.Lock()
+	drained := mux.drainActiveChBytesOnly()
+	mux.stateMu.Unlock()
+
+	if drained != 3 {
+		t.Errorf("drained = %d; want 3 (the byte events)", drained)
+	}
+
+	// The lifecycle error must still be readable from activeCh.
+	select {
+	case ev := <-mux.activeCh:
+		if ev.kind != activeEventError {
+			t.Errorf("preserved event kind = %d; want activeEventError (%d)", ev.kind, activeEventError)
+		}
+		if ev.err != io.EOF {
+			t.Errorf("preserved event err = %v; want io.EOF", ev.err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("activeCh empty after drain; lifecycle error was discarded (P12 P1 regression)")
+	}
+
+	// activeCh should now be empty.
+	select {
+	case ev := <-mux.activeCh:
+		t.Errorf("unexpected event left in activeCh after drain: kind=%d byte=0x%02X err=%v", ev.kind, ev.b, ev.err)
+	default:
+	}
 }
 
 // P12 — sendLoop drains stale activeCh bytes BEFORE recordSent. The


### PR DESCRIPTION
## Summary

Agent deep-dive 2026-05-10 of the 10 residual echo_mismatch events post-P11 identified a **single shared root cause** for `post_grant_ack` (5 events) and `pre_echo_syn` (2 events):

The **inter-byte queue-empty window** between `matchEcho` consuming byte K's echo and `sendLoop` arming byte K+1. In that brief window: queue empty, `gatewayTxnActive=true`, `bytesDeliveredToActive>0` → `activePathExpectsByte` returns true (response phase open) → stale upstream bytes delivered to `activeCh`.

`post_grant_collision_target` (3 events) is NOT_FIXABLE in software — real eBUS arbitration races / adapter firmware territory. Upper-layer `ErrBusCollision` retry handles them invisibly.

## Fix

`sendLoop` drains `activeCh` in the `stateMu` critical section BEFORE `recordSent`. Same lock as `recordWritePrefix` + `gatewayTxnActive` flip, so `onReceived` cannot interleave between drain and arm.

New counter `InterWriteDrainTotal` on `ActiveTxnSnapshot` for operator visibility.

## Test plan

- [x] `TestP12_InterWriteDrainStale` (new) — feeds stale 0x00 in inter-write window, asserts drain + correct next-byte echo delivery
- [x] All existing P11/P10.2 tests still pass
- [x] `go test -race -count=1 ./...` PASS (18 packages)
- [x] `scripts/ci_local.sh` PASS
- [ ] Post-deploy: `post_grant_ack` + `pre_echo_syn` drop to single-digit per hour (or zero)

🤖 Generated with [Claude Code](https://claude.com/claude-code)