### PR TITLE
chore: ignore __pycache__ + *.pyc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ portal/web/node_modules/
 
 # Claude Code orchestrator-session artifacts (per-session tool/skills config, not repo-tracked)
 .claude/
+
+# Python bytecode caches
+__pycache__/
+*.pyc


### PR DESCRIPTION
## Summary

`scripts/__pycache__/` was bleeding into `git status`. Standard-issue ignore entries; matches existing `.claude/` pattern.

## Test plan

- [x] `git status` shows clean working tree after change
- [x] No tracked files affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)