### PR TITLE
chore(transport-matrix): M0A — 88-case baseline for runtime-state-w19-26

### DIFF
--- a/transport-matrix-baseline-runtime-state-w19-26.json
+++ b/transport-matrix-baseline-runtime-state-w19-26.json
@@ -1,0 +1,1921 @@
+{
+  "artifact": "transport-matrix-baseline-runtime-state-w19-26",
+  "artifact_schema": 1,
+  "generated_at": "2026-05-10T15:00:02Z",
+  "plan": {
+    "name": "runtime-state-w19-26.locked",
+    "sha256": "f1129d0c442d3b2704f6f7e7eed2042c05df3f83e21ad57ccebdd6884f42241d",
+    "meta_issue": "https://github.com/Project-Helianthus/helianthus-execution-plans/issues/27",
+    "milestone": "M0A_TRANSPORT_BASELINE"
+  },
+  "git": {
+    "branch": "feat/runtime-state-m0a-transport-baseline",
+    "current_main_sha": "da230c773a0cd3f92ee56d51e885931c30380ff3"
+  },
+  "matrix_runner": {
+    "suite": "full88",
+    "target": "local",
+    "mode": "dry-run-planning",
+    "command": "/tmp/matrix-runner --output-dir /tmp/matrix-baseline-runtime-state-w19-26 --target local --suite full88",
+    "source_sha": "da230c773a0cd3f92ee56d51e885931c30380ff3",
+    "binary_path": "/tmp/matrix-runner",
+    "binary_sha256": "bbaf32bcbee164bde6cbcffe7e2e46a9fcd3b66dc8570759f3d06a1b9f528ce7",
+    "build_info": [
+      "/tmp/matrix-runner: go1.26.2",
+      "\tpath\tgithub.com/Project-Helianthus/helianthus-ebusgateway/cmd/matrix-runner",
+      "\tmod\tgithub.com/Project-Helianthus/helianthus-ebusgateway\tv0.5.1-0.20260510115258-da230c773a0c+dirty\t",
+      "\tbuild\t-buildmode=exe",
+      "\tbuild\t-compiler=gc",
+      "\tbuild\tDefaultGODEBUG=containermaxprocs=0,cryptocustomrand=1,decoratemappings=0,gotestjsonbuildtext=1,httpcookiemaxnum=0,multipathtcp=0,randseednop=0,rsa1024min=0,tlsmlkem=0,tlssecpmlkem=0,tlssha1=1,updatemaxprocs=0,urlmaxqueryparams=0,urlstrictcolons=0,x509rsacrt=0,x509sha256skid=0,x509usepolicies=0",
+      "\tbuild\tCGO_ENABLED=1",
+      "\tbuild\tCGO_CFLAGS=",
+      "\tbuild\tCGO_CPPFLAGS=",
+      "\tbuild\tCGO_CXXFLAGS=",
+      "\tbuild\tCGO_LDFLAGS=",
+      "\tbuild\tGOARCH=arm64",
+      "\tbuild\tGOOS=darwin",
+      "\tbuild\tGOARM64=v8.0",
+      "\tbuild\tvcs=git",
+      "\tbuild\tvcs.revision=da230c773a0cd3f92ee56d51e885931c30380ff3",
+      "\tbuild\tvcs.time=2026-05-10T11:52:58Z",
+      "\tbuild\tvcs.modified=true"
+    ]
+  },
+  "case_count": 88,
+  "case_ids": [
+    "T01",
+    "T02",
+    "T03",
+    "T04",
+    "T05",
+    "T06",
+    "T07",
+    "T08",
+    "T09",
+    "T10",
+    "T11",
+    "T12",
+    "T13",
+    "T14",
+    "T15",
+    "T16",
+    "T17",
+    "T18",
+    "T19",
+    "T20",
+    "T21",
+    "T22",
+    "T23",
+    "T24",
+    "T25",
+    "T26",
+    "T27",
+    "T28",
+    "T29",
+    "T30",
+    "T31",
+    "T32",
+    "T33",
+    "T34",
+    "T35",
+    "T36",
+    "T37",
+    "T38",
+    "T39",
+    "T40",
+    "T41",
+    "T42",
+    "T43",
+    "T44",
+    "T45",
+    "T46",
+    "T47",
+    "T48",
+    "T49",
+    "T50",
+    "T51",
+    "T52",
+    "T53",
+    "T54",
+    "T55",
+    "T56",
+    "T57",
+    "T58",
+    "T59",
+    "T60",
+    "T61",
+    "T62",
+    "T63",
+    "T64",
+    "T65",
+    "T66",
+    "T67",
+    "T68",
+    "T69",
+    "T70",
+    "T71",
+    "T72",
+    "T73",
+    "T74",
+    "T75",
+    "T76",
+    "T77",
+    "T78",
+    "T79",
+    "T80",
+    "T81",
+    "T82",
+    "T83",
+    "T84",
+    "T85",
+    "T86",
+    "T87",
+    "T88"
+  ],
+  "outcome_summary": {
+    "planned": 88,
+    "pass": 0,
+    "fail": 0,
+    "xfail": 0,
+    "xpass": 0,
+    "blocked": 0
+  },
+  "cases": [
+    {
+      "case_id": "T01",
+      "suite": "full88",
+      "kind": "direct-adapter",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T01/configs/helianthus.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T01/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T02",
+      "suite": "full88",
+      "kind": "direct-adapter",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T02/configs/helianthus.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T02/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T03",
+      "suite": "full88",
+      "kind": "direct-adapter",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T03/configs/helianthus.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T03/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T04",
+      "suite": "full88",
+      "kind": "direct-adapter",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T04/configs/helianthus.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T04/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T05",
+      "suite": "full88",
+      "kind": "via-ebusd-tcp",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T05/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T05/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T05/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T06",
+      "suite": "full88",
+      "kind": "via-ebusd-tcp",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T06/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T06/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T06/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T07",
+      "suite": "full88",
+      "kind": "via-ebusd-tcp",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "ebusd direct udp/tcp to adapter reports no signal in matrix runs",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T07/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T07/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T07/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T08",
+      "suite": "full88",
+      "kind": "via-ebusd-tcp",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "ebusd direct udp/tcp to adapter reports no signal in matrix runs",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T08/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T08/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T08/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T09",
+      "suite": "full88",
+      "kind": "proxy-single-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T09/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T09/configs/proxy.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T09/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T10",
+      "suite": "full88",
+      "kind": "proxy-single-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T10/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T10/configs/proxy.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T10/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T11",
+      "suite": "full88",
+      "kind": "proxy-single-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T11/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T11/configs/proxy.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T11/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T12",
+      "suite": "full88",
+      "kind": "proxy-single-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T12/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T12/configs/proxy.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T12/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T13",
+      "suite": "full88",
+      "kind": "proxy-single-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T13/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T13/configs/proxy.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T13/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T14",
+      "suite": "full88",
+      "kind": "proxy-single-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T14/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T14/configs/proxy.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T14/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T15",
+      "suite": "full88",
+      "kind": "proxy-single-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T15/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T15/configs/proxy.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T15/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T16",
+      "suite": "full88",
+      "kind": "proxy-single-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T16/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T16/configs/proxy.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T16/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T17",
+      "suite": "full88",
+      "kind": "proxy-single-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T17/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T17/configs/proxy.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T17/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T18",
+      "suite": "full88",
+      "kind": "proxy-single-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T18/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T18/configs/proxy.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T18/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T19",
+      "suite": "full88",
+      "kind": "proxy-single-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T19/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T19/configs/proxy.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T19/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T20",
+      "suite": "full88",
+      "kind": "proxy-single-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T20/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T20/configs/proxy.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T20/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T21",
+      "suite": "full88",
+      "kind": "proxy-single-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T21/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T21/configs/proxy.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T21/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T22",
+      "suite": "full88",
+      "kind": "proxy-single-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T22/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T22/configs/proxy.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T22/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T23",
+      "suite": "full88",
+      "kind": "proxy-single-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T23/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T23/configs/proxy.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T23/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T24",
+      "suite": "full88",
+      "kind": "proxy-single-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T24/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T24/configs/proxy.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T24/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T25",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T25/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T25/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T25/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T25/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T26",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T26/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T26/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T26/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T26/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T27",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with ebusd northbound udp reports no signal",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T27/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T27/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T27/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T27/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T28",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T28/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T28/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T28/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T28/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T29",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T29/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T29/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T29/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T29/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T30",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T30/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T30/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T30/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T30/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T31",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with ebusd northbound udp reports no signal",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T31/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T31/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T31/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T31/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T32",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T32/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T32/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T32/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T32/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T33",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with southbound udp reports no signal (ens/enh clients also show host comm framing)",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T33/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T33/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T33/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T33/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T34",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with southbound udp reports no signal (ens/enh clients also show host comm framing)",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T34/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T34/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T34/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T34/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T35",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with southbound udp reports no signal (ens/enh clients also show host comm framing)",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T35/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T35/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T35/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T35/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T36",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with southbound udp reports no signal (ens/enh clients also show host comm framing)",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T36/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T36/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T36/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T36/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T37",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with southbound tcp reports no signal (ens/enh clients also show host comm framing)",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T37/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T37/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T37/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T37/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T38",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with southbound tcp reports no signal (ens/enh clients also show host comm framing)",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T38/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T38/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T38/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T38/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T39",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with southbound tcp reports no signal (ens/enh clients also show host comm framing)",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T39/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T39/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T39/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T39/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T40",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with southbound tcp reports no signal (ens/enh clients also show host comm framing)",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T40/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T40/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T40/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T40/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T41",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T41/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T41/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T41/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T41/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T42",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T42/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T42/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T42/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T42/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T43",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with ebusd northbound udp reports no signal",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T43/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T43/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T43/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T43/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T44",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T44/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T44/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T44/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T44/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T45",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T45/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T45/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T45/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T45/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T46",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T46/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T46/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T46/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T46/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T47",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with ebusd northbound udp reports no signal",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T47/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T47/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T47/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T47/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T48",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T48/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T48/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T48/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T48/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T49",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with southbound udp reports no signal (ens/enh clients also show host comm framing)",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T49/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T49/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T49/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T49/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T50",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with southbound udp reports no signal (ens/enh clients also show host comm framing)",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T50/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T50/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T50/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T50/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T51",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with southbound udp reports no signal (ens/enh clients also show host comm framing)",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T51/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T51/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T51/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T51/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T52",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with southbound udp reports no signal (ens/enh clients also show host comm framing)",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T52/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T52/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T52/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T52/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T53",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with southbound tcp reports no signal (ens/enh clients also show host comm framing)",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T53/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T53/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T53/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T53/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T54",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with southbound tcp reports no signal (ens/enh clients also show host comm framing)",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T54/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T54/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T54/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T54/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T55",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with southbound tcp reports no signal (ens/enh clients also show host comm framing)",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T55/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T55/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T55/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T55/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T56",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with southbound tcp reports no signal (ens/enh clients also show host comm framing)",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T56/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T56/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T56/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T56/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T57",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T57/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T57/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T57/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T57/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T58",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T58/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T58/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T58/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T58/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T59",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with ebusd northbound udp reports no signal",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T59/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T59/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T59/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T59/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T60",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T60/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T60/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T60/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T60/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T61",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T61/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T61/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T61/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T61/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T62",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T62/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T62/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T62/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T62/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T63",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with ebusd northbound udp reports no signal",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T63/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T63/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T63/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T63/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T64",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T64/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T64/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T64/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T64/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T65",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with southbound udp reports no signal (ens/enh clients also show host comm framing)",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T65/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T65/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T65/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T65/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T66",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with southbound udp reports no signal (ens/enh clients also show host comm framing)",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T66/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T66/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T66/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T66/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T67",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with southbound udp reports no signal (ens/enh clients also show host comm framing)",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T67/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T67/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T67/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T67/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T68",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with southbound udp reports no signal (ens/enh clients also show host comm framing)",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T68/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T68/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T68/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T68/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T69",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with southbound tcp reports no signal (ens/enh clients also show host comm framing)",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T69/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T69/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T69/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T69/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T70",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with southbound tcp reports no signal (ens/enh clients also show host comm framing)",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T70/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T70/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T70/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T70/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T71",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with southbound tcp reports no signal (ens/enh clients also show host comm framing)",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T71/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T71/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T71/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T71/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T72",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with southbound tcp reports no signal (ens/enh clients also show host comm framing)",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T72/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T72/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T72/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T72/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T73",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T73/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T73/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T73/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T73/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T74",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T74/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T74/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T74/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T74/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T75",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with ebusd northbound udp reports no signal",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T75/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T75/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T75/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T75/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T76",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T76/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T76/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T76/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T76/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T77",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T77/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T77/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T77/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T77/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T78",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T78/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T78/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T78/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T78/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T79",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with ebusd northbound udp reports no signal",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T79/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T79/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T79/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T79/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T80",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "pass",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T80/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T80/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T80/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T80/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T81",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with southbound udp reports no signal (ens/enh clients also show host comm framing)",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T81/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T81/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T81/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T81/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T82",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with southbound udp reports no signal (ens/enh clients also show host comm framing)",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T82/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T82/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T82/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T82/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T83",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with southbound udp reports no signal (ens/enh clients also show host comm framing)",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T83/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T83/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T83/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T83/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T84",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with southbound udp reports no signal (ens/enh clients also show host comm framing)",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T84/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T84/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T84/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T84/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T85",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with southbound tcp reports no signal (ens/enh clients also show host comm framing)",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T85/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T85/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T85/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T85/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T86",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with southbound tcp reports no signal (ens/enh clients also show host comm framing)",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T86/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T86/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T86/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T86/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T87",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with southbound tcp reports no signal (ens/enh clients also show host comm framing)",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T87/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T87/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T87/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T87/logs/runner.log"
+      ],
+      "commands": []
+    },
+    {
+      "case_id": "T88",
+      "suite": "full88",
+      "kind": "proxy-dual-client",
+      "target": "local",
+      "status": "planned",
+      "outcome": "planned",
+      "expected": "fail",
+      "expectation": "proxy dual-client with southbound tcp reports no signal (ens/enh clients also show host comm framing)",
+      "started_at": "2026-05-10T14:59:24Z",
+      "ended_at": "2026-05-10T14:59:24Z",
+      "config_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T88/configs/helianthus.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T88/configs/proxy.json",
+        "/tmp/matrix-baseline-runtime-state-w19-26/T88/configs/ebusd.json"
+      ],
+      "log_files": [
+        "/tmp/matrix-baseline-runtime-state-w19-26/T88/logs/runner.log"
+      ],
+      "commands": []
+    }
+  ],
+  "evidence_class": "dry-run-planning",
+  "acceptance_caveat": "This is a dry-run planning baseline (no live bus execution). M8_TRANSPORT_VERIFY post-merge dry-run vs this index must show 0 unexpected fail/xpass deltas. Live-execution runs are out of scope for M0A."
+}

--- a/transport-matrix-baseline-runtime-state-w19-26.json
+++ b/transport-matrix-baseline-runtime-state-w19-26.json
@@ -39,7 +39,8 @@
       "\tbuild\tvcs.revision=da230c773a0cd3f92ee56d51e885931c30380ff3",
       "\tbuild\tvcs.time=2026-05-10T11:52:58Z",
       "\tbuild\tvcs.modified=true"
-    ]
+    ],
+    "normalized_cases_sha256": "5e28aadae2ddee904a8c6287b130879e5ae3061f1487ea2f3b6d4a7362ddb9ff"
   },
   "case_count": 88,
   "case_ids": [
@@ -152,12 +153,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T01/configs/helianthus.json"
+        "T01/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T01/logs/runner.log"
+        "T01/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T01",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": false,
+          "gateway_transport": "ens",
+          "kind": "direct-adapter",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": false,
+          "uses_proxy": false
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T02",
@@ -170,12 +190,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T02/configs/helianthus.json"
+        "T02/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T02/logs/runner.log"
+        "T02/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T02",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": false,
+          "gateway_transport": "enh",
+          "kind": "direct-adapter",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": false,
+          "uses_proxy": false
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T03",
@@ -188,12 +227,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T03/configs/helianthus.json"
+        "T03/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T03/logs/runner.log"
+        "T03/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T03",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": false,
+          "gateway_transport": "udp",
+          "kind": "direct-adapter",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": false,
+          "uses_proxy": false
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T04",
@@ -206,12 +264,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T04/configs/helianthus.json"
+        "T04/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T04/logs/runner.log"
+        "T04/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T04",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": false,
+          "gateway_transport": "tcp",
+          "kind": "direct-adapter",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": false,
+          "uses_proxy": false
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T05",
@@ -224,13 +301,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T05/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T05/configs/ebusd.json"
+        "T05/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T05/logs/runner.log"
+        "T05/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T05",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": false,
+          "gateway_transport": "ebusd-tcp",
+          "kind": "via-ebusd-tcp",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": false
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T06",
@@ -243,13 +338,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T06/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T06/configs/ebusd.json"
+        "T06/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T06/logs/runner.log"
+        "T06/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T06",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": false,
+          "gateway_transport": "ebusd-tcp",
+          "kind": "via-ebusd-tcp",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": false
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T07",
@@ -263,13 +376,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T07/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T07/configs/ebusd.json"
+        "T07/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T07/logs/runner.log"
+        "T07/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T07",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": false,
+          "gateway_transport": "ebusd-tcp",
+          "kind": "via-ebusd-tcp",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": false
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T08",
@@ -283,13 +413,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T08/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T08/configs/ebusd.json"
+        "T08/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T08/logs/runner.log"
+        "T08/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T08",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": false,
+          "gateway_transport": "ebusd-tcp",
+          "kind": "via-ebusd-tcp",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": false
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T09",
@@ -302,13 +449,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T09/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T09/configs/proxy.json"
+        "T09/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T09/logs/runner.log"
+        "T09/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T09",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": false,
+          "gateway_transport": "ens",
+          "kind": "proxy-single-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": false,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T10",
@@ -321,13 +486,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T10/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T10/configs/proxy.json"
+        "T10/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T10/logs/runner.log"
+        "T10/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T10",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": false,
+          "gateway_transport": "ens",
+          "kind": "proxy-single-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": false,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T11",
@@ -340,13 +523,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T11/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T11/configs/proxy.json"
+        "T11/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T11/logs/runner.log"
+        "T11/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T11",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": false,
+          "gateway_transport": "ens",
+          "kind": "proxy-single-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": false,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T12",
@@ -359,13 +560,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T12/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T12/configs/proxy.json"
+        "T12/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T12/logs/runner.log"
+        "T12/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T12",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": false,
+          "gateway_transport": "ens",
+          "kind": "proxy-single-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": false,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T13",
@@ -378,13 +597,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T13/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T13/configs/proxy.json"
+        "T13/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T13/logs/runner.log"
+        "T13/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T13",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": false,
+          "gateway_transport": "enh",
+          "kind": "proxy-single-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": false,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T14",
@@ -397,13 +634,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T14/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T14/configs/proxy.json"
+        "T14/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T14/logs/runner.log"
+        "T14/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T14",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": false,
+          "gateway_transport": "enh",
+          "kind": "proxy-single-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": false,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T15",
@@ -416,13 +671,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T15/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T15/configs/proxy.json"
+        "T15/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T15/logs/runner.log"
+        "T15/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T15",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": false,
+          "gateway_transport": "enh",
+          "kind": "proxy-single-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": false,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T16",
@@ -435,13 +708,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T16/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T16/configs/proxy.json"
+        "T16/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T16/logs/runner.log"
+        "T16/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T16",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": false,
+          "gateway_transport": "enh",
+          "kind": "proxy-single-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": false,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T17",
@@ -454,13 +745,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T17/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T17/configs/proxy.json"
+        "T17/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T17/logs/runner.log"
+        "T17/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T17",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": false,
+          "gateway_transport": "udp",
+          "kind": "proxy-single-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": false,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T18",
@@ -473,13 +782,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T18/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T18/configs/proxy.json"
+        "T18/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T18/logs/runner.log"
+        "T18/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T18",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": false,
+          "gateway_transport": "udp",
+          "kind": "proxy-single-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": false,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T19",
@@ -492,13 +819,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T19/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T19/configs/proxy.json"
+        "T19/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T19/logs/runner.log"
+        "T19/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T19",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": false,
+          "gateway_transport": "udp",
+          "kind": "proxy-single-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": false,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T20",
@@ -511,13 +856,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T20/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T20/configs/proxy.json"
+        "T20/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T20/logs/runner.log"
+        "T20/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T20",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": false,
+          "gateway_transport": "udp",
+          "kind": "proxy-single-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": false,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T21",
@@ -530,13 +893,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T21/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T21/configs/proxy.json"
+        "T21/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T21/logs/runner.log"
+        "T21/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T21",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": false,
+          "gateway_transport": "tcp",
+          "kind": "proxy-single-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": false,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T22",
@@ -549,13 +930,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T22/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T22/configs/proxy.json"
+        "T22/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T22/logs/runner.log"
+        "T22/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T22",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": false,
+          "gateway_transport": "tcp",
+          "kind": "proxy-single-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": false,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T23",
@@ -568,13 +967,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T23/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T23/configs/proxy.json"
+        "T23/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T23/logs/runner.log"
+        "T23/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T23",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": false,
+          "gateway_transport": "tcp",
+          "kind": "proxy-single-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": false,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T24",
@@ -587,13 +1004,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T24/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T24/configs/proxy.json"
+        "T24/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T24/logs/runner.log"
+        "T24/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T24",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": false,
+          "gateway_transport": "tcp",
+          "kind": "proxy-single-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": false,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T25",
@@ -606,14 +1041,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T25/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T25/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T25/configs/ebusd.json"
+        "T25/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T25/logs/runner.log"
+        "T25/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T25",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "ens",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T26",
@@ -626,14 +1078,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T26/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T26/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T26/configs/ebusd.json"
+        "T26/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T26/logs/runner.log"
+        "T26/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T26",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "ens",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T27",
@@ -647,14 +1116,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T27/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T27/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T27/configs/ebusd.json"
+        "T27/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T27/logs/runner.log"
+        "T27/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T27",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "ens",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T28",
@@ -667,14 +1152,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T28/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T28/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T28/configs/ebusd.json"
+        "T28/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T28/logs/runner.log"
+        "T28/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T28",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "ens",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T29",
@@ -687,14 +1189,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T29/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T29/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T29/configs/ebusd.json"
+        "T29/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T29/logs/runner.log"
+        "T29/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T29",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "ens",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T30",
@@ -707,14 +1226,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T30/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T30/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T30/configs/ebusd.json"
+        "T30/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T30/logs/runner.log"
+        "T30/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T30",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "ens",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T31",
@@ -728,14 +1264,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T31/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T31/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T31/configs/ebusd.json"
+        "T31/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T31/logs/runner.log"
+        "T31/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T31",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "ens",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T32",
@@ -748,14 +1300,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T32/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T32/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T32/configs/ebusd.json"
+        "T32/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T32/logs/runner.log"
+        "T32/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T32",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "ens",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T33",
@@ -769,14 +1338,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T33/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T33/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T33/configs/ebusd.json"
+        "T33/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T33/logs/runner.log"
+        "T33/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T33",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "ens",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T34",
@@ -790,14 +1375,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T34/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T34/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T34/configs/ebusd.json"
+        "T34/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T34/logs/runner.log"
+        "T34/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T34",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "ens",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T35",
@@ -811,14 +1412,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T35/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T35/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T35/configs/ebusd.json"
+        "T35/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T35/logs/runner.log"
+        "T35/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T35",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "ens",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T36",
@@ -832,14 +1449,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T36/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T36/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T36/configs/ebusd.json"
+        "T36/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T36/logs/runner.log"
+        "T36/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T36",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "ens",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T37",
@@ -853,14 +1486,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T37/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T37/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T37/configs/ebusd.json"
+        "T37/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T37/logs/runner.log"
+        "T37/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T37",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "ens",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T38",
@@ -874,14 +1523,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T38/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T38/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T38/configs/ebusd.json"
+        "T38/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T38/logs/runner.log"
+        "T38/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T38",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "ens",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T39",
@@ -895,14 +1560,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T39/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T39/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T39/configs/ebusd.json"
+        "T39/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T39/logs/runner.log"
+        "T39/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T39",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "ens",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T40",
@@ -916,14 +1597,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T40/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T40/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T40/configs/ebusd.json"
+        "T40/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T40/logs/runner.log"
+        "T40/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T40",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "ens",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T41",
@@ -936,14 +1633,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T41/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T41/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T41/configs/ebusd.json"
+        "T41/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T41/logs/runner.log"
+        "T41/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T41",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "enh",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T42",
@@ -956,14 +1670,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T42/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T42/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T42/configs/ebusd.json"
+        "T42/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T42/logs/runner.log"
+        "T42/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T42",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "enh",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T43",
@@ -977,14 +1708,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T43/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T43/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T43/configs/ebusd.json"
+        "T43/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T43/logs/runner.log"
+        "T43/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T43",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "enh",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T44",
@@ -997,14 +1744,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T44/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T44/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T44/configs/ebusd.json"
+        "T44/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T44/logs/runner.log"
+        "T44/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T44",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "enh",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T45",
@@ -1017,14 +1781,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T45/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T45/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T45/configs/ebusd.json"
+        "T45/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T45/logs/runner.log"
+        "T45/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T45",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "enh",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T46",
@@ -1037,14 +1818,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T46/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T46/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T46/configs/ebusd.json"
+        "T46/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T46/logs/runner.log"
+        "T46/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T46",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "enh",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T47",
@@ -1058,14 +1856,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T47/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T47/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T47/configs/ebusd.json"
+        "T47/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T47/logs/runner.log"
+        "T47/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T47",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "enh",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T48",
@@ -1078,14 +1892,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T48/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T48/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T48/configs/ebusd.json"
+        "T48/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T48/logs/runner.log"
+        "T48/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T48",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "enh",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T49",
@@ -1099,14 +1930,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T49/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T49/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T49/configs/ebusd.json"
+        "T49/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T49/logs/runner.log"
+        "T49/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T49",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "enh",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T50",
@@ -1120,14 +1967,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T50/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T50/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T50/configs/ebusd.json"
+        "T50/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T50/logs/runner.log"
+        "T50/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T50",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "enh",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T51",
@@ -1141,14 +2004,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T51/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T51/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T51/configs/ebusd.json"
+        "T51/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T51/logs/runner.log"
+        "T51/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T51",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "enh",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T52",
@@ -1162,14 +2041,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T52/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T52/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T52/configs/ebusd.json"
+        "T52/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T52/logs/runner.log"
+        "T52/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T52",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "enh",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T53",
@@ -1183,14 +2078,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T53/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T53/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T53/configs/ebusd.json"
+        "T53/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T53/logs/runner.log"
+        "T53/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T53",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "enh",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T54",
@@ -1204,14 +2115,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T54/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T54/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T54/configs/ebusd.json"
+        "T54/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T54/logs/runner.log"
+        "T54/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T54",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "enh",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T55",
@@ -1225,14 +2152,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T55/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T55/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T55/configs/ebusd.json"
+        "T55/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T55/logs/runner.log"
+        "T55/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T55",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "enh",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T56",
@@ -1246,14 +2189,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T56/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T56/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T56/configs/ebusd.json"
+        "T56/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T56/logs/runner.log"
+        "T56/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T56",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "enh",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T57",
@@ -1266,14 +2225,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T57/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T57/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T57/configs/ebusd.json"
+        "T57/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T57/logs/runner.log"
+        "T57/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T57",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "udp",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T58",
@@ -1286,14 +2262,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T58/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T58/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T58/configs/ebusd.json"
+        "T58/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T58/logs/runner.log"
+        "T58/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T58",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "udp",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T59",
@@ -1307,14 +2300,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T59/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T59/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T59/configs/ebusd.json"
+        "T59/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T59/logs/runner.log"
+        "T59/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T59",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "udp",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T60",
@@ -1327,14 +2336,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T60/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T60/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T60/configs/ebusd.json"
+        "T60/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T60/logs/runner.log"
+        "T60/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T60",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "udp",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T61",
@@ -1347,14 +2373,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T61/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T61/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T61/configs/ebusd.json"
+        "T61/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T61/logs/runner.log"
+        "T61/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T61",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "udp",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T62",
@@ -1367,14 +2410,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T62/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T62/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T62/configs/ebusd.json"
+        "T62/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T62/logs/runner.log"
+        "T62/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T62",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "udp",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T63",
@@ -1388,14 +2448,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T63/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T63/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T63/configs/ebusd.json"
+        "T63/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T63/logs/runner.log"
+        "T63/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T63",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "udp",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T64",
@@ -1408,14 +2484,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T64/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T64/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T64/configs/ebusd.json"
+        "T64/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T64/logs/runner.log"
+        "T64/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T64",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "udp",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T65",
@@ -1429,14 +2522,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T65/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T65/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T65/configs/ebusd.json"
+        "T65/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T65/logs/runner.log"
+        "T65/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T65",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "udp",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T66",
@@ -1450,14 +2559,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T66/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T66/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T66/configs/ebusd.json"
+        "T66/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T66/logs/runner.log"
+        "T66/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T66",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "udp",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T67",
@@ -1471,14 +2596,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T67/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T67/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T67/configs/ebusd.json"
+        "T67/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T67/logs/runner.log"
+        "T67/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T67",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "udp",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T68",
@@ -1492,14 +2633,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T68/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T68/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T68/configs/ebusd.json"
+        "T68/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T68/logs/runner.log"
+        "T68/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T68",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "udp",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T69",
@@ -1513,14 +2670,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T69/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T69/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T69/configs/ebusd.json"
+        "T69/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T69/logs/runner.log"
+        "T69/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T69",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "udp",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T70",
@@ -1534,14 +2707,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T70/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T70/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T70/configs/ebusd.json"
+        "T70/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T70/logs/runner.log"
+        "T70/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T70",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "udp",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T71",
@@ -1555,14 +2744,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T71/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T71/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T71/configs/ebusd.json"
+        "T71/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T71/logs/runner.log"
+        "T71/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T71",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "udp",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T72",
@@ -1576,14 +2781,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T72/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T72/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T72/configs/ebusd.json"
+        "T72/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T72/logs/runner.log"
+        "T72/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T72",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "udp",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T73",
@@ -1596,14 +2817,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T73/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T73/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T73/configs/ebusd.json"
+        "T73/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T73/logs/runner.log"
+        "T73/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T73",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "tcp",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T74",
@@ -1616,14 +2854,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T74/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T74/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T74/configs/ebusd.json"
+        "T74/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T74/logs/runner.log"
+        "T74/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T74",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "tcp",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T75",
@@ -1637,14 +2892,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T75/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T75/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T75/configs/ebusd.json"
+        "T75/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T75/logs/runner.log"
+        "T75/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T75",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "tcp",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T76",
@@ -1657,14 +2928,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T76/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T76/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T76/configs/ebusd.json"
+        "T76/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T76/logs/runner.log"
+        "T76/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T76",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "tcp",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T77",
@@ -1677,14 +2965,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T77/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T77/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T77/configs/ebusd.json"
+        "T77/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T77/logs/runner.log"
+        "T77/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T77",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "tcp",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T78",
@@ -1697,14 +3002,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T78/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T78/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T78/configs/ebusd.json"
+        "T78/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T78/logs/runner.log"
+        "T78/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T78",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "tcp",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T79",
@@ -1718,14 +3040,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T79/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T79/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T79/configs/ebusd.json"
+        "T79/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T79/logs/runner.log"
+        "T79/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T79",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "tcp",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T80",
@@ -1738,14 +3076,31 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T80/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T80/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T80/configs/ebusd.json"
+        "T80/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T80/logs/runner.log"
+        "T80/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T80",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "tcp",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "expectation": "",
+      "error": ""
     },
     {
       "case_id": "T81",
@@ -1759,14 +3114,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T81/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T81/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T81/configs/ebusd.json"
+        "T81/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T81/logs/runner.log"
+        "T81/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T81",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "tcp",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T82",
@@ -1780,14 +3151,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T82/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T82/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T82/configs/ebusd.json"
+        "T82/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T82/logs/runner.log"
+        "T82/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T82",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "tcp",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T83",
@@ -1801,14 +3188,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T83/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T83/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T83/configs/ebusd.json"
+        "T83/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T83/logs/runner.log"
+        "T83/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T83",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "tcp",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T84",
@@ -1822,14 +3225,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T84/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T84/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T84/configs/ebusd.json"
+        "T84/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T84/logs/runner.log"
+        "T84/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T84",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "tcp",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T85",
@@ -1843,14 +3262,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T85/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T85/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T85/configs/ebusd.json"
+        "T85/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T85/logs/runner.log"
+        "T85/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T85",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "tcp",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T86",
@@ -1864,14 +3299,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T86/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T86/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T86/configs/ebusd.json"
+        "T86/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T86/logs/runner.log"
+        "T86/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T86",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "tcp",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T87",
@@ -1885,14 +3336,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T87/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T87/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T87/configs/ebusd.json"
+        "T87/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T87/logs/runner.log"
+        "T87/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T87",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "tcp",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     },
     {
       "case_id": "T88",
@@ -1906,14 +3373,30 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T88/configs/helianthus.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T88/configs/proxy.json",
-        "/tmp/matrix-baseline-runtime-state-w19-26/T88/configs/ebusd.json"
+        "T88/configs/helianthus.json"
       ],
       "log_files": [
-        "/tmp/matrix-baseline-runtime-state-w19-26/T88/logs/runner.log"
+        "T88/logs/runner.log"
       ],
-      "commands": []
+      "commands": [],
+      "planned_targets": {
+        "helianthus": {
+          "adapter_addr_env": "MATRIX_ADAPTER_ADDR",
+          "case_id": "T88",
+          "ebusd_tcp_addr_env": "MATRIX_EBUSD_TCP_ADDR",
+          "ebusd_via_proxy": true,
+          "gateway_transport": "tcp",
+          "kind": "proxy-dual-client",
+          "passive_mode": "",
+          "proxy_addr_env": "MATRIX_PROXY_ADDR",
+          "suite": "full88",
+          "target": "local",
+          "uses_ebusd": true,
+          "uses_proxy": true
+        }
+      },
+      "passive_mode": "",
+      "error": ""
     }
   ],
   "evidence_class": "dry-run-planning",

--- a/transport-matrix-baseline-runtime-state-w19-26.json
+++ b/transport-matrix-baseline-runtime-state-w19-26.json
@@ -40,7 +40,7 @@
       "\tbuild\tvcs.time=2026-05-10T11:52:58Z",
       "\tbuild\tvcs.modified=true"
     ],
-    "normalized_cases_sha256": "5e28aadae2ddee904a8c6287b130879e5ae3061f1487ea2f3b6d4a7362ddb9ff"
+    "normalized_cases_sha256": "3cc203ace880724a0c404abc8e9b625616a4a0eae0ac2579d6af4b7be20ee039"
   },
   "case_count": 88,
   "case_ids": [
@@ -301,7 +301,8 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T05/configs/helianthus.json"
+        "T05/configs/helianthus.json",
+        "T05/configs/ebusd.json"
       ],
       "log_files": [
         "T05/logs/runner.log"
@@ -321,6 +322,19 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": false
+        },
+        "ebusd": {
+          "case_id": "T05",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_ADAPTER_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "ens",
+          "upstream": "adapter"
         }
       },
       "passive_mode": "",
@@ -338,7 +352,8 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T06/configs/helianthus.json"
+        "T06/configs/helianthus.json",
+        "T06/configs/ebusd.json"
       ],
       "log_files": [
         "T06/logs/runner.log"
@@ -358,6 +373,19 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": false
+        },
+        "ebusd": {
+          "case_id": "T06",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_ADAPTER_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "enh",
+          "upstream": "adapter"
         }
       },
       "passive_mode": "",
@@ -376,7 +404,8 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T07/configs/helianthus.json"
+        "T07/configs/helianthus.json",
+        "T07/configs/ebusd.json"
       ],
       "log_files": [
         "T07/logs/runner.log"
@@ -396,6 +425,19 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": false
+        },
+        "ebusd": {
+          "case_id": "T07",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_ADAPTER_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "udp",
+          "upstream": "adapter"
         }
       },
       "passive_mode": "",
@@ -413,7 +455,8 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T08/configs/helianthus.json"
+        "T08/configs/helianthus.json",
+        "T08/configs/ebusd.json"
       ],
       "log_files": [
         "T08/logs/runner.log"
@@ -433,6 +476,19 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": false
+        },
+        "ebusd": {
+          "case_id": "T08",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_ADAPTER_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "tcp",
+          "upstream": "adapter"
         }
       },
       "passive_mode": "",
@@ -449,7 +505,8 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T09/configs/helianthus.json"
+        "T09/configs/helianthus.json",
+        "T09/configs/proxy.json"
       ],
       "log_files": [
         "T09/logs/runner.log"
@@ -469,6 +526,17 @@
           "target": "local",
           "uses_ebusd": false,
           "uses_proxy": true
+        },
+        "proxy": {
+          "case_id": "T09",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "ens",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -486,7 +554,8 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T10/configs/helianthus.json"
+        "T10/configs/helianthus.json",
+        "T10/configs/proxy.json"
       ],
       "log_files": [
         "T10/logs/runner.log"
@@ -506,6 +575,17 @@
           "target": "local",
           "uses_ebusd": false,
           "uses_proxy": true
+        },
+        "proxy": {
+          "case_id": "T10",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "enh",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -523,7 +603,8 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T11/configs/helianthus.json"
+        "T11/configs/helianthus.json",
+        "T11/configs/proxy.json"
       ],
       "log_files": [
         "T11/logs/runner.log"
@@ -543,6 +624,17 @@
           "target": "local",
           "uses_ebusd": false,
           "uses_proxy": true
+        },
+        "proxy": {
+          "case_id": "T11",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "udp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -560,7 +652,8 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T12/configs/helianthus.json"
+        "T12/configs/helianthus.json",
+        "T12/configs/proxy.json"
       ],
       "log_files": [
         "T12/logs/runner.log"
@@ -580,6 +673,17 @@
           "target": "local",
           "uses_ebusd": false,
           "uses_proxy": true
+        },
+        "proxy": {
+          "case_id": "T12",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "tcp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -597,7 +701,8 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T13/configs/helianthus.json"
+        "T13/configs/helianthus.json",
+        "T13/configs/proxy.json"
       ],
       "log_files": [
         "T13/logs/runner.log"
@@ -617,6 +722,17 @@
           "target": "local",
           "uses_ebusd": false,
           "uses_proxy": true
+        },
+        "proxy": {
+          "case_id": "T13",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "ens",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -634,7 +750,8 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T14/configs/helianthus.json"
+        "T14/configs/helianthus.json",
+        "T14/configs/proxy.json"
       ],
       "log_files": [
         "T14/logs/runner.log"
@@ -654,6 +771,17 @@
           "target": "local",
           "uses_ebusd": false,
           "uses_proxy": true
+        },
+        "proxy": {
+          "case_id": "T14",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "enh",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -671,7 +799,8 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T15/configs/helianthus.json"
+        "T15/configs/helianthus.json",
+        "T15/configs/proxy.json"
       ],
       "log_files": [
         "T15/logs/runner.log"
@@ -691,6 +820,17 @@
           "target": "local",
           "uses_ebusd": false,
           "uses_proxy": true
+        },
+        "proxy": {
+          "case_id": "T15",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "udp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -708,7 +848,8 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T16/configs/helianthus.json"
+        "T16/configs/helianthus.json",
+        "T16/configs/proxy.json"
       ],
       "log_files": [
         "T16/logs/runner.log"
@@ -728,6 +869,17 @@
           "target": "local",
           "uses_ebusd": false,
           "uses_proxy": true
+        },
+        "proxy": {
+          "case_id": "T16",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "tcp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -745,7 +897,8 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T17/configs/helianthus.json"
+        "T17/configs/helianthus.json",
+        "T17/configs/proxy.json"
       ],
       "log_files": [
         "T17/logs/runner.log"
@@ -765,6 +918,17 @@
           "target": "local",
           "uses_ebusd": false,
           "uses_proxy": true
+        },
+        "proxy": {
+          "case_id": "T17",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "ens",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -782,7 +946,8 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T18/configs/helianthus.json"
+        "T18/configs/helianthus.json",
+        "T18/configs/proxy.json"
       ],
       "log_files": [
         "T18/logs/runner.log"
@@ -802,6 +967,17 @@
           "target": "local",
           "uses_ebusd": false,
           "uses_proxy": true
+        },
+        "proxy": {
+          "case_id": "T18",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "enh",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -819,7 +995,8 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T19/configs/helianthus.json"
+        "T19/configs/helianthus.json",
+        "T19/configs/proxy.json"
       ],
       "log_files": [
         "T19/logs/runner.log"
@@ -839,6 +1016,17 @@
           "target": "local",
           "uses_ebusd": false,
           "uses_proxy": true
+        },
+        "proxy": {
+          "case_id": "T19",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "udp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -856,7 +1044,8 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T20/configs/helianthus.json"
+        "T20/configs/helianthus.json",
+        "T20/configs/proxy.json"
       ],
       "log_files": [
         "T20/logs/runner.log"
@@ -876,6 +1065,17 @@
           "target": "local",
           "uses_ebusd": false,
           "uses_proxy": true
+        },
+        "proxy": {
+          "case_id": "T20",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "tcp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -893,7 +1093,8 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T21/configs/helianthus.json"
+        "T21/configs/helianthus.json",
+        "T21/configs/proxy.json"
       ],
       "log_files": [
         "T21/logs/runner.log"
@@ -913,6 +1114,17 @@
           "target": "local",
           "uses_ebusd": false,
           "uses_proxy": true
+        },
+        "proxy": {
+          "case_id": "T21",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "ens",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -930,7 +1142,8 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T22/configs/helianthus.json"
+        "T22/configs/helianthus.json",
+        "T22/configs/proxy.json"
       ],
       "log_files": [
         "T22/logs/runner.log"
@@ -950,6 +1163,17 @@
           "target": "local",
           "uses_ebusd": false,
           "uses_proxy": true
+        },
+        "proxy": {
+          "case_id": "T22",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "enh",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -967,7 +1191,8 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T23/configs/helianthus.json"
+        "T23/configs/helianthus.json",
+        "T23/configs/proxy.json"
       ],
       "log_files": [
         "T23/logs/runner.log"
@@ -987,6 +1212,17 @@
           "target": "local",
           "uses_ebusd": false,
           "uses_proxy": true
+        },
+        "proxy": {
+          "case_id": "T23",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "udp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -1004,7 +1240,8 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T24/configs/helianthus.json"
+        "T24/configs/helianthus.json",
+        "T24/configs/proxy.json"
       ],
       "log_files": [
         "T24/logs/runner.log"
@@ -1024,6 +1261,17 @@
           "target": "local",
           "uses_ebusd": false,
           "uses_proxy": true
+        },
+        "proxy": {
+          "case_id": "T24",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "tcp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -1041,7 +1289,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T25/configs/helianthus.json"
+        "T25/configs/helianthus.json",
+        "T25/configs/ebusd.json",
+        "T25/configs/proxy.json"
       ],
       "log_files": [
         "T25/logs/runner.log"
@@ -1061,6 +1311,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T25",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_ENS_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "ens",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T25",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "ens",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -1078,7 +1352,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T26/configs/helianthus.json"
+        "T26/configs/helianthus.json",
+        "T26/configs/ebusd.json",
+        "T26/configs/proxy.json"
       ],
       "log_files": [
         "T26/logs/runner.log"
@@ -1098,6 +1374,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T26",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_ENH_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "enh",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T26",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "ens",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -1116,7 +1416,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T27/configs/helianthus.json"
+        "T27/configs/helianthus.json",
+        "T27/configs/ebusd.json",
+        "T27/configs/proxy.json"
       ],
       "log_files": [
         "T27/logs/runner.log"
@@ -1136,6 +1438,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T27",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_UDP_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "udp",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T27",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "ens",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -1152,7 +1478,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T28/configs/helianthus.json"
+        "T28/configs/helianthus.json",
+        "T28/configs/ebusd.json",
+        "T28/configs/proxy.json"
       ],
       "log_files": [
         "T28/logs/runner.log"
@@ -1172,6 +1500,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T28",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_TCP_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "tcp",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T28",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "ens",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -1189,7 +1541,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T29/configs/helianthus.json"
+        "T29/configs/helianthus.json",
+        "T29/configs/ebusd.json",
+        "T29/configs/proxy.json"
       ],
       "log_files": [
         "T29/logs/runner.log"
@@ -1209,6 +1563,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T29",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_ENS_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "ens",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T29",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "enh",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -1226,7 +1604,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T30/configs/helianthus.json"
+        "T30/configs/helianthus.json",
+        "T30/configs/ebusd.json",
+        "T30/configs/proxy.json"
       ],
       "log_files": [
         "T30/logs/runner.log"
@@ -1246,6 +1626,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T30",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_ENH_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "enh",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T30",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "enh",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -1264,7 +1668,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T31/configs/helianthus.json"
+        "T31/configs/helianthus.json",
+        "T31/configs/ebusd.json",
+        "T31/configs/proxy.json"
       ],
       "log_files": [
         "T31/logs/runner.log"
@@ -1284,6 +1690,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T31",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_UDP_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "udp",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T31",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "enh",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -1300,7 +1730,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T32/configs/helianthus.json"
+        "T32/configs/helianthus.json",
+        "T32/configs/ebusd.json",
+        "T32/configs/proxy.json"
       ],
       "log_files": [
         "T32/logs/runner.log"
@@ -1320,6 +1752,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T32",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_TCP_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "tcp",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T32",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "enh",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -1338,7 +1794,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T33/configs/helianthus.json"
+        "T33/configs/helianthus.json",
+        "T33/configs/ebusd.json",
+        "T33/configs/proxy.json"
       ],
       "log_files": [
         "T33/logs/runner.log"
@@ -1358,6 +1816,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T33",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_ENS_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "ens",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T33",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "udp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -1375,7 +1857,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T34/configs/helianthus.json"
+        "T34/configs/helianthus.json",
+        "T34/configs/ebusd.json",
+        "T34/configs/proxy.json"
       ],
       "log_files": [
         "T34/logs/runner.log"
@@ -1395,6 +1879,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T34",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_ENH_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "enh",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T34",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "udp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -1412,7 +1920,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T35/configs/helianthus.json"
+        "T35/configs/helianthus.json",
+        "T35/configs/ebusd.json",
+        "T35/configs/proxy.json"
       ],
       "log_files": [
         "T35/logs/runner.log"
@@ -1432,6 +1942,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T35",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_UDP_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "udp",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T35",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "udp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -1449,7 +1983,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T36/configs/helianthus.json"
+        "T36/configs/helianthus.json",
+        "T36/configs/ebusd.json",
+        "T36/configs/proxy.json"
       ],
       "log_files": [
         "T36/logs/runner.log"
@@ -1469,6 +2005,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T36",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_TCP_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "tcp",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T36",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "udp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -1486,7 +2046,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T37/configs/helianthus.json"
+        "T37/configs/helianthus.json",
+        "T37/configs/ebusd.json",
+        "T37/configs/proxy.json"
       ],
       "log_files": [
         "T37/logs/runner.log"
@@ -1506,6 +2068,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T37",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_ENS_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "ens",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T37",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "tcp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -1523,7 +2109,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T38/configs/helianthus.json"
+        "T38/configs/helianthus.json",
+        "T38/configs/ebusd.json",
+        "T38/configs/proxy.json"
       ],
       "log_files": [
         "T38/logs/runner.log"
@@ -1543,6 +2131,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T38",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_ENH_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "enh",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T38",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "tcp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -1560,7 +2172,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T39/configs/helianthus.json"
+        "T39/configs/helianthus.json",
+        "T39/configs/ebusd.json",
+        "T39/configs/proxy.json"
       ],
       "log_files": [
         "T39/logs/runner.log"
@@ -1580,6 +2194,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T39",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_UDP_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "udp",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T39",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "tcp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -1597,7 +2235,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T40/configs/helianthus.json"
+        "T40/configs/helianthus.json",
+        "T40/configs/ebusd.json",
+        "T40/configs/proxy.json"
       ],
       "log_files": [
         "T40/logs/runner.log"
@@ -1617,6 +2257,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T40",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_TCP_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "tcp",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T40",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "tcp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -1633,7 +2297,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T41/configs/helianthus.json"
+        "T41/configs/helianthus.json",
+        "T41/configs/ebusd.json",
+        "T41/configs/proxy.json"
       ],
       "log_files": [
         "T41/logs/runner.log"
@@ -1653,6 +2319,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T41",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_ENS_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "ens",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T41",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "ens",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -1670,7 +2360,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T42/configs/helianthus.json"
+        "T42/configs/helianthus.json",
+        "T42/configs/ebusd.json",
+        "T42/configs/proxy.json"
       ],
       "log_files": [
         "T42/logs/runner.log"
@@ -1690,6 +2382,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T42",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_ENH_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "enh",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T42",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "ens",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -1708,7 +2424,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T43/configs/helianthus.json"
+        "T43/configs/helianthus.json",
+        "T43/configs/ebusd.json",
+        "T43/configs/proxy.json"
       ],
       "log_files": [
         "T43/logs/runner.log"
@@ -1728,6 +2446,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T43",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_UDP_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "udp",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T43",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "ens",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -1744,7 +2486,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T44/configs/helianthus.json"
+        "T44/configs/helianthus.json",
+        "T44/configs/ebusd.json",
+        "T44/configs/proxy.json"
       ],
       "log_files": [
         "T44/logs/runner.log"
@@ -1764,6 +2508,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T44",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_TCP_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "tcp",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T44",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "ens",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -1781,7 +2549,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T45/configs/helianthus.json"
+        "T45/configs/helianthus.json",
+        "T45/configs/ebusd.json",
+        "T45/configs/proxy.json"
       ],
       "log_files": [
         "T45/logs/runner.log"
@@ -1801,6 +2571,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T45",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_ENS_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "ens",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T45",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "enh",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -1818,7 +2612,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T46/configs/helianthus.json"
+        "T46/configs/helianthus.json",
+        "T46/configs/ebusd.json",
+        "T46/configs/proxy.json"
       ],
       "log_files": [
         "T46/logs/runner.log"
@@ -1838,6 +2634,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T46",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_ENH_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "enh",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T46",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "enh",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -1856,7 +2676,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T47/configs/helianthus.json"
+        "T47/configs/helianthus.json",
+        "T47/configs/ebusd.json",
+        "T47/configs/proxy.json"
       ],
       "log_files": [
         "T47/logs/runner.log"
@@ -1876,6 +2698,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T47",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_UDP_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "udp",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T47",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "enh",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -1892,7 +2738,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T48/configs/helianthus.json"
+        "T48/configs/helianthus.json",
+        "T48/configs/ebusd.json",
+        "T48/configs/proxy.json"
       ],
       "log_files": [
         "T48/logs/runner.log"
@@ -1912,6 +2760,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T48",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_TCP_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "tcp",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T48",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "enh",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -1930,7 +2802,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T49/configs/helianthus.json"
+        "T49/configs/helianthus.json",
+        "T49/configs/ebusd.json",
+        "T49/configs/proxy.json"
       ],
       "log_files": [
         "T49/logs/runner.log"
@@ -1950,6 +2824,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T49",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_ENS_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "ens",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T49",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "udp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -1967,7 +2865,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T50/configs/helianthus.json"
+        "T50/configs/helianthus.json",
+        "T50/configs/ebusd.json",
+        "T50/configs/proxy.json"
       ],
       "log_files": [
         "T50/logs/runner.log"
@@ -1987,6 +2887,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T50",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_ENH_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "enh",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T50",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "udp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -2004,7 +2928,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T51/configs/helianthus.json"
+        "T51/configs/helianthus.json",
+        "T51/configs/ebusd.json",
+        "T51/configs/proxy.json"
       ],
       "log_files": [
         "T51/logs/runner.log"
@@ -2024,6 +2950,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T51",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_UDP_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "udp",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T51",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "udp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -2041,7 +2991,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T52/configs/helianthus.json"
+        "T52/configs/helianthus.json",
+        "T52/configs/ebusd.json",
+        "T52/configs/proxy.json"
       ],
       "log_files": [
         "T52/logs/runner.log"
@@ -2061,6 +3013,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T52",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_TCP_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "tcp",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T52",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "udp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -2078,7 +3054,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T53/configs/helianthus.json"
+        "T53/configs/helianthus.json",
+        "T53/configs/ebusd.json",
+        "T53/configs/proxy.json"
       ],
       "log_files": [
         "T53/logs/runner.log"
@@ -2098,6 +3076,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T53",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_ENS_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "ens",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T53",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "tcp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -2115,7 +3117,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T54/configs/helianthus.json"
+        "T54/configs/helianthus.json",
+        "T54/configs/ebusd.json",
+        "T54/configs/proxy.json"
       ],
       "log_files": [
         "T54/logs/runner.log"
@@ -2135,6 +3139,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T54",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_ENH_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "enh",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T54",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "tcp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -2152,7 +3180,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T55/configs/helianthus.json"
+        "T55/configs/helianthus.json",
+        "T55/configs/ebusd.json",
+        "T55/configs/proxy.json"
       ],
       "log_files": [
         "T55/logs/runner.log"
@@ -2172,6 +3202,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T55",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_UDP_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "udp",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T55",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "tcp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -2189,7 +3243,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T56/configs/helianthus.json"
+        "T56/configs/helianthus.json",
+        "T56/configs/ebusd.json",
+        "T56/configs/proxy.json"
       ],
       "log_files": [
         "T56/logs/runner.log"
@@ -2209,6 +3265,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T56",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_TCP_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "tcp",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T56",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "tcp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -2225,7 +3305,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T57/configs/helianthus.json"
+        "T57/configs/helianthus.json",
+        "T57/configs/ebusd.json",
+        "T57/configs/proxy.json"
       ],
       "log_files": [
         "T57/logs/runner.log"
@@ -2245,6 +3327,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T57",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_ENS_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "ens",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T57",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "ens",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -2262,7 +3368,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T58/configs/helianthus.json"
+        "T58/configs/helianthus.json",
+        "T58/configs/ebusd.json",
+        "T58/configs/proxy.json"
       ],
       "log_files": [
         "T58/logs/runner.log"
@@ -2282,6 +3390,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T58",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_ENH_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "enh",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T58",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "ens",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -2300,7 +3432,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T59/configs/helianthus.json"
+        "T59/configs/helianthus.json",
+        "T59/configs/ebusd.json",
+        "T59/configs/proxy.json"
       ],
       "log_files": [
         "T59/logs/runner.log"
@@ -2320,6 +3454,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T59",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_UDP_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "udp",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T59",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "ens",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -2336,7 +3494,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T60/configs/helianthus.json"
+        "T60/configs/helianthus.json",
+        "T60/configs/ebusd.json",
+        "T60/configs/proxy.json"
       ],
       "log_files": [
         "T60/logs/runner.log"
@@ -2356,6 +3516,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T60",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_TCP_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "tcp",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T60",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "ens",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -2373,7 +3557,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T61/configs/helianthus.json"
+        "T61/configs/helianthus.json",
+        "T61/configs/ebusd.json",
+        "T61/configs/proxy.json"
       ],
       "log_files": [
         "T61/logs/runner.log"
@@ -2393,6 +3579,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T61",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_ENS_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "ens",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T61",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "enh",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -2410,7 +3620,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T62/configs/helianthus.json"
+        "T62/configs/helianthus.json",
+        "T62/configs/ebusd.json",
+        "T62/configs/proxy.json"
       ],
       "log_files": [
         "T62/logs/runner.log"
@@ -2430,6 +3642,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T62",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_ENH_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "enh",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T62",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "enh",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -2448,7 +3684,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T63/configs/helianthus.json"
+        "T63/configs/helianthus.json",
+        "T63/configs/ebusd.json",
+        "T63/configs/proxy.json"
       ],
       "log_files": [
         "T63/logs/runner.log"
@@ -2468,6 +3706,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T63",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_UDP_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "udp",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T63",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "enh",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -2484,7 +3746,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T64/configs/helianthus.json"
+        "T64/configs/helianthus.json",
+        "T64/configs/ebusd.json",
+        "T64/configs/proxy.json"
       ],
       "log_files": [
         "T64/logs/runner.log"
@@ -2504,6 +3768,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T64",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_TCP_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "tcp",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T64",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "enh",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -2522,7 +3810,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T65/configs/helianthus.json"
+        "T65/configs/helianthus.json",
+        "T65/configs/ebusd.json",
+        "T65/configs/proxy.json"
       ],
       "log_files": [
         "T65/logs/runner.log"
@@ -2542,6 +3832,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T65",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_ENS_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "ens",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T65",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "udp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -2559,7 +3873,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T66/configs/helianthus.json"
+        "T66/configs/helianthus.json",
+        "T66/configs/ebusd.json",
+        "T66/configs/proxy.json"
       ],
       "log_files": [
         "T66/logs/runner.log"
@@ -2579,6 +3895,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T66",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_ENH_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "enh",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T66",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "udp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -2596,7 +3936,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T67/configs/helianthus.json"
+        "T67/configs/helianthus.json",
+        "T67/configs/ebusd.json",
+        "T67/configs/proxy.json"
       ],
       "log_files": [
         "T67/logs/runner.log"
@@ -2616,6 +3958,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T67",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_UDP_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "udp",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T67",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "udp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -2633,7 +3999,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T68/configs/helianthus.json"
+        "T68/configs/helianthus.json",
+        "T68/configs/ebusd.json",
+        "T68/configs/proxy.json"
       ],
       "log_files": [
         "T68/logs/runner.log"
@@ -2653,6 +4021,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T68",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_TCP_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "tcp",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T68",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "udp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -2670,7 +4062,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T69/configs/helianthus.json"
+        "T69/configs/helianthus.json",
+        "T69/configs/ebusd.json",
+        "T69/configs/proxy.json"
       ],
       "log_files": [
         "T69/logs/runner.log"
@@ -2690,6 +4084,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T69",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_ENS_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "ens",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T69",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "tcp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -2707,7 +4125,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T70/configs/helianthus.json"
+        "T70/configs/helianthus.json",
+        "T70/configs/ebusd.json",
+        "T70/configs/proxy.json"
       ],
       "log_files": [
         "T70/logs/runner.log"
@@ -2727,6 +4147,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T70",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_ENH_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "enh",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T70",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "tcp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -2744,7 +4188,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T71/configs/helianthus.json"
+        "T71/configs/helianthus.json",
+        "T71/configs/ebusd.json",
+        "T71/configs/proxy.json"
       ],
       "log_files": [
         "T71/logs/runner.log"
@@ -2764,6 +4210,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T71",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_UDP_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "udp",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T71",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "tcp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -2781,7 +4251,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T72/configs/helianthus.json"
+        "T72/configs/helianthus.json",
+        "T72/configs/ebusd.json",
+        "T72/configs/proxy.json"
       ],
       "log_files": [
         "T72/logs/runner.log"
@@ -2801,6 +4273,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T72",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_TCP_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "tcp",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T72",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "tcp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -2817,7 +4313,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T73/configs/helianthus.json"
+        "T73/configs/helianthus.json",
+        "T73/configs/ebusd.json",
+        "T73/configs/proxy.json"
       ],
       "log_files": [
         "T73/logs/runner.log"
@@ -2837,6 +4335,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T73",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_ENS_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "ens",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T73",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "ens",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -2854,7 +4376,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T74/configs/helianthus.json"
+        "T74/configs/helianthus.json",
+        "T74/configs/ebusd.json",
+        "T74/configs/proxy.json"
       ],
       "log_files": [
         "T74/logs/runner.log"
@@ -2874,6 +4398,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T74",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_ENH_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "enh",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T74",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "ens",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -2892,7 +4440,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T75/configs/helianthus.json"
+        "T75/configs/helianthus.json",
+        "T75/configs/ebusd.json",
+        "T75/configs/proxy.json"
       ],
       "log_files": [
         "T75/logs/runner.log"
@@ -2912,6 +4462,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T75",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_UDP_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "udp",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T75",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "ens",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -2928,7 +4502,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T76/configs/helianthus.json"
+        "T76/configs/helianthus.json",
+        "T76/configs/ebusd.json",
+        "T76/configs/proxy.json"
       ],
       "log_files": [
         "T76/logs/runner.log"
@@ -2948,6 +4524,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T76",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_TCP_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "tcp",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T76",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "ens",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -2965,7 +4565,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T77/configs/helianthus.json"
+        "T77/configs/helianthus.json",
+        "T77/configs/ebusd.json",
+        "T77/configs/proxy.json"
       ],
       "log_files": [
         "T77/logs/runner.log"
@@ -2985,6 +4587,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T77",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_ENS_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "ens",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T77",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "enh",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -3002,7 +4628,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T78/configs/helianthus.json"
+        "T78/configs/helianthus.json",
+        "T78/configs/ebusd.json",
+        "T78/configs/proxy.json"
       ],
       "log_files": [
         "T78/logs/runner.log"
@@ -3022,6 +4650,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T78",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_ENH_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "enh",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T78",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "enh",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -3040,7 +4692,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T79/configs/helianthus.json"
+        "T79/configs/helianthus.json",
+        "T79/configs/ebusd.json",
+        "T79/configs/proxy.json"
       ],
       "log_files": [
         "T79/logs/runner.log"
@@ -3060,6 +4714,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T79",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_UDP_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "udp",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T79",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "enh",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -3076,7 +4754,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T80/configs/helianthus.json"
+        "T80/configs/helianthus.json",
+        "T80/configs/ebusd.json",
+        "T80/configs/proxy.json"
       ],
       "log_files": [
         "T80/logs/runner.log"
@@ -3096,6 +4776,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T80",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_TCP_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "tcp",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T80",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "enh",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -3114,7 +4818,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T81/configs/helianthus.json"
+        "T81/configs/helianthus.json",
+        "T81/configs/ebusd.json",
+        "T81/configs/proxy.json"
       ],
       "log_files": [
         "T81/logs/runner.log"
@@ -3134,6 +4840,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T81",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_ENS_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "ens",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T81",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "udp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -3151,7 +4881,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T82/configs/helianthus.json"
+        "T82/configs/helianthus.json",
+        "T82/configs/ebusd.json",
+        "T82/configs/proxy.json"
       ],
       "log_files": [
         "T82/logs/runner.log"
@@ -3171,6 +4903,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T82",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_ENH_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "enh",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T82",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "udp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -3188,7 +4944,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T83/configs/helianthus.json"
+        "T83/configs/helianthus.json",
+        "T83/configs/ebusd.json",
+        "T83/configs/proxy.json"
       ],
       "log_files": [
         "T83/logs/runner.log"
@@ -3208,6 +4966,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T83",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_UDP_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "udp",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T83",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "udp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -3225,7 +5007,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T84/configs/helianthus.json"
+        "T84/configs/helianthus.json",
+        "T84/configs/ebusd.json",
+        "T84/configs/proxy.json"
       ],
       "log_files": [
         "T84/logs/runner.log"
@@ -3245,6 +5029,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T84",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_TCP_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "tcp",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T84",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "udp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -3262,7 +5070,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T85/configs/helianthus.json"
+        "T85/configs/helianthus.json",
+        "T85/configs/ebusd.json",
+        "T85/configs/proxy.json"
       ],
       "log_files": [
         "T85/logs/runner.log"
@@ -3282,6 +5092,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T85",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_ENS_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "ens",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T85",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "tcp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -3299,7 +5133,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T86/configs/helianthus.json"
+        "T86/configs/helianthus.json",
+        "T86/configs/ebusd.json",
+        "T86/configs/proxy.json"
       ],
       "log_files": [
         "T86/logs/runner.log"
@@ -3319,6 +5155,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T86",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_ENH_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "enh",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T86",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "tcp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -3336,7 +5196,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T87/configs/helianthus.json"
+        "T87/configs/helianthus.json",
+        "T87/configs/ebusd.json",
+        "T87/configs/proxy.json"
       ],
       "log_files": [
         "T87/logs/runner.log"
@@ -3356,6 +5218,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T87",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_UDP_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "udp",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T87",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "tcp",
+          "target": "local"
         }
       },
       "passive_mode": "",
@@ -3373,7 +5259,9 @@
       "started_at": "2026-05-10T14:59:24Z",
       "ended_at": "2026-05-10T14:59:24Z",
       "config_files": [
-        "T88/configs/helianthus.json"
+        "T88/configs/helianthus.json",
+        "T88/configs/ebusd.json",
+        "T88/configs/proxy.json"
       ],
       "log_files": [
         "T88/logs/runner.log"
@@ -3393,6 +5281,30 @@
           "target": "local",
           "uses_ebusd": true,
           "uses_proxy": true
+        },
+        "ebusd": {
+          "case_id": "T88",
+          "commandline_opts": "--enablehex",
+          "config_path_env": "MATRIX_EBUSD_CONFIG_PATH",
+          "http_port_env": "MATRIX_EBUSD_HTTP_PORT",
+          "mqtt_host_env": "MATRIX_MQTT_HOST",
+          "mqtt_port_env": "MATRIX_MQTT_PORT",
+          "network_device": "MATRIX_PROXY_TCP_ADDR",
+          "scanconfig": true,
+          "target": "local",
+          "transport": "tcp",
+          "upstream": "proxy"
+        },
+        "proxy": {
+          "case_id": "T88",
+          "max_parallel_sessions": 2,
+          "northbound_enh_env": "MATRIX_PROXY_ENH_ADDR",
+          "northbound_ens_env": "MATRIX_PROXY_ENS_ADDR",
+          "northbound_tcp_env": "MATRIX_PROXY_TCP_ADDR",
+          "northbound_udp_env": "MATRIX_PROXY_UDP_ADDR",
+          "southbound_addr_env": "MATRIX_ADAPTER_ADDR",
+          "southbound_transport": "tcp",
+          "target": "local"
         }
       },
       "passive_mode": "",


### PR DESCRIPTION
## Summary

M0A_TRANSPORT_BASELINE for the [`runtime-state-w19-26.locked`](https://github.com/Project-Helianthus/helianthus-execution-plans/tree/main/runtime-state-w19-26.locked) plan. Captures the 88-case transport-matrix planning index for current main as a baseline before any runtime-state code lands.

Per AD20 transport-gate: M8_TRANSPORT_VERIFY post-merge dry-run must compare against this baseline and show 0 unexpected fail/xpass deltas.

Closes RTS-GW-00A from [90-issue-map.md](https://github.com/Project-Helianthus/helianthus-execution-plans/blob/main/runtime-state-w19-26.locked/90-issue-map.md).

## What's in scope

`transport-matrix-baseline-runtime-state-w19-26.json` — 88-case dry-run-planning matrix index for gateway main `da230c7`. Same evidence class as the prior `transport-matrix-baseline-w19-26.json` (address-table plan).

## Generation

```
go build -o /tmp/matrix-runner ./cmd/matrix-runner
/tmp/matrix-runner --output-dir /tmp/baseline --target local --suite full88
```

Wrapped with metadata: plan ref, plan SHA256, git SHA, matrix-runner binary SHA, build_info.

## Outcome summary

88 planned, 0 pass/fail/xfail/xpass/blocked. Same shape as the address-table baseline.

## Plan-side acceptance

- [x] `transport-matrix-baseline-runtime-state-w19-26.json` committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)