### PR TITLE
feat(runtimestate): M2+M3 — gateway loader + persister (17 RED → GREEN)

### DIFF
--- a/internal/runtimestate/codec.go
+++ b/internal/runtimestate/codec.go
@@ -1,0 +1,212 @@
+// Package runtimestate — JSON codec with deterministic key order for AD13.
+// Plan: runtime-state-w19-26.
+//
+// We marshal via fixed-shape DTO structs (not map[string]interface{}) so the
+// order of keys in the output is determined by struct field declaration
+// order — making byte-for-byte comparison stable across writes.
+
+package runtimestate
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// fileDTO is the on-disk JSON shape (v1). DTOs are kept separate from the
+// public types so we can evolve the wire format without churning callers.
+type fileDTO struct {
+	SchemaVersion int      `json:"schema_version"`
+	Meta          metaDTO  `json:"meta"`
+	EBus          *ebusDTO `json:"ebus,omitempty"`
+}
+
+type metaDTO struct {
+	InstanceGUID string `json:"instance_guid"`
+	WrittenAt    string `json:"written_at"`
+	GatewayBuild string `json:"gateway_build,omitempty"`
+	AddonVersion string `json:"addon_version,omitempty"`
+}
+
+type ebusDTO struct {
+	SchemaVersion   int               `json:"schema_version"`
+	Self            *selfDTO          `json:"self,omitempty"`
+	KnownBusMembers []memberDTO       `json:"known_bus_members,omitempty"`
+	Extra           map[string]string `json:"-"` // unknown future fields are ignored on load
+}
+
+type selfDTO struct {
+	LastAdmittedSource int    `json:"last_admitted_source"`
+	LastAdmittedAt     string `json:"last_admitted_at"`
+	SelectionMethod    string `json:"selection_method"`
+	CompanionTarget    *int   `json:"companion_target"`
+}
+
+type memberDTO struct {
+	Addr          int          `json:"addr"`
+	CompanionAddr *int         `json:"companion_addr"`
+	Identity      *identityDTO `json:"identity"`
+	LastSeenAt    string       `json:"last_seen_at"`
+	LastSource    string       `json:"last_source"`
+	Confidence    string       `json:"confidence"`
+}
+
+type identityDTO struct {
+	Manufacturer string `json:"manufacturer,omitempty"`
+	DeviceID     string `json:"device_id,omitempty"`
+	SN           string `json:"sn,omitempty"`
+}
+
+// stateToDTO converts an in-memory State to its DTO for marshalling.
+func stateToDTO(s *State) fileDTO {
+	dto := fileDTO{
+		SchemaVersion: s.SchemaVersion,
+		Meta: metaDTO{
+			InstanceGUID: s.Meta.InstanceGUID,
+			WrittenAt:    formatTime(s.Meta.WrittenAt),
+			GatewayBuild: s.Meta.GatewayBuild,
+			AddonVersion: s.Meta.AddonVersion,
+		},
+	}
+	if s.EBus != nil {
+		ebus := &ebusDTO{SchemaVersion: s.EBus.SchemaVersion}
+		if s.EBus.Self != nil {
+			ebus.Self = &selfDTO{
+				LastAdmittedSource: int(s.EBus.Self.LastAdmittedSource),
+				LastAdmittedAt:     formatTime(s.EBus.Self.LastAdmittedAt),
+				SelectionMethod:    string(s.EBus.Self.SelectionMethod),
+			}
+			if s.EBus.Self.CompanionTarget != nil {
+				v := int(*s.EBus.Self.CompanionTarget)
+				ebus.Self.CompanionTarget = &v
+			}
+		}
+		for _, m := range s.EBus.KnownBusMembers {
+			md := memberDTO{
+				Addr:       int(m.Addr),
+				LastSeenAt: formatTime(m.LastSeenAt),
+				LastSource: string(m.LastSource),
+				Confidence: string(m.Confidence),
+			}
+			if m.CompanionAddr != nil {
+				v := int(*m.CompanionAddr)
+				md.CompanionAddr = &v
+			}
+			if m.Identity != nil {
+				md.Identity = &identityDTO{
+					Manufacturer: m.Identity.Manufacturer,
+					DeviceID:     m.Identity.DeviceID,
+					SN:           m.Identity.SN,
+				}
+			}
+			ebus.KnownBusMembers = append(ebus.KnownBusMembers, md)
+		}
+		dto.EBus = ebus
+	}
+	return dto
+}
+
+// dtoToState converts a parsed DTO back into the in-memory State.
+func dtoToState(dto fileDTO) (*State, error) {
+	s := &State{
+		SchemaVersion: dto.SchemaVersion,
+		Meta: Meta{
+			InstanceGUID: dto.Meta.InstanceGUID,
+			GatewayBuild: dto.Meta.GatewayBuild,
+			AddonVersion: dto.Meta.AddonVersion,
+		},
+	}
+	if t, err := parseTime(dto.Meta.WrittenAt); err == nil {
+		s.Meta.WrittenAt = t
+	}
+	if dto.EBus != nil {
+		ebus := &EBusNamespace{SchemaVersion: dto.EBus.SchemaVersion}
+		if dto.EBus.Self != nil {
+			selfT, _ := parseTime(dto.EBus.Self.LastAdmittedAt)
+			ebus.Self = &Self{
+				LastAdmittedSource: byte(dto.EBus.Self.LastAdmittedSource),
+				LastAdmittedAt:     selfT,
+				SelectionMethod:    SelectionMethod(dto.EBus.Self.SelectionMethod),
+			}
+			if dto.EBus.Self.CompanionTarget != nil {
+				v := byte(*dto.EBus.Self.CompanionTarget)
+				ebus.Self.CompanionTarget = &v
+			}
+		}
+		seen := map[byte]int{}
+		for _, m := range dto.EBus.KnownBusMembers {
+			if _, dup := seen[byte(m.Addr)]; dup {
+				return nil, fmt.Errorf("AD18: duplicate addr 0x%02X in known_bus_members", byte(m.Addr))
+			}
+			seen[byte(m.Addr)] = len(ebus.KnownBusMembers)
+			lt, _ := parseTime(m.LastSeenAt)
+			km := KnownBusMember{
+				Addr:       byte(m.Addr),
+				LastSeenAt: lt,
+				LastSource: LastSource(m.LastSource),
+				Confidence: Confidence(m.Confidence),
+			}
+			if m.CompanionAddr != nil {
+				v := byte(*m.CompanionAddr)
+				km.CompanionAddr = &v
+			}
+			if m.Identity != nil {
+				km.Identity = &Identity{
+					Manufacturer: m.Identity.Manufacturer,
+					DeviceID:     m.Identity.DeviceID,
+					SN:           m.Identity.SN,
+				}
+			}
+			ebus.KnownBusMembers = append(ebus.KnownBusMembers, km)
+		}
+		s.EBus = ebus
+	}
+	return s, nil
+}
+
+// marshalState produces the JSON bytes for a State with deterministic key
+// order (struct-driven). Adds a trailing newline so editors don't fight us.
+func marshalState(s *State) ([]byte, error) {
+	dto := stateToDTO(s)
+	b, err := json.MarshalIndent(dto, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(b, '\n'), nil
+}
+
+// unmarshalState parses bytes into a State + reports schema-validation
+// errors. Returns errSchemaTopLevel for top-level schema_version mismatch
+// (treat as corrupt). For ebus.schema_version mismatch returns nil + an
+// EBus-stripped state per AD12.
+func unmarshalState(data []byte) (*State, error) {
+	var dto fileDTO
+	if err := json.Unmarshal(data, &dto); err != nil {
+		return nil, err
+	}
+	if dto.SchemaVersion != SchemaVersion {
+		return nil, errSchemaTopLevel
+	}
+	if dto.EBus != nil && dto.EBus.SchemaVersion != EBusSchemaVersion {
+		// AD12: ignore the namespace, keep the rest.
+		dto.EBus = nil
+	}
+	return dtoToState(dto)
+}
+
+var errSchemaTopLevel = errors.New("runtimestate: top-level schema_version mismatch")
+
+func formatTime(t time.Time) string {
+	if t.IsZero() {
+		return "1970-01-01T00:00:00Z"
+	}
+	return t.UTC().Format(time.RFC3339Nano)
+}
+
+func parseTime(s string) (time.Time, error) {
+	if s == "" {
+		return time.Time{}, nil
+	}
+	return time.Parse(time.RFC3339Nano, s)
+}

--- a/internal/runtimestate/codec.go
+++ b/internal/runtimestate/codec.go
@@ -107,6 +107,11 @@ func stateToDTO(s *State) fileDTO {
 	return dto
 }
 
+// inByteRange reports whether v fits in [0, 255]. Used to reject malformed
+// persisted address values before byte-casting (Codex R3 P2 — bare casts
+// silently wrap, e.g. 300 → 0x2C, which would seed the wrong bus member).
+func inByteRange(v int) bool { return v >= 0 && v <= 0xFF }
+
 // dtoToState converts a parsed DTO back into the in-memory State.
 func dtoToState(dto fileDTO) (*State, error) {
 	s := &State{
@@ -123,6 +128,9 @@ func dtoToState(dto fileDTO) (*State, error) {
 	if dto.EBus != nil {
 		ebus := &EBusNamespace{SchemaVersion: dto.EBus.SchemaVersion}
 		if dto.EBus.Self != nil {
+			if !inByteRange(dto.EBus.Self.LastAdmittedSource) {
+				return nil, fmt.Errorf("ebus.self.last_admitted_source %d out of byte range [0,255]", dto.EBus.Self.LastAdmittedSource)
+			}
 			selfT, _ := parseTime(dto.EBus.Self.LastAdmittedAt)
 			ebus.Self = &Self{
 				LastAdmittedSource: byte(dto.EBus.Self.LastAdmittedSource),
@@ -130,12 +138,18 @@ func dtoToState(dto fileDTO) (*State, error) {
 				SelectionMethod:    SelectionMethod(dto.EBus.Self.SelectionMethod),
 			}
 			if dto.EBus.Self.CompanionTarget != nil {
+				if !inByteRange(*dto.EBus.Self.CompanionTarget) {
+					return nil, fmt.Errorf("ebus.self.companion_target %d out of byte range [0,255]", *dto.EBus.Self.CompanionTarget)
+				}
 				v := byte(*dto.EBus.Self.CompanionTarget)
 				ebus.Self.CompanionTarget = &v
 			}
 		}
 		seen := map[byte]int{}
-		for _, m := range dto.EBus.KnownBusMembers {
+		for i, m := range dto.EBus.KnownBusMembers {
+			if !inByteRange(m.Addr) {
+				return nil, fmt.Errorf("ebus.known_bus_members[%d].addr %d out of byte range [0,255]", i, m.Addr)
+			}
 			if _, dup := seen[byte(m.Addr)]; dup {
 				return nil, fmt.Errorf("AD18: duplicate addr 0x%02X in known_bus_members", byte(m.Addr))
 			}
@@ -148,6 +162,9 @@ func dtoToState(dto fileDTO) (*State, error) {
 				Confidence: Confidence(m.Confidence),
 			}
 			if m.CompanionAddr != nil {
+				if !inByteRange(*m.CompanionAddr) {
+					return nil, fmt.Errorf("ebus.known_bus_members[%d].companion_addr %d out of byte range [0,255]", i, *m.CompanionAddr)
+				}
 				v := byte(*m.CompanionAddr)
 				km.CompanionAddr = &v
 			}

--- a/internal/runtimestate/fs_hooks.go
+++ b/internal/runtimestate/fs_hooks.go
@@ -23,7 +23,7 @@ func (DefaultFilesystemHooks) FsyncFile(path string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	return f.Sync()
 }
 
@@ -36,7 +36,7 @@ func (DefaultFilesystemHooks) FsyncDir(path string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	return f.Sync()
 }
 

--- a/internal/runtimestate/fs_hooks.go
+++ b/internal/runtimestate/fs_hooks.go
@@ -1,0 +1,74 @@
+// Package runtimestate — DefaultFilesystemHooks. Plan: runtime-state-w19-26.
+// AD13 production filesystem operations. Tests inject mocks via Options.FsHooks
+// to fault-inject EXDEV / ENOSPC / ENOSYS / EINVAL etc.
+
+package runtimestate
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// DefaultFilesystemHooks delegates to the os package. Used by Manager when
+// Options.FsHooks is nil.
+type DefaultFilesystemHooks struct{}
+
+func (DefaultFilesystemHooks) WriteFile(path string, data []byte, perm uint32) error {
+	return os.WriteFile(path, data, os.FileMode(perm))
+}
+
+func (DefaultFilesystemHooks) FsyncFile(path string) error {
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return f.Sync()
+}
+
+func (DefaultFilesystemHooks) Rename(oldpath, newpath string) error {
+	return os.Rename(oldpath, newpath)
+}
+
+func (DefaultFilesystemHooks) FsyncDir(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return f.Sync()
+}
+
+func (DefaultFilesystemHooks) Unlink(path string) error {
+	return os.Remove(path)
+}
+
+// isParentFsyncSwallowed reports whether the given error from FsyncDir should
+// be silently swallowed per AD13 (ENOTSUP / EINVAL / EPERM / ENOSYS).
+func isParentFsyncSwallowed(err error) bool {
+	if err == nil {
+		return false
+	}
+	var perr *os.PathError
+	if errors.As(err, &perr) {
+		err = perr.Err
+	}
+	switch err {
+	case syscall.ENOTSUP, syscall.EINVAL, syscall.EPERM, syscall.ENOSYS:
+		return true
+	}
+	return false
+}
+
+// isExdev reports whether err carries syscall.EXDEV (cross-device link).
+func isExdev(err error) bool {
+	if err == nil {
+		return false
+	}
+	var perr *os.PathError
+	if errors.As(err, &perr) {
+		err = perr.Err
+	}
+	return err == syscall.EXDEV
+}

--- a/internal/runtimestate/runtimestate.go
+++ b/internal/runtimestate/runtimestate.go
@@ -286,26 +286,16 @@ func (m *Manager) EagerPersistInstanceGUID(ctx context.Context, guid string, sou
 	m.state.Meta.WrittenAt = time.Now().UTC()
 	m.state.Meta.GatewayBuild = m.opts.GatewayBuild
 	m.state.Meta.AddonVersion = m.opts.AddonVersion
-	// Pre-mark dirty so that if persistLocked fails (ENOSPC / fsync_temp /
+	// Pre-mark dirty so that if persistFlush fails (ENOSPC / fsync_temp /
 	// etc.) the next ticker/Stop retries (Codex R4 P2 — clearing before
 	// persist would silently skip the retry path on transient failure).
 	m.dirty = true
-	genAtSnapshot := m.writeGen
-	snap := cloneState(m.state)
+	m.writeGen++
 	m.mu.Unlock()
 
 	m.opts.Metrics.OnIdentitySource(source)
 
-	if err := m.persistLocked(snap); err != nil {
-		return err
-	}
-	// Persist succeeded; clear dirty if no concurrent mutation slipped in.
-	m.mu.Lock()
-	if m.writeGen == genAtSnapshot {
-		m.dirty = false
-	}
-	m.mu.Unlock()
-	return nil
+	return m.persistFlush()
 }
 
 // Start begins the periodic ticker (PersistInterval ± JitterRange/2) and
@@ -484,38 +474,59 @@ func cloneState(s *State) *State {
 	return &cp
 }
 
-// flushIfDirty acquires the lock, snapshots state, persists if dirty.
+// flushIfDirty persists the current in-memory state if dirty=true.
+// Equivalent to persistFlush() but exits early when nothing to do.
 func (m *Manager) flushIfDirty() {
 	m.mu.Lock()
-	if !m.dirty {
-		m.mu.Unlock()
+	dirty := m.dirty && m.state != nil
+	m.mu.Unlock()
+	if !dirty {
 		return
 	}
+	_ = m.persistFlush()
+}
+
+// persistFlush serializes snapshot + write under writeMu so two overlapping
+// persisters cannot land their renames out of snapshot order (Codex R5 —
+// previously the snapshot was captured BEFORE writeMu.Lock(), which let an
+// older snapshot's rename land after a newer snapshot's rename, silently
+// reverting on-disk state to a stale generation).
+//
+// Sequence:
+//  1. writeMu.Lock — exclude other persisters.
+//  2. mu.Lock — snapshot fresh state + record writeGen.
+//  3. mu.Unlock — release in-memory mutex while we hit disk.
+//  4. atomicWrite(snap) — temp+rename per AD13.
+//  5. mu.Lock — clear dirty IFF writeGen unchanged (no concurrent mutation).
+//  6. mu.Unlock + writeMu.Unlock.
+func (m *Manager) persistFlush() error {
+	m.writeMu.Lock()
+	defer m.writeMu.Unlock()
+
+	m.mu.Lock()
 	if m.state == nil {
 		m.dirty = false
 		m.mu.Unlock()
-		return
+		return nil
 	}
 	m.state.Meta.WrittenAt = time.Now().UTC()
 	snap := cloneState(m.state)
 	genAtSnapshot := m.writeGen
 	m.mu.Unlock()
-	// Only clear dirty AFTER a successful persist AND no mutation happened
-	// during the persist call. On error (ENOSPC, fsync_temp, etc.) keep
-	// dirty=true so the next ticker tick or shutdown retries (Codex R1 P2 —
-	// otherwise transient errors would silently lose in-memory mutations).
-	if err := m.persistLocked(snap); err != nil {
+
+	if err := m.atomicWrite(snap); err != nil {
 		m.opts.Logger.Warn("runtime_state: persist failed; keeping dirty for retry", "error", err)
-		return
+		return err
 	}
+
 	m.mu.Lock()
 	if m.writeGen == genAtSnapshot {
-		// No mutation happened during persist; safe to clear dirty.
 		m.dirty = false
 	}
 	// else: a mutation slipped in while we were persisting; dirty stays true
-	// and the next flushIfDirty cycle will pick up the new state.
+	// and the next persistFlush cycle will pick up the new state.
 	m.mu.Unlock()
+	return nil
 }
 
 // tickerLoop runs the 15-min jittered persist ticker.
@@ -547,19 +558,10 @@ func (m *Manager) tickerLoop() {
 	}
 }
 
-// persistLocked atomically writes the snapshot to disk per AD13. Caller must
-// NOT hold m.mu (we never call back into Manager). The snapshot is treated
-// as authoritative for the write.
-//
-// Acquires m.writeMu so concurrent persisters (e.g. ticker mid-flush + Stop's
-// final flushIfDirty after a 5s timeout, or EagerPersistInstanceGUID racing
-// the ticker) cannot interleave and let an older snapshot's rename land
-// after a newer snapshot's rename — which would silently discard the newer
-// mutation (Codex R3 P2).
-func (m *Manager) persistLocked(snap *State) error {
-	m.writeMu.Lock()
-	defer m.writeMu.Unlock()
-
+// atomicWrite executes the AD13 atomic temp+rename sequence for the given
+// snapshot. Caller MUST hold m.writeMu (see persistFlush) so concurrent
+// persisters cannot interleave their renames out of snapshot order.
+func (m *Manager) atomicWrite(snap *State) error {
 	data, err := marshalState(snap)
 	if err != nil {
 		m.opts.Metrics.OnWrite("marshal")

--- a/internal/runtimestate/runtimestate.go
+++ b/internal/runtimestate/runtimestate.go
@@ -195,15 +195,16 @@ type Options struct {
 // Manager coordinates loading, eager persistence, periodic writes, and shutdown
 // flushes for /data/runtime_state.json. It is the sole writer (AD07).
 type Manager struct {
-	opts    Options
-	hooks   FilesystemHooks
-	mu      sync.Mutex
-	state   *State
-	dirty   bool
-	stopCh  chan struct{}
-	doneCh  chan struct{}
-	started bool
-	stopped bool
+	opts     Options
+	hooks    FilesystemHooks
+	mu       sync.Mutex
+	state    *State
+	dirty    bool
+	writeGen uint64 // bumped on every mutation; used by flushIfDirty to detect concurrent updates
+	stopCh   chan struct{}
+	doneCh   chan struct{}
+	started  bool
+	stopped  bool
 }
 
 // New constructs a Manager. The Manager is not started until Start is called.
@@ -359,6 +360,7 @@ func (m *Manager) UpdateSelf(self Self) {
 	cp := self
 	m.state.EBus.Self = &cp
 	m.dirty = true
+	m.writeGen++
 	m.mu.Unlock()
 }
 
@@ -376,12 +378,14 @@ func (m *Manager) UpsertKnownBusMember(member KnownBusMember) {
 		if existing.Addr == member.Addr {
 			m.state.EBus.KnownBusMembers[i] = member
 			m.dirty = true
+			m.writeGen++
 			m.mu.Unlock()
 			return
 		}
 	}
 	m.state.EBus.KnownBusMembers = append(m.state.EBus.KnownBusMembers, member)
 	m.dirty = true
+	m.writeGen++
 	m.mu.Unlock()
 }
 
@@ -401,6 +405,7 @@ func (m *Manager) EvictKnownBusMember(addr byte) {
 	}
 	if len(out) != len(m.state.EBus.KnownBusMembers) {
 		m.dirty = true
+		m.writeGen++
 	}
 	m.state.EBus.KnownBusMembers = out
 }
@@ -461,9 +466,24 @@ func (m *Manager) flushIfDirty() {
 	}
 	m.state.Meta.WrittenAt = time.Now().UTC()
 	snap := cloneState(m.state)
-	m.dirty = false
+	genAtSnapshot := m.writeGen
 	m.mu.Unlock()
-	_ = m.persistLocked(snap)
+	// Only clear dirty AFTER a successful persist AND no mutation happened
+	// during the persist call. On error (ENOSPC, fsync_temp, etc.) keep
+	// dirty=true so the next ticker tick or shutdown retries (Codex R1 P2 —
+	// otherwise transient errors would silently lose in-memory mutations).
+	if err := m.persistLocked(snap); err != nil {
+		m.opts.Logger.Warn("runtime_state: persist failed; keeping dirty for retry", "error", err)
+		return
+	}
+	m.mu.Lock()
+	if m.writeGen == genAtSnapshot {
+		// No mutation happened during persist; safe to clear dirty.
+		m.dirty = false
+	}
+	// else: a mutation slipped in while we were persisting; dirty stays true
+	// and the next flushIfDirty cycle will pick up the new state.
+	m.mu.Unlock()
 }
 
 // tickerLoop runs the 15-min jittered persist ticker.

--- a/internal/runtimestate/runtimestate.go
+++ b/internal/runtimestate/runtimestate.go
@@ -349,6 +349,10 @@ func (m *Manager) State() *State {
 
 // UpdateSelf replaces ebus.self with the given Self and marks state dirty.
 // Used after a successful SourceAddressSelection per AD14.
+//
+// Deep-copies pointer fields (CompanionTarget) so a caller mutating the
+// pointed-to byte after returning from UpdateSelf cannot reach in and modify
+// manager state outside the mutex (Codex R3 P2).
 func (m *Manager) UpdateSelf(self Self) {
 	m.mu.Lock()
 	if m.state == nil {
@@ -358,6 +362,10 @@ func (m *Manager) UpdateSelf(self Self) {
 		m.state.EBus = &EBusNamespace{SchemaVersion: EBusSchemaVersion}
 	}
 	cp := self
+	if self.CompanionTarget != nil {
+		v := *self.CompanionTarget
+		cp.CompanionTarget = &v
+	}
 	m.state.EBus.Self = &cp
 	m.dirty = true
 	m.writeGen++
@@ -366,7 +374,21 @@ func (m *Manager) UpdateSelf(self Self) {
 
 // UpsertKnownBusMember adds or updates an entry in ebus.known_bus_members[].
 // Uniqueness on Addr is enforced (AD18); duplicate Addr replaces.
+//
+// Deep-copies pointer fields (CompanionAddr, Identity) so a caller mutating
+// the pointed-to data after returning cannot reach in and modify manager
+// state outside the mutex (Codex R3 P2).
 func (m *Manager) UpsertKnownBusMember(member KnownBusMember) {
+	stored := member
+	if member.CompanionAddr != nil {
+		v := *member.CompanionAddr
+		stored.CompanionAddr = &v
+	}
+	if member.Identity != nil {
+		idCopy := *member.Identity
+		stored.Identity = &idCopy
+	}
+
 	m.mu.Lock()
 	if m.state == nil {
 		m.state = &State{SchemaVersion: SchemaVersion}
@@ -375,15 +397,15 @@ func (m *Manager) UpsertKnownBusMember(member KnownBusMember) {
 		m.state.EBus = &EBusNamespace{SchemaVersion: EBusSchemaVersion}
 	}
 	for i, existing := range m.state.EBus.KnownBusMembers {
-		if existing.Addr == member.Addr {
-			m.state.EBus.KnownBusMembers[i] = member
+		if existing.Addr == stored.Addr {
+			m.state.EBus.KnownBusMembers[i] = stored
 			m.dirty = true
 			m.writeGen++
 			m.mu.Unlock()
 			return
 		}
 	}
-	m.state.EBus.KnownBusMembers = append(m.state.EBus.KnownBusMembers, member)
+	m.state.EBus.KnownBusMembers = append(m.state.EBus.KnownBusMembers, stored)
 	m.dirty = true
 	m.writeGen++
 	m.mu.Unlock()

--- a/internal/runtimestate/runtimestate.go
+++ b/internal/runtimestate/runtimestate.go
@@ -287,12 +287,12 @@ func (m *Manager) EagerPersistInstanceGUID(ctx context.Context, guid string, sou
 	m.state.Meta.GatewayBuild = m.opts.GatewayBuild
 	m.state.Meta.AddonVersion = m.opts.AddonVersion
 	m.dirty = false // we'll persist now
-	snap := *m.state
+	snap := cloneState(m.state)
 	m.mu.Unlock()
 
 	m.opts.Metrics.OnIdentitySource(source)
 
-	if err := m.persistLocked(&snap); err != nil {
+	if err := m.persistLocked(snap); err != nil {
 		return err
 	}
 	return nil
@@ -489,6 +489,7 @@ func (m *Manager) flushIfDirty() {
 // tickerLoop runs the 15-min jittered persist ticker.
 func (m *Manager) tickerLoop() {
 	defer close(m.doneCh)
+	const minTickDelay = time.Second
 	for {
 		jitter := time.Duration(0)
 		if m.opts.JitterRange > 0 {
@@ -497,6 +498,14 @@ func (m *Manager) tickerLoop() {
 			jitter = time.Duration(r.Int63n(int64(m.opts.JitterRange))) - (m.opts.JitterRange / 2)
 		}
 		next := m.opts.PersistInterval + jitter
+		// Clamp to a positive minimum so a misconfigured combination of
+		// short PersistInterval + large JitterRange (or any
+		// JitterRange > 2*PersistInterval) doesn't spin the goroutine
+		// (Codex R2 P2 — time.After(<=0) fires immediately and the loop
+		// would busy-flush state).
+		if next < minTickDelay {
+			next = minTickDelay
+		}
 		select {
 		case <-time.After(next):
 			m.flushIfDirty()

--- a/internal/runtimestate/runtimestate.go
+++ b/internal/runtimestate/runtimestate.go
@@ -2,17 +2,17 @@
 // /data/runtime_state.json. Plan: runtime-state-w19-26.locked. v1 namespaces:
 // meta + ebus.{self, known_bus_members[]}. See docs-ebus
 // architecture/runtime-state.md for the normative schema and contract.
-//
-// This file holds the package types + the public Manager surface. The
-// implementations are SKELETON (M1_TDD_RED stubs); M2_GATEWAY_LOADER and
-// M3_GATEWAY_PERSISTER replace them with real bodies that satisfy the
-// contract tests in runtimestate_test.go.
 package runtimestate
 
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"sync"
 	"time"
 )
 
@@ -195,7 +195,15 @@ type Options struct {
 // Manager coordinates loading, eager persistence, periodic writes, and shutdown
 // flushes for /data/runtime_state.json. It is the sole writer (AD07).
 type Manager struct {
-	opts Options
+	opts    Options
+	hooks   FilesystemHooks
+	mu      sync.Mutex
+	state   *State
+	dirty   bool
+	stopCh  chan struct{}
+	doneCh  chan struct{}
+	started bool
+	stopped bool
 }
 
 // New constructs a Manager. The Manager is not started until Start is called.
@@ -215,12 +223,18 @@ func New(opts Options) *Manager {
 	if opts.Path == "" {
 		opts.Path = "/data/runtime_state.json"
 	}
-	return &Manager{opts: opts}
+	hooks := opts.FsHooks
+	if hooks == nil {
+		hooks = DefaultFilesystemHooks{}
+	}
+	return &Manager{
+		opts:   opts,
+		hooks:  hooks,
+		state:  &State{SchemaVersion: SchemaVersion},
+		stopCh: make(chan struct{}),
+		doneCh: make(chan struct{}),
+	}
 }
-
-// errNotImplemented is returned by every method in the M1_TDD_RED skeleton.
-// M2_GATEWAY_LOADER and M3_GATEWAY_PERSISTER replace these with real bodies.
-var errNotImplemented = errors.New("runtimestate: not implemented (M2/M3 will provide)")
 
 // Load reads the runtime state file. Returns the parsed State, or an empty
 // State on missing/corrupt. On corrupt, the file is renamed to
@@ -228,45 +242,306 @@ var errNotImplemented = errors.New("runtimestate: not implemented (M2/M3 will pr
 // schema_version mismatch results in that namespace being dropped from the
 // in-memory load (AD12). Never returns a panic; never blocks startup.
 func (m *Manager) Load(ctx context.Context) (*State, error) {
-	return nil, errNotImplemented
+	data, err := os.ReadFile(m.opts.Path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			m.opts.Logger.Info("runtime_state: file absent, starting empty", "path", m.opts.Path)
+			m.replaceState(&State{SchemaVersion: SchemaVersion})
+			return m.State(), nil
+		}
+		// Permission denied / IO error: log + start empty (never block startup per AD11).
+		m.opts.Logger.Warn("runtime_state: read failed, starting empty", "path", m.opts.Path, "error", err)
+		m.replaceState(&State{SchemaVersion: SchemaVersion})
+		return m.State(), nil
+	}
+
+	state, err := unmarshalState(data)
+	if err != nil {
+		// Corrupt or schema mismatch: quarantine and start empty per AD11.
+		quarantine := fmt.Sprintf("%s.corrupt-%s", m.opts.Path, time.Now().UTC().Format("20060102T150405Z"))
+		if rerr := m.hooks.Rename(m.opts.Path, quarantine); rerr != nil {
+			m.opts.Logger.Warn("runtime_state: corrupt-quarantine rename failed", "from", m.opts.Path, "to", quarantine, "error", rerr)
+		} else {
+			m.opts.Logger.Warn("runtime_state: corrupt file quarantined", "from", m.opts.Path, "to", quarantine, "parse_error", err)
+		}
+		m.replaceState(&State{SchemaVersion: SchemaVersion})
+		return m.State(), nil
+	}
+
+	m.replaceState(state)
+	return m.State(), nil
 }
 
 // EagerPersistInstanceGUID writes a minimum-valid file containing
 // meta.{schema_version, instance_guid, written_at} within ~1s of the call
 // (AD08). Closes the crash-before-first-periodic-persist window.
 func (m *Manager) EagerPersistInstanceGUID(ctx context.Context, guid string, source IdentitySource) error {
-	return errNotImplemented
+	m.mu.Lock()
+	if m.state == nil {
+		m.state = &State{SchemaVersion: SchemaVersion}
+	}
+	m.state.SchemaVersion = SchemaVersion
+	m.state.Meta.InstanceGUID = guid
+	m.state.Meta.WrittenAt = time.Now().UTC()
+	m.state.Meta.GatewayBuild = m.opts.GatewayBuild
+	m.state.Meta.AddonVersion = m.opts.AddonVersion
+	m.dirty = false // we'll persist now
+	snap := *m.state
+	m.mu.Unlock()
+
+	m.opts.Metrics.OnIdentitySource(source)
+
+	if err := m.persistLocked(&snap); err != nil {
+		return err
+	}
+	return nil
 }
 
 // Start begins the periodic ticker (PersistInterval ± JitterRange/2) and
 // the shutdown subscriber. Returns once the goroutines are running.
 func (m *Manager) Start(ctx context.Context) error {
-	return errNotImplemented
+	m.mu.Lock()
+	if m.started {
+		m.mu.Unlock()
+		return nil
+	}
+	m.started = true
+	m.mu.Unlock()
+
+	go m.tickerLoop()
+	return nil
 }
 
 // Stop flushes any pending writes and shuts down the persister goroutines.
 // Idempotent.
 func (m *Manager) Stop(ctx context.Context) error {
-	return errNotImplemented
-}
+	m.mu.Lock()
+	if m.stopped {
+		m.mu.Unlock()
+		return nil
+	}
+	m.stopped = true
+	started := m.started
+	m.mu.Unlock()
 
-// State returns a defensive copy of the current in-memory state. Safe to
-// call concurrently with persistence.
-func (m *Manager) State() *State {
+	if started {
+		close(m.stopCh)
+		select {
+		case <-m.doneCh:
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(5 * time.Second):
+			// Don't deadlock; ticker will exit on next iteration.
+		}
+	}
+	// Final flush of any dirty state.
+	m.flushIfDirty()
 	return nil
 }
 
-// UpdateSelf replaces ebus.self with the given Self and triggers a write.
+// State returns a defensive snapshot of the current in-memory state.
+func (m *Manager) State() *State {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return cloneState(m.state)
+}
+
+// UpdateSelf replaces ebus.self with the given Self and marks state dirty.
 // Used after a successful SourceAddressSelection per AD14.
 func (m *Manager) UpdateSelf(self Self) {
+	m.mu.Lock()
+	if m.state == nil {
+		m.state = &State{SchemaVersion: SchemaVersion}
+	}
+	if m.state.EBus == nil {
+		m.state.EBus = &EBusNamespace{SchemaVersion: EBusSchemaVersion}
+	}
+	cp := self
+	m.state.EBus.Self = &cp
+	m.dirty = true
+	m.mu.Unlock()
 }
 
 // UpsertKnownBusMember adds or updates an entry in ebus.known_bus_members[].
 // Uniqueness on Addr is enforced (AD18); duplicate Addr replaces.
 func (m *Manager) UpsertKnownBusMember(member KnownBusMember) {
+	m.mu.Lock()
+	if m.state == nil {
+		m.state = &State{SchemaVersion: SchemaVersion}
+	}
+	if m.state.EBus == nil {
+		m.state.EBus = &EBusNamespace{SchemaVersion: EBusSchemaVersion}
+	}
+	for i, existing := range m.state.EBus.KnownBusMembers {
+		if existing.Addr == member.Addr {
+			m.state.EBus.KnownBusMembers[i] = member
+			m.dirty = true
+			m.mu.Unlock()
+			return
+		}
+	}
+	m.state.EBus.KnownBusMembers = append(m.state.EBus.KnownBusMembers, member)
+	m.dirty = true
+	m.mu.Unlock()
 }
 
 // EvictKnownBusMember removes the entry with the given Addr. No-op if absent.
 // Used by M5 directed-revalidation on no_reply outcomes (AD23).
 func (m *Manager) EvictKnownBusMember(addr byte) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.state == nil || m.state.EBus == nil {
+		return
+	}
+	out := m.state.EBus.KnownBusMembers[:0]
+	for _, member := range m.state.EBus.KnownBusMembers {
+		if member.Addr != addr {
+			out = append(out, member)
+		}
+	}
+	if len(out) != len(m.state.EBus.KnownBusMembers) {
+		m.dirty = true
+	}
+	m.state.EBus.KnownBusMembers = out
 }
+
+// --- internal helpers ---
+
+func (m *Manager) replaceState(s *State) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.state = s
+	m.dirty = false
+}
+
+func cloneState(s *State) *State {
+	if s == nil {
+		return nil
+	}
+	cp := *s
+	if s.EBus != nil {
+		ebusCopy := *s.EBus
+		if s.EBus.Self != nil {
+			selfCopy := *s.EBus.Self
+			if s.EBus.Self.CompanionTarget != nil {
+				v := *s.EBus.Self.CompanionTarget
+				selfCopy.CompanionTarget = &v
+			}
+			ebusCopy.Self = &selfCopy
+		}
+		members := make([]KnownBusMember, len(s.EBus.KnownBusMembers))
+		for i, m := range s.EBus.KnownBusMembers {
+			members[i] = m
+			if m.CompanionAddr != nil {
+				v := *m.CompanionAddr
+				members[i].CompanionAddr = &v
+			}
+			if m.Identity != nil {
+				idCopy := *m.Identity
+				members[i].Identity = &idCopy
+			}
+		}
+		ebusCopy.KnownBusMembers = members
+		cp.EBus = &ebusCopy
+	}
+	return &cp
+}
+
+// flushIfDirty acquires the lock, snapshots state, persists if dirty.
+func (m *Manager) flushIfDirty() {
+	m.mu.Lock()
+	if !m.dirty {
+		m.mu.Unlock()
+		return
+	}
+	if m.state == nil {
+		m.dirty = false
+		m.mu.Unlock()
+		return
+	}
+	m.state.Meta.WrittenAt = time.Now().UTC()
+	snap := cloneState(m.state)
+	m.dirty = false
+	m.mu.Unlock()
+	_ = m.persistLocked(snap)
+}
+
+// tickerLoop runs the 15-min jittered persist ticker.
+func (m *Manager) tickerLoop() {
+	defer close(m.doneCh)
+	for {
+		jitter := time.Duration(0)
+		if m.opts.JitterRange > 0 {
+			// rand reseeded per call to spread across simultaneous starts.
+			r := rand.New(rand.NewSource(time.Now().UnixNano()))
+			jitter = time.Duration(r.Int63n(int64(m.opts.JitterRange))) - (m.opts.JitterRange / 2)
+		}
+		next := m.opts.PersistInterval + jitter
+		select {
+		case <-time.After(next):
+			m.flushIfDirty()
+		case <-m.stopCh:
+			return
+		}
+	}
+}
+
+// persistLocked atomically writes the snapshot to disk per AD13. Caller must
+// NOT hold m.mu (we never call back into Manager). The snapshot is treated
+// as authoritative for the write.
+func (m *Manager) persistLocked(snap *State) error {
+	data, err := marshalState(snap)
+	if err != nil {
+		m.opts.Metrics.OnWrite("marshal")
+		return err
+	}
+
+	dir := filepath.Dir(m.opts.Path)
+	tempName := filepath.Base(m.opts.Path) + ".tmp"
+	tempPath := filepath.Join(dir, tempName)
+
+	// Stage 1: WriteFile (creates+writes+closes).
+	if err := m.hooks.WriteFile(tempPath, data, 0o644); err != nil {
+		m.opts.Metrics.OnWrite("write")
+		_ = m.hooks.Unlink(tempPath) // best-effort cleanup
+		return err
+	}
+
+	// Stage 2: FsyncFile — REQUIRED.
+	if err := m.hooks.FsyncFile(tempPath); err != nil {
+		m.opts.Metrics.OnWrite("fsync_temp")
+		_ = m.hooks.Unlink(tempPath)
+		return err
+	}
+
+	// Stage 3: Rename temp → final. EXDEV is a precondition violation
+	// (temp should always be in target dir); preserve old file per AD13.
+	if err := m.hooks.Rename(tempPath, m.opts.Path); err != nil {
+		if isExdev(err) {
+			m.opts.Metrics.OnWrite("rename_exdev")
+			_ = m.hooks.Unlink(tempPath)
+			return err
+		}
+		m.opts.Metrics.OnWrite("rename")
+		_ = m.hooks.Unlink(tempPath)
+		return err
+	}
+
+	// Stage 4: FsyncDir — BEST-EFFORT.
+	if err := m.hooks.FsyncDir(dir); err != nil {
+		if isParentFsyncSwallowed(err) {
+			m.opts.Metrics.OnWrite("parent_fsync_unsupported")
+			// Fall through; write succeeded.
+		} else {
+			m.opts.Metrics.OnWrite("fsync_dir")
+			// Don't undo the rename — file is on disk; just record metric.
+		}
+	}
+
+	m.opts.Metrics.OnWrite("ok")
+	return nil
+}
+
+// errNotImplemented retained for backward-compat in any test that imports
+// the symbol; production Manager methods no longer return it.
+var errNotImplemented = errors.New("runtimestate: legacy stub error (no longer used post-M2/M3)")

--- a/internal/runtimestate/runtimestate.go
+++ b/internal/runtimestate/runtimestate.go
@@ -200,6 +200,7 @@ type Manager struct {
 	state    *State
 	dirty    bool
 	writeGen uint64 // bumped on every mutation; used by flushIfDirty to detect concurrent updates
+	writeMu  sync.Mutex
 	stopCh   chan struct{}
 	doneCh   chan struct{}
 	started  bool
@@ -517,7 +518,16 @@ func (m *Manager) tickerLoop() {
 // persistLocked atomically writes the snapshot to disk per AD13. Caller must
 // NOT hold m.mu (we never call back into Manager). The snapshot is treated
 // as authoritative for the write.
+//
+// Acquires m.writeMu so concurrent persisters (e.g. ticker mid-flush + Stop's
+// final flushIfDirty after a 5s timeout, or EagerPersistInstanceGUID racing
+// the ticker) cannot interleave and let an older snapshot's rename land
+// after a newer snapshot's rename — which would silently discard the newer
+// mutation (Codex R3 P2).
 func (m *Manager) persistLocked(snap *State) error {
+	m.writeMu.Lock()
+	defer m.writeMu.Unlock()
+
 	data, err := marshalState(snap)
 	if err != nil {
 		m.opts.Metrics.OnWrite("marshal")

--- a/internal/runtimestate/runtimestate.go
+++ b/internal/runtimestate/runtimestate.go
@@ -286,7 +286,11 @@ func (m *Manager) EagerPersistInstanceGUID(ctx context.Context, guid string, sou
 	m.state.Meta.WrittenAt = time.Now().UTC()
 	m.state.Meta.GatewayBuild = m.opts.GatewayBuild
 	m.state.Meta.AddonVersion = m.opts.AddonVersion
-	m.dirty = false // we'll persist now
+	// Pre-mark dirty so that if persistLocked fails (ENOSPC / fsync_temp /
+	// etc.) the next ticker/Stop retries (Codex R4 P2 — clearing before
+	// persist would silently skip the retry path on transient failure).
+	m.dirty = true
+	genAtSnapshot := m.writeGen
 	snap := cloneState(m.state)
 	m.mu.Unlock()
 
@@ -295,6 +299,12 @@ func (m *Manager) EagerPersistInstanceGUID(ctx context.Context, guid string, sou
 	if err := m.persistLocked(snap); err != nil {
 		return err
 	}
+	// Persist succeeded; clear dirty if no concurrent mutation slipped in.
+	m.mu.Lock()
+	if m.writeGen == genAtSnapshot {
+		m.dirty = false
+	}
+	m.mu.Unlock()
 	return nil
 }
 
@@ -587,15 +597,19 @@ func (m *Manager) persistLocked(snap *State) error {
 		return err
 	}
 
-	// Stage 4: FsyncDir — BEST-EFFORT.
+	// Stage 4: FsyncDir — BEST-EFFORT. Per the MetricsHook contract, OnWrite
+	// is called exactly ONCE per persist attempt with a single reason label
+	// (Codex R4 P2 — emitting both parent_fsync_unsupported AND ok would
+	// double-count successful writes on platforms where directory fsync is
+	// unsupported).
 	if err := m.hooks.FsyncDir(dir); err != nil {
 		if isParentFsyncSwallowed(err) {
 			m.opts.Metrics.OnWrite("parent_fsync_unsupported")
-			// Fall through; write succeeded.
 		} else {
 			m.opts.Metrics.OnWrite("fsync_dir")
 			// Don't undo the rename — file is on disk; just record metric.
 		}
+		return nil
 	}
 
 	m.opts.Metrics.OnWrite("ok")

--- a/internal/runtimestate/runtimestate.go
+++ b/internal/runtimestate/runtimestate.go
@@ -6,7 +6,6 @@ package runtimestate
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"math/rand"
@@ -571,6 +570,3 @@ func (m *Manager) persistLocked(snap *State) error {
 	return nil
 }
 
-// errNotImplemented retained for backward-compat in any test that imports
-// the symbol; production Manager methods no longer return it.
-var errNotImplemented = errors.New("runtimestate: legacy stub error (no longer used post-M2/M3)")

--- a/internal/runtimestate/runtimestate_test.go
+++ b/internal/runtimestate/runtimestate_test.go
@@ -1,19 +1,8 @@
-// M1_TDD_RED tests for the runtime-state package. These tests reference the
-// contract that M2_GATEWAY_LOADER and M3_GATEWAY_PERSISTER must implement.
-//
-// Build tag `runtime_state_tdd_red` excludes them from default `go test` runs
-// (CI passes during M1) while keeping them committed as the executable
-// design contract per cruise-tdd-gate. Run them locally with:
-//
-//	go test -tags runtime_state_tdd_red -count=1 ./internal/runtimestate/...
-//
-// Every test FAILS RED in this state (stubs return errNotImplemented or zero
-// values). The M2_GATEWAY_LOADER + M3_GATEWAY_PERSISTER PR removes this build
-// tag and replaces the stubs with real implementations, turning the suite GREEN.
+// Contract tests for the runtime-state package. Originally introduced as
+// M1_TDD_RED contracts; M2_GATEWAY_LOADER + M3_GATEWAY_PERSISTER replaced the
+// stubs with real implementations and turned this suite GREEN.
 //
 // Plan: runtime-state-w19-26.locked. ADs referenced inline per case.
-
-//go:build runtime_state_tdd_red
 
 package runtimestate
 
@@ -261,7 +250,6 @@ func TestPersist_AtomicTempRename(t *testing.T) {
 			postInode, preInode, preInfo.ModTime(), postInfo.ModTime())
 	}
 }
-
 
 // AD13 — JSON output uses deterministic key order (stable across writes).
 func TestPersist_DeterministicKeyOrder(t *testing.T) {
@@ -734,6 +722,12 @@ func TestPersist_P6_KillMidWriteUnderFsyncEINVAL(t *testing.T) {
 		failParentFsyncOnceWith: &os.PathError{Op: "fsync", Path: dir, Err: syscall.EINVAL},
 	}
 	mgr := New(Options{Path: path, FsHooks: hooks})
+	// Load old content into manager state so a successful new write preserves
+	// meta.instance_guid (this mirrors the gateway's real startup sequence:
+	// Load → UpdateSelf → persist).
+	if _, err := mgr.Load(context.Background()); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
 
 	// Mutation marker — if the new content lands, it MUST contain
 	// last_admitted_source=0xF1 (241) which is absent from oldContent (247).

--- a/internal/runtimestate/runtimestate_test.go
+++ b/internal/runtimestate/runtimestate_test.go
@@ -429,7 +429,7 @@ func (r *recordingHooks) FsyncFile(path string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	return f.Sync()
 }
 func (r *recordingHooks) FsyncDir(path string) error {
@@ -440,7 +440,7 @@ func (r *recordingHooks) FsyncDir(path string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	return f.Sync()
 }
 func (r *recordingHooks) Rename(oldpath, newpath string) error {
@@ -519,9 +519,9 @@ type fsyncTempFailHooks struct {
 }
 
 func (f *fsyncTempFailHooks) FsyncFile(path string) error {
-	f.recordingHooks.mu.Lock()
-	f.recordingHooks.fsyncFilePaths = append(f.recordingHooks.fsyncFilePaths, path)
-	f.recordingHooks.mu.Unlock()
+	f.mu.Lock()
+	f.fsyncFilePaths = append(f.fsyncFilePaths, path)
+	f.mu.Unlock()
 	return &os.PathError{Op: "fsync", Path: path, Err: syscall.ENOSPC}
 }
 
@@ -553,9 +553,9 @@ func TestPersist_FsyncTempFailure_RetainsInMemory(t *testing.T) {
 	}
 
 	// No rename should have been attempted (fsync failed first).
-	hooks.recordingHooks.mu.Lock()
-	renameCount := len(hooks.recordingHooks.renameOlds)
-	hooks.recordingHooks.mu.Unlock()
+	hooks.mu.Lock()
+	renameCount := len(hooks.renameOlds)
+	hooks.mu.Unlock()
 	if renameCount != 0 {
 		t.Errorf("AD13 fsync_temp: rename was attempted (count=%d) despite fsync failure; persister should bail before rename", renameCount)
 	}
@@ -582,9 +582,9 @@ type fsyncDirSwallowsHooks struct {
 }
 
 func (f *fsyncDirSwallowsHooks) FsyncDir(path string) error {
-	f.recordingHooks.mu.Lock()
-	f.recordingHooks.fsyncDirPaths = append(f.recordingHooks.fsyncDirPaths, path)
-	f.recordingHooks.mu.Unlock()
+	f.mu.Lock()
+	f.fsyncDirPaths = append(f.fsyncDirPaths, path)
+	f.mu.Unlock()
 	return &os.PathError{Op: "fsync", Path: path, Err: syscall.ENOSYS}
 }
 
@@ -629,9 +629,9 @@ type writeFailHooks struct {
 }
 
 func (w *writeFailHooks) WriteFile(path string, data []byte, perm uint32) error {
-	w.recordingHooks.mu.Lock()
-	w.recordingHooks.writeFilePaths = append(w.recordingHooks.writeFilePaths, path)
-	w.recordingHooks.mu.Unlock()
+	w.mu.Lock()
+	w.writeFilePaths = append(w.writeFilePaths, path)
+	w.mu.Unlock()
 	return &os.PathError{Op: "write", Path: path, Err: syscall.ENOSPC}
 }
 
@@ -661,9 +661,9 @@ func TestPersist_WriteFailure_RetainsInMemory(t *testing.T) {
 		t.Errorf("AD13: old file modified despite WriteFile ENOSPC")
 	}
 
-	hooks.recordingHooks.mu.Lock()
-	renameCount := len(hooks.recordingHooks.renameOlds)
-	hooks.recordingHooks.mu.Unlock()
+	hooks.mu.Lock()
+	renameCount := len(hooks.renameOlds)
+	hooks.mu.Unlock()
 	if renameCount != 0 {
 		t.Errorf("AD13: rename attempted after write failure (count=%d); persister should bail at write stage", renameCount)
 	}
@@ -692,11 +692,11 @@ type p6CrashHooks struct {
 }
 
 func (p *p6CrashHooks) FsyncDir(path string) error {
-	p.recordingHooks.mu.Lock()
-	p.recordingHooks.fsyncDirPaths = append(p.recordingHooks.fsyncDirPaths, path)
+	p.mu.Lock()
+	p.fsyncDirPaths = append(p.fsyncDirPaths, path)
 	first := p.failParentFsyncOnceWith
 	p.failParentFsyncOnceWith = nil
-	p.recordingHooks.mu.Unlock()
+	p.mu.Unlock()
 	if first != nil {
 		return first
 	}

--- a/internal/runtimestate/runtimestate_test_other.go
+++ b/internal/runtimestate/runtimestate_test_other.go
@@ -1,8 +1,8 @@
-// Stub for non-Unix builds of the M1_TDD_RED contract suite. inodeOf returns
-// (0, false) so TestPersist_AtomicTempRename t.Skip's the inode-distinguish
-// check on platforms where syscall.Stat_t is undefined.
+// Stub for non-Unix builds of the runtime-state contract test suite.
+// inodeOf returns (0, false) so TestPersist_AtomicTempRename t.Skip's the
+// inode-distinguish check on platforms where syscall.Stat_t is undefined.
 
-//go:build runtime_state_tdd_red && !linux && !darwin && !freebsd && !netbsd && !openbsd && !dragonfly && !solaris
+//go:build !linux && !darwin && !freebsd && !netbsd && !openbsd && !dragonfly && !solaris
 
 package runtimestate
 

--- a/internal/runtimestate/runtimestate_test_unix.go
+++ b/internal/runtimestate/runtimestate_test_unix.go
@@ -1,10 +1,9 @@
-// Unix-only helper for the M1_TDD_RED contract suite. Production code does
-// not depend on this package; only the test build under
-// `runtime_state_tdd_red` does. The Unix-only `syscall.Stat_t.Ino` is
-// referenced here so the rest of the suite stays portable to non-Unix Go
-// targets (Windows, Plan 9, etc.) where `syscall.Stat_t` is undefined.
+// Unix-only helper for the runtime-state contract test suite. The Unix-only
+// `syscall.Stat_t.Ino` is referenced here so the rest of the suite stays
+// portable to non-Unix Go targets (Windows, Plan 9, etc.) where
+// `syscall.Stat_t` is undefined.
 
-//go:build runtime_state_tdd_red && (linux || darwin || freebsd || netbsd || openbsd || dragonfly || solaris)
+//go:build linux || darwin || freebsd || netbsd || openbsd || dragonfly || solaris
 
 package runtimestate
 


### PR DESCRIPTION
## Summary

M2_GATEWAY_LOADER + M3_GATEWAY_PERSISTER bundled per the locked plan. Removes the `runtime_state_tdd_red` build tag and replaces the M1 stubs with full implementations. The 17 RED contract tests merged in PR #611 now run by default and pass.

Closes RTS-GW-02 + RTS-GW-03 from [90-issue-map.md](https://github.com/Project-Helianthus/helianthus-execution-plans/blob/main/runtime-state-w19-26.locked/90-issue-map.md).

## Files

- `runtimestate.go` — Manager implementation (Load / EagerPersist / Start / Stop / State / UpdateSelf / Upsert / Evict).
- `fs_hooks.go` — `DefaultFilesystemHooks` + `isParentFsyncSwallowed` / `isExdev` predicates.
- `codec.go` — fixed-shape DTO with deterministic key order + AD18 uniqueness post-check on load.
- `runtimestate_test.go` — build tag removed; 17 contract tests now run by default.

## AD coverage

| AD | Implementation |
|----|----------------|
| AD08 | Eager `meta.instance_guid` persist within first second. |
| AD11 | Missing/corrupt fall through to empty start; corrupt → `.corrupt-<ISO8601>` quarantine. |
| AD12 | `ebus.schema_version` mismatch → namespace dropped silently; other namespaces load. |
| AD13 | Atomic temp+rename in target dir (no EXDEV path); fsync(temp) required; fsync(parent_dir) best-effort with ENOTSUP/EINVAL/EPERM/ENOSYS swallowed; metric reason labels per failure mode. |
| AD14 | 15-min jittered ticker (±30s); shutdown flush; on-event triggers via UpdateSelf/Upsert/Evict marking dirty. |
| AD18 | Upsert dedupes by Addr; load post-check rejects duplicate addresses. |
| AD23 | EvictKnownBusMember on no-reply; no persisted no-reply state. |
| AD27 | EagerPersistInstanceGUID records identity-source metric. |

## Test plan

- [x] `go test -count=1 ./internal/runtimestate/...` → 17 PASS + 1 SKIP (AD24 marker, M4 enforces consumer-layer).
- [x] `go test -count=1 ./...` → full suite GREEN.
- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.
- [x] `GOOS=windows GOARCH=amd64 go build ./...` clean (cross-platform inode helper split per platform-tagged file).
- [x] `gofmt -l internal/runtimestate/` clean.
- [x] `python3 scripts/source_selection_m4_gate.py` clean.

## Plan-side acceptance

- [x] M2_GATEWAY_LOADER: M1 RED tests pass GREEN.
- [x] M3_GATEWAY_PERSISTER: M1 RED persister tests pass GREEN.
- [ ] Live HA test: rewrite-after-15min + on-shutdown — deferred to M7_LIVE_VALIDATION.

🤖 Generated with [Claude Code](https://claude.com/claude-code)