### PR TITLE
feat(runtime-state): M5_ADDRESS_TABLE_REVALIDATE — Revalidator core (Part 1/2)

### DIFF
--- a/internal/runtimestate/revalidate.go
+++ b/internal/runtimestate/revalidate.go
@@ -1,0 +1,186 @@
+package runtimestate
+
+import (
+	"context"
+	"sort"
+)
+
+// RevalidationOutcome classifies the result of a single member revalidation
+// per the runtime-state-w19-26.locked M5_ADDRESS_TABLE_REVALIDATE telemetry
+// label set.
+type RevalidationOutcome string
+
+const (
+	// OutcomeResponder: directed 07 04 produced a responder identification.
+	// Caller should refresh confidence=verified, last_source=directed_07_04,
+	// last_seen_at=now via Manager.UpsertKnownBusMember and let the
+	// address-table-inserter normal path enrich identity.
+	OutcomeResponder RevalidationOutcome = "responder"
+	// OutcomeNoReply: directed 07 04 timed out / NACKed. Per AD23 the
+	// caller MUST evict the member immediately via Manager.EvictKnownBusMember
+	// and increment the counter.
+	OutcomeNoReply RevalidationOutcome = "no_reply"
+	// OutcomeSkippedPassiveRefresh: member was passively re-observed during
+	// warmup, so the directed probe was skipped (M5 constraint (a)). No
+	// cache mutation; counter increments for observability.
+	OutcomeSkippedPassiveRefresh RevalidationOutcome = "skipped_passive_refresh"
+)
+
+// RevalidationCap is the per-cycle maximum number of directed probes the
+// gateway will issue (M5 constraint (c)). Rationale: ~84 ms wall-clock per
+// 07 04 probe under contention → 32 probes ~ 2.7 s peak burst, well under
+// SourceAddressSelector warmup tail latency.
+const RevalidationCap = 32
+
+// RevalidationProbeFn issues a directed 07 04 probe against the target
+// address and returns true on responder identification, false on no-reply
+// (timeout / NACK / collision after retries). Errors that are not "probe
+// outcome" semantics (context cancellation, transport failure) MUST be
+// surfaced through ctx.Err()/panic — Revalidator does not consult them.
+type RevalidationProbeFn func(ctx context.Context, target byte) bool
+
+// PassivelyRefreshedFn returns true when the given address was already
+// re-observed during warmup. Members for which it returns true are counted
+// as skipped_passive_refresh and DO NOT consume cap slots — the cap
+// applies exclusively to bus-touching probes.
+type PassivelyRefreshedFn func(addr byte) bool
+
+// RevalidationCounter is the metric hook for outcome telemetry. Wired to a
+// Prometheus counter labelled
+// `ebus_runtime_state_revalidate_total{outcome=...}`.
+type RevalidationCounter interface {
+	Inc(outcome RevalidationOutcome)
+}
+
+// NopRevalidationCounter is a no-op metric hook for tests.
+type NopRevalidationCounter struct{}
+
+// Inc satisfies RevalidationCounter.
+func (NopRevalidationCounter) Inc(RevalidationOutcome) {}
+
+// Revalidator probes cached known_bus_members[] after admission warmup
+// completes. It refreshes presence for live members (responder → caller
+// upserts confidence=verified) and evicts ghosts (no_reply → caller calls
+// EvictKnownBusMember per AD23).
+//
+// The Revalidator is pure logic: it does not touch the runtimestate Manager
+// directly. Probe / PassivelyRefreshed / Counter are injected by the
+// caller, who also performs the cache mutations from the returned Result.
+// This separation keeps the Revalidator unit-testable without standing up
+// a Manager + bus.
+type Revalidator struct {
+	Probe              RevalidationProbeFn
+	PassivelyRefreshed PassivelyRefreshedFn
+	Counter            RevalidationCounter
+	// Cap overrides RevalidationCap when non-zero. Tests use Cap to
+	// exercise small fixtures.
+	Cap int
+}
+
+// ProbeResult describes the outcome for a single member during a
+// Revalidator cycle.
+type ProbeResult struct {
+	Addr    byte
+	Outcome RevalidationOutcome
+}
+
+// Result is one revalidation cycle's snapshot. Probed lists the members
+// processed in order (skipped + actually-probed); Postponed lists members
+// beyond cap that were not touched and stay at unchanged confidence per
+// M5 constraint "Postponement".
+type Result struct {
+	Probed    []ProbeResult
+	Postponed []byte
+}
+
+// orderedMembers returns members sorted by last_seen_at DESC (most recently
+// active first), tie-break addr ASC, per M5 ordering rule.
+func orderedMembers(members []KnownBusMember) []KnownBusMember {
+	out := make([]KnownBusMember, len(members))
+	copy(out, members)
+	sort.SliceStable(out, func(i, j int) bool {
+		if !out[i].LastSeenAt.Equal(out[j].LastSeenAt) {
+			return out[i].LastSeenAt.After(out[j].LastSeenAt)
+		}
+		return out[i].Addr < out[j].Addr
+	})
+	return out
+}
+
+// Run executes one revalidation cycle. Members are ordered by last_seen_at
+// DESC (tie-break addr ASC) and processed sequentially:
+//
+//   - Members for which PassivelyRefreshed returns true → counted as
+//     skipped_passive_refresh; cap NOT consumed.
+//   - Other members → directed probe; outcome counted; cap consumed by 1.
+//   - Once cap probes have been issued, remaining unprocessed members are
+//     stopped and returned in Postponed for the next cycle.
+//
+// PassivelyRefreshed and Counter MAY be nil — Run defaults them to "never
+// refreshed" / no-op respectively. Probe MUST be non-nil; Run panics
+// otherwise (a nil probe would silently report every member as no_reply
+// AD23 → mass eviction, which is precisely the failure mode the test
+// suite exists to catch).
+func (r *Revalidator) Run(ctx context.Context, members []KnownBusMember) Result {
+	if r.Probe == nil {
+		panic("runtimestate.Revalidator.Run: Probe is nil; refusing to silently report every member as no_reply (AD23 mass eviction risk)")
+	}
+	cap := r.Cap
+	if cap == 0 {
+		cap = RevalidationCap
+	}
+	counter := r.Counter
+	if counter == nil {
+		counter = NopRevalidationCounter{}
+	}
+	passivelyRefreshed := r.PassivelyRefreshed
+	if passivelyRefreshed == nil {
+		passivelyRefreshed = func(byte) bool { return false }
+	}
+
+	ordered := orderedMembers(members)
+	result := Result{
+		Probed:    make([]ProbeResult, 0, len(ordered)),
+		Postponed: nil,
+	}
+	probesIssued := 0
+	for i, m := range ordered {
+		if err := ctx.Err(); err != nil {
+			// Context cancelled mid-cycle: postpone the rest. Already-
+			// processed entries stay in Probed; their Counter.Inc has
+			// already fired.
+			result.Postponed = collectAddrs(ordered[i:])
+			return result
+		}
+		if passivelyRefreshed(m.Addr) {
+			counter.Inc(OutcomeSkippedPassiveRefresh)
+			result.Probed = append(result.Probed, ProbeResult{Addr: m.Addr, Outcome: OutcomeSkippedPassiveRefresh})
+			continue
+		}
+		if probesIssued >= cap {
+			result.Postponed = collectAddrs(ordered[i:])
+			return result
+		}
+		probesIssued++
+		var outcome RevalidationOutcome
+		if r.Probe(ctx, m.Addr) {
+			outcome = OutcomeResponder
+		} else {
+			outcome = OutcomeNoReply
+		}
+		counter.Inc(outcome)
+		result.Probed = append(result.Probed, ProbeResult{Addr: m.Addr, Outcome: outcome})
+	}
+	return result
+}
+
+func collectAddrs(members []KnownBusMember) []byte {
+	if len(members) == 0 {
+		return nil
+	}
+	out := make([]byte, len(members))
+	for i, m := range members {
+		out[i] = m.Addr
+	}
+	return out
+}

--- a/internal/runtimestate/revalidate.go
+++ b/internal/runtimestate/revalidate.go
@@ -149,7 +149,7 @@ func (r *Revalidator) Run(ctx context.Context, members []KnownBusMember) Result 
 			// Context cancelled mid-cycle: postpone the rest. Already-
 			// processed entries stay in Probed; their Counter.Inc has
 			// already fired.
-			result.Postponed = collectAddrs(ordered[i:])
+			result.Postponed = append(result.Postponed, collectAddrs(ordered[i:])...)
 			return result
 		}
 		if passivelyRefreshed(m.Addr) {
@@ -158,8 +158,14 @@ func (r *Revalidator) Run(ctx context.Context, members []KnownBusMember) Result 
 			continue
 		}
 		if probesIssued >= cap {
-			result.Postponed = collectAddrs(ordered[i:])
-			return result
+			// Cap full but iteration continues — passively-refreshed
+			// members further down the list still need their telemetry
+			// counters (per the contract that cap applies exclusively
+			// to bus-touching probes). Probe-eligible members hitting
+			// the cap accumulate in Postponed for the next cycle.
+			// (Codex P2 follow-up on PR #614.)
+			result.Postponed = append(result.Postponed, m.Addr)
+			continue
 		}
 		probesIssued++
 		probeResponded := r.Probe(ctx, m.Addr)
@@ -178,7 +184,7 @@ func (r *Revalidator) Run(ctx context.Context, members []KnownBusMember) Result 
 			// independent of subsequent cancellation. (Codex P1
 			// follow-up on PR #614.)
 			if err := ctx.Err(); err != nil {
-				result.Postponed = collectAddrs(ordered[i:])
+				result.Postponed = append(result.Postponed, collectAddrs(ordered[i:])...)
 				return result
 			}
 			counter.Inc(OutcomeNoReply)

--- a/internal/runtimestate/revalidate.go
+++ b/internal/runtimestate/revalidate.go
@@ -162,14 +162,31 @@ func (r *Revalidator) Run(ctx context.Context, members []KnownBusMember) Result 
 			return result
 		}
 		probesIssued++
-		var outcome RevalidationOutcome
-		if r.Probe(ctx, m.Addr) {
-			outcome = OutcomeResponder
-		} else {
-			outcome = OutcomeNoReply
+		probeResponded := r.Probe(ctx, m.Addr)
+		if !probeResponded {
+			// AD23 mass-eviction guardrail: a typical ctx-aware probe
+			// returns false after ctx.Err() becomes non-nil. Mapping
+			// that false to OutcomeNoReply would let the caller evict
+			// the address even though there's no evidence the
+			// responder is actually gone — shutdown / transport
+			// cancellation must NOT be observable as "device left the
+			// bus". Re-check ctx.Err() and postpone the rest (including
+			// this member, since we don't know its actual state).
+			//
+			// True outcomes are NOT re-checked: a responder
+			// confirmation is concrete evidence the device exists,
+			// independent of subsequent cancellation. (Codex P1
+			// follow-up on PR #614.)
+			if err := ctx.Err(); err != nil {
+				result.Postponed = collectAddrs(ordered[i:])
+				return result
+			}
+			counter.Inc(OutcomeNoReply)
+			result.Probed = append(result.Probed, ProbeResult{Addr: m.Addr, Outcome: OutcomeNoReply})
+			continue
 		}
-		counter.Inc(outcome)
-		result.Probed = append(result.Probed, ProbeResult{Addr: m.Addr, Outcome: outcome})
+		counter.Inc(OutcomeResponder)
+		result.Probed = append(result.Probed, ProbeResult{Addr: m.Addr, Outcome: OutcomeResponder})
 	}
 	return result
 }

--- a/internal/runtimestate/revalidate_test.go
+++ b/internal/runtimestate/revalidate_test.go
@@ -305,6 +305,57 @@ func TestRevalidator_ContextCancellationPostponesUnprocessed(t *testing.T) {
 }
 
 // -----------------------------------------------------------------------------
+// AD23 guardrail: a probe that returns false because ctx was cancelled
+// in-flight MUST NOT be mapped to OutcomeNoReply (which the caller would
+// turn into eviction). The post-probe ctx.Err() recheck postpones the
+// member instead. Codex P1 follow-up on PR #614.
+// -----------------------------------------------------------------------------
+
+func TestRevalidator_CtxCancelledDuringProbeIsPostponedNotEvicted(t *testing.T) {
+	t0 := time.Date(2026, 5, 10, 19, 0, 0, 0, time.UTC)
+	members := []KnownBusMember{
+		makeMember(0x01, t0),
+		makeMember(0x02, t0.Add(-1*time.Second)),
+		makeMember(0x03, t0.Add(-2*time.Second)),
+	}
+	counter := &recordingCounter{}
+	ctx, cancel := context.WithCancel(context.Background())
+	r := &Revalidator{
+		Probe: func(probeCtx context.Context, addr byte) bool {
+			if addr == 0x02 {
+				// Simulate a ctx-aware probe whose underlying transport
+				// returns false after the parent cancels mid-flight.
+				cancel()
+				return false
+			}
+			return true
+		},
+		Counter: counter,
+	}
+	result := r.Run(ctx, members)
+
+	// 0x01 was probed normally (responder).
+	// 0x02 returned false but ctx is cancelled → postpone (NOT no_reply).
+	// 0x03 was never reached.
+	if len(result.Probed) != 1 {
+		t.Fatalf("Probed length = %d; want 1 (only 0x01 has a real outcome)", len(result.Probed))
+	}
+	if result.Probed[0].Addr != 0x01 || result.Probed[0].Outcome != OutcomeResponder {
+		t.Errorf("Probed[0] = %+v; want {0x01, responder}", result.Probed[0])
+	}
+	if len(result.Postponed) != 2 || result.Postponed[0] != 0x02 || result.Postponed[1] != 0x03 {
+		t.Errorf("Postponed = %x; want [0x02, 0x03] (cancelled member + untouched)", result.Postponed)
+	}
+	// Critical: counter must NOT have a no_reply increment for 0x02.
+	if got := counter.Counts()[OutcomeNoReply]; got != 0 {
+		t.Errorf("counter[no_reply] = %d; want 0 (ctx-cancelled probe must not be evicted)", got)
+	}
+	if got := counter.Counts()[OutcomeResponder]; got != 1 {
+		t.Errorf("counter[responder] = %d; want 1", got)
+	}
+}
+
+// -----------------------------------------------------------------------------
 // Nil-probe panic guardrail (catches AD23 mass-eviction misconfiguration).
 // -----------------------------------------------------------------------------
 

--- a/internal/runtimestate/revalidate_test.go
+++ b/internal/runtimestate/revalidate_test.go
@@ -1,0 +1,340 @@
+package runtimestate
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// recordingCounter captures Inc calls in order so tests can assert telemetry.
+type recordingCounter struct {
+	mu       sync.Mutex
+	outcomes []RevalidationOutcome
+}
+
+func (c *recordingCounter) Inc(o RevalidationOutcome) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.outcomes = append(c.outcomes, o)
+}
+
+func (c *recordingCounter) Counts() map[RevalidationOutcome]int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make(map[RevalidationOutcome]int)
+	for _, o := range c.outcomes {
+		out[o]++
+	}
+	return out
+}
+
+func makeMember(addr byte, lastSeenAt time.Time) KnownBusMember {
+	return KnownBusMember{
+		Addr:       addr,
+		LastSeenAt: lastSeenAt,
+		LastSource: LastSourcePassiveObserved,
+		Confidence: ConfidenceCorroborated,
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Ordering: last_seen_at DESC, tie-break addr ASC.
+// -----------------------------------------------------------------------------
+
+func TestRevalidator_OrdersByLastSeenAtDescThenAddrAsc(t *testing.T) {
+	t0 := time.Date(2026, 5, 10, 19, 0, 0, 0, time.UTC)
+	members := []KnownBusMember{
+		makeMember(0x08, t0.Add(-3*time.Minute)),
+		makeMember(0x15, t0),
+		makeMember(0xF6, t0),                  // tie with 0x15 → addr ASC means 0x15 first
+		makeMember(0x26, t0.Add(-1*time.Minute)),
+		makeMember(0x04, t0.Add(-3*time.Minute)), // tie with 0x08 → addr ASC means 0x04 first
+	}
+	wantOrder := []byte{0x15, 0xF6, 0x26, 0x04, 0x08}
+
+	probedOrder := []byte{}
+	r := &Revalidator{
+		Probe: func(_ context.Context, addr byte) bool {
+			probedOrder = append(probedOrder, addr)
+			return true
+		},
+	}
+	r.Run(context.Background(), members)
+
+	if len(probedOrder) != len(wantOrder) {
+		t.Fatalf("probed %d members; want %d", len(probedOrder), len(wantOrder))
+	}
+	for i := range probedOrder {
+		if probedOrder[i] != wantOrder[i] {
+			t.Errorf("probe order[%d] = 0x%02x; want 0x%02x (full got=%x want=%x)",
+				i, probedOrder[i], wantOrder[i], probedOrder, wantOrder)
+		}
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Cap: synthetic 64-member acceptance test (M5 acceptance criterion).
+// -----------------------------------------------------------------------------
+
+func TestRevalidator_Cap32_64MemberFixture_FirstHalfProbedRestPostponed(t *testing.T) {
+	t0 := time.Date(2026, 5, 10, 19, 0, 0, 0, time.UTC)
+	members := make([]KnownBusMember, 0, 64)
+	// Build 64 members with strictly decreasing last_seen_at so the
+	// ordering is unambiguous: addr 0x01 is the most recently seen,
+	// addr 0x40 the oldest. Cap=32 means the first 32 (0x01..0x20) must
+	// be probed; the remaining 32 (0x21..0x40) must be postponed.
+	for i := 0; i < 64; i++ {
+		members = append(members, makeMember(byte(0x01+i), t0.Add(-time.Duration(i)*time.Second)))
+	}
+
+	probed := []byte{}
+	counter := &recordingCounter{}
+	r := &Revalidator{
+		Probe: func(_ context.Context, addr byte) bool {
+			probed = append(probed, addr)
+			return true
+		},
+		Counter: counter,
+	}
+	result := r.Run(context.Background(), members)
+
+	if len(probed) != 32 {
+		t.Fatalf("probed count = %d; want 32 (RevalidationCap)", len(probed))
+	}
+	if len(result.Postponed) != 32 {
+		t.Fatalf("postponed count = %d; want 32", len(result.Postponed))
+	}
+	for i, addr := range probed {
+		want := byte(0x01 + i)
+		if addr != want {
+			t.Errorf("probed[%d] = 0x%02x; want 0x%02x", i, addr, want)
+		}
+	}
+	for i, addr := range result.Postponed {
+		want := byte(0x21 + i)
+		if addr != want {
+			t.Errorf("postponed[%d] = 0x%02x; want 0x%02x", i, addr, want)
+		}
+	}
+	if counter.Counts()[OutcomeResponder] != 32 {
+		t.Errorf("responder count = %d; want 32", counter.Counts()[OutcomeResponder])
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Skip-passive-refresh: passively-observed members do NOT consume cap slots.
+// -----------------------------------------------------------------------------
+
+func TestRevalidator_PassivelyRefreshedMembersDoNotConsumeCap(t *testing.T) {
+	t0 := time.Date(2026, 5, 10, 19, 0, 0, 0, time.UTC)
+	// 5 members ordered most-recent-first: 0x01, 0x02, 0x03, 0x04, 0x05.
+	// Passively refreshed: {0x02, 0x04}. Cap=2 (probes).
+	// Cap applies to PROBES only, so passively-refreshed members are
+	// telemetry-only and continue to be processed past the cap. The
+	// post-cap iteration stops only at the first PROBE-eligible member.
+	// Expected:
+	//   0x01: probed (cap=1)
+	//   0x02: passive skip (no cap consumed)
+	//   0x03: probed (cap=2)
+	//   0x04: passive skip (no cap consumed; cap full but passives still flow)
+	//   0x05: would probe; cap full → postponed; loop returns.
+	members := []KnownBusMember{
+		makeMember(0x01, t0),
+		makeMember(0x02, t0.Add(-1*time.Second)),
+		makeMember(0x03, t0.Add(-2*time.Second)),
+		makeMember(0x04, t0.Add(-3*time.Second)),
+		makeMember(0x05, t0.Add(-4*time.Second)),
+	}
+	passivelyRefreshed := map[byte]bool{0x02: true, 0x04: true}
+
+	probed := []byte{}
+	counter := &recordingCounter{}
+	r := &Revalidator{
+		Probe: func(_ context.Context, addr byte) bool {
+			probed = append(probed, addr)
+			return true
+		},
+		PassivelyRefreshed: func(addr byte) bool { return passivelyRefreshed[addr] },
+		Counter:            counter,
+		Cap:                2,
+	}
+	result := r.Run(context.Background(), members)
+
+	if len(probed) != 2 {
+		t.Fatalf("probed count = %d; want 2 (cap)", len(probed))
+	}
+	if probed[0] != 0x01 || probed[1] != 0x03 {
+		t.Errorf("probed = %x; want [0x01, 0x03] (skipping 0x02 passive)", probed)
+	}
+	if len(result.Postponed) != 1 || result.Postponed[0] != 0x05 {
+		t.Errorf("postponed = %x; want [0x05]", result.Postponed)
+	}
+	// Counter: 2× responder, 2× skipped_passive_refresh (0x02 and 0x04).
+	// 0x04's passive skip IS counted because passively-refreshed members
+	// don't consume cap slots — only probe-eligible members trigger the
+	// cap-full → postpone branch (which captured 0x05).
+	wantCounts := map[RevalidationOutcome]int{
+		OutcomeResponder:             2,
+		OutcomeSkippedPassiveRefresh: 2,
+	}
+	for outcome, want := range wantCounts {
+		if got := counter.Counts()[outcome]; got != want {
+			t.Errorf("counter[%s] = %d; want %d", outcome, got, want)
+		}
+	}
+	if got := counter.Counts()[OutcomeNoReply]; got != 0 {
+		t.Errorf("counter[no_reply] = %d; want 0", got)
+	}
+	// Result.Probed includes both probes AND skips, in order:
+	wantProbedOrder := []ProbeResult{
+		{Addr: 0x01, Outcome: OutcomeResponder},
+		{Addr: 0x02, Outcome: OutcomeSkippedPassiveRefresh},
+		{Addr: 0x03, Outcome: OutcomeResponder},
+		{Addr: 0x04, Outcome: OutcomeSkippedPassiveRefresh},
+	}
+	if len(result.Probed) != len(wantProbedOrder) {
+		t.Fatalf("Result.Probed length = %d; want %d", len(result.Probed), len(wantProbedOrder))
+	}
+	for i, want := range wantProbedOrder {
+		if result.Probed[i] != want {
+			t.Errorf("Result.Probed[%d] = %+v; want %+v", i, result.Probed[i], want)
+		}
+	}
+}
+
+// -----------------------------------------------------------------------------
+// No-reply outcome (AD23 immediate eviction signal).
+// -----------------------------------------------------------------------------
+
+func TestRevalidator_NoReplyOutcomeReportedAndCounted(t *testing.T) {
+	t0 := time.Date(2026, 5, 10, 19, 0, 0, 0, time.UTC)
+	members := []KnownBusMember{
+		makeMember(0x08, t0),                  // responder
+		makeMember(0x15, t0.Add(-1*time.Second)), // no-reply
+		makeMember(0xF6, t0.Add(-2*time.Second)), // responder
+	}
+	counter := &recordingCounter{}
+	r := &Revalidator{
+		Probe: func(_ context.Context, addr byte) bool {
+			return addr != 0x15 // 0x15 returns no-reply
+		},
+		Counter: counter,
+	}
+	result := r.Run(context.Background(), members)
+
+	if len(result.Probed) != 3 {
+		t.Fatalf("probed count = %d; want 3", len(result.Probed))
+	}
+	wantOutcomes := []RevalidationOutcome{OutcomeResponder, OutcomeNoReply, OutcomeResponder}
+	for i, want := range wantOutcomes {
+		if result.Probed[i].Outcome != want {
+			t.Errorf("probed[%d].Outcome = %s; want %s (addr=0x%02x)",
+				i, result.Probed[i].Outcome, want, result.Probed[i].Addr)
+		}
+	}
+	if counter.Counts()[OutcomeNoReply] != 1 {
+		t.Errorf("counter[no_reply] = %d; want 1", counter.Counts()[OutcomeNoReply])
+	}
+	if counter.Counts()[OutcomeResponder] != 2 {
+		t.Errorf("counter[responder] = %d; want 2", counter.Counts()[OutcomeResponder])
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Empty members list.
+// -----------------------------------------------------------------------------
+
+func TestRevalidator_EmptyMembersIsNoOp(t *testing.T) {
+	counter := &recordingCounter{}
+	probed := false
+	r := &Revalidator{
+		Probe:   func(context.Context, byte) bool { probed = true; return true },
+		Counter: counter,
+	}
+	result := r.Run(context.Background(), nil)
+	if probed {
+		t.Errorf("probe was invoked on empty members list")
+	}
+	if len(result.Probed) != 0 {
+		t.Errorf("probed count = %d; want 0", len(result.Probed))
+	}
+	if len(result.Postponed) != 0 {
+		t.Errorf("postponed count = %d; want 0", len(result.Postponed))
+	}
+	if len(counter.outcomes) != 0 {
+		t.Errorf("counter increments = %d; want 0", len(counter.outcomes))
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Context cancellation mid-cycle.
+// -----------------------------------------------------------------------------
+
+func TestRevalidator_ContextCancellationPostponesUnprocessed(t *testing.T) {
+	t0 := time.Date(2026, 5, 10, 19, 0, 0, 0, time.UTC)
+	members := []KnownBusMember{
+		makeMember(0x01, t0),
+		makeMember(0x02, t0.Add(-1*time.Second)),
+		makeMember(0x03, t0.Add(-2*time.Second)),
+		makeMember(0x04, t0.Add(-3*time.Second)),
+	}
+	counter := &recordingCounter{}
+	ctx, cancel := context.WithCancel(context.Background())
+	probedCount := 0
+	r := &Revalidator{
+		Probe: func(_ context.Context, _ byte) bool {
+			probedCount++
+			if probedCount == 2 {
+				// Cancel after the second probe completes; the next loop
+				// iteration must observe ctx.Err() and postpone the rest.
+				cancel()
+			}
+			return true
+		},
+		Counter: counter,
+	}
+	result := r.Run(ctx, members)
+
+	if probedCount != 2 {
+		t.Fatalf("probed count = %d; want 2 (cancelled mid-cycle)", probedCount)
+	}
+	if len(result.Postponed) != 2 || result.Postponed[0] != 0x03 || result.Postponed[1] != 0x04 {
+		t.Errorf("postponed = %x; want [0x03, 0x04]", result.Postponed)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Nil-probe panic guardrail (catches AD23 mass-eviction misconfiguration).
+// -----------------------------------------------------------------------------
+
+func TestRevalidator_NilProbePanics(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatalf("expected panic on nil Probe")
+		}
+	}()
+	(&Revalidator{}).Run(context.Background(), []KnownBusMember{makeMember(0x01, time.Now())})
+}
+
+// -----------------------------------------------------------------------------
+// Default cap when r.Cap == 0 uses RevalidationCap (32).
+// -----------------------------------------------------------------------------
+
+func TestRevalidator_DefaultCapIsRevalidationCap(t *testing.T) {
+	t0 := time.Date(2026, 5, 10, 19, 0, 0, 0, time.UTC)
+	members := make([]KnownBusMember, 0, 40)
+	for i := 0; i < 40; i++ {
+		members = append(members, makeMember(byte(0x01+i), t0.Add(-time.Duration(i)*time.Second)))
+	}
+	probedCount := 0
+	r := &Revalidator{
+		Probe: func(context.Context, byte) bool { probedCount++; return true },
+		// Cap not set — should default to RevalidationCap (32).
+	}
+	r.Run(context.Background(), members)
+	if probedCount != RevalidationCap {
+		t.Errorf("probed count = %d; want RevalidationCap=%d", probedCount, RevalidationCap)
+	}
+}

--- a/internal/runtimestate/revalidate_test.go
+++ b/internal/runtimestate/revalidate_test.go
@@ -305,6 +305,71 @@ func TestRevalidator_ContextCancellationPostponesUnprocessed(t *testing.T) {
 }
 
 // -----------------------------------------------------------------------------
+// Cap-full + passive suffix: passive members AFTER a cap-full probe-eligible
+// member still get telemetry counted (cap applies exclusively to bus probes).
+// Codex P2 follow-up on PR #614.
+// -----------------------------------------------------------------------------
+
+func TestRevalidator_PassiveRefreshAfterCapStillFlows(t *testing.T) {
+	t0 := time.Date(2026, 5, 10, 19, 0, 0, 0, time.UTC)
+	// Codex's exact fixture: [probe, probe, active-miss, passive-refresh].
+	// Cap=2 → first two probed; third is probe-eligible but cap full
+	// → postponed; fourth is passive-refresh and must be telemetry-
+	// counted, NOT lumped into Postponed.
+	members := []KnownBusMember{
+		makeMember(0x01, t0),                     // probe
+		makeMember(0x02, t0.Add(-1*time.Second)), // probe
+		makeMember(0x03, t0.Add(-2*time.Second)), // active-miss → postponed
+		makeMember(0x04, t0.Add(-3*time.Second)), // passive-refresh → counted
+	}
+	passivelyRefreshed := map[byte]bool{0x04: true}
+
+	probed := []byte{}
+	counter := &recordingCounter{}
+	r := &Revalidator{
+		Probe: func(_ context.Context, addr byte) bool {
+			probed = append(probed, addr)
+			return true
+		},
+		PassivelyRefreshed: func(addr byte) bool { return passivelyRefreshed[addr] },
+		Counter:            counter,
+		Cap:                2,
+	}
+	result := r.Run(context.Background(), members)
+
+	if len(probed) != 2 || probed[0] != 0x01 || probed[1] != 0x02 {
+		t.Errorf("probed = %x; want [0x01, 0x02]", probed)
+	}
+	// 0x03 hits cap → Postponed; 0x04 keeps flowing (passive-refresh).
+	if len(result.Postponed) != 1 || result.Postponed[0] != 0x03 {
+		t.Errorf("Postponed = %x; want [0x03] only (0x04 is passive, must be counted not postponed)",
+			result.Postponed)
+	}
+	// Counter must have the skipped_passive_refresh increment for 0x04
+	// even though cap was full when we reached it.
+	if got := counter.Counts()[OutcomeSkippedPassiveRefresh]; got != 1 {
+		t.Errorf("counter[skipped_passive_refresh] = %d; want 1 (post-cap passive must still flow)", got)
+	}
+	if got := counter.Counts()[OutcomeResponder]; got != 2 {
+		t.Errorf("counter[responder] = %d; want 2", got)
+	}
+	// Result.Probed must include the post-cap passive-refresh entry.
+	wantProbedOrder := []ProbeResult{
+		{Addr: 0x01, Outcome: OutcomeResponder},
+		{Addr: 0x02, Outcome: OutcomeResponder},
+		{Addr: 0x04, Outcome: OutcomeSkippedPassiveRefresh},
+	}
+	if len(result.Probed) != len(wantProbedOrder) {
+		t.Fatalf("Probed length = %d; want %d", len(result.Probed), len(wantProbedOrder))
+	}
+	for i, want := range wantProbedOrder {
+		if result.Probed[i] != want {
+			t.Errorf("Probed[%d] = %+v; want %+v", i, result.Probed[i], want)
+		}
+	}
+}
+
+// -----------------------------------------------------------------------------
 // AD23 guardrail: a probe that returns false because ctx was cancelled
 // in-flight MUST NOT be mapped to OutcomeNoReply (which the caller would
 // turn into eviction). The post-probe ctx.Err() recheck postpones the


### PR DESCRIPTION
## Summary

M5_ADDRESS_TABLE_REVALIDATE for `runtime-state-w19-26.locked` — Part 1/2.

Adds the standalone `Revalidator` that probes cached `known_bus_members[]` after SourceAddressSelector warmup completes. This PR is the **pure-logic core** — the gateway-side wiring into `cmd/gateway/main.go` (Manager.New + Load on boot → trigger Revalidator on `activeProbePassed` → eviction/upsert plumbing → counter wiring to expvar) lands in Part 2/2 along with the M4 Manager-into-main-go wiring.

## Revalidator contract

- **Ordering**: `last_seen_at` DESC, tie-break `addr` ASC.
- **PassivelyRefreshed callback**: members already re-observed during warmup are telemetry-only (`skipped_passive_refresh`) and DO NOT consume cap slots — cap applies exclusively to bus-touching probes.
- **Cap = 32** (default `RevalidationCap`, configurable). Per M5(c) the rationale is ~84 ms wall-clock per directed 07 04 → 32 probes ≈ 2.7 s peak burst, well under SourceAddressSelector warmup tail latency.
- **Postponement** (M5 final paragraph): members beyond cap go to `Result.Postponed` at unchanged confidence; revalidation resumes them in the next cycle.
- **Outcomes**:
  - `responder` → caller refreshes confidence=verified, last_source=directed_07_04 via `Manager.UpsertKnownBusMember`
  - `no_reply` → AD23 immediate eviction via `Manager.EvictKnownBusMember`
  - `skipped_passive_refresh` → no cache mutation
- **Context cancellation** mid-cycle postpones the rest cleanly.
- **Nil Probe panics** (catches AD23 mass-eviction misconfiguration: a nil probe would silently report every member as no_reply → blanket eviction).

The Revalidator is pure logic. It does not import the Manager API surface — caller injects `PassivelyRefreshedFn` (typically backed by busObservability evidence) and `Counter` (typically Prometheus), and applies the returned `ProbeResult` slice to the Manager.

## Test plan (8 cases)

- [x] ordering: last_seen_at DESC + addr ASC tie-break
- [x] **64-member cap=32 acceptance fixture** (M5 acceptance criterion)
- [x] passively-refreshed do not consume cap (5-member cap=2 fixture)
- [x] no_reply outcome reported + counted
- [x] empty members list = no-op
- [x] context cancellation mid-cycle → postponed
- [x] nil Probe panics (mass-eviction guardrail)
- [x] default cap = RevalidationCap (32)
- [x] `go test ./...` — 19 packages green
- [x] `go vet ./...` clean

## Plan reference

- Plan: `runtime-state-w19-26.locked`
- Milestone: M5_ADDRESS_TABLE_REVALIDATE
- Issue map: RTS-GW-05
- Canonical-SHA256: `5f723d7122dd24c81357dc7adb640cbdb805679a5d91c8b8dedcbe6ef60edede`

## Out of scope (Part 2/2)

The actual wiring into `cmd/gateway/main.go` — Manager init/Load/UpdateSelf/Stop, Revalidator trigger on `activeProbePassed`, counter wiring, address-table-inserter responder plumbing, eviction on no_reply — lands in a follow-up PR. Folding both M5 and the deferred M4 main.go wiring into one integration PR avoids landing partial Manager state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)