### PR TITLE
feat(runtime-state): M5 Part 2/2 — main.go Manager + Revalidator wiring

### DIFF
--- a/address_table_inserter.go
+++ b/address_table_inserter.go
@@ -12,6 +12,21 @@ type AddressObservation struct {
 	PositiveACKCount int
 }
 
+// RuntimeStateObserver is the runtime-state cache notification hook.
+// AddressTableInserter calls it once per passive observation (new insert
+// OR refresh of an existing slot) so the runtimestate.Manager can
+// populate/refresh known_bus_members[] for M5 revalidation.
+//
+// observedAt is the bus-event timestamp; reportedSource is the
+// runtimestate.LastSource string (e.g. "passive_observed").
+//
+// Production wiring lives in cmd/gateway/main.go, calling
+// runtimeStateMgr.UpsertKnownBusMember. The hook is fired
+// synchronously inside maybeInsert; observers MUST be cheap (the
+// Manager's UpsertKnownBusMember is a brief mu-guarded field swap and
+// is safe to call at bus-event rate).
+type RuntimeStateObserver func(addr byte, observedAt time.Time, reportedSource string)
+
 type AddressTableInserter struct {
 	table              *AddressTable
 	cfg                Config
@@ -33,6 +48,10 @@ type AddressTableInserter struct {
 	// 2026-05-08): without this hook, passive-observed entries stay
 	// at empty manufacturer indefinitely. Nil-safe.
 	enrichmentIdentityProbeFn func(addr byte)
+	// runtimeStateObserver is called once per passive observation so
+	// the runtimestate.Manager can populate/refresh known_bus_members[]
+	// for M5_ADDRESS_TABLE_REVALIDATE. Nil-safe.
+	runtimeStateObserver RuntimeStateObserver
 }
 
 func NewAddressTableInserter(table *AddressTable, cfg Config) *AddressTableInserter {
@@ -72,6 +91,20 @@ func (i *AddressTableInserter) SetEnrichmentIdentityProbeFn(fn func(addr byte)) 
 		return
 	}
 	i.enrichmentIdentityProbeFn = fn
+}
+
+// SetRuntimeStateObserver wires the runtime-state Manager hook. The
+// inserter calls fn once per passive observation (new insert OR refresh
+// of an existing slot) so known_bus_members[] gets populated and
+// LastSeenAt stays current as a basis for M5 revalidation ordering.
+// Codex P2 follow-up on PR #615 — without this wiring, runtime_state.json's
+// known_bus_members[] stays empty after a fresh install and M5 has
+// nothing to revalidate.
+func (i *AddressTableInserter) SetRuntimeStateObserver(fn RuntimeStateObserver) {
+	if i == nil {
+		return
+	}
+	i.runtimeStateObserver = fn
 }
 
 // BackfillUnidentifiedAddresses iterates the registry's existing
@@ -275,6 +308,14 @@ func (i *AddressTableInserter) maybeInsert(addr byte, role string, admittedSrc b
 	}
 	if addr == admittedSrc || addr == 0xFE {
 		return
+	}
+	// Notify runtime-state on every passive observation (new insert OR
+	// refresh of existing slot). The Manager.UpsertKnownBusMember call
+	// behind this hook is a brief mu-guarded field swap and is safe to
+	// call at bus-event rate; the persister batches writes on the
+	// 15-min ticker. Codex P2 follow-up on PR #615.
+	if i.runtimeStateObserver != nil {
+		i.runtimeStateObserver(addr, observedAt, "passive_observed")
 	}
 	if _, exists := i.table.Lookup(addr); exists {
 		// Already in registry (active scan, prior passive observation,

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -261,18 +261,17 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 	addressTable := ebusgateway.NewAddressTable(gateway.Registry)
 	addressTableInserter := ebusgateway.NewAddressTableInserter(addressTable, addressTableCfg)
 	// M3 + M5 wiring: every passive observation flowing through the
-	// inserter also feeds the runtime-state Manager so
-	// known_bus_members[] populates and refreshes for M5 revalidation
-	// ordering. Without this, a fresh install would leave the cache
-	// permanently empty and revalidation would have nothing to probe.
-	// (Codex P2 follow-up on PR #615.)
+	// inserter feeds the runtime-state Manager via
+	// RefreshKnownBusMemberPresence — a presence-only refresh that
+	// preserves Identity / CompanionAddr / Confidence on existing
+	// entries (the directed-probe responder path is the only writer
+	// that may upgrade Confidence to verified, and identity probes
+	// are the only writer to Identity / CompanionAddr). Without this
+	// wiring known_bus_members[] would stay empty after a fresh
+	// install and M5 would have nothing to revalidate. (Codex P2
+	// follow-up on PR #615.)
 	addressTableInserter.SetRuntimeStateObserver(func(addr byte, observedAt time.Time, reportedSource string) {
-		runtimeStateMgr.UpsertKnownBusMember(runtimestate.KnownBusMember{
-			Addr:       addr,
-			LastSeenAt: observedAt,
-			LastSource: runtimestate.LastSource(reportedSource),
-			Confidence: runtimestate.ConfidenceCorroborated,
-		})
+		runtimeStateMgr.RefreshKnownBusMemberPresence(addr, observedAt, runtimestate.LastSource(reportedSource))
 	})
 	if busObservability != nil {
 		builder.SetBusObservabilityProvider(newGraphQLBusObservabilityProvider(busObservability))

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -641,17 +641,16 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 
 					// M5_ADDRESS_TABLE_REVALIDATE: now that admission
 					// is finalized and AdmittedSource() returns the
-					// selected source, run one revalidation cycle
-					// against cached known_bus_members[]. Done in a
-					// goroutine so the activeProbePassed callback
-					// remains non-blocking; the gateway proceeds to
-					// semantic discovery regardless of revalidate
-					// outcome (responders refresh confidence; no-reply
-					// triggers AD23 eviction; postponed members wait
-					// for the next periodic cycle).
-					go func(source byte) {
-						revalidateRuntimeStateMembers(ctx, runtimeStateMgr, gateway, cfg, source)
-					}(sourceSelection.Source)
+					// selected source, schedule an immediate
+					// revalidation cycle against cached
+					// known_bus_members[] plus periodic cycles at
+					// 15-min cadence. The periodic loop is what
+					// guarantees postponed members (overflow beyond
+					// cap=32) are eventually probed; without it
+					// stale ghosts beyond the first 32 would remain
+					// cached until process restart (Codex P2
+					// follow-up on PR #615).
+					startRuntimeStateRevalidator(ctx, runtimeStateMgr, gateway, cfg, sourceSelection.Source, 0)
 				}
 			case <-startupScanSignals.admissionFailed:
 				if sourceSelection != nil {

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Project-Helianthus/helianthus-ebusgateway"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/graphql"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/adaptermux"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/runtimestate"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp/ebus_standard"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mdns"
@@ -110,6 +111,22 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 	if len(cfg.Providers) == 0 {
 		cfg.Providers = vaillantproviders.Default()
 	}
+
+	// Initialize the runtime-state Manager early so the cached
+	// ebus.self.last_admitted_source can be passed as a hint to the
+	// SourceAddressSelector below, and the Manager is available for
+	// post-admission UpdateSelf and address-table-revalidate write-back.
+	// Errors during Load are tolerated — Manager.Load returns an empty
+	// state on missing/corrupt and the gateway continues without a hint.
+	// (runtime-state-w19-26.locked M2_GATEWAY_LOADER + M4_SOURCE_SELECTION_HINT)
+	runtimeStateMgr, runtimeState := initRuntimeStateManager(ctx, cfg)
+	defer func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := runtimeStateMgr.Stop(stopCtx); err != nil {
+			log.Printf("runtime_state stop: %v", err)
+		}
+	}()
 
 	// Wire adapter-direct mode: create multiplexer, configure active
 	// and passive transports before gateway construction.
@@ -441,7 +458,19 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 		if err != nil {
 			return fmt.Errorf("m3: new source address selection bus: %w", err)
 		}
-		selector := protocol.NewSourceAddressSelector(selectionBus, ebusgateway.DefaultStartupAdmissionSourceSelectionConfig())
+		// M4_SOURCE_SELECTION_HINT: bias candidate ordering toward the
+		// cached ebus.self.last_admitted_source from the prior admission
+		// cycle. Validation still runs in full — the hint is a candidate-
+		// ordering aid, NEVER a bypass of warmup or evidence checks.
+		// AD24: HintFromState is the only exported surface that emits
+		// the cached byte; the Manager.State() field exposes it as a
+		// plain struct member but every consumer routes through this
+		// helper for clarity.
+		hintCandidate, hintSet := runtimestate.HintFromState(runtimeState)
+		if hintSet {
+			log.Printf("source address selection hint=0x%02X (cached from prior admission cycle; warmup validation still required)", hintCandidate)
+		}
+		selector := protocol.NewSourceAddressSelector(selectionBus, ebusgateway.StartupAdmissionConfigWithHint(hintCandidate, hintSet))
 
 		// Install AD08/AD22 stability window on the bus_observability store
 		// before the first source-selection state observation. Window is sized
@@ -592,6 +621,37 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 					// selected source — closes the directed-probe window
 					// where admitted=0 could leak gateway-own probes.
 					subscribeAddressTableInserter()
+
+					// M4 write-back: persist the validated source to
+					// runtime_state.ebus.self so the next boot can use
+					// it as a hint. Best-effort; persistence failure
+					// here doesn't gate startup (the gateway is already
+					// admitted; the cache is an optimisation).
+					selectionMethod := runtimestate.SelectionMethodWarmup
+					if overrideSet {
+						selectionMethod = runtimestate.SelectionMethodExplicitValidateOnly
+					}
+					companion := sourceSelection.Companion
+					runtimeStateMgr.UpdateSelf(runtimestate.Self{
+						LastAdmittedSource: sourceSelection.Source,
+						LastAdmittedAt:     time.Now().UTC(),
+						SelectionMethod:    selectionMethod,
+						CompanionTarget:    &companion,
+					})
+
+					// M5_ADDRESS_TABLE_REVALIDATE: now that admission
+					// is finalized and AdmittedSource() returns the
+					// selected source, run one revalidation cycle
+					// against cached known_bus_members[]. Done in a
+					// goroutine so the activeProbePassed callback
+					// remains non-blocking; the gateway proceeds to
+					// semantic discovery regardless of revalidate
+					// outcome (responders refresh confidence; no-reply
+					// triggers AD23 eviction; postponed members wait
+					// for the next periodic cycle).
+					go func(source byte) {
+						revalidateRuntimeStateMembers(ctx, runtimeStateMgr, gateway, cfg, source)
+					}(sourceSelection.Source)
 				}
 			case <-startupScanSignals.admissionFailed:
 				if sourceSelection != nil {
@@ -1009,6 +1069,13 @@ func bindFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) {
 		cfg.InstanceGUID = normalized
 		return nil
 	})
+	fs.StringVar(&cfg.InstanceGUIDSource, "instance-guid-source",
+		cfg.InstanceGUIDSource,
+		"AD27 provenance tag for -instance-guid (runtime_state | legacy_migrated | generated | cli-override); "+
+			"empty defaults to cli-override with a deprecation log when -instance-guid is provided")
+	fs.StringVar(&cfg.RuntimeStatePath, "runtime-state-path",
+		cfg.RuntimeStatePath,
+		"override /data/runtime_state.json path (empty uses runtimestate package default)")
 	fs.StringVar(&cfg.DumpOutputDir, "dump-output-dir", cfg.DumpOutputDir, "unknown device dump output dir")
 	fs.StringVar(&cfg.DumpUploadURL, "dump-upload-url", cfg.DumpUploadURL, "unknown device dump upload url (internal)")
 	fs.BoolVar(&cfg.DumpIncludePII, "dump-include-pii", cfg.DumpIncludePII, "include identifiers in unknown device dumps")
@@ -2161,4 +2228,64 @@ func applyStaticSeedTable(reg *registry.DeviceRegistry) {
 		}
 	}
 	log.Printf("static seed table: planted %d address(es) across %d device(s) at startup (source=productids.LoadSeedTable, label=static_seed/candidate)", count, len(seeds))
+}
+
+// initRuntimeStateManager constructs and starts the runtime-state Manager,
+// wiring AD08 eager-persist for the instance-guid CLI flag (when present)
+// and exposing the loaded state for hint extraction.
+//
+// On Manager.Load failure (missing / corrupt file), Manager.Load returns an
+// empty state and the gateway continues without a hint — the cache is a
+// best-effort optimisation, not a startup requirement (AD11 + M2 spec).
+func initRuntimeStateManager(ctx context.Context, cfg ebusgateway.Config) (*runtimestate.Manager, *runtimestate.State) {
+	mgr := runtimestate.New(runtimestate.Options{
+		Path:         cfg.RuntimeStatePath,
+		GatewayBuild: fmt.Sprintf("%s+%s", buildVersion, buildID),
+		AddonVersion: "", // populated by add-on via future flag if needed
+	})
+	state, err := mgr.Load(ctx)
+	if err != nil {
+		log.Printf("runtime_state: load returned error (continuing with empty state): %v", err)
+		state = &runtimestate.State{}
+	}
+
+	// AD08 eager persist: when -instance-guid is supplied, durably write
+	// meta.{schema_version, instance_guid, written_at} within ~1 s so the
+	// crash-before-first-periodic-persist window is closed. Provenance per
+	// AD27.
+	if cfg.InstanceGUID != "" {
+		source := identitySourceFromCfg(cfg.InstanceGUIDSource)
+		if perr := mgr.EagerPersistInstanceGUID(ctx, cfg.InstanceGUID, source); perr != nil {
+			log.Printf("runtime_state: eager-persist instance_guid failed (continuing): %v", perr)
+		}
+	}
+
+	if serr := mgr.Start(ctx); serr != nil {
+		log.Printf("runtime_state: start failed (continuing without periodic persister): %v", serr)
+	}
+
+	return mgr, state
+}
+
+// identitySourceFromCfg maps the CLI -instance-guid-source flag value to the
+// runtimestate.IdentitySource enum, with AD27 deprecation log when the flag
+// is absent. The well-formed value set is enforced here; unknown values fall
+// back to "cli-override" with a warning rather than failing startup.
+func identitySourceFromCfg(raw string) runtimestate.IdentitySource {
+	switch raw {
+	case string(runtimestate.IdentitySourceRuntimeState):
+		return runtimestate.IdentitySourceRuntimeState
+	case string(runtimestate.IdentitySourceLegacyMigrated):
+		return runtimestate.IdentitySourceLegacyMigrated
+	case string(runtimestate.IdentitySourceGenerated):
+		return runtimestate.IdentitySourceGenerated
+	case string(runtimestate.IdentitySourceCLIOverride):
+		return runtimestate.IdentitySourceCLIOverride
+	case "":
+		log.Print("runtime_state: -instance-guid-source absent; defaulting to cli-override (deprecated; pass -instance-guid-source explicitly)")
+		return runtimestate.IdentitySourceCLIOverride
+	default:
+		log.Printf("runtime_state: -instance-guid-source=%q is not a recognised AD27 value; treating as cli-override", raw)
+		return runtimestate.IdentitySourceCLIOverride
+	}
 }

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -540,6 +540,18 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 		// (override / static fallback). Bind the inserter now that
 		// AdmittedSource() returns the real source.
 		subscribeAddressTableInserter()
+		// M4/M5: also finalize runtime-state for override + static-
+		// fallback admissions. Without this, cached known_bus_members[]
+		// would only ever be revalidated on warmup-based admissions and
+		// stale entries would persist indefinitely on configured
+		// transports (Codex P2 follow-up on PR #615). The selection
+		// method varies by path: ebusd-tcp → ebusd-tcp-fallback,
+		// override / explicit static → explicit_validate_only.
+		selectionMethod := runtimestate.SelectionMethodExplicitValidateOnly
+		if isEbusdTransportProtocol(cfg.TransportConfig.Protocol) {
+			selectionMethod = runtimestate.SelectionMethodEbusdTCPFallback
+		}
+		finalizeRuntimeStateForAdmittedSource(ctx, runtimeStateMgr, gateway, cfg, source, 0, selectionMethod, false)
 	} else {
 		builder.ClearAdmittedMutationSource()
 	}
@@ -622,35 +634,15 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 					// where admitted=0 could leak gateway-own probes.
 					subscribeAddressTableInserter()
 
-					// M4 write-back: persist the validated source to
-					// runtime_state.ebus.self so the next boot can use
-					// it as a hint. Best-effort; persistence failure
-					// here doesn't gate startup (the gateway is already
-					// admitted; the cache is an optimisation).
+					// M4 write-back + M5 revalidator wiring delegate to
+					// finalizeRuntimeStateForAdmittedSource so override
+					// + static-fallback admissions get the same
+					// treatment (Codex P2 follow-up on PR #615).
 					selectionMethod := runtimestate.SelectionMethodWarmup
 					if overrideSet {
 						selectionMethod = runtimestate.SelectionMethodExplicitValidateOnly
 					}
-					companion := sourceSelection.Companion
-					runtimeStateMgr.UpdateSelf(runtimestate.Self{
-						LastAdmittedSource: sourceSelection.Source,
-						LastAdmittedAt:     time.Now().UTC(),
-						SelectionMethod:    selectionMethod,
-						CompanionTarget:    &companion,
-					})
-
-					// M5_ADDRESS_TABLE_REVALIDATE: now that admission
-					// is finalized and AdmittedSource() returns the
-					// selected source, schedule an immediate
-					// revalidation cycle against cached
-					// known_bus_members[] plus periodic cycles at
-					// 15-min cadence. The periodic loop is what
-					// guarantees postponed members (overflow beyond
-					// cap=32) are eventually probed; without it
-					// stale ghosts beyond the first 32 would remain
-					// cached until process restart (Codex P2
-					// follow-up on PR #615).
-					startRuntimeStateRevalidator(ctx, runtimeStateMgr, gateway, cfg, sourceSelection.Source, 0)
+					finalizeRuntimeStateForAdmittedSource(ctx, runtimeStateMgr, gateway, cfg, sourceSelection.Source, sourceSelection.Companion, selectionMethod, true)
 				}
 			case <-startupScanSignals.admissionFailed:
 				if sourceSelection != nil {

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -260,6 +260,20 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 	}
 	addressTable := ebusgateway.NewAddressTable(gateway.Registry)
 	addressTableInserter := ebusgateway.NewAddressTableInserter(addressTable, addressTableCfg)
+	// M3 + M5 wiring: every passive observation flowing through the
+	// inserter also feeds the runtime-state Manager so
+	// known_bus_members[] populates and refreshes for M5 revalidation
+	// ordering. Without this, a fresh install would leave the cache
+	// permanently empty and revalidation would have nothing to probe.
+	// (Codex P2 follow-up on PR #615.)
+	addressTableInserter.SetRuntimeStateObserver(func(addr byte, observedAt time.Time, reportedSource string) {
+		runtimeStateMgr.UpsertKnownBusMember(runtimestate.KnownBusMember{
+			Addr:       addr,
+			LastSeenAt: observedAt,
+			LastSource: runtimestate.LastSource(reportedSource),
+			Confidence: runtimestate.ConfidenceCorroborated,
+		})
+	})
 	if busObservability != nil {
 		builder.SetBusObservabilityProvider(newGraphQLBusObservabilityProvider(busObservability))
 	}

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -271,6 +271,11 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 	// install and M5 would have nothing to revalidate. (Codex P2
 	// follow-up on PR #615.)
 	addressTableInserter.SetRuntimeStateObserver(func(addr byte, observedAt time.Time, reportedSource string) {
+		// Fresh passive evidence clears any M5 eviction blocklist
+		// entry — the AD23 stale-ghost premise no longer holds when
+		// the address is observed on the bus again. (Codex P2
+		// follow-up on PR #615.)
+		globalEvictionBlocklist.clear(addr)
 		runtimeStateMgr.RefreshKnownBusMemberPresence(addr, observedAt, runtimestate.LastSource(reportedSource))
 	})
 	if busObservability != nil {
@@ -547,24 +552,25 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 		cfg.ScanSourceAuto = false
 	}
 	builder.SetStatusProvider(newRuntimeStatusProvider(cfg, semanticRuntime.Provider()))
-	if source, admitted := admittedMutationSourceForGateway(cfg, admissionPath, overrideSet); admitted {
-		builder.SetAdmittedMutationSource(source)
+	syncStaticAdmittedSource, syncStaticAdmitted := admittedMutationSourceForGateway(cfg, admissionPath, overrideSet)
+	if syncStaticAdmitted {
+		builder.SetAdmittedMutationSource(syncStaticAdmittedSource)
 		// Phase A.5 (Codex P2 round 3): admission resolved synchronously
 		// (override / static fallback). Bind the inserter now that
 		// AdmittedSource() returns the real source.
 		subscribeAddressTableInserter()
-		// M4/M5: also finalize runtime-state for override + static-
-		// fallback admissions. Without this, cached known_bus_members[]
-		// would only ever be revalidated on warmup-based admissions and
-		// stale entries would persist indefinitely on configured
-		// transports (Codex P2 follow-up on PR #615). The selection
-		// method varies by path: ebusd-tcp → ebusd-tcp-fallback,
-		// override / explicit static → explicit_validate_only.
+		// M4: write the validated source to runtime_state.ebus.self
+		// synchronously — this is just a cache update, not bus
+		// traffic, so it's safe to run before the startup directed-
+		// probe phase. M5 revalidator start is DEFERRED to
+		// post-validation (after startupScanSignals.activeProbePassed)
+		// so directed 07 04 probes don't race the startup admission
+		// scan's bus traffic. Codex P2 follow-up on PR #615.
 		selectionMethod := runtimestate.SelectionMethodExplicitValidateOnly
 		if isEbusdTransportProtocol(cfg.TransportConfig.Protocol) {
 			selectionMethod = runtimestate.SelectionMethodEbusdTCPFallback
 		}
-		finalizeRuntimeStateForAdmittedSource(ctx, runtimeStateMgr, gateway, cfg, source, 0, selectionMethod, false)
+		recordAdmittedSourceInRuntimeState(runtimeStateMgr, syncStaticAdmittedSource, 0, selectionMethod, false)
 	} else {
 		builder.ClearAdmittedMutationSource()
 	}
@@ -625,6 +631,27 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 		artifactBuilder.SetExplicitSource(startupCfg.ScanSource)
 	}
 	startupScanSignals := startDiscoveryScanLoopFn(ctx, startupCfg, gateway, builder, adapterClassifier)
+
+	// Synchronous static / override admission path: defer the M5
+	// revalidator start until activeProbePassed (or ctx cancel) to keep
+	// directed 07 04 probes outside the startup admission scan window.
+	// (Codex P2 follow-up on PR #615 — without this defer, M5 would
+	// emit bus traffic concurrent with startup directed-probe phase.)
+	if syncStaticAdmitted && !sourceSelectionAdmission {
+		go func(source byte) {
+			select {
+			case <-ctx.Done():
+				return
+			case <-startupScanSignals.activeProbePassed:
+				startRuntimeStateRevalidator(ctx, runtimeStateMgr, gateway, cfg, source, 0)
+			case <-startupScanSignals.admissionFailed:
+				// Admission failed mid-validation; skip M5 start —
+				// no point probing cached members when we don't have
+				// a healthy admitted source on the bus.
+				return
+			}
+		}(syncStaticAdmittedSource)
+	}
 
 	if semanticBarrier != nil || sourceSelection != nil {
 		go func() {

--- a/cmd/gateway/revalidate_runtime.go
+++ b/cmd/gateway/revalidate_runtime.go
@@ -194,3 +194,39 @@ type revalidateCounterAdapter struct{}
 func (revalidateCounterAdapter) Inc(o runtimestate.RevalidationOutcome) {
 	revalidateOutcomesTotal.Add(string(o), 1)
 }
+
+// finalizeRuntimeStateForAdmittedSource performs the M4 ebus.self write-back
+// and starts the M5 periodic revalidator for any admitted source — whether
+// it came from a SourceAddressSelector warmup, an explicit operator
+// override, an ebusd-tcp fallback, or any other path that finalizes
+// builder.SetAdmittedMutationSource. Codex P2 follow-up on PR #615
+// (without this, override and static-fallback admissions skipped the
+// runtime-state finalization entirely and cached known_bus_members[]
+// stayed stale indefinitely on those transports).
+//
+// hasCompanion gates whether companion is written into ebus.self.
+// Synchronous static-path admissions don't have a SourceAddressSelection
+// result and therefore no companion to record (CompanionTarget remains
+// nil per AD03 — the Manager preserves nil for "no valid companion per
+// bit-pattern rule" rather than synthesising one).
+func finalizeRuntimeStateForAdmittedSource(
+	ctx context.Context,
+	mgr *runtimestate.Manager,
+	gw *ebusgateway.Gateway,
+	cfg ebusgateway.Config,
+	admittedSource byte,
+	companion byte,
+	selectionMethod runtimestate.SelectionMethod,
+	hasCompanion bool,
+) {
+	self := runtimestate.Self{
+		LastAdmittedSource: admittedSource,
+		LastAdmittedAt:     time.Now().UTC(),
+		SelectionMethod:    selectionMethod,
+	}
+	if hasCompanion {
+		self.CompanionTarget = &companion
+	}
+	mgr.UpdateSelf(self)
+	startRuntimeStateRevalidator(ctx, mgr, gw, cfg, admittedSource, 0)
+}

--- a/cmd/gateway/revalidate_runtime.go
+++ b/cmd/gateway/revalidate_runtime.go
@@ -110,6 +110,30 @@ func revalidateRuntimeStateMembers(
 	if mgr == nil || gw == nil || gw.Bus == nil || gw.Registry == nil {
 		return runtimestate.Result{}
 	}
+
+	// Reconcile registry → Manager before each cycle. The
+	// AddressTableInserter passive observer (db9075d/92ae86a) feeds the
+	// Manager from passive bus traffic; the registry additionally
+	// receives entries from the active startup scan path
+	// (registry.ScanDirected from cmd/gateway/startup_scan.go) which
+	// doesn't pass through the inserter. Walking IterateSnapshots and
+	// calling RefreshKnownBusMemberPresence ensures both discovery
+	// paths converge into known_bus_members[]. RefreshKnownBusMemberPresence
+	// preserves existing Identity / CompanionAddr / Confidence on
+	// addresses already in the cache (idempotent for hot iterations
+	// where the same addr has been observed thousands of times).
+	// Codex P2 follow-up on PR #615.
+	now := time.Now().UTC()
+	gw.Registry.IterateSnapshots(func(snap registry.DeviceEntrySnapshot) bool {
+		for _, addr := range snap.Addresses {
+			if addr == admittedSource || addr == 0xFE || addr == 0x00 {
+				continue
+			}
+			mgr.RefreshKnownBusMemberPresence(addr, now, runtimestate.LastSourcePassiveObserved)
+		}
+		return true
+	})
+
 	state := mgr.State()
 	if state == nil || state.EBus == nil || len(state.EBus.KnownBusMembers) == 0 {
 		return runtimestate.Result{}

--- a/cmd/gateway/revalidate_runtime.go
+++ b/cmd/gateway/revalidate_runtime.go
@@ -12,6 +12,50 @@ import (
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
 )
 
+// evictionBlocklist tracks addresses that M5 has evicted (no_reply outcome)
+// in the current process lifetime. The registry → Manager reconciliation
+// step at the top of revalidateRuntimeStateMembers MUST skip these addrs;
+// otherwise an AD23 eviction would be undone within 15 min by the
+// reconciler re-inserting the stale registry entry, repeating
+// indefinitely for static/registry-only entries. (Codex P2 follow-up on
+// PR #615.)
+//
+// Entries clear on fresh passive observation via the AddressTableInserter
+// observer hook — that's evidence the address is alive again on the bus
+// (the AD23 stale-ghost premise no longer holds).
+//
+// In-process state by design; a process restart loses the blocklist,
+// which is correct: Manager.Load reads runtime_state.json which already
+// has the address evicted (M5 persisted the eviction), so the reconciler
+// won't re-add it unless the registry has it AND fresh evidence arrives.
+type evictionBlocklist struct {
+	mu      sync.Mutex
+	evicted map[byte]struct{}
+}
+
+func newEvictionBlocklist() *evictionBlocklist {
+	return &evictionBlocklist{evicted: make(map[byte]struct{})}
+}
+
+func (b *evictionBlocklist) markEvicted(addr byte) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.evicted[addr] = struct{}{}
+}
+
+func (b *evictionBlocklist) clear(addr byte) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	delete(b.evicted, addr)
+}
+
+func (b *evictionBlocklist) isEvicted(addr byte) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	_, ok := b.evicted[addr]
+	return ok
+}
+
 // revalidationRotation tracks which cached addresses have been probed in
 // the current rotation round. This is in-process state (deliberately not
 // persisted) — a process restart re-reads runtime_state.json and starts
@@ -106,6 +150,7 @@ func revalidateRuntimeStateMembers(
 	cfg ebusgateway.Config,
 	admittedSource byte,
 	rotation *revalidationRotation,
+	blocklist *evictionBlocklist,
 ) runtimestate.Result {
 	if mgr == nil || gw == nil || gw.Bus == nil || gw.Registry == nil {
 		return runtimestate.Result{}
@@ -127,6 +172,14 @@ func revalidateRuntimeStateMembers(
 	gw.Registry.IterateSnapshots(func(snap registry.DeviceEntrySnapshot) bool {
 		for _, addr := range snap.Addresses {
 			if addr == admittedSource || addr == 0xFE || addr == 0x00 {
+				continue
+			}
+			// AD23 anti-resurrection: skip addresses M5 has evicted in
+			// this process lifetime. They only re-enter when fresh
+			// passive bus traffic arrives via the AddressTableInserter
+			// observer hook, which clears the blocklist entry. (Codex
+			// P2 follow-up on PR #615.)
+			if blocklist != nil && blocklist.isEvicted(addr) {
 				continue
 			}
 			mgr.RefreshKnownBusMemberPresence(addr, now, runtimestate.LastSourcePassiveObserved)
@@ -265,6 +318,13 @@ func revalidateRuntimeStateMembers(
 			if rotation != nil {
 				rotation.markProbed(p.Addr)
 			}
+			// AD23 anti-resurrection (Codex P2 follow-up on PR #615):
+			// block the registry reconciler from re-adding this addr
+			// until fresh passive traffic clears the blocklist via the
+			// inserter observer hook.
+			if blocklist != nil {
+				blocklist.markEvicted(p.Addr)
+			}
 		case runtimestate.OutcomeSkippedPassiveRefresh:
 			// No-op: member already refreshed via warmup-window passive
 			// observation; the address-table inserter normal path is
@@ -303,10 +363,11 @@ func startRuntimeStateRevalidator(
 		interval = 15 * time.Minute
 	}
 	rotation := newRevalidationRotation()
+	blocklist := globalEvictionBlocklist
 	go func() {
 		// First cycle runs immediately so cached responders refresh
 		// confidence within ~5 s of admission per M5 acceptance.
-		revalidateRuntimeStateMembers(ctx, mgr, gw, cfg, admittedSource, rotation)
+		revalidateRuntimeStateMembers(ctx, mgr, gw, cfg, admittedSource, rotation, blocklist)
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 		for {
@@ -314,11 +375,19 @@ func startRuntimeStateRevalidator(
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				revalidateRuntimeStateMembers(ctx, mgr, gw, cfg, admittedSource, rotation)
+				revalidateRuntimeStateMembers(ctx, mgr, gw, cfg, admittedSource, rotation, blocklist)
 			}
 		}
 	}()
 }
+
+// globalEvictionBlocklist is the per-process M5 eviction blocklist used by
+// both the revalidator loop (to skip resurrection during reconciliation)
+// and the AddressTableInserter observer hook (to clear entries on fresh
+// passive traffic). Package-level singleton so the observer wired in
+// main.go can clear without taking a function parameter. In-process
+// state; cleared on restart by virtue of process termination.
+var globalEvictionBlocklist = newEvictionBlocklist()
 
 // revalidateCounterAdapter bridges runtimestate.RevalidationOutcome to the
 // expvar map. Each Inc adds 1 to the per-outcome key.
@@ -329,25 +398,22 @@ func (revalidateCounterAdapter) Inc(o runtimestate.RevalidationOutcome) {
 	revalidateOutcomesTotal.Add(string(o), 1)
 }
 
-// finalizeRuntimeStateForAdmittedSource performs the M4 ebus.self write-back
-// and starts the M5 periodic revalidator for any admitted source — whether
-// it came from a SourceAddressSelector warmup, an explicit operator
-// override, an ebusd-tcp fallback, or any other path that finalizes
-// builder.SetAdmittedMutationSource. Codex P2 follow-up on PR #615
-// (without this, override and static-fallback admissions skipped the
-// runtime-state finalization entirely and cached known_bus_members[]
-// stayed stale indefinitely on those transports).
+// recordAdmittedSourceInRuntimeState writes ebus.self with the validated
+// source, companion (if any), and SelectionMethod. Cache mutation only —
+// no bus traffic — so it's safe to call synchronously regardless of
+// startup-scan progress. The M5 revalidator start is intentionally
+// separated into startRuntimeStateRevalidator so the caller can defer it
+// to post-validation (after startupScanSignals.activeProbePassed) and
+// avoid emitting directed 07 04 probes during the startup admission
+// scan window. (Codex P2 follow-up on PR #615.)
 //
-// hasCompanion gates whether companion is written into ebus.self.
-// Synchronous static-path admissions don't have a SourceAddressSelection
-// result and therefore no companion to record (CompanionTarget remains
-// nil per AD03 — the Manager preserves nil for "no valid companion per
-// bit-pattern rule" rather than synthesising one).
-func finalizeRuntimeStateForAdmittedSource(
-	ctx context.Context,
+// hasCompanion gates whether companion is written. Synchronous static-
+// path admissions don't have a SourceAddressSelection result and
+// therefore no companion to record (CompanionTarget remains nil per
+// AD03 — "no valid companion per bit-pattern rule" — rather than
+// synthesising one).
+func recordAdmittedSourceInRuntimeState(
 	mgr *runtimestate.Manager,
-	gw *ebusgateway.Gateway,
-	cfg ebusgateway.Config,
 	admittedSource byte,
 	companion byte,
 	selectionMethod runtimestate.SelectionMethod,
@@ -362,5 +428,24 @@ func finalizeRuntimeStateForAdmittedSource(
 		self.CompanionTarget = &companion
 	}
 	mgr.UpdateSelf(self)
+}
+
+// finalizeRuntimeStateForAdmittedSource is the convenience composition
+// used by the warmup admission path (where activeProbePassed has already
+// fired): records ebus.self synchronously AND immediately starts the M5
+// revalidator. For the synchronous static / override admission path,
+// the caller MUST instead call recordAdmittedSourceInRuntimeState
+// directly and defer startRuntimeStateRevalidator to post-validation.
+func finalizeRuntimeStateForAdmittedSource(
+	ctx context.Context,
+	mgr *runtimestate.Manager,
+	gw *ebusgateway.Gateway,
+	cfg ebusgateway.Config,
+	admittedSource byte,
+	companion byte,
+	selectionMethod runtimestate.SelectionMethod,
+	hasCompanion bool,
+) {
+	recordAdmittedSourceInRuntimeState(mgr, admittedSource, companion, selectionMethod, hasCompanion)
 	startRuntimeStateRevalidator(ctx, mgr, gw, cfg, admittedSource, 0)
 }

--- a/cmd/gateway/revalidate_runtime.go
+++ b/cmd/gateway/revalidate_runtime.go
@@ -4,12 +4,75 @@ import (
 	"context"
 	"expvar"
 	"log"
+	"sync"
 	"time"
 
 	"github.com/Project-Helianthus/helianthus-ebusgateway"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/runtimestate"
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
 )
+
+// revalidationRotation tracks which cached addresses have been probed in
+// the current rotation round. This is in-process state (deliberately not
+// persisted) — a process restart re-reads runtime_state.json and starts
+// fresh with all members eligible.
+//
+// Rotation rule (Codex P2 follow-up on PR #615): the Revalidator
+// orders members by last_seen_at DESC, so without rotation the
+// MOST-RECENTLY-ACTIVE 32 members would be probed every cycle and
+// the older 32 (which got postponed in cycle 1) would never reach the
+// probe window. The rotation excludes already-probed members from
+// subsequent cycles until ALL members have been probed once; then the
+// round resets and the next 15-min cycle starts a fresh rotation.
+//
+// "Probed" here means OutcomeResponder OR OutcomeNoReply — outcomes
+// where the bus was actually touched. OutcomeSkippedPassiveRefresh
+// does NOT advance the rotation; postponements (cap / ctx-abort)
+// don't either, by definition.
+type revalidationRotation struct {
+	mu     sync.Mutex
+	probed map[byte]struct{}
+}
+
+func newRevalidationRotation() *revalidationRotation {
+	return &revalidationRotation{probed: make(map[byte]struct{})}
+}
+
+// shouldSkip reports whether addr has already been probed in the current
+// rotation round.
+func (r *revalidationRotation) shouldSkip(addr byte) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	_, ok := r.probed[addr]
+	return ok
+}
+
+// markProbed records that addr was probed (responder or no_reply) in the
+// current rotation round.
+func (r *revalidationRotation) markProbed(addr byte) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.probed[addr] = struct{}{}
+}
+
+// resetIfRoundComplete returns true and clears the round if every cached
+// addr in the supplied list is already probed (i.e. nothing left to
+// rotate to). Caller invokes BEFORE filtering so the next cycle sees a
+// fresh round.
+func (r *revalidationRotation) resetIfRoundComplete(addrs []byte) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(addrs) == 0 {
+		return false
+	}
+	for _, a := range addrs {
+		if _, ok := r.probed[a]; !ok {
+			return false
+		}
+	}
+	r.probed = make(map[byte]struct{})
+	return true
+}
 
 // revalidateOutcomesTotal is the M5_ADDRESS_TABLE_REVALIDATE per-outcome
 // counter exposed via /debug/vars. Labels: responder, no_reply,
@@ -42,6 +105,7 @@ func revalidateRuntimeStateMembers(
 	gw *ebusgateway.Gateway,
 	cfg ebusgateway.Config,
 	admittedSource byte,
+	rotation *revalidationRotation,
 ) runtimestate.Result {
 	if mgr == nil || gw == nil || gw.Bus == nil || gw.Registry == nil {
 		return runtimestate.Result{}
@@ -49,6 +113,37 @@ func revalidateRuntimeStateMembers(
 	state := mgr.State()
 	if state == nil || state.EBus == nil || len(state.EBus.KnownBusMembers) == 0 {
 		return runtimestate.Result{}
+	}
+
+	// Rotation: probe only members that haven't been probed yet in the
+	// current round. When all cached addrs have been probed once, reset
+	// and start a fresh round so re-emerging activity gets re-validated.
+	// (Codex P2 follow-up on PR #615 — the Revalidator's
+	// last_seen_at-DESC ordering would otherwise repeatedly probe the
+	// same newest 32 members, starving postponed older members.)
+	allAddrs := make([]byte, 0, len(state.EBus.KnownBusMembers))
+	for _, m := range state.EBus.KnownBusMembers {
+		allAddrs = append(allAddrs, m.Addr)
+	}
+	if rotation != nil {
+		if rotation.resetIfRoundComplete(allAddrs) {
+			log.Printf("runtime_state revalidate: rotation round complete (%d members probed); starting new round", len(allAddrs))
+		}
+	}
+	eligibleMembers := state.EBus.KnownBusMembers
+	if rotation != nil {
+		eligibleMembers = make([]runtimestate.KnownBusMember, 0, len(state.EBus.KnownBusMembers))
+		for _, m := range state.EBus.KnownBusMembers {
+			if rotation.shouldSkip(m.Addr) {
+				continue
+			}
+			eligibleMembers = append(eligibleMembers, m)
+		}
+		if len(eligibleMembers) == 0 {
+			// All cached addrs have been probed; nothing eligible
+			// this cycle. Will rotate fresh on the next tick.
+			return runtimestate.Result{}
+		}
 	}
 
 	// Respect the caller's ScanRequestTimeout per-probe so a stuck
@@ -105,7 +200,7 @@ func revalidateRuntimeStateMembers(
 		Counter: revalidateCounterAdapter{},
 	}
 
-	result := revalidator.Run(probeCtx, state.EBus.KnownBusMembers)
+	result := revalidator.Run(probeCtx, eligibleMembers)
 
 	// Build an addr→cached entry index so responder refreshes can MERGE
 	// presence metadata with existing identity/companion_addr instead of
@@ -118,13 +213,19 @@ func revalidateRuntimeStateMembers(
 		cachedByAddr[m.Addr] = m
 	}
 
-	now := time.Now().UTC()
 	for _, p := range result.Probed {
 		switch p.Outcome {
 		case runtimestate.OutcomeResponder:
 			refreshed := cachedByAddr[p.Addr] // zero value when address wasn't cached
 			refreshed.Addr = p.Addr
-			refreshed.LastSeenAt = now
+			// LastSeenAt deliberately preserved from the prior entry —
+			// updating it would create sticky last_seen_at-DESC
+			// ordering that prevents postponed older members from
+			// reaching the probe window on the next cycle (Codex P2
+			// follow-up on PR #615). Passive observation of bus
+			// traffic is the authoritative LastSeenAt updater; a
+			// directed-probe responder confirms presence without
+			// implying new activity.
 			refreshed.LastSource = runtimestate.LastSourceDirected0704
 			refreshed.Confidence = runtimestate.ConfidenceVerified
 			// Identity / CompanionAddr preserved from prior entry. The
@@ -132,12 +233,20 @@ func revalidateRuntimeStateMembers(
 			// independently when richer data arrives via passive
 			// observation.
 			mgr.UpsertKnownBusMember(refreshed)
+			if rotation != nil {
+				rotation.markProbed(p.Addr)
+			}
 		case runtimestate.OutcomeNoReply:
 			mgr.EvictKnownBusMember(p.Addr)
+			if rotation != nil {
+				rotation.markProbed(p.Addr)
+			}
 		case runtimestate.OutcomeSkippedPassiveRefresh:
 			// No-op: member already refreshed via warmup-window passive
 			// observation; the address-table inserter normal path is
-			// authoritative.
+			// authoritative. Also DOES NOT advance the rotation —
+			// passive-refreshed members weren't bus-touched, so they
+			// still need a chance at the probe window in this round.
 		}
 	}
 
@@ -169,10 +278,11 @@ func startRuntimeStateRevalidator(
 	if interval <= 0 {
 		interval = 15 * time.Minute
 	}
+	rotation := newRevalidationRotation()
 	go func() {
 		// First cycle runs immediately so cached responders refresh
 		// confidence within ~5 s of admission per M5 acceptance.
-		revalidateRuntimeStateMembers(ctx, mgr, gw, cfg, admittedSource)
+		revalidateRuntimeStateMembers(ctx, mgr, gw, cfg, admittedSource, rotation)
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 		for {
@@ -180,7 +290,7 @@ func startRuntimeStateRevalidator(
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				revalidateRuntimeStateMembers(ctx, mgr, gw, cfg, admittedSource)
+				revalidateRuntimeStateMembers(ctx, mgr, gw, cfg, admittedSource, rotation)
 			}
 		}
 	}()

--- a/cmd/gateway/revalidate_runtime.go
+++ b/cmd/gateway/revalidate_runtime.go
@@ -89,16 +89,31 @@ func revalidateRuntimeStateMembers(
 
 	result := revalidator.Run(ctx, state.EBus.KnownBusMembers)
 
+	// Build an addr→cached entry index so responder refreshes can MERGE
+	// presence metadata with existing identity/companion_addr instead of
+	// replacing them. Manager.UpsertKnownBusMember is replace-by-addr,
+	// not merge, so a sparse refresh entry would drop cached
+	// Identity/CompanionAddr until the next inserter enrichment fires.
+	// (Codex P2 follow-up on PR #615.)
+	cachedByAddr := make(map[byte]runtimestate.KnownBusMember, len(state.EBus.KnownBusMembers))
+	for _, m := range state.EBus.KnownBusMembers {
+		cachedByAddr[m.Addr] = m
+	}
+
 	now := time.Now().UTC()
 	for _, p := range result.Probed {
 		switch p.Outcome {
 		case runtimestate.OutcomeResponder:
-			mgr.UpsertKnownBusMember(runtimestate.KnownBusMember{
-				Addr:       p.Addr,
-				LastSeenAt: now,
-				LastSource: runtimestate.LastSourceDirected0704,
-				Confidence: runtimestate.ConfidenceVerified,
-			})
+			refreshed := cachedByAddr[p.Addr] // zero value when address wasn't cached
+			refreshed.Addr = p.Addr
+			refreshed.LastSeenAt = now
+			refreshed.LastSource = runtimestate.LastSourceDirected0704
+			refreshed.Confidence = runtimestate.ConfidenceVerified
+			// Identity / CompanionAddr preserved from prior entry. The
+			// address-table-inserter normal path will refine identity
+			// independently when richer data arrives via passive
+			// observation.
+			mgr.UpsertKnownBusMember(refreshed)
 		case runtimestate.OutcomeNoReply:
 			mgr.EvictKnownBusMember(p.Addr)
 		case runtimestate.OutcomeSkippedPassiveRefresh:
@@ -113,6 +128,44 @@ func revalidateRuntimeStateMembers(
 			len(result.Postponed), runtimestate.RevalidationCap)
 	}
 	return result
+}
+
+// startRuntimeStateRevalidator runs an immediate revalidation cycle and
+// then schedules periodic cycles at the supplied cadence (defaults to
+// 15 min when interval ≤ 0). Each cycle reads the current member list
+// from Manager.State so postponed members from earlier cycles are
+// naturally re-included on the next tick — no separate Postponed
+// queue is needed. (Codex P2 follow-up on PR #615 — without periodic
+// cycles, postponed members beyond cap would stay stale until process
+// restart.)
+//
+// Returns immediately; the cycle goroutine exits on ctx cancellation.
+func startRuntimeStateRevalidator(
+	ctx context.Context,
+	mgr *runtimestate.Manager,
+	gw *ebusgateway.Gateway,
+	cfg ebusgateway.Config,
+	admittedSource byte,
+	interval time.Duration,
+) {
+	if interval <= 0 {
+		interval = 15 * time.Minute
+	}
+	go func() {
+		// First cycle runs immediately so cached responders refresh
+		// confidence within ~5 s of admission per M5 acceptance.
+		revalidateRuntimeStateMembers(ctx, mgr, gw, cfg, admittedSource)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				revalidateRuntimeStateMembers(ctx, mgr, gw, cfg, admittedSource)
+			}
+		}
+	}()
 }
 
 // revalidateCounterAdapter bridges runtimestate.RevalidationOutcome to the

--- a/cmd/gateway/revalidate_runtime.go
+++ b/cmd/gateway/revalidate_runtime.go
@@ -30,17 +30,17 @@ import (
 // won't re-add it unless the registry has it AND fresh evidence arrives.
 type evictionBlocklist struct {
 	mu      sync.Mutex
-	evicted map[byte]struct{}
+	evicted map[byte]time.Time
 }
 
 func newEvictionBlocklist() *evictionBlocklist {
-	return &evictionBlocklist{evicted: make(map[byte]struct{})}
+	return &evictionBlocklist{evicted: make(map[byte]time.Time)}
 }
 
 func (b *evictionBlocklist) markEvicted(addr byte) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	b.evicted[addr] = struct{}{}
+	b.evicted[addr] = time.Now().UTC()
 }
 
 func (b *evictionBlocklist) clear(addr byte) {
@@ -49,10 +49,22 @@ func (b *evictionBlocklist) clear(addr byte) {
 	delete(b.evicted, addr)
 }
 
-func (b *evictionBlocklist) isEvicted(addr byte) bool {
+// evictionTime returns (when, true) if addr is blocklisted; (zero, false)
+// otherwise. Used by the reconciler to compare with registry's
+// LastObservedAt and accept fresh evidence newer than the eviction.
+// (Codex P2 follow-up on PR #615 — active scans can resurrect evicted
+// addrs once their registry LastObservedAt advances past the eviction.)
+func (b *evictionBlocklist) evictionTime(addr byte) (time.Time, bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	_, ok := b.evicted[addr]
+	t, ok := b.evicted[addr]
+	return t, ok
+}
+
+// isEvicted reports whether addr is currently blocklisted. Convenience
+// for callers that don't need the timestamp.
+func (b *evictionBlocklist) isEvicted(addr byte) bool {
+	_, ok := b.evictionTime(addr)
 	return ok
 }
 
@@ -174,13 +186,23 @@ func revalidateRuntimeStateMembers(
 			if addr == admittedSource || addr == 0xFE || addr == 0x00 {
 				continue
 			}
-			// AD23 anti-resurrection: skip addresses M5 has evicted in
-			// this process lifetime. They only re-enter when fresh
-			// passive bus traffic arrives via the AddressTableInserter
-			// observer hook, which clears the blocklist entry. (Codex
-			// P2 follow-up on PR #615.)
-			if blocklist != nil && blocklist.isEvicted(addr) {
-				continue
+			// AD23 anti-resurrection: addresses M5 has evicted are
+			// blocklisted with their eviction timestamp. Active rediscovery
+			// (startup directed scan, background full scan) updates
+			// LastObservedAt in the registry — when that timestamp is
+			// AFTER the eviction time, the AD23 stale-ghost premise no
+			// longer holds and we clear the blocklist. Passive observation
+			// clears via the AddressTableInserter observer hook (already
+			// wired in main.go). (Codex P2 follow-up on PR #615.)
+			if blocklist != nil {
+				if evictedAt, ok := blocklist.evictionTime(addr); ok {
+					slotSnap, slotOK := gw.Registry.LookupSlotSnapshot(addr)
+					if slotOK && slotSnap.LastObservedAt.After(evictedAt) {
+						blocklist.clear(addr)
+					} else {
+						continue
+					}
+				}
 			}
 			mgr.RefreshKnownBusMemberPresence(addr, now, runtimestate.LastSourcePassiveObserved)
 		}

--- a/cmd/gateway/revalidate_runtime.go
+++ b/cmd/gateway/revalidate_runtime.go
@@ -55,13 +55,31 @@ func revalidateRuntimeStateMembers(
 	// responder can't block the entire 32-probe burst.
 	probeBus := &timeoutBus{bus: gw.Bus, timeout: cfg.ScanRequestTimeout}
 
-	probe := func(probeCtx context.Context, target byte) bool {
+	// Sub-context lets the probe abort the cycle on transport-level
+	// errors. Without this, ScanDirected returning a non-nil error for
+	// a bus / arbitration / adapter-disconnect failure would map to
+	// `false` → OutcomeNoReply → AD23 eviction, deleting valid cached
+	// members during a transient bus failure (Codex P2 follow-up on
+	// PR #615). On cancellation the Revalidator's existing ctx.Err()
+	// recheck postpones the rest of the cycle for retry next tick.
+	probeCtx, cancelProbe := context.WithCancel(ctx)
+	defer cancelProbe()
+
+	probe := func(_ context.Context, target byte) bool {
 		entries, err := registry.ScanDirected(probeCtx, probeBus, gw.Registry, admittedSource, []byte{target})
 		if err != nil {
-			// Errors here include context cancellation (Revalidator
-			// will recheck ctx.Err() and postpone), or transport
-			// failures that we treat as "no_reply" since the device
-			// effectively didn't answer this cycle.
+			// Transport / arbitration / adapter-level failure.
+			// Cancel the sub-context so the Revalidator's
+			// post-probe ctx.Err() recheck postpones this member +
+			// the rest of the cycle. Returning false on a
+			// healthy bus would have meant "no reply"; with ctx
+			// cancelled it's interpreted as "cycle aborted".
+			//
+			// We log here rather than letting the failure stay
+			// silent — the cycle abort is observable but the
+			// reason should be too.
+			log.Printf("runtime_state revalidate: ScanDirected target=0x%02X failed (cycle aborted, members postponed): %v", target, err)
+			cancelProbe()
 			return false
 		}
 		// Responder iff the scan returned an entry whose addresses
@@ -87,7 +105,7 @@ func revalidateRuntimeStateMembers(
 		Counter: revalidateCounterAdapter{},
 	}
 
-	result := revalidator.Run(ctx, state.EBus.KnownBusMembers)
+	result := revalidator.Run(probeCtx, state.EBus.KnownBusMembers)
 
 	// Build an addr→cached entry index so responder refreshes can MERGE
 	// presence metadata with existing identity/companion_addr instead of

--- a/cmd/gateway/revalidate_runtime.go
+++ b/cmd/gateway/revalidate_runtime.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"context"
+	"expvar"
+	"log"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgateway"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/runtimestate"
+	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+)
+
+// revalidateOutcomesTotal is the M5_ADDRESS_TABLE_REVALIDATE per-outcome
+// counter exposed via /debug/vars. Labels: responder, no_reply,
+// skipped_passive_refresh.
+//
+// Plan: runtime-state-w19-26.locked M5(d)+(e). Naming follows existing
+// helianthus_runtime_state_* prefix for cross-product consistency.
+var revalidateOutcomesTotal = expvar.NewMap("ebus_runtime_state_revalidate_total")
+
+// revalidateRuntimeStateMembers triggers one revalidation cycle against the
+// cached known_bus_members[] now that admission warmup has completed.
+//
+// On responder outcome: refresh confidence=verified + last_source=directed_07_04
+// via Manager.UpsertKnownBusMember (the address-table inserter normal path
+// will pick up identity refinement separately via passive observation).
+// On no_reply outcome: AD23 immediate eviction via Manager.EvictKnownBusMember.
+// On skipped_passive_refresh: no cache mutation (member already refreshed
+// by warmup-window passive traffic via the existing inserter path).
+//
+// Returns synchronously after one cycle. Caller (the activeProbePassed
+// goroutine in main.run) decides whether to schedule a follow-up cycle
+// for postponed members; the current implementation lets the next
+// 15-min Manager.Start tick handle them naturally. (TODO: explicit
+// next-cycle schedule for the postponed list to honor M5 acceptance
+// "synthetic test with 64 cached members ... next cycle probes them"
+// without waiting for the periodic ticker.)
+func revalidateRuntimeStateMembers(
+	ctx context.Context,
+	mgr *runtimestate.Manager,
+	gw *ebusgateway.Gateway,
+	cfg ebusgateway.Config,
+	admittedSource byte,
+) runtimestate.Result {
+	if mgr == nil || gw == nil || gw.Bus == nil || gw.Registry == nil {
+		return runtimestate.Result{}
+	}
+	state := mgr.State()
+	if state == nil || state.EBus == nil || len(state.EBus.KnownBusMembers) == 0 {
+		return runtimestate.Result{}
+	}
+
+	// Respect the caller's ScanRequestTimeout per-probe so a stuck
+	// responder can't block the entire 32-probe burst.
+	probeBus := &timeoutBus{bus: gw.Bus, timeout: cfg.ScanRequestTimeout}
+
+	probe := func(probeCtx context.Context, target byte) bool {
+		entries, err := registry.ScanDirected(probeCtx, probeBus, gw.Registry, admittedSource, []byte{target})
+		if err != nil {
+			// Errors here include context cancellation (Revalidator
+			// will recheck ctx.Err() and postpone), or transport
+			// failures that we treat as "no_reply" since the device
+			// effectively didn't answer this cycle.
+			return false
+		}
+		// Responder iff the scan returned an entry whose addresses
+		// include the probed target. ScanDirected only sends 07 04 to
+		// the requested target, so any non-empty result with this
+		// address is a confirmed responder.
+		for _, e := range entries {
+			for _, addr := range e.Addresses() {
+				if addr == target {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	revalidator := &runtimestate.Revalidator{
+		Probe: probe,
+		// PassivelyRefreshedFn intentionally nil for now: the Revalidator
+		// always probes. Wiring busObservability evidence as the
+		// passive-refresh signal is a follow-up — leaving it nil today
+		// is conservative (more probes, but no missed evictions).
+		Counter: revalidateCounterAdapter{},
+	}
+
+	result := revalidator.Run(ctx, state.EBus.KnownBusMembers)
+
+	now := time.Now().UTC()
+	for _, p := range result.Probed {
+		switch p.Outcome {
+		case runtimestate.OutcomeResponder:
+			mgr.UpsertKnownBusMember(runtimestate.KnownBusMember{
+				Addr:       p.Addr,
+				LastSeenAt: now,
+				LastSource: runtimestate.LastSourceDirected0704,
+				Confidence: runtimestate.ConfidenceVerified,
+			})
+		case runtimestate.OutcomeNoReply:
+			mgr.EvictKnownBusMember(p.Addr)
+		case runtimestate.OutcomeSkippedPassiveRefresh:
+			// No-op: member already refreshed via warmup-window passive
+			// observation; the address-table inserter normal path is
+			// authoritative.
+		}
+	}
+
+	if len(result.Postponed) > 0 {
+		log.Printf("runtime_state revalidate: %d cached members postponed (cap=%d, next cycle will resume)",
+			len(result.Postponed), runtimestate.RevalidationCap)
+	}
+	return result
+}
+
+// revalidateCounterAdapter bridges runtimestate.RevalidationOutcome to the
+// expvar map. Each Inc adds 1 to the per-outcome key.
+type revalidateCounterAdapter struct{}
+
+// Inc satisfies runtimestate.RevalidationCounter.
+func (revalidateCounterAdapter) Inc(o runtimestate.RevalidationOutcome) {
+	revalidateOutcomesTotal.Add(string(o), 1)
+}

--- a/cmd/gateway/revalidate_runtime_test.go
+++ b/cmd/gateway/revalidate_runtime_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"testing"
+	"time"
 )
 
 // TestEvictionBlocklist_MarkClearLifecycle pins the AD23 anti-resurrection
@@ -35,6 +36,36 @@ func TestEvictionBlocklist_MarkClearLifecycle(t *testing.T) {
 	b.markEvicted(0x08)
 	if !b.isEvicted(0x08) {
 		t.Errorf("re-marking after clear must work")
+	}
+}
+
+// TestEvictionBlocklist_EvictionTimeMonotonic verifies that evictionTime
+// returns a non-zero timestamp after markEvicted, and that the timestamp
+// advances when an addr is re-evicted after a clear (the reconciler uses
+// this timestamp to gate against registry LastObservedAt for active-
+// rediscovery resurrection — Codex P2 follow-up on PR #615).
+func TestEvictionBlocklist_EvictionTimeMonotonic(t *testing.T) {
+	b := newEvictionBlocklist()
+
+	if _, ok := b.evictionTime(0x08); ok {
+		t.Errorf("fresh blocklist: evictionTime(0x08) must return ok=false")
+	}
+
+	b.markEvicted(0x08)
+	t1, ok := b.evictionTime(0x08)
+	if !ok {
+		t.Fatalf("after markEvicted: evictionTime(0x08) must return ok=true")
+	}
+	if t1.IsZero() {
+		t.Errorf("evictionTime must be a real timestamp, not zero")
+	}
+
+	time.Sleep(2 * time.Millisecond)
+	b.clear(0x08)
+	b.markEvicted(0x08)
+	t2, _ := b.evictionTime(0x08)
+	if !t2.After(t1) {
+		t.Errorf("re-eviction timestamp t2=%v must be after t1=%v", t2, t1)
 	}
 }
 

--- a/cmd/gateway/revalidate_runtime_test.go
+++ b/cmd/gateway/revalidate_runtime_test.go
@@ -4,6 +4,40 @@ import (
 	"testing"
 )
 
+// TestEvictionBlocklist_MarkClearLifecycle pins the AD23 anti-resurrection
+// contract: M5 eviction marks an addr; subsequent passive observation
+// (via the AddressTableInserter observer hook) clears it; the registry
+// reconciler skips marked addrs. Codex P2 follow-up on PR #615.
+func TestEvictionBlocklist_MarkClearLifecycle(t *testing.T) {
+	b := newEvictionBlocklist()
+
+	if b.isEvicted(0x08) {
+		t.Errorf("fresh blocklist: 0x08 must not be evicted")
+	}
+
+	b.markEvicted(0x08)
+	if !b.isEvicted(0x08) {
+		t.Errorf("after markEvicted(0x08): isEvicted must return true")
+	}
+	if b.isEvicted(0x15) {
+		t.Errorf("other addrs must not be affected by markEvicted(0x08)")
+	}
+
+	// Fresh passive observation clears the eviction.
+	b.clear(0x08)
+	if b.isEvicted(0x08) {
+		t.Errorf("after clear(0x08): isEvicted must return false")
+	}
+
+	// Re-eviction (later cycle re-discovers the address as no_reply)
+	// is idempotent.
+	b.markEvicted(0x08)
+	b.markEvicted(0x08)
+	if !b.isEvicted(0x08) {
+		t.Errorf("re-marking after clear must work")
+	}
+}
+
 // TestRevalidationRotation_ShouldSkipBeforeAndAfterMark verifies the basic
 // "probed-once then skip" contract.
 func TestRevalidationRotation_ShouldSkipBeforeAndAfterMark(t *testing.T) {

--- a/cmd/gateway/revalidate_runtime_test.go
+++ b/cmd/gateway/revalidate_runtime_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"testing"
+)
+
+// TestRevalidationRotation_ShouldSkipBeforeAndAfterMark verifies the basic
+// "probed-once then skip" contract.
+func TestRevalidationRotation_ShouldSkipBeforeAndAfterMark(t *testing.T) {
+	r := newRevalidationRotation()
+
+	if r.shouldSkip(0x08) {
+		t.Errorf("addr 0x08 must not be skipped before any markProbed")
+	}
+
+	r.markProbed(0x08)
+	if !r.shouldSkip(0x08) {
+		t.Errorf("addr 0x08 must be skipped after markProbed")
+	}
+	if r.shouldSkip(0x15) {
+		t.Errorf("addr 0x15 must not be skipped (only 0x08 was marked)")
+	}
+}
+
+// TestRevalidationRotation_ResetWhenRoundComplete verifies the round-complete
+// detection: every cached addr probed → reset and start fresh.
+func TestRevalidationRotation_ResetWhenRoundComplete(t *testing.T) {
+	r := newRevalidationRotation()
+	addrs := []byte{0x08, 0x15, 0xF6}
+
+	// Empty round → not complete (no addrs supplied).
+	if r.resetIfRoundComplete(nil) {
+		t.Errorf("empty addrs must not trigger reset")
+	}
+
+	// Partial probing → not complete.
+	r.markProbed(0x08)
+	r.markProbed(0x15)
+	if r.resetIfRoundComplete(addrs) {
+		t.Errorf("partial round (2/3 probed) must not trigger reset")
+	}
+	if r.shouldSkip(0xF6) {
+		t.Errorf("addr 0xF6 must still be eligible (not yet probed)")
+	}
+
+	// All probed → reset.
+	r.markProbed(0xF6)
+	if !r.resetIfRoundComplete(addrs) {
+		t.Errorf("complete round (3/3 probed) must trigger reset")
+	}
+
+	// After reset, every addr is eligible again.
+	for _, a := range addrs {
+		if r.shouldSkip(a) {
+			t.Errorf("addr 0x%02X must NOT be skipped after round reset", a)
+		}
+	}
+}
+
+// TestRevalidationRotation_64MemberRoundRobinAcceptance simulates the M5
+// 64-member fixture across multiple cycles and verifies that ALL members
+// are probed within two cap=32 cycles + reset on cycle 3 (Codex P2 follow-up
+// on PR #615 — without rotation, the same 32 newest members would be
+// probed every cycle indefinitely).
+func TestRevalidationRotation_64MemberRoundRobinAcceptance(t *testing.T) {
+	r := newRevalidationRotation()
+	addrs := make([]byte, 64)
+	for i := range addrs {
+		addrs[i] = byte(0x01 + i)
+	}
+
+	// Simulate cycle 1: 32 newest get marked probed.
+	for i := 0; i < 32; i++ {
+		r.markProbed(addrs[i])
+	}
+	if r.resetIfRoundComplete(addrs) {
+		t.Errorf("after cycle 1 (32/64), round must NOT be complete")
+	}
+	for i := 0; i < 32; i++ {
+		if !r.shouldSkip(addrs[i]) {
+			t.Errorf("cycle 1: addr 0x%02X must be skipped (already probed)", addrs[i])
+		}
+	}
+	for i := 32; i < 64; i++ {
+		if r.shouldSkip(addrs[i]) {
+			t.Errorf("cycle 1: addr 0x%02X must be eligible (not yet probed)", addrs[i])
+		}
+	}
+
+	// Simulate cycle 2: remaining 32 get probed.
+	for i := 32; i < 64; i++ {
+		r.markProbed(addrs[i])
+	}
+	// Now resetIfRoundComplete should clear and return true.
+	if !r.resetIfRoundComplete(addrs) {
+		t.Errorf("after cycle 2 (64/64), round MUST be complete and reset")
+	}
+
+	// Cycle 3 starts fresh — all 64 eligible again.
+	for _, a := range addrs {
+		if r.shouldSkip(a) {
+			t.Errorf("cycle 3 (post-reset): addr 0x%02X must be eligible", a)
+		}
+	}
+}

--- a/config.go
+++ b/config.go
@@ -157,6 +157,16 @@ type Config struct {
 	MDNSAdvertise                           bool
 	MDNSInstance                            string
 	InstanceGUID                            string
+	// InstanceGUIDSource is the AD27 provenance tag passed by the
+	// add-on alongside InstanceGUID. One of: "runtime_state",
+	// "legacy_migrated", "generated", "cli-override". Empty when the
+	// flag wasn't supplied (older add-on, direct CLI invocation), in
+	// which case the Manager defaults to "cli-override" with a
+	// deprecation log.
+	InstanceGUIDSource string
+	// RuntimeStatePath overrides /data/runtime_state.json for tests +
+	// alternate deployments. Empty uses the runtimestate package default.
+	RuntimeStatePath string
 	DumpOutputDir                           string
 	DumpUploadPath                          string
 	DumpUploadURL                           string
@@ -253,6 +263,8 @@ func DefaultConfig() Config {
 		MDNSAdvertise:                           true,
 		MDNSInstance:                            "helianthus",
 		InstanceGUID:                            "",
+		InstanceGUIDSource:                      "",
+		RuntimeStatePath:                        "",
 		DumpOutputDir:                           "./dumps",
 		ObserveFirstEnabled:                     featureFlags.ObserveFirstEnabled(),
 		PassiveStateDirectApply:                 true,

--- a/internal/runtimestate/runtimestate.go
+++ b/internal/runtimestate/runtimestate.go
@@ -411,6 +411,54 @@ func (m *Manager) UpsertKnownBusMember(member KnownBusMember) {
 	m.mu.Unlock()
 }
 
+// RefreshKnownBusMemberPresence atomically updates LastSeenAt + LastSource
+// for an existing entry without touching Identity / CompanionAddr /
+// Confidence — the address-table-inserter passive-observation hook calls
+// this on every bus event to keep LastSeenAt current as a basis for M5
+// revalidation ordering, without overwriting cached identity that earlier
+// directed probes / enrichment populated. (Codex P2 follow-up on PR #615 —
+// the observer's prior call to UpsertKnownBusMember dropped Identity and
+// downgraded ConfidenceVerified back to corroborated on every passive
+// observation.)
+//
+// When the address is not yet in the cache, inserts a new entry with
+// Confidence=corroborated as the initial classification; subsequent
+// directed-probe responder outcomes upgrade it to verified.
+//
+// Atomic under m.mu; safe to call at bus-event rate.
+func (m *Manager) RefreshKnownBusMemberPresence(addr byte, observedAt time.Time, source LastSource) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.state == nil {
+		m.state = &State{SchemaVersion: SchemaVersion}
+	}
+	if m.state.EBus == nil {
+		m.state.EBus = &EBusNamespace{SchemaVersion: EBusSchemaVersion}
+	}
+	for i := range m.state.EBus.KnownBusMembers {
+		if m.state.EBus.KnownBusMembers[i].Addr == addr {
+			// In-place refresh of presence-only fields. Identity,
+			// CompanionAddr, and Confidence preserved verbatim.
+			m.state.EBus.KnownBusMembers[i].LastSeenAt = observedAt
+			m.state.EBus.KnownBusMembers[i].LastSource = source
+			m.dirty = true
+			m.writeGen++
+			return
+		}
+	}
+	// New address: insert with conservative defaults. Subsequent
+	// directed-probe responder outcomes will upgrade Confidence via
+	// the M5 revalidator's UpsertKnownBusMember call.
+	m.state.EBus.KnownBusMembers = append(m.state.EBus.KnownBusMembers, KnownBusMember{
+		Addr:       addr,
+		LastSeenAt: observedAt,
+		LastSource: source,
+		Confidence: ConfidenceCorroborated,
+	})
+	m.dirty = true
+	m.writeGen++
+}
+
 // EvictKnownBusMember removes the entry with the given Addr. No-op if absent.
 // Used by M5 directed-revalidation on no_reply outcomes (AD23).
 func (m *Manager) EvictKnownBusMember(addr byte) {

--- a/internal/runtimestate/runtimestate_test.go
+++ b/internal/runtimestate/runtimestate_test.go
@@ -955,6 +955,94 @@ func TestEvict_RemovesEntry(t *testing.T) {
 	}
 }
 
+// RefreshKnownBusMemberPresence — Codex P2 follow-up on PR #615.
+// Passive-observation hook must NOT overwrite Identity / CompanionAddr /
+// Confidence on existing entries. New addresses get inserted with
+// conservative defaults (Confidence=Corroborated).
+func TestRefreshKnownBusMemberPresence_PreservesIdentityAndConfidence(t *testing.T) {
+	dir := freshTempDir(t)
+	path := filepath.Join(dir, "runtime_state.json")
+	mgr := New(Options{Path: path})
+
+	companion := byte(0x13)
+	original := KnownBusMember{
+		Addr:          0x08,
+		CompanionAddr: &companion,
+		Identity: &Identity{
+			Manufacturer: "Vaillant",
+			DeviceID:     "BAI00",
+			SN:           "0x21000567",
+		},
+		LastSeenAt: time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC),
+		LastSource: LastSourceDirected0704,
+		Confidence: ConfidenceVerified,
+	}
+	mgr.UpsertKnownBusMember(original)
+
+	refreshAt := time.Date(2026, 5, 11, 0, 5, 0, 0, time.UTC)
+	mgr.RefreshKnownBusMemberPresence(0x08, refreshAt, LastSourcePassiveObserved)
+
+	st := mgr.State()
+	var got KnownBusMember
+	for _, m := range st.EBus.KnownBusMembers {
+		if m.Addr == 0x08 {
+			got = m
+			break
+		}
+	}
+	if got.Addr != 0x08 {
+		t.Fatalf("addr 0x08 missing after refresh")
+	}
+	if !got.LastSeenAt.Equal(refreshAt) {
+		t.Errorf("LastSeenAt = %v; want %v", got.LastSeenAt, refreshAt)
+	}
+	if got.LastSource != LastSourcePassiveObserved {
+		t.Errorf("LastSource = %v; want %v", got.LastSource, LastSourcePassiveObserved)
+	}
+	if got.Confidence != ConfidenceVerified {
+		t.Errorf("Confidence = %v; want %v (passive refresh must not downgrade)", got.Confidence, ConfidenceVerified)
+	}
+	if got.Identity == nil || got.Identity.Manufacturer != "Vaillant" || got.Identity.DeviceID != "BAI00" {
+		t.Errorf("Identity = %+v; want preserved Vaillant/BAI00", got.Identity)
+	}
+	if got.CompanionAddr == nil || *got.CompanionAddr != 0x13 {
+		t.Errorf("CompanionAddr = %v; want preserved 0x13", got.CompanionAddr)
+	}
+}
+
+func TestRefreshKnownBusMemberPresence_InsertsNewAddrWithCorroborated(t *testing.T) {
+	dir := freshTempDir(t)
+	path := filepath.Join(dir, "runtime_state.json")
+	mgr := New(Options{Path: path})
+
+	now := time.Date(2026, 5, 11, 0, 5, 0, 0, time.UTC)
+	mgr.RefreshKnownBusMemberPresence(0x15, now, LastSourcePassiveObserved)
+
+	st := mgr.State()
+	if st == nil || st.EBus == nil {
+		t.Fatalf("state nil after refresh of new addr")
+	}
+	if len(st.EBus.KnownBusMembers) != 1 {
+		t.Fatalf("KnownBusMembers length = %d; want 1", len(st.EBus.KnownBusMembers))
+	}
+	got := st.EBus.KnownBusMembers[0]
+	if got.Addr != 0x15 {
+		t.Errorf("Addr = 0x%02x; want 0x15", got.Addr)
+	}
+	if got.Confidence != ConfidenceCorroborated {
+		t.Errorf("Confidence = %v; want %v (initial passive observation is corroborated, not verified)", got.Confidence, ConfidenceCorroborated)
+	}
+	if got.LastSource != LastSourcePassiveObserved {
+		t.Errorf("LastSource = %v; want %v", got.LastSource, LastSourcePassiveObserved)
+	}
+	if got.Identity != nil {
+		t.Errorf("Identity = %+v; want nil for new passive entry", got.Identity)
+	}
+	if got.CompanionAddr != nil {
+		t.Errorf("CompanionAddr = %v; want nil for new passive entry", got.CompanionAddr)
+	}
+}
+
 // =============================================================================
 // AD24 HINT VS SOURCE-OF-TRUTH (test scaffolds; full enforcement is M4)
 // =============================================================================


### PR DESCRIPTION
## Summary

M5 Part 2/2 for `runtime-state-w19-26.locked` — completes M5_ADDRESS_TABLE_REVALIDATE production wiring and delivers the deferred M4 production integration. Builds on merged [#614](https://github.com/Project-Helianthus/helianthus-ebusgateway/pull/614) (Revalidator core).

## What's wired

### Manager lifecycle in run()
- `initRuntimeStateManager` — Load (best effort, empty state on miss/corrupt) → eager-persist instance_guid (AD08) → Start periodic ticker
- Deferred Stop on context cancellation flushes pending writes
- AD11 best-effort: load/eager-persist/start failures log a warning; gateway continues

### CLI flags
- `-instance-guid-source` (AD27 provenance tag) — empty defaults to `cli-override` with deprecation log
- `-runtime-state-path` overrides `/data/runtime_state.json` for tests

### M4 hint integration (deferred from #613)
The source-selection-capable path extracts `ebus.self.last_admitted_source` via `runtimestate.HintFromState` and passes it through `ebusgateway.StartupAdmissionConfigWithHint` to the selector. Warmup validation still runs in full — AD24 preserved.

### activeProbePassed write-back
After `builder.SetAdmittedMutationSource(...)`, `Manager.UpdateSelf` persists the validated source + companion + SelectionMethod (warmup or explicit_validate_only).

### M5 Revalidator trigger
New `cmd/gateway/revalidate_runtime.go`:
- `revalidateRuntimeStateMembers` runs one cycle against cached `known_bus_members[]` using `registry.ScanDirected` (with `cfg.ScanRequestTimeout` per probe)
- Responder → `Manager.UpsertKnownBusMember(confidence=verified, last_source=directed_07_04)`
- No-reply → `Manager.EvictKnownBusMember` (AD23)
- `expvar.NewMap(\"ebus_runtime_state_revalidate_total\")` exposes per-outcome counter at `/debug/vars`

Trigger fires asynchronously inside the activeProbePassed goroutine — gateway proceeds to semantic discovery regardless of revalidate outcome.

## Known limitations (follow-up scope)

- `PassivelyRefreshedFn` is intentionally nil for now (always probe). Wiring busObservability evidence as the passive-refresh signal is a follow-up — conservative behavior (more probes, no missed evictions).
- Static-fallback / explicit-source admission paths don't yet call `Manager.UpdateSelf` (only the SourceAddressSelector path does). The cache only populates after a warmup-based admission; explicit operator override paths can be added similarly later.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — 19 packages green
- [x] runtimestate package: 27 tests (revalidate × 10 + hint × 6 + AD24 × 2 + existing manager × 9)
- [x] cmd/gateway: AD24 invariant tests still pass

## Plan reference

- Plan: `runtime-state-w19-26.locked`
- Milestones: M4 deferred wiring + M5_ADDRESS_TABLE_REVALIDATE Part 2/2
- Canonical-SHA256: `5f723d7122dd24c81357dc7adb640cbdb805679a5d91c8b8dedcbe6ef60edede`

🤖 Generated with [Claude Code](https://claude.com/claude-code)