### PR TITLE
fix(adaptermux): F-4 fairness window + F-6 per-session frame logging

### DIFF
--- a/internal/adaptermux/arbitration.go
+++ b/internal/adaptermux/arbitration.go
@@ -3,24 +3,40 @@ package adaptermux
 import "sync"
 
 // arbitrator manages bus ownership between the gateway (internal) and
-// external sessions (ebusd) using a two-class priority model.
+// external sessions (ebusd) using a two-class priority model with an
+// adaptive fairness window.
 //
-// XR_GATEWAY_PRIORITY — scheduling policy:
+// XR_GATEWAY_PRIORITY (default behavior, no external sessions):
 //
 //	At each SYN boundary (or idle tick), tryGrant checks pendingGateway
 //	BEFORE pendingExternal. The gateway always gets first pick for bus
-//	ownership. External requests are serviced at the next boundary when
-//	the gateway has no pending work.
+//	ownership.
 //
-//	This is a deliberate design choice: the gateway's semantic poller
-//	drives periodic register scans that must complete within their
-//	polling window. External clients (ebusd) are best-effort consumers
-//	that can tolerate arbitration delays without functional impact.
+//	The gateway's semantic poller drives periodic register scans that
+//	must complete within their polling window; treating it as the
+//	priority class minimises poll-window jitter when no external
+//	clients are connected.
+//
+// XR_EXTERNAL_FAIRNESS_WINDOW (when ≥1 external session has a pending
+// START AND fairnessCounter has reached FairnessRatio — F-4 fix per
+// EBUSD-VERIFICATION-2026-05-10.md):
+//
+//	Every FairnessRatio'th tryGrant rotation with both classes pending,
+//	the external FIFO is serviced before pendingGateway. This bounds
+//	the worst-case external START latency to ~FairnessRatio gateway-
+//	transaction windows even when the semantic poller is continuously
+//	busy, which restores ebusd's ability to complete its initial scan
+//	(its per-START retry budget is 3× ~1.5 s = 4.5 s; the gateway's
+//	typical 200–300 ms grants comfortably fit into 1-in-4 fairness).
+//
+//	When no external sessions are pending, fairness reduces to a no-op
+//	and gateway-priority is unchanged — zero overhead in the standalone
+//	helianthus deployment.
 //
 // The arbitrator is informed by the proxy's boundary-based arbitration
 // (proxy M2) but simplified for a two-class model:
-//   - Gateway (sessionID = gatewaySessionID): always has priority
-//   - External sessions: queued FIFO, serviced when gateway is idle
+//   - Gateway (sessionID = gatewaySessionID): priority class
+//   - External sessions: FIFO with adaptive fairness window
 type arbitrator struct {
 	mu sync.Mutex
 
@@ -42,7 +58,28 @@ type arbitrator struct {
 	// currentInitiator is the eBUS source address of the current
 	// owner's START request.
 	currentInitiator byte
+
+	// fairnessCounter tracks tryGrant rotations where BOTH gateway and
+	// external have pending requests. When it reaches FairnessRatio,
+	// the next such rotation grants to external FIFO instead of
+	// gateway, then resets. F-4 anti-starvation. Only advances when
+	// both classes have pending work — otherwise gateway-priority is
+	// unchanged and the counter holds at its current value (no-op
+	// when standalone).
+	fairnessCounter int
 }
+
+// FairnessRatio is the every-Nth grant that goes to external FIFO when
+// both gateway and ≥1 external session have pending START requests.
+// Default 4 = ~25% of grants under contention go to external,
+// bounding worst-case external START latency to ~4 gateway-transaction
+// windows (typical 200–300 ms each → ~1 s worst case, well within
+// ebusd's ~4.5 s per-scan-iteration deadline).
+//
+// Constant for now; can be promoted to a config field if operators
+// need to tune the balance between gateway poll-window jitter and
+// external client throughput.
+const FairnessRatio = 4
 
 // startRequest represents a pending START arbitration request.
 type startRequest struct {
@@ -151,15 +188,34 @@ func (a *arbitrator) tryGrant() (sessionID uint64, initiator byte, notify chan s
 		return 0, 0, nil, false
 	}
 
-	// Gateway-priority: check gateway first.
-	if a.pendingGateway != nil {
+	gatewayPending := a.pendingGateway != nil
+	externalPending := len(a.pendingExternal) > 0
+
+	// F-4 fairness window: when BOTH classes are pending AND the
+	// fairness counter has reached the ratio, prefer external FIFO
+	// this rotation. Reset the counter and fall through to the
+	// external-FIFO branch below. When only one class is pending the
+	// counter doesn't advance — gateway-priority is unchanged in the
+	// no-external-clients case.
+	preferExternalThisGrant := false
+	if gatewayPending && externalPending {
+		a.fairnessCounter++
+		if a.fairnessCounter >= FairnessRatio {
+			a.fairnessCounter = 0
+			preferExternalThisGrant = true
+		}
+	}
+
+	if gatewayPending && !preferExternalThisGrant {
 		req := a.pendingGateway
 		a.pendingGateway = nil
 		return gatewaySessionID, req.initiator, req.notify, true
 	}
 
-	// External FIFO: grant to first external request.
-	if len(a.pendingExternal) > 0 {
+	// External FIFO: grant to first external request. Reached when
+	// (a) gateway has no pending request, or (b) fairness window
+	// rotated this grant to external.
+	if externalPending {
 		req := a.pendingExternal[0]
 		a.pendingExternal = a.pendingExternal[1:]
 		return req.sessionID, req.initiator, req.notify, true

--- a/internal/adaptermux/arbitration_test.go
+++ b/internal/adaptermux/arbitration_test.go
@@ -382,3 +382,108 @@ func TestArbitrator_DuplicateReplaceCarriesInitiator(t *testing.T) {
 		t.Fatal("timeout")
 	}
 }
+
+// --- F-4 fix: external fairness window (EBUSD-VERIFICATION-2026-05-10.md) ---
+
+// TestArbitrator_FairnessWindow_ExternalGetsEveryNthGrant verifies the
+// adaptive fairness rotation: when BOTH gateway and external have
+// continuously-renewed pending START requests, every FairnessRatio'th
+// grant goes to external FIFO instead of gateway. This bounds the
+// worst-case external START latency to ~FairnessRatio gateway-transaction
+// windows so ebusd can complete its initial scan despite continuous
+// semantic poller activity.
+func TestArbitrator_FairnessWindow_ExternalGetsEveryNthGrant(t *testing.T) {
+	arb := newArbitrator()
+
+	totalRounds := FairnessRatio * 3 // 3 full fairness cycles
+	gatewayGrants := 0
+	externalGrants := 0
+
+	for i := 0; i < totalRounds; i++ {
+		// Both gateway and external request — simulating continuous
+		// contention (gateway poller + ebusd initial scan).
+		gwCh := arb.requestStart(gatewaySessionID, 0x71)
+		extCh := arb.requestStart(1, 0x31)
+
+		sessionID, _, notify, granted := arb.tryGrant()
+		if !granted {
+			t.Fatalf("round %d: expected grant", i)
+		}
+
+		// Confirm + complete the grant so we can loop.
+		arb.confirmOwnership(sessionID, 0)
+		notify <- startResult{granted: true}
+
+		if sessionID == gatewaySessionID {
+			gatewayGrants++
+			// External must still be pending — cancel it before next
+			// iteration so requestStart's "one pending per session"
+			// invariant holds.
+			arb.cancelStart(1)
+			<-extCh
+		} else {
+			externalGrants++
+			// Gateway still pending — cancel it.
+			arb.cancelStart(gatewaySessionID)
+			<-gwCh
+		}
+
+		arb.releaseOwnership(sessionID)
+	}
+
+	// Expect exactly 3 external grants out of 12 total (every 4th).
+	wantExternal := totalRounds / FairnessRatio
+	wantGateway := totalRounds - wantExternal
+	if externalGrants != wantExternal {
+		t.Errorf("externalGrants = %d; want %d (1-in-%d fairness over %d rounds)",
+			externalGrants, wantExternal, FairnessRatio, totalRounds)
+	}
+	if gatewayGrants != wantGateway {
+		t.Errorf("gatewayGrants = %d; want %d", gatewayGrants, wantGateway)
+	}
+}
+
+// TestArbitrator_FairnessWindow_NoOpWhenNoExternal verifies that the
+// fairness rotation does NOT advance when no external session is
+// pending — gateway-priority remains the steady-state when running
+// standalone (no ebusd attached). Zero overhead in the common case.
+func TestArbitrator_FairnessWindow_NoOpWhenNoExternal(t *testing.T) {
+	arb := newArbitrator()
+
+	for i := 0; i < FairnessRatio*5; i++ {
+		gwCh := arb.requestStart(gatewaySessionID, 0x71)
+		sessionID, _, notify, granted := arb.tryGrant()
+		if !granted || sessionID != gatewaySessionID {
+			t.Fatalf("round %d: gateway must win every grant when no external pending; got sessionID=%d granted=%v", i, sessionID, granted)
+		}
+		arb.confirmOwnership(sessionID, 0)
+		notify <- startResult{granted: true}
+		<-gwCh
+		arb.releaseOwnership(sessionID)
+	}
+	// fairnessCounter must remain at 0 — never advanced since no
+	// external was ever pending.
+	if arb.fairnessCounter != 0 {
+		t.Errorf("fairnessCounter = %d; want 0 (no external pending = no rotation)", arb.fairnessCounter)
+	}
+}
+
+// TestArbitrator_FairnessWindow_GatewayAloneWhenExternalAbsent verifies
+// the inverse of the previous test: when only external is pending,
+// gateway-priority is structurally unreachable so external wins
+// immediately. (Sanity for the asymmetric branch.)
+func TestArbitrator_FairnessWindow_GatewayAloneWhenExternalAbsent(t *testing.T) {
+	arb := newArbitrator()
+
+	extCh := arb.requestStart(1, 0x31)
+	sessionID, _, notify, granted := arb.tryGrant()
+	if !granted || sessionID != 1 {
+		t.Fatalf("only external pending: want sessionID=1; got sessionID=%d granted=%v", sessionID, granted)
+	}
+	arb.confirmOwnership(sessionID, 0)
+	notify <- startResult{granted: true}
+	<-extCh
+	if arb.fairnessCounter != 0 {
+		t.Errorf("fairnessCounter = %d; want 0 (only-external grants don't advance the counter)", arb.fairnessCounter)
+	}
+}

--- a/internal/adaptermux/session.go
+++ b/internal/adaptermux/session.go
@@ -274,6 +274,10 @@ func (s *session) handleMessage(msg transport.ENHMessage) {
 func (s *session) handleSend(data byte) {
 	if !s.mux.arb.isOwner(s.id) {
 		// Session is not bus owner — host-side error, not bus error.
+		// F-6 observability: log so operators can correlate orphan
+		// SEND attempts with missing/lost STARTs
+		// (EBUSD-VERIFICATION-2026-05-10.md).
+		s.mux.logger.Printf("adaptermux: session %d SEND 0x%02X rejected — session does not own bus", s.id, data)
 		s.deliverErrorHost()
 		return
 	}
@@ -316,12 +320,18 @@ func (s *session) handleStart(initiator byte) {
 	// P1 fix: also cancel any in-flight pending START at the adapter
 	// level if it belongs to this session.
 	if initiator == protocol.SymbolSyn {
+		s.mux.logger.Printf("adaptermux: session %d START 0xAA (SYN cancel)", s.id)
 		s.mux.arb.cancelStart(s.id)
 		s.mux.arb.releaseOwnership(s.id)
 		s.mux.cancelPendingStart(s.id)
 		return
 	}
 
+	// F-6 observability: log every START dispatch so operators can
+	// distinguish "no client traffic" from "client traffic but no
+	// grants" when debugging arbitration starvation
+	// (EBUSD-VERIFICATION-2026-05-10.md).
+	s.mux.logger.Printf("adaptermux: session %d START 0x%02X requested (RequestStart(0x%02X) sent for session %d)", s.id, initiator, initiator, s.id)
 	ch := s.mux.arb.requestStart(s.id, initiator)
 
 	// Wait for arbitration result in a tracked goroutine.
@@ -372,6 +382,9 @@ func (s *session) handleInit(features byte) {
 	if stored == 0 {
 		stored = features
 	}
+	// F-6 observability: log INIT handshake so operators can confirm
+	// ENH framing reached the mux (EBUSD-VERIFICATION-2026-05-10.md).
+	s.mux.logger.Printf("adaptermux: session %d INIT features=0x%02X (stored=0x%02X)", s.id, features, stored)
 	s.deliverReset(stored)
 }
 
@@ -380,6 +393,8 @@ func (s *session) handleInit(features byte) {
 // instead of querying the upstream transport directly, avoiding
 // readMu contention with the readLoop.
 func (s *session) handleInfo(id byte) {
+	// F-6 observability: log INFO dispatch (EBUSD-VERIFICATION-2026-05-10.md).
+	s.mux.logger.Printf("adaptermux: session %d INFO id=0x%02X", s.id, id)
 	data, err := s.mux.CachedInfo(transport.AdapterInfoID(id))
 	if err != nil {
 		s.mux.logger.Printf("adaptermux: session %d INFO id=0x%02X: %v", s.id, id, err)

--- a/internal/adaptermux/session.go
+++ b/internal/adaptermux/session.go
@@ -281,6 +281,12 @@ func (s *session) handleSend(data byte) {
 		s.deliverErrorHost()
 		return
 	}
+	// F-6 observability: log accepted SEND bytes too. Without this, the
+	// happy-path forwarding to activeSendCh is silent and session logs
+	// can show START/INIT/INFO with no per-session SEND traffic even
+	// though bytes are flowing to the bus
+	// (EBUSD-VERIFICATION-2026-05-10.md, Codex P2 follow-up on PR #617).
+	s.mux.logger.Printf("adaptermux: session %d SEND 0x%02X forwarded", s.id, data)
 
 	result := make(chan error, 1)
 	select {


### PR DESCRIPTION
## Summary

Addresses **F-4** and **F-6** from `_work_adaptermux_audit/EBUSD-VERIFICATION-2026-05-10.md`. These block running ebusd-via-proxy alongside helianthus's semantic poller and gate the addon `EBUSGATEWAY_VERSION` bump required for `runtime-state-w19-26.locked` M7 live validation.

## F-4: external fairness window

Symptom: ebusd's initial scan repeatedly fails with `[bus error] send to fe: ERR: arbitration lost`. Root cause: `XR_GATEWAY_PRIORITY` unconditionally prefers `pendingGateway` over `pendingExternal` at every `tryGrant`. With the semantic poller continuously busy, external sessions never reach the bus.

Fix: adaptive fairness rotation. When BOTH classes have pending requests, a counter advances; every `FairnessRatio`'th rotation (default `4`) the next grant goes to external FIFO instead of gateway. When no external session is pending, the counter never advances and gateway-priority is unchanged — **zero overhead in the standalone helianthus deployment**.

Rationale for ratio = 4: gateway's typical 200–300 ms transaction × 4 ≈ 1 s worst-case external START latency, comfortably inside ebusd's 4.5 s per-scan deadline.

3 new tests cover:
- 12-round contention produces exactly 3 external + 9 gateway grants (1-in-4)
- 20 gateway-only rounds keep `fairnessCounter=0`
- External-only grant doesn't advance the counter

## F-6: per-session frame logging

Symptom: 5+ min of `session 1` logs contained only the connect line — no STARTs/SENDs/INITs/INFOs, so the verification killer test couldn't distinguish dropped frames from observability gaps.

Fix: structured log lines on entry of `handleStart`/`handleSend`/`handleInit`/`handleInfo`. Pattern matches the standalone proxy's `session.go` logging shape so existing grep tooling works:
- `session N START 0xXX requested` / `RequestStart(0xXX) sent for session N`
- `session N START 0xAA (SYN cancel)`
- `session N INIT features=0xXX (stored=0xXX)`
- `session N INFO id=0xXX`
- `session N SEND 0xXX rejected — session does not own bus`

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — 19 packages green
- [x] `go test ./internal/adaptermux -count=1 -timeout=180s` — full 83 s suite green
- [x] 3 new fairness tests cover the rotation contract

## Plan reference

- Source report: `_work_adaptermux_audit/EBUSD-VERIFICATION-2026-05-10.md`
- Findings: F-4 (architectural starvation) + F-6 (observability gap)
- Blocks: addon Dockerfile `EBUSGATEWAY_VERSION` bump (M7 live validation prerequisite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)