### PR TITLE
fix(adaptermux): F-7 raw-TCP client diagnostic + auto-close

### DIFF
--- a/internal/adaptermux/session.go
+++ b/internal/adaptermux/session.go
@@ -52,9 +52,35 @@ type session struct {
 	// enh.md:128 — reset parser after arbitration complete).
 	parserResetNeeded atomic.Bool
 
+	// sawHandshake records whether the client has ever sent an INIT,
+	// INFO, or START frame. Clients that have NOT performed any
+	// handshake yet (sawHandshake.Load() == false) but flood the
+	// listener with SEND bytes are almost certainly speaking raw TCP
+	// rather than ENH — most commonly an ebusd configured with
+	// `network_device: "HOST:PORT"` (no `enh:` scheme prefix).
+	// Tracked atomically because handleMessage runs on the readLoop
+	// goroutine while the diagnostic check below reads the value
+	// without holding any session-wide lock.
+	// (EBUSD-VERIFICATION-2026-05-10.md F-7 diagnostic.)
+	sawHandshake atomic.Bool
+
+	// rejectedSendsWithoutHandshake counts handleSend calls that hit
+	// the not-bus-owner rejection path while sawHandshake is still
+	// false. Once this exceeds rawTCPDiagnosticThreshold, the session
+	// is closed with a clear "did you forget enh:HOST:PORT?" log line.
+	rejectedSendsWithoutHandshake atomic.Uint32
+
 	// wg waits for reader, writer, and handleStart goroutines to finish.
 	wg sync.WaitGroup
 }
+
+// rawTCPDiagnosticThreshold is the number of consecutive SEND-rejections
+// (with no preceding ENH handshake) after which the listener emits the
+// F-7 raw-TCP diagnostic and closes the session. 16 chosen so a short
+// burst of legitimate-but-misordered traffic doesn't trip it — the
+// observed-in-the-wild pattern shows tens of rejections per second from
+// a misconfigured client, so 16 fires within ~1 s of connect.
+const rawTCPDiagnosticThreshold uint32 = 16
 
 // sessionFrame is a frame to deliver to an external session.
 type sessionFrame struct {
@@ -278,6 +304,31 @@ func (s *session) handleSend(data byte) {
 		// SEND attempts with missing/lost STARTs
 		// (EBUSD-VERIFICATION-2026-05-10.md).
 		s.mux.logger.Printf("adaptermux: session %d SEND 0x%02X rejected — session does not own bus", s.id, data)
+		// F-7 diagnostic: a client that has never sent an ENH
+		// INIT/INFO/START but floods the listener with SEND
+		// rejections is almost certainly speaking raw TCP, not ENH.
+		// The most common cause (observed in the wild) is an ebusd
+		// configured with `network_device: "HOST:PORT"` instead of
+		// `network_device: "enh:HOST:PORT"` — ebusd then transmits
+		// raw eBUS bytes, our parser decodes each one as a short-
+		// form ENHResReceived (== SEND), and every byte fails the
+		// owner check. After rawTCPDiagnosticThreshold consecutive
+		// rejections without a handshake, emit a clear diagnostic
+		// and close the session so the misconfiguration is obvious
+		// instead of an ever-spinning log spam.
+		// (EBUSD-VERIFICATION-2026-05-10.md F-7.)
+		if !s.sawHandshake.Load() {
+			n := s.rejectedSendsWithoutHandshake.Add(1)
+			if n == rawTCPDiagnosticThreshold {
+				remote := "unknown"
+				if s.conn != nil && s.conn.RemoteAddr() != nil {
+					remote = s.conn.RemoteAddr().String()
+				}
+				s.mux.logger.Printf("adaptermux: session %d (%s) sent %d SEND frames with no preceding ENH INIT/INFO/START — closing as suspected raw-TCP client (did you forget the `enh:` scheme prefix? e.g. ebusd `network_device: enh:HOST:PORT`)",
+					s.id, remote, rawTCPDiagnosticThreshold)
+				go s.mux.RemoveSession(s.id) // goroutine: close out-of-band so handleMessage can return
+			}
+		}
 		s.deliverErrorHost()
 		return
 	}
@@ -327,6 +378,7 @@ func (s *session) handleStart(initiator byte) {
 	// level if it belongs to this session.
 	if initiator == protocol.SymbolSyn {
 		s.mux.logger.Printf("adaptermux: session %d START 0xAA (SYN cancel)", s.id)
+		s.sawHandshake.Store(true) // F-7: SYN-cancel is still a START
 		s.mux.arb.cancelStart(s.id)
 		s.mux.arb.releaseOwnership(s.id)
 		s.mux.cancelPendingStart(s.id)
@@ -338,6 +390,7 @@ func (s *session) handleStart(initiator byte) {
 	// grants" when debugging arbitration starvation
 	// (EBUSD-VERIFICATION-2026-05-10.md).
 	s.mux.logger.Printf("adaptermux: session %d START 0x%02X requested (RequestStart(0x%02X) sent for session %d)", s.id, initiator, initiator, s.id)
+	s.sawHandshake.Store(true) // F-7 diagnostic: legitimate ENH client
 	ch := s.mux.arb.requestStart(s.id, initiator)
 
 	// Wait for arbitration result in a tracked goroutine.
@@ -391,6 +444,7 @@ func (s *session) handleInit(features byte) {
 	// F-6 observability: log INIT handshake so operators can confirm
 	// ENH framing reached the mux (EBUSD-VERIFICATION-2026-05-10.md).
 	s.mux.logger.Printf("adaptermux: session %d INIT features=0x%02X (stored=0x%02X)", s.id, features, stored)
+	s.sawHandshake.Store(true) // F-7 diagnostic: legitimate ENH client
 	s.deliverReset(stored)
 }
 
@@ -401,6 +455,7 @@ func (s *session) handleInit(features byte) {
 func (s *session) handleInfo(id byte) {
 	// F-6 observability: log INFO dispatch (EBUSD-VERIFICATION-2026-05-10.md).
 	s.mux.logger.Printf("adaptermux: session %d INFO id=0x%02X", s.id, id)
+	s.sawHandshake.Store(true) // F-7 diagnostic: legitimate ENH client
 	data, err := s.mux.CachedInfo(transport.AdapterInfoID(id))
 	if err != nil {
 		s.mux.logger.Printf("adaptermux: session %d INFO id=0x%02X: %v", s.id, id, err)

--- a/internal/adaptermux/session_test.go
+++ b/internal/adaptermux/session_test.go
@@ -756,3 +756,94 @@ func TestMux_CloseConcurrent(t *testing.T) {
 		}
 	}
 }
+
+// --- F-7 raw-TCP diagnostic (EBUSD-VERIFICATION-2026-05-10.md) ---
+
+// TestSession_RawTCPDiagnosticFiresAfterFloodWithoutHandshake verifies
+// that a client which sends >= rawTCPDiagnosticThreshold SEND bytes
+// without ever sending INIT/INFO/START is closed by the diagnostic
+// path. This catches the operationally-common case of ebusd configured
+// with `network_device: "HOST:PORT"` (no `enh:` scheme prefix), where
+// ebusd transmits raw eBUS bytes that our parser decodes as short-form
+// ENHResReceived (== SEND).
+func TestSession_RawTCPDiagnosticFiresAfterFloodWithoutHandshake(t *testing.T) {
+	mux, _, cleanup := newTestMux(t)
+	defer cleanup()
+
+	client, server := net.Pipe()
+	defer closeOrLog(t, client, "client")
+
+	id := mux.AddSession(server)
+	if id == 0 {
+		t.Fatalf("AddSession returned 0")
+	}
+
+	// Flood with short-form ENHResReceived bytes (every byte < 0x80 is
+	// parsed as one). 0x31 is a typical eBUS master address that ebusd
+	// emits raw. None of these preceded by an INIT/INFO/START.
+	for i := 0; i < int(rawTCPDiagnosticThreshold)+4; i++ {
+		// Short-form ENH: a single byte < 0x80 represents ENHResReceived.
+		if _, err := client.Write([]byte{0x31}); err != nil {
+			break // pipe closes on session removal — expected
+		}
+	}
+
+	// Wait for the session to be removed. The diagnostic threshold
+	// triggers a goroutine that calls mux.RemoveSession; give it time.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mux.sessionsMu.Lock()
+		_, exists := mux.sessions[id]
+		mux.sessionsMu.Unlock()
+		if !exists {
+			return // session removed — diagnostic fired correctly
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("session %d still present after raw-TCP flood; diagnostic should have closed it", id)
+}
+
+// TestSession_LegitimateENHClientNotClosedByDiagnostic verifies the
+// inverse: a well-behaved ENH client that performs an INIT handshake
+// before any SEND is NOT closed even if a transient ownership race
+// causes individual SEND rejections.
+func TestSession_LegitimateENHClientNotClosedByDiagnostic(t *testing.T) {
+	mux, _, cleanup := newTestMux(t)
+	defer cleanup()
+
+	client, server := net.Pipe()
+	defer closeOrLog(t, client, "client")
+
+	id := mux.AddSession(server)
+	if id == 0 {
+		t.Fatalf("AddSession returned 0")
+	}
+	defer mux.RemoveSession(id)
+
+	// Proper ENH handshake first: INIT with requested features.
+	initReq := transport.EncodeENH(transport.ENHReqInit, 0x01)
+	if _, err := client.Write(initReq[:]); err != nil {
+		t.Fatalf("write INIT: %v", err)
+	}
+	// Drain the RESETTED response so the pipe doesn't back up.
+	_ = readENHFrame(t, client, 2*time.Second)
+
+	// Now flood with SEND attempts (rejected because no bus ownership)
+	// — but the diagnostic must NOT fire because sawHandshake is set.
+	for i := 0; i < int(rawTCPDiagnosticThreshold)+10; i++ {
+		sendReq := transport.EncodeENH(transport.ENHReqSend, 0x31)
+		if _, err := client.Write(sendReq[:]); err != nil {
+			break
+		}
+	}
+
+	// Give the diagnostic time to fire if it were going to.
+	time.Sleep(500 * time.Millisecond)
+
+	mux.sessionsMu.Lock()
+	_, exists := mux.sessions[id]
+	mux.sessionsMu.Unlock()
+	if !exists {
+		t.Fatalf("session %d removed despite legitimate ENH INIT handshake; diagnostic must not fire when sawHandshake=true", id)
+	}
+}

--- a/internal/adaptermux/session_test.go
+++ b/internal/adaptermux/session_test.go
@@ -779,8 +779,8 @@ func TestSession_RawTCPDiagnosticFiresAfterFloodWithoutHandshake(t *testing.T) {
 	}
 
 	// Flood with short-form ENHResReceived bytes (every byte < 0x80 is
-	// parsed as one). 0x31 is a typical eBUS master address that ebusd
-	// emits raw. None of these preceded by an INIT/INFO/START.
+	// parsed as one). 0x31 is a typical eBUS initiator address that
+	// ebusd emits raw. None of these preceded by an INIT/INFO/START.
 	for i := 0; i < int(rawTCPDiagnosticThreshold)+4; i++ {
 		// Short-form ENH: a single byte < 0x80 represents ENHResReceived.
 		if _, err := client.Write([]byte{0x31}); err != nil {


### PR DESCRIPTION
## Summary

Addresses **F-7** from `_work_adaptermux_audit/EBUSD-VERIFICATION-2026-05-10.md` batch-2 results.

The batch-2 verification confirmed the killer-test outcome: ebusd connected without an `enh:` scheme prefix in its `network_device`, sending raw eBUS bytes our ENH parser decoded as short-form `ENHResReceived (== SEND)`. Pattern: 115 SEND-rejected log lines with **0 INIT / 0 INFO / 0 START** — a silent misconfiguration indistinguishable from a real parser bug.

Structural fix candidates were docs-only / listener auto-detect / friendly diagnostic. This PR ships the **friendly diagnostic**: smallest blast radius, no protocol-semantics change, operator sees the root cause in one log line.

## Mechanism

- New session fields: `sawHandshake` (atomic.Bool) + `rejectedSendsWithoutHandshake` (atomic.Uint32).
- `handleInit` / `handleInfo` / `handleStart` (incl. SYN cancel) set `sawHandshake = true`.
- `handleSend`'s not-bus-owner branch increments the rejection counter only while `sawHandshake` is still false.
- When the counter reaches `rawTCPDiagnosticThreshold` (16), the listener logs:
  ```
  adaptermux: session N (REMOTE) sent 16 SEND frames with no preceding ENH INIT/INFO/START — closing as suspected raw-TCP client (did you forget the `enh:` scheme prefix? e.g. ebusd `network_device: enh:HOST:PORT`)
  ```
  and schedules `mux.RemoveSession(id)` in a goroutine so handleSend returns cleanly.

## Threshold rationale

16 SEND rejections fires within ~1 s of connect on a misconfigured ebusd (observed: tens of rejections per second in the wild). A legitimate ENH client completing INIT before any SEND is unaffected because `sawHandshake = true` short-circuits the counter.

## Tests

- `TestSession_RawTCPDiagnosticFiresAfterFloodWithoutHandshake` — 20 raw 0x31 bytes → session removed within 2 s
- `TestSession_LegitimateENHClientNotClosedByDiagnostic` — INIT first then 26 SENDs → session NOT removed

## Other batch-2 findings (status separate)

- **F-8** (migration spam): leaving at ERROR — the action IS required; downgrade would hide critical migration steps. Acceptable transient spam during once-per-upgrade event.
- **F-9** (stale grant race): defer + investigate. Mux's `armPendingStartAbsorbLocked` does suppress the stale STARTED from the session, but the bus-level arbitration is async — ebusd sees the wire-level win regardless. Fundamental fix likely needs ebusd-side or a bus-cancel mechanism. 5/N occurrences = degraded, not urgent.
- **F-10** (read timeout): needs killer test first. Operator: run ebusd with `--readtimeout=1000`. If timeouts disappear → downstream-bus slow under poller load; if not → look at `deliverReceived` drop path.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — 19 packages green
- [x] 2 new diagnostic tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)