### PR TITLE
fix(adaptermux): synthesize arbitration-winner byte to sessions (F-9 + F-10 root cause)

### DIFF
--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -1006,11 +1006,11 @@ func (m *Mux) readLoop() {
 			// of echoing it via ResReceived. Without this synthesis,
 			// external sessions like ebusd see the gateway's
 			// transaction stream as `... SYN, 0x15 (target), 0xB5,
-			// 0x24, ...` with no master-byte boundary. Their bus
+			// 0x24, ...` with no initiator-byte boundary. Their bus
 			// parser then discards the frame as malformed (0x15 isn't
-			// a valid master byte — low nibble 5 isn't a valid
+			// a valid initiator byte — low nibble 5 isn't a valid
 			// arbitration nibble) and the gateway's traffic vanishes
-			// from their grab buffer / master enumeration. Worse,
+			// from their grab buffer / initiator enumeration. Worse,
 			// their bus state machine thinks the bus is idle when it
 			// isn't, leading to mis-timed bid attempts and the
 			// "won in invalid state" + read-timeout cascade seen in
@@ -1029,7 +1029,7 @@ func (m *Mux) readLoop() {
 		case transport.StreamEventFailed:
 			m.logger.Printf("adaptermux: readLoop got StreamEventFailed data=0x%02X", event.Data)
 			m.handleArbitrationResponse(false, event.Data)
-			// Symmetric synthesis: when another master beats our
+			// Symmetric synthesis: when another initiator beats our
 			// gateway's bid, the winner byte was on the wire but
 			// the adapter consumed it as a FAILED control event.
 			// External sessions need to see the winner byte to

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -1066,7 +1066,9 @@ func (m *Mux) readLoop() {
 				if startedBidderSessionID == gatewaySessionID {
 					// Gateway won — every external session needs
 					// the byte; no per-session control event
-					// competes.
+					// competes. Passive observers are intentionally
+					// NOT notified (gateway-owned bytes are
+					// suppressed in onReceived too — consistent).
 					m.deliverToSessions(event.Data, gatewaySessionID, true, time.Now())
 				} else {
 					// External session won — skip the winner (its
@@ -1078,6 +1080,19 @@ func (m *Mux) readLoop() {
 					// it they'd misread the next target/PB byte as
 					// the frame source. (Codex P2 round 3.)
 					m.deliverWinnerByteToOtherSessions(event.Data, startedBidderSessionID)
+					// Passive observer pipeline also needs the
+					// non-gateway winner byte — the PassiveTransport
+					// / bus reconstructor otherwise sees the next
+					// target/PB byte as the frame source for
+					// externally-owned frames. onReceived's normal
+					// PassiveEventSymbol path is bypassed for
+					// StreamEventStarted, so synthesize here.
+					// (Codex P2 round 5 on PR #620.)
+					m.emitPassive(PassiveEvent{
+						Kind:       PassiveEventSymbol,
+						Symbol:     event.Data,
+						ObservedAt: time.Now(),
+					})
 				}
 			}
 			continue
@@ -1133,6 +1148,19 @@ func (m *Mux) readLoop() {
 				m.deliverToSessions(event.Data, 0, false, time.Now())
 			} else if externalBidderValid {
 				m.deliverWinnerByteToOtherSessions(event.Data, externalBidderSessionID)
+			}
+			// FAILED always means a non-gateway initiator won the
+			// arbitration (gateway-win produces STARTED, not FAILED).
+			// Emit the winner byte to passive observers so the bus
+			// reconstructor sees the correct frame source for the
+			// third-party transaction that's about to flow through
+			// onReceived. (Codex P2 round 5 on PR #620.)
+			if gatewayWasBidder || externalBidderValid {
+				m.emitPassive(PassiveEvent{
+					Kind:       PassiveEventSymbol,
+					Symbol:     event.Data,
+					ObservedAt: time.Now(),
+				})
 			}
 			continue
 		case transport.StreamEventReset:

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -1042,18 +1042,45 @@ func (m *Mux) readLoop() {
 			continue
 		case transport.StreamEventFailed:
 			m.logger.Printf("adaptermux: readLoop got StreamEventFailed data=0x%02X", event.Data)
+			// Peek the pending bidder's session ID BEFORE
+			// handleArbitrationResponse clears pendingStart. We need
+			// it to decide whether this FAILED was for a gateway-
+			// initiated bid (synthesis safe — no per-session control
+			// event will race) or an external-session bid (the
+			// session's handleStart goroutine will deliver
+			// ENHResFailed asynchronously; synthesizing here races
+			// that). Codex P2 round 2 on PR #620.
+			//
+			// pendingStartAbsorb > 0 means the response is for a
+			// cancelled bid — neither path needs synthesis, the bus
+			// state for that bid is already torn down on the gateway
+			// side.
+			m.stateMu.Lock()
+			gatewayWasBidder := false
+			if m.pendingStartAbsorb == 0 && m.pendingStart != nil && m.pendingStart.sessionID == gatewaySessionID {
+				gatewayWasBidder = true
+			}
+			m.stateMu.Unlock()
+
 			m.handleArbitrationResponse(false, event.Data)
-			// No synthesis on FAILED. The losing bidder's session
-			// receives ENHResFailed(winner) via its own handleStart
-			// goroutine; adding a synthesized ENHResReceived(winner)
-			// here would race the FAILED frame for the same byte,
-			// presenting an out-of-order arbitration result. The
-			// FAILED frame itself already carries the winner
-			// address, so the bidder has the information it needs
-			// to update bus state. Other sessions (in the rare
-			// multi-external-session case) miss the winner byte,
-			// but the impact is bounded and lower-risk than the
-			// ordering hazard. (Codex P2 follow-up on PR #620.)
+
+			// Synthesize the winner byte only when the gateway was
+			// the losing bidder. External monitors (e.g. ebusd) need
+			// to see the byte to update their bus state — without
+			// it, they'll misread the next target/PB byte as the
+			// frame source, in the same way the pre-fix gateway-win
+			// case desynchronized them. Gateway-side state has
+			// already been torn down by handleArbitrationResponse;
+			// no per-session control event competes with this synth.
+			//
+			// When an external session was the losing bidder, that
+			// session's deliverFailed delivers ENHResFailed(winner)
+			// via its handleStart goroutine. We skip synthesis there
+			// to avoid the ordering race. (Other multi-external-
+			// session cases miss the winner byte; bounded impact.)
+			if gatewayWasBidder {
+				m.deliverToSessions(event.Data, 0, false, time.Now())
+			}
 			continue
 		case transport.StreamEventReset:
 			m.handleReset()

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -1000,44 +1000,60 @@ func (m *Mux) readLoop() {
 			m.logger.Printf("adaptermux: readLoop got StreamEventStarted data=0x%02X", event.Data)
 			m.handleArbitrationResponse(true, event.Data)
 			// Synthesize the arbitration-winner byte as a passive
-			// observation for external sessions. The wire DID carry
-			// this byte (e.g. 0x7F) at this point, but the ENH
-			// adapter consumes it as a STARTED control event instead
-			// of echoing it via ResReceived. Without this synthesis,
-			// external sessions like ebusd see the gateway's
-			// transaction stream as `... SYN, 0x15 (target), 0xB5,
-			// 0x24, ...` with no initiator-byte boundary. Their bus
-			// parser then discards the frame as malformed (0x15 isn't
-			// a valid initiator byte — low nibble 5 isn't a valid
-			// arbitration nibble) and the gateway's traffic vanishes
-			// from their grab buffer / initiator enumeration. Worse,
-			// their bus state machine thinks the bus is idle when it
-			// isn't, leading to mis-timed bid attempts and the
-			// "won in invalid state" + read-timeout cascade seen in
+			// observation for external sessions ONLY when the gateway
+			// is the winner. The wire DID carry this byte (e.g. 0x7F)
+			// at this point, but the ENH adapter consumes it as a
+			// STARTED control event instead of echoing it via
+			// ResReceived. Without this synthesis, external sessions
+			// like ebusd see the gateway's transaction stream as
+			// `... SYN, 0x15 (target), 0xB5, 0x24, ...` with no
+			// initiator-byte boundary. Their bus parser discards the
+			// frame as malformed (0x15 isn't a valid initiator byte
+			// — low nibble 5 isn't a valid arbitration nibble) and
+			// the gateway's traffic vanishes from their grab buffer
+			// / initiator enumeration. Worse, their bus state
+			// machine thinks the bus is idle when it isn't, leading
+			// to mis-timed bid attempts and the "won in invalid
+			// state" + read-timeout cascade seen in
 			// EBUSD-VERIFICATION-2026-05-10.md F-9 / F-10.
 			//
-			// Query the actual owner from the arbitrator (set by
-			// handleArbitrationResponse above) — could be gateway OR
-			// an external session that just won. If hasOwner is
-			// false, the STARTED was absorbed as stale and we should
-			// NOT synthesize (it belongs to a cancelled bid; nobody
-			// is using the bus from this win).
-			if owner, _, owned := m.arb.owner(); owned {
+			// We restrict synthesis to gateway-wins because:
+			//   - When an external session wins, it receives
+			//     ENHResStarted via its own handleStart goroutine
+			//     (session.go: deliverStarted). That goroutine and
+			//     this readLoop are independent, so an unconditional
+			//     synthesis here could enqueue ENHResReceived
+			//     (winner_byte) BEFORE the session's own
+			//     ENHResStarted, presenting an out-of-order
+			//     arbitration result to a strict ENH parser
+			//     (Codex P2 follow-up on PR #620).
+			//   - For gateway wins, there is no competing per-
+			//     session control event — the gateway consumes
+			//     STARTED synchronously, so no goroutine race
+			//     exists.
+			//
+			// If hasOwner is false after handleArbitrationResponse,
+			// the STARTED was absorbed as stale (cancelled bid).
+			// Don't synthesize — nobody is using the bus from this
+			// stale win.
+			if owner, _, owned := m.arb.owner(); owned && owner == gatewaySessionID {
 				m.deliverToSessions(event.Data, owner, true, time.Now())
 			}
 			continue
 		case transport.StreamEventFailed:
 			m.logger.Printf("adaptermux: readLoop got StreamEventFailed data=0x%02X", event.Data)
 			m.handleArbitrationResponse(false, event.Data)
-			// Symmetric synthesis: when another initiator beats our
-			// gateway's bid, the winner byte was on the wire but
-			// the adapter consumed it as a FAILED control event.
-			// External sessions need to see the winner byte to
-			// keep their bus state machine synchronized with the
-			// physical wire. Includes the no-owner indicator
-			// because the gateway's bid lost and the winner is a
-			// third-party device, not one of our sessions.
-			m.deliverToSessions(event.Data, 0, false, time.Now())
+			// No synthesis on FAILED. The losing bidder's session
+			// receives ENHResFailed(winner) via its own handleStart
+			// goroutine; adding a synthesized ENHResReceived(winner)
+			// here would race the FAILED frame for the same byte,
+			// presenting an out-of-order arbitration result. The
+			// FAILED frame itself already carries the winner
+			// address, so the bidder has the information it needs
+			// to update bus state. Other sessions (in the rare
+			// multi-external-session case) miss the winner byte,
+			// but the impact is bounded and lower-risk than the
+			// ordering hazard. (Codex P2 follow-up on PR #620.)
 			continue
 		case transport.StreamEventReset:
 			m.handleReset()

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -999,10 +999,45 @@ func (m *Mux) readLoop() {
 		case transport.StreamEventStarted:
 			m.logger.Printf("adaptermux: readLoop got StreamEventStarted data=0x%02X", event.Data)
 			m.handleArbitrationResponse(true, event.Data)
+			// Synthesize the arbitration-winner byte as a passive
+			// observation for external sessions. The wire DID carry
+			// this byte (e.g. 0x7F) at this point, but the ENH
+			// adapter consumes it as a STARTED control event instead
+			// of echoing it via ResReceived. Without this synthesis,
+			// external sessions like ebusd see the gateway's
+			// transaction stream as `... SYN, 0x15 (target), 0xB5,
+			// 0x24, ...` with no master-byte boundary. Their bus
+			// parser then discards the frame as malformed (0x15 isn't
+			// a valid master byte — low nibble 5 isn't a valid
+			// arbitration nibble) and the gateway's traffic vanishes
+			// from their grab buffer / master enumeration. Worse,
+			// their bus state machine thinks the bus is idle when it
+			// isn't, leading to mis-timed bid attempts and the
+			// "won in invalid state" + read-timeout cascade seen in
+			// EBUSD-VERIFICATION-2026-05-10.md F-9 / F-10.
+			//
+			// Query the actual owner from the arbitrator (set by
+			// handleArbitrationResponse above) — could be gateway OR
+			// an external session that just won. If hasOwner is
+			// false, the STARTED was absorbed as stale and we should
+			// NOT synthesize (it belongs to a cancelled bid; nobody
+			// is using the bus from this win).
+			if owner, _, owned := m.arb.owner(); owned {
+				m.deliverToSessions(event.Data, owner, true, time.Now())
+			}
 			continue
 		case transport.StreamEventFailed:
 			m.logger.Printf("adaptermux: readLoop got StreamEventFailed data=0x%02X", event.Data)
 			m.handleArbitrationResponse(false, event.Data)
+			// Symmetric synthesis: when another master beats our
+			// gateway's bid, the winner byte was on the wire but
+			// the adapter consumed it as a FAILED control event.
+			// External sessions need to see the winner byte to
+			// keep their bus state machine synchronized with the
+			// physical wire. Includes the no-owner indicator
+			// because the gateway's bid lost and the winner is a
+			// third-party device, not one of our sessions.
+			m.deliverToSessions(event.Data, 0, false, time.Now())
 			continue
 		case transport.StreamEventReset:
 			m.handleReset()

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -1147,43 +1147,43 @@ func (m *Mux) readLoop() {
 			continue
 		case transport.StreamEventFailed:
 			m.logger.Printf("adaptermux: readLoop got StreamEventFailed data=0x%02X", event.Data)
-			// Peek the pending bidder's session ID BEFORE
-			// handleArbitrationResponse clears pendingStart. We need
-			// it to decide whether this FAILED was for a gateway-
-			// initiated bid (synthesis safe — no per-session control
-			// event will race) or an external-session bid (the
-			// session's handleStart goroutine will deliver
-			// ENHResFailed asynchronously; synthesizing here races
-			// that). Codex P2 round 2 on PR #620.
+			// Peek the *active* bidder (if any) BEFORE
+			// handleArbitrationResponse clears pendingStart. The
+			// presence and identity of the bidder dictate how we
+			// route the synthesized winner byte; the wire byte
+			// itself always needs to flow to observers regardless.
 			//
-			// pendingStartAbsorb > 0 means the response is for a
-			// cancelled bid — neither path needs synthesis, the bus
-			// state for that bid is already torn down on the gateway
-			// side.
+			// `pendingStartAbsorb > 0` indicates this FAILED is the
+			// stale response to a cancelled bid. The bid is gone, so
+			// no per-session control event races us — but the byte
+			// was still consumed from the wire and the third-party
+			// transaction continues, so observers still need it.
+			// (Codex P2 round 8 on PR #620.)
+			//
+			// `pendingStart == nil` (no bid at all) is similarly a
+			// pure passive observation: deliver to all sessions +
+			// emit passive.
 			m.stateMu.Lock()
-			gatewayWasBidder := false
-			if m.pendingStartAbsorb == 0 && m.pendingStart != nil && m.pendingStart.sessionID == gatewaySessionID {
-				gatewayWasBidder = true
-			}
-			m.stateMu.Unlock()
-
-			// Snapshot the external bidder (if not gateway) so we can
-			// skip-the-bidder for the multi-session synthesis below.
-			m.stateMu.Lock()
-			var externalBidderSessionID uint64
-			var externalBidderValid bool
-			if !gatewayWasBidder && m.pendingStartAbsorb == 0 && m.pendingStart != nil {
-				externalBidderSessionID = m.pendingStart.sessionID
-				externalBidderValid = true
+			var activeBidderSessionID uint64
+			var hasActiveBidder bool
+			if m.pendingStartAbsorb == 0 && m.pendingStart != nil {
+				activeBidderSessionID = m.pendingStart.sessionID
+				hasActiveBidder = true
 			}
 			m.stateMu.Unlock()
 
 			m.handleArbitrationResponse(false, event.Data)
 
 			// Synthesize the winner byte:
-			//   - Gateway-lost: deliver to all external sessions (no
-			//     per-session control event competes — the gateway
-			//     has no session in m.sessions).
+			//   - No active bidder (absorbed-stale OR no pending):
+			//     deliver to all external sessions. The wire byte
+			//     was consumed; the rest of the third-party frame
+			//     will continue through onReceived. Without this,
+			//     external monitors and the passive reconstructor
+			//     would parse the next target/PB byte as the frame
+			//     source and desynchronize.
+			//   - Gateway-lost: deliver to all external sessions
+			//     (gateway has no session in m.sessions, no skip).
 			//   - External-lost: deliver to all OTHER external
 			//     sessions (skip the losing bidder; their session's
 			//     handleStart goroutine delivers ENHResFailed via
@@ -1191,26 +1191,27 @@ func (m *Mux) readLoop() {
 			//     RECEIVED(winner)). Multi-monitor deployments need
 			//     the byte on the non-bidder sessions to keep their
 			//     bus state synced. (Codex P2 round 3 on PR #620.)
-			//   - Absorbed-stale: skip entirely — bus state for the
-			//     cancelled bid is already torn down.
-			if gatewayWasBidder {
+			switch {
+			case !hasActiveBidder:
 				m.deliverToSessions(event.Data, 0, false, time.Now())
-			} else if externalBidderValid {
-				m.deliverWinnerByteToOtherSessions(event.Data, externalBidderSessionID)
+			case activeBidderSessionID == gatewaySessionID:
+				m.deliverToSessions(event.Data, 0, false, time.Now())
+			default:
+				m.deliverWinnerByteToOtherSessions(event.Data, activeBidderSessionID)
 			}
 			// FAILED always means a non-gateway initiator won the
 			// arbitration (gateway-win produces STARTED, not FAILED).
 			// Emit the winner byte to passive observers so the bus
 			// reconstructor sees the correct frame source for the
 			// third-party transaction that's about to flow through
-			// onReceived. (Codex P2 round 5 on PR #620.)
-			if gatewayWasBidder || externalBidderValid {
-				m.emitPassive(PassiveEvent{
-					Kind:       PassiveEventSymbol,
-					Symbol:     event.Data,
-					ObservedAt: time.Now(),
-				})
-			}
+			// onReceived. Emit unconditionally — the wire byte
+			// happened irrespective of whether a gateway bid was
+			// pending. (Codex P2 round 5 + round 8 on PR #620.)
+			m.emitPassive(PassiveEvent{
+				Kind:       PassiveEventSymbol,
+				Symbol:     event.Data,
+				ObservedAt: time.Now(),
+			})
 			continue
 		case transport.StreamEventReset:
 			m.handleReset()

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -998,6 +998,26 @@ func (m *Mux) readLoop() {
 		switch event.Kind {
 		case transport.StreamEventStarted:
 			m.logger.Printf("adaptermux: readLoop got StreamEventStarted data=0x%02X", event.Data)
+			// Peek the pending bidder's session ID BEFORE
+			// handleArbitrationResponse fires. Without this, an
+			// external winner can call RemoveSession immediately
+			// after receiving STARTED (e.g. ebusd disconnects on
+			// transaction completion) which releases ownership;
+			// our subsequent m.arb.owner() would return owned=false
+			// and we'd miss the chance to synthesize for non-winner
+			// sessions. Codex P2 round 4 on PR #620.
+			//
+			// pendingStartAbsorb > 0 means the response is for a
+			// cancelled bid — bus state is already torn down, no
+			// synthesis needed regardless of bidder identity.
+			m.stateMu.Lock()
+			var startedBidderSessionID uint64
+			var startedBidderValid bool
+			if m.pendingStartAbsorb == 0 && m.pendingStart != nil {
+				startedBidderSessionID = m.pendingStart.sessionID
+				startedBidderValid = true
+			}
+			m.stateMu.Unlock()
 			m.handleArbitrationResponse(true, event.Data)
 			// Synthesize the arbitration-winner byte as a passive
 			// observation for external sessions ONLY when the gateway
@@ -1036,21 +1056,28 @@ func (m *Mux) readLoop() {
 			// the STARTED was absorbed as stale (cancelled bid).
 			// Don't synthesize — nobody is using the bus from this
 			// stale win.
-			if owner, _, owned := m.arb.owner(); owned {
-				if owner == gatewaySessionID {
-					// Gateway won — every external session needs the
-					// byte; no per-session control event competes.
-					m.deliverToSessions(event.Data, owner, true, time.Now())
+			// Use the snapshotted bidder identity (NOT a fresh
+			// owner() read) so a winner-disconnect-then-release
+			// race doesn't skip synthesis for the remaining
+			// monitors. The wire byte was already consumed by the
+			// adapter; synthesis is required regardless of whether
+			// the winning session is still attached.
+			if startedBidderValid {
+				if startedBidderSessionID == gatewaySessionID {
+					// Gateway won — every external session needs
+					// the byte; no per-session control event
+					// competes.
+					m.deliverToSessions(event.Data, gatewaySessionID, true, time.Now())
 				} else {
 					// External session won — skip the winner (its
 					// handleStart goroutine delivers ENHResStarted
-					// asynchronously; synthesis here would race that
-					// frame). Other external sessions (multi-monitor
-					// deployments) still need the byte to keep their
-					// bus state synced — without it they'd misread
-					// the next target/PB byte as the frame source.
-					// (Codex P2 round 3 on PR #620.)
-					m.deliverWinnerByteToOtherSessions(event.Data, owner)
+					// asynchronously; synthesis here would race
+					// that frame). Other external sessions
+					// (multi-monitor deployments) still need the
+					// byte to keep their bus state synced — without
+					// it they'd misread the next target/PB byte as
+					// the frame source. (Codex P2 round 3.)
+					m.deliverWinnerByteToOtherSessions(event.Data, startedBidderSessionID)
 				}
 			}
 			continue

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -1036,8 +1036,22 @@ func (m *Mux) readLoop() {
 			// the STARTED was absorbed as stale (cancelled bid).
 			// Don't synthesize — nobody is using the bus from this
 			// stale win.
-			if owner, _, owned := m.arb.owner(); owned && owner == gatewaySessionID {
-				m.deliverToSessions(event.Data, owner, true, time.Now())
+			if owner, _, owned := m.arb.owner(); owned {
+				if owner == gatewaySessionID {
+					// Gateway won — every external session needs the
+					// byte; no per-session control event competes.
+					m.deliverToSessions(event.Data, owner, true, time.Now())
+				} else {
+					// External session won — skip the winner (its
+					// handleStart goroutine delivers ENHResStarted
+					// asynchronously; synthesis here would race that
+					// frame). Other external sessions (multi-monitor
+					// deployments) still need the byte to keep their
+					// bus state synced — without it they'd misread
+					// the next target/PB byte as the frame source.
+					// (Codex P2 round 3 on PR #620.)
+					m.deliverWinnerByteToOtherSessions(event.Data, owner)
+				}
 			}
 			continue
 		case transport.StreamEventFailed:
@@ -1062,24 +1076,36 @@ func (m *Mux) readLoop() {
 			}
 			m.stateMu.Unlock()
 
+			// Snapshot the external bidder (if not gateway) so we can
+			// skip-the-bidder for the multi-session synthesis below.
+			m.stateMu.Lock()
+			var externalBidderSessionID uint64
+			var externalBidderValid bool
+			if !gatewayWasBidder && m.pendingStartAbsorb == 0 && m.pendingStart != nil {
+				externalBidderSessionID = m.pendingStart.sessionID
+				externalBidderValid = true
+			}
+			m.stateMu.Unlock()
+
 			m.handleArbitrationResponse(false, event.Data)
 
-			// Synthesize the winner byte only when the gateway was
-			// the losing bidder. External monitors (e.g. ebusd) need
-			// to see the byte to update their bus state — without
-			// it, they'll misread the next target/PB byte as the
-			// frame source, in the same way the pre-fix gateway-win
-			// case desynchronized them. Gateway-side state has
-			// already been torn down by handleArbitrationResponse;
-			// no per-session control event competes with this synth.
-			//
-			// When an external session was the losing bidder, that
-			// session's deliverFailed delivers ENHResFailed(winner)
-			// via its handleStart goroutine. We skip synthesis there
-			// to avoid the ordering race. (Other multi-external-
-			// session cases miss the winner byte; bounded impact.)
+			// Synthesize the winner byte:
+			//   - Gateway-lost: deliver to all external sessions (no
+			//     per-session control event competes — the gateway
+			//     has no session in m.sessions).
+			//   - External-lost: deliver to all OTHER external
+			//     sessions (skip the losing bidder; their session's
+			//     handleStart goroutine delivers ENHResFailed via
+			//     deliverFailed, which would race a synthesized
+			//     RECEIVED(winner)). Multi-monitor deployments need
+			//     the byte on the non-bidder sessions to keep their
+			//     bus state synced. (Codex P2 round 3 on PR #620.)
+			//   - Absorbed-stale: skip entirely — bus state for the
+			//     cancelled bid is already torn down.
 			if gatewayWasBidder {
 				m.deliverToSessions(event.Data, 0, false, time.Now())
+			} else if externalBidderValid {
+				m.deliverWinnerByteToOtherSessions(event.Data, externalBidderSessionID)
 			}
 			continue
 		case transport.StreamEventReset:
@@ -2669,6 +2695,30 @@ func (m *Mux) deliverToSessions(symbol byte, currentOwner uint64, hasOwner bool,
 					sess.deliverReceived(b)
 				}
 			}
+		}
+		sess.deliverReceived(symbol)
+	}
+}
+
+// deliverWinnerByteToOtherSessions delivers an arbitration-winner byte
+// as a passive observation to every external session EXCEPT the one
+// identified by exceptSessionID. Used by the readLoop's STARTED/FAILED
+// synthesis paths when an external session won (STARTED) or lost
+// (FAILED): the winning/losing session's handleStart goroutine
+// delivers ENHResStarted/ENHResFailed asynchronously, so adding a
+// synthesized ENHResReceived(winner_byte) to that session would race
+// the control frame. Other external sessions (in multi-monitor
+// deployments) still need the byte to keep their bus state synced
+// with physical wire reality.
+//
+// EBUSD-VERIFICATION-2026-05-10.md F-9/F-10 follow-up; Codex P2
+// round 3 on PR #620.
+func (m *Mux) deliverWinnerByteToOtherSessions(symbol byte, exceptSessionID uint64) {
+	m.sessionsMu.Lock()
+	defer m.sessionsMu.Unlock()
+	for _, sess := range m.sessions {
+		if sess.id == exceptSessionID {
+			continue
 		}
 		sess.deliverReceived(symbol)
 	}

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -1122,12 +1122,16 @@ func (m *Mux) readLoop() {
 						m.deliverToSessions(event.Data, 0, false, time.Now())
 					} else {
 						// External session was bidder but lost.
-						// Skip the loser (its handleStart will
-						// receive ENHResFailed via the failed
-						// pending notify channel — synthesizing
-						// RECEIVED(winner) here would race it on
-						// the same session). Other external
-						// sessions still need the byte.
+						// Skip the loser: handleArbitrationResponse's
+						// mismatch path now notifies the bidder with
+						// initiator=event.Data (the third-party
+						// winner) — see Codex P2 round 7 fix. The
+						// bidder's handleStart goroutine therefore
+						// delivers ENHResFailed(winner_byte), which
+						// conveys the actual wire owner and keeps the
+						// bidder's bus reconstructor in sync. A
+						// synthesized RECEIVED(winner) here would
+						// race that frame on the same session.
 						m.deliverWinnerByteToOtherSessions(event.Data, startedBidderSessionID)
 					}
 					// Third-party winner byte is a true passive
@@ -2467,9 +2471,18 @@ func (m *Mux) handleArbitrationResponse(started bool, data byte) {
 			}
 			m.stateMu.Unlock()
 			m.logger.Printf("adaptermux: STARTED mismatch: got initiator 0x%02X, pending 0x%02X — failing pending session %d (AM56)", data, pending.initiator, pending.sessionID)
+			// Notify the bidder with the THIRD-PARTY winner byte (`data`),
+			// not the bidder's own `pending.initiator`. This matches the
+			// regular FAILED-path semantics below: the bidder's handleStart
+			// goroutine forwards `result.initiator` to deliverFailed, so the
+			// external session sees ENHResFailed(winner_byte) and learns
+			// the actual wire owner. Without this, the bidder would only
+			// learn its own bid byte from the failure and its bus
+			// reconstructor would misread the next target/PB byte as the
+			// frame source (Codex P2 round 7 on PR #620).
 			pending.notify <- startResult{
 				granted:   false,
-				initiator: pending.initiator,
+				initiator: data,
 				err:       fmt.Errorf("adaptermux: STARTED mismatch (got 0x%02X, want 0x%02X)", data, pending.initiator),
 			}
 			// After resolving, check if more requests are pending.

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -1012,9 +1012,11 @@ func (m *Mux) readLoop() {
 			// synthesis needed regardless of bidder identity.
 			m.stateMu.Lock()
 			var startedBidderSessionID uint64
+			var startedBidderInitiator byte
 			var startedBidderValid bool
 			if m.pendingStartAbsorb == 0 && m.pendingStart != nil {
 				startedBidderSessionID = m.pendingStart.sessionID
+				startedBidderInitiator = m.pendingStart.initiator
 				startedBidderValid = true
 			}
 			m.stateMu.Unlock()
@@ -1063,31 +1065,74 @@ func (m *Mux) readLoop() {
 			// adapter; synthesis is required regardless of whether
 			// the winning session is still attached.
 			if startedBidderValid {
-				if startedBidderSessionID == gatewaySessionID {
-					// Gateway won — every external session needs
-					// the byte; no per-session control event
-					// competes. Passive observers are intentionally
-					// NOT notified (gateway-owned bytes are
-					// suppressed in onReceived too — consistent).
-					m.deliverToSessions(event.Data, gatewaySessionID, true, time.Now())
+				if event.Data == startedBidderInitiator {
+					// Matched STARTED — handleArbitrationResponse
+					// granted ownership to the bidder, so event.Data
+					// is the bidder's own initiator byte.
+					if startedBidderSessionID == gatewaySessionID {
+						// Gateway won — every external session
+						// needs the byte; no per-session control
+						// event competes. Passive observers are
+						// intentionally NOT notified (gateway-
+						// owned bytes are suppressed in
+						// onReceived too — consistent).
+						m.deliverToSessions(event.Data, gatewaySessionID, true, time.Now())
+					} else {
+						// External session won — skip the winner
+						// (its handleStart goroutine delivers
+						// ENHResStarted asynchronously; synthesis
+						// here would race that frame). Other
+						// external sessions (multi-monitor
+						// deployments) still need the byte to
+						// keep their bus state synced — without
+						// it they'd misread the next target/PB
+						// byte as the frame source. (Codex P2
+						// round 3.)
+						m.deliverWinnerByteToOtherSessions(event.Data, startedBidderSessionID)
+						// Passive observer pipeline also needs
+						// the non-gateway winner byte — the
+						// PassiveTransport / bus reconstructor
+						// otherwise sees the next target/PB byte
+						// as the frame source for externally-
+						// owned frames. onReceived's normal
+						// PassiveEventSymbol path is bypassed for
+						// StreamEventStarted, so synthesize here.
+						// (Codex P2 round 5 on PR #620.)
+						m.emitPassive(PassiveEvent{
+							Kind:       PassiveEventSymbol,
+							Symbol:     event.Data,
+							ObservedAt: time.Now(),
+						})
+					}
 				} else {
-					// External session won — skip the winner (its
-					// handleStart goroutine delivers ENHResStarted
-					// asynchronously; synthesis here would race
-					// that frame). Other external sessions
-					// (multi-monitor deployments) still need the
-					// byte to keep their bus state synced — without
-					// it they'd misread the next target/PB byte as
-					// the frame source. (Codex P2 round 3.)
-					m.deliverWinnerByteToOtherSessions(event.Data, startedBidderSessionID)
-					// Passive observer pipeline also needs the
-					// non-gateway winner byte — the PassiveTransport
-					// / bus reconstructor otherwise sees the next
-					// target/PB byte as the frame source for
-					// externally-owned frames. onReceived's normal
-					// PassiveEventSymbol path is bypassed for
-					// StreamEventStarted, so synthesize here.
-					// (Codex P2 round 5 on PR #620.)
+					// Mismatched STARTED (AM56): the wire byte
+					// belongs to some third party, not the bidder.
+					// handleArbitrationResponse has already failed
+					// the bidder session and armed absorb, so the
+					// bidder is no longer the winner. The third-
+					// party winner byte still needs to flow to the
+					// non-bidder sessions and passive observers so
+					// their bus state stays synced with physical
+					// reality. (Codex P2 round 6 on PR #620.)
+					if startedBidderSessionID == gatewaySessionID {
+						// Gateway was bidder but lost to a third
+						// party — every external session needs
+						// the byte (gateway has no session in
+						// m.sessions; no echo suppression needed).
+						m.deliverToSessions(event.Data, 0, false, time.Now())
+					} else {
+						// External session was bidder but lost.
+						// Skip the loser (its handleStart will
+						// receive ENHResFailed via the failed
+						// pending notify channel — synthesizing
+						// RECEIVED(winner) here would race it on
+						// the same session). Other external
+						// sessions still need the byte.
+						m.deliverWinnerByteToOtherSessions(event.Data, startedBidderSessionID)
+					}
+					// Third-party winner byte is a true passive
+					// observation regardless of who the bidder was
+					// — always emit it for the passive pipeline.
 					m.emitPassive(PassiveEvent{
 						Kind:       PassiveEventSymbol,
 						Symbol:     event.Data,

--- a/internal/adaptermux/p3_test.go
+++ b/internal/adaptermux/p3_test.go
@@ -1399,6 +1399,12 @@ func TestHandleArbitrationResponse_StaleStartedFailsPending(t *testing.T) {
 	}
 
 	// AM56: FAILED must have been delivered on the notify channel.
+	// Codex P2 round 7 on PR #620: result.initiator carries the
+	// THIRD-PARTY winner byte (the value observed on the wire), not the
+	// pending bidder's own initiator. This matches normal FAILED
+	// semantics so the bidder's handleStart goroutine can deliver
+	// ENHResFailed(winner_byte), giving the external session enough
+	// information to keep its bus reconstructor in sync.
 	select {
 	case result := <-ch:
 		if result.granted {
@@ -1407,8 +1413,8 @@ func TestHandleArbitrationResponse_StaleStartedFailsPending(t *testing.T) {
 		if result.err == nil {
 			t.Fatal("expected error on STARTED mismatch")
 		}
-		if result.initiator != 0x71 {
-			t.Fatalf("result.initiator = 0x%02X, want 0x71 (pending initiator)", result.initiator)
+		if result.initiator != 0x31 {
+			t.Fatalf("result.initiator = 0x%02X, want 0x31 (third-party winner observed on wire, Codex P2 round 7 PR #620)", result.initiator)
 		}
 	default:
 		t.Fatal("expected result on notify channel after STARTED mismatch")

--- a/internal/adaptermux/session_test.go
+++ b/internal/adaptermux/session_test.go
@@ -1017,3 +1017,77 @@ func TestArbitrationWinnerSynthesis_SkippedWhenExternalSessionWins(t *testing.T)
 		}
 	}
 }
+
+// TestArbitrationWinnerSynthesis_MultiSessionDeliversToNonWinner verifies
+// the multi-session future-proofing rule (Codex P2 round 3 on PR #620):
+// when an external session wins arbitration, OTHER external sessions
+// (e.g. a second bus monitor) still need the winner byte for their bus
+// state, but the WINNING session must NOT receive the synthesized byte
+// (its handleStart goroutine delivers ENHResStarted asynchronously and
+// the synthesis would race the control frame).
+func TestArbitrationWinnerSynthesis_MultiSessionDeliversToNonWinner(t *testing.T) {
+	mux, _, cleanup := newTestMux(t)
+	defer cleanup()
+
+	// Two external sessions: A (winner of arbitration) and B (passive
+	// monitor). We use deliverWinnerByteToOtherSessions directly so the
+	// test pins the helper's exclusion contract without standing up a
+	// full ENH winner-handshake flow.
+	clientA, serverA := net.Pipe()
+	defer closeOrLog(t, clientA, "clientA")
+	clientB, serverB := net.Pipe()
+	defer closeOrLog(t, clientB, "clientB")
+
+	idA := mux.AddSession(serverA)
+	idB := mux.AddSession(serverB)
+	if idA == 0 || idB == 0 {
+		t.Fatalf("AddSession returned 0 (idA=%d idB=%d)", idA, idB)
+	}
+	defer mux.RemoveSession(idA)
+	defer mux.RemoveSession(idB)
+
+	// Drain INIT chatter from both pipes; flag any 0x7F appearance.
+	sawWinnerOnA := make(chan struct{}, 1)
+	sawWinnerOnB := make(chan struct{}, 1)
+	drain := func(c net.Conn, sink chan<- struct{}) {
+		buf := make([]byte, 256)
+		deadline := time.Now().Add(700 * time.Millisecond)
+		for time.Now().Before(deadline) {
+			_ = c.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+			n, err := c.Read(buf)
+			if err != nil {
+				continue
+			}
+			for i := 0; i < n; i++ {
+				if buf[i] == 0x7F {
+					select {
+					case sink <- struct{}{}:
+					default:
+					}
+				}
+			}
+		}
+	}
+	go drain(clientA, sawWinnerOnA)
+	go drain(clientB, sawWinnerOnB)
+
+	// Simulate: session A won arbitration with 0x7F. Synthesis should
+	// skip A (its handleStart goroutine would deliver STARTED) and
+	// deliver to B.
+	mux.deliverWinnerByteToOtherSessions(0x7F, idA)
+
+	// Wait briefly and verify A did NOT receive 0x7F; B DID.
+	time.Sleep(400 * time.Millisecond)
+
+	select {
+	case <-sawWinnerOnA:
+		t.Errorf("winning session A received synthesized 0x7F — ordering-race regression (PR #620 round 3)")
+	default:
+	}
+	select {
+	case <-sawWinnerOnB:
+		// Expected.
+	default:
+		t.Errorf("non-winning session B did NOT receive synthesized 0x7F — multi-session synthesis broken (PR #620 round 3)")
+	}
+}

--- a/internal/adaptermux/session_test.go
+++ b/internal/adaptermux/session_test.go
@@ -854,7 +854,7 @@ func TestSession_LegitimateENHClientNotClosedByDiagnostic(t *testing.T) {
 // when the mux processes a StreamEventStarted (or equivalent), the
 // arbitration-winner byte is delivered to external sessions as a passive
 // observation. Without this, external bus monitors (e.g. ebusd) never see
-// gateway-initiated master wins on the wire — the ENH adapter consumes
+// gateway-initiated arbitration wins on the wire — the ENH adapter consumes
 // the byte as a control event — and their bus parsers desynchronize from
 // physical wire reality. (EBUSD-VERIFICATION-2026-05-10.md F-9/F-10
 // root-cause discovery.)

--- a/internal/adaptermux/session_test.go
+++ b/internal/adaptermux/session_test.go
@@ -847,3 +847,95 @@ func TestSession_LegitimateENHClientNotClosedByDiagnostic(t *testing.T) {
 		t.Fatalf("session %d removed despite legitimate ENH INIT handshake; diagnostic must not fire when sawHandshake=true", id)
 	}
 }
+
+// --- F-9/F-10 architectural fix: arbitration-winner byte synthesis ---
+
+// TestArbitrationWinnerSynthesis_DeliveredToExternalSession verifies that
+// when the mux processes a StreamEventStarted (or equivalent), the
+// arbitration-winner byte is delivered to external sessions as a passive
+// observation. Without this, external bus monitors (e.g. ebusd) never see
+// gateway-initiated master wins on the wire — the ENH adapter consumes
+// the byte as a control event — and their bus parsers desynchronize from
+// physical wire reality. (EBUSD-VERIFICATION-2026-05-10.md F-9/F-10
+// root-cause discovery.)
+//
+// The test exercises the deliverToSessions code path directly (which is
+// what the synthesis call invokes after handleArbitrationResponse). End-
+// to-end coverage of the StreamEventStarted handler requires a fake
+// adapter that emits STARTED frames; that integration is implicit when
+// the readLoop processes a real STARTED — this unit test pins the
+// session-side delivery semantics.
+func TestArbitrationWinnerSynthesis_DeliveredToExternalSession(t *testing.T) {
+	mux, _, cleanup := newTestMux(t)
+	defer cleanup()
+
+	client, server := net.Pipe()
+	defer closeOrLog(t, client, "client")
+
+	id := mux.AddSession(server)
+	if id == 0 {
+		t.Fatalf("AddSession returned 0")
+	}
+	defer mux.RemoveSession(id)
+
+	// Drain the initial INIT-response RESETTED that AddSession's flow
+	// or session bootstrap might emit, so the pipe doesn't back up.
+	drainDone := make(chan struct{})
+	received := make(chan byte, 16)
+	go func() {
+		defer close(drainDone)
+		buf := make([]byte, 256)
+		deadline := time.Now().Add(1500 * time.Millisecond)
+		for time.Now().Before(deadline) {
+			_ = client.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+			n, err := client.Read(buf)
+			if err != nil {
+				continue
+			}
+			for i := 0; i < n; i++ {
+				b := buf[i]
+				// Short-form ENHResReceived: a byte < 0x80 is the
+				// payload directly. We're looking for 0x7F to confirm
+				// the synthesized arbitration-winner reached the
+				// session's TCP socket.
+				if b < 0x80 {
+					select {
+					case received <- b:
+					default:
+					}
+				}
+			}
+		}
+	}()
+
+	// Simulate the synthesis call that StreamEventStarted handling
+	// in readLoop now makes. owner = gatewaySessionID, hasOwner = true
+	// (the gateway just won arbitration; confirmOwnership was called
+	// by handleArbitrationResponse before this point).
+	mux.arb.confirmOwnership(gatewaySessionID, 0x7F)
+	mux.deliverToSessions(0x7F, gatewaySessionID, true, time.Now())
+
+	// Expect the byte to arrive at the external session's TCP socket.
+	select {
+	case got := <-received:
+		if got != 0x7F {
+			// We may have read other bytes first (INIT-response etc.);
+			// keep draining until we either see 0x7F or run out of time.
+			for {
+				select {
+				case got := <-received:
+					if got == 0x7F {
+						return
+					}
+				case <-time.After(500 * time.Millisecond):
+					t.Fatalf("never received synthesized arbitration-winner 0x7F at session; got other bytes but not the synthesized one")
+				}
+			}
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatalf("synthesized arbitration-winner 0x7F was never delivered to session 1")
+	}
+
+	mux.arb.releaseOwnership(gatewaySessionID)
+	_ = drainDone
+}

--- a/internal/adaptermux/session_test.go
+++ b/internal/adaptermux/session_test.go
@@ -939,3 +939,81 @@ func TestArbitrationWinnerSynthesis_DeliveredToExternalSession(t *testing.T) {
 	mux.arb.releaseOwnership(gatewaySessionID)
 	_ = drainDone
 }
+
+// TestArbitrationWinnerSynthesis_SkippedWhenExternalSessionWins pins the
+// ordering rule from Codex P2 on PR #620: when an external session wins
+// arbitration, the readLoop must NOT synthesize the winner byte. The
+// session's own handleStart goroutine delivers ENHResStarted via a
+// separate goroutine; an additional synthesized ENHResReceived would
+// race the STARTED frame and present an out-of-order arbitration result.
+//
+// The test verifies the inverse of the gateway-win case: after setting
+// up external ownership directly and calling deliverToSessions only when
+// gateway owns, the winning session does NOT receive a synthesized
+// passive-observation byte for its own winning address.
+func TestArbitrationWinnerSynthesis_SkippedWhenExternalSessionWins(t *testing.T) {
+	mux, _, cleanup := newTestMux(t)
+	defer cleanup()
+
+	client, server := net.Pipe()
+	defer closeOrLog(t, client, "client")
+
+	id := mux.AddSession(server)
+	if id == 0 {
+		t.Fatalf("AddSession returned 0")
+	}
+	defer mux.RemoveSession(id)
+
+	// Drain INIT response.
+	received := make(chan byte, 32)
+	drainStop := make(chan struct{})
+	go func() {
+		buf := make([]byte, 256)
+		for {
+			select {
+			case <-drainStop:
+				return
+			default:
+			}
+			_ = client.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+			n, err := client.Read(buf)
+			if err != nil {
+				continue
+			}
+			for i := 0; i < n; i++ {
+				if buf[i] < 0x80 {
+					select {
+					case received <- buf[i]:
+					default:
+					}
+				}
+			}
+		}
+	}()
+	defer close(drainStop)
+
+	// Simulate ebusd winning arbitration: confirm ownership for the
+	// external session (sessionID=id) and replicate the readLoop's
+	// gateway-only-synthesis rule. The rule is implemented in mux.go;
+	// this test pins the behavior at the call-site level.
+	mux.arb.confirmOwnership(id, 0x31)
+	// Replicate readLoop logic: only synthesize when gateway owns.
+	if owner, _, owned := mux.arb.owner(); owned && owner == gatewaySessionID {
+		mux.deliverToSessions(0x31, owner, true, time.Now())
+	}
+
+	// Wait briefly and verify 0x31 did NOT arrive via the passive path.
+	deadline := time.After(400 * time.Millisecond)
+	for {
+		select {
+		case got := <-received:
+			if got == 0x31 {
+				t.Errorf("0x31 was synthesized to the winning external session — Codex P2 ordering race regression (PR #620)")
+				return
+			}
+			// Other bytes (INIT reset etc.) ignored.
+		case <-deadline:
+			return // No spurious 0x31 delivery — rule honored.
+		}
+	}
+}


### PR DESCRIPTION
## Summary

**Root-cause fix** for F-9 and F-10 from `_work_adaptermux_audit/EBUSD-VERIFICATION-2026-05-10.md`. Discovered while diagnosing live HA — `ebusctl grab result all` shows only **2 frames from gateway source 0x7F** vs thousands from passive observations of other masters (0x10, 0xF1, 0x03).

## Mechanism

The ENH adapter delivers arbitration results as control events (`StreamEventStarted` / `StreamEventFailed` carrying the winner byte), not as `StreamEventByte`. Before this fix, `mux.readLoop` handled those control events with `handleArbitrationResponse` + `continue` — never calling `deliverToSessions`.

So when the gateway won arbitration with 0x7F:
- The byte WAS on the physical wire
- Internal state was updated correctly
- **External sessions (ebusd) never saw the byte**

For sessions like ebusd, the wire stream then looks like:
`... SYN → 0x15 (target) → 0xB5 → 0x24 → ...`

0x15 isn't a valid master-byte arbitration nibble → ebusd's parser discards the entire frame as malformed → the gateway's transactions are structurally invisible.

## Downstream effects this fix should resolve

1. **Missing 0x7F in `ebusctl info` masters list and grab buffer** (cosmetic-but-real diagnostic gap)
2. **F-9 "won in invalid state ready/skip"** — ebusd's bus parser doesn't track gateway transactions, so its state machine drifts; legitimate wins land in unexpected states
3. **F-10 "send to fe: ERR: read timeout"** — ebusd's intra-transaction byte parsing is contaminated by gateway-injected bytes its parser can't contextualize
4. **High max arbitration latency** — ebusd mis-times bids because its "bus busy" model is incomplete

## Fix

```go
case transport.StreamEventStarted:
    m.handleArbitrationResponse(true, event.Data)
    if owner, _, owned := m.arb.owner(); owned {
        m.deliverToSessions(event.Data, owner, true, time.Now())
    }
    continue
case transport.StreamEventFailed:
    m.handleArbitrationResponse(false, event.Data)
    m.deliverToSessions(event.Data, 0, false, time.Now())  // no-owner passive observation
    continue
```

For `Started`: only synthesize when `hasOwner` is true. A stale `STARTED` that's been absorbed via `pendingStartAbsorb` shouldn't reach sessions — it belongs to a cancelled bid; nobody owns the bus from it.

For `Failed`: always synthesize as a no-owner passive observation. The winner is a third-party master.

## Tests

- `TestArbitrationWinnerSynthesis_DeliveredToExternalSession` — sets up gateway ownership, calls `deliverToSessions` with 0x7F, verifies the byte arrives at the external session's TCP socket as short-form `ENHResReceived`.
- Existing 30+ adaptermux tests unaffected (the `continue` is preserved for the byte-event path; only the missing session delivery is restored).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — 19 packages green
- [x] `go test ./internal/adaptermux -count=1 -timeout=180s` — full 89 s suite green
- [x] New synthesis test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)