### PR TITLE
fix(adaptermux): revert C4/R4 upstream-reconnect on cancelled STARTED (v0.6.5 regression)

### DIFF
--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -2901,29 +2901,35 @@ func (m *Mux) handleArbitrationResponse(started bool, data byte) {
 		// (no-grant) so the bus is released cleanly and the next
 		// tryGrantAndStart re-picks the session's current request.
 		if pending.req != nil && pending.req.cancelled.Load() {
+			// REVERTED in 0.6.6 (operator hand-off after the v0.6.5
+			// regression): previously this branch closed the upstream
+			// TCP to the adapter to "resync" after a cancelled bid's
+			// STARTED arrived. Live capture proved that reconnect
+			// produced a continuous 5-second cycle of "device invalid"
+			// / "signal lost" on ebusd's side and tore down the
+			// upstream every time any session replaced an in-flight
+			// START. The adapter does NOT need TCP resync on a
+			// cancelled-bid STARTED — the eBUS protocol is per-SYN
+			// stateless from the adapter's perspective; the next SYN
+			// boundary resets arbitration. The minimum-correct
+			// behaviour is to absorb the STARTED, never deliver it
+			// to the originating session, and leave the upstream and
+			// every other session alone.
+			//
+			// This is essentially the original spec for C4/R4:
+			// "convert STARTED to FAILED for cancelled requests"
+			// without any cross-cutting transport action.
 			m.pendingStart = nil
 			if pending.deadline != nil {
 				pending.deadline.Stop() // AM8: cancel deadline timer
 			}
-			// Adapter resync (Codex P1 round 3 on PR #623): the
-			// STARTED we are consuming is a real adapter grant —
-			// the adapter believes the abandoned bid won the bus
-			// and is now driving its in-progress transaction state
-			// for that grant. Launching a fresh RequestStart on the
-			// same transport would put us one arbitration behind
-			// the adapter (mux thinks no owner, adapter still
-			// holding the cancelled session's grant). Mirror the
-			// stale-STARTED-absorb reconnect: close the upstream
-			// conn so readLoop's error handler invokes reconnect(),
-			// which fails/re-queues arbitration safely. Do NOT
-			// invoke tryGrantAndStart in-line — the reconnect path
-			// advances the queue.
 			m.stateMu.Unlock()
-			m.logger.Printf("adaptermux: suppressing STARTED for session %d — request was replaced; forcing reconnect for adapter resync (C4/R4)", pending.sessionID)
+			m.logger.Printf("adaptermux: suppressing STARTED for session %d — request was cancelled/replaced; absorbed (C4/R4)", pending.sessionID)
 			// Best-effort send: the old notify channel is buffered
-			// to 1 and may already hold the replace's
-			// granted=false result, so a stale STARTED never blocks
-			// the readLoop here.
+			// to 1 and may already hold the replace's granted=false
+			// result. A late STARTED for a cancelled bid still
+			// resolves the channel cleanly when the read-side
+			// hasn't drained it yet.
 			select {
 			case pending.notify <- startResult{
 				granted:   false,
@@ -2932,15 +2938,11 @@ func (m *Mux) handleArbitrationResponse(started bool, data byte) {
 			}:
 			default:
 			}
-			m.connMu.Lock()
-			c := m.conn
-			m.connMu.Unlock()
-			if c != nil {
-				if err := c.Close(); err != nil {
-					m.logger.Printf("adaptermux: cancelled-STARTED reconnect close: %v", err)
-				} else {
-					m.logger.Printf("adaptermux: cancelled-STARTED triggered transport reconnect for adapter resync")
-				}
+			// Advance the queue if anything else is pending. The
+			// adapter is fine; eBUS arbitration is per-SYN; no
+			// transport-level action is required.
+			if m.arb.hasPending() {
+				m.tryGrantAndStart()
 			}
 			return
 		}

--- a/internal/adaptermux/requeststart_wrapper_test.go
+++ b/internal/adaptermux/requeststart_wrapper_test.go
@@ -1,8 +1,12 @@
 package adaptermux
 
 import (
+	"bytes"
 	"context"
+	"log"
 	"net"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -130,21 +134,23 @@ func TestRequestStartForSession_IdleKickDispatchesImmediately(t *testing.T) {
 	}
 }
 
-// TestHandleArbitrationResponse_CancelledStartedResyncsAndDoesNotArmAbsorb
-// pins two Codex P1 rounds on PR #623:
+// TestHandleArbitrationResponse_CancelledStartedAbsorbsWithoutReconnect
+// pins the 0.6.6 revert of the earlier "force reconnect on cancelled
+// STARTED" behaviour:
 //
-//   - Round 2: handleArbitrationResponse MUST NOT arm
-//     pendingStartAbsorb when consuming a cancelled STARTED — there's
-//     no further stale response in flight; arming would gate the next
-//     tryGrantAndStart on the absorb barrier for up to StartDeadline.
+//   - pendingStartAbsorb MUST stay at 0 (round 2 of PR #623 review).
+//     The STARTED we are consuming is the only adapter response for
+//     the cancelled request; nothing further to swallow.
 //
-//   - Round 3: the adapter has already granted the abandoned bid, so
-//     before any replacement START can launch, the mux must force a
-//     transport resync (close the upstream conn so readLoop's error
-//     handler invokes reconnect). Otherwise the adapter is one
-//     arbitration ahead of the mux's view and the replacement would
-//     collide with the in-progress (but abandoned) transaction.
-func TestHandleArbitrationResponse_CancelledStartedResyncsAndDoesNotArmAbsorb(t *testing.T) {
+//   - The upstream conn MUST NOT be closed (regression introduced by
+//     Codex round-3 advice on PR #623, surfaced as the v0.6.5
+//     "device invalid" / "signal lost" 5-second cycle observed by
+//     the operator). eBUS arbitration is per-SYN stateless from the
+//     adapter's perspective; the next SYN boundary resets state, so
+//     no TCP teardown is required. Round-3's "the adapter is one
+//     arbitration ahead" intuition turned out to be wrong in
+//     practice on the live bus.
+func TestHandleArbitrationResponse_CancelledStartedAbsorbsWithoutReconnect(t *testing.T) {
 	mux := New(Config{
 		Protocol:        "enh",
 		Network:         "tcp",
@@ -154,7 +160,7 @@ func TestHandleArbitrationResponse_CancelledStartedResyncsAndDoesNotArmAbsorb(t 
 		PendingStartTTL: 24 * time.Hour,
 	})
 
-	// Install a fake conn so we can observe the reconnect-via-close.
+	// Install a fake conn whose Close-counter we can assert on.
 	connMock := newCancelledStartedConnMock()
 	mux.connMu.Lock()
 	mux.conn = connMock
@@ -182,19 +188,93 @@ func TestHandleArbitrationResponse_CancelledStartedResyncsAndDoesNotArmAbsorb(t 
 	// Stage 2: feed the STARTED response for the cancelled request.
 	mux.handleArbitrationResponse(true, 0x31)
 
-	// Round-2 assertion: pendingStartAbsorb MUST be zero.
+	// Assertion 1: pendingStartAbsorb MUST be zero.
 	mux.stateMu.Lock()
 	absorb := mux.pendingStartAbsorb
 	mux.stateMu.Unlock()
 	if absorb != 0 {
-		t.Errorf("pendingStartAbsorb = %d after consuming cancelled STARTED; want 0 (Codex P1 round 2 regression)", absorb)
+		t.Errorf("pendingStartAbsorb = %d after consuming cancelled STARTED; want 0", absorb)
 	}
 
-	// Round-3 assertion: the upstream conn MUST have been closed to
-	// force a reconnect/resync with the adapter.
-	if !connMock.closed.Load() {
-		t.Error("upstream conn was NOT closed after cancelled STARTED — adapter resync skipped (Codex P1 round 3 regression)")
+	// Assertion 2: the upstream conn MUST NOT have been closed. This
+	// is the v0.6.5 regression guard: closing the upstream produces a
+	// continuous teardown/reconnect cycle that takes ebusd offline
+	// every ~5 s (StartDeadline). Live capture confirmed the
+	// "forcing reconnect for adapter resync (C4/R4)" log line fired
+	// on every external re-submit. Reverted in 0.6.6.
+	if connMock.closed.Load() {
+		t.Error("upstream conn was closed after cancelled STARTED — v0.6.5 regression has returned; cancelled-STARTED MUST NOT force transport resync")
 	}
+}
+
+// TestCancelledStartedLog_DoesNotMentionReconnect is a string-level
+// regression guard. The "forcing reconnect for adapter resync (C4/R4)"
+// log line was the visible signature of the v0.6.5 regression — keep
+// it from coming back via a subtle re-introduction in another
+// commit.
+func TestCancelledStartedLog_DoesNotMentionReconnect(t *testing.T) {
+	var buf cancelledStartedLogBuffer
+	mux := New(Config{
+		Protocol:        "enh",
+		Network:         "tcp",
+		Address:         "127.0.0.1:0",
+		ReadTimeout:     200 * time.Millisecond,
+		SYNInterval:     time.Hour,
+		PendingStartTTL: 24 * time.Hour,
+		Logger:          log.New(&buf, "", 0),
+	})
+
+	// Same setup as the test above.
+	mux.connMu.Lock()
+	mux.conn = newCancelledStartedConnMock()
+	mux.connMu.Unlock()
+	_ = mux.arb.requestStart(1, 0x31)
+	mux.stateMu.Lock()
+	reqA := mux.arb.pendingExternal[0]
+	mux.arb.pendingExternal = mux.arb.pendingExternal[:0]
+	mux.pendingStart = &pendingStartState{
+		sessionID: 1, initiator: 0x31, notify: reqA.notify, req: reqA,
+	}
+	reqA.cancelled.Store(true)
+	mux.stateMu.Unlock()
+
+	mux.handleArbitrationResponse(true, 0x31)
+
+	got := buf.String()
+	bannedSubstrings := []string{
+		"forcing reconnect for adapter resync",
+		"cancelled-STARTED triggered transport reconnect",
+		"cancelled-STARTED reconnect close",
+	}
+	for _, banned := range bannedSubstrings {
+		if strings.Contains(got, banned) {
+			t.Errorf("log output mentions banned regression substring %q\nfull log:\n%s", banned, got)
+		}
+	}
+	// Sanity: positive marker for the absorb branch should appear.
+	if !strings.Contains(got, "absorbed (C4/R4)") {
+		t.Errorf("expected absorb-suppression log line, got:\n%s", got)
+	}
+}
+
+// cancelledStartedLogBuffer is a goroutine-safe log.Logger sink for
+// the regression test above. log.Logger holds its own mutex around
+// each Write, but the test reads the buffer concurrently with the
+// goroutines triggered by handleArbitrationResponse → tryGrantAndStart.
+type cancelledStartedLogBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *cancelledStartedLogBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+func (b *cancelledStartedLogBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }
 
 // cancelledStartedConnMock is a minimal net.Conn-compatible stub used


### PR DESCRIPTION
## Summary

**URGENT — v0.6.5 functional regression on ebusd.** The C4/R4 path closed the upstream TCP to the adapter every time an external session re-submitted a START while a previous request was still in flight at the adapter. Operator's live capture (batch-5 verification) showed a continuous ~5-second cycle: `device invalid` → `signal lost` → `signal acquired` (cfg.StartDeadline = 5 s). Addon is functionally worse than v0.6.3 in this regime.

## Root cause (verbatim log evidence from operator)

```
21:51:43 readLoop got StreamEventStarted data=0x31
21:51:43 arbitration response started=true data=0x31
21:51:43 suppressing STARTED for session 8 — request was replaced;
         forcing reconnect for adapter resync (C4/R4)               ← THIS
21:51:43 cancelled-STARTED triggered transport reconnect for adapter resync
21:51:43 read error: enh transport read closed
21:51:43 old conn close: ... use of closed network connection
21:51:43 session 8 read error: EOF
21:51:43 session 8 disconnected
```

The reconnect was Codex round-3 advice on PR #623: "the adapter is one arbitration ahead, force a resync." That theory turned out to be wrong on the live bus — eBUS arbitration is per-SYN stateless from the adapter's perspective; the next SYN resets state. No TCP rebuild is required.

## Change

Restore the minimum-correct behaviour from the original C4 spec:

| Step | Before (bad) | After (revert) |
| --- | --- | --- |
| Clear pendingStart | ✅ | ✅ |
| Stop deadline timer | ✅ | ✅ |
| Deliver granted=false on abandoned notify | ✅ | ✅ |
| Close upstream conn | ❌ **REMOVED** | (no-op) |
| Trigger reconnect | ❌ **REMOVED** | (no-op) |
| `tryGrantAndStart` if more pending | (skipped — reconnect path would handle) | ✅ |

Log line:
- Before: `"suppressing STARTED for session N — request was replaced; forcing reconnect for adapter resync (C4/R4)"`
- After: `"suppressing STARTED for session N — request was cancelled/replaced; absorbed (C4/R4)"`

## Tests

- **`TestHandleArbitrationResponse_CancelledStartedAbsorbsWithoutReconnect`** — renamed + inverted from the v0.6.5 test that asserted the upstream MUST be closed. Now asserts `conn.Close` was NOT called.
- **`TestCancelledStartedLog_DoesNotMentionReconnect`** — string-level regression guard. Banned substrings: `"forcing reconnect for adapter resync"`, `"cancelled-STARTED triggered transport reconnect"`, `"cancelled-STARTED reconnect close"`. Required substring: `"absorbed (C4/R4)"`.

Full repo `go test ./...` green; adaptermux `-race` green (~104 s).

## Expected post-deploy verification (from operator hand-off)

```bash
# Continuous loop should show only "arbitration lost" (or success);
# NO "no signal", NO "device invalid", NO "signal lost".
while true; do docker exec addon_2ad9b828_ebusd ebusctl scan ec; done

# Pre-revert: ~6/min reconnect events. Post-revert target: 0.
ha apps logs local_helianthus --lines 1000 \
  | grep -cE 'old conn close|triggered transport reconnect'

# Pre-revert: ~6/min device-invalid events. Post-revert target: 0.
ha apps logs 2ad9b828_ebusd --lines 500 \
  | grep -cE 'signal lost|device invalid|no signal'
```

## Process notes

The PR cycle for #623 reached 5 review rounds + #624 added 2 more. Round 3's "force reconnect" advice changed a working design into a regression; the live capture only surfaced the symptom after deploy. Lesson: when a Codex finding asks for a heavier remediation than the original spec, prefer the lighter path unless evidence requires otherwise. Acknowledged inline in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)