### PR TITLE
fix(adaptermux): F-17 retry-loop + F-15 reconnect symmetry + cancelled-flag contract sweep (v0.6.7)

### DIFF
--- a/internal/adaptermux/arbitration.go
+++ b/internal/adaptermux/arbitration.go
@@ -274,13 +274,26 @@ func (a *arbitrator) setPolicy(pendingStartTTL time.Duration) {
 
 // cancelStart cancels a pending START request for the given session.
 // Returns true if a request was found and cancelled.
+//
+// AM55 / F-17 follow-up (PR #626 review round-1, angry-tester finding
+// F-2): callers are session.handleStart on a client-initiated SYN
+// cancel (session.go:493). The session has signalled it no longer
+// wants the bid, so the silent-return branch in handleStart
+// (session.go:524 — gated on `result.cancelled`) is the correct
+// resolution. Without `cancelled: true` on the notify, the old wait
+// goroutine falls through to deliverFailed → ENHResFailed on the
+// wire — exactly the failure mode F-17 was filed to fix. Pre-existing
+// latent before this PR (no observed-wild repro) but trivially racy
+// with the SYN-cancel-before-tryGrant window; fixed for symmetry with
+// every other cancellation path in the arbitrator.
 func (a *arbitrator) cancelStart(sessionID uint64) bool {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
 	if sessionID == gatewaySessionID {
 		if a.pendingGateway != nil {
-			a.pendingGateway.notify <- startResult{granted: false, initiator: a.pendingGateway.initiator}
+			a.pendingGateway.cancelled.Store(true)
+			a.pendingGateway.notify <- startResult{granted: false, cancelled: true, initiator: a.pendingGateway.initiator}
 			a.pendingGateway = nil
 			return true
 		}
@@ -289,7 +302,8 @@ func (a *arbitrator) cancelStart(sessionID uint64) bool {
 
 	for i, req := range a.pendingExternal {
 		if req.sessionID == sessionID {
-			req.notify <- startResult{granted: false, initiator: req.initiator}
+			req.cancelled.Store(true)
+			req.notify <- startResult{granted: false, cancelled: true, initiator: req.initiator}
 			a.pendingExternal = append(a.pendingExternal[:i], a.pendingExternal[i+1:]...)
 			return true
 		}

--- a/internal/adaptermux/arbitration.go
+++ b/internal/adaptermux/arbitration.go
@@ -493,6 +493,20 @@ func (a *arbitrator) hasPending() bool {
 
 // failAllPending fails all pending START requests (e.g., on shutdown
 // or adapter RESETTED).
+//
+// F-17 follow-up (PR #626 review round-2, angry-tester finding F-NEW-6
+// documentation): callers pass a non-nil `err` that
+// `isResetOrDisconnectError` matches (adapter disconnect, adapter
+// reset, mux closed). Session.go's handleStart routes such results to
+// `deliverReset(...)`, which is the correct boundary-event notification
+// for the client. This function MUST NOT set `cancelled: true` on the
+// startResult — even when `req.cancelled.Load()` is true — because
+// session.go's branch order (`granted → cancelled → err(reset) →
+// deliverFailed`) favors `cancelled` and would silent-return on a
+// boundary event where the client legitimately needs RESETTED.
+// The current code accidentally relies on this NOT setting cancelled;
+// the comment makes the precedence explicit so future "consistency"
+// edits don't regress reset delivery.
 func (a *arbitrator) failAllPending(err error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/internal/adaptermux/arbitration.go
+++ b/internal/adaptermux/arbitration.go
@@ -174,7 +174,35 @@ func (a *arbitrator) requestStart(sessionID uint64, initiator byte) <-chan start
 		// abandoned the grant. (Proxy-bug C4 / R4.)
 		if a.pendingGateway != nil {
 			a.pendingGateway.cancelled.Store(true)
-			a.pendingGateway.notify <- startResult{granted: false, initiator: a.pendingGateway.initiator}
+			// F-17 (operator hand-off, batch-9): MUST set
+			// startResult.cancelled = true so the waiter's
+			// handleStart goroutine takes the silent-suppression
+			// branch in session.go (around line 524 — same path
+			// that AM55 SYN-cancel uses) instead of the
+			// deliverFailed(initiator) branch that produces a
+			// spurious ENHResFailed on the wire. Without this,
+			// ebusd reads the FAILED as "lost arbitration to its
+			// own master byte," retries within ~50 ms, and
+			// triggers the positive-feedback loop where no
+			// request ever reaches the adapter. pcap-confirmed
+			// root cause of "ebusd never lands a frame."
+			//
+			// startRequest.cancelled (struct field) is separate
+			// from startResult.cancelled (channel value):
+			//   - The struct flag is checked by the mux's late-
+			//     STARTED suppression path (C4/R4) when the
+			//     request has already been popped into
+			//     pendingStart.
+			//   - The result flag is checked by the session's
+			//     handleStart goroutine when the request is
+			//     still in pendingExternal and gets a
+			//     not-granted result.
+			// Both flags must be set on a cancellation.
+			a.pendingGateway.notify <- startResult{
+				granted:   false,
+				cancelled: true,
+				initiator: a.pendingGateway.initiator,
+			}
 		}
 		a.pendingGateway = req
 	} else {
@@ -182,7 +210,26 @@ func (a *arbitrator) requestStart(sessionID uint64, initiator byte) <-chan start
 		for i, existing := range a.pendingExternal {
 			if existing.sessionID == sessionID {
 				existing.cancelled.Store(true)
-				existing.notify <- startResult{granted: false, initiator: existing.initiator}
+				// F-17 (operator hand-off, batch-9): see the
+				// gateway-path comment above. Without
+				// `cancelled: true` here, ebusd's handleStart
+				// receives a startResult{granted: false}
+				// (default cancelled=false), takes the
+				// deliverFailed branch in session.go, and
+				// emits ENHResFailed(0x31) on the wire within
+				// ~0.3 ms — far faster than the bus can
+				// possibly arbitrate (eBUS bit-time ~4 ms).
+				// ebusd reads it as "lost arbitration to my
+				// own master byte 0x31" and retries within
+				// ~50 ms, producing a same-session-replace
+				// that cancels the new request, and so on.
+				// Positive-feedback loop; no bid ever
+				// reaches the adapter for real arbitration.
+				existing.notify <- startResult{
+					granted:   false,
+					cancelled: true,
+					initiator: existing.initiator,
+				}
 				a.pendingExternal = append(a.pendingExternal[:i], a.pendingExternal[i+1:]...)
 				break
 			}

--- a/internal/adaptermux/arbitration.go
+++ b/internal/adaptermux/arbitration.go
@@ -182,7 +182,7 @@ func (a *arbitrator) requestStart(sessionID uint64, initiator byte) <-chan start
 			// deliverFailed(initiator) branch that produces a
 			// spurious ENHResFailed on the wire. Without this,
 			// ebusd reads the FAILED as "lost arbitration to its
-			// own master byte," retries within ~50 ms, and
+			// own initiator byte," retries within ~50 ms, and
 			// triggers the positive-feedback loop where no
 			// request ever reaches the adapter. pcap-confirmed
 			// root cause of "ebusd never lands a frame."
@@ -220,7 +220,7 @@ func (a *arbitrator) requestStart(sessionID uint64, initiator byte) <-chan start
 				// ~0.3 ms — far faster than the bus can
 				// possibly arbitrate (eBUS bit-time ~4 ms).
 				// ebusd reads it as "lost arbitration to my
-				// own master byte 0x31" and retries within
+				// own initiator byte 0x31" and retries within
 				// ~50 ms, producing a same-session-replace
 				// that cancels the new request, and so on.
 				// Positive-feedback loop; no bid ever

--- a/internal/adaptermux/f15_am8_deadline_reconnect_test.go
+++ b/internal/adaptermux/f15_am8_deadline_reconnect_test.go
@@ -1,0 +1,201 @@
+package adaptermux
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+// TestAM8Deadline_NonBlockingPath_NoReconnect pins F-15 (operator
+// hand-off, batch-9/11): when the AM8 pendingStart deadline fires on
+// the non-blocking ENH RequestStart path, the upstream conn MUST NOT
+// be closed. The absorb safety-net at armPendingStartAbsorbLocked
+// already handles the rare truly-hung case via its own deadline timer
+// (mux.go:3056) — the unconditional reconnect that used to live in
+// the AM8 callback was an asymmetric design defect.
+//
+// Background: prior to v0.6.7 the deadline callback hard-coded
+// `needReconnect := true`, so every slow-but-not-hung adapter
+// response on the non-blocking path tore down the TCP transport.
+// Under F-17's retry storm this amplified into a feedback loop —
+// adapter backlog → slow STARTED → AM8 deadline trips → forced
+// reconnect → next ReqStart aborted → another retry. Live evidence
+// across 30k log lines: zero absorb-timeout reconnects fired in
+// production, so the safety-net was sufficient and the AM8 reconnect
+// was load-bearing only on the legacy blocking transport.
+//
+// Symmetry with cancelPendingStart (mux.go:3013) is the design
+// invariant: both code paths drop the pending and gate the
+// reconnect on `pending.blockingArb`.
+func TestAM8Deadline_NonBlockingPath_NoReconnect(t *testing.T) {
+	mock := newP3MockTransport()
+
+	mux := New(Config{
+		Protocol:        "enh",
+		Network:         "tcp",
+		Address:         "127.0.0.1:0",
+		ReadTimeout:     200 * time.Millisecond,
+		StartDeadline:   150 * time.Millisecond, // short for test speed
+		PendingStartTTL: 24 * time.Hour,
+		SYNInterval:     time.Hour, // keep idle path quiet
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mux.ctx, mux.cancel = ctx, cancel
+	mux.connMu.Lock()
+	mux.upstream = mock
+	mux.conn = newCancelledStartedConnMock()
+	connMock := mux.conn.(*cancelledStartedConnMock)
+	mux.connMu.Unlock()
+	mux.upstreamFeatures.Store(0x01)
+
+	mux.wg.Add(2)
+	go mux.readLoop()
+	go mux.sendLoop()
+	defer func() {
+		cancel()
+		_ = mock.Close()
+		mux.wg.Wait()
+	}()
+
+	// Queue a gateway START and feed a SYN so tryGrantAndStart pops
+	// it into pendingStart via the non-blocking RequestStart path.
+	gwCh := mux.arb.requestStart(gatewaySessionID, 0x71)
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0xAA}
+
+	// Wait for RequestStart to be called (confirms pendingStart is
+	// armed on the non-blocking path with blockingArb=false).
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if len(mock.getStartRequests()) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := mock.getStartRequests(); len(got) == 0 {
+		t.Fatal("setup: RequestStart was never dispatched to the non-blocking mock")
+	}
+
+	mux.stateMu.Lock()
+	if mux.pendingStart == nil {
+		mux.stateMu.Unlock()
+		t.Fatal("setup: pendingStart not armed")
+	}
+	if mux.pendingStart.blockingArb {
+		mux.stateMu.Unlock()
+		t.Fatal("setup: blockingArb=true on non-blocking RequestStart path (test invariant violated)")
+	}
+	mux.stateMu.Unlock()
+
+	// Wait for the AM8 deadline (150ms) to fire and propagate.
+	select {
+	case result := <-gwCh:
+		if result.granted {
+			t.Fatal("expected granted=false after AM8 deadline")
+		}
+		if result.err == nil {
+			t.Fatal("expected non-nil err on deadline-expired result")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for AM8 deadline failure result")
+	}
+
+	// Give the deadline goroutine a moment to complete its
+	// post-notify housekeeping (no reconnect should happen, but the
+	// goroutine still runs to completion).
+	time.Sleep(50 * time.Millisecond)
+
+	// F-15 ASSERTION: upstream conn MUST NOT have been closed. Prior
+	// to the fix this would fail — `needReconnect := true` forced a
+	// close on every deadline expiry regardless of transport type.
+	if connMock.closed.Load() {
+		t.Fatal("upstream conn was closed by AM8 deadline on the non-blocking path — F-15 regression: AM8 must mirror cancelPendingStart and gate the reconnect on pending.blockingArb")
+	}
+
+	// Sanity: pendingStart must be cleared after the deadline.
+	mux.stateMu.Lock()
+	pendingAfter := mux.pendingStart
+	mux.stateMu.Unlock()
+	if pendingAfter != nil {
+		t.Fatal("pendingStart must be nil after AM8 deadline")
+	}
+}
+
+// TestAM8Deadline_BlockingPath_StillReconnects pins the other half of
+// F-15: the blocking StartArbitration path (legacy transport) MUST
+// still trigger an upstream reconnect when the AM8 deadline fires,
+// because the goroutine may still be hung in the transport call and
+// the reconnect is the only safe way to unstick it. This is the
+// same behavior cancelPendingStart implements at mux.go:3013.
+//
+// We use the same slowBlockingStartTransport mock from
+// pr502_review_test.go (TestBlockingStartArbitrationDeadlineReal),
+// but also install an inspectable upstream conn so we can assert
+// Close was actually called on it.
+func TestAM8Deadline_BlockingPath_StillReconnects(t *testing.T) {
+	mock := &slowBlockingStartTransport{
+		readCh: make(chan byte, 256),
+		gate:   make(chan struct{}),
+	}
+
+	mux := New(Config{
+		Protocol:      "enh",
+		Network:       "tcp",
+		Address:       "127.0.0.1:0",
+		ReadTimeout:   200 * time.Millisecond,
+		StartDeadline: 150 * time.Millisecond,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mux.ctx, mux.cancel = ctx, cancel
+
+	connMock := newCancelledStartedConnMock()
+	mux.connMu.Lock()
+	mux.upstream = mock
+	mux.conn = connMock
+	mux.connMu.Unlock()
+	mux.upstreamFeatures.Store(0x01)
+
+	// Queue a gateway request and dispatch on the blocking path.
+	gwCh := mux.arb.requestStart(gatewaySessionID, 0x71)
+	mux.tryGrantAndStart()
+
+	// Confirm the blocking goroutine is in flight before the
+	// deadline fires.
+	time.Sleep(50 * time.Millisecond)
+	mux.stateMu.Lock()
+	if mux.pendingStart == nil || !mux.pendingStart.blockingArb {
+		mux.stateMu.Unlock()
+		t.Fatal("setup: expected pendingStart with blockingArb=true on blocking path")
+	}
+	mux.stateMu.Unlock()
+
+	// Wait for the AM8 deadline.
+	select {
+	case result := <-gwCh:
+		if result.granted {
+			t.Fatal("expected granted=false after AM8 deadline")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for AM8 deadline failure result")
+	}
+
+	// Give the reconnect path a moment to run.
+	time.Sleep(50 * time.Millisecond)
+
+	// F-15 ASSERTION (blocking-half): conn MUST have been closed
+	// on the blocking path. Removing or weakening this branch would
+	// regress unstick-on-hung behavior for the legacy transport.
+	if !connMock.closed.Load() {
+		t.Fatal("upstream conn was NOT closed by AM8 deadline on the blocking path — F-15 regression: blocking path must still trigger reconnect to unstick the hung StartArbitration goroutine")
+	}
+
+	// Allow the gated blocking transport goroutine to complete so
+	// the test does not leak a hanging goroutine into the test
+	// runner.
+	close(mock.gate)
+}

--- a/internal/adaptermux/f15_am8_deadline_reconnect_test.go
+++ b/internal/adaptermux/f15_am8_deadline_reconnect_test.go
@@ -11,10 +11,12 @@ import (
 // TestAM8Deadline_NonBlockingPath_NoReconnect pins F-15 (operator
 // hand-off, batch-9/11): when the AM8 pendingStart deadline fires on
 // the non-blocking ENH RequestStart path, the upstream conn MUST NOT
-// be closed. The absorb safety-net at armPendingStartAbsorbLocked
-// already handles the rare truly-hung case via its own deadline timer
-// (mux.go:3056) — the unconditional reconnect that used to live in
-// the AM8 callback was an asymmetric design defect.
+// be closed. The absorb safety-net inside
+// `armPendingStartAbsorbLocked` already handles the rare truly-hung
+// case via its own deadline timer (covered by
+// `TestAM8Deadline_NonBlockingPath_AbsorbTimerReconnectsOnTrulyHungAdapter`)
+// — the unconditional reconnect that used to live in the AM8 callback
+// was an asymmetric design defect.
 //
 // Background: prior to v0.6.7 the deadline callback hard-coded
 // `needReconnect := true`, so every slow-but-not-hung adapter
@@ -26,9 +28,9 @@ import (
 // production, so the safety-net was sufficient and the AM8 reconnect
 // was load-bearing only on the legacy blocking transport.
 //
-// Symmetry with cancelPendingStart (mux.go:3013) is the design
-// invariant: both code paths drop the pending and gate the
-// reconnect on `pending.blockingArb`.
+// Symmetry with `cancelPendingStart` is the design invariant: both
+// code paths drop the pending and gate the reconnect on
+// `pending.blockingArb`.
 func TestAM8Deadline_NonBlockingPath_NoReconnect(t *testing.T) {
 	mock := newP3MockTransport()
 
@@ -129,7 +131,7 @@ func TestAM8Deadline_NonBlockingPath_NoReconnect(t *testing.T) {
 // still trigger an upstream reconnect when the AM8 deadline fires,
 // because the goroutine may still be hung in the transport call and
 // the reconnect is the only safe way to unstick it. This is the
-// same behavior cancelPendingStart implements at mux.go:3013.
+// same behavior `cancelPendingStart` implements.
 //
 // We use the same slowBlockingStartTransport mock from
 // pr502_review_test.go (TestBlockingStartArbitrationDeadlineReal),
@@ -150,7 +152,6 @@ func TestAM8Deadline_BlockingPath_StillReconnects(t *testing.T) {
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	mux.ctx, mux.cancel = ctx, cancel
 
 	connMock := newCancelledStartedConnMock()
@@ -159,6 +160,28 @@ func TestAM8Deadline_BlockingPath_StillReconnects(t *testing.T) {
 	mux.conn = connMock
 	mux.connMu.Unlock()
 	mux.upstreamFeatures.Store(0x01)
+
+	// F-4 (review round-1): drain the spawned blocking goroutine
+	// before the test function returns so we do not leak post-test
+	// state mutations into the next test in the same package. The
+	// gated goroutine inside StartArbitration is wg.Add'd by the
+	// dispatch path; close(mock.gate) wakes it, mux.wg.Wait drains it.
+	defer func() {
+		// Close the gate first so any goroutine still parked inside
+		// StartArbitration returns. Then cancel the context to
+		// release readLoop/sendLoop, and wait on the WaitGroup with
+		// a bounded timeout so a stray goroutine surfaces as a test
+		// failure instead of a deadlock.
+		close(mock.gate)
+		cancel()
+		done := make(chan struct{})
+		go func() { mux.wg.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("mux goroutine drain exceeded 2s — possible leak from blocking-path teardown")
+		}
+	}()
 
 	// Queue a gateway request and dispatch on the blocking path.
 	gwCh := mux.arb.requestStart(gatewaySessionID, 0x71)
@@ -193,9 +216,92 @@ func TestAM8Deadline_BlockingPath_StillReconnects(t *testing.T) {
 	if !connMock.closed.Load() {
 		t.Fatal("upstream conn was NOT closed by AM8 deadline on the blocking path — F-15 regression: blocking path must still trigger reconnect to unstick the hung StartArbitration goroutine")
 	}
-
-	// Allow the gated blocking transport goroutine to complete so
-	// the test does not leak a hanging goroutine into the test
-	// runner.
-	close(mock.gate)
 }
+
+// TestAM8Deadline_NonBlockingPath_AbsorbTimerReconnectsOnTrulyHungAdapter
+// pins the F-15 fallback contract surfaced by review round-1 finding
+// F-3: when the non-blocking adapter is TRULY hung (no STARTED or
+// FAILED ever arrives), the AM8 deadline must NOT itself reconnect
+// (proven by `TestAM8Deadline_NonBlockingPath_NoReconnect` above), but
+// the absorb safety-net (armPendingStartAbsorbLocked's own
+// time.AfterFunc) MUST drive a reconnect after another StartDeadline
+// elapses. Otherwise the mux is permanently stuck behind the
+// pendingStartAbsorb>0 guard at tryGrantAndStart and no new arbitration
+// can proceed.
+//
+// This test waits past 2×StartDeadline against a silent non-blocking
+// adapter and asserts conn.Close was eventually invoked by the absorb
+// timer path.
+func TestAM8Deadline_NonBlockingPath_AbsorbTimerReconnectsOnTrulyHungAdapter(t *testing.T) {
+	mock := newP3MockTransport()
+
+	const startDeadline = 120 * time.Millisecond
+
+	mux := New(Config{
+		Protocol:        "enh",
+		Network:         "tcp",
+		Address:         "127.0.0.1:0",
+		ReadTimeout:     200 * time.Millisecond,
+		StartDeadline:   startDeadline,
+		PendingStartTTL: 24 * time.Hour,
+		SYNInterval:     time.Hour,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mux.ctx, mux.cancel = ctx, cancel
+	mux.connMu.Lock()
+	mux.upstream = mock
+	mux.conn = newCancelledStartedConnMock()
+	connMock := mux.conn.(*cancelledStartedConnMock)
+	mux.connMu.Unlock()
+	mux.upstreamFeatures.Store(0x01)
+
+	mux.wg.Add(2)
+	go mux.readLoop()
+	go mux.sendLoop()
+	defer func() {
+		cancel()
+		_ = mock.Close()
+		done := make(chan struct{})
+		go func() { mux.wg.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("mux goroutine drain exceeded 2s")
+		}
+	}()
+
+	// Dispatch a START on the non-blocking path. Adapter never
+	// responds (mock.eventCh stays empty for STARTED/FAILED, only
+	// the priming SYN below is fed).
+	_ = mux.arb.requestStart(gatewaySessionID, 0x71)
+	// Prime tryGrantAndStart via a SYN byte (0xAA).
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0xAA}
+
+	// Wait for the first AM8 deadline (≈ startDeadline). Asserting
+	// no reconnect AT this point is already done by the sibling
+	// test — here we just need the absorb counter to be armed so
+	// the safety-net timer is ticking.
+	time.Sleep(startDeadline + 30*time.Millisecond)
+
+	if connMock.closed.Load() {
+		t.Fatal("F-15 broke: non-blocking AM8 deadline reconnected directly — see sibling TestAM8Deadline_NonBlockingPath_NoReconnect")
+	}
+
+	// Wait for the absorb timer's own StartDeadline to fire and
+	// close the conn. Total elapsed ≈ 2×StartDeadline + slack.
+	deadline := time.Now().Add(2*startDeadline + 500*time.Millisecond)
+	for time.Now().Before(deadline) {
+		if connMock.closed.Load() {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// F-3 ASSERTION: absorb-safety-net must have closed the conn.
+	if !connMock.closed.Load() {
+		t.Fatal("absorb safety-net did NOT close the conn after AM8 deadline + absorb timer window — F-15's claim that armPendingStartAbsorbLocked covers the truly-hung case is unsubstantiated; either the absorb timer never fired, or its reconnect path was removed. Recovery from a permanently silent non-blocking adapter requires this fallback to fire reliably.")
+	}
+}
+

--- a/internal/adaptermux/f15_am8_deadline_reconnect_test.go
+++ b/internal/adaptermux/f15_am8_deadline_reconnect_test.go
@@ -57,10 +57,19 @@ func TestAM8Deadline_NonBlockingPath_NoReconnect(t *testing.T) {
 	mux.wg.Add(2)
 	go mux.readLoop()
 	go mux.sendLoop()
+	// L3 (review round-3): bound the drain so a stray goroutine
+	// surfaces as a test failure rather than a deadlock. Sibling
+	// tests already use this pattern.
 	defer func() {
 		cancel()
 		_ = mock.Close()
-		mux.wg.Wait()
+		done := make(chan struct{})
+		go func() { mux.wg.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("mux goroutine drain exceeded 2s")
+		}
 	}()
 
 	// Queue a gateway START and feed a SYN so tryGrantAndStart pops
@@ -187,15 +196,24 @@ func TestAM8Deadline_BlockingPath_StillReconnects(t *testing.T) {
 	gwCh := mux.arb.requestStart(gatewaySessionID, 0x71)
 	mux.tryGrantAndStart()
 
-	// Confirm the blocking goroutine is in flight before the
-	// deadline fires.
-	time.Sleep(50 * time.Millisecond)
-	mux.stateMu.Lock()
-	if mux.pendingStart == nil || !mux.pendingStart.blockingArb {
+	// L2 (review round-3): poll for pendingStart-armed instead of a
+	// fixed sleep. Under -race on slow CI the fixed 50ms could miss
+	// the window between dispatch and the AM8 deadline (150ms).
+	setupDeadline := time.Now().Add(500 * time.Millisecond)
+	armed := false
+	for time.Now().Before(setupDeadline) {
+		mux.stateMu.Lock()
+		if mux.pendingStart != nil && mux.pendingStart.blockingArb {
+			armed = true
+			mux.stateMu.Unlock()
+			break
+		}
 		mux.stateMu.Unlock()
-		t.Fatal("setup: expected pendingStart with blockingArb=true on blocking path")
+		time.Sleep(5 * time.Millisecond)
 	}
-	mux.stateMu.Unlock()
+	if !armed {
+		t.Fatal("setup: expected pendingStart with blockingArb=true on blocking path within 500ms")
+	}
 
 	// Wait for the AM8 deadline.
 	select {

--- a/internal/adaptermux/f15_am8_deadline_reconnect_test.go
+++ b/internal/adaptermux/f15_am8_deadline_reconnect_test.go
@@ -235,7 +235,13 @@ func TestAM8Deadline_BlockingPath_StillReconnects(t *testing.T) {
 func TestAM8Deadline_NonBlockingPath_AbsorbTimerReconnectsOnTrulyHungAdapter(t *testing.T) {
 	mock := newP3MockTransport()
 
-	const startDeadline = 120 * time.Millisecond
+	// F-NEW-2 (review round-2): use 200ms StartDeadline + 1500ms
+	// slack so the chained AM8 → absorb timer wait stays robust on
+	// slow CI runners under -race (each time.AfterFunc can jitter
+	// 150-200ms; two timers compound). Nominal expected time to
+	// conn.Close: 2 × 200ms = 400ms; ceiling 2 × 200ms + 1500ms =
+	// 1900ms.
+	const startDeadline = 200 * time.Millisecond
 
 	mux := New(Config{
 		Protocol:        "enh",
@@ -290,8 +296,10 @@ func TestAM8Deadline_NonBlockingPath_AbsorbTimerReconnectsOnTrulyHungAdapter(t *
 	}
 
 	// Wait for the absorb timer's own StartDeadline to fire and
-	// close the conn. Total elapsed ≈ 2×StartDeadline + slack.
-	deadline := time.Now().Add(2*startDeadline + 500*time.Millisecond)
+	// close the conn. Total elapsed ≈ 2×StartDeadline + 1500ms
+	// slack (review round-2 F-NEW-2 — robust against -race jitter
+	// on slow CI runners).
+	deadline := time.Now().Add(2*startDeadline + 1500*time.Millisecond)
 	for time.Now().Before(deadline) {
 		if connMock.closed.Load() {
 			break

--- a/internal/adaptermux/f15_codex_p1_absorb_late_started_test.go
+++ b/internal/adaptermux/f15_codex_p1_absorb_late_started_test.go
@@ -1,0 +1,139 @@
+package adaptermux
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+// TestAbsorbLateStarted_NonBlockingPath_DoesNotReconnect pins the
+// Codex bot P1 finding on PR #626 (reviewing commits b3b7f13 and
+// e6b96ee, 2026-05-11): the F-15 fix prevented the IMMEDIATE AM8
+// deadline reconnect on the non-blocking path, but
+// `handleArbitrationResponse`'s absorb-consume branch still had
+// `needReconnect := started`, so the LATE STARTED arriving after
+// the deadline armed pendingStartAbsorb would tear down the TCP
+// transport via the absorb path. That preserves the F-17 / F-15
+// retry-feedback-loop on a delayed path.
+//
+// Reproducer:
+//  1. Dispatch a START on the non-blocking ENH path; adapter does
+//     not respond before StartDeadline.
+//  2. AM8 deadline fires → armPendingStartAbsorbLocked("deadline")
+//     arms pendingStartAbsorb=1. F-15 fix: no immediate conn.Close.
+//  3. Adapter eventually responds with STARTED (the late
+//     "slow-not-hung" response that F-15 was filed for).
+//  4. handleArbitrationResponse enters the absorb branch
+//     (pendingStartAbsorb>0), decrements counter, and PREVIOUSLY
+//     would conn.Close because `needReconnect := started`.
+//  5. Codex bot P1 fix (mirror F-15 transport-type gate): on the
+//     non-blocking RequestStart path, the absorb-consume must NOT
+//     close the conn — eBUS is per-SYN stateless, the counter has
+//     already done its bookkeeping job.
+//
+// Invariant: end-to-end on non-blocking transport, a slow-not-hung
+// STARTED arriving after AM8 deadline must NOT close the upstream.
+func TestAbsorbLateStarted_NonBlockingPath_DoesNotReconnect(t *testing.T) {
+	mock := newP3MockTransport()
+
+	mux := New(Config{
+		Protocol:        "enh",
+		Network:         "tcp",
+		Address:         "127.0.0.1:0",
+		ReadTimeout:     200 * time.Millisecond,
+		StartDeadline:   150 * time.Millisecond,
+		PendingStartTTL: 24 * time.Hour,
+		SYNInterval:     time.Hour,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	mux.ctx, mux.cancel = ctx, cancel
+	mux.connMu.Lock()
+	mux.upstream = mock
+	mux.conn = newCancelledStartedConnMock()
+	connMock := mux.conn.(*cancelledStartedConnMock)
+	mux.connMu.Unlock()
+	mux.upstreamFeatures.Store(0x01)
+
+	mux.wg.Add(2)
+	go mux.readLoop()
+	go mux.sendLoop()
+	defer func() {
+		cancel()
+		_ = mock.Close()
+		done := make(chan struct{})
+		go func() { mux.wg.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("mux goroutine drain exceeded 2s")
+		}
+	}()
+
+	// Step 1: dispatch a START on the non-blocking path; adapter
+	// will respond LATE (after AM8 deadline).
+	gwCh := mux.arb.requestStart(gatewaySessionID, 0x71)
+	// Prime tryGrantAndStart via a SYN byte.
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0xAA}
+
+	// Wait for AM8 deadline to fire (the first failure result).
+	select {
+	case result := <-gwCh:
+		if result.granted {
+			t.Fatal("expected granted=false after AM8 deadline")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for AM8 deadline failure result")
+	}
+
+	// F-15 invariant: AM8 deadline itself must NOT have reconnected
+	// the non-blocking path.
+	if connMock.closed.Load() {
+		t.Fatal("F-15 regression: AM8 deadline reconnected the non-blocking path")
+	}
+
+	// Confirm absorb counter is armed (the AM8 deadline path armed
+	// it via armPendingStartAbsorbLocked("deadline")).
+	mux.stateMu.Lock()
+	absorbArmed := mux.pendingStartAbsorb
+	mux.stateMu.Unlock()
+	if absorbArmed == 0 {
+		t.Fatal("setup: expected pendingStartAbsorb > 0 after AM8 deadline")
+	}
+
+	// Step 3: now feed the LATE STARTED (the slow-but-not-hung
+	// response that finally arrived). This drives
+	// handleArbitrationResponse's absorb-consume branch.
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventStarted, Byte: 0x71}
+
+	// Give readLoop a moment to consume the event and run the
+	// absorb branch.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		mux.stateMu.Lock()
+		consumed := mux.pendingStartAbsorb < absorbArmed
+		mux.stateMu.Unlock()
+		if consumed {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	mux.stateMu.Lock()
+	finalAbsorb := mux.pendingStartAbsorb
+	mux.stateMu.Unlock()
+	if finalAbsorb >= absorbArmed {
+		t.Fatalf("late STARTED was not absorbed: pendingStartAbsorb stayed at %d (was %d)", finalAbsorb, absorbArmed)
+	}
+
+	// CODEX P1 ASSERTION: the absorb-consume of the late STARTED
+	// must NOT close the upstream conn on the non-blocking path.
+	// Prior to this fix `needReconnect := started` was true in the
+	// absorb branch and the conn was torn down.
+	time.Sleep(50 * time.Millisecond) // let any deferred close fire
+	if connMock.closed.Load() {
+		t.Fatal("upstream conn was closed by absorb-consume of late STARTED on non-blocking path — Codex P1 regression: the F-15 retry-feedback-loop is preserved on a delayed path. The absorb branch must gate reconnect on isBlockingPath, mirroring F-15.")
+	}
+}

--- a/internal/adaptermux/f17_cancelled_result_flag_test.go
+++ b/internal/adaptermux/f17_cancelled_result_flag_test.go
@@ -1,0 +1,107 @@
+package adaptermux
+
+import (
+	"testing"
+	"time"
+)
+
+// TestArbitrator_SameSessionReplace_StartResultCarriesCancelledFlag
+// pins F-17 (operator hand-off, batch-9): when a session re-submits a
+// START while it still has a pending entry in the arbitrator queue,
+// the previous request's notify channel MUST receive a startResult
+// with `cancelled = true`. The handleStart goroutine in session.go
+// uses that flag to silently suppress the FAILED delivery instead of
+// firing `deliverFailed(initiator)` on the wire.
+//
+// Without `cancelled: true` on the result, the bidder reads a spurious
+// `ENHResFailed(initiator)` within ~0.3 ms of its own ReqStart (faster
+// than the bus can possibly arbitrate). ebusd interprets that as "you
+// lost arbitration to your own master byte" and retries within ~50 ms,
+// which cancels the just-queued entry, producing another spurious
+// FAILED, and so on — positive-feedback loop where no bid ever reaches
+// the adapter. This is the pcap-confirmed root cause of "ebusd never
+// lands a frame on the bus through the proxy."
+//
+// Note: this flag is on the startResult VALUE (the channel message),
+// distinct from the `cancelled` atomic.Bool on the startRequest STRUCT.
+// Both must be set on a same-session cancellation:
+//   - struct flag (atomic.Bool): checked by mux's C4/R4 late-STARTED
+//     suppression path when the request has been popped to pendingStart
+//   - result flag (channel value): checked by session.go's handleStart
+//     when the request is still in pendingExternal
+func TestArbitrator_SameSessionReplace_StartResultCarriesCancelledFlag(t *testing.T) {
+	t.Run("external_session_replace", func(t *testing.T) {
+		arb := newArbitrator()
+		arb.setPolicy(24 * time.Hour) // disable C3 TTL for this test
+
+		chOld := arb.requestStart(1, 0x31)
+		_ = arb.requestStart(1, 0x32) // replaces chOld in pendingExternal
+
+		select {
+		case result := <-chOld:
+			if result.granted {
+				t.Fatal("replaced request must not be granted")
+			}
+			if !result.cancelled {
+				t.Fatalf("startResult.cancelled = %v on same-session-replace; want true (F-17 regression — would produce spurious ENHResFailed and trigger the same-session retry feedback loop)", result.cancelled)
+			}
+			if result.initiator != 0x31 {
+				t.Fatalf("startResult.initiator = 0x%02X, want 0x31 (old request's bid byte)", result.initiator)
+			}
+		case <-time.After(1 * time.Second):
+			t.Fatal("replaced request's notify channel did not fire")
+		}
+	})
+
+	t.Run("gateway_session_replace", func(t *testing.T) {
+		arb := newArbitrator()
+		arb.setPolicy(24 * time.Hour)
+
+		chOld := arb.requestStart(gatewaySessionID, 0x71)
+		_ = arb.requestStart(gatewaySessionID, 0x72) // replaces pendingGateway
+
+		select {
+		case result := <-chOld:
+			if result.granted {
+				t.Fatal("replaced gateway request must not be granted")
+			}
+			if !result.cancelled {
+				t.Fatalf("startResult.cancelled = %v on gateway same-session-replace; want true (F-17 regression, symmetric path)", result.cancelled)
+			}
+			if result.initiator != 0x71 {
+				t.Fatalf("startResult.initiator = 0x%02X, want 0x71", result.initiator)
+			}
+		case <-time.After(1 * time.Second):
+			t.Fatal("replaced gateway request's notify channel did not fire")
+		}
+	})
+}
+
+// TestArbitrator_SameSessionReplace_StructFlagAlsoSet pins that the
+// startRequest.cancelled atomic.Bool flag (the one the C4/R4 mux path
+// reads) is also set when the same-session replace happens. F-17's
+// fix is to set BOTH flags; verify the previously-correct struct flag
+// is not regressed.
+func TestArbitrator_SameSessionReplace_StructFlagAlsoSet(t *testing.T) {
+	arb := newArbitrator()
+	arb.setPolicy(24 * time.Hour)
+
+	_ = arb.requestStart(1, 0x31)
+	arb.mu.Lock()
+	oldReq := arb.pendingExternal[0]
+	arb.mu.Unlock()
+
+	if oldReq.cancelled.Load() {
+		t.Fatal("setup: cancelled flag set prematurely")
+	}
+
+	// Drain the channel so the replace's send doesn't block on a full
+	// buffer.
+	go func() { <-oldReq.notify }()
+
+	_ = arb.requestStart(1, 0x32)
+
+	if !oldReq.cancelled.Load() {
+		t.Fatal("startRequest.cancelled (struct flag) not set on same-session-replace (would break the C4/R4 in-flight-cancel suppression)")
+	}
+}

--- a/internal/adaptermux/f17_cancelled_result_flag_test.go
+++ b/internal/adaptermux/f17_cancelled_result_flag_test.go
@@ -16,7 +16,7 @@ import (
 // Without `cancelled: true` on the result, the bidder reads a spurious
 // `ENHResFailed(initiator)` within ~0.3 ms of its own ReqStart (faster
 // than the bus can possibly arbitrate). ebusd interprets that as "you
-// lost arbitration to your own master byte" and retries within ~50 ms,
+// lost arbitration to your own initiator byte" and retries within ~50 ms,
 // which cancels the just-queued entry, producing another spurious
 // FAILED, and so on — positive-feedback loop where no bid ever reaches
 // the adapter. This is the pcap-confirmed root cause of "ebusd never

--- a/internal/adaptermux/f17_review_round1_test.go
+++ b/internal/adaptermux/f17_review_round1_test.go
@@ -267,7 +267,7 @@ func TestHandleArbitrationResponse_InFlightCancelled_AM56Mismatch_SuppressedSile
 	mux.stateMu.Unlock()
 	reqA.cancelled.Store(true)
 
-	// Feed STARTED with a MISMATCHED byte (some other master won;
+	// Feed STARTED with a MISMATCHED byte (some other initiator won;
 	// adapter delivered a stale STARTED for a previous bid).
 	mux.handleArbitrationResponse(true, 0x10)
 

--- a/internal/adaptermux/f17_review_round1_test.go
+++ b/internal/adaptermux/f17_review_round1_test.go
@@ -1,0 +1,260 @@
+package adaptermux
+
+import (
+	"log"
+	"strings"
+	"testing"
+	"time"
+)
+
+// PR #626 review round-1 — angry-tester findings F-1 and F-2.
+//
+// F-1 (HIGH): the original PR fixed `arbitration.requestStart`'s
+// same-session-replace path but missed the in-flight branch.
+// `requestStartForSession` calls `markInFlightCancelled` (sets the
+// startRequest.cancelled atomic.Bool) when the prior request has
+// already been popped into m.pendingStart by tryGrant. The deferred
+// channel-value send was supposed to happen in
+// handleArbitrationResponse when the STARTED or FAILED arrives — but
+// the original code sent `startResult{granted: false, …}` WITHOUT
+// `cancelled: true`. Result: session.go's handleStart goroutine fell
+// through to deliverFailed(initiator) and put ENHResFailed(0x31) on
+// the wire — exactly the failure mode F-17 was filed to fix, just
+// on the in-flight branch.
+//
+// F-2 (MEDIUM): pre-existing latent. arbitrator.cancelStart resolves
+// pending SYN-cancel by sending `startResult{granted: false, …}`
+// without `cancelled: true`. Race window is short (SYN-cancel arriving
+// before tryGrant pops the bid into m.pendingStart) but real on idle
+// buses. F-17 makes the inconsistency obvious; AM55 was supposed to
+// cover this exact case.
+
+// TestHandleArbitrationResponse_InFlightCancelled_STARTED_SuppressedSilently
+// pins F-1's STARTED-half: after markInFlightCancelled flips the
+// struct flag, a STARTED arriving for the old (now-cancelled) request
+// MUST resolve the old notify channel with `cancelled: true` so
+// session.go's handleStart silent-returns instead of emitting
+// ENHResFailed on the wire.
+func TestHandleArbitrationResponse_InFlightCancelled_STARTED_SuppressedSilently(t *testing.T) {
+	mux := New(Config{
+		Protocol:        "enh",
+		Network:         "tcp",
+		Address:         "127.0.0.1:0",
+		ReadTimeout:     200 * time.Millisecond,
+		SYNInterval:     time.Hour,
+		PendingStartTTL: 24 * time.Hour,
+	})
+
+	// Stage 1: simulate request popped into m.pendingStart.
+	chA := mux.arb.requestStart(1, 0x31)
+	mux.stateMu.Lock()
+	if len(mux.arb.pendingExternal) == 0 {
+		mux.stateMu.Unlock()
+		t.Fatal("setup: pendingExternal empty after requestStart")
+	}
+	reqA := mux.arb.pendingExternal[0]
+	mux.arb.pendingExternal = mux.arb.pendingExternal[:0]
+	mux.pendingStart = &pendingStartState{
+		sessionID: 1,
+		initiator: 0x31,
+		notify:    reqA.notify,
+		req:       reqA,
+	}
+	mux.stateMu.Unlock()
+
+	// Stage 2: mark the in-flight request cancelled (what
+	// requestStartForSession does on a same-session re-submit).
+	reqA.cancelled.Store(true)
+
+	// Stage 3: feed STARTED for the cancelled request.
+	mux.handleArbitrationResponse(true, 0x31)
+
+	// F-1 ASSERTION: the channel-value cancelled flag MUST be true.
+	select {
+	case result := <-chA:
+		if result.granted {
+			t.Fatal("cancelled in-flight STARTED must not be granted")
+		}
+		if !result.cancelled {
+			t.Fatalf("startResult.cancelled = %v on in-flight-cancel STARTED-half; want true (F-1 regression — session.go handleStart would fall through to deliverFailed and emit ENHResFailed on the wire, regressing F-17 fix for the C4/R4 path)", result.cancelled)
+		}
+		if result.initiator != 0x31 {
+			t.Fatalf("startResult.initiator = 0x%02X, want 0x31", result.initiator)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("notify channel did not fire after handleArbitrationResponse(STARTED)")
+	}
+}
+
+// TestHandleArbitrationResponse_InFlightCancelled_FAILED_SuppressedSilently
+// pins F-1's FAILED-half: when the bus genuinely arbitrates and someone
+// else wins (FAILED arrives with the winner's byte), the result for a
+// cancelled in-flight bid MUST also carry `cancelled: true`. Otherwise
+// session.go emits ENHResFailed(winner_byte) on the wire for a session
+// that has already moved on — same retry-loop class as F-17.
+func TestHandleArbitrationResponse_InFlightCancelled_FAILED_SuppressedSilently(t *testing.T) {
+	mux := New(Config{
+		Protocol:        "enh",
+		Network:         "tcp",
+		Address:         "127.0.0.1:0",
+		ReadTimeout:     200 * time.Millisecond,
+		SYNInterval:     time.Hour,
+		PendingStartTTL: 24 * time.Hour,
+	})
+
+	// Setup identical to STARTED-half.
+	chA := mux.arb.requestStart(1, 0x31)
+	mux.stateMu.Lock()
+	reqA := mux.arb.pendingExternal[0]
+	mux.arb.pendingExternal = mux.arb.pendingExternal[:0]
+	mux.pendingStart = &pendingStartState{
+		sessionID: 1,
+		initiator: 0x31,
+		notify:    reqA.notify,
+		req:       reqA,
+	}
+	mux.stateMu.Unlock()
+	reqA.cancelled.Store(true)
+
+	// Feed FAILED (someone else won the bus with byte 0x10).
+	mux.handleArbitrationResponse(false, 0x10)
+
+	select {
+	case result := <-chA:
+		if result.granted {
+			t.Fatal("cancelled in-flight FAILED must not be granted")
+		}
+		if !result.cancelled {
+			t.Fatalf("startResult.cancelled = %v on in-flight-cancel FAILED-half; want true (F-1 regression — session.go handleStart would emit ENHResFailed(0x10) on the wire to a session that has moved on, triggering the same retry feedback loop F-17 fixed)", result.cancelled)
+		}
+		// initiator field carries the bidder's byte (so any stray
+		// downstream consumer sees the bidder's own bid, not the
+		// third-party winner). Either value is acceptable for the
+		// silent-suppression branch since session.go returns
+		// silently — but pin the design choice so it doesn't drift.
+		if result.initiator != 0x31 {
+			t.Fatalf("startResult.initiator = 0x%02X on suppressed FAILED-half; want 0x31 (the bidder's byte, matching STARTED-half symmetry)", result.initiator)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("notify channel did not fire after handleArbitrationResponse(FAILED)")
+	}
+}
+
+// TestHandleArbitrationResponse_InFlightCancelled_FAILED_LogMarksSuppression
+// is a log-level guard: the FAILED-half suppression should emit a
+// distinct log line so the diagnostic trail clearly shows F-1's
+// FAILED-half firing in production.
+func TestHandleArbitrationResponse_InFlightCancelled_FAILED_LogMarksSuppression(t *testing.T) {
+	var buf cancelledStartedLogBuffer
+	mux := New(Config{
+		Protocol:        "enh",
+		Network:         "tcp",
+		Address:         "127.0.0.1:0",
+		ReadTimeout:     200 * time.Millisecond,
+		SYNInterval:     time.Hour,
+		PendingStartTTL: 24 * time.Hour,
+		Logger:          log.New(&buf, "", 0),
+	})
+
+	_ = mux.arb.requestStart(1, 0x31)
+	mux.stateMu.Lock()
+	reqA := mux.arb.pendingExternal[0]
+	mux.arb.pendingExternal = mux.arb.pendingExternal[:0]
+	mux.pendingStart = &pendingStartState{
+		sessionID: 1, initiator: 0x31, notify: reqA.notify, req: reqA,
+	}
+	mux.stateMu.Unlock()
+	reqA.cancelled.Store(true)
+
+	mux.handleArbitrationResponse(false, 0x10)
+
+	got := buf.String()
+	if !strings.Contains(got, "FAILED-half") {
+		t.Errorf("expected FAILED-half suppression log line, got:\n%s", got)
+	}
+}
+
+// TestArbitrator_CancelStart_ExternalSession_SetsCancelledFlag pins
+// F-2 for the external-session path: SYN-cancel before tryGrant pops
+// the bid into m.pendingStart MUST resolve the notify channel with
+// cancelled=true so handleStart silent-returns.
+func TestArbitrator_CancelStart_ExternalSession_SetsCancelledFlag(t *testing.T) {
+	arb := newArbitrator()
+	arb.setPolicy(24 * time.Hour)
+
+	ch := arb.requestStart(1, 0x31)
+	if !arb.cancelStart(1) {
+		t.Fatal("expected cancelStart to find the pending request")
+	}
+
+	select {
+	case result := <-ch:
+		if result.granted {
+			t.Fatal("cancelled request must not be granted")
+		}
+		if !result.cancelled {
+			t.Fatalf("startResult.cancelled = %v on external cancelStart; want true (F-2 regression — session.go handleStart would fall through to deliverFailed and emit ENHResFailed on the wire for a session that already initiated SYN-cancel)", result.cancelled)
+		}
+		if result.initiator != 0x31 {
+			t.Fatalf("startResult.initiator = 0x%02X, want 0x31", result.initiator)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("notify channel did not fire on cancelStart")
+	}
+}
+
+// TestArbitrator_CancelStart_GatewaySession_SetsCancelledFlag pins F-2
+// for the gateway-session path. Same contract as the external path.
+func TestArbitrator_CancelStart_GatewaySession_SetsCancelledFlag(t *testing.T) {
+	arb := newArbitrator()
+	arb.setPolicy(24 * time.Hour)
+
+	ch := arb.requestStart(gatewaySessionID, 0x71)
+	if !arb.cancelStart(gatewaySessionID) {
+		t.Fatal("expected cancelStart to find the gateway pending request")
+	}
+
+	select {
+	case result := <-ch:
+		if result.granted {
+			t.Fatal("cancelled gateway request must not be granted")
+		}
+		if !result.cancelled {
+			t.Fatalf("startResult.cancelled = %v on gateway cancelStart; want true (F-2 regression, symmetric path)", result.cancelled)
+		}
+		if result.initiator != 0x71 {
+			t.Fatalf("startResult.initiator = 0x%02X, want 0x71", result.initiator)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("notify channel did not fire on gateway cancelStart")
+	}
+}
+
+// TestArbitrator_CancelStart_AlsoSetsStructFlag is the symmetric
+// guard to F-17's TestArbitrator_SameSessionReplace_StructFlagAlsoSet:
+// callers downstream may still read the struct flag (e.g., the C4/R4
+// late-STARTED suppression path), so cancelStart must set both flags.
+func TestArbitrator_CancelStart_AlsoSetsStructFlag(t *testing.T) {
+	arb := newArbitrator()
+	arb.setPolicy(24 * time.Hour)
+
+	_ = arb.requestStart(1, 0x31)
+	arb.mu.Lock()
+	req := arb.pendingExternal[0]
+	arb.mu.Unlock()
+
+	if req.cancelled.Load() {
+		t.Fatal("setup: cancelled flag set prematurely")
+	}
+
+	// Drain the channel asynchronously so the send doesn't block.
+	go func() { <-req.notify }()
+
+	if !arb.cancelStart(1) {
+		t.Fatal("expected cancelStart to find the pending request")
+	}
+
+	if !req.cancelled.Load() {
+		t.Fatal("startRequest.cancelled (struct flag) not set by cancelStart (F-2 regression — would leave any downstream observer of the struct flag in the wrong state)")
+	}
+}

--- a/internal/adaptermux/f17_review_round1_test.go
+++ b/internal/adaptermux/f17_review_round1_test.go
@@ -230,6 +230,80 @@ func TestArbitrator_CancelStart_GatewaySession_SetsCancelledFlag(t *testing.T) {
 	}
 }
 
+// TestHandleArbitrationResponse_InFlightCancelled_AM56Mismatch_SuppressedSilently
+// pins F-NEW-1 (review round-2): the third branch of
+// handleArbitrationResponse — the AM56 STARTED-mismatch path where
+// the adapter responds with a STARTED whose byte does not match
+// pending.initiator — must also honor `pending.req.cancelled`. The
+// reproducer: slow adapter, fast client re-submit, adapter delivers
+// stale STARTED for a previous unrelated bid that happens to be in
+// flight. Without the cancelled check, the AM56 branch delivers
+// `{granted:false, initiator:winner_byte, err:STARTED-mismatch}` —
+// session.go's handleStart falls through to `deliverFailed(winner)`,
+// emitting ENHResFailed(winner) on the wire to a session that has
+// already moved on. Same retry-loop class as F-1.
+func TestHandleArbitrationResponse_InFlightCancelled_AM56Mismatch_SuppressedSilently(t *testing.T) {
+	var buf cancelledStartedLogBuffer
+	mux := New(Config{
+		Protocol:        "enh",
+		Network:         "tcp",
+		Address:         "127.0.0.1:0",
+		ReadTimeout:     200 * time.Millisecond,
+		SYNInterval:     time.Hour,
+		PendingStartTTL: 24 * time.Hour,
+		Logger:          log.New(&buf, "", 0),
+	})
+
+	chA := mux.arb.requestStart(1, 0x31)
+	mux.stateMu.Lock()
+	reqA := mux.arb.pendingExternal[0]
+	mux.arb.pendingExternal = mux.arb.pendingExternal[:0]
+	mux.pendingStart = &pendingStartState{
+		sessionID: 1,
+		initiator: 0x31,
+		notify:    reqA.notify,
+		req:       reqA,
+	}
+	mux.stateMu.Unlock()
+	reqA.cancelled.Store(true)
+
+	// Feed STARTED with a MISMATCHED byte (some other master won;
+	// adapter delivered a stale STARTED for a previous bid).
+	mux.handleArbitrationResponse(true, 0x10)
+
+	select {
+	case result := <-chA:
+		if result.granted {
+			t.Fatal("AM56 mismatch must not grant")
+		}
+		if !result.cancelled {
+			t.Fatalf("startResult.cancelled = %v on AM56 mismatch + in-flight-cancelled; want true (F-NEW-1 regression — session.go handleStart would emit ENHResFailed(0x10) on the wire to a session that moved on, regressing F-17 closure on the AM56 branch)", result.cancelled)
+		}
+		// Initiator carries the bidder's own byte (0x31), not the
+		// stale-STARTED winner. Symmetric with the FAILED-half
+		// suppression at handleArbitrationResponse's tail: the
+		// cancelled session is silent-returning, so the field is
+		// not consumed — but pinning it prevents future drift.
+		if result.initiator != 0x31 {
+			t.Fatalf("startResult.initiator = 0x%02X on suppressed AM56-half; want 0x31 (bidder's byte, matching STARTED-half + FAILED-half symmetry)", result.initiator)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("notify channel did not fire after handleArbitrationResponse(STARTED-mismatch)")
+	}
+
+	// F-NEW-5 log-marker invariant: AM56-half must emit a distinct
+	// log line so the diagnostic trail clearly shows the suppression.
+	got := buf.String()
+	if !strings.Contains(got, "AM56-half") {
+		t.Errorf("expected AM56-half suppression log line, got:\n%s", got)
+	}
+	// And it must NOT emit the un-suppressed "STARTED mismatch:
+	// got initiator ... failing pending session" line.
+	if strings.Contains(got, "STARTED mismatch: got initiator") {
+		t.Errorf("AM56-mismatch + cancelled-in-flight must NOT log the un-suppressed failure line; got:\n%s", got)
+	}
+}
+
 // TestArbitrator_CancelStart_AlsoSetsStructFlag is the symmetric
 // guard to F-17's TestArbitrator_SameSessionReplace_StructFlagAlsoSet:
 // callers downstream may still read the struct flag (e.g., the C4/R4

--- a/internal/adaptermux/f17_review_round3_test.go
+++ b/internal/adaptermux/f17_review_round3_test.go
@@ -191,6 +191,77 @@ func TestRequestStartErr_InFlightCancelled_SuppressedSilently(t *testing.T) {
 	}
 }
 
+// TestRequestStartErr_InFlightCancelled_ResetErr_DeliversReset pins the
+// Codex bot P2 finding on PR #626 (2026-05-11): when the M2 RequestStart
+// err path observes BOTH `cancelledInFlight=true` AND a transport err
+// matching `isResetOrDisconnectError` (e.g. "adapter disconnected" /
+// "adapter reset" / "adaptermux: closed" / ErrAdapterReset), the result
+// MUST NOT carry `cancelled: true`. session.go's branch order is
+// `granted → cancelled → err(reset) → deliverFailed`, so setting both
+// flags would silent-return on the cancelled branch and the session
+// would miss the RESETTED boundary event the client needs.
+//
+// The contract is documented in arbitration.failAllPending's block
+// comment. The M2 fix originally violated it for the narrow case where
+// a same-session re-submit raced with an adapter-reset-triggered
+// RequestStart failure. Codex bot caught the gap; this test pins it.
+func TestRequestStartErr_InFlightCancelled_ResetErr_DeliversReset(t *testing.T) {
+	mock := &requestStartErrTransport{
+		eventCh: make(chan transport.StreamEvent, 16),
+		err:     errors.New("adapter disconnected during RequestStart"),
+	}
+
+	mux := New(Config{
+		Protocol:        "enh",
+		Network:         "tcp",
+		Address:         "127.0.0.1:0",
+		ReadTimeout:     200 * time.Millisecond,
+		StartDeadline:   2 * time.Second,
+		PendingStartTTL: 24 * time.Hour,
+		SYNInterval:     time.Hour,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mux.ctx, mux.cancel = ctx, cancel
+	mux.connMu.Lock()
+	mux.upstream = mock
+	mux.connMu.Unlock()
+	mux.upstreamFeatures.Store(0x01)
+
+	// Same setup as TestRequestStartErr_InFlightCancelled_SuppressedSilently:
+	// pre-flip the struct flag so the err-path observes cancelledInFlight.
+	ch := mux.arb.requestStart(1, 0x31)
+	mux.arb.mu.Lock()
+	req := mux.arb.pendingExternal[0]
+	mux.arb.mu.Unlock()
+	req.cancelled.Store(true)
+
+	mux.tryGrantAndStart()
+
+	select {
+	case result := <-ch:
+		if result.granted {
+			t.Fatal("expected granted=false after RequestStart error")
+		}
+		// Codex P2 ASSERTION: the result MUST NOT carry cancelled=true
+		// when the err matches isResetOrDisconnectError, even though
+		// the in-flight request was cancelled. Setting both would
+		// suppress the RESETTED delivery the client needs.
+		if result.cancelled {
+			t.Fatalf("startResult.cancelled = true on RequestStart-err + cancelledInFlight + reset-err; want false so session.go's err(reset) → deliverReset branch fires (Codex P2 regression — the precedence rule in failAllPending's contract block applies here too)")
+		}
+		if result.err == nil {
+			t.Fatal("expected non-nil err on transport-failure result")
+		}
+		if !isResetOrDisconnectError(result.err) {
+			t.Fatalf("result.err must still match isResetOrDisconnectError so session.go routes to deliverReset; got: %v", result.err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for RequestStart-err result")
+	}
+}
+
 // requestStartErrTransport implements arbitrationRequester returning
 // a fixed error from RequestStart. Used to exercise M2's
 // non-blocking-half err branch deterministically.

--- a/internal/adaptermux/f17_review_round3_test.go
+++ b/internal/adaptermux/f17_review_round3_test.go
@@ -1,0 +1,239 @@
+package adaptermux
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+// PR #626 review round-3 — angry-tester findings M1 and M2.
+//
+// M1 (MEDIUM): the AM8 deadline path in mux.go sends a startResult
+// for the pending request without honoring `pending.req.cancelled`.
+// This path fires PRECISELY when the adapter is slow — the exact
+// production condition that motivated this PR cycle. A same-session
+// re-submit that flipped `pending.req.cancelled` via
+// markInFlightCancelled, followed by the AM8 deadline firing before
+// the slow STARTED/FAILED arrives, makes session.go's handleStart
+// fall through to deliverFailed → ENHResFailed on the wire. Same
+// retry-loop class as F-17 / F-NEW-1.
+//
+// M2 (MEDIUM): transport-call err paths (non-blocking RequestStart
+// + blocking StartArbitration) also send a startResult with the
+// transport error without honoring the cancelled flag. Lower
+// probability than M1 but same class.
+
+// TestAM8Deadline_NonBlockingPath_InFlightCancelled_SuppressedSilently
+// pins M1: after markInFlightCancelled, the AM8 deadline firing
+// while the adapter is silent MUST resolve the old notify channel
+// with `cancelled: true` so session.go silent-returns.
+func TestAM8Deadline_NonBlockingPath_InFlightCancelled_SuppressedSilently(t *testing.T) {
+	mock := newP3MockTransport()
+
+	mux := New(Config{
+		Protocol:        "enh",
+		Network:         "tcp",
+		Address:         "127.0.0.1:0",
+		ReadTimeout:     200 * time.Millisecond,
+		StartDeadline:   150 * time.Millisecond,
+		PendingStartTTL: 24 * time.Hour,
+		SYNInterval:     time.Hour,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	mux.ctx, mux.cancel = ctx, cancel
+	mux.connMu.Lock()
+	mux.upstream = mock
+	mux.conn = newCancelledStartedConnMock()
+	connMock := mux.conn.(*cancelledStartedConnMock)
+	mux.connMu.Unlock()
+	mux.upstreamFeatures.Store(0x01)
+
+	mux.wg.Add(2)
+	go mux.readLoop()
+	go mux.sendLoop()
+	defer func() {
+		cancel()
+		_ = mock.Close()
+		done := make(chan struct{})
+		go func() { mux.wg.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("mux goroutine drain exceeded 2s")
+		}
+	}()
+
+	// Dispatch a START on the non-blocking path; adapter never
+	// responds (eventCh stays empty except for the priming SYN).
+	gwCh := mux.arb.requestStart(gatewaySessionID, 0x71)
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0xAA}
+
+	// Wait for pendingStart to be armed.
+	armDeadline := time.Now().Add(500 * time.Millisecond)
+	armed := false
+	for time.Now().Before(armDeadline) {
+		mux.stateMu.Lock()
+		if mux.pendingStart != nil {
+			armed = true
+			mux.stateMu.Unlock()
+			break
+		}
+		mux.stateMu.Unlock()
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !armed {
+		t.Fatal("setup: pendingStart not armed within 500ms")
+	}
+
+	// Flip the in-flight cancelled flag (what markInFlightCancelled
+	// does when a same-session re-submit comes in while pendingStart
+	// is still in flight).
+	mux.stateMu.Lock()
+	if mux.pendingStart.req == nil {
+		mux.stateMu.Unlock()
+		t.Fatal("setup: pendingStart.req unexpectedly nil — round-3 invariant relies on this being set by production code")
+	}
+	mux.pendingStart.req.cancelled.Store(true)
+	mux.stateMu.Unlock()
+
+	// Wait for the AM8 deadline to fire.
+	select {
+	case result := <-gwCh:
+		if result.granted {
+			t.Fatal("expected granted=false after AM8 deadline")
+		}
+		if !result.cancelled {
+			t.Fatalf("startResult.cancelled = %v on AM8 deadline + in-flight-cancelled; want true (M1 regression — session.go handleStart would emit ENHResFailed(0x71) on the wire to a session that has moved on, regressing F-17 closure on the deadline path that fires whenever the adapter is slow)", result.cancelled)
+		}
+		if result.initiator != 0x71 {
+			t.Fatalf("startResult.initiator = 0x%02X, want 0x71 (bidder's byte)", result.initiator)
+		}
+		if result.err == nil {
+			t.Fatal("expected non-nil err on deadline-expired result")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for AM8 deadline failure result")
+	}
+
+	// Non-blocking path must NOT reconnect on AM8 deadline.
+	time.Sleep(50 * time.Millisecond)
+	if connMock.closed.Load() {
+		t.Fatal("upstream conn was closed by AM8 deadline on non-blocking path — F-15 regression")
+	}
+}
+
+// TestRequestStartErr_InFlightCancelled_SuppressedSilently pins M2's
+// non-blocking-half: if the transport's RequestStart returns an error
+// AND a same-session re-submit has flipped pending.req.cancelled,
+// the old wait goroutine MUST silent-return rather than emit
+// ENHResFailed.
+//
+// We construct this by injecting a transport that fails RequestStart
+// after pre-cancellation: arm pendingStart with cancelled=true, then
+// invoke tryGrantAndStart so the RequestStart err path runs.
+func TestRequestStartErr_InFlightCancelled_SuppressedSilently(t *testing.T) {
+	mock := &requestStartErrTransport{
+		eventCh: make(chan transport.StreamEvent, 16),
+		err:     errors.New("adaptermux-test: simulated RequestStart failure"),
+	}
+
+	mux := New(Config{
+		Protocol:        "enh",
+		Network:         "tcp",
+		Address:         "127.0.0.1:0",
+		ReadTimeout:     200 * time.Millisecond,
+		StartDeadline:   2 * time.Second, // long; we want the err path, not the deadline
+		PendingStartTTL: 24 * time.Hour,
+		SYNInterval:     time.Hour,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mux.ctx, mux.cancel = ctx, cancel
+	mux.connMu.Lock()
+	mux.upstream = mock
+	mux.connMu.Unlock()
+	mux.upstreamFeatures.Store(0x01)
+
+	// Enqueue a request whose struct flag is pre-flipped, simulating
+	// the markInFlightCancelled outcome from a same-session re-submit
+	// happening just before tryGrantAndStart pops it. We need to
+	// flip the flag BEFORE tryGrant pops so the err path observes
+	// pending.req.cancelled == true.
+	ch := mux.arb.requestStart(1, 0x31)
+	mux.arb.mu.Lock()
+	req := mux.arb.pendingExternal[0]
+	mux.arb.mu.Unlock()
+	req.cancelled.Store(true)
+
+	// Force-grant via tryGrantAndStart; the RequestStart-err branch
+	// runs synchronously after popping.
+	mux.tryGrantAndStart()
+
+	select {
+	case result := <-ch:
+		if result.granted {
+			t.Fatal("expected granted=false after RequestStart error")
+		}
+		if !result.cancelled {
+			t.Fatalf("startResult.cancelled = %v on RequestStart-err + in-flight-cancelled; want true (M2 regression — session.go handleStart would emit ENHResFailed on the wire on transport-call failure for a cancelled session)", result.cancelled)
+		}
+		if result.err == nil {
+			t.Fatal("expected non-nil err on transport-failure result (M2 must preserve err for diagnostic trail)")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for RequestStart-err result")
+	}
+}
+
+// requestStartErrTransport implements arbitrationRequester returning
+// a fixed error from RequestStart. Used to exercise M2's
+// non-blocking-half err branch deterministically.
+type requestStartErrTransport struct {
+	eventCh    chan transport.StreamEvent
+	err        error
+	calls      atomic.Int32
+	closed     atomic.Bool
+}
+
+func (t *requestStartErrTransport) RequestStart(initiator byte) error {
+	t.calls.Add(1)
+	return t.err
+}
+
+func (t *requestStartErrTransport) ReadEvent() (transport.StreamEvent, error) {
+	ev, ok := <-t.eventCh
+	if !ok {
+		return transport.StreamEvent{}, errors.New("transport closed")
+	}
+	return ev, nil
+}
+
+func (t *requestStartErrTransport) ReadByte() (byte, error) {
+	for {
+		ev, err := t.ReadEvent()
+		if err != nil {
+			return 0, err
+		}
+		if ev.Kind == transport.StreamEventByte {
+			return ev.Byte, nil
+		}
+	}
+}
+
+func (t *requestStartErrTransport) Write(p []byte) (int, error) { return len(p), nil }
+
+func (t *requestStartErrTransport) Close() error {
+	if t.closed.CompareAndSwap(false, true) {
+		close(t.eventCh)
+	}
+	return nil
+}
+
+func (t *requestStartErrTransport) Init(features byte) (byte, error) { return features, nil }
+func (t *requestStartErrTransport) BytesAreUnescaped() bool          { return true }

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -2591,13 +2591,26 @@ func (m *Mux) tryGrantAndStart() {
 				// cancelled-in-flight, suppress with `cancelled: true`
 				// so the old wait goroutine silent-returns rather than
 				// emitting ENHResFailed on the wire (same class as M1).
+				//
+				// F-17 follow-up (PR #626 Codex bot P2, 2026-05-11):
+				// EXCEPTION — when the transport err is a reset/
+				// disconnect boundary event (isResetOrDisconnectError),
+				// the cancelled flag MUST NOT be set, even if the
+				// in-flight req is cancelled. Session.go's branch order
+				// (`granted → cancelled → err(reset) → deliverFailed`)
+				// would silent-return on `cancelled: true` and the
+				// client would miss the RESETTED delivery it needs to
+				// observe the boundary event. This is the same
+				// precedence rule documented in
+				// `arbitration.failAllPending`'s contract block.
 				cancelledInFlight := m.pendingStart.req != nil && m.pendingStart.req.cancelled.Load()
+				deliverAsCancelled := cancelledInFlight && !isResetOrDisconnectError(err)
 				if m.pendingStart.deadline != nil {
 					m.pendingStart.deadline.Stop() // AM8: cancel deadline timer
 				}
 				m.pendingStart = nil
 				m.stateMu.Unlock()
-				if cancelledInFlight {
+				if deliverAsCancelled {
 					notify <- startResult{granted: false, cancelled: true, initiator: initiator, err: err}
 				} else {
 					notify <- startResult{granted: false, initiator: initiator, err: err}
@@ -2705,13 +2718,22 @@ func (m *Mux) tryGrantAndStart() {
 					// could race with the transport-call returning an
 					// error. Suppress with `cancelled: true` when the
 					// in-flight req is cancelled.
+					//
+					// F-17 follow-up (PR #626 Codex bot P2, 2026-05-11):
+					// EXCEPTION — when the transport err is a reset/
+					// disconnect boundary event, the cancelled flag MUST
+					// NOT be set so session.go's err-routing path drives
+					// deliverReset(...) instead of silent-returning. Same
+					// precedence as the non-blocking RequestStart-err
+					// path above.
 					cancelledInFlight := m.pendingStart.req != nil && m.pendingStart.req.cancelled.Load()
+					deliverAsCancelled := cancelledInFlight && !isResetOrDisconnectError(err)
 					if m.pendingStart.deadline != nil {
 						m.pendingStart.deadline.Stop() // AM8: cancel deadline timer
 					}
 					m.pendingStart = nil
 					m.stateMu.Unlock()
-					if cancelledInFlight {
+					if deliverAsCancelled {
 						notify <- startResult{granted: false, cancelled: true, initiator: initiator, err: err}
 					} else {
 						notify <- startResult{granted: false, initiator: initiator, err: err}

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -2484,8 +2484,8 @@ func (m *Mux) tryGrantAndStart() {
 			m.pendingStart = nil
 			m.armPendingStartAbsorbLocked("deadline")
 			// F-15 (operator hand-off, batch-9/11): gate the reconnect by
-			// transport type, mirroring cancelPendingStart's existing
-			// pattern (mux.go:3004 `wasBlocking := pending.blockingArb`).
+			// transport type, mirroring `cancelPendingStart`'s existing
+			// `wasBlocking := pending.blockingArb` pattern.
 			//
 			// PRIOR BUG (`needReconnect := true` unconditionally): every
 			// deadline expiry forced an upstream reconnect — including on
@@ -2497,18 +2497,19 @@ func (m *Mux) tryGrantAndStart() {
 			// non-blocking path.
 			//
 			// LIVE EVIDENCE: 0 absorb-timeout reconnects across the entire
-			// 30k-line batch-9 log. The absorb safety-net at
-			// armPendingStartAbsorbLocked (mux.go:3056) drained naturally
-			// on every late-STARTED in production. The unconditional
-			// reconnect here was therefore never needed for the
-			// non-blocking transport in observed runs; for the rare
-			// truly-hung case the absorb timer's own
-			// StartDeadline-bounded reconnect path takes over.
+			// 30k-line batch-9 log. The absorb safety-net inside
+			// `armPendingStartAbsorbLocked` drained naturally on every
+			// late-STARTED in production. The unconditional reconnect
+			// here was therefore never needed for the non-blocking
+			// transport in observed runs; for the rare truly-hung case
+			// the absorb timer's own StartDeadline-bounded reconnect path
+			// takes over (covered by
+			// `TestAM8Deadline_NonBlockingPath_AbsorbTimerReconnectsOnTrulyHungAdapter`).
 			//
 			// BLOCKING TRANSPORT (legacy StartArbitration): the goroutine
 			// may still be hung in the transport call after the deadline,
 			// so the reconnect is still required to unstick it — same
-			// shape as cancelPendingStart at mux.go:3013.
+			// shape as `cancelPendingStart`.
 			wasBlocking := pending.blockingArb
 			m.stateMu.Unlock()
 			m.logger.Printf("adaptermux: pendingStart deadline expired for session %d (AM8, wasBlocking=%v)", pending.sessionID, wasBlocking)
@@ -2944,14 +2945,37 @@ func (m *Mux) handleArbitrationResponse(started bool, data byte) {
 			}
 			m.stateMu.Unlock()
 			m.logger.Printf("adaptermux: suppressing STARTED for session %d — request was cancelled/replaced; absorbed (C4/R4)", pending.sessionID)
-			// Best-effort send: the old notify channel is buffered
-			// to 1 and may already hold the replace's granted=false
+			// F-17 follow-up (PR #626 review round-1, angry-tester
+			// finding F-1): the old notify channel MUST receive
+			// `cancelled: true` so session.go's handleStart goroutine
+			// (session.go:524) takes the silent-return branch instead
+			// of falling through to deliverFailed(initiator). Without
+			// this flag, the old goroutine still emits
+			// ENHResFailed(0x31) on the wire — the exact failure mode
+			// F-17 was filed to fix, just on the in-flight-cancel
+			// branch instead of the pendingExternal-replace branch.
+			//
+			// Symmetry: arb.requestStart's pendingExternal-replace and
+			// pendingGateway-replace paths set both the struct flag
+			// AND the channel-value flag (arbitration.go:175,188).
+			// arb.cancelStart sets both as well (arbitration.go:283,
+			// 292). markInFlightCancelled (called from
+			// requestStartForSession) sets only the struct flag
+			// because the channel-value send was deferred to whichever
+			// handleArbitrationResponse path eventually fires — THIS
+			// branch. The contract is: any code that observes a
+			// cancelled startRequest and resolves its notify channel
+			// MUST set `cancelled: true` on the value.
+			//
+			// Best-effort send: the old notify channel is buffered to
+			// 1 and may already hold the replace's granted=false
 			// result. A late STARTED for a cancelled bid still
-			// resolves the channel cleanly when the read-side
-			// hasn't drained it yet.
+			// resolves the channel cleanly when the read-side hasn't
+			// drained it yet.
 			select {
 			case pending.notify <- startResult{
 				granted:   false,
+				cancelled: true,
 				initiator: pending.initiator,
 				err:       errors.New("adaptermux: START superseded by client re-submit"),
 			}:
@@ -2972,15 +2996,42 @@ func (m *Mux) handleArbitrationResponse(started bool, data byte) {
 		m.stateMu.Unlock()
 		m.completeArbitrationGrant(pending.sessionID, pending.initiator, pending.notify)
 	} else {
+		// F-17 follow-up (PR #626 review round-1, angry-tester finding
+		// F-1, FAILED-half): if the in-flight request was cancelled by
+		// markInFlightCancelled (called from requestStartForSession on
+		// a same-session re-submit), the FAILED arriving for the OLD
+		// bid is also addressed to a session that has already moved
+		// on. Without `cancelled: true` on the notify, session.go's
+		// handleStart goroutine takes the deliverFailed branch and
+		// emits ENHResFailed(winner) on the wire — same
+		// retry-feedback-loop class as F-17's STARTED-half. Suppress
+		// silently with the cancelled flag; the new request waits on
+		// its own fresh notify channel and the queue advances below.
+		cancelledInFlight := pending.req != nil && pending.req.cancelled.Load()
 		m.pendingStart = nil
 		if pending.deadline != nil {
 			pending.deadline.Stop() // AM8: cancel deadline timer
 		}
 		m.stateMu.Unlock()
-		pending.notify <- startResult{
-			granted:   false,
-			initiator: data,
-			err:       fmt.Errorf("adaptermux: arbitration lost to 0x%02X: %w", data, ebuserrors.ErrBusCollision),
+		if cancelledInFlight {
+			m.logger.Printf("adaptermux: suppressing FAILED(0x%02X) for session %d — request was cancelled/replaced; absorbed (C4/R4 FAILED-half)", data, pending.sessionID)
+			// Best-effort send (cap-1 channel may already hold the
+			// replace's granted=false result).
+			select {
+			case pending.notify <- startResult{
+				granted:   false,
+				cancelled: true,
+				initiator: pending.initiator,
+				err:       errors.New("adaptermux: START superseded by client re-submit (FAILED arrived)"),
+			}:
+			default:
+			}
+		} else {
+			pending.notify <- startResult{
+				granted:   false,
+				initiator: data,
+				err:       fmt.Errorf("adaptermux: arbitration lost to 0x%02X: %w", data, ebuserrors.ErrBusCollision),
+			}
 		}
 	}
 

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -2511,12 +2511,41 @@ func (m *Mux) tryGrantAndStart() {
 			// so the reconnect is still required to unstick it — same
 			// shape as `cancelPendingStart`.
 			wasBlocking := pending.blockingArb
+			// F-17 follow-up (PR #626 review round-3, angry-tester
+			// finding M1): the AM8 deadline path resolves the same
+			// pending startRequest that the three branches of
+			// handleArbitrationResponse resolve, and it can fire
+			// PRECISELY when the adapter is slow — the exact
+			// production condition that motivated this PR cycle.
+			// Without the cancelled-check, a same-session re-submit
+			// that flipped `pending.req.cancelled` via
+			// markInFlightCancelled will see the old wait goroutine
+			// fall through to deliverFailed("…deadline expired…")
+			// → ENHResFailed on the wire. Same retry-feedback-loop
+			// class as F-17 / F-NEW-1, just gated on AM8 instead of
+			// the normal arrival.
+			cancelledInFlight := pending.req != nil && pending.req.cancelled.Load()
 			m.stateMu.Unlock()
-			m.logger.Printf("adaptermux: pendingStart deadline expired for session %d (AM8, wasBlocking=%v)", pending.sessionID, wasBlocking)
+			m.logger.Printf("adaptermux: pendingStart deadline expired for session %d (AM8, wasBlocking=%v, cancelledInFlight=%v)", pending.sessionID, wasBlocking, cancelledInFlight)
 			// AM8: guard the send — if another path already delivered a
 			// result, the channel is full and this send would block forever.
+			var result startResult
+			if cancelledInFlight {
+				result = startResult{
+					granted:   false,
+					cancelled: true,
+					initiator: pending.initiator,
+					err:       errors.New("adaptermux: START deadline expired (superseded by client re-submit)"),
+				}
+			} else {
+				result = startResult{
+					granted:   false,
+					initiator: pending.initiator,
+					err:       errors.New("adaptermux: START deadline expired"),
+				}
+			}
 			select {
-			case pending.notify <- startResult{granted: false, initiator: pending.initiator, err: errors.New("adaptermux: START deadline expired")}:
+			case pending.notify <- result:
 			default:
 				m.logger.Printf("adaptermux: pendingStart deadline: notify channel full for session %d, result already delivered", pending.sessionID)
 			}
@@ -2556,12 +2585,23 @@ func (m *Mux) tryGrantAndStart() {
 			// on the cap-1 channel would block forever, pinning readLoop.
 			m.stateMu.Lock()
 			if m.pendingStart != nil && m.pendingStart.notify == notify {
+				// F-17 follow-up (PR #626 review round-3, angry-tester
+				// finding M2): a same-session re-submit could race
+				// with the transport-call returning an error. If
+				// cancelled-in-flight, suppress with `cancelled: true`
+				// so the old wait goroutine silent-returns rather than
+				// emitting ENHResFailed on the wire (same class as M1).
+				cancelledInFlight := m.pendingStart.req != nil && m.pendingStart.req.cancelled.Load()
 				if m.pendingStart.deadline != nil {
 					m.pendingStart.deadline.Stop() // AM8: cancel deadline timer
 				}
 				m.pendingStart = nil
 				m.stateMu.Unlock()
-				notify <- startResult{granted: false, initiator: initiator, err: err}
+				if cancelledInFlight {
+					notify <- startResult{granted: false, cancelled: true, initiator: initiator, err: err}
+				} else {
+					notify <- startResult{granted: false, initiator: initiator, err: err}
+				}
 			} else {
 				// RequestStart failed AND pending was already cancelled.
 				// Since the adapter never received the START, no stale
@@ -2659,12 +2699,23 @@ func (m *Mux) tryGrantAndStart() {
 					m.blockingArbActive = false
 				}
 				if m.pendingStart != nil && m.pendingStart.notify == notify {
+					// F-17 follow-up (PR #626 review round-3, angry-tester
+					// finding M2, blocking-half): same as the non-blocking
+					// RequestStart-err path — a same-session re-submit
+					// could race with the transport-call returning an
+					// error. Suppress with `cancelled: true` when the
+					// in-flight req is cancelled.
+					cancelledInFlight := m.pendingStart.req != nil && m.pendingStart.req.cancelled.Load()
 					if m.pendingStart.deadline != nil {
 						m.pendingStart.deadline.Stop() // AM8: cancel deadline timer
 					}
 					m.pendingStart = nil
 					m.stateMu.Unlock()
-					notify <- startResult{granted: false, initiator: initiator, err: err}
+					if cancelledInFlight {
+						notify <- startResult{granted: false, cancelled: true, initiator: initiator, err: err}
+					} else {
+						notify <- startResult{granted: false, initiator: initiator, err: err}
+					}
 				} else {
 					// StartArbitration failed AND pending was already cancelled.
 					// Codex-R8: scope absorb decrement + queue advance to our

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -2483,16 +2483,35 @@ func (m *Mux) tryGrantAndStart() {
 			pending := m.pendingStart
 			m.pendingStart = nil
 			m.armPendingStartAbsorbLocked("deadline")
-			// Once START times out we no longer trust adapter arbitration
-			// state, even on the non-blocking RequestStart path. A later
-			// STARTED means the adapter granted the old request after we
-			// had already abandoned it; if we simply absorb that event and
-			// launch a new RequestStart, the mux and adapter can stay one
-			// arbitration behind forever. Reconnect is the only reliable
-			// resync boundary for both blocking and non-blocking paths.
-			needReconnect := true
+			// F-15 (operator hand-off, batch-9/11): gate the reconnect by
+			// transport type, mirroring cancelPendingStart's existing
+			// pattern (mux.go:3004 `wasBlocking := pending.blockingArb`).
+			//
+			// PRIOR BUG (`needReconnect := true` unconditionally): every
+			// deadline expiry forced an upstream reconnect — including on
+			// the non-blocking ENH RequestStart path where the adapter is
+			// only slow, not hung. F-17's retry storm amplified this:
+			// adapter backlog → slow STARTED → AM8 trips → forced
+			// reconnect → drops the next ReqStart → loop. Even without
+			// F-17 the asymmetric reconnect is a design defect on the
+			// non-blocking path.
+			//
+			// LIVE EVIDENCE: 0 absorb-timeout reconnects across the entire
+			// 30k-line batch-9 log. The absorb safety-net at
+			// armPendingStartAbsorbLocked (mux.go:3056) drained naturally
+			// on every late-STARTED in production. The unconditional
+			// reconnect here was therefore never needed for the
+			// non-blocking transport in observed runs; for the rare
+			// truly-hung case the absorb timer's own
+			// StartDeadline-bounded reconnect path takes over.
+			//
+			// BLOCKING TRANSPORT (legacy StartArbitration): the goroutine
+			// may still be hung in the transport call after the deadline,
+			// so the reconnect is still required to unstick it — same
+			// shape as cancelPendingStart at mux.go:3013.
+			wasBlocking := pending.blockingArb
 			m.stateMu.Unlock()
-			m.logger.Printf("adaptermux: pendingStart deadline expired for session %d (AM8)", pending.sessionID)
+			m.logger.Printf("adaptermux: pendingStart deadline expired for session %d (AM8, wasBlocking=%v)", pending.sessionID, wasBlocking)
 			// AM8: guard the send — if another path already delivered a
 			// result, the channel is full and this send would block forever.
 			select {
@@ -2500,7 +2519,7 @@ func (m *Mux) tryGrantAndStart() {
 			default:
 				m.logger.Printf("adaptermux: pendingStart deadline: notify channel full for session %d, result already delivered", pending.sessionID)
 			}
-			if needReconnect {
+			if wasBlocking {
 				// Close the current conn to force the hung blocking
 				// StartArbitration call to return with an I/O error.
 				// readLoop's error handler invokes reconnect() which

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -2882,13 +2882,36 @@ func (m *Mux) handleArbitrationResponse(started bool, data byte) {
 	if m.pendingStartAbsorb > 0 {
 		m.pendingStartAbsorb--
 		shouldAdvance := !started && m.pendingStartAbsorb == 0 && m.pendingStart == nil && m.arb.hasPending()
-		needReconnect := started
+		// F-15 follow-up (PR #626 Codex bot review on b3b7f13 + e6b96ee
+		// — P1 finding): the absorb-consume branch used to reconnect
+		// unconditionally on STARTED (`needReconnect := started`). On
+		// the non-blocking ENH path that's the same asymmetric design
+		// defect F-15 fixed in the AM8 deadline callback — just
+		// delayed: AM8 arms absorb without closing, but then the late
+		// STARTED arrives, hits THIS branch, and conn.Close fires.
+		// The F-15 fix only prevented the IMMEDIATE close; the late
+		// absorb still tore down TCP, preserving the retry-feedback
+		// loop F-15 was meant to eliminate.
+		//
+		// Mirror F-15's transport-type gate: reconnect only on the
+		// blocking StartArbitration path (where a hung goroutine may
+		// still need unsticking). On the non-blocking RequestStart
+		// path the adapter is merely slow, eBUS arbitration is
+		// per-SYN stateless, and the absorb counter has already done
+		// its bookkeeping job by decrementing.
+		m.connMu.Lock()
+		tr := m.upstream
+		m.connMu.Unlock()
+		_, hasRequestStart := tr.(arbitrationRequester)
+		_, hasBlockingStart := tr.(interface{ StartArbitration(byte) error })
+		isBlockingPath := !hasRequestStart && hasBlockingStart
+		needReconnect := started && isBlockingPath
 		m.stateMu.Unlock()
 		kind := "FAILED"
 		if started {
 			kind = "STARTED"
 		}
-		m.logger.Printf("adaptermux: absorbed stale %s from cancelled request (data=0x%02X)", kind, data)
+		m.logger.Printf("adaptermux: absorbed stale %s from cancelled request (data=0x%02X, isBlockingPath=%v)", kind, data, isBlockingPath)
 		if needReconnect {
 			m.connMu.Lock()
 			c := m.conn
@@ -2897,7 +2920,7 @@ func (m *Mux) handleArbitrationResponse(started bool, data byte) {
 				if err := c.Close(); err != nil {
 					m.logger.Printf("adaptermux: stale STARTED reconnect close: %v", err)
 				} else {
-					m.logger.Printf("adaptermux: stale STARTED triggered transport reconnect for arbitration resync")
+					m.logger.Printf("adaptermux: stale STARTED triggered transport reconnect for arbitration resync (blocking path)")
 				}
 			}
 		}

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -2875,6 +2875,19 @@ func (m *Mux) handleArbitrationResponse(started bool, data byte) {
 			// The adapter sent this STARTED for a previous RequestStart that
 			// is no longer tracked. The real response for our pending request
 			// may still arrive — absorb it when it does.
+			//
+			// F-17 follow-up (PR #626 review round-2, angry-tester finding
+			// F-NEW-1): like the matched-STARTED and FAILED branches below,
+			// the AM56 mismatch branch must also honor an in-flight
+			// `pending.req.cancelled` flag. If the session has issued a
+			// same-session re-submit (markInFlightCancelled flipped the
+			// struct flag) and the adapter responds with a STALE STARTED
+			// whose byte happens not to match the cancelled bid, the
+			// session has already moved on. Delivering
+			// `ENHResFailed(winner_byte)` to the old wait goroutine
+			// reproduces F-17's retry feedback loop on a narrow but real
+			// path. Suppress silently with cancelled=true.
+			cancelledInFlight := pending.req != nil && pending.req.cancelled.Load()
 			m.pendingStart = nil
 			m.armPendingStartAbsorbLocked("started-mismatch")
 			if pending.deadline != nil {
@@ -2888,20 +2901,33 @@ func (m *Mux) handleArbitrationResponse(started bool, data byte) {
 			// on PR #623.)
 			m.lastWireActivity = time.Now()
 			m.stateMu.Unlock()
-			m.logger.Printf("adaptermux: STARTED mismatch: got initiator 0x%02X, pending 0x%02X — failing pending session %d (AM56)", data, pending.initiator, pending.sessionID)
-			// Notify the bidder with the THIRD-PARTY winner byte (`data`),
-			// not the bidder's own `pending.initiator`. This matches the
-			// regular FAILED-path semantics below: the bidder's handleStart
-			// goroutine forwards `result.initiator` to deliverFailed, so the
-			// external session sees ENHResFailed(winner_byte) and learns
-			// the actual wire owner. Without this, the bidder would only
-			// learn its own bid byte from the failure and its bus
-			// reconstructor would misread the next target/PB byte as the
-			// frame source (Codex P2 round 7 on PR #620).
-			pending.notify <- startResult{
-				granted:   false,
-				initiator: data,
-				err:       fmt.Errorf("adaptermux: STARTED mismatch (got 0x%02X, want 0x%02X)", data, pending.initiator),
+			if cancelledInFlight {
+				m.logger.Printf("adaptermux: suppressing STARTED-mismatch(0x%02X, pending 0x%02X) for session %d — request was cancelled/replaced; absorbed (C4/R4 AM56-half)", data, pending.initiator, pending.sessionID)
+				select {
+				case pending.notify <- startResult{
+					granted:   false,
+					cancelled: true,
+					initiator: pending.initiator,
+					err:       errors.New("adaptermux: STARTED-mismatch superseded by client re-submit"),
+				}:
+				default:
+				}
+			} else {
+				m.logger.Printf("adaptermux: STARTED mismatch: got initiator 0x%02X, pending 0x%02X — failing pending session %d (AM56)", data, pending.initiator, pending.sessionID)
+				// Notify the bidder with the THIRD-PARTY winner byte (`data`),
+				// not the bidder's own `pending.initiator`. This matches the
+				// regular FAILED-path semantics below: the bidder's handleStart
+				// goroutine forwards `result.initiator` to deliverFailed, so the
+				// external session sees ENHResFailed(winner_byte) and learns
+				// the actual wire owner. Without this, the bidder would only
+				// learn its own bid byte from the failure and its bus
+				// reconstructor would misread the next target/PB byte as the
+				// frame source (Codex P2 round 7 on PR #620).
+				pending.notify <- startResult{
+					granted:   false,
+					initiator: data,
+					err:       fmt.Errorf("adaptermux: STARTED mismatch (got 0x%02X, want 0x%02X)", data, pending.initiator),
+				}
 			}
 			// After resolving, check if more requests are pending.
 			if m.arb.hasPending() {
@@ -2955,17 +2981,30 @@ func (m *Mux) handleArbitrationResponse(started bool, data byte) {
 			// F-17 was filed to fix, just on the in-flight-cancel
 			// branch instead of the pendingExternal-replace branch.
 			//
-			// Symmetry: arb.requestStart's pendingExternal-replace and
-			// pendingGateway-replace paths set both the struct flag
-			// AND the channel-value flag (arbitration.go:175,188).
-			// arb.cancelStart sets both as well (arbitration.go:283,
-			// 292). markInFlightCancelled (called from
-			// requestStartForSession) sets only the struct flag
+			// Symmetry: `arb.requestStart`'s pendingExternal-replace
+			// and pendingGateway-replace paths set both the struct
+			// flag AND the channel-value flag. `arb.cancelStart` sets
+			// both as well. `markInFlightCancelled` (called from
+			// `requestStartForSession`) sets only the struct flag
 			// because the channel-value send was deferred to whichever
-			// handleArbitrationResponse path eventually fires — THIS
-			// branch. The contract is: any code that observes a
-			// cancelled startRequest and resolves its notify channel
-			// MUST set `cancelled: true` on the value.
+			// `handleArbitrationResponse` path eventually fires —
+			// THIS branch (matched STARTED for cancelled bid), the
+			// FAILED-with-cancelled-req branch below, AND the AM56
+			// STARTED-mismatch-with-cancelled-req branch above.
+			//
+			// The contract is: any code in `handleArbitrationResponse`
+			// that observes a cancelled startRequest while resolving
+			// the bid normally (no transport-level error) MUST set
+			// `cancelled: true` on the value so `session.handleStart`'s
+			// branch order (`granted → cancelled → err(reset) →
+			// deliverFailed`) silent-returns.
+			//
+			// EXCEPTION: code paths that deliver a transport-level
+			// boundary error via `err` matching `isResetOrDisconnectError`
+			// (e.g., `failAllPending` on shutdown / `reconnect`) MUST
+			// NOT set `cancelled: true`. Session.go's check order
+			// favors `cancelled` over `err(reset)`, so setting both
+			// would suppress the RESETTED delivery the client needs.
 			//
 			// Best-effort send: the old notify channel is buffered to
 			// 1 and may already hold the replace's granted=false


### PR DESCRIPTION
## Summary

v0.6.7 candidate. Closes the pcap-confirmed "ebusd never lands a frame through the proxy" retry-feedback-loop, plus AM8 reconnect-asymmetry, plus a four-round adversarial-review sweep of every code path that resolves a cancelled startRequest.

**Status (review round 4 / final):** SHIP.

## The original bug — F-17

Microsecond-resolution TCP capture (operator's batch-9 audit,
[`_work_adaptermux_audit/EBUSD-VERIFICATION-2026-05-11-batch9.md`](_work_adaptermux_audit/EBUSD-VERIFICATION-2026-05-11-batch9.md))
showed every `ReqStart(0x31)` from ebusd received `ENHResFailed(0x31)`
within ~0.3 ms — far faster than the bus can physically arbitrate
(eBUS bit-time ~4 ms). The proxy was synthesizing these failures
locally with `data = 0x31` (ebusd's own master byte), telling ebusd
"you lost to yourself."

### Root cause

`startRequest` carries a struct-field `cancelled atomic.Bool` for
in-flight-at-adapter suppression. `startResult` carries a
value-field `cancelled bool` for the channel handshake. Both must be
set on cancellation: the struct flag lets `handleArbitrationResponse`
suppress late STARTED/FAILED; the value flag lets
`session.handleStart` silent-return instead of falling through to
`deliverFailed(initiator)` and emitting `ENHResFailed` on the wire.

`arbitration.requestStart`'s same-session-replace paths set the
struct flag but NOT the value flag. Result: every same-session
replace produced `ENHResFailed(0x31)` on the wire in ~0.3 ms. ebusd
read it as arbitration-lost-to-self, retried within ~50 ms, cancelled
the just-queued entry, produced another spurious FAILED —
positive-feedback loop. No bid ever physically arbitrated.

## What this PR ships

### Production code

| Path | Fix | Round |
| --- | --- | --- |
| `arb.requestStart` gateway-replace | `cancelled: true` on result | initial |
| `arb.requestStart` external-replace | `cancelled: true` on result | initial |
| AM8 deadline reconnect | gated by `pending.blockingArb` (mirror `cancelPendingStart`) | F-15 |
| `handleArbitrationResponse` matched STARTED + cancelled | `cancelled: true` on suppression | round 1 (F-1) |
| `handleArbitrationResponse` FAILED + cancelled | `cancelled: true` on suppression | round 1 (F-1) |
| `arb.cancelStart` gateway + external | `cancelled: true` + struct flag | round 1 (F-2) |
| `handleArbitrationResponse` AM56 mismatch + cancelled | `cancelled: true` on suppression | round 2 (F-NEW-1) |
| AM8 deadline + cancelled in flight | `cancelled: true` on result | round 3 (M1) |
| RequestStart err + cancelled in flight | `cancelled: true` on result | round 3 (M2) |
| StartArbitration err + cancelled in flight | `cancelled: true` on result | round 3 (M2) |

### The contract (now documented in code)

Any code path that resolves a cancelled `startRequest` via the
**normal (non-boundary) resolution path** MUST set `cancelled: true`
on the `startResult`. Code paths that resolve via a
**transport-level boundary error** (`failAllPending`, `reconnect`,
`handleReset`, `Close`) MUST NOT set `cancelled: true` — session.go's
branch order is `granted → cancelled → err(reset) → deliverFailed`,
so the err-routing path is required to drive `deliverReset(...)` on
RESETTED/disconnect events. The precedence is documented in:
- `arbitration.go` `failAllPending` docstring
- `arbitration.go` `cancelStart` docstring
- `mux.go` STARTED-suppression branch comment

### F-15 — AM8 deadline asymmetric reconnect

The AM8 deadline callback in `mux.go` previously used
`needReconnect := true` unconditionally. Every deadline expiry forced
an upstream conn.Close — including on the non-blocking ENH
RequestStart path where the adapter is merely slow, not hung.

Under F-17's retry storm this asymmetry amplified into a feedback
loop: adapter backlog → slow STARTED → AM8 trips → forced reconnect
→ next ReqStart dropped → another retry. Even without F-17 the
unconditional reconnect is a design defect: the absorb safety-net at
`armPendingStartAbsorbLocked` already handles the rare truly-hung
case via its own `StartDeadline`-bounded reconnect.

Fix: mirror `cancelPendingStart`'s existing `wasBlocking := pending.blockingArb`
pattern. Blocking transport keeps its reconnect (goroutine may still
be hung in the transport call).

## Adversarial review trail

Four rounds, 7 angry-tester findings, all addressed in-PR:

| Round | Finding | Severity | Description | Status |
| --- | --- | --- | --- | --- |
| 1 | F-1 | HIGH | F-17 incomplete on C4/R4 in-flight branch | fixed |
| 1 | F-2 | MEDIUM | `arb.cancelStart` missing flag (pre-existing latent) | fixed |
| 1 | F-3 | MEDIUM | absorb-safety-net claim un-tested | covered by new test |
| 1 | F-4 | LOW | blocking-path test leaked goroutine | fixed |
| 1 | F-5 | NIT | stale line refs in comments | refreshed |
| 2 | F-NEW-1 | MEDIUM | AM56 STARTED-mismatch branch missed flag | fixed |
| 2 | F-NEW-2 | LOW | absorb-timer test had tight CI margin | widened |
| 2 | F-NEW-4 | NIT | contract comment overclaim | narrowed |
| 2 | F-NEW-5 | NIT | log positive marker for FAILED-half | added |
| 2 | F-NEW-6 | NIT | `failAllPending` precedence not documented | documented |
| 3 | M1 | MEDIUM | AM8 deadline path missed flag (fires when adapter slow!) | fixed |
| 3 | M2 | MEDIUM | transport-err paths missed flag | fixed |
| 3 | L2 | LOW | blocking-path test setup race | replaced with polling |
| 3 | L3 | LOW | NoReconnect test unbounded `wg.Wait` | bounded |
| 4 | — | — | **VERDICT: SHIP** | — |

## Tests added

15 regression tests across 4 files:
- `f17_cancelled_result_flag_test.go` (initial) — 3 tests
- `f15_am8_deadline_reconnect_test.go` (F-15) — 3 tests
- `f17_review_round1_test.go` (rounds 1-2) — 7 tests
- `f17_review_round3_test.go` (round 3) — 2 tests

Plus log-marker invariants for all three `handleArbitrationResponse`
suppression branches, and a dedicated absorb-safety-net positive test
(rare truly-hung non-blocking adapter).

## Validation

- `go build ./...` clean.
- `go vet ./...` clean.
- Full adaptermux suite: ~104 s green.
- Adaptermux `-race`: ~108 s green.

## Predicted post-deploy outcome (operator's batch-9 table)

| Metric | v0.6.6 | After v0.6.7 |
| --- | --- | --- |
| `FAILED(0x31)` response within <1 ms of ReqStart | 100 % | < 5 % |
| `grab result all` frames with src=0x31 | **0** | > 0 within 60 s |
| ebusd `messages` counter (15 min uptime) | 17 plateau | > 50 |
| ebusd "won in invalid state" rate | many/scan | < 1/5 min |

## Test plan

- [ ] Operator merge gateway PR #626
- [ ] Addon bump 0.6.6 → 0.6.7 (Dockerfile pin, config.json, build.yml, MIN)
- [ ] Addon `CHANGELOG.md` 0.6.7 entry: F-17 + F-15 + cancelled-flag-contract sweep, new log markers `absorbed (C4/R4)`, `absorbed (C4/R4 AM56-half)`, `absorbed (C4/R4 FAILED-half)`
- [ ] Addon PR → operator merge → GHCR multi-arch build
- [ ] Cache-bypass retag deploy (`pull :0.6.7-aarch64` → `tag :0.6.1`)
- [ ] Run `while true; do ebusctl scan 08; done` loop, verify against batch-9 predicted table
- [ ] Check log markers fire as expected during scan (`grep absorbed`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)