### PR TITLE
fix(passive): F-19 passive reconstructor early-abandon + arbitration fragment classification

### DIFF
--- a/passive_reconstructor_f19_test.go
+++ b/passive_reconstructor_f19_test.go
@@ -1,0 +1,322 @@
+package ebusgateway
+
+// F-19 regression tests
+// (_work_adaptermux_audit/EBUSD-VERIFICATION-2026-05-12-batch15.md).
+//
+// F-19a — LEN-completion parseFrame failure must abandon early instead
+// of continuing to absorb bytes from the next frame. The pre-F-19a
+// path "kept accumulating", cascading the corruption into the next
+// frame's buffer. Live evidence (batch-14): ~146 src=0x10 abandons per
+// 30k log lines, all matching the `req_raw=10 26 B5 23 01 AA AA`
+// shape (LEN=1 buffer where both 0xAA bytes were absorbed as
+// data+CRC and the CRC check failed).
+//
+// F-19b — A 4-byte buffer reaching SB but not LEN is structurally an
+// arbitration fragment (lost arbitration / wire byte loss), not a
+// corrupted_request. The pre-F-19b threshold `<= 3` mis-classified
+// these. Live evidence (batch-14): ~115 src=0xF1 abandons per 30k
+// lines, all in the 4-byte truncated shape.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+)
+
+// TestPassiveReconstructor_F19a_LenCompletionCRCFail_AbandonsEarly is
+// the headline F-19a invariant: the operator's `req_raw=10 26 B5 23
+// 01 AA AA` example must produce ONE abandon event at the second
+// 0xAA's timestamp, with no carryover of buffered bytes into the next
+// frame.
+func TestPassiveReconstructor_F19a_LenCompletionCRCFail_AbandonsEarly(t *testing.T) {
+	t.Parallel()
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	// Wire: SYN gate + the operator's example bytes.
+	// eBUS CRC8(0x9B) of `10 26 B5 23 01 AA` is 0x7C — so when both
+	// 0xAA bytes are absorbed as data+CRC by the F-19a-affected
+	// predicate path, the buffer's CRC check (CRC byte == 0xAA)
+	// fails (expected 0x7C). Pre-F-19a: parser continued accumulating
+	// until the next SYN/over-length. Post-F-19a: abandon at this
+	// exact byte boundary.
+	wire := []byte{
+		protocol.SymbolSyn, // gate
+		0x10,               // SRC
+		0x26,               // DST
+		0xB5,               // PB
+		0x23,               // SB
+		0x01,               // LEN=1
+		0xAA,               // DATA[0] — absorbed by isMidRequestFrame
+		0xAA,               // CRC position — also absorbed; CRC check
+		// will fail (real CRC is 0x7C).
+	}
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0), wire)
+
+	event := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventAbandonedTransaction)
+	if event.AbandonReason != PassiveAbandonReasonCorruptedRequest {
+		t.Errorf("AbandonReason = %v; want corrupted_request (F-19a: parseFrame failure at LEN-completion must abandon as corrupted_request when not self-echo / scan-collision)", event.AbandonReason)
+	}
+
+	// F-19a Layer-1 invariant: no wire SYN was consumed when the
+	// buffer hit len=6+LEN, so the next observed wire SYN must
+	// re-engage the synced gate. Feed a valid follow-up frame to
+	// pin this: a broadcast frame from a different SRC.
+	follow := protocol.Frame{
+		Source:    0x30,
+		Target:    protocol.AddressBroadcast,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{0x07},
+	}
+	feedPassiveSymbols(reconstructor, time.Unix(0, 1), frameBytes(follow))
+
+	next := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventBroadcastFrame)
+	if next.Request.Source != 0x30 {
+		t.Errorf("follow-up broadcast Request.Source = 0x%02X; want 0x30 (F-19a: the abandoned buffer must not have leaked into the next frame's reconstruction)", next.Request.Source)
+	}
+}
+
+// TestPassiveReconstructor_F19a_PreservesClassification_SelfEcho pins
+// angry-tester Finding C: the new early-abandon path must replicate
+// the SYN-triggered path's classification (self_echo / scan_collision)
+// — not silently downgrade everything to corrupted_request.
+func TestPassiveReconstructor_F19a_PreservesClassification_SelfEcho(t *testing.T) {
+	t.Parallel()
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	reconstructor.SetLocalAddressSnapshotter(testLocalSnapshotter{address: 0x71, known: true})
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	// Same shape as the headline F-19a test but with SRC=0x71 (the
+	// gateway's own address). isSelfOriginatedRaw matches → abandon
+	// classifies as self_echo, not corrupted_request.
+	wire := []byte{
+		protocol.SymbolSyn,
+		0x71, // gateway SRC
+		0x26,
+		0xB5,
+		0x23,
+		0x01,
+		0xAA,
+		0xAA,
+	}
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0), wire)
+
+	event := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventAbandonedTransaction)
+	if event.AbandonReason != PassiveAbandonReasonSelfEcho {
+		t.Errorf("AbandonReason = %v; want self_echo (F-19a classification replication: SRC=0x71 must classify as self_echo even on the new early-abandon path)", event.AbandonReason)
+	}
+}
+
+// TestPassiveReconstructor_F19a_PreservesClassification_ScanCollision
+// pins the other half of angry-tester Finding C: scan-probe shaped
+// requests (PB=0x07 SB=0x04) that fail CRC at LEN-completion must
+// classify as scan_collision, not corrupted_request.
+func TestPassiveReconstructor_F19a_PreservesClassification_ScanCollision(t *testing.T) {
+	t.Parallel()
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	// Wire: SYN gate + a scan probe (PB=0x07 SB=0x04) with garbled
+	// data+CRC bytes (both 0xAA). isScanProbeRaw matches via the
+	// raw[2]==0x07 raw[3]==0x04 check, so abandon classifies as
+	// scan_collision.
+	wire := []byte{
+		protocol.SymbolSyn,
+		0x10, // SRC
+		0xFE, // DST (broadcast — typical scan dest)
+		0x07, // PB (scan)
+		0x04, // SB (scan)
+		0x01, // LEN
+		0xAA, // DATA[0]
+		0xAA, // CRC position (will fail CRC validation)
+	}
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0), wire)
+
+	event := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventAbandonedTransaction)
+	if event.AbandonReason != PassiveAbandonReasonScanCollision {
+		t.Errorf("AbandonReason = %v; want scan_collision (F-19a classification replication: PB=0x07 SB=0x04 must classify as scan_collision on the new early-abandon path)", event.AbandonReason)
+	}
+}
+
+// TestPassiveReconstructor_F19b_FourByteFragment_ClassifiesAsArbitrationFragment
+// pins the F-19b reclassification: a 4-byte buffer reaching SB but
+// not LEN must classify as arbitration_fragment (was
+// corrupted_request pre-F-19b). The operator's `req_raw=F1 15 B5 24`
+// example exemplifies this shape.
+func TestPassiveReconstructor_F19b_FourByteFragment_ClassifiesAsArbitrationFragment(t *testing.T) {
+	t.Parallel()
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	// Wire: SYN gate + the operator's example: 4 bytes then SYN at
+	// LEN position. Layer 1 syncs, 4 bytes accumulate, SYN at
+	// position 5 → isMidRequestFrame returns false → SYN-handling
+	// path. Pre-F-19b: corrupted_request (len > 3). Post-F-19b:
+	// arbitration_fragment (len < 5).
+	wire := []byte{
+		protocol.SymbolSyn,
+		0xF1, // SRC (NETX3-like initiator)
+		0x15, // DST
+		0xB5, // PB
+		0x24, // SB
+		protocol.SymbolSyn,
+	}
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0), wire)
+
+	event := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventAbandonedTransaction)
+	if event.AbandonReason != PassiveAbandonReasonArbitrationFragment {
+		t.Errorf("AbandonReason = %v; want arbitration_fragment (F-19b: len<5 truncation must classify as arbitration_fragment, not corrupted_request)", event.AbandonReason)
+	}
+}
+
+// TestPassiveReconstructor_F19_NoRegression_ValidLEN1Frame proves the
+// fix does NOT regress legitimate frames where data or CRC happens to
+// be 0xAA (P7.1 invariant). Constructs a LEN=1 broadcast frame with
+// DATA[0]=0xAA and the actual computed CRC; the frame must commit.
+func TestPassiveReconstructor_F19_NoRegression_ValidLEN1Frame(t *testing.T) {
+	t.Parallel()
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	frame := protocol.Frame{
+		Source:    0x10,
+		Target:    protocol.AddressBroadcast,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{0xAA}, // legitimate 0xAA payload byte
+	}
+	// frameBytes appends the actual computed CRC + trailing SYN. The
+	// CRC of this specific frame won't equal 0xAA by accident, so this
+	// exercises the "0xAA in data but CRC is the real value" case.
+	feedPassiveSymbols(reconstructor, time.Unix(0, 0), frameBytes(frame))
+
+	event := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventBroadcastFrame)
+	if !event.HasRequest {
+		t.Fatal("F-19 regression: valid LEN=1 frame with DATA[0]=0xAA must commit, not abandon")
+	}
+	if len(event.Request.Data) != 1 || event.Request.Data[0] != 0xAA {
+		t.Fatalf("F-19 regression: Request.Data = % X; want [AA]", event.Request.Data)
+	}
+}
+
+// TestPassiveReconstructor_F19_NoRegression_BroadcastDeferToSYN is the
+// regression guard for the disambiguation fix in the implementation:
+// when parseFrame succeeds at LEN-completion but the frame is a
+// Broadcast (whose canonical commit is on the trailing SYN per the
+// commitRequestFrameLocked docstring), the new F-19a code path must
+// NOT abandon. It must fall through to the SYN-trigger path which
+// dispatches the broadcast cleanly.
+func TestPassiveReconstructor_F19_NoRegression_BroadcastDeferToSYN(t *testing.T) {
+	t.Parallel()
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	// Standard broadcast: parseFrame succeeds at LEN-completion but
+	// commitRequestFrameLocked defers to SYN-trigger for canonical
+	// timing.
+	frame := protocol.Frame{
+		Source:    0x10,
+		Target:    protocol.AddressBroadcast,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{0x01, 0x02},
+	}
+	feedPassiveSymbols(reconstructor, time.Unix(0, 0), frameBytes(frame))
+
+	event := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventBroadcastFrame)
+	if !event.HasRequest {
+		t.Fatal("F-19a regression: broadcast frames where parseFrame succeeds at LEN-completion must defer to SYN-trigger and commit, NOT abandon")
+	}
+}
+
+// TestPassiveReconstructor_F19a_LayerOneInvariant_NoAfterSynReset pins
+// the Layer 1 invariant: after F-19a's early abandon, the synced gate
+// must be re-engaged via the NEXT wire SYN (not held over from before
+// the abandon). Implementation calls resetStateLocked (NOT
+// resetStateLockedAfterSyn) because no wire SYN was consumed at the
+// LEN+CRC boundary. This test verifies the Layer 1 gate behavior by
+// feeding a non-SYN byte immediately after the abandon and confirming
+// it does NOT engage frame collection.
+func TestPassiveReconstructor_F19a_LayerOneInvariant_NoAfterSynReset(t *testing.T) {
+	t.Parallel()
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	// Step 1: trigger F-19a abandon.
+	wire := []byte{
+		protocol.SymbolSyn,
+		0x10,
+		0x26,
+		0xB5,
+		0x23,
+		0x01,
+		0xAA,
+		0xAA,
+	}
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0), wire)
+
+	event := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventAbandonedTransaction)
+	if event.AbandonReason != PassiveAbandonReasonCorruptedRequest {
+		t.Fatalf("setup: F-19a abandon AbandonReason = %v; want corrupted_request", event.AbandonReason)
+	}
+
+	// Step 2: feed a non-SYN byte. The synced gate should be CLOSED
+	// (resetStateLocked was called, not resetStateLockedAfterSyn).
+	// The byte should be dropped silently — no new abandon event.
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 1), []byte{0x30, 0x08, 0xB5, 0x09})
+
+	// Step 3: feed a wire SYN + a valid follow-up frame. The SYN
+	// re-engages the synced gate via the Idle handler; the follow-up
+	// frame must reconstruct cleanly.
+	follow := protocol.Frame{
+		Source:    0x30,
+		Target:    protocol.AddressBroadcast,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{0x07},
+	}
+	wireFollow := append([]byte{protocol.SymbolSyn}, frameBytes(follow)...)
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 2), wireFollow)
+
+	next := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventBroadcastFrame)
+	if next.Request.Source != 0x30 {
+		t.Fatalf("F-19a Layer 1 invariant: follow-up frame Source = 0x%02X; want 0x30 (the dropped bytes between abandon and SYN must not have polluted the next frame's reconstruction)", next.Request.Source)
+	}
+}

--- a/passive_reconstructor_f19_test.go
+++ b/passive_reconstructor_f19_test.go
@@ -261,22 +261,29 @@ func TestPassiveReconstructor_F19_NoRegression_BroadcastDeferToSYN(t *testing.T)
 	}
 }
 
-// TestPassiveReconstructor_F19a_LayerOneInvariant_SynConsumed_KeepsSynced
-// pins the Codex-bot P2 finding (2026-05-12): when F-19a is triggered
-// by a SYN-valued byte (the operator's exact `... AA AA` case, where
-// the second 0xAA is an escape-decoded wire SYN), the implementation
-// MUST call resetStateLockedAfterSyn — the wire SYN we absorbed
-// satisfies the Layer-1 inter-frame invariant; the next non-SYN byte
-// can start a fresh frame immediately.
+// TestPassiveReconstructor_F19a_LayerOneInvariant_EscapeDecodedAA_ClosesGate
+// pins the Codex-bot P2 round-2 finding (2026-05-12): in the
+// operator's exact `... AA AA` case, the second 0xAA was
+// escape-decoded by the tap (from wire `0xA9 0x01`) and is NOT a
+// real wire SYN. The Layer-1 inter-frame gate must NOT be left
+// engaged just because the logical byte value happens to equal
+// SymbolSyn — that would incorrectly accept the very next byte
+// (typically an ACK/NACK/body byte of the in-progress wire
+// transaction) as a new frame's SRC, creating a second false
+// reconstruction cascade.
 //
-// Pre-fix: resetStateLocked was called unconditionally → Layer-1 gate
-// closed → next frame's SRC byte was dropped → CASCADE CONTINUED
-// (exactly what this PR was meant to stop).
+// The fix: always call plain resetStateLocked at the F-19a
+// abandon site, regardless of the symbol's value. The next
+// observed real wire SYN re-engages the synced gate via the Idle
+// handler. The "wasted SYN" cost (one SRC dropped if the symbol
+// genuinely was a wire SYN — which we cannot distinguish without
+// a WasEscaped flag on the tap) is bounded by the next
+// guaranteed inter-frame wire SYN.
 //
-// Post-fix: resetStateLockedAfterSyn keeps synced=true after a
-// SYN-valued absorbed byte → next non-SYN byte engages frame collection
-// immediately.
-func TestPassiveReconstructor_F19a_LayerOneInvariant_SynConsumed_KeepsSynced(t *testing.T) {
+// This test pins the safe-fail behavior: after F-19a abandons on
+// an absorbed 0xAA-valued byte, the gate is CLOSED, and any
+// non-SYN bytes that follow are dropped until the next wire SYN.
+func TestPassiveReconstructor_F19a_LayerOneInvariant_EscapeDecodedAA_ClosesGate(t *testing.T) {
 	t.Parallel()
 
 	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
@@ -286,16 +293,15 @@ func TestPassiveReconstructor_F19a_LayerOneInvariant_SynConsumed_KeepsSynced(t *
 	}
 	defer subscription.Close()
 
-	// Step 1: trigger F-19a abandon via the operator's exact `... AA AA`
-	// shape. Both 0xAA bytes are SYN-valued (escape-decoded from
-	// `0xA9 0x01` on wire). The SECOND 0xAA is the symbol that
-	// triggers the LEN-completion CRC fail → F-19a abandon. The
-	// reset variant MUST be AfterSyn (post-Codex-bot-P2 fix).
+	// Step 1: trigger F-19a abandon via the operator's exact
+	// `... AA AA` shape. The trailing 0xAA cannot be reliably
+	// distinguished from an escape-decoded data byte at this
+	// layer, so the safe choice is to close the gate.
 	wire := []byte{
 		protocol.SymbolSyn, // Layer 1 gate
 		0x10, 0x26, 0xB5, 0x23, 0x01,
-		0xAA, // DATA[0]
-		0xAA, // CRC position — SYN-valued byte triggering F-19a abandon
+		0xAA, // DATA[0] (escape-decoded)
+		0xAA, // CRC position (potentially escape-decoded too)
 	}
 	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0), wire)
 
@@ -304,14 +310,16 @@ func TestPassiveReconstructor_F19a_LayerOneInvariant_SynConsumed_KeepsSynced(t *
 		t.Fatalf("setup: F-19a abandon AbandonReason = %v; want corrupted_request", event.AbandonReason)
 	}
 
-	// Step 2: feed a NON-SYN byte (the start of the next frame's SRC).
-	// Post-Codex-bot-P2 fix: synced=true (carried over from the
-	// absorbed SYN-valued 0xAA), so this byte engages frame collection
-	// at requestRaw[0]. Pre-fix: it would have been dropped because
-	// resetStateLocked closed the gate.
-	//
-	// Then feed the rest of a valid broadcast frame to confirm it
-	// reconstructs cleanly with SRC=0x30 in position 0.
+	// Step 2: feed a NON-SYN byte. The gate MUST be closed
+	// (resetStateLocked, NOT AfterSyn). This byte is dropped
+	// silently because we cannot prove the previous 0xAA was a
+	// wire SYN. Without this guarantee, an in-progress wire
+	// transaction's ACK/NACK/body byte could be misinterpreted
+	// as a new frame's SRC.
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 1), []byte{0x30, 0x08, 0xB5, 0x09})
+
+	// Step 3: feed a real wire SYN + a valid follow-up frame. The
+	// wire SYN re-engages the synced gate via the Idle handler.
 	follow := protocol.Frame{
 		Source:    0x30,
 		Target:    protocol.AddressBroadcast,
@@ -319,24 +327,22 @@ func TestPassiveReconstructor_F19a_LayerOneInvariant_SynConsumed_KeepsSynced(t *
 		Secondary: 0x16,
 		Data:      []byte{0x07},
 	}
-	// No leading SYN here — the SYN-valued byte we absorbed in step 1
-	// is what re-engages the gate. Append a trailing SYN so the
-	// broadcast commits via the SYN-triggered path.
-	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 1), frameBytes(follow))
+	wireFollow := append([]byte{protocol.SymbolSyn}, frameBytes(follow)...)
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 2), wireFollow)
 
 	next := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventBroadcastFrame)
 	if next.Request.Source != 0x30 {
-		t.Fatalf("F-19a Codex-P2 regression: follow-up frame Source = 0x%02X; want 0x30 (the SYN-valued byte that triggered F-19a abandon must satisfy Layer 1 — resetStateLockedAfterSyn keeps synced=true so the next SRC byte engages frame collection immediately)", next.Request.Source)
+		t.Fatalf("F-19a Layer-1 safe-fail: follow-up frame Source = 0x%02X; want 0x30 (non-SYN bytes after F-19a abandon must be dropped until a real wire SYN re-engages the gate; the dropped bytes from step 2 must not have polluted the reconstruction)", next.Request.Source)
 	}
 }
 
 // TestPassiveReconstructor_F19a_LayerOneInvariant_NonSynTrigger_RequiresNextSyn
-// pins the other half of the Codex-bot-P2 reset-selection logic: when
-// F-19a is triggered by a NON-SYN byte (a non-0xAA byte that fails
-// CRC validation at LEN-completion — rarer but possible), the
-// implementation MUST call resetStateLocked (NOT AfterSyn). No wire
-// SYN was consumed; the next observed wire SYN re-engages the synced
-// gate via the Idle handler.
+// pins the same safe-fail behavior for the non-SYN-byte case (a
+// non-0xAA byte that fails CRC validation at LEN-completion).
+// Implementation calls plain resetStateLocked in BOTH branches
+// (the SYN-valued and non-SYN-valued cases) post-Codex-P2-round-2;
+// this test pins that the non-SYN-trigger path behaves
+// identically to the escape-decoded-0xAA path.
 func TestPassiveReconstructor_F19a_LayerOneInvariant_NonSynTrigger_RequiresNextSyn(t *testing.T) {
 	t.Parallel()
 
@@ -366,8 +372,7 @@ func TestPassiveReconstructor_F19a_LayerOneInvariant_NonSynTrigger_RequiresNextS
 	}
 
 	// Step 2: feed a NON-SYN byte. The Layer-1 gate is CLOSED
-	// (resetStateLocked, not AfterSyn) because no wire SYN was
-	// consumed in step 1. This byte must be dropped silently.
+	// (plain resetStateLocked). This byte must be dropped silently.
 	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 1), []byte{0x30, 0x08, 0xB5, 0x09})
 
 	// Step 3: feed a wire SYN + valid follow-up. The SYN re-engages

--- a/passive_reconstructor_f19_test.go
+++ b/passive_reconstructor_f19_test.go
@@ -261,15 +261,22 @@ func TestPassiveReconstructor_F19_NoRegression_BroadcastDeferToSYN(t *testing.T)
 	}
 }
 
-// TestPassiveReconstructor_F19a_LayerOneInvariant_NoAfterSynReset pins
-// the Layer 1 invariant: after F-19a's early abandon, the synced gate
-// must be re-engaged via the NEXT wire SYN (not held over from before
-// the abandon). Implementation calls resetStateLocked (NOT
-// resetStateLockedAfterSyn) because no wire SYN was consumed at the
-// LEN+CRC boundary. This test verifies the Layer 1 gate behavior by
-// feeding a non-SYN byte immediately after the abandon and confirming
-// it does NOT engage frame collection.
-func TestPassiveReconstructor_F19a_LayerOneInvariant_NoAfterSynReset(t *testing.T) {
+// TestPassiveReconstructor_F19a_LayerOneInvariant_SynConsumed_KeepsSynced
+// pins the Codex-bot P2 finding (2026-05-12): when F-19a is triggered
+// by a SYN-valued byte (the operator's exact `... AA AA` case, where
+// the second 0xAA is an escape-decoded wire SYN), the implementation
+// MUST call resetStateLockedAfterSyn — the wire SYN we absorbed
+// satisfies the Layer-1 inter-frame invariant; the next non-SYN byte
+// can start a fresh frame immediately.
+//
+// Pre-fix: resetStateLocked was called unconditionally → Layer-1 gate
+// closed → next frame's SRC byte was dropped → CASCADE CONTINUED
+// (exactly what this PR was meant to stop).
+//
+// Post-fix: resetStateLockedAfterSyn keeps synced=true after a
+// SYN-valued absorbed byte → next non-SYN byte engages frame collection
+// immediately.
+func TestPassiveReconstructor_F19a_LayerOneInvariant_SynConsumed_KeepsSynced(t *testing.T) {
 	t.Parallel()
 
 	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
@@ -279,16 +286,16 @@ func TestPassiveReconstructor_F19a_LayerOneInvariant_NoAfterSynReset(t *testing.
 	}
 	defer subscription.Close()
 
-	// Step 1: trigger F-19a abandon.
+	// Step 1: trigger F-19a abandon via the operator's exact `... AA AA`
+	// shape. Both 0xAA bytes are SYN-valued (escape-decoded from
+	// `0xA9 0x01` on wire). The SECOND 0xAA is the symbol that
+	// triggers the LEN-completion CRC fail → F-19a abandon. The
+	// reset variant MUST be AfterSyn (post-Codex-bot-P2 fix).
 	wire := []byte{
-		protocol.SymbolSyn,
-		0x10,
-		0x26,
-		0xB5,
-		0x23,
-		0x01,
-		0xAA,
-		0xAA,
+		protocol.SymbolSyn, // Layer 1 gate
+		0x10, 0x26, 0xB5, 0x23, 0x01,
+		0xAA, // DATA[0]
+		0xAA, // CRC position — SYN-valued byte triggering F-19a abandon
 	}
 	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0), wire)
 
@@ -297,14 +304,74 @@ func TestPassiveReconstructor_F19a_LayerOneInvariant_NoAfterSynReset(t *testing.
 		t.Fatalf("setup: F-19a abandon AbandonReason = %v; want corrupted_request", event.AbandonReason)
 	}
 
-	// Step 2: feed a non-SYN byte. The synced gate should be CLOSED
-	// (resetStateLocked was called, not resetStateLockedAfterSyn).
-	// The byte should be dropped silently — no new abandon event.
+	// Step 2: feed a NON-SYN byte (the start of the next frame's SRC).
+	// Post-Codex-bot-P2 fix: synced=true (carried over from the
+	// absorbed SYN-valued 0xAA), so this byte engages frame collection
+	// at requestRaw[0]. Pre-fix: it would have been dropped because
+	// resetStateLocked closed the gate.
+	//
+	// Then feed the rest of a valid broadcast frame to confirm it
+	// reconstructs cleanly with SRC=0x30 in position 0.
+	follow := protocol.Frame{
+		Source:    0x30,
+		Target:    protocol.AddressBroadcast,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{0x07},
+	}
+	// No leading SYN here — the SYN-valued byte we absorbed in step 1
+	// is what re-engages the gate. Append a trailing SYN so the
+	// broadcast commits via the SYN-triggered path.
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 1), frameBytes(follow))
+
+	next := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventBroadcastFrame)
+	if next.Request.Source != 0x30 {
+		t.Fatalf("F-19a Codex-P2 regression: follow-up frame Source = 0x%02X; want 0x30 (the SYN-valued byte that triggered F-19a abandon must satisfy Layer 1 — resetStateLockedAfterSyn keeps synced=true so the next SRC byte engages frame collection immediately)", next.Request.Source)
+	}
+}
+
+// TestPassiveReconstructor_F19a_LayerOneInvariant_NonSynTrigger_RequiresNextSyn
+// pins the other half of the Codex-bot-P2 reset-selection logic: when
+// F-19a is triggered by a NON-SYN byte (a non-0xAA byte that fails
+// CRC validation at LEN-completion — rarer but possible), the
+// implementation MUST call resetStateLocked (NOT AfterSyn). No wire
+// SYN was consumed; the next observed wire SYN re-engages the synced
+// gate via the Idle handler.
+func TestPassiveReconstructor_F19a_LayerOneInvariant_NonSynTrigger_RequiresNextSyn(t *testing.T) {
+	t.Parallel()
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	// Step 1: trigger F-19a abandon with a NON-SYN CRC byte that
+	// happens to fail CRC. Wire: SRC=0x10 DST=0x26 PB=0xB5 SB=0x23
+	// LEN=1 DATA=0x55 CRC=0x42. Real CRC of `10 26 B5 23 01 55` is
+	// not 0x42 (we deliberately use a wrong CRC value to trigger
+	// the F-19a path with a non-SYN-valued terminal byte).
+	wire := []byte{
+		protocol.SymbolSyn,
+		0x10, 0x26, 0xB5, 0x23, 0x01,
+		0x55, // DATA[0]
+		0x42, // wrong CRC (real CRC differs) — NON-SYN byte triggering F-19a
+	}
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0), wire)
+
+	event := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventAbandonedTransaction)
+	if event.AbandonReason != PassiveAbandonReasonCorruptedRequest {
+		t.Fatalf("setup: F-19a non-SYN abandon AbandonReason = %v; want corrupted_request", event.AbandonReason)
+	}
+
+	// Step 2: feed a NON-SYN byte. The Layer-1 gate is CLOSED
+	// (resetStateLocked, not AfterSyn) because no wire SYN was
+	// consumed in step 1. This byte must be dropped silently.
 	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 1), []byte{0x30, 0x08, 0xB5, 0x09})
 
-	// Step 3: feed a wire SYN + a valid follow-up frame. The SYN
-	// re-engages the synced gate via the Idle handler; the follow-up
-	// frame must reconstruct cleanly.
+	// Step 3: feed a wire SYN + valid follow-up. The SYN re-engages
+	// the gate; the follow-up reconstructs cleanly.
 	follow := protocol.Frame{
 		Source:    0x30,
 		Target:    protocol.AddressBroadcast,
@@ -317,6 +384,6 @@ func TestPassiveReconstructor_F19a_LayerOneInvariant_NoAfterSynReset(t *testing.
 
 	next := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventBroadcastFrame)
 	if next.Request.Source != 0x30 {
-		t.Fatalf("F-19a Layer 1 invariant: follow-up frame Source = 0x%02X; want 0x30 (the dropped bytes between abandon and SYN must not have polluted the next frame's reconstruction)", next.Request.Source)
+		t.Fatalf("F-19a Layer-1 invariant (non-SYN trigger): follow-up frame Source = 0x%02X; want 0x30 (after non-SYN abandon the gate is closed, requiring the explicit wire SYN to re-engage; the dropped bytes between abandon and SYN must not pollute the next frame's reconstruction)", next.Request.Source)
 	}
 }

--- a/passive_reconstructor_p71_escape_test.go
+++ b/passive_reconstructor_p71_escape_test.go
@@ -311,6 +311,15 @@ func TestPassiveReconstructor_P71_ResponseCRC0xAA_Commits(t *testing.T) {
 // and abandons. This covers the "isMidRequestFrame returns false when
 // len < 5" branch and ensures the fix does not silently mask
 // genuinely-corrupt arbitration fragments.
+//
+// F-19b (batch-15) update: the abandon reason changed from
+// corrupted_request to arbitration_fragment. The original threshold
+// was `len <= 3` for fragment classification; F-19b widens it to
+// `len < 5` (i.e., LEN byte never observed) because a 4-byte buffer
+// reaching SB but not LEN is structurally a truncated arbitration
+// attempt, not a corrupted frame. The premature-SYN-rejection
+// invariant is unchanged — the abandon still fires, just with the
+// more accurate metric label.
 func TestPassiveReconstructor_P71_WireSYNBeforeLENStillAbandons(t *testing.T) {
 	t.Parallel()
 
@@ -324,10 +333,8 @@ func TestPassiveReconstructor_P71_WireSYNBeforeLENStillAbandons(t *testing.T) {
 	// Wire: SYN (gates Layer 1) + initiator-class src + DST + PB + SB +
 	// SYN. 4 bytes accumulated when the SYN arrives — still below LEN
 	// position (5). isMidRequestFrame returns false → SYN-handling path
-	// → abandon. requestRaw len > 3 disqualifies the
-	// arbitration_fragment classification, so the abandon reason is
-	// corrupted_request — proving the predicate didn't silently swallow
-	// the premature SYN as data.
+	// → abandon. Post-F-19b, requestRaw len < 5 classifies as
+	// arbitration_fragment.
 	wire := []byte{
 		protocol.SymbolSyn, // gate
 		0x10,               // initiator src (BASV2 initiator face)
@@ -339,8 +346,8 @@ func TestPassiveReconstructor_P71_WireSYNBeforeLENStillAbandons(t *testing.T) {
 	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0), wire)
 
 	event := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventAbandonedTransaction)
-	if event.AbandonReason != PassiveAbandonReasonCorruptedRequest {
-		t.Errorf("AbandonReason = %v; want corrupted_request (premature SYN must still abandon)", event.AbandonReason)
+	if event.AbandonReason != PassiveAbandonReasonArbitrationFragment {
+		t.Errorf("AbandonReason = %v; want arbitration_fragment (F-19b: len<5 truncation classifies as arbitration_fragment, not corrupted_request)", event.AbandonReason)
 	}
 }
 

--- a/passive_transaction_reconstructor.go
+++ b/passive_transaction_reconstructor.go
@@ -711,11 +711,26 @@ func (reconstructor *PassiveTransactionReconstructor) handleRequestSymbolLocked(
 					//
 					// Fix: abandon immediately, replicating the same
 					// classification helpers the SYN-triggered path
-					// uses (line ~689-696). The Layer 1 invariant is
-					// preserved by calling resetStateLocked (NOT
-					// resetStateLockedAfterSyn) — no wire SYN has been
-					// consumed at this point; the next real wire SYN
-					// re-engages the synced gate via the Idle handler.
+					// uses (line ~689-696).
+					//
+					// Layer 1 invariant (Codex bot P2 review, 2026-05-12):
+					// the current `symbol` was just absorbed into the
+					// buffer. It may be either a SYN-valued byte (the
+					// operator's `... AA AA` case — escape-decoded 0xAA
+					// at CRC position) or a non-SYN byte (some other
+					// CRC mismatch). The reset variant depends:
+					//   - symbol == SymbolSyn: use AfterSyn variant. The
+					//     SYN we consumed satisfies the inter-frame
+					//     invariant; the next non-SYN byte can start a
+					//     fresh frame immediately. Calling the plain
+					//     resetStateLocked here would close the Layer-1
+					//     gate and drop the next frame's SRC byte,
+					//     CONTINUING the cascade this fix is meant to
+					//     stop.
+					//   - symbol != SymbolSyn: use plain reset. No wire
+					//     SYN has been consumed; the next observed wire
+					//     SYN re-engages the synced gate via the Idle
+					//     handler.
 					reason := PassiveAbandonReasonCorruptedRequest
 					if reconstructor.isSelfOriginatedRaw() {
 						reason = PassiveAbandonReasonSelfEcho
@@ -724,7 +739,11 @@ func (reconstructor *PassiveTransactionReconstructor) handleRequestSymbolLocked(
 					}
 					events = append(events, reconstructor.abandonLocked(reason, observedAt, ebuserrors.ErrInvalidPayload))
 					reconstructor.state.phase = passivePhaseAbandoned
-					reconstructor.resetStateLocked()
+					if symbol == protocol.SymbolSyn {
+						reconstructor.resetStateLockedAfterSyn()
+					} else {
+						reconstructor.resetStateLocked()
+					}
 					return events
 				}
 				// Case (B): broadcast/unknown defer path. Keep

--- a/passive_transaction_reconstructor.go
+++ b/passive_transaction_reconstructor.go
@@ -674,8 +674,62 @@ func (reconstructor *PassiveTransactionReconstructor) handleRequestSymbolLocked(
 				if events, ok := reconstructor.commitRequestFrameLocked(events, observedAt); ok {
 					return events
 				}
-				// parseFrame failed: keep accumulating and let the
-				// SYN-triggered path classify the abandon below.
+				// commitRequestFrameLocked returned ok=false for one of
+				// two distinct reasons:
+				//
+				//   (A) parseFrame failed (CRC mismatch / structural
+				//       invalid) — this is the F-19a case.
+				//
+				//   (B) parseFrame succeeded but the frame is Broadcast
+				//       or Unknown; commitRequestFrameLocked defers to
+				//       the SYN-triggered path for canonical timing
+				//       (commitRequestFrameLocked docstring at
+				//       lines 723-730).
+				//
+				// Re-parse to disambiguate. For (A), abandon early per
+				// F-19a (below). For (B), preserve the pre-F-19a
+				// behavior: keep accumulating, let the trailing SYN
+				// commit the broadcast cleanly.
+				if _, parseOk := parseFrame(reconstructor.state.requestRaw); !parseOk {
+					// F-19a (batch-15): parseFrame failed at
+					// LEN-completion. This is the "logical 0xAA
+					// absorbed at the CRC position" scenario: a
+					// wire-SYN byte that should have terminated a
+					// shorter frame was routed into the buffer by
+					// isMidRequestFrame() (it returns true while
+					// len < 6+LEN), and the resulting len=6+LEN buffer
+					// fails CRC validation.
+					//
+					// Pre-F-19a: this path "kept accumulating" —
+					// consuming bytes from the NEXT frame into a buffer
+					// that would never validate. The eventual abandon
+					// (via SYN at line ~684 or over-length at line
+					// ~612) cascaded the corruption: bytes that
+					// legitimately belonged to the next frame were
+					// lost. Live evidence (batch-14): ~146 src=0x10
+					// abandons per 30k log lines.
+					//
+					// Fix: abandon immediately, replicating the same
+					// classification helpers the SYN-triggered path
+					// uses (line ~689-696). The Layer 1 invariant is
+					// preserved by calling resetStateLocked (NOT
+					// resetStateLockedAfterSyn) — no wire SYN has been
+					// consumed at this point; the next real wire SYN
+					// re-engages the synced gate via the Idle handler.
+					reason := PassiveAbandonReasonCorruptedRequest
+					if reconstructor.isSelfOriginatedRaw() {
+						reason = PassiveAbandonReasonSelfEcho
+					} else if isScanProbeRaw(reconstructor.state.requestRaw) {
+						reason = PassiveAbandonReasonScanCollision
+					}
+					events = append(events, reconstructor.abandonLocked(reason, observedAt, ebuserrors.ErrInvalidPayload))
+					reconstructor.state.phase = passivePhaseAbandoned
+					reconstructor.resetStateLocked()
+					return events
+				}
+				// Case (B): broadcast/unknown defer path. Keep
+				// accumulating; the trailing wire SYN commits the
+				// frame via dispatchParsedRequestLocked.
 			}
 		}
 		return events
@@ -687,7 +741,17 @@ func (reconstructor *PassiveTransactionReconstructor) handleRequestSymbolLocked(
 	frame, ok := parseFrame(reconstructor.state.requestRaw)
 	if !ok {
 		reason := PassiveAbandonReasonCorruptedRequest
-		if len(reconstructor.state.requestRaw) <= 3 {
+		// F-19b (batch-15): widen arbitration_fragment from `<= 3` to
+		// `< 5`. A buffer of length 4 (SRC DST PB SB) has reached SB
+		// but never observed LEN — structurally this is a truncated
+		// arbitration attempt (lost to a higher-priority initiator,
+		// or wire byte loss), not a corrupted frame. The previous
+		// `<= 3` threshold mis-attributed these to corrupted_request,
+		// inflating the F-19 metric for src values that frequently
+		// lose arbitration on a 3-initiator bus (live evidence
+		// batch-14: ~115 src=0xF1 abandons per 30k lines, almost all
+		// in the 4-byte truncated shape).
+		if len(reconstructor.state.requestRaw) < 5 {
 			reason = PassiveAbandonReasonArbitrationFragment
 		} else if reconstructor.isSelfOriginatedRaw() {
 			reason = PassiveAbandonReasonSelfEcho

--- a/passive_transaction_reconstructor.go
+++ b/passive_transaction_reconstructor.go
@@ -713,24 +713,38 @@ func (reconstructor *PassiveTransactionReconstructor) handleRequestSymbolLocked(
 					// classification helpers the SYN-triggered path
 					// uses (line ~689-696).
 					//
-					// Layer 1 invariant (Codex bot P2 review, 2026-05-12):
-					// the current `symbol` was just absorbed into the
-					// buffer. It may be either a SYN-valued byte (the
-					// operator's `... AA AA` case — escape-decoded 0xAA
-					// at CRC position) or a non-SYN byte (some other
-					// CRC mismatch). The reset variant depends:
-					//   - symbol == SymbolSyn: use AfterSyn variant. The
-					//     SYN we consumed satisfies the inter-frame
-					//     invariant; the next non-SYN byte can start a
-					//     fresh frame immediately. Calling the plain
-					//     resetStateLocked here would close the Layer-1
-					//     gate and drop the next frame's SRC byte,
-					//     CONTINUING the cascade this fix is meant to
-					//     stop.
-					//   - symbol != SymbolSyn: use plain reset. No wire
-					//     SYN has been consumed; the next observed wire
-					//     SYN re-engages the synced gate via the Idle
-					//     handler.
+					// Layer 1 invariant (Codex bot P2 review rounds 1 + 2,
+					// 2026-05-12): use plain resetStateLocked here.
+					//
+					// The current `symbol` MAY be SYN-valued (the
+					// operator's `... AA AA` case) but the predicate at
+					// line 609 only routes a 0xAA into this accumulation
+					// branch when isMidRequestFrame() returns true —
+					// which means the byte is being treated as
+					// escape-decoded payload data (logical 0xAA decoded
+					// from wire `0xA9 0x01`), NOT a real wire SYN. The
+					// passive tap does not carry a `WasEscaped` flag, so
+					// we cannot distinguish a real wire SYN from an
+					// escape-decoded 0xAA at this layer.
+					//
+					// Using resetStateLockedAfterSyn would incorrectly
+					// keep the Layer-1 gate open in the
+					// escape-decoded-0xAA case, allowing the very next
+					// byte (which is typically an ACK / NACK / body byte
+					// of the in-progress wire transaction, NOT a fresh
+					// SRC) to be accepted as a new frame's leader. That
+					// would create a SECOND false reconstruction
+					// cascade.
+					//
+					// The "wasted SYN" cost of plain resetStateLocked
+					// (one frame's SRC byte dropped if the symbol
+					// genuinely was a wire SYN) is bounded by the next
+					// inter-frame wire SYN, which the eBUS spec
+					// guarantees between transactions. Future work
+					// (F-19c forensic instrumentation) could plumb
+					// WasEscaped through the tap to make this branch
+					// precise; for now plain reset is the
+					// provably-safe choice.
 					reason := PassiveAbandonReasonCorruptedRequest
 					if reconstructor.isSelfOriginatedRaw() {
 						reason = PassiveAbandonReasonSelfEcho
@@ -739,11 +753,7 @@ func (reconstructor *PassiveTransactionReconstructor) handleRequestSymbolLocked(
 					}
 					events = append(events, reconstructor.abandonLocked(reason, observedAt, ebuserrors.ErrInvalidPayload))
 					reconstructor.state.phase = passivePhaseAbandoned
-					if symbol == protocol.SymbolSyn {
-						reconstructor.resetStateLockedAfterSyn()
-					} else {
-						reconstructor.resetStateLocked()
-					}
+					reconstructor.resetStateLocked()
 					return events
 				}
 				// Case (B): broadcast/unknown defer path. Keep


### PR DESCRIPTION
## Summary

Decomposes F-19 into two distinct sub-mechanisms in the passive reconstructor and fixes both. Spec: [`_work_adaptermux_audit/EBUSD-VERIFICATION-2026-05-12-batch15.md`](../_work_adaptermux_audit/EBUSD-VERIFICATION-2026-05-12-batch15.md).

## Background

v0.6.8 (F-18) post-deploy verification (batch-14) confirmed F-18 fixed but surfaced F-19: passive reconstructor abandons 146 src=0x10 + 115 src=0xF1 frames per 30k log lines as `corrupted_request phase=1`. Operator hypothesis: "interleaved-master frame extraction in the passive reconstructor's state machine. Two SYN terminators (AA AA) caught inside what was treated as one frame."

2-agent convergence (Explore code-walk + angry-tester adversarial attack) confirmed the hypothesis for src=0x10 (long-buffer case) **and** decomposed F-19 into TWO sub-mechanisms that both produce the same `corrupted_request phase=1` reason string, masking them as one bug.

## F-19a — LEN-completion parseFrame failure (src=0x10, ~146/30k)

**Wire example:** `req_raw=10 26 B5 23 01 AA AA resp_raw=<empty>`

**Mechanism:** eBUS CRC8(0x9B) of `10 26 B5 23 01 AA` = **0x7C, not 0xAA**. The `isMidRequestFrame()` predicate (`passive_transaction_reconstructor.go:569`) returns true while `len < 6+LEN`, so both 0xAA bytes are absorbed as data+CRC. At `len=6+LEN`, parseFrame fails on the CRC mismatch but the explicit comment at line 659-663 says "keeps accumulating and lets the SYN-triggered path classify the abandon below" — consuming bytes from the NEXT frame into a buffer that will never validate. Cascading corruption.

**Fix:** in `handleRequestSymbolLocked` at the LEN-completion path, when `commitRequestFrameLocked` returns `ok=false`, re-parse to disambiguate:
- (A) parseFrame failed → F-19a abandon early with replicated classification helpers (`self_echo` / `scan_collision` / `corrupted_request`).
- (B) parseFrame succeeded but frame is Broadcast/Unknown → defer to SYN-trigger as before (preserves the pre-F-19a behavior for `commitRequestFrameLocked`'s deferred-broadcast path at lines 723-730).

**Layer 1 invariant:** F-19a's abandon calls `resetStateLocked` (NOT `resetStateLockedAfterSyn`) — no wire SYN consumed at the LEN+CRC boundary; the next observed wire SYN re-engages the synced gate via the Idle handler.

## F-19b — 4-byte truncated arbitration fragment (src=0xF1, ~115/30k)

**Wire example:** `req_raw=F1 15 B5 24 resp_raw=<empty>`

**Mechanism:** a buffer of length 4 (SRC DST PB SB) reached SB but never observed LEN. Pre-F-19b: `len <= 3` was the `arbitration_fragment` threshold, so 4-byte truncations were mis-classified as `corrupted_request`. Structurally these are truncated arbitration attempts (lost to a higher-priority initiator, or wire byte loss), not corrupted frames.

**Fix:** widen `arbitration_fragment` threshold from `<= 3` to `< 5`. Pure metric-attribution change; abandon still fires, just with the correct reason.

## Adversarial review trail

| Round | Agent | Outcome |
|---|---|---|
| 0 | Explore (code-walk) | Identified `isMidRequestFrame()` at line 569 + explicit "keep accumulating" comment at lines 659-663 as the bug surface |
| 0 | angry-tester (adversarial attack) | Confirmed eBUS CRC8(`10 26 B5 23 01 AA`) = 0x7C, validating hypothesis. **Decomposed F-19 into F-19a + F-19b.** Critical Finding C: classification replication mandatory. Finding D: phase=4 unexpected_symbol is NOT F-19 (out of scope, F-20). |
| 1 | Codex CLI (review of diff) | **VERDICT: SHIP.** No real defects. Verified disambiguation correctness, Layer 1 invariant, F-19b reclassification scope, classification precedence. |

## Code changes

| File | Lines | Fix |
|---|---|---|
| `passive_transaction_reconstructor.go` | ~+50/-3 | F-19a re-parse + early abandon; F-19b threshold widening |
| `passive_reconstructor_p71_escape_test.go` | ~+13/-6 | Update `TestPassiveReconstructor_P71_WireSYNBeforeLENStillAbandons` to assert new F-19b semantic |
| `passive_reconstructor_f19_test.go` | new, +322 | 7 new regression tests |

## Tests added

1. `TestPassiveReconstructor_F19a_LenCompletionCRCFail_AbandonsEarly` — operator's exact wire example
2. `TestPassiveReconstructor_F19a_PreservesClassification_SelfEcho` — angry-tester Finding C guard
3. `TestPassiveReconstructor_F19a_PreservesClassification_ScanCollision` — angry-tester Finding C guard
4. `TestPassiveReconstructor_F19b_FourByteFragment_ClassifiesAsArbitrationFragment` — F-19b primary
5. `TestPassiveReconstructor_F19_NoRegression_ValidLEN1Frame` — P7.1 invariant guard (0xAA in data)
6. `TestPassiveReconstructor_F19_NoRegression_BroadcastDeferToSYN` — disambiguation regression guard
7. `TestPassiveReconstructor_F19a_LayerOneInvariant_NoAfterSynReset` — resetStateLocked vs AfterSyn

## Pass criteria (v0.6.9 post-deploy)

| Metric | v0.6.8 baseline | v0.6.9 target |
|---|---|---|
| `passive_reconstructor abandon ... reason=corrupted_request phase=1 src=0x10` per 30k | ~146 | < 20 (residuals from real wire corruption only) |
| `passive_reconstructor abandon ... reason=corrupted_request phase=1 src=0xF1` per 30k | ~115 | ≈ 0 (all reclassify as `arbitration_fragment`) |
| `passive_reconstructor abandon ... reason=arbitration_fragment` per 30k | small | ≈ 115 + epsilon |
| Other F-18 metrics (SEND-byte multiplicity, ebusctl `messages`, `signal: acquired`) | green | unchanged |

## Validation

- `go build ./...` clean
- `go vet ./...` clean
- `gofmt -l` on changed files clean (pre-existing gofmt issues on `internal/adaptermux/*` and `internal/runtimestate/*` on `main` are out of F-19 scope)
- Full repo `go test ./...` green
- `-race` sweep on `PassiveReconstructor*` tests green
- Codex CLI adversarial review: **VERDICT: SHIP**

## Out of scope (per spec)

- **F-19c** (forensic instrumentation: per-byte timestamps, abandon-trigger-site logging) — deferred
- **F-20** (`phase=4 unexpected_symbol` abandons — response-side, different fault class)
- `arbitration_fragment` widening beyond `< 5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)