### PR TITLE
feat(passive): F-19e forensic instrumentation for unexpected_symbol diagnostics

### DIFF
--- a/passive_reconstructor_f19e_instrumentation_test.go
+++ b/passive_reconstructor_f19e_instrumentation_test.go
@@ -1,0 +1,356 @@
+package ebusgateway
+
+// F-19e (batch-18) forensic instrumentation tests for the passive
+// reconstructor's `unexpected_symbol` abandons. F-19e is
+// INSTRUMENTATION-ONLY — no behavior changes. The tests pin:
+//
+//   1. The `OffendingSymbol` + `OffendingWasEscaped` fields propagate
+//      from the symbol-handler to the emitted PassiveClassifiedEvent
+//      at each of the three WaitACK / WaitFinalACK / WaitTerminal
+//      abandon sites where `unexpected_symbol` currently fires in
+//      production (~0.7 events/min per
+//      _work_adaptermux_audit/EBUSD-VERIFICATION-2026-05-13-batch18.md).
+//
+//   2. The forensic log line emitted by logForensicsLocked includes
+//      the new `offending_symbol=0xXX offending_was_escaped=v` tokens
+//      so post-deploy bucketing can grep them.
+//
+//   3. F-19c and F-19d forensic behavior is unchanged — the new
+//      fields are additive; legacy req_raw/resp_raw/phase/src/dst
+//      tokens still emit unchanged, and the AbandonReason set is
+//      stable.
+//
+// Spec references:
+//   - _work_adaptermux_audit/EBUSD-VERIFICATION-2026-05-13-batch18.md
+//     (live evidence: 50 unexpected_symbol events / 69 min).
+//   - F-19d batch-17 wasEscaped plumbing (passive_bus_tap.go +
+//     passive_transaction_reconstructor.go).
+//   - john30/ebusd `symbol.h:79-82` (escape rule: A9 00→A9, A9 01→AA,
+//     raw AA → wire SYN).
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+)
+
+// TestF19e_UnexpectedSymbol_AtWaitACK drives the reconstructor through
+// a valid M2T request and then feeds a byte that is neither ACK
+// (0x00), NACK (0xFF), nor SYN (0xAA) at the WaitACK phase. The
+// default arm of handleACKSymbolLocked must abandon with
+// reason=unexpected_symbol AND populate event.OffendingSymbol with
+// the exact byte (0x42) plus event.OffendingWasEscaped=false.
+func TestF19e_UnexpectedSymbol_AtWaitACK(t *testing.T) {
+	t.Parallel()
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	req := protocol.Frame{
+		Source:    0x10,
+		Target:    0x08, // BAI — target-class, drives M2T
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{0x55},
+	}
+	reqBytes := requestFrameBytes(req)
+
+	// Wire: [SYN gate] [request bytes ending in CRC] [0x42 offending]
+	wire := append([]byte{protocol.SymbolSyn}, reqBytes...)
+	wire = append(wire, 0x42)
+
+	// Explicit all-false mask — every byte is raw-wire, no escape
+	// decoding. 0x42 is not 0xAA so the mask state is irrelevant at
+	// that index; the explicit false documents intent for the
+	// post-CRC byte.
+	escapes := make([]bool, len(wire))
+	feedPassiveSymbolsRawWithEscapes(reconstructor, time.Unix(0, 0), wire, escapes)
+
+	event := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventAbandonedTransaction)
+	if event.AbandonReason != PassiveAbandonReasonUnexpectedSymbol {
+		t.Fatalf("AbandonReason = %v; want unexpected_symbol", event.AbandonReason)
+	}
+	if event.OffendingSymbol != 0x42 {
+		t.Fatalf("OffendingSymbol = 0x%02X; want 0x42 (the byte that arrived at WaitACK default arm)", event.OffendingSymbol)
+	}
+	if event.OffendingWasEscaped {
+		t.Fatalf("OffendingWasEscaped = true; want false (raw-wire byte, not escape-decoded)")
+	}
+}
+
+// TestF19e_UnexpectedSymbol_AtWaitFinalACK drives a complete request
+// + ACK + response, then feeds a non-ACK/NACK/SYN byte at WaitFinalACK.
+// The default arm of handleFinalACKSymbolLocked must abandon with
+// reason=unexpected_symbol and capture the offending byte.
+func TestF19e_UnexpectedSymbol_AtWaitFinalACK(t *testing.T) {
+	t.Parallel()
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	req := protocol.Frame{
+		Source:    0x10,
+		Target:    0x08,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{0x55},
+	}
+	reqBytes := requestFrameBytes(req)
+
+	// Response: NN_s=0x01, data=0x77, CRC computed from those two
+	// bytes. The reconstructor only requires len(responseRaw) ==
+	// responseExpectedLen to advance to WaitFinalACK — the CRC
+	// validity is recorded separately on state.responseCRCValid but
+	// does NOT block the phase transition. We compute the correct
+	// CRC anyway so the path through parsePassiveResponse is the
+	// clean "frame parsed" branch.
+	respPayload := []byte{0x01, 0x77}
+	respCRC := protocol.CRC(respPayload)
+	resp := append(respPayload, respCRC)
+
+	// Wire layout:
+	//   [SYN gate] [request..CRC] [target ACK = 0x00] [resp..CRC]
+	//   [0x42 offending]
+	wire := append([]byte{protocol.SymbolSyn}, reqBytes...)
+	wire = append(wire, protocol.SymbolAck) // S_ACK
+	wire = append(wire, resp...)
+	wire = append(wire, 0x42) // offending at WaitFinalACK
+
+	escapes := make([]bool, len(wire))
+	feedPassiveSymbolsRawWithEscapes(reconstructor, time.Unix(0, 0), wire, escapes)
+
+	event := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventAbandonedTransaction)
+	if event.AbandonReason != PassiveAbandonReasonUnexpectedSymbol {
+		t.Fatalf("AbandonReason = %v; want unexpected_symbol", event.AbandonReason)
+	}
+	if event.OffendingSymbol != 0x42 {
+		t.Fatalf("OffendingSymbol = 0x%02X; want 0x42 (the byte that arrived at WaitFinalACK default arm)", event.OffendingSymbol)
+	}
+	if event.OffendingWasEscaped {
+		t.Fatalf("OffendingWasEscaped = true; want false")
+	}
+}
+
+// TestF19e_UnexpectedSymbol_AtWaitTerminal drives an M2I (initiator-
+// initiator) transaction: request + ACK transitions directly to
+// WaitTerminal (no response phase). The next byte must be a wire SYN;
+// any other byte triggers the non-SYN abandon path with
+// reason=unexpected_symbol.
+func TestF19e_UnexpectedSymbol_AtWaitTerminal(t *testing.T) {
+	t.Parallel()
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	// M2I: target is also an initiator address. 0x71 has nibbles 7
+	// and 1, both in the initiator-nibble set {0,1,3,7,F}, so
+	// protocol.FrameType resolves to InitiatorInitiator.
+	req := protocol.Frame{
+		Source:    0x10,
+		Target:    0x71,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{0x55},
+	}
+	reqBytes := requestFrameBytes(req)
+
+	wire := append([]byte{protocol.SymbolSyn}, reqBytes...)
+	wire = append(wire, protocol.SymbolAck) // target ACK; for M2I this advances directly to WaitTerminal
+	wire = append(wire, 0x42)               // offending non-SYN byte
+
+	escapes := make([]bool, len(wire))
+	feedPassiveSymbolsRawWithEscapes(reconstructor, time.Unix(0, 0), wire, escapes)
+
+	event := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventAbandonedTransaction)
+	if event.AbandonReason != PassiveAbandonReasonUnexpectedSymbol {
+		t.Fatalf("AbandonReason = %v; want unexpected_symbol", event.AbandonReason)
+	}
+	if event.OffendingSymbol != 0x42 {
+		t.Fatalf("OffendingSymbol = 0x%02X; want 0x42 (the byte that arrived at WaitTerminal non-SYN guard)", event.OffendingSymbol)
+	}
+	if event.OffendingWasEscaped {
+		t.Fatalf("OffendingWasEscaped = true; want false")
+	}
+}
+
+// TestF19e_LogLineFormat captures the forensic log emitted by
+// logForensicsLocked for an UnexpectedSymbol abandon and asserts the
+// new tokens render exactly as `offending_symbol=0x42
+// offending_was_escaped=false`. Pins the wire format so post-deploy
+// log-bucketing scripts can grep deterministically.
+func TestF19e_LogLineFormat(t *testing.T) {
+	// No t.Parallel(): the test captures the global log writer.
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	req := protocol.Frame{
+		Source:    0x10,
+		Target:    0x08,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{0x55},
+	}
+	reqBytes := requestFrameBytes(req)
+	wire := append([]byte{protocol.SymbolSyn}, reqBytes...)
+	wire = append(wire, 0x42) // offending at WaitACK default
+
+	var logBuf bytes.Buffer
+	restore := captureGoLog(&logBuf)
+	defer restore()
+
+	escapes := make([]bool, len(wire))
+	feedPassiveSymbolsRawWithEscapes(reconstructor, time.Unix(0, 0), wire, escapes)
+
+	event := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventAbandonedTransaction)
+	if event.AbandonReason != PassiveAbandonReasonUnexpectedSymbol {
+		t.Fatalf("AbandonReason = %v; want unexpected_symbol", event.AbandonReason)
+	}
+
+	logText := logBuf.String()
+	// Exact-token pins. `0x%02X` upper-cases the hex digits to match
+	// the existing src/dst/prim/sec rendering convention used by
+	// logForensicsLocked.
+	if !strings.Contains(logText, "offending_symbol=0x42") {
+		t.Fatalf("forensic log missing `offending_symbol=0x42` token. Got:\n%s", logText)
+	}
+	if !strings.Contains(logText, "offending_was_escaped=false") {
+		t.Fatalf("forensic log missing `offending_was_escaped=false` token. Got:\n%s", logText)
+	}
+	// The new tokens must appear AFTER the existing observed_at
+	// token so legacy regexes anchored at the leading fields keep
+	// matching. Verify ordering:
+	idxObservedAt := strings.Index(logText, "observed_at=")
+	idxOffending := strings.Index(logText, "offending_symbol=")
+	if idxObservedAt < 0 || idxOffending < 0 || idxOffending < idxObservedAt {
+		t.Fatalf("`offending_symbol=` must appear after `observed_at=` to preserve legacy regex compatibility. Got:\n%s", logText)
+	}
+	// Sanity: existing reason/phase/src/dst tokens still present.
+	for _, want := range []string{
+		"reason=unexpected_symbol",
+		"phase=",
+		"src=0x10",
+		"dst=0x08",
+		"prim=0xB5",
+		"sec=0x16",
+	} {
+		if !strings.Contains(logText, want) {
+			t.Fatalf("F-19e instrumentation must not regress legacy log tokens: missing %q in:\n%s", want, logText)
+		}
+	}
+}
+
+// TestF19e_F19c_UnchangedForensics replays the live-evidence
+// invalid_nn_m=0x84 wire pattern from F-19c (batch-16) and asserts:
+//
+//	(a) the abandon reason is still invalid_nn_m (no F-19c regression);
+//	(b) OffendingSymbol equals 0x84 (the bogus NN_m), with
+//	    OffendingWasEscaped=false (NN_m=0x84 cannot arise from an
+//	    escape sequence in this synthetic feed);
+//	(c) the legacy forensic log tokens (req_raw=, reason=) still
+//	    emit alongside the new offending tokens.
+func TestF19e_F19c_UnchangedForensics(t *testing.T) {
+	// No t.Parallel(): captures global log writer.
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	// Replicates the batch-16 live evidence: 0x10 0x08 0x00 0x09 0x84.
+	// At rawLen=5, the per-offset NN_m check fires.
+	wire := []byte{
+		protocol.SymbolSyn,
+		0x10, 0x08, 0x00, 0x09,
+		0x84, // NN_m = 132 — invalid
+	}
+
+	var logBuf bytes.Buffer
+	restore := captureGoLog(&logBuf)
+	defer restore()
+
+	feedPassiveSymbolsRaw(reconstructor, time.Unix(0, 0), wire)
+
+	event := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventAbandonedTransaction)
+	if event.AbandonReason != PassiveAbandonReasonInvalidNNMaster {
+		t.Fatalf("AbandonReason = %v; want invalid_nn_m (F-19c regression guard)", event.AbandonReason)
+	}
+	if event.OffendingSymbol != 0x84 {
+		t.Fatalf("OffendingSymbol = 0x%02X; want 0x84 (the bogus NN_m)", event.OffendingSymbol)
+	}
+	if event.OffendingWasEscaped {
+		t.Fatalf("OffendingWasEscaped = true; want false (auto-escape mask never marks NN_m position)")
+	}
+
+	logText := logBuf.String()
+	for _, want := range []string{
+		"reason=invalid_nn_m",
+		"req_raw=10 08 00 09 84",
+		"offending_symbol=0x84",
+		"offending_was_escaped=false",
+	} {
+		if !strings.Contains(logText, want) {
+			t.Fatalf("F-19c forensic log regression — missing %q in:\n%s", want, logText)
+		}
+	}
+}
+
+// TestF19e_F19d_UnchangedForensics replays an F-19d mid-frame wire-SYN
+// abort pattern and asserts the OffendingWasEscaped field reflects the
+// upstream truth — a raw wire SYN is wasEscaped=false. Pins that
+// F-19d's wasEscaped plumbing is still flowing through the new
+// instrumentation channel without being masked or inverted.
+func TestF19e_F19d_UnchangedForensics(t *testing.T) {
+	t.Parallel()
+
+	reconstructor := newPassiveTransactionReconstructorCore(DefaultConfig())
+	subscription, err := reconstructor.Subscribe("test", PassiveSubscriberCritical, 8)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	// Mid-request wire SYN: announce NN_m=15 then send 1 data byte
+	// followed by an un-escaped 0xAA. F-19d's SYN-trigger path fires
+	// with reason=unexpected_syn.
+	wire := []byte{
+		protocol.SymbolSyn,           // gate
+		0x10, 0x26, 0xB5, 0x23, 0x0F, // SRC DST PB SB NN_m=15
+		0x05,               // DATA[0]
+		protocol.SymbolSyn, // un-escaped wire SYN — mid-frame terminator
+	}
+	escapes := make([]bool, len(wire)) // all false — every byte is raw-wire
+	feedPassiveSymbolsRawWithEscapes(reconstructor, time.Unix(0, 0), wire, escapes)
+
+	event := requirePassiveClassifiedEvent(t, subscription, PassiveClassifiedEventAbandonedTransaction)
+	if event.AbandonReason != PassiveAbandonReasonUnexpectedSYN {
+		t.Fatalf("AbandonReason = %v; want unexpected_syn (F-19d regression guard)", event.AbandonReason)
+	}
+	if event.OffendingSymbol != protocol.SymbolSyn {
+		t.Fatalf("OffendingSymbol = 0x%02X; want 0x%02X (the wire SYN that terminated the frame)", event.OffendingSymbol, protocol.SymbolSyn)
+	}
+	if event.OffendingWasEscaped {
+		t.Fatalf("OffendingWasEscaped = true; want false (un-escaped wire SYN)")
+	}
+}

--- a/passive_transaction_reconstructor.go
+++ b/passive_transaction_reconstructor.go
@@ -157,6 +157,26 @@ type PassiveClassifiedEvent struct {
 	ACKCorrelation      PassiveACKCorrelation
 	Err                 error
 	Subscriber          string
+	// OffendingSymbol is the raw observed byte that triggered the
+	// abandon at the moment abandonLocked was called. Populated for
+	// abandons whose cause is a single observed wire byte (e.g.
+	// UnexpectedSymbol, NACK, UnexpectedSYN, InvalidQQ/ZZ/NN, NN-bound
+	// overruns). Zero for lifecycle abandons that are not byte-driven
+	// (Shutdown, TransportReset, NoProgress watchdog) and for default
+	// frame-type defensive fall-throughs that cannot identify a single
+	// causal byte. F-19e (batch-18, 2026-05-13): added so the 0.7
+	// events/min `unexpected_symbol` rate observed post-F-19d becomes
+	// forensically diagnosable — the offending byte distribution
+	// reveals whether the cascade is dominated by wire SYN at
+	// unexpected phases, mid-frame data bytes, or escape-sequence
+	// fragments.
+	OffendingSymbol byte
+	// OffendingWasEscaped carries the upstream wasEscaped flag
+	// (F-19d) for the offending byte. Meaningful for phases that
+	// receive bytes from the unescape decoder (Request, Response);
+	// always false for phases that observe only structural bytes
+	// (Idle, ACK, FinalACK, Terminal) or for lifecycle abandons.
+	OffendingWasEscaped bool
 }
 
 type PassiveSubscriberPriority uint8
@@ -463,7 +483,11 @@ func (reconstructor *PassiveTransactionReconstructor) handleTapEventLocked(event
 
 func (reconstructor *PassiveTransactionReconstructor) handleTransportDiscontinuityLocked(events []PassiveClassifiedEvent, observedAt time.Time, reason PassiveDiscontinuityReason, abandonReason PassiveAbandonReason, err error) []PassiveClassifiedEvent {
 	if reconstructor.state.phase != passivePhaseIdle && reconstructor.state.phase != passivePhaseAbandoned {
-		events = append(events, reconstructor.abandonLocked(abandonReason, observedAt, err))
+		// F-19e (batch-18): transport-level discontinuities (reset,
+		// decode_fault, disconnect) are not byte-driven — there is
+		// no observed wire byte that triggered the abandon. Pass
+		// (0, false) per the abandonLocked contract.
+		events = append(events, reconstructor.abandonLocked(abandonReason, observedAt, err, 0, false))
 	}
 	switch reason {
 	case PassiveDiscontinuityTransportReset, PassiveDiscontinuityDecodeFault:
@@ -485,7 +509,10 @@ func (reconstructor *PassiveTransactionReconstructor) expireIfStaleLocked(events
 	if observedAt.Sub(reconstructor.state.lastProgressAt) <= reconstructor.watchdog {
 		return events
 	}
-	events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonNoProgress, observedAt, ebuserrors.ErrTimeout))
+	// F-19e (batch-18): the NoProgress watchdog fires when the bus
+	// goes silent (no byte received within the watchdog window). No
+	// single causal byte exists — pass (0, false).
+	events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonNoProgress, observedAt, ebuserrors.ErrTimeout, 0, false))
 	reconstructor.state.phase = passivePhaseAbandoned
 	return events
 }
@@ -559,8 +586,9 @@ func (reconstructor *PassiveTransactionReconstructor) handleSymbolLocked(events 
 		// HERE, between the Layer-2 gate and startRequestLocked, so
 		// it is reachable independent of Layer 2's evolution.
 		if !isInitiatorAddr(symbol) {
+			// F-19e: the offending byte is the failed QQ candidate.
 			events = append(events, reconstructor.abandonLocked(
-				PassiveAbandonReasonInvalidQQ, observedAt, ebuserrors.ErrInvalidPayload))
+				PassiveAbandonReasonInvalidQQ, observedAt, ebuserrors.ErrInvalidPayload, symbol, wasEscaped))
 			reconstructor.state.phase = passivePhaseAbandoned
 			reconstructor.resetStateLocked()
 			return events
@@ -570,13 +598,13 @@ func (reconstructor *PassiveTransactionReconstructor) handleSymbolLocked(events 
 	case passivePhaseRequest:
 		return reconstructor.handleRequestSymbolLocked(events, symbol, wasEscaped, observedAt)
 	case passivePhaseWaitACK:
-		return reconstructor.handleACKSymbolLocked(events, symbol, observedAt)
+		return reconstructor.handleACKSymbolLocked(events, symbol, wasEscaped, observedAt)
 	case passivePhaseWaitResponse:
 		return reconstructor.handleResponseSymbolLocked(events, symbol, wasEscaped, observedAt)
 	case passivePhaseWaitFinalACK:
-		return reconstructor.handleFinalACKSymbolLocked(events, symbol, observedAt)
+		return reconstructor.handleFinalACKSymbolLocked(events, symbol, wasEscaped, observedAt)
 	case passivePhaseWaitTerminal:
-		return reconstructor.handleTerminalSymbolLocked(events, symbol, observedAt)
+		return reconstructor.handleTerminalSymbolLocked(events, symbol, wasEscaped, observedAt)
 	case passivePhaseAbandoned:
 		if symbol == protocol.SymbolSyn {
 			// SYN-consuming reset: re-engage the Layer 1 gate so the
@@ -687,15 +715,24 @@ func (reconstructor *PassiveTransactionReconstructor) handleRequestSymbolLocked(
 			// classes could otherwise slip through.
 			zz := reconstructor.state.requestRaw[1]
 			if zz == 0xAA || zz == 0xA9 {
+				// F-19e: the offending byte is the ZZ candidate. The
+				// current symbol parameter holds the same value when
+				// the per-offset check fires at rawLen==2 (ZZ just
+				// landed), but we forward zz explicitly to keep the
+				// log line semantically aligned with the reason name.
+				// QQ/ZZ are never escape-encoded (symbol.h:41), so
+				// pass wasEscaped=false unconditionally; if a wire
+				// 0xAA reaches this position it is mis-routed wire
+				// SYN, not an escape sequence.
 				events = append(events, reconstructor.abandonLocked(
-					PassiveAbandonReasonInvalidZZ, observedAt, ebuserrors.ErrInvalidPayload))
+					PassiveAbandonReasonInvalidZZ, observedAt, ebuserrors.ErrInvalidPayload, zz, false))
 				reconstructor.state.phase = passivePhaseAbandoned
 				reconstructor.resetStateLocked()
 				return events
 			}
 			if zz != 0xFE && !isInitiatorAddr(zz) && !isValidTargetAddr(zz) {
 				events = append(events, reconstructor.abandonLocked(
-					PassiveAbandonReasonInvalidZZ, observedAt, ebuserrors.ErrInvalidPayload))
+					PassiveAbandonReasonInvalidZZ, observedAt, ebuserrors.ErrInvalidPayload, zz, false))
 				reconstructor.state.phase = passivePhaseAbandoned
 				reconstructor.resetStateLocked()
 				return events
@@ -709,8 +746,13 @@ func (reconstructor *PassiveTransactionReconstructor) handleRequestSymbolLocked(
 			// before the SYN-trigger path classifies the abandon.
 			nnM := reconstructor.state.requestRaw[4]
 			if int(nnM) > maxPassiveDataLen {
+				// F-19e: the offending byte is the NN_m value that
+				// exceeds the spec cap. NN_m can legitimately be an
+				// escape-decoded 0xAA (decoded 0xAA = data-side
+				// length-byte sentinel), so forward the current
+				// wasEscaped flag rather than hardcoding false.
 				events = append(events, reconstructor.abandonLocked(
-					PassiveAbandonReasonInvalidNNMaster, observedAt, ebuserrors.ErrInvalidPayload))
+					PassiveAbandonReasonInvalidNNMaster, observedAt, ebuserrors.ErrInvalidPayload, nnM, wasEscaped))
 				reconstructor.state.phase = passivePhaseAbandoned
 				reconstructor.resetStateLocked()
 				return events
@@ -727,8 +769,10 @@ func (reconstructor *PassiveTransactionReconstructor) handleRequestSymbolLocked(
 		// looser maxPassiveRequestBytes=512 cap that previously
 		// fired here.
 		if rawLen > maxPassiveLogicalRequestBytes {
+			// F-19e: the offending byte is the current symbol that
+			// pushed rawLen past the watchdog threshold.
 			events = append(events, reconstructor.abandonLocked(
-				PassiveAbandonReasonBufferOverflow, observedAt, ebuserrors.ErrInvalidPayload))
+				PassiveAbandonReasonBufferOverflow, observedAt, ebuserrors.ErrInvalidPayload, symbol, wasEscaped))
 			reconstructor.state.phase = passivePhaseAbandoned
 			reconstructor.resetStateLocked()
 			return events
@@ -866,7 +910,10 @@ func (reconstructor *PassiveTransactionReconstructor) handleRequestSymbolLocked(
 					} else if isScanProbeRaw(reconstructor.state.requestRaw) {
 						reason = PassiveAbandonReasonScanCollision
 					}
-					events = append(events, reconstructor.abandonLocked(reason, observedAt, ebuserrors.ErrInvalidPayload))
+					// F-19e: the offending byte at LEN-completion is
+					// the current symbol that completed the buffer to
+					// a structurally-invalid (CRC-failing) frame.
+					events = append(events, reconstructor.abandonLocked(reason, observedAt, ebuserrors.ErrInvalidPayload, symbol, wasEscaped))
 					reconstructor.state.phase = passivePhaseAbandoned
 					reconstructor.resetStateLocked()
 					return events
@@ -920,7 +967,14 @@ func (reconstructor *PassiveTransactionReconstructor) handleRequestSymbolLocked(
 				reconstructor.pendingRecoveryReason = string(PassiveAbandonReasonUnexpectedSYN)
 			}
 		}
-		events = append(events, reconstructor.abandonLocked(reason, observedAt, ebuserrors.ErrInvalidPayload))
+		// F-19e: the offending byte is the trailing wire SYN that
+		// terminated the structurally-incomplete buffer; wasEscaped
+		// here is the upstream truth flag for that terminating byte
+		// (false for an un-escaped wire SYN — the typical case post
+		// F-19d). Forward the parameter unconditionally so the
+		// post-deploy bucket can confirm 100% un-escaped at this
+		// site.
+		events = append(events, reconstructor.abandonLocked(reason, observedAt, ebuserrors.ErrInvalidPayload, symbol, wasEscaped))
 		// P6 Layer 1 — symbol that triggered this reset is the
 		// trailing SymbolSyn proven at the top of handleRequestSymbolLocked.
 		reconstructor.resetStateLockedAfterSyn()
@@ -1005,7 +1059,15 @@ func (reconstructor *PassiveTransactionReconstructor) dispatchParsedRequestLocke
 	// behavior (Codex P7 review pass 2 FINDING_1).
 	frameType := frame.Type()
 	if frameType == protocol.FrameTypeUnknown {
-		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonCorruptedTarget, observedAt, ebuserrors.ErrInvalidPayload))
+		// F-19e: corrupted-target abandons fire after a structurally
+		// valid frame parse on a frame whose target byte places it in
+		// FrameTypeUnknown. The "offending byte" concept does not map
+		// cleanly to a single observed wire byte — the failure is at
+		// the frame-classification layer, not the byte layer. Pass
+		// (0, false) per the abandonLocked contract; the existing
+		// req_raw/resp_raw fields in the forensic log already carry
+		// the diagnostic evidence for this reason.
+		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonCorruptedTarget, observedAt, ebuserrors.ErrInvalidPayload, 0, false))
 		reset()
 		return events
 	}
@@ -1039,7 +1101,10 @@ func (reconstructor *PassiveTransactionReconstructor) dispatchParsedRequestLocke
 		// enum extensions. State has already been populated above
 		// (matches the pre-refactor SYN-path default branch which
 		// also wrote state.request before abandon).
-		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonCorruptedTarget, observedAt, ebuserrors.ErrInvalidPayload))
+		//
+		// F-19e: see CorruptedTarget rationale above — frame-class
+		// failure is not byte-driven. Pass (0, false).
+		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonCorruptedTarget, observedAt, ebuserrors.ErrInvalidPayload, 0, false))
 		reset()
 	}
 	return events
@@ -1098,7 +1163,7 @@ func (reconstructor *PassiveTransactionReconstructor) isSelfOriginatedParsed() b
 	return snapshot.Known && reconstructor.state.request.Source == snapshot.Address
 }
 
-func (reconstructor *PassiveTransactionReconstructor) handleACKSymbolLocked(events []PassiveClassifiedEvent, symbol byte, observedAt time.Time) []PassiveClassifiedEvent {
+func (reconstructor *PassiveTransactionReconstructor) handleACKSymbolLocked(events []PassiveClassifiedEvent, symbol byte, wasEscaped bool, observedAt time.Time) []PassiveClassifiedEvent {
 	switch symbol {
 	case protocol.SymbolAck:
 		reconstructor.state.lastProgressAt = observedAt
@@ -1114,7 +1179,7 @@ func (reconstructor *PassiveTransactionReconstructor) handleACKSymbolLocked(even
 		return events
 	case protocol.SymbolNack:
 		reconstructor.state.ackCorrelation = m2aRequestACKCorrelation(symbol)
-		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonNACK, observedAt, ebuserrors.ErrNACK))
+		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonNACK, observedAt, ebuserrors.ErrNACK, symbol, wasEscaped))
 		// P6 — after a request-phase NACK the eBUS spec (AM2 in
 		// internal/adaptermux/wire_phase.go:185-198) permits the
 		// initiator to retransmit the request immediately without a
@@ -1126,18 +1191,26 @@ func (reconstructor *PassiveTransactionReconstructor) handleACKSymbolLocked(even
 		return events
 	case protocol.SymbolSyn:
 		if reconstructor.isScanTimeoutLocked() {
-			events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonScanTimeout, observedAt, ebuserrors.ErrTimeout))
+			events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonScanTimeout, observedAt, ebuserrors.ErrTimeout, symbol, wasEscaped))
 		} else if reconstructor.isSelfOriginatedParsed() {
-			events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonSelfEcho, observedAt, ebuserrors.ErrTimeout))
+			events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonSelfEcho, observedAt, ebuserrors.ErrTimeout, symbol, wasEscaped))
 		} else {
-			events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonUnexpectedSYN, observedAt, ebuserrors.ErrTimeout))
+			events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonUnexpectedSYN, observedAt, ebuserrors.ErrTimeout, symbol, wasEscaped))
 			reconstructor.pendingRecoveryReason = string(PassiveAbandonReasonUnexpectedSYN)
 		}
 		// P6 Layer 1 — explicit SymbolSyn case in this arm.
 		reconstructor.resetStateLockedAfterSyn()
 		return events
 	default:
-		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonUnexpectedSymbol, observedAt, ebuserrors.ErrInvalidPayload))
+		// F-19e (batch-18): forensic instrumentation. The default arm
+		// fires when a non-ACK/NACK/SYN byte arrives at the WaitACK
+		// phase — production rate ~0.7 events/min per batch-18
+		// recommendation. Capture the offending byte so the
+		// post-deploy bucketing pass can determine whether the
+		// distribution clusters at specific bytes (e.g. 0x00 / 0xFF
+		// near-ACK values, escape-sequence fragments, or arbitrary
+		// data bytes that hint at upstream phase-tracking drift).
+		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonUnexpectedSymbol, observedAt, ebuserrors.ErrInvalidPayload, symbol, wasEscaped))
 		reconstructor.state.phase = passivePhaseAbandoned
 		return events
 	}
@@ -1151,7 +1224,11 @@ func (reconstructor *PassiveTransactionReconstructor) handleResponseSymbolLocked
 		// 0xAA at this offset (wasEscaped=true) means the
 		// responder's NN_s = 0xAA — which fails the F-19c NN bound
 		// check below since 0xAA > maxPassiveDataLen.
-		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonNoResponse, observedAt, ebuserrors.ErrTimeout))
+		// F-19e: the offending byte is the trailing un-escaped wire
+		// SYN that terminated the empty response. wasEscaped is
+		// guaranteed false here (the guard above tests `!wasEscaped`)
+		// but we forward the parameter anyway for site uniformity.
+		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonNoResponse, observedAt, ebuserrors.ErrTimeout, symbol, wasEscaped))
 		// P6 Layer 1 — explicit SymbolSyn at this branch.
 		reconstructor.resetStateLockedAfterSyn()
 		return events
@@ -1165,7 +1242,9 @@ func (reconstructor *PassiveTransactionReconstructor) handleResponseSymbolLocked
 		// data-byte cascades. With wasEscaped carrying the upstream
 		// truth, the disambiguation is now precise: escaped 0xAA →
 		// data, un-escaped 0xAA → wire SYN.
-		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonUnexpectedSYN, observedAt, ebuserrors.ErrTimeout))
+		// F-19e: the offending byte is the mid-response un-escaped
+		// wire SYN. wasEscaped is guaranteed false (guard above).
+		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonUnexpectedSYN, observedAt, ebuserrors.ErrTimeout, symbol, wasEscaped))
 		reconstructor.pendingRecoveryReason = string(PassiveAbandonReasonUnexpectedSYN)
 		// P6 Layer 1 — explicit SymbolSyn at this branch.
 		reconstructor.resetStateLockedAfterSyn()
@@ -1197,8 +1276,12 @@ func (reconstructor *PassiveTransactionReconstructor) handleResponseSymbolLocked
 		// inclusion (the previous P2 fix) was meant to preserve.
 		if int(symbol) > maxPassiveDataLen {
 			reconstructor.state.responseRaw = append(reconstructor.state.responseRaw, symbol)
+			// F-19e: the offending byte IS the NN_s value that
+			// exceeds the spec cap. wasEscaped is forwarded from the
+			// upstream decoder — an escape-decoded 0xAA (logical NN_s
+			// = 170) hits this guard with wasEscaped=true.
 			events = append(events, reconstructor.abandonLocked(
-				PassiveAbandonReasonInvalidNNSlave, observedAt, ebuserrors.ErrInvalidPayload))
+				PassiveAbandonReasonInvalidNNSlave, observedAt, ebuserrors.ErrInvalidPayload, symbol, wasEscaped))
 			reconstructor.state.phase = passivePhaseAbandoned
 			// Plain reset: the offending byte is the NN_s data
 			// byte, not a wire SYN. Layer 1 re-syncs on the next
@@ -1215,7 +1298,16 @@ func (reconstructor *PassiveTransactionReconstructor) handleResponseSymbolLocked
 		return events
 	}
 	if len(reconstructor.state.responseRaw) > reconstructor.state.responseExpectedLen {
-		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonUnexpectedSymbol, observedAt, ebuserrors.ErrInvalidPayload))
+		// F-19e (batch-18): response overrun is one of the five
+		// unexpected_symbol emit sites in the operator's diagnostic
+		// spec. The offending byte is the current symbol that pushed
+		// responseRaw past responseExpectedLen — i.e. the
+		// post-completion byte that should have been a structural
+		// SYN-or-ACK but landed inside the response phase. wasEscaped
+		// is the per-byte truth flag from the upstream decoder, so
+		// the bucketing pass can correlate "post-completion overrun"
+		// with "escape-sequence drift".
+		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonUnexpectedSymbol, observedAt, ebuserrors.ErrInvalidPayload, symbol, wasEscaped))
 		reconstructor.state.phase = passivePhaseAbandoned
 		return events
 	}
@@ -1226,11 +1318,11 @@ func (reconstructor *PassiveTransactionReconstructor) handleResponseSymbolLocked
 	return events
 }
 
-func (reconstructor *PassiveTransactionReconstructor) handleFinalACKSymbolLocked(events []PassiveClassifiedEvent, symbol byte, observedAt time.Time) []PassiveClassifiedEvent {
+func (reconstructor *PassiveTransactionReconstructor) handleFinalACKSymbolLocked(events []PassiveClassifiedEvent, symbol byte, wasEscaped bool, observedAt time.Time) []PassiveClassifiedEvent {
 	switch symbol {
 	case protocol.SymbolAck:
 		if !reconstructor.state.responseCRCValid {
-			events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonCRCMismatch, observedAt, ebuserrors.ErrCRCMismatch))
+			events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonCRCMismatch, observedAt, ebuserrors.ErrCRCMismatch, symbol, wasEscaped))
 			reconstructor.state.phase = passivePhaseAbandoned
 			return events
 		}
@@ -1238,25 +1330,31 @@ func (reconstructor *PassiveTransactionReconstructor) handleFinalACKSymbolLocked
 		reconstructor.state.phase = passivePhaseWaitTerminal
 		return events
 	case protocol.SymbolNack:
-		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonAmbiguousRetransmit, observedAt, ebuserrors.ErrNACK))
+		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonAmbiguousRetransmit, observedAt, ebuserrors.ErrNACK, symbol, wasEscaped))
 		reconstructor.state.phase = passivePhaseAbandoned
 		return events
 	case protocol.SymbolSyn:
-		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonUnexpectedSYN, observedAt, ebuserrors.ErrTimeout))
+		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonUnexpectedSYN, observedAt, ebuserrors.ErrTimeout, symbol, wasEscaped))
 		reconstructor.pendingRecoveryReason = string(PassiveAbandonReasonUnexpectedSYN)
 		// P6 Layer 1 — explicit SymbolSyn case in handleFinalACKSymbolLocked.
 		reconstructor.resetStateLockedAfterSyn()
 		return events
 	default:
-		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonUnexpectedSymbol, observedAt, ebuserrors.ErrInvalidPayload))
+		// F-19e (batch-18): forensic instrumentation. WaitFinalACK
+		// expects ACK / NACK / SYN; anything else captured here is
+		// diagnostic evidence for the post-deploy bucketing pass.
+		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonUnexpectedSymbol, observedAt, ebuserrors.ErrInvalidPayload, symbol, wasEscaped))
 		reconstructor.state.phase = passivePhaseAbandoned
 		return events
 	}
 }
 
-func (reconstructor *PassiveTransactionReconstructor) handleTerminalSymbolLocked(events []PassiveClassifiedEvent, symbol byte, observedAt time.Time) []PassiveClassifiedEvent {
+func (reconstructor *PassiveTransactionReconstructor) handleTerminalSymbolLocked(events []PassiveClassifiedEvent, symbol byte, wasEscaped bool, observedAt time.Time) []PassiveClassifiedEvent {
 	if symbol != protocol.SymbolSyn {
-		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonUnexpectedSymbol, observedAt, ebuserrors.ErrInvalidPayload))
+		// F-19e (batch-18): forensic instrumentation. WaitTerminal
+		// only accepts a trailing wire SYN; capture the offending
+		// byte for the post-deploy bucketing pass.
+		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonUnexpectedSymbol, observedAt, ebuserrors.ErrInvalidPayload, symbol, wasEscaped))
 		reconstructor.state.phase = passivePhaseAbandoned
 		return events
 	}
@@ -1290,7 +1388,15 @@ func (reconstructor *PassiveTransactionReconstructor) handleTerminalSymbolLocked
 			ACKCorrelation: reconstructor.state.ackCorrelation,
 		})
 	default:
-		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonUnexpectedSymbol, observedAt, ebuserrors.ErrInvalidPayload))
+		// F-19e (batch-18): defensive fall-through for future
+		// protocol.FrameType enum extensions. This branch is
+		// unreachable in normal operation (FrameType enum is
+		// exhausted by the cases above); pass (0, false) since no
+		// single observed wire byte triggered the abandon — the
+		// failure is a frame-classification fall-through, not a
+		// per-byte event. Per the operator's F-19e spec: "this case
+		// is unreachable in normal operation; static 0 is fine".
+		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonUnexpectedSymbol, observedAt, ebuserrors.ErrInvalidPayload, 0, false))
 	}
 	// P6 Layer 1 — handleTerminalSymbolLocked only reaches this site
 	// after the leading-symbol SymbolSyn check at the top.
@@ -1298,7 +1404,14 @@ func (reconstructor *PassiveTransactionReconstructor) handleTerminalSymbolLocked
 	return events
 }
 
-func (reconstructor *PassiveTransactionReconstructor) abandonLocked(reason PassiveAbandonReason, observedAt time.Time, err error) PassiveClassifiedEvent {
+// abandonLocked builds and records an AbandonedTransaction event. The
+// trailing offendingSymbol/offendingWasEscaped pair (added F-19e,
+// batch-18) captures the observed wire byte that triggered the
+// abandon — when the abandon is byte-driven. Lifecycle / structural
+// abandons (Shutdown, TransportReset, NoProgress watchdog,
+// FrameTypeUnknown defensive fall-through) pass (0, false) because
+// no single causal byte exists.
+func (reconstructor *PassiveTransactionReconstructor) abandonLocked(reason PassiveAbandonReason, observedAt time.Time, err error, offendingSymbol byte, offendingWasEscaped bool) PassiveClassifiedEvent {
 	hasRequest := reconstructor.state.frameType != protocol.FrameTypeUnknown
 	hasResponse := reconstructor.state.responseExpectedLen > 0
 	// P1.5 (post-Phase-C live validation 2026-05-08): strip stale
@@ -1325,23 +1438,25 @@ func (reconstructor *PassiveTransactionReconstructor) abandonLocked(reason Passi
 		ackCorrelation = PassiveACKCorrelation{}
 	}
 	event := PassiveClassifiedEvent{
-		Kind:           PassiveClassifiedEventAbandonedTransaction,
-		FrameType:      reconstructor.state.frameType,
-		Request:        reconstructor.state.request,
-		Response:       reconstructor.state.response,
-		HasRequest:     hasRequest,
-		HasResponse:    hasResponse,
-		Timing:         reconstructor.state.timing,
-		ObservedAt:     observedAt,
-		AbandonReason:  reason,
-		ACKCorrelation: ackCorrelation,
-		Err:            err,
+		Kind:                PassiveClassifiedEventAbandonedTransaction,
+		FrameType:           reconstructor.state.frameType,
+		Request:             reconstructor.state.request,
+		Response:            reconstructor.state.response,
+		HasRequest:          hasRequest,
+		HasResponse:         hasResponse,
+		Timing:              reconstructor.state.timing,
+		ObservedAt:          observedAt,
+		AbandonReason:       reason,
+		ACKCorrelation:      ackCorrelation,
+		Err:                 err,
+		OffendingSymbol:     offendingSymbol,
+		OffendingWasEscaped: offendingWasEscaped,
 	}
 	event.Timing.Terminal = observedAt
 	// A.8 — forensic logging for protocol-classification failures the
 	// inserter cannot consume.
 	if shouldLogReconstructorForensics(reason) {
-		reconstructor.logForensicsLocked(reason, observedAt)
+		reconstructor.logForensicsLocked(reason, observedAt, offendingSymbol, offendingWasEscaped)
 	}
 	// A.9 — per-reason counter so operators can compare Helianthus
 	// abandon rate to Grafana ground-truth frame counts without
@@ -1383,7 +1498,7 @@ func shouldLogReconstructorForensics(reason PassiveAbandonReason) bool {
 	return false
 }
 
-func (reconstructor *PassiveTransactionReconstructor) logForensicsLocked(reason PassiveAbandonReason, observedAt time.Time) {
+func (reconstructor *PassiveTransactionReconstructor) logForensicsLocked(reason PassiveAbandonReason, observedAt time.Time, offendingSymbol byte, offendingWasEscaped bool) {
 	src, dst, prim, sec := byte(0), byte(0), byte(0), byte(0)
 	if reconstructor.state.frameType != protocol.FrameTypeUnknown {
 		src = reconstructor.state.request.Source
@@ -1398,12 +1513,36 @@ func (reconstructor *PassiveTransactionReconstructor) logForensicsLocked(reason 
 	}
 	reqHex := hexBytes(reconstructor.state.requestRaw)
 	respHex := hexBytes(reconstructor.state.responseRaw)
-	log.Printf("passive_reconstructor abandon reason=%s phase=%d src=0x%02X dst=0x%02X prim=0x%02X sec=0x%02X req_raw=%s resp_raw=%s observed_at=%s",
+	// F-19e (batch-18, 2026-05-13): emit offending_symbol +
+	// offending_was_escaped at the END of the line so existing log
+	// regexes that match the leading fields keep working; new
+	// post-deploy analysis can grep the trailing tokens to bucket
+	// the offending-byte distribution. `0x%02X` matches the existing
+	// src/dst/prim/sec field rendering.
+	//
+	// Ambiguity note: the truly-lifecycle reasons (shutdown,
+	// transport_reset, decode_fault, no_progress watchdog,
+	// disconnected) pass (0, false) and are gated OUT of forensics
+	// by shouldLogReconstructorForensics, so their zero values
+	// never reach this log line.
+	//
+	// The remaining `(0, false)`-passing site is `corrupted_target`,
+	// which DOES log forensics (the reason is reachable via a frame
+	// whose parsed type maps to FrameTypeUnknown or a future enum
+	// extension). When that fires, the log line will show
+	// `offending_symbol=0x00 offending_was_escaped=false`; the
+	// `reason=corrupted_target` token plus the `req_raw=` evidence
+	// disambiguate it from a real byte-driven
+	// `reason=unexpected_symbol offending_symbol=0x00`. Post-deploy
+	// analysis scripts MUST key off `reason=` before interpreting
+	// the offending tokens.
+	log.Printf("passive_reconstructor abandon reason=%s phase=%d src=0x%02X dst=0x%02X prim=0x%02X sec=0x%02X req_raw=%s resp_raw=%s observed_at=%s offending_symbol=0x%02X offending_was_escaped=%v",
 		reason,
 		int(reconstructor.state.phase),
 		src, dst, prim, sec,
 		reqHex, respHex,
-		observedAt.Format(time.RFC3339Nano))
+		observedAt.Format(time.RFC3339Nano),
+		offendingSymbol, offendingWasEscaped)
 }
 
 func hexBytes(b []byte) string {
@@ -1575,7 +1714,11 @@ func (reconstructor *PassiveTransactionReconstructor) shutdownEvents() []Passive
 	events := make([]PassiveClassifiedEvent, 0, 2)
 	now := time.Now()
 	if reconstructor.state.phase != passivePhaseIdle && reconstructor.state.phase != passivePhaseAbandoned {
-		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonShutdown, now, context.Canceled))
+		// F-19e: shutdown is a lifecycle event, not byte-driven.
+		// Pass (0, false). `shutdown` is also excluded from
+		// shouldLogReconstructorForensics, so the zero values never
+		// reach the log line.
+		events = append(events, reconstructor.abandonLocked(PassiveAbandonReasonShutdown, now, context.Canceled, 0, false))
 	}
 	reconstructor.resetStateLocked()
 	return append(events, PassiveClassifiedEvent{

--- a/passive_transaction_reconstructor.go
+++ b/passive_transaction_reconstructor.go
@@ -715,24 +715,31 @@ func (reconstructor *PassiveTransactionReconstructor) handleRequestSymbolLocked(
 			// classes could otherwise slip through.
 			zz := reconstructor.state.requestRaw[1]
 			if zz == 0xAA || zz == 0xA9 {
-				// F-19e: the offending byte is the ZZ candidate. The
-				// current symbol parameter holds the same value when
-				// the per-offset check fires at rawLen==2 (ZZ just
-				// landed), but we forward zz explicitly to keep the
-				// log line semantically aligned with the reason name.
-				// QQ/ZZ are never escape-encoded (symbol.h:41), so
-				// pass wasEscaped=false unconditionally; if a wire
-				// 0xAA reaches this position it is mis-routed wire
-				// SYN, not an escape sequence.
+				// F-19e (Codex bot P2 on PR #631): the offending byte
+				// IS the ZZ candidate just appended on line 684.
+				// `symbol` and `requestRaw[1]` reference the same
+				// byte at this rawLen==2 site, so the handler's
+				// `wasEscaped` parameter is the upstream truth flag
+				// for the ZZ byte. The spec rule (symbol.h:41 — QQ/ZZ
+				// are never escape-encoded) is what the SENDER must
+				// do; a wasEscaped=true byte arriving at ZZ would be
+				// a spec violation that the F-19e forensic data
+				// SHOULD preserve, not hide. Forward `wasEscaped`
+				// directly so post-deploy analysis can distinguish
+				// "raw 0xAA at ZZ position = mis-routed wire SYN"
+				// from "escape-encoded byte at ZZ position = sender
+				// or wire corruption".
 				events = append(events, reconstructor.abandonLocked(
-					PassiveAbandonReasonInvalidZZ, observedAt, ebuserrors.ErrInvalidPayload, zz, false))
+					PassiveAbandonReasonInvalidZZ, observedAt, ebuserrors.ErrInvalidPayload, zz, wasEscaped))
 				reconstructor.state.phase = passivePhaseAbandoned
 				reconstructor.resetStateLocked()
 				return events
 			}
 			if zz != 0xFE && !isInitiatorAddr(zz) && !isValidTargetAddr(zz) {
+				// F-19e: same forwarding rationale as above — ZZ at
+				// rawLen==2 is the current handler byte.
 				events = append(events, reconstructor.abandonLocked(
-					PassiveAbandonReasonInvalidZZ, observedAt, ebuserrors.ErrInvalidPayload, zz, false))
+					PassiveAbandonReasonInvalidZZ, observedAt, ebuserrors.ErrInvalidPayload, zz, wasEscaped))
 				reconstructor.state.phase = passivePhaseAbandoned
 				reconstructor.resetStateLocked()
 				return events


### PR DESCRIPTION
## Summary

- INSTRUMENTATION-ONLY patch. No behavior changes, no new abandon reasons, no logic changes.
- Captures the offending wire byte + its F-19d wasEscaped flag at every passive-reconstructor abandon. Surfaces 50 events / 69 min of `unexpected_symbol` (per batch-18 live verification) as bucketable post-deploy data.
- Extends `abandonLocked` signature, `PassiveClassifiedEvent` struct, and `logForensicsLocked` output. Threads `wasEscaped` (F-19d, batch-17) into the three handlers that did not yet carry it (ACK / FinalACK / Terminal).

## Context

Batch-18 (`_work_adaptermux_audit/EBUSD-VERIFICATION-2026-05-13-batch18.md`) confirmed F-19d (PR #630, v0.6.11) eliminated the AA-cascade fingerprint (7 → 0 mid-frame wire-SYN events) and now ranks `unexpected_symbol` at 0.72/min as the next-largest abandon category. The forensic log previously emitted `reason / phase / src / dst / prim / sec / req_raw / resp_raw / observed_at` but did NOT include the single observed byte that drove the abandon — so the 50 events/hour were undiagnosable.

This patch adds two trailing tokens to the log line:

```
... observed_at=... offending_symbol=0x42 offending_was_escaped=false
```

…and two trailing fields to `PassiveClassifiedEvent`. Post-deploy v0.6.12 will run ≥60 min and the test agent will bucket the `offending_symbol` distribution to determine whether the rate clusters at specific bytes (escape-sequence fragments, near-ACK values like 0x00/0xFF, or arbitrary data bytes hinting at upstream phase-tracking drift).

## Changes

| File | Δ | Notes |
|---|---|---|
| `passive_transaction_reconstructor.go` | +192 / −49 | abandonLocked signature; PassiveClassifiedEvent fields; logForensicsLocked log line; wasEscaped threaded into ACK/FinalACK/Terminal; 27 call sites updated |
| `passive_reconstructor_f19e_instrumentation_test.go` | +356 / 0 | 6 new tests pinning per-site behavior + log format + F-19c/F-19d unchanged forensics |

All 27 `abandonLocked` call sites updated:
- **byte-driven sites** pass `(symbol, wasEscaped)` or `(stored-offset-byte, wasEscaped)`.
- **lifecycle sites** (Shutdown, TransportReset, DecodeFault, NoProgress watchdog) pass `(0, false)`; gated out of forensics by `shouldLogReconstructorForensics`, so zero never reaches the log line.
- **frame-classification sites** (CorruptedTarget, defensive frame-type default) pass `(0, false)`. CorruptedTarget DOES log; `reason=corrupted_target` + `req_raw=` disambiguate from byte-driven `unexpected_symbol 0x00`. Documented inline at logForensicsLocked.

## Tests

Six new tests in `passive_reconstructor_f19e_instrumentation_test.go`:

- `TestF19e_UnexpectedSymbol_AtWaitACK` — M2T request, sends 0x42 at WaitACK default arm.
- `TestF19e_UnexpectedSymbol_AtWaitFinalACK` — request+ACK+response, sends 0x42 at WaitFinalACK default arm.
- `TestF19e_UnexpectedSymbol_AtWaitTerminal` — M2I request+ACK to WaitTerminal, sends 0x42.
- `TestF19e_LogLineFormat` — captures log; asserts `offending_symbol=0x42 offending_was_escaped=false`; asserts tokens appear AFTER `observed_at=`; asserts legacy `reason/phase/src/dst/prim/sec` tokens still present.
- `TestF19e_F19c_UnchangedForensics` — replays InvalidNNMaster=0x84 live evidence; asserts new fields populate (`OffendingSymbol=0x84`) without F-19c regression.
- `TestF19e_F19d_UnchangedForensics` — replays mid-frame wire-SYN; asserts `OffendingWasEscaped=false` for un-escaped wire SYN.

## Pre-merge gates

- ✅ `go vet ./...`
- ✅ `go build ./...`
- ✅ `go test -race -count=1 ./...` (full suite, all green incl. F-19c/F-19d regressions)
- ✅ `python3 scripts/passive_canary_verifier_test.py` (168 tests)
- ✅ `python3 scripts/source_selection_m4_gate_test.py` (5)
- ✅ `python3 scripts/transport_gate_test.py` (7)
- ✅ `python3 scripts/passive_smoke_gate_test.py` (5)
- ✅ Codex CLI adversarial review (`gpt-5.5`, sandbox=read-only) — ship verdict, one non-blocking comment overstatement addressed in-PR
- ⚠️ Pre-existing gofmt drift on `internal/adaptermux/*` and `internal/runtimestate/*` — out of scope, documented in #629 / #630

## Test plan

- [x] Local: full `go test -race`, F-19e tests pass, F-19c/F-19d regression guards pass
- [ ] Post-merge: bump addon to v0.6.12, GHCR build, cache-bypass retag deploy on 192.168.100.4
- [ ] Run ≥60 min in production
- [ ] Dispatch test agent for batch-19 verification: bucket `offending_symbol=0xXX offending_was_escaped=v` distribution from logs

Spec source: `_work_adaptermux_audit/EBUSD-VERIFICATION-2026-05-13-batch18.md` (Option B forensic-instrumentation pathway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)