### PR TITLE
fix(adaptermux): revert F-22 stale-window over-extension (livelock fix)

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -1302,12 +1302,31 @@ func wireAdapterDirect(ctx context.Context, cfg *ebusgateway.Config) (func() err
 		// phantom, and the passive emit / logging still fires for
 		// observability.
 		IsKnownInitiatorByte: func(b byte) bool {
-			// Known bit-arbitration phantoms on this bus:
-			//   0x71 = 0x7F (gateway) & 0xF1 (master #10)
-			// Other phantoms have not been observed in production
-			// traces; add them here if forensic capture surfaces
-			// new ones.
-			return b != 0x71
+			// F-31 (batch-28, iter8, 2026-05-14): generalize the
+			// phantom filter to the observed master set on this bus.
+			// Any byte NOT in the discovered master list is treated as
+			// a bit-arbitration phantom and routed away from external
+			// sessions.
+			//
+			// Bootstrap: this list is hardcoded for the production
+			// deployment (per ebusctl info: masters 0x03, 0x10, 0x31,
+			// 0x7F, 0xF1, 0xFF — 6 active masters). The gateway address
+			// 0x7F and ebusd's address 0x31 are both included. Iter9
+			// will promote this to a runtime_state.known_bus_members-
+			// backed lookup that adapts dynamically.
+			//
+			// Filtered phantoms include (any AND-result of the above
+			// pairs that isn't itself a member):
+			//   0x7F & 0xF1 = 0x71  ✗ phantom
+			//   0x31 & 0x03 = 0x01  ✗ phantom
+			//   0x7F & 0xFF = 0x7F  ✓ self
+			//   0x31 & 0xF1 = 0x31  ✓ self
+			//   ...etc
+			switch b {
+			case 0x03, 0x10, 0x31, 0x7F, 0xF1, 0xFF:
+				return true
+			}
+			return false
 		},
 	}
 	if muxCfg.DialTimeout == 0 {

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -1302,31 +1302,13 @@ func wireAdapterDirect(ctx context.Context, cfg *ebusgateway.Config) (func() err
 		// phantom, and the passive emit / logging still fires for
 		// observability.
 		IsKnownInitiatorByte: func(b byte) bool {
-			// F-31 (batch-28, iter8, 2026-05-14): generalize the
-			// phantom filter to the observed master set on this bus.
-			// Any byte NOT in the discovered master list is treated as
-			// a bit-arbitration phantom and routed away from external
-			// sessions.
-			//
-			// Bootstrap: this list is hardcoded for the production
-			// deployment (per ebusctl info: masters 0x03, 0x10, 0x31,
-			// 0x7F, 0xF1, 0xFF — 6 active masters). The gateway address
-			// 0x7F and ebusd's address 0x31 are both included. Iter9
-			// will promote this to a runtime_state.known_bus_members-
-			// backed lookup that adapts dynamically.
-			//
-			// Filtered phantoms include (any AND-result of the above
-			// pairs that isn't itself a member):
-			//   0x7F & 0xF1 = 0x71  ✗ phantom
-			//   0x31 & 0x03 = 0x01  ✗ phantom
-			//   0x7F & 0xFF = 0x7F  ✓ self
-			//   0x31 & 0xF1 = 0x31  ✓ self
-			//   ...etc
-			switch b {
-			case 0x03, 0x10, 0x31, 0x7F, 0xF1, 0xFF:
-				return true
-			}
-			return false
+			// F-30 (iter7) narrow filter: reject ONLY the dominant
+			// phantom 0x71 = 0x7F (gateway) & 0xF1 (master #10).
+			// F-31's broader allowlist regressed in production (variance
+			// 60% vs F-30's 71%); reverted in iter9. The narrow filter
+			// is more conservative: it doesn't drop any REAL FAILED
+			// winner byte that might be a transient unobserved master.
+			return b != 0x71
 		},
 	}
 	if muxCfg.DialTimeout == 0 {

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -1270,6 +1270,45 @@ func wireAdapterDirect(ctx context.Context, cfg *ebusgateway.Config) (func() err
 		DialTimeout:  cfg.TransportConfig.DialTimeout,
 		ReadTimeout:  cfg.TransportConfig.ReadTimeout,
 		WriteTimeout: cfg.TransportConfig.WriteTimeout,
+		// F-30 (batch-27, iter7, 2026-05-14): wire IsKnownInitiatorByte
+		// to filter bit-arbitration phantom bytes from external session
+		// forwarding. When the gateway loses arbitration to another
+		// master, the adapter reports FAILED with the bit-wise-AND
+		// result of the colliding initiators. This AND result is often
+		// NOT a real master on the bus (e.g., 0x7F & 0xF1 = 0x71,
+		// where no 0x71 master exists on the observed bus).
+		//
+		// Pre-F-30: phantom bytes were forwarded to ebusd as ENH_RES_FAILED
+		// data; ebusd's bus reconstructor interpreted each phantom as a
+		// real frame source and advanced its state machine to expect a
+		// frame from that fictitious master. The next real wire bytes
+		// (from the actual winning master) then mismatched, leaving
+		// ebusd's state in bs_recvCmd/bs_skip — the "arbitration won in
+		// invalid state" trigger when ebusd's NEXT grant arrives.
+		//
+		// Iter6 forensic measured 58 invalid-state events / 5 min
+		// despite F-28+F-29 cooldowns reducing the cause-1 (timeout)
+		// path. Cause-2 (state mismatch from phantom forwarding) is now
+		// the dominant residual.
+		//
+		// Pragmatic filter (iter7, hardcoded): reject the SPECIFIC
+		// phantom 0x71 observed on this bus. Generalizes to a
+		// runtime_state.known_bus_members-backed lookup in iter8.
+		//
+		// Returning false on the predicate routes the FAILED byte
+		// through the gateway's suppression path (mux.go ~1523): the
+		// byte is NOT delivered to external sessions, the per-session
+		// notify gets the bidder's own initiator instead of the
+		// phantom, and the passive emit / logging still fires for
+		// observability.
+		IsKnownInitiatorByte: func(b byte) bool {
+			// Known bit-arbitration phantoms on this bus:
+			//   0x71 = 0x7F (gateway) & 0xF1 (master #10)
+			// Other phantoms have not been observed in production
+			// traces; add them here if forensic capture surfaces
+			// new ones.
+			return b != 0x71
+		},
 	}
 	if muxCfg.DialTimeout == 0 {
 		muxCfg.DialTimeout = 5 * time.Second

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Project-Helianthus/helianthus-ebusgateway
 go 1.22
 
 require (
-	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260513160603-5215685f2376
+	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260514220931-5882b7c274f0
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Project-Helianthus/helianthus-ebusgateway
 go 1.22
 
 require (
-	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260514220931-5882b7c274f0
+	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260514222921-444f08676038
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260513160603-5215685f2376 h1:sBdjQmjfmVDUJ+M5tu7SL570TLeYNHd4m0yqgCiYD3k=
 github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260513160603-5215685f2376/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
+github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260514220931-5882b7c274f0 h1:bPvbsT7CuTAHeMPNX+W5lxqhsal/cMFfpVW17Qz0ZTU=
+github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260514220931-5882b7c274f0/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2 h1:6VFOfwe5L0GQkVRMcjdjCjnfBWcDoelnmoP1wIflrKM=
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260513160603-5215685f
 github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260513160603-5215685f2376/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
 github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260514220931-5882b7c274f0 h1:bPvbsT7CuTAHeMPNX+W5lxqhsal/cMFfpVW17Qz0ZTU=
 github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260514220931-5882b7c274f0/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
+github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260514222921-444f08676038 h1:P5N21Xo6d2N+8balyb4pT63iPUb/BsRjDq2ka/nejlM=
+github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260514222921-444f08676038/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2 h1:6VFOfwe5L0GQkVRMcjdjCjnfBWcDoelnmoP1wIflrKM=
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=

--- a/internal/adaptermux/absorb_timeout_revert_test.go
+++ b/internal/adaptermux/absorb_timeout_revert_test.go
@@ -1,0 +1,475 @@
+package adaptermux
+
+import (
+	"context"
+	"log"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+// absorb_timeout_revert_test.go pins the contract for the v0.6.13 →
+// v0.6.14 revert of the over-extended "drop-on-late-response" window
+// that shipped on top of the F-22 absorb-timeout fix.
+//
+// (NOTE: the literal forbidden-prefix tokens used by
+// TestF22_NoStaleAbsorbWindowFieldsRemain are built via string
+// concatenation lower in this file so a global grep for those tokens
+// over internal/adaptermux/*.go does NOT false-positive on this
+// guard test. The reflection check still matches by full field name
+// because the runtime value is identical to the concatenated source
+// literal.)
+//
+// Background (live evidence, 2026-05-13 21:17:30 cycle):
+//
+//   absorb timeout reset reason=deadline (was waiting for 1) (F-22)
+//   RequestStart(0x7F) sent for session 0           ← fresh bid
+//   readLoop got StreamEventStarted data=0x7F       ← adapter GRANTS
+//   readLoop dropping late-response STARTED (F-22)  ← BUG: drops grant
+//   pendingStart deadline expired (AM8 ...)
+//   absorb timeout reset reason=deadline ...        ← LOOPS every 10s
+//
+// The drop-on-late-response mechanism shipped in v0.6.13 was supposed
+// to absorb late STARTED/FAILED responses from cancelled bids (the
+// original reconnect-replacement Codex P1 raised on PR #632). The
+// implementation over-classified: when the absorb safety-net fired and
+// immediately after the bus poll loop issued a NEW RequestStart, the
+// mux's readLoop dropped the FRESH grant as if it belonged to the
+// cancelled bid. The gateway then AM8-timed out the new pendingStart
+// 5 s later and the cycle restarted — a permanent livelock on the
+// active path while the bus stayed otherwise healthy (ebusctl
+// signal=acquired, other masters operating).
+//
+// The revert removes:
+//   - the post-reset deadline field + timer on Mux
+//   - readLoop drop guard for StreamEventStarted
+//   - readLoop drop guard for StreamEventFailed
+//   - snapshot gating in StreamEventStarted/Failed handlers
+//   - the in-handleArbitrationResponse window-absorb helper
+//   - the deadline.Store(windowEnd) call at armPendingStartAbsorbLocked
+//
+// The revert KEEPS (legitimate F-22):
+//   - absorbResetTotal counter
+//   - the absorb-timeout reset path (log + counter reset, NO transport
+//     reconnect)
+//   - the existing pendingStartAbsorb-counter-decrement path in
+//     handleArbitrationResponse (handles legitimate late-responses to
+//     ACTIVE pending requests — untouched by v0.6.13's over-extension)
+//
+// All other fixes (F-15, F-17, F-18, F-19a/c/d/e, F-23 consumer side)
+// are unaffected by this revert. The helianthus-ebusgo F-23 escape
+// decoder is in a separate repo and unchanged.
+
+// forbiddenAbsorbFieldPrefixes is the list of struct-field-name prefixes
+// that, if reintroduced, would indicate the v0.6.13 over-extension came
+// back. Built from concatenated parts so a grep over
+// internal/adaptermux/*.go does not surface this test file as a
+// false-positive match. Compile-time string concatenation yields the
+// same runtime value as the literal prefix.
+func forbiddenAbsorbFieldPrefixes() []string {
+	return []string{
+		"stale" + "Absorb",
+		"stale" + "Window",
+	}
+}
+
+// droppedLogToken / windowAbsorbedLogToken are the log substrings the
+// pre-revert build would emit. Constructed from parts for the same
+// grep-hygiene reason as forbiddenAbsorbFieldPrefixes.
+func droppedLogToken() string {
+	return "dropping " + "stale" + "-window"
+}
+func windowAbsorbedLogToken() string {
+	return "stale" + "-absorb window absorbed"
+}
+
+// TestF22_FreshRequestStartGrantNotDroppedAsStale exercises the
+// livelock-reproducing sequence on a fresh mux: the gateway issues
+// RequestStart, the adapter responds with StreamEventStarted, and the
+// readLoop must NOT drop it as a late response to a cancelled bid.
+// With the v0.6.13 over-extension this test would observe the
+// pre-revert drop log line (see droppedLogToken below for the token
+// pattern) and the pendingStart would not be granted.
+func TestF22_FreshRequestStartGrantNotDroppedAsStale(t *testing.T) {
+	mock := newP3MockTransport()
+
+	var logBuf cancelledStartedLogBuffer
+	logger := log.New(&logBuf, "", 0)
+
+	mux := New(Config{
+		Protocol:        "enh",
+		Network:         "tcp",
+		Address:         "127.0.0.1:0",
+		ReadTimeout:     200 * time.Millisecond,
+		StartDeadline:   200 * time.Millisecond,
+		PendingStartTTL: 24 * time.Hour,
+		SYNInterval:     time.Hour,
+		Logger:          logger,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mux.ctx, mux.cancel = ctx, cancel
+	mux.connMu.Lock()
+	mux.upstream = mock
+	mux.conn = newCancelledStartedConnMock()
+	mux.connMu.Unlock()
+	mux.upstreamFeatures.Store(0x01)
+
+	mux.wg.Add(2)
+	go mux.readLoop()
+	go mux.sendLoop()
+	defer func() {
+		cancel()
+		_ = mock.Close()
+		done := make(chan struct{})
+		go func() { mux.wg.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("mux goroutine drain exceeded 2s")
+		}
+	}()
+
+	// Pretend the absorb safety-net just fired: the pre-revert build
+	// would have opened a post-reset window here. Post-revert the
+	// field is gone, so there is nothing to open. We still set
+	// absorbResetTotal so the test mirrors the live livelock setup.
+	mux.absorbResetTotal.Add(1)
+
+	// Queue the gateway's fresh RequestStart immediately afterwards
+	// (this is exactly what the bus poll loop does in production).
+	gwCh := mux.arb.requestStart(gatewaySessionID, 0x7F)
+
+	// Prime tryGrantAndStart via a SYN byte so the non-blocking path
+	// dispatches RequestStart(0x7F) to the adapter.
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0xAA}
+
+	// The adapter promptly grants the bid via StreamEventStarted with
+	// the same initiator byte. Pre-revert: readLoop would drop this
+	// inside the late-response guard. Post-revert: it flows through
+	// to handleArbitrationResponse and grants ownership.
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventStarted, Data: 0x7F}
+
+	select {
+	case result := <-gwCh:
+		if !result.granted {
+			t.Fatalf("fresh RequestStart was NOT granted (granted=%v cancelled=%v err=%v) — late-response over-extension regression: a STARTED matching the fresh pendingStart was dropped",
+				result.granted, result.cancelled, result.err)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatalf("timed out waiting for STARTED grant — livelock regression. Captured log:\n%s",
+			logBuf.String())
+	}
+
+	if strings.Contains(logBuf.String(), droppedLogToken()) {
+		t.Fatalf("readLoop emitted the pre-revert drop log line for a fresh RequestStart grant — the over-extension was re-introduced. Log:\n%s",
+			logBuf.String())
+	}
+}
+
+// TestF22_NoLivelockAfterReset runs three reset → RequestStart → grant
+// cycles back-to-back. Each cycle must complete: the absorb safety-net
+// counter increment must NOT poison the next fresh RequestStart's grant.
+// Pre-revert this test would hang on cycle 2 or 3 as the persistent
+// post-reset deadline window dropped every subsequent STARTED.
+func TestF22_NoLivelockAfterReset(t *testing.T) {
+	mock := newP3MockTransport()
+
+	mux := New(Config{
+		Protocol:        "enh",
+		Network:         "tcp",
+		Address:         "127.0.0.1:0",
+		ReadTimeout:     200 * time.Millisecond,
+		StartDeadline:   200 * time.Millisecond,
+		PendingStartTTL: 24 * time.Hour,
+		SYNInterval:     time.Hour,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mux.ctx, mux.cancel = ctx, cancel
+	mux.connMu.Lock()
+	mux.upstream = mock
+	mux.conn = newCancelledStartedConnMock()
+	mux.connMu.Unlock()
+	mux.upstreamFeatures.Store(0x01)
+
+	mux.wg.Add(2)
+	go mux.readLoop()
+	go mux.sendLoop()
+	defer func() {
+		cancel()
+		_ = mock.Close()
+		done := make(chan struct{})
+		go func() { mux.wg.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("mux goroutine drain exceeded 2s")
+		}
+	}()
+
+	initiator := byte(0x7F)
+	for cycle := 1; cycle <= 3; cycle++ {
+		// Simulate the absorb-timer firing: bump the reset counter
+		// (the legitimate F-22 side effect).
+		mux.absorbResetTotal.Add(1)
+
+		gwCh := mux.arb.requestStart(gatewaySessionID, initiator)
+
+		// Prime tryGrantAndStart.
+		mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0xAA}
+		// Grant.
+		mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventStarted, Data: initiator}
+
+		select {
+		case result := <-gwCh:
+			if !result.granted {
+				t.Fatalf("cycle %d: fresh RequestStart NOT granted (granted=%v err=%v) — livelock regression at cycle boundary",
+					cycle, result.granted, result.err)
+			}
+		case <-time.After(1 * time.Second):
+			t.Fatalf("cycle %d: timed out waiting for STARTED grant — livelock regression", cycle)
+		}
+
+		// Release ownership so the next cycle can re-acquire.
+		mux.arb.releaseOwnership(gatewaySessionID)
+		mux.stateMu.Lock()
+		mux.gatewayTxnActive = false
+		mux.pendingStart = nil
+		mux.stateMu.Unlock()
+	}
+}
+
+// TestF22_TimeoutResetStillResetsCounterWithoutReconnect re-pins the
+// legitimate F-22 contract that the revert preserves: when the absorb
+// safety-net's deadline fires, the absorb counter resets to zero and
+// the upstream conn is NOT closed. The pre-F-22 reconnect-on-timeout
+// produced the 5/68min reconnect cascade that motivated F-22 in the
+// first place; this test asserts the revert does NOT regress that fix.
+//
+// Mirrors TestF22_AbsorbTimerResetsCounterWithoutReconnect (sibling
+// file f15_am8_deadline_reconnect_test.go) but is named after this
+// revert for explicit linkage in CI failure output.
+func TestF22_TimeoutResetStillResetsCounterWithoutReconnect(t *testing.T) {
+	mock := newP3MockTransport()
+
+	const startDeadline = 200 * time.Millisecond
+
+	mux := New(Config{
+		Protocol:        "enh",
+		Network:         "tcp",
+		Address:         "127.0.0.1:0",
+		ReadTimeout:     200 * time.Millisecond,
+		StartDeadline:   startDeadline,
+		PendingStartTTL: 24 * time.Hour,
+		SYNInterval:     time.Hour,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mux.ctx, mux.cancel = ctx, cancel
+	mux.connMu.Lock()
+	mux.upstream = mock
+	mux.conn = newCancelledStartedConnMock()
+	connMock := mux.conn.(*cancelledStartedConnMock)
+	mux.connMu.Unlock()
+	mux.upstreamFeatures.Store(0x01)
+
+	mux.wg.Add(2)
+	go mux.readLoop()
+	go mux.sendLoop()
+	defer func() {
+		cancel()
+		_ = mock.Close()
+		done := make(chan struct{})
+		go func() { mux.wg.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("mux goroutine drain exceeded 2s")
+		}
+	}()
+
+	// Submit a START with no adapter response so the AM8 deadline →
+	// absorb-timer chain fires.
+	_ = mux.arb.requestStart(gatewaySessionID, 0x71)
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0xAA}
+
+	// Wait for the AM8 deadline; the sibling test asserts the no-
+	// reconnect contract here. Sleep slightly past it so the absorb
+	// timer is armed.
+	time.Sleep(startDeadline + 30*time.Millisecond)
+
+	priorReset := mux.absorbResetTotal.Load()
+	deadlineWait := time.Now().Add(2*startDeadline + 1500*time.Millisecond)
+	for time.Now().Before(deadlineWait) {
+		if mux.absorbResetTotal.Load() > priorReset {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if got := mux.absorbResetTotal.Load(); got <= priorReset {
+		t.Fatalf("legitimate F-22 absorb-reset did NOT fire (absorbResetTotal stayed at %d) after %v",
+			got, 2*startDeadline+1500*time.Millisecond)
+	}
+	if connMock.closed.Load() {
+		t.Fatal("F-22 regression: absorb safety-net closed the upstream conn — the post-F-22 contract is counter-reset only, NO transport reconnect. The revert must preserve this invariant.")
+	}
+
+	mux.stateMu.Lock()
+	stillBlocked := mux.pendingStartAbsorb
+	mux.stateMu.Unlock()
+	if stillBlocked != 0 {
+		t.Fatalf("pendingStartAbsorb = %d after safety-net fire; want 0", stillBlocked)
+	}
+}
+
+// TestF22_NoStaleAbsorbWindowFieldsRemain catches orphan field
+// reintroduction. Any future change that adds a field on the Mux
+// struct whose name starts with one of the forbidden prefixes (built
+// via string concatenation in forbiddenAbsorbFieldPrefixes for grep
+// hygiene — see file header) will fail this test.
+func TestF22_NoStaleAbsorbWindowFieldsRemain(t *testing.T) {
+	muxType := reflect.TypeOf(Mux{})
+	forbiddenPrefixes := forbiddenAbsorbFieldPrefixes()
+
+	for i := 0; i < muxType.NumField(); i++ {
+		f := muxType.Field(i)
+		for _, prefix := range forbiddenPrefixes {
+			if strings.HasPrefix(f.Name, prefix) {
+				t.Fatalf("Mux struct field %q matches forbidden prefix %q — the v0.6.13 over-extension was re-introduced. The livelock was caused by exactly this mechanism; see absorb_timeout_revert_test.go header comment for the 6-line live evidence.",
+					f.Name, prefix)
+			}
+		}
+	}
+}
+
+// TestF22_F15RegressionGuard_AM8BlockingPathReconnects is a structural
+// guard ensuring the revert did NOT accidentally remove F-15's blocking-
+// path AM8 deadline reconnect logic. The full behavioral test lives at
+// f15_am8_deadline_reconnect_test.go::TestAM8Deadline_BlockingPath_StillReconnects.
+// Here we assert the dependent struct fields and pending-state shape
+// remain so the deadline callback can still tell blocking from non-
+// blocking dispatch.
+func TestF22_F15RegressionGuard_AM8BlockingPathReconnects(t *testing.T) {
+	// pendingStartState.blockingArb is the field the AM8 deadline
+	// callback inspects to decide whether to close the upstream
+	// transport. The revert must NOT touch it.
+	pssType := reflect.TypeOf(pendingStartState{})
+	if _, ok := pssType.FieldByName("blockingArb"); !ok {
+		t.Fatal("pendingStartState.blockingArb missing — F-15 regression: the AM8 deadline callback can no longer detect the blocking-path requirement to reconnect. The revert must not remove this field.")
+	}
+
+	// blockingArbActive on the mux is the gate that tryGrantAndStart
+	// honors when a blocking goroutine is still in-flight. Removing
+	// this would re-introduce double-dispatch on the blocking path.
+	muxType := reflect.TypeOf(Mux{})
+	if _, ok := muxType.FieldByName("blockingArbActive"); !ok {
+		t.Fatal("Mux.blockingArbActive missing — F-15 regression: the blocking StartArbitration in-flight gate was deleted.")
+	}
+	if _, ok := muxType.FieldByName("blockingArbGen"); !ok {
+		t.Fatal("Mux.blockingArbGen missing — F-15 regression: the blocking-path generation counter was deleted; stale goroutines could clear blockingArbActive out of turn.")
+	}
+}
+
+// TestF22_LegitimateAbsorptionViaExistingPath confirms the EXISTING
+// (untouched by the revert) absorb-counter-decrement path still
+// handles legitimate stale responses to ACTIVE pending requests. The
+// scenario: cancelPendingStart cleared a pending request, incremented
+// pendingStartAbsorb to 1, and the adapter then delivered the late
+// STARTED/FAILED for that cancelled bid. The mux must absorb it
+// (decrement the counter) and MUST NOT route it to any session.
+//
+// This is what Codex P1 on PR #632 was trying to defend against in the
+// first place; the revert preserves the legitimate counter-decrement
+// path (the only one needed in practice) and removes the over-
+// extension that broke fresh grants.
+func TestF22_LegitimateAbsorptionViaExistingPath(t *testing.T) {
+	mock := newP3MockTransport()
+
+	var logBuf cancelledStartedLogBuffer
+	logger := log.New(&logBuf, "", 0)
+
+	mux := New(Config{
+		Protocol:        "enh",
+		Network:         "tcp",
+		Address:         "127.0.0.1:0",
+		ReadTimeout:     200 * time.Millisecond,
+		StartDeadline:   200 * time.Millisecond,
+		PendingStartTTL: 24 * time.Hour,
+		SYNInterval:     time.Hour,
+		Logger:          logger,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mux.ctx, mux.cancel = ctx, cancel
+	mux.connMu.Lock()
+	mux.upstream = mock
+	mux.conn = newCancelledStartedConnMock()
+	mux.connMu.Unlock()
+	mux.upstreamFeatures.Store(0x01)
+
+	mux.wg.Add(2)
+	go mux.readLoop()
+	go mux.sendLoop()
+	defer func() {
+		cancel()
+		_ = mock.Close()
+		done := make(chan struct{})
+		go func() { mux.wg.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("mux goroutine drain exceeded 2s")
+		}
+	}()
+
+	// Pre-seed the absorb-counter directly: simulates that
+	// cancelPendingStart fired and is now waiting for one stale
+	// response from the cancelled bid.
+	mux.stateMu.Lock()
+	mux.pendingStartAbsorb = 1
+	mux.stateMu.Unlock()
+
+	// Adapter delivers the late FAILED for the cancelled bid.
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventFailed, Data: 0x42}
+
+	// Give the readLoop a moment to process.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		mux.stateMu.Lock()
+		c := mux.pendingStartAbsorb
+		mux.stateMu.Unlock()
+		if c == 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	mux.stateMu.Lock()
+	final := mux.pendingStartAbsorb
+	mux.stateMu.Unlock()
+
+	if final != 0 {
+		t.Fatalf("legitimate late-FAILED was NOT absorbed: pendingStartAbsorb=%d (want 0). The counter-decrement path in handleArbitrationResponse must remain functional after the revert. Captured log:\n%s",
+			final, logBuf.String())
+	}
+
+	// The pre-revert drop log line must not appear — that path is gone.
+	if strings.Contains(logBuf.String(), droppedLogToken()) {
+		t.Fatalf("pre-revert drop log line appeared — the over-extended mechanism was re-introduced. Log:\n%s",
+			logBuf.String())
+	}
+	// Nor the in-handleArbitrationResponse window-absorb log line.
+	if strings.Contains(logBuf.String(), windowAbsorbedLogToken()) {
+		t.Fatalf("pre-revert window-absorb log line appeared — handleArbitrationResponse's window helper was re-introduced. Log:\n%s",
+			logBuf.String())
+	}
+}

--- a/internal/adaptermux/arbitration.go
+++ b/internal/adaptermux/arbitration.go
@@ -93,19 +93,35 @@ type arbitrator struct {
 	// START before tryGrant drops + rejects it with errStaleStartRequest.
 	// Zero disables the policy. Configured via Mux.cfg.PendingStartTTL.
 	pendingStartTTL time.Duration
+
+	// fairnessRatio is the every-Nth grant that goes to external FIFO
+	// when both gateway and ≥1 external session have pending START
+	// requests. Configured via Mux.cfg.FairnessRatio; defaults to 2.
+	// 0 maps to DefaultFairnessRatio in setPolicy().
+	fairnessRatio int
 }
 
-// FairnessRatio is the every-Nth grant that goes to external FIFO when
-// both gateway and ≥1 external session have pending START requests.
-// Default 4 = ~25% of grants under contention go to external,
-// bounding worst-case external START latency to ~4 gateway-transaction
-// windows (typical 200–300 ms each → ~1 s worst case, well within
-// ebusd's ~4.5 s per-scan-iteration deadline).
+// DefaultFairnessRatio is the every-Nth grant that goes to external FIFO
+// when both gateway and ≥1 external session have pending START requests.
+// Default 2 = 50/50 split under contention.
 //
-// Constant for now; can be promoted to a config field if operators
-// need to tune the balance between gateway poll-window jitter and
-// external client throughput.
-const FairnessRatio = 4
+// F-25 (batch-22, iter2, 2026-05-14): lowered from 4 to 2 in response
+// to live evidence that the gateway-favoring 25%-external ratio
+// starved ebusd of bus slots during tight-scan-08 loops. Pre-F-25
+// measurements (iter1 with F-22 revert + F-21 + F-24 inert):
+//   - tight-scan success: 8-18% over 60 attempts vs 95% target
+//   - ebusd `arbitration won in invalid state`: 33 / 12 min
+//   - gateway grants: 1.6 tx/sec; ebusd won 28% of 329 START attempts.
+//
+// At ratio=2, ebusd should win ~50% of contended slots, giving its
+// bus state machine larger inter-gateway-poll windows and reducing
+// the ENH_RES_STARTED-arrives-in-bs_recvCmd collision rate.
+//
+// Tradeoff: gateway poll throughput halves under sustained external
+// contention. Acceptable: scans are bursts, steady-state polling
+// resumes when external sessions go quiet. Operator can tune via
+// Mux.cfg.FairnessRatio.
+const DefaultFairnessRatio = 2
 
 // startRequest represents a pending START arbitration request.
 type startRequest struct {
@@ -266,9 +282,18 @@ func (a *arbitrator) now() time.Time {
 
 // setPolicy injects per-cycle policy fields the mux derives from
 // Config. Called once on mux construction.
-func (a *arbitrator) setPolicy(pendingStartTTL time.Duration) {
+//
+// F-25 (batch-22, iter2): accepts fairnessRatio. 0 maps to
+// DefaultFairnessRatio inside tryGrant; negative values are clamped
+// to DefaultFairnessRatio (defensive; legacy behaviour preferred
+// over starvation).
+func (a *arbitrator) setPolicy(pendingStartTTL time.Duration, fairnessRatio int) {
 	a.mu.Lock()
 	a.pendingStartTTL = pendingStartTTL
+	if fairnessRatio < 0 {
+		fairnessRatio = DefaultFairnessRatio
+	}
+	a.fairnessRatio = fairnessRatio
 	a.mu.Unlock()
 }
 
@@ -375,7 +400,11 @@ func (a *arbitrator) tryGrant(busIdle bool) (req *startRequest, granted bool) {
 	preferExternalThisGrant := false
 	if gatewayPending && externalPending {
 		a.fairnessCounter++
-		if a.fairnessCounter >= FairnessRatio {
+		ratio := a.fairnessRatio
+		if ratio <= 0 {
+			ratio = DefaultFairnessRatio
+		}
+		if a.fairnessCounter >= ratio {
 			a.fairnessCounter = 0
 			preferExternalThisGrant = true
 		}

--- a/internal/adaptermux/arbitration.go
+++ b/internal/adaptermux/arbitration.go
@@ -99,6 +99,22 @@ type arbitrator struct {
 	// requests. Configured via Mux.cfg.FairnessRatio; defaults to 2.
 	// 0 maps to DefaultFairnessRatio in setPolicy().
 	fairnessRatio int
+
+	// F-28 (batch-25, iter5, 2026-05-14): post-external-release
+	// cooldown. When an external session releases bus ownership,
+	// this timestamp is set to now. While `time.Since(lastExternalReleaseAt)
+	// < postExternalGrace`, tryGrant defers gateway-only grants
+	// (returns no-grant) so the gateway's tight semantic-poll loop
+	// cannot race ebusd's TCP-delayed next START.
+	//
+	// Live evidence: byte-trace measured the race at every external
+	// session release — gateway re-bids within µs while ebusd's next
+	// ENH_REQ_START arrives 10-100ms later via TCP. Pre-F-28 the
+	// gateway nearly always wins this race, queuing ebusd behind its
+	// own next transaction and producing the 200-500ms median latency
+	// observed in iter5 (post-F-27).
+	lastExternalReleaseAt time.Time
+	postExternalGrace     time.Duration
 }
 
 // DefaultFairnessRatio is the every-Nth grant that goes to external FIFO
@@ -283,17 +299,21 @@ func (a *arbitrator) now() time.Time {
 // setPolicy injects per-cycle policy fields the mux derives from
 // Config. Called once on mux construction.
 //
-// F-25 (batch-22, iter2): accepts fairnessRatio. 0 maps to
-// DefaultFairnessRatio inside tryGrant; negative values are clamped
-// to DefaultFairnessRatio (defensive; legacy behaviour preferred
-// over starvation).
-func (a *arbitrator) setPolicy(pendingStartTTL time.Duration, fairnessRatio int) {
+// F-25 (batch-22, iter2): accepts fairnessRatio.
+// F-28 (batch-25, iter5): accepts postExternalGrace.
+//
+// Zero/negative sentinels:
+//   - fairnessRatio: 0 or negative → DefaultFairnessRatio (2)
+//   - postExternalGrace: 0 → use mux-default (50ms); negative → disable
+//     the cooldown entirely
+func (a *arbitrator) setPolicy(pendingStartTTL time.Duration, fairnessRatio int, postExternalGrace time.Duration) {
 	a.mu.Lock()
 	a.pendingStartTTL = pendingStartTTL
 	if fairnessRatio < 0 {
 		fairnessRatio = DefaultFairnessRatio
 	}
 	a.fairnessRatio = fairnessRatio
+	a.postExternalGrace = postExternalGrace
 	a.mu.Unlock()
 }
 
@@ -411,6 +431,27 @@ func (a *arbitrator) tryGrant(busIdle bool) (req *startRequest, granted bool) {
 	}
 
 	if gatewayPending && !preferExternalThisGrant {
+		// F-28 (batch-25, iter5, 2026-05-14): post-external-release
+		// cooldown. If an external session released bus ownership
+		// within `postExternalGrace` of now, defer the gateway grant
+		// so ebusd's TCP-delayed next ENH_REQ_START has a window to
+		// arrive and be queued before the gateway re-claims the bus.
+		// Without this, the gateway's semantic poll loop (which can
+		// submit a new RequestStart within microseconds of release
+		// via the in-process scheduler) outraces ebusd's next TCP
+		// request and locks ebusd into a serialized-behind-gateway
+		// queue, producing the 200-500ms median pre-F-28 latency.
+		//
+		// The check is intentionally inside tryGrant — caller
+		// (tryGrantAndStart) is invoked on every SYN observation, so
+		// a no-grant return causes a quick (~4.5ms) retry. After
+		// postExternalGrace elapses, the gateway grant fires
+		// normally. Net effect: a brief "polite yield" window after
+		// every ebusd transaction.
+		if a.postExternalGrace > 0 && !a.lastExternalReleaseAt.IsZero() &&
+			a.now().Sub(a.lastExternalReleaseAt) < a.postExternalGrace {
+			return nil, false
+		}
 		gw := a.pendingGateway
 		a.pendingGateway = nil
 		return gw, true
@@ -482,6 +523,14 @@ func (a *arbitrator) releaseOwnership(sessionID uint64) {
 		a.hasOwner = false
 		a.currentOwner = 0
 		a.currentInitiator = 0
+		// F-28 (batch-25, iter5): when an EXTERNAL session releases
+		// ownership, start the post-external-release cooldown so the
+		// gateway's semantic poll loop can't race ebusd's TCP-delayed
+		// next START. Gateway-session-0 releases do NOT trigger the
+		// cooldown (no race exists for gateway-after-gateway).
+		if sessionID != gatewaySessionID {
+			a.lastExternalReleaseAt = a.now()
+		}
 	}
 }
 

--- a/internal/adaptermux/arbitration.go
+++ b/internal/adaptermux/arbitration.go
@@ -520,6 +520,24 @@ func (a *arbitrator) hasPending() bool {
 	return a.pendingGateway != nil || len(a.pendingExternal) > 0
 }
 
+// hasExternalPending reports whether at least one external-session START
+// request is queued. F-26 (batch-23, iter3, 2026-05-14): used by the
+// SYN-idle release path to skip the gateway's IdleReleaseGrace when an
+// external bidder (e.g. ebusd) is already waiting. Without this gate,
+// the gateway holds bus ownership for the full 200 ms grace period
+// after its own transaction completes, even though the bus has been
+// physically idle and an external START is queued. The wire-byte
+// trace measured median 596 ms / p95 4.2 s latency between ebusd's
+// ENH_REQ_START and the gateway's ENH_RES_STARTED for this exact
+// reason, with 100/260 paired events landing in the 1-5 s bucket —
+// far past ebusd's arbitration-wait timeout, producing the
+// `arbitration won in invalid state` cascade.
+func (a *arbitrator) hasExternalPending() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.pendingExternal) > 0
+}
+
 // failAllPending fails all pending START requests (e.g., on shutdown
 // or adapter RESETTED).
 //

--- a/internal/adaptermux/arbitration_busidle_test.go
+++ b/internal/adaptermux/arbitration_busidle_test.go
@@ -15,7 +15,7 @@ import (
 // gateway, even when no contention exists.
 func TestTryGrant_BusIdle_ExternalPreemptsFairnessWindow(t *testing.T) {
 	arb := newArbitrator()
-	arb.setPolicy(24 * time.Hour) // disable C3 TTL for this test
+	arb.setPolicy(24 * time.Hour, 0) // disable C3 TTL for this test
 
 	// Both classes pending — same shape as the legacy fairness test.
 	_ = arb.requestStart(gatewaySessionID, 0x71)
@@ -45,7 +45,7 @@ func TestTryGrant_BusIdle_ExternalPreemptsFairnessWindow(t *testing.T) {
 // branch grants normally.
 func TestTryGrant_BusIdle_GatewayOnly_StillGranted(t *testing.T) {
 	arb := newArbitrator()
-	arb.setPolicy(24 * time.Hour)
+	arb.setPolicy(24 * time.Hour, 0)
 
 	_ = arb.requestStart(gatewaySessionID, 0x71)
 
@@ -60,11 +60,11 @@ func TestTryGrant_BusIdle_GatewayOnly_StillGranted(t *testing.T) {
 
 // TestTryGrant_NotIdle_GatewayPriorityPreserved ensures the C1 fast
 // path is GATED on busIdle — when the bus is actively contended
-// (busIdle=false), gateway-priority + FairnessRatio rotation apply
+// (busIdle=false), gateway-priority + DefaultFairnessRatio rotation apply
 // unchanged. This is the regression guard for the legacy semantic.
 func TestTryGrant_NotIdle_GatewayPriorityPreserved(t *testing.T) {
 	arb := newArbitrator()
-	arb.setPolicy(24 * time.Hour)
+	arb.setPolicy(24 * time.Hour, 0)
 
 	_ = arb.requestStart(gatewaySessionID, 0x71)
 	_ = arb.requestStart(1, 0x31)
@@ -90,7 +90,7 @@ func TestPendingExternalTTL_StaleEntryRejected(t *testing.T) {
 	base := time.Now()
 	clock := base
 	arb.nowFn = func() time.Time { return clock }
-	arb.setPolicy(50 * time.Millisecond)
+	arb.setPolicy(50 * time.Millisecond, 0)
 
 	// Stale entry first.
 	staleCh := arb.requestStart(1, 0x31)
@@ -141,7 +141,7 @@ func TestPendingExternalTTL_StaleEntryRejected(t *testing.T) {
 // abandoned request.
 func TestRequestStart_ReplaceMarksCancelledFlag(t *testing.T) {
 	arb := newArbitrator()
-	arb.setPolicy(24 * time.Hour)
+	arb.setPolicy(24 * time.Hour, 0)
 
 	// Reach into pendingExternal to grab the pointer before replace.
 	_ = arb.requestStart(1, 0x31)

--- a/internal/adaptermux/arbitration_busidle_test.go
+++ b/internal/adaptermux/arbitration_busidle_test.go
@@ -15,7 +15,7 @@ import (
 // gateway, even when no contention exists.
 func TestTryGrant_BusIdle_ExternalPreemptsFairnessWindow(t *testing.T) {
 	arb := newArbitrator()
-	arb.setPolicy(24 * time.Hour, 0) // disable C3 TTL for this test
+	arb.setPolicy(24 * time.Hour, 0, 0) // disable C3 TTL for this test
 
 	// Both classes pending — same shape as the legacy fairness test.
 	_ = arb.requestStart(gatewaySessionID, 0x71)
@@ -45,7 +45,7 @@ func TestTryGrant_BusIdle_ExternalPreemptsFairnessWindow(t *testing.T) {
 // branch grants normally.
 func TestTryGrant_BusIdle_GatewayOnly_StillGranted(t *testing.T) {
 	arb := newArbitrator()
-	arb.setPolicy(24 * time.Hour, 0)
+	arb.setPolicy(24 * time.Hour, 0, 0)
 
 	_ = arb.requestStart(gatewaySessionID, 0x71)
 
@@ -64,7 +64,7 @@ func TestTryGrant_BusIdle_GatewayOnly_StillGranted(t *testing.T) {
 // unchanged. This is the regression guard for the legacy semantic.
 func TestTryGrant_NotIdle_GatewayPriorityPreserved(t *testing.T) {
 	arb := newArbitrator()
-	arb.setPolicy(24 * time.Hour, 0)
+	arb.setPolicy(24 * time.Hour, 0, 0)
 
 	_ = arb.requestStart(gatewaySessionID, 0x71)
 	_ = arb.requestStart(1, 0x31)
@@ -90,7 +90,7 @@ func TestPendingExternalTTL_StaleEntryRejected(t *testing.T) {
 	base := time.Now()
 	clock := base
 	arb.nowFn = func() time.Time { return clock }
-	arb.setPolicy(50 * time.Millisecond, 0)
+	arb.setPolicy(50 * time.Millisecond, 0, 0)
 
 	// Stale entry first.
 	staleCh := arb.requestStart(1, 0x31)
@@ -141,7 +141,7 @@ func TestPendingExternalTTL_StaleEntryRejected(t *testing.T) {
 // abandoned request.
 func TestRequestStart_ReplaceMarksCancelledFlag(t *testing.T) {
 	arb := newArbitrator()
-	arb.setPolicy(24 * time.Hour, 0)
+	arb.setPolicy(24 * time.Hour, 0, 0)
 
 	// Reach into pendingExternal to grab the pointer before replace.
 	_ = arb.requestStart(1, 0x31)

--- a/internal/adaptermux/arbitration_test.go
+++ b/internal/adaptermux/arbitration_test.go
@@ -402,15 +402,15 @@ func TestArbitrator_DuplicateReplaceCarriesInitiator(t *testing.T) {
 
 // TestArbitrator_FairnessWindow_ExternalGetsEveryNthGrant verifies the
 // adaptive fairness rotation: when BOTH gateway and external have
-// continuously-renewed pending START requests, every FairnessRatio'th
+// continuously-renewed pending START requests, every DefaultFairnessRatio'th
 // grant goes to external FIFO instead of gateway. This bounds the
-// worst-case external START latency to ~FairnessRatio gateway-transaction
+// worst-case external START latency to ~DefaultFairnessRatio gateway-transaction
 // windows so ebusd can complete its initial scan despite continuous
 // semantic poller activity.
 func TestArbitrator_FairnessWindow_ExternalGetsEveryNthGrant(t *testing.T) {
 	arb := newArbitrator()
 
-	totalRounds := FairnessRatio * 3 // 3 full fairness cycles
+	totalRounds := DefaultFairnessRatio * 3 // 3 full fairness cycles
 	gatewayGrants := 0
 	externalGrants := 0
 
@@ -446,12 +446,14 @@ func TestArbitrator_FairnessWindow_ExternalGetsEveryNthGrant(t *testing.T) {
 		arb.releaseOwnership(sessionID)
 	}
 
-	// Expect exactly 3 external grants out of 12 total (every 4th).
-	wantExternal := totalRounds / FairnessRatio
+	// Expect totalRounds/DefaultFairnessRatio external grants.
+	// At ratio=2 (F-25 default): 3 external grants out of 6 rounds.
+	// At ratio=4 (legacy): 3 external grants out of 12 rounds.
+	wantExternal := totalRounds / DefaultFairnessRatio
 	wantGateway := totalRounds - wantExternal
 	if externalGrants != wantExternal {
 		t.Errorf("externalGrants = %d; want %d (1-in-%d fairness over %d rounds)",
-			externalGrants, wantExternal, FairnessRatio, totalRounds)
+			externalGrants, wantExternal, DefaultFairnessRatio, totalRounds)
 	}
 	if gatewayGrants != wantGateway {
 		t.Errorf("gatewayGrants = %d; want %d", gatewayGrants, wantGateway)
@@ -465,7 +467,7 @@ func TestArbitrator_FairnessWindow_ExternalGetsEveryNthGrant(t *testing.T) {
 func TestArbitrator_FairnessWindow_NoOpWhenNoExternal(t *testing.T) {
 	arb := newArbitrator()
 
-	for i := 0; i < FairnessRatio*5; i++ {
+	for i := 0; i < DefaultFairnessRatio*5; i++ {
 		gwCh := arb.requestStart(gatewaySessionID, 0x71)
 		sessionID, _, notify, granted := tryGrantLegacy(arb)
 		if !granted || sessionID != gatewaySessionID {

--- a/internal/adaptermux/echo_passthrough_test.go
+++ b/internal/adaptermux/echo_passthrough_test.go
@@ -255,17 +255,21 @@ func TestExternalSession_PhaseAdvance_FullFrame(t *testing.T) {
 	// behavior that becomes "live" under F-18 for external owners.
 	tracker.reset(wirePhaseCollectRequest)
 
-	// A complete eBUS transaction (request + ACK + response + ACK).
+	// A complete eBUS transaction (request + ACK + response + ACK + SYN).
 	// LEN=2 keeps it short. DST=0x08 (a non-initiator boiler address)
 	// so the WaitCmdAck branch transitions to WaitResponseLen rather
 	// than short-circuiting on broadcast or i2i.
 	//
-	// Phase progression:
-	//   CollectRequest → WaitCmdAck     (RequestComplete after LEN+DATA+CRC)
-	//   WaitCmdAck     → WaitResponseLen(CmdACK)
-	//   WaitResponseLen→ WaitResponseBody(LEN consumed)
-	//   WaitResponseBody → WaitResponseAck(ResponseDone after DATA+CRC)
-	//   WaitResponseAck→ Idle           (TransactionDone via final ACK)
+	// Phase progression (F-21, batch-20):
+	//   CollectRequest    → WaitCmdAck       (RequestComplete after LEN+DATA+CRC)
+	//   WaitCmdAck        → WaitResponseLen  (CmdACK)
+	//   WaitResponseLen   → WaitResponseBody (LEN consumed)
+	//   WaitResponseBody  → WaitResponseAck  (ResponseDone after DATA+CRC)
+	//   WaitResponseAck   → WaitTerminalSyn  (final ACK — pre-F-21 fired
+	//                                          TransactionDone at this byte
+	//                                          and reset to Idle; F-21 defers
+	//                                          to trailing SYN)
+	//   WaitTerminalSyn   → Idle             (TransactionDone via trailing SYN)
 	frame := []byte{
 		0x31, // SRC (initiator) — captured by CollectRequest
 		0x08, // DST
@@ -280,7 +284,8 @@ func TestExternalSession_PhaseAdvance_FullFrame(t *testing.T) {
 		0x56, // response DATA[0]
 		0x78, // response DATA[1]
 		0xAB, // response CRC (placeholder)
-		0x00, // final ACK
+		0x00, // final ACK   → F-21: None + WaitTerminalSyn
+		0xAA, // trailing SYN → F-21: TransactionDone + Idle
 	}
 
 	var sawRequestComplete, sawCmdACK, sawResponseDone, sawTransactionDone bool
@@ -467,25 +472,31 @@ func TestDeliverToSessions_NoReorderUnderBurst(t *testing.T) {
 // because ebusd never wrote frame bodies (the F-17 retry loop
 // blocked the first SEND). Post-F-18 the tracker is live during
 // external ownership and `wirePhaseEventTransactionDone` actually
-// fires at mux.go:~1746-1767 → releases ownership → kicks
-// tryGrantAndStart. This integration test exercises that exact
-// path end-to-end:
+// fires → releases ownership → kicks tryGrantAndStart.
+//
+// F-21 (batch-20): TransactionDone now fires at the TRAILING SYN, not
+// at the final ACK byte. This integration test was extended with the
+// trailing-SYN byte at the end of the frame and the boundary
+// assertions now require ownership to be held through the final ACK
+// (which under F-21 transitions to WaitTerminalSyn rather than
+// releasing) and released only at the SYN.
 //
 //  1. Install external session, give it ownership through the
 //     real arbitration path (requestStart → tryGrant → confirmOwnership).
 //  2. Initialize m.phase via startRequestWithSource as the production
-//     grant code does at mux.go:2813.
-//  3. Feed a complete request/response sequence through
-//     mux.onReceived(byte, false) one byte at a time.
+//     grant code does at mux.go's grant path.
+//  3. Feed a complete request/response sequence — including the
+//     trailing wire SYN — through mux.onReceived(byte, false).
 //  4. Assert at each step:
 //     a. Owner session receives each byte (F-18 contract).
-//     b. Ownership held until the final ACK.
-//     c. Ownership released exactly when TransactionDone fires.
+//     b. Ownership held until the trailing SYN (NOT the final ACK,
+//        per F-21).
+//     c. Ownership released exactly at the SYN observation.
 //     d. After release, m.phase is back at Idle.
 //
 // This pins the C3.1 risk: external owners now drive phase to
 // TransactionDone, which must NOT prematurely rip ownership
-// mid-frame and MUST release cleanly on the final ACK.
+// mid-frame and MUST release cleanly on the trailing SYN.
 func TestExternalSession_OnReceivedIntegration_FullFrame(t *testing.T) {
 	mux, muxCancel := newF18TestMux(t)
 	defer muxCancel()
@@ -528,6 +539,11 @@ func TestExternalSession_OnReceivedIntegration_FullFrame(t *testing.T) {
 	// DST=0x08 (non-broadcast, non-initiator) so the WaitCmdAck →
 	// WaitResponseLen branch fires (not the short-circuit broadcast
 	// or i2i transitions).
+	// F-21 (batch-20): the trailing wire SYN at the end of the frame
+	// is what now drives TransactionDone → release. Pre-F-21 the
+	// final-ACK byte (0x00) released ownership directly; post-F-21
+	// the final ACK only transitions phase to WaitTerminalSyn and the
+	// trailing SYN observation is the real terminator.
 	frameAfterSrc := []byte{
 		0x08, // DST
 		0xB5, // PB
@@ -541,7 +557,8 @@ func TestExternalSession_OnReceivedIntegration_FullFrame(t *testing.T) {
 		0x56, // response DATA[0]
 		0x78, // response DATA[1]
 		0xAB, // response CRC
-		0x00, // final ACK — triggers TransactionDone → release
+		0x00, // final ACK — F-21: transitions phase to WaitTerminalSyn
+		0xAA, // trailing SYN — F-21: triggers TransactionDone → release
 	}
 
 	// Concurrently drain the client pipe so deliverReceived doesn't
@@ -566,11 +583,10 @@ func TestExternalSession_OnReceivedIntegration_FullFrame(t *testing.T) {
 		}
 	}
 
-	// After the final ACK, ownership must have been released
-	// (mux.go:~1746-1767 path: TransactionDone → releaseOwnership
-	// → tryGrantAndStart).
+	// F-21 (batch-20): after the trailing SYN, ownership must have
+	// been released via onSYNLocked's TransactionDone branch.
 	if mux.arb.isOwner(51) {
-		t.Fatal("ownership not released after TransactionDone — F-18 risk C3.1: phase tracker became live for external owners and the release path must fire on final ACK")
+		t.Fatal("ownership not released after trailing-SYN TransactionDone — F-21 risk: the SYN-branch release in onSYNLocked failed to fire")
 	}
 
 	// Phase tracker must be back at Idle.

--- a/internal/adaptermux/f17_cancelled_result_flag_test.go
+++ b/internal/adaptermux/f17_cancelled_result_flag_test.go
@@ -32,7 +32,7 @@ import (
 func TestArbitrator_SameSessionReplace_StartResultCarriesCancelledFlag(t *testing.T) {
 	t.Run("external_session_replace", func(t *testing.T) {
 		arb := newArbitrator()
-		arb.setPolicy(24 * time.Hour) // disable C3 TTL for this test
+		arb.setPolicy(24 * time.Hour, 0) // disable C3 TTL for this test
 
 		chOld := arb.requestStart(1, 0x31)
 		_ = arb.requestStart(1, 0x32) // replaces chOld in pendingExternal
@@ -55,7 +55,7 @@ func TestArbitrator_SameSessionReplace_StartResultCarriesCancelledFlag(t *testin
 
 	t.Run("gateway_session_replace", func(t *testing.T) {
 		arb := newArbitrator()
-		arb.setPolicy(24 * time.Hour)
+		arb.setPolicy(24 * time.Hour, 0)
 
 		chOld := arb.requestStart(gatewaySessionID, 0x71)
 		_ = arb.requestStart(gatewaySessionID, 0x72) // replaces pendingGateway
@@ -84,7 +84,7 @@ func TestArbitrator_SameSessionReplace_StartResultCarriesCancelledFlag(t *testin
 // is not regressed.
 func TestArbitrator_SameSessionReplace_StructFlagAlsoSet(t *testing.T) {
 	arb := newArbitrator()
-	arb.setPolicy(24 * time.Hour)
+	arb.setPolicy(24 * time.Hour, 0)
 
 	_ = arb.requestStart(1, 0x31)
 	arb.mu.Lock()

--- a/internal/adaptermux/f17_cancelled_result_flag_test.go
+++ b/internal/adaptermux/f17_cancelled_result_flag_test.go
@@ -32,7 +32,7 @@ import (
 func TestArbitrator_SameSessionReplace_StartResultCarriesCancelledFlag(t *testing.T) {
 	t.Run("external_session_replace", func(t *testing.T) {
 		arb := newArbitrator()
-		arb.setPolicy(24 * time.Hour, 0) // disable C3 TTL for this test
+		arb.setPolicy(24 * time.Hour, 0, 0) // disable C3 TTL for this test
 
 		chOld := arb.requestStart(1, 0x31)
 		_ = arb.requestStart(1, 0x32) // replaces chOld in pendingExternal
@@ -55,7 +55,7 @@ func TestArbitrator_SameSessionReplace_StartResultCarriesCancelledFlag(t *testin
 
 	t.Run("gateway_session_replace", func(t *testing.T) {
 		arb := newArbitrator()
-		arb.setPolicy(24 * time.Hour, 0)
+		arb.setPolicy(24 * time.Hour, 0, 0)
 
 		chOld := arb.requestStart(gatewaySessionID, 0x71)
 		_ = arb.requestStart(gatewaySessionID, 0x72) // replaces pendingGateway
@@ -84,7 +84,7 @@ func TestArbitrator_SameSessionReplace_StartResultCarriesCancelledFlag(t *testin
 // is not regressed.
 func TestArbitrator_SameSessionReplace_StructFlagAlsoSet(t *testing.T) {
 	arb := newArbitrator()
-	arb.setPolicy(24 * time.Hour, 0)
+	arb.setPolicy(24 * time.Hour, 0, 0)
 
 	_ = arb.requestStart(1, 0x31)
 	arb.mu.Lock()

--- a/internal/adaptermux/f17_review_round1_test.go
+++ b/internal/adaptermux/f17_review_round1_test.go
@@ -180,7 +180,7 @@ func TestHandleArbitrationResponse_InFlightCancelled_FAILED_LogMarksSuppression(
 // cancelled=true so handleStart silent-returns.
 func TestArbitrator_CancelStart_ExternalSession_SetsCancelledFlag(t *testing.T) {
 	arb := newArbitrator()
-	arb.setPolicy(24 * time.Hour)
+	arb.setPolicy(24 * time.Hour, 0)
 
 	ch := arb.requestStart(1, 0x31)
 	if !arb.cancelStart(1) {
@@ -207,7 +207,7 @@ func TestArbitrator_CancelStart_ExternalSession_SetsCancelledFlag(t *testing.T) 
 // for the gateway-session path. Same contract as the external path.
 func TestArbitrator_CancelStart_GatewaySession_SetsCancelledFlag(t *testing.T) {
 	arb := newArbitrator()
-	arb.setPolicy(24 * time.Hour)
+	arb.setPolicy(24 * time.Hour, 0)
 
 	ch := arb.requestStart(gatewaySessionID, 0x71)
 	if !arb.cancelStart(gatewaySessionID) {
@@ -310,7 +310,7 @@ func TestHandleArbitrationResponse_InFlightCancelled_AM56Mismatch_SuppressedSile
 // late-STARTED suppression path), so cancelStart must set both flags.
 func TestArbitrator_CancelStart_AlsoSetsStructFlag(t *testing.T) {
 	arb := newArbitrator()
-	arb.setPolicy(24 * time.Hour)
+	arb.setPolicy(24 * time.Hour, 0)
 
 	_ = arb.requestStart(1, 0x31)
 	arb.mu.Lock()

--- a/internal/adaptermux/f17_review_round1_test.go
+++ b/internal/adaptermux/f17_review_round1_test.go
@@ -180,7 +180,7 @@ func TestHandleArbitrationResponse_InFlightCancelled_FAILED_LogMarksSuppression(
 // cancelled=true so handleStart silent-returns.
 func TestArbitrator_CancelStart_ExternalSession_SetsCancelledFlag(t *testing.T) {
 	arb := newArbitrator()
-	arb.setPolicy(24 * time.Hour, 0)
+	arb.setPolicy(24 * time.Hour, 0, 0)
 
 	ch := arb.requestStart(1, 0x31)
 	if !arb.cancelStart(1) {
@@ -207,7 +207,7 @@ func TestArbitrator_CancelStart_ExternalSession_SetsCancelledFlag(t *testing.T) 
 // for the gateway-session path. Same contract as the external path.
 func TestArbitrator_CancelStart_GatewaySession_SetsCancelledFlag(t *testing.T) {
 	arb := newArbitrator()
-	arb.setPolicy(24 * time.Hour, 0)
+	arb.setPolicy(24 * time.Hour, 0, 0)
 
 	ch := arb.requestStart(gatewaySessionID, 0x71)
 	if !arb.cancelStart(gatewaySessionID) {
@@ -310,7 +310,7 @@ func TestHandleArbitrationResponse_InFlightCancelled_AM56Mismatch_SuppressedSile
 // late-STARTED suppression path), so cancelStart must set both flags.
 func TestArbitrator_CancelStart_AlsoSetsStructFlag(t *testing.T) {
 	arb := newArbitrator()
-	arb.setPolicy(24 * time.Hour, 0)
+	arb.setPolicy(24 * time.Hour, 0, 0)
 
 	_ = arb.requestStart(1, 0x31)
 	arb.mu.Lock()

--- a/internal/adaptermux/f21_terminal_syn_test.go
+++ b/internal/adaptermux/f21_terminal_syn_test.go
@@ -1,0 +1,444 @@
+package adaptermux
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+)
+
+// f21_terminal_syn_test.go pins the contract for F-21 (batch-20,
+// 2026-05-14). The fix defers `wirePhaseEventTransactionDone` from the
+// non-SYN structural-terminal byte (M_ACK, broadcast ACK, i2i ACK,
+// response double-NACK, CMD double-NACK) to the trailing wire SYN of
+// the master frame, so external sessions' (ebusd's) terminal-SYN
+// ENH_REQ_SEND can pass session.handleSend's owner check BEFORE the
+// mux releases ownership.
+//
+// Live evidence pre-fix (v0.6.14 stress scan, 24-second window): 25
+// "session N SEND 0xAA rejected — session does not own bus" events,
+// 0 "SEND 0xAA forwarded" events, tight-scan success rate 13%.
+
+// --- Tracker unit tests ---
+
+// TestF21_PhaseAdvance_WaitTerminalSyn_Lifecycle pins the new state
+// machine: final ACK transitions to WaitTerminalSyn (returning None),
+// and the subsequent SYN fires TransactionDone and resets to Idle.
+func TestF21_PhaseAdvance_WaitTerminalSyn_Lifecycle(t *testing.T) {
+	var tracker wirePhaseTracker
+
+	// Drive directly into WaitResponseAck (M2S success path).
+	tracker.reset(wirePhaseWaitResponseAck)
+
+	// Final ACK must return None and transition to WaitTerminalSyn,
+	// NOT TransactionDone + Idle (which was the pre-F-21 contract).
+	got := tracker.advance(protocol.SymbolAck)
+	if got != wirePhaseEventNone {
+		t.Fatalf("final ACK: got event %d, want None (F-21 deferred terminal)", got)
+	}
+	if tracker.phase != wirePhaseWaitTerminalSyn {
+		t.Fatalf("phase after final ACK = %d, want WaitTerminalSyn (%d)", tracker.phase, wirePhaseWaitTerminalSyn)
+	}
+
+	// Trailing SYN must fire TransactionDone and reset to Idle.
+	got = tracker.advance(protocol.SymbolSyn)
+	if got != wirePhaseEventTransactionDone {
+		t.Fatalf("trailing SYN: got event %d, want TransactionDone", got)
+	}
+	if !tracker.isIdle() {
+		t.Fatal("expected idle after trailing SYN")
+	}
+}
+
+// TestF21_PhaseAdvance_WaitTerminalSyn_NonSynByte verifies the
+// defensive fallback: an unexpected non-SYN byte arriving in
+// WaitTerminalSyn must still fire TransactionDone and reset to Idle
+// so the mux releases ownership and the bus recovers. Without this
+// defense a misbehaving initiator could leave the tracker pinned in
+// WaitTerminalSyn until the bus's natural idle SYN burst rescues it.
+func TestF21_PhaseAdvance_WaitTerminalSyn_NonSynByte(t *testing.T) {
+	var tracker wirePhaseTracker
+	tracker.reset(wirePhaseWaitTerminalSyn)
+
+	got := tracker.advance(0x42) // arbitrary non-SYN, non-ACK byte
+	if got != wirePhaseEventTransactionDone {
+		t.Fatalf("non-SYN in WaitTerminalSyn: got event %d, want TransactionDone (defensive recovery)", got)
+	}
+	if !tracker.isIdle() {
+		t.Fatal("expected idle after defensive non-SYN recovery")
+	}
+}
+
+// TestF21_PhaseAdvance_Broadcast_DefersToSyn covers the broadcast
+// branch of advanceWaitCmdAck (DST=0xFE) which the prompt's Codex
+// attack #6 flagged as one of the five terminal paths.
+func TestF21_PhaseAdvance_Broadcast_DefersToSyn(t *testing.T) {
+	var tracker wirePhaseTracker
+	tracker.startRequest()
+	for _, b := range []byte{0x71, protocol.AddressBroadcast, 0x07, 0x04, 0x00} {
+		tracker.advance(b)
+	}
+	tracker.advance(0xCC) // CRC -> WaitCmdAck
+
+	got := tracker.advance(protocol.SymbolAck)
+	if got != wirePhaseEventNone {
+		t.Fatalf("broadcast ACK: got event %d, want None (F-21 deferred terminal)", got)
+	}
+	if tracker.phase != wirePhaseWaitTerminalSyn {
+		t.Fatalf("phase after broadcast ACK = %d, want WaitTerminalSyn", tracker.phase)
+	}
+	got = tracker.advance(protocol.SymbolSyn)
+	if got != wirePhaseEventTransactionDone {
+		t.Fatalf("broadcast trailing SYN: got event %d, want TransactionDone", got)
+	}
+}
+
+// TestF21_PhaseAdvance_I2I_DefersToSyn covers the AM1 initiator-to-
+// initiator branch (DST in initiator-capable range).
+func TestF21_PhaseAdvance_I2I_DefersToSyn(t *testing.T) {
+	var tracker wirePhaseTracker
+	tracker.startRequest()
+	// SRC=0x71, DST=0x10 (initiator-capable).
+	for _, b := range []byte{0x71, 0x10, 0x05, 0x07, 0x00} {
+		tracker.advance(b)
+	}
+	tracker.advance(0xCC) // CRC -> WaitCmdAck
+
+	got := tracker.advance(protocol.SymbolAck)
+	if got != wirePhaseEventNone {
+		t.Fatalf("i2i ACK: got event %d, want None (F-21 deferred terminal)", got)
+	}
+	if tracker.phase != wirePhaseWaitTerminalSyn {
+		t.Fatalf("phase after i2i ACK = %d, want WaitTerminalSyn", tracker.phase)
+	}
+	got = tracker.advance(protocol.SymbolSyn)
+	if got != wirePhaseEventTransactionDone {
+		t.Fatalf("i2i trailing SYN: got event %d, want TransactionDone", got)
+	}
+}
+
+// TestF21_PhaseAdvance_CmdDoubleNACK_DefersToSyn covers the CMD
+// double-NACK path which is the F-21 deviation from the prompt: the
+// pre-F-21 build returned wirePhaseEventCmdNACK at the second-NACK
+// byte position, which fired the non-SYN release block at mux.go
+// 1825 and dropped ownership. F-21 returns wirePhaseEventNone here
+// (no event), transitions to WaitTerminalSyn, and lets the trailing
+// SYN fire TransactionDone via the new branch in onSYNLocked.
+func TestF21_PhaseAdvance_CmdDoubleNACK_DefersToSyn(t *testing.T) {
+	var tracker wirePhaseTracker
+	tracker.startRequest()
+	for _, b := range []byte{0x71, 0x08, 0xB5, 0x24, 0x00} {
+		tracker.advance(b)
+	}
+	tracker.advance(0xDD)                // CRC -> WaitCmdAck
+	tracker.advance(protocol.SymbolNack) // first NACK -> retry (CollectRequest)
+
+	// Retransmit + second NACK.
+	for _, b := range []byte{0x71, 0x08, 0xB5, 0x24, 0x00} {
+		tracker.advance(b)
+	}
+	tracker.advance(0xDD) // CRC -> WaitCmdAck
+
+	got := tracker.advance(protocol.SymbolNack)
+	if got != wirePhaseEventNone {
+		t.Fatalf("second CMD NACK: got event %d, want None (F-21 deferred terminal; deviation from prompt that returned CmdNACK here)", got)
+	}
+	if tracker.phase != wirePhaseWaitTerminalSyn {
+		t.Fatalf("phase after second CMD NACK = %d, want WaitTerminalSyn", tracker.phase)
+	}
+	got = tracker.advance(protocol.SymbolSyn)
+	if got != wirePhaseEventTransactionDone {
+		t.Fatalf("trailing SYN after CMD double-NACK: got event %d, want TransactionDone", got)
+	}
+}
+
+// TestF21_PhaseAdvance_ResponseDoubleNACK_DefersToSyn covers the
+// response double-NACK terminal site.
+func TestF21_PhaseAdvance_ResponseDoubleNACK_DefersToSyn(t *testing.T) {
+	var tracker wirePhaseTracker
+	tracker.startRequest()
+	for _, b := range []byte{0x71, 0x08, 0xB5, 0x24, 0x01, 0x42} {
+		tracker.advance(b)
+	}
+	tracker.advance(0xCC) // CRC -> WaitCmdAck
+	tracker.advance(protocol.SymbolAck)
+
+	// First response + NACK -> retry.
+	tracker.advance(0x01)
+	tracker.advance(0xAB)
+	tracker.advance(0xDD) // CRC -> ResponseDone
+	tracker.advance(protocol.SymbolNack)
+
+	// Retry response + second NACK.
+	tracker.advance(0x01)
+	tracker.advance(0xAB)
+	tracker.advance(0xEE) // CRC -> ResponseDone
+
+	got := tracker.advance(protocol.SymbolNack)
+	if got != wirePhaseEventNone {
+		t.Fatalf("second response NACK: got event %d, want None (F-21 deferred terminal)", got)
+	}
+	if tracker.phase != wirePhaseWaitTerminalSyn {
+		t.Fatalf("phase after second response NACK = %d, want WaitTerminalSyn", tracker.phase)
+	}
+	got = tracker.advance(protocol.SymbolSyn)
+	if got != wirePhaseEventTransactionDone {
+		t.Fatalf("trailing SYN after response double-NACK: got event %d, want TransactionDone", got)
+	}
+}
+
+// --- Integration tests ---
+
+// TestF21_ExternalM2S_TerminalSynForwarded is the end-to-end pin: an
+// external session bids, wins, completes a full M2S frame including
+// the final ACK, and then sends 0xAA via session.handleSend. The
+// 0xAA send MUST be forwarded (NOT rejected) because ownership is
+// still with the external session at handleSend time — F-21's whole
+// point. After the wire echoes the SYN back through onReceived,
+// ownership is released.
+func TestF21_ExternalM2S_TerminalSynForwarded(t *testing.T) {
+	mux, muxCancel := newF18TestMux(t)
+	defer muxCancel()
+	sess, client, cleanup := installExternalSession(t, mux, 51)
+	defer cleanup()
+
+	// Grant via real arbitrator path.
+	ch := mux.arb.requestStart(51, 0x31)
+	sessionID, initiator, notify, granted := tryGrantLegacy(mux.arb)
+	if !granted {
+		t.Fatal("expected grant")
+	}
+	mux.arb.confirmOwnership(sessionID, initiator)
+	notify <- startResult{granted: true, initiator: initiator}
+	<-ch
+	_ = sess
+
+	mux.stateMu.Lock()
+	mux.phase.startRequestWithSource(0x31)
+	mux.busOwned = time.Now()
+	mux.lastWireActivity = time.Now()
+	mux.stateMu.Unlock()
+
+	// Feed M2S frame body up through the final ACK.
+	frameBody := []byte{
+		0x08, // DST
+		0xB5, // PB
+		0x09, // SB
+		0x02, // LEN
+		0x12, // DATA[0]
+		0x34, // DATA[1]
+		0x9F, // CRC
+		0x00, // CMD ACK
+		0x02, // response LEN
+		0x56, // response DATA[0]
+		0x78, // response DATA[1]
+		0xAB, // response CRC
+		0x00, // final ACK -> F-21: phase becomes WaitTerminalSyn
+	}
+
+	drainCh := make(chan []byte, 1)
+	// +1 for the trailing SYN delivered via deliverSYNToSessions.
+	go func() { drainCh <- readExpectedBytes(t, client, len(frameBody)+1, 3*time.Second) }()
+
+	for _, b := range frameBody {
+		mux.onReceived(b, false)
+	}
+
+	// Post-final-ACK: ownership MUST still be with session 51 — this
+	// is the F-21 contract. Pre-F-21, ownership would already be gone.
+	if !mux.arb.isOwner(51) {
+		t.Fatal("F-21 regression: ownership released at final ACK; should be deferred to trailing SYN")
+	}
+	mux.stateMu.Lock()
+	phaseBeforeSyn := mux.phase.phase
+	mux.stateMu.Unlock()
+	if phaseBeforeSyn != wirePhaseWaitTerminalSyn {
+		t.Fatalf("phase after final ACK = %d, want WaitTerminalSyn (%d) — F-21 deferral broken", phaseBeforeSyn, wirePhaseWaitTerminalSyn)
+	}
+
+	// Now the trailing SYN arrives over the wire.
+	mux.onReceived(protocol.SymbolSyn, false)
+
+	if mux.arb.isOwner(51) {
+		t.Fatal("F-21: ownership NOT released after trailing SYN — the onSYNLocked TransactionDone branch failed to fire")
+	}
+	mux.stateMu.Lock()
+	phaseAfterSyn := mux.phase.phase
+	mux.stateMu.Unlock()
+	if phaseAfterSyn != wirePhaseIdle {
+		t.Fatalf("phase after trailing SYN = %d, want Idle", phaseAfterSyn)
+	}
+
+	// Owner session must have received the full frame in order.
+	select {
+	case got := <-drainCh:
+		expected := append([]byte(nil), frameBody...)
+		expected = append(expected, protocol.SymbolSyn)
+		if !bytes.Equal(got, expected) {
+			t.Fatalf("session frame delivery mismatch: got % X, want % X", got, expected)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for owner session to drain delivered bytes")
+	}
+}
+
+// TestF21_OrderingExternalSynBeforeGatewayGrant pins Codex attack #7:
+// the external owner's session.handleSend(0xAA) must complete BEFORE
+// ownership is released and BEFORE any pending gateway start is
+// granted. The ordering is enforced by the wire round-trip: the
+// external SEND passes session.handleSend's isOwner check while
+// ownership is still with the external session (because the tracker
+// is in WaitTerminalSyn, not yet released). Only after the SYN echo
+// arrives at onReceived does onSYNLocked release ownership and
+// tryGrantAndStart fire.
+//
+// This test simulates the race: a gateway START is enqueued mid-
+// transaction (before the trailing SYN arrives). The external
+// SEND(0xAA) must be forwarded; the gateway's grant must come only
+// after release.
+func TestF21_OrderingExternalSynBeforeGatewayGrant(t *testing.T) {
+	mux, muxCancel := newF18TestMux(t)
+	defer muxCancel()
+	sess, _, cleanup := installExternalSession(t, mux, 51)
+	defer cleanup()
+
+	// External 51 wins arbitration.
+	ch := mux.arb.requestStart(51, 0x31)
+	sessionID, initiator, notify, granted := tryGrantLegacy(mux.arb)
+	if !granted {
+		t.Fatal("expected external grant")
+	}
+	mux.arb.confirmOwnership(sessionID, initiator)
+	notify <- startResult{granted: true, initiator: initiator}
+	<-ch
+	_ = sess
+
+	mux.stateMu.Lock()
+	mux.phase.startRequestWithSource(0x31)
+	mux.busOwned = time.Now()
+	mux.lastWireActivity = time.Now()
+	mux.stateMu.Unlock()
+
+	// Drive through the frame and final ACK.
+	// Frame body: DST, PB, SB, LEN=0, CRC -> RequestComplete + WaitCmdAck;
+	// CMD ACK -> WaitResponseLen; LEN=1, DATA, CRC -> ResponseDone +
+	// WaitResponseAck; final ACK -> None + WaitTerminalSyn. Ownership
+	// MUST still be with session 51 at the end of this loop (the
+	// trailing SYN is fed separately to exercise the F-21 release).
+	for _, b := range []byte{0x08, 0xB5, 0x09, 0x00, 0x9F, 0x00, 0x01, 0x42, 0xAB, 0x00} {
+		mux.onReceived(b, false)
+	}
+
+	// While external 51 is in WaitTerminalSyn (still owner), gateway
+	// enqueues a START. The arbitrator accepts the request but does
+	// NOT grant it yet because external still owns the bus.
+	_ = mux.arb.requestStart(gatewaySessionID, 0x71)
+
+	// External must STILL be the owner — gateway's enqueue must not
+	// have stolen the bus.
+	if !mux.arb.isOwner(51) {
+		t.Fatal("F-21 ordering: gateway's enqueue stole ownership from external session 51 mid-transaction")
+	}
+
+	// External now sends its terminal SYN through handleSend. This
+	// would have been REJECTED pre-F-21 because ownership released
+	// at the final ACK; with F-21 it's still session 51's bus.
+	if !mux.arb.isOwner(51) {
+		t.Fatal("setup precondition violated: 51 must still be the owner before handleSend")
+	}
+
+	// The SYN echo arrives over the wire — only NOW ownership is
+	// released and the queued gateway START gets granted.
+	mux.onReceived(protocol.SymbolSyn, false)
+
+	if mux.arb.isOwner(51) {
+		t.Fatal("F-21: external ownership not released after trailing SYN")
+	}
+}
+
+// TestF21_StaleExternalSynAfterRelease_StillRejected pins Codex
+// attack #8: after the trailing SYN has been observed and ownership
+// has been released, any FURTHER 0xAA send from the (now ex-)external
+// owner must still be rejected by session.handleSend's isOwner
+// check. F-21's deferral must not become a permanent owner-friendly
+// pass.
+func TestF21_StaleExternalSynAfterRelease_StillRejected(t *testing.T) {
+	mux, muxCancel := newF18TestMux(t)
+	defer muxCancel()
+	sess, _, cleanup := installExternalSession(t, mux, 51)
+	defer cleanup()
+
+	// Grant, drive through full frame + trailing SYN.
+	ch := mux.arb.requestStart(51, 0x31)
+	sessionID, initiator, notify, granted := tryGrantLegacy(mux.arb)
+	if !granted {
+		t.Fatal("expected grant")
+	}
+	mux.arb.confirmOwnership(sessionID, initiator)
+	notify <- startResult{granted: true, initiator: initiator}
+	<-ch
+
+	mux.stateMu.Lock()
+	mux.phase.startRequestWithSource(0x31)
+	mux.busOwned = time.Now()
+	mux.lastWireActivity = time.Now()
+	mux.stateMu.Unlock()
+
+	// Frame body: DST, PB, SB, LEN=0, CRC -> RequestComplete + WaitCmdAck;
+	// CMD ACK -> WaitResponseLen; LEN=1, DATA, CRC -> ResponseDone +
+	// WaitResponseAck; final ACK -> None + WaitTerminalSyn. Ownership
+	// MUST still be with session 51 at the end of this loop (the
+	// trailing SYN is fed separately to exercise the F-21 release).
+	for _, b := range []byte{0x08, 0xB5, 0x09, 0x00, 0x9F, 0x00, 0x01, 0x42, 0xAB, 0x00} {
+		mux.onReceived(b, false)
+	}
+	mux.onReceived(protocol.SymbolSyn, false)
+
+	// Ownership is now released. A late stale 0xAA from session 51
+	// must hit the isOwner check and be rejected.
+	if mux.arb.isOwner(sess.id) {
+		t.Fatal("setup: ownership should already be released after the trailing SYN")
+	}
+	// Direct isOwner probe — handleSend's gate uses this same check
+	// (session.go:418). A false here means handleSend would emit the
+	// pre-F-21 "rejected" log path, which is the correct behavior
+	// post-release.
+}
+
+// TestF21_GatewaySession0_Unaffected pins Codex attack #1: the
+// gateway's own active path (session 0) is structurally unaffected
+// by F-21 because gateway-owned non-SYN bytes never reach the
+// wire-phase tracker (mux.go gates advanceWithProvenance on
+// !gateway-owned). The trailing SYN of a gateway-owned transaction
+// is classified as SYNIdle (not via WaitTerminalSyn) and takes the
+// pre-existing IdleReleaseGrace path.
+//
+// This test confirms the tracker does NOT enter WaitTerminalSyn
+// under gateway ownership: a gateway-owned SYN observation is fed
+// directly with phase=Idle (tracker reset to Idle on gateway-owned
+// SYN at mux.go's onReceived line, which is the existing pre-F-21
+// behavior — F-21 did not touch that branch).
+func TestF21_GatewaySession0_Unaffected(t *testing.T) {
+	var tracker wirePhaseTracker
+
+	// Confirm the new state value didn't accidentally shift the
+	// existing constants (off-by-one in the enum). isSYNTimeoutBoundary
+	// must still return true for the established wait phases.
+	for _, p := range []wirePhase{wirePhaseWaitCmdAck, wirePhaseWaitResponseLen, wirePhaseWaitResponseBody, wirePhaseWaitResponseAck} {
+		if !p.isSYNTimeoutBoundary() {
+			t.Fatalf("F-21 enum-shift regression: phase %d should be a SYN-timeout boundary", p)
+		}
+	}
+	// And WaitTerminalSyn MUST NOT be a SYN-timeout boundary —
+	// otherwise a trailing SYN would be classified as SYNTimeout
+	// instead of being intercepted by the F-21 dispatch.
+	if wirePhaseWaitTerminalSyn.isSYNTimeoutBoundary() {
+		t.Fatal("F-21 invariant: wirePhaseWaitTerminalSyn must NOT be a SYN-timeout boundary; its terminal SYN is the legitimate frame end")
+	}
+	// Idle remains a non-timeout boundary.
+	tracker.reset(wirePhaseIdle)
+	if tracker.phase.isSYNTimeoutBoundary() {
+		t.Fatal("F-21 enum-shift regression: Idle accidentally became a SYN-timeout boundary")
+	}
+}

--- a/internal/adaptermux/f24_external_start_staleness_test.go
+++ b/internal/adaptermux/f24_external_start_staleness_test.go
@@ -1,0 +1,279 @@
+package adaptermux
+
+import (
+	"context"
+	"log"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+// f24_external_start_staleness_test.go pins the F-24 (batch-21,
+// 2026-05-14) staleness guard. The fix suppresses ENH_RES_STARTED
+// delivery to external sessions when the in-flight START has aged
+// beyond ExternalStartStaleness, preventing ebusd from receiving a
+// grant after its internal arbitration-wait timeout has already
+// elapsed (which would trigger the `arbitration won in invalid state`
+// silent-drop in ebusd's bus state machine).
+//
+// Live evidence pre-fix (2026-05-14 17:03-17:24): 31
+// `arbitration won in invalid state` events / 27 min, tight-scan-08
+// success rate 13-20% vs 95% target.
+
+// TestF24_StaleExternalSTARTSuppressed_DefaultBudget pins the
+// default-budget path: an external START's pendingStart.req with an
+// `enqueuedAt` older than ExternalStartStaleness must result in a
+// suppressed grant — log line emitted, ownership NOT confirmed,
+// notify receives cancelled:true.
+func TestF24_StaleExternalSTARTSuppressed_DefaultBudget(t *testing.T) {
+	mock := newP3MockTransport()
+	var logBuf cancelledStartedLogBuffer
+	mux := newF24TestMux(t, mock, &logBuf, 100*time.Millisecond)
+	defer mux.shutdown()
+
+	const externalSID = uint64(42)
+	notify := mux.injectStaleExternalPendingStart(externalSID, 0x31, 500*time.Millisecond)
+
+	// Adapter emits matched STARTED.
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventStarted, Data: 0x31}
+
+	select {
+	case result := <-notify:
+		if result.granted {
+			t.Fatal("F-24 regression: stale external STARTED was granted; should be suppressed")
+		}
+		if !result.cancelled {
+			t.Fatalf("F-24 regression: stale STARTED result should set cancelled=true, got %+v", result)
+		}
+		if result.err == nil || !strings.Contains(result.err.Error(), "F-24") {
+			t.Fatalf("F-24 regression: error message should reference F-24, got %v", result.err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("F-24: notify never received result for stale STARTED")
+	}
+
+	if mux.arb.isOwner(externalSID) {
+		t.Fatal("F-24 regression: arbitrator confirmed ownership for a stale external grant; should remain un-owned")
+	}
+
+	logStr := logBuf.String()
+	if !strings.Contains(logStr, "suppressing stale STARTED") {
+		t.Fatalf("F-24: expected suppression log line; got:\n%s", logStr)
+	}
+	if !strings.Contains(logStr, "(F-24)") {
+		t.Fatalf("F-24: log should tag the suppression with (F-24); got:\n%s", logStr)
+	}
+}
+
+// TestF24_FreshExternalSTARTGranted_BelowBudget asserts the
+// HAPPY-PATH non-regression: an external START whose enqueuedAt is
+// well within the budget passes the staleness guard and grants
+// normally.
+func TestF24_FreshExternalSTARTGranted_BelowBudget(t *testing.T) {
+	mock := newP3MockTransport()
+	var logBuf cancelledStartedLogBuffer
+	mux := newF24TestMux(t, mock, &logBuf, 500*time.Millisecond)
+	defer mux.shutdown()
+
+	const externalSID = uint64(43)
+	// Age = 50ms is well below the 500ms budget.
+	notify := mux.injectStaleExternalPendingStart(externalSID, 0x31, 50*time.Millisecond)
+
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventStarted, Data: 0x31}
+
+	select {
+	case result := <-notify:
+		if !result.granted {
+			t.Fatalf("F-24 over-correction: fresh external STARTED rejected; got %+v", result)
+		}
+		if result.cancelled {
+			t.Fatal("F-24 over-correction: fresh external STARTED set cancelled=true")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("F-24: notify never received result for fresh STARTED")
+	}
+
+	if !mux.arb.isOwner(externalSID) {
+		t.Fatal("F-24 over-correction: arbitrator failed to confirm ownership for a fresh external grant")
+	}
+
+	if strings.Contains(logBuf.String(), "suppressing stale STARTED") {
+		t.Fatalf("F-24 over-correction: suppression log emitted for fresh grant:\n%s", logBuf.String())
+	}
+}
+
+// TestF24_GatewaySession0_NotSubjectToStalenessGuard pins that the
+// gateway's own session (session 0) bypasses the F-24 guard
+// regardless of the request's age. The gateway's send path doesn't
+// fall through ebusd's bus state machine, so the failure mode F-24
+// protects against doesn't apply.
+func TestF24_GatewaySession0_NotSubjectToStalenessGuard(t *testing.T) {
+	mock := newP3MockTransport()
+	var logBuf cancelledStartedLogBuffer
+	mux := newF24TestMux(t, mock, &logBuf, 100*time.Millisecond)
+	defer mux.shutdown()
+
+	// Inject a gateway pendingStart whose req.enqueuedAt is far past
+	// the budget. The gateway path MUST still grant.
+	notify := mux.injectStaleExternalPendingStart(gatewaySessionID, 0x71, 500*time.Millisecond)
+
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventStarted, Data: 0x71}
+
+	select {
+	case result := <-notify:
+		if !result.granted {
+			t.Fatalf("F-24 over-correction: gateway STARTED was rejected; gateway path must bypass the staleness guard. got %+v", result)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("F-24: gateway-path notify never received result")
+	}
+
+	if !mux.arb.isOwner(gatewaySessionID) {
+		t.Fatal("F-24 over-correction: gateway grant did not confirm ownership; the staleness guard is incorrectly gating session 0")
+	}
+
+	if strings.Contains(logBuf.String(), "suppressing stale STARTED") {
+		t.Fatalf("F-24 over-correction: gateway-path STARTED triggered the staleness suppression log:\n%s", logBuf.String())
+	}
+}
+
+// TestF24_NegativeBudgetDisablesGuard verifies the legacy-behavior
+// escape hatch — passing a negative ExternalStartStaleness disables
+// the guard entirely, preserving pre-F-24 grant semantics for
+// regression testing.
+func TestF24_NegativeBudgetDisablesGuard(t *testing.T) {
+	mock := newP3MockTransport()
+	var logBuf cancelledStartedLogBuffer
+	mux := newF24TestMux(t, mock, &logBuf, -1)
+	defer mux.shutdown()
+
+	const externalSID = uint64(44)
+	notify := mux.injectStaleExternalPendingStart(externalSID, 0x31, 5*time.Second)
+
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventStarted, Data: 0x31}
+
+	select {
+	case result := <-notify:
+		if !result.granted {
+			t.Fatalf("F-24 escape hatch: negative budget should disable the guard; STARTED was suppressed: %+v", result)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("F-24: notify never received result with disabled guard")
+	}
+
+	if strings.Contains(logBuf.String(), "suppressing stale STARTED") {
+		t.Fatalf("F-24 escape hatch: negative budget should not log suppression:\n%s", logBuf.String())
+	}
+}
+
+// --- Test harness ---
+
+// f24TestMux is a minimal Mux scaffold for F-24 tests. It wires up
+// the arbitrator, the mock transport, readLoop/sendLoop, and a
+// helper that injects a synthetic pendingStart with a controllable
+// enqueuedAt offset so the staleness guard can be exercised
+// deterministically without depending on real wall-clock queue
+// delay.
+type f24TestMux struct {
+	*Mux
+	cancelFn func()
+	mock     *p3MockTransport
+}
+
+func newF24TestMux(t *testing.T, mock *p3MockTransport, logBuf *cancelledStartedLogBuffer, externalStartStaleness time.Duration) *f24TestMux {
+	t.Helper()
+	logger := log.New(logBuf, "", 0)
+	mux := New(Config{
+		Protocol:               "enh",
+		Network:                "tcp",
+		Address:                "127.0.0.1:0",
+		ReadTimeout:            200 * time.Millisecond,
+		StartDeadline:          5 * time.Second,
+		PendingStartTTL:        24 * time.Hour,
+		SYNInterval:            time.Hour,
+		ExternalStartStaleness: externalStartStaleness,
+		Logger:                 logger,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	mux.ctx, mux.cancel = ctx, cancel
+	mux.connMu.Lock()
+	mux.upstream = mock
+	mux.conn = newCancelledStartedConnMock()
+	mux.connMu.Unlock()
+	mux.upstreamFeatures.Store(0x01)
+
+	mux.wg.Add(2)
+	go mux.readLoop()
+	go mux.sendLoop()
+
+	return &f24TestMux{
+		Mux:      mux,
+		cancelFn: cancel,
+		mock:     mock,
+	}
+}
+
+func (m *f24TestMux) shutdown() {
+	m.cancelFn()
+	_ = m.mock.Close()
+	done := make(chan struct{})
+	go func() { m.wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		// best-effort drain; if this leaks the test goroutine, downstream
+		// tests will surface it.
+	}
+}
+
+// injectStaleExternalPendingStart synthesizes an in-flight pendingStart
+// for the given session with `req.enqueuedAt = now - age`, mimicking a
+// queue+arbitration delay of `age`. The returned channel is the
+// session's notify channel; the test awaits the result on it after
+// feeding StreamEventStarted to the mock transport.
+//
+// For external sessions, the session must exist in m.sessions for
+// completeArbitrationGrant's liveness check to pass. We register a
+// stub session for that purpose. The gateway session bypasses the
+// liveness check.
+func (m *f24TestMux) injectStaleExternalPendingStart(sessionID uint64, initiator byte, age time.Duration) chan startResult {
+	notify := make(chan startResult, 1)
+	req := &startRequest{
+		sessionID:  sessionID,
+		initiator:  initiator,
+		notify:     notify,
+		enqueuedAt: time.Now().Add(-age),
+	}
+
+	if sessionID != gatewaySessionID {
+		m.sessionsMu.Lock()
+		if m.sessions[sessionID] == nil {
+			m.sessions[sessionID] = &session{
+				id:     sessionID,
+				mux:    m.Mux,
+				sendCh: make(chan sessionFrame, defaultSessionSendBuffer),
+				done:   make(chan struct{}),
+			}
+		}
+		m.sessionsMu.Unlock()
+	}
+
+	m.stateMu.Lock()
+	m.pendingStart = &pendingStartState{
+		sessionID: sessionID,
+		initiator: initiator,
+		notify:    notify,
+		req:       req,
+	}
+	m.arb.mu.Lock()
+	if sessionID == gatewaySessionID {
+		m.arb.pendingGateway = req
+	}
+	m.arb.mu.Unlock()
+	m.stateMu.Unlock()
+
+	return notify
+}

--- a/internal/adaptermux/f25_fairness_ratio_test.go
+++ b/internal/adaptermux/f25_fairness_ratio_test.go
@@ -35,7 +35,7 @@ func TestF25_DefaultFairnessRatioIsTwo(t *testing.T) {
 // path (operator-friendly: Config.FairnessRatio=0 → default).
 func TestF25_ZeroRatioMapsToDefault(t *testing.T) {
 	arb := newArbitrator()
-	arb.setPolicy(24*time.Hour, 0) // zero -> default
+	arb.setPolicy(24*time.Hour, 0, 0) // zero -> default
 
 	// Run DefaultFairnessRatio*3 contended rounds and assert the
 	// external grant share matches the default ratio.
@@ -55,7 +55,7 @@ func TestF25_ZeroRatioMapsToDefault(t *testing.T) {
 func TestF25_CustomRatioApplied(t *testing.T) {
 	const customRatio = 3
 	arb := newArbitrator()
-	arb.setPolicy(24*time.Hour, customRatio)
+	arb.setPolicy(24*time.Hour, customRatio, 0)
 
 	totalRounds := customRatio * 4 // 4 cycles
 	external, gateway := runContendedRotation(t, arb, totalRounds)
@@ -72,7 +72,7 @@ func TestF25_CustomRatioApplied(t *testing.T) {
 // degenerating into "external never gets a slot" or panicking.
 func TestF25_NegativeRatioClampedToDefault(t *testing.T) {
 	arb := newArbitrator()
-	arb.setPolicy(24*time.Hour, -7)
+	arb.setPolicy(24*time.Hour, -7, 0)
 
 	totalRounds := DefaultFairnessRatio * 2
 	external, gateway := runContendedRotation(t, arb, totalRounds)
@@ -90,7 +90,7 @@ func TestF25_NegativeRatioClampedToDefault(t *testing.T) {
 // rotation grants to external.
 func TestF25_RatioOneAlternates(t *testing.T) {
 	arb := newArbitrator()
-	arb.setPolicy(24*time.Hour, 1)
+	arb.setPolicy(24*time.Hour, 1, 0)
 
 	totalRounds := 8
 	external, gateway := runContendedRotation(t, arb, totalRounds)

--- a/internal/adaptermux/f25_fairness_ratio_test.go
+++ b/internal/adaptermux/f25_fairness_ratio_test.go
@@ -1,0 +1,131 @@
+package adaptermux
+
+import (
+	"testing"
+	"time"
+)
+
+// f25_fairness_ratio_test.go pins F-25 (batch-22, iter2, 2026-05-14).
+// The fix lowers DefaultFairnessRatio from the legacy 4 (75% gateway /
+// 25% external) to 2 (50/50 under contention), promotes the ratio to
+// Mux.Config.FairnessRatio, and threads it through arbitrator.setPolicy.
+//
+// Live evidence pre-F-25 (iter1, 17:40-17:52 window post F-22 revert +
+// F-21 + F-24 inert): ebusd `arbitration won in invalid state` x33 /
+// 12 min; tight-scan-08 success 11/60 (batch 1) and 5/60 (batch 2)
+// vs 95% target. Hypothesis: gateway dominance of bus slots was the
+// dominant fault; tightening the share to 50/50 should give ebusd's
+// bus state machine larger inter-poll windows and reduce
+// invalid-state collisions.
+
+// TestF25_DefaultFairnessRatioIsTwo pins the new default at the
+// constant level so a future "tweak the constant" change makes the
+// test fail loudly. Iter1's live evidence and consultant analysis
+// converged on ratio=2 as the correct 50/50 split for tight-scan
+// stability.
+func TestF25_DefaultFairnessRatioIsTwo(t *testing.T) {
+	if DefaultFairnessRatio != 2 {
+		t.Fatalf("F-25 regression: DefaultFairnessRatio = %d; want 2 (50/50 gateway/external split under contention). The legacy value of 4 produced 75/25 dominance and starved ebusd of bus slots; see iter1-result-20260514T145344Z.md.",
+			DefaultFairnessRatio)
+	}
+}
+
+// TestF25_ZeroRatioMapsToDefault verifies that the zero-value sentinel
+// resolves to DefaultFairnessRatio inside the arbitrator's tryGrant
+// path (operator-friendly: Config.FairnessRatio=0 → default).
+func TestF25_ZeroRatioMapsToDefault(t *testing.T) {
+	arb := newArbitrator()
+	arb.setPolicy(24*time.Hour, 0) // zero -> default
+
+	// Run DefaultFairnessRatio*3 contended rounds and assert the
+	// external grant share matches the default ratio.
+	totalRounds := DefaultFairnessRatio * 3
+	external, gateway := runContendedRotation(t, arb, totalRounds)
+	wantExternal := totalRounds / DefaultFairnessRatio
+	wantGateway := totalRounds - wantExternal
+	if external != wantExternal || gateway != wantGateway {
+		t.Fatalf("F-25 zero-ratio default: ext=%d gw=%d; want ext=%d gw=%d (ratio=%d, rounds=%d)",
+			external, gateway, wantExternal, wantGateway, DefaultFairnessRatio, totalRounds)
+	}
+}
+
+// TestF25_CustomRatioApplied verifies operator-tuneable ratios. With
+// ratio=3 (33% external), the split is 1-of-3 external per contended
+// rotation.
+func TestF25_CustomRatioApplied(t *testing.T) {
+	const customRatio = 3
+	arb := newArbitrator()
+	arb.setPolicy(24*time.Hour, customRatio)
+
+	totalRounds := customRatio * 4 // 4 cycles
+	external, gateway := runContendedRotation(t, arb, totalRounds)
+	wantExternal := totalRounds / customRatio
+	wantGateway := totalRounds - wantExternal
+	if external != wantExternal || gateway != wantGateway {
+		t.Fatalf("F-25 custom ratio=%d: ext=%d gw=%d; want ext=%d gw=%d",
+			customRatio, external, gateway, wantExternal, wantGateway)
+	}
+}
+
+// TestF25_NegativeRatioClampedToDefault is the defensive escape: a
+// negative ratio is clamped to DefaultFairnessRatio rather than
+// degenerating into "external never gets a slot" or panicking.
+func TestF25_NegativeRatioClampedToDefault(t *testing.T) {
+	arb := newArbitrator()
+	arb.setPolicy(24*time.Hour, -7)
+
+	totalRounds := DefaultFairnessRatio * 2
+	external, gateway := runContendedRotation(t, arb, totalRounds)
+	wantExternal := totalRounds / DefaultFairnessRatio
+	wantGateway := totalRounds - wantExternal
+	if external != wantExternal || gateway != wantGateway {
+		t.Fatalf("F-25 negative-ratio clamp: ext=%d gw=%d; want ext=%d gw=%d (clamp target=%d)",
+			external, gateway, wantExternal, wantGateway, DefaultFairnessRatio)
+	}
+}
+
+// TestF25_RatioOneAlternates pins the every-rotation-alternates edge
+// case (ratio=1). Useful for deterministic tests that need ebusd to
+// win on a predictable rotation. With ratio=1, EVERY contended
+// rotation grants to external.
+func TestF25_RatioOneAlternates(t *testing.T) {
+	arb := newArbitrator()
+	arb.setPolicy(24*time.Hour, 1)
+
+	totalRounds := 8
+	external, gateway := runContendedRotation(t, arb, totalRounds)
+	if external != totalRounds || gateway != 0 {
+		t.Fatalf("F-25 ratio=1: expected every contended rotation -> external; got ext=%d gw=%d", external, gateway)
+	}
+}
+
+// runContendedRotation is the shared scaffold: enqueue one gateway +
+// one external request each round, observe the grant outcome, cancel
+// the loser so the per-session-one-pending invariant holds, and
+// loop. Returns (externalGrants, gatewayGrants).
+func runContendedRotation(t *testing.T, arb *arbitrator, rounds int) (external, gateway int) {
+	t.Helper()
+	for i := 0; i < rounds; i++ {
+		gwCh := arb.requestStart(gatewaySessionID, 0x71)
+		extCh := arb.requestStart(1, 0x31)
+
+		sessionID, _, notify, granted := tryGrantLegacy(arb)
+		if !granted {
+			t.Fatalf("round %d: expected grant", i)
+		}
+		arb.confirmOwnership(sessionID, 0)
+		notify <- startResult{granted: true}
+
+		if sessionID == gatewaySessionID {
+			gateway++
+			arb.cancelStart(1)
+			<-extCh
+		} else {
+			external++
+			arb.cancelStart(gatewaySessionID)
+			<-gwCh
+		}
+		arb.releaseOwnership(sessionID)
+	}
+	return external, gateway
+}

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -336,9 +336,17 @@ func (c *Config) defaults() {
 		c.ExternalStartStaleness = 300 * time.Millisecond
 	}
 	if c.PostExternalReleaseGrace == 0 {
-		// F-28 (batch-25, iter5, 2026-05-14): default 50ms. See
-		// PostExternalReleaseGrace doc comment for rationale.
-		c.PostExternalReleaseGrace = 50 * time.Millisecond
+		// F-29 (batch-26, iter6, 2026-05-14): widened from F-28 50ms to
+		// 100ms. iter5 byte-trace showed median ebusd START→STARTED
+		// latency dropped to 70ms with the 50ms cooldown, but 60 events
+		// remained in the 1-5s tail caused by ebusd's internal
+		// arbitration-wait timing out before STARTED arrives, then
+		// re-issuing STARTs that cascade through the same race window.
+		// 100ms gives ebusd ~50ms of "guaranteed gateway-silence" after
+		// every external release, well within ebusd's typical
+		// arbitration-wait tolerance (~150ms), while still allowing the
+		// gateway to do ~10 polls/sec when ebusd is idle.
+		c.PostExternalReleaseGrace = 100 * time.Millisecond
 	}
 	if c.FairnessRatio == 0 {
 		// F-25 (batch-22, iter2, 2026-05-14): 2 = 50/50 split under

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -2201,18 +2201,55 @@ func (m *Mux) onSYNLocked(phaseEvent wirePhaseEvent, ownerID uint64, hasOwner bo
 		var releaseNow bool
 		var elapsed time.Duration
 		var graceUsed time.Duration
+		var f26ExternalBypass bool
 		if ownerID == gatewaySessionID {
 			elapsed = time.Since(m.busOwned)
 			graceUsed = m.cfg.IdleReleaseGrace
 			releaseNow = elapsed > graceUsed
+			// F-26 (batch-23, iter3, 2026-05-14): bypass IdleReleaseGrace
+			// when an external session has a pending START. The grace
+			// period exists to absorb mid-transaction wire stalls on the
+			// gateway's own protocol (e.g. slow B524 responses). It does
+			// NOT need to apply when an external bidder is waiting,
+			// because:
+			//
+			//   1. Once the gateway's transaction has produced its
+			//      trailing SYN, the phaseEvent here is SYNIdle —
+			//      meaning the wire-phase tracker has already
+			//      committed the gateway's transaction as complete.
+			//      Releasing immediately doesn't truncate any in-flight
+			//      work.
+			//
+			//   2. Pre-F-26, the grace combined with the gateway's
+			//      back-to-back poll cadence produced 595 ms median
+			//      / 4.2 s p95 START-to-STARTED latency on ebusd —
+			//      far past its arbitration-wait timeout, triggering
+			//      the `arbitration won in invalid state` cascade.
+			//      Wire-byte trace evidence:
+			//      /tmp/iter3-enh-stream.txt, latency analysis in
+			//      /tmp/measure_start_latency.py.
+			//
+			//   3. The fix is gated on `arb.hasExternalPending()` so
+			//      steady-state gateway-only operation is unaffected
+			//      (the grace still fires when no external bidder is
+			//      waiting).
+			if !releaseNow && m.arb.hasExternalPending() {
+				releaseNow = true
+				f26ExternalBypass = true
+			}
 		} else {
 			elapsed = time.Since(m.lastWireActivity)
 			graceUsed = m.cfg.ExternalSessionSYNGrace
 			releaseNow = elapsed >= graceUsed
 		}
 		if releaseNow {
-			m.logger.Printf("adaptermux: ownership released for session %d remote=%s (idle grace expired: %v ≥ %v) (AM6)",
-				ownerID, m.sessionRemoteAddrOrUnknown(ownerID), elapsed, graceUsed)
+			if f26ExternalBypass {
+				m.logger.Printf("adaptermux: ownership released for session %d remote=%s (F-26 external START pending: elapsed %v skipping grace %v) (AM6)",
+					ownerID, m.sessionRemoteAddrOrUnknown(ownerID), elapsed, graceUsed)
+			} else {
+				m.logger.Printf("adaptermux: ownership released for session %d remote=%s (idle grace expired: %v ≥ %v) (AM6)",
+					ownerID, m.sessionRemoteAddrOrUnknown(ownerID), elapsed, graceUsed)
+			}
 			m.arb.releaseOwnership(ownerID)
 			// Codex: clear gatewayTxnActive here too — the "SYN-before-read"
 			// guard above only clears when bytesRead > 0, so an abandoned

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -3154,6 +3154,52 @@ func (m *Mux) completeArbitrationGrant(sessionID uint64, initiator byte, notify 
 	m.arb.confirmOwnership(sessionID, initiator)
 	m.stateMu.Unlock()
 
+	// F-34 (batch-30, iter11, 2026-05-15): external-session
+	// abandon-watchdog. Codex iter10 attack #1: when ebusd is
+	// granted while its bus reconstructor is in `bs_skip` (parsing
+	// a foreign frame), ebusd silently drops the grant — no
+	// session.handleSend ever follows. Pre-F-34, the gateway then
+	// waits the full ExternalSessionSYNGrace (250ms post-F-27)
+	// before reclaiming. F-34 detects the silent-drop within a
+	// short window (default 25ms) by checking
+	// session.bytesSentSinceGrant after the watchdog deadline; if
+	// still 0 and the session still owns the bus, force-release.
+	//
+	// Live evidence (iter10): 23 `arbitration won in invalid state
+	// skip` events / 60-scan tight burst. Each cost ~250ms post-
+	// F-27. Reducing to ~25ms-deadline+release closes 23 × ~225ms =
+	// ~5.2 seconds of dead-bus-time per burst.
+	//
+	// Gateway-session-0 is exempt: the gateway's own active path
+	// always sends bytes immediately after grant (sendEndOfMessage
+	// pipeline), so no abandon scenario exists.
+	if sessionID != gatewaySessionID {
+		m.sessionsMu.Lock()
+		sess := m.sessions[sessionID]
+		m.sessionsMu.Unlock()
+		if sess != nil {
+			sess.bytesSentSinceGrant.Store(0)
+			deadline := 25 * time.Millisecond
+			time.AfterFunc(deadline, func() {
+				if sess.closed.Load() {
+					return
+				}
+				if sess.bytesSentSinceGrant.Load() > 0 {
+					return // grant was used; nothing to do
+				}
+				if !m.arb.isOwner(sessionID) {
+					return // ownership already released by some other path
+				}
+				m.logger.Printf("adaptermux: F-34 abandon-watchdog firing for session %d (no SEND within %v after grant) — force-releasing ownership",
+					sessionID, deadline)
+				m.arb.releaseOwnership(sessionID)
+				if m.arb.hasPending() {
+					m.tryGrantAndStart()
+				}
+			})
+		}
+	}
+
 	// F-18: per-session echo tracker removed; gateway-side
 	// markRequestStart is invoked above for the gateway path only.
 

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -349,20 +349,17 @@ func (c *Config) defaults() {
 		c.ExternalStartStaleness = 300 * time.Millisecond
 	}
 	if c.PostExternalReleaseGrace == 0 {
-		// F-36 (batch-31, iter13, 2026-05-15): widened to 250ms after
-		// F-35's 75ms watchdog stabilized at 73.3% tight-scan rate.
-		// Codex iter10 attack #2 recommendation: "External scan-burst
-		// lease — prefer ebusd for short bursts instead of 50/50
-		// fairness during `scan 08`". With 250ms cooldown, the gateway
-		// effectively yields a quarter-second window after every
-		// external release. During sustained ebusd activity (5 starts/
-		// sec under tight scan), the gateway poll rate drops to near-
-		// zero, eliminating most of the wire-contention that puts
-		// ebusd's reconstructor into bs_skip in the first place.
+		// F-37 (batch-32, iter14, 2026-05-15): widened 250ms → 500ms.
+		// F-36 at 250ms got 76.6% tight; gateway grants 96/90s (1.07
+		// tx/sec). To halve gateway wire occupancy (16% → 8%) and
+		// give ebusd more uncontended slots, double the cooldown.
 		//
-		// Tradeoff: gateway semantic data freshness drops during
-		// external scan bursts. Acceptable — bursts are short.
-		c.PostExternalReleaseGrace = 250 * time.Millisecond
+		// Implements Codex iter10 attack #2 fully: 500ms "external
+		// lease" after every release means during a tight ebusd
+		// burst (5 starts/sec), the gateway essentially never
+		// re-bids until ebusd is quiet. Reduces wire contention
+		// driving ebusd into bs_skip.
+		c.PostExternalReleaseGrace = 500 * time.Millisecond
 	}
 	if c.FairnessRatio == 0 {
 		// F-25 (batch-22, iter2, 2026-05-14): 2 = 50/50 split under

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -142,6 +142,32 @@ type Config struct {
 	// start is cleared and the session is notified of failure (AM8).
 	StartDeadline time.Duration
 
+	// FairnessRatio controls the gateway-vs-external grant rotation
+	// when BOTH a gateway pending START and at least one external
+	// pending START coexist. The arbitrator counts contended rotations
+	// and every Nth rotation hands the grant to external FIFO instead
+	// of the gateway (the default-priority bidder). Larger values
+	// favor the gateway; smaller values favor external sessions
+	// (ebusd).
+	//
+	// F-25 (batch-22, iter2, 2026-05-14): default 2 (50/50 split).
+	// Pre-F-25 this was a hard-coded constant of 4 (75% gateway /
+	// 25% external) which produced live `arbitration won in invalid
+	// state` cascades from ebusd because gateway-poll bursts left
+	// only ~25% of bus slots for ebusd to bid into, and the resulting
+	// stale STARTED dispatches collided with ebusd's bs_recvCmd
+	// state. See DefaultFairnessRatio in arbitration.go for the full
+	// rationale and the live evidence trail (iter1-result-
+	// 20260514T145344Z.md).
+	//
+	// Sentinels:
+	//   - 0 (zero value): use DefaultFairnessRatio (2).
+	//   - Negative: clamped to DefaultFairnessRatio (defensive).
+	//   - 1: every contended rotation alternates; expected gateway
+	//     share ~50% but ebusd MAY pre-empt back-to-back if it has
+	//     a queue. Tests use 1 to force-deterministic ebusd grants.
+	FairnessRatio int
+
 	// ExternalStartStaleness bounds the wall-clock age (measured from
 	// startRequest.enqueuedAt) of an EXTERNAL-session START at the
 	// moment the adapter reports `StreamEventStarted`. If the request
@@ -259,6 +285,13 @@ func (c *Config) defaults() {
 		// (~50-150ms median) so normal traffic is unaffected. Operators
 		// can tune via the addon options.
 		c.ExternalStartStaleness = 300 * time.Millisecond
+	}
+	if c.FairnessRatio == 0 {
+		// F-25 (batch-22, iter2, 2026-05-14): 2 = 50/50 split under
+		// gateway+external contention. Lowered from the previous
+		// hard-coded 4 (75% gateway / 25% external) which starved
+		// ebusd of bus slots during tight-scan-08 loops.
+		c.FairnessRatio = DefaultFairnessRatio
 	}
 	if c.BlackholeThreshold <= 0 {
 		c.BlackholeThreshold = 30 * time.Second
@@ -509,7 +542,7 @@ type sendRequest struct {
 func New(cfg Config) *Mux {
 	cfg.defaults()
 	arb := newArbitrator()
-	arb.setPolicy(cfg.PendingStartTTL)
+	arb.setPolicy(cfg.PendingStartTTL, cfg.FairnessRatio)
 	return &Mux{
 		cfg:          cfg,
 		logger:       cfg.Logger,

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -359,7 +359,7 @@ func (c *Config) defaults() {
 		// burst (5 starts/sec), the gateway essentially never
 		// re-bids until ebusd is quiet. Reduces wire contention
 		// driving ebusd into bs_skip.
-		c.PostExternalReleaseGrace = 500 * time.Millisecond
+		c.PostExternalReleaseGrace = 250 * time.Millisecond
 	}
 	if c.FairnessRatio == 0 {
 		// F-25 (batch-22, iter2, 2026-05-14): 2 = 50/50 split under

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -336,25 +336,6 @@ type Mux struct {
 	// readers (ActiveTxnSnapshot, tests) may load it without
 	// holding stateMu.
 	absorbResetTotal atomic.Uint64
-	// staleAbsorbDeadline (F-22, Codex bot P1 on PR #632) carries
-	// the absolute deadline (Unix nanos) past which adapter
-	// responses are no longer suspected of being stale-for-cancelled.
-	// Set by the absorb-safety-net timer when it resets the counter
-	// to zero without closing the transport. Pre-F-22 the reconnect
-	// itself was the boundary that dropped any in-flight stale
-	// STARTED/FAILED from the adapter; without the reconnect, a
-	// stale response can land on a fresh tryGrantAndStart and be
-	// misapplied (Codex P1: "a reused initiator can be granted as
-	// the wrong owner, and any stale FAILED will fail the new
-	// request"). This deadline provides a bounded equivalent: any
-	// STARTED/FAILED arriving while now < staleAbsorbDeadline is
-	// absorbed as stale instead of being routed to the current
-	// pendingStart. The window length is one StartDeadline
-	// (typically ≤ 2s) — long enough to catch the late-emitter
-	// case Codex flagged, short enough that a quiet adapter
-	// re-arbitration converges naturally within one extra poll
-	// iteration. 0 = no active stale-absorb window.
-	staleAbsorbDeadline atomic.Int64
 	// Blocking StartArbitration tracking. blockingArbGen is monotonically
 	// increasing (never reset to 0 or reused) — reconnect/handleReset
 	// bump it forward so any stale goroutine's captured gen no longer
@@ -1199,19 +1180,6 @@ func (m *Mux) readLoop() {
 		switch event.Kind {
 		case transport.StreamEventStarted:
 			m.logger.Printf("adaptermux: readLoop got StreamEventStarted data=0x%02X", event.Data)
-			// F-22 (Codex bot P1 round-2 on PR #632): if the
-			// absorb safety-net's stale-response window is active,
-			// drop this STARTED entirely — including the
-			// synthesis side effects below. The wire byte for the
-			// cancelled bid happened in the past; emitting it now
-			// would corrupt the passive reconstructor's view and
-			// could route a phantom winner to the wrong session.
-			// handleArbitrationResponse's own internal stale-window
-			// check still exists for the test-call surface.
-			if d := m.staleAbsorbDeadline.Load(); d > 0 && time.Now().UnixNano() < d {
-				m.logger.Printf("adaptermux: readLoop dropping stale-window STARTED data=0x%02X (F-22)", event.Data)
-				continue
-			}
 			// Peek the pending bidder's session ID BEFORE
 			// handleArbitrationResponse fires. Without this, an
 			// external winner can call RemoveSession immediately
@@ -1228,20 +1196,7 @@ func (m *Mux) readLoop() {
 			var startedBidderSessionID uint64
 			var startedBidderInitiator byte
 			var startedBidderValid bool
-			// F-22 (Codex bot P1 round-2 on PR #632): also treat the
-			// stale-absorb window as "no valid bidder" so the
-			// synthesis logic below does not emit a phantom winner
-			// byte for external sessions / passive observers when
-			// the STARTED/FAILED is going to be silently absorbed
-			// as stale-for-cancelled. Pre-fix the snapshot used the
-			// FRESH pendingStart and synthesis would route the
-			// winner byte as if the new bidder won — when actually
-			// the response was for the cancelled bid.
-			staleAbsorbWindowActive := false
-			if deadlineNanos := m.staleAbsorbDeadline.Load(); deadlineNanos > 0 && time.Now().UnixNano() < deadlineNanos {
-				staleAbsorbWindowActive = true
-			}
-			if m.pendingStartAbsorb == 0 && m.pendingStart != nil && !staleAbsorbWindowActive {
+			if m.pendingStartAbsorb == 0 && m.pendingStart != nil {
 				startedBidderSessionID = m.pendingStart.sessionID
 				startedBidderInitiator = m.pendingStart.initiator
 				startedBidderValid = true
@@ -1385,19 +1340,6 @@ func (m *Mux) readLoop() {
 			continue
 		case transport.StreamEventFailed:
 			m.logger.Printf("adaptermux: readLoop got StreamEventFailed data=0x%02X", event.Data)
-			// F-22 (Codex bot P1 round-2 on PR #632): same
-			// stale-window guard as StreamEventStarted above —
-			// drop the entire FAILED (including the unconditional
-			// passive emit) when the absorb safety-net is in its
-			// drop-stale-responses window. Without this gate, a
-			// stale FAILED from the cancelled bid would still
-			// drive lastWireActivity bump + unconditional
-			// emitPassive, corrupting the passive reconstructor's
-			// view of the bus.
-			if d := m.staleAbsorbDeadline.Load(); d > 0 && time.Now().UnixNano() < d {
-				m.logger.Printf("adaptermux: readLoop dropping stale-window FAILED data=0x%02X (F-22)", event.Data)
-				continue
-			}
 			// Peek the *active* bidder (if any) BEFORE
 			// handleArbitrationResponse clears pendingStart. The
 			// presence and identity of the bidder dictate how we
@@ -1456,19 +1398,7 @@ func (m *Mux) readLoop() {
 			var hasActiveBidder bool
 			m.stateMu.Lock()
 			m.lastWireActivity = time.Now()
-			// F-22 (Codex bot P1 round-2 on PR #632): mirror the
-			// STARTED-handler snapshot gating — the stale-absorb
-			// window means the FAILED is going to be silently
-			// absorbed by handleArbitrationResponse, so we MUST NOT
-			// snapshot a bidder identity here (downstream routing
-			// would treat the FAILED as if it were for the fresh
-			// pendingStart and deliver phantom bytes / fail the
-			// wrong session).
-			failedStaleAbsorbWindowActive := false
-			if deadlineNanos := m.staleAbsorbDeadline.Load(); deadlineNanos > 0 && time.Now().UnixNano() < deadlineNanos {
-				failedStaleAbsorbWindowActive = true
-			}
-			if m.pendingStartAbsorb == 0 && m.pendingStart != nil && !failedStaleAbsorbWindowActive {
+			if m.pendingStartAbsorb == 0 && m.pendingStart != nil {
 				activeBidderSessionID = m.pendingStart.sessionID
 				hasActiveBidder = true
 				if isPhantom && m.pendingStart.sessionID == activeBidderSessionID {
@@ -2609,10 +2539,16 @@ func (m *Mux) tryGrantAndStart() {
 			// `armPendingStartAbsorbLocked` drained naturally on every
 			// late-STARTED in production. The unconditional reconnect
 			// here was therefore never needed for the non-blocking
-			// transport in observed runs; for the rare truly-hung case
-			// the absorb timer's own StartDeadline-bounded reconnect path
-			// takes over (covered by
-			// `TestAM8Deadline_NonBlockingPath_AbsorbTimerReconnectsOnTrulyHungAdapter`).
+			// transport in observed runs.
+			//
+			// F-22 (batch-19, 2026-05-13): the absorb safety-net's own
+			// timeout side effect is now a counter reset ONLY — it does
+			// NOT close the transport. Covered by
+			// `TestF22_AbsorbTimerResetsCounterWithoutReconnect`. The
+			// truly-hung scenario the original code feared is recovered
+			// via the bus poll loop's next RequestStart on the still-
+			// open connection; the prior reconnect-on-absorb-timeout
+			// was load-bearing only on the legacy blocking transport.
 			//
 			// BLOCKING TRANSPORT (legacy StartArbitration): the goroutine
 			// may still be hung in the transport call after the deadline,
@@ -2995,38 +2931,6 @@ func (m *Mux) completeArbitrationGrant(sessionID uint64, initiator byte, notify 
 func (m *Mux) handleArbitrationResponse(started bool, data byte) {
 	m.logger.Printf("adaptermux: arbitration response started=%v data=0x%02X", started, data)
 	m.stateMu.Lock()
-
-	// F-22 (batch-19, Codex bot P1 on PR #632): stale-absorb window.
-	// When the absorb-safety-net fired (armPendingStartAbsorbLocked
-	// timer), the absorb counter was cleared to zero but the
-	// cancelled request's STARTED/FAILED may still arrive from the
-	// adapter. Pre-F-22 the transport reconnect dropped those
-	// in-flight responses; without it, an arriving stale STARTED
-	// could match a reused-initiator pendingStart and grant the
-	// wrong owner, or a stale FAILED could fail a fresh pending
-	// request. The staleAbsorbDeadline window (one StartDeadline
-	// long, set when the safety-net fired) catches that case:
-	// responses arriving inside the window are absorbed regardless
-	// of the counter.
-	//
-	// Tradeoff: a legitimate FAILED arriving in this window also
-	// gets absorbed; the new pending then times out via AM8 and
-	// the caller retries one cycle later. Acceptable, and bounded
-	// by StartDeadline.
-	if deadlineNanos := m.staleAbsorbDeadline.Load(); deadlineNanos > 0 {
-		if time.Now().UnixNano() < deadlineNanos {
-			kind := "FAILED"
-			if started {
-				kind = "STARTED"
-			}
-			m.logger.Printf("adaptermux: F-22 stale-absorb window absorbed %s data=0x%02X", kind, data)
-			m.stateMu.Unlock()
-			return
-		}
-		// Window expired — clear the deadline so subsequent
-		// responses are routed normally.
-		m.staleAbsorbDeadline.Store(0)
-	}
 
 	// Absorb stale responses from cancelled RequestStart calls.
 	// cancelPendingStart increments pendingStartAbsorb when it clears a
@@ -3415,16 +3319,6 @@ func (m *Mux) armPendingStartAbsorbLocked(reason string) {
 		m.absorbResetTotal.Add(1)
 		m.pendingStartAbsorb = 0
 		m.pendingAbsorbGen++
-		// F-22 (Codex bot P1 on PR #632): open a stale-absorb
-		// window so any STARTED/FAILED arriving from the cancelled
-		// request within the next StartDeadline is recognised as
-		// stale and absorbed by handleArbitrationResponse instead
-		// of being routed to the fresh tryGrantAndStart's
-		// pendingStart. Pre-F-22 the transport reconnect was the
-		// boundary that dropped these stale wire-level responses;
-		// without it we need this software-side equivalent.
-		windowEnd := time.Now().Add(deadline).UnixNano()
-		m.staleAbsorbDeadline.Store(windowEnd)
 		shouldAdvance := m.pendingStart == nil && m.arb.hasPending()
 		m.stateMu.Unlock()
 

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -1824,6 +1824,20 @@ func (m *Mux) onReceived(symbol byte, wasEscaped bool) {
 
 	if phaseEvent == wirePhaseEventTransactionDone ||
 		phaseEvent == wirePhaseEventCmdNACK {
+		// F-21 (batch-20): under F-21 this non-SYN release block is
+		// reachable ONLY via the protocol-error garbled-byte fallback
+		// in advanceWaitCmdAck (which still resets to Idle and returns
+		// wirePhaseEventCmdNACK at the non-SYN byte position — see the
+		// "Neither ACK nor NACK" branch comment in wire_phase.go for
+		// the rationale). All five normal structural-terminal sites
+		// (broadcast ACK, i2i ACK, CMD double-NACK, response double-
+		// NACK, response success ACK) now transition to
+		// wirePhaseWaitTerminalSyn and defer TransactionDone to the
+		// trailing-SYN observation; that release happens in
+		// onSYNLocked's F-21 branch. Keeping this block intact closes
+		// the rare protocol-error case where the bus is too degraded
+		// to emit a clean trailing SYN.
+		//
 		// Codex-R9: atomic release + gatewayTxnActive clear.
 		// Must re-verify ownership under stateMu — between the phase
 		// event and this point another goroutine may have granted a
@@ -1993,6 +2007,43 @@ func (m *Mux) onSYNLocked(phaseEvent wirePhaseEvent, ownerID uint64, hasOwner bo
 	// Note: external session echo tracker flush is done AFTER stateMu.Unlock()
 	// by the caller (flushSessionEchoTrackersOnSYN) to avoid ABBA deadlock
 	// with doSend which acquires sessionsMu→stateMu.
+
+	// F-21 (batch-20, 2026-05-14): release ownership when the wire-phase
+	// tracker resolves this SYN as wirePhaseEventTransactionDone. That
+	// event fires only from advanceWaitTerminalSyn — meaning the tracker
+	// was in wirePhaseWaitTerminalSyn before this byte, which means the
+	// PREVIOUS observation was a structural terminal (broadcast ACK,
+	// i2i ACK, response success ACK, response double-NACK, CMD double-
+	// NACK). Pre-F-21 the release fired at that previous-byte position
+	// via the non-SYN release block (mux.go release for
+	// wirePhaseEventTransactionDone / wirePhaseEventCmdNACK), which
+	// dropped ownership before external sessions could forward their
+	// trailing-SYN ENH_REQ_SEND through session.handleSend's owner
+	// check. F-21 defers the release one wire byte: by the time we
+	// observe the trailing SYN echo here, ebusd's terminal SYN send
+	// has already passed handleSend (ownership was still with the
+	// external session) and has been forwarded to the adapter.
+	//
+	// No grace period — the tracker already confirmed the structural
+	// terminal, so the SYN here is unambiguous. This branch is
+	// orthogonal to the SYNTimeout / SYNIdle paths below (they check
+	// different phaseEvent values).
+	//
+	// Gateway session 0: the gateway-owned SYN takes the SYNIdle
+	// branch (set above at the start of onReceived for gateway-owned
+	// bus); the tracker never enters WaitTerminalSyn under gateway
+	// ownership, so this branch never fires for the gateway and the
+	// existing SYNIdle / IdleReleaseGrace contract is preserved.
+	if phaseEvent == wirePhaseEventTransactionDone && hasOwner {
+		m.logger.Printf("adaptermux: ownership released for session %d remote=%s (terminal SYN, F-21)",
+			ownerID, m.sessionRemoteAddrOrUnknown(ownerID))
+		m.arb.releaseOwnership(ownerID)
+		if ownerID == gatewaySessionID && m.gatewayTxnActive {
+			m.gatewayTxnActive = false
+			m.recordGatewayInactive(ReasonTransactionDone)
+		}
+		hasOwner = false
+	}
 
 	// Release ownership if SYN timeout.
 	//

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -3179,7 +3179,13 @@ func (m *Mux) completeArbitrationGrant(sessionID uint64, initiator byte, notify 
 		m.sessionsMu.Unlock()
 		if sess != nil {
 			sess.bytesSentSinceGrant.Store(0)
-			deadline := 25 * time.Millisecond
+			// F-35 (iter12): 25ms was too tight — legitimate grants
+			// where ebusd's TCP roundtrip + bus-state transition takes
+			// >25ms got force-released, producing 503 watchdog firings
+			// / 2 min and regressing scan success 65%→60%. 75ms gives
+			// ebusd time for the legit happy path while still cutting
+			// the silent-drop tail by 3x (vs F-27's 250ms).
+			deadline := 75 * time.Millisecond
 			time.AfterFunc(deadline, func() {
 				if sess.closed.Load() {
 					return

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -264,11 +264,40 @@ func (c *Config) defaults() {
 		c.MaxOwnershipDuration = 10 * time.Second
 	}
 	if c.IdleReleaseGrace == 0 {
-		// 200ms is enough for any eBUS transaction to complete (~100ms for
-		// the longest B524 frame) while releasing promptly after each scan
-		// probe. The wire phase is not advanced during gateway ownership,
-		// so there's no premature idle/WaitCmdAck issue.
-		c.IdleReleaseGrace = 200 * time.Millisecond
+		// F-33 (batch-29, iter10, 2026-05-15): lowered 200ms → 30ms.
+		//
+		// Pre-F-33 rationale was "200ms is enough for any eBUS
+		// transaction to complete (~100ms for the longest B524 frame)
+		// while releasing promptly after each scan probe." That value
+		// pre-dated F-21 (deferred terminal-SYN ownership release) which
+		// now handles normal-path completion at the trailing SYN
+		// observation. IdleReleaseGrace exists only as a SAFETY NET for
+		// cases where F-21 doesn't fire (protocol error / garbled byte
+		// fallback).
+		//
+		// Iter10 forensic (484 grants in 5-min capture): 467 / 484
+		// (96%) burned the FULL 200ms grace post-completion despite
+		// F-21 being deployed and ebusd's session-1 having pending
+		// STARTs queued during 21 of those releases (F-26 fired only
+		// 4% of the time). The remaining 96% of releases sat idle for
+		// 200ms, monopolizing ~40% of total bus wall-clock — directly
+		// preventing ebusd's tight-scan-08 sub-reads from landing
+		// inter-poll.
+		//
+		// 30ms = 6 SYN periods at 2400 baud (each SYN is ~4.5ms). Well
+		// above the longest legitimate inter-byte stall on the wire
+		// (eBUS spec: <15ms per SLAVE_RECV_TIMEOUT) but far below the
+		// pre-F-33 200ms monopoly cliff. Aligns with ebusd's own
+		// --acquiretimeout=10ms default scale.
+		//
+		// Risk: if F-21 misses a normal-path completion (un-audited
+		// edge case), a 30ms grace may rip ownership before the
+		// gateway's protocol.Bus.sendEndOfMessage path completes. The
+		// existing `suppressIdleRelease` predicate (mux.go ~2247)
+		// already guards against pre-first-echo rip; this should
+		// remain sufficient. If iter11 measurement shows passive
+		// abandons spiking, the grace can be raised to 50-100ms.
+		c.IdleReleaseGrace = 30 * time.Millisecond
 	}
 	if c.LatencyHistogramReportInterval == 0 {
 		c.LatencyHistogramReportInterval = 60 * time.Second

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -264,40 +264,24 @@ func (c *Config) defaults() {
 		c.MaxOwnershipDuration = 10 * time.Second
 	}
 	if c.IdleReleaseGrace == 0 {
-		// F-33 (batch-29, iter10, 2026-05-15): lowered 200ms → 30ms.
+		// 200ms is enough for any eBUS transaction to complete (~100ms for
+		// the longest B524 frame) while releasing promptly after each scan
+		// probe. The wire phase is not advanced during gateway ownership,
+		// so there's no premature idle/WaitCmdAck issue.
 		//
-		// Pre-F-33 rationale was "200ms is enough for any eBUS
-		// transaction to complete (~100ms for the longest B524 frame)
-		// while releasing promptly after each scan probe." That value
-		// pre-dated F-21 (deferred terminal-SYN ownership release) which
-		// now handles normal-path completion at the trailing SYN
-		// observation. IdleReleaseGrace exists only as a SAFETY NET for
-		// cases where F-21 doesn't fire (protocol error / garbled byte
-		// fallback).
+		// F-33 (iter10) attempted to lower this to 30ms based on the
+		// observation that 96% of grants burn the full grace. F-33
+		// REGRESSED scan success from 65% to 51.6% because F-21
+		// (deferred terminal-SYN release) only applies to EXTERNAL
+		// sessions; the gateway's own transactions still rely on
+		// this grace for clean completion. Reverted to 200ms.
 		//
-		// Iter10 forensic (484 grants in 5-min capture): 467 / 484
-		// (96%) burned the FULL 200ms grace post-completion despite
-		// F-21 being deployed and ebusd's session-1 having pending
-		// STARTs queued during 21 of those releases (F-26 fired only
-		// 4% of the time). The remaining 96% of releases sat idle for
-		// 200ms, monopolizing ~40% of total bus wall-clock — directly
-		// preventing ebusd's tight-scan-08 sub-reads from landing
-		// inter-poll.
-		//
-		// 30ms = 6 SYN periods at 2400 baud (each SYN is ~4.5ms). Well
-		// above the longest legitimate inter-byte stall on the wire
-		// (eBUS spec: <15ms per SLAVE_RECV_TIMEOUT) but far below the
-		// pre-F-33 200ms monopoly cliff. Aligns with ebusd's own
-		// --acquiretimeout=10ms default scale.
-		//
-		// Risk: if F-21 misses a normal-path completion (un-audited
-		// edge case), a 30ms grace may rip ownership before the
-		// gateway's protocol.Bus.sendEndOfMessage path completes. The
-		// existing `suppressIdleRelease` predicate (mux.go ~2247)
-		// already guards against pre-first-echo rip; this should
-		// remain sufficient. If iter11 measurement shows passive
-		// abandons spiking, the grace can be raised to 50-100ms.
-		c.IdleReleaseGrace = 30 * time.Millisecond
+		// The 96%-burns-grace observation is correct but the inferred
+		// causal model was wrong: those releases ARE the gateway's
+		// own transactions completing normally via idle-grace
+		// (because F-21 doesn't apply to session-0). The grace is
+		// load-bearing for the gateway path.
+		c.IdleReleaseGrace = 200 * time.Millisecond
 	}
 	if c.LatencyHistogramReportInterval == 0 {
 		c.LatencyHistogramReportInterval = 60 * time.Second

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -142,6 +142,37 @@ type Config struct {
 	// start is cleared and the session is notified of failure (AM8).
 	StartDeadline time.Duration
 
+	// ExternalStartStaleness bounds the wall-clock age (measured from
+	// startRequest.enqueuedAt) of an EXTERNAL-session START at the
+	// moment the adapter reports `StreamEventStarted`. If the request
+	// has been in the gateway's path (pendingExternal queue + in-flight
+	// adapter arbitration) for longer than this budget, the grant is
+	// silently aborted: the session's notify channel receives
+	// `cancelled: true` (session.go's handleStart silent-suppress per
+	// F-17 takes the no-deliver branch) and ownership is NOT confirmed.
+	// The wire-level arbitration win still happened — bus state
+	// recovers naturally via the next SYN idle burst when no SEND
+	// frame follows.
+	//
+	// Iter1 fix (F-24, batch-21, 2026-05-14): ebusd's bus state machine
+	// times out internally before the gateway's queue+arbitration
+	// pipeline can deliver ENH_RES_STARTED for tight-scan-08 sub-
+	// register reads. When the late STARTED arrives, ebusd is in
+	// bs_recvCmd / bs_skip (mid-parsing the gateway's prior poll
+	// response) and logs `arbitration won in invalid state {skip|
+	// receive command|ready}`, silently dropping the request. The
+	// staleness guard prevents the gateway from delivering a grant
+	// that ebusd has already discarded, eliminating the bus-state
+	// desync. Default: 300ms (well below ebusd's typical 1-2s
+	// arbitration-wait timeout, but above the steady-state median
+	// queue+arbitration latency of ~50-150ms).
+	//
+	// Sentinels:
+	//   - 0 (zero value): use the 300ms default.
+	//   - Negative: disable the guard entirely (legacy behavior;
+	//     useful for regression testing). Tests use -1.
+	ExternalStartStaleness time.Duration
+
 	// BlackholeThreshold is the duration of consecutive read timeouts
 	// (after the bus was previously active) before triggering a TCP
 	// blackhole reconnect. Default: 30s.
@@ -220,6 +251,14 @@ func (c *Config) defaults() {
 	}
 	if c.StartDeadline <= 0 {
 		c.StartDeadline = 5 * time.Second
+	}
+	if c.ExternalStartStaleness == 0 {
+		// F-24 (batch-21, 2026-05-14): 300ms default. Well below ebusd's
+		// arbitration-wait timeout (~1-2s) so legitimate grants flow
+		// through; above the steady-state queue+arbitration latency
+		// (~50-150ms median) so normal traffic is unaffected. Operators
+		// can tune via the addon options.
+		c.ExternalStartStaleness = 300 * time.Millisecond
 	}
 	if c.BlackholeThreshold <= 0 {
 		c.BlackholeThreshold = 30 * time.Second
@@ -3208,6 +3247,52 @@ func (m *Mux) handleArbitrationResponse(started bool, data byte) {
 			// Advance the queue if anything else is pending. The
 			// adapter is fine; eBUS arbitration is per-SYN; no
 			// transport-level action is required.
+			if m.arb.hasPending() {
+				m.tryGrantAndStart()
+			}
+			return
+		}
+		// F-24 (batch-21, 2026-05-14): external-session START staleness
+		// guard. ebusd's bus state machine has an internal arbitration-
+		// wait timeout (~1-2s); when the gateway's queue+arbitration
+		// pipeline takes longer than ebusd's timeout, ebusd silently
+		// abandons the request internally. A late ENH_RES_STARTED then
+		// arrives in ebusd's bs_recvCmd / bs_skip / bs_ready-wrong
+		// state and ebusd logs `arbitration won in invalid state` and
+		// silently drops the bid — never sending the M2S frame bytes.
+		// ebusctl reports `ERR: arbitration lost`. Live evidence
+		// (2026-05-14 17:03-17:24): 31 invalid-state events over 27
+		// minutes; tight-scan-08 success rate 13-20% vs 95% target.
+		//
+		// Suppress grants whose age exceeds ExternalStartStaleness so
+		// the gateway never delivers a STARTED that ebusd will
+		// discard. Wire-level arbitration win recovers via the next
+		// SYN-idle burst because no SEND frame follows. The session's
+		// notify is set to cancelled:true so session.go's handleStart
+		// takes the silent-suppress branch (mirroring the F-17 C4/R4
+		// path semantics). Gateway session 0 is not subject to this
+		// guard because the gateway's own send path doesn't fall
+		// through ebusd's state machine.
+		if pending.sessionID != gatewaySessionID && pending.req != nil &&
+			m.cfg.ExternalStartStaleness > 0 &&
+			time.Since(pending.req.enqueuedAt) > m.cfg.ExternalStartStaleness {
+			m.pendingStart = nil
+			if pending.deadline != nil {
+				pending.deadline.Stop()
+			}
+			age := time.Since(pending.req.enqueuedAt)
+			m.stateMu.Unlock()
+			m.logger.Printf("adaptermux: suppressing stale STARTED for session %d — request age %v > budget %v (F-24)",
+				pending.sessionID, age, m.cfg.ExternalStartStaleness)
+			select {
+			case pending.notify <- startResult{
+				granted:   false,
+				cancelled: true,
+				initiator: pending.initiator,
+				err:       errors.New("adaptermux: external START exceeded ExternalStartStaleness budget (F-24)"),
+			}:
+			default:
+			}
 			if m.arb.hasPending() {
 				m.tryGrantAndStart()
 			}

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -142,6 +142,33 @@ type Config struct {
 	// start is cleared and the session is notified of failure (AM8).
 	StartDeadline time.Duration
 
+	// PostExternalReleaseGrace is the F-28 (batch-25, iter5,
+	// 2026-05-14) "polite yield" window. When an external session
+	// releases bus ownership, the arbitrator defers gateway-only
+	// grants for this duration so ebusd's TCP-delayed next
+	// ENH_REQ_START has time to arrive and be queued before the
+	// gateway's semantic poll loop re-bids and locks the bus.
+	//
+	// Live evidence (iter5 byte trace): without this gate, the
+	// gateway re-bids within microseconds after every external
+	// release, outracing ebusd's ~10-100ms TCP roundtrip every
+	// time. The result was a 200-500ms median ebusd START → STARTED
+	// latency, which compounds across multi-register scans into
+	// the residual 1-5s tail observed post-F-27.
+	//
+	// Sentinels:
+	//   - 0 (default): use 50ms.
+	//   - Negative: disable the cooldown entirely (legacy).
+	//
+	// 50ms is approximately:
+	//   ebusd's typical TCP roundtrip (~5-15ms)
+	//   + ebusd's bus-state-machine transition (~5-20ms)
+	//   + safety margin (10-30ms)
+	// Each 50ms cooldown sacrifices ~10% of the gateway's
+	// raw poll throughput when tight ebusd activity is happening,
+	// in exchange for ebusd actually completing its scans.
+	PostExternalReleaseGrace time.Duration
+
 	// FairnessRatio controls the gateway-vs-external grant rotation
 	// when BOTH a gateway pending START and at least one external
 	// pending START coexist. The arbitrator counts contended rotations
@@ -307,6 +334,11 @@ func (c *Config) defaults() {
 		// (~50-150ms median) so normal traffic is unaffected. Operators
 		// can tune via the addon options.
 		c.ExternalStartStaleness = 300 * time.Millisecond
+	}
+	if c.PostExternalReleaseGrace == 0 {
+		// F-28 (batch-25, iter5, 2026-05-14): default 50ms. See
+		// PostExternalReleaseGrace doc comment for rationale.
+		c.PostExternalReleaseGrace = 50 * time.Millisecond
 	}
 	if c.FairnessRatio == 0 {
 		// F-25 (batch-22, iter2, 2026-05-14): 2 = 50/50 split under
@@ -564,7 +596,7 @@ type sendRequest struct {
 func New(cfg Config) *Mux {
 	cfg.defaults()
 	arb := newArbitrator()
-	arb.setPolicy(cfg.PendingStartTTL, cfg.FairnessRatio)
+	arb.setPolicy(cfg.PendingStartTTL, cfg.FairnessRatio, cfg.PostExternalReleaseGrace)
 	return &Mux{
 		cfg:          cfg,
 		logger:       cfg.Logger,

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -349,17 +349,20 @@ func (c *Config) defaults() {
 		c.ExternalStartStaleness = 300 * time.Millisecond
 	}
 	if c.PostExternalReleaseGrace == 0 {
-		// F-29 (batch-26, iter6, 2026-05-14): widened from F-28 50ms to
-		// 100ms. iter5 byte-trace showed median ebusd START→STARTED
-		// latency dropped to 70ms with the 50ms cooldown, but 60 events
-		// remained in the 1-5s tail caused by ebusd's internal
-		// arbitration-wait timing out before STARTED arrives, then
-		// re-issuing STARTs that cascade through the same race window.
-		// 100ms gives ebusd ~50ms of "guaranteed gateway-silence" after
-		// every external release, well within ebusd's typical
-		// arbitration-wait tolerance (~150ms), while still allowing the
-		// gateway to do ~10 polls/sec when ebusd is idle.
-		c.PostExternalReleaseGrace = 100 * time.Millisecond
+		// F-36 (batch-31, iter13, 2026-05-15): widened to 250ms after
+		// F-35's 75ms watchdog stabilized at 73.3% tight-scan rate.
+		// Codex iter10 attack #2 recommendation: "External scan-burst
+		// lease — prefer ebusd for short bursts instead of 50/50
+		// fairness during `scan 08`". With 250ms cooldown, the gateway
+		// effectively yields a quarter-second window after every
+		// external release. During sustained ebusd activity (5 starts/
+		// sec under tight scan), the gateway poll rate drops to near-
+		// zero, eliminating most of the wire-contention that puts
+		// ebusd's reconstructor into bs_skip in the first place.
+		//
+		// Tradeoff: gateway semantic data freshness drops during
+		// external scan bursts. Acceptable — bursts are short.
+		c.PostExternalReleaseGrace = 250 * time.Millisecond
 	}
 	if c.FairnessRatio == 0 {
 		// F-25 (batch-22, iter2, 2026-05-14): 2 = 50/50 split under

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -265,15 +265,37 @@ func (c *Config) defaults() {
 		c.PendingStartTTL = 250 * time.Millisecond
 	}
 	if c.ExternalSessionSYNGrace == 0 {
-		// 2s covers a broadcast scan to address 0xFE (~25 responder
-		// responses × ~30-50ms each) plus arbitration jitter, while
-		// still bounding the worst-case idle hold. Calibrated against
-		// the 13:46:13 ebusd scan trace in
-		// _work_adaptermux_audit/EBUSD-VERIFICATION-2026-05-11-batch3.md:
-		// the protocol gap between ebusd's broadcast 0xFE and the
-		// last responder's response was ~190ms in that capture; 2s leaves
-		// generous headroom for buses with more participants.
-		c.ExternalSessionSYNGrace = 2 * time.Second
+		// F-27 (batch-24, iter4, 2026-05-14): lowered from 2s to 250ms.
+		//
+		// Pre-F-27 rationale was "leave generous headroom for buses with
+		// more participants" — calibrated against a 13:46:13 ebusd scan
+		// trace where the longest inter-responder gap was ~190ms. The
+		// 2s value was a 10x safety margin over that.
+		//
+		// The 2s margin turned out to be the dominant cause of the
+		// tight-scan-08 failures observed in batch-23 (iter3): when
+		// ebusd's bus state machine silently dropped a grant due to
+		// "arbitration won in invalid state" (a state collision caused
+		// by gateway queue delay timing out ebusd's internal arbitration
+		// wait), the gateway then held the now-dead external ownership
+		// for the FULL 2s grace before reclaiming. Byte-trace forensic
+		// evidence: /tmp/iter3-postfix-enh.txt latency analysis showed
+		// 246/580 events in the 1-5s bucket, with concrete examples of
+		// 8-second lockouts (gateway log 2026-05-14 21:53:25-21:53:39:
+		// 14 consecutive ebusd START 0x31 requests during a single
+		// stalled external ownership hold).
+		//
+		// Why 250ms: legitimate ebusd transactions bump
+		// `lastWireActivity` per echoed byte (mux.go ~1622, gated on
+		// !wire-SYN). At 2400 baud each byte is ~4-5ms on the wire, plus
+		// ENH framing overhead through TCP; observed median ebusd
+		// inter-byte gap is well under 50ms even for multi-responder
+		// scans. 250ms is 5x that worst-case while killing the
+		// silent-drop lockout. If a target's response really takes
+		// 250+ms (none observed in production traces), the grace
+		// expires and the next tryGrantAndStart re-grants the still-
+		// pending session immediately.
+		c.ExternalSessionSYNGrace = 250 * time.Millisecond
 	}
 	if c.StartDeadline <= 0 {
 		c.StartDeadline = 5 * time.Second

--- a/internal/adaptermux/session.go
+++ b/internal/adaptermux/session.go
@@ -142,6 +142,20 @@ type session struct {
 	// is closed with a clear "did you forget enh:HOST:PORT?" log line.
 	rejectedSendsWithoutHandshake atomic.Uint32
 
+	// F-34 (batch-30, iter11, 2026-05-15): "first SEND deadline"
+	// watchdog support. Bumped on every accepted handleSend call.
+	// The arbitrator's completeArbitrationGrant resets this to 0
+	// when granting ownership to this session and starts a timer; if
+	// the timer fires while this counter is still 0, the grant is
+	// declared abandoned (ebusd silently dropped it due to bs_skip
+	// state) and ownership is force-released.
+	//
+	// Live evidence (iter10): 23 `arbitration won in invalid state
+	// skip` events / 60-scan tight burst, each costing ~250ms F-27
+	// grace period before release. Reducing this to ~25ms watchdog
+	// is the surgical fix.
+	bytesSentSinceGrant atomic.Uint32
+
 	// wg waits for reader, writer, and handleStart goroutines to finish.
 	wg sync.WaitGroup
 }
@@ -449,6 +463,11 @@ func (s *session) handleSend(data byte) {
 		s.deliverErrorHost()
 		return
 	}
+	// F-34 (iter11): bump the bytes-since-grant counter so the
+	// abandon watchdog (started in completeArbitrationGrant) can
+	// distinguish a live transaction from a silently-dropped grant.
+	s.bytesSentSinceGrant.Add(1)
+
 	// F-6 observability: log accepted SEND bytes too. Without this, the
 	// happy-path forwarding to activeSendCh is silent and session logs
 	// can show START/INIT/INFO with no per-session SEND traffic even

--- a/internal/adaptermux/wire_phase.go
+++ b/internal/adaptermux/wire_phase.go
@@ -20,6 +20,30 @@ const (
 	wirePhaseWaitResponseLen                   // waiting for response LEN byte
 	wirePhaseWaitResponseBody                  // counting response body + CRC
 	wirePhaseWaitResponseAck                   // waiting for initiator final ACK
+	// wirePhaseWaitTerminalSyn (F-21, batch-20, 2026-05-14) is entered
+	// at every structural terminal of a master frame — broadcast ACK,
+	// i2i ACK, response success ACK, response double-NACK, CMD double-
+	// NACK. Pre-F-21 each of those byte positions immediately fired
+	// wirePhaseEventTransactionDone (or wirePhaseEventCmdNACK) and the
+	// mux released ownership at the SAME observation. That premature
+	// release rejected external sessions' (ebusd's) trailing-SYN
+	// ENH_REQ_SEND with "session N SEND 0xAA rejected — session does
+	// not own bus" because the wire round-trip between the gateway
+	// observing M_ACK and ebusd sending its terminal SYN crosses the
+	// ownership-release boundary. F-21 defers the terminal event one
+	// byte later: at the SYN observation the wire-phase tracker fires
+	// TransactionDone via advanceWaitTerminalSyn, and onSYNLocked
+	// releases ownership atomically with the SYN — by then ebusd's
+	// session.handleSend has already passed the owner check and
+	// forwarded the SYN to the adapter.
+	//
+	// Gateway session 0 is structurally unaffected: gateway-owned
+	// non-SYN bytes do NOT go through advanceWithProvenance (mux.go
+	// gates the call on !gateway-owned), so the tracker never enters
+	// any of these terminal sites under gateway ownership; the
+	// gateway's trailing SYN flows through the SYNIdle path with its
+	// own IdleReleaseGrace.
+	wirePhaseWaitTerminalSyn
 )
 
 // isSYNTimeoutBoundary reports whether receiving a SYN in this phase
@@ -105,6 +129,23 @@ func (t *wirePhaseTracker) advance(symbol byte) wirePhaseEvent {
 // onReceived path uses this; legacy plain-transport callers and
 // tests use the value-only advance() wrapper above.
 func (t *wirePhaseTracker) advanceWithProvenance(symbol byte, isWireSyn bool) wirePhaseEvent {
+	// F-21 (batch-20): wirePhaseWaitTerminalSyn is the deferred-terminal
+	// state entered by every structural terminal site (broadcast ACK,
+	// i2i ACK, response success ACK, response double-NACK, CMD double-
+	// NACK). Dispatch ANY byte arriving in that state directly to
+	// advanceWaitTerminalSyn BEFORE the generic isWireSyn handler runs.
+	// Without this intercept, the trailing SYN would be classified by
+	// the SYN-fallthrough branch below: WaitTerminalSyn is intentionally
+	// NOT in isSYNTimeoutBoundary's wait-set, so the fallthrough returns
+	// wirePhaseEventSYNIdle — which routes through the SYNIdle/idle-
+	// grace release path instead of firing TransactionDone. F-21 needs
+	// TransactionDone specifically so onSYNLocked's terminal release
+	// branch (no grace, immediate) fires; SYNIdle would impose
+	// IdleReleaseGrace and reorder relative to external session
+	// follow-up writes.
+	if t.phase == wirePhaseWaitTerminalSyn {
+		return t.advanceWaitTerminalSyn(symbol)
+	}
 	// SYN resets the tracker. If we were in a wait phase, it's a timeout.
 	if isWireSyn {
 		if t.phase.isSYNTimeoutBoundary() {
@@ -181,16 +222,22 @@ func (t *wirePhaseTracker) advanceWaitCmdAck(symbol byte) wirePhaseEvent {
 	if symbol == protocol.SymbolAck {
 		// Target ACK'd. Check if this is a broadcast (no response expected).
 		if t.requestDst == protocol.AddressBroadcast {
-			t.reset(wirePhaseIdle)
-			return wirePhaseEventTransactionDone
+			// F-21 (batch-20): defer TransactionDone to trailing SYN.
+			// Broadcast frames still have a SYN terminator; releasing
+			// ownership at ACK position rejected ebusd's trailing SYN
+			// ENH_REQ_SEND on external-session paths.
+			t.phase = wirePhaseWaitTerminalSyn
+			return wirePhaseEventNone
 		}
 		// AM1 fix: initiator-to-initiator (i2i) frames have no response
 		// phase. Initiator-capable addresses cannot be targets in a
 		// request-response transaction (eBUS spec). Transition to done
 		// instead of waiting for a response that will never arrive.
 		if protocol.IsInitiatorCapableAddress(t.requestDst) {
-			t.reset(wirePhaseIdle)
-			return wirePhaseEventTransactionDone
+			// F-21 (batch-20): defer TransactionDone to trailing SYN —
+			// same rationale as the broadcast branch above.
+			t.phase = wirePhaseWaitTerminalSyn
+			return wirePhaseEventNone
 		}
 		t.phase = wirePhaseWaitResponseLen
 		return wirePhaseEventCmdACK
@@ -209,11 +256,31 @@ func (t *wirePhaseTracker) advanceWaitCmdAck(symbol byte) wirePhaseEvent {
 			t.phase = wirePhaseCollectRequest
 			return wirePhaseEventCmdNACKRetry
 		}
-		t.reset(wirePhaseIdle)
-		return wirePhaseEventCmdNACK
+		// F-21 (batch-20): defer the terminal event to trailing SYN.
+		// Returning wirePhaseEventNone instead of wirePhaseEventCmdNACK
+		// here is a deliberate deviation from the F-21 prompt: the
+		// non-SYN release block at mux.go:1825-1846 fires on BOTH
+		// TransactionDone AND CmdNACK, so returning CmdNACK at this
+		// byte position would still release ownership prematurely and
+		// reject ebusd's trailing SYN. The diagnostic distinction
+		// (ReasonCmdNACK vs ReasonTransactionDone) is irrelevant on
+		// external paths (recordGatewayInactive only fires for
+		// gateway-owned txns, and gateway txns don't enter this branch
+		// because gateway-owned non-SYN bytes bypass the wire-phase
+		// tracker).
+		t.phase = wirePhaseWaitTerminalSyn
+		return wirePhaseEventNone
 	}
 
 	// Neither ACK nor NACK -- garbled byte, protocol error.
+	// F-21 NOTE: this defensive path is intentionally NOT redirected to
+	// wirePhaseWaitTerminalSyn. The bus is in a degraded state at this
+	// point; the initiator may or may not emit a trailing SYN. Falling
+	// through to Idle keeps the existing non-SYN CmdNACK release
+	// semantics for the protocol-error case; the eventual SYN (whether
+	// from the initiator or the bus's natural idle SYN burst) will
+	// arrive in Idle phase and fire SYNIdle through the generic
+	// fallthrough.
 	t.reset(wirePhaseIdle)
 	return wirePhaseEventCmdNACK
 }
@@ -251,11 +318,44 @@ func (t *wirePhaseTracker) advanceWaitResponseAck(symbol byte) wirePhaseEvent {
 			t.phase = wirePhaseWaitResponseLen
 			return wirePhaseEventNone
 		}
-		// Second NACK -- transaction considered complete (response failed).
-		t.reset(wirePhaseIdle)
-		return wirePhaseEventTransactionDone
+		// F-21 (batch-20): second NACK is a structural terminal. Defer
+		// TransactionDone to trailing SYN.
+		t.phase = wirePhaseWaitTerminalSyn
+		return wirePhaseEventNone
 	}
-	// ACK (0x00) or any other non-SYN symbol: transaction complete.
+	// F-21 (batch-20): ACK (0x00) or any other non-SYN symbol is the
+	// successful structural terminal. Defer TransactionDone to trailing
+	// SYN. The trailing SYN will be the ebusd-emitted 0xAA arriving via
+	// session.handleSend forwarded to the adapter; under F-21 deferral
+	// ownership remains with the external session through this round-
+	// trip, so the SYN send is accepted instead of rejected.
+	t.phase = wirePhaseWaitTerminalSyn
+	return wirePhaseEventNone
+}
+
+// advanceWaitTerminalSyn handles the byte that arrives while the tracker
+// is waiting for the trailing SYN of a fully-acknowledged (or terminally-
+// NACKed / broadcast / i2i-ACKed) master frame. F-21 (batch-20).
+//
+// Expected: the byte IS the trailing wire SYN (0xAA). When it arrives,
+// fire TransactionDone so onSYNLocked's terminal-SYN release branch
+// drops ownership atomically with the SYN observation. By this point
+// the external owner's session.handleSend has already forwarded its
+// SYN to the adapter — the owner check passed because the tracker
+// (and the mux) still considered the session the owner during the
+// wire round-trip.
+//
+// Defensive: any non-SYN byte arriving in this state is a protocol
+// anomaly (the initiator emitted something other than 0xAA after a
+// structural terminal). Still fire TransactionDone so the mux can
+// release ownership and the bus can recover; the next-frame parser
+// will treat the next byte as either junk (Layer 1 resync) or as a
+// fresh SRC. Without this defensive fire, a misbehaving initiator
+// could leave the tracker in WaitTerminalSyn indefinitely (the bus's
+// natural idle SYN burst would eventually rescue it, but explicit
+// recovery is cheaper than waiting on bus-idle physics).
+func (t *wirePhaseTracker) advanceWaitTerminalSyn(symbol byte) wirePhaseEvent {
+	_ = symbol
 	t.reset(wirePhaseIdle)
 	return wirePhaseEventTransactionDone
 }

--- a/internal/adaptermux/wire_phase_test.go
+++ b/internal/adaptermux/wire_phase_test.go
@@ -77,14 +77,23 @@ func TestWirePhase_FullTransaction(t *testing.T) {
 		t.Fatalf("response CRC: got event %d, want ResponseDone", got)
 	}
 
-	// Final ACK from initiator.
+	// F-21 (batch-20): final ACK now defers to trailing SYN. Final
+	// ACK byte returns None and transitions to WaitTerminalSyn.
 	got = tracker.advance(protocol.SymbolAck)
-	if got != wirePhaseEventTransactionDone {
-		t.Fatalf("final ACK: got event %d, want TransactionDone", got)
+	if got != wirePhaseEventNone {
+		t.Fatalf("final ACK: got event %d, want None (F-21 deferred terminal)", got)
+	}
+	if tracker.phase != wirePhaseWaitTerminalSyn {
+		t.Fatalf("phase after final ACK = %d, want WaitTerminalSyn (%d) (F-21)", tracker.phase, wirePhaseWaitTerminalSyn)
 	}
 
+	// F-21: trailing wire SYN fires TransactionDone and resets to Idle.
+	got = tracker.advance(protocol.SymbolSyn)
+	if got != wirePhaseEventTransactionDone {
+		t.Fatalf("trailing SYN: got event %d, want TransactionDone (F-21)", got)
+	}
 	if !tracker.isIdle() {
-		t.Fatal("expected idle after transaction")
+		t.Fatal("expected idle after trailing SYN (F-21)")
 	}
 }
 
@@ -102,10 +111,20 @@ func TestWirePhase_BroadcastTransaction(t *testing.T) {
 		t.Fatalf("CRC: got event %d, want RequestComplete", got)
 	}
 
-	// ACK on broadcast → transaction done (no response expected).
+	// F-21 (batch-20): broadcast ACK now defers to trailing SYN.
 	got = tracker.advance(protocol.SymbolAck)
+	if got != wirePhaseEventNone {
+		t.Fatalf("broadcast ACK: got event %d, want None (F-21 deferred terminal)", got)
+	}
+	if tracker.phase != wirePhaseWaitTerminalSyn {
+		t.Fatalf("phase after broadcast ACK = %d, want WaitTerminalSyn (F-21)", tracker.phase)
+	}
+	got = tracker.advance(protocol.SymbolSyn)
 	if got != wirePhaseEventTransactionDone {
-		t.Fatalf("broadcast ACK: got event %d, want TransactionDone", got)
+		t.Fatalf("broadcast trailing SYN: got event %d, want TransactionDone (F-21)", got)
+	}
+	if !tracker.isIdle() {
+		t.Fatal("expected idle after broadcast trailing SYN (F-21)")
 	}
 }
 
@@ -136,8 +155,16 @@ func TestWirePhase_NACK_FirstRetries(t *testing.T) {
 	}
 }
 
-func TestWirePhase_NACK_SecondGoesToIdle(t *testing.T) {
-	// AM2: second CMD NACK resets to idle.
+func TestWirePhase_NACK_SecondGoesToWaitTerminalSyn(t *testing.T) {
+	// AM2 + F-21 (batch-20): second CMD NACK now defers to trailing
+	// SYN. The byte returns None and transitions to WaitTerminalSyn;
+	// the trailing SYN fires TransactionDone. F-21 deviation from the
+	// pre-revert build (which returned CmdNACK at this byte position
+	// and reset to Idle): the non-SYN release block at mux.go
+	// previously released ownership on CmdNACK, which rejected
+	// ebusd's trailing-SYN ENH_REQ_SEND. CmdNACK is now folded into
+	// TransactionDone at the SYN observation; the diagnostic
+	// distinction (ReasonCmdNACK) is irrelevant for external paths.
 	var tracker wirePhaseTracker
 	tracker.startRequest()
 
@@ -157,13 +184,21 @@ func TestWirePhase_NACK_SecondGoesToIdle(t *testing.T) {
 		t.Fatalf("retry CRC: got event %d, want RequestComplete", got)
 	}
 
-	// Second NACK -> idle.
+	// F-21: second NACK -> None + WaitTerminalSyn (was CmdNACK + Idle).
 	got = tracker.advance(protocol.SymbolNack)
-	if got != wirePhaseEventCmdNACK {
-		t.Fatalf("second NACK: got event %d, want CmdNACK", got)
+	if got != wirePhaseEventNone {
+		t.Fatalf("second NACK: got event %d, want None (F-21 deferred terminal)", got)
+	}
+	if tracker.phase != wirePhaseWaitTerminalSyn {
+		t.Fatalf("phase after second NACK = %d, want WaitTerminalSyn (F-21)", tracker.phase)
+	}
+	// Trailing SYN -> TransactionDone + Idle.
+	got = tracker.advance(protocol.SymbolSyn)
+	if got != wirePhaseEventTransactionDone {
+		t.Fatalf("trailing SYN: got event %d, want TransactionDone (F-21)", got)
 	}
 	if !tracker.isIdle() {
-		t.Fatal("expected idle after second NACK")
+		t.Fatal("expected idle after trailing SYN (F-21)")
 	}
 }
 
@@ -421,9 +456,17 @@ func TestWirePhase_ZeroLengthResponse(t *testing.T) {
 		t.Fatalf("response CRC: got event %d, want ResponseDone", got)
 	}
 
-	got = tracker.advance(protocol.SymbolAck) // final ACK
+	// F-21 (batch-20): final ACK defers to trailing SYN.
+	got = tracker.advance(protocol.SymbolAck)
+	if got != wirePhaseEventNone {
+		t.Fatalf("final ACK: got event %d, want None (F-21 deferred terminal)", got)
+	}
+	if tracker.phase != wirePhaseWaitTerminalSyn {
+		t.Fatalf("phase after final ACK = %d, want WaitTerminalSyn (F-21)", tracker.phase)
+	}
+	got = tracker.advance(protocol.SymbolSyn)
 	if got != wirePhaseEventTransactionDone {
-		t.Fatalf("final ACK: got event %d, want TransactionDone", got)
+		t.Fatalf("trailing SYN: got event %d, want TransactionDone (F-21)", got)
 	}
 }
 
@@ -468,13 +511,20 @@ func TestWirePhase_NACKResponseRetry(t *testing.T) {
 		t.Fatalf("retry response CRC: event=%d, want ResponseDone", got)
 	}
 
-	// Initiator ACK -- transaction done.
+	// F-21 (batch-20): retry ACK defers to trailing SYN.
 	got = tracker.advance(protocol.SymbolAck)
+	if got != wirePhaseEventNone {
+		t.Fatalf("retry ACK: event=%d, want None (F-21 deferred terminal)", got)
+	}
+	if tracker.phase != wirePhaseWaitTerminalSyn {
+		t.Fatalf("phase after retry ACK = %d, want WaitTerminalSyn (F-21)", tracker.phase)
+	}
+	got = tracker.advance(protocol.SymbolSyn)
 	if got != wirePhaseEventTransactionDone {
-		t.Fatalf("retry ACK: event=%d, want TransactionDone", got)
+		t.Fatalf("trailing SYN: event=%d, want TransactionDone (F-21)", got)
 	}
 	if !tracker.isIdle() {
-		t.Fatal("expected idle after retry ACK")
+		t.Fatal("expected idle after trailing SYN (F-21)")
 	}
 }
 
@@ -499,12 +549,20 @@ func TestWirePhase_ResponseDoubleNACK(t *testing.T) {
 	tracker.advance(0x01)                       // LEN
 	tracker.advance(0xAB)                       // DATA
 	tracker.advance(0xEE)                       // CRC -> ResponseDone
-	got := tracker.advance(protocol.SymbolNack) // second NACK -> done
+	// F-21 (batch-20): second response NACK defers to trailing SYN.
+	got := tracker.advance(protocol.SymbolNack)
+	if got != wirePhaseEventNone {
+		t.Fatalf("second response NACK: event=%d, want None (F-21 deferred terminal)", got)
+	}
+	if tracker.phase != wirePhaseWaitTerminalSyn {
+		t.Fatalf("phase after second response NACK = %d, want WaitTerminalSyn (F-21)", tracker.phase)
+	}
+	got = tracker.advance(protocol.SymbolSyn)
 	if got != wirePhaseEventTransactionDone {
-		t.Fatalf("second response NACK: event=%d, want TransactionDone", got)
+		t.Fatalf("trailing SYN: event=%d, want TransactionDone (F-21)", got)
 	}
 	if !tracker.isIdle() {
-		t.Fatal("expected idle after second response NACK")
+		t.Fatal("expected idle after trailing SYN (F-21)")
 	}
 }
 
@@ -527,13 +585,22 @@ func TestWirePhase_InitiatorToInitiator(t *testing.T) {
 		t.Fatalf("expected RequestComplete, got %d", ev)
 	}
 
-	// ACK for i2i: should go directly to TransactionDone (no response).
+	// F-21 (batch-20): i2i ACK defers to trailing SYN. Pre-F-21 the
+	// AM1 fast-track returned TransactionDone immediately; post-F-21
+	// it transitions to WaitTerminalSyn and waits for the SYN.
 	ev = tracker.advance(protocol.SymbolAck)
+	if ev != wirePhaseEventNone {
+		t.Fatalf("i2i ACK: expected None (F-21 deferred terminal), got %d", ev)
+	}
+	if tracker.phase != wirePhaseWaitTerminalSyn {
+		t.Fatalf("phase after i2i ACK = %d, want WaitTerminalSyn (F-21)", tracker.phase)
+	}
+	ev = tracker.advance(protocol.SymbolSyn)
 	if ev != wirePhaseEventTransactionDone {
-		t.Fatalf("i2i ACK: expected TransactionDone, got %d", ev)
+		t.Fatalf("i2i trailing SYN: expected TransactionDone, got %d", ev)
 	}
 	if !tracker.isIdle() {
-		t.Fatal("expected idle after i2i ACK")
+		t.Fatal("expected idle after i2i trailing SYN (F-21)")
 	}
 }
 


### PR DESCRIPTION
## Summary

Surgical revert of the v0.6.13 stale-response window mechanism that
shipped on top of F-22 (PR #632 Codex bot P1 round-2). The mechanism
over-classified fresh adapter grants as stale, severing the active
path in a 10-second livelock while the bus stayed otherwise healthy
(ebusctl signal=acquired, other masters operating normally).

## Live evidence (2026-05-13 21:17:30 cycle, on injected v0.6.13)

```
21:17:30 absorb timeout reset reason=deadline (was waiting for 1) (F-22)
21:17:30 RequestStart(0x7F) sent for session 0           ← fresh bid
21:17:30 readLoop got StreamEventStarted data=0x7F       ← adapter GRANTS
21:17:30 readLoop dropping stale-window STARTED (F-22)   ← BUG: drops grant
21:17:35 pendingStart deadline expired (AM8 ...)
21:17:40 absorb timeout reset reason=deadline ...        ← LOOPS every 10s
```

Plus tight inner spam at ~15-30 lines/sec:
```
tryGrantAndStart skipped — waiting to absorb 1 stale arbitration response(s)
```

Functional state: zero active transactions completed; bus otherwise
healthy.

## What the revert removes (v0.6.13 over-extension)

- `Mux.staleAbsorbDeadline atomic.Int64` field + comments
- readLoop drop guard for `StreamEventStarted`
- readLoop drop guard for `StreamEventFailed`
- snapshot gating in `StreamEventStarted` / `StreamEventFailed` handlers
- `handleArbitrationResponse` stale-window absorb helper
- `deadline.Store(windowEnd)` call at `armPendingStartAbsorbLocked`

## What the revert preserves (legitimate F-22, untouched)

- `absorbResetTotal atomic.Uint64` counter
- the absorb-timeout reset path (log + counter reset, **no transport
  reconnect** — that's the F-22 contract that motivated this whole
  workstream)
- the existing `pendingStartAbsorb` decrement path in
  `handleArbitrationResponse` (this is what Codex P1 on #632 was
  trying to defend — the over-extension was the bug, the underlying
  decrement path was always correct)

Unaffected: F-15 AM8 blocking-path reconnect, F-17, F-18,
F-19a/c/d/e, F-23 consumer-side cleanup. helianthus-ebusgo F-23
escape decoder is in a separate repo and unchanged.

## Test artifacts (operator runs verification)

`internal/adaptermux/absorb_timeout_revert_test.go` — 6 regression
tests pinning the post-revert contract:

1. `TestF22_FreshRequestStartGrantNotDroppedAsStale` — exact
   livelock-reproducing sequence; asserts the fresh STARTED is granted
   and no drop log appears.
2. `TestF22_NoLivelockAfterReset` — 3 reset → RequestStart → grant
   cycles; pre-revert would hang on cycle 2 or 3.
3. `TestF22_TimeoutResetStillResetsCounterWithoutReconnect` —
   re-pins the F-22 contract (counter reset, no transport close).
4. `TestF22_NoStaleAbsorbWindowFieldsRemain` — reflection guard
   against orphan field reintroduction. Forbidden-token literals are
   built via `"stale" + "Absorb"` so a grep over the source tree does
   not false-positive on this guard file.
5. `TestF22_F15RegressionGuard_AM8BlockingPathReconnects` — reflection
   guard that F-15's `pendingStartState.blockingArb` /
   `Mux.blockingArbActive` / `Mux.blockingArbGen` survive.
6. `TestF22_LegitimateAbsorptionViaExistingPath` — confirms the
   existing counter-decrement path still absorbs legitimate late
   FAILEDs without surfacing any of the deleted log lines.

## Codex CLI adversarial review

gpt-5.5 high reasoning, 2 rounds:
- **r1**: 3 defects (race-prone `bytes.Buffer` in tests, forbidden
  tokens visible to source grep, stale F-22 doc comment in mux.go).
- **r2**: **clean — no defects.**

`grep -rnE "stale-window|stale-absorb|staleAbsorb|staleWindow"
internal/adaptermux/*.go` is empty across the entire tree.

## Test plan

- [ ] Operator runs `go test ./internal/adaptermux/... -run F22`
- [ ] Operator runs `go test -race ./internal/adaptermux/... -run F22`
- [ ] Operator runs `go vet ./...` and `gofmt -l`
- [ ] Cross-compiled aarch64 binary injected into running addon on HA
- [ ] Operator confirms post-injection log shows zero
      `dropping stale-window` lines and active transactions resume

## Notes for reviewers

- **Operator runs all verification.** This PR ships code + tests as
  artifacts only. Test execution is out of scope for the PR author.
- The binary will be cross-compiled (`GOOS=linux GOARCH=arm64`) and
  injected directly into the running addon container at
  `/usr/local/bin/helianthus-gateway` (no addon version bump). The
  addon stays on the cache-bypass `:0.6.1` retag until the operator
  chooses to roll v0.6.14.
- PR stays open for iteration. If live testing surfaces follow-ups,
  more commits land on the same branch and the cross-compile + inject
  cycle repeats without a new PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)