### PR TITLE
deps: bump ebusgo to 930830b8 for round-9 AUTO-SYN absorb

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Project-Helianthus/helianthus-ebusgateway
 go 1.22
 
 require (
-	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260518114417-249a8c75ded3
+	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260518144146-930830b8b1be
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260518052315-b0b2d881
 github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260518052315-b0b2d8812034/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
 github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260518114417-249a8c75ded3 h1:MKt2ULxqmRUi+NiFqs2KlaeL+VUthTnsXb8Eflkvmho=
 github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260518114417-249a8c75ded3/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
+github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260518144146-930830b8b1be h1:uAhT4Ff4Bk5+3OhyCQgI8v1f1wWNbGpDWj874ds/WCk=
+github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260518144146-930830b8b1be/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2 h1:6VFOfwe5L0GQkVRMcjdjCjnfBWcDoelnmoP1wIflrKM=
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=


### PR DESCRIPTION
Consumes helianthus-ebusgo PR #159 (merged at 930830b8). Live forensic data on HA bus confirmed 100% of pre_echo_syn_raw events fire at the payload-0xAA echo guard in sendRawWithEcho. The bus-level AUTO-SYN absorption (bounded cap 3) closes that path. Predicted ratio drop: ~5% → near zero.