### PR TITLE
Phase 3 Step B3.3: v8 classifier escape-decoder provenance counters

### DIFF
--- a/internal/adaptermux/v8classifier/classifier.go
+++ b/internal/adaptermux/v8classifier/classifier.go
@@ -184,9 +184,9 @@ func (c *Classifier) Observe(event transport.StreamEvent, now time.Time) (drop b
 
 // classifyByteProvenance increments exactly one of the four
 // provenance counters based on the (b, wasEscaped) tuple. Extracted
-// for testability — the routing logic is small but the four-way
-// branch deserves its own coverage in
-// classifier_provenance_test.go.
+// to keep Observe small and to support direct table-test coverage
+// of the four-way branch (see
+// classifier_provenance_test.go::TestClassifyByteProvenance_TableDriven).
 //
 // The taxonomy (per the Classifier struct field doc):
 //
@@ -199,16 +199,24 @@ func (c *Classifier) Observe(event transport.StreamEvent, now time.Time) (drop b
 //   - all (0x00..0xA8, false)
 //   - (0xA9, false) — should be impossible in a well-formed v8
 //     ENHTransport stream (a bare 0xA9 wire byte is the escape
-//     lead, not an emitted decoded byte), but counted defensively
-//     as plain to avoid silent drops.
+//     lead, not an emitted decoded byte). Folded into plain so the
+//     sum invariant holds; B3.3 INTENTIONALLY does NOT surface
+//     this as a separate anomaly counter — that is a follow-up
+//     enhancement once B3.4+ has the FSM context to decide whether
+//     the anomaly is meaningful (mid-frame anomaly vs harmless
+//     idle artifact).
 //   - all (0xAB..0xFF, false)
 //   - any (b, true) where b is neither 0xAA nor 0xA9 — should be
 //     impossible (the v8 escape decoder only emits wasEscaped=true
-//     for the two valid escape pairs), but counted defensively.
+//     for the two valid escape pairs). Same B3.3-intentional
+//     "fold into plain, don't surface separately" treatment.
 //
 // The defensive branches mean ALL StreamEventByte events
 // monotonically increment exactly one counter, regardless of
-// upstream bug or future protocol extension.
+// upstream bug or future protocol extension. If operators want
+// distinct visibility into these "impossible" cases, a future
+// PR can split out anomaly counters without breaking any existing
+// accessor's contract — the sum invariant is preserved either way.
 func (c *Classifier) classifyByteProvenance(b byte, wasEscaped bool) {
 	if wasEscaped {
 		switch b {

--- a/internal/adaptermux/v8classifier/classifier.go
+++ b/internal/adaptermux/v8classifier/classifier.go
@@ -55,6 +55,62 @@ type Classifier struct {
 	// operators can confirm the classifier is wired to the
 	// ENHTransport's admin event surface.
 	observedAdminEventsTotal atomic.Uint64
+
+	// Phase 3 Step B3.3 (escape-decoder observer counters): the v8
+	// design (§1.3 / §1.4) needs to distinguish four byte-class
+	// shapes emerging from the upstream ENHTransport's AA-aware
+	// escape decoder, ALL emitted as StreamEventByte but with
+	// different (Byte, WasEscaped) tuples:
+	//
+	//   (1) escapedPayloadAaTotal — Byte=0xAA, WasEscaped=true.
+	//       A data byte that happens to equal the SYN value,
+	//       transported on the wire as the escape pair 0xA9 0x01.
+	//       The B3.4 telegram FSM treats this as PAYLOAD; the
+	//       B3.6 AA-filter uses this counter to confirm the
+	//       proxy is correctly delivering payload-AA bytes
+	//       (vs dropping them as injection noise).
+	//
+	//   (2) escapedPayloadEscTotal — Byte=0xA9, WasEscaped=true.
+	//       A data byte that happens to equal the ESC lead value,
+	//       transported on the wire as the escape pair 0xA9 0x00.
+	//       Rare in production traffic; useful for operator
+	//       sanity-checking. The B3.4 FSM treats this as PAYLOAD.
+	//
+	//   (3) wireAutoSynTotal — Byte=0xAA, WasEscaped=false.
+	//       A REAL wire AUTO-SYN byte (bus-idle marker). The
+	//       B3.4 FSM treats this as either inter-telegram filler
+	//       (when IDLE) or invariant violation (when mid-frame —
+	//       AA-injection that the v8 escape decoder did NOT
+	//       absorb because it was inter-frame, not mid-pair).
+	//
+	//   (4) plainByteTotal — any other (Byte, WasEscaped=false)
+	//       tuple. Regular data bytes (telegram header, CRC,
+	//       ACK/NACK, source/target/PB/SB, NN, body bytes that
+	//       don't equal 0xAA or 0xA9).
+	//
+	// Invariants:
+	//   - (1) + (2) + (3) + (4) == count of StreamEventByte
+	//     events passing through Observe (excludes WireSyn /
+	//     Started / Failed / Reset which have their own counter
+	//     paths via observedBytesTotal but NOT via these four).
+	//   - Each counter monotonically non-decreasing.
+	//   - Atomic, race-tolerant, single-producer write side per
+	//     the Concurrency contract above.
+	//
+	// These counters are the building blocks for:
+	//   - B3.4 telegram FSM transitions (which need the
+	//     payload-vs-SYN distinction)
+	//   - B3.5 per-session pacer (which needs to know whether a
+	//     0xAA is filler or payload)
+	//   - B3.6 AA-injection filter (the ModeEnforce drop
+	//     decision keys on WasEscaped + FSM-phase)
+	//   - B3.7 shadow-mode divergence comparison (counts the
+	//     same shapes the existing pre-v8 path would have
+	//     applied round-7/round-9 mitigations to)
+	escapedPayloadAaTotal  atomic.Uint64
+	escapedPayloadEscTotal atomic.Uint64
+	wireAutoSynTotal       atomic.Uint64
+	plainByteTotal         atomic.Uint64
 }
 
 // New constructs a Classifier in the given mode. The zero-value
@@ -77,36 +133,106 @@ func (c *Classifier) Mode() Mode {
 // transport.StreamEvent that flows through the upstream. The hook
 // is allocation-free on the hot path.
 //
-// Phase 3 Step B3.2 (this file): in ModeOff the hook is a constant-
-// time no-op. In ModeShadow and ModeEnforce the hook increments
-// observedBytesTotal. Subsequent PRs will add:
+// Phase 3 Step B3.3 (this file): in ModeOff the hook is a constant-
+// time no-op. In ModeShadow / ModeEnforce the hook:
 //
-//   B3.3: route StreamEventByte / StreamEventWireSyn through the v8
-//         AA-aware escape decoder (already in ebusgo transport).
-//   B3.4: per-session telegram FSM instances.
-//   B3.5: per-session pacer + L_rtt EMA.
-//   B3.6: admin channel for PROTOCOL_FAULT + queue overflow.
-//   B3.7: shadow-mode divergence comparison vs the current path.
+//   - increments observedBytesTotal (every StreamEvent kind);
+//   - for StreamEventByte ONLY, classifies the byte into one of
+//     four provenance buckets based on (Byte, WasEscaped) and
+//     increments the matching counter (escapedPayloadAaTotal /
+//     escapedPayloadEscTotal / wireAutoSynTotal / plainByteTotal).
+//     See the field doc on Classifier for the full taxonomy.
+//
+// Future stacked PRs add:
+//
+//	B3.4: per-session telegram FSM instances (consumes the
+//	      provenance counters' underlying signal to drive
+//	      classify-then-transition rules from v8 §4).
+//	B3.5: per-session pacer + L_rtt EMA.
+//	B3.6: admin channel wiring + AA-injection drop decisions
+//	      (this is where Observe starts returning drop=true in
+//	      ModeEnforce for the right (Byte=0xAA, WasEscaped=false,
+//	      FSM phase != IDLE) tuple).
+//	B3.7: shadow-mode divergence comparison vs the current path.
 //
 // The `now` parameter is the monotonic-clock observation time for
 // this event (v8 I0). Callers that don't care about clock semantics
-// may pass time.Time{} — the scaffold ignores it; future PRs use
-// it for L_rtt / pacer.
+// may pass time.Time{} — B3.3 ignores it; B3.5+ use it for L_rtt /
+// pacer.
 //
 // Returns true if the caller should DROP this event from emission
 // to sessions. In ModeOff / ModeShadow the return is always false.
-// ModeEnforce will start returning true in B3.3 for filtered
-// AA-injection bytes. Callers in B3.2 may ignore the return value.
+// In B3.3 ModeEnforce also returns false (real filtering lands in
+// B3.6). Callers MAY ignore the return value until B3.6.
 func (c *Classifier) Observe(event transport.StreamEvent, now time.Time) (drop bool) {
 	if c == nil || c.mode == ModeOff {
 		return false
 	}
 	c.observedBytesTotal.Add(1)
-	// ModeShadow and ModeEnforce: no behavioral change yet. B3.3+
-	// will populate this path with real classification logic.
-	_ = event
+
+	// Provenance classification fires only for StreamEventByte.
+	// WireSyn / Started / Failed / Reset / unknown kinds bypass —
+	// they have their own semantic meaning and do NOT carry a
+	// (Byte, WasEscaped) tuple the escape-decoder provenance
+	// taxonomy applies to.
+	if event.Kind == transport.StreamEventByte {
+		c.classifyByteProvenance(event.Byte, event.WasEscaped)
+	}
 	_ = now
 	return false
+}
+
+// classifyByteProvenance increments exactly one of the four
+// provenance counters based on the (b, wasEscaped) tuple. Extracted
+// for testability — the routing logic is small but the four-way
+// branch deserves its own coverage in
+// classifier_provenance_test.go.
+//
+// The taxonomy (per the Classifier struct field doc):
+//
+//	(0xAA, true)  → escapedPayloadAaTotal   — payload 0xAA byte
+//	(0xA9, true)  → escapedPayloadEscTotal  — payload 0xA9 byte
+//	(0xAA, false) → wireAutoSynTotal        — real wire AUTO-SYN
+//	anything else → plainByteTotal          — regular data byte
+//
+// The "anything else" branch covers:
+//   - all (0x00..0xA8, false)
+//   - (0xA9, false) — should be impossible in a well-formed v8
+//     ENHTransport stream (a bare 0xA9 wire byte is the escape
+//     lead, not an emitted decoded byte), but counted defensively
+//     as plain to avoid silent drops.
+//   - all (0xAB..0xFF, false)
+//   - any (b, true) where b is neither 0xAA nor 0xA9 — should be
+//     impossible (the v8 escape decoder only emits wasEscaped=true
+//     for the two valid escape pairs), but counted defensively.
+//
+// The defensive branches mean ALL StreamEventByte events
+// monotonically increment exactly one counter, regardless of
+// upstream bug or future protocol extension.
+func (c *Classifier) classifyByteProvenance(b byte, wasEscaped bool) {
+	if wasEscaped {
+		switch b {
+		case 0xAA:
+			c.escapedPayloadAaTotal.Add(1)
+			return
+		case 0xA9:
+			c.escapedPayloadEscTotal.Add(1)
+			return
+		default:
+			// Defensive: escape decoder emitted wasEscaped=true
+			// for an unexpected byte. Treat as plain to avoid
+			// silent drop; downstream FSM will surface the
+			// anomaly via its own validation paths.
+			c.plainByteTotal.Add(1)
+			return
+		}
+	}
+	// wasEscaped == false.
+	if b == 0xAA {
+		c.wireAutoSynTotal.Add(1)
+		return
+	}
+	c.plainByteTotal.Add(1)
 }
 
 // OnAdminEvent is the per-admin-event hook that B3.6 will call
@@ -154,4 +280,55 @@ func (c *Classifier) ObservedAdminEventsTotal() uint64 {
 		return 0
 	}
 	return c.observedAdminEventsTotal.Load()
+}
+
+// EscapedPayloadAaTotal returns the cumulative count of payload
+// 0xAA bytes (Byte=0xAA, WasEscaped=true — wire-transported as the
+// escape pair 0xA9 0x01). Per Phase 3 Step B3.3 / v8 §1.4 this
+// distinguishes a real data byte equal to the SYN value from a
+// bus-idle wire AUTO-SYN (see WireAutoSynTotal). Returns 0 in
+// ModeOff. Safe to call from any goroutine.
+func (c *Classifier) EscapedPayloadAaTotal() uint64 {
+	if c == nil {
+		return 0
+	}
+	return c.escapedPayloadAaTotal.Load()
+}
+
+// EscapedPayloadEscTotal returns the cumulative count of payload
+// 0xA9 bytes (Byte=0xA9, WasEscaped=true — wire-transported as the
+// escape pair 0xA9 0x00). Rare in production traffic; exposed for
+// operator sanity-checking and shadow-mode comparison. Returns 0
+// in ModeOff. Safe to call from any goroutine.
+func (c *Classifier) EscapedPayloadEscTotal() uint64 {
+	if c == nil {
+		return 0
+	}
+	return c.escapedPayloadEscTotal.Load()
+}
+
+// WireAutoSynTotal returns the cumulative count of real wire
+// AUTO-SYN bytes (Byte=0xAA, WasEscaped=false). The bus-idle
+// marker. Per v8 §1.4 the FSM-driven AA filter (B3.6) decides
+// per-byte whether to forward the byte or drop it as
+// AA-injection based on the FSM phase; the count here records
+// every such byte regardless of forwarding decision. Returns 0
+// in ModeOff. Safe to call from any goroutine.
+func (c *Classifier) WireAutoSynTotal() uint64 {
+	if c == nil {
+		return 0
+	}
+	return c.wireAutoSynTotal.Load()
+}
+
+// PlainByteTotal returns the cumulative count of regular data
+// bytes — any (Byte, WasEscaped=false) tuple where Byte != 0xAA,
+// plus the defensive fall-through bucket for any unexpected
+// (WasEscaped=true, Byte not in {0xAA, 0xA9}) tuple. Returns 0
+// in ModeOff. Safe to call from any goroutine.
+func (c *Classifier) PlainByteTotal() uint64 {
+	if c == nil {
+		return 0
+	}
+	return c.plainByteTotal.Load()
 }

--- a/internal/adaptermux/v8classifier/classifier_provenance_test.go
+++ b/internal/adaptermux/v8classifier/classifier_provenance_test.go
@@ -1,0 +1,267 @@
+package v8classifier
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+// Phase 3 Step B3.3: tests for the per-byte escape-decoder
+// provenance taxonomy added by the Observe path. Each test pins
+// one of the four (Byte, WasEscaped) → counter mappings, plus the
+// defensive fall-through branches and the cross-counter invariants.
+
+// observeByte is a tiny helper that constructs a StreamEventByte
+// with the given (Byte, WasEscaped) and feeds it to the classifier.
+// Reduces noise in the assertions below.
+func observeByte(c *Classifier, b byte, wasEscaped bool) {
+	c.Observe(transport.StreamEvent{
+		Kind:       transport.StreamEventByte,
+		Byte:       b,
+		WasEscaped: wasEscaped,
+	}, time.Unix(0, 0))
+}
+
+// TestProvenance_EscapedPayloadAa pins the v8 §1.4 happy path: a
+// (0xAA, WasEscaped=true) event represents a data byte equal to
+// the SYN value, transported as 0xA9 0x01 on the wire. It MUST
+// land in escapedPayloadAaTotal, NOT wireAutoSynTotal.
+func TestProvenance_EscapedPayloadAa(t *testing.T) {
+	t.Parallel()
+	c := New(ModeShadow)
+	const n = 5
+	for i := 0; i < n; i++ {
+		observeByte(c, 0xAA, true)
+	}
+	if got := c.EscapedPayloadAaTotal(); got != n {
+		t.Errorf("EscapedPayloadAaTotal()=%d; want %d", got, n)
+	}
+	if got := c.WireAutoSynTotal(); got != 0 {
+		t.Errorf("WireAutoSynTotal()=%d; want 0 (must not bleed into wire-syn bucket)", got)
+	}
+	if got := c.EscapedPayloadEscTotal(); got != 0 {
+		t.Errorf("EscapedPayloadEscTotal()=%d; want 0", got)
+	}
+	if got := c.PlainByteTotal(); got != 0 {
+		t.Errorf("PlainByteTotal()=%d; want 0", got)
+	}
+}
+
+// TestProvenance_EscapedPayloadEsc pins the rarer escape pair
+// 0xA9 0x00 → logical 0xA9.
+func TestProvenance_EscapedPayloadEsc(t *testing.T) {
+	t.Parallel()
+	c := New(ModeShadow)
+	observeByte(c, 0xA9, true)
+	observeByte(c, 0xA9, true)
+	if got := c.EscapedPayloadEscTotal(); got != 2 {
+		t.Errorf("EscapedPayloadEscTotal()=%d; want 2", got)
+	}
+	if got := c.EscapedPayloadAaTotal(); got != 0 {
+		t.Errorf("EscapedPayloadAaTotal()=%d; want 0", got)
+	}
+}
+
+// TestProvenance_WireAutoSyn pins the canonical SYN: (0xAA, false)
+// is a real wire AUTO-SYN, NOT a payload-AA. This is the
+// provenance distinction the FSM (B3.4) and AA filter (B3.6)
+// depend on.
+func TestProvenance_WireAutoSyn(t *testing.T) {
+	t.Parallel()
+	c := New(ModeShadow)
+	for i := 0; i < 10; i++ {
+		observeByte(c, 0xAA, false)
+	}
+	if got := c.WireAutoSynTotal(); got != 10 {
+		t.Errorf("WireAutoSynTotal()=%d; want 10", got)
+	}
+	if got := c.EscapedPayloadAaTotal(); got != 0 {
+		t.Errorf("EscapedPayloadAaTotal()=%d; want 0 (must not bleed into payload bucket)", got)
+	}
+}
+
+// TestProvenance_PlainByte covers regular data bytes: any
+// (Byte != 0xAA, WasEscaped=false). Source/target addresses,
+// PB/SB, NN, CRC, ACK/NACK, body bytes that don't equal 0xAA all
+// land here.
+func TestProvenance_PlainByte(t *testing.T) {
+	t.Parallel()
+	c := New(ModeShadow)
+	plainBytes := []byte{0x00, 0x01, 0x08, 0x10, 0x55, 0x71, 0x7F, 0xB5, 0xFE, 0xFF}
+	for _, b := range plainBytes {
+		observeByte(c, b, false)
+	}
+	if got := c.PlainByteTotal(); got != uint64(len(plainBytes)) {
+		t.Errorf("PlainByteTotal()=%d; want %d", got, len(plainBytes))
+	}
+	if got := c.WireAutoSynTotal(); got != 0 {
+		t.Errorf("WireAutoSynTotal()=%d; want 0", got)
+	}
+	if got := c.EscapedPayloadAaTotal(); got != 0 {
+		t.Errorf("EscapedPayloadAaTotal()=%d; want 0", got)
+	}
+}
+
+// TestProvenance_DefensiveFallThrough_BareA9NotEscaped covers the
+// defensive branch: a (0xA9, WasEscaped=false) tuple should not
+// occur in a well-formed v8 stream (a bare 0xA9 wire byte is the
+// escape lead, not an emitted decoded byte), but if it ever does,
+// it lands in plainByteTotal (not silently dropped).
+func TestProvenance_DefensiveFallThrough_BareA9NotEscaped(t *testing.T) {
+	t.Parallel()
+	c := New(ModeShadow)
+	observeByte(c, 0xA9, false)
+	if got := c.PlainByteTotal(); got != 1 {
+		t.Errorf("PlainByteTotal()=%d; want 1 (bare 0xA9 is defensively counted as plain)", got)
+	}
+}
+
+// TestProvenance_DefensiveFallThrough_UnexpectedEscaped covers the
+// other defensive branch: a (b, WasEscaped=true) tuple where b is
+// neither 0xAA nor 0xA9. The v8 escape decoder should never emit
+// this, but if it does (bug or future protocol extension), the
+// byte is defensively counted as plain — NOT silently dropped.
+func TestProvenance_DefensiveFallThrough_UnexpectedEscaped(t *testing.T) {
+	t.Parallel()
+	c := New(ModeShadow)
+	for _, b := range []byte{0x00, 0x55, 0x80, 0xFF} {
+		observeByte(c, b, true)
+	}
+	if got := c.PlainByteTotal(); got != 4 {
+		t.Errorf("PlainByteTotal()=%d; want 4 (unexpected escaped bytes defensively counted as plain)", got)
+	}
+	if got := c.EscapedPayloadAaTotal(); got != 0 {
+		t.Errorf("EscapedPayloadAaTotal()=%d; want 0", got)
+	}
+}
+
+// TestProvenance_SumInvariant pins the core invariant: for any
+// stream of StreamEventByte events, the four provenance counters
+// sum to the count of StreamEventByte events observed. Non-Byte
+// events (WireSyn, Started, Failed, Reset) MUST NOT contribute
+// to any of the four.
+func TestProvenance_SumInvariant(t *testing.T) {
+	t.Parallel()
+	c := New(ModeShadow)
+	now := time.Unix(0, 0)
+
+	// Mixed StreamEventByte stream.
+	for _, e := range []transport.StreamEvent{
+		{Kind: transport.StreamEventByte, Byte: 0xAA, WasEscaped: true},  // payload AA
+		{Kind: transport.StreamEventByte, Byte: 0xAA, WasEscaped: false}, // wire SYN
+		{Kind: transport.StreamEventByte, Byte: 0x55, WasEscaped: false}, // plain
+		{Kind: transport.StreamEventByte, Byte: 0xA9, WasEscaped: true},  // payload ESC
+		{Kind: transport.StreamEventByte, Byte: 0x71, WasEscaped: false}, // plain
+		// Mixed-in non-Byte events that MUST be observed but NOT
+		// land in any provenance bucket.
+		{Kind: transport.StreamEventWireSyn, Byte: 0xAA},
+		{Kind: transport.StreamEventStarted, Data: 0x71},
+		{Kind: transport.StreamEventFailed, Data: 0x10},
+		{Kind: transport.StreamEventReset},
+	} {
+		c.Observe(e, now)
+	}
+
+	const streamEventByteCount = 5
+
+	sum := c.EscapedPayloadAaTotal() +
+		c.EscapedPayloadEscTotal() +
+		c.WireAutoSynTotal() +
+		c.PlainByteTotal()
+	if sum != streamEventByteCount {
+		t.Errorf("sum of provenance counters = %d; want %d (one bucket per StreamEventByte)", sum, streamEventByteCount)
+	}
+
+	// Per-bucket breakdown.
+	if got := c.EscapedPayloadAaTotal(); got != 1 {
+		t.Errorf("EscapedPayloadAaTotal()=%d; want 1", got)
+	}
+	if got := c.EscapedPayloadEscTotal(); got != 1 {
+		t.Errorf("EscapedPayloadEscTotal()=%d; want 1", got)
+	}
+	if got := c.WireAutoSynTotal(); got != 1 {
+		t.Errorf("WireAutoSynTotal()=%d; want 1", got)
+	}
+	if got := c.PlainByteTotal(); got != 2 {
+		t.Errorf("PlainByteTotal()=%d; want 2", got)
+	}
+
+	// Non-Byte events DID increment observedBytesTotal (per B3.2
+	// contract — every StreamEvent kind counts there) but did NOT
+	// touch any provenance bucket.
+	if got := c.ObservedBytesTotal(); got != 9 {
+		t.Errorf("ObservedBytesTotal()=%d; want 9 (5 Byte + 4 other)", got)
+	}
+}
+
+// TestProvenance_OffMode_AllCountersZero pins the production-default
+// invariant: ModeOff yields ZERO observation overhead — no
+// provenance bucket ever increments.
+func TestProvenance_OffMode_AllCountersZero(t *testing.T) {
+	t.Parallel()
+	c := New(ModeOff)
+	for i := 0; i < 20; i++ {
+		observeByte(c, 0xAA, true)
+		observeByte(c, 0xAA, false)
+		observeByte(c, 0x55, false)
+	}
+	if got := c.EscapedPayloadAaTotal(); got != 0 {
+		t.Errorf("EscapedPayloadAaTotal()=%d; want 0 in ModeOff", got)
+	}
+	if got := c.WireAutoSynTotal(); got != 0 {
+		t.Errorf("WireAutoSynTotal()=%d; want 0 in ModeOff", got)
+	}
+	if got := c.PlainByteTotal(); got != 0 {
+		t.Errorf("PlainByteTotal()=%d; want 0 in ModeOff", got)
+	}
+	if got := c.EscapedPayloadEscTotal(); got != 0 {
+		t.Errorf("EscapedPayloadEscTotal()=%d; want 0 in ModeOff", got)
+	}
+}
+
+// TestProvenance_NilReceiverSafe pins that all four new accessors
+// accept a nil receiver and return 0. Lets adaptermux callsites
+// use them without nil-checking.
+func TestProvenance_NilReceiverSafe(t *testing.T) {
+	t.Parallel()
+	var c *Classifier
+	if got := c.EscapedPayloadAaTotal(); got != 0 {
+		t.Errorf("nil.EscapedPayloadAaTotal()=%d; want 0", got)
+	}
+	if got := c.EscapedPayloadEscTotal(); got != 0 {
+		t.Errorf("nil.EscapedPayloadEscTotal()=%d; want 0", got)
+	}
+	if got := c.WireAutoSynTotal(); got != 0 {
+		t.Errorf("nil.WireAutoSynTotal()=%d; want 0", got)
+	}
+	if got := c.PlainByteTotal(); got != 0 {
+		t.Errorf("nil.PlainByteTotal()=%d; want 0", got)
+	}
+}
+
+// TestProvenance_EnforceMode_DoesNotDropYet pins the B3.3 scaffold-
+// only contract: even with provenance classification active, the
+// classifier in ModeEnforce returns drop=false for every byte. Real
+// filtering decisions (which CAN return drop=true on
+// AA-injection mid-frame) land in B3.6 once the FSM (B3.4) and
+// admin channel are in.
+func TestProvenance_EnforceMode_DoesNotDropYet(t *testing.T) {
+	t.Parallel()
+	c := New(ModeEnforce)
+	now := time.Unix(0, 0)
+	// Feed the four canonical shapes plus the two defensive
+	// fall-throughs. NONE should produce drop=true.
+	for _, e := range []transport.StreamEvent{
+		{Kind: transport.StreamEventByte, Byte: 0xAA, WasEscaped: true},
+		{Kind: transport.StreamEventByte, Byte: 0xA9, WasEscaped: true},
+		{Kind: transport.StreamEventByte, Byte: 0xAA, WasEscaped: false},
+		{Kind: transport.StreamEventByte, Byte: 0x55, WasEscaped: false},
+		{Kind: transport.StreamEventByte, Byte: 0xA9, WasEscaped: false}, // defensive
+		{Kind: transport.StreamEventByte, Byte: 0x42, WasEscaped: true},  // defensive
+	} {
+		if drop := c.Observe(e, now); drop {
+			t.Errorf("Observe(%+v) returned drop=true in ModeEnforce; B3.3 scaffold MUST always return false until B3.6 wires real filtering", e)
+		}
+	}
+}

--- a/internal/adaptermux/v8classifier/classifier_provenance_test.go
+++ b/internal/adaptermux/v8classifier/classifier_provenance_test.go
@@ -240,6 +240,76 @@ func TestProvenance_NilReceiverSafe(t *testing.T) {
 	}
 }
 
+// TestClassifyByteProvenance_TableDriven exercises classifyByteProvenance
+// directly (NOT through Observe) so the four-way routing branch has
+// dedicated, isolated coverage. Per Codex round-1 hygiene note on
+// PR #640: the method's doc-comment claims testability as the
+// extraction rationale; this is the test that earns that claim.
+//
+// Each row asserts: feeding (b, wasEscaped) to classifyByteProvenance
+// increments exactly the expected counter by 1 and leaves the
+// other three at 0.
+func TestClassifyByteProvenance_TableDriven(t *testing.T) {
+	t.Parallel()
+
+	rows := []struct {
+		name        string
+		b           byte
+		wasEscaped  bool
+		wantPayloadAa, wantPayloadEsc, wantWireSyn, wantPlain uint64
+	}{
+		// Canonical taxonomy.
+		{"PayloadAA", 0xAA, true, 1, 0, 0, 0},
+		{"PayloadESC", 0xA9, true, 0, 1, 0, 0},
+		{"WireSYN", 0xAA, false, 0, 0, 1, 0},
+		// Several plain-byte representatives across the byte range.
+		{"Plain_0x00", 0x00, false, 0, 0, 0, 1},
+		{"Plain_0x55", 0x55, false, 0, 0, 0, 1},
+		{"Plain_0x71_gateway", 0x71, false, 0, 0, 0, 1},
+		{"Plain_0xA8_belowAA", 0xA8, false, 0, 0, 0, 1},
+		{"Plain_0xAB_aboveAA", 0xAB, false, 0, 0, 0, 1},
+		{"Plain_0xFE_broadcast", 0xFE, false, 0, 0, 0, 1},
+		{"Plain_0xFF", 0xFF, false, 0, 0, 0, 1},
+		// Defensive fall-throughs (impossible in a well-formed
+		// v8 stream but folded into plain by design).
+		{"Defensive_bareA9_notEscaped", 0xA9, false, 0, 0, 0, 1},
+		{"Defensive_0x42_escaped", 0x42, true, 0, 0, 0, 1},
+		{"Defensive_0xFF_escaped", 0xFF, true, 0, 0, 0, 1},
+		{"Defensive_0x00_escaped", 0x00, true, 0, 0, 0, 1},
+	}
+
+	for _, row := range rows {
+		row := row
+		t.Run(row.name, func(t *testing.T) {
+			t.Parallel()
+			// Fresh classifier per row — isolation.
+			c := New(ModeShadow)
+			c.classifyByteProvenance(row.b, row.wasEscaped)
+
+			if got := c.EscapedPayloadAaTotal(); got != row.wantPayloadAa {
+				t.Errorf("EscapedPayloadAaTotal()=%d; want %d", got, row.wantPayloadAa)
+			}
+			if got := c.EscapedPayloadEscTotal(); got != row.wantPayloadEsc {
+				t.Errorf("EscapedPayloadEscTotal()=%d; want %d", got, row.wantPayloadEsc)
+			}
+			if got := c.WireAutoSynTotal(); got != row.wantWireSyn {
+				t.Errorf("WireAutoSynTotal()=%d; want %d", got, row.wantWireSyn)
+			}
+			if got := c.PlainByteTotal(); got != row.wantPlain {
+				t.Errorf("PlainByteTotal()=%d; want %d", got, row.wantPlain)
+			}
+
+			// Sum invariant always holds: exactly one counter
+			// incremented per call.
+			sum := c.EscapedPayloadAaTotal() + c.EscapedPayloadEscTotal() +
+				c.WireAutoSynTotal() + c.PlainByteTotal()
+			if sum != 1 {
+				t.Errorf("sum=%d; want 1 (exactly one bucket per call)", sum)
+			}
+		})
+	}
+}
+
 // TestProvenance_EnforceMode_DoesNotDropYet pins the B3.3 scaffold-
 // only contract: even with provenance classification active, the
 // classifier in ModeEnforce returns drop=false for every byte. Real

--- a/internal/adaptermux/v8classifier/mode.go
+++ b/internal/adaptermux/v8classifier/mode.go
@@ -14,24 +14,24 @@
 //
 // Mode rollout (per v8 §1.10):
 //
-//   off     — classifier is dormant. No observation, no counters,
-//             no behavioral effect. Production default until B3.7
-//             live-bus validation closes.
-//   shadow  — classifier observes every wire byte AND admin event
-//             from the upstream transport and computes its
-//             classification decisions, but DOES NOT alter the
-//             byte stream forwarded to sessions. Divergences vs
-//             the current pre-v8 path are logged to the admin
-//             channel for operator inspection. Used during live-
-//             bus validation (Step C / B3.7).
-//   enforce — classifier replaces the pre-v8 read path. Round-7
-//             mitigations (betweenWritesSyn, queueJustDrained,
-//             payloadAaAutoSyn*) become unreachable code paths;
-//             v8 round-9 absorb counter
-//             (Bus.Round9AbsorbEntered) should stay at 0 under
-//             a healthy proxy. The Prometheus alert
-//             HelianthusRound9FiredUnderProxy (v8 §1.12) is the
-//             primary safety net.
+//	off     — classifier is dormant. No observation, no counters,
+//	          no behavioral effect. Production default until B3.7
+//	          live-bus validation closes.
+//	shadow  — classifier observes every wire byte AND admin event
+//	          from the upstream transport and computes its
+//	          classification decisions, but DOES NOT alter the
+//	          byte stream forwarded to sessions. Divergences vs
+//	          the current pre-v8 path are logged to the admin
+//	          channel for operator inspection. Used during live-
+//	          bus validation (Step C / B3.7).
+//	enforce — classifier replaces the pre-v8 read path. Round-7
+//	          mitigations (betweenWritesSyn, queueJustDrained,
+//	          payloadAaAutoSyn*) become unreachable code paths;
+//	          v8 round-9 absorb counter
+//	          (Bus.Round9AbsorbEntered) should stay at 0 under
+//	          a healthy proxy. The Prometheus alert
+//	          HelianthusRound9FiredUnderProxy (v8 §1.12) is the
+//	          primary safety net.
 package v8classifier
 
 import (

--- a/internal/adaptermux/v8classifier/mode_test.go
+++ b/internal/adaptermux/v8classifier/mode_test.go
@@ -68,13 +68,13 @@ func TestParseMode_UnknownLabels(t *testing.T) {
 	for _, in := range []string{
 		"enfource", // typo
 		"shadows",
-		"on",        // ambiguous — must be off|shadow|enforce
-		"1",         // arabic-numeral truthy — could be confused with "on"
-		"yes",       // truthy
-		"true",      // truthy
-		"force",     // half-word
-		"shadow!",   // suffix
-		"v8",        // shorthand
+		"on",      // ambiguous — must be off|shadow|enforce
+		"1",       // arabic-numeral truthy — could be confused with "on"
+		"yes",     // truthy
+		"true",    // truthy
+		"force",   // half-word
+		"shadow!", // suffix
+		"v8",      // shorthand
 	} {
 		got, err := ParseMode(in)
 		if err == nil {

--- a/internal/adaptermux/v8classifier_wiring_test.go
+++ b/internal/adaptermux/v8classifier_wiring_test.go
@@ -123,6 +123,79 @@ func TestV8Classifier_ShadowMode_InstantiatedAndObserves(t *testing.T) {
 	}
 }
 
+// TestV8Classifier_ShadowMode_ProvenanceCountersThroughMux pins the
+// B3.3 provenance taxonomy at the mux boundary: bytes with
+// different (Byte, WasEscaped) tuples flowing through the
+// readLoop must land in the correct provenance buckets.
+//
+// Three event shapes:
+//   - (0xAA, WasEscaped=true)  → escapedPayloadAaTotal
+//   - (0xAA, WasEscaped=false) → wireAutoSynTotal
+//   - (0x55, WasEscaped=false) → plainByteTotal
+func TestV8Classifier_ShadowMode_ProvenanceCountersThroughMux(t *testing.T) {
+	mux, mock, _, cleanup := newClassifiedTestMux(t, v8classifier.ModeShadow)
+	defer cleanup()
+
+	c := mux.V8Classifier()
+	if c == nil {
+		t.Fatal("V8Classifier() = nil in ModeShadow; want non-nil")
+	}
+
+	// Push 3 of each shape (9 StreamEventByte events).
+	for i := 0; i < 3; i++ {
+		mock.eventCh <- transport.StreamEvent{
+			Kind:       transport.StreamEventByte,
+			Byte:       0xAA,
+			WasEscaped: true,
+		}
+		mock.eventCh <- transport.StreamEvent{
+			Kind:       transport.StreamEventByte,
+			Byte:       0xAA,
+			WasEscaped: false,
+		}
+		mock.eventCh <- transport.StreamEvent{
+			Kind:       transport.StreamEventByte,
+			Byte:       0x55,
+			WasEscaped: false,
+		}
+	}
+
+	// Poll until all 9 events are observed.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if c.ObservedBytesTotal() >= 9 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := c.ObservedBytesTotal(); got != 9 {
+		t.Fatalf("ObservedBytesTotal()=%d; want 9 (readLoop must dispatch every StreamEvent)", got)
+	}
+
+	if got := c.EscapedPayloadAaTotal(); got != 3 {
+		t.Errorf("EscapedPayloadAaTotal()=%d; want 3 (3 payload-AA events)", got)
+	}
+	if got := c.WireAutoSynTotal(); got != 3 {
+		t.Errorf("WireAutoSynTotal()=%d; want 3 (3 wire-SYN events)", got)
+	}
+	if got := c.PlainByteTotal(); got != 3 {
+		t.Errorf("PlainByteTotal()=%d; want 3 (3 plain-byte events)", got)
+	}
+	// EscapedPayloadEsc should stay 0 — we didn't send any.
+	if got := c.EscapedPayloadEscTotal(); got != 0 {
+		t.Errorf("EscapedPayloadEscTotal()=%d; want 0 (no payload-ESC events sent)", got)
+	}
+
+	// Cross-counter invariant from the unit test, re-verified at
+	// the mux level: sum of provenance buckets == count of
+	// StreamEventByte events == 9.
+	sum := c.EscapedPayloadAaTotal() + c.EscapedPayloadEscTotal() +
+		c.WireAutoSynTotal() + c.PlainByteTotal()
+	if sum != 9 {
+		t.Errorf("sum of provenance counters = %d; want 9", sum)
+	}
+}
+
 // TestV8Classifier_EnforceMode_InstantiatedAndObservesButDoesNotDrop
 // pins the B3.2-scaffold invariant for enforce mode: even when the
 // caller explicitly opts in to ModeEnforce, the classifier in this


### PR DESCRIPTION
## Summary

Extends the B3.2 classifier scaffold with the per-byte
`(Byte, WasEscaped)` provenance taxonomy that the v8 telegram FSM
(B3.4), per-session pacer (B3.5), AA-injection filter (B3.6), and
shadow-mode comparison (B3.7) all depend on.

**Shadow-mode observation only — no enforce-mode filtering, no drop decisions.** Real filtering still lands in B3.6.

## Taxonomy (v8 §1.4)

| (Byte, WasEscaped) | Counter | What it represents |
|---|---|---|
| (0xAA, true) | `EscapedPayloadAaTotal` | Payload byte = SYN value, wire-transported as `0xA9 0x01`. FSM treats as PAYLOAD. |
| (0xA9, true) | `EscapedPayloadEscTotal` | Payload byte = ESC value, wire-transported as `0xA9 0x00`. FSM treats as PAYLOAD. Rare. |
| (0xAA, false) | `WireAutoSynTotal` | **Real wire AUTO-SYN** (bus-idle marker). FSM treats as filler (IDLE) or invariant violation (mid-frame). |
| anything else | `PlainByteTotal` | Regular data bytes + defensive fall-through for malformed (b, true) tuples the v8 decoder shouldn't emit. |

## Invariants

- (1) + (2) + (3) + (4) == count of `StreamEventByte` events observed.
- Each counter monotonically non-decreasing.
- Defensive branches guarantee every `StreamEventByte` increments exactly one provenance counter regardless of upstream bug.
- `ModeOff` is still strictly **zero observation overhead** via the call-site nil-guard from B3.2.

## Tests (11 new, all green under `-race`)

`classifier_provenance_test.go` (10 tests):
- Per-shape happy paths (PayloadAa / PayloadEsc / WireAutoSyn / PlainByte)
- 2 defensive fall-throughs (bare 0xA9 not escaped; unexpected (b, true) tuples)
- `SumInvariant` — pins the cross-counter invariant
- `OffMode_AllCountersZero` — zero-overhead default
- `NilReceiverSafe` — accessors accept nil
- `EnforceMode_DoesNotDropYet` — B3.3 SCAFFOLD invariant: even in enforce mode, `drop=false` for every byte until B3.6 wires real filtering

`v8classifier_wiring_test.go` (1 extended test):
- `ShadowMode_ProvenanceCountersThroughMux` — 9 events with 3 distinct provenance shapes flowing through `readLoop`; verifies each lands in the right bucket and the sum invariant holds at the mux boundary.

## Test plan

- [x] `GOWORK=off go build ./...` — clean
- [x] `GOWORK=off go test ./... -race` — full gateway suite green (109s adaptermux + 2s v8classifier)
- [x] `GOWORK=off go vet ./...` — clean
- [x] `gofmt -l` — clean
- [x] Terminology gate — clean

## What this PR does NOT do

- ❌ No FSM (B3.4)
- ❌ No pacer / L_rtt (B3.5)
- ❌ No admin channel / drop decisions (B3.6)
- ❌ No shadow-mode divergence comparison (B3.7)

## References

- frame-atomic-visibility-v8 §1.3 — escape decoder spec
- frame-atomic-visibility-v8 §1.4 — provenance distinguishability
- frame-atomic-visibility-v8 §4 — classify-then-transition FSM
- frame-atomic-visibility-v8 §1.10 — phased rollout order
- Corrected implementation plan v2.1 — Phase 3 Step B3.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)