### PR TITLE
Phase 3 Step B3.4: wire per-byte telegram FSM into the v8 classifier

### DIFF
--- a/internal/adaptermux/v8classifier/classifier.go
+++ b/internal/adaptermux/v8classifier/classifier.go
@@ -163,6 +163,25 @@ type Classifier struct {
 	// boundaries the legacy passive observer sees.
 	fsmEnterPassiveTotal atomic.Uint64
 	fsmResetTotal        atomic.Uint64
+
+	// Atomic snapshots of the FSM's externally-visible state. Per
+	// Codex round-1 review on PR #641: telegram_fsm.Machine is NOT
+	// thread-safe (its Machine.State() reads the same mutable
+	// fields Observe writes via Feed/Enter*/Reset). Direct
+	// accessors that touched c.fsm would race against the mux
+	// read goroutine's Observe calls.
+	//
+	// Fix: Observe writes these atomic snapshots AFTER each FSM
+	// mutation. The accessors (FSMState/FSMInternalState/
+	// FSMIsPassive) read ONLY from the atomics — never touch
+	// c.fsm — so concurrent diagnostics readers are race-free.
+	//
+	// Encoding: telegram_fsm.State is uint8; we store it in
+	// atomic.Uint32 (Go has no atomic.Uint8). FSMIsPassive uses
+	// atomic.Bool.
+	fsmStateSnapshot         atomic.Uint32 // telegram_fsm.State cast to uint32
+	fsmInternalStateSnapshot atomic.Uint32 // telegram_fsm.State cast to uint32
+	fsmIsPassiveSnapshot     atomic.Bool
 }
 
 // New constructs a Classifier in the given mode. The zero-value
@@ -257,10 +276,10 @@ func (c *Classifier) Observe(event transport.StreamEvent, now time.Time) (drop b
 	return false
 }
 
-// driveFSMByte feeds one wire byte into the FSM and counts the
-// returned Decision. Single producer per the Classifier concurrency
-// contract; FSM state is NOT race-tolerant — callers MUST hold the
-// mux read goroutine identity.
+// driveFSMByte feeds one wire byte into the FSM, counts the
+// returned Decision, AND updates the atomic state snapshots so
+// concurrent diagnostic readers see fresh values. Single producer
+// per the Classifier concurrency contract.
 //
 // B3.4 OBSERVES the Decision but does NOT yet act on it. B3.6 will
 // extend this site with the ModeEnforce DropAaInjection path that
@@ -278,6 +297,23 @@ func (c *Classifier) driveFSMByte(b byte, wasEscaped bool) {
 	case telegram_fsm.DecisionProtocolFault:
 		c.fsmProtocolFaultTotal.Add(1)
 	}
+	c.publishFSMSnapshotLocked()
+}
+
+// publishFSMSnapshotLocked writes the FSM's current externally-
+// visible state into the atomic snapshot fields. "Locked" here
+// means "called from the single-producer Observe path" — the
+// snapshot writes are atomics, no mutex involved. Concurrent
+// readers (FSMState/FSMInternalState/FSMIsPassive) read ONLY from
+// these atomics, so they never race against c.fsm's mutable
+// fields.
+//
+// MUST be called after every FSM mutation in driveFSMByte,
+// fsmEnterPassive, and fsmReset.
+func (c *Classifier) publishFSMSnapshotLocked() {
+	c.fsmStateSnapshot.Store(uint32(c.fsm.State()))
+	c.fsmInternalStateSnapshot.Store(uint32(c.fsm.InternalState()))
+	c.fsmIsPassiveSnapshot.Store(c.fsm.IsPassive())
 }
 
 // fsmEnterPassive routes a StreamEventStarted or StreamEventFailed
@@ -287,17 +323,27 @@ func (c *Classifier) driveFSMByte(b byte, wasEscaped bool) {
 //
 // If the FSM is not currently in StateIdle (e.g. a stale Started
 // arrives while we're still tracking a prior telegram), the
-// EnterPassiveTracking call still wins — the FSM library treats it
-// as a forced reset-then-enter. This matches the wire-truth
-// invariant: an actual STARTED/FAILED on the wire MUST drive the
-// classifier's view, even if our prior state expected a different
-// continuation.
+// FSM library's EnterPassiveTracking implementation clears the
+// per-telegram fields (masterNN, masterBytesConsumed, masterDest,
+// retx counters, slaveNN) BEFORE setting the new
+// StateMasterHeader / passive=true. It does NOT call ResetToIdle
+// internally, but the field-clear is equivalent for the
+// classifier's purposes — no stale telegram-1 fields leak into
+// telegram-2 tracking. If the FSM library ever adds new
+// per-telegram fields that EnterPassiveTracking doesn't clear,
+// this site would need an explicit ResetToIdle prefix. (Codex
+// round-1 LOW finding on PR #641, 2026-05-19.)
+//
+// This matches the wire-truth invariant: an actual STARTED/FAILED
+// on the wire MUST drive the classifier's view, even if our
+// prior state expected a different continuation.
 func (c *Classifier) fsmEnterPassive(_ transport.StreamEvent) {
 	if c.fsm == nil {
 		return
 	}
 	c.fsm.EnterPassiveTracking()
 	c.fsmEnterPassiveTotal.Add(1)
+	c.publishFSMSnapshotLocked()
 }
 
 // fsmReset routes a StreamEventReset into the FSM's hard reset.
@@ -308,6 +354,7 @@ func (c *Classifier) fsmReset() {
 	}
 	c.fsm.ResetToIdle()
 	c.fsmResetTotal.Add(1)
+	c.publishFSMSnapshotLocked()
 }
 
 // classifyByteProvenance increments exactly one of the four
@@ -472,18 +519,22 @@ func (c *Classifier) PlainByteTotal() uint64 {
 // FSMState returns the current point-in-time snapshot of the
 // telegram FSM's externally-visible state (StatePassiveTracking
 // composite collapsed via Machine.State). Returns telegram_fsm.StateIdle
-// when fsm is nil (ModeOff or pre-construction). Safe to call from
-// other goroutines for diagnostics; concurrent readers see a
-// possibly-stale snapshot but no torn read.
+// when fsm is nil (ModeOff or pre-construction).
+//
+// Race-safe via the fsmStateSnapshot atomic: this accessor reads
+// ONLY the atomic field, never touches c.fsm directly. Concurrent
+// callers may see a snapshot one or two Observe calls stale but
+// will never see a torn read. (Codex round-1 HIGH finding on
+// PR #641: telegram_fsm.Machine is not thread-safe.)
 //
 // Phase 3 Step B3.4 exposes this primarily for shadow-mode
 // operator-visibility and for the wiring tests that assert the
 // FSM is actually being driven through telegram boundaries.
 func (c *Classifier) FSMState() telegram_fsm.State {
-	if c == nil || c.fsm == nil {
+	if c == nil {
 		return telegram_fsm.StateIdle
 	}
-	return c.fsm.State()
+	return telegram_fsm.State(c.fsmStateSnapshot.Load())
 }
 
 // FSMInternalState returns the FSM's raw sub-phase (un-collapsed
@@ -491,21 +542,27 @@ func (c *Classifier) FSMState() telegram_fsm.State {
 // telegram_fsm.StateIdle when fsm is nil. Useful for tests that
 // want to assert "the FSM is in MASTER_DATA right now" without
 // the StatePassiveTracking collapse hiding the sub-phase.
+//
+// Race-safe via the fsmInternalStateSnapshot atomic; same
+// stale-but-not-torn guarantee as FSMState.
 func (c *Classifier) FSMInternalState() telegram_fsm.State {
-	if c == nil || c.fsm == nil {
+	if c == nil {
 		return telegram_fsm.StateIdle
 	}
-	return c.fsm.InternalState()
+	return telegram_fsm.State(c.fsmInternalStateSnapshot.Load())
 }
 
 // FSMIsPassive reports whether the FSM is currently in
 // PASSIVE_TRACKING (we're observing a foreign initiator's
 // telegram). Returns false when fsm is nil.
+//
+// Race-safe via the fsmIsPassiveSnapshot atomic; same
+// stale-but-not-torn guarantee as FSMState.
 func (c *Classifier) FSMIsPassive() bool {
-	if c == nil || c.fsm == nil {
+	if c == nil {
 		return false
 	}
-	return c.fsm.IsPassive()
+	return c.fsmIsPassiveSnapshot.Load()
 }
 
 // FsmForwardTotal returns the cumulative count of

--- a/internal/adaptermux/v8classifier/classifier.go
+++ b/internal/adaptermux/v8classifier/classifier.go
@@ -4,6 +4,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol/telegram_fsm"
 	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
 )
 
@@ -111,13 +112,72 @@ type Classifier struct {
 	escapedPayloadEscTotal atomic.Uint64
 	wireAutoSynTotal       atomic.Uint64
 	plainByteTotal         atomic.Uint64
+
+	// Phase 3 Step B3.4 (per-byte telegram FSM driver, v8 §3 / §4):
+	// fsm is the single mux-wide telegram FSM instance the classifier
+	// drives. The instance is created in New() when mode != ModeOff;
+	// it remains nil in ModeOff (zero-allocation default).
+	//
+	// FSM lifecycle:
+	//   - StreamEventByte → fsm.Feed(byte, wasEscaped). The returned
+	//     Decision goes into one of the three fsmDecision*Total
+	//     counters below.
+	//   - StreamEventStarted / StreamEventFailed → fsm.EnterPassiveTracking().
+	//     Both events signal "a telegram is starting on the wire and
+	//     the event Data carries QQ"; the classifier observes the
+	//     subsequent bytes as PASSIVE_TRACKING from MASTER_HEADER
+	//     byte 1 onward (matching the FSM library's EnterPassiveTracking
+	//     contract: QQ already consumed via event.Data, next byte
+	//     is ZZ).
+	//   - StreamEventReset → fsm.ResetToIdle(). Transport reset
+	//     invalidates any in-flight telegram state.
+	//
+	// Per the Concurrency contract above, fsm is single-producer
+	// (mux read goroutine). FSM state accessors (FSMState,
+	// FSMInternalState, IsPassiveTracking) return point-in-time
+	// snapshots and are safe to call from other goroutines for
+	// diagnostics; tests using the accessors must accept that the
+	// state may change between the call and any subsequent read.
+	//
+	// B3.4 is OBSERVE-ONLY. The Decision returned by Feed is counted
+	// but does NOT yet affect emission (B3.6 wires the
+	// DecisionDropAaInjection → drop=true path in ModeEnforce).
+	fsm *telegram_fsm.Machine
+
+	// FSM decision counters. The three values that telegram_fsm.Decision
+	// can take (Forward, DropAaInjection, ProtocolFault) each get
+	// their own counter. Sum across the three == count of
+	// StreamEventByte events that the FSM Feed processed, with two
+	// caveats: (1) when fsm is nil (ModeOff) NONE of these
+	// increment; (2) bytes arriving while the FSM is in
+	// StateAborted will continue through Feed but the Decision
+	// breakdown depends on the FSM library's own contract — see
+	// telegram_fsm.go.
+	fsmForwardTotal         atomic.Uint64
+	fsmDropAaInjectionTotal atomic.Uint64
+	fsmProtocolFaultTotal   atomic.Uint64
+
+	// FSM lifecycle event counters. Pin how many times we entered
+	// passive tracking vs reset, for shadow-mode operators who want
+	// to confirm the classifier is seeing the same telegram
+	// boundaries the legacy passive observer sees.
+	fsmEnterPassiveTotal atomic.Uint64
+	fsmResetTotal        atomic.Uint64
 }
 
 // New constructs a Classifier in the given mode. The zero-value
 // Classifier (i.e. mode=ModeOff) is also valid; New exists for
 // explicit construction.
+//
+// Phase 3 Step B3.4: when mode != ModeOff the classifier owns a
+// fresh telegram_fsm.Machine (StateIdle). In ModeOff the fsm field
+// remains nil, preserving the zero-allocation default.
 func New(mode Mode) *Classifier {
-	return &Classifier{mode: mode}
+	c := &Classifier{mode: mode}
+	if mode != ModeOff {
+		c.fsm = telegram_fsm.New()
+	}
+	return c
 }
 
 // Mode returns the immutable runtime mode of the classifier.
@@ -175,11 +235,79 @@ func (c *Classifier) Observe(event transport.StreamEvent, now time.Time) (drop b
 	// they have their own semantic meaning and do NOT carry a
 	// (Byte, WasEscaped) tuple the escape-decoder provenance
 	// taxonomy applies to.
-	if event.Kind == transport.StreamEventByte {
+	switch event.Kind {
+	case transport.StreamEventByte:
 		c.classifyByteProvenance(event.Byte, event.WasEscaped)
+		c.driveFSMByte(event.Byte, event.WasEscaped)
+	case transport.StreamEventStarted, transport.StreamEventFailed:
+		// Both events signal "a telegram is starting on the wire and
+		// event.Data carries QQ" — the FSM's EnterPassiveTracking
+		// contract matches both cases (QQ already consumed,
+		// MASTER_HEADER byte 1 is the next byte fed). For mux-wide
+		// observation we do NOT distinguish "we won" from
+		// "someone else won" here; that distinction is per-session
+		// and lands in B3.5+. EnterArbitrating is intentionally NOT
+		// called by the mux-wide classifier — the wire stream is
+		// observed passively in both cases.
+		c.fsmEnterPassive(event)
+	case transport.StreamEventReset:
+		c.fsmReset()
 	}
 	_ = now
 	return false
+}
+
+// driveFSMByte feeds one wire byte into the FSM and counts the
+// returned Decision. Single producer per the Classifier concurrency
+// contract; FSM state is NOT race-tolerant — callers MUST hold the
+// mux read goroutine identity.
+//
+// B3.4 OBSERVES the Decision but does NOT yet act on it. B3.6 will
+// extend this site with the ModeEnforce DropAaInjection path that
+// makes Observe return drop=true.
+func (c *Classifier) driveFSMByte(b byte, wasEscaped bool) {
+	if c.fsm == nil {
+		return
+	}
+	decision := c.fsm.Feed(b, wasEscaped)
+	switch decision {
+	case telegram_fsm.DecisionForward:
+		c.fsmForwardTotal.Add(1)
+	case telegram_fsm.DecisionDropAaInjection:
+		c.fsmDropAaInjectionTotal.Add(1)
+	case telegram_fsm.DecisionProtocolFault:
+		c.fsmProtocolFaultTotal.Add(1)
+	}
+}
+
+// fsmEnterPassive routes a StreamEventStarted or StreamEventFailed
+// into the FSM's passive-tracking entry. Per v8 §3.1: the event's
+// Data byte IS the winner's QQ; EnterPassiveTracking sets the FSM
+// to MASTER_HEADER byte 1 (skipping over QQ).
+//
+// If the FSM is not currently in StateIdle (e.g. a stale Started
+// arrives while we're still tracking a prior telegram), the
+// EnterPassiveTracking call still wins — the FSM library treats it
+// as a forced reset-then-enter. This matches the wire-truth
+// invariant: an actual STARTED/FAILED on the wire MUST drive the
+// classifier's view, even if our prior state expected a different
+// continuation.
+func (c *Classifier) fsmEnterPassive(_ transport.StreamEvent) {
+	if c.fsm == nil {
+		return
+	}
+	c.fsm.EnterPassiveTracking()
+	c.fsmEnterPassiveTotal.Add(1)
+}
+
+// fsmReset routes a StreamEventReset into the FSM's hard reset.
+// Transport-level reset invalidates any in-flight telegram state.
+func (c *Classifier) fsmReset() {
+	if c.fsm == nil {
+		return
+	}
+	c.fsm.ResetToIdle()
+	c.fsmResetTotal.Add(1)
 }
 
 // classifyByteProvenance increments exactly one of the four
@@ -339,4 +467,101 @@ func (c *Classifier) PlainByteTotal() uint64 {
 		return 0
 	}
 	return c.plainByteTotal.Load()
+}
+
+// FSMState returns the current point-in-time snapshot of the
+// telegram FSM's externally-visible state (StatePassiveTracking
+// composite collapsed via Machine.State). Returns telegram_fsm.StateIdle
+// when fsm is nil (ModeOff or pre-construction). Safe to call from
+// other goroutines for diagnostics; concurrent readers see a
+// possibly-stale snapshot but no torn read.
+//
+// Phase 3 Step B3.4 exposes this primarily for shadow-mode
+// operator-visibility and for the wiring tests that assert the
+// FSM is actually being driven through telegram boundaries.
+func (c *Classifier) FSMState() telegram_fsm.State {
+	if c == nil || c.fsm == nil {
+		return telegram_fsm.StateIdle
+	}
+	return c.fsm.State()
+}
+
+// FSMInternalState returns the FSM's raw sub-phase (un-collapsed
+// by the PassiveTracking composite mapping). Returns
+// telegram_fsm.StateIdle when fsm is nil. Useful for tests that
+// want to assert "the FSM is in MASTER_DATA right now" without
+// the StatePassiveTracking collapse hiding the sub-phase.
+func (c *Classifier) FSMInternalState() telegram_fsm.State {
+	if c == nil || c.fsm == nil {
+		return telegram_fsm.StateIdle
+	}
+	return c.fsm.InternalState()
+}
+
+// FSMIsPassive reports whether the FSM is currently in
+// PASSIVE_TRACKING (we're observing a foreign initiator's
+// telegram). Returns false when fsm is nil.
+func (c *Classifier) FSMIsPassive() bool {
+	if c == nil || c.fsm == nil {
+		return false
+	}
+	return c.fsm.IsPassive()
+}
+
+// FsmForwardTotal returns the cumulative count of
+// telegram_fsm.DecisionForward decisions the FSM emitted for
+// StreamEventByte events observed in non-off mode. Returns 0 in
+// ModeOff. Safe to call from any goroutine.
+func (c *Classifier) FsmForwardTotal() uint64 {
+	if c == nil {
+		return 0
+	}
+	return c.fsmForwardTotal.Load()
+}
+
+// FsmDropAaInjectionTotal returns the cumulative count of
+// telegram_fsm.DecisionDropAaInjection decisions. Per v8 §4 these
+// are the bytes the AA-injection filter would drop in ModeEnforce.
+// In B3.4 the drop is NOT applied — the byte still flows to
+// downstream observers — but the counter exposes how often the
+// filter WOULD have fired. Returns 0 in ModeOff. Safe to call
+// from any goroutine.
+func (c *Classifier) FsmDropAaInjectionTotal() uint64 {
+	if c == nil {
+		return 0
+	}
+	return c.fsmDropAaInjectionTotal.Load()
+}
+
+// FsmProtocolFaultTotal returns the cumulative count of
+// telegram_fsm.DecisionProtocolFault decisions. Per v8 invariant
+// I10: PROTOCOL_FAULT bytes are FORWARDED to all observers PLUS an
+// admin event is emitted; B3.6 wires the admin-event side.
+// Returns 0 in ModeOff. Safe to call from any goroutine.
+func (c *Classifier) FsmProtocolFaultTotal() uint64 {
+	if c == nil {
+		return 0
+	}
+	return c.fsmProtocolFaultTotal.Load()
+}
+
+// FsmEnterPassiveTotal returns the cumulative count of times the
+// classifier invoked fsm.EnterPassiveTracking() in response to a
+// StreamEventStarted or StreamEventFailed. Returns 0 in ModeOff.
+// Safe to call from any goroutine.
+func (c *Classifier) FsmEnterPassiveTotal() uint64 {
+	if c == nil {
+		return 0
+	}
+	return c.fsmEnterPassiveTotal.Load()
+}
+
+// FsmResetTotal returns the cumulative count of times the classifier
+// invoked fsm.ResetToIdle() in response to a StreamEventReset.
+// Returns 0 in ModeOff. Safe to call from any goroutine.
+func (c *Classifier) FsmResetTotal() uint64 {
+	if c == nil {
+		return 0
+	}
+	return c.fsmResetTotal.Load()
 }

--- a/internal/adaptermux/v8classifier/classifier_fsm_test.go
+++ b/internal/adaptermux/v8classifier/classifier_fsm_test.go
@@ -1,0 +1,298 @@
+package v8classifier
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol/telegram_fsm"
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+// Phase 3 Step B3.4: tests for the per-byte telegram FSM driver
+// added by Observe. Each test pins one slice of the FSM-classifier
+// integration:
+//
+//   - Lifecycle: New() creates a fresh FSM in non-Off modes; ModeOff
+//     leaves fsm=nil.
+//   - StreamEventStarted / StreamEventFailed → EnterPassiveTracking
+//     (passive observation; QQ already consumed via event.Data).
+//   - StreamEventReset → ResetToIdle.
+//   - StreamEventByte → Feed → Decision counter increment.
+//   - Decision counters faithfully record what the FSM library
+//     emits (verified by feeding canonical telegram shapes).
+//   - Nil-receiver safety for the new accessors.
+
+// observeEvent feeds an arbitrary StreamEvent to the classifier
+// (helper to reduce noise in the FSM-state assertions below).
+func observeEvent(c *Classifier, e transport.StreamEvent) {
+	c.Observe(e, time.Unix(0, 0))
+}
+
+// TestFSM_NewClassifier_OffMode_NilFSM pins the production-default:
+// ModeOff yields a nil fsm field, no allocation. All FSM accessors
+// return zero values.
+func TestFSM_NewClassifier_OffMode_NilFSM(t *testing.T) {
+	t.Parallel()
+	c := New(ModeOff)
+	if got := c.FSMState(); got != telegram_fsm.StateIdle {
+		t.Errorf("FSMState()=%v; want StateIdle in ModeOff", got)
+	}
+	if got := c.FSMInternalState(); got != telegram_fsm.StateIdle {
+		t.Errorf("FSMInternalState()=%v; want StateIdle in ModeOff", got)
+	}
+	if c.FSMIsPassive() {
+		t.Error("FSMIsPassive()=true in ModeOff; want false")
+	}
+	// Drive a byte through Observe. ModeOff → no-op, no counters.
+	observeEvent(c, transport.StreamEvent{
+		Kind: transport.StreamEventByte,
+		Byte: 0xAA, WasEscaped: true,
+	})
+	if got := c.FsmForwardTotal(); got != 0 {
+		t.Errorf("FsmForwardTotal()=%d; want 0 in ModeOff", got)
+	}
+}
+
+// TestFSM_NewClassifier_ShadowMode_FreshFSM pins the shadow-mode
+// invariant: a fresh classifier in ModeShadow has a non-nil FSM in
+// StateIdle.
+func TestFSM_NewClassifier_ShadowMode_FreshFSM(t *testing.T) {
+	t.Parallel()
+	c := New(ModeShadow)
+	if got := c.FSMState(); got != telegram_fsm.StateIdle {
+		t.Errorf("FSMState()=%v; want StateIdle for fresh classifier", got)
+	}
+	if c.FSMIsPassive() {
+		t.Error("FSMIsPassive()=true at construction; want false")
+	}
+}
+
+// TestFSM_StreamEventStarted_EntersPassiveTracking pins the
+// StreamEventStarted → EnterPassiveTracking mapping. After the
+// event, the FSM should be in StatePassiveTracking (composite) and
+// IsPassive should be true.
+func TestFSM_StreamEventStarted_EntersPassiveTracking(t *testing.T) {
+	t.Parallel()
+	c := New(ModeShadow)
+	observeEvent(c, transport.StreamEvent{
+		Kind: transport.StreamEventStarted,
+		Data: 0x71, // winning QQ — the gateway's own initiator
+	})
+	if got := c.FSMState(); got != telegram_fsm.StatePassiveTracking {
+		t.Errorf("FSMState()=%v; want StatePassiveTracking after StreamEventStarted", got)
+	}
+	if !c.FSMIsPassive() {
+		t.Error("FSMIsPassive()=false; want true after StreamEventStarted")
+	}
+	if got := c.FsmEnterPassiveTotal(); got != 1 {
+		t.Errorf("FsmEnterPassiveTotal()=%d; want 1", got)
+	}
+}
+
+// TestFSM_StreamEventFailed_EntersPassiveTracking pins the
+// StreamEventFailed → EnterPassiveTracking mapping. Same observable
+// effect as Started (both signal "telegram is starting; event.Data
+// is QQ"); the classifier doesn't distinguish.
+func TestFSM_StreamEventFailed_EntersPassiveTracking(t *testing.T) {
+	t.Parallel()
+	c := New(ModeShadow)
+	observeEvent(c, transport.StreamEvent{
+		Kind: transport.StreamEventFailed,
+		Data: 0x10, // foreign initiator's QQ
+	})
+	if got := c.FSMState(); got != telegram_fsm.StatePassiveTracking {
+		t.Errorf("FSMState()=%v; want StatePassiveTracking after StreamEventFailed", got)
+	}
+	if !c.FSMIsPassive() {
+		t.Error("FSMIsPassive()=false; want true after StreamEventFailed")
+	}
+	if got := c.FsmEnterPassiveTotal(); got != 1 {
+		t.Errorf("FsmEnterPassiveTotal()=%d; want 1", got)
+	}
+}
+
+// TestFSM_StreamEventReset_ResetsToIdle pins the
+// StreamEventReset → ResetToIdle mapping. Even if the FSM was
+// mid-telegram, Reset must drive it back to StateIdle.
+func TestFSM_StreamEventReset_ResetsToIdle(t *testing.T) {
+	t.Parallel()
+	c := New(ModeShadow)
+
+	// First, enter passive tracking.
+	observeEvent(c, transport.StreamEvent{
+		Kind: transport.StreamEventStarted,
+		Data: 0x71,
+	})
+	if got := c.FSMState(); got != telegram_fsm.StatePassiveTracking {
+		t.Fatalf("precondition: FSMState()=%v; want StatePassiveTracking", got)
+	}
+
+	// Now reset.
+	observeEvent(c, transport.StreamEvent{Kind: transport.StreamEventReset})
+	if got := c.FSMState(); got != telegram_fsm.StateIdle {
+		t.Errorf("FSMState()=%v; want StateIdle after StreamEventReset", got)
+	}
+	if c.FSMIsPassive() {
+		t.Error("FSMIsPassive()=true after reset; want false")
+	}
+	if got := c.FsmResetTotal(); got != 1 {
+		t.Errorf("FsmResetTotal()=%d; want 1", got)
+	}
+}
+
+// TestFSM_StreamEventByte_FeedsForwardDecision pins the canonical
+// path: a benign payload byte fed mid-telegram should produce a
+// DecisionForward and increment FsmForwardTotal.
+//
+// Telegram shape: 0x71 (QQ, consumed via Started.Data) → 0x10 (ZZ,
+// fed via StreamEventByte) → ... The 0x10 in MASTER_HEADER byte 1
+// is a plain destination byte and the FSM should emit Forward.
+func TestFSM_StreamEventByte_FeedsForwardDecision(t *testing.T) {
+	t.Parallel()
+	c := New(ModeShadow)
+	observeEvent(c, transport.StreamEvent{
+		Kind: transport.StreamEventStarted,
+		Data: 0x71,
+	})
+
+	// Feed ZZ = 0x10 (broadcast or directed destination, plain).
+	observeEvent(c, transport.StreamEvent{
+		Kind: transport.StreamEventByte,
+		Byte: 0x10,
+		// wasEscaped=false (plain byte)
+	})
+	if got := c.FsmForwardTotal(); got != 1 {
+		t.Errorf("FsmForwardTotal()=%d; want 1 (one forward decision)", got)
+	}
+	if got := c.FsmDropAaInjectionTotal(); got != 0 {
+		t.Errorf("FsmDropAaInjectionTotal()=%d; want 0", got)
+	}
+	if got := c.FsmProtocolFaultTotal(); got != 0 {
+		t.Errorf("FsmProtocolFaultTotal()=%d; want 0", got)
+	}
+}
+
+// TestFSM_StreamEventByte_OffMode_DoesNotFeedFSM pins that ModeOff
+// completely bypasses the FSM driver — even if Observe were called
+// the nil fsm guard prevents counter increments.
+func TestFSM_StreamEventByte_OffMode_DoesNotFeedFSM(t *testing.T) {
+	t.Parallel()
+	c := New(ModeOff)
+	for i := 0; i < 10; i++ {
+		observeEvent(c, transport.StreamEvent{
+			Kind: transport.StreamEventByte,
+			Byte: byte(i),
+		})
+	}
+	if got := c.FsmForwardTotal(); got != 0 {
+		t.Errorf("FsmForwardTotal()=%d; want 0 in ModeOff", got)
+	}
+	if got := c.FsmDropAaInjectionTotal(); got != 0 {
+		t.Errorf("FsmDropAaInjectionTotal()=%d; want 0 in ModeOff", got)
+	}
+	if got := c.FsmProtocolFaultTotal(); got != 0 {
+		t.Errorf("FsmProtocolFaultTotal()=%d; want 0 in ModeOff", got)
+	}
+}
+
+// TestFSM_NilReceiverSafe pins that all new FSM-related accessors
+// accept a nil receiver and return zero values.
+func TestFSM_NilReceiverSafe(t *testing.T) {
+	t.Parallel()
+	var c *Classifier
+	if got := c.FSMState(); got != telegram_fsm.StateIdle {
+		t.Errorf("nil.FSMState()=%v; want StateIdle", got)
+	}
+	if got := c.FSMInternalState(); got != telegram_fsm.StateIdle {
+		t.Errorf("nil.FSMInternalState()=%v; want StateIdle", got)
+	}
+	if c.FSMIsPassive() {
+		t.Error("nil.FSMIsPassive()=true; want false")
+	}
+	if got := c.FsmForwardTotal(); got != 0 {
+		t.Errorf("nil.FsmForwardTotal()=%d; want 0", got)
+	}
+	if got := c.FsmDropAaInjectionTotal(); got != 0 {
+		t.Errorf("nil.FsmDropAaInjectionTotal()=%d; want 0", got)
+	}
+	if got := c.FsmProtocolFaultTotal(); got != 0 {
+		t.Errorf("nil.FsmProtocolFaultTotal()=%d; want 0", got)
+	}
+	if got := c.FsmEnterPassiveTotal(); got != 0 {
+		t.Errorf("nil.FsmEnterPassiveTotal()=%d; want 0", got)
+	}
+	if got := c.FsmResetTotal(); got != 0 {
+		t.Errorf("nil.FsmResetTotal()=%d; want 0", got)
+	}
+}
+
+// TestFSM_EnforceMode_DoesNotDropYet pins the B3.4 SCAFFOLD
+// invariant: even when the FSM emits a DecisionDropAaInjection
+// (which B3.6 will translate to drop=true in ModeEnforce), B3.4
+// still returns drop=false from Observe. The counter increments,
+// but no behavioral change. Future-regression guard.
+func TestFSM_EnforceMode_DoesNotDropYet(t *testing.T) {
+	t.Parallel()
+	c := New(ModeEnforce)
+	now := time.Unix(0, 0)
+
+	// Enter passive tracking so subsequent AA bytes are
+	// classified mid-frame (where the FSM would emit
+	// DropAaInjection per v8 §4).
+	c.Observe(transport.StreamEvent{
+		Kind: transport.StreamEventStarted,
+		Data: 0x71,
+	}, now)
+
+	// Feed a wire AUTO-SYN mid-frame — the FSM should emit
+	// DropAaInjection.
+	drop := c.Observe(transport.StreamEvent{
+		Kind: transport.StreamEventByte,
+		Byte: 0xAA,
+		// wasEscaped=false (real wire SYN, mid-frame = AA-injection)
+	}, now)
+	if drop {
+		t.Error("Observe(mid-frame wire 0xAA) returned drop=true in ModeEnforce; B3.4 must return drop=false until B3.6 wires real filtering")
+	}
+
+	// The FSM should have counted the drop decision.
+	if got := c.FsmDropAaInjectionTotal(); got == 0 {
+		t.Errorf("FsmDropAaInjectionTotal()=0; expected non-zero (FSM should emit DropAaInjection for mid-frame wire SYN)")
+	}
+}
+
+// TestFSM_MultipleTelegrams_StateLifecycle pins the end-to-end
+// state lifecycle across multiple telegram boundaries: idle →
+// passive → byte forward → reset → idle → passive again.
+func TestFSM_MultipleTelegrams_StateLifecycle(t *testing.T) {
+	t.Parallel()
+	c := New(ModeShadow)
+
+	// Telegram 1.
+	observeEvent(c, transport.StreamEvent{Kind: transport.StreamEventStarted, Data: 0x71})
+	if !c.FSMIsPassive() {
+		t.Fatal("after Started #1: not passive")
+	}
+	observeEvent(c, transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x10})
+	observeEvent(c, transport.StreamEvent{Kind: transport.StreamEventReset})
+	if c.FSMIsPassive() {
+		t.Fatal("after Reset #1: still passive")
+	}
+
+	// Telegram 2.
+	observeEvent(c, transport.StreamEvent{Kind: transport.StreamEventStarted, Data: 0x10})
+	if !c.FSMIsPassive() {
+		t.Fatal("after Started #2: not passive")
+	}
+
+	// Final counters.
+	if got := c.FsmEnterPassiveTotal(); got != 2 {
+		t.Errorf("FsmEnterPassiveTotal()=%d; want 2", got)
+	}
+	if got := c.FsmResetTotal(); got != 1 {
+		t.Errorf("FsmResetTotal()=%d; want 1", got)
+	}
+	if got := c.FsmForwardTotal(); got != 1 {
+		t.Errorf("FsmForwardTotal()=%d; want 1 (one byte forwarded between Started #1 and Reset)", got)
+	}
+}

--- a/internal/adaptermux/v8classifier/classifier_fsm_test.go
+++ b/internal/adaptermux/v8classifier/classifier_fsm_test.go
@@ -261,6 +261,168 @@ func TestFSM_EnforceMode_DoesNotDropYet(t *testing.T) {
 	}
 }
 
+// TestFSM_StateAborted_ContinuationCountsFaults pins the documented
+// behavior when the FSM enters StateAborted: subsequent Feed calls
+// continue to emit DecisionProtocolFault until a Started / Failed /
+// Reset arrives. This is the FSM library's own contract; the
+// classifier just records it.
+//
+// Operators reading FsmProtocolFaultTotal during a fault cascade
+// will see N+1 increments for an N-byte trailing tail after the
+// abort. Per Codex round-1 MEDIUM finding on PR #641: B3.4
+// intentionally does NOT auto-reset on first fault — that would
+// hide the cascade depth from operators. B3.6+ may revisit if
+// the operator UX requires it; until then the test pins the
+// "keep counting" behavior.
+func TestFSM_StateAborted_ContinuationCountsFaults(t *testing.T) {
+	t.Parallel()
+	c := New(ModeShadow)
+	now := time.Unix(0, 0)
+
+	// Enter passive tracking, then feed a byte that triggers a
+	// protocol fault. The simplest trigger is a wire-byte stream
+	// where MASTER_HEADER receives a byte with WasEscaped=true
+	// (escape-decoded payload byte at QQ position is invalid by
+	// the FSM's per-phase rules — QQ MUST be plain). The FSM
+	// emits DecisionProtocolFault and transitions to StateAborted.
+	c.Observe(transport.StreamEvent{
+		Kind: transport.StreamEventStarted,
+		Data: 0x71,
+	}, now)
+	// MASTER_HEADER byte 1 (ZZ destination). Plain byte 0x10 is
+	// valid; FSM stays clean.
+	c.Observe(transport.StreamEvent{
+		Kind: transport.StreamEventByte,
+		Byte: 0x10,
+	}, now)
+
+	// Now feed a byte that the FSM will treat as a fault. Per the
+	// telegram_fsm library, a wire AUTO-SYN (Byte=0xAA, WasEscaped=
+	// false) in the middle of MASTER_HEADER is AA-injection and
+	// gets DecisionDropAaInjection (NOT a fault). The fault
+	// trigger differs by phase. To force a fault, use the
+	// MASTER_HEADER NN-byte position: if NN > 16 the FSM faults.
+	// Pre-position the FSM to MASTER_HEADER byte 4 (NN slot) by
+	// feeding 3 more plain bytes (PB SB at bytes 2-3, then byte 4
+	// is NN).
+	for _, b := range []byte{0xB5, 0x16} {
+		c.Observe(transport.StreamEvent{
+			Kind: transport.StreamEventByte, Byte: b,
+		}, now)
+	}
+	// Now byte 4 is NN. Feed 0xFF (NN=255, exceeds the 16-byte
+	// cap per v8) — FSM emits DecisionProtocolFault.
+	c.Observe(transport.StreamEvent{
+		Kind: transport.StreamEventByte, Byte: 0xFF,
+	}, now)
+
+	if got := c.FsmProtocolFaultTotal(); got != 1 {
+		t.Errorf("after first fault: FsmProtocolFaultTotal()=%d; want 1", got)
+	}
+	if got := c.FSMState(); got != telegram_fsm.StateAborted {
+		t.Errorf("after fault: FSMState()=%v; want StateAborted", got)
+	}
+
+	// Continuation: feed 5 more bytes. Each should also emit
+	// DecisionProtocolFault (FSM stays in StateAborted until
+	// Reset/Started/Failed).
+	for i := 0; i < 5; i++ {
+		c.Observe(transport.StreamEvent{
+			Kind: transport.StreamEventByte, Byte: byte(i),
+		}, now)
+	}
+	if got := c.FsmProtocolFaultTotal(); got != 6 {
+		t.Errorf("after continuation: FsmProtocolFaultTotal()=%d; want 6 (1 initial + 5 continuation)", got)
+	}
+	if got := c.FSMState(); got != telegram_fsm.StateAborted {
+		t.Errorf("during continuation: FSMState()=%v; want StateAborted (no auto-reset)", got)
+	}
+
+	// A Reset clears the fault cascade.
+	c.Observe(transport.StreamEvent{Kind: transport.StreamEventReset}, now)
+	if got := c.FSMState(); got != telegram_fsm.StateIdle {
+		t.Errorf("after Reset: FSMState()=%v; want StateIdle", got)
+	}
+	// Subsequent bytes after Reset go to the Idle handler, which
+	// has its own per-byte semantics (mostly plain → Forward).
+	c.Observe(transport.StreamEvent{
+		Kind: transport.StreamEventByte, Byte: 0x55,
+	}, now)
+	// The protocol fault counter must NOT increment further once
+	// we're back in StateIdle.
+	if got := c.FsmProtocolFaultTotal(); got != 6 {
+		t.Errorf("after Reset+plain byte: FsmProtocolFaultTotal()=%d; want 6 (no further faults)", got)
+	}
+}
+
+// TestFSM_Accessors_ConcurrentReader_DataRaceFree pins the Codex
+// round-1 HIGH fix: FSMState/FSMInternalState/FSMIsPassive read
+// from atomic snapshots that Observe publishes after each FSM
+// mutation. The accessors MUST NOT touch the underlying FSM
+// (telegram_fsm.Machine is not thread-safe).
+//
+// This test launches concurrent readers AND a single Observe
+// goroutine; under `go test -race` any direct read of the FSM
+// would fire a race condition. Passing under -race proves the
+// atomic-snapshot pattern is correctly applied.
+func TestFSM_Accessors_ConcurrentReader_DataRaceFree(t *testing.T) {
+	t.Parallel()
+	c := New(ModeShadow)
+
+	// Pre-populate with a known state.
+	c.Observe(transport.StreamEvent{
+		Kind: transport.StreamEventStarted, Data: 0x71,
+	}, time.Unix(0, 0))
+
+	stop := make(chan struct{})
+	defer close(stop)
+
+	// Two reader goroutines that hammer the accessors.
+	for i := 0; i < 2; i++ {
+		go func() {
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_ = c.FSMState()
+					_ = c.FSMInternalState()
+					_ = c.FSMIsPassive()
+					_ = c.FsmForwardTotal()
+					_ = c.FsmDropAaInjectionTotal()
+					_ = c.FsmProtocolFaultTotal()
+				}
+			}
+		}()
+	}
+
+	// Single producer Observe-driving goroutine (per the
+	// Classifier concurrency contract — Observe is single-
+	// producer, the readers above are MULTI-CONSUMER which IS
+	// allowed).
+	now := time.Unix(0, 0)
+	for i := 0; i < 200; i++ {
+		c.Observe(transport.StreamEvent{
+			Kind: transport.StreamEventByte, Byte: byte(i),
+		}, now)
+		if i%20 == 0 {
+			c.Observe(transport.StreamEvent{
+				Kind: transport.StreamEventReset,
+			}, now)
+			c.Observe(transport.StreamEvent{
+				Kind: transport.StreamEventStarted, Data: 0x71,
+			}, now)
+		}
+	}
+	// The test asserts no race fires via -race instrumentation.
+	// We also do a final sanity check that counters are
+	// monotonically positive (they should be — we fed 200
+	// bytes).
+	if got := c.ObservedBytesTotal(); got < 200 {
+		t.Errorf("ObservedBytesTotal()=%d; want >= 200", got)
+	}
+}
+
 // TestFSM_MultipleTelegrams_StateLifecycle pins the end-to-end
 // state lifecycle across multiple telegram boundaries: idle →
 // passive → byte forward → reset → idle → passive again.

--- a/internal/adaptermux/v8classifier/classifier_provenance_test.go
+++ b/internal/adaptermux/v8classifier/classifier_provenance_test.go
@@ -253,9 +253,9 @@ func TestClassifyByteProvenance_TableDriven(t *testing.T) {
 	t.Parallel()
 
 	rows := []struct {
-		name        string
-		b           byte
-		wasEscaped  bool
+		name                                                  string
+		b                                                     byte
+		wasEscaped                                            bool
 		wantPayloadAa, wantPayloadEsc, wantWireSyn, wantPlain uint64
 	}{
 		// Canonical taxonomy.

--- a/internal/adaptermux/v8classifier_wiring_test.go
+++ b/internal/adaptermux/v8classifier_wiring_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol/telegram_fsm"
 	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
 
 	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/adaptermux/v8classifier"
@@ -193,6 +194,77 @@ func TestV8Classifier_ShadowMode_ProvenanceCountersThroughMux(t *testing.T) {
 		c.WireAutoSynTotal() + c.PlainByteTotal()
 	if sum != 9 {
 		t.Errorf("sum of provenance counters = %d; want 9", sum)
+	}
+}
+
+// TestV8Classifier_ShadowMode_FSMDrivenThroughMux pins the B3.4
+// integration: a StreamEventStarted dispatched by readLoop must
+// cause the classifier's FSM to enter passive-tracking, and
+// subsequent StreamEventByte events must increment the FSM
+// decision counter at the mux boundary.
+func TestV8Classifier_ShadowMode_FSMDrivenThroughMux(t *testing.T) {
+	mux, mock, _, cleanup := newClassifiedTestMux(t, v8classifier.ModeShadow)
+	defer cleanup()
+
+	c := mux.V8Classifier()
+	if c == nil {
+		t.Fatal("V8Classifier() = nil in ModeShadow; want non-nil")
+	}
+
+	// Push StreamEventStarted (winner = 0x71). FSM should enter
+	// passive tracking after readLoop dispatches the event.
+	mock.eventCh <- transport.StreamEvent{
+		Kind: transport.StreamEventStarted,
+		Data: 0x71,
+	}
+	// Then push 3 plain payload bytes — each should yield a
+	// Forward decision.
+	for _, b := range []byte{0x10, 0xB5, 0x09} {
+		mock.eventCh <- transport.StreamEvent{
+			Kind: transport.StreamEventByte,
+			Byte: b,
+		}
+	}
+
+	// Poll until the classifier has observed all 4 events.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if c.ObservedBytesTotal() >= 4 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := c.ObservedBytesTotal(); got != 4 {
+		t.Fatalf("ObservedBytesTotal()=%d; want 4", got)
+	}
+
+	// FSM should be in passive tracking (or its internal
+	// MASTER_HEADER sub-phase, collapsed via FSMState).
+	if got := c.FSMState(); got != telegram_fsm.StatePassiveTracking {
+		t.Errorf("FSMState()=%v; want StatePassiveTracking through mux", got)
+	}
+	if !c.FSMIsPassive() {
+		t.Error("FSMIsPassive()=false; want true through mux")
+	}
+
+	// Lifecycle counters: 1 enter passive, 0 resets.
+	if got := c.FsmEnterPassiveTotal(); got != 1 {
+		t.Errorf("FsmEnterPassiveTotal()=%d; want 1 through mux", got)
+	}
+	if got := c.FsmResetTotal(); got != 0 {
+		t.Errorf("FsmResetTotal()=%d; want 0 (no reset events sent)", got)
+	}
+
+	// Decision counters: 3 forwards (one per plain payload byte),
+	// 0 drops, 0 faults.
+	if got := c.FsmForwardTotal(); got != 3 {
+		t.Errorf("FsmForwardTotal()=%d; want 3 (three plain bytes)", got)
+	}
+	if got := c.FsmDropAaInjectionTotal(); got != 0 {
+		t.Errorf("FsmDropAaInjectionTotal()=%d; want 0", got)
+	}
+	if got := c.FsmProtocolFaultTotal(); got != 0 {
+		t.Errorf("FsmProtocolFaultTotal()=%d; want 0", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Extends the B3.3 provenance taxonomy with the per-byte telegram FSM
driver from `helianthus-ebusgo/protocol/telegram_fsm`. The classifier
now carries a single mux-wide FSM instance and drives it through the
four StreamEvent kinds it observes.

**Mux-wide FSM, observed passively.** Both `StreamEventStarted` and
`StreamEventFailed` enter PASSIVE_TRACKING (event.Data = QQ already
consumed; FSM resumes from MASTER_HEADER byte 1). Per-session FSM
multiplication is deferred to B3.5+ when per-client filtering
decisions need distinct phase context.

## Event → FSM mapping

| StreamEvent | FSM call | Notes |
|---|---|---|
| `StreamEventByte` | `Feed(byte, wasEscaped) → Decision` | Decision counter increments per-bucket |
| `StreamEventStarted` | `EnterPassiveTracking()` | QQ already consumed via event.Data |
| `StreamEventFailed` | `EnterPassiveTracking()` | Same — both events mean "telegram starting, Data = QQ" |
| `StreamEventReset` | `ResetToIdle()` | Transport reset invalidates in-flight state |

## What ships

- **`classifier.go`**: `fsm *telegram_fsm.Machine` field (lazy-allocated in non-Off modes); `driveFSMByte()`, `fsmEnterPassive()`, `fsmReset()` helpers; 5 new atomic counters; 8 new nil-safe accessors (`FSMState`, `FSMInternalState`, `FSMIsPassive`, `FsmForwardTotal`, `FsmDropAaInjectionTotal`, `FsmProtocolFaultTotal`, `FsmEnterPassiveTotal`, `FsmResetTotal`).

- **`classifier_fsm_test.go`** (new): 10 deterministic tests including the scaffold invariant `EnforceMode_DoesNotDropYet` and the end-to-end `MultipleTelegrams_StateLifecycle`.

- **`v8classifier_wiring_test.go`** (extended): `ShadowMode_FSMDrivenThroughMux` — exercises the FSM via readLoop's StreamEvent dispatch.

## Tests (11 new, all green under `-race`)

| Test | Asserts |
|---|---|
| `NewClassifier_OffMode_NilFSM` | production-default zero-alloc |
| `NewClassifier_ShadowMode_FreshFSM` | non-Off mode allocates FSM |
| `StreamEventStarted_EntersPassiveTracking` | Started → PassiveTracking |
| `StreamEventFailed_EntersPassiveTracking` | Failed → PassiveTracking |
| `StreamEventReset_ResetsToIdle` | Reset clears mid-telegram state |
| `StreamEventByte_FeedsForwardDecision` | plain byte → Forward counter |
| `StreamEventByte_OffMode_DoesNotFeedFSM` | ModeOff doesn't touch FSM |
| `NilReceiverSafe` | all 8 accessors accept nil |
| `EnforceMode_DoesNotDropYet` | **scaffold invariant**: even when FSM emits DecisionDropAaInjection, Observe returns drop=false (B3.6 wires real filtering) |
| `MultipleTelegrams_StateLifecycle` | end-to-end idle → passive → forward → reset → passive |
| `ShadowMode_FSMDrivenThroughMux` | FSM driven via readLoop's dispatch |

## Test plan

- [x] `GOWORK=off go build ./...` — clean
- [x] `GOWORK=off go test ./... -race -timeout 600s` — full gateway suite green
- [x] `GOWORK=off go vet ./...` — clean
- [x] `gofmt -l` — clean
- [x] Terminology gate — clean

## What this PR does NOT do

- ❌ No per-session FSM instances (mux-wide for now)
- ❌ No pacer / L_rtt (B3.5)
- ❌ No admin channel / DropAaInjection drop decisions (B3.6)
- ❌ No shadow-mode divergence comparison (B3.7)

## References

- frame-atomic-visibility-v8 §3 — telegram FSM phases
- frame-atomic-visibility-v8 §4 — classify-then-transition rules
- frame-atomic-visibility-v8 §1.10 — phased rollout order
- ebusgo PRs #161, #162, #163 — `telegram_fsm` package
- Corrected implementation plan v2.1 — Phase 3 Step B3.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)