### PR TITLE
Phase 3 Step B3.5: per-session output pacer + L_rtt EMA (computation only)

### DIFF
--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -4196,6 +4196,23 @@ func (m *Mux) doSend(sessionID uint64, data byte) error {
 	// recordSent without the matching matchEcho consumer would let the
 	// per-session queue grow to the 256-byte cap and trigger spurious
 	// totalOverflowResets alarms every 256 external SENDs.
+	// B3.6 INTEGRATION HOOK POINT (Phase 3, frame-atomic-visibility
+	// v8 §1.4 / §4.5): this is the adapter-write choke point where
+	// the v8classifier.Pacer's BeforeActiveWrite + EchoDeadlines +
+	// (after tr.Write completes and the echo arrives) RecordEcho
+	// must be invoked when V8ClassifierMode != Off. See
+	// internal/adaptermux/v8classifier/pacer.go for the API; the
+	// pacer is a per-session struct that lands in B3.6 (not yet
+	// instantiated in B3.5). Sequence per the pacer's design:
+	//   pacer.BeforeActiveWrite(now)
+	//   soft, hard, hardEnabled := pacer.EchoDeadlines()
+	//   arm watchdog with (soft, hard, hardEnabled)
+	//   tr.Write(byte)                            <-- here
+	//   ... wait for echo arrival ...
+	//   pacer.RecordEcho(echoRtt, echoArrivedAt)
+	// Do NOT conflate this hook point with session.writeLoop's
+	// sendCh draining (that's the OUTPUT pacer side per v8 §4.5,
+	// which uses Schedule / LastScheduledEmit instead).
 	_, err := tr.Write([]byte{data})
 	if err != nil {
 		return fmt.Errorf("%w: %v", errAdapterWrite, err)

--- a/internal/adaptermux/session.go
+++ b/internal/adaptermux/session.go
@@ -765,6 +765,21 @@ func (s *session) writeFrame(frame sessionFrame) error {
 		return fmt.Errorf("adaptermux: unknown session frame kind %d", frame.kind)
 	}
 
+	// B3.6 INTEGRATION HOOK POINT (Phase 3, frame-atomic-visibility
+	// v8 §4.5): this is the TCP-egress choke point where the
+	// v8classifier.Pacer's Schedule must be consulted when
+	// V8ClassifierMode != Off and the session is a cross-proxy
+	// observer. See internal/adaptermux/v8classifier/pacer.go for
+	// the API; the pacer is a per-session struct that lands in
+	// B3.6 (not yet instantiated in B3.5). Sequence per the
+	// pacer's design:
+	//   emitAt := pacer.Schedule(time.Now())
+	//   if emitAt.After(time.Now()) { sleep until emitAt }
+	//   s.conn.Write(buf)                          <-- here
+	// Do NOT conflate this hook point with mux.doSend's tr.Write
+	// (that's the L_rtt-EMA / BeforeActiveWrite side per v8 §1.4,
+	// which uses BeforeActiveWrite + EchoDeadlines + RecordEcho
+	// against the adapter, NOT the client's TCP egress).
 	_, err := s.conn.Write(buf)
 	return err
 }

--- a/internal/adaptermux/v8classifier/pacer.go
+++ b/internal/adaptermux/v8classifier/pacer.go
@@ -1,0 +1,318 @@
+package v8classifier
+
+import (
+	"sync"
+	"time"
+)
+
+// Phase 3 Step B3.5 (frame-atomic-visibility v8 §1.4 / §4.5,
+// invariant I3): the per-session output pacer and L_rtt EMA.
+//
+// Two responsibilities, distinct but co-located because they share
+// the "this session's view of wire timing" state:
+//
+//   (1) Output pacer — schedules egress byte emissions so the
+//       client sees ~τ_wire_byte (4.17ms) between bytes, matching
+//       the natural cadence a real ENS adapter would deliver at
+//       2400 baud. Without this, the proxy would burst-flush a
+//       buffered telegram in a single TCP write (<1 ms perceived
+//       by the client), violating §0 transparency.
+//
+//   (2) L_rtt EMA — tracks the round-trip time of the gateway's
+//       own active-mode echoes (bytes we wrote to the wire and
+//       observed echoed back). Per v8 §1.4 we ABANDON passive-mode
+//       sampling entirely (Codex MAJOR finding on v7) — the
+//       passive estimate poisoned the EMA with target think-time
+//       and adapter jitter. Active-only sampling gives a clean
+//       link-latency signal.
+//
+//       Grace-bootstrap regime per v8 §1.4:
+//         - On long idle (>= GraceIdleThreshold), the next 3
+//           echoes are GRACE_BOOTSTRAP samples.
+//         - During grace, echo soft-timeout = L_rtt_EMA + 500ms;
+//           hard-timeout is disabled.
+//         - After 3 grace samples, normal-mode deadlines fire:
+//         - Normal soft = L_rtt_EMA + 100ms.
+//         - Normal hard = 2 * L_rtt_EMA + 200ms.
+//
+// PR scope contract — B3.5 lands the COMPUTATION, not the wiring
+// into actual session emission. Schedule and RecordEcho can be
+// called by tests and (eventually) by session.go; they return
+// timing decisions without applying them. B3.6 will integrate the
+// pacer into session.go's sendCh draining path so the timing
+// decisions actually affect emission.
+//
+// Concurrency: Pacer is a per-session state machine. A given
+// Pacer instance MUST be accessed serially by one goroutine
+// (typically the session's writer). The struct has a mutex to
+// guard internal state — this makes accessors safe to call from
+// any goroutine for diagnostics, but Schedule/RecordEcho callers
+// must still serialize per-session.
+
+const (
+	// TauWireByte is the canonical inter-byte spacing of the eBUS
+	// wire at 2400 baud with 10-bit UART framing (1 start + 8 data
+	// + 1 stop). Computed as 10 bit-periods × 1/2400 sec/bit =
+	// 4.1667 ms, rounded to 4167 microseconds. Per v8 §4.5 the
+	// pacer schedules egress bytes at this cadence so cross-proxy
+	// clients see naturally-paced wire bytes.
+	TauWireByte = 4167 * time.Microsecond
+
+	// LrttBootstrapInitial is the conservative initial L_rtt EMA
+	// value on connect or after Reset. Per v8 §1.4. Bootstrap
+	// large to avoid premature soft-timeouts during the first
+	// echo before any samples have converged.
+	LrttBootstrapInitial = 100 * time.Millisecond
+
+	// LrttEmaAlpha is the exponential-moving-average weight for
+	// new L_rtt samples. Per v8 §1.4. α=0.3 → new sample
+	// contributes 30%, history contributes 70%. Balances
+	// responsiveness vs noise rejection.
+	LrttEmaAlpha = 0.3
+
+	// GraceIdleThreshold is the duration of active-mode idle
+	// (no echoes recorded) that triggers grace-bootstrap on the
+	// next active write. Per v8 §1.4: ">30 s without active
+	// write" → soft-only deadlines for the first 3 echoes.
+	GraceIdleThreshold = 30 * time.Second
+
+	// GraceBootstrapSamples is the number of consecutive echo
+	// samples treated as grace after long idle. Per v8 §1.4.
+	GraceBootstrapSamples = 3
+
+	// SoftDeadlineGrace is the soft-timeout slack during grace
+	// mode. Per v8 §1.4: "L_rtt_EMA + 500 ms (very loose); hard
+	// disabled".
+	SoftDeadlineGrace = 500 * time.Millisecond
+
+	// SoftDeadlineNormal is the soft-timeout slack during normal
+	// mode. Per v8 §1.4: "L_rtt_EMA + 100 ms".
+	SoftDeadlineNormal = 100 * time.Millisecond
+
+	// HardDeadlineNormalAdd is the additive component of the
+	// hard-timeout deadline during normal mode. Per v8 §1.4:
+	// "hard = 2 × L_rtt_EMA + 200 ms".
+	HardDeadlineNormalAdd = 200 * time.Millisecond
+)
+
+// Pacer carries per-session output-pacing and L_rtt EMA state.
+// Construct via NewPacer; the zero value is NOT valid (the
+// internal mutex and the L_rtt bootstrap value need
+// initialization).
+type Pacer struct {
+	mu sync.Mutex
+
+	// tau is the inter-byte cadence the pacer enforces.
+	// Constant after construction — exposed as a field for
+	// future per-session symbol_rate adaptation (B3.7 may
+	// re-introduce dynamic tau if cross-proxy session pacing
+	// needs to vary).
+	tau time.Duration
+
+	// lastScheduledEmit is the wall-clock time at which the most
+	// recent byte was scheduled to emit (NOT necessarily when it
+	// actually emitted — that's the caller's responsibility).
+	// Schedule() advances this on every call to maintain the
+	// inter-byte cadence regardless of caller scheduling jitter.
+	//
+	// Zero value (time.Time{}) means "no byte scheduled yet";
+	// the first Schedule call emits immediately (no
+	// retroactive padding to bootstrap a cadence the caller
+	// can't observe).
+	lastScheduledEmit time.Time
+
+	// lRttEMA is the current exponential-moving-average estimate
+	// of echo round-trip time. Bootstrapped to
+	// LrttBootstrapInitial, updated by RecordEcho per v8 §1.4
+	// active-only sampling.
+	lRttEMA time.Duration
+
+	// graceRemaining counts how many more echoes will be treated
+	// as grace-bootstrap samples (soft-only deadlines, no hard
+	// timeout). Decremented by RecordEcho. Set to
+	// GraceBootstrapSamples on transition from long-idle to
+	// active. Zero == normal mode.
+	graceRemaining int
+
+	// lastEchoAt is the wall-clock time of the most recent echo
+	// observed via RecordEcho. Used to detect the long-idle
+	// transition (now - lastEchoAt >= GraceIdleThreshold → enter
+	// grace bootstrap on the next echo).
+	//
+	// Zero value means "no echoes observed yet". The first
+	// RecordEcho call after construction does NOT trigger grace
+	// bootstrap because there was no "prior active period" to be
+	// idle from; bootstrap is the construction state.
+	lastEchoAt time.Time
+
+	// recordedSamples counts how many RecordEcho calls have
+	// arrived. Useful for tests and diagnostics that need to
+	// distinguish "pre-bootstrap" from "post-first-sample".
+	recordedSamples uint64
+}
+
+// NewPacer returns a Pacer with default τ_wire_byte and
+// LrttBootstrapInitial L_rtt EMA. Caller may override tau via
+// SetTau (e.g. for per-session symbol_rate adaptation in B3.7).
+func NewPacer() *Pacer {
+	return &Pacer{
+		tau:     TauWireByte,
+		lRttEMA: LrttBootstrapInitial,
+	}
+}
+
+// SetTau overrides the inter-byte cadence. Exposed for B3.7
+// per-session symbol_rate adaptation; until then callers should
+// rely on the constructor default.
+func (p *Pacer) SetTau(tau time.Duration) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.tau = tau
+}
+
+// Schedule reports when the next byte should be emitted given the
+// current wall-clock time `now`. The returned time is
+// max(now, lastScheduledEmit + tau), and lastScheduledEmit is
+// advanced to the returned value.
+//
+// Caller usage: a session writer goroutine that has a buffered
+// byte ready calls Schedule(time.Now()), then sleeps until the
+// returned time before pushing the byte to the client TCP egress.
+//
+// PR B3.5 scope: this method is callable but the session writer
+// is NOT yet wired to use it. B3.6 integrates Schedule into
+// session.go's sendCh draining.
+func (p *Pacer) Schedule(now time.Time) time.Time {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	var emitAt time.Time
+	if p.lastScheduledEmit.IsZero() {
+		// First call — emit immediately. No retroactive padding.
+		emitAt = now
+	} else {
+		next := p.lastScheduledEmit.Add(p.tau)
+		if next.After(now) {
+			emitAt = next
+		} else {
+			emitAt = now
+		}
+	}
+	p.lastScheduledEmit = emitAt
+	return emitAt
+}
+
+// LastScheduledEmit returns the most recent Schedule output.
+// Returns zero time if Schedule has never been called. Safe to
+// call from any goroutine.
+func (p *Pacer) LastScheduledEmit() time.Time {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.lastScheduledEmit
+}
+
+// RecordEcho feeds an observed echo round-trip time into the
+// L_rtt EMA. Per v8 §1.4 this is called ONLY in active mode
+// (echoes of the gateway's own writes); passive-mode bytes do
+// NOT contribute samples.
+//
+// The first call after long idle (now - lastEchoAt >=
+// GraceIdleThreshold) sets graceRemaining =
+// GraceBootstrapSamples, putting the next GraceBootstrapSamples
+// echoes into grace-bootstrap mode.
+//
+// During grace bootstrap, the EMA still updates normally; only
+// the deadline computation differs (see EchoDeadlines).
+func (p *Pacer) RecordEcho(rtt time.Duration, now time.Time) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Long-idle detection: if we have prior echo history AND the
+	// gap exceeds the grace threshold, enter grace bootstrap.
+	if !p.lastEchoAt.IsZero() && now.Sub(p.lastEchoAt) >= GraceIdleThreshold {
+		p.graceRemaining = GraceBootstrapSamples
+	}
+
+	// Standard EMA update: new = α × sample + (1-α) × old.
+	// Done in float64 to avoid integer-truncation drift over many
+	// samples; result is rounded back to time.Duration.
+	alpha := LrttEmaAlpha
+	newEma := alpha*float64(rtt) + (1.0-alpha)*float64(p.lRttEMA)
+	p.lRttEMA = time.Duration(newEma)
+
+	p.lastEchoAt = now
+	p.recordedSamples++
+
+	// Decrement grace counter AFTER the EMA update so this
+	// echo's sample counts as one of the bootstrap samples per
+	// v8 §1.4 ("3 grace samples").
+	if p.graceRemaining > 0 {
+		p.graceRemaining--
+	}
+}
+
+// Lrtt returns the current L_rtt EMA estimate. Safe to call from
+// any goroutine.
+func (p *Pacer) Lrtt() time.Duration {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.lRttEMA
+}
+
+// InGraceBootstrap reports whether the pacer is currently in
+// grace-bootstrap mode (next echo's deadline uses the loose
+// grace slack rather than the normal slack). Safe to call from
+// any goroutine.
+func (p *Pacer) InGraceBootstrap() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.graceRemaining > 0
+}
+
+// RecordedSamples returns the cumulative count of RecordEcho
+// calls since construction. Safe to call from any goroutine.
+func (p *Pacer) RecordedSamples() uint64 {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.recordedSamples
+}
+
+// EchoDeadlines returns the (soft, hard) deadlines for the NEXT
+// echo, expressed as durations relative to the write time. Per
+// v8 §1.4:
+//
+//   - Grace mode (graceRemaining > 0):
+//     soft = L_rtt_EMA + 500ms
+//     hard = 0 (disabled — caller MUST NOT enforce a hard
+//     timeout while grace is active)
+//
+//   - Normal mode (graceRemaining == 0):
+//     soft = L_rtt_EMA + 100ms
+//     hard = 2 × L_rtt_EMA + 200ms
+//
+// Callers SHOULD treat hard=0 as "no hard deadline; rely on
+// transport-layer timeouts". B3.6 will wire these into the
+// session's echo-watchdog timer.
+//
+// Safe to call from any goroutine.
+func (p *Pacer) EchoDeadlines() (soft, hard time.Duration) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.graceRemaining > 0 {
+		return p.lRttEMA + SoftDeadlineGrace, 0
+	}
+	return p.lRttEMA + SoftDeadlineNormal,
+		2*p.lRttEMA + HardDeadlineNormalAdd
+}
+
+// ResetLrtt resets the L_rtt EMA to the bootstrap value, clears
+// the lastEchoAt anchor, and resets grace state. Used on session
+// reconnect or transport reset boundary. Pacing state
+// (lastScheduledEmit) is preserved — the pacer remains in cadence
+// across an L_rtt reset.
+func (p *Pacer) ResetLrtt() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.lRttEMA = LrttBootstrapInitial
+	p.lastEchoAt = time.Time{}
+	p.graceRemaining = 0
+}

--- a/internal/adaptermux/v8classifier/pacer.go
+++ b/internal/adaptermux/v8classifier/pacer.go
@@ -36,11 +36,41 @@ import (
 //         - Normal hard = 2 * L_rtt_EMA + 200ms.
 //
 // PR scope contract — B3.5 lands the COMPUTATION, not the wiring
-// into actual session emission. Schedule and RecordEcho can be
-// called by tests and (eventually) by session.go; they return
-// timing decisions without applying them. B3.6 will integrate the
-// pacer into session.go's sendCh draining path so the timing
-// decisions actually affect emission.
+// into actual session emission. Schedule, BeforeActiveWrite,
+// RecordEcho, and EchoDeadlines can be called by tests and
+// (eventually) by callsites in adaptermux; they return timing
+// decisions without applying them.
+//
+// B3.6 integration map (per Codex round-2 MEDIUM on PR #642 —
+// these two halves of the Pacer hook into DIFFERENT adaptermux
+// paths and must NOT be conflated):
+//
+//   - Output pacer (Schedule, LastScheduledEmit):
+//     hooks into session.go's TCP-egress path that pushes bytes
+//     back to the cross-proxy CLIENT. Per v8 §4.5 ("intra-
+//     telegram pacing"), each per-session sendCh-drain → conn.Write
+//     emission gets paced at τ_wire_byte. The relevant choke
+//     point is session.writeLoop (the goroutine draining sendCh
+//     to the client TCP socket).
+//
+//   - L_rtt regime (BeforeActiveWrite, RecordEcho, EchoDeadlines,
+//     ResetLrtt, Lrtt, InGraceBootstrap):
+//     hooks into the gateway's ADAPTER-WRITE path that puts bytes
+//     onto the eBUS wire. Per v8 §1.4 active-only sampling, the
+//     relevant choke point is mux.go's sendLoop / doSend (or
+//     wherever bytes reach transport.Write). The watchdog must
+//     arm BEFORE tr.Write fires, in this sequence:
+//        BeforeActiveWrite(now)        → maybe enter grace
+//        soft, hard, hardEnabled := EchoDeadlines()
+//        arm watchdog with (soft, hard, hardEnabled)
+//        tr.Write(byte)                → byte on wire
+//        ... wait for echo ...
+//        RecordEcho(echoRtt, now)      → EMA update + consume grace
+//
+//   - Conflating the two halves (applying BeforeActiveWrite at
+//     session.writeLoop, or applying Schedule at mux.doSend) would
+//     defeat the design — the v8 timing decisions hinge on these
+//     call sites being correctly distinguished.
 //
 // Concurrency: Pacer is a per-session state machine. A given
 // Pacer instance MUST be accessed serially by one goroutine
@@ -198,13 +228,16 @@ func (p *Pacer) SetTau(tau time.Duration) (accepted bool) {
 // max(now, lastScheduledEmit + tau), and lastScheduledEmit is
 // advanced to the returned value.
 //
-// Caller usage: a session writer goroutine that has a buffered
-// byte ready calls Schedule(time.Now()), then sleeps until the
-// returned time before pushing the byte to the client TCP egress.
+// Caller usage: session.writeLoop (the goroutine that drains
+// sendCh to the client's TCP socket — NOT the adapter-write
+// path) calls Schedule(time.Now()) for each byte before
+// conn.Write, sleeps until the returned time, then writes.
 //
-// PR B3.5 scope: this method is callable but the session writer
+// PR B3.5 scope: this method is callable but session.writeLoop
 // is NOT yet wired to use it. B3.6 integrates Schedule into
-// session.go's sendCh draining.
+// session.go's sendCh-draining loop (TCP egress to the
+// cross-proxy CLIENT — NOT the active-write path that goes to
+// the adapter via mux.go).
 func (p *Pacer) Schedule(now time.Time) time.Time {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -238,13 +271,22 @@ func (p *Pacer) LastScheduledEmit() time.Time {
 	return p.lastScheduledEmit
 }
 
-// BeforeActiveWrite is called by the session writer BEFORE arming
-// the echo-watchdog for a new active write. Per Codex round-1
-// MAJOR on PR #642: grace bootstrap MUST enter before the first
-// echo of a long-idle write, so the watchdog uses grace
-// deadlines on the very first post-idle echo. Doing the long-idle
-// check inside RecordEcho was too late — by then the first echo
-// had already been waited on with normal deadlines.
+// BeforeActiveWrite is called by the ADAPTER-WRITE path (NOT the
+// session TCP-egress path) BEFORE arming the echo-watchdog for a
+// new active write. The choke point is mux.go's sendLoop or
+// doSend — wherever the byte is about to hit transport.Write.
+// Per Codex round-1 MAJOR on PR #642: grace bootstrap MUST enter
+// before the first echo of a long-idle write, so the watchdog
+// uses grace deadlines on the very first post-idle echo. Doing
+// the long-idle check inside RecordEcho was too late — by then
+// the first echo had already been waited on with normal
+// deadlines.
+//
+// Calling at the wrong site (e.g. session.writeLoop / sendCh
+// draining) DEFEATS this fix because sendCh-draining is the TCP
+// egress back to the cross-proxy client, which does NOT cause
+// adapter echoes. Per Codex round-2 MEDIUM on PR #642: do NOT
+// conflate these two paths.
 //
 // Behavior:
 //   - If the pacer has prior echo history (lastEchoAt non-zero)

--- a/internal/adaptermux/v8classifier/pacer.go
+++ b/internal/adaptermux/v8classifier/pacer.go
@@ -114,12 +114,21 @@ type Pacer struct {
 	// actually emitted — that's the caller's responsibility).
 	// Schedule() advances this on every call to maintain the
 	// inter-byte cadence regardless of caller scheduling jitter.
-	//
-	// Zero value (time.Time{}) means "no byte scheduled yet";
-	// the first Schedule call emits immediately (no
-	// retroactive padding to bootstrap a cadence the caller
-	// can't observe).
 	lastScheduledEmit time.Time
+
+	// scheduledInitialized tracks whether Schedule has ever been
+	// called. The first Schedule call emits at `now` (no
+	// retroactive padding to bootstrap a cadence the caller
+	// can't observe); subsequent calls enforce the τ cadence.
+	//
+	// Per Codex round-1 LOW on PR #642: previously this state
+	// was inferred from lastScheduledEmit.IsZero(). That broke
+	// if a caller ever passed time.Time{} as `now` — the first
+	// Schedule(zero) would emit at zero, set lastScheduledEmit
+	// to zero, and the NEXT call would again skip cadence
+	// enforcement. The explicit boolean removes the zero-time
+	// sentinel leak.
+	scheduledInitialized bool
 
 	// lRttEMA is the current exponential-moving-average estimate
 	// of echo round-trip time. Bootstrapped to
@@ -164,10 +173,24 @@ func NewPacer() *Pacer {
 // SetTau overrides the inter-byte cadence. Exposed for B3.7
 // per-session symbol_rate adaptation; until then callers should
 // rely on the constructor default.
-func (p *Pacer) SetTau(tau time.Duration) {
+//
+// Per Codex round-1 MEDIUM on PR #642: invalid values (tau <= 0)
+// are REJECTED silently — the prior tau is preserved. A negative
+// tau would otherwise let `lastScheduledEmit.Add(p.tau)` move
+// backwards, defeating monotonic pacing. A zero tau would
+// collapse a burst into identical emit times (no pacing at all).
+//
+// Returns true if the new tau was accepted, false if rejected.
+// Callers that want the "must apply or fail loudly" contract
+// can assert on the bool.
+func (p *Pacer) SetTau(tau time.Duration) (accepted bool) {
+	if tau <= 0 {
+		return false
+	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.tau = tau
+	return true
 }
 
 // Schedule reports when the next byte should be emitted given the
@@ -186,9 +209,14 @@ func (p *Pacer) Schedule(now time.Time) time.Time {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	var emitAt time.Time
-	if p.lastScheduledEmit.IsZero() {
+	if !p.scheduledInitialized {
 		// First call — emit immediately. No retroactive padding.
+		// The explicit scheduledInitialized flag (not
+		// lastScheduledEmit.IsZero) prevents a caller passing
+		// time.Time{} as `now` from re-triggering this branch on
+		// the SECOND call.
 		emitAt = now
+		p.scheduledInitialized = true
 	} else {
 		next := p.lastScheduledEmit.Add(p.tau)
 		if next.After(now) {
@@ -210,27 +238,72 @@ func (p *Pacer) LastScheduledEmit() time.Time {
 	return p.lastScheduledEmit
 }
 
+// BeforeActiveWrite is called by the session writer BEFORE arming
+// the echo-watchdog for a new active write. Per Codex round-1
+// MAJOR on PR #642: grace bootstrap MUST enter before the first
+// echo of a long-idle write, so the watchdog uses grace
+// deadlines on the very first post-idle echo. Doing the long-idle
+// check inside RecordEcho was too late — by then the first echo
+// had already been waited on with normal deadlines.
+//
+// Behavior:
+//   - If the pacer has prior echo history (lastEchoAt non-zero)
+//     AND now - lastEchoAt >= GraceIdleThreshold, sets
+//     graceRemaining = GraceBootstrapSamples.
+//   - If never sampled (lastEchoAt zero), does nothing — the
+//     construction state already represents bootstrap; no need
+//     to re-enter grace.
+//   - If we already have grace samples queued, takes the max
+//     (idempotent if called twice before any RecordEcho).
+//
+// Callers SHOULD invoke BeforeActiveWrite immediately before
+// querying EchoDeadlines() for the first byte of an active write.
+// Calling it more than once before the corresponding RecordEcho
+// is safe (the second call is a no-op as long as
+// graceRemaining is already at GraceBootstrapSamples).
+func (p *Pacer) BeforeActiveWrite(now time.Time) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.lastEchoAt.IsZero() {
+		return
+	}
+	if now.Sub(p.lastEchoAt) < GraceIdleThreshold {
+		return
+	}
+	if p.graceRemaining < GraceBootstrapSamples {
+		p.graceRemaining = GraceBootstrapSamples
+	}
+}
+
 // RecordEcho feeds an observed echo round-trip time into the
 // L_rtt EMA. Per v8 §1.4 this is called ONLY in active mode
 // (echoes of the gateway's own writes); passive-mode bytes do
 // NOT contribute samples.
 //
-// The first call after long idle (now - lastEchoAt >=
-// GraceIdleThreshold) sets graceRemaining =
-// GraceBootstrapSamples, putting the next GraceBootstrapSamples
-// echoes into grace-bootstrap mode.
+// Per Codex round-1 MEDIUM on PR #642: invalid samples (rtt <= 0)
+// are REJECTED — neither the EMA, the lastEchoAt anchor, nor the
+// recordedSamples counter is updated. A future call site that
+// computes rtt from mismatched clock anchors would otherwise
+// poison the EMA. Validation chosen over silent clamping so
+// callers see the rejection in the recordedSamples counter (it
+// won't increment).
+//
+// Grace bootstrap entry is now handled by BeforeActiveWrite (B3.5
+// round-1 MAJOR fix). RecordEcho only decrements the grace
+// counter as samples arrive, consuming the slots set by
+// BeforeActiveWrite.
 //
 // During grace bootstrap, the EMA still updates normally; only
 // the deadline computation differs (see EchoDeadlines).
 func (p *Pacer) RecordEcho(rtt time.Duration, now time.Time) {
+	if rtt <= 0 {
+		// Invalid sample — reject. Documented contract: callers
+		// must compute rtt from a single clock source with
+		// observed write time predating echo time.
+		return
+	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
-
-	// Long-idle detection: if we have prior echo history AND the
-	// gap exceeds the grace threshold, enter grace bootstrap.
-	if !p.lastEchoAt.IsZero() && now.Sub(p.lastEchoAt) >= GraceIdleThreshold {
-		p.graceRemaining = GraceBootstrapSamples
-	}
 
 	// Standard EMA update: new = α × sample + (1-α) × old.
 	// Done in float64 to avoid integer-truncation drift over many
@@ -276,32 +349,36 @@ func (p *Pacer) RecordedSamples() uint64 {
 	return p.recordedSamples
 }
 
-// EchoDeadlines returns the (soft, hard) deadlines for the NEXT
-// echo, expressed as durations relative to the write time. Per
-// v8 §1.4:
+// EchoDeadlines returns the deadlines for the NEXT echo,
+// expressed as durations relative to the write time. Per v8 §1.4:
 //
 //   - Grace mode (graceRemaining > 0):
-//     soft = L_rtt_EMA + 500ms
-//     hard = 0 (disabled — caller MUST NOT enforce a hard
-//     timeout while grace is active)
+//     soft        = L_rtt_EMA + 500ms
+//     hard        = 0 (caller MUST ignore this value)
+//     hardEnabled = false
 //
 //   - Normal mode (graceRemaining == 0):
-//     soft = L_rtt_EMA + 100ms
-//     hard = 2 × L_rtt_EMA + 200ms
+//     soft        = L_rtt_EMA + 100ms
+//     hard        = 2 × L_rtt_EMA + 200ms
+//     hardEnabled = true
 //
-// Callers SHOULD treat hard=0 as "no hard deadline; rely on
-// transport-layer timeouts". B3.6 will wire these into the
-// session's echo-watchdog timer.
+// Per Codex round-1 LOW on PR #642: the signature returns an
+// explicit hardEnabled bool rather than relying on hard=0 as a
+// "disabled" sentinel. This protects against the legitimate-zero
+// edge case (e.g. a future configuration where L_rtt could land
+// on zero would otherwise conflate "disabled" with "compute to
+// zero"). Callers MUST consult hardEnabled before honoring hard.
 //
 // Safe to call from any goroutine.
-func (p *Pacer) EchoDeadlines() (soft, hard time.Duration) {
+func (p *Pacer) EchoDeadlines() (soft, hard time.Duration, hardEnabled bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.graceRemaining > 0 {
-		return p.lRttEMA + SoftDeadlineGrace, 0
+		return p.lRttEMA + SoftDeadlineGrace, 0, false
 	}
 	return p.lRttEMA + SoftDeadlineNormal,
-		2*p.lRttEMA + HardDeadlineNormalAdd
+		2*p.lRttEMA + HardDeadlineNormalAdd,
+		true
 }
 
 // ResetLrtt resets the L_rtt EMA to the bootstrap value, clears

--- a/internal/adaptermux/v8classifier/pacer_test.go
+++ b/internal/adaptermux/v8classifier/pacer_test.go
@@ -1,0 +1,319 @@
+package v8classifier
+
+import (
+	"testing"
+	"time"
+)
+
+// Phase 3 Step B3.5: tests for the per-session output Pacer and
+// L_rtt EMA. The pacer is purely a computation layer in B3.5 —
+// callers can invoke Schedule/RecordEcho/EchoDeadlines and inspect
+// the results, but no production code yet acts on those decisions.
+// B3.6 wires the pacer into session.go's emission path.
+
+// Helper: t0 is the canonical synthetic-time anchor for tests.
+var t0 = time.Unix(1_000_000_000, 0)
+
+// TestPacer_NewPacer_DefaultState pins the constructor invariants.
+func TestPacer_NewPacer_DefaultState(t *testing.T) {
+	t.Parallel()
+	p := NewPacer()
+	if got := p.Lrtt(); got != LrttBootstrapInitial {
+		t.Errorf("Lrtt() at construction = %v; want %v (bootstrap)", got, LrttBootstrapInitial)
+	}
+	if p.InGraceBootstrap() {
+		t.Error("InGraceBootstrap()=true at construction; want false (not entered yet)")
+	}
+	if got := p.RecordedSamples(); got != 0 {
+		t.Errorf("RecordedSamples()=%d; want 0 at construction", got)
+	}
+	if !p.LastScheduledEmit().IsZero() {
+		t.Error("LastScheduledEmit()=non-zero at construction; want zero")
+	}
+}
+
+// TestPacer_Schedule_FirstCallEmitsImmediately pins that the very
+// first byte after construction emits at `now` without retroactive
+// padding (no fictitious "previous emit at -∞" anchor).
+func TestPacer_Schedule_FirstCallEmitsImmediately(t *testing.T) {
+	t.Parallel()
+	p := NewPacer()
+	emit := p.Schedule(t0)
+	if !emit.Equal(t0) {
+		t.Errorf("first Schedule(t0) = %v; want t0 (%v)", emit, t0)
+	}
+}
+
+// TestPacer_Schedule_SubsequentCallEnforcesCadence pins that the
+// second byte is scheduled at first + τ when the caller's `now` is
+// within τ of the first emit (caller is "ahead" of cadence).
+func TestPacer_Schedule_SubsequentCallEnforcesCadence(t *testing.T) {
+	t.Parallel()
+	p := NewPacer()
+
+	first := p.Schedule(t0)
+	// Caller calls Schedule again 1 ms later (within τ=4.17ms);
+	// pacer must schedule the second byte at first + τ to enforce
+	// cadence.
+	tooEarly := t0.Add(1 * time.Millisecond)
+	second := p.Schedule(tooEarly)
+	want := first.Add(TauWireByte)
+	if !second.Equal(want) {
+		t.Errorf("second Schedule = %v; want %v (first + τ_wire_byte)", second, want)
+	}
+}
+
+// TestPacer_Schedule_CallerLateAdvancesCadence pins that if the
+// caller is LATE (now > last + τ), the pacer schedules at `now`
+// and the new lastScheduledEmit is `now` — the cadence advances
+// rather than back-filling.
+func TestPacer_Schedule_CallerLateAdvancesCadence(t *testing.T) {
+	t.Parallel()
+	p := NewPacer()
+
+	p.Schedule(t0)
+	late := t0.Add(100 * time.Millisecond) // way past τ
+	emit := p.Schedule(late)
+	if !emit.Equal(late) {
+		t.Errorf("late Schedule = %v; want %v (late time)", emit, late)
+	}
+	if got := p.LastScheduledEmit(); !got.Equal(late) {
+		t.Errorf("LastScheduledEmit()=%v; want %v after late call", got, late)
+	}
+}
+
+// TestPacer_Schedule_BurstSequence pins the canonical pattern: a
+// 6-byte burst arriving "instantly" (all calls with the same
+// `now`) gets spaced at τ intervals.
+func TestPacer_Schedule_BurstSequence(t *testing.T) {
+	t.Parallel()
+	p := NewPacer()
+	const n = 6
+	emits := make([]time.Time, n)
+	for i := 0; i < n; i++ {
+		emits[i] = p.Schedule(t0)
+	}
+	// emits[0] = t0; emits[i] = t0 + i*τ.
+	for i := 0; i < n; i++ {
+		want := t0.Add(time.Duration(i) * TauWireByte)
+		if !emits[i].Equal(want) {
+			t.Errorf("emit[%d] = %v; want %v", i, emits[i], want)
+		}
+	}
+}
+
+// TestPacer_RecordEcho_EMAConvergence pins that repeated identical
+// samples converge the EMA toward the sample value.
+func TestPacer_RecordEcho_EMAConvergence(t *testing.T) {
+	t.Parallel()
+	p := NewPacer()
+
+	const sample = 50 * time.Millisecond
+	// 100 samples should converge the EMA far below the initial
+	// 100ms toward the sample (50ms) — α=0.3 means after N
+	// samples, the residual error decays as (0.7)^N.
+	for i := 0; i < 100; i++ {
+		p.RecordEcho(sample, t0.Add(time.Duration(i)*100*time.Millisecond))
+	}
+	// After 100 samples of 50ms with bootstrap 100ms, the EMA
+	// should be very close to 50ms.
+	got := p.Lrtt()
+	if got > 55*time.Millisecond || got < 45*time.Millisecond {
+		t.Errorf("Lrtt() after 100×50ms samples = %v; want ~50ms (converged)", got)
+	}
+}
+
+// TestPacer_RecordEcho_FirstSampleUpdatesEMA pins the first-sample
+// behavior: with bootstrap=100ms and α=0.3, a 50ms sample produces
+// EMA = 0.3 × 50 + 0.7 × 100 = 85ms.
+func TestPacer_RecordEcho_FirstSampleUpdatesEMA(t *testing.T) {
+	t.Parallel()
+	p := NewPacer()
+	p.RecordEcho(50*time.Millisecond, t0)
+	got := p.Lrtt()
+	// 0.3 × 50 + 0.7 × 100 = 15 + 70 = 85 ms (allow ±1 ms float
+	// drift).
+	want := 85 * time.Millisecond
+	delta := got - want
+	if delta < -1*time.Millisecond || delta > 1*time.Millisecond {
+		t.Errorf("Lrtt() after first sample = %v; want %v (±1ms)", got, want)
+	}
+	if got := p.RecordedSamples(); got != 1 {
+		t.Errorf("RecordedSamples()=%d; want 1", got)
+	}
+}
+
+// TestPacer_GraceBootstrap_TriggeredByLongIdle pins the v8 §1.4
+// long-idle trigger: a RecordEcho call with now-lastEcho >= 30s
+// sets graceRemaining to 3.
+func TestPacer_GraceBootstrap_TriggeredByLongIdle(t *testing.T) {
+	t.Parallel()
+	p := NewPacer()
+
+	// First sample establishes lastEchoAt.
+	p.RecordEcho(50*time.Millisecond, t0)
+	if p.InGraceBootstrap() {
+		t.Error("InGraceBootstrap()=true after first sample; want false (no prior idle)")
+	}
+
+	// Long-idle: next sample 31s later → grace bootstrap.
+	tLate := t0.Add(31 * time.Second)
+	p.RecordEcho(50*time.Millisecond, tLate)
+	// After this call: graceRemaining was set to 3, then
+	// decremented to 2 by the RecordEcho's tail.
+	if !p.InGraceBootstrap() {
+		t.Error("InGraceBootstrap()=false after long-idle sample; want true (entered grace)")
+	}
+
+	// Two more samples → graceRemaining 1 → 0 (exits grace).
+	p.RecordEcho(50*time.Millisecond, tLate.Add(100*time.Millisecond))
+	if !p.InGraceBootstrap() {
+		t.Error("InGraceBootstrap()=false after 2nd grace sample; want true (still in grace)")
+	}
+	p.RecordEcho(50*time.Millisecond, tLate.Add(200*time.Millisecond))
+	if p.InGraceBootstrap() {
+		t.Error("InGraceBootstrap()=true after 3rd grace sample; want false (grace exhausted)")
+	}
+}
+
+// TestPacer_GraceBootstrap_NotTriggeredByShortIdle pins the
+// boundary: idle < 30s does NOT enter grace.
+func TestPacer_GraceBootstrap_NotTriggeredByShortIdle(t *testing.T) {
+	t.Parallel()
+	p := NewPacer()
+	p.RecordEcho(50*time.Millisecond, t0)
+	// 29 seconds — below the 30s threshold.
+	p.RecordEcho(50*time.Millisecond, t0.Add(29*time.Second))
+	if p.InGraceBootstrap() {
+		t.Error("InGraceBootstrap()=true after 29s idle; want false")
+	}
+}
+
+// TestPacer_EchoDeadlines_NormalMode pins the v8 §1.4 formula:
+// soft = L_rtt + 100ms, hard = 2×L_rtt + 200ms.
+func TestPacer_EchoDeadlines_NormalMode(t *testing.T) {
+	t.Parallel()
+	p := NewPacer()
+	// At construction: L_rtt = 100ms, no grace.
+	soft, hard := p.EchoDeadlines()
+	wantSoft := 100*time.Millisecond + SoftDeadlineNormal
+	wantHard := 2*100*time.Millisecond + HardDeadlineNormalAdd
+	if soft != wantSoft {
+		t.Errorf("soft=%v; want %v", soft, wantSoft)
+	}
+	if hard != wantHard {
+		t.Errorf("hard=%v; want %v", hard, wantHard)
+	}
+}
+
+// TestPacer_EchoDeadlines_GraceMode pins that during grace, soft
+// uses the loose 500ms slack and hard is disabled (returns 0).
+func TestPacer_EchoDeadlines_GraceMode(t *testing.T) {
+	t.Parallel()
+	p := NewPacer()
+	// Trigger grace by long-idle pattern.
+	p.RecordEcho(50*time.Millisecond, t0)
+	p.RecordEcho(50*time.Millisecond, t0.Add(31*time.Second))
+	if !p.InGraceBootstrap() {
+		t.Fatal("precondition: should be in grace")
+	}
+	soft, hard := p.EchoDeadlines()
+	// L_rtt should be ~85ms after two 50ms samples (first 100 → 85,
+	// second 85 → 79.5). Either way the formula adds 500ms slack.
+	if hard != 0 {
+		t.Errorf("hard=%v in grace mode; want 0 (disabled)", hard)
+	}
+	if soft <= 500*time.Millisecond {
+		t.Errorf("soft=%v in grace mode; want > 500ms (L_rtt + 500ms slack)", soft)
+	}
+}
+
+// TestPacer_ResetLrtt pins ResetLrtt clears the EMA, idle anchor,
+// and grace state — but does NOT touch the pacing state.
+func TestPacer_ResetLrtt(t *testing.T) {
+	t.Parallel()
+	p := NewPacer()
+
+	// Build up state.
+	p.RecordEcho(50*time.Millisecond, t0)
+	p.RecordEcho(50*time.Millisecond, t0.Add(31*time.Second))
+	scheduledBefore := p.Schedule(t0.Add(31 * time.Second))
+	if !p.InGraceBootstrap() {
+		t.Fatal("precondition: should be in grace")
+	}
+	if p.Lrtt() == LrttBootstrapInitial {
+		t.Fatal("precondition: Lrtt should have moved off bootstrap")
+	}
+
+	p.ResetLrtt()
+
+	if got := p.Lrtt(); got != LrttBootstrapInitial {
+		t.Errorf("after ResetLrtt: Lrtt()=%v; want %v (bootstrap)", got, LrttBootstrapInitial)
+	}
+	if p.InGraceBootstrap() {
+		t.Error("after ResetLrtt: InGraceBootstrap()=true; want false")
+	}
+	// Pacing state preserved.
+	if got := p.LastScheduledEmit(); !got.Equal(scheduledBefore) {
+		t.Errorf("after ResetLrtt: LastScheduledEmit()=%v; want %v (pacing preserved)", got, scheduledBefore)
+	}
+}
+
+// TestPacer_TauOverride pins SetTau and that subsequent Schedule
+// calls use the new τ.
+func TestPacer_TauOverride(t *testing.T) {
+	t.Parallel()
+	p := NewPacer()
+	const customTau = 10 * time.Millisecond
+	p.SetTau(customTau)
+
+	p.Schedule(t0)
+	emit := p.Schedule(t0)
+	want := t0.Add(customTau)
+	if !emit.Equal(want) {
+		t.Errorf("Schedule with custom τ = %v; want %v", emit, want)
+	}
+}
+
+// TestPacer_ConcurrentRead pins that the accessors (Lrtt,
+// InGraceBootstrap, RecordedSamples, LastScheduledEmit,
+// EchoDeadlines) are safe to call from another goroutine while a
+// single producer is calling Schedule/RecordEcho.
+//
+// The mutex inside Pacer makes this race-free; the test fires
+// under -race to prove it.
+func TestPacer_ConcurrentRead(t *testing.T) {
+	t.Parallel()
+	p := NewPacer()
+	stop := make(chan struct{})
+	defer close(stop)
+
+	// Reader goroutine.
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = p.Lrtt()
+				_ = p.InGraceBootstrap()
+				_ = p.RecordedSamples()
+				_ = p.LastScheduledEmit()
+				_, _ = p.EchoDeadlines()
+			}
+		}
+	}()
+
+	// Producer: 1000 Schedule + interleaved RecordEcho calls.
+	now := t0
+	for i := 0; i < 1000; i++ {
+		p.Schedule(now)
+		if i%5 == 0 {
+			p.RecordEcho(time.Duration(40+i)*time.Millisecond, now)
+		}
+		now = now.Add(1 * time.Millisecond)
+	}
+	if got := p.RecordedSamples(); got != 200 {
+		t.Errorf("RecordedSamples()=%d; want 200 (1000/5)", got)
+	}
+}

--- a/internal/adaptermux/v8classifier/pacer_test.go
+++ b/internal/adaptermux/v8classifier/pacer_test.go
@@ -143,10 +143,14 @@ func TestPacer_RecordEcho_FirstSampleUpdatesEMA(t *testing.T) {
 	}
 }
 
-// TestPacer_GraceBootstrap_TriggeredByLongIdle pins the v8 §1.4
-// long-idle trigger: a RecordEcho call with now-lastEcho >= 30s
-// sets graceRemaining to 3.
-func TestPacer_GraceBootstrap_TriggeredByLongIdle(t *testing.T) {
+// TestPacer_GraceBootstrap_TriggeredByBeforeActiveWrite pins the
+// v8 §1.4 long-idle trigger via the new BeforeActiveWrite path
+// (Codex round-1 MAJOR fix): a write call after >=30s idle from
+// the last echo sets graceRemaining = GraceBootstrapSamples.
+// Critically, this fires BEFORE the first post-idle echo, so
+// EchoDeadlines() called between BeforeActiveWrite and the first
+// RecordEcho already returns grace deadlines.
+func TestPacer_GraceBootstrap_TriggeredByBeforeActiveWrite(t *testing.T) {
 	t.Parallel()
 	p := NewPacer()
 
@@ -156,46 +160,104 @@ func TestPacer_GraceBootstrap_TriggeredByLongIdle(t *testing.T) {
 		t.Error("InGraceBootstrap()=true after first sample; want false (no prior idle)")
 	}
 
-	// Long-idle: next sample 31s later → grace bootstrap.
+	// Long-idle write: 31s later, call BeforeActiveWrite BEFORE
+	// any new echo arrives. This is the critical fix for the
+	// round-1 MAJOR — the FIRST post-idle echo's deadline must
+	// already be in grace mode at the moment the watchdog arms.
 	tLate := t0.Add(31 * time.Second)
-	p.RecordEcho(50*time.Millisecond, tLate)
-	// After this call: graceRemaining was set to 3, then
-	// decremented to 2 by the RecordEcho's tail.
+	p.BeforeActiveWrite(tLate)
+
 	if !p.InGraceBootstrap() {
-		t.Error("InGraceBootstrap()=false after long-idle sample; want true (entered grace)")
+		t.Error("InGraceBootstrap()=false after BeforeActiveWrite + long idle; want true")
+	}
+	_, _, hardEnabled := p.EchoDeadlines()
+	if hardEnabled {
+		t.Error("hardEnabled=true after BeforeActiveWrite; want false (grace must protect FIRST post-idle echo)")
 	}
 
-	// Two more samples → graceRemaining 1 → 0 (exits grace).
+	// Three samples consume grace: 3 → 2 → 1 → 0.
+	p.RecordEcho(50*time.Millisecond, tLate)
+	if !p.InGraceBootstrap() {
+		t.Error("InGraceBootstrap()=false after 1st grace echo; want true")
+	}
 	p.RecordEcho(50*time.Millisecond, tLate.Add(100*time.Millisecond))
 	if !p.InGraceBootstrap() {
-		t.Error("InGraceBootstrap()=false after 2nd grace sample; want true (still in grace)")
+		t.Error("InGraceBootstrap()=false after 2nd grace echo; want true")
 	}
 	p.RecordEcho(50*time.Millisecond, tLate.Add(200*time.Millisecond))
 	if p.InGraceBootstrap() {
-		t.Error("InGraceBootstrap()=true after 3rd grace sample; want false (grace exhausted)")
+		t.Error("InGraceBootstrap()=true after 3rd grace echo; want false (grace exhausted)")
 	}
 }
 
 // TestPacer_GraceBootstrap_NotTriggeredByShortIdle pins the
-// boundary: idle < 30s does NOT enter grace.
+// boundary: BeforeActiveWrite with idle < 30s does NOT enter grace.
 func TestPacer_GraceBootstrap_NotTriggeredByShortIdle(t *testing.T) {
 	t.Parallel()
 	p := NewPacer()
 	p.RecordEcho(50*time.Millisecond, t0)
 	// 29 seconds — below the 30s threshold.
-	p.RecordEcho(50*time.Millisecond, t0.Add(29*time.Second))
+	p.BeforeActiveWrite(t0.Add(29 * time.Second))
 	if p.InGraceBootstrap() {
 		t.Error("InGraceBootstrap()=true after 29s idle; want false")
 	}
 }
 
+// TestPacer_GraceBootstrap_BoundaryExactly30s pins the >=
+// boundary: exactly 30 s of idle DOES trigger grace.
+func TestPacer_GraceBootstrap_BoundaryExactly30s(t *testing.T) {
+	t.Parallel()
+	p := NewPacer()
+	p.RecordEcho(50*time.Millisecond, t0)
+	// Exactly 30 seconds — at the >= boundary.
+	p.BeforeActiveWrite(t0.Add(GraceIdleThreshold))
+	if !p.InGraceBootstrap() {
+		t.Error("InGraceBootstrap()=false at exactly 30s idle; want true (>= boundary)")
+	}
+}
+
+// TestPacer_BeforeActiveWrite_NoPriorHistoryIsNoOp pins that
+// calling BeforeActiveWrite on a fresh pacer (no prior
+// RecordEcho) is a no-op — the construction state already
+// represents bootstrap, no need to re-enter grace.
+func TestPacer_BeforeActiveWrite_NoPriorHistoryIsNoOp(t *testing.T) {
+	t.Parallel()
+	p := NewPacer()
+	p.BeforeActiveWrite(t0)
+	if p.InGraceBootstrap() {
+		t.Error("InGraceBootstrap()=true on fresh pacer after BeforeActiveWrite; want false (no prior history)")
+	}
+}
+
+// TestPacer_BeforeActiveWrite_Idempotent pins that calling
+// BeforeActiveWrite twice (before any RecordEcho) does not
+// double-arm grace beyond GraceBootstrapSamples.
+func TestPacer_BeforeActiveWrite_Idempotent(t *testing.T) {
+	t.Parallel()
+	p := NewPacer()
+	p.RecordEcho(50*time.Millisecond, t0)
+	p.BeforeActiveWrite(t0.Add(31 * time.Second))
+	p.BeforeActiveWrite(t0.Add(32 * time.Second))
+	// Both calls should leave graceRemaining at exactly
+	// GraceBootstrapSamples (not 2× that).
+	for i := 0; i < GraceBootstrapSamples; i++ {
+		if !p.InGraceBootstrap() {
+			t.Errorf("iter %d: InGraceBootstrap()=false; want true", i)
+		}
+		p.RecordEcho(50*time.Millisecond, t0.Add(time.Duration(32+i)*time.Second))
+	}
+	if p.InGraceBootstrap() {
+		t.Error("InGraceBootstrap()=true after consuming all grace samples; want false (idempotent — not double-armed)")
+	}
+}
+
 // TestPacer_EchoDeadlines_NormalMode pins the v8 §1.4 formula:
-// soft = L_rtt + 100ms, hard = 2×L_rtt + 200ms.
+// soft = L_rtt + 100ms, hard = 2×L_rtt + 200ms, hardEnabled = true.
 func TestPacer_EchoDeadlines_NormalMode(t *testing.T) {
 	t.Parallel()
 	p := NewPacer()
 	// At construction: L_rtt = 100ms, no grace.
-	soft, hard := p.EchoDeadlines()
+	soft, hard, hardEnabled := p.EchoDeadlines()
 	wantSoft := 100*time.Millisecond + SoftDeadlineNormal
 	wantHard := 2*100*time.Millisecond + HardDeadlineNormalAdd
 	if soft != wantSoft {
@@ -204,24 +266,31 @@ func TestPacer_EchoDeadlines_NormalMode(t *testing.T) {
 	if hard != wantHard {
 		t.Errorf("hard=%v; want %v", hard, wantHard)
 	}
+	if !hardEnabled {
+		t.Error("hardEnabled=false in normal mode; want true")
+	}
 }
 
 // TestPacer_EchoDeadlines_GraceMode pins that during grace, soft
-// uses the loose 500ms slack and hard is disabled (returns 0).
+// uses the loose 500ms slack, hardEnabled is false (so the hard
+// value MUST be ignored by callers).
 func TestPacer_EchoDeadlines_GraceMode(t *testing.T) {
 	t.Parallel()
 	p := NewPacer()
-	// Trigger grace by long-idle pattern.
+	// Trigger grace via BeforeActiveWrite after long idle.
 	p.RecordEcho(50*time.Millisecond, t0)
-	p.RecordEcho(50*time.Millisecond, t0.Add(31*time.Second))
+	p.BeforeActiveWrite(t0.Add(31 * time.Second))
 	if !p.InGraceBootstrap() {
-		t.Fatal("precondition: should be in grace")
+		t.Fatal("precondition: should be in grace after BeforeActiveWrite + long idle")
 	}
-	soft, hard := p.EchoDeadlines()
-	// L_rtt should be ~85ms after two 50ms samples (first 100 → 85,
-	// second 85 → 79.5). Either way the formula adds 500ms slack.
+	soft, hard, hardEnabled := p.EchoDeadlines()
+	// L_rtt should be ~85ms after one 50ms sample (100→85).
+	if hardEnabled {
+		t.Errorf("hardEnabled=true in grace mode; want false")
+	}
+	// hard value MUST be 0 when disabled (the contract):
 	if hard != 0 {
-		t.Errorf("hard=%v in grace mode; want 0 (disabled)", hard)
+		t.Errorf("hard=%v in grace mode; want 0", hard)
 	}
 	if soft <= 500*time.Millisecond {
 		t.Errorf("soft=%v in grace mode; want > 500ms (L_rtt + 500ms slack)", soft)
@@ -236,7 +305,7 @@ func TestPacer_ResetLrtt(t *testing.T) {
 
 	// Build up state.
 	p.RecordEcho(50*time.Millisecond, t0)
-	p.RecordEcho(50*time.Millisecond, t0.Add(31*time.Second))
+	p.BeforeActiveWrite(t0.Add(31 * time.Second))
 	scheduledBefore := p.Schedule(t0.Add(31 * time.Second))
 	if !p.InGraceBootstrap() {
 		t.Fatal("precondition: should be in grace")
@@ -260,12 +329,15 @@ func TestPacer_ResetLrtt(t *testing.T) {
 }
 
 // TestPacer_TauOverride pins SetTau and that subsequent Schedule
-// calls use the new τ.
+// calls use the new τ. Per Codex round-1 fix on PR #642: SetTau
+// returns bool indicating accepted/rejected. Valid value → true.
 func TestPacer_TauOverride(t *testing.T) {
 	t.Parallel()
 	p := NewPacer()
 	const customTau = 10 * time.Millisecond
-	p.SetTau(customTau)
+	if !p.SetTau(customTau) {
+		t.Fatal("SetTau(10ms) returned false; want true (valid value)")
+	}
 
 	p.Schedule(t0)
 	emit := p.Schedule(t0)
@@ -299,7 +371,7 @@ func TestPacer_ConcurrentRead(t *testing.T) {
 				_ = p.InGraceBootstrap()
 				_ = p.RecordedSamples()
 				_ = p.LastScheduledEmit()
-				_, _ = p.EchoDeadlines()
+				_, _, _ = p.EchoDeadlines()
 			}
 		}
 	}()
@@ -315,5 +387,109 @@ func TestPacer_ConcurrentRead(t *testing.T) {
 	}
 	if got := p.RecordedSamples(); got != 200 {
 		t.Errorf("RecordedSamples()=%d; want 200 (1000/5)", got)
+	}
+}
+
+// TestPacer_RecordEcho_RejectsInvalidRtt pins the Codex round-1
+// MEDIUM fix: rtt <= 0 is rejected without updating the EMA, the
+// lastEchoAt anchor, or the recordedSamples counter. A future
+// caller computing rtt from mismatched clocks otherwise poisons
+// the EMA.
+func TestPacer_RecordEcho_RejectsInvalidRtt(t *testing.T) {
+	t.Parallel()
+	p := NewPacer()
+	lrttBefore := p.Lrtt()
+
+	// Negative rtt — reject.
+	p.RecordEcho(-1*time.Millisecond, t0)
+	if got := p.Lrtt(); got != lrttBefore {
+		t.Errorf("Lrtt()=%v after negative RTT; want unchanged %v", got, lrttBefore)
+	}
+	if got := p.RecordedSamples(); got != 0 {
+		t.Errorf("RecordedSamples()=%d after negative RTT; want 0 (rejected)", got)
+	}
+
+	// Zero rtt — also reject.
+	p.RecordEcho(0, t0)
+	if got := p.Lrtt(); got != lrttBefore {
+		t.Errorf("Lrtt()=%v after zero RTT; want unchanged %v", got, lrttBefore)
+	}
+	if got := p.RecordedSamples(); got != 0 {
+		t.Errorf("RecordedSamples()=%d after zero RTT; want 0 (rejected)", got)
+	}
+
+	// Positive rtt — accept.
+	p.RecordEcho(50*time.Millisecond, t0)
+	if got := p.Lrtt(); got == lrttBefore {
+		t.Errorf("Lrtt()=%v after valid RTT; want changed", got)
+	}
+	if got := p.RecordedSamples(); got != 1 {
+		t.Errorf("RecordedSamples()=%d after valid RTT; want 1", got)
+	}
+}
+
+// TestPacer_SetTau_RejectsInvalid pins the Codex round-1 MEDIUM
+// fix: zero or negative tau is rejected; the prior tau is
+// preserved. The bool return reports rejection.
+func TestPacer_SetTau_RejectsInvalid(t *testing.T) {
+	t.Parallel()
+	p := NewPacer()
+
+	// Establish a known custom tau.
+	if !p.SetTau(5 * time.Millisecond) {
+		t.Fatal("SetTau(5ms) rejected; precondition failed")
+	}
+
+	// Now try to set zero — must reject.
+	if p.SetTau(0) {
+		t.Error("SetTau(0) returned true; want false (rejected)")
+	}
+	// And negative — must reject.
+	if p.SetTau(-1 * time.Second) {
+		t.Error("SetTau(-1s) returned true; want false (rejected)")
+	}
+
+	// The previously-set tau must be preserved. Verify by
+	// observing Schedule behavior.
+	p.Schedule(t0)
+	emit := p.Schedule(t0)
+	want := t0.Add(5 * time.Millisecond)
+	if !emit.Equal(want) {
+		t.Errorf("Schedule after rejected SetTau = %v; want %v (prior 5ms preserved)", emit, want)
+	}
+}
+
+// TestPacer_Schedule_ZeroNow_NoSentinelLeak pins the Codex
+// round-1 LOW fix: passing time.Time{} (zero) as `now` does NOT
+// re-trigger the "first call" branch on the next Schedule, even
+// though lastScheduledEmit is now zero. The explicit
+// scheduledInitialized bool removes the zero-time sentinel leak.
+func TestPacer_Schedule_ZeroNow_NoSentinelLeak(t *testing.T) {
+	t.Parallel()
+	p := NewPacer()
+
+	// First call with zero now — accepted, emits at zero.
+	emit1 := p.Schedule(time.Time{})
+	if !emit1.IsZero() {
+		t.Errorf("first Schedule(zero) = %v; want zero", emit1)
+	}
+
+	// Second call with t0 — must NOT re-trigger the "first call"
+	// branch (would return t0 immediately); MUST enforce the τ
+	// cadence from the prior zero-time emit.
+	//
+	// emit2 = max(t0, zero + τ_wire_byte) = t0 if t0 > τ from
+	// zero (which it is, since t0 is far past the epoch).
+	emit2 := p.Schedule(t0)
+	want := t0
+	if !emit2.Equal(want) {
+		t.Errorf("Schedule after zero-now: %v; want %v (cadence enforced)", emit2, want)
+	}
+
+	// Third call with t0 — now must enforce cadence vs emit2.
+	emit3 := p.Schedule(t0)
+	want3 := emit2.Add(TauWireByte)
+	if !emit3.Equal(want3) {
+		t.Errorf("third Schedule(t0): %v; want %v", emit3, want3)
 	}
 }


### PR DESCRIPTION
## Summary

Adds the per-session timing primitives the v8 classifier needs to produce wire-density-correct egress (§4.5) and to bound active-mode echo waits (§1.4).

**PR scope contract: computation only.** `Schedule` / `RecordEcho` / `EchoDeadlines` can be called and inspected by tests, but no production code yet acts on the results — B3.6 integrates the pacer into `session.go`'s sendCh draining and the echo-watchdog timer.

## Pacer responsibilities

| Responsibility | Per | Method |
|---|---|---|
| **Output pacing** at ~τ_wire_byte (4.17 ms) | session | `Schedule(now) → emitAt` |
| **L_rtt EMA** (active-mode-only, per v8 §1.4) | session | `RecordEcho(rtt, now)` |
| **Grace-bootstrap** (first 3 echoes after >30s idle) | session | `EchoDeadlines() → (soft, hard)` |
| **Reset** (transport reconnect, etc.) | session | `ResetLrtt()` |

Per v8 §1.4: passive-mode sampling is **ABANDONED**. Only active writes contribute to the EMA; the classifier surface (FSM driver from B3.4) does NOT yet call `RecordEcho` — that's a session.go-side integration in B3.6.

## v8-spec'd constants

| Constant | Value | Source |
|---|---|---|
| `TauWireByte` | 4167 µs | 10 bit-periods @ 2400 baud (v8 §4.5) |
| `LrttBootstrapInitial` | 100 ms | v8 §1.4 |
| `LrttEmaAlpha` | 0.3 | v8 §1.4 |
| `GraceIdleThreshold` | 30 s | v8 §1.4 |
| `GraceBootstrapSamples` | 3 | v8 §1.4 |
| `SoftDeadlineGrace` | 500 ms | v8 §1.4 |
| `SoftDeadlineNormal` | 100 ms | v8 §1.4 |
| `HardDeadlineNormalAdd` | 200 ms | v8 §1.4 |

## Tests (14 new, all green under `-race`)

| Test | Pins |
|---|---|
| `NewPacer_DefaultState` | constructor invariants |
| `Schedule_FirstCallEmitsImmediately` | no retroactive padding |
| `Schedule_SubsequentCallEnforcesCadence` | τ enforcement under "caller ahead" |
| `Schedule_CallerLateAdvancesCadence` | τ enforcement under "caller late" |
| `Schedule_BurstSequence` | 6-byte burst gets τ-spaced |
| `RecordEcho_EMAConvergence` | 100 identical samples converge |
| `RecordEcho_FirstSampleUpdatesEMA` | exact α=0.3 formula |
| `GraceBootstrap_TriggeredByLongIdle` | 31s gap → grace |
| `GraceBootstrap_NotTriggeredByShortIdle` | 29s gap → no grace (boundary) |
| `EchoDeadlines_NormalMode` | soft = L_rtt+100ms, hard = 2L_rtt+200ms |
| `EchoDeadlines_GraceMode` | soft loose (+500ms), hard disabled (= 0) |
| `ResetLrtt` | EMA/grace cleared, pacing state preserved |
| `TauOverride` | SetTau honored by next Schedule |
| `ConcurrentRead` | accessors race-free vs producer |

## Concurrency contract

The Pacer has an internal mutex, so accessors are safe to call from other goroutines for diagnostics. `Schedule` and `RecordEcho` callers must still serialize per-session (single-writer semantics) — typically the session's writer goroutine owns these calls. `ConcurrentRead` test fires under `-race` to prove the read-side serialization works.

## What this PR does NOT do

- ❌ No `session.go` integration (B3.6)
- ❌ No actual emission-pacing applied (still burst-flushed in production until B3.6 wires `Schedule` into `sendCh` draining)
- ❌ No echo-watchdog timer (B3.6 wires `EchoDeadlines` into the session's active-write timer)
- ❌ No admin channel for echo-deadline violations (B3.6)
- ❌ No shadow-mode divergence comparison (B3.7)

## Test plan

- [x] `GOWORK=off go build ./...` — clean
- [x] `GOWORK=off go test ./... -race -timeout 600s` — full gateway suite green (107s adaptermux + 1.2s v8classifier with the 14 new tests)
- [x] `GOWORK=off go vet ./...` — clean
- [x] `gofmt -l` — clean
- [x] Terminology gate — clean

## References

- frame-atomic-visibility-v8 §1.4 — L_rtt regime + grace bootstrap
- frame-atomic-visibility-v8 §4.5 — intra-telegram pacing
- frame-atomic-visibility-v8 invariant I3 — pacer τ_wire_byte cap
- Corrected implementation plan v2.1 — Phase 3 Step B3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)