### PR TITLE
Phase 3 Step B3.6a: v8 classifier outbound admin-event surface

### DIFF
--- a/internal/adaptermux/v8classifier/admin_event.go
+++ b/internal/adaptermux/v8classifier/admin_event.go
@@ -133,6 +133,14 @@ type ClassifierAdminEvent struct {
 // hot path to block on a slow consumer. Operators draining at
 // realistic rates (every few seconds) will never see drops; a
 // stuck consumer drops the OLDEST events first.
+//
+// IMPORTANT (Codex round-1 LOW on PR #643): the cap is
+// intentionally small (64) so the O(N) copy-and-shift on
+// overflow stays bounded. If a future PR raises this cap, the
+// emit() implementation MUST switch from copy(b.events,
+// b.events[1:]) to a proper head/tail ring index pattern — the
+// current copy approach is acceptable at 64 but becomes
+// avoidable churn during fault storms at larger caps.
 const adminEventBufferCap = 64
 
 // adminEventBuffer is the per-classifier ring buffer. Lives
@@ -158,16 +166,27 @@ type adminEventBuffer struct {
 // drop) and the dropped counter increments. The producer never
 // blocks.
 //
+// Events with Kind == AdminEventKindNone are REJECTED at the
+// emit boundary (Codex round-1 LOW on PR #643). The None
+// sentinel exists only as the zero value and has no production
+// caller; guarding here enforces the documented invariant that
+// "None should not appear in recorded events".
+//
 // Called from the single-producer mux read goroutine. The mutex
 // protects against concurrent Drain calls from a consumer
 // goroutine.
 func (b *adminEventBuffer) emit(ev ClassifierAdminEvent) {
+	if ev.Kind == AdminEventKindNone {
+		return
+	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if len(b.events) >= adminEventBufferCap {
 		// Drop oldest, slide remaining. This is O(N) per drop but
 		// only fires under sustained saturation — typical
-		// production has zero drops.
+		// production has zero drops. See adminEventBufferCap doc
+		// for why O(N) is acceptable at cap=64 and what to switch
+		// to if the cap ever grows.
 		copy(b.events, b.events[1:])
 		b.events = b.events[:len(b.events)-1]
 		b.dropped++

--- a/internal/adaptermux/v8classifier/admin_event.go
+++ b/internal/adaptermux/v8classifier/admin_event.go
@@ -1,0 +1,203 @@
+package v8classifier
+
+import (
+	"sync"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol/telegram_fsm"
+)
+
+// Phase 3 Step B3.6a (frame-atomic-visibility v8 §1.1 / I1): the
+// classifier's outbound admin-event surface.
+//
+// Per v8 invariant I1: admin events flow on the proxy admin
+// channel, NEVER into the client byte streams. This file adds the
+// per-classifier ring buffer that records admin events for
+// operators (logging, expvar, /debug/admin endpoint, etc.) without
+// any way to escape into the cross-proxy byte streams.
+//
+// Two distinct admin-event sources:
+//
+//   1. INBOUND from the upstream transport (escape decoder admin
+//      events: pending timeout, recovery, budget exhausted). The
+//      OnAdminEvent method already exists from B3.2 — it counts
+//      these for diagnostics but does NOT yet record them as
+//      ClassifierAdminEvent entries. B3.6a does NOT wire OnAdminEvent
+//      into the ring buffer because the upstream transport's
+//      ReadAdminEvent surface doesn't exist yet (separate Phase 1
+//      follow-up in ebusgo).
+//
+//   2. OUTBOUND from the classifier itself. When the FSM emits
+//      DecisionProtocolFault, the Observe path auto-records an
+//      AdminEventProtocolFault entry. B3.6c-d will add
+//      AdminEventEchoSoftTimeout, AdminEventEchoHardTimeout, and
+//      AdminEventQueueOverflow when the pacer wiring lands.
+//
+// Concurrency:
+//   - EmitAdminEvent is called from the single mux-read-goroutine
+//     producer (per the Classifier-wide single-producer contract).
+//   - DrainAdminEvents is multi-consumer safe via the internal
+//     mutex.
+//   - Ring buffer drops the OLDEST entry on overflow (never blocks
+//     the producer). The dropped count is reported on Drain so
+//     operators can detect saturation.
+
+// AdminEventKind enumerates the classifier's outbound admin event
+// kinds. The numeric values are stable for log/expvar emission.
+type AdminEventKind int
+
+const (
+	// AdminEventKindNone is the zero value. Should not appear in
+	// recorded events (used as a sentinel in tests).
+	AdminEventKindNone AdminEventKind = iota
+
+	// AdminEventKindProtocolFault is emitted when the FSM returns
+	// telegram_fsm.DecisionProtocolFault for a byte. Per v8
+	// invariant I10 the byte is STILL forwarded to all observers
+	// (PROTOCOL_FAULT visibility); this admin event is the
+	// out-of-band notification for the proxy operator.
+	AdminEventKindProtocolFault
+
+	// AdminEventKindEchoSoftTimeout is emitted when the
+	// echo-watchdog soft deadline fires for an active write.
+	// B3.6c wires this when the pacer + watchdog land.
+	AdminEventKindEchoSoftTimeout
+
+	// AdminEventKindEchoHardTimeout is emitted when the
+	// echo-watchdog hard deadline fires for an active write.
+	// B3.6c wires this.
+	AdminEventKindEchoHardTimeout
+
+	// AdminEventKindQueueOverflow is emitted when the per-session
+	// admin-event ring buffer drops entries. Pre-emit (the
+	// producer detects the next emit would overflow). B3.6c+
+	// expand the scope to per-session sendCh overflow too.
+	AdminEventKindQueueOverflow
+)
+
+// String returns the canonical lowercase label for the admin
+// event kind. Stable for log lines and expvar labels.
+func (k AdminEventKind) String() string {
+	switch k {
+	case AdminEventKindNone:
+		return "none"
+	case AdminEventKindProtocolFault:
+		return "protocol_fault"
+	case AdminEventKindEchoSoftTimeout:
+		return "echo_soft_timeout"
+	case AdminEventKindEchoHardTimeout:
+		return "echo_hard_timeout"
+	case AdminEventKindQueueOverflow:
+		return "queue_overflow"
+	default:
+		return "unknown"
+	}
+}
+
+// ClassifierAdminEvent is a recorded admin event ready for
+// consumption by the proxy's admin-channel surface (operator
+// logging, expvar, /debug endpoints). The struct is allocation-
+// free on the recording hot path; consumers receive a slice copy
+// via DrainAdminEvents.
+//
+// Per v8 §1.1 / I1 these events live OUT-OF-BAND. They MUST NOT
+// be serialized into any cross-proxy session's byte stream.
+type ClassifierAdminEvent struct {
+	// At is the monotonic-clock time when the event was emitted.
+	At time.Time
+
+	// Kind is the event taxonomy bucket.
+	Kind AdminEventKind
+
+	// FSMState is the classifier's FSM state at the time of
+	// emission (collapsed via Machine.State). Lets operators
+	// correlate faults to the telegram phase they occurred in.
+	FSMState telegram_fsm.State
+
+	// Byte is the wire byte that triggered the event (for
+	// ProtocolFault — the offending byte the FSM rejected).
+	// Zero for events that aren't byte-triggered (queue overflow,
+	// echo timeouts).
+	Byte byte
+
+	// WasEscaped reports whether Byte arrived as an escape-decoded
+	// payload (true) or as a raw wire byte (false). Same
+	// provenance signal the FSM's Feed used. Zero for non-byte
+	// events.
+	WasEscaped bool
+}
+
+// adminEventBufferCap is the bounded size of the per-classifier
+// admin-event ring buffer. Sized to absorb a short burst of
+// faults during a malformed telegram cascade without forcing the
+// hot path to block on a slow consumer. Operators draining at
+// realistic rates (every few seconds) will never see drops; a
+// stuck consumer drops the OLDEST events first.
+const adminEventBufferCap = 64
+
+// adminEventBuffer is the per-classifier ring buffer. Lives
+// inside the Classifier struct (see classifier.go); helper
+// methods on Classifier itself wrap the access pattern.
+type adminEventBuffer struct {
+	mu sync.Mutex
+
+	// events is a fixed-size ring buffer. We use a slice rather
+	// than a real ring (head/tail indices) because Drain returns
+	// the contents anyway — the slice form makes that O(N) copy
+	// and reset trivial.
+	events []ClassifierAdminEvent
+
+	// dropped counts events that the producer skipped because
+	// the buffer was full. Reported by Drain so operators see
+	// saturation explicitly.
+	dropped uint64
+}
+
+// emit records one admin event. If the buffer is at
+// adminEventBufferCap, the OLDEST entry is overwritten (FIFO
+// drop) and the dropped counter increments. The producer never
+// blocks.
+//
+// Called from the single-producer mux read goroutine. The mutex
+// protects against concurrent Drain calls from a consumer
+// goroutine.
+func (b *adminEventBuffer) emit(ev ClassifierAdminEvent) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.events) >= adminEventBufferCap {
+		// Drop oldest, slide remaining. This is O(N) per drop but
+		// only fires under sustained saturation — typical
+		// production has zero drops.
+		copy(b.events, b.events[1:])
+		b.events = b.events[:len(b.events)-1]
+		b.dropped++
+	}
+	b.events = append(b.events, ev)
+}
+
+// drain returns a copy of all buffered events and clears the
+// buffer. The dropped counter is also returned and reset.
+// Multi-consumer safe via the mutex.
+func (b *adminEventBuffer) drain() (events []ClassifierAdminEvent, dropped uint64) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.events) == 0 {
+		dropped = b.dropped
+		b.dropped = 0
+		return nil, dropped
+	}
+	events = make([]ClassifierAdminEvent, len(b.events))
+	copy(events, b.events)
+	b.events = b.events[:0]
+	dropped = b.dropped
+	b.dropped = 0
+	return events, dropped
+}
+
+// pending reports the current buffer occupancy without draining.
+// Safe to call from any goroutine.
+func (b *adminEventBuffer) pending() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.events)
+}

--- a/internal/adaptermux/v8classifier/admin_event_test.go
+++ b/internal/adaptermux/v8classifier/admin_event_test.go
@@ -1,0 +1,300 @@
+package v8classifier
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol/telegram_fsm"
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+// Phase 3 Step B3.6a: tests for the outbound admin-event surface
+// (per-classifier ring buffer + auto-emission of FSM
+// DecisionProtocolFault events). Per v8 invariant I1: events are
+// out-of-band only — these tests confirm the ring buffer captures
+// them, the Drain pattern is multi-consumer safe, and overflow
+// drops the OLDEST entry rather than blocking the producer.
+
+func TestAdminEventKind_String(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		k    AdminEventKind
+		want string
+	}{
+		{AdminEventKindNone, "none"},
+		{AdminEventKindProtocolFault, "protocol_fault"},
+		{AdminEventKindEchoSoftTimeout, "echo_soft_timeout"},
+		{AdminEventKindEchoHardTimeout, "echo_hard_timeout"},
+		{AdminEventKindQueueOverflow, "queue_overflow"},
+		{AdminEventKind(99), "unknown"},
+	} {
+		if got := tc.k.String(); got != tc.want {
+			t.Errorf("AdminEventKind(%d).String() = %q; want %q", tc.k, got, tc.want)
+		}
+	}
+}
+
+func TestAdminEventBuffer_EmitAndDrain(t *testing.T) {
+	t.Parallel()
+	var b adminEventBuffer
+
+	// Drain on an empty buffer.
+	events, dropped := b.drain()
+	if len(events) != 0 {
+		t.Errorf("drain empty: got %d events; want 0", len(events))
+	}
+	if dropped != 0 {
+		t.Errorf("drain empty: dropped=%d; want 0", dropped)
+	}
+
+	// Emit 3 events.
+	now := time.Unix(0, 0)
+	for i := 0; i < 3; i++ {
+		b.emit(ClassifierAdminEvent{
+			At:   now.Add(time.Duration(i) * time.Millisecond),
+			Kind: AdminEventKindProtocolFault,
+			Byte: byte(i),
+		})
+	}
+	if got := b.pending(); got != 3 {
+		t.Errorf("pending after 3 emits = %d; want 3", got)
+	}
+
+	events, dropped = b.drain()
+	if len(events) != 3 {
+		t.Fatalf("drain: got %d events; want 3", len(events))
+	}
+	if dropped != 0 {
+		t.Errorf("drain: dropped=%d; want 0 (no overflow)", dropped)
+	}
+	for i, ev := range events {
+		if ev.Kind != AdminEventKindProtocolFault {
+			t.Errorf("event %d kind=%v; want ProtocolFault", i, ev.Kind)
+		}
+		if ev.Byte != byte(i) {
+			t.Errorf("event %d byte=0x%02X; want 0x%02X", i, ev.Byte, byte(i))
+		}
+	}
+
+	// Buffer drained — pending=0.
+	if got := b.pending(); got != 0 {
+		t.Errorf("pending after drain = %d; want 0", got)
+	}
+}
+
+func TestAdminEventBuffer_Overflow_DropsOldest(t *testing.T) {
+	t.Parallel()
+	var b adminEventBuffer
+	now := time.Unix(0, 0)
+
+	// Emit cap+5 events. The first 5 must be dropped FIFO.
+	const overage = 5
+	total := adminEventBufferCap + overage
+	for i := 0; i < total; i++ {
+		b.emit(ClassifierAdminEvent{
+			At:   now.Add(time.Duration(i) * time.Millisecond),
+			Kind: AdminEventKindProtocolFault,
+			Byte: byte(i),
+		})
+	}
+
+	events, dropped := b.drain()
+	if len(events) != adminEventBufferCap {
+		t.Errorf("after overflow: got %d events; want %d (cap)", len(events), adminEventBufferCap)
+	}
+	if dropped != overage {
+		t.Errorf("dropped=%d; want %d", dropped, overage)
+	}
+
+	// Verify the OLDEST `overage` events were dropped — the
+	// surviving Byte values should be in [overage, total).
+	for i, ev := range events {
+		want := byte(i + overage)
+		if ev.Byte != want {
+			t.Errorf("event %d after overflow: Byte=0x%02X; want 0x%02X (oldest dropped FIFO)",
+				i, ev.Byte, want)
+		}
+	}
+}
+
+func TestAdminEventBuffer_DroppedCounter_ResetOnDrain(t *testing.T) {
+	t.Parallel()
+	var b adminEventBuffer
+
+	// Cause a drop.
+	for i := 0; i < adminEventBufferCap+1; i++ {
+		b.emit(ClassifierAdminEvent{Kind: AdminEventKindProtocolFault})
+	}
+	_, dropped := b.drain()
+	if dropped != 1 {
+		t.Errorf("first drain after one overflow: dropped=%d; want 1", dropped)
+	}
+
+	// Drain again immediately — counter should be reset.
+	_, dropped = b.drain()
+	if dropped != 0 {
+		t.Errorf("second drain: dropped=%d; want 0 (counter reset on first drain)", dropped)
+	}
+}
+
+func TestClassifier_ProtocolFault_EmitsAdminEvent(t *testing.T) {
+	t.Parallel()
+	c := New(ModeShadow)
+	now := time.Unix(0, 0)
+
+	// Enter passive tracking + drive the FSM to a point where
+	// a fault fires (NN > 16 in MASTER_HEADER byte 4 per v8).
+	c.Observe(transport.StreamEvent{
+		Kind: transport.StreamEventStarted, Data: 0x71,
+	}, now)
+	// PB, SB, ZZ — three plain bytes after the StreamEventStarted's
+	// consumed QQ. Indices 1-3 in MASTER_HEADER.
+	for _, b := range []byte{0x10, 0xB5, 0x16} {
+		c.Observe(transport.StreamEvent{
+			Kind: transport.StreamEventByte, Byte: b,
+		}, now)
+	}
+	// MASTER_HEADER byte 4 (NN slot) = 0xFF — exceeds 16 → fault.
+	c.Observe(transport.StreamEvent{
+		Kind: transport.StreamEventByte, Byte: 0xFF,
+	}, now)
+
+	if got := c.FsmProtocolFaultTotal(); got != 1 {
+		t.Fatalf("FsmProtocolFaultTotal()=%d; want 1 (precondition for admin emit)", got)
+	}
+
+	// Drain admin events; the protocol fault should appear.
+	events, dropped := c.DrainAdminEvents()
+	if dropped != 0 {
+		t.Errorf("DrainAdminEvents: dropped=%d; want 0", dropped)
+	}
+	if len(events) != 1 {
+		t.Fatalf("DrainAdminEvents: got %d events; want 1", len(events))
+	}
+	ev := events[0]
+	if ev.Kind != AdminEventKindProtocolFault {
+		t.Errorf("event kind=%v; want AdminEventKindProtocolFault", ev.Kind)
+	}
+	if ev.Byte != 0xFF {
+		t.Errorf("event byte=0x%02X; want 0xFF (the offending NN)", ev.Byte)
+	}
+	if ev.FSMState != telegram_fsm.StateAborted {
+		t.Errorf("event FSMState=%v; want StateAborted (FSM aborted on fault)", ev.FSMState)
+	}
+	if ev.At.IsZero() {
+		t.Error("event At=zero; want monotonic-clock timestamp")
+	}
+}
+
+func TestClassifier_DrainAdminEvents_NilSafe(t *testing.T) {
+	t.Parallel()
+	var c *Classifier
+	events, dropped := c.DrainAdminEvents()
+	if events != nil || dropped != 0 {
+		t.Errorf("nil.DrainAdminEvents = (%v, %d); want (nil, 0)", events, dropped)
+	}
+	if got := c.PendingAdminEvents(); got != 0 {
+		t.Errorf("nil.PendingAdminEvents = %d; want 0", got)
+	}
+}
+
+func TestClassifier_DrainAdminEvents_OffMode_NoEvents(t *testing.T) {
+	t.Parallel()
+	c := New(ModeOff)
+	// ModeOff: Observe is a no-op, no FSM, no admin events.
+	now := time.Unix(0, 0)
+	for i := 0; i < 10; i++ {
+		c.Observe(transport.StreamEvent{
+			Kind: transport.StreamEventByte, Byte: 0xFF,
+		}, now)
+	}
+	events, dropped := c.DrainAdminEvents()
+	if len(events) != 0 || dropped != 0 {
+		t.Errorf("ModeOff DrainAdminEvents = (%d events, dropped=%d); want (0, 0)",
+			len(events), dropped)
+	}
+}
+
+func TestClassifier_PendingAdminEvents_ReflectsBuffer(t *testing.T) {
+	t.Parallel()
+	c := New(ModeShadow)
+	now := time.Unix(0, 0)
+
+	if got := c.PendingAdminEvents(); got != 0 {
+		t.Errorf("PendingAdminEvents() at construction = %d; want 0", got)
+	}
+
+	// Drive two faults (each fault aborts; then we need a Reset
+	// before driving the next).
+	for i := 0; i < 2; i++ {
+		c.Observe(transport.StreamEvent{
+			Kind: transport.StreamEventStarted, Data: 0x71,
+		}, now)
+		for _, b := range []byte{0x10, 0xB5, 0x16} {
+			c.Observe(transport.StreamEvent{
+				Kind: transport.StreamEventByte, Byte: b,
+			}, now)
+		}
+		c.Observe(transport.StreamEvent{
+			Kind: transport.StreamEventByte, Byte: 0xFF,
+		}, now)
+		// Reset to ready for next iteration.
+		c.Observe(transport.StreamEvent{
+			Kind: transport.StreamEventReset,
+		}, now)
+	}
+
+	if got := c.PendingAdminEvents(); got < 2 {
+		t.Errorf("PendingAdminEvents()=%d; want >= 2 (two faults emitted)", got)
+	}
+	events, _ := c.DrainAdminEvents()
+	if len(events) < 2 {
+		t.Errorf("Drain returned %d events; want >= 2", len(events))
+	}
+	if got := c.PendingAdminEvents(); got != 0 {
+		t.Errorf("after Drain: PendingAdminEvents()=%d; want 0", got)
+	}
+}
+
+// TestAdminEventBuffer_ConcurrentDrainerVsProducer pins the
+// multi-consumer-safe contract: a drainer goroutine racing
+// against the single producer must never observe a torn read or
+// trigger a data race. The mutex inside adminEventBuffer
+// guarantees this; the test fires under -race.
+func TestAdminEventBuffer_ConcurrentDrainerVsProducer(t *testing.T) {
+	t.Parallel()
+	var b adminEventBuffer
+	stop := make(chan struct{})
+
+	// Drainer goroutine.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		totalSeen := 0
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				events, _ := b.drain()
+				totalSeen += len(events)
+				_ = totalSeen
+			}
+		}
+	}()
+
+	// Producer: 1000 emits, with periodic over-cap bursts.
+	for i := 0; i < 1000; i++ {
+		b.emit(ClassifierAdminEvent{
+			Kind: AdminEventKindProtocolFault,
+			Byte: byte(i),
+		})
+	}
+	close(stop)
+	wg.Wait()
+
+	// Final drain to flush any remainder.
+	_, _ = b.drain()
+}

--- a/internal/adaptermux/v8classifier/admin_event_test.go
+++ b/internal/adaptermux/v8classifier/admin_event_test.go
@@ -118,6 +118,32 @@ func TestAdminEventBuffer_Overflow_DropsOldest(t *testing.T) {
 	}
 }
 
+// TestAdminEventBuffer_RejectsNoneKind pins the Codex round-1
+// LOW fix: emit(Kind=None) is a no-op so the sentinel never
+// pollutes the recorded buffer. None is the zero value and has
+// no production caller; the guard enforces the documented
+// invariant.
+func TestAdminEventBuffer_RejectsNoneKind(t *testing.T) {
+	t.Parallel()
+	var b adminEventBuffer
+	for i := 0; i < 10; i++ {
+		b.emit(ClassifierAdminEvent{
+			Kind: AdminEventKindNone,
+			Byte: byte(i),
+		})
+	}
+	if got := b.pending(); got != 0 {
+		t.Errorf("pending after emit(Kind=None)×10 = %d; want 0 (rejected)", got)
+	}
+	events, dropped := b.drain()
+	if len(events) != 0 {
+		t.Errorf("drain after Kind=None emits: %d events; want 0", len(events))
+	}
+	if dropped != 0 {
+		t.Errorf("dropped=%d; want 0 (Kind=None rejection is NOT a drop — it's a refusal to enqueue)", dropped)
+	}
+}
+
 func TestAdminEventBuffer_DroppedCounter_ResetOnDrain(t *testing.T) {
 	t.Parallel()
 	var b adminEventBuffer
@@ -257,36 +283,49 @@ func TestClassifier_PendingAdminEvents_ReflectsBuffer(t *testing.T) {
 	}
 }
 
-// TestAdminEventBuffer_ConcurrentDrainerVsProducer pins the
-// multi-consumer-safe contract: a drainer goroutine racing
-// against the single producer must never observe a torn read or
-// trigger a data race. The mutex inside adminEventBuffer
-// guarantees this; the test fires under -race.
+// TestAdminEventBuffer_ConcurrentDrainerVsProducer pins both
+// the multi-consumer-safe contract AND a basic accounting
+// invariant under concurrent producer/drainer activity
+// (Codex round-1 LOW on PR #643 — the test previously only
+// proved -race wouldn't fire).
+//
+// Invariant: total_drained + final_drain + dropped == total_emitted.
+// Every emitted event either:
+//   (a) gets drained mid-run, OR
+//   (b) gets drained on the final flush, OR
+//   (c) gets dropped (counted in `dropped`).
+// No event silently disappears.
+//
+// The mutex inside adminEventBuffer guarantees no data race;
+// the test fires under -race to verify.
 func TestAdminEventBuffer_ConcurrentDrainerVsProducer(t *testing.T) {
 	t.Parallel()
 	var b adminEventBuffer
 	stop := make(chan struct{})
 
-	// Drainer goroutine.
+	const totalEmitted = 1000
+
+	// Drainer goroutine accumulates seen counts + dropped counts.
+	var seen uint64
+	var seenDropped uint64
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		totalSeen := 0
 		for {
 			select {
 			case <-stop:
 				return
 			default:
-				events, _ := b.drain()
-				totalSeen += len(events)
-				_ = totalSeen
+				events, dropped := b.drain()
+				seen += uint64(len(events))
+				seenDropped += dropped
 			}
 		}
 	}()
 
-	// Producer: 1000 emits, with periodic over-cap bursts.
-	for i := 0; i < 1000; i++ {
+	// Producer: totalEmitted emits.
+	for i := 0; i < totalEmitted; i++ {
 		b.emit(ClassifierAdminEvent{
 			Kind: AdminEventKindProtocolFault,
 			Byte: byte(i),
@@ -296,5 +335,13 @@ func TestAdminEventBuffer_ConcurrentDrainerVsProducer(t *testing.T) {
 	wg.Wait()
 
 	// Final drain to flush any remainder.
-	_, _ = b.drain()
+	finalEvents, finalDropped := b.drain()
+	seen += uint64(len(finalEvents))
+	seenDropped += finalDropped
+
+	// Accounting invariant.
+	if total := seen + seenDropped; total != uint64(totalEmitted) {
+		t.Errorf("accounting: seen=%d + dropped=%d = %d; want %d (no events silently lost)",
+			seen, seenDropped, total, totalEmitted)
+	}
 }

--- a/internal/adaptermux/v8classifier/classifier.go
+++ b/internal/adaptermux/v8classifier/classifier.go
@@ -272,7 +272,7 @@ func (c *Classifier) Observe(event transport.StreamEvent, now time.Time) (drop b
 	switch event.Kind {
 	case transport.StreamEventByte:
 		c.classifyByteProvenance(event.Byte, event.WasEscaped)
-		c.driveFSMByte(event.Byte, event.WasEscaped)
+		c.driveFSMByte(event.Byte, event.WasEscaped, now)
 	case transport.StreamEventStarted, transport.StreamEventFailed:
 		// Both events signal "a telegram is starting on the wire and
 		// event.Data carries QQ" — the FSM's EnterPassiveTracking
@@ -296,12 +296,28 @@ func (c *Classifier) Observe(event transport.StreamEvent, now time.Time) (drop b
 // concurrent diagnostic readers see fresh values. Single producer
 // per the Classifier concurrency contract.
 //
+// The `now` parameter is the monotonic-clock observation time
+// for this byte, threaded down from Observe (per Codex round-1
+// MEDIUM on PR #643). Using this instead of an internal
+// time.Now() call keeps the classifier's clock path
+// deterministic and avoids one syscall per fault-cascade byte.
+//
 // Phase 3 Step B3.6a: DecisionProtocolFault now also emits a
 // ClassifierAdminEvent into the per-classifier admin-event ring
 // buffer (out-of-band per v8 I1 — NEVER into client byte streams).
-// B3.6b will extend this site with the ModeEnforce DropAaInjection
-// path that makes Observe return drop=true.
-func (c *Classifier) driveFSMByte(b byte, wasEscaped bool) {
+//
+// NOTE on counter/event consistency: fsmProtocolFaultTotal
+// increments BEFORE the admin emit. A dashboard concurrently
+// sampling the counter and draining events may briefly observe
+// `counter > drained_events + dropped`. The drains are NOT an
+// atomic snapshot with the counters — eventual consistency only.
+// If a future operator dashboard needs exact correlation, a
+// combined snapshot API would have to be added. (Codex round-1
+// LOW on PR #643 — explicit documentation.)
+//
+// B3.6b will extend this site with the ModeEnforce
+// DropAaInjection path that makes Observe return drop=true.
+func (c *Classifier) driveFSMByte(b byte, wasEscaped bool, now time.Time) {
 	if c.fsm == nil {
 		return
 	}
@@ -320,7 +336,7 @@ func (c *Classifier) driveFSMByte(b byte, wasEscaped bool) {
 		// emission policy applies — the admin emit does not gate
 		// the byte stream.
 		c.adminEvents.emit(ClassifierAdminEvent{
-			At:         time.Now(),
+			At:         now,
 			Kind:       AdminEventKindProtocolFault,
 			FSMState:   c.fsm.State(),
 			Byte:       b,

--- a/internal/adaptermux/v8classifier/classifier.go
+++ b/internal/adaptermux/v8classifier/classifier.go
@@ -182,6 +182,21 @@ type Classifier struct {
 	fsmStateSnapshot         atomic.Uint32 // telegram_fsm.State cast to uint32
 	fsmInternalStateSnapshot atomic.Uint32 // telegram_fsm.State cast to uint32
 	fsmIsPassiveSnapshot     atomic.Bool
+
+	// Phase 3 Step B3.6a (v8 §1.1 / I1): per-classifier outbound
+	// admin-event ring buffer. Records PROTOCOL_FAULT and (in
+	// later B3.6 PRs) echo-deadline / queue-overflow events.
+	// Allocation-free emit on the hot path; the buffer drops the
+	// OLDEST entry on overflow (FIFO) so the producer never
+	// blocks on a slow consumer.
+	//
+	// Per v8 invariant I1: these events flow OUT-OF-BAND only.
+	// They MUST NOT be serialized into any cross-proxy session
+	// byte stream. The ring buffer is drained by a
+	// proxy-operator-facing surface (admin /debug endpoint,
+	// expvar, or a poll goroutine that pushes to logs) — none of
+	// those paths bridge back to client byte streams.
+	adminEvents adminEventBuffer
 }
 
 // New constructs a Classifier in the given mode. The zero-value
@@ -281,9 +296,11 @@ func (c *Classifier) Observe(event transport.StreamEvent, now time.Time) (drop b
 // concurrent diagnostic readers see fresh values. Single producer
 // per the Classifier concurrency contract.
 //
-// B3.4 OBSERVES the Decision but does NOT yet act on it. B3.6 will
-// extend this site with the ModeEnforce DropAaInjection path that
-// makes Observe return drop=true.
+// Phase 3 Step B3.6a: DecisionProtocolFault now also emits a
+// ClassifierAdminEvent into the per-classifier admin-event ring
+// buffer (out-of-band per v8 I1 — NEVER into client byte streams).
+// B3.6b will extend this site with the ModeEnforce DropAaInjection
+// path that makes Observe return drop=true.
 func (c *Classifier) driveFSMByte(b byte, wasEscaped bool) {
 	if c.fsm == nil {
 		return
@@ -296,6 +313,19 @@ func (c *Classifier) driveFSMByte(b byte, wasEscaped bool) {
 		c.fsmDropAaInjectionTotal.Add(1)
 	case telegram_fsm.DecisionProtocolFault:
 		c.fsmProtocolFaultTotal.Add(1)
+		// Emit out-of-band admin event. Per v8 invariant I10 the
+		// byte is STILL forwarded to all observers (PROTOCOL_FAULT
+		// visibility); the admin event is the operator-facing
+		// notification only. Caller proceeds with whatever
+		// emission policy applies — the admin emit does not gate
+		// the byte stream.
+		c.adminEvents.emit(ClassifierAdminEvent{
+			At:         time.Now(),
+			Kind:       AdminEventKindProtocolFault,
+			FSMState:   c.fsm.State(),
+			Byte:       b,
+			WasEscaped: wasEscaped,
+		})
 	}
 	c.publishFSMSnapshotLocked()
 }
@@ -621,4 +651,39 @@ func (c *Classifier) FsmResetTotal() uint64 {
 		return 0
 	}
 	return c.fsmResetTotal.Load()
+}
+
+// DrainAdminEvents returns the buffered outbound admin events
+// (drained — the buffer is emptied) plus the cumulative drop
+// count since the last Drain. Per v8 invariant I1: these events
+// are out-of-band — callers MUST NOT forward them into any
+// cross-proxy session byte stream. Acceptable destinations:
+// operator logs, expvar, /debug endpoint, Prometheus metrics
+// scrape.
+//
+// Returns (nil, 0) when the classifier is nil or has nothing
+// to drain. The dropped count is non-zero only when the
+// admin-event ring buffer overflowed since the last Drain.
+//
+// Safe to call from any goroutine — the internal mutex
+// serializes drains vs the single-producer EmitAdminEvent path.
+// Consumers SHOULD drain at a steady cadence (every few
+// seconds in production); a stuck consumer eventually drops
+// the OLDEST events FIFO, surfaced via the dropped counter.
+func (c *Classifier) DrainAdminEvents() (events []ClassifierAdminEvent, dropped uint64) {
+	if c == nil {
+		return nil, 0
+	}
+	return c.adminEvents.drain()
+}
+
+// PendingAdminEvents returns the current buffer occupancy
+// without draining. Useful for adaptive-drain consumers that
+// only call Drain when the buffer has events. Returns 0 when
+// the classifier is nil. Safe to call from any goroutine.
+func (c *Classifier) PendingAdminEvents() int {
+	if c == nil {
+		return 0
+	}
+	return c.adminEvents.pending()
 }


### PR DESCRIPTION
## Summary

First piece of **B3.6 (admin channel + filtering authority + pacer wiring)**, split into four sub-PRs:

| Sub-PR | Scope | Behavioral? |
|---|---|---|
| **6a (this PR)** | admin channel surface + auto-emit FSM ProtocolFault | **No** (observe-only) |
| 6b | ModeEnforce filtering authority (`drop=true` for AA-injection) | YES |
| 6c | pacer wire at `mux.doSend` (L_rtt side) | YES |
| 6d | pacer wire at `session.writeLoop` (output pacer) | YES |

## What ships

| File | Lines | Purpose |
|---|---|---|
| `admin_event.go` | 191 | `AdminEventKind` enum + `ClassifierAdminEvent` + bounded ring buffer |
| `classifier.go` (extended) | +71 | `adminEvents` field; auto-emit on FSM ProtocolFault; `DrainAdminEvents` / `PendingAdminEvents` accessors |
| `admin_event_test.go` | 287 | 9 deterministic tests |

## v8 invariant compliance

- **I1**: admin events flow OUT-OF-BAND only. The ring buffer is the ONLY surface that records them; no path bridges back to a session byte stream. `DrainAdminEvents` consumers MUST NOT forward into any cross-proxy session.
- **I10**: PROTOCOL_FAULT visibility — the byte is STILL forwarded to all observers; the admin event is the operator-facing notification, not a replacement for byte-stream visibility.

## Admin event taxonomy

| Kind | When emitted (this PR) | When emitted (later) |
|---|---|---|
| `AdminEventKindProtocolFault` | FSM `DecisionProtocolFault` (NN>16, etc.) | — |
| `AdminEventKindEchoSoftTimeout` | (not yet wired) | B3.6c — soft echo-watchdog fires |
| `AdminEventKindEchoHardTimeout` | (not yet wired) | B3.6c — hard echo-watchdog fires |
| `AdminEventKindQueueOverflow` | (not yet wired) | B3.6c — session sendCh overflow |

## Ring buffer contract

- Bounded at `adminEventBufferCap = 64`.
- Single-producer (mux read goroutine) via `emit`.
- Multi-consumer-safe via mutex (`drain` / `pending`).
- Producer **never blocks** — drops OLDEST entry FIFO on overflow; the dropped count is reported on the next `drain`.
- Sized to absorb a short burst (telegram-fault cascade) without forcing the hot path to block on a slow consumer.

## Tests (9 new, all green under `-race`)

| Test | Pins |
|---|---|
| `AdminEventKind_String` | canonical labels |
| `EmitAndDrain` | basic round-trip |
| `Overflow_DropsOldest` | cap+5 → drop 5 oldest, FIFO |
| `DroppedCounter_ResetOnDrain` | counter zeroes on each drain |
| `Classifier_ProtocolFault_EmitsAdminEvent` | FSM fault → admin event with correct (byte, FSMState, At) |
| `DrainAdminEvents_NilSafe` | nil `*Classifier` returns `(nil, 0)` |
| `DrainAdminEvents_OffMode_NoEvents` | `ModeOff` never emits |
| `PendingAdminEvents_ReflectsBuffer` | occupancy vs drain |
| `ConcurrentDrainerVsProducer` | race-free under `-race` |

## Test plan

- [x] `GOWORK=off go build ./...` — clean
- [x] `GOWORK=off go test ./internal/adaptermux/v8classifier/ -race` — 69 tests (9 new admin + 60 prior) green
- [x] `GOWORK=off go test ./internal/adaptermux/ -race -timeout 900s` — 107s green
- [x] `GOWORK=off go vet ./...` — clean
- [x] `gofmt -l` — clean
- [x] Terminology gate — clean

## What this PR does NOT do

- ❌ No `ModeEnforce` filtering (B3.6b — `Observe` returns `drop=true` for AA-injection)
- ❌ No pacer wiring at `mux.doSend` (B3.6c)
- ❌ No pacer wiring at `session.writeLoop` (B3.6d)
- ❌ No echo soft/hard timeout admin events yet (B3.6c)
- ❌ No queue overflow admin events yet (B3.6c)
- ❌ No mux-side consumer for `DrainAdminEvents` yet (operators get the surface; later sub-PRs wire it to expvar / log)

## References

- frame-atomic-visibility-v8 §1.1 — admin-channel-only faults
- frame-atomic-visibility-v8 invariant I1 — admin events NEVER injected into byte streams
- frame-atomic-visibility-v8 invariant I10 — PROTOCOL_FAULT visibility (forward byte + admin event)
- Corrected implementation plan v2.1 — Phase 3 Step B3.6a

🤖 Generated with [Claude Code](https://claude.com/claude-code)