### PR TITLE
Phase 3 Step B3.6b: v8 classifier ModeEnforce filtering authority

### DIFF
--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -1408,15 +1408,28 @@ func (m *Mux) readLoop() {
 		firstTimeoutTime = time.Time{} // AM27: reset timeout streak on successful read
 		lastDataTime = time.Now()      // AM27: track last data for blackhole detection
 
-		// Phase 3 Step B3.2: route every StreamEvent through the v8
-		// classifier BEFORE the dispatch switch. The nil-guard
-		// short-circuits BOTH the method call AND the time.Now()
-		// evaluation when the classifier is off (production default),
-		// keeping the hot-path overhead at zero. B3.2 scaffold:
-		// `drop` is always false; future stacked PRs (B3.3..B3.7)
-		// will honor the return value at appropriate dispatch sites.
+		// Phase 3 Step B3.2 / B3.6b: route every StreamEvent through
+		// the v8 classifier BEFORE the dispatch switch. The
+		// nil-guard short-circuits BOTH the method call AND the
+		// time.Now() evaluation when the classifier is off
+		// (production default), keeping the hot-path overhead at
+		// zero.
+		//
+		// B3.6b: in ModeEnforce the classifier may return drop=true
+		// for AA-injection bytes (FSM DecisionDropAaInjection).
+		// When that happens we SKIP the legacy dispatch entirely
+		// for THIS event — the byte is filtered out of session
+		// streams, classifier counters still record it via
+		// EnforceDropsAppliedTotal + fsmDropAaInjectionTotal.
+		//
+		// ModeShadow always returns drop=false even when the FSM
+		// recommends a drop — operators run Shadow first to
+		// validate the classifier against the wire before
+		// promoting to Enforce.
 		if m.v8 != nil {
-			_ = m.v8.Observe(event, time.Now())
+			if m.v8.Observe(event, time.Now()) {
+				continue
+			}
 		}
 
 		switch event.Kind {

--- a/internal/adaptermux/v8classifier/admin_event_test.go
+++ b/internal/adaptermux/v8classifier/admin_event_test.go
@@ -291,9 +291,11 @@ func TestClassifier_PendingAdminEvents_ReflectsBuffer(t *testing.T) {
 //
 // Invariant: total_drained + final_drain + dropped == total_emitted.
 // Every emitted event either:
-//   (a) gets drained mid-run, OR
-//   (b) gets drained on the final flush, OR
-//   (c) gets dropped (counted in `dropped`).
+//
+//	(a) gets drained mid-run, OR
+//	(b) gets drained on the final flush, OR
+//	(c) gets dropped (counted in `dropped`).
+//
 // No event silently disappears.
 //
 // The mutex inside adminEventBuffer guarantees no data race;

--- a/internal/adaptermux/v8classifier/classifier.go
+++ b/internal/adaptermux/v8classifier/classifier.go
@@ -197,6 +197,24 @@ type Classifier struct {
 	// expvar, or a poll goroutine that pushes to logs) — none of
 	// those paths bridge back to client byte streams.
 	adminEvents adminEventBuffer
+
+	// Phase 3 Step B3.6b (v8 §4 AA-injection filter): cumulative
+	// count of bytes the classifier ACTUALLY DROPPED in
+	// ModeEnforce. Distinct from fsmDropAaInjectionTotal:
+	//   - fsmDropAaInjectionTotal counts every time the FSM
+	//     returned DecisionDropAaInjection, in ALL modes
+	//     (including Shadow, where the drop is observed but NOT
+	//     applied — the byte still reaches onReceived).
+	//   - enforceDropsAppliedTotal counts only the cases where
+	//     mode == Enforce AND Observe returned drop=true to its
+	//     caller (the mux's readLoop).
+	// In ModeShadow this counter stays at 0 even when
+	// fsmDropAaInjectionTotal accumulates. The difference between
+	// the two counters under sustained Shadow operation is the
+	// "would have dropped if we were enforcing" estimate — useful
+	// for pre-enforce validation runs (Step C live-bus
+	// validation, B3.7).
+	enforceDropsAppliedTotal atomic.Uint64
 }
 
 // New constructs a Classifier in the given mode. The zero-value
@@ -256,8 +274,16 @@ func (c *Classifier) Mode() Mode {
 //
 // Returns true if the caller should DROP this event from emission
 // to sessions. In ModeOff / ModeShadow the return is always false.
-// In B3.3 ModeEnforce also returns false (real filtering lands in
-// B3.6). Callers MAY ignore the return value until B3.6.
+//
+// Phase 3 Step B3.6b (v8 §4 AA-injection filter): ModeEnforce now
+// returns true when the byte is StreamEventByte AND the FSM
+// returns DecisionDropAaInjection. The caller (Mux.readLoop) MUST
+// honor this signal by skipping the byte's dispatch to onReceived
+// — otherwise sessions would still see the AA-injection bytes and
+// the v8 filter would be a no-op. The drop is also counted in
+// enforceDropsAppliedTotal so operators can distinguish
+// "would-have-dropped" (fsmDropAaInjectionTotal, all modes) from
+// "actually-dropped" (enforceDropsAppliedTotal, Enforce only).
 func (c *Classifier) Observe(event transport.StreamEvent, now time.Time) (drop bool) {
 	if c == nil || c.mode == ModeOff {
 		return false
@@ -272,7 +298,13 @@ func (c *Classifier) Observe(event transport.StreamEvent, now time.Time) (drop b
 	switch event.Kind {
 	case transport.StreamEventByte:
 		c.classifyByteProvenance(event.Byte, event.WasEscaped)
-		c.driveFSMByte(event.Byte, event.WasEscaped, now)
+		// driveFSMByte returns true when the byte should be
+		// dropped in the current mode. Propagate to the caller.
+		drop = c.driveFSMByte(event.Byte, event.WasEscaped, now)
+		if drop {
+			c.enforceDropsAppliedTotal.Add(1)
+		}
+		return drop
 	case transport.StreamEventStarted, transport.StreamEventFailed:
 		// Both events signal "a telegram is starting on the wire and
 		// event.Data carries QQ" — the FSM's EnterPassiveTracking
@@ -296,13 +328,25 @@ func (c *Classifier) Observe(event transport.StreamEvent, now time.Time) (drop b
 // concurrent diagnostic readers see fresh values. Single producer
 // per the Classifier concurrency contract.
 //
+// Returns true when the caller (Observe) should propagate
+// drop=true to the mux's readLoop. This is governed by the v8 §4
+// AA-injection filter rules:
+//
+//   - ModeOff / ModeShadow: always returns false (Shadow OBSERVES
+//     the FSM decision but does NOT yet alter the byte stream).
+//   - ModeEnforce + DecisionDropAaInjection: returns true. The
+//     byte is dropped from session dispatch. The drop counter
+//     (enforceDropsAppliedTotal) is bumped in Observe.
+//   - ModeEnforce + DecisionProtocolFault: returns false — per
+//     v8 invariant I10, PROTOCOL_FAULT bytes are STILL forwarded
+//     to all observers; the admin event is the operator-facing
+//     notification only.
+//
 // The `now` parameter is the monotonic-clock observation time
 // for this byte, threaded down from Observe (per Codex round-1
-// MEDIUM on PR #643). Using this instead of an internal
-// time.Now() call keeps the classifier's clock path
-// deterministic and avoids one syscall per fault-cascade byte.
+// MEDIUM on PR #643).
 //
-// Phase 3 Step B3.6a: DecisionProtocolFault now also emits a
+// Phase 3 Step B3.6a: DecisionProtocolFault emits a
 // ClassifierAdminEvent into the per-classifier admin-event ring
 // buffer (out-of-band per v8 I1 — NEVER into client byte streams).
 //
@@ -314,12 +358,9 @@ func (c *Classifier) Observe(event transport.StreamEvent, now time.Time) (drop b
 // If a future operator dashboard needs exact correlation, a
 // combined snapshot API would have to be added. (Codex round-1
 // LOW on PR #643 — explicit documentation.)
-//
-// B3.6b will extend this site with the ModeEnforce
-// DropAaInjection path that makes Observe return drop=true.
-func (c *Classifier) driveFSMByte(b byte, wasEscaped bool, now time.Time) {
+func (c *Classifier) driveFSMByte(b byte, wasEscaped bool, now time.Time) (drop bool) {
 	if c.fsm == nil {
-		return
+		return false
 	}
 	decision := c.fsm.Feed(b, wasEscaped)
 	switch decision {
@@ -327,14 +368,20 @@ func (c *Classifier) driveFSMByte(b byte, wasEscaped bool, now time.Time) {
 		c.fsmForwardTotal.Add(1)
 	case telegram_fsm.DecisionDropAaInjection:
 		c.fsmDropAaInjectionTotal.Add(1)
+		// Phase 3 Step B3.6b: ModeEnforce honors the FSM's drop
+		// decision. ModeShadow counts but does NOT alter the byte
+		// stream — operators run shadow first to validate the
+		// classifier against the wire before promoting to enforce.
+		if c.mode == ModeEnforce {
+			drop = true
+		}
 	case telegram_fsm.DecisionProtocolFault:
 		c.fsmProtocolFaultTotal.Add(1)
 		// Emit out-of-band admin event. Per v8 invariant I10 the
 		// byte is STILL forwarded to all observers (PROTOCOL_FAULT
 		// visibility); the admin event is the operator-facing
-		// notification only. Caller proceeds with whatever
-		// emission policy applies — the admin emit does not gate
-		// the byte stream.
+		// notification only. drop stays false — fault bytes are
+		// NEVER filtered out regardless of mode.
 		c.adminEvents.emit(ClassifierAdminEvent{
 			At:         now,
 			Kind:       AdminEventKindProtocolFault,
@@ -344,6 +391,7 @@ func (c *Classifier) driveFSMByte(b byte, wasEscaped bool, now time.Time) {
 		})
 	}
 	c.publishFSMSnapshotLocked()
+	return drop
 }
 
 // publishFSMSnapshotLocked writes the FSM's current externally-
@@ -702,4 +750,29 @@ func (c *Classifier) PendingAdminEvents() int {
 		return 0
 	}
 	return c.adminEvents.pending()
+}
+
+// EnforceDropsAppliedTotal returns the cumulative count of bytes
+// the classifier ACTUALLY DROPPED from session dispatch under
+// ModeEnforce. Phase 3 Step B3.6b (v8 §4 AA-injection filter).
+//
+// Relationship to fsmDropAaInjectionTotal:
+//   - fsmDropAaInjectionTotal: count of FSM DecisionDropAaInjection
+//     verdicts, in ALL modes (Shadow counts even though it doesn't
+//     enforce).
+//   - EnforceDropsAppliedTotal: subset where mode == Enforce AND
+//     Observe returned drop=true to the mux's readLoop.
+//
+// During a Shadow validation run before enforce promotion, the
+// difference (fsmDropAaInjectionTotal - EnforceDropsAppliedTotal)
+// is the "would have dropped" estimate operators can use to
+// project enforce impact.
+//
+// Returns 0 in ModeOff or when the classifier is nil. Safe to
+// call from any goroutine.
+func (c *Classifier) EnforceDropsAppliedTotal() uint64 {
+	if c == nil {
+		return 0
+	}
+	return c.enforceDropsAppliedTotal.Load()
 }

--- a/internal/adaptermux/v8classifier/classifier_fsm_test.go
+++ b/internal/adaptermux/v8classifier/classifier_fsm_test.go
@@ -226,38 +226,139 @@ func TestFSM_NilReceiverSafe(t *testing.T) {
 	}
 }
 
-// TestFSM_EnforceMode_DoesNotDropYet pins the B3.4 SCAFFOLD
-// invariant: even when the FSM emits a DecisionDropAaInjection
-// (which B3.6 will translate to drop=true in ModeEnforce), B3.4
-// still returns drop=false from Observe. The counter increments,
-// but no behavioral change. Future-regression guard.
-func TestFSM_EnforceMode_DoesNotDropYet(t *testing.T) {
+// TestFSM_EnforceMode_DropsAaInjection pins the B3.6b
+// behavioral contract: when the FSM emits DecisionDropAaInjection
+// AND mode == ModeEnforce, Observe returns drop=true AND the
+// drop counter (EnforceDropsAppliedTotal) increments. Replaces
+// the B3.4 SCAFFOLD-only TestFSM_EnforceMode_DoesNotDropYet.
+//
+// This is the v8 §4 AA-injection filter contract — operators
+// promoting from Shadow to Enforce expect mid-frame wire SYNs to
+// be filtered out of cross-proxy byte streams.
+func TestFSM_EnforceMode_DropsAaInjection(t *testing.T) {
 	t.Parallel()
 	c := New(ModeEnforce)
 	now := time.Unix(0, 0)
 
 	// Enter passive tracking so subsequent AA bytes are
-	// classified mid-frame (where the FSM would emit
-	// DropAaInjection per v8 §4).
+	// classified mid-frame (where the FSM emits DropAaInjection
+	// per v8 §4).
 	c.Observe(transport.StreamEvent{
 		Kind: transport.StreamEventStarted,
 		Data: 0x71,
 	}, now)
 
-	// Feed a wire AUTO-SYN mid-frame — the FSM should emit
-	// DropAaInjection.
+	// Feed a wire AUTO-SYN mid-frame — the FSM emits
+	// DropAaInjection AND ModeEnforce propagates drop=true.
 	drop := c.Observe(transport.StreamEvent{
 		Kind: transport.StreamEventByte,
 		Byte: 0xAA,
 		// wasEscaped=false (real wire SYN, mid-frame = AA-injection)
 	}, now)
-	if drop {
-		t.Error("Observe(mid-frame wire 0xAA) returned drop=true in ModeEnforce; B3.4 must return drop=false until B3.6 wires real filtering")
+	if !drop {
+		t.Error("Observe(mid-frame wire 0xAA) returned drop=false in ModeEnforce; B3.6b MUST drop AA-injection")
 	}
 
-	// The FSM should have counted the drop decision.
-	if got := c.FsmDropAaInjectionTotal(); got == 0 {
-		t.Errorf("FsmDropAaInjectionTotal()=0; expected non-zero (FSM should emit DropAaInjection for mid-frame wire SYN)")
+	// Counter accounting:
+	//   - FsmDropAaInjectionTotal records every FSM decision (any mode)
+	//   - EnforceDropsAppliedTotal records the subset where Enforce
+	//     actually applied the drop
+	if got := c.FsmDropAaInjectionTotal(); got != 1 {
+		t.Errorf("FsmDropAaInjectionTotal()=%d; want 1", got)
+	}
+	if got := c.EnforceDropsAppliedTotal(); got != 1 {
+		t.Errorf("EnforceDropsAppliedTotal()=%d; want 1", got)
+	}
+}
+
+// TestFSM_ShadowMode_AaInjectionCounted_NotDropped pins the
+// Shadow-mode contract: the FSM emits DecisionDropAaInjection
+// (and FsmDropAaInjectionTotal increments), but Observe still
+// returns drop=false and EnforceDropsAppliedTotal stays at 0.
+// The difference between the two counters during a Shadow
+// validation run is the "would have dropped" estimate operators
+// use to project enforce impact.
+func TestFSM_ShadowMode_AaInjectionCounted_NotDropped(t *testing.T) {
+	t.Parallel()
+	c := New(ModeShadow)
+	now := time.Unix(0, 0)
+
+	c.Observe(transport.StreamEvent{
+		Kind: transport.StreamEventStarted,
+		Data: 0x71,
+	}, now)
+	drop := c.Observe(transport.StreamEvent{
+		Kind: transport.StreamEventByte,
+		Byte: 0xAA,
+	}, now)
+	if drop {
+		t.Error("Observe in ModeShadow returned drop=true; Shadow must NEVER drop (observation-only contract)")
+	}
+	if got := c.FsmDropAaInjectionTotal(); got != 1 {
+		t.Errorf("FsmDropAaInjectionTotal()=%d; want 1 (FSM decision still counted in Shadow)", got)
+	}
+	if got := c.EnforceDropsAppliedTotal(); got != 0 {
+		t.Errorf("EnforceDropsAppliedTotal()=%d; want 0 (Shadow never applies drops)", got)
+	}
+}
+
+// TestFSM_EnforceMode_ProtocolFaultStillForwards pins v8 I10:
+// PROTOCOL_FAULT bytes are FORWARDED to all observers regardless
+// of mode. Only AA-injection is filtered.
+func TestFSM_EnforceMode_ProtocolFaultStillForwards(t *testing.T) {
+	t.Parallel()
+	c := New(ModeEnforce)
+	now := time.Unix(0, 0)
+
+	// Drive the FSM into the position where the next byte
+	// triggers ProtocolFault (NN>16 in MASTER_HEADER byte 4).
+	c.Observe(transport.StreamEvent{
+		Kind: transport.StreamEventStarted, Data: 0x71,
+	}, now)
+	for _, b := range []byte{0x10, 0xB5, 0x16} {
+		c.Observe(transport.StreamEvent{
+			Kind: transport.StreamEventByte, Byte: b,
+		}, now)
+	}
+	// NN=0xFF — exceeds the 16-byte cap, FSM emits ProtocolFault.
+	drop := c.Observe(transport.StreamEvent{
+		Kind: transport.StreamEventByte, Byte: 0xFF,
+	}, now)
+	if drop {
+		t.Error("Observe(ProtocolFault byte) returned drop=true; v8 I10 requires fault bytes to be FORWARDED")
+	}
+	if got := c.FsmProtocolFaultTotal(); got != 1 {
+		t.Errorf("FsmProtocolFaultTotal()=%d; want 1", got)
+	}
+	// EnforceDropsAppliedTotal MUST stay at 0 — protocol faults
+	// don't count as drops.
+	if got := c.EnforceDropsAppliedTotal(); got != 0 {
+		t.Errorf("EnforceDropsAppliedTotal()=%d; want 0 (faults are forwarded, not dropped)", got)
+	}
+}
+
+// TestFSM_EnforceMode_LegitimateBytesNotDropped pins that
+// Forward-class bytes (most of the telegram) are NOT dropped
+// even in ModeEnforce. Only DropAaInjection triggers a drop.
+func TestFSM_EnforceMode_LegitimateBytesNotDropped(t *testing.T) {
+	t.Parallel()
+	c := New(ModeEnforce)
+	now := time.Unix(0, 0)
+
+	c.Observe(transport.StreamEvent{
+		Kind: transport.StreamEventStarted, Data: 0x71,
+	}, now)
+	// Plain payload bytes — all Forward decisions.
+	for _, b := range []byte{0x10, 0xB5, 0x16} {
+		drop := c.Observe(transport.StreamEvent{
+			Kind: transport.StreamEventByte, Byte: b,
+		}, now)
+		if drop {
+			t.Errorf("Observe(legitimate byte 0x%02X) returned drop=true; want false", b)
+		}
+	}
+	if got := c.EnforceDropsAppliedTotal(); got != 0 {
+		t.Errorf("EnforceDropsAppliedTotal()=%d; want 0 (only AA-injection drops)", got)
 	}
 }
 

--- a/internal/adaptermux/v8classifier/classifier_provenance_test.go
+++ b/internal/adaptermux/v8classifier/classifier_provenance_test.go
@@ -310,18 +310,21 @@ func TestClassifyByteProvenance_TableDriven(t *testing.T) {
 	}
 }
 
-// TestProvenance_EnforceMode_DoesNotDropYet pins the B3.3 scaffold-
-// only contract: even with provenance classification active, the
-// classifier in ModeEnforce returns drop=false for every byte. Real
-// filtering decisions (which CAN return drop=true on
-// AA-injection mid-frame) land in B3.6 once the FSM (B3.4) and
-// admin channel are in.
-func TestProvenance_EnforceMode_DoesNotDropYet(t *testing.T) {
+// TestProvenance_EnforceMode_IdleStateAllBytesForwarded pins the
+// B3.6b contract for IDLE-state bytes: the four canonical
+// provenance shapes plus the two defensive fall-throughs are ALL
+// forwarded (drop=false) when fed in IDLE. The FSM's IDLE handler
+// emits Forward for every byte regardless of provenance, so no
+// drops fire. AA-injection drops require MID-FRAME context (see
+// TestFSM_EnforceMode_DropsAaInjection for that path).
+//
+// Replaces the B3.3 SCAFFOLD-only TestProvenance_EnforceMode_DoesNotDropYet.
+func TestProvenance_EnforceMode_IdleStateAllBytesForwarded(t *testing.T) {
 	t.Parallel()
 	c := New(ModeEnforce)
 	now := time.Unix(0, 0)
 	// Feed the four canonical shapes plus the two defensive
-	// fall-throughs. NONE should produce drop=true.
+	// fall-throughs. NONE should produce drop=true in IDLE.
 	for _, e := range []transport.StreamEvent{
 		{Kind: transport.StreamEventByte, Byte: 0xAA, WasEscaped: true},
 		{Kind: transport.StreamEventByte, Byte: 0xA9, WasEscaped: true},
@@ -331,7 +334,10 @@ func TestProvenance_EnforceMode_DoesNotDropYet(t *testing.T) {
 		{Kind: transport.StreamEventByte, Byte: 0x42, WasEscaped: true},  // defensive
 	} {
 		if drop := c.Observe(e, now); drop {
-			t.Errorf("Observe(%+v) returned drop=true in ModeEnforce; B3.3 scaffold MUST always return false until B3.6 wires real filtering", e)
+			t.Errorf("Observe(%+v) in IDLE returned drop=true; want false (IDLE forwards all bytes)", e)
 		}
+	}
+	if got := c.EnforceDropsAppliedTotal(); got != 0 {
+		t.Errorf("EnforceDropsAppliedTotal() = %d; want 0 (no AA-injection in IDLE)", got)
 	}
 }

--- a/internal/adaptermux/v8classifier/classifier_test.go
+++ b/internal/adaptermux/v8classifier/classifier_test.go
@@ -70,12 +70,17 @@ func TestClassifier_Observe_ShadowMode_CountsButDoesNotDrop(t *testing.T) {
 	}
 }
 
-func TestClassifier_Observe_EnforceMode_CountsButDoesNotDropYet(t *testing.T) {
+func TestClassifier_Observe_EnforceMode_IdleStateBytesNotDropped(t *testing.T) {
 	t.Parallel()
 
-	// B3.2 scaffold: even in ModeEnforce the classifier does not
-	// drop anything yet. The actual filtering decisions land in
-	// B3.3+. This test pins the SCAFFOLD-ONLY contract.
+	// Phase 3 Step B3.6b: even in ModeEnforce, bytes the FSM
+	// classifies as Forward (most non-frame traffic and any byte
+	// observed without a Started/Failed predecessor) are NOT
+	// dropped. Replaces the B3.2 SCAFFOLD-ONLY test — the
+	// invariant has shifted from "ModeEnforce drops nothing" to
+	// "ModeEnforce drops AA-injection only" (which requires
+	// being mid-frame; bytes in IDLE state get Forward and pass
+	// through cleanly).
 	c := New(ModeEnforce)
 	now := time.Unix(0, 0)
 	const n = 25
@@ -85,11 +90,14 @@ func TestClassifier_Observe_EnforceMode_CountsButDoesNotDropYet(t *testing.T) {
 			Byte: byte(i),
 		}, now)
 		if drop {
-			t.Errorf("iter %d: Observe(...) returned drop=true in ModeEnforce; B3.2 scaffold returns false until B3.3 wires real filtering", i)
+			t.Errorf("iter %d: Observe(byte 0x%02X in IDLE) returned drop=true; want false (only AA-injection mid-frame drops)", i, byte(i))
 		}
 	}
 	if got := c.ObservedBytesTotal(); got != n {
 		t.Errorf("ObservedBytesTotal() = %d; want %d in ModeEnforce", got, n)
+	}
+	if got := c.EnforceDropsAppliedTotal(); got != 0 {
+		t.Errorf("EnforceDropsAppliedTotal() = %d; want 0 (no AA-injection in IDLE)", got)
 	}
 }
 

--- a/internal/adaptermux/v8classifier_wiring_test.go
+++ b/internal/adaptermux/v8classifier_wiring_test.go
@@ -296,18 +296,8 @@ func classifiedTestMuxWithSession(t *testing.T, mode v8classifier.Mode) (
 	}
 
 	// Drain whatever ENH framing the writeLoop emits during INIT
-	// so subsequent assertions read fresh bytes only.
-	drain := make(chan struct{})
-	go func() {
-		defer close(drain)
-		buf := make([]byte, 256)
-		deadline := time.Now().Add(150 * time.Millisecond)
-		for time.Now().Before(deadline) {
-			_ = clientConn.SetReadDeadline(time.Now().Add(40 * time.Millisecond))
-			_, _ = clientConn.Read(buf)
-		}
-	}()
-	<-drain
+	// using the event-driven idle-window pattern.
+	drainSessionUntilIdle(t, clientConn, 50*time.Millisecond, 500*time.Millisecond)
 
 	cleanup = func() {
 		_ = clientConn.Close()
@@ -315,6 +305,47 @@ func classifiedTestMuxWithSession(t *testing.T, mode v8classifier.Mode) (
 		baseCleanup()
 	}
 	return mux, mock, clientConn, sid, cleanup
+}
+
+// drainSessionUntilIdle reads from clientConn until no bytes
+// arrive within `idleWindow`, or until `hardDeadline` is exceeded.
+//
+// Per Codex round-2 MEDIUM on PR #644: fixed-duration drains
+// leave a race where a delayed Started-mirror frame can leak
+// into the AA-injection probe window, causing false-fail
+// (Enforce) or false-pass (Shadow). Event-driven idle detection
+// fixes this — we keep reading until the pipe is genuinely
+// silent for `idleWindow`, proving any pre-injection framing
+// has been consumed.
+//
+// The function returns the total byte count drained — useful
+// for tests that want to assert SOMETHING flowed before the
+// idle period (e.g. "Started's mirror frame WAS forwarded").
+func drainSessionUntilIdle(t *testing.T, conn net.Conn, idleWindow, hardDeadline time.Duration) int {
+	t.Helper()
+	buf := make([]byte, 256)
+	total := 0
+	hard := time.Now().Add(hardDeadline)
+	for time.Now().Before(hard) {
+		// Read with a short deadline (the idle window). If the
+		// read times out without bytes, we've hit an idle
+		// period — the pipe is quiet enough to start the
+		// per-test injection.
+		_ = conn.SetReadDeadline(time.Now().Add(idleWindow))
+		n, err := conn.Read(buf)
+		if n > 0 {
+			total += n
+			continue
+		}
+		// Timeout (or other error) with no bytes — idle window
+		// satisfied.
+		_ = err
+		return total
+	}
+	// Hard deadline hit — pipe wasn't idle for `idleWindow` within
+	// the whole budget. Tests should rarely see this on net.Pipe
+	// + the small frames involved.
+	return total
 }
 
 // TestV8Classifier_EnforceMode_AaInjectionDoesNotReachSession is
@@ -351,20 +382,11 @@ func TestV8Classifier_EnforceMode_AaInjectionDoesNotReachSession(t *testing.T) {
 	}
 
 	// Drain any frame the session emitted in response to Started
-	// (the mux mirrors Started to external sessions in the
-	// expected ENH form). We want to start counting bytes ONLY
-	// after that.
-	drain := make(chan struct{})
-	go func() {
-		defer close(drain)
-		buf := make([]byte, 256)
-		d2 := time.Now().Add(100 * time.Millisecond)
-		for time.Now().Before(d2) {
-			_ = clientConn.SetReadDeadline(time.Now().Add(30 * time.Millisecond))
-			_, _ = clientConn.Read(buf)
-		}
-	}()
-	<-drain
+	// using the event-driven idle-window pattern (per Codex
+	// round-2 MEDIUM on PR #644): read until 50ms of silence,
+	// proving the Started-mirror frame has been fully consumed
+	// from the pipe before we start the AA probe.
+	_ = drainSessionUntilIdle(t, clientConn, 50*time.Millisecond, 500*time.Millisecond)
 
 	// LOAD-BEARING INJECTION: mid-frame wire AUTO-SYN → FSM emits
 	// DropAaInjection → ModeEnforce returns drop=true → readLoop
@@ -436,18 +458,9 @@ func TestV8Classifier_ShadowMode_AaInjectionReachesSession(t *testing.T) {
 		time.Sleep(5 * time.Millisecond)
 	}
 
-	// Drain Started's mirror frame.
-	drain := make(chan struct{})
-	go func() {
-		defer close(drain)
-		buf := make([]byte, 256)
-		d2 := time.Now().Add(100 * time.Millisecond)
-		for time.Now().Before(d2) {
-			_ = clientConn.SetReadDeadline(time.Now().Add(30 * time.Millisecond))
-			_, _ = clientConn.Read(buf)
-		}
-	}()
-	<-drain
+	// Drain Started's mirror frame via the event-driven idle
+	// pattern (per Codex round-2 MEDIUM on PR #644).
+	_ = drainSessionUntilIdle(t, clientConn, 50*time.Millisecond, 500*time.Millisecond)
 
 	mock.eventCh <- transport.StreamEvent{
 		Kind: transport.StreamEventByte, Byte: 0xAA, WasEscaped: false,

--- a/internal/adaptermux/v8classifier_wiring_test.go
+++ b/internal/adaptermux/v8classifier_wiring_test.go
@@ -2,6 +2,7 @@ package adaptermux
 
 import (
 	"context"
+	"net"
 	"testing"
 	"time"
 
@@ -268,18 +269,65 @@ func TestV8Classifier_ShadowMode_FSMDrivenThroughMux(t *testing.T) {
 	}
 }
 
-// TestV8Classifier_EnforceMode_AaInjectionSkipsOnReceived pins
-// the B3.6b behavioral contract at the mux boundary: when the
-// classifier returns drop=true (FSM DropAaInjection in
-// ModeEnforce), the mux's readLoop MUST skip the byte's dispatch
-// to onReceived. The byte still flows through the classifier
-// (counters increment), but does NOT reach the session
-// fan-out.
+// classifiedTestMuxWithSession returns a mux + a real attached
+// session whose client-side pipe end can be read by the test to
+// observe what bytes actually flow out (or get filtered).
 //
-// Replaces the B3.2 SCAFFOLD-only
-// TestV8Classifier_EnforceMode_InstantiatedAndObservesButDoesNotDrop.
-func TestV8Classifier_EnforceMode_AaInjectionSkipsOnReceived(t *testing.T) {
-	mux, mock, _, cleanup := newClassifiedTestMux(t, v8classifier.ModeEnforce)
+// Per Codex round-1 MEDIUM on PR #644: the previous version of
+// the mux-boundary tests only asserted classifier counters; a
+// buggy readLoop that incremented EnforceDropsAppliedTotal AND
+// still dispatched the byte would have passed those tests.
+// Reading from a real session pipe is the load-bearing assertion
+// that the drop actually skipped onReceived.
+func classifiedTestMuxWithSession(t *testing.T, mode v8classifier.Mode) (
+	mux *Mux,
+	mock *p3MockTransport,
+	clientConn net.Conn,
+	sid uint64,
+	cleanup func(),
+) {
+	t.Helper()
+	mux, mock, _, baseCleanup := newClassifiedTestMux(t, mode)
+
+	clientConn, serverConn := net.Pipe()
+	sid = mux.AddSession(serverConn)
+	if sid == 0 {
+		t.Fatal("AddSession returned 0")
+	}
+
+	// Drain whatever ENH framing the writeLoop emits during INIT
+	// so subsequent assertions read fresh bytes only.
+	drain := make(chan struct{})
+	go func() {
+		defer close(drain)
+		buf := make([]byte, 256)
+		deadline := time.Now().Add(150 * time.Millisecond)
+		for time.Now().Before(deadline) {
+			_ = clientConn.SetReadDeadline(time.Now().Add(40 * time.Millisecond))
+			_, _ = clientConn.Read(buf)
+		}
+	}()
+	<-drain
+
+	cleanup = func() {
+		_ = clientConn.Close()
+		mux.RemoveSession(sid)
+		baseCleanup()
+	}
+	return mux, mock, clientConn, sid, cleanup
+}
+
+// TestV8Classifier_EnforceMode_AaInjectionDoesNotReachSession is
+// the LOAD-BEARING B3.6b behavioral test (Codex round-1 MEDIUM
+// fix). It proves that under ModeEnforce, an AA-injection wire
+// byte is filtered BEFORE the session sees it — by reading from
+// a real session's pipe end and asserting NO bytes arrive in the
+// post-injection window.
+//
+// Counter assertions remain as secondary confirmation but the
+// PRIMARY pin is the session-pipe silence.
+func TestV8Classifier_EnforceMode_AaInjectionDoesNotReachSession(t *testing.T) {
+	mux, mock, clientConn, _, cleanup := classifiedTestMuxWithSession(t, v8classifier.ModeEnforce)
 	defer cleanup()
 
 	c := mux.V8Classifier()
@@ -287,12 +335,10 @@ func TestV8Classifier_EnforceMode_AaInjectionSkipsOnReceived(t *testing.T) {
 		t.Fatal("V8Classifier() = nil in ModeEnforce; want non-nil")
 	}
 
-	// Drive the classifier into mid-frame so the next wire AUTO-SYN
-	// is treated as AA-injection (FSM DropAaInjection).
+	// Drive the FSM into mid-frame via Started.
 	mock.eventCh <- transport.StreamEvent{
 		Kind: transport.StreamEventStarted, Data: 0x71,
 	}
-	// Wait for the Started to be processed.
 	deadline := time.Now().Add(1 * time.Second)
 	for time.Now().Before(deadline) {
 		if c.FsmEnterPassiveTotal() >= 1 {
@@ -301,16 +347,34 @@ func TestV8Classifier_EnforceMode_AaInjectionSkipsOnReceived(t *testing.T) {
 		time.Sleep(5 * time.Millisecond)
 	}
 	if got := c.FsmEnterPassiveTotal(); got != 1 {
-		t.Fatalf("FsmEnterPassiveTotal()=%d; want 1 (Started not yet processed)", got)
+		t.Fatalf("FsmEnterPassiveTotal()=%d; want 1 (Started not processed)", got)
 	}
 
-	// Now push a mid-frame wire AUTO-SYN — AA-injection per v8 §4.
-	// The classifier MUST count + drop it.
+	// Drain any frame the session emitted in response to Started
+	// (the mux mirrors Started to external sessions in the
+	// expected ENH form). We want to start counting bytes ONLY
+	// after that.
+	drain := make(chan struct{})
+	go func() {
+		defer close(drain)
+		buf := make([]byte, 256)
+		d2 := time.Now().Add(100 * time.Millisecond)
+		for time.Now().Before(d2) {
+			_ = clientConn.SetReadDeadline(time.Now().Add(30 * time.Millisecond))
+			_, _ = clientConn.Read(buf)
+		}
+	}()
+	<-drain
+
+	// LOAD-BEARING INJECTION: mid-frame wire AUTO-SYN → FSM emits
+	// DropAaInjection → ModeEnforce returns drop=true → readLoop
+	// `continue`s past onReceived → session pipe sees NOTHING.
 	mock.eventCh <- transport.StreamEvent{
 		Kind: transport.StreamEventByte, Byte: 0xAA, WasEscaped: false,
 	}
 
-	deadline = time.Now().Add(2 * time.Second)
+	// Wait for the classifier to confirm it processed the byte.
+	deadline = time.Now().Add(1 * time.Second)
 	for time.Now().Before(deadline) {
 		if c.EnforceDropsAppliedTotal() >= 1 {
 			break
@@ -318,21 +382,42 @@ func TestV8Classifier_EnforceMode_AaInjectionSkipsOnReceived(t *testing.T) {
 		time.Sleep(5 * time.Millisecond)
 	}
 	if got := c.EnforceDropsAppliedTotal(); got != 1 {
-		t.Errorf("EnforceDropsAppliedTotal()=%d; want 1 (AA-injection dropped by enforce)", got)
+		t.Fatalf("EnforceDropsAppliedTotal()=%d; want 1 (classifier should have applied the drop)", got)
 	}
+
+	// PRIMARY ASSERTION: zero bytes flow on the session pipe in
+	// the post-injection window. A regression that called Observe
+	// + incremented the counter AND dispatched the byte would
+	// produce >= 2 bytes here (the ENH-encoded ENHResReceived
+	// frame).
+	bytesAfterInject := 0
+	buf := make([]byte, 64)
+	probeUntil := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(probeUntil) {
+		_ = clientConn.SetReadDeadline(time.Now().Add(30 * time.Millisecond))
+		n, _ := clientConn.Read(buf)
+		bytesAfterInject += n
+	}
+	if bytesAfterInject != 0 {
+		t.Errorf("Enforce dropped AA-injection but session pipe got %d bytes; want 0 (filter must skip onReceived)", bytesAfterInject)
+	}
+
+	// Secondary: FsmDropAaInjectionTotal should also be 1.
 	if got := c.FsmDropAaInjectionTotal(); got != 1 {
 		t.Errorf("FsmDropAaInjectionTotal()=%d; want 1", got)
 	}
 }
 
-// TestV8Classifier_ShadowMode_AaInjectionForwarded pins the
-// Shadow-mode contract at the mux boundary: even when the FSM
-// recommends a drop (DecisionDropAaInjection), Shadow does NOT
-// apply the drop — the byte still reaches onReceived. This is
-// the pre-promotion validation mode operators run before
-// promoting to Enforce.
-func TestV8Classifier_ShadowMode_AaInjectionForwarded(t *testing.T) {
-	mux, mock, _, cleanup := newClassifiedTestMux(t, v8classifier.ModeShadow)
+// TestV8Classifier_ShadowMode_AaInjectionReachesSession is the
+// inverse: under ModeShadow, the FSM emits DropAaInjection
+// (FsmDropAaInjectionTotal increments) but the byte STILL reaches
+// the session pipe. EnforceDropsAppliedTotal stays at 0.
+//
+// This is the pre-promotion validation mode — operators count
+// would-have-dropped vs in-mode dropped before promoting to
+// Enforce.
+func TestV8Classifier_ShadowMode_AaInjectionReachesSession(t *testing.T) {
+	mux, mock, clientConn, _, cleanup := classifiedTestMuxWithSession(t, v8classifier.ModeShadow)
 	defer cleanup()
 
 	c := mux.V8Classifier()
@@ -343,7 +428,6 @@ func TestV8Classifier_ShadowMode_AaInjectionForwarded(t *testing.T) {
 	mock.eventCh <- transport.StreamEvent{
 		Kind: transport.StreamEventStarted, Data: 0x71,
 	}
-	// Wait for Started to land in classifier.
 	deadline := time.Now().Add(1 * time.Second)
 	for time.Now().Before(deadline) {
 		if c.FsmEnterPassiveTotal() >= 1 {
@@ -351,11 +435,26 @@ func TestV8Classifier_ShadowMode_AaInjectionForwarded(t *testing.T) {
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
+
+	// Drain Started's mirror frame.
+	drain := make(chan struct{})
+	go func() {
+		defer close(drain)
+		buf := make([]byte, 256)
+		d2 := time.Now().Add(100 * time.Millisecond)
+		for time.Now().Before(d2) {
+			_ = clientConn.SetReadDeadline(time.Now().Add(30 * time.Millisecond))
+			_, _ = clientConn.Read(buf)
+		}
+	}()
+	<-drain
+
 	mock.eventCh <- transport.StreamEvent{
 		Kind: transport.StreamEventByte, Byte: 0xAA, WasEscaped: false,
 	}
 
-	deadline = time.Now().Add(2 * time.Second)
+	// Wait for classifier to register the FSM verdict.
+	deadline = time.Now().Add(1 * time.Second)
 	for time.Now().Before(deadline) {
 		if c.FsmDropAaInjectionTotal() >= 1 {
 			break
@@ -363,10 +462,26 @@ func TestV8Classifier_ShadowMode_AaInjectionForwarded(t *testing.T) {
 		time.Sleep(5 * time.Millisecond)
 	}
 	if got := c.FsmDropAaInjectionTotal(); got != 1 {
-		t.Errorf("FsmDropAaInjectionTotal()=%d; want 1 (FSM verdict still counted in Shadow)", got)
+		t.Fatalf("FsmDropAaInjectionTotal()=%d; want 1 (FSM verdict counted in Shadow)", got)
 	}
-	// CRITICAL: Shadow MUST NOT apply the drop.
+
+	// PRIMARY ASSERTION: under Shadow, despite the FSM
+	// recommending a drop, the byte SHOULD reach the session.
+	// We expect >= 2 bytes (ENHResReceived frame).
+	bytesAfterInject := 0
+	buf := make([]byte, 64)
+	probeUntil := time.Now().Add(300 * time.Millisecond)
+	for time.Now().Before(probeUntil) && bytesAfterInject == 0 {
+		_ = clientConn.SetReadDeadline(time.Now().Add(30 * time.Millisecond))
+		n, _ := clientConn.Read(buf)
+		bytesAfterInject += n
+	}
+	if bytesAfterInject == 0 {
+		t.Error("Shadow mode dropped the AA byte from session — Shadow MUST forward (observe-only contract)")
+	}
+
+	// Secondary: EnforceDropsAppliedTotal MUST stay at 0.
 	if got := c.EnforceDropsAppliedTotal(); got != 0 {
-		t.Errorf("EnforceDropsAppliedTotal()=%d; want 0 (Shadow never applies drops)", got)
+		t.Errorf("EnforceDropsAppliedTotal()=%d; want 0 (Shadow must never apply drops)", got)
 	}
 }

--- a/internal/adaptermux/v8classifier_wiring_test.go
+++ b/internal/adaptermux/v8classifier_wiring_test.go
@@ -268,20 +268,17 @@ func TestV8Classifier_ShadowMode_FSMDrivenThroughMux(t *testing.T) {
 	}
 }
 
-// TestV8Classifier_EnforceMode_InstantiatedAndObservesButDoesNotDrop
-// pins the B3.2-scaffold invariant for enforce mode: even when the
-// caller explicitly opts in to ModeEnforce, the classifier in this
-// PR ONLY observes; it does NOT yet drop or rewrite any bytes.
-// Real filtering lands in B3.3+.
+// TestV8Classifier_EnforceMode_AaInjectionSkipsOnReceived pins
+// the B3.6b behavioral contract at the mux boundary: when the
+// classifier returns drop=true (FSM DropAaInjection in
+// ModeEnforce), the mux's readLoop MUST skip the byte's dispatch
+// to onReceived. The byte still flows through the classifier
+// (counters increment), but does NOT reach the session
+// fan-out.
 //
-// MAINTAINER NOTE: when B3.3+ wires real filtering authority into
-// the enforce path, this test MUST be UPDATED OR DELETED — its
-// purpose is to fire if a future PR accidentally enables filtering
-// before the full B3.3..B3.7 stack lands. Once enforce gains real
-// filtering, replace the "drop=false always" assertion with a
-// session-level behavior assertion that the right bytes are
-// filtered.
-func TestV8Classifier_EnforceMode_InstantiatedAndObservesButDoesNotDrop(t *testing.T) {
+// Replaces the B3.2 SCAFFOLD-only
+// TestV8Classifier_EnforceMode_InstantiatedAndObservesButDoesNotDrop.
+func TestV8Classifier_EnforceMode_AaInjectionSkipsOnReceived(t *testing.T) {
 	mux, mock, _, cleanup := newClassifiedTestMux(t, v8classifier.ModeEnforce)
 	defer cleanup()
 
@@ -289,25 +286,87 @@ func TestV8Classifier_EnforceMode_InstantiatedAndObservesButDoesNotDrop(t *testi
 	if c == nil {
 		t.Fatal("V8Classifier() = nil in ModeEnforce; want non-nil")
 	}
-	if got := c.Mode(); got != v8classifier.ModeEnforce {
-		t.Errorf("classifier mode = %v; want ModeEnforce", got)
+
+	// Drive the classifier into mid-frame so the next wire AUTO-SYN
+	// is treated as AA-injection (FSM DropAaInjection).
+	mock.eventCh <- transport.StreamEvent{
+		Kind: transport.StreamEventStarted, Data: 0x71,
 	}
-
-	// Push a single SYN. Classifier MUST observe it; mux MUST emit
-	// it normally (no drop). The latter is implicitly asserted by
-	// readLoop's existing onReceived dispatch — if Observe ever
-	// returned drop=true, the existing legacy adaptermux tests
-	// would surface the regression.
-	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0xAA}
-
+	// Wait for the Started to be processed.
 	deadline := time.Now().Add(1 * time.Second)
 	for time.Now().Before(deadline) {
-		if c.ObservedBytesTotal() >= 1 {
+		if c.FsmEnterPassiveTotal() >= 1 {
 			break
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
-	if got := c.ObservedBytesTotal(); got != 1 {
-		t.Errorf("ObservedBytesTotal() = %d; want 1 in ModeEnforce", got)
+	if got := c.FsmEnterPassiveTotal(); got != 1 {
+		t.Fatalf("FsmEnterPassiveTotal()=%d; want 1 (Started not yet processed)", got)
+	}
+
+	// Now push a mid-frame wire AUTO-SYN — AA-injection per v8 §4.
+	// The classifier MUST count + drop it.
+	mock.eventCh <- transport.StreamEvent{
+		Kind: transport.StreamEventByte, Byte: 0xAA, WasEscaped: false,
+	}
+
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if c.EnforceDropsAppliedTotal() >= 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := c.EnforceDropsAppliedTotal(); got != 1 {
+		t.Errorf("EnforceDropsAppliedTotal()=%d; want 1 (AA-injection dropped by enforce)", got)
+	}
+	if got := c.FsmDropAaInjectionTotal(); got != 1 {
+		t.Errorf("FsmDropAaInjectionTotal()=%d; want 1", got)
+	}
+}
+
+// TestV8Classifier_ShadowMode_AaInjectionForwarded pins the
+// Shadow-mode contract at the mux boundary: even when the FSM
+// recommends a drop (DecisionDropAaInjection), Shadow does NOT
+// apply the drop — the byte still reaches onReceived. This is
+// the pre-promotion validation mode operators run before
+// promoting to Enforce.
+func TestV8Classifier_ShadowMode_AaInjectionForwarded(t *testing.T) {
+	mux, mock, _, cleanup := newClassifiedTestMux(t, v8classifier.ModeShadow)
+	defer cleanup()
+
+	c := mux.V8Classifier()
+	if c == nil {
+		t.Fatal("V8Classifier() = nil in ModeShadow; want non-nil")
+	}
+
+	mock.eventCh <- transport.StreamEvent{
+		Kind: transport.StreamEventStarted, Data: 0x71,
+	}
+	// Wait for Started to land in classifier.
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		if c.FsmEnterPassiveTotal() >= 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	mock.eventCh <- transport.StreamEvent{
+		Kind: transport.StreamEventByte, Byte: 0xAA, WasEscaped: false,
+	}
+
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if c.FsmDropAaInjectionTotal() >= 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := c.FsmDropAaInjectionTotal(); got != 1 {
+		t.Errorf("FsmDropAaInjectionTotal()=%d; want 1 (FSM verdict still counted in Shadow)", got)
+	}
+	// CRITICAL: Shadow MUST NOT apply the drop.
+	if got := c.EnforceDropsAppliedTotal(); got != 0 {
+		t.Errorf("EnforceDropsAppliedTotal()=%d; want 0 (Shadow never applies drops)", got)
 	}
 }

--- a/internal/adaptermux/v8classifier_wiring_test.go
+++ b/internal/adaptermux/v8classifier_wiring_test.go
@@ -316,7 +316,8 @@ func classifiedTestMuxWithSession(t *testing.T, mode v8classifier.Mode) (
 // minBytes: if > 0, the helper MUST observe at least this many
 // bytes before the idle window starts counting. Used for
 // post-injection drains where a specific frame is expected to
-// arrive (e.g. Started's session-mirror frame). minBytes == 0
+// arrive (e.g. a Failed-event session-mirror frame).
+// minBytes == 0
 // is the "just drain whatever is queued, then wait for idle"
 // pattern used for INIT drains where the precondition is
 // unknown.

--- a/internal/adaptermux/v8classifier_wiring_test.go
+++ b/internal/adaptermux/v8classifier_wiring_test.go
@@ -2,6 +2,7 @@ package adaptermux
 
 import (
 	"context"
+	"errors"
 	"net"
 	"testing"
 	"time"
@@ -295,9 +296,10 @@ func classifiedTestMuxWithSession(t *testing.T, mode v8classifier.Mode) (
 		t.Fatal("AddSession returned 0")
 	}
 
-	// Drain whatever ENH framing the writeLoop emits during INIT
-	// using the event-driven idle-window pattern.
-	drainSessionUntilIdle(t, clientConn, 50*time.Millisecond, 500*time.Millisecond)
+	// Drain whatever ENH framing the writeLoop emits during
+	// INIT. minBytes=0: we don't pre-assume any specific frame
+	// arrives during INIT — just wait for idle.
+	drainSessionUntilIdle(t, clientConn, 0, 50*time.Millisecond, 500*time.Millisecond)
 
 	cleanup = func() {
 		_ = clientConn.Close()
@@ -307,45 +309,93 @@ func classifiedTestMuxWithSession(t *testing.T, mode v8classifier.Mode) (
 	return mux, mock, clientConn, sid, cleanup
 }
 
-// drainSessionUntilIdle reads from clientConn until no bytes
-// arrive within `idleWindow`, or until `hardDeadline` is exceeded.
+// drainSessionUntilIdle reads from clientConn enforcing a
+// "wait-for-frame then wait-for-idle" contract — both halves
+// must succeed within hardDeadline, otherwise t.Fatalf.
 //
-// Per Codex round-2 MEDIUM on PR #644: fixed-duration drains
-// leave a race where a delayed Started-mirror frame can leak
-// into the AA-injection probe window, causing false-fail
-// (Enforce) or false-pass (Shadow). Event-driven idle detection
-// fixes this — we keep reading until the pipe is genuinely
-// silent for `idleWindow`, proving any pre-injection framing
-// has been consumed.
+// minBytes: if > 0, the helper MUST observe at least this many
+// bytes before the idle window starts counting. Used for
+// post-injection drains where a specific frame is expected to
+// arrive (e.g. Started's session-mirror frame). minBytes == 0
+// is the "just drain whatever is queued, then wait for idle"
+// pattern used for INIT drains where the precondition is
+// unknown.
 //
-// The function returns the total byte count drained — useful
-// for tests that want to assert SOMETHING flowed before the
-// idle period (e.g. "Started's mirror frame WAS forwarded").
-func drainSessionUntilIdle(t *testing.T, conn net.Conn, idleWindow, hardDeadline time.Duration) int {
+// idleWindow: the duration the pipe must be silent BEFORE the
+// helper returns. Confirms no late-arriving frame will
+// contaminate the subsequent per-test probe.
+//
+// hardDeadline: total budget for both phases combined. If
+// minBytes isn't reached OR an idle window isn't observed
+// within this time, the helper FATALS — the test cannot
+// proceed under unproven preconditions.
+//
+// Per Codex round-3 review on PR #644:
+//   - Round 2's "wait for idle only" let delayed Started
+//     bytes leak past the helper when they arrived AFTER the
+//     first 50ms quiet period.
+//   - Round 3's minBytes>0 contract requires observing the
+//     expected frame BEFORE the idle window starts, closing
+//     the race.
+//   - Hard-deadline expiry and non-timeout read errors now
+//     surface as test failures rather than silent degradation.
+//
+// Returns total bytes drained.
+func drainSessionUntilIdle(t *testing.T, conn net.Conn, minBytes int, idleWindow, hardDeadline time.Duration) int {
 	t.Helper()
 	buf := make([]byte, 256)
 	total := 0
 	hard := time.Now().Add(hardDeadline)
-	for time.Now().Before(hard) {
-		// Read with a short deadline (the idle window). If the
-		// read times out without bytes, we've hit an idle
-		// period — the pipe is quiet enough to start the
-		// per-test injection.
+
+	// Phase 1: wait for at least minBytes (if specified). Skipped
+	// when minBytes == 0.
+	for total < minBytes {
+		if time.Now().After(hard) {
+			t.Fatalf("drainSessionUntilIdle: hard deadline %v elapsed before observing minBytes=%d (got %d) — expected frame did not arrive", hardDeadline, minBytes, total)
+		}
 		_ = conn.SetReadDeadline(time.Now().Add(idleWindow))
 		n, err := conn.Read(buf)
+		total += n
+		if err != nil && !isPipeTimeoutErr(err) {
+			t.Fatalf("drainSessionUntilIdle phase-1 read err: %v (n=%d total=%d)", err, n, total)
+		}
+		// Timeout with n==0 is fine; loop continues waiting for
+		// minBytes within the hard budget.
+	}
+
+	// Phase 2: wait for idleWindow of silence.
+	for {
+		if time.Now().After(hard) {
+			t.Fatalf("drainSessionUntilIdle: hard deadline %v elapsed before observing %v idle window (drained %d bytes total)", hardDeadline, idleWindow, total)
+		}
+		_ = conn.SetReadDeadline(time.Now().Add(idleWindow))
+		n, err := conn.Read(buf)
+		total += n
 		if n > 0 {
-			total += n
+			// More bytes — keep waiting for silence.
 			continue
 		}
-		// Timeout (or other error) with no bytes — idle window
-		// satisfied.
-		_ = err
+		if err != nil && !isPipeTimeoutErr(err) {
+			t.Fatalf("drainSessionUntilIdle phase-2 read err: %v (total=%d)", err, total)
+		}
+		// Timeout with n==0 — idle window satisfied.
 		return total
 	}
-	// Hard deadline hit — pipe wasn't idle for `idleWindow` within
-	// the whole budget. Tests should rarely see this on net.Pipe
-	// + the small frames involved.
-	return total
+}
+
+// isPipeTimeoutErr reports whether the read error is the
+// "deadline exceeded" kind that we treat as a successful idle
+// signal. EOF / closed pipe / other errors are real failures
+// and surface via t.Fatalf in drainSessionUntilIdle.
+func isPipeTimeoutErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	var nerr net.Error
+	if errors.As(err, &nerr) {
+		return nerr.Timeout()
+	}
+	return false
 }
 
 // TestV8Classifier_EnforceMode_AaInjectionDoesNotReachSession is
@@ -357,6 +407,17 @@ func drainSessionUntilIdle(t *testing.T, conn net.Conn, idleWindow, hardDeadline
 //
 // Counter assertions remain as secondary confirmation but the
 // PRIMARY pin is the session-pipe silence.
+//
+// Test setup uses StreamEventFailed (not Started) to drive the
+// FSM into PASSIVE_TRACKING because Failed reliably fans out
+// the winner byte to external sessions (per the phantom-filter
+// test pattern), giving us a concrete frame to wait for before
+// the AA probe. Started would be logged as "stale arbitration
+// response" without a pending bid in this minimal test setup
+// and produce nothing on the session pipe. From the v8
+// classifier's perspective, Started and Failed are semantically
+// equivalent — both trigger fsm.EnterPassiveTracking — so
+// either is fine for the FSM-state precondition.
 func TestV8Classifier_EnforceMode_AaInjectionDoesNotReachSession(t *testing.T) {
 	mux, mock, clientConn, _, cleanup := classifiedTestMuxWithSession(t, v8classifier.ModeEnforce)
 	defer cleanup()
@@ -366,9 +427,11 @@ func TestV8Classifier_EnforceMode_AaInjectionDoesNotReachSession(t *testing.T) {
 		t.Fatal("V8Classifier() = nil in ModeEnforce; want non-nil")
 	}
 
-	// Drive the FSM into mid-frame via Started.
+	// Drive the FSM into mid-frame via Failed (winner byte 0x71
+	// fans out to all external sessions per the mux's Failed
+	// handler, giving us a concrete frame to wait for).
 	mock.eventCh <- transport.StreamEvent{
-		Kind: transport.StreamEventStarted, Data: 0x71,
+		Kind: transport.StreamEventFailed, Data: 0x71,
 	}
 	deadline := time.Now().Add(1 * time.Second)
 	for time.Now().Before(deadline) {
@@ -378,15 +441,20 @@ func TestV8Classifier_EnforceMode_AaInjectionDoesNotReachSession(t *testing.T) {
 		time.Sleep(5 * time.Millisecond)
 	}
 	if got := c.FsmEnterPassiveTotal(); got != 1 {
-		t.Fatalf("FsmEnterPassiveTotal()=%d; want 1 (Started not processed)", got)
+		t.Fatalf("FsmEnterPassiveTotal()=%d; want 1 (Failed not processed)", got)
 	}
 
-	// Drain any frame the session emitted in response to Started
-	// using the event-driven idle-window pattern (per Codex
-	// round-2 MEDIUM on PR #644): read until 50ms of silence,
-	// proving the Started-mirror frame has been fully consumed
-	// from the pipe before we start the AA probe.
-	_ = drainSessionUntilIdle(t, clientConn, 50*time.Millisecond, 500*time.Millisecond)
+	// Drain Failed's session-mirror frame, then wait for idle.
+	// minBytes=1: the mirror produces at least 1 byte (exact
+	// count varies — sometimes 1, sometimes 2 of the ENH-
+	// framed pair depending on read batching). After the first
+	// byte arrives, the 50ms idle-window phase guarantees any
+	// remaining mirror bytes are also consumed before the AA
+	// probe starts. Per Codex round-3 MEDIUM on PR #644: this
+	// closes the race where a late-arriving mirror byte could
+	// have contaminated the probe under the round-2
+	// "idle-only" pattern.
+	_ = drainSessionUntilIdle(t, clientConn, 1, 50*time.Millisecond, 1*time.Second)
 
 	// LOAD-BEARING INJECTION: mid-frame wire AUTO-SYN → FSM emits
 	// DropAaInjection → ModeEnforce returns drop=true → readLoop
@@ -438,6 +506,10 @@ func TestV8Classifier_EnforceMode_AaInjectionDoesNotReachSession(t *testing.T) {
 // This is the pre-promotion validation mode — operators count
 // would-have-dropped vs in-mode dropped before promoting to
 // Enforce.
+//
+// Same test-setup choice as the Enforce sibling: Failed (not
+// Started) drives the FSM to passive tracking AND fans out a
+// concrete mirror frame for the drain helper to wait for.
 func TestV8Classifier_ShadowMode_AaInjectionReachesSession(t *testing.T) {
 	mux, mock, clientConn, _, cleanup := classifiedTestMuxWithSession(t, v8classifier.ModeShadow)
 	defer cleanup()
@@ -448,7 +520,7 @@ func TestV8Classifier_ShadowMode_AaInjectionReachesSession(t *testing.T) {
 	}
 
 	mock.eventCh <- transport.StreamEvent{
-		Kind: transport.StreamEventStarted, Data: 0x71,
+		Kind: transport.StreamEventFailed, Data: 0x71,
 	}
 	deadline := time.Now().Add(1 * time.Second)
 	for time.Now().Before(deadline) {
@@ -458,9 +530,8 @@ func TestV8Classifier_ShadowMode_AaInjectionReachesSession(t *testing.T) {
 		time.Sleep(5 * time.Millisecond)
 	}
 
-	// Drain Started's mirror frame via the event-driven idle
-	// pattern (per Codex round-2 MEDIUM on PR #644).
-	_ = drainSessionUntilIdle(t, clientConn, 50*time.Millisecond, 500*time.Millisecond)
+	// Drain Failed's session-mirror frame, then wait for idle.
+	_ = drainSessionUntilIdle(t, clientConn, 1, 50*time.Millisecond, 1*time.Second)
 
 	mock.eventCh <- transport.StreamEvent{
 		Kind: transport.StreamEventByte, Byte: 0xAA, WasEscaped: false,


### PR DESCRIPTION
## Summary

**The FIRST behavioral B3.x PR.** Previous B3.1-B3.6a established the classifier scaffold, FSM driver, pacer, and admin-channel surface WITHOUT altering the byte stream. B3.6b wires the FSM's `DecisionDropAaInjection` verdict into actual drop behavior in `ModeEnforce`: `Observe` returns `drop=true`, `Mux.readLoop` honors it by skipping the byte's `onReceived` dispatch.

## Behavior matrix

| Mode | FSM verdict | `Observe` return | Mux dispatch | Counter |
|---|---|---|---|---|
| `ModeOff` | (FSM not consulted) | always `false` | proceeds | — |
| `ModeShadow` | `DropAaInjection` | `false` | proceeds | `FsmDropAaInjectionTotal` only |
| `ModeShadow` | `ProtocolFault` | `false` | proceeds | `FsmProtocolFaultTotal` + admin event |
| `ModeShadow` | `Forward` | `false` | proceeds | `FsmForwardTotal` |
| **`ModeEnforce`** | **`DropAaInjection`** | **`true`** | **SKIPPED** ⇐ NEW | `FsmDropAaInjectionTotal` + `EnforceDropsAppliedTotal` |
| `ModeEnforce` | `ProtocolFault` | `false` (per v8 I10) | proceeds + admin event | — |
| `ModeEnforce` | `Forward` | `false` | proceeds | `FsmForwardTotal` |

## Production safety

`V8ClassifierMode` defaults to `ModeOff`. To enable filtering an operator MUST set `HELIANTHUS_V8_CLASSIFIER_MODE=enforce` (or programmatically via `Config`). **Existing deployments are unaffected.**

Recommended rollout: `ModeOff` → `ModeShadow` (validation) → `ModeEnforce` (live filtering). B3.7 will add the shadow-mode divergence comparison that makes validation actionable.

## Counter taxonomy

- `FsmDropAaInjectionTotal`: every FSM `DropAaInjection` verdict, in ANY mode (Shadow counts even though it doesn't enforce).
- `EnforceDropsAppliedTotal` **(NEW)**: subset where `mode == Enforce` AND drop was applied.

During a Shadow validation run, `FsmDropAaInjectionTotal - EnforceDropsAppliedTotal` is the "would have dropped" estimate operators use to project enforce impact.

## Scaffold-only tests replaced

Per the maintainer notes in B3.2/B3.3/B3.4 ("MUST UPDATE OR DELETE when B3.6 wires filtering"), 4 scaffold tests removed and replaced with positive assertions of B3.6b behavior:

| Removed | Added |
|---|---|
| `TestClassifier_Observe_EnforceMode_CountsButDoesNotDropYet` | `TestClassifier_Observe_EnforceMode_IdleStateBytesNotDropped` |
| `TestProvenance_EnforceMode_DoesNotDropYet` | `TestProvenance_EnforceMode_IdleStateAllBytesForwarded` |
| `TestFSM_EnforceMode_DoesNotDropYet` | `TestFSM_EnforceMode_DropsAaInjection` |
| `TestV8Classifier_EnforceMode_InstantiatedAndObservesButDoesNotDrop` | `TestV8Classifier_EnforceMode_AaInjectionSkipsOnReceived` |

Plus 4 new tests for the additional behavioral cases:

- `TestFSM_ShadowMode_AaInjectionCounted_NotDropped` — Shadow counts the FSM verdict but does NOT drop
- `TestFSM_EnforceMode_ProtocolFaultStillForwards` — v8 I10 invariant
- `TestFSM_EnforceMode_LegitimateBytesNotDropped` — payload bytes pass through
- `TestV8Classifier_ShadowMode_AaInjectionForwarded` — mux-level Shadow assertion

## Test plan

- [x] `GOWORK=off go build ./...` — clean
- [x] `GOWORK=off go test ./internal/adaptermux/v8classifier/ -race` — 79 tests (8 new + 4 replaced + 67 prior) green
- [x] `GOWORK=off go test ./internal/adaptermux/ -timeout 600s` — 106s green (legacy tests use default `ModeOff`, behavioral change masked)
- [x] `GOWORK=off go test ./... -timeout 600s` — full gateway suite green
- [x] `GOWORK=off go vet ./...` — clean
- [x] `gofmt -l` — clean

## What this PR does NOT do (remaining B3 work)

- ❌ No pacer wiring at `mux.doSend` (B3.6c — L_rtt side)
- ❌ No pacer wiring at `session.writeLoop` (B3.6d — output pacer)
- ❌ No echo soft/hard timeout admin events (B3.6c)
- ❌ No queue overflow admin events (B3.6c)
- ❌ No shadow-mode divergence comparison (B3.7)

## References

- frame-atomic-visibility-v8 §4 — AA-injection filter
- frame-atomic-visibility-v8 §1.10 — phased rollout order
- frame-atomic-visibility-v8 invariant I1 — admin channel only
- frame-atomic-visibility-v8 invariant I10 — PROTOCOL_FAULT visibility (forward byte + admin event)
- Corrected implementation plan v2.1 — Phase 3 Step B3.6b

🤖 Generated with [Claude Code](https://claude.com/claude-code)