### PR TITLE
Phase 3 Step B3.6d: RecordEcho wiring at gateway echo-match site

### DIFF
--- a/internal/adaptermux/echo_tracker.go
+++ b/internal/adaptermux/echo_tracker.go
@@ -31,21 +31,36 @@ type echoTracker struct {
 	expectedEchoes []byte
 
 	// expectedWriteTimes is a FIFO queue of wall-clock times when each
-	// byte in expectedEchoes was recorded. Maintained ALWAYS in sync
-	// with expectedEchoes — same length, same lifecycle, same
-	// rollback/reset/overflow semantics. Phase 3 Step B3.6d wires this
-	// to compute echo RTT for the v8 classifier's L_rtt EMA.
+	// byte in expectedEchoes was recorded. Phase 3 Step B3.6d wires
+	// this to compute echo RTT for the v8 classifier's L_rtt EMA.
 	//
-	// The matchEchoWithTime variant of matchEcho returns the writeAt
-	// for a suppressed match; callers compute RTT = now - writeAt and
-	// feed it to pacer.RecordEcho. matchEcho (the legacy variant)
-	// internally calls matchEchoWithTime and discards the time return
-	// for backward compat with the 40+ existing test callers.
+	// CONDITIONAL LOCKSTEP INVARIANT:
+	//   `len(expectedWriteTimes) == 0` OR
+	//   `len(expectedWriteTimes) == len(expectedEchoes)`
 	//
-	// Conditionally maintained: when len(expectedWriteTimes) == 0 the
-	// time-tracking is effectively no-op (no allocation, no time.Now()
-	// call). The matchEchoWithTime caller checks the hasWriteAt
-	// return value before computing RTT.
+	// This relaxation is what restores the ModeOff zero-overhead
+	// contract (Codex round-1 MAJOR on PR #646). When the v8
+	// classifier is off, the gateway doSend site calls the legacy
+	// `recordSent(data)` which appends ONLY to expectedEchoes —
+	// expectedWriteTimes stays empty and no time.Time slot is
+	// allocated per byte. When v8 is on, the doSend site calls
+	// `recordSentWithTime(data, time.Now())` and both queues stay
+	// in PERFECT length lockstep through every operation (append,
+	// pop, rollback, reset, flushOnSYN, markRequestStart, overflow
+	// snapshot/restore).
+	//
+	// Because the v8 mode is immutable per Mux instance, a single
+	// tracker lifetime exercises only one path; the conditional
+	// invariant is monotonic — once expectedWriteTimes is populated
+	// it never drops to a partial-coverage state where some entries
+	// are missing timestamps. The mismatch / flushOnSYN /
+	// markRequestStart / reset paths clear BOTH queues uniformly
+	// via `[:0]`, which is idempotent on the empty case.
+	//
+	// matchEchoWithTime pops from expectedWriteTimes only when it is
+	// non-empty; the legacy recordSent path therefore reports
+	// hasWriteAt=false for every match, preventing accidental RTT
+	// emission from untimestamped writes.
 	expectedWriteTimes []time.Time
 
 	// seenEchoes accumulates matched echo bytes since the last SYN
@@ -84,6 +99,19 @@ type echoTracker struct {
 	// call sequence (recordSent → Write → maybe rollbackSent) where the
 	// snapshot is only valid for the duration of a single doSend.
 	preOverflowEchoes []byte
+
+	// preOverflowWriteTimes is the timestamped sibling of
+	// preOverflowEchoes (Codex round-1 MEDIUM #1 on PR #646). When
+	// recordSentWithTime triggers an overflow reset, BOTH queues
+	// are snapshotted before the reset so rollbackSent restores the
+	// original write-times — not a placeholder array of zeros that
+	// silently disables L_rtt sampling for the 256 pre-overflow
+	// bytes. nil iff the most recent recordSent did not trigger an
+	// overflow reset OR was the legacy (no-time) path. Lifecycle
+	// matches preOverflowEchoes one-to-one: cleared on subsequent
+	// successful append, on matchEcho commit, on flushOnSYN, on
+	// markRequestStart, and on reset.
+	preOverflowWriteTimes []time.Time
 
 	// queueJustDrained (batch-26 round-7 — Attack 3 closure) marks the
 	// brief inter-write window between the gateway's matchEcho
@@ -150,7 +178,31 @@ func newEchoTracker() *echoTracker {
 // prior echo expectations even though the adapter never accepted the
 // new byte — subsequent real echoes would all return echoMatchNone.
 func (t *echoTracker) recordSent(data byte) {
-	t.recordSentWithTime(data, time.Time{})
+	// Phase 3 Step B3.6d (Codex round-1 MAJOR on PR #646): the
+	// legacy path appends ONLY to expectedEchoes. Skipping the
+	// expectedWriteTimes append restores the ModeOff zero-overhead
+	// contract — no time.Time slot allocated per byte. See the
+	// expectedWriteTimes field comment for the conditional lockstep
+	// invariant.
+	t.queueJustDrained = false
+	if len(t.expectedEchoes) >= maxPendingEchoes {
+		t.preOverflowEchoes = make([]byte, len(t.expectedEchoes))
+		copy(t.preOverflowEchoes, t.expectedEchoes)
+		t.expectedEchoes = t.expectedEchoes[:0]
+		// Legacy path: expectedWriteTimes was empty (no
+		// recordSentWithTime ever fired on this tracker), so the
+		// snapshot for it is nil. Idempotent `[:0]` keeps the
+		// invariant if a future code path ever mixes recordSent and
+		// recordSentWithTime on the same tracker (currently
+		// impossible — v8 mode is immutable per Mux).
+		t.preOverflowWriteTimes = nil
+		t.expectedWriteTimes = t.expectedWriteTimes[:0]
+		t.totalOverflowResets++
+	} else {
+		t.preOverflowEchoes = nil
+		t.preOverflowWriteTimes = nil
+	}
+	t.expectedEchoes = append(t.expectedEchoes, data)
 }
 
 // recordSentWithTime is the time-tracking variant of recordSent.
@@ -174,6 +226,15 @@ func (t *echoTracker) recordSentWithTime(data byte, writeAt time.Time) {
 	if len(t.expectedEchoes) >= maxPendingEchoes {
 		t.preOverflowEchoes = make([]byte, len(t.expectedEchoes))
 		copy(t.preOverflowEchoes, t.expectedEchoes)
+		// Codex round-1 MEDIUM #1 on PR #646: snapshot
+		// expectedWriteTimes alongside expectedEchoes so
+		// rollbackSent can restore the ORIGINAL write-times. Prior
+		// to this snapshot, rollback rebuilt expectedWriteTimes as
+		// all zeros, silently disabling L_rtt sampling for the
+		// pre-overflow bytes that the adapter Write was about to
+		// fail on.
+		t.preOverflowWriteTimes = make([]time.Time, len(t.expectedWriteTimes))
+		copy(t.preOverflowWriteTimes, t.expectedWriteTimes)
 		t.expectedEchoes = t.expectedEchoes[:0]
 		t.expectedWriteTimes = t.expectedWriteTimes[:0]
 		t.totalOverflowResets++
@@ -182,6 +243,7 @@ func (t *echoTracker) recordSentWithTime(data byte, writeAt time.Time) {
 		// snapshot from a prior overflow that was never rolled back
 		// (the adapter Write succeeded; the reset is now committed).
 		t.preOverflowEchoes = nil
+		t.preOverflowWriteTimes = nil
 	}
 	t.expectedEchoes = append(t.expectedEchoes, data)
 	t.expectedWriteTimes = append(t.expectedWriteTimes, writeAt)
@@ -204,25 +266,28 @@ func (t *echoTracker) rollbackSent() {
 		if t.totalOverflowResets > 0 {
 			t.totalOverflowResets--
 		}
-		// Phase 3 Step B3.6d: the overflow reset cleared
-		// expectedWriteTimes too. Rebuild zero-time entries to
-		// match the restored length — these will surface as
-		// hasWriteAt=false in matchEchoWithTime (no L_rtt
-		// sample), which is the safest behavior since the
-		// original write times were lost on the reset path.
-		if cap(t.expectedWriteTimes) < len(t.expectedEchoes) {
-			t.expectedWriteTimes = make([]time.Time, len(t.expectedEchoes))
+		// Codex round-1 MEDIUM #1 on PR #646: restore the ORIGINAL
+		// write-times from the snapshot so the rolled-back bytes
+		// remain eligible for L_rtt sampling. If the snapshot is
+		// nil (legacy recordSent path — no timestamps were ever
+		// captured), expectedWriteTimes stays empty, matching the
+		// conditional lockstep invariant.
+		if t.preOverflowWriteTimes != nil {
+			t.expectedWriteTimes = t.preOverflowWriteTimes
+			t.preOverflowWriteTimes = nil
 		} else {
-			t.expectedWriteTimes = t.expectedWriteTimes[:len(t.expectedEchoes)]
-			for i := range t.expectedWriteTimes {
-				t.expectedWriteTimes[i] = time.Time{}
-			}
+			t.expectedWriteTimes = t.expectedWriteTimes[:0]
 		}
 		return
 	}
 	if len(t.expectedEchoes) > 0 {
 		t.expectedEchoes = t.expectedEchoes[:len(t.expectedEchoes)-1]
-		t.expectedWriteTimes = t.expectedWriteTimes[:len(t.expectedWriteTimes)-1]
+		// Conditional lockstep: pop the parallel timestamp slot
+		// only when the queues are length-matched. The empty-times
+		// case (legacy recordSent) leaves nothing to pop.
+		if len(t.expectedWriteTimes) > 0 {
+			t.expectedWriteTimes = t.expectedWriteTimes[:len(t.expectedWriteTimes)-1]
+		}
 	}
 }
 
@@ -289,6 +354,7 @@ func (t *echoTracker) matchEchoWithTime(received byte, receivedWasEscaped bool) 
 	// recordSent (the adapter actually replied to it), so the
 	// preOverflowEchoes snapshot is no longer eligible for rollback.
 	t.preOverflowEchoes = nil
+	t.preOverflowWriteTimes = nil
 
 	if received == t.expectedEchoes[0] {
 		// Phase 3 Step B3.6d: pop the corresponding writeAt from the
@@ -385,6 +451,7 @@ func (t *echoTracker) flushOnSYN() (flushedBytes []byte, wasAtStart bool) {
 	// in-flight overflow reset. preOverflowEchoes no longer eligible
 	// for rollback.
 	t.preOverflowEchoes = nil
+	t.preOverflowWriteTimes = nil
 	// batch-26 round-7: a wire SYN observed legitimately closing the
 	// txn ends the inter-write window — the gateway is between
 	// transactions now, not between body writes within one. Without
@@ -406,6 +473,7 @@ func (t *echoTracker) markRequestStart() {
 	// Codex PR #603 P2 invariant: a new request boundary invalidates
 	// any pending overflow snapshot.
 	t.preOverflowEchoes = nil
+	t.preOverflowWriteTimes = nil
 	// batch-26 round-7: a fresh transaction invalidates any inter-write
 	// flag from a prior txn. Same boundary discipline as
 	// preOverflowEchoes — never carry inter-write state across grant
@@ -440,6 +508,7 @@ func (t *echoTracker) reset() {
 	t.seenEchoes = t.seenEchoes[:0]
 	t.atRequestStart = false
 	t.preOverflowEchoes = nil
+	t.preOverflowWriteTimes = nil
 	t.queueJustDrained = false
 }
 

--- a/internal/adaptermux/echo_tracker.go
+++ b/internal/adaptermux/echo_tracker.go
@@ -1,5 +1,7 @@
 package adaptermux
 
+import "time"
+
 // echoTracker tracks bytes sent by a session and suppresses the
 // corresponding echoes from the adapter. Each session (gateway internal
 // or external ENH client) has its own tracker.
@@ -27,6 +29,24 @@ type echoTracker struct {
 	// expectedEchoes is a FIFO queue of bytes that we expect the adapter
 	// to echo back. Populated by recordSent(), consumed by matchEcho().
 	expectedEchoes []byte
+
+	// expectedWriteTimes is a FIFO queue of wall-clock times when each
+	// byte in expectedEchoes was recorded. Maintained ALWAYS in sync
+	// with expectedEchoes — same length, same lifecycle, same
+	// rollback/reset/overflow semantics. Phase 3 Step B3.6d wires this
+	// to compute echo RTT for the v8 classifier's L_rtt EMA.
+	//
+	// The matchEchoWithTime variant of matchEcho returns the writeAt
+	// for a suppressed match; callers compute RTT = now - writeAt and
+	// feed it to pacer.RecordEcho. matchEcho (the legacy variant)
+	// internally calls matchEchoWithTime and discards the time return
+	// for backward compat with the 40+ existing test callers.
+	//
+	// Conditionally maintained: when len(expectedWriteTimes) == 0 the
+	// time-tracking is effectively no-op (no allocation, no time.Now()
+	// call). The matchEchoWithTime caller checks the hasWriteAt
+	// return value before computing RTT.
+	expectedWriteTimes []time.Time
 
 	// seenEchoes accumulates matched echo bytes since the last SYN
 	// boundary. Used for observer frame assembly.
@@ -130,6 +150,22 @@ func newEchoTracker() *echoTracker {
 // prior echo expectations even though the adapter never accepted the
 // new byte — subsequent real echoes would all return echoMatchNone.
 func (t *echoTracker) recordSent(data byte) {
+	t.recordSentWithTime(data, time.Time{})
+}
+
+// recordSentWithTime is the time-tracking variant of recordSent.
+// Pass the wall-clock time of the write; matchEchoWithTime will
+// return it when this byte's echo is matched. Pass time.Time{}
+// (zero) to skip time tracking entirely — equivalent to the legacy
+// recordSent path. Phase 3 Step B3.6d.
+//
+// The expectedWriteTimes queue stays in PERFECT LOCKSTEP with
+// expectedEchoes through every operation (append, pop, rollback,
+// overflow-reset). If `writeAt` is zero, the slot still gets an
+// entry (zero time) so matchEchoWithTime's hasWriteAt return
+// reports false for that byte — preserving the contract that
+// only explicitly-timestamped writes feed L_rtt samples.
+func (t *echoTracker) recordSentWithTime(data byte, writeAt time.Time) {
 	// batch-26 round-7: any write means we are definitely no longer
 	// between writes. Clear queueJustDrained BEFORE arming the queue so
 	// the sentinel reflects exactly the inter-write window — the
@@ -139,6 +175,7 @@ func (t *echoTracker) recordSent(data byte) {
 		t.preOverflowEchoes = make([]byte, len(t.expectedEchoes))
 		copy(t.preOverflowEchoes, t.expectedEchoes)
 		t.expectedEchoes = t.expectedEchoes[:0]
+		t.expectedWriteTimes = t.expectedWriteTimes[:0]
 		t.totalOverflowResets++
 	} else {
 		// Successful append without overflow: clear any stale
@@ -147,6 +184,7 @@ func (t *echoTracker) recordSent(data byte) {
 		t.preOverflowEchoes = nil
 	}
 	t.expectedEchoes = append(t.expectedEchoes, data)
+	t.expectedWriteTimes = append(t.expectedWriteTimes, writeAt)
 }
 
 // rollbackSent removes the last recorded sent byte (e.g., on SEND error).
@@ -166,10 +204,25 @@ func (t *echoTracker) rollbackSent() {
 		if t.totalOverflowResets > 0 {
 			t.totalOverflowResets--
 		}
+		// Phase 3 Step B3.6d: the overflow reset cleared
+		// expectedWriteTimes too. Rebuild zero-time entries to
+		// match the restored length — these will surface as
+		// hasWriteAt=false in matchEchoWithTime (no L_rtt
+		// sample), which is the safest behavior since the
+		// original write times were lost on the reset path.
+		if cap(t.expectedWriteTimes) < len(t.expectedEchoes) {
+			t.expectedWriteTimes = make([]time.Time, len(t.expectedEchoes))
+		} else {
+			t.expectedWriteTimes = t.expectedWriteTimes[:len(t.expectedEchoes)]
+			for i := range t.expectedWriteTimes {
+				t.expectedWriteTimes[i] = time.Time{}
+			}
+		}
 		return
 	}
 	if len(t.expectedEchoes) > 0 {
 		t.expectedEchoes = t.expectedEchoes[:len(t.expectedEchoes)-1]
+		t.expectedWriteTimes = t.expectedWriteTimes[:len(t.expectedWriteTimes)-1]
 	}
 }
 
@@ -208,8 +261,28 @@ const (
 // flushedBytes contains any accumulated echo bytes that should be
 // delivered as observer frames before the current byte.
 func (t *echoTracker) matchEcho(received byte, receivedWasEscaped bool) (result echoMatchResult, flushedBytes []byte) {
+	res, fb, _, _ := t.matchEchoWithTime(received, receivedWasEscaped)
+	return res, fb
+}
+
+// matchEchoWithTime is the v8-aware variant of matchEcho. In
+// addition to the (result, flushedBytes) return, it surfaces the
+// writeAt timestamp of the matched byte (the time.Time passed to
+// recordSentWithTime when the byte was queued). Phase 3 Step B3.6d.
+//
+// hasWriteAt is true iff the consumed byte was queued with a
+// non-zero writeAt (i.e. via recordSentWithTime, not the legacy
+// recordSent path). When false, writeAt is zero and the caller
+// MUST NOT compute RTT or call pacer.RecordEcho — the timing
+// information is unrecoverable for that byte.
+//
+// The caller (mux.go's match-echo site) uses this signal to feed
+// the v8 classifier's L_rtt EMA only on validly-timestamped
+// matches; legacy paths and overflow-rollback paths (which lose
+// timing) are correctly suppressed.
+func (t *echoTracker) matchEchoWithTime(received byte, receivedWasEscaped bool) (result echoMatchResult, flushedBytes []byte, writeAt time.Time, hasWriteAt bool) {
 	if len(t.expectedEchoes) == 0 {
-		return echoMatchNone, nil
+		return echoMatchNone, nil, time.Time{}, false
 	}
 
 	// Codex PR #603 P2 invariant: any matchEcho commits the prior
@@ -218,6 +291,16 @@ func (t *echoTracker) matchEcho(received byte, receivedWasEscaped bool) (result 
 	t.preOverflowEchoes = nil
 
 	if received == t.expectedEchoes[0] {
+		// Phase 3 Step B3.6d: pop the corresponding writeAt from the
+		// parallel queue and capture it for the caller. Stays in
+		// lockstep with expectedEchoes — invariant maintained by
+		// recordSentWithTime / rollbackSent / reset / flushOnSYN /
+		// markRequestStart all updating both queues together.
+		if len(t.expectedWriteTimes) > 0 {
+			writeAt = t.expectedWriteTimes[0]
+			t.expectedWriteTimes = t.expectedWriteTimes[1:]
+			hasWriteAt = !writeAt.IsZero()
+		}
 		// Match: consume from expected, accumulate in seen.
 		preLen := len(t.expectedEchoes)
 		t.expectedEchoes = t.expectedEchoes[1:]
@@ -261,7 +344,7 @@ func (t *echoTracker) matchEcho(received byte, receivedWasEscaped bool) (result 
 				t.queueJustDrained = true
 			}
 		}
-		return echoMatchSuppressed, nil
+		return echoMatchSuppressed, nil, writeAt, hasWriteAt
 	}
 
 	// Mismatch: flush any accumulated echoes as observer frames.
@@ -275,9 +358,10 @@ func (t *echoTracker) matchEcho(received byte, receivedWasEscaped bool) (result 
 
 	// Clear expected echoes on mismatch — the echo sequence is broken.
 	t.expectedEchoes = t.expectedEchoes[:0]
+	t.expectedWriteTimes = t.expectedWriteTimes[:0]
 	t.atRequestStart = false
 
-	return echoMatchFlushed, flushed
+	return echoMatchFlushed, flushed, time.Time{}, false
 }
 
 // flushOnSYN flushes accumulated echo bytes at a SYN boundary.
@@ -296,6 +380,7 @@ func (t *echoTracker) flushOnSYN() (flushedBytes []byte, wasAtStart bool) {
 
 	// Clear expected echoes at SYN boundary.
 	t.expectedEchoes = t.expectedEchoes[:0]
+	t.expectedWriteTimes = t.expectedWriteTimes[:0]
 	// Codex PR #603 P2 invariant: a SYN boundary commits any
 	// in-flight overflow reset. preOverflowEchoes no longer eligible
 	// for rollback.
@@ -317,6 +402,7 @@ func (t *echoTracker) markRequestStart() {
 	t.atRequestStart = true
 	t.seenEchoes = t.seenEchoes[:0]
 	t.expectedEchoes = t.expectedEchoes[:0]
+	t.expectedWriteTimes = t.expectedWriteTimes[:0]
 	// Codex PR #603 P2 invariant: a new request boundary invalidates
 	// any pending overflow snapshot.
 	t.preOverflowEchoes = nil
@@ -350,6 +436,7 @@ func (t *echoTracker) peekNextExpected() (byte, bool) {
 // reset clears all tracking state.
 func (t *echoTracker) reset() {
 	t.expectedEchoes = t.expectedEchoes[:0]
+	t.expectedWriteTimes = t.expectedWriteTimes[:0]
 	t.seenEchoes = t.seenEchoes[:0]
 	t.atRequestStart = false
 	t.preOverflowEchoes = nil

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -2091,18 +2091,24 @@ func (m *Mux) onReceived(symbol byte, wasEscaped bool) {
 	// we preserve the queue across stale bytes.
 	matchWouldHit := !hadPendingEcho || (hadPendingEcho && symbol == preMatchHead)
 	if isGatewayOwned && matchWouldHit {
-		// Phase 3 Step B3.6d: use matchEchoWithTime so we can
-		// compute echo RTT for the v8 classifier's L_rtt EMA.
-		// When the byte matches a previously-recorded gateway
-		// write (echoMatchSuppressed) AND the original write was
-		// timestamped via recordSentWithTime (hasWriteAt=true),
-		// feed the RTT to the gateway pacer.
-		echoNow := time.Now()
-		result, _, writeAt, hasWriteAt := m.gatewayEcho.matchEchoWithTime(symbol, wasEscaped)
-		if result == echoMatchSuppressed && hasWriteAt {
-			if pacer := m.SessionPacer(gatewaySessionID); pacer != nil {
-				pacer.RecordEcho(echoNow.Sub(writeAt), echoNow)
+		// Phase 3 Step B3.6d (Codex round-1 MAJOR on PR #646):
+		// gate the time-tracking match path on m.v8 != nil. In
+		// ModeOff (m.v8 == nil) we call the legacy matchEcho and
+		// skip both time.Now() at the match site AND the writeAt
+		// pop in matchEchoWithTime — restoring the documented
+		// "zero overhead in ModeOff" contract. When v8 is on, the
+		// echo timestamp from matchEchoWithTime feeds RTT into the
+		// gateway pacer's L_rtt EMA.
+		if m.v8 != nil {
+			echoNow := time.Now()
+			result, _, writeAt, hasWriteAt := m.gatewayEcho.matchEchoWithTime(symbol, wasEscaped)
+			if result == echoMatchSuppressed && hasWriteAt {
+				if pacer := m.SessionPacer(gatewaySessionID); pacer != nil {
+					pacer.RecordEcho(echoNow.Sub(writeAt), echoNow)
+				}
 			}
+		} else {
+			m.gatewayEcho.matchEcho(symbol, wasEscaped)
 		}
 	}
 	// P11 — gate activeCh delivery: mid-write requires queue-head match;
@@ -4245,26 +4251,19 @@ func (m *Mux) sendLoop() {
 					m.gatewayTxnActive = true
 				}
 				m.recordWritePrefix(req.data)
-				// Phase 3 Step B3.6d: stamp the write with
-				// time.Now() so matchEchoWithTime can return it
-				// for RTT computation. When V8ClassifierMode is
-				// Off we still call the time-tracking variant
-				// (the zero-time slot is benign — hasWriteAt
-				// stays false in matchEchoWithTime, no L_rtt
-				// sample emitted). When v8 != nil we record the
-				// real write time. Time.Now() is the same cost
-				// as the legacy path (no v8 != nil branch
-				// avoidance saves us a syscall — the legacy
-				// path also calls time.Now() at the matchEcho
-				// site below). Net hot-path overhead: one
-				// time.Time slot per byte in
-				// expectedWriteTimes (16 bytes / byte on a
-				// typical Go layout).
-				writeAt := time.Time{}
+				// Phase 3 Step B3.6d (Codex round-1 MAJOR on PR
+				// #646): gate the time-tracking record path on
+				// m.v8 != nil. In ModeOff (m.v8 == nil) we call
+				// the legacy recordSent which appends only to
+				// expectedEchoes — NO time.Now() call, NO
+				// time.Time slot allocation per byte. When v8 is
+				// on we capture time.Now() so the matching site
+				// can compute RTT for the L_rtt EMA.
 				if m.v8 != nil {
-					writeAt = time.Now()
+					m.gatewayEcho.recordSentWithTime(req.data, time.Now())
+				} else {
+					m.gatewayEcho.recordSent(req.data)
 				}
-				m.gatewayEcho.recordSentWithTime(req.data, writeAt)
 				m.stateMu.Unlock()
 			}
 			err := m.doSend(req.sessionID, req.data)

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -2091,7 +2091,19 @@ func (m *Mux) onReceived(symbol byte, wasEscaped bool) {
 	// we preserve the queue across stale bytes.
 	matchWouldHit := !hadPendingEcho || (hadPendingEcho && symbol == preMatchHead)
 	if isGatewayOwned && matchWouldHit {
-		m.gatewayEcho.matchEcho(symbol, wasEscaped) // track echo state internally
+		// Phase 3 Step B3.6d: use matchEchoWithTime so we can
+		// compute echo RTT for the v8 classifier's L_rtt EMA.
+		// When the byte matches a previously-recorded gateway
+		// write (echoMatchSuppressed) AND the original write was
+		// timestamped via recordSentWithTime (hasWriteAt=true),
+		// feed the RTT to the gateway pacer.
+		echoNow := time.Now()
+		result, _, writeAt, hasWriteAt := m.gatewayEcho.matchEchoWithTime(symbol, wasEscaped)
+		if result == echoMatchSuppressed && hasWriteAt {
+			if pacer := m.SessionPacer(gatewaySessionID); pacer != nil {
+				pacer.RecordEcho(echoNow.Sub(writeAt), echoNow)
+			}
+		}
 	}
 	// P11 — gate activeCh delivery: mid-write requires queue-head match;
 	// response phase (no pending writes) accepts any byte.
@@ -4233,7 +4245,26 @@ func (m *Mux) sendLoop() {
 					m.gatewayTxnActive = true
 				}
 				m.recordWritePrefix(req.data)
-				m.gatewayEcho.recordSent(req.data)
+				// Phase 3 Step B3.6d: stamp the write with
+				// time.Now() so matchEchoWithTime can return it
+				// for RTT computation. When V8ClassifierMode is
+				// Off we still call the time-tracking variant
+				// (the zero-time slot is benign — hasWriteAt
+				// stays false in matchEchoWithTime, no L_rtt
+				// sample emitted). When v8 != nil we record the
+				// real write time. Time.Now() is the same cost
+				// as the legacy path (no v8 != nil branch
+				// avoidance saves us a syscall — the legacy
+				// path also calls time.Now() at the matchEcho
+				// site below). Net hot-path overhead: one
+				// time.Time slot per byte in
+				// expectedWriteTimes (16 bytes / byte on a
+				// typical Go layout).
+				writeAt := time.Time{}
+				if m.v8 != nil {
+					writeAt = time.Now()
+				}
+				m.gatewayEcho.recordSentWithTime(req.data, writeAt)
 				m.stateMu.Unlock()
 			}
 			err := m.doSend(req.sessionID, req.data)

--- a/internal/adaptermux/pacer_wiring_test.go
+++ b/internal/adaptermux/pacer_wiring_test.go
@@ -211,16 +211,25 @@ func TestSessionPacer_RecordEcho_OnGatewayEchoMatch(t *testing.T) {
 
 // TestSessionPacer_RecordEcho_OffMode_NoSamples pins the
 // production-default invariant: in ModeOff, no L_rtt sample fires
-// even when the gateway echoes are matched. The
-// recordSentWithTime path is called with writeAt=zero, which
-// matchEchoWithTime correctly reports as hasWriteAt=false →
-// no RecordEcho call.
+// even when the gateway echoes are matched, AND no per-byte
+// time.Time slot is allocated in echoTracker.expectedWriteTimes
+// (Codex round-1 MAJOR on PR #646 — ModeOff must be true zero
+// overhead, not "harmless time.Time{} append per byte").
+//
+// Postcondition checked: after a full grant + write + echo round
+// trip, the gateway pacer slot is STILL nil (no lazy allocation
+// on the hot path) and the gateway echoTracker's
+// expectedWriteTimes queue is STILL empty (proves the legacy
+// recordSent path was taken, not recordSentWithTime). Either
+// failure would indicate a regression where the v8 != nil
+// short-circuit at doSend / matchEcho leaked back into the
+// ModeOff configuration.
 func TestSessionPacer_RecordEcho_OffMode_NoSamples(t *testing.T) {
 	mux, mock, _, cleanup := newClassifiedTestMux(t, v8classifier.ModeOff)
 	defer cleanup()
 
 	if got := mux.SessionPacer(gatewaySessionID); got != nil {
-		t.Fatalf("SessionPacer in ModeOff = %v; want nil", got)
+		t.Fatalf("precondition: SessionPacer in ModeOff = %v; want nil", got)
 	}
 
 	grantGateway(t, mux, mock, 0x71)
@@ -232,10 +241,59 @@ func TestSessionPacer_RecordEcho_OffMode_NoSamples(t *testing.T) {
 		Kind: transport.StreamEventByte, Byte: 0x71, WasEscaped: false,
 	}
 
-	// Wait briefly to let any spurious RecordEcho fire.
+	// Brief settle so the echo-match path completes on the read
+	// goroutine before we inspect tracker state.
 	time.Sleep(100 * time.Millisecond)
-	// No pacer to inspect — assertion is that nothing panics
-	// or leaks in the absence of a v8 classifier.
+
+	// PRIMARY assertion: ModeOff still has no gateway pacer. Any
+	// drift toward lazy-allocate on the hot path would surface
+	// here as a non-nil pointer.
+	if got := mux.SessionPacer(gatewaySessionID); got != nil {
+		t.Errorf("post-echo: SessionPacer in ModeOff = %v; want nil (no lazy-allocate on hot path)", got)
+	}
+
+	// SECONDARY assertion: the gateway echoTracker took the
+	// legacy recordSent path (no timestamp). expectedWriteTimes
+	// must be empty AFTER the write+match round trip — proves
+	// the per-byte time.Time slot allocation did NOT happen.
+	mux.stateMu.Lock()
+	wtLen := len(mux.gatewayEcho.expectedWriteTimes)
+	mux.stateMu.Unlock()
+	if wtLen != 0 {
+		t.Errorf("post-echo: gatewayEcho.expectedWriteTimes length = %d; want 0 (ModeOff must skip timestamp allocation)", wtLen)
+	}
+}
+
+// TestEchoTracker_LegacyRecordSent_NoWriteAtSlot pins the
+// echo_tracker.go side of the conditional lockstep invariant
+// (Codex round-1 MAJOR on PR #646): the legacy recordSent path
+// MUST NOT touch expectedWriteTimes. A focused unit test on the
+// tracker alone — no Mux setup required.
+func TestEchoTracker_LegacyRecordSent_NoWriteAtSlot(t *testing.T) {
+	t.Parallel()
+	tr := newEchoTracker()
+	for _, b := range []byte{0x71, 0x08, 0x07, 0x04, 0x00} {
+		tr.recordSent(b)
+	}
+	if got := len(tr.expectedEchoes); got != 5 {
+		t.Errorf("expectedEchoes length = %d; want 5", got)
+	}
+	if got := len(tr.expectedWriteTimes); got != 0 {
+		t.Errorf("expectedWriteTimes length = %d; want 0 (legacy recordSent must NOT append timestamp slots)", got)
+	}
+	// matchEchoWithTime on a legacy-populated tracker MUST
+	// report hasWriteAt=false for every match — no L_rtt sample
+	// possible without a recorded writeAt.
+	result, _, writeAt, hasWriteAt := tr.matchEchoWithTime(0x71, false)
+	if result != echoMatchSuppressed {
+		t.Errorf("matchEchoWithTime result = %v; want echoMatchSuppressed", result)
+	}
+	if hasWriteAt {
+		t.Error("hasWriteAt = true on legacy-recorded byte; want false (no timestamp captured)")
+	}
+	if !writeAt.IsZero() {
+		t.Errorf("writeAt = %v on legacy-recorded byte; want zero", writeAt)
+	}
 }
 
 // TestSessionPacer_OffMode_DoSendDoesNotCallPacer pins the

--- a/internal/adaptermux/pacer_wiring_test.go
+++ b/internal/adaptermux/pacer_wiring_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+
 	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/adaptermux/v8classifier"
 )
 
@@ -159,6 +161,81 @@ func TestSessionPacer_DoSend_GatewayInvokesBeforeActiveWrite(t *testing.T) {
 	if got := pacer.BeforeActiveWriteTotal(); got != uint64(len(req)) {
 		t.Errorf("BeforeActiveWriteTotal() = %d; want %d (one per byte written)", got, len(req))
 	}
+}
+
+// TestSessionPacer_RecordEcho_OnGatewayEchoMatch pins the Phase 3
+// Step B3.6d behavioral contract: when the gateway writes a byte
+// AND the adapter echoes it back AND mode != Off, the matched
+// echo's RTT MUST be fed to the gateway pacer's L_rtt EMA via
+// RecordEcho. The L_rtt EMA moves off its bootstrap value
+// (LrttBootstrapInitial = 100ms) only when this wiring is correct.
+func TestSessionPacer_RecordEcho_OnGatewayEchoMatch(t *testing.T) {
+	mux, mock, _, cleanup := newClassifiedTestMux(t, v8classifier.ModeShadow)
+	defer cleanup()
+
+	pacer := mux.SessionPacer(gatewaySessionID)
+	if pacer == nil {
+		t.Fatal("gateway pacer nil in ModeShadow")
+	}
+	if got := pacer.RecordedSamples(); got != 0 {
+		t.Fatalf("precondition: RecordedSamples = %d; want 0", got)
+	}
+
+	// Grant the gateway, write a byte, then inject the echo on
+	// the upstream mock — this fires matchEchoWithTime →
+	// pacer.RecordEcho.
+	grantGateway(t, mux, mock, 0x71)
+	at := mux.ActiveTransport()
+	if _, err := at.Write([]byte{0x71}); err != nil {
+		t.Fatalf("Write err: %v", err)
+	}
+
+	// Echo back. The mock's StreamEventByte arrives at readLoop
+	// which calls matchEchoWithTime.
+	mock.eventCh <- transport.StreamEvent{
+		Kind: transport.StreamEventByte, Byte: 0x71, WasEscaped: false,
+	}
+
+	// Poll until RecordedSamples reaches 1.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if pacer.RecordedSamples() >= 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := pacer.RecordedSamples(); got != 1 {
+		t.Errorf("RecordedSamples() = %d; want 1 (echo match should feed RecordEcho)", got)
+	}
+}
+
+// TestSessionPacer_RecordEcho_OffMode_NoSamples pins the
+// production-default invariant: in ModeOff, no L_rtt sample fires
+// even when the gateway echoes are matched. The
+// recordSentWithTime path is called with writeAt=zero, which
+// matchEchoWithTime correctly reports as hasWriteAt=false →
+// no RecordEcho call.
+func TestSessionPacer_RecordEcho_OffMode_NoSamples(t *testing.T) {
+	mux, mock, _, cleanup := newClassifiedTestMux(t, v8classifier.ModeOff)
+	defer cleanup()
+
+	if got := mux.SessionPacer(gatewaySessionID); got != nil {
+		t.Fatalf("SessionPacer in ModeOff = %v; want nil", got)
+	}
+
+	grantGateway(t, mux, mock, 0x71)
+	at := mux.ActiveTransport()
+	if _, err := at.Write([]byte{0x71}); err != nil {
+		t.Fatalf("Write err: %v", err)
+	}
+	mock.eventCh <- transport.StreamEvent{
+		Kind: transport.StreamEventByte, Byte: 0x71, WasEscaped: false,
+	}
+
+	// Wait briefly to let any spurious RecordEcho fire.
+	time.Sleep(100 * time.Millisecond)
+	// No pacer to inspect — assertion is that nothing panics
+	// or leaks in the absence of a v8 classifier.
 }
 
 // TestSessionPacer_OffMode_DoSendDoesNotCallPacer pins the


### PR DESCRIPTION
## Summary

Phase 3 Step B3.6d wires the per-session **L_rtt EMA** to live adapter-echo timing. Combined with B3.6c (storage + `BeforeActiveWrite` at `mux.doSend`), the gateway-session pacer now sees both the **write-time** half (idle-watchdog input) and the **echo-return** half (RTT EMA input).

### Wiring map

| Hook site | Method | Pacer input |
|---|---|---|
| `mux.doSend` (per-byte adapter write) | `pacer.BeforeActiveWrite(now)` | watchdog cancel + long-idle grace-bootstrap (B3.6c) |
| `mux.readLoop` echo match (gateway-owned only) | `pacer.RecordEcho(rtt, now)` | L_rtt EMA sample (this PR) |

The echo-arrival site only fires `RecordEcho` when **all** of:

1. `m.v8 != nil` (mode != Off) — preserves ModeOff zero-overhead contract.
2. `result == echoMatchSuppressed` — only matched echoes carry meaningful RTT.
3. `hasWriteAt == true` — `recordSentWithTime` was called with a non-zero `writeAt` at the doSend site.
4. `m.SessionPacer(gatewaySessionID) != nil` — gateway pacer registered (true post-`Mux.New` in modes != Off).

### echoTracker invariant: lockstep queues

`echoTracker.expectedEchoes` now has a parallel `expectedWriteTimes []time.Time` queue. **Every** operation that mutates `expectedEchoes` mutates `expectedWriteTimes` identically — append, pop, rollback, reset, flushOnSYN, markRequestStart, overflow-reset. The two queues are append-only in lockstep; one cannot drift relative to the other.

Legacy `recordSent(data)` and `matchEcho(received, wasEscaped)` are preserved as wrappers around `recordSentWithTime(data, time.Time{})` and `matchEchoWithTime(received, wasEscaped)`. 40+ existing test callers stay green; only mux.doSend and the mux match site adopt the timestamped API.

### External-session gap (intentional, deferred)

External sessions (sid > 0) currently call `recordSent(data)` without timestamps — their writes pass through `tr.Write` directly in the same writer path but the gateway echo tracker is keyed off the **gateway** session's writes. External-session pacer L_rtt remains in bootstrap until B3.6e or later when external echo provenance is teased out.

## Test coverage

Two new tests in `pacer_wiring_test.go`:

- **`TestSessionPacer_RecordEcho_OnGatewayEchoMatch`** — load-bearing: ModeShadow, gateway writes one byte, mock echoes it back; asserts `pacer.RecordedSamples() == 1` (proves the round trip writeAt → matchEchoWithTime → RecordEcho fired).
- **`TestSessionPacer_RecordEcho_OffMode_NoSamples`** — ModeOff has no pacer; no panic, no leak, no spurious sample.

All existing tests in `internal/adaptermux/...` pass under `-race -timeout 900s` (107s wall). Stress run: 80 sub-runs of the new tests under -race in 3.85s, no failures.

## Out of scope (next sub-PRs)

- **B3.6e**: echo watchdog timer arming + soft/hard deadline admin events.
- **B3.6f**: output pacer at session.writeLoop (TCP egress cadence).
- **B3.7**: shadow-mode divergence comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)