### PR TITLE
Phase 3 Step B3.6e: echo watchdog timer + soft/hard deadline admin events

### DIFF
--- a/internal/adaptermux/diag.go
+++ b/internal/adaptermux/diag.go
@@ -335,36 +335,36 @@ func (m *Mux) ActiveTxnSnapshot() ActiveTxnSnapshot {
 	rp := make([]byte, m.activeTxn.readPrefixLen)
 	copy(rp, m.activeTxn.readPrefix[:m.activeTxn.readPrefixLen])
 	return ActiveTxnSnapshot{
-		ID:                          m.activeTxn.id,
-		Initiator:                   m.activeTxn.initiator,
-		GrantedAt:                   m.activeTxn.grantedAt,
-		InactiveAt:                  m.activeTxn.inactiveAt,
-		InactiveReason:              m.activeTxn.inactiveReas,
-		DrainedOnGrant:              m.activeTxn.drainedOnGrant,
-		Active:                      m.gatewayTxnActive,
-		BytesWritten:                m.activeTxn.bytesWritten.Load(),
-		BytesRead:                   m.activeTxn.bytesRead.Load(),
-		GrantsTotal:                 m.activeTxn.grantsTotal.Load(),
-		WriteErrTotal:               m.activeTxn.writeErrTotal.Load(),
-		ReadTimeoutTot:              m.activeTxn.readTimeoutTot.Load(),
-		AfterInactive:               m.activeTxn.afterInactive.Load(),
-		TerminatorDropOnFullCh:      m.activeTxn.terminatorDropOnFullCh.Load(),
+		ID:                                 m.activeTxn.id,
+		Initiator:                          m.activeTxn.initiator,
+		GrantedAt:                          m.activeTxn.grantedAt,
+		InactiveAt:                         m.activeTxn.inactiveAt,
+		InactiveReason:                     m.activeTxn.inactiveReas,
+		DrainedOnGrant:                     m.activeTxn.drainedOnGrant,
+		Active:                             m.gatewayTxnActive,
+		BytesWritten:                       m.activeTxn.bytesWritten.Load(),
+		BytesRead:                          m.activeTxn.bytesRead.Load(),
+		GrantsTotal:                        m.activeTxn.grantsTotal.Load(),
+		WriteErrTotal:                      m.activeTxn.writeErrTotal.Load(),
+		ReadTimeoutTot:                     m.activeTxn.readTimeoutTot.Load(),
+		AfterInactive:                      m.activeTxn.afterInactive.Load(),
+		TerminatorDropOnFullCh:             m.activeTxn.terminatorDropOnFullCh.Load(),
 		SynSuppressedPreEcho:               m.activeTxn.synSuppressedPreEcho.Load(),
 		SynSeenDuringGrantWindow:           m.activeTxn.synSeenDuringGrantWindow.Load(),
 		SynSeenWhileInterWriteEmpty:        m.activeTxn.synSeenWhileInterWriteEmpty.Load(),
 		SynSeenAfterTransportWindowExpired: m.activeTxn.synSeenAfterTransportWindowExpired.Load(),
 		SynSuppressedBetweenWrites:         m.activeTxn.synSuppressedBetweenWrites.Load(),
-		InterWriteDrainTotal:        m.activeTxn.interWriteDrainTotal.Load(),
-		EchoQueueOverflowResets:     m.gatewayEcho.overflowResets(),
-		BytesDeliveredToActive:      m.activeTxn.bytesDeliveredToActive.Load(),
-		AbsorbResetTotal:            m.absorbResetTotal.Load(),
-		WritePrefix:                 wp,
-		ReadPrefix:                  rp,
-		EchoLike:                    m.activeTxn.echoLike.Load(),
-		NonEcho:                     m.activeTxn.nonEcho.Load(),
-		SynMarkers:                  m.activeTxn.synMarkers.Load(),
-		TxnClass:                    m.activeTxn.txnClass,
-		LastTxnClass:                m.activeTxn.lastClass,
+		InterWriteDrainTotal:               m.activeTxn.interWriteDrainTotal.Load(),
+		EchoQueueOverflowResets:            m.gatewayEcho.overflowResets(),
+		BytesDeliveredToActive:             m.activeTxn.bytesDeliveredToActive.Load(),
+		AbsorbResetTotal:                   m.absorbResetTotal.Load(),
+		WritePrefix:                        wp,
+		ReadPrefix:                         rp,
+		EchoLike:                           m.activeTxn.echoLike.Load(),
+		NonEcho:                            m.activeTxn.nonEcho.Load(),
+		SynMarkers:                         m.activeTxn.synMarkers.Load(),
+		TxnClass:                           m.activeTxn.txnClass,
+		LastTxnClass:                       m.activeTxn.lastClass,
 	}
 }
 
@@ -429,37 +429,91 @@ func (m *Mux) recordGatewayGrant(initiator byte, drained int) {
 // markActiveReadTimeout clears gatewayTxnActive with ReasonActiveReadTimeout.
 // Called from activeTransport.ReadByte/ReadEvent when the read times out.
 // Acquires stateMu internally. Caller must NOT hold stateMu.
+//
+// Codex round-2 MUST FIX on PR #647: if the transition fires AND
+// V8ClassifierMode != Off, the watchdog is cancelled outside stateMu
+// (pacer mutex is independent; nested-lock free). Closes the
+// stale-fire window where an armed watchdog would otherwise emit an
+// EchoSoftTimeout / EchoHardTimeout admin event for a write whose
+// active transaction was just torn down by the active-read-timeout
+// boundary.
 func (m *Mux) markActiveReadTimeout() {
 	m.stateMu.Lock()
+	transitioned := false
 	if m.gatewayTxnActive {
 		m.gatewayTxnActive = false
 		m.recordGatewayInactive(ReasonActiveReadTimeout)
+		transitioned = true
 	}
 	m.stateMu.Unlock()
+	if transitioned {
+		m.cancelGatewayWatchdog()
+	}
 }
 
 // markActiveWriteError clears gatewayTxnActive with ReasonActiveWriteError.
 // Called from activeTransport.Write when sendLoop returns an error.
 // Acquires stateMu internally. Caller must NOT hold stateMu.
+//
+// Codex round-2 MUST FIX on PR #647: same cancel-after-unlock
+// pattern as markActiveReadTimeout. Mirror of the doSend defer
+// cancel (which fires on the immediate write-error path); this
+// helper is called for write errors propagated UP from sendLoop's
+// error channel to activeTransport.Write callers, which can
+// happen even if doSend's own cancel already fired (the cancel
+// is idempotent so the second invocation is a no-op).
 func (m *Mux) markActiveWriteError() {
 	m.stateMu.Lock()
+	transitioned := false
 	if m.gatewayTxnActive {
 		m.gatewayTxnActive = false
 		m.recordGatewayInactive(ReasonActiveWriteError)
+		transitioned = true
 	}
 	m.stateMu.Unlock()
+	if transitioned {
+		m.cancelGatewayWatchdog()
+	}
 }
 
 // markActiveContextCancel clears gatewayTxnActive with ReasonContextCancel.
 // Called from activeTransport Read/Write when ctx.Done() fires.
 // Acquires stateMu internally. Caller must NOT hold stateMu.
+//
+// Codex round-2 MUST FIX on PR #647: same cancel-after-unlock
+// pattern. Context cancellation tears down the active transaction;
+// any pending echo watchdog is no longer meaningful.
 func (m *Mux) markActiveContextCancel() {
 	m.stateMu.Lock()
+	transitioned := false
 	if m.gatewayTxnActive {
 		m.gatewayTxnActive = false
 		m.recordGatewayInactive(ReasonContextCancel)
+		transitioned = true
 	}
 	m.stateMu.Unlock()
+	if transitioned {
+		m.cancelGatewayWatchdog()
+	}
+}
+
+// cancelGatewayWatchdog is the private helper used by all gateway
+// ownership / active-txn teardown paths to cancel any pending
+// echo watchdog. Codex round-2 MUST FIX on PR #647 + round-3
+// MUST FIX expansion: every site that clears gatewayTxnActive or
+// releases gateway ownership invokes this so a stale soft/hard
+// fire cannot emit an admin event for a write whose context is
+// gone.
+//
+// Safe to call when V8ClassifierMode == Off (SessionPacer
+// returns nil; the call is a no-op). Caller MUST NOT hold
+// stateMu — CancelEchoWatchdog uses the pacer's own mutex, which
+// is independent from stateMu (nested-lock free either order),
+// but callers should avoid nesting by convention.
+func (m *Mux) cancelGatewayWatchdog() {
+	if pacer := m.SessionPacer(gatewaySessionID); pacer != nil {
+		pacer.CancelEchoWatchdog()
+	}
 }
 
 // recordGatewayInactive marks the gateway transaction as inactive with

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -2032,7 +2032,8 @@ func (m *Mux) onReceived(symbol byte, wasEscaped bool) {
 		// gatewayTxnActive=false is the correct state for delivery —
 		// capture AFTER to skip the trailing SYN that has no consumer.
 		var preEchoSuppressed bool
-		passiveEvents, shouldTryGrant, preEchoSuppressed = m.onSYNLocked(phaseEvent, ownerID, hasOwner, now)
+		var cancelGatewayWatchdogFromSYN bool
+		passiveEvents, shouldTryGrant, preEchoSuppressed, cancelGatewayWatchdogFromSYN = m.onSYNLocked(phaseEvent, ownerID, hasOwner, now)
 		activeExpects := m.activePathExpectsByte(symbol)
 		if preEchoSuppressed {
 			// Pre-echo SYN suppression (echo_mismatch root cause fix).
@@ -2057,10 +2058,10 @@ func (m *Mux) onReceived(symbol byte, wasEscaped bool) {
 		// Codex round-2 MUST FIX on PR #647: if the gateway lost
 		// ownership via max-duration timeout while a watchdog was
 		// armed, the echo will never arrive — cancel.
-		if ownershipTimedOutGateway {
-			if pacer := m.SessionPacer(gatewaySessionID); pacer != nil {
-				pacer.CancelEchoWatchdog()
-			}
+		// Codex round-3 MUST FIX #1: same for SYN-timeout /
+		// SYN-idle teardown branches inside onSYNLocked.
+		if ownershipTimedOutGateway || cancelGatewayWatchdogFromSYN {
+			m.cancelGatewayWatchdog()
 		}
 
 		// --- Phase 2: deliver outside all locks ---
@@ -2315,8 +2316,15 @@ func (m *Mux) onReceived(symbol byte, wasEscaped bool) {
 // and whether this SYN is pre-echo noise that the caller must suppress
 // from activeCh delivery (see echo_mismatch root-cause comment at the
 // call site).
-func (m *Mux) onSYNLocked(phaseEvent wirePhaseEvent, ownerID uint64, hasOwner bool, now time.Time) ([]PassiveEvent, bool, bool) {
+// Codex round-3 MUST FIX #1 on PR #647: returns an additional
+// `cancelGatewayWatchdog` bool. When true, the caller MUST invoke
+// m.cancelGatewayWatchdog() after releasing stateMu — set by the
+// SYN-timeout / SYN-idle teardown branches inside onSYNLocked
+// when they transition the gateway out of an active txn, so the
+// echo watchdog cannot fire stale after the txn is gone.
+func (m *Mux) onSYNLocked(phaseEvent wirePhaseEvent, ownerID uint64, hasOwner bool, now time.Time) ([]PassiveEvent, bool, bool, bool) {
 	var passiveEvents []PassiveEvent
+	var cancelGatewayWatchdog bool
 
 	// F-24-fix (Codex PR #634 P1 thread "Wait for idle after
 	// suppressing stale STARTED"): any SYN observation marks a bus-
@@ -2603,6 +2611,13 @@ func (m *Mux) onSYNLocked(phaseEvent wirePhaseEvent, ownerID uint64, hasOwner bo
 			if ownerID == gatewaySessionID && m.gatewayTxnActive {
 				m.gatewayTxnActive = false
 				m.recordGatewayInactive(ReasonSYNTimeout)
+				// Codex round-3 MUST FIX #1 on PR #647: signal
+				// the caller (onReceived SYN branch at line ~2035)
+				// to cancel the gateway echo watchdog after
+				// releasing stateMu. The teardown path released
+				// gateway ownership; an armed watchdog must not
+				// emit a stale soft/hard event for the lost txn.
+				cancelGatewayWatchdog = true
 			}
 		}
 	}
@@ -2738,6 +2753,12 @@ func (m *Mux) onSYNLocked(phaseEvent wirePhaseEvent, ownerID uint64, hasOwner bo
 				m.gatewayEcho.ClearQueueJustDrained()
 				m.gatewayTxnActive = false
 				m.recordGatewayInactive(ReasonSYNIdle)
+				// Codex round-3 MUST FIX #1 on PR #647: same as
+				// SYN timeout above — flag the caller to cancel
+				// the watchdog after stateMu unlock so a stale
+				// timer fire cannot emit an admin event for the
+				// torn-down txn.
+				cancelGatewayWatchdog = true
 			}
 		}
 	}
@@ -2891,7 +2912,7 @@ func (m *Mux) onSYNLocked(phaseEvent wirePhaseEvent, ownerID uint64, hasOwner bo
 	// onReceived), so with gatewayTxnActive cleared it becomes false and
 	// the caller's deliverToActive is skipped. No double-delivery.
 	_ = terminatorDelivered
-	return passiveEvents, shouldTryGrant, preEchoSuppressed
+	return passiveEvents, shouldTryGrant, preEchoSuppressed, cancelGatewayWatchdog
 }
 
 // handleReset handles an adapter RESETTED event.

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -4290,7 +4290,27 @@ func (m *Mux) sendLoop() {
 				if m.v8 != nil {
 					writeAt := time.Now()
 					m.gatewayEcho.recordSentWithTime(req.data, writeAt)
+					// Codex round-1 MAJOR #1 on PR #647:
+					// BeforeActiveWrite MUST run before
+					// ArmEchoWatchdog so a long-idle gateway
+					// write enters grace-bootstrap (graceRemaining
+					// set non-zero) before the watchdog computes
+					// deadlines from EchoDeadlines. Without this
+					// hoist, the arm at the sendLoop site used
+					// pre-grace L_rtt state — the first
+					// post-idle echo was waited on with normal
+					// (tight) deadlines instead of grace (loose),
+					// defeating the B3.5 grace-bootstrap fix.
+					//
+					// BeforeActiveWrite is idempotent if called
+					// twice before any RecordEcho (per its
+					// docstring), so doSend's existing
+					// BeforeActiveWrite call below remains
+					// harmless for non-gateway sessions and is a
+					// no-op for the gateway pacer at the second
+					// invocation.
 					if pacer := m.SessionPacer(gatewaySessionID); pacer != nil {
+						pacer.BeforeActiveWrite(writeAt)
 						pacer.ArmEchoWatchdog(writeAt)
 					}
 				} else {
@@ -4328,6 +4348,19 @@ func (m *Mux) doSend(sessionID uint64, data byte) error {
 		}
 		m.gatewayEcho.rollbackSent()
 		m.stateMu.Unlock()
+		// Codex round-1 MUST FIX #2 on PR #647: write-error
+		// rollback must ALSO cancel the watchdog the sendLoop
+		// armed before doSend. Without this, the soft / hard
+		// timer would fire later and emit a stale admin event
+		// for a byte that never reached the adapter. The pacer
+		// comment lists write-fail as a documented cancellation
+		// boundary; this call closes that path.
+		//
+		// Outside stateMu — CancelEchoWatchdog uses the pacer's
+		// own mutex; nested-lock free.
+		if pacer := m.SessionPacer(gatewaySessionID); pacer != nil {
+			pacer.CancelEchoWatchdog()
+		}
 	}()
 
 	if !m.arb.isOwner(sessionID) {
@@ -4363,18 +4396,28 @@ func (m *Mux) doSend(sessionID uint64, data byte) error {
 	// BEFORE the first post-idle echo is awaited. Skipped when
 	// V8ClassifierMode == Off (SessionPacer returns nil).
 	//
+	// Codex round-1 MAJOR #1 on PR #647: for GATEWAY sessions the
+	// sendLoop now invokes BeforeActiveWrite BEFORE ArmEchoWatchdog
+	// (so the watchdog sees post-grace L_rtt). To preserve the
+	// canonical "exactly one BeforeActiveWrite per active write"
+	// semantics (asserted by TestSessionPacer_DoSend_GatewayInvokesBeforeActiveWrite),
+	// gateway sessions skip the doSend call. External sessions
+	// (sessionID > 0) still take the doSend path — they don't go
+	// through sendLoop's gateway-only critical section, so this is
+	// their canonical site.
+	//
 	// Pacer integration plan (B3.6c..B3.6f):
-	//   B3.6c (THIS PR): BeforeActiveWrite at the doSend pre-Write
-	//                    hot path. Grace-bootstrap accounted, but
-	//                    no L_rtt EMA samples yet, no enforced
-	//                    deadlines.
-	//   B3.6d:           RecordEcho wiring at the echo-arrival site
-	//                    so the L_rtt EMA actually moves.
-	//   B3.6e:           Echo watchdog timer enforcing soft/hard
-	//                    deadlines + admin events.
-	//   B3.6f:           Output pacer at session.writeLoop.
-	if pacer := m.SessionPacer(sessionID); pacer != nil {
-		pacer.BeforeActiveWrite(time.Now())
+	//   B3.6c: BeforeActiveWrite at the active-write pre-Write
+	//          hot path (sendLoop for gateway; doSend for external).
+	//   B3.6d: RecordEcho wiring at the echo-arrival site
+	//          so the L_rtt EMA actually moves.
+	//   B3.6e: Echo watchdog timer enforcing soft/hard
+	//          deadlines + admin events (gateway only).
+	//   B3.6f: Output pacer at session.writeLoop.
+	if !isGateway {
+		if pacer := m.SessionPacer(sessionID); pacer != nil {
+			pacer.BeforeActiveWrite(time.Now())
+		}
 	}
 	_, err := tr.Write([]byte{data})
 	if err != nil {

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -779,7 +779,13 @@ func (m *Mux) ensureSessionPacer(sessionID uint64) {
 	if _, ok := m.sessionPacers.Load(sessionID); ok {
 		return
 	}
-	m.sessionPacers.LoadOrStore(sessionID, v8classifier.NewPacer())
+	// Phase 3 Step B3.6e: use NewPacerForSession so the per-session
+	// pacer's echo watchdog has its admin-event emitter pre-wired
+	// to the classifier's adminEvents ring buffer. Falling back to
+	// v8classifier.NewPacer here would leave the watchdog firing
+	// silently — counters increment, but operator-facing
+	// ClassifierAdminEvent entries would never appear.
+	m.sessionPacers.LoadOrStore(sessionID, m.v8.NewPacerForSession())
 }
 
 // Start connects to the adapter and begins the multiplexer loop.
@@ -2099,12 +2105,22 @@ func (m *Mux) onReceived(symbol byte, wasEscaped bool) {
 		// "zero overhead in ModeOff" contract. When v8 is on, the
 		// echo timestamp from matchEchoWithTime feeds RTT into the
 		// gateway pacer's L_rtt EMA.
+		//
+		// Phase 3 Step B3.6e: on a suppressed (matched) echo,
+		// cancel the echo-watchdog timer that doSend armed —
+		// otherwise a delayed soft/hard fire would spuriously
+		// emit an admin event for a write whose echo already
+		// landed. CancelEchoWatchdog is idempotent and lock-free
+		// from the caller's perspective.
 		if m.v8 != nil {
 			echoNow := time.Now()
 			result, _, writeAt, hasWriteAt := m.gatewayEcho.matchEchoWithTime(symbol, wasEscaped)
-			if result == echoMatchSuppressed && hasWriteAt {
+			if result == echoMatchSuppressed {
 				if pacer := m.SessionPacer(gatewaySessionID); pacer != nil {
-					pacer.RecordEcho(echoNow.Sub(writeAt), echoNow)
+					pacer.CancelEchoWatchdog()
+					if hasWriteAt {
+						pacer.RecordEcho(echoNow.Sub(writeAt), echoNow)
+					}
 				}
 			}
 		} else {
@@ -4259,8 +4275,24 @@ func (m *Mux) sendLoop() {
 				// time.Time slot allocation per byte. When v8 is
 				// on we capture time.Now() so the matching site
 				// can compute RTT for the L_rtt EMA.
+				//
+				// Phase 3 Step B3.6e: when v8 is on, ALSO arm the
+				// echo-watchdog using the (soft, hard, hardEnabled)
+				// tuple from the gateway pacer's EchoDeadlines.
+				// BeforeActiveWrite (B3.6c) was already called
+				// earlier at the doSend pre-write hook; the
+				// watchdog is armed here using the post-grace
+				// L_rtt state. If the echo arrives in time, the
+				// match site cancels the watchdog. If the soft
+				// (and conditionally hard) deadline expires
+				// first, the pacer emits an admin event into the
+				// classifier's adminEvents ring buffer.
 				if m.v8 != nil {
-					m.gatewayEcho.recordSentWithTime(req.data, time.Now())
+					writeAt := time.Now()
+					m.gatewayEcho.recordSentWithTime(req.data, writeAt)
+					if pacer := m.SessionPacer(gatewaySessionID); pacer != nil {
+						pacer.ArmEchoWatchdog(writeAt)
+					}
 				} else {
 					m.gatewayEcho.recordSent(req.data)
 				}

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -896,6 +896,16 @@ func (m *Mux) Close() error {
 		}
 		m.connMu.Unlock()
 
+		// Codex round-2 MUST FIX on PR #647: cancel any pending
+		// gateway echo watchdog. Close is the strongest teardown
+		// boundary; an armed watchdog could otherwise fire a soft
+		// or hard timeout admin event AFTER Close returned, which
+		// would surface as a phantom event on a mux that has
+		// already shut down.
+		if pacer := m.SessionPacer(gatewaySessionID); pacer != nil {
+			pacer.CancelEchoWatchdog()
+		}
+
 		m.wg.Wait()
 	})
 	return m.closeErr
@@ -1301,6 +1311,13 @@ func (m *Mux) reconnect() error {
 		m.gatewayTxnActive = false
 		m.recordGatewayInactive(ReasonReconnect)
 	}
+	// Codex round-2 MUST FIX on PR #647: reconnect tears down
+	// gateway echo state — the in-flight watchdog is no longer
+	// meaningful (the byte's echo will never arrive over the
+	// replaced transport). Cancel here, NOT inside the SessionPacer
+	// nil-check block above — the cancel call uses the pacer's
+	// own mutex (independent of stateMu) and is nested-lock free.
+	pacerToCancel := m.SessionPacer(gatewaySessionID)
 	// Bump gen forward (monotonic) — any in-flight goroutine's captured
 	// arbGen will no longer match, so it cannot clear blockingArbActive.
 	// Clear blockingArbActive here because the transport is being replaced.
@@ -1324,6 +1341,12 @@ func (m *Mux) reconnect() error {
 		pendingToCancel.deadline.Stop() // AM8: cancel deadline timer
 	}
 	m.stateMu.Unlock()
+
+	// Cancel the pacer watchdog OUTSIDE stateMu (Codex round-2
+	// MUST FIX on PR #647 — see captured pacerToCancel above).
+	if pacerToCancel != nil {
+		pacerToCancel.CancelEchoWatchdog()
+	}
 
 	// Cancel in-flight pending START if any.
 	if pendingToCancel != nil {
@@ -1455,6 +1478,7 @@ func (m *Mux) readLoop() {
 				// Enforce ownership timeout on quiet bus — onReceived
 				// won't run to check MaxOwnershipDuration.
 				quietBusTimedOut := false
+				var quietBusOwnerWasGateway bool
 				m.stateMu.Lock()
 				ownerID, _, hasOwner := m.arb.owner()
 				if hasOwner && !m.busOwned.IsZero() &&
@@ -1464,10 +1488,22 @@ func (m *Mux) readLoop() {
 					if ownerID == gatewaySessionID && m.gatewayTxnActive {
 						m.gatewayTxnActive = false
 						m.recordGatewayInactive(ReasonMaxOwnership)
+						quietBusOwnerWasGateway = true
 					}
 					quietBusTimedOut = true
 				}
 				m.stateMu.Unlock()
+				// Codex round-2 MUST FIX on PR #647: if the
+				// gateway lost ownership via max-duration timeout
+				// while a watchdog was armed, the echo will never
+				// arrive on this transport instance — cancel so
+				// no stale soft/hard fire emits an admin event
+				// for a write whose context is gone.
+				if quietBusOwnerWasGateway {
+					if pacer := m.SessionPacer(gatewaySessionID); pacer != nil {
+						pacer.CancelEchoWatchdog()
+					}
+				}
 
 				// F-18: per-session echo trackers removed; nothing to
 				// reset for external sessions on ownership timeout.
@@ -1961,6 +1997,7 @@ func (m *Mux) onReceived(symbol byte, wasEscaped bool) {
 	// AM11: track ownership timeout so we can reset external session
 	// echo trackers after releasing stateMu (ABBA avoidance).
 	ownershipTimedOut := false
+	var ownershipTimedOutGateway bool
 	if hasOwner && !m.busOwned.IsZero() &&
 		time.Since(m.busOwned) > m.cfg.MaxOwnershipDuration {
 		m.arb.releaseOwnership(ownerID)
@@ -1968,6 +2005,7 @@ func (m *Mux) onReceived(symbol byte, wasEscaped bool) {
 		if ownerID == gatewaySessionID && m.gatewayTxnActive {
 			m.gatewayTxnActive = false
 			m.recordGatewayInactive(ReasonMaxOwnership)
+			ownershipTimedOutGateway = true
 		}
 		hasOwner = false
 		ownershipTimedOut = true
@@ -2016,6 +2054,14 @@ func (m *Mux) onReceived(symbol byte, wasEscaped bool) {
 		// to perform. Gateway-side echo handling continues unchanged
 		// via m.gatewayEcho.
 		_ = ownershipTimedOut
+		// Codex round-2 MUST FIX on PR #647: if the gateway lost
+		// ownership via max-duration timeout while a watchdog was
+		// armed, the echo will never arrive — cancel.
+		if ownershipTimedOutGateway {
+			if pacer := m.SessionPacer(gatewaySessionID); pacer != nil {
+				pacer.CancelEchoWatchdog()
+			}
+		}
 
 		// --- Phase 2: deliver outside all locks ---
 
@@ -2166,6 +2212,14 @@ func (m *Mux) onReceived(symbol byte, wasEscaped bool) {
 	// F-18: per-session echo trackers removed; nothing to reset on
 	// ownership timeout.
 	_ = ownershipTimedOut
+	// Codex round-2 MUST FIX on PR #647: cancel the gateway
+	// watchdog when ownership was forcibly released. Mirror of
+	// the same cancel at the SYN-branch unlock above.
+	if ownershipTimedOutGateway {
+		if pacer := m.SessionPacer(gatewaySessionID); pacer != nil {
+			pacer.CancelEchoWatchdog()
+		}
+	}
 
 	// --- Phase 2: deliver outside all locks ---
 	// Codex PR #502 P2: revalidate active-path gating atomically with
@@ -2853,6 +2907,7 @@ func (m *Mux) handleReset() {
 	m.stateMu.Lock()
 	m.phase.reset(wirePhaseIdle)
 	m.gatewayEcho.reset()
+	wasGatewayActive := m.gatewayTxnActive
 	if m.gatewayTxnActive {
 		m.gatewayTxnActive = false
 		m.recordGatewayInactive(ReasonReset)
@@ -2873,6 +2928,21 @@ func (m *Mux) handleReset() {
 		pendingToCancel.deadline.Stop() // AM8: cancel deadline timer
 	}
 	m.stateMu.Unlock()
+
+	// Codex round-2 MUST FIX on PR #647: a RESETTED boundary
+	// erases any in-flight gateway transaction. Cancel the
+	// watchdog OUTSIDE stateMu so the pacer mutex doesn't nest
+	// inside stateMu. The gateway-active condition was captured
+	// under stateMu above (wasGatewayActive); the cancel is
+	// idempotent so racing a concurrent ArmEchoWatchdog (which
+	// can't happen here because the only producer is sendLoop's
+	// gateway-only block, and post-reset there is no gateway
+	// transaction) is still safe.
+	if wasGatewayActive {
+		if pacer := m.SessionPacer(gatewaySessionID); pacer != nil {
+			pacer.CancelEchoWatchdog()
+		}
+	}
 
 	// Cancel in-flight pending START if any.
 	if pendingToCancel != nil {

--- a/internal/adaptermux/p3_test.go
+++ b/internal/adaptermux/p3_test.go
@@ -138,12 +138,12 @@ func newP3TestMux(t *testing.T) (*Mux, *p3MockTransport, context.CancelFunc, fun
 	mock := newP3MockTransport()
 
 	mux := New(Config{
-		Protocol:    "enh",
-		Network:     "tcp",
-		Address:     "127.0.0.1:0",
-		ReadTimeout: 200 * time.Millisecond,
-	PendingStartTTL: 24 * time.Hour,  // disable C3 TTL drain in legacy tests
-	SYNInterval: time.Hour,  // disable C1 idle fast path in legacy tests
+		Protocol:        "enh",
+		Network:         "tcp",
+		Address:         "127.0.0.1:0",
+		ReadTimeout:     200 * time.Millisecond,
+		PendingStartTTL: 24 * time.Hour, // disable C3 TTL drain in legacy tests
+		SYNInterval:     time.Hour,      // disable C1 idle fast path in legacy tests
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -626,12 +626,12 @@ func TestCancelPendingStart_DuringRequestStart(t *testing.T) {
 	}
 
 	mux := New(Config{
-		Protocol:    "enh",
-		Network:     "tcp",
-		Address:     "127.0.0.1:0",
-		ReadTimeout: 200 * time.Millisecond,
-	PendingStartTTL: 24 * time.Hour,  // disable C3 TTL drain in legacy tests
-	SYNInterval: time.Hour,  // disable C1 idle fast path in legacy tests
+		Protocol:        "enh",
+		Network:         "tcp",
+		Address:         "127.0.0.1:0",
+		ReadTimeout:     200 * time.Millisecond,
+		PendingStartTTL: 24 * time.Hour, // disable C3 TTL drain in legacy tests
+		SYNInterval:     time.Hour,      // disable C1 idle fast path in legacy tests
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -970,12 +970,12 @@ func TestP3_Close_ClearsPendingStart(t *testing.T) {
 	mock := newP3MockTransport()
 
 	mux := New(Config{
-		Protocol:    "enh",
-		Network:     "tcp",
-		Address:     "127.0.0.1:0",
-		ReadTimeout: 200 * time.Millisecond,
-	PendingStartTTL: 24 * time.Hour,  // disable C3 TTL drain in legacy tests
-	SYNInterval: time.Hour,  // disable C1 idle fast path in legacy tests
+		Protocol:        "enh",
+		Network:         "tcp",
+		Address:         "127.0.0.1:0",
+		ReadTimeout:     200 * time.Millisecond,
+		PendingStartTTL: 24 * time.Hour, // disable C3 TTL drain in legacy tests
+		SYNInterval:     time.Hour,      // disable C1 idle fast path in legacy tests
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1029,12 +1029,12 @@ func TestP3_FallbackStartArbitration(t *testing.T) {
 	}
 
 	mux := New(Config{
-		Protocol:    "enh",
-		Network:     "tcp",
-		Address:     "127.0.0.1:0",
-		ReadTimeout: 200 * time.Millisecond,
-	PendingStartTTL: 24 * time.Hour,  // disable C3 TTL drain in legacy tests
-	SYNInterval: time.Hour,  // disable C1 idle fast path in legacy tests
+		Protocol:        "enh",
+		Network:         "tcp",
+		Address:         "127.0.0.1:0",
+		ReadTimeout:     200 * time.Millisecond,
+		PendingStartTTL: 24 * time.Hour, // disable C3 TTL drain in legacy tests
+		SYNInterval:     time.Hour,      // disable C1 idle fast path in legacy tests
 	})
 	mux.ctx, mux.cancel = ctx, cancel
 
@@ -1143,12 +1143,12 @@ func TestRequestStartFailAfterCancel_NoDoubleSend(t *testing.T) {
 	}
 
 	mux := New(Config{
-		Protocol:    "enh",
-		Network:     "tcp",
-		Address:     "127.0.0.1:0",
-		ReadTimeout: 200 * time.Millisecond,
-	PendingStartTTL: 24 * time.Hour,  // disable C3 TTL drain in legacy tests
-	SYNInterval: time.Hour,  // disable C1 idle fast path in legacy tests
+		Protocol:        "enh",
+		Network:         "tcp",
+		Address:         "127.0.0.1:0",
+		ReadTimeout:     200 * time.Millisecond,
+		PendingStartTTL: 24 * time.Hour, // disable C3 TTL drain in legacy tests
+		SYNInterval:     time.Hour,      // disable C1 idle fast path in legacy tests
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1244,12 +1244,12 @@ func TestAbsorbDecrementOnRequestStartFailAfterCancel(t *testing.T) {
 	}
 
 	mux := New(Config{
-		Protocol:    "enh",
-		Network:     "tcp",
-		Address:     "127.0.0.1:0",
-		ReadTimeout: 200 * time.Millisecond,
-	PendingStartTTL: 24 * time.Hour,  // disable C3 TTL drain in legacy tests
-	SYNInterval: time.Hour,  // disable C1 idle fast path in legacy tests
+		Protocol:        "enh",
+		Network:         "tcp",
+		Address:         "127.0.0.1:0",
+		ReadTimeout:     200 * time.Millisecond,
+		PendingStartTTL: 24 * time.Hour, // disable C3 TTL drain in legacy tests
+		SYNInterval:     time.Hour,      // disable C1 idle fast path in legacy tests
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1702,12 +1702,12 @@ func TestConcurrentTryGrantAndStart(t *testing.T) {
 	}
 
 	mux := New(Config{
-		Protocol:    "enh",
-		Network:     "tcp",
-		Address:     "127.0.0.1:0",
-		ReadTimeout: 200 * time.Millisecond,
-	PendingStartTTL: 24 * time.Hour,  // disable C3 TTL drain in legacy tests
-	SYNInterval: time.Hour,  // disable C1 idle fast path in legacy tests
+		Protocol:        "enh",
+		Network:         "tcp",
+		Address:         "127.0.0.1:0",
+		ReadTimeout:     200 * time.Millisecond,
+		PendingStartTTL: 24 * time.Hour, // disable C3 TTL drain in legacy tests
+		SYNInterval:     time.Hour,      // disable C1 idle fast path in legacy tests
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1842,12 +1842,12 @@ func TestBlockingFallbackSuccessAfterCancel_NoDoubleSend(t *testing.T) {
 	}
 
 	mux := New(Config{
-		Protocol:    "enh",
-		Network:     "tcp",
-		Address:     "127.0.0.1:0",
-		ReadTimeout: 200 * time.Millisecond,
-	PendingStartTTL: 24 * time.Hour,  // disable C3 TTL drain in legacy tests
-	SYNInterval: time.Hour,  // disable C1 idle fast path in legacy tests
+		Protocol:        "enh",
+		Network:         "tcp",
+		Address:         "127.0.0.1:0",
+		ReadTimeout:     200 * time.Millisecond,
+		PendingStartTTL: 24 * time.Hour, // disable C3 TTL drain in legacy tests
+		SYNInterval:     time.Hour,      // disable C1 idle fast path in legacy tests
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1939,12 +1939,12 @@ func TestBlockingFallbackErrorAfterCancel_NoDoubleSend(t *testing.T) {
 	}
 
 	mux := New(Config{
-		Protocol:    "enh",
-		Network:     "tcp",
-		Address:     "127.0.0.1:0",
-		ReadTimeout: 200 * time.Millisecond,
-	PendingStartTTL: 24 * time.Hour,  // disable C3 TTL drain in legacy tests
-	SYNInterval: time.Hour,  // disable C1 idle fast path in legacy tests
+		Protocol:        "enh",
+		Network:         "tcp",
+		Address:         "127.0.0.1:0",
+		ReadTimeout:     200 * time.Millisecond,
+		PendingStartTTL: 24 * time.Hour, // disable C3 TTL drain in legacy tests
+		SYNInterval:     time.Hour,      // disable C1 idle fast path in legacy tests
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -2371,7 +2371,7 @@ func TestSYNTimeoutRelease_BranchesOnOwnerIdentity(t *testing.T) {
 		mux.busOwned = time.Now()
 		mux.lastWireActivity = mux.busOwned
 		mux.gatewayTxnActive = true
-		_, _, _ = mux.onSYNLocked(wirePhaseEventSYNTimeout, gatewaySessionID, true, time.Now())
+		_, _, _, _ = mux.onSYNLocked(wirePhaseEventSYNTimeout, gatewaySessionID, true, time.Now())
 		_, _, owned := mux.arb.owner()
 		mux.stateMu.Unlock()
 
@@ -2390,7 +2390,7 @@ func TestSYNTimeoutRelease_BranchesOnOwnerIdentity(t *testing.T) {
 		mux.arb.confirmOwnership(extSessionID, 0x31)
 		mux.busOwned = time.Now() // just acquired → elapsed ~0
 		mux.lastWireActivity = mux.busOwned
-		_, _, _ = mux.onSYNLocked(wirePhaseEventSYNTimeout, extSessionID, true, time.Now())
+		_, _, _, _ = mux.onSYNLocked(wirePhaseEventSYNTimeout, extSessionID, true, time.Now())
 		ownerID, _, owned := mux.arb.owner()
 		mux.stateMu.Unlock()
 
@@ -2415,7 +2415,7 @@ func TestSYNTimeoutRelease_BranchesOnOwnerIdentity(t *testing.T) {
 		// 30ms grace.
 		mux.busOwned = time.Now().Add(-100 * time.Millisecond)
 		mux.lastWireActivity = mux.busOwned // no wire activity since grant
-		_, _, _ = mux.onSYNLocked(wirePhaseEventSYNTimeout, extSessionID, true, time.Now())
+		_, _, _, _ = mux.onSYNLocked(wirePhaseEventSYNTimeout, extSessionID, true, time.Now())
 		_, _, owned := mux.arb.owner()
 		mux.stateMu.Unlock()
 
@@ -2540,7 +2540,7 @@ func TestExternalSessionRelease_MeasuresGapNotGrant(t *testing.T) {
 		now := time.Now()
 		mux.busOwned = now.Add(-5 * time.Second)
 		mux.lastWireActivity = now.Add(-10 * time.Millisecond)
-		_, _, _ = mux.onSYNLocked(wirePhaseEventSYNTimeout, extSessionID, true, now)
+		_, _, _, _ = mux.onSYNLocked(wirePhaseEventSYNTimeout, extSessionID, true, now)
 		_, _, owned := mux.arb.owner()
 		mux.stateMu.Unlock()
 
@@ -2561,7 +2561,7 @@ func TestExternalSessionRelease_MeasuresGapNotGrant(t *testing.T) {
 		now := time.Now()
 		mux.busOwned = now.Add(-5 * time.Second)
 		mux.lastWireActivity = now.Add(-200 * time.Millisecond)
-		_, _, _ = mux.onSYNLocked(wirePhaseEventSYNTimeout, extSessionID, true, now)
+		_, _, _, _ = mux.onSYNLocked(wirePhaseEventSYNTimeout, extSessionID, true, now)
 		_, _, owned := mux.arb.owner()
 		mux.stateMu.Unlock()
 
@@ -2586,7 +2586,7 @@ func TestExternalSessionRelease_MeasuresGapNotGrant(t *testing.T) {
 		// gap-based grace (500ms) hasn't elapsed.
 		mux.busOwned = now.Add(-200 * time.Millisecond)
 		mux.lastWireActivity = now.Add(-10 * time.Millisecond)
-		_, _, _ = mux.onSYNLocked(wirePhaseEventSYNIdle, extSessionID, true, now)
+		_, _, _, _ = mux.onSYNLocked(wirePhaseEventSYNIdle, extSessionID, true, now)
 		_, _, owned := mux.arb.owner()
 		mux.stateMu.Unlock()
 
@@ -2606,7 +2606,7 @@ func TestExternalSessionRelease_MeasuresGapNotGrant(t *testing.T) {
 		// Gateway uses grant-age, not gap. Grant is 200ms old → release.
 		mux.busOwned = now.Add(-200 * time.Millisecond)
 		mux.lastWireActivity = now // even with fresh "activity"
-		_, _, _ = mux.onSYNLocked(wirePhaseEventSYNIdle, gatewaySessionID, true, now)
+		_, _, _, _ = mux.onSYNLocked(wirePhaseEventSYNIdle, gatewaySessionID, true, now)
 		_, _, owned := mux.arb.owner()
 		mux.stateMu.Unlock()
 

--- a/internal/adaptermux/pacer_wiring_test.go
+++ b/internal/adaptermux/pacer_wiring_test.go
@@ -353,21 +353,28 @@ func TestSessionPacer_Watchdog_ArmedOnDoSend(t *testing.T) {
 		t.Fatalf("Write err: %v", err)
 	}
 
-	// Poll briefly — Write returns after doSend completes, but the
-	// arm runs under stateMu so we may see a brief window where
-	// the call hasn't fully returned. Polling tolerates that.
-	deadline := time.Now().Add(500 * time.Millisecond)
+	// Codex round-1 MEDIUM #1 on PR #647: the previous 500ms
+	// poll window exceeded the normal-mode hard deadline (~400ms),
+	// so an unrelated CI stall could let the hard timer fire and
+	// clear WatchdogArmed before the assertion checked it. Switch
+	// to a tight poll window (50ms — well under the soft deadline
+	// of ~200ms) and cancel IMMEDIATELY after the first observed
+	// armed=true.
+	deadline := time.Now().Add(50 * time.Millisecond)
+	armed := false
 	for time.Now().Before(deadline) {
 		if pacer.WatchdogArmed() {
+			armed = true
 			break
 		}
-		time.Sleep(2 * time.Millisecond)
+		time.Sleep(1 * time.Millisecond)
 	}
-	if !pacer.WatchdogArmed() {
-		t.Errorf("WatchdogArmed() = false after gateway write; want true (B3.6e arm at doSend)")
+	if !armed {
+		t.Errorf("WatchdogArmed() = false after gateway write; want true (B3.6e arm at sendLoop)")
 	}
-	// Cancel so the watchdog doesn't fire during cleanup and emit a
-	// spurious admin event that could confuse downstream tests.
+	// Cancel immediately so the watchdog cannot fire during
+	// cleanup and emit a spurious admin event that could confuse
+	// downstream tests.
 	pacer.CancelEchoWatchdog()
 }
 

--- a/internal/adaptermux/pacer_wiring_test.go
+++ b/internal/adaptermux/pacer_wiring_test.go
@@ -327,3 +327,113 @@ func TestSessionPacer_OffMode_DoSendDoesNotCallPacer(t *testing.T) {
 		t.Errorf("SessionPacer(gateway) = %v after write in ModeOff; want nil (no lazy-create)", got)
 	}
 }
+
+// TestSessionPacer_Watchdog_ArmedOnDoSend pins the Phase 3 Step
+// B3.6e wiring at the mux.doSend hot path: when V8ClassifierMode
+// != Off, a gateway-internal active write MUST arm the gateway
+// pacer's echo watchdog. We verify by checking WatchdogArmed
+// immediately after the write — before any echo arrives, the
+// watchdog must still be running.
+func TestSessionPacer_Watchdog_ArmedOnDoSend(t *testing.T) {
+	mux, mock, _, cleanup := newClassifiedTestMux(t, v8classifier.ModeShadow)
+	defer cleanup()
+
+	pacer := mux.SessionPacer(gatewaySessionID)
+	if pacer == nil {
+		t.Fatal("gateway Pacer nil in ModeShadow")
+	}
+	if pacer.WatchdogArmed() {
+		t.Fatal("precondition: WatchdogArmed=true before any write")
+	}
+
+	grantGateway(t, mux, mock, 0x71)
+	at := mux.ActiveTransport()
+	req := []byte{0x71}
+	if _, err := at.Write(req); err != nil {
+		t.Fatalf("Write err: %v", err)
+	}
+
+	// Poll briefly — Write returns after doSend completes, but the
+	// arm runs under stateMu so we may see a brief window where
+	// the call hasn't fully returned. Polling tolerates that.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if pacer.WatchdogArmed() {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	if !pacer.WatchdogArmed() {
+		t.Errorf("WatchdogArmed() = false after gateway write; want true (B3.6e arm at doSend)")
+	}
+	// Cancel so the watchdog doesn't fire during cleanup and emit a
+	// spurious admin event that could confuse downstream tests.
+	pacer.CancelEchoWatchdog()
+}
+
+// TestSessionPacer_Watchdog_CancelledOnEchoMatch pins that the
+// match-site cancellation (B3.6e) actually fires: once the
+// adapter echoes the gateway's write back, the watchdog must
+// disarm so a delayed timer fire cannot emit a stale admin
+// event for an already-completed transaction.
+func TestSessionPacer_Watchdog_CancelledOnEchoMatch(t *testing.T) {
+	mux, mock, _, cleanup := newClassifiedTestMux(t, v8classifier.ModeShadow)
+	defer cleanup()
+
+	pacer := mux.SessionPacer(gatewaySessionID)
+	if pacer == nil {
+		t.Fatal("gateway Pacer nil in ModeShadow")
+	}
+
+	grantGateway(t, mux, mock, 0x71)
+	at := mux.ActiveTransport()
+	if _, err := at.Write([]byte{0x71}); err != nil {
+		t.Fatalf("Write err: %v", err)
+	}
+
+	// Inject the echo so matchEchoWithTime fires → CancelEchoWatchdog.
+	mock.eventCh <- transport.StreamEvent{
+		Kind: transport.StreamEventByte, Byte: 0x71, WasEscaped: false,
+	}
+
+	// Poll until the cancel propagates.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if !pacer.WatchdogArmed() {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if pacer.WatchdogArmed() {
+		t.Error("WatchdogArmed() = true after echo match; want false (B3.6e cancel at match site)")
+	}
+	// And confirm no spurious timeout fired during the round trip.
+	if got := pacer.SoftTimeoutTotal(); got != 0 {
+		t.Errorf("SoftTimeoutTotal() = %d after fast echo; want 0 (echo arrived before soft deadline)", got)
+	}
+}
+
+// TestSessionPacer_Watchdog_OffMode_NoArm pins the ModeOff
+// zero-overhead contract on the watchdog side: in ModeOff there
+// is no pacer, so there is no watchdog to arm. The test exercises
+// the doSend path and confirms (a) SessionPacer remains nil and
+// (b) no panic / no goroutine leak.
+func TestSessionPacer_Watchdog_OffMode_NoArm(t *testing.T) {
+	mux, mock, _, cleanup := newClassifiedTestMux(t, v8classifier.ModeOff)
+	defer cleanup()
+
+	if got := mux.SessionPacer(gatewaySessionID); got != nil {
+		t.Fatalf("precondition: SessionPacer in ModeOff = %v; want nil", got)
+	}
+
+	grantGateway(t, mux, mock, 0x71)
+	at := mux.ActiveTransport()
+	if _, err := at.Write([]byte{0x71}); err != nil {
+		t.Fatalf("Write err: %v", err)
+	}
+
+	// Post-write: still nil. (No lazy-create on the watchdog path.)
+	if got := mux.SessionPacer(gatewaySessionID); got != nil {
+		t.Errorf("post-write SessionPacer in ModeOff = %v; want nil (no watchdog lazy-create)", got)
+	}
+}

--- a/internal/adaptermux/session.go
+++ b/internal/adaptermux/session.go
@@ -14,6 +14,8 @@ import (
 	ebuserrors "github.com/Project-Helianthus/helianthus-ebusgo/errors"
 	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
 	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/adaptermux/v8classifier"
 )
 
 // F-10 diagnostic instrumentation (EBUSD-VERIFICATION-2026-05-10.md):
@@ -300,6 +302,17 @@ func (m *Mux) RemoveSession(id uint64) {
 
 	// Phase 3 Step B3.6c: drop the per-session v8 pacer. No-op
 	// when V8ClassifierMode == Off (the entry was never created).
+	//
+	// Phase 3 Step B3.6e: cancel any pending echo-watchdog timers
+	// BEFORE the Delete so a delayed soft/hard timer fire after
+	// the session is gone cannot emit a stale ClassifierAdminEvent
+	// for a sessionID that no longer exists. The cancel runs
+	// idempotent if the watchdog was never armed.
+	if v, ok := m.sessionPacers.Load(id); ok {
+		if pacer, _ := v.(*v8classifier.Pacer); pacer != nil {
+			pacer.CancelEchoWatchdog()
+		}
+	}
 	m.sessionPacers.Delete(id)
 
 	if ok {

--- a/internal/adaptermux/v8classifier/classifier.go
+++ b/internal/adaptermux/v8classifier/classifier.go
@@ -752,6 +752,34 @@ func (c *Classifier) PendingAdminEvents() int {
 	return c.adminEvents.pending()
 }
 
+// NewPacerForSession returns a new per-session Pacer wired to
+// this classifier's admin-event buffer (Phase 3 Step B3.6e). The
+// pacer's watchdog timeouts (soft / hard) emit ClassifierAdminEvent
+// entries with the appropriate kind, routed through the same ring
+// buffer that ProtocolFault uses (per v8 invariant I1 — admin
+// events stay out-of-band, never cross into client byte streams).
+//
+// Callers (typically Mux.ensureSessionPacer in adaptermux) use
+// this in place of v8classifier.NewPacer so the watchdog is
+// pre-wired without having to call SetAdminEventEmitter
+// separately at every construction site.
+//
+// Returns nil if the classifier is nil (so call sites in ModeOff
+// where m.v8 == nil get a defensive nil rather than panicking).
+func (c *Classifier) NewPacerForSession() *Pacer {
+	if c == nil {
+		return nil
+	}
+	p := NewPacer()
+	p.SetAdminEventEmitter(func(kind AdminEventKind, at time.Time) {
+		c.adminEvents.emit(ClassifierAdminEvent{
+			At:   at,
+			Kind: kind,
+		})
+	})
+	return p
+}
+
 // EnforceDropsAppliedTotal returns the cumulative count of bytes
 // the classifier ACTUALLY DROPPED from session dispatch under
 // ModeEnforce. Phase 3 Step B3.6b (v8 §4 AA-injection filter).

--- a/internal/adaptermux/v8classifier/pacer.go
+++ b/internal/adaptermux/v8classifier/pacer.go
@@ -194,7 +194,51 @@ type Pacer struct {
 	// dashboards to confirm the adapter-write path is correctly
 	// invoking the pacer's pre-write hook.
 	beforeActiveWriteTotal uint64
+
+	// Phase 3 Step B3.6e — echo watchdog state.
+	//
+	// adminEventEmit is the callback invoked when a soft or hard
+	// echo deadline fires. nil disables watchdog admin-event
+	// emission — counters still increment, no admin event is
+	// recorded. Wired by Classifier.NewPacerForSession (which
+	// routes the callback into the classifier's adminEvents ring).
+	adminEventEmit AdminEventEmitFunc
+
+	// softTimer and hardTimer are the active watchdog timers. Set
+	// by ArmEchoWatchdog, cleared by CancelEchoWatchdog or by the
+	// timer fire callback. nil when no active write is
+	// outstanding. The Pacer tracks AT MOST ONE outstanding
+	// write's watchdog — production callers follow
+	// bus.sendRawWithEcho's strict "write one, wait for echo,
+	// write next" cadence, so pipelined-write contention is not
+	// produced. Concurrent calls to ArmEchoWatchdog cancel the
+	// prior arm (the first byte's watchdog is replaced by the
+	// second byte's — the first byte's echo arrival simply finds
+	// no timer to cancel).
+	softTimer *time.Timer
+	hardTimer *time.Timer
+
+	// softTimeoutTotal and hardTimeoutTotal count fired timeouts.
+	// Diagnostic counters for operator dashboards and tests —
+	// confirm the watchdog actually fires when echoes are
+	// delayed, distinguishing it from no-arm misconfigurations.
+	softTimeoutTotal uint64
+	hardTimeoutTotal uint64
 }
+
+// AdminEventEmitFunc is the callback signature for echo-watchdog
+// timeout admin events. Invoked by the soft and hard timer fire
+// paths with the kind (EchoSoftTimeout / EchoHardTimeout) and the
+// wall-clock time of the fire. The receiver is expected to route
+// the event into the classifier's adminEvents ring buffer (or to
+// any other operator-visible surface).
+//
+// IMPORTANT: the callback is invoked from the time.AfterFunc
+// goroutine — it MUST NOT block, MUST be safe for concurrent
+// invocation if multiple pacers share a sink, and MUST NOT
+// re-acquire the Pacer's internal mutex (the timer fire path
+// drops the lock before invoking the callback).
+type AdminEventEmitFunc func(kind AdminEventKind, at time.Time)
 
 // NewPacer returns a Pacer with default τ_wire_byte and
 // LrttBootstrapInitial L_rtt EMA. Caller may override tau via
@@ -451,4 +495,170 @@ func (p *Pacer) ResetLrtt() {
 	p.lRttEMA = LrttBootstrapInitial
 	p.lastEchoAt = time.Time{}
 	p.graceRemaining = 0
+}
+
+// SetAdminEventEmitter registers the callback invoked when the
+// soft or hard echo deadline fires (Phase 3 Step B3.6e). nil
+// disables admin-event emission — the counters still increment so
+// tests / operators can verify the watchdog mechanics, but no
+// ClassifierAdminEvent is recorded. Typically wired once at
+// pacer construction by Classifier.NewPacerForSession.
+//
+// Safe to call from any goroutine. Subsequent calls overwrite the
+// prior callback; setting nil disables emission immediately
+// (already-armed timers fire with whatever emitter was current at
+// fire time — re-arming via ArmEchoWatchdog atomically picks up
+// the new emitter).
+func (p *Pacer) SetAdminEventEmitter(f AdminEventEmitFunc) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.adminEventEmit = f
+}
+
+// ArmEchoWatchdog arms the soft (and conditionally hard) echo
+// deadline timers for the current outstanding write. Called by
+// mux.doSend IMMEDIATELY after BeforeActiveWrite — the deadlines
+// computed here use the (possibly grace-bootstrapped) L_rtt state
+// that BeforeActiveWrite established. Per Codex round-1 MAJOR on
+// PR #642 the grace-bootstrap entry MUST precede the watchdog
+// arm; this method takes the current grace state at face value.
+//
+// Cancellation semantics:
+//   - Any prior arm (soft AND hard) is cancelled before the new
+//     timers are set. The Pacer tracks AT MOST ONE outstanding
+//     write's watchdog; a second ArmEchoWatchdog before the prior
+//     echo lands replaces the prior watchdog rather than stacking
+//     a second one. Production callers follow
+//     bus.sendRawWithEcho's strict "write one, wait for echo,
+//     write next" cadence so pipelined arms do not appear in
+//     practice. Tests can drive both shapes via direct calls.
+//
+// Fire semantics:
+//   - Soft timer fires after `soft` duration (always). Callback
+//     increments softTimeoutTotal and emits
+//     AdminEventKindEchoSoftTimeout via the registered emitter.
+//   - Hard timer fires after `hard` duration ONLY when grace mode
+//     is inactive (hardEnabled == true). Callback increments
+//     hardTimeoutTotal and emits AdminEventKindEchoHardTimeout.
+//   - Both timer-fire callbacks clear their own timer field so
+//     the next ArmEchoWatchdog sees a clean slate.
+//
+// Per EchoDeadlines semantics: in grace mode the soft deadline is
+// L_rtt_EMA + 500ms and the hard deadline is suppressed; in
+// normal mode soft = L_rtt_EMA + 100ms, hard = 2×L_rtt_EMA + 200ms.
+//
+// Thread-safety: the arm path holds the Pacer mutex while
+// stopping prior timers and starting new ones. The fire callback
+// reacquires the mutex briefly to bump counters + read the
+// emitter; the emitter callback itself runs WITHOUT the mutex (so
+// it cannot deadlock if it itself calls back into the Pacer for
+// state inspection).
+func (p *Pacer) ArmEchoWatchdog(now time.Time) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.cancelTimersLocked()
+	var soft, hard time.Duration
+	var hardEnabled bool
+	if p.graceRemaining > 0 {
+		soft = p.lRttEMA + SoftDeadlineGrace
+		hardEnabled = false
+	} else {
+		soft = p.lRttEMA + SoftDeadlineNormal
+		hard = 2*p.lRttEMA + HardDeadlineNormalAdd
+		hardEnabled = true
+	}
+	p.softTimer = time.AfterFunc(soft, p.onSoftTimeout)
+	if hardEnabled {
+		p.hardTimer = time.AfterFunc(hard, p.onHardTimeout)
+	}
+}
+
+// CancelEchoWatchdog cancels both watchdog timers without firing.
+// Called by the mux when the matching echo lands AND when the
+// session closes / write fails / arbitration is lost — any
+// pre-completion path that ends an outstanding write needs to
+// disarm the watchdog so a delayed timer fire after the abort
+// doesn't emit a spurious admin event.
+//
+// Idempotent: cancelling already-stopped timers is safe. Safe to
+// call from any goroutine.
+func (p *Pacer) CancelEchoWatchdog() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.cancelTimersLocked()
+}
+
+// cancelTimersLocked is the lock-held helper used by both the
+// public CancelEchoWatchdog and the ArmEchoWatchdog re-arm path.
+// Stops both timers and nils the fields. Caller MUST hold p.mu.
+func (p *Pacer) cancelTimersLocked() {
+	if p.softTimer != nil {
+		p.softTimer.Stop()
+		p.softTimer = nil
+	}
+	if p.hardTimer != nil {
+		p.hardTimer.Stop()
+		p.hardTimer = nil
+	}
+}
+
+// onSoftTimeout is the soft-timer fire callback. Increments the
+// counter, captures the emitter under the mutex, then drops the
+// mutex BEFORE invoking the emitter so the emitter callback
+// (which may run arbitrary code, including code that calls back
+// into the Pacer) cannot deadlock.
+func (p *Pacer) onSoftTimeout() {
+	now := time.Now()
+	p.mu.Lock()
+	p.softTimeoutTotal++
+	emit := p.adminEventEmit
+	// Clear our own timer field so a subsequent
+	// ArmEchoWatchdog's cancelTimersLocked correctly observes the
+	// fired state. (Stop() on a fired timer is a no-op and
+	// returns false; nil-ing avoids a stale pointer.)
+	p.softTimer = nil
+	p.mu.Unlock()
+	if emit != nil {
+		emit(AdminEventKindEchoSoftTimeout, now)
+	}
+}
+
+// onHardTimeout is the hard-timer fire callback. Same locking
+// pattern as onSoftTimeout.
+func (p *Pacer) onHardTimeout() {
+	now := time.Now()
+	p.mu.Lock()
+	p.hardTimeoutTotal++
+	emit := p.adminEventEmit
+	p.hardTimer = nil
+	p.mu.Unlock()
+	if emit != nil {
+		emit(AdminEventKindEchoHardTimeout, now)
+	}
+}
+
+// SoftTimeoutTotal returns the cumulative number of soft-deadline
+// fires. Safe to call from any goroutine.
+func (p *Pacer) SoftTimeoutTotal() uint64 {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.softTimeoutTotal
+}
+
+// HardTimeoutTotal returns the cumulative number of hard-deadline
+// fires. Safe to call from any goroutine.
+func (p *Pacer) HardTimeoutTotal() uint64 {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.hardTimeoutTotal
+}
+
+// WatchdogArmed reports whether the echo watchdog currently has
+// at least one timer outstanding. Used by tests to verify
+// arm/cancel correctness without resorting to timing-based
+// observations. Safe to call from any goroutine.
+func (p *Pacer) WatchdogArmed() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.softTimer != nil || p.hardTimer != nil
 }

--- a/internal/adaptermux/v8classifier/pacer.go
+++ b/internal/adaptermux/v8classifier/pacer.go
@@ -242,6 +242,26 @@ type Pacer struct {
 	// delayed, distinguishing it from no-arm misconfigurations.
 	softTimeoutTotal uint64
 	hardTimeoutTotal uint64
+
+	// onTimeoutEnterHook is a TEST-ONLY synchronization hook,
+	// invoked by onSoftTimeout / onHardTimeout BEFORE the
+	// p.mu.Lock() that performs the generation check. Production
+	// callers leave it nil; the
+	// TestPacer_ArmEchoWatchdog_StaleFireRace_Deterministic test
+	// uses it to deterministically interleave a Cancel call
+	// between the timer fire and the lock acquisition — the
+	// exact race that Codex round-1 MUST FIX #1 closes.
+	//
+	// Per Codex round-2 MAJOR #1 on PR #647: the earlier
+	// counter-poll-based race test only exercised the race after
+	// the fire callback had fully completed, which the
+	// generation guard didn't actually defend against. The hook
+	// pauses the callback at the perfect spot for the race to
+	// be deterministic.
+	//
+	// Unexported (lowercase). Test access uses a same-package
+	// helper in pacer_test.go.
+	onTimeoutEnterHook func()
 }
 
 // AdminEventEmitFunc is the callback signature for echo-watchdog
@@ -656,6 +676,14 @@ func (p *Pacer) cancelTimersLocked() {
 // Codex round-1 MUST FIX #1 on PR #647: takes `gen` (the
 // generation value captured BY VALUE in the AfterFunc closure at
 // arm time) and no-ops if it no longer matches p.armGeneration.
+// Codex round-2 LOW #1 comment refresh: this is GENERATION
+// checking, not pointer identity. The earlier pointer-identity
+// approach was abandoned because the closure capturing `softT`
+// by reference raced (race detector flagged the unsynchronized
+// read in the timer-fire goroutine against the write in the
+// arm goroutine). Generation values are captured by value into
+// the closure — no shared mutable state.
+//
 // This guards against the Stop()-returns-false race: when
 // ArmEchoWatchdog cancels a timer that has already fired (or is
 // in the process of firing), the stale callback would otherwise
@@ -663,11 +691,21 @@ func (p *Pacer) cancelTimersLocked() {
 // landed and (b) clear the NEWER arm's timer pointer
 // (`p.softTimer = nil`), breaking cancel semantics for the
 // in-flight write. Generation-checking makes both effects
-// impossible — AND avoids the data race the pointer-identity
-// variant had (closure captures variable by reference; race
-// detector flags the unsynchronized write/read on that variable).
+// impossible.
+//
+// Generation overflow is not practically reachable (2^64
+// arm/cancel pairs takes centuries at any realistic rate).
+// Codex round-2 confirmed not blocking.
 func (p *Pacer) onSoftTimeout(gen uint64) {
 	now := time.Now()
+	// Codex round-2 MAJOR #1 on PR #647: test-only hook fires
+	// BEFORE the lock acquisition so a test can deterministically
+	// race a Cancel call against this fire callback. nil in
+	// production; lock-free read is fine because tests serialize
+	// the set vs the timer-fire arrival.
+	if hook := p.onTimeoutEnterHook; hook != nil {
+		hook()
+	}
 	p.mu.Lock()
 	if p.armGeneration != gen {
 		// Stale fire — this callback belonged to a previously
@@ -690,9 +728,16 @@ func (p *Pacer) onSoftTimeout(gen uint64) {
 }
 
 // onHardTimeout is the hard-timer fire callback. Same locking +
-// generation-check pattern as onSoftTimeout.
+// generation-check pattern as onSoftTimeout. Codex round-2 LOW
+// #1: comment refresh — generation, not pointer identity.
 func (p *Pacer) onHardTimeout(gen uint64) {
 	now := time.Now()
+	// Codex round-2 MAJOR #1 on PR #647: same test-only hook
+	// pattern as onSoftTimeout. Production: nil; tests: optional
+	// synchronization point.
+	if hook := p.onTimeoutEnterHook; hook != nil {
+		hook()
+	}
 	p.mu.Lock()
 	if p.armGeneration != gen {
 		p.mu.Unlock()

--- a/internal/adaptermux/v8classifier/pacer.go
+++ b/internal/adaptermux/v8classifier/pacer.go
@@ -262,6 +262,15 @@ type Pacer struct {
 	// Unexported (lowercase). Test access uses a same-package
 	// helper in pacer_test.go.
 	onTimeoutEnterHook func()
+
+	// onTimeoutGenMismatchHook is a TEST-ONLY synchronization
+	// hook fired ONLY when the timer-fire callback observes a
+	// generation mismatch and is about to no-op. Used by
+	// TestPacer_ArmEchoWatchdog_StaleFireRace_Deterministic to
+	// signal when the stale callback has finished the no-op
+	// path — replacing the round-2 fixed-sleep (Codex round-3
+	// MAJOR #1 on PR #647). Production callers leave it nil.
+	onTimeoutGenMismatchHook func()
 }
 
 // AdminEventEmitFunc is the callback signature for echo-watchdog
@@ -712,7 +721,11 @@ func (p *Pacer) onSoftTimeout(gen uint64) {
 		// armed timer that has since been cancelled / replaced.
 		// Discard silently; do NOT clear p.softTimer (it belongs
 		// to a newer arm) and do NOT increment the counter.
+		mismatchHook := p.onTimeoutGenMismatchHook
 		p.mu.Unlock()
+		if mismatchHook != nil {
+			mismatchHook()
+		}
 		return
 	}
 	p.softTimeoutTotal++
@@ -740,7 +753,11 @@ func (p *Pacer) onHardTimeout(gen uint64) {
 	}
 	p.mu.Lock()
 	if p.armGeneration != gen {
+		mismatchHook := p.onTimeoutGenMismatchHook
 		p.mu.Unlock()
+		if mismatchHook != nil {
+			mismatchHook()
+		}
 		return
 	}
 	p.hardTimeoutTotal++

--- a/internal/adaptermux/v8classifier/pacer.go
+++ b/internal/adaptermux/v8classifier/pacer.go
@@ -218,6 +218,24 @@ type Pacer struct {
 	softTimer *time.Timer
 	hardTimer *time.Timer
 
+	// armGeneration counts ArmEchoWatchdog invocations. Each
+	// arm's timer-fire closures capture the generation value at
+	// arm time (BY VALUE) and onSoftTimeout / onHardTimeout
+	// no-op if the captured generation no longer matches
+	// p.armGeneration at fire time.
+	//
+	// Codex round-1 MUST FIX #1 on PR #647: pointer-identity
+	// against `p.softTimer` was the initial attempt, but the
+	// `softT` variable that the closure captures by reference
+	// is itself written by the Arm goroutine and read by the
+	// timer-fire goroutine — the race detector (correctly)
+	// flags that even though the temporal ordering would make
+	// the read safe in practice. The generation counter is
+	// captured by VALUE inside each closure, so the closure
+	// holds a stable snapshot that doesn't race with the next
+	// arm's writes.
+	armGeneration uint64
+
 	// softTimeoutTotal and hardTimeoutTotal count fired timeouts.
 	// Diagnostic counters for operator dashboards and tests —
 	// confirm the watchdog actually fires when echoes are
@@ -233,11 +251,14 @@ type Pacer struct {
 // the event into the classifier's adminEvents ring buffer (or to
 // any other operator-visible surface).
 //
-// IMPORTANT: the callback is invoked from the time.AfterFunc
-// goroutine — it MUST NOT block, MUST be safe for concurrent
-// invocation if multiple pacers share a sink, and MUST NOT
-// re-acquire the Pacer's internal mutex (the timer fire path
-// drops the lock before invoking the callback).
+// CONTRACT (Codex round-1 LOW on PR #647): the callback runs
+// AFTER the Pacer's internal mutex is dropped — so callback code
+// MAY re-enter Pacer methods (e.g. WatchdogArmed, SoftTimeoutTotal,
+// even ArmEchoWatchdog) without deadlock. The mutex-drop is
+// intentional precisely to enable diagnostic call-backs. The
+// callback MUST NOT block indefinitely (the time.AfterFunc
+// goroutine is single-purpose) and MUST be safe for concurrent
+// invocation if multiple pacers share a sink.
 type AdminEventEmitFunc func(kind AdminEventKind, at time.Time)
 
 // NewPacer returns a Pacer with default τ_wire_byte and
@@ -517,31 +538,40 @@ func (p *Pacer) SetAdminEventEmitter(f AdminEventEmitFunc) {
 
 // ArmEchoWatchdog arms the soft (and conditionally hard) echo
 // deadline timers for the current outstanding write. Called by
-// mux.doSend IMMEDIATELY after BeforeActiveWrite — the deadlines
-// computed here use the (possibly grace-bootstrapped) L_rtt state
-// that BeforeActiveWrite established. Per Codex round-1 MAJOR on
-// PR #642 the grace-bootstrap entry MUST precede the watchdog
-// arm; this method takes the current grace state at face value.
+// the gateway send path IMMEDIATELY after BeforeActiveWrite — the
+// deadlines computed here use the (possibly grace-bootstrapped)
+// L_rtt state that BeforeActiveWrite established. Per Codex
+// round-1 MAJOR on PR #642 the grace-bootstrap entry MUST precede
+// the watchdog arm; this method takes the current grace state at
+// face value.
 //
-// Cancellation semantics:
-//   - Any prior arm (soft AND hard) is cancelled before the new
-//     timers are set. The Pacer tracks AT MOST ONE outstanding
-//     write's watchdog; a second ArmEchoWatchdog before the prior
-//     echo lands replaces the prior watchdog rather than stacking
-//     a second one. Production callers follow
-//     bus.sendRawWithEcho's strict "write one, wait for echo,
-//     write next" cadence so pipelined arms do not appear in
-//     practice. Tests can drive both shapes via direct calls.
+// Cancellation semantics (Codex round-1 MUST FIX #1 on PR #647):
+//   - Any prior arm is cancelled via Stop(); the new timers are
+//     created with their pointer captured in the fire closure so
+//     stale fires from cancelled timers are no-op'd by an
+//     identity check inside onSoftTimeout / onHardTimeout. This
+//     closes the Stop()-returns-false race where the
+//     already-running fire callback would otherwise clear a
+//     newer arm's timer pointer.
+//   - The Pacer tracks AT MOST ONE outstanding write's
+//     watchdog; a second ArmEchoWatchdog before the prior echo
+//     lands replaces the prior watchdog rather than stacking a
+//     second one.
+//
+// The `now` parameter is currently unused; it is reserved as a
+// future hook for emitting an arm-time admin event (Codex round-1
+// LOW #2 on PR #647) and keeps the call-site signature consistent
+// with BeforeActiveWrite / RecordEcho for diagnostic logging.
 //
 // Fire semantics:
 //   - Soft timer fires after `soft` duration (always). Callback
-//     increments softTimeoutTotal and emits
-//     AdminEventKindEchoSoftTimeout via the registered emitter.
+//     identity-checks against p.softTimer, then increments
+//     softTimeoutTotal and emits AdminEventKindEchoSoftTimeout via
+//     the registered emitter.
 //   - Hard timer fires after `hard` duration ONLY when grace mode
-//     is inactive (hardEnabled == true). Callback increments
-//     hardTimeoutTotal and emits AdminEventKindEchoHardTimeout.
-//   - Both timer-fire callbacks clear their own timer field so
-//     the next ArmEchoWatchdog sees a clean slate.
+//     is inactive (hardEnabled == true). Callback identity-checks
+//     against p.hardTimer, then increments hardTimeoutTotal and
+//     emits AdminEventKindEchoHardTimeout.
 //
 // Per EchoDeadlines semantics: in grace mode the soft deadline is
 // L_rtt_EMA + 500ms and the hard deadline is suppressed; in
@@ -549,11 +579,11 @@ func (p *Pacer) SetAdminEventEmitter(f AdminEventEmitFunc) {
 //
 // Thread-safety: the arm path holds the Pacer mutex while
 // stopping prior timers and starting new ones. The fire callback
-// reacquires the mutex briefly to bump counters + read the
-// emitter; the emitter callback itself runs WITHOUT the mutex (so
-// it cannot deadlock if it itself calls back into the Pacer for
-// state inspection).
+// reacquires the mutex briefly to identity-check + bump counters
+// + read the emitter; the emitter callback itself runs WITHOUT
+// the mutex (so the emitter MAY safely re-enter Pacer methods).
 func (p *Pacer) ArmEchoWatchdog(now time.Time) {
+	_ = now // reserved for future arm-time diagnostics
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.cancelTimersLocked()
@@ -567,9 +597,17 @@ func (p *Pacer) ArmEchoWatchdog(now time.Time) {
 		hard = 2*p.lRttEMA + HardDeadlineNormalAdd
 		hardEnabled = true
 	}
-	p.softTimer = time.AfterFunc(soft, p.onSoftTimeout)
+	// Codex round-1 MUST FIX #1 on PR #647: capture the
+	// generation BY VALUE in each fire closure. cancelTimersLocked
+	// already bumped armGeneration above, so `gen` here is the
+	// post-bump value that the closure binds. Any stale fire
+	// from a previously-cancelled timer carries the old
+	// generation and gets no-op'd in onSoftTimeout /
+	// onHardTimeout via the armGeneration mismatch check.
+	gen := p.armGeneration
+	p.softTimer = time.AfterFunc(soft, func() { p.onSoftTimeout(gen) })
 	if hardEnabled {
-		p.hardTimer = time.AfterFunc(hard, p.onHardTimeout)
+		p.hardTimer = time.AfterFunc(hard, func() { p.onHardTimeout(gen) })
 	}
 }
 
@@ -590,7 +628,14 @@ func (p *Pacer) CancelEchoWatchdog() {
 
 // cancelTimersLocked is the lock-held helper used by both the
 // public CancelEchoWatchdog and the ArmEchoWatchdog re-arm path.
-// Stops both timers and nils the fields. Caller MUST hold p.mu.
+// Stops both timers, nils the fields, AND bumps armGeneration so
+// any timer callback that was already queued / running but
+// hadn't yet acquired p.mu sees a generation mismatch and
+// no-ops. Caller MUST hold p.mu.
+//
+// Codex round-1 MUST FIX #1 on PR #647: bumping the generation
+// here (rather than only on Arm) gives CancelEchoWatchdog the
+// same race-safety as ArmEchoWatchdog's re-arm.
 func (p *Pacer) cancelTimersLocked() {
 	if p.softTimer != nil {
 		p.softTimer.Stop()
@@ -600,22 +645,43 @@ func (p *Pacer) cancelTimersLocked() {
 		p.hardTimer.Stop()
 		p.hardTimer = nil
 	}
+	p.armGeneration++
 }
 
 // onSoftTimeout is the soft-timer fire callback. Increments the
 // counter, captures the emitter under the mutex, then drops the
-// mutex BEFORE invoking the emitter so the emitter callback
-// (which may run arbitrary code, including code that calls back
-// into the Pacer) cannot deadlock.
-func (p *Pacer) onSoftTimeout() {
+// mutex BEFORE invoking the emitter so the emitter callback may
+// freely re-enter Pacer methods.
+//
+// Codex round-1 MUST FIX #1 on PR #647: takes `gen` (the
+// generation value captured BY VALUE in the AfterFunc closure at
+// arm time) and no-ops if it no longer matches p.armGeneration.
+// This guards against the Stop()-returns-false race: when
+// ArmEchoWatchdog cancels a timer that has already fired (or is
+// in the process of firing), the stale callback would otherwise
+// (a) increment the counter for a write whose echo already
+// landed and (b) clear the NEWER arm's timer pointer
+// (`p.softTimer = nil`), breaking cancel semantics for the
+// in-flight write. Generation-checking makes both effects
+// impossible — AND avoids the data race the pointer-identity
+// variant had (closure captures variable by reference; race
+// detector flags the unsynchronized write/read on that variable).
+func (p *Pacer) onSoftTimeout(gen uint64) {
 	now := time.Now()
 	p.mu.Lock()
+	if p.armGeneration != gen {
+		// Stale fire — this callback belonged to a previously
+		// armed timer that has since been cancelled / replaced.
+		// Discard silently; do NOT clear p.softTimer (it belongs
+		// to a newer arm) and do NOT increment the counter.
+		p.mu.Unlock()
+		return
+	}
 	p.softTimeoutTotal++
 	emit := p.adminEventEmit
 	// Clear our own timer field so a subsequent
 	// ArmEchoWatchdog's cancelTimersLocked correctly observes the
-	// fired state. (Stop() on a fired timer is a no-op and
-	// returns false; nil-ing avoids a stale pointer.)
+	// fired state.
 	p.softTimer = nil
 	p.mu.Unlock()
 	if emit != nil {
@@ -623,11 +689,15 @@ func (p *Pacer) onSoftTimeout() {
 	}
 }
 
-// onHardTimeout is the hard-timer fire callback. Same locking
-// pattern as onSoftTimeout.
-func (p *Pacer) onHardTimeout() {
+// onHardTimeout is the hard-timer fire callback. Same locking +
+// generation-check pattern as onSoftTimeout.
+func (p *Pacer) onHardTimeout(gen uint64) {
 	now := time.Now()
 	p.mu.Lock()
+	if p.armGeneration != gen {
+		p.mu.Unlock()
+		return
+	}
 	p.hardTimeoutTotal++
 	emit := p.adminEventEmit
 	p.hardTimer = nil

--- a/internal/adaptermux/v8classifier/pacer_test.go
+++ b/internal/adaptermux/v8classifier/pacer_test.go
@@ -615,7 +615,10 @@ func TestPacer_CancelEchoWatchdog_BeforeFire(t *testing.T) {
 // TestPacer_SoftDeadlineFires pins that the soft timer fires
 // after the configured deadline AND emits a soft-timeout admin
 // event. Default L_rtt bootstrap = 100ms, soft normal = +100ms
-// → ~200ms total.
+// → ~200ms total. Cancel the hard timer immediately after the
+// soft fires (Codex round-1 MEDIUM #2 on PR #647: do not let
+// the hard timer fire here — it would race the per-test deadline
+// on slow CI and pollute the assertion).
 func TestPacer_SoftDeadlineFires(t *testing.T) {
 	t.Parallel()
 	p := NewPacer()
@@ -628,16 +631,23 @@ func TestPacer_SoftDeadlineFires(t *testing.T) {
 	})
 
 	p.ArmEchoWatchdog(time.Now())
-	// Wait past soft deadline but well before hard deadline.
-	// L_rtt_EMA = 100ms (bootstrap), soft = 100ms+100ms = 200ms.
-	// Hard = 2*100ms+200ms = 400ms.
-	time.Sleep(300 * time.Millisecond)
-
+	// Codex round-1 MEDIUM #2 on PR #647: poll the counter
+	// instead of sleeping a fixed duration. Robust on slow CI.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if p.SoftTimeoutTotal() >= 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
 	if got := p.SoftTimeoutTotal(); got != 1 {
 		t.Errorf("SoftTimeoutTotal() = %d after soft window; want 1", got)
 	}
+	// Cancel the hard timer before it can fire — keeps the
+	// assertion below honest regardless of CI scheduling.
+	p.CancelEchoWatchdog()
 	if got := p.HardTimeoutTotal(); got != 0 {
-		t.Errorf("HardTimeoutTotal() = %d after soft window (before hard); want 0", got)
+		t.Errorf("HardTimeoutTotal() = %d after cancel; want 0", got)
 	}
 	mu.Lock()
 	gotKinds := append([]AdminEventKind{}, emitted...)
@@ -649,7 +659,8 @@ func TestPacer_SoftDeadlineFires(t *testing.T) {
 
 // TestPacer_HardDeadlineFires pins that the hard timer fires
 // after the configured deadline AND emits a hard-timeout admin
-// event. Soft fires first, then hard.
+// event. Soft fires first, then hard. Codex round-1 MEDIUM #2 on
+// PR #647: poll instead of fixed-sleep.
 func TestPacer_HardDeadlineFires(t *testing.T) {
 	t.Parallel()
 	p := NewPacer()
@@ -662,8 +673,15 @@ func TestPacer_HardDeadlineFires(t *testing.T) {
 	})
 
 	p.ArmEchoWatchdog(time.Now())
-	// Wait past hard deadline. L_rtt=100ms, hard=2*100+200=400ms.
-	time.Sleep(500 * time.Millisecond)
+	// Poll the hard counter. L_rtt=100ms, hard=2*100+200=400ms;
+	// generous 2s deadline tolerates slow CI.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if p.HardTimeoutTotal() >= 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
 
 	if got := p.SoftTimeoutTotal(); got != 1 {
 		t.Errorf("SoftTimeoutTotal() = %d after hard window; want 1", got)
@@ -709,10 +727,17 @@ func TestPacer_GraceMode_HardTimerNotArmed(t *testing.T) {
 	})
 
 	p.ArmEchoWatchdog(time.Now())
-	// Wait past where hard would have fired in normal mode
-	// (~500ms). In grace mode soft = L_rtt + 500ms ≈ 550ms, so
-	// we need a longer wait to catch the soft fire.
-	time.Sleep(700 * time.Millisecond)
+	// Codex round-1 MEDIUM #2 on PR #647: poll the soft counter
+	// (grace soft = L_rtt + 500ms ≈ 550ms). 3s deadline tolerates
+	// slow CI; if hard were erroneously armed at 400ms we'd see
+	// it long before this deadline.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if p.SoftTimeoutTotal() >= 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
 
 	if got := p.HardTimeoutTotal(); got != 0 {
 		t.Errorf("HardTimeoutTotal() = %d in grace mode; want 0 (hard timer must not be armed)", got)
@@ -753,6 +778,100 @@ func TestPacer_ArmEchoWatchdog_ReplacesPriorArm(t *testing.T) {
 	}
 }
 
+// TestPacer_ArmEchoWatchdog_StaleFireRaceNoOp pins the Codex
+// round-1 MUST FIX #1 invariant: when ArmEchoWatchdog cancels a
+// timer whose Stop() returns false (fired or firing), the
+// already-queued fire callback must NOT increment counters and
+// must NOT clear the NEWER arm's timer pointer.
+//
+// To exercise the Stop()-returns-false path we use the
+// short-lived pacer pattern: arm with the default L_rtt (soft
+// ~200ms), let the soft timer FIRE, then re-arm. The fired
+// callback for the first arm has finished (incremented counter
+// once). A subsequent re-arm should NOT see the first arm's
+// callback continue to clear the new timer. We then cancel the
+// second arm and confirm the counter stayed at 1 (only the
+// first arm fired) — proving the second arm's timer was clean
+// and not cleared by a stale fire.
+func TestPacer_ArmEchoWatchdog_StaleFireRaceNoOp(t *testing.T) {
+	t.Parallel()
+	p := NewPacer()
+	p.SetAdminEventEmitter(func(kind AdminEventKind, at time.Time) {})
+
+	// First arm — let it fire its soft deadline.
+	p.ArmEchoWatchdog(time.Now())
+	// Poll for the fire instead of sleeping a fixed duration —
+	// robust on slow CI.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if p.SoftTimeoutTotal() >= 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := p.SoftTimeoutTotal(); got != 1 {
+		t.Fatalf("first arm SoftTimeoutTotal = %d; want 1 (precondition)", got)
+	}
+
+	// Second arm — the first arm's timer has already fired and
+	// completed, so its callback is in some state that cannot
+	// affect this arm IF the generation-bump pattern works.
+	p.ArmEchoWatchdog(time.Now())
+	if !p.WatchdogArmed() {
+		t.Fatal("WatchdogArmed=false after second arm; the first arm's stale callback must have cleared it (regression of MUST FIX #1)")
+	}
+
+	// Cancel cleanly. The second arm should not have fired.
+	p.CancelEchoWatchdog()
+	if got := p.SoftTimeoutTotal(); got != 1 {
+		t.Errorf("SoftTimeoutTotal after re-arm + cancel = %d; want 1 (second arm must NOT fire and stale first-arm callback must NOT re-increment)", got)
+	}
+}
+
+// TestPacer_EmitterMayReenterPacer pins the Codex round-1 LOW #1
+// contract refinement: the emitter callback runs AFTER the
+// Pacer mutex is dropped, so it MAY safely re-enter Pacer
+// methods. We verify by having the emitter call WatchdogArmed
+// and SoftTimeoutTotal from inside the callback — neither
+// would return without deadlock if the contract were broken.
+func TestPacer_EmitterMayReenterPacer(t *testing.T) {
+	t.Parallel()
+	p := NewPacer()
+	var mu sync.Mutex
+	var observedSoftTotal uint64
+	var firstFire sync.Once
+	firstSeen := make(chan struct{})
+	p.SetAdminEventEmitter(func(kind AdminEventKind, at time.Time) {
+		// Re-enter the pacer from the emitter callback. If the
+		// pacer mutex were still held at this point this would
+		// deadlock and the test would time out.
+		armed := p.WatchdogArmed()
+		soft := p.SoftTimeoutTotal()
+		mu.Lock()
+		observedSoftTotal = soft
+		mu.Unlock()
+		_ = armed
+		firstFire.Do(func() { close(firstSeen) })
+	})
+
+	p.ArmEchoWatchdog(time.Now())
+	select {
+	case <-firstSeen:
+	case <-time.After(2 * time.Second):
+		t.Fatal("emitter callback did not complete within 2s — contract broken (mutex held during emit, or no fire)")
+	}
+	// Cancel any remaining timers so the hard fire doesn't race
+	// the test exit.
+	p.CancelEchoWatchdog()
+
+	mu.Lock()
+	got := observedSoftTotal
+	mu.Unlock()
+	if got < 1 {
+		t.Errorf("observedSoftTotal inside emitter = %d; want >= 1", got)
+	}
+}
+
 // TestPacer_NilEmitter_CountersStillIncrement pins that the
 // counters increment even when no emitter callback is registered.
 // Diagnostic-only callers (tests, smoke harnesses) need this
@@ -762,11 +881,22 @@ func TestPacer_NilEmitter_CountersStillIncrement(t *testing.T) {
 	p := NewPacer()
 	// Explicitly DO NOT set emitter (or set to nil).
 	p.ArmEchoWatchdog(time.Now())
-	time.Sleep(300 * time.Millisecond)
+	// Codex round-1 MEDIUM #2 on PR #647: poll instead of fixed
+	// sleep.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if p.SoftTimeoutTotal() >= 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
 
 	if got := p.SoftTimeoutTotal(); got != 1 {
 		t.Errorf("SoftTimeoutTotal() with nil emitter = %d; want 1", got)
 	}
+	// Cancel to prevent the hard timer from polluting subsequent
+	// state if this test ever runs longer than expected.
+	p.CancelEchoWatchdog()
 }
 
 // TestClassifier_NewPacerForSession_WiresAdminEvents pins the
@@ -781,9 +911,18 @@ func TestClassifier_NewPacerForSession_WiresAdminEvents(t *testing.T) {
 	if p == nil {
 		t.Fatal("NewPacerForSession() = nil; want non-nil")
 	}
-	// Arm watchdog and wait past soft deadline.
+	// Arm watchdog and poll for the soft fire (Codex round-1
+	// MEDIUM #2 on PR #647: counter polling, not fixed sleep).
 	p.ArmEchoWatchdog(time.Now())
-	time.Sleep(300 * time.Millisecond)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if p.SoftTimeoutTotal() >= 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	// Cancel hard timer so the event count stays at 1 (soft only).
+	p.CancelEchoWatchdog()
 
 	events, dropped := c.DrainAdminEvents()
 	if dropped != 0 {

--- a/internal/adaptermux/v8classifier/pacer_test.go
+++ b/internal/adaptermux/v8classifier/pacer_test.go
@@ -971,6 +971,12 @@ func (e *emitMutex) Unlock() { e.m.Unlock() }
 // AFTER the fire callback completed — by then the generation
 // guard had already fired. This test uses the onTimeoutEnterHook
 // to pause the callback at the deterministic race window.
+//
+// Codex round-3 MAJOR #1 on PR #647: the round-2 version
+// relied on a 50ms sleep before asserting. Replaced with a
+// deterministic mismatch-hook signal so the test waits on the
+// stale callback completing its no-op branch, not on a fixed
+// duration.
 func TestPacer_ArmEchoWatchdog_StaleFireRace_Deterministic(t *testing.T) {
 	t.Parallel()
 	p := NewPacer()
@@ -987,6 +993,19 @@ func TestPacer_ArmEchoWatchdog_StaleFireRace_Deterministic(t *testing.T) {
 			close(entered)
 		}
 		<-released
+	}
+	// Codex round-3 MAJOR #1 on PR #647: deterministic
+	// completion signal — the stale callback closes this after
+	// passing the generation-mismatch no-op branch, so the test
+	// asserts ONLY after the stale path is provably finished.
+	staleNoOpDone := make(chan struct{})
+	p.onTimeoutGenMismatchHook = func() {
+		select {
+		case <-staleNoOpDone:
+			// Already signalled — second fire from hard timer.
+		default:
+			close(staleNoOpDone)
+		}
 	}
 
 	p.ArmEchoWatchdog(time.Now())
@@ -1006,17 +1025,21 @@ func TestPacer_ArmEchoWatchdog_StaleFireRace_Deterministic(t *testing.T) {
 	p.onTimeoutEnterHook = nil // clear hook before re-arm so the new arm doesn't deadlock
 	p.ArmEchoWatchdog(time.Now())
 	// Release the stale callback. It should observe the new
-	// generation and no-op.
+	// generation and no-op (signalling staleNoOpDone).
 	close(released)
 
-	// Give the stale callback a moment to run + bail out, then
-	// cancel the new arm cleanly.
-	time.Sleep(50 * time.Millisecond)
+	// Deterministically wait for the stale callback to finish
+	// its no-op path. NO fixed sleep.
+	select {
+	case <-staleNoOpDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stale callback did not reach generation-mismatch no-op within 2s — generation guard may be broken")
+	}
 
 	// PRIMARY ASSERTION: softTimeoutTotal stayed at 0. The stale
 	// callback did NOT increment.
 	if got := p.SoftTimeoutTotal(); got != 0 {
-		t.Errorf("SoftTimeoutTotal() = %d after stale fire was released; want 0 (stale fire must no-op via gen mismatch)", got)
+		t.Errorf("SoftTimeoutTotal() = %d after stale fire completed no-op; want 0 (stale fire must no-op via gen mismatch)", got)
 	}
 	// SECONDARY ASSERTION: the new arm's softTimer is still set
 	// (was NOT cleared by the stale fire's p.softTimer = nil).
@@ -1032,18 +1055,32 @@ func TestPacer_ArmEchoWatchdog_StaleFireRace_Deterministic(t *testing.T) {
 // reentry test covered read-only methods; this one covers the
 // state-mutating Arm path.
 //
-// Mechanics: the emitter Arms a NEW watchdog from inside the
-// fire callback. The first arm fired (incremented counter to
-// 1) and called the emitter; the emitter re-arms; cancel and
-// confirm the counter stayed at 1 (the re-armed timer did not
-// also fire).
+// Codex round-3 MEDIUM #1 on PR #647: the round-2 version
+// had a race window — the re-armed timer's 200ms could elapse
+// before the test goroutine called Cancel under CI stall. Now
+// the re-arm installs a SECOND-PHASE entry hook that blocks
+// the re-armed fire callback indefinitely. The test cancels
+// while the re-armed timer is blocked, then releases the hook;
+// the cancel bumped the generation so the post-block fire
+// no-ops on gen mismatch.
 func TestPacer_EmitterMayReArm(t *testing.T) {
 	t.Parallel()
 	p := NewPacer()
 	var armOnce sync.Once
 	armed := make(chan struct{})
+	rearmedFireBlock := make(chan struct{})
+	rearmedFireEntered := make(chan struct{})
+	rearmedEnteredOnce := sync.Once{}
 	p.SetAdminEventEmitter(func(kind AdminEventKind, at time.Time) {
 		armOnce.Do(func() {
+			// Install the SECOND-PHASE hook BEFORE re-arming so
+			// the re-armed timer's fire blocks deterministically
+			// on rearmedFireBlock (and the test can cancel
+			// before the block is released).
+			p.onTimeoutEnterHook = func() {
+				rearmedEnteredOnce.Do(func() { close(rearmedFireEntered) })
+				<-rearmedFireBlock
+			}
 			// Re-arm from inside the emitter. If the Pacer mutex
 			// were still held this would deadlock.
 			p.ArmEchoWatchdog(time.Now())
@@ -1058,12 +1095,27 @@ func TestPacer_EmitterMayReArm(t *testing.T) {
 		t.Fatal("emitter's ArmEchoWatchdog call did not complete within 2s — likely deadlock")
 	}
 
-	// Cancel the re-armed watchdog cleanly. The total count
-	// reflects ONLY the first arm's fire (the re-armed timer
-	// was cancelled before it could fire).
+	// Wait for the re-armed timer to fire and enter the hook.
+	// This guarantees the re-arm is in-flight before we cancel.
+	select {
+	case <-rearmedFireEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("re-armed timer did not fire within 2s")
+	}
+
+	// Cancel the re-armed watchdog (bumps generation). When we
+	// release the hook below, the re-armed fire will observe
+	// the gen mismatch and no-op.
 	p.CancelEchoWatchdog()
+	close(rearmedFireBlock)
+
+	// Brief settle so the released callback finishes its no-op
+	// path. We don't have a mismatch-hook signal wired here
+	// (the round-3 fix only added it to the dedicated stale-fire
+	// test), so a small bounded sleep is acceptable.
+	time.Sleep(50 * time.Millisecond)
 
 	if got := p.SoftTimeoutTotal(); got != 1 {
-		t.Errorf("SoftTimeoutTotal() = %d after re-arm-from-emitter + cancel; want 1 (only first arm fired)", got)
+		t.Errorf("SoftTimeoutTotal() = %d after re-arm-from-emitter + cancel; want 1 (only first arm fired; re-armed fire must no-op via gen mismatch)", got)
 	}
 }

--- a/internal/adaptermux/v8classifier/pacer_test.go
+++ b/internal/adaptermux/v8classifier/pacer_test.go
@@ -957,3 +957,113 @@ type emitMutex struct {
 
 func (e *emitMutex) Lock()   { e.m.Lock() }
 func (e *emitMutex) Unlock() { e.m.Unlock() }
+
+// TestPacer_ArmEchoWatchdog_StaleFireRace_Deterministic pins
+// the EXACT race that Codex round-1 MUST FIX #1 closes: a timer
+// fire callback that has reached the AfterFunc goroutine but has
+// not yet acquired the Pacer mutex, while a concurrent
+// CancelEchoWatchdog bumps the generation. Without the
+// generation guard the stale fire would (a) increment
+// softTimeoutTotal and (b) clear p.softTimer for a NEWER arm.
+//
+// Codex round-2 MAJOR #1 on PR #647: the prior race test
+// (TestPacer_ArmEchoWatchdog_StaleFireRaceNoOp) only checked
+// AFTER the fire callback completed — by then the generation
+// guard had already fired. This test uses the onTimeoutEnterHook
+// to pause the callback at the deterministic race window.
+func TestPacer_ArmEchoWatchdog_StaleFireRace_Deterministic(t *testing.T) {
+	t.Parallel()
+	p := NewPacer()
+	// Block soft-fire callback BEFORE its lock acquisition.
+	released := make(chan struct{})
+	entered := make(chan struct{})
+	p.onTimeoutEnterHook = func() {
+		select {
+		case <-entered:
+			// already signalled — second fire (e.g. hard timer
+			// after a soft-only race) re-enters but doesn't
+			// re-signal.
+		default:
+			close(entered)
+		}
+		<-released
+	}
+
+	p.ArmEchoWatchdog(time.Now())
+	// Wait for the soft-fire callback to enter the hook.
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("soft fire callback did not enter onTimeoutEnterHook within 2s")
+	}
+	// Cancel the watchdog — bumps generation. The blocked
+	// callback below should observe the mismatched gen and
+	// no-op when we release it.
+	p.CancelEchoWatchdog()
+	// Also re-arm to ensure the stale callback can't clobber the
+	// new arm's softTimer pointer (the load-bearing part of MUST
+	// FIX #1's second effect).
+	p.onTimeoutEnterHook = nil // clear hook before re-arm so the new arm doesn't deadlock
+	p.ArmEchoWatchdog(time.Now())
+	// Release the stale callback. It should observe the new
+	// generation and no-op.
+	close(released)
+
+	// Give the stale callback a moment to run + bail out, then
+	// cancel the new arm cleanly.
+	time.Sleep(50 * time.Millisecond)
+
+	// PRIMARY ASSERTION: softTimeoutTotal stayed at 0. The stale
+	// callback did NOT increment.
+	if got := p.SoftTimeoutTotal(); got != 0 {
+		t.Errorf("SoftTimeoutTotal() = %d after stale fire was released; want 0 (stale fire must no-op via gen mismatch)", got)
+	}
+	// SECONDARY ASSERTION: the new arm's softTimer is still set
+	// (was NOT cleared by the stale fire's p.softTimer = nil).
+	if !p.WatchdogArmed() {
+		t.Error("WatchdogArmed() = false after stale fire; want true (stale fire must not clear the new arm's softTimer)")
+	}
+	p.CancelEchoWatchdog()
+}
+
+// TestPacer_EmitterMayReArm pins Codex round-2 MEDIUM #1: the
+// emitter callback may safely call ArmEchoWatchdog (not just
+// the read-only WatchdogArmed / SoftTimeoutTotal). The earlier
+// reentry test covered read-only methods; this one covers the
+// state-mutating Arm path.
+//
+// Mechanics: the emitter Arms a NEW watchdog from inside the
+// fire callback. The first arm fired (incremented counter to
+// 1) and called the emitter; the emitter re-arms; cancel and
+// confirm the counter stayed at 1 (the re-armed timer did not
+// also fire).
+func TestPacer_EmitterMayReArm(t *testing.T) {
+	t.Parallel()
+	p := NewPacer()
+	var armOnce sync.Once
+	armed := make(chan struct{})
+	p.SetAdminEventEmitter(func(kind AdminEventKind, at time.Time) {
+		armOnce.Do(func() {
+			// Re-arm from inside the emitter. If the Pacer mutex
+			// were still held this would deadlock.
+			p.ArmEchoWatchdog(time.Now())
+			close(armed)
+		})
+	})
+
+	p.ArmEchoWatchdog(time.Now())
+	select {
+	case <-armed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("emitter's ArmEchoWatchdog call did not complete within 2s — likely deadlock")
+	}
+
+	// Cancel the re-armed watchdog cleanly. The total count
+	// reflects ONLY the first arm's fire (the re-armed timer
+	// was cancelled before it could fire).
+	p.CancelEchoWatchdog()
+
+	if got := p.SoftTimeoutTotal(); got != 1 {
+		t.Errorf("SoftTimeoutTotal() = %d after re-arm-from-emitter + cancel; want 1 (only first arm fired)", got)
+	}
+}

--- a/internal/adaptermux/v8classifier/pacer_test.go
+++ b/internal/adaptermux/v8classifier/pacer_test.go
@@ -1,6 +1,7 @@
 package v8classifier
 
 import (
+	"sync"
 	"testing"
 	"time"
 )
@@ -524,3 +525,296 @@ func TestPacer_Schedule_ZeroNow_NoSentinelLeak(t *testing.T) {
 		t.Errorf("third Schedule(t0): %v; want %v", emit3, want3)
 	}
 }
+
+// =============================================================
+// Phase 3 Step B3.6e — echo watchdog tests
+// =============================================================
+//
+// These tests exercise the soft/hard deadline timer fire path
+// against a Pacer with an artificially small L_rtt EMA so the
+// timers fire fast enough to validate the wiring without slowing
+// the test suite. The default L_rtt bootstrap is 100ms; to get
+// sub-100ms soft deadlines we use SetTau (no — tau doesn't affect
+// deadlines) — instead we feed RecordEcho samples that pull the
+// EMA down to a small value, OR we accept the ~100ms wait for
+// the default bootstrap to fire.
+//
+// For tests we shrink the deadlines by feeding a tiny RecordEcho
+// sample (e.g. 1ms) which collapses the EMA quickly. Soft becomes
+// ~100ms+1ms*α (still ~100ms) — so we use a different approach:
+// run with the default L_rtt and just wait ~120ms for soft. Hard
+// is 2*L_rtt + 200ms = ~400ms. Tests must tolerate this latency.
+
+// TestPacer_Watchdog_NotArmedAtConstruction pins the production-
+// default state: a freshly-constructed Pacer has no watchdog
+// armed. WatchdogArmed() is false; SoftTimeoutTotal /
+// HardTimeoutTotal are zero.
+func TestPacer_Watchdog_NotArmedAtConstruction(t *testing.T) {
+	t.Parallel()
+	p := NewPacer()
+	if p.WatchdogArmed() {
+		t.Error("WatchdogArmed() = true at construction; want false")
+	}
+	if got := p.SoftTimeoutTotal(); got != 0 {
+		t.Errorf("SoftTimeoutTotal() = %d at construction; want 0", got)
+	}
+	if got := p.HardTimeoutTotal(); got != 0 {
+		t.Errorf("HardTimeoutTotal() = %d at construction; want 0", got)
+	}
+}
+
+// TestPacer_ArmEchoWatchdog_ArmsTimers pins the basic arm
+// contract: after ArmEchoWatchdog, WatchdogArmed reports true.
+// Then CancelEchoWatchdog clears the state.
+func TestPacer_ArmEchoWatchdog_ArmsTimers(t *testing.T) {
+	t.Parallel()
+	p := NewPacer()
+	p.ArmEchoWatchdog(t0)
+	if !p.WatchdogArmed() {
+		t.Error("WatchdogArmed() = false after Arm; want true")
+	}
+	p.CancelEchoWatchdog()
+	if p.WatchdogArmed() {
+		t.Error("WatchdogArmed() = true after Cancel; want false")
+	}
+}
+
+// TestPacer_CancelEchoWatchdog_BeforeFire pins that a cancel
+// before the timer fires prevents the soft/hard counters from
+// incrementing and prevents any emitter callback.
+func TestPacer_CancelEchoWatchdog_BeforeFire(t *testing.T) {
+	t.Parallel()
+	p := NewPacer()
+	var emittedKinds []AdminEventKind
+	var mu emitMutex
+	p.SetAdminEventEmitter(func(kind AdminEventKind, at time.Time) {
+		mu.Lock()
+		emittedKinds = append(emittedKinds, kind)
+		mu.Unlock()
+	})
+
+	p.ArmEchoWatchdog(time.Now())
+	// Cancel immediately, well before the soft deadline (~100ms).
+	p.CancelEchoWatchdog()
+	// Wait past the would-be soft deadline to confirm no fire.
+	time.Sleep(150 * time.Millisecond)
+
+	if got := p.SoftTimeoutTotal(); got != 0 {
+		t.Errorf("SoftTimeoutTotal() after cancel = %d; want 0", got)
+	}
+	if got := p.HardTimeoutTotal(); got != 0 {
+		t.Errorf("HardTimeoutTotal() after cancel = %d; want 0", got)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(emittedKinds) != 0 {
+		t.Errorf("emittedKinds after cancel = %v; want empty", emittedKinds)
+	}
+}
+
+// TestPacer_SoftDeadlineFires pins that the soft timer fires
+// after the configured deadline AND emits a soft-timeout admin
+// event. Default L_rtt bootstrap = 100ms, soft normal = +100ms
+// → ~200ms total.
+func TestPacer_SoftDeadlineFires(t *testing.T) {
+	t.Parallel()
+	p := NewPacer()
+	var emitted []AdminEventKind
+	var mu emitMutex
+	p.SetAdminEventEmitter(func(kind AdminEventKind, at time.Time) {
+		mu.Lock()
+		emitted = append(emitted, kind)
+		mu.Unlock()
+	})
+
+	p.ArmEchoWatchdog(time.Now())
+	// Wait past soft deadline but well before hard deadline.
+	// L_rtt_EMA = 100ms (bootstrap), soft = 100ms+100ms = 200ms.
+	// Hard = 2*100ms+200ms = 400ms.
+	time.Sleep(300 * time.Millisecond)
+
+	if got := p.SoftTimeoutTotal(); got != 1 {
+		t.Errorf("SoftTimeoutTotal() = %d after soft window; want 1", got)
+	}
+	if got := p.HardTimeoutTotal(); got != 0 {
+		t.Errorf("HardTimeoutTotal() = %d after soft window (before hard); want 0", got)
+	}
+	mu.Lock()
+	gotKinds := append([]AdminEventKind{}, emitted...)
+	mu.Unlock()
+	if len(gotKinds) != 1 || gotKinds[0] != AdminEventKindEchoSoftTimeout {
+		t.Errorf("emitted kinds = %v; want [EchoSoftTimeout]", gotKinds)
+	}
+}
+
+// TestPacer_HardDeadlineFires pins that the hard timer fires
+// after the configured deadline AND emits a hard-timeout admin
+// event. Soft fires first, then hard.
+func TestPacer_HardDeadlineFires(t *testing.T) {
+	t.Parallel()
+	p := NewPacer()
+	var emitted []AdminEventKind
+	var mu emitMutex
+	p.SetAdminEventEmitter(func(kind AdminEventKind, at time.Time) {
+		mu.Lock()
+		emitted = append(emitted, kind)
+		mu.Unlock()
+	})
+
+	p.ArmEchoWatchdog(time.Now())
+	// Wait past hard deadline. L_rtt=100ms, hard=2*100+200=400ms.
+	time.Sleep(500 * time.Millisecond)
+
+	if got := p.SoftTimeoutTotal(); got != 1 {
+		t.Errorf("SoftTimeoutTotal() = %d after hard window; want 1", got)
+	}
+	if got := p.HardTimeoutTotal(); got != 1 {
+		t.Errorf("HardTimeoutTotal() = %d after hard window; want 1", got)
+	}
+	mu.Lock()
+	gotKinds := append([]AdminEventKind{}, emitted...)
+	mu.Unlock()
+	if len(gotKinds) != 2 {
+		t.Fatalf("emitted kinds = %v; want 2 (soft then hard)", gotKinds)
+	}
+	if gotKinds[0] != AdminEventKindEchoSoftTimeout {
+		t.Errorf("emitted[0] = %v; want EchoSoftTimeout", gotKinds[0])
+	}
+	if gotKinds[1] != AdminEventKindEchoHardTimeout {
+		t.Errorf("emitted[1] = %v; want EchoHardTimeout", gotKinds[1])
+	}
+}
+
+// TestPacer_GraceMode_HardTimerNotArmed pins the grace-mode
+// invariant: when graceRemaining > 0, EchoDeadlines reports
+// hardEnabled=false, and ArmEchoWatchdog must NOT arm the hard
+// timer. Even if we wait past where hard would have fired, only
+// soft fires.
+func TestPacer_GraceMode_HardTimerNotArmed(t *testing.T) {
+	t.Parallel()
+	p := NewPacer()
+	// Trigger grace by simulating long-idle BeforeActiveWrite.
+	// First seed a prior echo so lastEchoAt is non-zero.
+	p.RecordEcho(50*time.Millisecond, t0)
+	// Now call BeforeActiveWrite far in the future (>= 30s) to
+	// trip grace.
+	p.BeforeActiveWrite(t0.Add(60 * time.Second))
+
+	var emitted []AdminEventKind
+	var mu emitMutex
+	p.SetAdminEventEmitter(func(kind AdminEventKind, at time.Time) {
+		mu.Lock()
+		emitted = append(emitted, kind)
+		mu.Unlock()
+	})
+
+	p.ArmEchoWatchdog(time.Now())
+	// Wait past where hard would have fired in normal mode
+	// (~500ms). In grace mode soft = L_rtt + 500ms ≈ 550ms, so
+	// we need a longer wait to catch the soft fire.
+	time.Sleep(700 * time.Millisecond)
+
+	if got := p.HardTimeoutTotal(); got != 0 {
+		t.Errorf("HardTimeoutTotal() = %d in grace mode; want 0 (hard timer must not be armed)", got)
+	}
+	if got := p.SoftTimeoutTotal(); got != 1 {
+		t.Errorf("SoftTimeoutTotal() = %d in grace mode; want 1 (soft must still fire)", got)
+	}
+	mu.Lock()
+	gotKinds := append([]AdminEventKind{}, emitted...)
+	mu.Unlock()
+	if len(gotKinds) != 1 || gotKinds[0] != AdminEventKindEchoSoftTimeout {
+		t.Errorf("emitted kinds = %v; want [EchoSoftTimeout] only", gotKinds)
+	}
+}
+
+// TestPacer_ArmEchoWatchdog_ReplacesPriorArm pins that a second
+// Arm before the first echo cancels the first arm's timers — at
+// most ONE outstanding watchdog per pacer. The first arm's soft
+// deadline must NOT fire if the second arm replaces it before
+// that deadline.
+func TestPacer_ArmEchoWatchdog_ReplacesPriorArm(t *testing.T) {
+	t.Parallel()
+	p := NewPacer()
+	p.SetAdminEventEmitter(func(kind AdminEventKind, at time.Time) {})
+
+	p.ArmEchoWatchdog(time.Now())
+	// Re-arm well before soft deadline (~200ms).
+	time.Sleep(20 * time.Millisecond)
+	p.ArmEchoWatchdog(time.Now())
+	// Cancel before the second arm's deadline too.
+	time.Sleep(20 * time.Millisecond)
+	p.CancelEchoWatchdog()
+	// Wait past where either arm could fire.
+	time.Sleep(300 * time.Millisecond)
+
+	if got := p.SoftTimeoutTotal(); got != 0 {
+		t.Errorf("SoftTimeoutTotal() after re-arm + cancel = %d; want 0", got)
+	}
+}
+
+// TestPacer_NilEmitter_CountersStillIncrement pins that the
+// counters increment even when no emitter callback is registered.
+// Diagnostic-only callers (tests, smoke harnesses) need this
+// signal without having to wire a full emitter.
+func TestPacer_NilEmitter_CountersStillIncrement(t *testing.T) {
+	t.Parallel()
+	p := NewPacer()
+	// Explicitly DO NOT set emitter (or set to nil).
+	p.ArmEchoWatchdog(time.Now())
+	time.Sleep(300 * time.Millisecond)
+
+	if got := p.SoftTimeoutTotal(); got != 1 {
+		t.Errorf("SoftTimeoutTotal() with nil emitter = %d; want 1", got)
+	}
+}
+
+// TestClassifier_NewPacerForSession_WiresAdminEvents pins the
+// integration contract: NewPacerForSession returns a Pacer whose
+// echo-watchdog timeouts surface in the classifier's adminEvents
+// ring buffer. Soft fires → drain returns an
+// AdminEventKindEchoSoftTimeout entry.
+func TestClassifier_NewPacerForSession_WiresAdminEvents(t *testing.T) {
+	t.Parallel()
+	c := New(ModeShadow)
+	p := c.NewPacerForSession()
+	if p == nil {
+		t.Fatal("NewPacerForSession() = nil; want non-nil")
+	}
+	// Arm watchdog and wait past soft deadline.
+	p.ArmEchoWatchdog(time.Now())
+	time.Sleep(300 * time.Millisecond)
+
+	events, dropped := c.DrainAdminEvents()
+	if dropped != 0 {
+		t.Errorf("dropped = %d; want 0", dropped)
+	}
+	if len(events) != 1 {
+		t.Fatalf("len(events) = %d; want 1", len(events))
+	}
+	if events[0].Kind != AdminEventKindEchoSoftTimeout {
+		t.Errorf("events[0].Kind = %v; want EchoSoftTimeout", events[0].Kind)
+	}
+}
+
+// TestClassifier_NewPacerForSession_NilClassifier pins the
+// defensive nil-return: calling NewPacerForSession on a nil
+// classifier (which can happen during ModeOff cleanup paths)
+// returns nil rather than panicking.
+func TestClassifier_NewPacerForSession_NilClassifier(t *testing.T) {
+	t.Parallel()
+	var c *Classifier
+	if got := c.NewPacerForSession(); got != nil {
+		t.Errorf("nil-classifier NewPacerForSession() = %v; want nil", got)
+	}
+}
+
+// emitMutex is a thin sync.Mutex wrapper so the watchdog tests
+// can guard their shared `emitted` slice from the timer-fire
+// goroutine without litering the test bodies with sync imports.
+type emitMutex struct {
+	m sync.Mutex
+}
+
+func (e *emitMutex) Lock()   { e.m.Lock() }
+func (e *emitMutex) Unlock() { e.m.Unlock() }


### PR DESCRIPTION
## Summary

Phase 3 Step B3.6e wires the v8 echo watchdog at the gateway pacer. Combined with B3.6c (BeforeActiveWrite) and B3.6d (RecordEcho), the per-session pacer is now fully active on the gateway path: every active write arms a soft (and conditionally hard) deadline timer; the matching echo arrival cancels both; timer expiry surfaces an admin event into the classifier's adminEvents ring buffer.

### Wiring map

| Pacer method | Hook site | Action |
|---|---|---|
| `BeforeActiveWrite(now)` | `mux.doSend` (pre-write) — B3.6c | Grace bootstrap if long-idle |
| `ArmEchoWatchdog(now)` | `mux.doSend` (after `recordSentWithTime`) — **this PR** | Arm soft (+ hard if hardEnabled) timer |
| `RecordEcho(rtt, now)` | `mux.readLoop` echo-match site — B3.6d | L_rtt EMA sample |
| `CancelEchoWatchdog()` | `mux.readLoop` echo-match site — **this PR** | Disarm both timers |
| `CancelEchoWatchdog()` | `mux.RemoveSession` — **this PR** | Disarm before pacer Delete |

The arm/cancel pair is symmetric per active write. AT MOST ONE outstanding watchdog per pacer — a second `ArmEchoWatchdog` before the first echo lands cancels the prior arm. Production callers follow `bus.sendRawWithEcho`'s strict "write one, wait for echo, write next" cadence, so pipelined contention is not produced.

### Pacer additions (`internal/adaptermux/v8classifier/pacer.go`, +210 lines)

- **`AdminEventEmitFunc`** type — callback signature for watchdog timeouts. Invoked from `time.AfterFunc` goroutine; emitter callback runs WITHOUT the Pacer mutex held (no deadlock if emitter calls back into the pacer).
- **`softTimer`/`hardTimer`** state + **`softTimeoutTotal`/`hardTimeoutTotal`** counters.
- **`SetAdminEventEmitter(f)`** — register the callback (typically wired once at construction by `Classifier.NewPacerForSession`).
- **`ArmEchoWatchdog(now)`** — cancel any prior arm, query `EchoDeadlines`, set the new timers.
- **`CancelEchoWatchdog()`** — stop both timers idempotently.
- **`onSoftTimeout` / `onHardTimeout`** — timer-fire callbacks. Counter under the pacer mutex; emitter callback invoked unlocked.
- **`WatchdogArmed()` / `SoftTimeoutTotal()` / `HardTimeoutTotal()`** accessors for diagnostic introspection.

### Classifier wrapper (`internal/adaptermux/v8classifier/classifier.go`, +28 lines)

- **`NewPacerForSession()`** — returns a Pacer with the admin-event emitter pre-wired to the classifier's `adminEvents` ring buffer. Replaces raw `NewPacer()` at the mux's `ensureSessionPacer` call site so all per-session pacers automatically surface watchdog timeouts in the classifier's drain.
- Defensive nil-receiver handling — `(*Classifier)(nil).NewPacerForSession()` returns nil rather than panicking.

### Mux/session wiring

- **`Mux.ensureSessionPacer`** now uses `m.v8.NewPacerForSession()` — pre-wires the emitter.
- **`Mux.doSend`** arms the watchdog after `recordSentWithTime` when `m.v8 != nil`.
- **Echo-match site** cancels the watchdog on `echoMatchSuppressed` BEFORE the `RecordEcho` call (closes the post-RecordEcho timer-fire window).
- **`Mux.RemoveSession`** cancels the watchdog BEFORE the `sessionPacers.Delete(id)` — closes the post-Remove timer-fire window where a delayed soft/hard fire could emit a stale event for a sessionID that no longer exists.
- **ModeOff zero-overhead contract preserved**: all watchdog paths are inside the `m.v8 != nil` branch. ModeOff's doSend and match site remain identical to pre-B3.6c.

### v8 §1.4 deadline semantics

`EchoDeadlines()` (unchanged) returns:

- **Grace mode** (`graceRemaining > 0`): `soft = L_rtt_EMA + 500ms`, `hardEnabled = false`. The hard timer is NOT armed.
- **Normal mode** (`graceRemaining == 0`): `soft = L_rtt_EMA + 100ms`, `hard = 2 × L_rtt_EMA + 200ms`, `hardEnabled = true`. Both timers armed.

`ArmEchoWatchdog` respects `hardEnabled` — the test `TestPacer_GraceMode_HardTimerNotArmed` pins that the hard timer is NEVER armed in grace mode regardless of how long we wait past the would-be hard deadline.

## Test coverage

**`internal/adaptermux/v8classifier/pacer_test.go` (+10 tests, +294 lines):**
- `TestPacer_Watchdog_NotArmedAtConstruction` — fresh pacer has no watchdog.
- `TestPacer_ArmEchoWatchdog_ArmsTimers` + `TestPacer_CancelEchoWatchdog_BeforeFire` — basic arm/cancel.
- `TestPacer_SoftDeadlineFires` — 300ms wait → 1 soft fire + 1 EchoSoftTimeout event.
- `TestPacer_HardDeadlineFires` — 500ms wait → 1 soft + 1 hard fire + 2 events in order.
- `TestPacer_GraceMode_HardTimerNotArmed` — grace mode: 700ms wait → only soft fires.
- `TestPacer_ArmEchoWatchdog_ReplacesPriorArm` — second arm cancels first.
- `TestPacer_NilEmitter_CountersStillIncrement` — counters work without emitter.
- `TestClassifier_NewPacerForSession_WiresAdminEvents` — integration: timeout surfaces in classifier drain.
- `TestClassifier_NewPacerForSession_NilClassifier` — defensive nil handling.

**`internal/adaptermux/pacer_wiring_test.go` (+3 tests, +110 lines):**
- `TestSessionPacer_Watchdog_ArmedOnDoSend` — write fires → `WatchdogArmed=true`.
- `TestSessionPacer_Watchdog_CancelledOnEchoMatch` — echo arrival → `WatchdogArmed=false`.
- `TestSessionPacer_Watchdog_OffMode_NoArm` — ModeOff has no watchdog at all.

## Verification

- 13 new tests green under `-race`: mux 6.7s, v8classifier 23.2s.
- 30x stress (count=30) under `-race`: all green.
- Full mux suite under `-race`: 108s wall, all tests pass.
- Build + vet + gofmt clean on touched files.

## Production safety

`V8ClassifierMode` defaults to `ModeOff`. The watchdog is dormant until explicit opt-in via `HELIANTHUS_V8_CLASSIFIER_MODE=shadow` or `enforce`. Existing deployments unaffected.

## Out of scope (next sub-PRs)

- **B3.6f**: output pacer at `session.writeLoop` (TCP egress cadence via `Schedule`).
- **B3.7**: shadow-mode divergence comparison vs the current pre-v8 path.
- **L_rtt penalty on hard timeout** — separate enforcement concern; this PR is observability only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)