### PR TITLE
Phase 3 Step B3.6f: output pacer at session.writeLoop (TCP egress cadence)

### DIFF
--- a/internal/adaptermux/pacer_wiring_test.go
+++ b/internal/adaptermux/pacer_wiring_test.go
@@ -444,3 +444,140 @@ func TestSessionPacer_Watchdog_OffMode_NoArm(t *testing.T) {
 		t.Errorf("post-write SessionPacer in ModeOff = %v; want nil (no watchdog lazy-create)", got)
 	}
 }
+
+// TestSessionPacer_OutputPacer_SchedulesFrameEgress pins the
+// Phase 3 Step B3.6f wiring: in V8ClassifierMode != Off, each
+// frame written by session.writeFrame consults the per-session
+// pacer's Schedule. The cadence anchor advances by τ_wire_byte
+// per byte (4.17ms per byte). We exercise this by writing two
+// 1-byte frames in quick succession on the same session and
+// confirming the LastScheduledEmit advances by at least one τ
+// between them.
+func TestSessionPacer_OutputPacer_SchedulesFrameEgress(t *testing.T) {
+	mux, _, _, cleanup := newClassifiedTestMux(t, v8classifier.ModeShadow)
+	defer cleanup()
+
+	// Add an external session via the same plumbing that
+	// production AddSession exercises.
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	sid := mux.AddSession(serverConn)
+	if sid == 0 {
+		t.Fatal("AddSession returned 0")
+	}
+	defer mux.RemoveSession(sid)
+
+	pacer := mux.SessionPacer(sid)
+	if pacer == nil {
+		t.Fatalf("SessionPacer(%d) = nil; want non-nil", sid)
+	}
+	// Precondition: LastScheduledEmit is zero (no Schedule fired).
+	if got := pacer.LastScheduledEmit(); !got.IsZero() {
+		t.Fatalf("precondition: LastScheduledEmit = %v; want zero", got)
+	}
+
+	// Drive a frame egress: enqueue a single-byte ENH frame on
+	// the session's sendCh. The writeLoop drains it and calls
+	// writeFrame, which fires our new Schedule wiring.
+	// Use a payload byte < 0x80 so writeFrame takes the "short
+	// form" path (1-byte buf).
+	mux.sessions[sid].sendCh <- sessionFrame{
+		kind:    sessionFrameReceived,
+		payload: 0x42,
+	}
+	// Read from the pipe so writeLoop's Write doesn't block.
+	go func() {
+		buf := make([]byte, 32)
+		_, _ = clientConn.Read(buf)
+	}()
+
+	// Poll LastScheduledEmit until it advances (post-Schedule call).
+	deadline := time.Now().Add(2 * time.Second)
+	var emit1 time.Time
+	for time.Now().Before(deadline) {
+		emit1 = pacer.LastScheduledEmit()
+		if !emit1.IsZero() {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if emit1.IsZero() {
+		t.Fatal("LastScheduledEmit stayed zero after frame egress — Schedule was not called")
+	}
+
+	// Enqueue a SECOND frame and confirm the anchor advances by
+	// at least one τ.
+	mux.sessions[sid].sendCh <- sessionFrame{
+		kind:    sessionFrameReceived,
+		payload: 0x43,
+	}
+	go func() {
+		buf := make([]byte, 32)
+		_, _ = clientConn.Read(buf)
+	}()
+
+	deadline = time.Now().Add(2 * time.Second)
+	var emit2 time.Time
+	for time.Now().Before(deadline) {
+		emit2 = pacer.LastScheduledEmit()
+		if emit2.After(emit1) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !emit2.After(emit1) {
+		t.Errorf("LastScheduledEmit did not advance between frames: emit1=%v emit2=%v", emit1, emit2)
+	}
+	// Verify the advance is AT LEAST τ_wire_byte (4.17ms). It
+	// can be MORE if wall clock advanced past the prior emit
+	// (writeLoop scheduling latency, GC, etc).
+	advance := emit2.Sub(emit1)
+	if advance < v8classifier.TauWireByte {
+		t.Errorf("cadence advance %v < TauWireByte %v; pacer enforcement broken", advance, v8classifier.TauWireByte)
+	}
+}
+
+// TestSessionPacer_OutputPacer_OffMode_NoSchedule pins the
+// ModeOff zero-overhead contract on the output-pacer side: when
+// V8ClassifierMode == Off, writeFrame must NOT call Schedule
+// (and obviously must not allocate a pacer). The pipe still
+// receives the frame promptly.
+func TestSessionPacer_OutputPacer_OffMode_NoSchedule(t *testing.T) {
+	mux, _, _, cleanup := newClassifiedTestMux(t, v8classifier.ModeOff)
+	defer cleanup()
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	sid := mux.AddSession(serverConn)
+	if sid == 0 {
+		t.Fatal("AddSession returned 0")
+	}
+	defer mux.RemoveSession(sid)
+
+	// SessionPacer is nil in ModeOff.
+	if got := mux.SessionPacer(sid); got != nil {
+		t.Fatalf("SessionPacer in ModeOff = %v; want nil", got)
+	}
+
+	mux.sessions[sid].sendCh <- sessionFrame{
+		kind:    sessionFrameReceived,
+		payload: 0x42,
+	}
+	// Read promptly — confirms the frame egress did NOT block on
+	// any pacer Schedule (which doesn't exist in ModeOff).
+	if err := serverConn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	buf := make([]byte, 32)
+	n, err := clientConn.Read(buf)
+	if err != nil {
+		t.Fatalf("clientConn.Read err: %v", err)
+	}
+	if n < 1 {
+		t.Errorf("clientConn.Read returned %d bytes; want >= 1", n)
+	}
+	// Post-write: SessionPacer STILL nil — no lazy-create.
+	if got := mux.SessionPacer(sid); got != nil {
+		t.Errorf("post-write SessionPacer in ModeOff = %v; want nil (no lazy-create)", got)
+	}
+}

--- a/internal/adaptermux/pacer_wiring_test.go
+++ b/internal/adaptermux/pacer_wiring_test.go
@@ -542,6 +542,11 @@ func TestSessionPacer_OutputPacer_SchedulesFrameEgress(t *testing.T) {
 // V8ClassifierMode == Off, writeFrame must NOT call Schedule
 // (and obviously must not allocate a pacer). The pipe still
 // receives the frame promptly.
+//
+// Codex round-1 MEDIUM #1 on PR #648: SetReadDeadline is set on
+// the CLIENT side (the side we're reading from), not the server
+// side — net.Pipe deadlines are per-endpoint, so a regression
+// would otherwise hang the test until the package timeout.
 func TestSessionPacer_OutputPacer_OffMode_NoSchedule(t *testing.T) {
 	mux, _, _, cleanup := newClassifiedTestMux(t, v8classifier.ModeOff)
 	defer cleanup()
@@ -564,8 +569,9 @@ func TestSessionPacer_OutputPacer_OffMode_NoSchedule(t *testing.T) {
 		payload: 0x42,
 	}
 	// Read promptly — confirms the frame egress did NOT block on
-	// any pacer Schedule (which doesn't exist in ModeOff).
-	if err := serverConn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+	// any pacer Schedule (which doesn't exist in ModeOff). The
+	// deadline goes on the CLIENT side (the reader).
+	if err := clientConn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
 		t.Fatalf("SetReadDeadline: %v", err)
 	}
 	buf := make([]byte, 32)
@@ -580,4 +586,95 @@ func TestSessionPacer_OutputPacer_OffMode_NoSchedule(t *testing.T) {
 	if got := mux.SessionPacer(sid); got != nil {
 		t.Errorf("post-write SessionPacer in ModeOff = %v; want nil (no lazy-create)", got)
 	}
+}
+
+// TestSessionPacer_OutputPacer_FrameAtomicEgress pins the
+// frame-average pacing semantics (Codex round-1 MUST FIX on PR
+// #648): a 2-byte ENH frame is written ATOMICALLY by a single
+// conn.Write — the cross-proxy client sees both bytes appear at
+// the SAME emit time, NOT one byte at +0 and the second at +τ.
+// This is the load-bearing assertion of frame-atomic visibility:
+// per-byte intra-frame splitting would let ebusd's TCP receiver
+// observe a partial ENH escape sequence during the τ gap, which
+// would corrupt the frame.
+//
+// The inter-FRAME cadence (between two consecutive frames) is
+// covered by TestSessionPacer_OutputPacer_SchedulesFrameEgress.
+// This test is the intra-frame complement.
+func TestSessionPacer_OutputPacer_FrameAtomicEgress(t *testing.T) {
+	mux, _, _, cleanup := newClassifiedTestMux(t, v8classifier.ModeShadow)
+	defer cleanup()
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	sid := mux.AddSession(serverConn)
+	if sid == 0 {
+		t.Fatal("AddSession returned 0")
+	}
+	defer mux.RemoveSession(sid)
+
+	pacer := mux.SessionPacer(sid)
+	if pacer == nil {
+		t.Fatalf("SessionPacer(%d) = nil; want non-nil", sid)
+	}
+
+	// Enqueue a 2-byte ENH frame: sessionFrameStarted encodes
+	// to ENHResStarted + payload (always 2 bytes regardless of
+	// payload value).
+	mux.sessions[sid].sendCh <- sessionFrame{
+		kind:    sessionFrameStarted,
+		payload: 0x31,
+	}
+
+	// Read both bytes from the client and measure the time
+	// delta between byte 0 and byte 1. Set the read deadline on
+	// the client side (Codex round-1 MEDIUM #1).
+	if err := clientConn.SetReadDeadline(time.Now().Add(3 * time.Second)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+
+	var buf1 [1]byte
+	n1, err := clientConn.Read(buf1[:])
+	if err != nil {
+		t.Fatalf("clientConn.Read byte 1 err: %v", err)
+	}
+	if n1 != 1 {
+		t.Fatalf("clientConn.Read byte 1 returned %d bytes; want 1", n1)
+	}
+	tAfterByte1 := time.Now()
+
+	var buf2 [1]byte
+	n2, err := clientConn.Read(buf2[:])
+	if err != nil {
+		t.Fatalf("clientConn.Read byte 2 err: %v", err)
+	}
+	if n2 != 1 {
+		t.Fatalf("clientConn.Read byte 2 returned %d bytes; want 1", n2)
+	}
+	tAfterByte2 := time.Now()
+
+	// PRIMARY ASSERTION: the gap between byte 1 and byte 2 is
+	// well under τ_wire_byte (4.17ms). If we accidentally split
+	// the Write into per-byte writes with intra-frame sleep,
+	// this delta would be ≥ τ. We allow a generous 1ms ceiling
+	// because net.Pipe + goroutine scheduling can introduce
+	// sub-ms jitter on contended CI.
+	intraFrameGap := tAfterByte2.Sub(tAfterByte1)
+	if intraFrameGap >= v8classifier.TauWireByte {
+		t.Errorf("intra-frame byte gap = %v; want < TauWireByte (%v) — frame-atomic visibility violated", intraFrameGap, v8classifier.TauWireByte)
+	}
+
+	// SECONDARY ASSERTION: the cadence anchor advanced by AT
+	// LEAST 2×τ (one tau per byte). Confirms the per-byte
+	// Schedule loop fired len(buf) times.
+	lastEmit := pacer.LastScheduledEmit()
+	if lastEmit.IsZero() {
+		t.Fatal("LastScheduledEmit zero after frame write — Schedule was not called")
+	}
+	// The anchor floor is the emit time of the LAST byte slot
+	// reserved, which is firstEmit + (N-1)×τ. The anchor is
+	// monotonic from now=t0, so the floor we can assert is just
+	// "anchor moved AT LEAST one τ past now-at-write-time" —
+	// the inter-frame test pins the more precise count.
+	_ = lastEmit
 }

--- a/internal/adaptermux/pacer_wiring_test.go
+++ b/internal/adaptermux/pacer_wiring_test.go
@@ -1,7 +1,9 @@
 package adaptermux
 
 import (
+	"io"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -448,17 +450,20 @@ func TestSessionPacer_Watchdog_OffMode_NoArm(t *testing.T) {
 // TestSessionPacer_OutputPacer_SchedulesFrameEgress pins the
 // Phase 3 Step B3.6f wiring: in V8ClassifierMode != Off, each
 // frame written by session.writeFrame consults the per-session
-// pacer's Schedule. The cadence anchor advances by τ_wire_byte
-// per byte (4.17ms per byte). We exercise this by writing two
-// 1-byte frames in quick succession on the same session and
-// confirming the LastScheduledEmit advances by at least one τ
-// between them.
+// pacer's Schedule AND honors the sleep before conn.Write.
+//
+// Codex round-2 MAJOR #2 on PR #648: the earlier version only
+// checked LastScheduledEmit anchor movement, which would pass
+// even if the actual sleep was removed (a real regression). The
+// load-bearing assertion is now WALL-CLOCK: the second frame's
+// first byte must not arrive at the client before
+// firstFrameStart + N*τ_wire_byte. We use a 2-byte ENH frame
+// (sessionFrameStarted) so the inter-frame gap is 2×τ ≈ 8.3ms
+// — comfortably above scheduler jitter.
 func TestSessionPacer_OutputPacer_SchedulesFrameEgress(t *testing.T) {
 	mux, _, _, cleanup := newClassifiedTestMux(t, v8classifier.ModeShadow)
 	defer cleanup()
 
-	// Add an external session via the same plumbing that
-	// production AddSession exercises.
 	clientConn, serverConn := net.Pipe()
 	defer clientConn.Close()
 	sid := mux.AddSession(serverConn)
@@ -471,69 +476,68 @@ func TestSessionPacer_OutputPacer_SchedulesFrameEgress(t *testing.T) {
 	if pacer == nil {
 		t.Fatalf("SessionPacer(%d) = nil; want non-nil", sid)
 	}
-	// Precondition: LastScheduledEmit is zero (no Schedule fired).
 	if got := pacer.LastScheduledEmit(); !got.IsZero() {
 		t.Fatalf("precondition: LastScheduledEmit = %v; want zero", got)
 	}
 
-	// Drive a frame egress: enqueue a single-byte ENH frame on
-	// the session's sendCh. The writeLoop drains it and calls
-	// writeFrame, which fires our new Schedule wiring.
-	// Use a payload byte < 0x80 so writeFrame takes the "short
-	// form" path (1-byte buf).
+	if err := clientConn.SetReadDeadline(time.Now().Add(3 * time.Second)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+
+	// Capture the wall-clock time BEFORE we enqueue the first
+	// frame so we can later assert the second frame's first
+	// byte didn't arrive earlier than the wire-equivalent.
+	tStart := time.Now()
+
+	// Enqueue TWO 2-byte ENH frames back-to-back. Each frame is
+	// 2 bytes; the cadence anchor advances by 2τ per frame, so
+	// the second frame's first byte should emit no earlier than
+	// tStart + 2*TauWireByte.
 	mux.sessions[sid].sendCh <- sessionFrame{
-		kind:    sessionFrameReceived,
-		payload: 0x42,
+		kind:    sessionFrameStarted,
+		payload: 0x31,
 	}
-	// Read from the pipe so writeLoop's Write doesn't block.
-	go func() {
-		buf := make([]byte, 32)
-		_, _ = clientConn.Read(buf)
-	}()
-
-	// Poll LastScheduledEmit until it advances (post-Schedule call).
-	deadline := time.Now().Add(2 * time.Second)
-	var emit1 time.Time
-	for time.Now().Before(deadline) {
-		emit1 = pacer.LastScheduledEmit()
-		if !emit1.IsZero() {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-	if emit1.IsZero() {
-		t.Fatal("LastScheduledEmit stayed zero after frame egress — Schedule was not called")
-	}
-
-	// Enqueue a SECOND frame and confirm the anchor advances by
-	// at least one τ.
 	mux.sessions[sid].sendCh <- sessionFrame{
-		kind:    sessionFrameReceived,
-		payload: 0x43,
+		kind:    sessionFrameStarted,
+		payload: 0x32,
 	}
-	go func() {
-		buf := make([]byte, 32)
-		_, _ = clientConn.Read(buf)
-	}()
 
-	deadline = time.Now().Add(2 * time.Second)
-	var emit2 time.Time
-	for time.Now().Before(deadline) {
-		emit2 = pacer.LastScheduledEmit()
-		if emit2.After(emit1) {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
+	// Read the first frame (2 bytes) and timestamp its arrival.
+	frame1 := make([]byte, 2)
+	_, err := io.ReadFull(clientConn, frame1)
+	if err != nil {
+		t.Fatalf("read frame1: %v", err)
 	}
-	if !emit2.After(emit1) {
-		t.Errorf("LastScheduledEmit did not advance between frames: emit1=%v emit2=%v", emit1, emit2)
+	// Read the second frame and timestamp its arrival.
+	frame2 := make([]byte, 2)
+	_, err = io.ReadFull(clientConn, frame2)
+	if err != nil {
+		t.Fatalf("read frame2: %v", err)
 	}
-	// Verify the advance is AT LEAST τ_wire_byte (4.17ms). It
-	// can be MORE if wall clock advanced past the prior emit
-	// (writeLoop scheduling latency, GC, etc).
-	advance := emit2.Sub(emit1)
-	if advance < v8classifier.TauWireByte {
-		t.Errorf("cadence advance %v < TauWireByte %v; pacer enforcement broken", advance, v8classifier.TauWireByte)
+	tFrame2 := time.Now()
+
+	// PRIMARY ASSERTION (Codex round-2 MAJOR #2): the second
+	// frame's first byte must not have been readable at the
+	// client before tStart + 2*τ_wire_byte. A regression that
+	// deletes the sleep inside writeFrame would let the second
+	// frame egress immediately after the first, and this
+	// assertion would clearly fail.
+	elapsed := tFrame2.Sub(tStart)
+	requiredFloor := 2 * v8classifier.TauWireByte
+	if elapsed < requiredFloor {
+		t.Errorf("frame2 arrived at +%v after tStart; want >= %v (frame1 was 2 bytes so frame2 must wait 2*τ — the sleep at writeFrame may have been bypassed)", elapsed, requiredFloor)
+	}
+
+	// SECONDARY ASSERTION: the pacer's anchor advanced
+	// monotonically. After two 2-byte frames, lastScheduledEmit
+	// is at tStart + (2*2 - 1)*τ = tStart + 3*τ (last reserved
+	// byte slot).
+	emit := pacer.LastScheduledEmit()
+	if emit.IsZero() {
+		t.Fatal("LastScheduledEmit zero after two frames — Schedule was not called")
+	}
+	if !emit.After(tStart) {
+		t.Errorf("LastScheduledEmit = %v; want after tStart %v", emit, tStart)
 	}
 }
 
@@ -590,91 +594,94 @@ func TestSessionPacer_OutputPacer_OffMode_NoSchedule(t *testing.T) {
 
 // TestSessionPacer_OutputPacer_FrameAtomicEgress pins the
 // frame-average pacing semantics (Codex round-1 MUST FIX on PR
-// #648): a 2-byte ENH frame is written ATOMICALLY by a single
-// conn.Write — the cross-proxy client sees both bytes appear at
-// the SAME emit time, NOT one byte at +0 and the second at +τ.
-// This is the load-bearing assertion of frame-atomic visibility:
-// per-byte intra-frame splitting would let ebusd's TCP receiver
-// observe a partial ENH escape sequence during the τ gap, which
-// would corrupt the frame.
+// #648): writeFrame issues a SINGLE conn.Write per frame — no
+// deliberate intra-frame pacing or splitting. The reader sees
+// both bytes of a 2-byte ENH frame arrive together (modulo TCP
+// segmentation, which is not a concern for sub-MSS payloads).
 //
-// The inter-FRAME cadence (between two consecutive frames) is
-// covered by TestSessionPacer_OutputPacer_SchedulesFrameEgress.
-// This test is the intra-frame complement.
+// Codex round-2 MAJOR #1 on PR #648: the earlier version read
+// byte-by-byte and measured the inter-Read delta, which conflates
+// the writer's TCP write behavior with the test goroutine's own
+// scheduling latency between Reads. A regression that adds an
+// intra-frame sleep would correctly fail, but a fast machine
+// could ALSO falsely pass if scheduling jitter were lower than
+// τ. The new version uses io.ReadFull to atomically drain the
+// frame, and the regression vector is detected differently: we
+// install a recording net.Conn wrapper that counts the number
+// of Write calls per frame. Exactly ONE Write call per
+// sessionFrame ensures no per-byte syscall split.
+//
+// The inter-FRAME wall-clock cadence is covered by
+// TestSessionPacer_OutputPacer_SchedulesFrameEgress.
 func TestSessionPacer_OutputPacer_FrameAtomicEgress(t *testing.T) {
 	mux, _, _, cleanup := newClassifiedTestMux(t, v8classifier.ModeShadow)
 	defer cleanup()
 
-	clientConn, serverConn := net.Pipe()
+	clientConn, pipeServerConn := net.Pipe()
 	defer clientConn.Close()
-	sid := mux.AddSession(serverConn)
+	// Wrap the server side of the pipe with a writeCounter so we
+	// can assert the per-frame Write count (Codex round-2 MAJOR #1).
+	recorder := &writeCountingConn{Conn: pipeServerConn}
+	sid := mux.AddSession(recorder)
 	if sid == 0 {
 		t.Fatal("AddSession returned 0")
 	}
 	defer mux.RemoveSession(sid)
 
-	pacer := mux.SessionPacer(sid)
-	if pacer == nil {
-		t.Fatalf("SessionPacer(%d) = nil; want non-nil", sid)
-	}
-
-	// Enqueue a 2-byte ENH frame: sessionFrameStarted encodes
-	// to ENHResStarted + payload (always 2 bytes regardless of
-	// payload value).
+	// Enqueue a 2-byte ENH frame.
 	mux.sessions[sid].sendCh <- sessionFrame{
 		kind:    sessionFrameStarted,
 		payload: 0x31,
 	}
 
-	// Read both bytes from the client and measure the time
-	// delta between byte 0 and byte 1. Set the read deadline on
-	// the client side (Codex round-1 MEDIUM #1).
 	if err := clientConn.SetReadDeadline(time.Now().Add(3 * time.Second)); err != nil {
 		t.Fatalf("SetReadDeadline: %v", err)
 	}
-
-	var buf1 [1]byte
-	n1, err := clientConn.Read(buf1[:])
-	if err != nil {
-		t.Fatalf("clientConn.Read byte 1 err: %v", err)
-	}
-	if n1 != 1 {
-		t.Fatalf("clientConn.Read byte 1 returned %d bytes; want 1", n1)
-	}
-	tAfterByte1 := time.Now()
-
-	var buf2 [1]byte
-	n2, err := clientConn.Read(buf2[:])
-	if err != nil {
-		t.Fatalf("clientConn.Read byte 2 err: %v", err)
-	}
-	if n2 != 1 {
-		t.Fatalf("clientConn.Read byte 2 returned %d bytes; want 1", n2)
-	}
-	tAfterByte2 := time.Now()
-
-	// PRIMARY ASSERTION: the gap between byte 1 and byte 2 is
-	// well under τ_wire_byte (4.17ms). If we accidentally split
-	// the Write into per-byte writes with intra-frame sleep,
-	// this delta would be ≥ τ. We allow a generous 1ms ceiling
-	// because net.Pipe + goroutine scheduling can introduce
-	// sub-ms jitter on contended CI.
-	intraFrameGap := tAfterByte2.Sub(tAfterByte1)
-	if intraFrameGap >= v8classifier.TauWireByte {
-		t.Errorf("intra-frame byte gap = %v; want < TauWireByte (%v) — frame-atomic visibility violated", intraFrameGap, v8classifier.TauWireByte)
+	// Drain the full 2-byte frame in one ReadFull.
+	frame := make([]byte, 2)
+	if _, err := io.ReadFull(clientConn, frame); err != nil {
+		t.Fatalf("io.ReadFull: %v", err)
 	}
 
-	// SECONDARY ASSERTION: the cadence anchor advanced by AT
-	// LEAST 2×τ (one tau per byte). Confirms the per-byte
-	// Schedule loop fired len(buf) times.
-	lastEmit := pacer.LastScheduledEmit()
-	if lastEmit.IsZero() {
-		t.Fatal("LastScheduledEmit zero after frame write — Schedule was not called")
+	// PRIMARY ASSERTION: writeFrame issued EXACTLY ONE Write
+	// call for the 2-byte frame. A regression that split the
+	// Write into per-byte calls would surface as N writes.
+	if got := recorder.writeCount(); got != 1 {
+		t.Errorf("writeFrame issued %d Write calls for 2-byte frame; want exactly 1 (per-byte splitting would break frame-atomic visibility)", got)
 	}
-	// The anchor floor is the emit time of the LAST byte slot
-	// reserved, which is firstEmit + (N-1)×τ. The anchor is
-	// monotonic from now=t0, so the floor we can assert is just
-	// "anchor moved AT LEAST one τ past now-at-write-time" —
-	// the inter-frame test pins the more precise count.
-	_ = lastEmit
+	// Sanity: the single Write delivered the full frame.
+	if got := recorder.totalBytes(); got != 2 {
+		t.Errorf("recorder totalBytes = %d; want 2", got)
+	}
+}
+
+// writeCountingConn wraps a net.Conn to count Write call
+// frequency + total bytes written. Used by the
+// FrameAtomicEgress test to assert the writer issues exactly
+// one Write per session frame (no per-byte splitting).
+type writeCountingConn struct {
+	net.Conn
+	mu     sync.Mutex
+	writes int
+	bytes  int
+}
+
+func (w *writeCountingConn) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	w.writes++
+	w.bytes += len(p)
+	w.mu.Unlock()
+	return w.Conn.Write(p)
+}
+
+func (w *writeCountingConn) writeCount() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.writes
+}
+
+func (w *writeCountingConn) totalBytes() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.bytes
 }

--- a/internal/adaptermux/session.go
+++ b/internal/adaptermux/session.go
@@ -796,32 +796,35 @@ func (s *session) writeFrame(frame sessionFrame) error {
 	// across frames — see "frame-average pacing semantics" below.
 	//
 	// SEMANTICS — frame-average pacing (Codex round-1 MUST FIX on
-	// PR #648): each session frame is written ATOMICALLY in a
-	// single conn.Write call, NOT split into per-byte syscalls.
-	// Splitting the Write would let the cross-proxy client (ebusd)
-	// read partial ENH frames from its TCP receive buffer and
-	// process them with an incomplete escape sequence (the
-	// `0xA9 NN` two-byte form would be readable as just `0xA9`
-	// during the τ gap), which would directly violate frame-atomic
-	// visibility — the v8 §4.5 invariant the pacer is supposed
-	// to enforce.
+	// PR #648, refined by round-2 MEDIUM #1): each session frame
+	// is written via a SINGLE conn.Write call — the writer makes
+	// NO deliberate intra-frame pacing or splitting. TCP itself
+	// is a byte stream and does NOT preserve application write
+	// boundaries for the peer's Read calls; the peer may receive
+	// the frame as 1 read or N reads depending on its own buffer
+	// management and TCP segmentation. What the pacer guarantees
+	// is that the WRITER never inserts an intra-frame τ gap that
+	// could let the peer's Read coincide with a partial ENH
+	// escape sequence (`0xA9 NN`).
 	//
 	// The cadence is enforced AT FRAME GRANULARITY:
-	//   - The pacer's lastScheduledEmit anchor advances by N×τ
-	//     for an N-byte frame.
-	//   - The NEXT frame's first byte emits at
-	//     prevFrameStart + prevFrameByteCount × τ.
-	//   - INTRA-frame byte arrival is atomic (all bytes of a
-	//     frame observable at the frame's emit time, not at
-	//     `emitTime + i×τ`).
+	//   - For an N-byte frame, the Schedule loop reserves N
+	//     byte slots. After the loop, lastScheduledEmit points at
+	//     the LAST reserved slot (frameStart + (N-1)*τ); the
+	//     NEXT frame's first Schedule call advances it to
+	//     frameStart + N*τ (Codex round-2 MEDIUM #2 precision).
+	//   - NEXT frame's first byte therefore emits no earlier
+	//     than prevFrameStart + N*τ — the wire-equivalent rate
+	//     for N bytes.
+	//   - Within a frame, the writer issues ONE Write; there is
+	//     no deliberate intra-frame sleep.
 	//
 	// This matches how the bus itself would emit a multi-byte
 	// frame — the bytes are wire-encoded back-to-back at the
 	// adapter, then arrive at the gateway's read side together
-	// (modulo TCP fragmentation jitter). The client (ebusd)
-	// always reads ENH frames as atomic units from its TCP
-	// buffer anyway, so frame-average pacing is the correct
-	// trade-off.
+	// (modulo TCP fragmentation jitter). Frame-average pacing
+	// is the correct trade-off: inter-frame cadence is wire-
+	// equivalent, intra-frame writes are atomic at the WRITER.
 	//
 	// Wiring contract:
 	//   1. Call Schedule(now) ONCE to get the FIRST byte's emit

--- a/internal/adaptermux/session.go
+++ b/internal/adaptermux/session.go
@@ -792,25 +792,46 @@ func (s *session) writeFrame(frame sessionFrame) error {
 
 	// Phase 3 Step B3.6f (frame-atomic-visibility v8 §4.5): pace
 	// the TCP egress through the per-session v8classifier.Pacer.
-	// The pacer enforces τ_wire_byte=4.17ms inter-byte cadence so
-	// the cross-proxy client (ebusd) cannot observe egress bytes
-	// arriving faster than the bus wire-byte rate — a v8 invariant
-	// for frame-atomic visibility.
+	// The pacer enforces τ_wire_byte=4.17ms cadence on AVERAGE
+	// across frames — see "frame-average pacing semantics" below.
+	//
+	// SEMANTICS — frame-average pacing (Codex round-1 MUST FIX on
+	// PR #648): each session frame is written ATOMICALLY in a
+	// single conn.Write call, NOT split into per-byte syscalls.
+	// Splitting the Write would let the cross-proxy client (ebusd)
+	// read partial ENH frames from its TCP receive buffer and
+	// process them with an incomplete escape sequence (the
+	// `0xA9 NN` two-byte form would be readable as just `0xA9`
+	// during the τ gap), which would directly violate frame-atomic
+	// visibility — the v8 §4.5 invariant the pacer is supposed
+	// to enforce.
+	//
+	// The cadence is enforced AT FRAME GRANULARITY:
+	//   - The pacer's lastScheduledEmit anchor advances by N×τ
+	//     for an N-byte frame.
+	//   - The NEXT frame's first byte emits at
+	//     prevFrameStart + prevFrameByteCount × τ.
+	//   - INTRA-frame byte arrival is atomic (all bytes of a
+	//     frame observable at the frame's emit time, not at
+	//     `emitTime + i×τ`).
+	//
+	// This matches how the bus itself would emit a multi-byte
+	// frame — the bytes are wire-encoded back-to-back at the
+	// adapter, then arrive at the gateway's read side together
+	// (modulo TCP fragmentation jitter). The client (ebusd)
+	// always reads ENH frames as atomic units from its TCP
+	// buffer anyway, so frame-average pacing is the correct
+	// trade-off.
 	//
 	// Wiring contract:
 	//   1. Call Schedule(now) ONCE to get the FIRST byte's emit
 	//      time. This is what we sleep until.
 	//   2. Call Schedule(now) (len(buf)-1) more times to advance
 	//      the pacer's cadence anchor by τ per byte, so the NEXT
-	//      frame's first-byte emit is paced from
-	//      lastEmit + N×τ, not from `now`.
+	//      frame's first byte is paced from lastEmit + N×τ.
 	//   3. Sleep until emitAt with shutdown-responsive cancel via
 	//      s.done / s.mux.ctx.Done.
-	//   4. Write the whole frame in a single Write — the cadence
-	//      is enforced at frame-emit-time, not by splitting the
-	//      Write into per-byte syscalls (which would multiply
-	//      kernel overhead without changing the wall-clock
-	//      perceived cadence at the client's TCP receive buffer).
+	//   4. Write the whole frame in a single conn.Write.
 	//
 	// ModeOff zero-overhead contract: when m.v8 == nil OR the
 	// per-session pacer is nil (which can happen during the brief

--- a/internal/adaptermux/session.go
+++ b/internal/adaptermux/session.go
@@ -790,21 +790,74 @@ func (s *session) writeFrame(frame sessionFrame) error {
 		return fmt.Errorf("adaptermux: unknown session frame kind %d", frame.kind)
 	}
 
-	// B3.6 INTEGRATION HOOK POINT (Phase 3, frame-atomic-visibility
-	// v8 §4.5): this is the TCP-egress choke point where the
-	// v8classifier.Pacer's Schedule must be consulted when
-	// V8ClassifierMode != Off and the session is a cross-proxy
-	// observer. See internal/adaptermux/v8classifier/pacer.go for
-	// the API; the pacer is a per-session struct that lands in
-	// B3.6 (not yet instantiated in B3.5). Sequence per the
-	// pacer's design:
-	//   emitAt := pacer.Schedule(time.Now())
-	//   if emitAt.After(time.Now()) { sleep until emitAt }
-	//   s.conn.Write(buf)                          <-- here
+	// Phase 3 Step B3.6f (frame-atomic-visibility v8 §4.5): pace
+	// the TCP egress through the per-session v8classifier.Pacer.
+	// The pacer enforces τ_wire_byte=4.17ms inter-byte cadence so
+	// the cross-proxy client (ebusd) cannot observe egress bytes
+	// arriving faster than the bus wire-byte rate — a v8 invariant
+	// for frame-atomic visibility.
+	//
+	// Wiring contract:
+	//   1. Call Schedule(now) ONCE to get the FIRST byte's emit
+	//      time. This is what we sleep until.
+	//   2. Call Schedule(now) (len(buf)-1) more times to advance
+	//      the pacer's cadence anchor by τ per byte, so the NEXT
+	//      frame's first-byte emit is paced from
+	//      lastEmit + N×τ, not from `now`.
+	//   3. Sleep until emitAt with shutdown-responsive cancel via
+	//      s.done / s.mux.ctx.Done.
+	//   4. Write the whole frame in a single Write — the cadence
+	//      is enforced at frame-emit-time, not by splitting the
+	//      Write into per-byte syscalls (which would multiply
+	//      kernel overhead without changing the wall-clock
+	//      perceived cadence at the client's TCP receive buffer).
+	//
+	// ModeOff zero-overhead contract: when m.v8 == nil OR the
+	// per-session pacer is nil (which can happen during the brief
+	// window between AddSession and ensureSessionPacer completing —
+	// though in practice they're sequential), the pacer path is
+	// fully bypassed — no Schedule call, no time.Now, no sleep.
+	// External-session active writes through mux.doSend already
+	// pace independently of this output cadence.
+	//
 	// Do NOT conflate this hook point with mux.doSend's tr.Write
 	// (that's the L_rtt-EMA / BeforeActiveWrite side per v8 §1.4,
 	// which uses BeforeActiveWrite + EchoDeadlines + RecordEcho
 	// against the adapter, NOT the client's TCP egress).
+	// Defensive nil-check on s.mux — production callers always
+	// have a mux (session is constructed via Mux.AddSession), but
+	// unit tests (e.g. TestSession_WriteFrameErrorHost) build a
+	// bare session struct without a mux to exercise the encoder
+	// path in isolation. Without this guard those tests panic on
+	// s.mux.v8.
+	if s.mux != nil && s.mux.v8 != nil {
+		if pacer := s.mux.SessionPacer(s.id); pacer != nil {
+			now := time.Now()
+			emitAt := pacer.Schedule(now)
+			// Advance the cadence anchor for the remaining
+			// bytes in this frame. Each Schedule call increments
+			// lastScheduledEmit by τ; we discard the returned
+			// emit-times for byte indexes 1..N-1 because the
+			// frame is written in a single Write, but the anchor
+			// advance is what enforces inter-FRAME cadence on
+			// the next iteration.
+			for i := 1; i < len(buf); i++ {
+				_ = pacer.Schedule(now)
+			}
+			if delay := time.Until(emitAt); delay > 0 {
+				timer := time.NewTimer(delay)
+				select {
+				case <-timer.C:
+				case <-s.done:
+					timer.Stop()
+					return net.ErrClosed
+				case <-s.mux.ctx.Done():
+					timer.Stop()
+					return s.mux.ctx.Err()
+				}
+			}
+		}
+	}
 	_, err := s.conn.Write(buf)
 	return err
 }

--- a/internal/adaptermux/v8classifier/pacer_test.go
+++ b/internal/adaptermux/v8classifier/pacer_test.go
@@ -631,11 +631,16 @@ func TestPacer_SoftDeadlineFires(t *testing.T) {
 	})
 
 	p.ArmEchoWatchdog(time.Now())
-	// Codex round-1 MEDIUM #2 on PR #647: poll the counter
-	// instead of sleeping a fixed duration. Robust on slow CI.
+	// Poll len(emitted) (not the counter) because the counter
+	// is bumped under p.mu while the emit callback fires AFTER
+	// p.mu is dropped — a tight read of the counter can race
+	// the emit append.
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		if p.SoftTimeoutTotal() >= 1 {
+		mu.Lock()
+		n := len(emitted)
+		mu.Unlock()
+		if n >= 1 {
 			break
 		}
 		time.Sleep(5 * time.Millisecond)
@@ -673,11 +678,16 @@ func TestPacer_HardDeadlineFires(t *testing.T) {
 	})
 
 	p.ArmEchoWatchdog(time.Now())
-	// Poll the hard counter. L_rtt=100ms, hard=2*100+200=400ms;
-	// generous 2s deadline tolerates slow CI.
+	// Poll len(emitted) >= 2 — both soft AND hard emits must
+	// have appended. Counter-based polling here races the emit
+	// append (counter bumped under mutex; emit callback fires
+	// unlocked).
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		if p.HardTimeoutTotal() >= 1 {
+		mu.Lock()
+		n := len(emitted)
+		mu.Unlock()
+		if n >= 2 {
 			break
 		}
 		time.Sleep(5 * time.Millisecond)
@@ -727,13 +737,17 @@ func TestPacer_GraceMode_HardTimerNotArmed(t *testing.T) {
 	})
 
 	p.ArmEchoWatchdog(time.Now())
-	// Codex round-1 MEDIUM #2 on PR #647: poll the soft counter
-	// (grace soft = L_rtt + 500ms ≈ 550ms). 3s deadline tolerates
-	// slow CI; if hard were erroneously armed at 400ms we'd see
-	// it long before this deadline.
+	// Poll the emitted SLICE rather than SoftTimeoutTotal: the
+	// counter bumps under p.mu and the emit callback fires AFTER
+	// p.mu is dropped, so a tight read of the counter can see
+	// "1" before the emit has appended. Polling len(emitted) is
+	// the correct visibility signal.
 	deadline := time.Now().Add(3 * time.Second)
 	for time.Now().Before(deadline) {
-		if p.SoftTimeoutTotal() >= 1 {
+		mu.Lock()
+		n := len(emitted)
+		mu.Unlock()
+		if n >= 1 {
 			break
 		}
 		time.Sleep(5 * time.Millisecond)
@@ -911,12 +925,15 @@ func TestClassifier_NewPacerForSession_WiresAdminEvents(t *testing.T) {
 	if p == nil {
 		t.Fatal("NewPacerForSession() = nil; want non-nil")
 	}
-	// Arm watchdog and poll for the soft fire (Codex round-1
-	// MEDIUM #2 on PR #647: counter polling, not fixed sleep).
+	// Arm watchdog and poll PendingAdminEvents — the integration
+	// path bumps the pacer counter under mutex BUT the emitter
+	// callback (which routes to adminEvents.emit) fires after
+	// the mutex is dropped. Polling PendingAdminEvents directly
+	// observes the integration we're testing.
 	p.ArmEchoWatchdog(time.Now())
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		if p.SoftTimeoutTotal() >= 1 {
+		if c.PendingAdminEvents() >= 1 {
 			break
 		}
 		time.Sleep(5 * time.Millisecond)


### PR DESCRIPTION
## Summary

Phase 3 Step B3.6f wires the per-session `v8classifier.Pacer.Schedule()` at `session.writeFrame`'s TCP egress choke point. This is the **session TCP-egress** side of the pacer (cross-proxy clients like ebusd), NOT the adapter-write side (which already uses BeforeActiveWrite + ArmEchoWatchdog via B3.6c/d/e).

Per v8 §4.5 — frame-atomic visibility invariant: cross-proxy clients must not observe egress bytes arriving faster than the bus wire-byte rate (τ_wire_byte = 4.17ms inter-byte cadence).

### Wiring

In `session.writeFrame`, immediately before `s.conn.Write(buf)`:

```go
if s.mux != nil && s.mux.v8 != nil {
    if pacer := s.mux.SessionPacer(s.id); pacer != nil {
        now := time.Now()
        emitAt := pacer.Schedule(now)
        // Advance the cadence anchor for remaining bytes (Schedule advances by τ per call).
        for i := 1; i < len(buf); i++ {
            _ = pacer.Schedule(now)
        }
        if delay := time.Until(emitAt); delay > 0 {
            timer := time.NewTimer(delay)
            select {
            case <-timer.C:
            case <-s.done:
                timer.Stop()
                return net.ErrClosed
            case <-s.mux.ctx.Done():
                timer.Stop()
                return s.mux.ctx.Err()
            }
        }
    }
}
```

**Design choices:**

1. **Single Write per frame, multiple Schedule calls.** ENH frames are 1-2 bytes; splitting into per-byte writes would multiply kernel overhead without changing the wall-clock cadence at the client's TCP receive buffer. Schedule called `len(buf)` times advances the cadence anchor by `N×τ`, so the NEXT frame's first-byte emit is paced correctly.

2. **Defensive `s.mux != nil` nil-check.** Production callers always have a mux (session constructed via `Mux.AddSession`), but unit tests (`TestSession_WriteFrameErrorHost`) build bare `session{}` structs to exercise the encoder in isolation. Without this guard those tests panic on `s.mux.v8`.

3. **Shutdown-responsive sleep.** `time.NewTimer` + `select` on `s.done` + `s.mux.ctx.Done` so a session close or mux shutdown doesn't have to wait for the timer.

4. **ModeOff zero-overhead.** When `m.v8 == nil` the whole pacer path is skipped — no Schedule call, no `time.Now`, no sleep, no allocation.

## Test coverage

**`pacer_wiring_test.go` (2 new tests, 137 lines):**

- **`TestSessionPacer_OutputPacer_SchedulesFrameEgress`** — load-bearing: ModeShadow, AddSession, enqueue two 1-byte frames, assert `LastScheduledEmit` advances by ≥ `TauWireByte` between them. Proves the cadence-anchor advance actually fires.
- **`TestSessionPacer_OutputPacer_OffMode_NoSchedule`** — ModeOff: assert `SessionPacer == nil` pre + post, pipe receives the frame promptly (proves no spurious pacer allocation, no sleep blocking egress).

## Bonus fixes caught by the full-suite run

The full mux + v8classifier suite under -race revealed two unrelated-to-this-PR-but-needed-for-this-PR test issues:

1. **`TestSession_WriteFrameErrorHost`** built a bare `session{}` without `s.mux`, triggering a nil-deref on my new pacer wiring. Fixed by the defensive nil-check above.
2. **4 watchdog tests** (`SoftDeadlineFires`, `HardDeadlineFires`, `GraceMode_HardTimerNotArmed`, `NewPacerForSession_WiresAdminEvents`) polled `SoftTimeoutTotal` then asserted on `len(emitted)` — a visibility race where the counter bumps under `p.mu` but the emit callback fires AFTER `p.mu` drops. Switched to polling `len(emitted)` / `PendingAdminEvents()` directly. These would have surfaced as flakes in CI once any session ran B3.6f's `writeFrame` concurrently.

## Verification

- 2 new B3.6f tests green under `-race`.
- 30x stress on all SessionPacer + Pacer + WriteFrame tests: green (13s mux + 19s v8classifier).
- Full mux suite green under `-race` in 111s wall.
- Full v8classifier suite green in 2s wall.
- Build + vet + gofmt clean.

## Production safety

`V8ClassifierMode` defaults to `ModeOff` — `writeFrame`'s pacer path is fully bypassed. ModeShadow / ModeEnforce paths are opt-in via `HELIANTHUS_V8_CLASSIFIER_MODE`.

## Closes Phase 3 Step B3.6

This is the last of the B3.6c..B3.6f pacer integration sub-PRs:

- **B3.6c** (#645) — per-session pacer storage + `BeforeActiveWrite` at `mux.doSend`.
- **B3.6d** (#646) — `RecordEcho` wiring at the gateway echo-match site.
- **B3.6e** (#647) — `ArmEchoWatchdog` / `CancelEchoWatchdog` + soft/hard deadline admin events.
- **B3.6f** (this PR) — output pacer at `session.writeLoop`.

Next: B3.7 — shadow-mode divergence comparison vs the current pre-v8 path. Or skip directly to Phase 1 → main promotion + release tag + gateway pin re-bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)