### PR TITLE
Phase 1 promotion blocker: wire HELIANTHUS_V8_CLASSIFIER_MODE env into gateway main

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Project-Helianthus/helianthus-ebusgateway"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/graphql"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/adaptermux"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/adaptermux/v8classifier"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/runtimestate"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp/ebus_standard"
@@ -1408,6 +1409,26 @@ func wireAdapterDirect(ctx context.Context, cfg *ebusgateway.Config) (func() err
 	muxCfg.ReadTimeout = 50 * time.Millisecond
 	if muxCfg.WriteTimeout == 0 {
 		muxCfg.WriteTimeout = 5 * time.Second
+	}
+
+	// Phase 3 Step B3.7 (Codex round-1 MAJOR on PR #650): wire the
+	// HELIANTHUS_V8_CLASSIFIER_MODE env var into the mux config.
+	// Without this read, the v8 classifier is unreachable in
+	// production — Config.V8ClassifierMode would always be the
+	// zero-value (ModeOff) regardless of what operators set in
+	// the addon options. ParseMode handles case-insensitive
+	// "off|shadow|enforce" plus convenience synonyms ("disabled",
+	// "false", etc.); an unset env var defaults to ModeOff (safe);
+	// an unrecognized value fails loudly via the returned error.
+	if envMode := os.Getenv(v8classifier.EnvVarName); envMode != "" {
+		parsedMode, err := v8classifier.ParseMode(envMode)
+		if err != nil {
+			log.Fatalf("invalid %s=%q: %v (expected off|shadow|enforce)", v8classifier.EnvVarName, envMode, err)
+		}
+		muxCfg.V8ClassifierMode = parsedMode
+		if parsedMode != v8classifier.ModeOff {
+			log.Printf("v8 classifier enabled: mode=%s", parsedMode)
+		}
 	}
 
 	mux := adaptermux.New(muxCfg)

--- a/cmd/gateway/v8mode_env_test.go
+++ b/cmd/gateway/v8mode_env_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/adaptermux/v8classifier"
+)
+
+// TestV8ClassifierMode_EnvParse pins the production wiring contract
+// surfaced by Codex round-1 MAJOR on promotion PR #650: the
+// HELIANTHUS_V8_CLASSIFIER_MODE env var MUST be parseable by
+// v8classifier.ParseMode in the way cmd/gateway/main.go consumes
+// it (cmd/gateway/main.go reads os.Getenv(v8classifier.EnvVarName)
+// and feeds the value to ParseMode).
+//
+// This is a unit-level guard: if a future refactor renames the
+// env var, changes the ParseMode contract, or removes the
+// production wiring branch in main.go, this test won't directly
+// catch it — but it WILL flag breaking changes to the env-parse
+// surface that the production code relies on.
+//
+// The full integration (env var → muxCfg.V8ClassifierMode →
+// Mux.New constructs a non-nil classifier) is best validated by
+// a smoke test on the live deployment; this unit test pins the
+// API stability the production code depends on.
+func TestV8ClassifierMode_EnvParse(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		input   string
+		want    v8classifier.Mode
+		wantErr bool
+	}{
+		{"empty defaults to Off", "", v8classifier.ModeOff, false},
+		{"off literal", "off", v8classifier.ModeOff, false},
+		{"shadow literal", "shadow", v8classifier.ModeShadow, false},
+		{"enforce literal", "enforce", v8classifier.ModeEnforce, false},
+		{"case-insensitive Shadow", "Shadow", v8classifier.ModeShadow, false},
+		{"case-insensitive ENFORCE", "ENFORCE", v8classifier.ModeEnforce, false},
+		{"whitespace-trimmed", "  shadow  ", v8classifier.ModeShadow, false},
+		{"synonym disabled", "disabled", v8classifier.ModeOff, false},
+		{"synonym false", "false", v8classifier.ModeOff, false},
+		{"unknown errors", "enfource", v8classifier.ModeOff, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := v8classifier.ParseMode(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("ParseMode(%q) err=nil; want non-nil", tc.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("ParseMode(%q) err=%v; want nil", tc.input, err)
+				return
+			}
+			if got != tc.want {
+				t.Errorf("ParseMode(%q) = %v; want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+
+	// EnvVarName is what cmd/gateway/main.go reads — pin the
+	// exact string so a rename surfaces here.
+	if got := v8classifier.EnvVarName; got != "HELIANTHUS_V8_CLASSIFIER_MODE" {
+		t.Errorf("v8classifier.EnvVarName = %q; want \"HELIANTHUS_V8_CLASSIFIER_MODE\"", got)
+	}
+}


### PR DESCRIPTION
## Summary

**Phase 1 promotion blocker fix** caught by [Codex round-1 review on promotion PR #650](https://github.com/Project-Helianthus/helianthus-ebusgateway/pull/650): the advertised `HELIANTHUS_V8_CLASSIFIER_MODE` env var was never wired into the production startup path.

`cmd/gateway/main.go` built `muxCfg` without ever calling `os.Getenv(v8classifier.EnvVarName)` or `v8classifier.ParseMode`, so `Config.V8ClassifierMode` stayed at the zero value (`ModeOff`) regardless of operator configuration. The classifier was unreachable in production — only tests could enable it by setting the field directly.

## Fix

At the `muxCfg` construction site in `cmd/gateway/main.go` (after read/write timeout defaults, before `adaptermux.New`):

```go
if envMode := os.Getenv(v8classifier.EnvVarName); envMode != "" {
    parsedMode, err := v8classifier.ParseMode(envMode)
    if err != nil {
        log.Fatalf("invalid %s=%q: %v (expected off|shadow|enforce)", v8classifier.EnvVarName, envMode, err)
    }
    muxCfg.V8ClassifierMode = parsedMode
    if parsedMode != v8classifier.ModeOff {
        log.Printf("v8 classifier enabled: mode=%s", parsedMode)
    }
}
```

- **Unset env**: defaults to `ModeOff` (safe — the rollout's whole point is that off = no behavior change).
- **Recognized values** (case-insensitive: `off|disabled|0|false|no|shadow|enforce`): parsed and applied.
- **Unrecognized**: fails loudly via `log.Fatalf` so operators catch typos at startup, not silently run with `ModeOff`.
- **Enabled mode**: emits a single startup-log breadcrumb confirming the env was applied.

## Test

`cmd/gateway/v8mode_env_test.go` pins the `ParseMode` contract the production code depends on:

- 10 sub-cases: empty, `off`, `shadow`, `enforce`, case-insensitive variants, whitespace-trimmed, synonyms, unknown-value error.
- Pins `v8classifier.EnvVarName == "HELIANTHUS_V8_CLASSIFIER_MODE"` literally so a rename surfaces here.

The full integration (env var → muxCfg → Mux.New constructs non-nil classifier) is best validated by a smoke test on the live deployment; this unit test pins the API stability the production code depends on.

## Why this is a promotion blocker

Without it, **v0.5.0 ships with the classifier nonfunctional in production**. Operators following the deployment guide would set `HELIANTHUS_V8_CLASSIFIER_MODE=shadow`, restart the addon, and observe... nothing. The whole v8 rollout would be dead code in the release build.

Once this lands on `frame-atomic-visibility`, the promotion PR #650 auto-updates and unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)