### PR TITLE
Phase 1 promotion blockers: Codex bot P1 + P2 fixes on PR #650

### DIFF
--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -896,17 +896,27 @@ func (m *Mux) Close() error {
 		}
 		m.connMu.Unlock()
 
-		// Codex round-2 MUST FIX on PR #647: cancel any pending
-		// gateway echo watchdog. Close is the strongest teardown
-		// boundary; an armed watchdog could otherwise fire a soft
-		// or hard timeout admin event AFTER Close returned, which
-		// would surface as a phantom event on a mux that has
-		// already shut down.
+		m.wg.Wait()
+
+		// Codex round-2 MUST FIX on PR #647 + Codex GitHub-bot P2
+		// review on PR #650: cancel any pending gateway echo
+		// watchdog. Close is the strongest teardown boundary; an
+		// armed watchdog could otherwise fire a soft or hard
+		// timeout admin event AFTER Close returned, which would
+		// surface as a phantom event on a mux that has already
+		// shut down.
+		//
+		// P2 follow-up: do the cancel AFTER m.wg.Wait() so the
+		// sendLoop has provably stopped before we cancel. The
+		// earlier "cancel before wg.Wait" pattern had a window
+		// where sendLoop could process a queued gateway write
+		// during shutdown (the select's send case can win
+		// against ctx.Done()) and re-arm the watchdog after the
+		// cancel ran. With cancel-after-wait, sendLoop is gone
+		// before the cancel — no possible re-arm.
 		if pacer := m.SessionPacer(gatewaySessionID); pacer != nil {
 			pacer.CancelEchoWatchdog()
 		}
-
-		m.wg.Wait()
 	})
 	return m.closeErr
 }
@@ -1344,8 +1354,17 @@ func (m *Mux) reconnect() error {
 
 	// Cancel the pacer watchdog OUTSIDE stateMu (Codex round-2
 	// MUST FIX on PR #647 — see captured pacerToCancel above).
+	// Codex GitHub-bot P2 review on PR #650: reconnect is a hard
+	// reset of the upstream transport; the previous L_rtt EMA and
+	// lastEchoAt anchor reflect the OLD connection's latency
+	// characteristics and would produce spurious soft/hard
+	// timeouts on the FIRST post-reconnect write if the new
+	// connection has different latency. ResetLrtt rebootstraps
+	// L_rtt to the initial value and clears lastEchoAt so the
+	// next BeforeActiveWrite re-enters grace bootstrap.
 	if pacerToCancel != nil {
 		pacerToCancel.CancelEchoWatchdog()
+		pacerToCancel.ResetLrtt()
 	}
 
 	// Cancel in-flight pending START if any.
@@ -2521,6 +2540,17 @@ func (m *Mux) onSYNLocked(phaseEvent wirePhaseEvent, ownerID uint64, hasOwner bo
 		}
 		m.gatewayTxnActive = false
 		m.recordGatewayInactive(ReasonSYNTerminator)
+		// Codex GitHub-bot P1 review on PR #650: the normal
+		// gateway-txn completion path (SYN terminator echo) must
+		// cancel the watchdog. Without this, every successful
+		// gateway transaction in ModeShadow / ModeEnforce leaves
+		// the timer armed; a subsequent quiet period (no new
+		// writes to re-arm) fires the soft/hard deadline and
+		// emits a false-positive admin event for a transaction
+		// that already completed successfully. Mirror of the
+		// SYN-timeout / SYN-idle cancel signaling — set the flag,
+		// caller cancels after stateMu unlock.
+		cancelGatewayWatchdog = true
 	}
 
 	// Note: external session echo tracker flush is done AFTER stateMu.Unlock()


### PR DESCRIPTION
## Summary

Addresses 3 unresolved Codex GitHub-bot review threads on the v0.5.0 promotion PR #650 that were blocking the merge under base branch policy ("must resolve all conversations before merge").

### P1 (BLOCKING) — Cancel watchdog at SYN-terminator path

`onSYNLocked`'s `ReasonSYNTerminator` branch (the **normal gateway-txn completion path** — terminator SYN echo) cleared `gatewayTxnActive` but did NOT cancel the watchdog. After EVERY successful gateway transaction in `ModeShadow` / `ModeEnforce`, the timer stayed armed. Once the bus went quiet enough that no new write re-armed within soft/hard deadline (typically 200ms+), the watchdog fired and emitted a false-positive `EchoSoftTimeout` / `EchoHardTimeout` admin event for a transaction that had already completed successfully.

**Fix**: signal `cancelGatewayWatchdog=true` in the SYNTerminator branch, mirroring the SYN-timeout and SYN-idle branches. The caller's existing post-`stateMu` cancel handles the rest.

This would have produced **continuous false-positive admin events in production shadow/enforce mode** — a release blocker.

### P2 #1 — Reset L_rtt state on reconnect boundary

Reconnect cancels the watchdog but keeps the pacer's L_rtt EMA and `lastEchoAt` anchor pointing at the OLD connection's latency characteristics. If the post-reconnect latency is different (quick reconnect under `GraceIdleThreshold`, or operator-driven reconnect to a different adapter), the first post-reconnect write computes deadlines from stale L_rtt and may emit spurious soft/hard timeouts.

**Fix**: call `pacer.ResetLrtt()` after `pacer.CancelEchoWatchdog()` in the reconnect path.

### P2 #2 — Close shutdown race

`Close()` previously cancelled the gateway watchdog BEFORE `m.wg.Wait()`. The `sendLoop` could still process a queued gateway write during shutdown (the select's send case can win against `ctx.Done()`) and re-arm the watchdog AFTER the cancel ran.

**Fix**: move the cancel to AFTER `m.wg.Wait()`. The `sendLoop` has provably exited before the cancel — no possible re-arm.

## Verification

- All `TestSessionPacer_`, `TestPacer_`, `TestF24` tests green under `-race`.
- Build + vet + gofmt clean.

Once merged into `frame-atomic-visibility`, the promotion PR #650 auto-updates with these fixes + the 3 review threads can be resolved → merge unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)