### PR TITLE
v0.5.1: bump ebusgo pin to main-branch pseudo-version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Project-Helianthus/helianthus-ebusgateway
 go 1.22
 
 require (
-	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260519172908-3fca19de9735
+	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260520030132-808674a01091
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260519172908-3fca19de9735 h1:vyx0mdtB7NtZVGgu86Jesn7+RmVMjKof5Mtz2h6FspM=
-github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260519172908-3fca19de9735/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
+github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260520030132-808674a01091 h1:7P1dQh9S+Ly1waW8kRVxWySfBbE7HwBDYOjyB4JMfdM=
+github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260520030132-808674a01091/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2 h1:6VFOfwe5L0GQkVRMcjdjCjnfBWcDoelnmoP1wIflrKM=
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=


### PR DESCRIPTION
## Summary

Closes the v0.5.0 known transient: re-pins `helianthus-ebusgo` from the frame-atomic-visibility branch pseudo-version to a main-branch pseudo-version now that ebusgo's [PR #166](https://github.com/Project-Helianthus/helianthus-ebusgo/pull/166) (frame-atomic-visibility → main) has merged.

## Diff

```diff
-	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260519172908-3fca19de9735
+	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260520030132-808674a01091
```

| | Before | After |
|---|---|---|
| Branch | frame-atomic-visibility | main |
| Commit | 3fca19de9735 (PR #165 AA escape decoder) | 808674a01091 (squashed promotion #166) |
| Timestamp | 2026-05-19T17:29:08Z | 2026-05-20T03:01:32Z |

**Functionality is identical** — the squash commit on main contains exactly the same diff that the frame-atomic-visibility HEAD did. What changes is release provenance: the gateway no longer depends on an integration-branch commit.

## Verification

- `go mod tidy` clean.
- `go build ./...` clean.
- `go test -race ./internal/adaptermux/...` green (mux suite ~108s, v8classifier ~2s).

## Tag plan

This is the v0.5.1 release-prep commit. On merge: tag `v0.5.1` with release notes covering "ebusgo pin re-pinned to main; functionality unchanged from v0.5.0".

🤖 Generated with [Claude Code](https://claude.com/claude-code)