### PR TITLE
v0.6.19: bump buildVersion constant to 0.6.19 (release-tag alignment)

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -36,7 +36,7 @@ import (
 )
 
 var (
-	buildVersion                              = "0.6.0"
+	buildVersion                              = "0.6.19"
 	buildID                                   = "unknown"
 	wireObserveFirstObserversFn               = wireObserveFirstObservers
 	startDiscoveryScanLoopFn                  = startDiscoveryScanLoopWithClassifier


### PR DESCRIPTION
## Summary

One-line constant bump in \`cmd/gateway/main.go\`:

\`\`\`diff
-	buildVersion = \"0.6.0\"
+	buildVersion = \"0.6.19\"
\`\`\`

## Context

The 0.6.x train has been shipping via the HA addon's \`config.json\` \`version\` field (currently at 0.6.17 pre-v8) without updating this source-side constant. Now that the v8 frame-atomic-visibility rollout has landed on main (squash commit \`aafedef\`, tagged v0.6.18 as a documentary marker), this PR closes the runtime-version mismatch: the next tag (v0.6.19) lands on main with the constant matching.

## Tag plan

After merge: tag the post-merge main HEAD as **v0.6.19**. That release covers:
- The frame-atomic-visibility v8 promotion squash (\`aafedef\`).
- The ebusgo pin re-bump to main (\`bbdd4f4\`).
- This buildVersion alignment.

Going forward, every 0.6.x tag includes its matching buildVersion bump as a small dedicated PR before the tag.

## Verification

- \`go build ./...\` clean.
- \`go vet ./...\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)