### PR TITLE
feat(v8): expose AA-injection drop events via /debug/v8/admin-events

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -1745,12 +1745,12 @@ func handleV8AdminEvents(w http.ResponseWriter, r *http.Request) {
 		var events []v8classifier.ClassifierAdminEvent
 		var dropped uint64
 		if peekOnly {
-			// Non-destructive read. Snapshot the ring + dropped
-			// counter without clearing. The classifier exposes
-			// this via a separate method so the drain path stays
-			// the canonical destructive operation.
-			events = classifier.PeekAdminEvents()
-			dropped = classifier.AdminEventsDroppedTotal()
+			// Non-destructive ATOMIC read: events + dropped come
+			// from a single mutex acquire (Codex round-2 MEDIUM
+			// on PR #657 — separate calls would race against a
+			// concurrent drain/overflow emit). The classifier
+			// exposes the destructive variant via DrainAdminEvents.
+			events, dropped = classifier.PeekAdminEvents()
 		} else {
 			events, dropped = classifier.DrainAdminEvents()
 		}
@@ -1771,10 +1771,16 @@ func handleV8AdminEvents(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	if peekOnly {
-		// Peek is idempotent — short-cache is fine, but keep
-		// it brief so operators get fresh data across short
-		// polling intervals.
-		w.Header().Set("Cache-Control", "max-age=1")
+		// Peek is idempotent. `private` keeps shared
+		// intermediary caches (CDNs, reverse proxies) from
+		// storing the response on behalf of unrelated
+		// operators — this is a debug surface, not public
+		// content. `max-age=1` keeps tooling that polls every
+		// few seconds from seeing stale data while still
+		// allowing the browser's own cache to debounce
+		// duplicate-refresh storms. Codex round-2 LOW on
+		// PR #657.
+		w.Header().Set("Cache-Control", "private, max-age=1")
 	} else {
 		// Drain is destructive, the same response is never
 		// valid twice. Tools that cache the response would

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"expvar"
 	"flag"
 	"fmt"
@@ -71,6 +72,17 @@ var (
 	// any more.
 	v8RolloutExpvarPublishOnce sync.Once
 	v8RolloutExpvarCurrent     atomic.Pointer[v8RolloutExpvarSource]
+
+	// v8AdminEventsCurrentClassifier is the indirection layer for
+	// the /debug/v8/admin-events HTTP surface. Same rationale as
+	// v8RolloutExpvarCurrent: the handler is registered ONCE at
+	// startHTTPServer and dereferences this atomic.Pointer at
+	// request time. run() updates the pointer on each invocation
+	// (test re-entry safe). When the active transport isn't
+	// adapter-direct, classifier is nil; the handler returns an
+	// empty events array + dropped=0 in that case so the contract
+	// degrades cleanly without 404-ing.
+	v8AdminEventsCurrentClassifier atomic.Pointer[v8classifier.Classifier]
 )
 
 // v8RolloutExpvarSource is the indirection layer for the five
@@ -326,6 +338,16 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 			bus:        bus,
 			classifier: classifier,
 		})
+		// F-NEW-26: pin the current classifier for the
+		// /debug/v8/admin-events HTTP handler too. Same atomic-
+		// pointer pattern as v8RolloutExpvarCurrent — handler
+		// registered ONCE per process at startHTTPServer,
+		// dereferences this pointer at request time. classifier
+		// may be nil (non-adapter-direct transports); the
+		// handler's nil-check returns an empty event list in
+		// that case so the surface stays available across
+		// transports for tooling that probes it unconditionally.
+		v8AdminEventsCurrentClassifier.Store(classifier)
 		v8RolloutExpvarPublishOnce.Do(func() {
 			expvar.Publish("helianthus_round9_absorb_entered_total",
 				expvar.Func(func() any {
@@ -1620,6 +1642,115 @@ func wireAdapterDirect(ctx context.Context, cfg *ebusgateway.Config) (func() err
 	return closer, activeTxnClassifier(mux), nil
 }
 
+// v8AdminEventsResponse is the JSON envelope returned by
+// /debug/v8/admin-events. Stable wire format — operator tooling
+// (dashboards, classifier-tuning workflows) parse this.
+//
+// Fields:
+//
+//   - Events: copy of all events the ring buffer held at drain
+//     time, in FIFO order (oldest first). Each event includes the
+//     wire byte, FSM state at decision time, escape-decoded
+//     provenance, and monotonic-clock timestamp.
+//
+//   - Dropped: number of events the ring buffer dropped (oldest-
+//     first FIFO) since the last drain. Non-zero indicates the
+//     consumer is polling too slowly for the production event
+//     rate; saturate response is acceptable but the operator
+//     should tighten the poll cadence.
+//
+//   - Kind / FSMState: JSON-encoded as their stable string labels
+//     via the v8AdminEventJSON intermediate so the wire format
+//     doesn't expose numeric enum values that could shift across
+//     gateway versions.
+type v8AdminEventsResponse struct {
+	Events  []v8AdminEventJSON `json:"events"`
+	Dropped uint64             `json:"dropped"`
+}
+
+// v8AdminEventJSON is the per-event wire shape returned by
+// /debug/v8/admin-events. Mirrors v8classifier.ClassifierAdminEvent
+// but encodes the enums as stable string labels.
+type v8AdminEventJSON struct {
+	// At is the monotonic-clock observation time of the event.
+	// Encoded as RFC3339Nano for human-readable parsing without
+	// loss of resolution.
+	At time.Time `json:"at"`
+
+	// Kind is the v8classifier.AdminEventKind label (e.g.
+	// "protocol_fault", "aa_injection_drop").
+	Kind string `json:"kind"`
+
+	// FSMState is the telegram_fsm.State label at the time of
+	// the event (e.g. "MASTER_HEADER", "MASTER_PAYLOAD").
+	FSMState string `json:"fsm_state"`
+
+	// Byte is the wire byte that triggered the event, encoded
+	// as a 0x-prefixed two-digit hex string for human
+	// readability (e.g. "0xAA"). Zero-valued for non-byte
+	// events (queue overflow, echo timeouts).
+	Byte string `json:"byte"`
+
+	// WasEscaped reports whether the byte arrived as an
+	// escape-decoded payload (true) or as a raw wire byte
+	// (false). The shadow→enforce promotion gate uses this to
+	// distinguish true-positive AA-injection (raw wire 0xAA
+	// mid-frame) from data-byte 0xAA that arrived legitimately
+	// via the ENS 0xA9 escape sequence.
+	WasEscaped bool `json:"was_escaped"`
+}
+
+// handleV8AdminEvents drains the active v8 classifier's admin
+// event ring buffer and returns the contents as JSON. See the
+// v8AdminEventsResponse doc and the mux.HandleFunc call site for
+// the full endpoint contract.
+//
+// Nil-safe: when no classifier is registered (non-adapter-direct
+// transport, or run() not yet completed), returns
+// `{"events": [], "dropped": 0}` so probing tooling sees a
+// well-formed response on every transport rather than 404-ing.
+//
+// Only GET is accepted — POST/etc respond 405 to avoid surprising
+// side effects (the drain IS state-mutating).
+func handleV8AdminEvents(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", "GET")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	resp := v8AdminEventsResponse{
+		Events: []v8AdminEventJSON{},
+	}
+
+	classifier := v8AdminEventsCurrentClassifier.Load()
+	if classifier != nil {
+		events, dropped := classifier.DrainAdminEvents()
+		resp.Dropped = dropped
+		if len(events) > 0 {
+			resp.Events = make([]v8AdminEventJSON, len(events))
+			for i, ev := range events {
+				resp.Events[i] = v8AdminEventJSON{
+					At:         ev.At,
+					Kind:       ev.Kind.String(),
+					FSMState:   ev.FSMState.String(),
+					Byte:       fmt.Sprintf("0x%02X", ev.Byte),
+					WasEscaped: ev.WasEscaped,
+				}
+			}
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	// Cache-Control: no-store — drain is destructive, the same
+	// response is never valid twice. Tools that cache responses
+	// would silently mask new events.
+	w.Header().Set("Cache-Control", "no-store")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		log.Printf("/debug/v8/admin-events: encode error: %v", err)
+	}
+}
+
 func startHTTPServer(
 	ctx context.Context,
 	cfg ebusgateway.Config,
@@ -1747,6 +1878,37 @@ func startHTTPServer(
 	// validation finding: M5 expvars were defined + Publish()'d but not
 	// reachable over HTTP.
 	mux.Handle("/debug/vars", expvar.Handler())
+	// F-NEW-26 (2026-05-21): expose the v8 classifier's admin
+	// event ring buffer over HTTP so operators can introspect the
+	// byte-level detail behind the helianthus_v8_shadow_would_have_dropped_total
+	// counter. Without this endpoint the aggregate counter is a
+	// black box: an operator running v8 in shadow mode sees the
+	// count rising but cannot distinguish true-positive (real wire
+	// AA-injection that SHOULD be filtered when promoted to enforce)
+	// from false-positive (legitimate traffic v8 over-eagerly flags).
+	// The per-event detail (byte value + FSM state + escape
+	// provenance + timestamp) is the operator's evidence base for
+	// the shadow→enforce promotion gate documented in
+	// helianthus-docs-ebus/deployment/prometheus-alerts.md.
+	//
+	// Endpoint contract:
+	//   GET /debug/v8/admin-events
+	//   Response: application/json
+	//   Body: {"events": [<ClassifierAdminEvent>...], "dropped": <uint64>}
+	//
+	// DRAIN semantics: each successful GET returns the events
+	// accumulated since the last drain and EMPTIES the ring
+	// buffer. Operators MUST poll at a steady cadence (every
+	// few seconds in production); a stuck consumer drops the
+	// OLDEST events FIFO and the "dropped" field surfaces the
+	// saturation.
+	//
+	// Nil-safe: when the classifier is unset (non-adapter-direct
+	// transport, or run() not yet completed), the handler returns
+	// `{"events": [], "dropped": 0}` — the surface stays
+	// available so tooling that probes it unconditionally does
+	// not 404.
+	mux.HandleFunc("/debug/v8/admin-events", handleV8AdminEvents)
 	mux.Handle(cfg.GraphQLPath, queryHandler)
 	mux.Handle(cfg.SnapshotPath, snapshotHandler)
 	mux.Handle(cfg.SubscriptionPath, subscriptionHandler)

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -1700,10 +1700,25 @@ type v8AdminEventJSON struct {
 	WasEscaped bool `json:"was_escaped"`
 }
 
-// handleV8AdminEvents drains the active v8 classifier's admin
-// event ring buffer and returns the contents as JSON. See the
-// v8AdminEventsResponse doc and the mux.HandleFunc call site for
-// the full endpoint contract.
+// handleV8AdminEvents returns the active v8 classifier's admin
+// event ring buffer as JSON.
+//
+// **Default GET drains the ring** (destructive). Each successful
+// GET returns the events accumulated since the last drain and
+// EMPTIES the buffer. This is the documented contract for
+// long-running poller tooling. Operators MUST poll at a steady
+// cadence (every few seconds in production); a stuck consumer
+// drops the OLDEST events FIFO and the `dropped` field surfaces
+// the saturation.
+//
+// **`?peek=true` returns events WITHOUT draining** (non-
+// destructive). For ad-hoc operator inspection (`curl | jq`,
+// browser visit, dashboards, health checks) that should NOT
+// consume the long-running poller's evidence stream. The full
+// ring contents are returned every time — the operator is
+// responsible for de-duplicating against prior peeks. Codex
+// round-1 LOW on PR #657 — the GET-drain footgun when
+// concurrent consumers share the HTTP surface.
 //
 // Nil-safe: when no classifier is registered (non-adapter-direct
 // transport, or run() not yet completed), returns
@@ -1711,7 +1726,7 @@ type v8AdminEventJSON struct {
 // well-formed response on every transport rather than 404-ing.
 //
 // Only GET is accepted — POST/etc respond 405 to avoid surprising
-// side effects (the drain IS state-mutating).
+// side effects.
 func handleV8AdminEvents(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		w.Header().Set("Allow", "GET")
@@ -1719,13 +1734,26 @@ func handleV8AdminEvents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	peekOnly := r.URL.Query().Get("peek") == "true"
+
 	resp := v8AdminEventsResponse{
 		Events: []v8AdminEventJSON{},
 	}
 
 	classifier := v8AdminEventsCurrentClassifier.Load()
 	if classifier != nil {
-		events, dropped := classifier.DrainAdminEvents()
+		var events []v8classifier.ClassifierAdminEvent
+		var dropped uint64
+		if peekOnly {
+			// Non-destructive read. Snapshot the ring + dropped
+			// counter without clearing. The classifier exposes
+			// this via a separate method so the drain path stays
+			// the canonical destructive operation.
+			events = classifier.PeekAdminEvents()
+			dropped = classifier.AdminEventsDroppedTotal()
+		} else {
+			events, dropped = classifier.DrainAdminEvents()
+		}
 		resp.Dropped = dropped
 		if len(events) > 0 {
 			resp.Events = make([]v8AdminEventJSON, len(events))
@@ -1742,10 +1770,17 @@ func handleV8AdminEvents(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	// Cache-Control: no-store — drain is destructive, the same
-	// response is never valid twice. Tools that cache responses
-	// would silently mask new events.
-	w.Header().Set("Cache-Control", "no-store")
+	if peekOnly {
+		// Peek is idempotent — short-cache is fine, but keep
+		// it brief so operators get fresh data across short
+		// polling intervals.
+		w.Header().Set("Cache-Control", "max-age=1")
+	} else {
+		// Drain is destructive, the same response is never
+		// valid twice. Tools that cache the response would
+		// silently mask new events.
+		w.Header().Set("Cache-Control", "no-store")
+	}
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		log.Printf("/debug/v8/admin-events: encode error: %v", err)
 	}

--- a/cmd/gateway/v8_admin_events_handler_test.go
+++ b/cmd/gateway/v8_admin_events_handler_test.go
@@ -160,6 +160,97 @@ func TestHandleV8AdminEvents_OnlyGetAllowed(t *testing.T) {
 	}
 }
 
+// TestHandleV8AdminEvents_PeekDoesNotDrain pins the
+// `?peek=true` non-destructive contract added to close
+// Codex round-1 LOW on PR #657 (GET-drain footgun). Two
+// successive peek requests return the same events; a
+// subsequent drain (no query param) still observes them.
+// Cache-Control header switches from `no-store` (drain) to
+// `max-age=1` (peek) so caching proxies treat the two modes
+// correctly.
+func TestHandleV8AdminEvents_PeekDoesNotDrain(t *testing.T) {
+	orig := v8AdminEventsCurrentClassifier.Load()
+	t.Cleanup(func() { v8AdminEventsCurrentClassifier.Store(orig) })
+
+	c := v8classifier.New(v8classifier.ModeShadow)
+	v8AdminEventsCurrentClassifier.Store(c)
+
+	// Populate the ring with one event.
+	now := time.Date(2026, 5, 21, 10, 0, 0, 0, time.UTC)
+	c.Observe(transport.StreamEvent{
+		Kind: transport.StreamEventStarted, Data: 0x71,
+	}, now)
+	c.Observe(transport.StreamEvent{
+		Kind: transport.StreamEventByte, Byte: 0xAA,
+	}, now)
+
+	// First peek.
+	rec1 := httptest.NewRecorder()
+	req1 := httptest.NewRequest(http.MethodGet, "/debug/v8/admin-events?peek=true", nil)
+	handleV8AdminEvents(rec1, req1)
+
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("peek status = %d; want 200", rec1.Code)
+	}
+	if cc := rec1.Header().Get("Cache-Control"); cc != "max-age=1" {
+		t.Errorf("peek Cache-Control = %q; want %q (peek is idempotent — short cache OK)",
+			cc, "max-age=1")
+	}
+
+	var resp1 struct {
+		Events []struct {
+			Kind string `json:"kind"`
+			Byte string `json:"byte"`
+		} `json:"events"`
+	}
+	if err := json.Unmarshal(rec1.Body.Bytes(), &resp1); err != nil {
+		t.Fatalf("first peek invalid JSON: %v", err)
+	}
+	if len(resp1.Events) != 1 {
+		t.Fatalf("first peek events = %d; want 1", len(resp1.Events))
+	}
+
+	// Second peek returns the SAME event.
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodGet, "/debug/v8/admin-events?peek=true", nil)
+	handleV8AdminEvents(rec2, req2)
+
+	var resp2 struct {
+		Events []struct {
+			Kind string `json:"kind"`
+			Byte string `json:"byte"`
+		} `json:"events"`
+	}
+	if err := json.Unmarshal(rec2.Body.Bytes(), &resp2); err != nil {
+		t.Fatalf("second peek invalid JSON: %v", err)
+	}
+	if len(resp2.Events) != 1 {
+		t.Fatalf("second peek events = %d; want 1 (peek must NOT drain)", len(resp2.Events))
+	}
+
+	// Drain (no peek param) finally consumes.
+	rec3 := httptest.NewRecorder()
+	req3 := httptest.NewRequest(http.MethodGet, "/debug/v8/admin-events", nil)
+	handleV8AdminEvents(rec3, req3)
+	if cc := rec3.Header().Get("Cache-Control"); cc != "no-store" {
+		t.Errorf("drain Cache-Control = %q; want %q (drain is destructive)", cc, "no-store")
+	}
+
+	// Post-drain peek sees empty.
+	rec4 := httptest.NewRecorder()
+	req4 := httptest.NewRequest(http.MethodGet, "/debug/v8/admin-events?peek=true", nil)
+	handleV8AdminEvents(rec4, req4)
+	var resp4 struct {
+		Events []struct{} `json:"events"`
+	}
+	if err := json.Unmarshal(rec4.Body.Bytes(), &resp4); err != nil {
+		t.Fatalf("post-drain peek invalid JSON: %v", err)
+	}
+	if len(resp4.Events) != 0 {
+		t.Errorf("post-drain peek events = %d; want 0 (drain failed)", len(resp4.Events))
+	}
+}
+
 // TestV8AdminEventsCurrentClassifier_AtomicSwap pins the
 // indirection contract used by the handler: the package-level
 // atomic.Pointer can be swapped at test re-entry without

--- a/cmd/gateway/v8_admin_events_handler_test.go
+++ b/cmd/gateway/v8_admin_events_handler_test.go
@@ -192,9 +192,9 @@ func TestHandleV8AdminEvents_PeekDoesNotDrain(t *testing.T) {
 	if rec1.Code != http.StatusOK {
 		t.Fatalf("peek status = %d; want 200", rec1.Code)
 	}
-	if cc := rec1.Header().Get("Cache-Control"); cc != "max-age=1" {
-		t.Errorf("peek Cache-Control = %q; want %q (peek is idempotent — short cache OK)",
-			cc, "max-age=1")
+	if cc := rec1.Header().Get("Cache-Control"); cc != "private, max-age=1" {
+		t.Errorf("peek Cache-Control = %q; want %q (peek idempotent; private prevents shared-cache leak)",
+			cc, "private, max-age=1")
 	}
 
 	var resp1 struct {

--- a/cmd/gateway/v8_admin_events_handler_test.go
+++ b/cmd/gateway/v8_admin_events_handler_test.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/adaptermux/v8classifier"
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+// v8_admin_events_handler_test.go pins the HTTP contract for the
+// /debug/v8/admin-events endpoint added by F-NEW-26 (2026-05-21).
+
+// TestHandleV8AdminEvents_NilClassifier_ReturnsEmptyResponse pins
+// the nil-safe degradation contract: when no classifier is
+// registered in v8AdminEventsCurrentClassifier (non-adapter-direct
+// transport, or run() not yet completed), the handler returns
+// `{"events": [], "dropped": 0}` with HTTP 200. Tooling that
+// probes this endpoint unconditionally must NOT see a 404.
+func TestHandleV8AdminEvents_NilClassifier_ReturnsEmptyResponse(t *testing.T) {
+	// Restore the original pointer after the test so subsequent
+	// tests that depend on a registered classifier (none today,
+	// but defensively) are not affected.
+	orig := v8AdminEventsCurrentClassifier.Load()
+	t.Cleanup(func() { v8AdminEventsCurrentClassifier.Store(orig) })
+
+	v8AdminEventsCurrentClassifier.Store(nil)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/debug/v8/admin-events", nil)
+	handleV8AdminEvents(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200 (nil-classifier must not 404)", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json; charset=utf-8" {
+		t.Errorf("Content-Type = %q; want application/json", ct)
+	}
+	if cc := rec.Header().Get("Cache-Control"); cc != "no-store" {
+		t.Errorf("Cache-Control = %q; want no-store (drain is destructive)", cc)
+	}
+
+	var resp struct {
+		Events  []map[string]any `json:"events"`
+		Dropped uint64           `json:"dropped"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v\nbody=%s", err, rec.Body.String())
+	}
+	if len(resp.Events) != 0 {
+		t.Errorf("events length = %d; want 0 (nil classifier)", len(resp.Events))
+	}
+	if resp.Dropped != 0 {
+		t.Errorf("dropped = %d; want 0", resp.Dropped)
+	}
+}
+
+// TestHandleV8AdminEvents_DrainsClassifierEvents pins the
+// happy-path contract: a registered classifier with buffered
+// admin events returns those events JSON-encoded, drains the
+// buffer, and a subsequent GET returns the empty envelope.
+func TestHandleV8AdminEvents_DrainsClassifierEvents(t *testing.T) {
+	orig := v8AdminEventsCurrentClassifier.Load()
+	t.Cleanup(func() { v8AdminEventsCurrentClassifier.Store(orig) })
+
+	c := v8classifier.New(v8classifier.ModeShadow)
+	v8AdminEventsCurrentClassifier.Store(c)
+
+	// Trigger an AA-injection drop to populate the ring buffer.
+	now := time.Date(2026, 5, 21, 9, 30, 0, 0, time.UTC)
+	c.Observe(transport.StreamEvent{
+		Kind: transport.StreamEventStarted, Data: 0x71,
+	}, now)
+	c.Observe(transport.StreamEvent{
+		Kind: transport.StreamEventByte, Byte: 0xAA,
+	}, now)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/debug/v8/admin-events", nil)
+	handleV8AdminEvents(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200", rec.Code)
+	}
+
+	var resp struct {
+		Events []struct {
+			At         time.Time `json:"at"`
+			Kind       string    `json:"kind"`
+			FSMState   string    `json:"fsm_state"`
+			Byte       string    `json:"byte"`
+			WasEscaped bool      `json:"was_escaped"`
+		} `json:"events"`
+		Dropped uint64 `json:"dropped"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v\nbody=%s", err, rec.Body.String())
+	}
+	if len(resp.Events) != 1 {
+		t.Fatalf("events length = %d; want 1 (drop did not emit admin event)", len(resp.Events))
+	}
+	ev := resp.Events[0]
+	if ev.Kind != "aa_injection_drop" {
+		t.Errorf("event kind = %q; want %q", ev.Kind, "aa_injection_drop")
+	}
+	if ev.Byte != "0xAA" {
+		t.Errorf("event byte = %q; want %q", ev.Byte, "0xAA")
+	}
+	if ev.WasEscaped {
+		t.Errorf("event was_escaped = true; want false (raw wire 0xAA)")
+	}
+	if !ev.At.Equal(now) {
+		t.Errorf("event at = %v; want %v (timestamp must round-trip JSON)", ev.At, now)
+	}
+
+	// Second GET must return empty — the first drained.
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodGet, "/debug/v8/admin-events", nil)
+	handleV8AdminEvents(rec2, req2)
+
+	var resp2 struct {
+		Events  []map[string]any `json:"events"`
+		Dropped uint64           `json:"dropped"`
+	}
+	if err := json.Unmarshal(rec2.Body.Bytes(), &resp2); err != nil {
+		t.Fatalf("second GET invalid JSON: %v", err)
+	}
+	if len(resp2.Events) != 0 {
+		t.Errorf("second GET events length = %d; want 0 (first GET should have drained)", len(resp2.Events))
+	}
+}
+
+// TestHandleV8AdminEvents_OnlyGetAllowed pins that POST/PUT/etc
+// respond 405 — the drain is state-mutating; only GET is the
+// documented action.
+func TestHandleV8AdminEvents_OnlyGetAllowed(t *testing.T) {
+	orig := v8AdminEventsCurrentClassifier.Load()
+	t.Cleanup(func() { v8AdminEventsCurrentClassifier.Store(orig) })
+
+	for _, method := range []string{
+		http.MethodPost,
+		http.MethodPut,
+		http.MethodDelete,
+		http.MethodPatch,
+	} {
+		t.Run(method, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(method, "/debug/v8/admin-events", nil)
+			handleV8AdminEvents(rec, req)
+			if rec.Code != http.StatusMethodNotAllowed {
+				t.Errorf("%s: status = %d; want 405", method, rec.Code)
+			}
+			if allow := rec.Header().Get("Allow"); allow != "GET" {
+				t.Errorf("%s: Allow = %q; want %q", method, allow, "GET")
+			}
+		})
+	}
+}
+
+// TestV8AdminEventsCurrentClassifier_AtomicSwap pins the
+// indirection contract used by the handler: the package-level
+// atomic.Pointer can be swapped at test re-entry without
+// affecting the registered handler. Mirrors the contract added
+// for v8RolloutExpvarCurrent in PR #655.
+func TestV8AdminEventsCurrentClassifier_AtomicSwap(t *testing.T) {
+	orig := v8AdminEventsCurrentClassifier.Load()
+	t.Cleanup(func() { v8AdminEventsCurrentClassifier.Store(orig) })
+
+	v8AdminEventsCurrentClassifier.Store(nil)
+	if got := v8AdminEventsCurrentClassifier.Load(); got != nil {
+		t.Errorf("after Store(nil) Load() = %v; want nil", got)
+	}
+
+	c := v8classifier.New(v8classifier.ModeShadow)
+	v8AdminEventsCurrentClassifier.Store(c)
+	if got := v8AdminEventsCurrentClassifier.Load(); got != c {
+		t.Errorf("after Store(c) Load() = %p; want %p", got, c)
+	}
+}

--- a/internal/adaptermux/v8classifier/admin_event.go
+++ b/internal/adaptermux/v8classifier/admin_event.go
@@ -246,3 +246,25 @@ func (b *adminEventBuffer) pending() int {
 	defer b.mu.Unlock()
 	return len(b.events)
 }
+
+// peek returns a copy of buffered events WITHOUT clearing the
+// buffer or resetting the dropped counter. Used by ad-hoc
+// operator tooling (browser, curl + jq) that should not
+// consume a long-running poller's evidence stream. F-NEW-26
+// follow-up — Codex round-1 LOW on PR #657: closes the GET-
+// drain footgun when concurrent consumers share the HTTP
+// surface. The dropped counter returned here is the CUMULATIVE
+// total since process start; consumers correlate against a
+// prior peek to compute deltas.
+//
+// Multi-consumer safe via the mutex.
+func (b *adminEventBuffer) peek() (events []ClassifierAdminEvent, dropped uint64) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.events) == 0 {
+		return nil, b.dropped
+	}
+	events = make([]ClassifierAdminEvent, len(b.events))
+	copy(events, b.events)
+	return events, b.dropped
+}

--- a/internal/adaptermux/v8classifier/admin_event.go
+++ b/internal/adaptermux/v8classifier/admin_event.go
@@ -247,15 +247,23 @@ func (b *adminEventBuffer) pending() int {
 	return len(b.events)
 }
 
-// peek returns a copy of buffered events WITHOUT clearing the
-// buffer or resetting the dropped counter. Used by ad-hoc
-// operator tooling (browser, curl + jq) that should not
-// consume a long-running poller's evidence stream. F-NEW-26
-// follow-up — Codex round-1 LOW on PR #657: closes the GET-
-// drain footgun when concurrent consumers share the HTTP
-// surface. The dropped counter returned here is the CUMULATIVE
-// total since process start; consumers correlate against a
-// prior peek to compute deltas.
+// peek returns a copy of buffered events AND the cumulative
+// dropped counter, WITHOUT clearing the buffer or resetting
+// the counter. Both values are returned from a single mutex
+// acquire so they form an internally-consistent snapshot
+// (Codex round-2 MEDIUM on PR #657: separate peek + counter
+// methods would race against concurrent drain/overflow emit).
+//
+// Used by ad-hoc operator tooling (browser, curl + jq) that
+// should not consume a long-running poller's evidence stream.
+// F-NEW-26 follow-up — Codex round-1 LOW on PR #657 closed
+// the GET-drain footgun for concurrent consumers.
+//
+// The dropped counter returned here is cumulative since the
+// last drain() call (NOT since process start) — drain resets
+// it atomically with the event-slice clear. Mixed peek+drain
+// consumers see it snap to zero on drain; peek-only consumers
+// see it grow monotonically until the next drain.
 //
 // Multi-consumer safe via the mutex.
 func (b *adminEventBuffer) peek() (events []ClassifierAdminEvent, dropped uint64) {

--- a/internal/adaptermux/v8classifier/admin_event.go
+++ b/internal/adaptermux/v8classifier/admin_event.go
@@ -73,6 +73,30 @@ const (
 	// producer detects the next emit would overflow). B3.6c+
 	// expand the scope to per-session sendCh overflow too.
 	AdminEventKindQueueOverflow
+
+	// AdminEventKindAaInjectionDrop is emitted when the FSM
+	// returns telegram_fsm.DecisionDropAaInjection — a mid-frame
+	// wire AUTO-SYN (0xAA) the v8 classifier identifies as an
+	// AA-injection event. In ModeShadow the byte is COUNTED only
+	// (ShadowWouldHaveDroppedTotal increments); in ModeEnforce
+	// the byte is dropped from the cross-proxy stream
+	// (EnforceDropsAppliedTotal increments). In ModeOff the FSM
+	// does not run and this kind is unreachable.
+	//
+	// The per-event surface is the operator's introspection
+	// channel for the shadow→enforce promotion gate: each event
+	// captures the wire byte and FSM state at the time of the
+	// would-have-drop decision, so the operator can correlate
+	// the aggregate counter against the actual byte patterns and
+	// decide whether the classifier is flagging true protocol
+	// garbage (safe to promote) or legitimate traffic (over-
+	// eager — do not promote).
+	//
+	// Per v8 §1.1 / I1 these events live OUT-OF-BAND and MUST
+	// NOT be serialized into any cross-proxy session's byte
+	// stream — the v8 invariant that motivated the whole
+	// admin-event channel design.
+	AdminEventKindAaInjectionDrop
 )
 
 // String returns the canonical lowercase label for the admin
@@ -89,6 +113,8 @@ func (k AdminEventKind) String() string {
 		return "echo_hard_timeout"
 	case AdminEventKindQueueOverflow:
 		return "queue_overflow"
+	case AdminEventKindAaInjectionDrop:
+		return "aa_injection_drop"
 	default:
 		return "unknown"
 	}

--- a/internal/adaptermux/v8classifier/admin_event_aa_drop_test.go
+++ b/internal/adaptermux/v8classifier/admin_event_aa_drop_test.go
@@ -150,3 +150,103 @@ func TestAdminEventKindAaInjectionDrop_String(t *testing.T) {
 			got, "aa_injection_drop")
 	}
 }
+
+// TestPeekAdminEvents_DoesNotDrain pins the non-destructive
+// peek contract added to close Codex round-1 LOW on PR #657
+// (GET-drain footgun). Multiple peeks return the same events;
+// a subsequent drain still observes them.
+func TestPeekAdminEvents_DoesNotDrain(t *testing.T) {
+	t.Parallel()
+	c := New(ModeShadow)
+	now := time.Unix(0, 0)
+
+	// Generate one drop event.
+	c.Observe(transport.StreamEvent{
+		Kind: transport.StreamEventStarted, Data: 0x71,
+	}, now)
+	c.Observe(transport.StreamEvent{
+		Kind: transport.StreamEventByte, Byte: 0xAA,
+	}, now)
+
+	// First peek sees the event.
+	events1 := c.PeekAdminEvents()
+	if len(events1) != 1 {
+		t.Fatalf("first peek: got %d events; want 1", len(events1))
+	}
+	if events1[0].Kind != AdminEventKindAaInjectionDrop {
+		t.Errorf("first peek event Kind=%v; want AdminEventKindAaInjectionDrop", events1[0].Kind)
+	}
+
+	// Second peek sees the SAME event (non-destructive).
+	events2 := c.PeekAdminEvents()
+	if len(events2) != 1 {
+		t.Fatalf("second peek: got %d events; want 1 (peek must not drain)", len(events2))
+	}
+	if events2[0] != events1[0] {
+		t.Errorf("second peek returned a different event than first; peek must be deterministic")
+	}
+
+	// Drain still sees the event (peek did not consume).
+	drained, _ := c.DrainAdminEvents()
+	if len(drained) != 1 {
+		t.Fatalf("post-peek drain: got %d events; want 1 (peek consumed events it should not have)", len(drained))
+	}
+
+	// Post-drain peek sees empty.
+	events3 := c.PeekAdminEvents()
+	if len(events3) != 0 {
+		t.Errorf("post-drain peek: got %d events; want 0 (drain failed to clear)", len(events3))
+	}
+}
+
+// TestPeekAdminEvents_NilSafe pins nil-receiver safety.
+func TestPeekAdminEvents_NilSafe(t *testing.T) {
+	t.Parallel()
+	var c *Classifier
+	events := c.PeekAdminEvents()
+	if events != nil {
+		t.Errorf("nil.PeekAdminEvents() = %v; want nil", events)
+	}
+	if got := c.AdminEventsDroppedTotal(); got != 0 {
+		t.Errorf("nil.AdminEventsDroppedTotal() = %d; want 0", got)
+	}
+}
+
+// TestAdminEventsDroppedTotal_Snapshot pins that the peek-side
+// dropped counter exposes the cumulative-since-drain value
+// (NOT a per-call delta). The destructive drain resets it; the
+// peek path does not.
+func TestAdminEventsDroppedTotal_Snapshot(t *testing.T) {
+	t.Parallel()
+	c := New(ModeShadow)
+
+	// AdminEventsDroppedTotal starts at 0.
+	if got := c.AdminEventsDroppedTotal(); got != 0 {
+		t.Fatalf("AdminEventsDroppedTotal() at construction = %d; want 0", got)
+	}
+
+	// Fill the ring to its cap and overflow it by one to force
+	// a drop. Use direct emit on the buffer (no FSM needed for
+	// this contract test).
+	for i := 0; i < adminEventBufferCap+1; i++ {
+		c.adminEvents.emit(ClassifierAdminEvent{
+			Kind: AdminEventKindProtocolFault,
+		})
+	}
+
+	// One drop expected.
+	if got := c.AdminEventsDroppedTotal(); got != 1 {
+		t.Errorf("AdminEventsDroppedTotal() after one overflow = %d; want 1", got)
+	}
+
+	// Multiple peeks return the same dropped count.
+	if got := c.AdminEventsDroppedTotal(); got != 1 {
+		t.Errorf("second AdminEventsDroppedTotal() = %d; want 1 (peek must not reset)", got)
+	}
+
+	// Drain resets it.
+	c.DrainAdminEvents()
+	if got := c.AdminEventsDroppedTotal(); got != 0 {
+		t.Errorf("post-drain AdminEventsDroppedTotal() = %d; want 0 (drain must reset)", got)
+	}
+}

--- a/internal/adaptermux/v8classifier/admin_event_aa_drop_test.go
+++ b/internal/adaptermux/v8classifier/admin_event_aa_drop_test.go
@@ -169,16 +169,19 @@ func TestPeekAdminEvents_DoesNotDrain(t *testing.T) {
 	}, now)
 
 	// First peek sees the event.
-	events1 := c.PeekAdminEvents()
+	events1, dropped1 := c.PeekAdminEvents()
 	if len(events1) != 1 {
 		t.Fatalf("first peek: got %d events; want 1", len(events1))
+	}
+	if dropped1 != 0 {
+		t.Errorf("first peek dropped=%d; want 0 (no overflow yet)", dropped1)
 	}
 	if events1[0].Kind != AdminEventKindAaInjectionDrop {
 		t.Errorf("first peek event Kind=%v; want AdminEventKindAaInjectionDrop", events1[0].Kind)
 	}
 
 	// Second peek sees the SAME event (non-destructive).
-	events2 := c.PeekAdminEvents()
+	events2, _ := c.PeekAdminEvents()
 	if len(events2) != 1 {
 		t.Fatalf("second peek: got %d events; want 1 (peek must not drain)", len(events2))
 	}
@@ -193,7 +196,7 @@ func TestPeekAdminEvents_DoesNotDrain(t *testing.T) {
 	}
 
 	// Post-drain peek sees empty.
-	events3 := c.PeekAdminEvents()
+	events3, _ := c.PeekAdminEvents()
 	if len(events3) != 0 {
 		t.Errorf("post-drain peek: got %d events; want 0 (drain failed to clear)", len(events3))
 	}
@@ -203,26 +206,30 @@ func TestPeekAdminEvents_DoesNotDrain(t *testing.T) {
 func TestPeekAdminEvents_NilSafe(t *testing.T) {
 	t.Parallel()
 	var c *Classifier
-	events := c.PeekAdminEvents()
+	events, dropped := c.PeekAdminEvents()
 	if events != nil {
-		t.Errorf("nil.PeekAdminEvents() = %v; want nil", events)
+		t.Errorf("nil.PeekAdminEvents() events = %v; want nil", events)
 	}
-	if got := c.AdminEventsDroppedTotal(); got != 0 {
-		t.Errorf("nil.AdminEventsDroppedTotal() = %d; want 0", got)
+	if dropped != 0 {
+		t.Errorf("nil.PeekAdminEvents() dropped = %d; want 0", dropped)
 	}
 }
 
-// TestAdminEventsDroppedTotal_Snapshot pins that the peek-side
-// dropped counter exposes the cumulative-since-drain value
-// (NOT a per-call delta). The destructive drain resets it; the
-// peek path does not.
-func TestAdminEventsDroppedTotal_Snapshot(t *testing.T) {
+// TestPeekAdminEvents_AtomicSnapshot pins the Codex-round-2
+// MEDIUM contract: events and dropped come from a single mutex
+// acquire so they form an internally-consistent pair. Drives
+// one ring overflow and asserts that multiple peeks return
+// (events, dropped) pairs where both stay stable across calls
+// (no interleaved drain/overflow); a subsequent drain resets
+// BOTH atomically.
+func TestPeekAdminEvents_AtomicSnapshot(t *testing.T) {
 	t.Parallel()
 	c := New(ModeShadow)
 
-	// AdminEventsDroppedTotal starts at 0.
-	if got := c.AdminEventsDroppedTotal(); got != 0 {
-		t.Fatalf("AdminEventsDroppedTotal() at construction = %d; want 0", got)
+	// Pre-condition: empty.
+	events0, dropped0 := c.PeekAdminEvents()
+	if len(events0) != 0 || dropped0 != 0 {
+		t.Fatalf("construction state: events=%d dropped=%d; want (0,0)", len(events0), dropped0)
 	}
 
 	// Fill the ring to its cap and overflow it by one to force
@@ -234,19 +241,27 @@ func TestAdminEventsDroppedTotal_Snapshot(t *testing.T) {
 		})
 	}
 
-	// One drop expected.
-	if got := c.AdminEventsDroppedTotal(); got != 1 {
-		t.Errorf("AdminEventsDroppedTotal() after one overflow = %d; want 1", got)
+	// Multiple peeks return the same (events, dropped) pair.
+	events1, dropped1 := c.PeekAdminEvents()
+	if len(events1) != adminEventBufferCap || dropped1 != 1 {
+		t.Errorf("first peek: events=%d dropped=%d; want (%d, 1)",
+			len(events1), dropped1, adminEventBufferCap)
+	}
+	events2, dropped2 := c.PeekAdminEvents()
+	if len(events2) != adminEventBufferCap || dropped2 != 1 {
+		t.Errorf("second peek: events=%d dropped=%d; want (%d, 1) (peek must not mutate)",
+			len(events2), dropped2, adminEventBufferCap)
 	}
 
-	// Multiple peeks return the same dropped count.
-	if got := c.AdminEventsDroppedTotal(); got != 1 {
-		t.Errorf("second AdminEventsDroppedTotal() = %d; want 1 (peek must not reset)", got)
+	// Drain resets BOTH atomically.
+	drainedEvents, drainedDropped := c.DrainAdminEvents()
+	if len(drainedEvents) != adminEventBufferCap || drainedDropped != 1 {
+		t.Errorf("drain: events=%d dropped=%d; want (%d, 1)",
+			len(drainedEvents), drainedDropped, adminEventBufferCap)
 	}
-
-	// Drain resets it.
-	c.DrainAdminEvents()
-	if got := c.AdminEventsDroppedTotal(); got != 0 {
-		t.Errorf("post-drain AdminEventsDroppedTotal() = %d; want 0 (drain must reset)", got)
+	events3, dropped3 := c.PeekAdminEvents()
+	if len(events3) != 0 || dropped3 != 0 {
+		t.Errorf("post-drain peek: events=%d dropped=%d; want (0, 0) (drain must reset both)",
+			len(events3), dropped3)
 	}
 }

--- a/internal/adaptermux/v8classifier/admin_event_aa_drop_test.go
+++ b/internal/adaptermux/v8classifier/admin_event_aa_drop_test.go
@@ -70,12 +70,12 @@ func TestClassifier_DropAaInjection_EmitsAdminEvent_ShadowMode(t *testing.T) {
 	if ev.At != now {
 		t.Errorf("event At=%v; want %v (now threaded from Observe per Codex round-1 MEDIUM)", ev.At, now)
 	}
-	// FSMState should be a MASTER_HEADER variant — the FSM has
-	// just consumed QQ from the STARTED stream event and the
-	// next byte (the 0xAA wire byte) lands in the master header
-	// region where AA-injection detection runs. Exact state
-	// label varies with FSM internals; we only check non-zero
-	// so future FSM-state refactors don't break this regression.
+	// FSMState should be in the initiator-header region — the
+	// FSM has just consumed QQ from the STARTED stream event
+	// and the next byte (the 0xAA wire byte) lands where the
+	// AA-injection detection runs. Exact state label varies
+	// with FSM internals; we only check non-zero so future
+	// FSM-state refactors don't break this regression.
 	if ev.FSMState == telegram_fsm.StateIdle {
 		t.Errorf("event FSMState=%v; want non-idle (FSM was mid-telegram at drop time)", ev.FSMState)
 	}

--- a/internal/adaptermux/v8classifier/admin_event_aa_drop_test.go
+++ b/internal/adaptermux/v8classifier/admin_event_aa_drop_test.go
@@ -1,0 +1,152 @@
+package v8classifier
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol/telegram_fsm"
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+// admin_event_aa_drop_test.go pins F-NEW-26 (2026-05-21): every
+// telegram_fsm.DecisionDropAaInjection in ModeShadow or ModeEnforce
+// emits a per-event ClassifierAdminEvent of kind
+// AdminEventKindAaInjectionDrop. Operators draining the ring via
+// /debug/v8/admin-events get the byte value + FSM state at decision
+// time so they can classify the shadow→enforce promotion candidates
+// as true- or false-positive by the actual wire pattern, not by
+// aggregate counter only.
+
+// TestClassifier_DropAaInjection_EmitsAdminEvent_ShadowMode pins
+// that ModeShadow emits the per-event detail alongside the
+// counter increment. Without this surface, the shadow→enforce
+// promotion gate has no byte-level evidence.
+func TestClassifier_DropAaInjection_EmitsAdminEvent_ShadowMode(t *testing.T) {
+	t.Parallel()
+	c := New(ModeShadow)
+	now := time.Unix(42, 0)
+
+	// Drive to mid-frame so the FSM classifies the next 0xAA as
+	// AA-injection (per v8 §4: mid-frame wire 0xAA without an
+	// escape prefix is the AA-injection signal).
+	c.Observe(transport.StreamEvent{
+		Kind: transport.StreamEventStarted, Data: 0x71,
+	}, now)
+	drop := c.Observe(transport.StreamEvent{
+		Kind: transport.StreamEventByte, Byte: 0xAA,
+	}, now)
+	if drop {
+		t.Fatal("Observe in ModeShadow returned drop=true; precondition violated (Shadow must not drop)")
+	}
+
+	// Aggregate counter increments (the established contract).
+	if got := c.FsmDropAaInjectionTotal(); got != 1 {
+		t.Fatalf("FsmDropAaInjectionTotal()=%d; want 1 (precondition for admin emit)", got)
+	}
+	if got := c.ShadowWouldHaveDroppedTotal(); got != 1 {
+		t.Fatalf("ShadowWouldHaveDroppedTotal()=%d; want 1", got)
+	}
+
+	// The new contract: the same drop also emits a per-event
+	// admin event into the ring buffer.
+	events, dropped := c.DrainAdminEvents()
+	if dropped != 0 {
+		t.Errorf("DrainAdminEvents: dropped=%d; want 0 (no ring saturation in this trivial test)", dropped)
+	}
+	if len(events) != 1 {
+		t.Fatalf("DrainAdminEvents: got %d events; want 1 (per-drop emit broken)", len(events))
+	}
+
+	ev := events[0]
+	if ev.Kind != AdminEventKindAaInjectionDrop {
+		t.Errorf("event Kind=%v; want AdminEventKindAaInjectionDrop", ev.Kind)
+	}
+	if ev.Byte != 0xAA {
+		t.Errorf("event Byte=0x%02X; want 0xAA (the AA-injection that triggered the drop)", ev.Byte)
+	}
+	if ev.WasEscaped {
+		t.Error("event WasEscaped=true; want false (raw wire 0xAA, not escape-decoded)")
+	}
+	if ev.At != now {
+		t.Errorf("event At=%v; want %v (now threaded from Observe per Codex round-1 MEDIUM)", ev.At, now)
+	}
+	// FSMState should be a MASTER_HEADER variant — the FSM has
+	// just consumed QQ from the STARTED stream event and the
+	// next byte (the 0xAA wire byte) lands in the master header
+	// region where AA-injection detection runs. Exact state
+	// label varies with FSM internals; we only check non-zero
+	// so future FSM-state refactors don't break this regression.
+	if ev.FSMState == telegram_fsm.StateIdle {
+		t.Errorf("event FSMState=%v; want non-idle (FSM was mid-telegram at drop time)", ev.FSMState)
+	}
+}
+
+// TestClassifier_DropAaInjection_EmitsAdminEvent_EnforceMode pins
+// the same contract for ModeEnforce. The enforce mode applies
+// the drop (drop=true) AND emits the event — the operator's
+// audit log of what got filtered.
+func TestClassifier_DropAaInjection_EmitsAdminEvent_EnforceMode(t *testing.T) {
+	t.Parallel()
+	c := New(ModeEnforce)
+	now := time.Unix(7, 0)
+
+	c.Observe(transport.StreamEvent{
+		Kind: transport.StreamEventStarted, Data: 0x71,
+	}, now)
+	drop := c.Observe(transport.StreamEvent{
+		Kind: transport.StreamEventByte, Byte: 0xAA,
+	}, now)
+	if !drop {
+		t.Fatal("Observe in ModeEnforce returned drop=false; precondition violated (Enforce must drop AA-injection)")
+	}
+	if got := c.EnforceDropsAppliedTotal(); got != 1 {
+		t.Fatalf("EnforceDropsAppliedTotal()=%d; want 1 (precondition)", got)
+	}
+
+	events, _ := c.DrainAdminEvents()
+	if len(events) != 1 {
+		t.Fatalf("DrainAdminEvents: got %d events; want 1 (enforce-mode emit broken)", len(events))
+	}
+	if events[0].Kind != AdminEventKindAaInjectionDrop {
+		t.Errorf("event Kind=%v; want AdminEventKindAaInjectionDrop", events[0].Kind)
+	}
+	if events[0].Byte != 0xAA {
+		t.Errorf("event Byte=0x%02X; want 0xAA", events[0].Byte)
+	}
+}
+
+// TestClassifier_DropAaInjection_NoEmit_ModeOff pins that
+// ModeOff does NOT emit (the FSM does not run; the drop
+// decision is unreachable). This is the zero-overhead contract.
+func TestClassifier_DropAaInjection_NoEmit_ModeOff(t *testing.T) {
+	t.Parallel()
+	c := New(ModeOff)
+	now := time.Unix(0, 0)
+
+	c.Observe(transport.StreamEvent{
+		Kind: transport.StreamEventStarted, Data: 0x71,
+	}, now)
+	c.Observe(transport.StreamEvent{
+		Kind: transport.StreamEventByte, Byte: 0xAA,
+	}, now)
+
+	// Counter must stay 0 (FSM doesn't run).
+	if got := c.FsmDropAaInjectionTotal(); got != 0 {
+		t.Errorf("FsmDropAaInjectionTotal()=%d in ModeOff; want 0", got)
+	}
+
+	// Ring must be empty.
+	events, _ := c.DrainAdminEvents()
+	if len(events) != 0 {
+		t.Errorf("DrainAdminEvents in ModeOff: got %d events; want 0 (zero-overhead contract)", len(events))
+	}
+}
+
+// TestAdminEventKindAaInjectionDrop_String pins the label.
+func TestAdminEventKindAaInjectionDrop_String(t *testing.T) {
+	t.Parallel()
+	if got := AdminEventKindAaInjectionDrop.String(); got != "aa_injection_drop" {
+		t.Errorf("AdminEventKindAaInjectionDrop.String() = %q; want %q",
+			got, "aa_injection_drop")
+	}
+}

--- a/internal/adaptermux/v8classifier/classifier.go
+++ b/internal/adaptermux/v8classifier/classifier.go
@@ -375,6 +375,29 @@ func (c *Classifier) driveFSMByte(b byte, wasEscaped bool, now time.Time) (drop 
 		if c.mode == ModeEnforce {
 			drop = true
 		}
+		// F-NEW-26 (2026-05-21): emit out-of-band admin event for
+		// every DropAaInjection decision. This is the operator
+		// introspection surface for the shadow→enforce promotion
+		// gate — the aggregate ShadowWouldHaveDroppedTotal counter
+		// tells operators HOW MANY bytes v8 wants to drop, but
+		// not WHICH bytes or under WHICH FSM state. Without this
+		// per-event detail an operator running shadow mode cannot
+		// distinguish true-positive (real wire AA-injection that
+		// SHOULD be filtered) from false-positive (legitimate
+		// traffic v8 over-eagerly flags). Emit in BOTH ModeShadow
+		// and ModeEnforce so the event log is consistent across
+		// the promotion path. Per v8 invariant I1 the event lives
+		// OUT-OF-BAND (admin channel only) — never serialized into
+		// cross-proxy byte streams.
+		if c.mode != ModeOff {
+			c.adminEvents.emit(ClassifierAdminEvent{
+				At:         now,
+				Kind:       AdminEventKindAaInjectionDrop,
+				FSMState:   c.fsm.State(),
+				Byte:       b,
+				WasEscaped: wasEscaped,
+			})
+		}
 	case telegram_fsm.DecisionProtocolFault:
 		c.fsmProtocolFaultTotal.Add(1)
 		// Emit out-of-band admin event. Per v8 invariant I10 the

--- a/internal/adaptermux/v8classifier/classifier.go
+++ b/internal/adaptermux/v8classifier/classifier.go
@@ -775,6 +775,51 @@ func (c *Classifier) PendingAdminEvents() int {
 	return c.adminEvents.pending()
 }
 
+// PeekAdminEvents returns a snapshot of the admin event ring
+// WITHOUT draining it. The returned slice is a copy, safe to
+// hold across other classifier calls. The dropped counter is
+// NOT included in this method's return — call
+// AdminEventsDroppedTotal for that signal.
+//
+// Use case: ad-hoc operator inspection that should not consume
+// a long-running poller's evidence stream. The canonical
+// destructive read remains DrainAdminEvents (which clears the
+// ring AND resets the dropped counter on read).
+//
+// Returns nil when the classifier is nil. Safe to call from
+// any goroutine; concurrent peek/drain pairs serialize through
+// the ring's internal mutex.
+func (c *Classifier) PeekAdminEvents() []ClassifierAdminEvent {
+	if c == nil {
+		return nil
+	}
+	events, _ := c.adminEvents.peek()
+	return events
+}
+
+// AdminEventsDroppedTotal returns the cumulative count of admin
+// events the ring buffer dropped (oldest-FIFO) since process
+// start. Companion to PeekAdminEvents — the destructive
+// DrainAdminEvents path returns and resets a per-drain
+// dropped counter; this method exposes the lifetime-cumulative
+// counter for non-destructive consumers that want to detect
+// saturation across peek calls.
+//
+// NOTE: this counter is reset to zero by DrainAdminEvents (see
+// adminEventBuffer.drain). Mixed peek+drain consumers see the
+// counter snap back to zero after a drain; peek-only consumers
+// see it grow monotonically until the next drain.
+//
+// Returns 0 when the classifier is nil. Safe to call from any
+// goroutine.
+func (c *Classifier) AdminEventsDroppedTotal() uint64 {
+	if c == nil {
+		return 0
+	}
+	_, dropped := c.adminEvents.peek()
+	return dropped
+}
+
 // NewPacerForSession returns a new per-session Pacer wired to
 // this classifier's admin-event buffer (Phase 3 Step B3.6e). The
 // pacer's watchdog timeouts (soft / hard) emit ClassifierAdminEvent

--- a/internal/adaptermux/v8classifier/classifier.go
+++ b/internal/adaptermux/v8classifier/classifier.go
@@ -776,48 +776,36 @@ func (c *Classifier) PendingAdminEvents() int {
 }
 
 // PeekAdminEvents returns a snapshot of the admin event ring
-// WITHOUT draining it. The returned slice is a copy, safe to
-// hold across other classifier calls. The dropped counter is
-// NOT included in this method's return — call
-// AdminEventsDroppedTotal for that signal.
+// AND the cumulative-since-last-drain dropped counter, in a
+// single atomic acquire of the ring's internal mutex. Mirrors
+// the (events, dropped) signature of DrainAdminEvents but does
+// NOT clear the ring or reset the dropped counter.
+//
+// Atomicity matters: if events and dropped were exposed as two
+// separate methods, a concurrent drain or overflow emit could
+// interleave between the calls — a peek consumer would see an
+// events slice that doesn't match the dropped count (Codex
+// round-2 MEDIUM on PR #657). One mutex acquire makes the
+// returned pair internally consistent.
 //
 // Use case: ad-hoc operator inspection that should not consume
 // a long-running poller's evidence stream. The canonical
 // destructive read remains DrainAdminEvents (which clears the
-// ring AND resets the dropped counter on read).
+// ring AND resets the dropped counter atomically).
 //
-// Returns nil when the classifier is nil. Safe to call from
-// any goroutine; concurrent peek/drain pairs serialize through
-// the ring's internal mutex.
-func (c *Classifier) PeekAdminEvents() []ClassifierAdminEvent {
+// Semantics of the returned dropped value: cumulative since the
+// last DrainAdminEvents call (NOT since process start). A mixed
+// peek+drain consumer sees the counter snap to zero on drain;
+// a peek-only consumer sees it grow monotonically until the
+// next drain.
+//
+// Returns (nil, 0) when the classifier is nil. Safe to call
+// from any goroutine.
+func (c *Classifier) PeekAdminEvents() (events []ClassifierAdminEvent, dropped uint64) {
 	if c == nil {
-		return nil
+		return nil, 0
 	}
-	events, _ := c.adminEvents.peek()
-	return events
-}
-
-// AdminEventsDroppedTotal returns the cumulative count of admin
-// events the ring buffer dropped (oldest-FIFO) since process
-// start. Companion to PeekAdminEvents — the destructive
-// DrainAdminEvents path returns and resets a per-drain
-// dropped counter; this method exposes the lifetime-cumulative
-// counter for non-destructive consumers that want to detect
-// saturation across peek calls.
-//
-// NOTE: this counter is reset to zero by DrainAdminEvents (see
-// adminEventBuffer.drain). Mixed peek+drain consumers see the
-// counter snap back to zero after a drain; peek-only consumers
-// see it grow monotonically until the next drain.
-//
-// Returns 0 when the classifier is nil. Safe to call from any
-// goroutine.
-func (c *Classifier) AdminEventsDroppedTotal() uint64 {
-	if c == nil {
-		return 0
-	}
-	_, dropped := c.adminEvents.peek()
-	return dropped
+	return c.adminEvents.peek()
 }
 
 // NewPacerForSession returns a new per-session Pacer wired to


### PR DESCRIPTION
## Why

Closes HIGH follow-up #1 from the v8 shadow validation iter-4 report (`_work_adaptermux_audit/v8-shadow-validation-20260520T055414Z.md`). Iter-6 confirmed `helianthus_v8_shadow_would_have_dropped_total` grows at ~210 bytes/min under healthy bus — but the aggregate counter is a black box. Operators cannot tell whether v8 is correctly identifying real wire AA-injection (safe to promote to enforce) or over-eagerly flagging legitimate traffic (do not promote).

This PR exposes the v8 classifier's existing admin event ring buffer over HTTP, with a new per-event admin emit on every `DecisionDropAaInjection` so the byte-level detail behind the aggregate counter becomes introspectable.

## What

### New AdminEventKindAaInjectionDrop

`internal/adaptermux/v8classifier/admin_event.go`:
- New enum value `AdminEventKindAaInjectionDrop` (label `"aa_injection_drop"`).

`internal/adaptermux/v8classifier/classifier.go`:
- `driveFSMByte` emits a `ClassifierAdminEvent` on EVERY `DecisionDropAaInjection` in `ModeShadow` or `ModeEnforce`. The event captures wire byte, FSM state at decision time, escape-decoded provenance, and the monotonic-clock observation time threaded down from `Observe`. `ModeOff` is unreachable (FSM doesn't run).

### New HTTP endpoint

```
GET /debug/v8/admin-events  →  application/json; charset=utf-8
                               Cache-Control: no-store

{
  "events": [
    {
      "at": "2026-05-21T09:30:00Z",
      "kind": "aa_injection_drop",
      "fsm_state": "MASTER_HEADER",
      "byte": "0xAA",
      "was_escaped": false
    }
  ],
  "dropped": 0
}
```

- Drains the ring on each GET; second GET returns the empty envelope.
- `dropped` field surfaces ring-buffer saturation (oldest-FIFO drops if the operator polls too slowly).
- Enum-as-string encoding (`kind`, `fsm_state`) so the wire format survives future numeric enum shifts.
- POST/PUT/DELETE/PATCH respond 405 with `Allow: GET`.
- Nil-safe: when the gateway is on a non-adapter-direct transport (no Mux, no classifier), the handler returns `{"events": [], "dropped": 0}` — tooling probing this endpoint unconditionally must not 404.

### Atomic.Pointer indirection (mirrors PR #655 pattern)

The handler dereferences a package-level `v8AdminEventsCurrentClassifier atomic.Pointer[v8classifier.Classifier]` that `run()` updates per invocation. The test harness re-entering `run()` swaps the pointer; handler remains correctly registered with the live classifier. Same test-re-entry-safety design established for `v8RolloutExpvarCurrent` in PR #655.

## Tests

- `v8classifier/admin_event_aa_drop_test.go`:
  - `TestClassifier_DropAaInjection_EmitsAdminEvent_ShadowMode` — Shadow mode emits the event alongside the counter increment.
  - `TestClassifier_DropAaInjection_EmitsAdminEvent_EnforceMode` — Enforce mode emits AND drops.
  - `TestClassifier_DropAaInjection_NoEmit_ModeOff` — ModeOff zero-overhead contract.
  - `TestAdminEventKindAaInjectionDrop_String` — stable label.

- `cmd/gateway/v8_admin_events_handler_test.go`:
  - `TestHandleV8AdminEvents_NilClassifier_ReturnsEmptyResponse` — degradation contract.
  - `TestHandleV8AdminEvents_DrainsClassifierEvents` — JSON round-trip + drain semantics.
  - `TestHandleV8AdminEvents_OnlyGetAllowed` — method gate.
  - `TestV8AdminEventsCurrentClassifier_AtomicSwap` — re-entry safety.

## Operator usage

After deploy, the shadow-mode promotion gate workflow becomes:

```
# Poll every few seconds during a representative production window:
curl -s http://192.168.100.4:8080/debug/v8/admin-events | jq '.events[] | {byte, fsm_state, was_escaped, at}'

# Aggregate distribution:
curl -s http://192.168.100.4:8080/debug/v8/admin-events | jq -r '.events[] | "\(.fsm_state) \(.byte) escaped=\(.was_escaped)"' | sort | uniq -c | sort -rn
```

If the distribution is dominated by `was_escaped=false` mid-frame `0xAA` bytes during master-header / master-payload phases — those are real AA-injection candidates and enforce-mode promotion is safe. If the distribution shows legitimate data-payload 0xAA bytes (with `was_escaped=true` or non-mid-frame FSM states) — the classifier is over-eager; investigate before promoting.

## Verification

- `go vet ./...` clean
- `go test -count=1 -short -timeout 240s ./internal/adaptermux/v8classifier/ ./cmd/gateway/ ./`: all pass
- gofmt clean on edited files (one pre-existing godoc-list formatting issue in `classifier.go:849-860` predates this PR and is untouched)

## Out of scope

- Counter-naming refinement on `helianthus_round9_absorb_entered_total` (iter-4 MEDIUM follow-up #2) — separate PR scope.
- Adding the same per-event surface for `EchoSoftTimeout` / `EchoHardTimeout` / `QueueOverflow` events. Those already emit via the existing `protocol_fault` admin-event path; only the AA-injection drop was missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)