### PR TITLE
fix(v8): close StreamEventWireSyn classifier bypass (F-NEW-27)

### DIFF
--- a/internal/adaptermux/v8classifier/admin_event_aa_drop_test.go
+++ b/internal/adaptermux/v8classifier/admin_event_aa_drop_test.go
@@ -142,6 +142,136 @@ func TestClassifier_DropAaInjection_NoEmit_ModeOff(t *testing.T) {
 	}
 }
 
+// TestStreamEventWireSyn_EnforceMode_Drops pins F-NEW-27: the
+// StreamEventWireSyn bypass closure. Before this fix, the
+// classifier's Observe switch had no case for StreamEventWireSyn —
+// the event fell through and returned drop=false regardless of mode.
+// Meanwhile mux.go:1946-1952 routes WireSyn to
+// onReceived(event.Byte, wasEscaped=false), i.e. as a raw wire 0xAA
+// byte. The bypass meant wire SYNs delivered via this event kind
+// reached the gateway's echo position unfiltered — producing
+// sustained round9 absorb entries in enforce mode (~2.6/min on the
+// production HA host on 2026-05-21).
+//
+// Post-fix: StreamEventWireSyn drives the FSM identically to a
+// StreamEventByte carrying 0xAA with WasEscaped=false. In enforce
+// mode, mid-frame WireSyn returns drop=true.
+func TestStreamEventWireSyn_EnforceMode_Drops(t *testing.T) {
+	t.Parallel()
+	c := New(ModeEnforce)
+	now := time.Unix(0, 0)
+
+	// Enter passive tracking so subsequent 0xAA bytes are
+	// classified mid-frame.
+	c.Observe(transport.StreamEvent{
+		Kind: transport.StreamEventStarted, Data: 0x71,
+	}, now)
+
+	// Pre-fix: this returns drop=false (bypass).
+	// Post-fix: this returns drop=true (filtered).
+	drop := c.Observe(transport.StreamEvent{
+		Kind: transport.StreamEventWireSyn, Byte: 0xAA,
+	}, now)
+	if !drop {
+		t.Fatal("StreamEventWireSyn(0xAA) in enforce mode returned drop=false — F-NEW-27 bypass NOT closed. " +
+			"The wire SYN would reach the gateway's echo position unfiltered, producing round9 absorb entries.")
+	}
+	if got := c.FsmDropAaInjectionTotal(); got != 1 {
+		t.Errorf("FsmDropAaInjectionTotal()=%d; want 1 (FSM drop verdict counted)", got)
+	}
+	if got := c.EnforceDropsAppliedTotal(); got != 1 {
+		t.Errorf("EnforceDropsAppliedTotal()=%d; want 1 (enforce actually applied the drop)", got)
+	}
+
+	// And the admin event ring captured the drop event with
+	// WasEscaped=false (kind forces raw wire provenance regardless
+	// of event.WasEscaped).
+	events, _ := c.DrainAdminEvents()
+	if len(events) != 1 {
+		t.Fatalf("DrainAdminEvents: got %d events; want 1", len(events))
+	}
+	if events[0].Kind != AdminEventKindAaInjectionDrop {
+		t.Errorf("admin event kind=%v; want AdminEventKindAaInjectionDrop", events[0].Kind)
+	}
+	if events[0].Byte != 0xAA {
+		t.Errorf("admin event byte=0x%02X; want 0xAA", events[0].Byte)
+	}
+	if events[0].WasEscaped {
+		t.Error("admin event WasEscaped=true; want false (StreamEventWireSyn kind implies raw wire)")
+	}
+}
+
+// TestStreamEventWireSyn_ShadowMode_CountedNotDropped pins the
+// shadow-mode contract for StreamEventWireSyn — same as the
+// StreamEventByte shadow-mode contract. The FSM still emits the
+// drop verdict (FsmDropAaInjectionTotal increments + ring event
+// fires + ShadowWouldHaveDroppedTotal increments) but Observe
+// returns drop=false (shadow never alters the byte stream).
+func TestStreamEventWireSyn_ShadowMode_CountedNotDropped(t *testing.T) {
+	t.Parallel()
+	c := New(ModeShadow)
+	now := time.Unix(0, 0)
+
+	c.Observe(transport.StreamEvent{Kind: transport.StreamEventStarted, Data: 0x71}, now)
+	drop := c.Observe(transport.StreamEvent{Kind: transport.StreamEventWireSyn, Byte: 0xAA}, now)
+	if drop {
+		t.Error("StreamEventWireSyn in ModeShadow returned drop=true; shadow must NEVER drop")
+	}
+	if got := c.FsmDropAaInjectionTotal(); got != 1 {
+		t.Errorf("FsmDropAaInjectionTotal()=%d; want 1 (FSM decision still counted in shadow)", got)
+	}
+	if got := c.ShadowWouldHaveDroppedTotal(); got != 1 {
+		t.Errorf("ShadowWouldHaveDroppedTotal()=%d; want 1 (divergence signal records WireSyn drops)", got)
+	}
+	if got := c.EnforceDropsAppliedTotal(); got != 0 {
+		t.Errorf("EnforceDropsAppliedTotal()=%d; want 0 (shadow never applies drops)", got)
+	}
+}
+
+// TestStreamEventWireSyn_OffMode_NoFSM pins the zero-overhead
+// contract: in ModeOff the FSM does not run, so WireSyn produces
+// no drop decision and no admin event.
+func TestStreamEventWireSyn_OffMode_NoFSM(t *testing.T) {
+	t.Parallel()
+	c := New(ModeOff)
+	now := time.Unix(0, 0)
+
+	c.Observe(transport.StreamEvent{Kind: transport.StreamEventStarted, Data: 0x71}, now)
+	drop := c.Observe(transport.StreamEvent{Kind: transport.StreamEventWireSyn, Byte: 0xAA}, now)
+	if drop {
+		t.Error("StreamEventWireSyn in ModeOff returned drop=true; ModeOff is zero-overhead, never drops")
+	}
+	if got := c.FsmDropAaInjectionTotal(); got != 0 {
+		t.Errorf("FsmDropAaInjectionTotal()=%d in ModeOff; want 0", got)
+	}
+	events, _ := c.DrainAdminEvents()
+	if len(events) != 0 {
+		t.Errorf("DrainAdminEvents in ModeOff: got %d events; want 0", len(events))
+	}
+}
+
+// TestStreamEventWireSyn_ProvenanceClassification pins that
+// WireSyn lands in the wire_auto_syn provenance bucket (forced
+// WasEscaped=false regardless of event.WasEscaped).
+func TestStreamEventWireSyn_ProvenanceClassification(t *testing.T) {
+	t.Parallel()
+	c := New(ModeShadow)
+	now := time.Unix(0, 0)
+
+	// Two WireSyn events — even if the (incorrect) event.WasEscaped
+	// were true, the classifier MUST force it to false because
+	// StreamEventWireSyn by definition is a raw wire byte.
+	c.Observe(transport.StreamEvent{Kind: transport.StreamEventWireSyn, Byte: 0xAA, WasEscaped: false}, now)
+	c.Observe(transport.StreamEvent{Kind: transport.StreamEventWireSyn, Byte: 0xAA, WasEscaped: true}, now)
+
+	if got := c.WireAutoSynTotal(); got != 2 {
+		t.Errorf("WireAutoSynTotal()=%d; want 2 (both WireSyn events bucketed as wire-auto-syn regardless of event.WasEscaped)", got)
+	}
+	if got := c.EscapedPayloadAaTotal(); got != 0 {
+		t.Errorf("EscapedPayloadAaTotal()=%d; want 0 (WireSyn must NOT route to escaped-payload bucket even if WasEscaped=true)", got)
+	}
+}
+
 // TestAdminEventKindAaInjectionDrop_String pins the label.
 func TestAdminEventKindAaInjectionDrop_String(t *testing.T) {
 	t.Parallel()

--- a/internal/adaptermux/v8classifier/classifier.go
+++ b/internal/adaptermux/v8classifier/classifier.go
@@ -305,6 +305,50 @@ func (c *Classifier) Observe(event transport.StreamEvent, now time.Time) (drop b
 			c.enforceDropsAppliedTotal.Add(1)
 		}
 		return drop
+	case transport.StreamEventWireSyn:
+		// F-NEW-27 (2026-05-21): close the StreamEventWireSyn bypass.
+		//
+		// PR #155 (2026-05-15) introduced StreamEventWireSyn as a
+		// pre-grant SYN passive marker emitted by enh_transport during
+		// awaitingStart, with downstream effect IDENTICAL to a wire SYN
+		// byte (mux.go:1946-1952 routes it to
+		// `onReceived(event.Byte, wasEscaped=false)`). The v8 classifier
+		// was designed before this event kind existed and the original
+		// Observe switch fell through for WireSyn — returning drop=false
+		// regardless of mode, so the wire SYN reached the gateway's echo
+		// position unfiltered.
+		//
+		// In production this bypass produced sustained round9 absorb
+		// entries (~2.6/min in enforce mode), each one a textbook I8
+		// invariant violation per HelianthusRound9FiredUnderProxy. The
+		// payload_aa_auto_syn_absorbed counter stayed at 0 across all
+		// entries — confirming the SYN reached the echo position but the
+		// post-leak drain reads failed (independent transport-storm
+		// issue). Diagnosed by Codex adversarial review of the 2026-05-21
+		// enforce-mode stress test baseline + my code verification of
+		// classifier.go vs mux.go event routing.
+		//
+		// Fix: treat StreamEventWireSyn identically to a StreamEventByte
+		// carrying 0xAA with WasEscaped=false. The byte path normalization
+		// is forced by the event kind — by mux.go:1952 construction the
+		// byte is always 0xAA and is always a raw wire SYN (NOT
+		// escape-decoded payload). Drive the FSM through the same
+		// classification path; in enforce mode the FSM returns
+		// DecisionDropAaInjection for mid-frame wire 0xAA and the byte
+		// is filtered out of session dispatch.
+		//
+		// We FORCE WasEscaped=false here regardless of event.WasEscaped.
+		// The kind itself is the source-of-truth for provenance — a
+		// StreamEventWireSyn is by definition a raw wire byte; if the
+		// upstream transport ever incorrectly populated WasEscaped=true
+		// on this event kind, trusting that flag would re-open the
+		// bypass.
+		c.classifyByteProvenance(event.Byte, false)
+		drop = c.driveFSMByte(event.Byte, false, now)
+		if drop {
+			c.enforceDropsAppliedTotal.Add(1)
+		}
+		return drop
 	case transport.StreamEventStarted, transport.StreamEventFailed:
 		// Both events signal "a telegram is starting on the wire and
 		// event.Data carries QQ" — the FSM's EnterPassiveTracking

--- a/internal/adaptermux/v8classifier/classifier.go
+++ b/internal/adaptermux/v8classifier/classifier.go
@@ -90,10 +90,14 @@ type Classifier struct {
 	//       don't equal 0xAA or 0xA9).
 	//
 	// Invariants:
-	//   - (1) + (2) + (3) + (4) == count of StreamEventByte
-	//     events passing through Observe (excludes WireSyn /
-	//     Started / Failed / Reset which have their own counter
-	//     paths via observedBytesTotal but NOT via these four).
+	//   - (1) + (2) + (3) + (4) == count of byte-bearing events
+	//     passing through Observe (StreamEventByte + StreamEventWireSyn).
+	//     F-NEW-27 (2026-05-21): StreamEventWireSyn IS byte-bearing
+	//     per mux.go:1946-1952 which routes it as
+	//     `onReceived(event.Byte, wasEscaped=false)`; the classifier
+	//     buckets it as wire_auto_syn regardless of event.WasEscaped.
+	//     Started / Failed / Reset are pure meta-events and do NOT
+	//     contribute to any of the four.
 	//   - Each counter monotonically non-decreasing.
 	//   - Atomic, race-tolerant, single-producer write side per
 	//     the Concurrency contract above.
@@ -122,6 +126,12 @@ type Classifier struct {
 	//   - StreamEventByte → fsm.Feed(byte, wasEscaped). The returned
 	//     Decision goes into one of the three fsmDecision*Total
 	//     counters below.
+	//   - StreamEventWireSyn → fsm.Feed(byte, false). F-NEW-27
+	//     (2026-05-21): WireSyn drives the FSM identically to
+	//     StreamEventByte with WasEscaped=false (the kind itself
+	//     implies raw wire). Without this the v8 enforce-mode
+	//     filter has a bypass — see the case body in Observe for
+	//     the production incident that motivated this case.
 	//   - StreamEventStarted / StreamEventFailed → fsm.EnterPassiveTracking().
 	//     Both events signal "a telegram is starting on the wire and
 	//     the event Data carries QQ"; the classifier observes the
@@ -146,13 +156,13 @@ type Classifier struct {
 
 	// FSM decision counters. The three values that telegram_fsm.Decision
 	// can take (Forward, DropAaInjection, ProtocolFault) each get
-	// their own counter. Sum across the three == count of
-	// StreamEventByte events that the FSM Feed processed, with two
-	// caveats: (1) when fsm is nil (ModeOff) NONE of these
-	// increment; (2) bytes arriving while the FSM is in
-	// StateAborted will continue through Feed but the Decision
-	// breakdown depends on the FSM library's own contract — see
-	// telegram_fsm.go.
+	// their own counter. Sum across the three == count of byte-bearing
+	// events (StreamEventByte + StreamEventWireSyn since F-NEW-27 2026-05-21)
+	// that the FSM Feed processed, with two caveats: (1) when fsm is
+	// nil (ModeOff) NONE of these increment; (2) bytes arriving while
+	// the FSM is in StateAborted will continue through Feed but the
+	// Decision breakdown depends on the FSM library's own contract —
+	// see telegram_fsm.go.
 	fsmForwardTotal         atomic.Uint64
 	fsmDropAaInjectionTotal atomic.Uint64
 	fsmProtocolFaultTotal   atomic.Uint64
@@ -249,11 +259,14 @@ func (c *Classifier) Mode() Mode {
 // time no-op. In ModeShadow / ModeEnforce the hook:
 //
 //   - increments observedBytesTotal (every StreamEvent kind);
-//   - for StreamEventByte ONLY, classifies the byte into one of
-//     four provenance buckets based on (Byte, WasEscaped) and
-//     increments the matching counter (escapedPayloadAaTotal /
-//     escapedPayloadEscTotal / wireAutoSynTotal / plainByteTotal).
-//     See the field doc on Classifier for the full taxonomy.
+//   - for byte-bearing events (StreamEventByte and StreamEventWireSyn
+//     — the latter added by F-NEW-27 (2026-05-21) to close the
+//     bypass that let pre-grant SYN markers reach the gateway
+//     unfiltered), classifies the byte into one of four
+//     provenance buckets and increments the matching counter
+//     (escapedPayloadAaTotal / escapedPayloadEscTotal /
+//     wireAutoSynTotal / plainByteTotal). See the field doc on
+//     Classifier for the full taxonomy.
 //
 // Future stacked PRs add:
 //
@@ -275,11 +288,12 @@ func (c *Classifier) Mode() Mode {
 // Returns true if the caller should DROP this event from emission
 // to sessions. In ModeOff / ModeShadow the return is always false.
 //
-// Phase 3 Step B3.6b (v8 §4 AA-injection filter): ModeEnforce now
-// returns true when the byte is StreamEventByte AND the FSM
-// returns DecisionDropAaInjection. The caller (Mux.readLoop) MUST
-// honor this signal by skipping the byte's dispatch to onReceived
-// — otherwise sessions would still see the AA-injection bytes and
+// Phase 3 Step B3.6b (v8 §4 AA-injection filter): ModeEnforce
+// returns true when the byte is byte-bearing (StreamEventByte OR
+// StreamEventWireSyn, per F-NEW-27) AND the FSM returns
+// DecisionDropAaInjection. The caller (Mux.readLoop) MUST honor
+// this signal by skipping the byte's dispatch to onReceived —
+// otherwise sessions would still see the AA-injection bytes and
 // the v8 filter would be a no-op. The drop is also counted in
 // enforceDropsAppliedTotal so operators can distinguish
 // "would-have-dropped" (fsmDropAaInjectionTotal, all modes) from
@@ -290,11 +304,13 @@ func (c *Classifier) Observe(event transport.StreamEvent, now time.Time) (drop b
 	}
 	c.observedBytesTotal.Add(1)
 
-	// Provenance classification fires only for StreamEventByte.
-	// WireSyn / Started / Failed / Reset / unknown kinds bypass —
-	// they have their own semantic meaning and do NOT carry a
-	// (Byte, WasEscaped) tuple the escape-decoder provenance
-	// taxonomy applies to.
+	// Provenance classification fires for byte-bearing events:
+	// StreamEventByte and StreamEventWireSyn. F-NEW-27 (2026-05-21)
+	// added the WireSyn case after the original "only StreamEventByte"
+	// design proved to be a v8 enforce-mode bypass — see the WireSyn
+	// case body below for the production incident. Started / Failed /
+	// Reset are pure meta-events and route through their own cases
+	// (FSM phase transitions) without provenance bucketing.
 	switch event.Kind {
 	case transport.StreamEventByte:
 		c.classifyByteProvenance(event.Byte, event.WasEscaped)

--- a/internal/adaptermux/v8classifier/classifier_provenance_test.go
+++ b/internal/adaptermux/v8classifier/classifier_provenance_test.go
@@ -137,25 +137,37 @@ func TestProvenance_DefensiveFallThrough_UnexpectedEscaped(t *testing.T) {
 }
 
 // TestProvenance_SumInvariant pins the core invariant: for any
-// stream of StreamEventByte events, the four provenance counters
-// sum to the count of StreamEventByte events observed. Non-Byte
-// events (WireSyn, Started, Failed, Reset) MUST NOT contribute
-// to any of the four.
+// stream of byte-bearing events, the four provenance counters sum
+// to the count of byte-bearing events observed.
+//
+// F-NEW-27 (2026-05-21): StreamEventWireSyn IS a byte-bearing event
+// even though its kind label differs from StreamEventByte. Per
+// mux.go:1946-1952 it routes downstream as
+// `onReceived(event.Byte, wasEscaped=false)` — identical to a
+// StreamEventByte carrying 0xAA with WasEscaped=false. The classifier
+// MUST classify it the same way; otherwise it bypasses the v8 filter
+// (PR introducing this test had assumed WireSyn was a meta-event
+// like Started/Failed/Reset — that assumption proved wrong in
+// production where the bypass produced sustained round9 entries
+// in enforce mode). Started, Failed, and Reset remain pure meta-
+// events that do NOT contribute to provenance buckets.
 func TestProvenance_SumInvariant(t *testing.T) {
 	t.Parallel()
 	c := New(ModeShadow)
 	now := time.Unix(0, 0)
 
-	// Mixed StreamEventByte stream.
+	// Mixed byte-bearing event stream.
 	for _, e := range []transport.StreamEvent{
 		{Kind: transport.StreamEventByte, Byte: 0xAA, WasEscaped: true},  // payload AA
 		{Kind: transport.StreamEventByte, Byte: 0xAA, WasEscaped: false}, // wire SYN
 		{Kind: transport.StreamEventByte, Byte: 0x55, WasEscaped: false}, // plain
 		{Kind: transport.StreamEventByte, Byte: 0xA9, WasEscaped: true},  // payload ESC
 		{Kind: transport.StreamEventByte, Byte: 0x71, WasEscaped: false}, // plain
-		// Mixed-in non-Byte events that MUST be observed but NOT
-		// land in any provenance bucket.
+		// StreamEventWireSyn IS a byte-bearing event after F-NEW-27 —
+		// it lands in the wire_auto_syn bucket (kind forces
+		// WasEscaped=false regardless of event.WasEscaped).
 		{Kind: transport.StreamEventWireSyn, Byte: 0xAA},
+		// Pure meta-events — observed but NOT classified.
 		{Kind: transport.StreamEventStarted, Data: 0x71},
 		{Kind: transport.StreamEventFailed, Data: 0x10},
 		{Kind: transport.StreamEventReset},
@@ -163,14 +175,15 @@ func TestProvenance_SumInvariant(t *testing.T) {
 		c.Observe(e, now)
 	}
 
-	const streamEventByteCount = 5
+	const byteBearingEventCount = 6 // 5 StreamEventByte + 1 StreamEventWireSyn
 
 	sum := c.EscapedPayloadAaTotal() +
 		c.EscapedPayloadEscTotal() +
 		c.WireAutoSynTotal() +
 		c.PlainByteTotal()
-	if sum != streamEventByteCount {
-		t.Errorf("sum of provenance counters = %d; want %d (one bucket per StreamEventByte)", sum, streamEventByteCount)
+	if sum != byteBearingEventCount {
+		t.Errorf("sum of provenance counters = %d; want %d (one bucket per byte-bearing event including WireSyn)",
+			sum, byteBearingEventCount)
 	}
 
 	// Per-bucket breakdown.
@@ -180,18 +193,21 @@ func TestProvenance_SumInvariant(t *testing.T) {
 	if got := c.EscapedPayloadEscTotal(); got != 1 {
 		t.Errorf("EscapedPayloadEscTotal()=%d; want 1", got)
 	}
-	if got := c.WireAutoSynTotal(); got != 1 {
-		t.Errorf("WireAutoSynTotal()=%d; want 1", got)
+	// WireAutoSynTotal = 2: one StreamEventByte(0xAA, !escaped) +
+	// one StreamEventWireSyn (forced-escape-false).
+	if got := c.WireAutoSynTotal(); got != 2 {
+		t.Errorf("WireAutoSynTotal()=%d; want 2 (1 Byte-stream + 1 WireSyn — F-NEW-27 closes the bypass)", got)
 	}
 	if got := c.PlainByteTotal(); got != 2 {
 		t.Errorf("PlainByteTotal()=%d; want 2", got)
 	}
 
-	// Non-Byte events DID increment observedBytesTotal (per B3.2
-	// contract — every StreamEvent kind counts there) but did NOT
-	// touch any provenance bucket.
+	// All event kinds DID increment observedBytesTotal (per B3.2
+	// contract — every StreamEvent kind counts there). Pure
+	// meta-events (Started/Failed/Reset) do NOT touch any
+	// provenance bucket.
 	if got := c.ObservedBytesTotal(); got != 9 {
-		t.Errorf("ObservedBytesTotal()=%d; want 9 (5 Byte + 4 other)", got)
+		t.Errorf("ObservedBytesTotal()=%d; want 9 (5 Byte + 1 WireSyn + 3 meta)", got)
 	}
 }
 


### PR DESCRIPTION
## Why

The 2026-05-21 enforce-mode stress test at T+1m baseline surfaced `helianthus_round9_absorb_entered_total = 38` with all `payload_aa_*` counters at 0 — sustained ~2.6/min throughout the held window. Codex + fresh Opus adversarial reviews of the snapshot independently traced it to a **classifier bypass**:

- `classifier.go::Observe` switch (line 298-321) handles `StreamEventByte`, `StreamEventStarted`/`Failed`, `StreamEventReset` — **no case for `StreamEventWireSyn`**. Falls through, returns `drop=false`.
- `mux.go:1946-1952` routes `StreamEventWireSyn` to `onReceived(event.Byte, wasEscaped=false)` — i.e. AS a raw wire 0xAA byte.

`StreamEventWireSyn` was introduced in PR #155 (2026-05-15) AFTER the v8 classifier was designed. The Observe switch was never updated. The result: wire SYNs delivered via this newer event kind reach the gateway's echo position unfiltered, producing sustained round9 entries — exactly the `HelianthusRound9FiredUnderProxy` I8 invariant violation the alert exists to catch.

## What

Adds `case transport.StreamEventWireSyn:` to `Observe`, delegating to the same `classifyByteProvenance` + `driveFSMByte` logic as `StreamEventByte` — with `WasEscaped` FORCED to false (kind is source-of-truth for provenance; trusting `event.WasEscaped` would re-open the bypass if upstream ever mispopulates the flag).

### Test updates

1. **`TestProvenance_SumInvariant` updated.** The pre-existing test asserted "Non-Byte events (WireSyn, Started, Failed, Reset) MUST NOT contribute to any [provenance bucket]" — that comment embodied the bypass as a design contract. After F-NEW-27, WireSyn IS a byte-bearing event per the mux routing. Started/Failed/Reset remain pure meta-events.

2. **New regression tests** in `admin_event_aa_drop_test.go`:
   - `TestStreamEventWireSyn_EnforceMode_Drops` — direct regression. Pre-fix this fails: drop=false instead of true.
   - `TestStreamEventWireSyn_ShadowMode_CountedNotDropped` — shadow contract.
   - `TestStreamEventWireSyn_OffMode_NoFSM` — zero-overhead.
   - `TestStreamEventWireSyn_ProvenanceClassification` — pins WasEscaped forcing.

## Verification

- `go vet ./...` clean
- `go test -count=1 ./internal/adaptermux/v8classifier/ ./internal/adaptermux/`: passes (110s including the long adaptermux race-suite)
- Pre-fix code fails `TestProvenance_SumInvariant` (sum=6 vs expected 5) and `TestStreamEventWireSyn_EnforceMode_Drops` (drop=false vs expected true)

## Out of scope

- The separate FSM-stuck-in-ABORTED noise issue (iter-7 known) — different bug, separate PR.
- Wire-storm root cause (signal-lost cycles on the physical adapter) — hardware/operational, not a code bug.

## Test plan

- [x] Targeted classifier tests pass
- [x] Full adaptermux suite passes (110s with race detector)
- [ ] Codex review
- [ ] CI green on PR
- [ ] Post-merge: addon pin bump to this commit (v0.6.24), redeploy on HA host
- [ ] Confirm `helianthus_round9_absorb_entered_total` stays FLAT in enforce mode under normal load (the 2026-05-21 stress test is HELD pending this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)