### PR TITLE
fix(adaptermux): plumb F-NEW-28 structural-write provenance through echo tracker

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Project-Helianthus/helianthus-ebusgateway
 go 1.22
 
 require (
-	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260520030132-808674a01091
+	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260521144203-f9919f4b1007
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260520030132-808674a01091 h1:7P1dQh9S+Ly1waW8kRVxWySfBbE7HwBDYOjyB4JMfdM=
-github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260520030132-808674a01091/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
+github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260521144203-f9919f4b1007 h1:jDZeSPLUo+pShLNg6j4TnLORPJq6ow1f6XZ/FsbG7vk=
+github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260521144203-f9919f4b1007/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2 h1:6VFOfwe5L0GQkVRMcjdjCjnfBWcDoelnmoP1wIflrKM=
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=

--- a/internal/adaptermux/active_path.go
+++ b/internal/adaptermux/active_path.go
@@ -3,6 +3,7 @@ package adaptermux
 import (
 	"errors"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	ebuserrors "github.com/Project-Helianthus/helianthus-ebusgo/errors"
@@ -16,15 +17,35 @@ import (
 // transport.StreamEventReader for RESETTED detection.
 type activeTransport struct {
 	mux *Mux
+
+	// nextWriteIsStructuralSyn is the F-NEW-28 (2026-05-21) one-shot
+	// flag toggled by SignalNextWriteIsStructuralSyn(). Consumed by
+	// the next Write call and reset to false afterwards. atomic.Bool
+	// for cheap concurrent-safe load/swap; in practice the signal
+	// and Write are issued sequentially from the same goroutine
+	// (bus.Send.sendRawWithEcho) so contention is minimal, but the
+	// atomic guards against accidental cross-goroutine misuse.
+	//
+	// The one-shot semantic — signal CONSUMED by next Write — keeps
+	// the contract simple: a signal that fires but isn't followed by
+	// a Write is harmless (the next Write that does happen will see
+	// stale `true` and propagate it, but that "next Write" by
+	// definition starts AFTER the prior call returned, so a missed
+	// signal would only mistag a structural write as structural —
+	// idempotent). Callers MUST issue Signal+Write in the order
+	// "Signal first, then Write", per the
+	// transport.StructuralWriteSignaler interface contract.
+	nextWriteIsStructuralSyn atomic.Bool
 }
 
 // Compile-time interface checks.
 var (
-	_ transport.RawTransport        = (*activeTransport)(nil)
-	_ transport.StreamEventReader   = (*activeTransport)(nil)
-	_ transport.InfoRequester       = (*activeTransport)(nil)
-	_ transport.EscapeAware         = (*activeTransport)(nil)
-	_ transport.EscapeFlaggedReader = (*activeTransport)(nil)
+	_ transport.RawTransport            = (*activeTransport)(nil)
+	_ transport.StreamEventReader       = (*activeTransport)(nil)
+	_ transport.InfoRequester           = (*activeTransport)(nil)
+	_ transport.EscapeAware             = (*activeTransport)(nil)
+	_ transport.EscapeFlaggedReader     = (*activeTransport)(nil)
+	_ transport.StructuralWriteSignaler = (*activeTransport)(nil)
 )
 
 // NOTE: activeTransport intentionally does NOT implement
@@ -158,12 +179,22 @@ func (t *activeTransport) Write(p []byte) (int, error) {
 	}
 
 	for i, b := range p {
+		// F-NEW-28 (2026-05-21): consume the one-shot structural
+		// signal flag. Swap-to-false so a single Signal applies to
+		// exactly one Write — if the caller passes a multi-byte slice
+		// after a Signal, ONLY the first byte is tagged structural
+		// (the contract per transport.StructuralWriteSignaler doc:
+		// "Signal IMMEDIATELY before Write, at most once per Write").
+		// bus.go's sendRawWithEcho always Writes single-byte slices,
+		// so the multi-byte caveat is purely defensive.
+		structural := t.nextWriteIsStructuralSyn.Swap(false)
 		result := make(chan error, 1)
 		select {
 		case t.mux.activeSendCh <- sendRequest{
-			sessionID: gatewaySessionID,
-			data:      b,
-			result:    result,
+			sessionID:  gatewaySessionID,
+			data:       b,
+			structural: structural,
+			result:     result,
 		}:
 		case <-t.mux.ctx.Done():
 			return i, fmt.Errorf("adaptermux: %w", t.mux.ctx.Err())
@@ -247,4 +278,23 @@ func (t *activeTransport) ArbitrationSendsSource() bool {
 // would misinterpret logical 0xAA bytes from the adapter as SYN markers.
 func (t *activeTransport) BytesAreUnescaped() bool {
 	return t.mux.bytesAreUnescaped()
+}
+
+// SignalNextWriteIsStructuralSyn implements
+// transport.StructuralWriteSignaler (F-NEW-28, 2026-05-21). Marks the
+// next Write call on this transport as a structural SymbolSyn
+// (end-of-message terminator) write. The flag is one-shot — consumed
+// by the next Write and reset to "payload" afterwards.
+//
+// Called by bus.go's sendRawWithEcho immediately before writing a
+// structural SymbolSyn (expectRawSyn=true). The flag flows through
+// activeSendCh's sendRequest.structural field into the gateway echo
+// tracker's expectedStructural slice, where the mux's
+// SYN-suppression predicate consults it to distinguish a pending
+// structural-terminator expected echo from a pending payload-0xAA
+// expected echo.
+//
+// See transport.StructuralWriteSignaler doc for the full contract.
+func (t *activeTransport) SignalNextWriteIsStructuralSyn() {
+	t.nextWriteIsStructuralSyn.Store(true)
 }

--- a/internal/adaptermux/classify_test.go
+++ b/internal/adaptermux/classify_test.go
@@ -177,8 +177,24 @@ func TestTxnClass_SYNTerminatorEchoOnly(t *testing.T) {
 		t.Fatalf("write err=%v", err)
 	}
 
+	// F-NEW-28 (2026-05-21): inject realistic ENH echo provenance.
+	// Pre-F-NEW-28 the mock emitted all echoes with WasEscaped=false
+	// — including the payload-0xAA byte (req[7]==0xAA). On the wire a
+	// payload byte equal to 0xAA is encoded as the escape pair
+	// `A9 01` and the adapter surfaces its decoded echo as
+	// logical 0xAA with WasEscaped=true (per the F-23 contract).
+	// The mux's SYN-suppression predicate at mux.go:2487 now uses
+	// this provenance to distinguish a payload-0xAA expected echo
+	// from a structural-terminator-SYN expected echo; emitting a
+	// wire-raw 0xAA echo for the payload byte would falsely look
+	// like a wire AUTO-SYN under v8 enforce and get suppressed,
+	// preventing the test from consuming all eight echoes.
 	for _, b := range req {
-		mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: b}
+		mock.eventCh <- transport.StreamEvent{
+			Kind:       transport.StreamEventByte,
+			Byte:       b,
+			WasEscaped: b == protocol.SymbolSyn, // payload-0xAA echo arrives escape-decoded
+		}
 	}
 	time.Sleep(30 * time.Millisecond)
 	for range req {

--- a/internal/adaptermux/e2e_test.go
+++ b/internal/adaptermux/e2e_test.go
@@ -155,7 +155,10 @@ func TestE2E_ScanB504_ToTarget0x08_SuccessFullFlow(t *testing.T) {
 	// Phase 2: emulate sendEndOfMessage. Issue the terminator write via
 	// the active path so recordSent populates gatewayEcho with [SymbolSyn],
 	// then signal the response goroutine to inject the wire echo.
-	go func() { _, _ = at.Write([]byte{protocol.SymbolSyn}) }()
+	// F-NEW-28 (2026-05-21): use writeTerminatorSyn helper so the
+	// structural-SYN provenance flag flows through the gateway echo
+	// tracker, matching bus.go's sendEndOfMessage path.
+	go writeTerminatorSyn(at)
 	time.Sleep(20 * time.Millisecond) // let recordSent run
 	terminatorReady <- struct{}{}
 

--- a/internal/adaptermux/echo_tracker.go
+++ b/internal/adaptermux/echo_tracker.go
@@ -30,6 +30,57 @@ type echoTracker struct {
 	// to echo back. Populated by recordSent(), consumed by matchEcho().
 	expectedEchoes []byte
 
+	// expectedStructural is the F-NEW-28 (2026-05-21) provenance-aware
+	// sibling of expectedEchoes. For each entry it records whether the
+	// gateway issued the corresponding write as a STRUCTURAL SymbolSyn
+	// (end-of-message terminator, expected wire echo: raw 0xAA with
+	// WasEscaped=false) or as a PAYLOAD byte (expected wire echo: the
+	// byte value with WasEscaped=true for 0xAA payload, false for
+	// non-0xAA payload).
+	//
+	// Set by recordSent's `structural` parameter, which is propagated
+	// from `sendRequest.structuralSyn` (mux.go) which in turn is set by
+	// `activeTransport.Write` consulting the one-shot
+	// `nextWriteIsStructuralSyn` flag toggled by bus.go's
+	// SignalNextWriteIsStructuralSyn() call before structural terminator
+	// writes.
+	//
+	// Used by the SYN-suppression predicate at `mux.go:2487`:
+	//
+	//   nextByte, nextStructural, hasPendingEcho :=
+	//       gatewayEcho.peekNextExpectedWithFlags()
+	//   midWriteSyn := hasPendingEcho &&
+	//       !(nextByte == protocol.SymbolSyn && nextStructural)
+	//   // "We're mid-payload-write UNLESS the pending echo is a
+	//   //  structural terminator."
+	//
+	// Closing the round-9 leak: pre-fix `midWriteSyn` was just
+	// `hasPendingEcho && nextByte != SymbolSyn`, which falsely treated a
+	// payload-0xAA expected echo as a structural-SYN expected echo,
+	// failing to suppress wire AUTO-SYNs that landed in echo position.
+	// With this flag the predicate distinguishes the two cases and the
+	// suppression fires correctly for payload-0xAA writes.
+	//
+	// CONDITIONAL LOCKSTEP INVARIANT (mirror of expectedWriteTimes):
+	//   `len(expectedStructural) == 0` OR
+	//   `len(expectedStructural) == len(expectedEchoes)`
+	//
+	// Unlike expectedWriteTimes (gated on v8 mode), expectedStructural
+	// MUST stay in PERFECT length lockstep with expectedEchoes at all
+	// times — the SYN-suppression predicate uses it on every wire SYN
+	// regardless of v8 mode. The recordSent path always appends to
+	// BOTH slices; matchEcho / rollbackSent / overflow-reset all
+	// maintain the lockstep.
+	expectedStructural []bool
+
+	// preOverflowStructural is the lockstep snapshot of
+	// expectedStructural taken at overflow-reset time, mirroring
+	// preOverflowEchoes / preOverflowWriteTimes. rollbackSent restores
+	// the structural flags alongside the byte values so the post-rollback
+	// queue is bit-identical to the pre-write state. nil iff the most
+	// recent recordSent did not trigger an overflow reset.
+	preOverflowStructural []bool
+
 	// expectedWriteTimes is a FIFO queue of wall-clock times when each
 	// byte in expectedEchoes was recorded. Phase 3 Step B3.6d wires
 	// this to compute echo RTT for the v8 classifier's L_rtt EMA.
@@ -178,31 +229,21 @@ func newEchoTracker() *echoTracker {
 // prior echo expectations even though the adapter never accepted the
 // new byte — subsequent real echoes would all return echoMatchNone.
 func (t *echoTracker) recordSent(data byte) {
-	// Phase 3 Step B3.6d (Codex round-1 MAJOR on PR #646): the
-	// legacy path appends ONLY to expectedEchoes. Skipping the
-	// expectedWriteTimes append restores the ModeOff zero-overhead
-	// contract — no time.Time slot allocated per byte. See the
-	// expectedWriteTimes field comment for the conditional lockstep
-	// invariant.
-	t.queueJustDrained = false
-	if len(t.expectedEchoes) >= maxPendingEchoes {
-		t.preOverflowEchoes = make([]byte, len(t.expectedEchoes))
-		copy(t.preOverflowEchoes, t.expectedEchoes)
-		t.expectedEchoes = t.expectedEchoes[:0]
-		// Legacy path: expectedWriteTimes was empty (no
-		// recordSentWithTime ever fired on this tracker), so the
-		// snapshot for it is nil. Idempotent `[:0]` keeps the
-		// invariant if a future code path ever mixes recordSent and
-		// recordSentWithTime on the same tracker (currently
-		// impossible — v8 mode is immutable per Mux).
-		t.preOverflowWriteTimes = nil
-		t.expectedWriteTimes = t.expectedWriteTimes[:0]
-		t.totalOverflowResets++
-	} else {
-		t.preOverflowEchoes = nil
-		t.preOverflowWriteTimes = nil
-	}
-	t.expectedEchoes = append(t.expectedEchoes, data)
+	t.recordSentInternal(data, false, time.Time{}, false)
+}
+
+// recordSentStructural records a byte with the F-NEW-28 structural
+// provenance flag. Called by the sendLoop when bus.go signalled a
+// structural SymbolSyn (terminator) write via
+// `SignalNextWriteIsStructuralSyn`. Distinct from a payload write of
+// the same byte value because the gateway's SYN-suppression predicate
+// at `mux.go:2487` distinguishes the two cases.
+//
+// Legacy path (no v8 time tracking) for the rare external-session
+// terminator writes. v8-on sites go through recordSentWithTime which
+// also takes the structural flag.
+func (t *echoTracker) recordSentStructural(data byte, structural bool) {
+	t.recordSentInternal(data, structural, time.Time{}, false)
 }
 
 // recordSentWithTime is the time-tracking variant of recordSent.
@@ -218,35 +259,70 @@ func (t *echoTracker) recordSent(data byte) {
 // reports false for that byte — preserving the contract that
 // only explicitly-timestamped writes feed L_rtt samples.
 func (t *echoTracker) recordSentWithTime(data byte, writeAt time.Time) {
+	t.recordSentInternal(data, false, writeAt, true)
+}
+
+// recordSentWithTimeStructural is the F-NEW-28 (2026-05-21) variant
+// that accepts both the v8 time-tracking writeAt AND the structural
+// provenance flag. Called by the sendLoop when bus.go signalled a
+// structural SymbolSyn write via SignalNextWriteIsStructuralSyn().
+// `structural=true` marks this byte as a structural terminator (raw
+// 0xAA expected echo); `structural=false` marks it as payload
+// (including payload-0xAA where the expected echo is logical 0xAA
+// with WasEscaped=true).
+func (t *echoTracker) recordSentWithTimeStructural(data byte, writeAt time.Time, structural bool) {
+	t.recordSentInternal(data, structural, writeAt, true)
+}
+
+// recordSentInternal is the single implementation that backs all
+// recordSent* variants. F-NEW-28 (2026-05-21): consolidates the four
+// combinations of {legacy/with-time} × {payload/structural} through
+// one path so the conditional-lockstep invariants for the three
+// queues (expectedEchoes, expectedStructural, expectedWriteTimes)
+// stay consistent. Caller-visible variants:
+//
+//   - recordSent(b)                                — payload, legacy
+//   - recordSentStructural(b, structural)          — payload-or-structural, legacy
+//   - recordSentWithTime(b, t)                     — payload, v8
+//   - recordSentWithTimeStructural(b, t, structural) — payload-or-structural, v8
+//
+// The withTime parameter gates expectedWriteTimes maintenance:
+// false → leave that slice untouched (legacy zero-overhead path),
+// true → keep it length-locked to expectedEchoes.
+// expectedStructural is ALWAYS length-locked (no gating) — the
+// SYN-suppression predicate uses it regardless of v8 mode.
+func (t *echoTracker) recordSentInternal(data byte, structural bool, writeAt time.Time, withTime bool) {
 	// batch-26 round-7: any write means we are definitely no longer
-	// between writes. Clear queueJustDrained BEFORE arming the queue so
-	// the sentinel reflects exactly the inter-write window — the
-	// recordSent here is what closes that window.
+	// between writes. Clear queueJustDrained BEFORE arming the queue
+	// so the sentinel reflects exactly the inter-write window.
 	t.queueJustDrained = false
 	if len(t.expectedEchoes) >= maxPendingEchoes {
 		t.preOverflowEchoes = make([]byte, len(t.expectedEchoes))
 		copy(t.preOverflowEchoes, t.expectedEchoes)
-		// Codex round-1 MEDIUM #1 on PR #646: snapshot
-		// expectedWriteTimes alongside expectedEchoes so
-		// rollbackSent can restore the ORIGINAL write-times. Prior
-		// to this snapshot, rollback rebuilt expectedWriteTimes as
-		// all zeros, silently disabling L_rtt sampling for the
-		// pre-overflow bytes that the adapter Write was about to
-		// fail on.
-		t.preOverflowWriteTimes = make([]time.Time, len(t.expectedWriteTimes))
-		copy(t.preOverflowWriteTimes, t.expectedWriteTimes)
+		t.preOverflowStructural = make([]bool, len(t.expectedStructural))
+		copy(t.preOverflowStructural, t.expectedStructural)
+		if withTime {
+			t.preOverflowWriteTimes = make([]time.Time, len(t.expectedWriteTimes))
+			copy(t.preOverflowWriteTimes, t.expectedWriteTimes)
+		} else {
+			t.preOverflowWriteTimes = nil
+		}
 		t.expectedEchoes = t.expectedEchoes[:0]
+		t.expectedStructural = t.expectedStructural[:0]
 		t.expectedWriteTimes = t.expectedWriteTimes[:0]
 		t.totalOverflowResets++
 	} else {
 		// Successful append without overflow: clear any stale
-		// snapshot from a prior overflow that was never rolled back
-		// (the adapter Write succeeded; the reset is now committed).
+		// snapshot from a prior overflow that was never rolled back.
 		t.preOverflowEchoes = nil
+		t.preOverflowStructural = nil
 		t.preOverflowWriteTimes = nil
 	}
 	t.expectedEchoes = append(t.expectedEchoes, data)
-	t.expectedWriteTimes = append(t.expectedWriteTimes, writeAt)
+	t.expectedStructural = append(t.expectedStructural, structural)
+	if withTime {
+		t.expectedWriteTimes = append(t.expectedWriteTimes, writeAt)
+	}
 }
 
 // rollbackSent removes the last recorded sent byte (e.g., on SEND error).
@@ -266,6 +342,16 @@ func (t *echoTracker) rollbackSent() {
 		if t.totalOverflowResets > 0 {
 			t.totalOverflowResets--
 		}
+		// F-NEW-28: restore the structural-flag snapshot in lockstep
+		// with the byte values. preOverflowStructural is always set
+		// alongside preOverflowEchoes by recordSentInternal, so a
+		// nil-check here is defensive.
+		if t.preOverflowStructural != nil {
+			t.expectedStructural = t.preOverflowStructural
+			t.preOverflowStructural = nil
+		} else {
+			t.expectedStructural = t.expectedStructural[:0]
+		}
 		// Codex round-1 MEDIUM #1 on PR #646: restore the ORIGINAL
 		// write-times from the snapshot so the rolled-back bytes
 		// remain eligible for L_rtt sampling. If the snapshot is
@@ -282,6 +368,13 @@ func (t *echoTracker) rollbackSent() {
 	}
 	if len(t.expectedEchoes) > 0 {
 		t.expectedEchoes = t.expectedEchoes[:len(t.expectedEchoes)-1]
+		// F-NEW-28: lockstep pop of the structural-flag slice.
+		// expectedStructural is always length-matched to
+		// expectedEchoes (no gating), so this pop is unconditional
+		// after the length check above.
+		if len(t.expectedStructural) > 0 {
+			t.expectedStructural = t.expectedStructural[:len(t.expectedStructural)-1]
+		}
 		// Conditional lockstep: pop the parallel timestamp slot
 		// only when the queues are length-matched. The empty-times
 		// case (legacy recordSent) leaves nothing to pop.
@@ -367,6 +460,12 @@ func (t *echoTracker) matchEchoWithTime(received byte, receivedWasEscaped bool) 
 			t.expectedWriteTimes = t.expectedWriteTimes[1:]
 			hasWriteAt = !writeAt.IsZero()
 		}
+		// F-NEW-28: pop the structural-flag head in lockstep with the
+		// byte queue. Always length-locked (no v8 gating), so this
+		// pop is unconditional once the head match succeeds.
+		if len(t.expectedStructural) > 0 {
+			t.expectedStructural = t.expectedStructural[1:]
+		}
 		// Match: consume from expected, accumulate in seen.
 		preLen := len(t.expectedEchoes)
 		t.expectedEchoes = t.expectedEchoes[1:]
@@ -424,6 +523,7 @@ func (t *echoTracker) matchEchoWithTime(received byte, receivedWasEscaped bool) 
 
 	// Clear expected echoes on mismatch — the echo sequence is broken.
 	t.expectedEchoes = t.expectedEchoes[:0]
+	t.expectedStructural = t.expectedStructural[:0]
 	t.expectedWriteTimes = t.expectedWriteTimes[:0]
 	t.atRequestStart = false
 
@@ -446,11 +546,13 @@ func (t *echoTracker) flushOnSYN() (flushedBytes []byte, wasAtStart bool) {
 
 	// Clear expected echoes at SYN boundary.
 	t.expectedEchoes = t.expectedEchoes[:0]
+	t.expectedStructural = t.expectedStructural[:0]
 	t.expectedWriteTimes = t.expectedWriteTimes[:0]
 	// Codex PR #603 P2 invariant: a SYN boundary commits any
 	// in-flight overflow reset. preOverflowEchoes no longer eligible
 	// for rollback.
 	t.preOverflowEchoes = nil
+	t.preOverflowStructural = nil
 	t.preOverflowWriteTimes = nil
 	// batch-26 round-7: a wire SYN observed legitimately closing the
 	// txn ends the inter-write window — the gateway is between
@@ -469,10 +571,12 @@ func (t *echoTracker) markRequestStart() {
 	t.atRequestStart = true
 	t.seenEchoes = t.seenEchoes[:0]
 	t.expectedEchoes = t.expectedEchoes[:0]
+	t.expectedStructural = t.expectedStructural[:0]
 	t.expectedWriteTimes = t.expectedWriteTimes[:0]
 	// Codex PR #603 P2 invariant: a new request boundary invalidates
 	// any pending overflow snapshot.
 	t.preOverflowEchoes = nil
+	t.preOverflowStructural = nil
 	t.preOverflowWriteTimes = nil
 	// batch-26 round-7: a fresh transaction invalidates any inter-write
 	// flag from a prior txn. Same boundary discipline as
@@ -501,13 +605,48 @@ func (t *echoTracker) peekNextExpected() (byte, bool) {
 	return t.expectedEchoes[0], true
 }
 
+// peekNextExpectedWithFlags returns the byte at the head of the
+// expected-echo queue, its F-NEW-28 structural-provenance flag, and a
+// boolean indicating whether the queue is non-empty.
+//
+// `structural=true` means the gateway issued the corresponding write
+// as a STRUCTURAL SymbolSyn (end-of-message terminator) — the legitimate
+// wire echo for this byte is a raw 0xAA with WasEscaped=false.
+//
+// `structural=false` means the write was a PAYLOAD byte (any value,
+// including byte=0xAA which is wire-encoded as the A9 01 escape pair
+// on ENH-class transports) — the legitimate wire echo is the byte
+// value with WasEscaped=true for 0xAA-payload, WasEscaped=false for
+// non-0xAA payload.
+//
+// Used by mux.go's SYN-suppression predicate to distinguish a
+// pending terminator-SYN expected echo from a pending payload-0xAA
+// expected echo. See echoTracker.expectedStructural field doc.
+//
+// Read-only; does NOT consume the queue head. Lockstep with
+// peekNextExpected — when the queue is non-empty, both slices have
+// length-locked entries at index 0.
+func (t *echoTracker) peekNextExpectedWithFlags() (b byte, structural bool, hasPending bool) {
+	if len(t.expectedEchoes) == 0 {
+		return 0, false, false
+	}
+	b = t.expectedEchoes[0]
+	if len(t.expectedStructural) > 0 {
+		structural = t.expectedStructural[0]
+	}
+	hasPending = true
+	return b, structural, hasPending
+}
+
 // reset clears all tracking state.
 func (t *echoTracker) reset() {
 	t.expectedEchoes = t.expectedEchoes[:0]
+	t.expectedStructural = t.expectedStructural[:0]
 	t.expectedWriteTimes = t.expectedWriteTimes[:0]
 	t.seenEchoes = t.seenEchoes[:0]
 	t.atRequestStart = false
 	t.preOverflowEchoes = nil
+	t.preOverflowStructural = nil
 	t.preOverflowWriteTimes = nil
 	t.queueJustDrained = false
 }

--- a/internal/adaptermux/echo_tracker.go
+++ b/internal/adaptermux/echo_tracker.go
@@ -246,21 +246,12 @@ func (t *echoTracker) recordSentStructural(data byte, structural bool) {
 	t.recordSentInternal(data, structural, time.Time{}, false)
 }
 
-// recordSentWithTime is the time-tracking variant of recordSent.
-// Pass the wall-clock time of the write; matchEchoWithTime will
-// return it when this byte's echo is matched. Pass time.Time{}
-// (zero) to skip time tracking entirely — equivalent to the legacy
-// recordSent path. Phase 3 Step B3.6d.
-//
-// The expectedWriteTimes queue stays in PERFECT LOCKSTEP with
-// expectedEchoes through every operation (append, pop, rollback,
-// overflow-reset). If `writeAt` is zero, the slot still gets an
-// entry (zero time) so matchEchoWithTime's hasWriteAt return
-// reports false for that byte — preserving the contract that
-// only explicitly-timestamped writes feed L_rtt samples.
-func (t *echoTracker) recordSentWithTime(data byte, writeAt time.Time) {
-	t.recordSentInternal(data, false, writeAt, true)
-}
+// recordSentWithTime — removed in F-NEW-28 (2026-05-21). The
+// time-tracking sendLoop callers were updated to
+// recordSentWithTimeStructural which threads the structural-provenance
+// flag through. Callers that don't need the structural flag pass
+// `structural=false`. Kept the comment for archaeology: time-tracking
+// variant of recordSent for v8 RTT sampling, Phase 3 Step B3.6d.
 
 // recordSentWithTimeStructural is the F-NEW-28 (2026-05-21) variant
 // that accepts both the v8 time-tracking writeAt AND the structural

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -739,7 +739,27 @@ var (
 type sendRequest struct {
 	sessionID uint64
 	data      byte
-	result    chan error
+	// structural is the F-NEW-28 (2026-05-21) provenance flag for the
+	// gateway session's writes. When true, this byte is being sent as
+	// a STRUCTURAL SymbolSyn (end-of-message terminator) — the
+	// expected wire echo is a raw 0xAA with WasEscaped=false. When
+	// false (the default for all payload bytes including payload-0xAA),
+	// the expected wire echo is the byte value with WasEscaped
+	// determined by the byte's escape state on the wire (true for
+	// 0xAA-as-payload, false for non-0xAA).
+	//
+	// Set by activeTransport.Write consulting the one-shot
+	// `nextWriteIsStructuralSyn` flag toggled by bus.go's
+	// SignalNextWriteIsStructuralSyn() call. Propagated by sendLoop to
+	// echoTracker.recordSentInternal so the SYN-suppression predicate
+	// at `mux.go:2487` can distinguish a pending terminator-SYN
+	// expected echo from a pending payload-0xAA expected echo, closing
+	// the round-9 enforce-mode leak.
+	//
+	// External sessions (ENH client traffic) always pass structural=false
+	// — only the gateway's structural-terminator writes use the flag.
+	structural bool
+	result     chan error
 }
 
 // New creates a new adapter multiplexer with the given configuration.
@@ -2483,8 +2503,38 @@ func (m *Mux) onSYNLocked(phaseEvent wirePhaseEvent, ownerID uint64, hasOwner bo
 	// decision — otherwise a mid-frame noise SYN that arrives after
 	// IdleReleaseGrace elapses (slow txn) would still abort the
 	// legitimate transaction even though we suppressed activeCh delivery.
-	nextExpectedEcho, hasPendingEcho := m.gatewayEcho.peekNextExpected()
-	midWriteSyn := hasPendingEcho && nextExpectedEcho != protocol.SymbolSyn
+	// F-NEW-28 (2026-05-21, round-9 layer-correct fix): peek the
+	// next-expected echo's STRUCTURAL flag in addition to its byte
+	// value. The flag distinguishes:
+	//
+	//   (a) `(SymbolSyn, structural=true)`  — the gateway just wrote
+	//        a structural terminator SYN; the legitimate wire echo
+	//        is raw 0xAA (WasEscaped=false). A wire AUTO-SYN here is
+	//        either the legitimate terminator echo OR (more rarely)
+	//        a pre-terminator-echo idle SYN; both flow paths are
+	//        already handled by the terminator-delivery gate at
+	//        line 2614.
+	//
+	//   (b) `(SymbolSyn, structural=false)` — the gateway just wrote
+	//        a PAYLOAD 0xAA; the legitimate wire echo is logical 0xAA
+	//        with WasEscaped=true (the adapter wire-encoded our byte
+	//        as `A9 01`). A wire AUTO-SYN here is INTERFERENCE
+	//        (round-9 invariant violation) — it MUST be suppressed
+	//        from activeCh delivery to keep `sendRawWithEcho`'s
+	//        round-9 absorb path at bus.go:1204 cold under v8 enforce
+	//        (HelianthusRound9FiredUnderProxy I8).
+	//
+	//   (c) `(non-SymbolSyn, *)`              — non-SYN expected echo;
+	//        a wire SYN here is mid-frame noise. Same suppression as
+	//        before.
+	//
+	// Pre-F-NEW-28 the predicate only checked the byte value, so
+	// case (b) was incorrectly NOT suppressed — that was the leak
+	// (production: ~4/min residual under v8 enforce). With the
+	// structural flag the predicate now treats case (b) the same as
+	// case (c): midWriteSyn=true → wire SYN suppressed.
+	nextExpectedEcho, nextStructural, hasPendingEcho := m.gatewayEcho.peekNextExpectedWithFlags()
+	midWriteSyn := hasPendingEcho && !(nextExpectedEcho == protocol.SymbolSyn && nextStructural)
 
 	// batch-26 round-7 — Attack 3 closure (inter-write empty-queue SYN
 	// leak). The peek-based P10.2 gate (midWriteSyn) cannot suppress a
@@ -4575,7 +4625,18 @@ func (m *Mux) sendLoop() {
 				// classifier's adminEvents ring buffer.
 				if m.v8 != nil {
 					writeAt := time.Now()
-					m.gatewayEcho.recordSentWithTime(req.data, writeAt)
+					// F-NEW-28 (2026-05-21): propagate the
+					// structural-write provenance flag from
+					// sendRequest (toggled by bus.go's
+					// SignalNextWriteIsStructuralSyn → activeTransport.Write)
+					// into echoTracker.expectedStructural. The
+					// mux's SYN-suppression predicate at
+					// `mux.go:2487` (midWriteSyn) consults this
+					// flag to distinguish a pending
+					// structural-terminator expected echo from a
+					// pending payload-0xAA expected echo, closing
+					// the round-9 enforce-mode leak.
+					m.gatewayEcho.recordSentWithTimeStructural(req.data, writeAt, req.structural)
 					// Codex round-1 MAJOR #1 on PR #647:
 					// BeforeActiveWrite MUST run before
 					// ArmEchoWatchdog so a long-idle gateway
@@ -4600,7 +4661,12 @@ func (m *Mux) sendLoop() {
 						pacer.ArmEchoWatchdog(writeAt)
 					}
 				} else {
-					m.gatewayEcho.recordSent(req.data)
+					// F-NEW-28: same provenance plumbing on the
+					// v8-off path. expectedStructural is always
+					// length-locked to expectedEchoes regardless of
+					// v8 mode (the SYN-suppression predicate uses
+					// it on every wire SYN).
+					m.gatewayEcho.recordSentStructural(req.data, req.structural)
 				}
 				m.stateMu.Unlock()
 			}

--- a/internal/adaptermux/p3_test.go
+++ b/internal/adaptermux/p3_test.go
@@ -18,6 +18,26 @@ import (
 	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
 )
 
+// writeTerminatorSyn is the F-NEW-28 (2026-05-21) test helper that
+// emulates bus.go's sendEndOfMessage path: signal the transport as a
+// structural-SYN write, then issue the Write. Used by tests that
+// exercise the gateway's terminator delivery code path via
+// activeTransport.Write directly (bypassing bus.go).
+//
+// Without this helper, the gateway's echo tracker records
+// `expectedStructural=false` for the terminator byte, and the
+// mux.go:2487 midWriteSyn predicate incorrectly treats it as a
+// payload-0xAA write — suppressing the legitimate terminator
+// delivery. Production code (helianthus-ebusgo bus.go) issues the
+// signal automatically via the StructuralWriteSignaler interface; the
+// tests must do the same to faithfully model the production path.
+func writeTerminatorSyn(at transport.RawTransport) {
+	if signaler, ok := at.(transport.StructuralWriteSignaler); ok {
+		signaler.SignalNextWriteIsStructuralSyn()
+	}
+	_, _ = at.Write([]byte{protocol.SymbolSyn})
+}
+
 // --- P3 test infrastructure ---
 
 // p3MockTransport simulates an ENH transport that supports non-blocking

--- a/internal/adaptermux/pr502_review_test.go
+++ b/internal/adaptermux/pr502_review_test.go
@@ -668,11 +668,15 @@ func grantGateway(t *testing.T, mux *Mux, mock *p3MockTransport, initiator byte)
 // The helper issues the Write in a goroutine so sendLoop can run while
 // the caller's stateMu critical section is not held, then sleeps
 // briefly to let recordSent populate the queue before returning.
+//
+// F-NEW-28 (2026-05-21): uses writeTerminatorSyn under the hood so the
+// structural-SYN provenance flag flows through the gateway echo
+// tracker, matching bus.go's sendEndOfMessage path.
 func gatewayEndOfMessage(t *testing.T, at transport.RawTransport) {
 	t.Helper()
 	done := make(chan struct{}, 1)
 	go func() {
-		_, _ = at.Write([]byte{protocol.SymbolSyn})
+		writeTerminatorSyn(at)
 		done <- struct{}{}
 	}()
 	time.Sleep(20 * time.Millisecond)

--- a/internal/adaptermux/pre_echo_syn_p102_test.go
+++ b/internal/adaptermux/pre_echo_syn_p102_test.go
@@ -138,8 +138,10 @@ func TestPreEchoSyn_LegitimateTerminator_Delivered(t *testing.T) {
 	}
 
 	// Gateway writes the terminator SYN itself (sendEndOfMessage path).
-	// expectedEchoes head is now SYN.
-	go func() { _, _ = at.Write([]byte{protocol.SymbolSyn}) }()
+	// expectedEchoes head is now SYN. F-NEW-28 (2026-05-21): use
+	// writeTerminatorSyn helper to signal structural-SYN provenance
+	// before the write, matching bus.go's sendEndOfMessage path.
+	go writeTerminatorSyn(at)
 	time.Sleep(20 * time.Millisecond)
 
 	// Wire echoes the SYN. The gate must let it through as terminator.

--- a/internal/adaptermux/syn_diag_test.go
+++ b/internal/adaptermux/syn_diag_test.go
@@ -52,7 +52,7 @@ func TestSynDiag_RecordsOwnershipTransition(t *testing.T) {
 	// active path. This populates gatewayEcho with [SymbolSyn] so the
 	// next wire SYN matches the terminator gate's
 	// `hasPendingEcho && nextExpected==SymbolSyn` branch.
-	go func() { _, _ = at.Write([]byte{protocol.SymbolSyn}) }()
+	go writeTerminatorSyn(at)
 	time.Sleep(20 * time.Millisecond)
 
 	// Inject the trailing SYN (wire echo of the terminator).
@@ -191,7 +191,7 @@ func TestOnSYNLocked_DeliversTerminatorToActive_WhenBytesReadPositive(t *testing
 	// via the active path. This populates gatewayEcho with [SymbolSyn]
 	// so the wire echo below matches via the hasPendingEcho+SymbolSyn
 	// branch of the terminator gate.
-	go func() { _, _ = at.Write([]byte{protocol.SymbolSyn}) }()
+	go writeTerminatorSyn(at)
 	time.Sleep(20 * time.Millisecond)
 
 	// Inject the trailing SYN — this should be delivered to activeCh.
@@ -423,7 +423,16 @@ func TestTerminatorSYN_AfterFirstDelivery(t *testing.T) {
 	// Round-6: emulate sendEndOfMessage by writing the terminator SYN
 	// via the active path. recordSent arms gatewayEcho with [SymbolSyn]
 	// so the wire echo below matches the explicit-terminator branch.
-	go func() { _, _ = at.Write([]byte{protocol.SymbolSyn}) }()
+	//
+	// F-NEW-28 (2026-05-21): bus.go's sendRawWithEcho signals the
+	// transport BEFORE writing a structural SymbolSyn so the gateway
+	// echo tracker records expectedStructural=true and the
+	// SYN-suppression predicate at mux.go:2487 distinguishes a
+	// terminator-SYN expected echo from a payload-0xAA expected echo.
+	// Tests that emulate sendEndOfMessage must do the same — otherwise
+	// the predicate treats this write as payload-0xAA and the
+	// terminator wire SYN is incorrectly suppressed.
+	go writeTerminatorSyn(at)
 	time.Sleep(20 * time.Millisecond)
 
 	// Inject trailing SYN. With round-6 gating (hasPendingEcho=true,


### PR DESCRIPTION
## Summary

Layer-correct fix for the round-9 enforce-mode leak (~4/min residual at 2026-05-21 production sampling, 99.78% v8 suppression rate). Companion to ebusgo PR #168 (`StructuralWriteSignaler` transport interface).

## What broke

`mux.go:2487` `midWriteSyn` predicate could not distinguish:
- pending `(SymbolSyn, structural-terminator)` expected echo → wire SYN here IS the legitimate terminator
- pending `(SymbolSyn, payload-0xAA)` expected echo → wire SYN here is INTERFERENCE (round-9 invariant violation)

Both cases satisfied the old predicate `nextByte == SymbolSyn → NOT mid-write`, letting interference through to bus.go's echo position.

## What this fix does

1. **echoTracker (echo_tracker.go)** — adds `expectedStructural []bool` length-locked to `expectedEchoes`. New `peekNextExpectedWithFlags()` API surfaces per-byte structural provenance. All mutation paths (`recordSent` / `match` / `rollback` / `reset` / `flush`) maintain the lockstep invariant.

2. **activeTransport (active_path.go)** — implements `transport.StructuralWriteSignaler` from ebusgo PR #168. One-shot atomic flag, consumed by the next Write call.

3. **sendLoop (mux.go)** — propagates `req.structural` into echoTracker via new `recordSentStructural` / `recordSentWithTimeStructural` variants.

4. **midWriteSyn predicate** — now reads `hasPendingEcho && !(nextByte == SymbolSyn && nextStructural)`. Wire AUTO-SYNs during payload-0xAA writes are correctly suppressed.

5. **ebusgo pin bump**: `808674a` → `f9919f4` (PR #168).

## Test plan

- [x] All 12 previously-failing tests pass with new `writeTerminatorSyn` helper (in `p3_test.go`)
- [x] `TestTxnClass_SYNTerminatorEchoOnly` mock updated to emit `WasEscaped=true` on payload-0xAA echoes (realistic ENH behavior; old version masked by looser predicate)
- [x] Full adaptermux suite: 109s, all pass
- [x] Full gateway suite: all pass
- [ ] Integration: stress test on HA host after addon v0.6.25 ships with this gateway pin. Pass criterion: `helianthus_round9_absorb_entered_total` rate → 0 within 5 min of deploy.

## Risk

- **Throughput regression**: batch-25 reverted a similar broadening that caused 65% throughput drop. This fix is **narrower** — only suppresses when pending echo is specifically `(SymbolSyn, structural=false)`. Legitimate terminator SYNs (the common case) are unaffected. To be empirically verified in HA-host stress test.
- **Cross-repo coordination**: pins to ebusgo `f9919f4`. ebusgo PR #168 must remain merged.

Refs:
- `_work_adaptermux_audit/v8-enforce-stress/findings.md` — full diagnosis
- ebusgo PR #168 — companion transport interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)