### PR TITLE
fix(adaptermux): rate-limit F-22 absorb-skip log to 1Hz with (N suppressed) suffix

### DIFF
--- a/internal/adaptermux/absorb_debounce_test.go
+++ b/internal/adaptermux/absorb_debounce_test.go
@@ -1,7 +1,9 @@
 package adaptermux
 
 import (
+	"fmt"
 	"log"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -55,6 +57,87 @@ func (b *armRateBuffer) String() string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return string(b.buf)
+}
+
+func TestAbsorbSkipLog_RateLimitedWithSuppressedSuffix(t *testing.T) {
+	var logBuf armRateBuffer
+	logger := log.New(&logBuf, "", 0)
+
+	mux := New(Config{
+		Protocol:        "enh",
+		Network:         "tcp",
+		Address:         "127.0.0.1:0",
+		ReadTimeout:     time.Second,
+		StartDeadline:   20 * time.Second,
+		PendingStartTTL: 24 * time.Hour,
+		SYNInterval:     time.Hour,
+		Logger:          logger,
+	})
+
+	mock := newP3MockTransport()
+	defer mock.Close()
+	mux.connMu.Lock()
+	mux.upstream = mock
+	mux.connMu.Unlock()
+
+	_ = mux.arb.requestStart(gatewaySessionID, 0x71)
+	mux.stateMu.Lock()
+	mux.pendingStartAbsorb = 1
+	mux.stateMu.Unlock()
+
+	const calls = 100
+	burstStart := time.Now()
+	for i := 0; i < calls; i++ {
+		mux.tryGrantAndStart()
+	}
+	if elapsed := time.Since(burstStart); elapsed >= time.Second {
+		t.Fatalf("test burst took %v; want <1s so the rate-limit window is not crossed", elapsed)
+	}
+
+	const prefix = "adaptermux: tryGrantAndStart skipped — waiting to absorb"
+	burstLog := logBuf.String()
+	burstLines := strings.Count(burstLog, prefix)
+	if burstLines > 2 {
+		t.Fatalf("%d skip log lines emitted during %d-call burst in <1s; want <=2. Log:\n%s",
+			burstLines, calls, burstLog)
+	}
+	if burstLines != 1 {
+		t.Fatalf("%d skip log lines emitted during %d-call burst; want exactly the initial visible line. Log:\n%s",
+			burstLines, calls, burstLog)
+	}
+	if strings.Contains(burstLog, "suppressed") {
+		t.Fatalf("suppressed suffix appeared before the next eligible emission. Log:\n%s", burstLog)
+	}
+
+	mux.stateMu.Lock()
+	suppressed := mux.absorbSkipLogSuppressedSince
+	lastEmit := mux.absorbSkipLogLastEmit
+	mux.stateMu.Unlock()
+	if want := uint64(calls - 1); suppressed != want {
+		t.Fatalf("suppressed count after burst = %d; want %d", suppressed, want)
+	}
+
+	if sleep := time.Until(lastEmit.Add(time.Second + 20*time.Millisecond)); sleep > 0 {
+		time.Sleep(sleep)
+	}
+	mux.tryGrantAndStart()
+
+	afterLog := logBuf.String()
+	afterLines := strings.Count(afterLog, prefix)
+	if afterLines != burstLines+1 {
+		t.Fatalf("skip log lines after next eligible call = %d; want %d. Log:\n%s",
+			afterLines, burstLines+1, afterLog)
+	}
+	if wantSuffix := fmt.Sprintf("(%d suppressed)", suppressed); !strings.Contains(afterLog, wantSuffix) {
+		t.Fatalf("next eligible skip log missing %q suffix. Log:\n%s", wantSuffix, afterLog)
+	}
+
+	mux.stateMu.Lock()
+	finalSuppressed := mux.absorbSkipLogSuppressedSince
+	mux.stateMu.Unlock()
+	if finalSuppressed != 0 {
+		t.Fatalf("suppressed count after eligible emission = %d; want 0", finalSuppressed)
+	}
 }
 
 // TestAbsorbReset_RapidArmsStillEventuallyReset arms

--- a/internal/adaptermux/absorb_debounce_test.go
+++ b/internal/adaptermux/absorb_debounce_test.go
@@ -59,6 +59,12 @@ func (b *armRateBuffer) String() string {
 	return string(b.buf)
 }
 
+func (b *armRateBuffer) Reset() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.buf = b.buf[:0]
+}
+
 func TestAbsorbSkipLog_RateLimitedWithSuppressedSuffix(t *testing.T) {
 	var logBuf armRateBuffer
 	logger := log.New(&logBuf, "", 0)
@@ -137,6 +143,85 @@ func TestAbsorbSkipLog_RateLimitedWithSuppressedSuffix(t *testing.T) {
 	mux.stateMu.Unlock()
 	if finalSuppressed != 0 {
 		t.Fatalf("suppressed count after eligible emission = %d; want 0", finalSuppressed)
+	}
+}
+
+// TestAbsorbSkipLog_NoCarryoverAcrossAbsorbEpisodes guards against the
+// Codex review finding on PR #660: when pendingStartAbsorb drains to 0
+// via a path OTHER than the visible skip-log emission or the F-22
+// deadline (e.g. normal stale-response consumption via
+// handleArbitrationResponse), the suppressed counter and last-emit
+// timestamp must be cleared so the next absorb episode does not carry
+// a stale `(N suppressed)` suffix or a stale rate-limit window.
+func TestAbsorbSkipLog_NoCarryoverAcrossAbsorbEpisodes(t *testing.T) {
+	var logBuf armRateBuffer
+	logger := log.New(&logBuf, "", 0)
+
+	mux := New(Config{
+		Protocol:        "enh",
+		Network:         "tcp",
+		Address:         "127.0.0.1:0",
+		ReadTimeout:     time.Second,
+		StartDeadline:   20 * time.Second,
+		PendingStartTTL: 24 * time.Hour,
+		SYNInterval:     time.Hour,
+		Logger:          logger,
+	})
+
+	mock := newP3MockTransport()
+	defer mock.Close()
+	mux.connMu.Lock()
+	mux.upstream = mock
+	mux.connMu.Unlock()
+
+	_ = mux.arb.requestStart(gatewaySessionID, 0x71)
+
+	// Episode 1: arm absorb, burst skip calls, then drain via the
+	// "normal stale-response consumption" decrement path. Suppressed
+	// counter is non-zero, last-emit is non-zero.
+	mux.stateMu.Lock()
+	mux.pendingStartAbsorb = 1
+	mux.stateMu.Unlock()
+	for i := 0; i < 25; i++ {
+		mux.tryGrantAndStart()
+	}
+	mux.stateMu.Lock()
+	if mux.absorbSkipLogSuppressedSince == 0 {
+		mux.stateMu.Unlock()
+		t.Fatal("episode 1: expected suppressed counter > 0 after burst")
+	}
+	// Simulate the stale-response decrement path that the Codex review
+	// flagged. Decrementing to 0 must trigger clearAbsorbSkipLogStateLocked.
+	mux.pendingStartAbsorb--
+	if mux.pendingStartAbsorb == 0 {
+		mux.clearAbsorbSkipLogStateLocked()
+	}
+	episode1Suppressed := mux.absorbSkipLogSuppressedSince
+	episode1LastEmit := mux.absorbSkipLogLastEmit
+	mux.stateMu.Unlock()
+
+	if episode1Suppressed != 0 {
+		t.Fatalf("after stale-response decrement to 0, suppressed = %d; want 0", episode1Suppressed)
+	}
+	if !episode1LastEmit.IsZero() {
+		t.Fatalf("after stale-response decrement to 0, lastEmit = %v; want zero time", episode1LastEmit)
+	}
+
+	// Episode 2: arm absorb again immediately. Within the same wall-clock
+	// second, the FIRST skip call must emit (lastEmit was cleared) and
+	// must NOT carry a `(N suppressed)` suffix referring to episode 1.
+	logBuf.Reset()
+	mux.stateMu.Lock()
+	mux.pendingStartAbsorb = 1
+	mux.stateMu.Unlock()
+	mux.tryGrantAndStart()
+	first := logBuf.String()
+	const prefix = "adaptermux: tryGrantAndStart skipped — waiting to absorb"
+	if !strings.Contains(first, prefix) {
+		t.Fatalf("episode 2 first skip did not emit a log line. Log:\n%s", first)
+	}
+	if strings.Contains(first, "suppressed") {
+		t.Fatalf("episode 2 first skip carried stale `(N suppressed)` from episode 1. Log:\n%s", first)
 	}
 }
 

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -530,6 +530,10 @@ type Mux struct {
 
 	pendingStart       *pendingStartState // in-flight START awaiting STARTED/FAILED
 	pendingStartAbsorb int                // stale adapter responses to absorb (FAILED/STARTED from cancelled requests)
+	// absorbSkipLog* rate-limits the hot tryGrantAndStart skip log while
+	// pendingStartAbsorb is acting as the stale-response barrier.
+	absorbSkipLogLastEmit        time.Time
+	absorbSkipLogSuppressedSince uint64
 	// pendingAbsorbResetTimer is the single persistent debounce timer
 	// that fires F-22's reset when pendingStartAbsorb has stayed
 	// > 0 for at least `cfg.StartDeadline` without a new arm or
@@ -3467,7 +3471,20 @@ func (m *Mux) tryGrantAndStart() {
 	// STARTED from the new one. Treat pendingStartAbsorb as a real regrant
 	// barrier, not just a best-effort diagnostic counter.
 	if m.pendingStartAbsorb > 0 {
-		m.logger.Printf("adaptermux: tryGrantAndStart skipped — waiting to absorb %d stale arbitration response(s)", m.pendingStartAbsorb)
+		now := time.Now()
+		if !m.absorbSkipLogLastEmit.IsZero() && now.Sub(m.absorbSkipLogLastEmit) < time.Second {
+			m.absorbSkipLogSuppressedSince++
+			m.stateMu.Unlock()
+			return
+		}
+		suppressed := m.absorbSkipLogSuppressedSince
+		m.absorbSkipLogSuppressedSince = 0
+		m.absorbSkipLogLastEmit = now
+		if suppressed > 0 {
+			m.logger.Printf("adaptermux: tryGrantAndStart skipped — waiting to absorb %d stale arbitration response(s) (%d suppressed)", m.pendingStartAbsorb, suppressed)
+		} else {
+			m.logger.Printf("adaptermux: tryGrantAndStart skipped — waiting to absorb %d stale arbitration response(s)", m.pendingStartAbsorb)
+		}
 		m.stateMu.Unlock()
 		return
 	}
@@ -4524,7 +4541,13 @@ func (m *Mux) fireAbsorbReset() {
 	}
 	count := m.pendingStartAbsorb
 	reason := m.pendingAbsorbLastReason
-	m.logger.Printf("adaptermux: absorb timeout reset reason=%s (was waiting for %d stale arbitration response(s)) (F-22 debounce)", reason, count)
+	suppressed := m.absorbSkipLogSuppressedSince
+	m.absorbSkipLogSuppressedSince = 0
+	if suppressed > 0 {
+		m.logger.Printf("adaptermux: absorb timeout reset reason=%s (was waiting for %d stale arbitration response(s)) (F-22 debounce) (%d suppressed)", reason, count, suppressed)
+	} else {
+		m.logger.Printf("adaptermux: absorb timeout reset reason=%s (was waiting for %d stale arbitration response(s)) (F-22 debounce)", reason, count)
+	}
 	m.absorbResetTotal.Add(1)
 	m.pendingStartAbsorb = 0
 	// Clear the due-at so subsequent stale callbacks (extremely

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -920,6 +920,7 @@ func (m *Mux) Close() error {
 		pendingToCancel := m.pendingStart
 		m.pendingStart = nil
 		m.pendingStartAbsorb = 0
+		m.clearAbsorbSkipLogStateLocked()
 		// F-NEW-25: stop the absorb-reset debounce timer if armed.
 		// Stop() is best-effort — if the callback is already
 		// running on another goroutine it will see
@@ -1437,6 +1438,7 @@ func (m *Mux) reconnect() error {
 	pendingToCancel := m.pendingStart
 	m.pendingStart = nil
 	m.pendingStartAbsorb = 0
+	m.clearAbsorbSkipLogStateLocked()
 	// F-NEW-25: stop the absorb-reset debounce timer on reconnect.
 	// reconnect explicitly drains pendingStartAbsorb here; leaving
 	// the timer running would either no-op when it fires (count
@@ -3111,6 +3113,7 @@ func (m *Mux) handleReset() {
 	pendingToCancel := m.pendingStart
 	m.pendingStart = nil
 	m.pendingStartAbsorb = 0 // reset clears adapter state; no stale responses will arrive
+	m.clearAbsorbSkipLogStateLocked()
 	// F-NEW-25: stop the absorb-reset debounce timer on RESETTED
 	// boundary. The reset semantics already drain pendingStartAbsorb;
 	// leaving the timer running would either no-op when it fires
@@ -3692,6 +3695,9 @@ func (m *Mux) tryGrantAndStart() {
 				shouldAdvance := false
 				if m.pendingStartAbsorb > 0 {
 					m.pendingStartAbsorb--
+					if m.pendingStartAbsorb == 0 {
+						m.clearAbsorbSkipLogStateLocked()
+					}
 					shouldAdvance = m.pendingStartAbsorb == 0 && m.arb.hasPending()
 				}
 				m.stateMu.Unlock()
@@ -3816,6 +3822,9 @@ func (m *Mux) tryGrantAndStart() {
 					isCurrentGen := m.blockingArbGen == arbGen
 					if isCurrentGen && m.pendingStartAbsorb > 0 {
 						m.pendingStartAbsorb--
+						if m.pendingStartAbsorb == 0 {
+							m.clearAbsorbSkipLogStateLocked()
+						}
 					}
 					m.stateMu.Unlock()
 					if isCurrentGen && m.arb.hasPending() {
@@ -3849,6 +3858,9 @@ func (m *Mux) tryGrantAndStart() {
 				// Codex-R8: scope absorb + queue advance to our generation.
 				if isCurrentGen && m.pendingStartAbsorb > 0 {
 					m.pendingStartAbsorb--
+					if m.pendingStartAbsorb == 0 {
+						m.clearAbsorbSkipLogStateLocked()
+					}
 				}
 				m.stateMu.Unlock()
 				if isCurrentGen && m.arb.hasPending() {
@@ -4032,6 +4044,9 @@ func (m *Mux) handleArbitrationResponse(started bool, data byte) {
 	// pending request.
 	if m.pendingStartAbsorb > 0 {
 		m.pendingStartAbsorb--
+		if m.pendingStartAbsorb == 0 {
+			m.clearAbsorbSkipLogStateLocked()
+		}
 		shouldAdvance := !started && m.pendingStartAbsorb == 0 && m.pendingStart == nil && m.arb.hasPending()
 		// F-15 follow-up (PR #626 Codex bot review on b3b7f13 + e6b96ee
 		// — P1 finding): the absorb-consume branch used to reconnect
@@ -4542,7 +4557,6 @@ func (m *Mux) fireAbsorbReset() {
 	count := m.pendingStartAbsorb
 	reason := m.pendingAbsorbLastReason
 	suppressed := m.absorbSkipLogSuppressedSince
-	m.absorbSkipLogSuppressedSince = 0
 	if suppressed > 0 {
 		m.logger.Printf("adaptermux: absorb timeout reset reason=%s (was waiting for %d stale arbitration response(s)) (F-22 debounce) (%d suppressed)", reason, count, suppressed)
 	} else {
@@ -4550,6 +4564,7 @@ func (m *Mux) fireAbsorbReset() {
 	}
 	m.absorbResetTotal.Add(1)
 	m.pendingStartAbsorb = 0
+	m.clearAbsorbSkipLogStateLocked()
 	// Clear the due-at so subsequent stale callbacks (extremely
 	// unlikely but possible if the runtime queued multiple fires)
 	// see the IsZero short-circuit and don't re-log.
@@ -4561,6 +4576,21 @@ func (m *Mux) fireAbsorbReset() {
 	if shouldAdvance {
 		m.tryGrantAndStart()
 	}
+}
+
+// clearAbsorbSkipLogStateLocked resets the rate-limit fields associated with
+// the absorb-skip log so the next absorb cycle starts with a fresh suppressed
+// counter and emit timestamp. Caller must hold stateMu.
+//
+// Why this exists: pendingStartAbsorb can return to zero via several paths
+// (fireAbsorbReset deadline, normal stale-response consumption via
+// handleArbitrationResponse + the cancelled-start decrement branches in
+// sendLoop). Without this reset, a stale (N suppressed) suffix from a
+// previous absorb episode could leak into the first eligible skip-log of
+// the next episode, misrepresenting the rate (Codex review on PR #660).
+func (m *Mux) clearAbsorbSkipLogStateLocked() {
+	m.absorbSkipLogSuppressedSince = 0
+	m.absorbSkipLogLastEmit = time.Time{}
 }
 
 // sendLoop processes send requests from the active path and external sessions.


### PR DESCRIPTION
## Summary

Under sustained stress (v0.6.25 post-deploy verification, 2026-05-22), the `tryGrantAndStart skipped — waiting to absorb N stale arbitration response(s)` log line at `mux.go:3470` emits up to **144 lines/second** (peak), producing **763 lines/minute** under contention. The skip itself is a microsecond no-op; only the log is noisy.

### Cause

Every SYN observation that lands while `pendingStartAbsorb > 0` calls `tryGrantAndStart` through the SYN handler path (mux.go:2224). At typical SYN cadence under heavy ENS+ebusd contention, that's ~200 Hz of log emission until the F-22 debounce timer (PR #656) clears the counter ~20s later. Operators reading logs lose signal-to-noise.

### Fix

Add two Mux fields (`absorbSkipLogLastEmit time.Time`, `absorbSkipLogSuppressedSince uint64`) and a 1-second rate-limit at the log site. While suppressed, increment the counter. The next eligible emission appends a `(M suppressed)` suffix; `fireAbsorbReset` also appends the suffix when it emits the deadline-reset line, then zeros the counter.

**No functional change.** The early-return + state check are unchanged, only the `logger.Printf` rate changes. All fields are accessed under `stateMu` which is already held at both sites — no atomic loads, no new lock acquisitions.

## Test plan

- [x] `go vet ./...` clean.
- [x] `go build ./...` clean.
- [x] New test `TestAbsorbSkipLog_RateLimitedWithSuppressedSuffix` passes (1.02s).
- [x] Full `go test ./internal/adaptermux/...` passes (110s).
- [ ] Field deploy on .4 to confirm the log rate drops by ~100× under stress (pending merge + new addon build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)