### PR TITLE
fix(adaptermux): F-NEW-29 first-byte arbitration revalidation (forward-not-drop master-class mismatch)

### DIFF
--- a/internal/adaptermux/diag.go
+++ b/internal/adaptermux/diag.go
@@ -74,7 +74,14 @@ type activeTxnDiag struct {
 	// legitimate frame terminator or pre-echo idle-buffer noise. Codex PR
 	// #502 P1 — superseded bytesWritten as the terminator/suppression gate.
 	bytesDeliveredToActive atomic.Uint64
-	drainedOnGrant         int // count of stale bytes drained just before this grant
+	// firstByteSuspectArbLoss is set by mux's first-byte arbitration
+	// revalidation predicate (F-NEW-29, 2026-05-23) when the first wire
+	// byte during a gateway-owned txn is a foreign initiator-class byte that
+	// doesn't match the gateway's first expected echo. Forwarded to
+	// activeCh so bus.go:1328-1378's first-byte-after-arbitration
+	// classifier can raise ErrBusCollision.
+	firstByteSuspectArbLoss atomic.Bool
+	drainedOnGrant          int // count of stale bytes drained just before this grant
 
 	// totals across the mux lifetime (never reset)
 	grantsTotal    atomic.Uint64
@@ -398,6 +405,7 @@ func (m *Mux) recordGatewayGrant(initiator byte, drained int) {
 	m.activeTxn.bytesWritten.Store(0)
 	m.activeTxn.bytesRead.Store(0)
 	m.activeTxn.bytesDeliveredToActive.Store(0)
+	m.activeTxn.firstByteSuspectArbLoss.Store(false)
 	m.activeTxn.drainedOnGrant = drained
 	m.activeTxn.grantsTotal.Add(1)
 	// batch-22 round-3 Attack 2: snapshot the upstream transport's
@@ -532,9 +540,10 @@ func (m *Mux) recordGatewayInactive(reason ActiveTxnInactiveReason) {
 	wp := m.activeTxn.writePrefix[:m.activeTxn.writePrefixLen]
 	rp := m.activeTxn.readPrefix[:m.activeTxn.readPrefixLen]
 	m.logger.Printf(
-		"adaptermux: activeTxn inactive id=%d reason=%s class=%s writes=%d reads=%d echoLike=%d nonEcho=%d synMarkers=%d writePrefix=% X readPrefix=% X dur=%s",
+		"adaptermux: activeTxn inactive id=%d reason=%s class=%s writes=%d reads=%d firstByteSuspectArbLoss=%v echoLike=%d nonEcho=%d synMarkers=%d writePrefix=% X readPrefix=% X dur=%s",
 		m.activeTxn.id, reason, class,
 		m.activeTxn.bytesWritten.Load(), m.activeTxn.bytesRead.Load(),
+		m.activeTxn.firstByteSuspectArbLoss.Load(),
 		m.activeTxn.echoLike.Load(), m.activeTxn.nonEcho.Load(), m.activeTxn.synMarkers.Load(),
 		wp, rp,
 		time.Since(m.activeTxn.grantedAt),

--- a/internal/adaptermux/echo_tracker.go
+++ b/internal/adaptermux/echo_tracker.go
@@ -124,6 +124,7 @@ type echoTracker struct {
 
 	// Stats.
 	totalSuppressed uint64
+	totalWritten    uint64
 	totalMismatches uint64
 
 	// totalOverflowResets counts how many times recordSent reset the
@@ -314,6 +315,7 @@ func (t *echoTracker) recordSentInternal(data byte, structural bool, writeAt tim
 	if withTime {
 		t.expectedWriteTimes = append(t.expectedWriteTimes, writeAt)
 	}
+	t.totalWritten++
 }
 
 // rollbackSent removes the last recorded sent byte (e.g., on SEND error).
@@ -564,6 +566,8 @@ func (t *echoTracker) markRequestStart() {
 	t.expectedEchoes = t.expectedEchoes[:0]
 	t.expectedStructural = t.expectedStructural[:0]
 	t.expectedWriteTimes = t.expectedWriteTimes[:0]
+	t.totalSuppressed = 0
+	t.totalWritten = 0
 	// Codex PR #603 P2 invariant: a new request boundary invalidates
 	// any pending overflow snapshot.
 	t.preOverflowEchoes = nil
@@ -636,6 +640,8 @@ func (t *echoTracker) reset() {
 	t.expectedWriteTimes = t.expectedWriteTimes[:0]
 	t.seenEchoes = t.seenEchoes[:0]
 	t.atRequestStart = false
+	t.totalSuppressed = 0
+	t.totalWritten = 0
 	t.preOverflowEchoes = nil
 	t.preOverflowStructural = nil
 	t.preOverflowWriteTimes = nil
@@ -684,6 +690,22 @@ func (t *echoTracker) ClearQueueJustDrained() {
 // stats returns echo tracking statistics.
 func (t *echoTracker) stats() (suppressed, mismatches uint64) {
 	return t.totalSuppressed, t.totalMismatches
+}
+
+// matchCount returns the cumulative number of echo matches consumed by
+// matchEcho for the current gateway txn. Reset on markRequestStart.
+// F-NEW-29 (2026-05-23): exposed for mux's first-byte arbitration
+// revalidation predicate.
+func (t *echoTracker) matchCount() uint64 {
+	return t.totalSuppressed
+}
+
+// writeCount returns the cumulative number of bytes the gateway has
+// issued via recordSent* since the last markRequestStart. Distinct from
+// len(expectedEchoes), which shrinks as matchEcho consumes entries.
+// F-NEW-29: exposed for mux's first-byte arbitration revalidation predicate.
+func (t *echoTracker) writeCount() uint64 {
+	return t.totalWritten
 }
 
 // overflowResets returns the number of times recordSent reset the

--- a/internal/adaptermux/f_new_29_arbitration_revalidate_test.go
+++ b/internal/adaptermux/f_new_29_arbitration_revalidate_test.go
@@ -1,0 +1,185 @@
+package adaptermux
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+func TestMux_ArbitrationRevalidate_ForwardsFirstForeignMasterByte(t *testing.T) {
+	const (
+		expectedEcho  byte = 0x15
+		foreignMaster byte = 0xF1
+	)
+	if got := protocol.AddressClassOf(foreignMaster); got != protocol.AddressClassMaster {
+		t.Fatalf("test premise broken: AddressClassOf(0x%02X) = %v; want master", foreignMaster, got)
+	}
+
+	mux, mock, _, cleanup := newP3TestMux(t)
+	defer cleanup()
+
+	grantGateway(t, mux, mock, 0x71)
+	at := mux.ActiveTransport()
+
+	if _, err := at.Write([]byte{expectedEcho}); err != nil {
+		t.Fatalf("Write(0x%02X) err=%v", expectedEcho, err)
+	}
+
+	mux.stateMu.Lock()
+	if got := mux.gatewayEcho.matchCount(); got != 0 {
+		t.Fatalf("matchCount after first write = %d; want 0", got)
+	}
+	if got := mux.gatewayEcho.writeCount(); got != 1 {
+		t.Fatalf("writeCount after first write = %d; want 1", got)
+	}
+	if head, pending := mux.gatewayEcho.peekNextExpected(); !pending || head != expectedEcho {
+		t.Fatalf("peekNextExpected = (0x%02X,%v); want (0x%02X,true)", head, pending, expectedEcho)
+	}
+	mux.stateMu.Unlock()
+
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: foreignMaster}
+	expectActiveByte(t, mux, foreignMaster)
+
+	if !mux.activeTxn.firstByteSuspectArbLoss.Load() {
+		t.Fatal("firstByteSuspectArbLoss=false; want true after first foreign master byte")
+	}
+}
+
+func TestMux_AfterFirstEchoMatch_StaleByteStillDropped(t *testing.T) {
+	const (
+		firstEcho     byte = 0x15
+		secondEcho    byte = 0xB5
+		foreignMaster byte = 0xF1
+	)
+	if got := protocol.AddressClassOf(foreignMaster); got != protocol.AddressClassMaster {
+		t.Fatalf("test premise broken: AddressClassOf(0x%02X) = %v; want master", foreignMaster, got)
+	}
+
+	mux, mock, _, cleanup := newP3TestMux(t)
+	defer cleanup()
+
+	grantGateway(t, mux, mock, 0x71)
+	at := mux.ActiveTransport()
+
+	if _, err := at.Write([]byte{firstEcho}); err != nil {
+		t.Fatalf("Write(0x%02X) err=%v", firstEcho, err)
+	}
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: firstEcho}
+	expectActiveByte(t, mux, firstEcho)
+
+	mux.stateMu.Lock()
+	if got := mux.gatewayEcho.matchCount(); got != 1 {
+		t.Fatalf("matchCount after first echo = %d; want 1", got)
+	}
+	if got := mux.gatewayEcho.writeCount(); got != 1 {
+		t.Fatalf("writeCount after first echo = %d; want 1", got)
+	}
+	if head, pending := mux.gatewayEcho.peekNextExpected(); pending {
+		t.Fatalf("peekNextExpected after first echo = (0x%02X,true); want no pending echo", head)
+	}
+	mux.stateMu.Unlock()
+
+	if _, err := at.Write([]byte{secondEcho}); err != nil {
+		t.Fatalf("Write(0x%02X) err=%v", secondEcho, err)
+	}
+
+	mux.stateMu.Lock()
+	if got := mux.gatewayEcho.matchCount(); got != 1 {
+		t.Fatalf("matchCount after second write = %d; want 1", got)
+	}
+	if got := mux.gatewayEcho.writeCount(); got != 2 {
+		t.Fatalf("writeCount after second write = %d; want 2", got)
+	}
+	if head, pending := mux.gatewayEcho.peekNextExpected(); !pending || head != secondEcho {
+		t.Fatalf("peekNextExpected = (0x%02X,%v); want (0x%02X,true)", head, pending, secondEcho)
+	}
+	mux.stateMu.Unlock()
+
+	beforeReadPrefix := len(mux.ActiveTxnSnapshot().ReadPrefix)
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: foreignMaster}
+	waitForReadPrefixLen(t, mux, beforeReadPrefix+1)
+
+	expectNoActiveByte(t, mux)
+	if mux.activeTxn.firstByteSuspectArbLoss.Load() {
+		t.Fatal("firstByteSuspectArbLoss=true after post-first-echo stale byte; want false")
+	}
+}
+
+func TestMux_ArbitrationRevalidate_DoesNotFireOnNonMasterNoise(t *testing.T) {
+	const (
+		expectedEcho   byte = 0x15
+		nonMasterNoise byte = 0x55
+	)
+	if got := protocol.AddressClassOf(nonMasterNoise); got == protocol.AddressClassMaster {
+		t.Fatalf("test premise broken: AddressClassOf(0x%02X) = master; want non-master", nonMasterNoise)
+	}
+
+	mux, mock, _, cleanup := newP3TestMux(t)
+	defer cleanup()
+
+	grantGateway(t, mux, mock, 0x71)
+	at := mux.ActiveTransport()
+
+	if _, err := at.Write([]byte{expectedEcho}); err != nil {
+		t.Fatalf("Write(0x%02X) err=%v", expectedEcho, err)
+	}
+
+	mux.stateMu.Lock()
+	if got := mux.gatewayEcho.matchCount(); got != 0 {
+		t.Fatalf("matchCount after first write = %d; want 0", got)
+	}
+	if got := mux.gatewayEcho.writeCount(); got != 1 {
+		t.Fatalf("writeCount after first write = %d; want 1", got)
+	}
+	if head, pending := mux.gatewayEcho.peekNextExpected(); !pending || head != expectedEcho {
+		t.Fatalf("peekNextExpected = (0x%02X,%v); want (0x%02X,true)", head, pending, expectedEcho)
+	}
+	mux.stateMu.Unlock()
+
+	beforeReadPrefix := len(mux.ActiveTxnSnapshot().ReadPrefix)
+	mock.eventCh <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: nonMasterNoise}
+	waitForReadPrefixLen(t, mux, beforeReadPrefix+1)
+
+	expectNoActiveByte(t, mux)
+	if mux.activeTxn.firstByteSuspectArbLoss.Load() {
+		t.Fatal("firstByteSuspectArbLoss=true after non-master noise; want false")
+	}
+}
+
+func expectActiveByte(t *testing.T, mux *Mux, want byte) {
+	t.Helper()
+	select {
+	case ev := <-mux.activeCh:
+		if ev.kind != activeEventByte {
+			t.Fatalf("activeCh event kind = %d; want byte", ev.kind)
+		}
+		if ev.b != want {
+			t.Fatalf("activeCh byte = 0x%02X; want 0x%02X", ev.b, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timeout waiting for activeCh byte 0x%02X", want)
+	}
+}
+
+func expectNoActiveByte(t *testing.T, mux *Mux) {
+	t.Helper()
+	select {
+	case ev := <-mux.activeCh:
+		t.Fatalf("unexpected activeCh event: kind=%d byte=0x%02X err=%v", ev.kind, ev.b, ev.err)
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+func waitForReadPrefixLen(t *testing.T, mux *Mux, want int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if got := len(mux.ActiveTxnSnapshot().ReadPrefix); got >= want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("readPrefix length did not reach %d within timeout", want)
+}

--- a/internal/adaptermux/f_new_29_arbitration_revalidate_test.go
+++ b/internal/adaptermux/f_new_29_arbitration_revalidate_test.go
@@ -14,7 +14,7 @@ func TestMux_ArbitrationRevalidate_ForwardsFirstForeignMasterByte(t *testing.T) 
 		foreignMaster byte = 0xF1
 	)
 	if got := protocol.AddressClassOf(foreignMaster); got != protocol.AddressClassMaster {
-		t.Fatalf("test premise broken: AddressClassOf(0x%02X) = %v; want master", foreignMaster, got)
+		t.Fatalf("test premise broken: AddressClassOf(0x%02X) = %v; want initiator class", foreignMaster, got)
 	}
 
 	mux, mock, _, cleanup := newP3TestMux(t)
@@ -43,7 +43,7 @@ func TestMux_ArbitrationRevalidate_ForwardsFirstForeignMasterByte(t *testing.T) 
 	expectActiveByte(t, mux, foreignMaster)
 
 	if !mux.activeTxn.firstByteSuspectArbLoss.Load() {
-		t.Fatal("firstByteSuspectArbLoss=false; want true after first foreign master byte")
+		t.Fatal("firstByteSuspectArbLoss=false; want true after first foreign initiator byte")
 	}
 }
 
@@ -54,7 +54,7 @@ func TestMux_AfterFirstEchoMatch_StaleByteStillDropped(t *testing.T) {
 		foreignMaster byte = 0xF1
 	)
 	if got := protocol.AddressClassOf(foreignMaster); got != protocol.AddressClassMaster {
-		t.Fatalf("test premise broken: AddressClassOf(0x%02X) = %v; want master", foreignMaster, got)
+		t.Fatalf("test premise broken: AddressClassOf(0x%02X) = %v; want initiator class", foreignMaster, got)
 	}
 
 	mux, mock, _, cleanup := newP3TestMux(t)
@@ -113,7 +113,7 @@ func TestMux_ArbitrationRevalidate_DoesNotFireOnNonMasterNoise(t *testing.T) {
 		nonMasterNoise byte = 0x55
 	)
 	if got := protocol.AddressClassOf(nonMasterNoise); got == protocol.AddressClassMaster {
-		t.Fatalf("test premise broken: AddressClassOf(0x%02X) = master; want non-master", nonMasterNoise)
+		t.Fatalf("test premise broken: AddressClassOf(0x%02X) = initiator class; want non-initiator class", nonMasterNoise)
 	}
 
 	mux, mock, _, cleanup := newP3TestMux(t)
@@ -144,7 +144,7 @@ func TestMux_ArbitrationRevalidate_DoesNotFireOnNonMasterNoise(t *testing.T) {
 
 	expectNoActiveByte(t, mux)
 	if mux.activeTxn.firstByteSuspectArbLoss.Load() {
-		t.Fatal("firstByteSuspectArbLoss=true after non-master noise; want false")
+		t.Fatal("firstByteSuspectArbLoss=true after non-initiator noise; want false")
 	}
 }
 

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -2311,8 +2311,33 @@ func (m *Mux) onReceived(symbol byte, wasEscaped bool) {
 	// writePrefix as the gate but those are capped diagnostic state;
 	// P11 round-2 uses gatewayEcho's pre-match queue head, which is
 	// protocol-accurate and uncapped.
+	//
+	// F-NEW-29 (2026-05-23, plan fix-p11-midwrite-byte-routing-w21-26):
+	// First-byte arbitration revalidation. When the gateway has just been
+	// granted arbitration (matchCount==0 && writeCount==1) and the very
+	// first wire byte we observe is a foreign initiator-class address that
+	// doesn't match our expected echo, the arbitration grant was a
+	// false-positive: another initiator actually has the bus. Forward the
+	// byte to activeCh (do NOT drop) so bus.go's existing first-byte-
+	// after-arbitration classifier (helianthus-ebusgo bus.go:1328-1378)
+	// can raise ErrBusCollision and sendWithRetries can retry naturally.
+	//
+	// Strict P11 mid-write drop remains active for ALL other mismatches:
+	// mid-frame stale bytes, non-initiator-class noise, post-first-echo wire
+	// intrusions. P11 round-2's design intent is preserved after ownership
+	// is validated by at least one echo.
+	firstByteSuspectArbLoss := false
+	if hadPendingEcho &&
+		m.gatewayEcho.matchCount() == 0 &&
+		m.gatewayEcho.writeCount() == 1 &&
+		symbol != preMatchHead &&
+		protocol.AddressClassOf(symbol) == protocol.AddressClassMaster {
+		firstByteSuspectArbLoss = true
+		m.activeTxn.firstByteSuspectArbLoss.Store(true)
+	}
+
 	activeExpects := m.gatewayTxnActive
-	if activeExpects && hadPendingEcho {
+	if activeExpects && hadPendingEcho && !firstByteSuspectArbLoss {
 		// Mid-write: only the next expected echo passes.
 		activeExpects = symbol == preMatchHead
 	}


### PR DESCRIPTION
Closes the semantic-layer recovery-time regression on production HA host. Pre-fix: ~9 hours to self-recover from contended-bus addon restart. Target: <60s.

Plan: [helianthus-execution-plans#30](https://github.com/Project-Helianthus/helianthus-execution-plans/issues/30) — `fix-p11-midwrite-byte-routing-w21-26.locked` (LOCKED 2026-05-23, canonical SHA `ddd1786c...`)

## Failure mode (Mode A)

`writes=1 echoLike=0 nonEcho=22 readPrefix=F1 15 B5 24 06 02 00 03`

After `StreamEventStarted data=0x7F` (gateway "wins" arbitration), the FIRST wire byte is a foreign Vaillant internal initiator's frame (`0xF1`). The P11 round-2 gate at `mux.go:2315-2317` (commit a35b51d1, 2026-05-10) drops it. `helianthus-ebusgo` `bus.go:1328-1378` first-byte-after-arbitration classifier never sees the byte → no `ErrBusCollision` → no `sendWithRetries` retry → 2s `active_read_timeout`. Discovery loop retries the same candidate every ~3 min for hours.

## Fix

Refined Direction C — event-driven first-byte arbitration revalidation with **forward-not-drop** semantics:

\`\`\`go
firstByteSuspectArbLoss := false
if hadPendingEcho &&
    m.gatewayEcho.matchCount() == 0 &&
    m.gatewayEcho.writeCount() == 1 &&
    symbol != preMatchHead &&
    protocol.AddressClassOf(symbol) == protocol.AddressClassMaster {
    firstByteSuspectArbLoss = true
    m.activeTxn.firstByteSuspectArbLoss.Store(true)
}

activeExpects := m.gatewayTxnActive
if activeExpects && hadPendingEcho && !firstByteSuspectArbLoss {
    activeExpects = symbol == preMatchHead   // P11 strict drop preserved
}
\`\`\`

When the predicate fires: byte flows to \`activeCh\` → \`bus.go:1328-1378\` raises \`ErrBusCollision\` → \`sendWithRetries\` retries cleanly.

P11 round-2's strict drop is **preserved unchanged** for all other mismatches (mid-frame, post-first-echo, non-master-class noise).

## Adversarial convergence

- **Codex R1** (gpt-5.5): recommended Direction C.
- **Fresh Opus R1** (angry-tester): identified Mode A vs Mode B failure split + matchWouldHit cascade interaction.
- **Fresh Opus R2 vs Codex R1**: pushed predicate to include \`AddressClassMaster\` + \`matchCount==0\` + \`writeCount==1\`; forward-not-drop (not synthetic \`ErrBusCollision\` side channel).

## Verification

- ✅ TDD strict: 3 RED tests committed first (build-failure RED state), then GREEN after impl.
- ✅ All 3 new tests pass: \`TestMux_ArbitrationRevalidate_ForwardsFirstForeignMasterByte\`, \`TestMux_AfterFirstEchoMatch_StaleByteStillDropped\`, \`TestMux_ArbitrationRevalidate_DoesNotFireOnNonMasterNoise\`.
- ✅ Full \`go test ./internal/adaptermux/...\` passes (110.3s).
- ✅ \`v8classifier\` suite passes (0.8s).
- ✅ Transport-gate AD path: unit-test evidence for AD01-AD12 via adaptermux suite.

## Mode B out of scope

A second failure mode (\`writes=11 echoLike=8 nonEcho=68\` — full frame written, late-frame echo loss + response phase fail) is tracked separately (will be a follow-up cruise plan).

## Test plan (live verification — M4)

- [ ] Deploy via addon bump (v0.6.27 — separate PR after this merges).
- [ ] Within 60s of addon restart, all 12 MCP semantic planes return non-null.
- [ ] \`discoverB524Root: address=0x15\` within 60s of \`RequestStart\`.
- [ ] \`round9_absorb_entered_total\` slope = 0/min (90-min stress).
- [ ] \`post_grant_ack\` rate ≤ 10 events/hour absolute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)