### PR TITLE
Publish empty FM5 planes during startup

### DIFF
--- a/cmd/gateway/semantic_provider.go
+++ b/cmd/gateway/semantic_provider.go
@@ -133,7 +133,7 @@ func (adapter mcpSemanticProviderAdapter) RadioDevices() []mcp.RadioDevice {
 		return nil
 	}
 	devices := adapter.provider.RadioDevices()
-	if len(devices) == 0 {
+	if devices == nil {
 		return nil
 	}
 	out := make([]mcp.RadioDevice, len(devices))
@@ -197,7 +197,7 @@ func (adapter mcpSemanticProviderAdapter) Cylinders() []mcp.CylinderStatus {
 		return nil
 	}
 	cylinders := adapter.provider.Cylinders()
-	if len(cylinders) == 0 {
+	if cylinders == nil {
 		return nil
 	}
 	out := make([]mcp.CylinderStatus, len(cylinders))

--- a/cmd/gateway/semantic_provider_test.go
+++ b/cmd/gateway/semantic_provider_test.go
@@ -45,6 +45,44 @@ func TestSemanticEnergyAdaptersExposeNeverSeenShapeWithoutPoints(t *testing.T) {
 	}
 }
 
+func TestMCPSemanticProviderAdapterPreservesEmptyCylinders(t *testing.T) {
+	provider := graphql.NewLiveSemanticProvider()
+	adapter := mcpSemanticProviderAdapter{provider: provider}
+
+	if got := adapter.Cylinders(); got != nil {
+		t.Fatalf("Cylinders() before publish = %#v; want nil", got)
+	}
+
+	provider.SetCylinders([]graphql.CylinderStatus{})
+	if got := adapter.Cylinders(); got == nil || len(got) != 0 {
+		t.Fatalf("Cylinders() after empty publish = %#v; want empty non-nil slice", got)
+	}
+
+	provider.SetCylinders(nil)
+	if got := adapter.Cylinders(); got != nil {
+		t.Fatalf("Cylinders() after nil publish = %#v; want nil", got)
+	}
+}
+
+func TestMCPSemanticProviderAdapterPreservesEmptyRadioDevices(t *testing.T) {
+	provider := graphql.NewLiveSemanticProvider()
+	adapter := mcpSemanticProviderAdapter{provider: provider}
+
+	if got := adapter.RadioDevices(); got != nil {
+		t.Fatalf("RadioDevices() before publish = %#v; want nil", got)
+	}
+
+	provider.SetRadioDevices([]graphql.RadioDevice{})
+	if got := adapter.RadioDevices(); got == nil || len(got) != 0 {
+		t.Fatalf("RadioDevices() after empty publish = %#v; want empty non-nil slice", got)
+	}
+
+	provider.SetRadioDevices(nil)
+	if got := adapter.RadioDevices(); got != nil {
+		t.Fatalf("RadioDevices() after nil publish = %#v; want nil", got)
+	}
+}
+
 type recordingSemanticWriter struct {
 	calls int
 }

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -1404,8 +1404,18 @@ func (p *vaillantSemanticPoller) startupL1PrimingStatus() startupL1PrimingStatus
 	fm5Required := fm5Evidence && moduleConfig != nil && *moduleConfig <= 2
 	zonesReady := len(p.provider.Zones()) > 0
 	solarReady := p.provider.Solar() != nil
-	cylindersReady := len(p.provider.Cylinders()) > 0
-	fm5Satisfied := !fm5Evidence || (fm5GateKnown && !fm5Required) || (fm5Required && solarReady && cylindersReady)
+	cylinders := p.provider.Cylinders()
+	cylindersPublished := cylinders != nil
+	interpretedCylindersReady := len(cylinders) > 0
+	fm5Mode := p.provider.FM5SemanticMode()
+	fm5NonInterpretedPublished := fm5Evidence &&
+		fm5Mode == graphql.Fm5SemanticModeGPIOOnly &&
+		solarReady &&
+		cylindersPublished
+	fm5Satisfied := !fm5Evidence ||
+		fm5NonInterpretedPublished ||
+		(fm5GateKnown && !fm5Required) ||
+		(fm5Required && solarReady && interpretedCylindersReady)
 	return startupL1PrimingStatus{
 		zones:        zonesReady,
 		dhw:          p.provider.DHW() != nil,
@@ -1417,7 +1427,7 @@ func (p *vaillantSemanticPoller) startupL1PrimingStatus() startupL1PrimingStatus
 		fm5Required:  fm5Required,
 		fm5Satisfied: fm5Satisfied,
 		solar:        solarReady,
-		cylinders:    cylindersReady,
+		cylinders:    cylindersPublished,
 		boilerStatus: p.provider.BoilerStatus() != nil,
 	}
 }
@@ -1432,7 +1442,7 @@ func (p *vaillantSemanticPoller) startupProbeContext(ctx context.Context) (conte
 func (p *vaillantSemanticPoller) readB524Startup(ctx context.Context, opcode, group, instance byte, addr uint16) ([]byte, bool) {
 	probeCtx, cancel := p.startupProbeContext(ctx)
 	defer cancel()
-	return p.readB524Value(probeCtx, opcode, group, instance, addr)
+	return p.readB524ValueLive(probeCtx, opcode, group, instance, addr)
 }
 
 func (p *vaillantSemanticPoller) readB524Uint16Startup(ctx context.Context, opcode, group, instance byte, addr uint16) (*uint16, bool) {
@@ -4872,13 +4882,15 @@ func (p *vaillantSemanticPoller) publishFM5Semantic(source semanticSnapshotSourc
 	}
 
 	if mode != graphql.Fm5SemanticModeInterpreted {
+		emptySolar := &graphql.SolarStatus{}
+		emptyCylinders := []graphql.CylinderStatus{}
 		switch source {
 		case semanticSnapshotSourceCache:
-			p.provider.SetSolarFromCache(nil)
-			p.provider.SetCylindersFromCache(nil)
+			p.provider.SetSolarFromCache(emptySolar)
+			p.provider.SetCylindersFromCache(emptyCylinders)
 		default:
-			p.provider.SetSolar(nil)
-			p.provider.SetCylinders(nil)
+			p.provider.SetSolar(emptySolar)
+			p.provider.SetCylinders(emptyCylinders)
 		}
 		p.publishCircuits(source)
 		return

--- a/cmd/gateway/semantic_vaillant_test.go
+++ b/cmd/gateway/semantic_vaillant_test.go
@@ -437,6 +437,44 @@ func TestParseB524ReadPayload(t *testing.T) {
 	}
 }
 
+func TestReadB524StartupUsesLivePathWithoutScheduler(t *testing.T) {
+	t.Parallel()
+
+	const (
+		opcode   = byte(0x02)
+		group    = byte(0x00)
+		instance = byte(0x00)
+		addr     = uint16(0x0036)
+	)
+
+	calls := 0
+	poller := &vaillantSemanticPoller{
+		sendFrameFn: func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+			calls++
+			if !slices.Equal(frame.Data, buildB524ReadSelector(opcode, group, instance, addr)) {
+				t.Fatalf("request selector = % x; want B524 selector", frame.Data)
+			}
+			return &protocol.Frame{
+				Data: []byte{0x01, instance, group, byte(addr), byte(addr >> 8), 0x02, 0x00},
+			}, nil
+		},
+		source:         0x7F,
+		controller:     0x15,
+		requestTimeout: 50 * time.Millisecond,
+	}
+
+	got, ok := poller.readB524Startup(context.Background(), opcode, group, instance, addr)
+	if !ok {
+		t.Fatal("readB524Startup() ok = false; want live direct read success")
+	}
+	if !slices.Equal(got, []byte{0x02, 0x00}) {
+		t.Fatalf("readB524Startup() = % x; want 02 00", got)
+	}
+	if calls != 1 {
+		t.Fatalf("send calls = %d; want 1", calls)
+	}
+}
+
 func TestParseB509ReadPayload(t *testing.T) {
 	t.Parallel()
 
@@ -3126,6 +3164,13 @@ func TestPublishFM5Semantic_DowngradeRehydratesCircuitOwnershipToUnknown(t *test
 	poller.mu.Unlock()
 	poller.publishFM5Semantic(semanticSnapshotSourceLive)
 
+	if provider.Solar() == nil {
+		t.Fatal("provider.Solar() = nil after GPIO-only FM5 publish; want empty non-null plane")
+	}
+	if cylinders := provider.Cylinders(); cylinders == nil || len(cylinders) != 0 {
+		t.Fatalf("provider.Cylinders() = %#v after GPIO-only FM5 publish; want empty non-null plane", cylinders)
+	}
+
 	status := provider.Circuits()
 	if len(status) != 1 {
 		t.Fatalf("provider.Circuits() = %d entries; want 1", len(status))
@@ -4988,6 +5033,80 @@ func TestStartupL1PrimingStatusRequiresFM5PlanesWhenInterpreted(t *testing.T) {
 	provider.SetCylinders([]graphql.CylinderStatus{{Index: 0}})
 	if status := poller.startupL1PrimingStatus(); !status.ready() {
 		t.Fatalf("startup status ready = false after interpreted FM5 planes; status=%s", status.String())
+	}
+}
+
+func TestStartupL1PrimingStatusRejectsEmptyInterpretedCylinders(t *testing.T) {
+	t.Parallel()
+
+	connected := true
+	provider := graphql.NewLiveSemanticProvider()
+	provider.SetZones([]graphql.Zone{{ID: "zone-1", Name: "Zone 1"}})
+	provider.SetDHW(&graphql.DhwStatus{})
+	provider.SetCircuits([]graphql.CircuitStatus{{Index: 0}})
+	provider.SetSystem(&graphql.SystemStatus{})
+	provider.SetRadioDevices([]graphql.RadioDevice{{
+		Group:           int(remoteFunctionalModules.group),
+		Instance:        0,
+		DeviceConnected: &connected,
+	}})
+	provider.SetFM5SemanticMode(graphql.Fm5SemanticModeInterpreted)
+	provider.SetSolar(&graphql.SolarStatus{})
+	provider.SetCylinders([]graphql.CylinderStatus{})
+	provider.SetBoilerStatus(&graphql.BoilerStatus{})
+
+	moduleConfig := uint16(1)
+	poller := &vaillantSemanticPoller{
+		provider: provider,
+		reg: newTestRegistry(
+			registry.DeviceInfo{Address: 0x26, Manufacturer: "Vaillant", DeviceID: "VR_71"},
+		),
+		system: &vaillantSystemSnapshot{ModuleConfigurationVR71: &moduleConfig},
+	}
+
+	status := poller.startupL1PrimingStatus()
+	if !status.cylinders {
+		t.Fatalf("interpreted empty cylinders status = %s; want published cylinders plane", status.String())
+	}
+	if status.fm5Satisfied {
+		t.Fatalf("interpreted empty cylinders status = %s; want FM5 unsatisfied until live cylinder evidence", status.String())
+	}
+	if status.ready() {
+		t.Fatalf("startup status ready = true with empty interpreted cylinders; status=%s", status.String())
+	}
+}
+
+func TestStartupL1PrimingStatusAcceptsPublishedGPIOOnlyFM5Planes(t *testing.T) {
+	t.Parallel()
+
+	connected := true
+	provider := graphql.NewLiveSemanticProvider()
+	provider.SetZones([]graphql.Zone{{ID: "zone-1", Name: "Zone 1"}})
+	provider.SetDHW(&graphql.DhwStatus{})
+	provider.SetCircuits([]graphql.CircuitStatus{{Index: 0}})
+	provider.SetSystem(&graphql.SystemStatus{})
+	provider.SetRadioDevices([]graphql.RadioDevice{{
+		Group:           int(remoteFunctionalModules.group),
+		Instance:        0,
+		DeviceConnected: &connected,
+	}})
+	provider.SetFM5SemanticMode(graphql.Fm5SemanticModeGPIOOnly)
+	provider.SetSolar(&graphql.SolarStatus{})
+	provider.SetCylinders([]graphql.CylinderStatus{})
+	provider.SetBoilerStatus(&graphql.BoilerStatus{})
+	poller := &vaillantSemanticPoller{
+		provider: provider,
+		reg: newTestRegistry(
+			registry.DeviceInfo{Address: 0x26, Manufacturer: "Vaillant", DeviceID: "VR_71"},
+		),
+	}
+
+	status := poller.startupL1PrimingStatus()
+	if !status.fm5Evidence || !status.fm5Satisfied {
+		t.Fatalf("GPIO-only FM5 status = %s; want evidence and satisfied", status.String())
+	}
+	if !status.ready() {
+		t.Fatalf("startup status ready = false for published GPIO-only FM5 planes; status=%s", status.String())
 	}
 }
 

--- a/graphql/semantic_live.go
+++ b/graphql/semantic_live.go
@@ -227,7 +227,7 @@ func (provider *LiveSemanticProvider) RadioDevices() []RadioDevice {
 	}
 	provider.mu.RLock()
 	defer provider.mu.RUnlock()
-	if len(provider.radio) == 0 {
+	if provider.radio == nil {
 		return nil
 	}
 	out := make([]RadioDevice, len(provider.radio))
@@ -264,7 +264,7 @@ func (provider *LiveSemanticProvider) Cylinders() []CylinderStatus {
 	}
 	provider.mu.RLock()
 	defer provider.mu.RUnlock()
-	if len(provider.cylinders) == 0 {
+	if provider.cylinders == nil {
 		return nil
 	}
 	return cloneCylinderStatuses(provider.cylinders)
@@ -305,7 +305,7 @@ func (provider *LiveSemanticProvider) SetCylinders(cylinders []CylinderStatus) {
 	}
 	provider.mu.Lock()
 	defer provider.mu.Unlock()
-	if len(cylinders) == 0 {
+	if cylinders == nil {
 		provider.cylinders = nil
 		return
 	}
@@ -489,14 +489,18 @@ func (provider *LiveSemanticProvider) setRadioDevicesWithSource(devices []RadioD
 		return
 	}
 
-	devicesCopy := make([]RadioDevice, len(devices))
-	for i, device := range devices {
-		devicesCopy[i] = cloneRadioDevice(device)
+	var devicesCopy []RadioDevice
+	if devices != nil {
+		devicesCopy = make([]RadioDevice, len(devices))
+		for i, device := range devices {
+			devicesCopy[i] = cloneRadioDevice(device)
+		}
 	}
 
 	var transition *phaseTransitionLog
 	provider.mu.Lock()
-	if equalRadioDevices(provider.radio, devicesCopy) {
+	samePublishedShape := (provider.radio == nil) == (devicesCopy == nil)
+	if samePublishedShape && equalRadioDevices(provider.radio, devicesCopy) {
 		if source == semanticDataSourceLive && len(devicesCopy) > 0 {
 			provider.radioLiveSeen = true
 		}
@@ -510,6 +514,8 @@ func (provider *LiveSemanticProvider) setRadioDevicesWithSource(devices []RadioD
 			provider.radioLiveSeen = true
 		}
 		transition = provider.recordEpochUpdateLocked(source, semanticStreamRadioDevices, reason)
+	} else if source == semanticDataSourceLive {
+		provider.radioLiveSeen = true
 	}
 	provider.mu.Unlock()
 	provider.logPhaseTransition(transition)
@@ -1344,7 +1350,7 @@ func cloneCylinderStatus(status CylinderStatus) CylinderStatus {
 }
 
 func cloneCylinderStatuses(cylinders []CylinderStatus) []CylinderStatus {
-	if len(cylinders) == 0 {
+	if cylinders == nil {
 		return nil
 	}
 	out := make([]CylinderStatus, len(cylinders))

--- a/graphql/semantic_live_test.go
+++ b/graphql/semantic_live_test.go
@@ -215,8 +215,17 @@ func TestLiveSemanticProvider_FM5SolarAndCylinders(t *testing.T) {
 	if provider.Solar() != nil {
 		t.Fatal("Solar() expected nil by default")
 	}
-	if len(provider.Cylinders()) != 0 {
-		t.Fatalf("Cylinders() len = %d; want 0", len(provider.Cylinders()))
+	if provider.Cylinders() != nil {
+		t.Fatalf("Cylinders() = %#v by default; want nil", provider.Cylinders())
+	}
+
+	provider.SetCylinders([]CylinderStatus{})
+	if cylinders := provider.Cylinders(); cylinders == nil || len(cylinders) != 0 {
+		t.Fatalf("Cylinders() after empty set = %#v; want empty non-nil slice", cylinders)
+	}
+	provider.SetCylinders(nil)
+	if provider.Cylinders() != nil {
+		t.Fatalf("Cylinders() after nil set = %#v; want nil", provider.Cylinders())
 	}
 
 	collector := 71.5
@@ -259,6 +268,24 @@ func TestLiveSemanticProvider_FM5SolarAndCylinders(t *testing.T) {
 	latestCylinders := provider.Cylinders()
 	if len(latestCylinders) != 1 || latestCylinders[0].TemperatureC == nil || *latestCylinders[0].TemperatureC != 48.0 {
 		t.Fatalf("provider cylinders mutated through getter: %#v", latestCylinders)
+	}
+}
+
+func TestLiveSemanticProvider_RadioDevicesPreservesEmptyPublication(t *testing.T) {
+	provider := NewLiveSemanticProvider()
+
+	if provider.RadioDevices() != nil {
+		t.Fatalf("RadioDevices() by default = %#v; want nil", provider.RadioDevices())
+	}
+
+	provider.SetRadioDevices([]RadioDevice{})
+	if devices := provider.RadioDevices(); devices == nil || len(devices) != 0 {
+		t.Fatalf("RadioDevices() after empty set = %#v; want empty non-nil slice", devices)
+	}
+
+	provider.SetRadioDevices(nil)
+	if provider.RadioDevices() != nil {
+		t.Fatalf("RadioDevices() after nil set = %#v; want nil", provider.RadioDevices())
 	}
 }
 

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -2434,7 +2434,7 @@ func cloneCircuitStatus(source CircuitStatus) CircuitStatus {
 }
 
 func cloneRadioDevices(source []RadioDevice) []RadioDevice {
-	if len(source) == 0 {
+	if source == nil {
 		return nil
 	}
 	out := make([]RadioDevice, len(source))
@@ -2858,7 +2858,7 @@ func (s *Server) snapshotRadioDevices(snapshot *snapshotState) []RadioDevice {
 		return nil
 	}
 	devices := s.semantic.RadioDevices()
-	if len(devices) == 0 {
+	if devices == nil {
 		return nil
 	}
 	out := cloneRadioDevices(devices)
@@ -2916,7 +2916,7 @@ func (s *Server) snapshotCylinders(snapshot *snapshotState) []CylinderStatus {
 		return nil
 	}
 	cylinders := s.semantic.Cylinders()
-	if len(cylinders) == 0 {
+	if cylinders == nil {
 		return nil
 	}
 	out := cloneCylinders(cylinders)
@@ -3294,7 +3294,7 @@ func cloneCylinder(status CylinderStatus) CylinderStatus {
 }
 
 func cloneCylinders(values []CylinderStatus) []CylinderStatus {
-	if len(values) == 0 {
+	if values == nil {
 		return nil
 	}
 	out := make([]CylinderStatus, len(values))

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -297,7 +297,7 @@ func (p testSemanticProvider) RadioDevices() []RadioDevice {
 	if p.radioDelay > 0 {
 		time.Sleep(p.radioDelay)
 	}
-	if len(p.radio) == 0 {
+	if p.radio == nil {
 		return nil
 	}
 	return cloneRadioDevices(p.radio)
@@ -1227,6 +1227,27 @@ func TestServer_ToolsCallSemanticSnapshots(t *testing.T) {
 		}
 	})
 
+	t.Run("radio empty payload", func(t *testing.T) {
+		emptyServer, err := NewServer(reg, &testInvoker{})
+		if err != nil {
+			t.Fatalf("NewServer error = %v", err)
+		}
+		emptyServer.SetSemanticProvider(testSemanticProvider{
+			radio: []RadioDevice{},
+		})
+		res := doRPC(t, emptyServer.Handler(), rpcRequest{
+			JSONRPC: "2.0",
+			ID:      18,
+			Method:  "tools/call",
+			Params:  json.RawMessage(`{"name":"ebus.v1.semantic.radio_devices.get","arguments":{}}`),
+		})
+		envelope := envelopeFromResult(t, res)
+		data, ok := envelope["data"].([]any)
+		if !ok || len(data) != 0 {
+			t.Fatalf("empty radio data = %#v; want empty array", envelope["data"])
+		}
+	})
+
 	t.Run("fm5 mode payload", func(t *testing.T) {
 		res := doRPC(t, server.Handler(), rpcRequest{
 			JSONRPC: "2.0",
@@ -1276,6 +1297,27 @@ func TestServer_ToolsCallSemanticSnapshots(t *testing.T) {
 		first, _ := data[0].(map[string]any)
 		if idx, _ := first["index"].(float64); int(idx) != 0 {
 			t.Fatalf("first cylinder index = %v; want 0", first["index"])
+		}
+	})
+
+	t.Run("cylinders empty payload", func(t *testing.T) {
+		emptyServer, err := NewServer(reg, &testInvoker{})
+		if err != nil {
+			t.Fatalf("NewServer error = %v", err)
+		}
+		emptyServer.SetSemanticProvider(testSemanticProvider{
+			cylinders: []CylinderStatus{},
+		})
+		res := doRPC(t, emptyServer.Handler(), rpcRequest{
+			JSONRPC: "2.0",
+			ID:      25,
+			Method:  "tools/call",
+			Params:  json.RawMessage(`{"name":"ebus.v1.semantic.cylinders.get","arguments":{}}`),
+		})
+		envelope := envelopeFromResult(t, res)
+		data, ok := envelope["data"].([]any)
+		if !ok || len(data) != 0 {
+			t.Fatalf("empty cylinders data = %#v; want empty array", envelope["data"])
 		}
 	})
 


### PR DESCRIPTION
## What
Publish non-null empty FM5-dependent semantic planes when FM5 is absent/GPIO-only instead of leaving `solar` and `cylinders` unknown/null, and preserve nil-vs-empty cylinders through GraphQL, the gateway MCP adapter, and MCP snapshots.

## Why
A real v0.6.28 image cold-start failed M4 O1 with `solar` and `cylinders` null after FM5 evidence was present but FM5 interpretation was gated. The local override with this patch passes the startup proof without inventing interpreted solar/cylinder values: empty means known absent/non-interpreted, nil remains unknown/unpublished.

## Evidence
- Failure artifact: `_work_adaptermux_audit/v8-enforce-stress/m4-verification/20260523T123702Z_m4.txt` (real image v0.6.28, O1 10/12, solar/cylinders null)
- Live override proof: `_work_adaptermux_audit/v8-enforce-stress/m4-verification/20260523T125425Z_m4.txt`
  - O1: PASS, 12/12 MCP planes non-null within 46s
  - O2: PASS, B524 root discovery within 49s
  - add-on logs: `Starting Helianthus gateway` and override at 2026-05-23 15:54:23 Europe/Bucharest; `semantic_startup_l1_priming result=ready` at 15:55:11 (48s from gateway start)

## Tests
- `go test ./cmd/gateway -count=1`
- `go test ./mcp ./graphql -count=1`
- `go test -race ./internal/adaptermux -run TestF24_DeferralLatchClearedOnClose -count=1 -timeout 60s`
- Focused startup/FM5 tests in `cmd/gateway`, plus MCP/GraphQL nil-vs-empty regressions

## Doc Gate
Docs PR already exists for the startup L1 priming gate (#312). A follow-up docs PR will note the empty-plane semantics for non-interpreted FM5.