### PR TITLE
fix(gateway): release startup semantic L1 before enrichment

### DIFF
--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -186,6 +186,7 @@ const (
 	semanticStartupProbeTimeout        = 900 * time.Millisecond
 	semanticStartupSlotFastMaxInstance = byte(0x02)
 	semanticStartupSlotFullMaxInstance = byte(0x0A)
+	semanticStartupCriticalDHWAttempts = 3
 )
 
 var (
@@ -1282,11 +1283,16 @@ func (p *vaillantSemanticPoller) refreshStartupSemanticPlanes(ctx context.Contex
 	for {
 		attempts++
 		status := p.startupL1PrimingStatus()
+		if !status.dhw {
+			p.refreshDHWStartupUntilReady(primingCtx, 1)
+			status = p.startupL1PrimingStatus()
+		}
 		if !status.zones {
 			p.refreshZoneDiscovery(primingCtx, true)
+			status = p.startupL1PrimingStatus()
 		}
 		if !status.dhw {
-			p.refreshDHWStartup(primingCtx)
+			p.refreshDHWStartupUntilReady(primingCtx, 1)
 		}
 		if !status.system {
 			p.refreshSystemStartup(primingCtx)
@@ -1337,6 +1343,67 @@ func (p *vaillantSemanticPoller) refreshStartupSemanticPlanes(ctx context.Contex
 		case <-timer.C:
 		}
 	}
+}
+
+func (p *vaillantSemanticPoller) refreshStartupCriticalSemanticPlanes(ctx context.Context) {
+	if p == nil || p.provider == nil {
+		return
+	}
+
+	p.publishStartupSchedules()
+	status := p.startupL1PrimingStatus()
+	if !status.dhw {
+		p.refreshDHWStartupUntilReady(ctx, semanticStartupCriticalDHWAttempts)
+	}
+	status = p.startupL1PrimingStatus()
+	if !status.system {
+		p.refreshSystemStartup(ctx)
+	}
+	status = p.startupL1PrimingStatus()
+	if !status.boilerStatus {
+		p.refreshBoilerStatusStartup(ctx)
+	}
+}
+
+func (p *vaillantSemanticPoller) refreshDHWStartupUntilReady(ctx context.Context, attempts int) bool {
+	if p == nil {
+		return false
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if attempts <= 0 {
+		attempts = 1
+	}
+	for attempt := 0; attempt < attempts; attempt++ {
+		if p.startupL1PrimingStatus().dhw {
+			return true
+		}
+		p.refreshDHWStartup(ctx)
+		if p.startupL1PrimingStatus().dhw {
+			return true
+		}
+		if attempt == attempts-1 {
+			break
+		}
+		delay := semanticStartupPrimingRetryDelay
+		if delay <= 0 {
+			delay = 50 * time.Millisecond
+		}
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return false
+		case <-timer.C:
+		}
+	}
+	return p.startupL1PrimingStatus().dhw
 }
 
 type startupL1PrimingStatus struct {
@@ -2362,6 +2429,9 @@ func (p *vaillantSemanticPoller) refreshDiscovery(ctx context.Context) {
 	}
 	p.mu.Unlock()
 
+	if primeStartup {
+		p.refreshStartupCriticalSemanticPlanes(ctx)
+	}
 	p.refreshZoneDiscovery(ctx, primeStartup)
 	if primeStartup {
 		p.refreshStartupSemanticPlanes(ctx)

--- a/cmd/gateway/semantic_vaillant_test.go
+++ b/cmd/gateway/semantic_vaillant_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"encoding/binary"
+	"errors"
 	"fmt"
 	"math"
 	"slices"
@@ -472,6 +474,131 @@ func TestReadB524StartupUsesLivePathWithoutScheduler(t *testing.T) {
 	}
 	if calls != 1 {
 		t.Fatalf("send calls = %d; want 1", calls)
+	}
+}
+
+func TestRefreshDiscoveryPrimesDHWBeforeStartupZoneScan(t *testing.T) {
+	t.Parallel()
+
+	var selectors [][]byte
+	poller := &vaillantSemanticPoller{
+		provider:       graphql.NewLiveSemanticProvider(),
+		reg:            newTestRegistry(registry.DeviceInfo{Address: 0x15, Manufacturer: "Vaillant", DeviceID: "BASV"}),
+		tasks:          newSemanticTaskScheduler(),
+		zones:          make(map[byte]*vaillantZoneSnapshot),
+		presence:       make(map[byte]*zonePresenceRecord),
+		circuits:       make(map[byte]*vaillantCircuitSnapshot),
+		radioDevices:   make(map[radioDeviceKey]*vaillantRadioDeviceSnapshot),
+		solarCylinders: make(map[byte]*vaillantCylinderSnapshot),
+		source:         0x7F,
+		requestTimeout: 50 * time.Millisecond,
+		b524ProbeFn: func(ctx context.Context, target, opcode, group, instance byte, addr uint16) bool {
+			return target == 0x15
+		},
+	}
+	poller.sendFrameFn = func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+		if frame.Primary != vaillantExtRegisterPrimary || frame.Secondary != vaillantExtRegisterSecondary || len(frame.Data) != 6 {
+			return &protocol.Frame{Data: []byte{0x00}}, nil
+		}
+		selector := slices.Clone(frame.Data)
+		selectors = append(selectors, selector)
+		group := selector[2]
+		instance := selector[3]
+		addr := uint16(selector[4]) | uint16(selector[5])<<8
+		payload := []byte{0x00}
+		switch {
+		case group == localDHW.group && instance == dhwInstance && addr == dhw_current_temp:
+			payload = make([]byte, 4)
+			binary.LittleEndian.PutUint32(payload, math.Float32bits(48.5))
+		case group == localDHW.group && instance == dhwInstance && addr == dhw_operation_mode:
+			payload = []byte{0x01, 0x00}
+		case group == localZones.group && addr == zone_index:
+			payload = []byte{0xFF}
+		}
+		data := []byte{0x01, instance, group, byte(addr), byte(addr >> 8)}
+		data = append(data, payload...)
+		return &protocol.Frame{Data: data}, nil
+	}
+
+	poller.refreshDiscovery(context.Background())
+
+	if len(selectors) == 0 {
+		t.Fatal("refreshDiscovery sent no B524 startup reads")
+	}
+	first := selectors[0]
+	if first[2] != localDHW.group || first[3] != dhwInstance {
+		t.Fatalf("first startup selector = % x; want DHW before zone scan", first)
+	}
+	if dhw := poller.provider.DHW(); dhw == nil {
+		t.Fatal("provider.DHW() = nil; want critical DHW singleton primed during discovery")
+	}
+}
+
+func TestRefreshDiscoveryRetriesDHWBeforeStartupZoneScan(t *testing.T) {
+	t.Parallel()
+
+	dhwRequests := 0
+	zoneRequestsBeforeDHWSuccess := 0
+	dhwSawLiveResponse := false
+	poller := &vaillantSemanticPoller{
+		provider:       graphql.NewLiveSemanticProvider(),
+		reg:            newTestRegistry(registry.DeviceInfo{Address: 0x15, Manufacturer: "Vaillant", DeviceID: "BASV"}),
+		tasks:          newSemanticTaskScheduler(),
+		zones:          make(map[byte]*vaillantZoneSnapshot),
+		presence:       make(map[byte]*zonePresenceRecord),
+		circuits:       make(map[byte]*vaillantCircuitSnapshot),
+		radioDevices:   make(map[radioDeviceKey]*vaillantRadioDeviceSnapshot),
+		solarCylinders: make(map[byte]*vaillantCylinderSnapshot),
+		source:         0x7F,
+		requestTimeout: 50 * time.Millisecond,
+		b524ProbeFn: func(ctx context.Context, target, opcode, group, instance byte, addr uint16) bool {
+			return target == 0x15
+		},
+	}
+	poller.sendFrameFn = func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+		if frame.Primary != vaillantExtRegisterPrimary || frame.Secondary != vaillantExtRegisterSecondary || len(frame.Data) != 6 {
+			return &protocol.Frame{Data: []byte{0x00}}, nil
+		}
+		selector := frame.Data
+		group := selector[2]
+		instance := selector[3]
+		addr := uint16(selector[4]) | uint16(selector[5])<<8
+		if group == localZones.group && !dhwSawLiveResponse {
+			zoneRequestsBeforeDHWSuccess++
+		}
+		if group == localDHW.group {
+			dhwRequests++
+			if dhwRequests <= 2 {
+				return nil, errors.New("transient dhw startup miss")
+			}
+		}
+		payload := []byte{0x00}
+		switch {
+		case group == localDHW.group && instance == dhwInstance && addr == dhw_current_temp:
+			payload = make([]byte, 4)
+			binary.LittleEndian.PutUint32(payload, math.Float32bits(48.5))
+			dhwSawLiveResponse = true
+		case group == localDHW.group && instance == dhwInstance && addr == dhw_operation_mode:
+			payload = []byte{0x01, 0x00}
+			dhwSawLiveResponse = true
+		case group == localZones.group && addr == zone_index:
+			payload = []byte{0xFF}
+		}
+		data := []byte{0x01, instance, group, byte(addr), byte(addr >> 8)}
+		data = append(data, payload...)
+		return &protocol.Frame{Data: data}, nil
+	}
+
+	poller.refreshDiscovery(context.Background())
+
+	if dhwRequests < 4 {
+		t.Fatalf("DHW startup requests = %d; want retry after first probe pair fails", dhwRequests)
+	}
+	if zoneRequestsBeforeDHWSuccess != 0 {
+		t.Fatalf("zone requests before DHW live response = %d; want 0", zoneRequestsBeforeDHWSuccess)
+	}
+	if dhw := poller.provider.DHW(); dhw == nil {
+		t.Fatal("provider.DHW() = nil; want retry to prime DHW before startup zone scan")
 	}
 }
 

--- a/cmd/gateway/startup_scan.go
+++ b/cmd/gateway/startup_scan.go
@@ -339,7 +339,7 @@ const proxyObserveFirstStartupSource byte = 0xF7
 const startupScanMaxUnconfirmedPasses = 5
 
 var (
-	postStartupIdentityRetryDelay    = 5 * time.Second
+	postStartupIdentityRetryDelay    = 75 * time.Second
 	postStartupIdentityRetryAttempts = 3
 )
 
@@ -861,6 +861,12 @@ func startDiscoveryScanLoopWithClassifier(ctx context.Context, cfg ebusgateway.C
 			if confirmationSatisfied || confirmationFallbackExhausted {
 				restrictedConfirmationAfterRecoveryPending = false
 				directScanConfirmationRetries = 0
+			}
+
+			if sourceSelectionActiveAdmission && activeConfirmed {
+				signalActiveProbePassed()
+				signalSemanticBootstrapReady()
+				return
 			}
 
 			if confirmationPending && usedRestrictedTargets && !retryingFullRange && !fullRangeRecoveryAttempted &&

--- a/cmd/gateway/startup_scan_test.go
+++ b/cmd/gateway/startup_scan_test.go
@@ -169,6 +169,112 @@ func TestShouldStopSourceAdmissionScan(t *testing.T) {
 	}
 }
 
+func TestStartDiscoveryScanLoop_SourceSelectionActiveProbeReleasesSemanticBootstrap(t *testing.T) {
+	gateway, err := ebusgateway.New(context.Background(), ebusgateway.Config{
+		Transport: transport.NewLoopback(),
+	})
+	if err != nil {
+		t.Fatalf("gateway.New error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := gateway.Close(); err != nil {
+			t.Fatalf("gateway.Close error = %v", err)
+		}
+	})
+
+	origRegistryScanDirectedFn := registryScanDirectedFn
+	origProbeFn := startupScanB524ProbeFn
+	origLoopExitFn := startupScanLoopExitFn
+	origEnrichVaillantIdentityFn := enrichVaillantIdentityFn
+	origEnrichSerialsFromEbusdFn := enrichSerialsFromEbusdFn
+	origPostStartupIdentityRetryFn := postStartupIdentityRetryFn
+	t.Cleanup(func() {
+		registryScanDirectedFn = origRegistryScanDirectedFn
+		startupScanB524ProbeFn = origProbeFn
+		startupScanLoopExitFn = origLoopExitFn
+		enrichVaillantIdentityFn = origEnrichVaillantIdentityFn
+		enrichSerialsFromEbusdFn = origEnrichSerialsFromEbusdFn
+		postStartupIdentityRetryFn = origPostStartupIdentityRetryFn
+	})
+
+	var (
+		mu      sync.Mutex
+		scanRun int
+	)
+	registryScanDirectedFn = func(_ context.Context, _ registry.ScanBus, reg *registry.DeviceRegistry, _ byte, _ []byte) ([]registry.DeviceEntry, error) {
+		mu.Lock()
+		scanRun++
+		mu.Unlock()
+		entry := reg.Register(registry.DeviceInfo{
+			Address:      0x15,
+			Manufacturer: "Vaillant",
+			DeviceID:     "BASV2",
+		})
+		return []registry.DeviceEntry{entry}, nil
+	}
+	startupScanB524ProbeFn = func(context.Context, byte, byte, byte, byte, uint16) bool {
+		return false
+	}
+	loopExited := make(chan struct{}, 1)
+	startupScanLoopExitFn = func() {
+		select {
+		case loopExited <- struct{}{}:
+		default:
+		}
+	}
+	enrichVaillantIdentityFn = func(context.Context, *ebusgateway.Gateway, ebusgateway.Config) {}
+	enrichSerialsFromEbusdFn = func(context.Context, *registry.DeviceRegistry, ebusgateway.TransportConfig) {}
+	postStartupIdentityRetryFn = func(context.Context, *ebusgateway.Gateway, *graphql.Builder, ebusgateway.Config, *ebusgateway.TransportConfig) {
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := ebusgateway.DefaultConfig()
+	cfg.ScanOnStart = true
+	cfg.ScanInterval = time.Hour
+	cfg.ScanSource = 0x7F
+	cfg.ScanSourceAuto = false
+	cfg.StartupCompanionTarget = 0x84
+	cfg.StartupProbeTargets = []byte{0x04, 0x08, 0x26}
+	cfg.TransportConfig.Protocol = ebusgateway.TransportENS
+	cfg.TransportConfig.Network = "tcp"
+	cfg.TransportConfig.Address = "127.0.0.1:19001"
+
+	signals := startDiscoveryScanLoop(ctx, cfg, gateway, nil)
+
+	select {
+	case <-signals.activeProbePassed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("activeProbePassed was not signaled from source-selection active evidence")
+	}
+	select {
+	case <-signals.semanticBootstrapReady:
+	case <-time.After(2 * time.Second):
+		t.Fatal("semanticBootstrapReady was not released with active source evidence")
+	}
+	select {
+	case <-loopExited:
+	case <-time.After(2 * time.Second):
+		t.Fatal("scan loop did not exit after source-selection active evidence")
+	}
+
+	mu.Lock()
+	gotScanRun := scanRun
+	mu.Unlock()
+	if gotScanRun != 1 {
+		t.Fatalf("directed scan runs = %d; want 1 before semantic bootstrap release", gotScanRun)
+	}
+}
+
+func TestPostStartupIdentityRetryDefaultDoesNotCompeteWithStartupL1(t *testing.T) {
+	t.Parallel()
+
+	if postStartupIdentityRetryDelay < 60*time.Second {
+		t.Fatalf("postStartupIdentityRetryDelay = %s; want >=60s so physical serial enrichment cannot consume the L1 startup window", postStartupIdentityRetryDelay)
+	}
+}
+
 func TestShouldRetryDiscoveryWithFullRange(t *testing.T) {
 	origProbeFn := startupScanB524ProbeFn
 	t.Cleanup(func() { startupScanB524ProbeFn = origProbeFn })


### PR DESCRIPTION
## What
Release the startup semantic L1 path before non-L1 identity enrichment work and make DHW singleton startup priming resilient to a transient first miss.

## Why
The v0.6.29 clean real-image M4 startup run failed O1 with DHW null at 60s. A first local override fixed DHW but exposed another startup scheduling issue: startup scan delayed serial enrichment and source-selection/root-confirmation work consumed the L1 window before semantic priming could complete.

This keeps protocol/bus.Send behavior unchanged. It only changes startup ordering around semantic bootstrap and non-L1 physical identity enrichment.

## Changes
- Prime DHW before the startup zone sweep and retry the critical DHW singleton path up to 3 times before heavy startup work.
- Release source-selection semantic bootstrap as soon as active source evidence exists, instead of waiting behind root-confirmation/full-range recovery work.
- Move delayed physical serial enrichment retry to 75s so it cannot consume the 60s semantic L1 window.
- Add regressions for DHW-before-zone ordering, DHW transient retry, source-selection bootstrap release, and delayed enrichment timing.

## Evidence
- `go test ./cmd/gateway -count=1`
- `go test ./internal/adaptermux -count=1`
- ARM64 override SHA: `dbf4e2cb5714f5edd69f431d7fee94c52d97be547363c86b090122151769f091`
- Clean override M4 report: `_work_adaptermux_audit/v8-enforce-stress/m4-verification/20260523T150427Z_m4.txt`
  - O1: PASS, 12/12 planes in 48s
  - O2: PASS, `semantic_b524_root_discovery address=0x15` at 2026-05-23 18:04:36 local

## Doc gate
Required: startup semantic/bootstrap ordering changed. Companion docs PR will document the L1 startup ordering contract and identity-enrichment deferral.

## Acceptance Criteria
- [x] Unit tests cover implemented code
- [x] Adaptermux tests pass
- [x] Live override M4 O1/O2 pass
- [ ] CI green
- [ ] Docs PR merged


Companion docs: Project-Helianthus/helianthus-docs-ebus#315

