### PR TITLE
fix(adaptermux): preserve fairness on idle contention

### DIFF
--- a/internal/adaptermux/arbitration.go
+++ b/internal/adaptermux/arbitration.go
@@ -445,9 +445,13 @@ func (a *arbitrator) cancelStart(sessionID uint64) bool {
 // holding an external pending START in the queue until a fairness
 // quantum elapses only wastes wall-clock that ebusd's local
 // arbitration deadline counts against the gateway. When busIdle is
-// true and external is pending, this function grants the external
-// FIFO head immediately and does NOT advance the fairness counter.
-// (Proxy-bug C1 / R1.)
+// true, external is pending, and the gateway is NOT pending, this
+// function grants the external FIFO head immediately and does NOT
+// advance the fairness counter. If both classes are pending, the
+// situation is real mux contention even if the wire is currently
+// between frames; F-25 fairness must still rotate the grant or a
+// continuous external scanner can hold the gateway near zero until it
+// stops. (Proxy-bug C1 / R1, bounded by F-25.)
 //
 // Ownership is NOT set here — the caller MUST call confirmOwnership
 // after the adapter's StartArbitration succeeds (Codex P1 #3060199707:
@@ -478,12 +482,12 @@ func (a *arbitrator) tryGrant(busIdle bool) (req *startRequest, granted bool) {
 	externalPending := len(a.pendingExternal) > 0
 
 	// Bus-idle fast path: grant external immediately and skip the
-	// fairness rotation entirely. The bus is wide open, so there's
-	// no reason to defer external for a fairness quantum. Gateway
-	// would also be granted on the next tryGrant invocation if it
-	// has any pending work (caller invokes tryGrantAndStart on every
-	// SYN boundary). (Proxy-bug C1 / R1.)
-	if busIdle && externalPending {
+	// fairness rotation entirely only when gateway is not also
+	// bidding. The bus is wide open and no gateway contender exists,
+	// so there is no fairness decision to make. When gatewayPending is
+	// true, this is a contended mux decision and must fall through to
+	// the normal F-25 rotation. (Proxy-bug C1 / R1 bounded by F-25.)
+	if busIdle && externalPending && !gatewayPending {
 		ext := a.pendingExternal[0]
 		a.pendingExternal = a.pendingExternal[1:]
 		return ext, true

--- a/internal/adaptermux/arbitration_busidle_test.go
+++ b/internal/adaptermux/arbitration_busidle_test.go
@@ -6,19 +6,18 @@ import (
 	"time"
 )
 
-// TestTryGrant_BusIdle_ExternalPreemptsFairnessWindow pins proxy-bug
-// C1 (R1): when both gateway and external are pending AND the wire
-// has been idle for at least one SYN interval, tryGrant must grant
-// external FIRST without advancing the fairness counter — on an
-// uncontended bus, the fairness rotation is wasted wall-clock that
-// ebusd's local arbitration deadline (~50 ms) counts against the
-// gateway, even when no contention exists.
-func TestTryGrant_BusIdle_ExternalPreemptsFairnessWindow(t *testing.T) {
+// TestTryGrant_BusIdle_ExternalOnlyUsesFastPath pins proxy-bug C1
+// (R1): when external is pending, gateway is not pending, and the wire
+// has been idle for at least one SYN interval, tryGrant grants external
+// immediately without advancing the fairness counter. With no gateway
+// contender there is no F-25 fairness decision to make, and waiting for
+// the SYN-driven grant rhythm wastes ebusd's local arbitration budget.
+func TestTryGrant_BusIdle_ExternalOnlyUsesFastPath(t *testing.T) {
 	arb := newArbitrator()
 	arb.setPolicy(24*time.Hour, 0, 0) // disable C3 TTL for this test
 
-	// Both classes pending — same shape as the legacy fairness test.
-	_ = arb.requestStart(gatewaySessionID, 0x71)
+	// Only external is pending. If gateway also has a request, the
+	// F-25 contention rotation must decide the grant instead.
 	_ = arb.requestStart(1, 0x31)
 
 	priorCounter := arb.fairnessCounter
@@ -34,7 +33,7 @@ func TestTryGrant_BusIdle_ExternalPreemptsFairnessWindow(t *testing.T) {
 		t.Fatalf("idle-bus fast path: granted initiator 0x%02X, want 0x31", req.initiator)
 	}
 	if got := arb.fairnessCounter; got != priorCounter {
-		t.Fatalf("fairness counter advanced (%d → %d) on idle-bus fast path; must NOT — fast path is not a contention rotation",
+		t.Fatalf("fairness counter advanced (%d → %d) on idle-bus fast path; must NOT — external-only fast path is not a contention rotation",
 			priorCounter, got)
 	}
 }

--- a/internal/adaptermux/arbitration_busidle_test.go
+++ b/internal/adaptermux/arbitration_busidle_test.go
@@ -15,7 +15,7 @@ import (
 // gateway, even when no contention exists.
 func TestTryGrant_BusIdle_ExternalPreemptsFairnessWindow(t *testing.T) {
 	arb := newArbitrator()
-	arb.setPolicy(24 * time.Hour, 0, 0) // disable C3 TTL for this test
+	arb.setPolicy(24*time.Hour, 0, 0) // disable C3 TTL for this test
 
 	// Both classes pending — same shape as the legacy fairness test.
 	_ = arb.requestStart(gatewaySessionID, 0x71)
@@ -39,13 +39,59 @@ func TestTryGrant_BusIdle_ExternalPreemptsFairnessWindow(t *testing.T) {
 	}
 }
 
+// TestTryGrant_BusIdle_BothPendingStillRotatesFairly pins the live
+// 2026-05-23 starvation regression: a continuous external scanner can
+// make every grant decision look "bus idle" at the mux boundary. The
+// idle fast path must not bypass F-25 when the gateway is also pending,
+// or a low-priority gateway initiator (0x7F) can be held near zero until
+// the external scanner (0x31) stops.
+func TestTryGrant_BusIdle_BothPendingStillRotatesFairly(t *testing.T) {
+	arb := newArbitrator()
+	arb.setPolicy(24*time.Hour, 0, 0)
+
+	totalRounds := DefaultFairnessRatio * 3
+	externalGrants := 0
+	gatewayGrants := 0
+
+	for i := 0; i < totalRounds; i++ {
+		gwCh := arb.requestStart(gatewaySessionID, 0x7F)
+		extCh := arb.requestStart(1, 0x31)
+
+		req, granted := arb.tryGrant(true)
+		if !granted {
+			t.Fatalf("round %d: expected grant", i)
+		}
+		arb.confirmOwnership(req.sessionID, req.initiator)
+		req.notify <- startResult{granted: true, initiator: req.initiator}
+
+		if req.sessionID == gatewaySessionID {
+			gatewayGrants++
+			arb.cancelStart(1)
+			<-extCh
+		} else {
+			externalGrants++
+			arb.cancelStart(gatewaySessionID)
+			<-gwCh
+		}
+
+		arb.releaseOwnership(req.sessionID)
+	}
+
+	wantExternal := totalRounds / DefaultFairnessRatio
+	wantGateway := totalRounds - wantExternal
+	if externalGrants != wantExternal || gatewayGrants != wantGateway {
+		t.Fatalf("idle contended rotation: ext=%d gw=%d; want ext=%d gw=%d",
+			externalGrants, gatewayGrants, wantExternal, wantGateway)
+	}
+}
+
 // TestTryGrant_BusIdle_GatewayOnly_StillGranted ensures the bus-idle
 // fast path doesn't break the standalone case: when only gateway is
 // pending, the fast path is a no-op and the regular gateway-priority
 // branch grants normally.
 func TestTryGrant_BusIdle_GatewayOnly_StillGranted(t *testing.T) {
 	arb := newArbitrator()
-	arb.setPolicy(24 * time.Hour, 0, 0)
+	arb.setPolicy(24*time.Hour, 0, 0)
 
 	_ = arb.requestStart(gatewaySessionID, 0x71)
 
@@ -64,7 +110,7 @@ func TestTryGrant_BusIdle_GatewayOnly_StillGranted(t *testing.T) {
 // unchanged. This is the regression guard for the legacy semantic.
 func TestTryGrant_NotIdle_GatewayPriorityPreserved(t *testing.T) {
 	arb := newArbitrator()
-	arb.setPolicy(24 * time.Hour, 0, 0)
+	arb.setPolicy(24*time.Hour, 0, 0)
 
 	_ = arb.requestStart(gatewaySessionID, 0x71)
 	_ = arb.requestStart(1, 0x31)
@@ -90,7 +136,7 @@ func TestPendingExternalTTL_StaleEntryRejected(t *testing.T) {
 	base := time.Now()
 	clock := base
 	arb.nowFn = func() time.Time { return clock }
-	arb.setPolicy(50 * time.Millisecond, 0, 0)
+	arb.setPolicy(50*time.Millisecond, 0, 0)
 
 	// Stale entry first.
 	staleCh := arb.requestStart(1, 0x31)
@@ -141,7 +187,7 @@ func TestPendingExternalTTL_StaleEntryRejected(t *testing.T) {
 // abandoned request.
 func TestRequestStart_ReplaceMarksCancelledFlag(t *testing.T) {
 	arb := newArbitrator()
-	arb.setPolicy(24 * time.Hour, 0, 0)
+	arb.setPolicy(24*time.Hour, 0, 0)
 
 	// Reach into pendingExternal to grab the pointer before replace.
 	_ = arb.requestStart(1, 0x31)


### PR DESCRIPTION
## What
Fix adaptermux arbitration so the bus-idle external fast path only applies when the gateway has no pending START request. When gateway and external are both pending, even at an idle boundary, F-25 fairness rotation now decides the grant.

## Why
Live stress traffic showed 0x31 external B524 traffic suppressing 0x7f gateway traffic until 0x31 stopped. The red test reproduced the scheduler shape: with both classes pending and busIdle=true, old code granted external 6/6 instead of the FairnessRatio=2 split of 3/3.

## Validation
- RED before fix: `go test ./internal/adaptermux -run 'TestTryGrant_BusIdle_BothPendingStillRotatesFairly|TestTryGrant_BusIdle_ExternalPreemptsFairnessWindow' -count=1` => ext=6 gw=0, want ext=3 gw=3\n- PASS: `go test ./internal/adaptermux -run 'TestTryGrant_BusIdle|TestArbitrator_FairnessWindow|TestF25' -count=1`\n- PASS: `go test ./internal/adaptermux -count=1`\n- PASS: `go test -race -count=1 ./internal/adaptermux`\n- PASS: `TRANSPORT_MATRIX_REPORT=results-matrix-ha/20260504T183356Z-sas02-ebusgo-c9a4697-full88-correct-adapter-signal/index.json HELIANTHUS_AD_GATE_SKIP='adaptermux AD01..AD12 unit evidence: go test ./internal/adaptermux -count=1 and go test -race ./internal/adaptermux passed; formal AD report pending' ./scripts/transport_gate.sh`\n\n## Local CI caveat\n`./scripts/ci_local.sh` currently stops at repo-wide gofmt before tests because unrelated pre-existing files are formatted differently by local Go 1.26.2. The touched files are gofmt-clean and the adaptermux package/race tests pass.\n\nDoc-gate: Project-Helianthus/helianthus-docs-ebus#316.