### PR TITLE
fix(gateway): coalesce semantic poll tasks

### DIFF
--- a/cmd/gateway/semantic_task_scheduler.go
+++ b/cmd/gateway/semantic_task_scheduler.go
@@ -86,9 +86,6 @@ func (s *semanticTaskScheduler) submitTask(key semanticTaskKey, priority semanti
 		return context.Canceled
 	}
 	if key != "" {
-		if s.runningKeys[key] {
-			return nil
-		}
 		if existing := s.pendingByKey[key]; existing != nil {
 			if priority > existing.priority {
 				existing.priority = priority

--- a/cmd/gateway/semantic_task_scheduler.go
+++ b/cmd/gateway/semantic_task_scheduler.go
@@ -9,6 +9,8 @@ import (
 
 var errSemanticTaskQueueOverloaded = errors.New("semantic task queue overloaded")
 
+type semanticTaskKey string
+
 type semanticTaskPriority int
 
 const (
@@ -30,6 +32,9 @@ type semanticTaskScheduler struct {
 	queue []*semanticTask
 	seq   uint64
 
+	pendingByKey map[semanticTaskKey]*semanticTask
+	runningKeys  map[semanticTaskKey]bool
+
 	maxDepth     int
 	promoteAfter time.Duration
 	emergencyAt  time.Duration
@@ -39,6 +44,7 @@ type semanticTaskScheduler struct {
 }
 
 type semanticTask struct {
+	key        semanticTaskKey
 	priority   semanticTaskPriority
 	enqueuedAt time.Time
 	seq        uint64
@@ -51,12 +57,25 @@ func newSemanticTaskScheduler() *semanticTaskScheduler {
 		promoteAfter: defaultSemanticTaskPromoteAfter,
 		emergencyAt:  defaultSemanticTaskEmergencyAt,
 		now:          time.Now,
+		pendingByKey: make(map[semanticTaskKey]*semanticTask),
+		runningKeys:  make(map[semanticTaskKey]bool),
 	}
 	s.cond = sync.NewCond(&s.mu)
 	return s
 }
 
 func (s *semanticTaskScheduler) submit(priority semanticTaskPriority, run func(context.Context)) error {
+	return s.submitTask("", priority, run)
+}
+
+func (s *semanticTaskScheduler) submitCoalesced(key semanticTaskKey, priority semanticTaskPriority, run func(context.Context)) error {
+	if key == "" {
+		return s.submit(priority, run)
+	}
+	return s.submitTask(key, priority, run)
+}
+
+func (s *semanticTaskScheduler) submitTask(key semanticTaskKey, priority semanticTaskPriority, run func(context.Context)) error {
 	if s == nil || run == nil {
 		return nil
 	}
@@ -66,17 +85,33 @@ func (s *semanticTaskScheduler) submit(priority semanticTaskPriority, run func(c
 	if s.stopped {
 		return context.Canceled
 	}
+	if key != "" {
+		if s.runningKeys[key] {
+			return nil
+		}
+		if existing := s.pendingByKey[key]; existing != nil {
+			if priority > existing.priority {
+				existing.priority = priority
+			}
+			return nil
+		}
+	}
 	if s.maxDepth > 0 && len(s.queue) >= s.maxDepth {
 		return errSemanticTaskQueueOverloaded
 	}
 
 	s.seq++
-	s.queue = append(s.queue, &semanticTask{
+	task := &semanticTask{
+		key:        key,
 		priority:   priority,
 		enqueuedAt: s.now(),
 		seq:        s.seq,
 		run:        run,
-	})
+	}
+	s.queue = append(s.queue, task)
+	if key != "" {
+		s.pendingByKey[key] = task
+	}
 	s.cond.Signal()
 	return nil
 }
@@ -107,7 +142,10 @@ func (s *semanticTaskScheduler) run(ctx context.Context) {
 		if task == nil {
 			return
 		}
-		task.run(ctx)
+		func() {
+			defer s.taskDone(task)
+			task.run(ctx)
+		}()
 	}
 }
 
@@ -132,7 +170,20 @@ func (s *semanticTaskScheduler) nextTask(ctx context.Context) *semanticTask {
 	}
 	task := s.queue[idx]
 	s.queue = append(s.queue[:idx], s.queue[idx+1:]...)
+	if task.key != "" {
+		delete(s.pendingByKey, task.key)
+		s.runningKeys[task.key] = true
+	}
 	return task
+}
+
+func (s *semanticTaskScheduler) taskDone(task *semanticTask) {
+	if s == nil || task == nil || task.key == "" {
+		return
+	}
+	s.mu.Lock()
+	delete(s.runningKeys, task.key)
+	s.mu.Unlock()
 }
 
 func (s *semanticTaskScheduler) nextTaskIndexLocked() int {

--- a/cmd/gateway/semantic_task_scheduler_test.go
+++ b/cmd/gateway/semantic_task_scheduler_test.go
@@ -108,3 +108,72 @@ func TestSemanticTaskScheduler_RunPriorityOrder(t *testing.T) {
 	cancel()
 	<-done
 }
+
+func TestSemanticTaskScheduler_CoalescesPendingTasksByKey(t *testing.T) {
+	scheduler := newSemanticTaskScheduler()
+
+	if err := scheduler.submitCoalesced("state", semanticTaskPriorityLow, func(context.Context) {}); err != nil {
+		t.Fatalf("submit low error = %v", err)
+	}
+	if err := scheduler.submitCoalesced("state", semanticTaskPriorityHigh, func(context.Context) {}); err != nil {
+		t.Fatalf("submit duplicate high error = %v", err)
+	}
+
+	if got := len(scheduler.queue); got != 1 {
+		t.Fatalf("queue length = %d; want 1", got)
+	}
+	if got := scheduler.queue[0].priority; got != semanticTaskPriorityHigh {
+		t.Fatalf("coalesced priority = %d; want %d", got, semanticTaskPriorityHigh)
+	}
+}
+
+func TestSemanticTaskScheduler_CoalescesRunningTasksByKey(t *testing.T) {
+	scheduler := newSemanticTaskScheduler()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	ran := make(chan struct{}, 2)
+
+	if err := scheduler.submitCoalesced("state", semanticTaskPriorityHigh, func(context.Context) {
+		close(started)
+		<-release
+		ran <- struct{}{}
+	}); err != nil {
+		t.Fatalf("submit initial error = %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		scheduler.run(ctx)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for task start")
+	}
+
+	if err := scheduler.submitCoalesced("state", semanticTaskPriorityHigh, func(context.Context) {
+		ran <- struct{}{}
+	}); err != nil {
+		t.Fatalf("submit duplicate while running error = %v", err)
+	}
+
+	close(release)
+	select {
+	case <-ran:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for initial task completion")
+	}
+	select {
+	case <-ran:
+		t.Fatal("duplicate running task executed")
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	cancel()
+	<-done
+}

--- a/cmd/gateway/semantic_task_scheduler_test.go
+++ b/cmd/gateway/semantic_task_scheduler_test.go
@@ -127,19 +127,19 @@ func TestSemanticTaskScheduler_CoalescesPendingTasksByKey(t *testing.T) {
 	}
 }
 
-func TestSemanticTaskScheduler_CoalescesRunningTasksByKey(t *testing.T) {
+func TestSemanticTaskScheduler_DefersOneRerunForRunningTaskKey(t *testing.T) {
 	scheduler := newSemanticTaskScheduler()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	started := make(chan struct{})
 	release := make(chan struct{})
-	ran := make(chan struct{}, 2)
+	ran := make(chan string, 3)
 
 	if err := scheduler.submitCoalesced("state", semanticTaskPriorityHigh, func(context.Context) {
 		close(started)
 		<-release
-		ran <- struct{}{}
+		ran <- "initial"
 	}); err != nil {
 		t.Fatalf("submit initial error = %v", err)
 	}
@@ -157,20 +157,36 @@ func TestSemanticTaskScheduler_CoalescesRunningTasksByKey(t *testing.T) {
 	}
 
 	if err := scheduler.submitCoalesced("state", semanticTaskPriorityHigh, func(context.Context) {
-		ran <- struct{}{}
+		ran <- "deferred"
 	}); err != nil {
 		t.Fatalf("submit duplicate while running error = %v", err)
+	}
+	if err := scheduler.submitCoalesced("state", semanticTaskPriorityLow, func(context.Context) {
+		ran <- "extra"
+	}); err != nil {
+		t.Fatalf("submit second duplicate while running error = %v", err)
 	}
 
 	close(release)
 	select {
-	case <-ran:
+	case got := <-ran:
+		if got != "initial" {
+			t.Fatalf("first task = %q; want initial", got)
+		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for initial task completion")
 	}
 	select {
-	case <-ran:
-		t.Fatal("duplicate running task executed")
+	case got := <-ran:
+		if got != "deferred" {
+			t.Fatalf("deferred task = %q; want deferred", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for deferred task completion")
+	}
+	select {
+	case got := <-ran:
+		t.Fatalf("extra duplicate running task executed: %q", got)
 	case <-time.After(25 * time.Millisecond):
 	}
 

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -593,6 +593,21 @@ type boilerStatusTierSchedule struct {
 	priority semanticTaskPriority
 }
 
+const (
+	semanticTaskRefreshRegulatorCapability semanticTaskKey = "refresh_regulator_capability"
+	semanticTaskRefreshDiscovery           semanticTaskKey = "refresh_discovery"
+	semanticTaskRefreshConfig              semanticTaskKey = "refresh_config"
+	semanticTaskRefreshState               semanticTaskKey = "refresh_state"
+	semanticTaskRefreshCircuits            semanticTaskKey = "refresh_circuits"
+	semanticTaskRefreshSystem              semanticTaskKey = "refresh_system"
+	semanticTaskRefreshRadioDevices        semanticTaskKey = "refresh_radio_devices"
+	semanticTaskRefreshEnergy              semanticTaskKey = "refresh_energy"
+	semanticTaskRefreshSchedules           semanticTaskKey = "refresh_schedules"
+	semanticTaskRefreshBoilerFast          semanticTaskKey = "refresh_boiler_fast"
+	semanticTaskRefreshBoilerMedium        semanticTaskKey = "refresh_boiler_medium"
+	semanticTaskRefreshBoilerSlow          semanticTaskKey = "refresh_boiler_slow"
+)
+
 var (
 	zoneConfigFieldSet = newSemanticFieldSet(
 		zoneFieldName,
@@ -1207,6 +1222,19 @@ func (p *vaillantSemanticPoller) boilerStatusTierTask(tier boilerStatusTier) fun
 	}
 }
 
+func boilerStatusTierTaskKey(tier boilerStatusTier) semanticTaskKey {
+	switch tier {
+	case boilerStatusTierFast:
+		return semanticTaskRefreshBoilerFast
+	case boilerStatusTierMedium:
+		return semanticTaskRefreshBoilerMedium
+	case boilerStatusTierSlow:
+		return semanticTaskRefreshBoilerSlow
+	default:
+		return semanticTaskKey("")
+	}
+}
+
 func (p *vaillantSemanticPoller) enqueueBoilerStatusPriming(ctx context.Context) {
 	if p == nil {
 		return
@@ -1221,7 +1249,7 @@ func (p *vaillantSemanticPoller) enqueueBoilerStatusPriming(ctx context.Context)
 		return
 	}
 	for _, schedule := range p.boilerStatusTierSchedules() {
-		p.enqueueTask(schedule.priority, p.boilerStatusTierTask(schedule.tier))
+		p.enqueueTask(boilerStatusTierTaskKey(schedule.tier), schedule.priority, p.boilerStatusTierTask(schedule.tier))
 	}
 }
 
@@ -1240,11 +1268,11 @@ func (p *vaillantSemanticPoller) enqueueControllerSemanticPriming(ctx context.Co
 		p.refreshEnergy(ctx)
 		return
 	}
-	p.enqueueTask(semanticTaskPriorityHigh, p.refreshConfig)
-	p.enqueueTask(semanticTaskPriorityMedium, p.refreshCircuits)
-	p.enqueueTask(semanticTaskPriorityMedium, p.refreshSystem)
-	p.enqueueTask(semanticTaskPriorityMedium, p.refreshRadioDevices)
-	p.enqueueTask(semanticTaskPriorityMedium, p.refreshEnergy)
+	p.enqueueTask(semanticTaskRefreshConfig, semanticTaskPriorityHigh, p.refreshConfig)
+	p.enqueueTask(semanticTaskRefreshCircuits, semanticTaskPriorityMedium, p.refreshCircuits)
+	p.enqueueTask(semanticTaskRefreshSystem, semanticTaskPriorityMedium, p.refreshSystem)
+	p.enqueueTask(semanticTaskRefreshRadioDevices, semanticTaskPriorityMedium, p.refreshRadioDevices)
+	p.enqueueTask(semanticTaskRefreshEnergy, semanticTaskPriorityMedium, p.refreshEnergy)
 }
 
 func (p *vaillantSemanticPoller) refreshStartupSemanticPlanes(ctx context.Context) {
@@ -2222,25 +2250,25 @@ func parsePassiveShadowPayload(event ebusgateway.AdjudicatedPassiveEvent, key eb
 
 func (p *vaillantSemanticPoller) startPollingLoops(ctx context.Context) {
 	// Discovery owns downstream startup/controller/boiler priming and avoids duplicate startup bursts.
-	p.enqueueTask(semanticTaskPriorityHigh, p.refreshDiscovery)
-	p.enqueueTask(semanticTaskPriorityLow, p.refreshSchedules)
+	p.enqueueTask(semanticTaskRefreshDiscovery, semanticTaskPriorityHigh, p.refreshDiscovery)
+	p.enqueueTask(semanticTaskRefreshSchedules, semanticTaskPriorityLow, p.refreshSchedules)
 
-	go p.runLoop(ctx, p.regulatorRecheckInterval, semanticTaskPriorityLow, p.refreshRegulatorCapability)
-	go p.runLoop(ctx, p.discoveryInterval, semanticTaskPriorityLow, p.refreshDiscovery)
-	go p.runLoop(ctx, p.configInterval, semanticTaskPriorityMedium, p.refreshConfig)
-	go p.runLoop(ctx, p.stateInterval, semanticTaskPriorityHigh, p.refreshState)
-	go p.runLoop(ctx, p.configInterval, semanticTaskPriorityLow, p.refreshCircuits)
-	go p.runLoop(ctx, p.configInterval, semanticTaskPriorityLow, p.refreshSystem)
-	go p.runLoop(ctx, p.configInterval, semanticTaskPriorityLow, p.refreshRadioDevices)
-	go p.runLoop(ctx, p.energyInterval, semanticTaskPriorityMedium, p.refreshEnergy)
-	go p.runLoop(ctx, p.scheduleInterval, semanticTaskPriorityLow, p.refreshSchedules)
+	go p.runLoop(ctx, p.regulatorRecheckInterval, semanticTaskRefreshRegulatorCapability, semanticTaskPriorityLow, p.refreshRegulatorCapability)
+	go p.runLoop(ctx, p.discoveryInterval, semanticTaskRefreshDiscovery, semanticTaskPriorityLow, p.refreshDiscovery)
+	go p.runLoop(ctx, p.configInterval, semanticTaskRefreshConfig, semanticTaskPriorityMedium, p.refreshConfig)
+	go p.runLoop(ctx, p.stateInterval, semanticTaskRefreshState, semanticTaskPriorityHigh, p.refreshState)
+	go p.runLoop(ctx, p.configInterval, semanticTaskRefreshCircuits, semanticTaskPriorityLow, p.refreshCircuits)
+	go p.runLoop(ctx, p.configInterval, semanticTaskRefreshSystem, semanticTaskPriorityLow, p.refreshSystem)
+	go p.runLoop(ctx, p.configInterval, semanticTaskRefreshRadioDevices, semanticTaskPriorityLow, p.refreshRadioDevices)
+	go p.runLoop(ctx, p.energyInterval, semanticTaskRefreshEnergy, semanticTaskPriorityMedium, p.refreshEnergy)
+	go p.runLoop(ctx, p.scheduleInterval, semanticTaskRefreshSchedules, semanticTaskPriorityLow, p.refreshSchedules)
 	go p.adapterInfo.run(ctx)
 	for _, schedule := range p.boilerStatusTierSchedules() {
-		go p.runLoop(ctx, schedule.interval, schedule.priority, p.boilerStatusTierTask(schedule.tier))
+		go p.runLoop(ctx, schedule.interval, boilerStatusTierTaskKey(schedule.tier), schedule.priority, p.boilerStatusTierTask(schedule.tier))
 	}
 }
 
-func (p *vaillantSemanticPoller) runLoop(ctx context.Context, interval time.Duration, priority semanticTaskPriority, fn func(context.Context)) {
+func (p *vaillantSemanticPoller) runLoop(ctx context.Context, interval time.Duration, key semanticTaskKey, priority semanticTaskPriority, fn func(context.Context)) {
 	if interval <= 0 {
 		return
 	}
@@ -2252,12 +2280,12 @@ func (p *vaillantSemanticPoller) runLoop(ctx context.Context, interval time.Dura
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			p.enqueueTask(priority, fn)
+			p.enqueueTask(key, priority, fn)
 		}
 	}
 }
 
-func (p *vaillantSemanticPoller) enqueueTask(priority semanticTaskPriority, fn func(context.Context)) {
+func (p *vaillantSemanticPoller) enqueueTask(key semanticTaskKey, priority semanticTaskPriority, fn func(context.Context)) {
 	if p == nil || fn == nil {
 		return
 	}
@@ -2266,15 +2294,15 @@ func (p *vaillantSemanticPoller) enqueueTask(priority semanticTaskPriority, fn f
 		fn(context.Background())
 		return
 	}
-	err := scheduler.submit(priority, func(taskCtx context.Context) {
+	err := scheduler.submitCoalesced(key, priority, func(taskCtx context.Context) {
 		p.withPollLock(taskCtx, fn)
 	})
 	if errors.Is(err, errSemanticTaskQueueOverloaded) {
-		log.Printf("semantic poll scheduler overloaded: skipping task (priority=%d)", priority)
+		log.Printf("semantic poll scheduler overloaded: skipping task key=%s priority=%d", key, priority)
 		return
 	}
 	if err != nil {
-		log.Printf("semantic poll scheduler submit failed: %v", err)
+		log.Printf("semantic poll scheduler submit failed key=%s err=%v", key, err)
 	}
 }
 
@@ -2338,7 +2366,7 @@ func (p *vaillantSemanticPoller) refreshRegulatorCapability(_ context.Context) {
 	// If device count changed, enqueue an immediate full discovery refresh.
 	if deviceCount != prevDeviceCount && prevDeviceCount > 0 {
 		log.Printf("semantic_regulator_recheck inventory_change prev=%d curr=%d", prevDeviceCount, deviceCount)
-		p.enqueueTask(semanticTaskPriorityLow, p.refreshDiscovery)
+		p.enqueueTask(semanticTaskRefreshDiscovery, semanticTaskPriorityLow, p.refreshDiscovery)
 	}
 }
 
@@ -7590,7 +7618,7 @@ func (p *vaillantSemanticPoller) EnqueueDiscoveryRefresh() {
 	if p == nil {
 		return
 	}
-	p.enqueueTask(semanticTaskPriorityHigh, p.refreshDiscovery)
+	p.enqueueTask(semanticTaskRefreshDiscovery, semanticTaskPriorityHigh, p.refreshDiscovery)
 }
 
 // EnqueueAddressIdentityProbe schedules a per-address identity


### PR DESCRIPTION
## Summary
- add stable scheduler keys for Vaillant semantic poll task families
- coalesce duplicate pending tasks and preserve one deferred rerun when a same-key signal arrives while the task is running
- keep bus.Send, adaptermux arbitration, retry classification, and semantic merge behavior unchanged

## Validation
- go test ./cmd/gateway -run 'TestSemanticTaskScheduler|TestVaillant'
- go test -race ./cmd/gateway -run 'TestSemanticTaskScheduler|TestVaillant'
- go test ./internal/adaptermux
- go test ./...
- gofmt -l cmd/gateway/semantic_task_scheduler.go cmd/gateway/semantic_task_scheduler_test.go cmd/gateway/semantic_vaillant.go

Note: ./scripts/ci_local.sh currently fails on pre-existing gofmt drift in unrelated files on main; touched files are gofmt-clean.

Docs companion: Project-Helianthus/helianthus-docs-ebus#317
Closes #666