### PR TITLE
gateway: reduce sustained B524 semantic overpolling

### DIFF
--- a/cmd/gateway/parse_hex_byte_list_test.go
+++ b/cmd/gateway/parse_hex_byte_list_test.go
@@ -74,11 +74,11 @@ func TestParseHexByteList_Invalid(t *testing.T) {
 	t.Parallel()
 
 	cases := []string{
-		"0xZZ",            // non-hex digits
-		"0x71,garbage",    // second item invalid
-		"0x71,0x100",      // value > 0xFF (8-bit overflow)
-		"0x71;0xFD",       // wrong separator
-		"not-a-hex-byte",  // wholly bogus
+		"0xZZ",           // non-hex digits
+		"0x71,garbage",   // second item invalid
+		"0x71,0x100",     // value > 0xFF (8-bit overflow)
+		"0x71;0xFD",      // wrong separator
+		"not-a-hex-byte", // wholly bogus
 	}
 	for _, in := range cases {
 		t.Run(in, func(t *testing.T) {

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -614,22 +614,10 @@ const (
 )
 
 var (
-	zoneConfigFieldSet = newSemanticFieldSet(
+	zoneConfigRefreshFieldSet = newSemanticFieldSet(
 		zoneFieldName,
-	)
-	zoneStateFieldSet = newSemanticFieldSet(
-		zoneFieldOperatingMode,
-		zoneFieldPreset,
-		zoneFieldHvacAction,
-		zoneFieldAllowedModes,
-		zoneFieldCurrentTempC,
-		zoneFieldTargetTempC,
-		zoneFieldCurrentHumidityPct,
-		zoneFieldZoneOperationModeRaw,
-		zoneFieldSpecialFunctionRaw,
 		zoneFieldRoomTemperatureZoneMappingRaw,
 		zoneFieldZoneCircuitIndexRaw,
-		zoneFieldZoneValveStatusRaw,
 		zoneFieldCircuitTypeRaw,
 		zoneFieldQuickVetoTempC,
 		zoneFieldQuickVetoDurationH,
@@ -640,6 +628,18 @@ var (
 		zoneFieldHolidaySetpointC,
 		zoneFieldHolidayStartTime,
 		zoneFieldHolidayEndTime,
+	)
+	zoneFastStateFieldSet = newSemanticFieldSet(
+		zoneFieldOperatingMode,
+		zoneFieldPreset,
+		zoneFieldHvacAction,
+		zoneFieldAllowedModes,
+		zoneFieldCurrentTempC,
+		zoneFieldTargetTempC,
+		zoneFieldCurrentHumidityPct,
+		zoneFieldZoneOperationModeRaw,
+		zoneFieldSpecialFunctionRaw,
+		zoneFieldZoneValveStatusRaw,
 	)
 	zoneGrabFieldSet = newSemanticFieldSet(
 		zoneFieldName,
@@ -2782,14 +2782,25 @@ func (p *vaillantSemanticPoller) refreshConfig(ctx context.Context) {
 			liveReadSuccess = true
 		}
 
-		incoming := &vaillantZoneSnapshot{
-			Name: composeZoneName(primaryName, prefix, suffix),
+		incoming, slowOK := p.refreshZoneSlowConfigFields(ctx, instance)
+		if slowOK {
+			liveReadSuccess = true
 		}
+		if incoming == nil {
+			incoming = &vaillantZoneSnapshot{}
+		}
+		incoming.Name = composeZoneName(primaryName, prefix, suffix)
+
 		p.mu.Lock()
 		if entry := p.zones[instance]; entry != nil {
-			mergeZoneSnapshotFields(entry, incoming, semanticSnapshotSourceLive, zoneConfigFieldSet)
+			mergeZoneSnapshotFields(entry, incoming, semanticSnapshotSourceLive, zoneConfigRefreshFieldSet)
 		}
 		p.mu.Unlock()
+	}
+
+	dhwSource := p.refreshDHWSlowConfig(ctx)
+	if dhwSource == semanticSnapshotSourceLive {
+		liveReadSuccess = true
 	}
 	if !liveReadSuccess && p.tryRefreshFromEbusdGrab(ctx) {
 		grabHydrated = true
@@ -2800,6 +2811,158 @@ func (p *vaillantSemanticPoller) refreshConfig(ctx context.Context) {
 		source = semanticSnapshotSourceLive
 	}
 	p.publishZones(source)
+	p.publishDHW(dhwSource)
+}
+
+func (p *vaillantSemanticPoller) refreshZoneSlowConfigFields(ctx context.Context, instance byte) (*vaillantZoneSnapshot, bool) {
+	incoming := &vaillantZoneSnapshot{}
+	liveReadSuccess := false
+
+	var qvTempPtr, qvDurPtr *float64
+	if value, ok := p.readB524Float32LE(ctx, localZones.opcode, localZones.group, instance, zone_quick_veto_temp); ok {
+		v := value
+		qvTempPtr = &v
+		liveReadSuccess = true
+	}
+	if value, ok := p.readB524Float32LE(ctx, localZones.opcode, localZones.group, instance, zone_quick_veto_duration); ok {
+		v := value
+		qvDurPtr = &v
+		liveReadSuccess = true
+	}
+	var qvEndTime, qvEndDate string
+	if raw, ok := p.readB524Value(ctx, localZones.opcode, localZones.group, instance, zone_quick_veto_end_time); ok && len(raw) >= 2 {
+		qvEndTime = fmt.Sprintf("%02d:%02d", raw[0], raw[1])
+		liveReadSuccess = true
+	}
+	if raw, ok := p.readB524Value(ctx, localZones.opcode, localZones.group, instance, zone_quick_veto_end_date); ok && len(raw) >= 3 {
+		year := 2000 + int(raw[2])
+		qvEndDate = fmt.Sprintf("%04d-%02d-%02d", year, raw[1], raw[0])
+		liveReadSuccess = true
+	}
+
+	var holidayStartDate, holidayEndDate, holidayStartTime, holidayEndTime string
+	var holidaySetpointPtr *float64
+	if raw, ok := p.readB524Value(ctx, localZones.opcode, localZones.group, instance, zone_holiday_start_date); ok && len(raw) >= 3 {
+		if date := decodeB524DateSuppressSentinel(raw); date != "" {
+			holidayStartDate = date
+		}
+		liveReadSuccess = true
+	}
+	if raw, ok := p.readB524Value(ctx, localZones.opcode, localZones.group, instance, zone_holiday_end_date); ok && len(raw) >= 3 {
+		if date := decodeB524DateSuppressSentinel(raw); date != "" {
+			holidayEndDate = date
+		}
+		liveReadSuccess = true
+	}
+	if value, ok := p.readB524Float32LE(ctx, localZones.opcode, localZones.group, instance, zone_holiday_setpoint); ok {
+		v := value
+		holidaySetpointPtr = &v
+		liveReadSuccess = true
+	}
+	if raw, ok := p.readB524Value(ctx, localZones.opcode, localZones.group, instance, zone_holiday_end_time); ok && len(raw) >= 2 {
+		holidayEndTime = fmt.Sprintf("%02d:%02d", raw[0], raw[1])
+		liveReadSuccess = true
+	}
+	if raw, ok := p.readB524Value(ctx, localZones.opcode, localZones.group, instance, zone_holiday_start_time); ok && len(raw) >= 2 {
+		holidayStartTime = fmt.Sprintf("%02d:%02d", raw[0], raw[1])
+		liveReadSuccess = true
+	}
+
+	zoneRoomTemperatureZoneMappingRaw, zoneRoomTemperatureZoneMappingRawOK := p.readB524Uint16(ctx, localZones.opcode, localZones.group, instance, zone_room_temperature_zone_mapping_raw)
+	if zoneRoomTemperatureZoneMappingRawOK {
+		liveReadSuccess = true
+	}
+	circuitInstance := resolveAssociatedCircuitInstance(zoneRoomTemperatureZoneMappingRaw, instance)
+	circuitType, hasCircuitType := p.readB524Uint16(ctx, localCircuits.opcode, localCircuits.group, circuitInstance, circuit_type)
+	if hasCircuitType {
+		liveReadSuccess = true
+	}
+	var associatedCircuitRaw *uint16
+	if zoneRoomTemperatureZoneMappingRaw != nil {
+		value := uint16(circuitInstance)
+		associatedCircuitRaw = &value
+	}
+
+	incoming.QuickVetoTempC = qvTempPtr
+	incoming.QuickVetoDurationH = qvDurPtr
+	incoming.QuickVetoEndTime = qvEndTime
+	incoming.QuickVetoEndDate = qvEndDate
+	incoming.HolidayStartDate = holidayStartDate
+	incoming.HolidayEndDate = holidayEndDate
+	incoming.HolidaySetpointC = holidaySetpointPtr
+	incoming.HolidayStartTime = holidayStartTime
+	incoming.HolidayEndTime = holidayEndTime
+	incoming.ConfigurationRoomTemperatureZoneMappingRaw = zoneRoomTemperatureZoneMappingRaw
+	incoming.ConfigurationAssociatedCircuitRaw = associatedCircuitRaw
+	incoming.ConfigurationCircuitTypeRaw = circuitType
+
+	return incoming, liveReadSuccess
+}
+
+func (p *vaillantSemanticPoller) refreshDHWSlowConfig(ctx context.Context) semanticSnapshotSource {
+	p.mu.Lock()
+	controller := p.controller
+	p.mu.Unlock()
+	if controller == 0 {
+		return semanticSnapshotSourceCache
+	}
+
+	attempted := make(semanticFieldSet)
+	liveReadSuccess := false
+	var dhwHolidayStartDate, dhwHolidayEndDate string
+	if raw, ok := p.readB524Value(ctx, localDHW.opcode, localDHW.group, dhwInstance, dhw_holiday_start_date); ok && len(raw) >= 3 {
+		if date := decodeB524DateSuppressSentinel(raw); date != "" {
+			dhwHolidayStartDate = date
+		}
+		liveReadSuccess = true
+		attempted[dhwFieldHolidayStartDate] = struct{}{}
+	}
+	if raw, ok := p.readB524Value(ctx, localDHW.opcode, localDHW.group, dhwInstance, dhw_holiday_end_date); ok && len(raw) >= 3 {
+		if date := decodeB524DateSuppressSentinel(raw); date != "" {
+			dhwHolidayEndDate = date
+		}
+		liveReadSuccess = true
+		attempted[dhwFieldHolidayEndDate] = struct{}{}
+	}
+	if !liveReadSuccess {
+		return semanticSnapshotSourceCache
+	}
+
+	status := &vaillantDhwSnapshot{
+		HolidayStartDate: dhwHolidayStartDate,
+		HolidayEndDate:   dhwHolidayEndDate,
+	}
+	p.mu.Lock()
+	if p.dhw == nil {
+		p.dhw = &vaillantDhwSnapshot{}
+	}
+	mergeDhwSnapshotFields(p.dhw, status, semanticSnapshotSourceLive, attempted)
+	p.markDHWUpdatedNowLocked()
+	p.mu.Unlock()
+	return semanticSnapshotSourceLive
+}
+
+func (p *vaillantSemanticPoller) cachedZoneCircuitType(instance byte) (*uint16, bool) {
+	if p == nil {
+		return nil, false
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	circuitInstance := instance
+	if zone := p.zones[instance]; zone != nil {
+		if zone.ConfigurationCircuitTypeRaw != nil {
+			return cloneUint16Ptr(zone.ConfigurationCircuitTypeRaw), true
+		}
+		if zone.ConfigurationAssociatedCircuitRaw != nil && *zone.ConfigurationAssociatedCircuitRaw <= 0xFF {
+			circuitInstance = byte(*zone.ConfigurationAssociatedCircuitRaw)
+		}
+	}
+	if circuit := p.circuits[circuitInstance]; circuit != nil && circuit.CircuitTypeRaw != nil {
+		return cloneUint16Ptr(circuit.CircuitTypeRaw), true
+	}
+	return nil, false
 }
 
 func (p *vaillantSemanticPoller) refreshState(ctx context.Context) {
@@ -2852,97 +3015,25 @@ func (p *vaillantSemanticPoller) refreshState(ctx context.Context) {
 			liveReadSuccess = true
 		}
 
-		var qvTempPtr, qvDurPtr *float64
-		if value, ok := p.readB524Float32LE(ctx, localZones.opcode, localZones.group, instance, zone_quick_veto_temp); ok {
-			v := value
-			qvTempPtr = &v
-			liveReadSuccess = true
-		}
-		if value, ok := p.readB524Float32LE(ctx, localZones.opcode, localZones.group, instance, zone_quick_veto_duration); ok {
-			v := value
-			qvDurPtr = &v
-			liveReadSuccess = true
-		}
-		var qvEndTime, qvEndDate string
-		if raw, ok := p.readB524Value(ctx, localZones.opcode, localZones.group, instance, zone_quick_veto_end_time); ok && len(raw) >= 2 {
-			qvEndTime = fmt.Sprintf("%02d:%02d", raw[0], raw[1])
-			liveReadSuccess = true
-		}
-		if raw, ok := p.readB524Value(ctx, localZones.opcode, localZones.group, instance, zone_quick_veto_end_date); ok && len(raw) >= 3 {
-			year := 2000 + int(raw[2])
-			qvEndDate = fmt.Sprintf("%04d-%02d-%02d", year, raw[1], raw[0])
-			liveReadSuccess = true
-		}
-
-		var holidayStartDate, holidayEndDate, holidayStartTime, holidayEndTime string
-		var holidaySetpointPtr *float64
-		if raw, ok := p.readB524Value(ctx, localZones.opcode, localZones.group, instance, zone_holiday_start_date); ok && len(raw) >= 3 {
-			if date := decodeB524DateSuppressSentinel(raw); date != "" {
-				holidayStartDate = date
-			}
-			liveReadSuccess = true
-		}
-		if raw, ok := p.readB524Value(ctx, localZones.opcode, localZones.group, instance, zone_holiday_end_date); ok && len(raw) >= 3 {
-			if date := decodeB524DateSuppressSentinel(raw); date != "" {
-				holidayEndDate = date
-			}
-			liveReadSuccess = true
-		}
-		if value, ok := p.readB524Float32LE(ctx, localZones.opcode, localZones.group, instance, zone_holiday_setpoint); ok {
-			v := value
-			holidaySetpointPtr = &v
-			liveReadSuccess = true
-		}
-		if raw, ok := p.readB524Value(ctx, localZones.opcode, localZones.group, instance, zone_holiday_end_time); ok && len(raw) >= 2 {
-			holidayEndTime = fmt.Sprintf("%02d:%02d", raw[0], raw[1])
-			liveReadSuccess = true
-		}
-		if raw, ok := p.readB524Value(ctx, localZones.opcode, localZones.group, instance, zone_holiday_start_time); ok && len(raw) >= 2 {
-			holidayStartTime = fmt.Sprintf("%02d:%02d", raw[0], raw[1])
-			liveReadSuccess = true
-		}
-
 		zoneOpMode, zoneOpModeOK := p.readB524Uint16(ctx, localZones.opcode, localZones.group, instance, zone_heating_op_mode)
 		zoneSF, zoneSFOK := p.readB524Uint16(ctx, localZones.opcode, localZones.group, instance, zone_special_function)
 		zoneValve, zoneValveOK := p.readB524Uint16(ctx, localZones.opcode, localZones.group, instance, zone_valve_status)
-		zoneRoomTemperatureZoneMappingRaw, zoneRoomTemperatureZoneMappingRawOK := p.readB524Uint16(ctx, localZones.opcode, localZones.group, instance, zone_room_temperature_zone_mapping_raw)
-		if zoneOpModeOK || zoneSFOK || zoneValveOK || zoneRoomTemperatureZoneMappingRawOK {
+		if zoneOpModeOK || zoneSFOK || zoneValveOK {
 			liveReadSuccess = true
 		}
-		circuitInstance := resolveAssociatedCircuitInstance(zoneRoomTemperatureZoneMappingRaw, instance)
-		circuitType, hasCircuitType := p.readB524Uint16(ctx, localCircuits.opcode, localCircuits.group, circuitInstance, circuit_type)
-		if hasCircuitType {
-			liveReadSuccess = true
-		}
-		var associatedCircuitRaw *uint16
-		if zoneRoomTemperatureZoneMappingRaw != nil {
-			value := uint16(circuitInstance)
-			associatedCircuitRaw = &value
-		}
+		circuitType, hasCircuitType := p.cachedZoneCircuitType(instance)
 
 		operatingMode, preset, allowedModes := deriveZoneModeAndPreset(zoneOpMode, zoneSF, circuitType, hasCircuitType)
 		hvacAction := deriveZoneHvacAction(zoneValve, circuitType, hasCircuitType)
 		incoming := &vaillantZoneSnapshot{
-			OperatingMode:      operatingMode,
-			Preset:             preset,
-			HvacAction:         hvacAction,
-			AllowedModes:       allowedModes,
-			CurrentTempC:       currentPtr,
-			TargetTempC:        targetPtr,
-			HumidityPct:        humidity,
-			QuickVetoTempC:     qvTempPtr,
-			QuickVetoDurationH: qvDurPtr,
-			QuickVetoEndTime:   qvEndTime,
-			QuickVetoEndDate:   qvEndDate,
-			HolidayStartDate:   holidayStartDate,
-			HolidayEndDate:     holidayEndDate,
-			HolidaySetpointC:   holidaySetpointPtr,
-			HolidayStartTime:   holidayStartTime,
-			HolidayEndTime:     holidayEndTime,
-			ConfigurationRoomTemperatureZoneMappingRaw: zoneRoomTemperatureZoneMappingRaw,
-			ConfigurationAssociatedCircuitRaw:          associatedCircuitRaw,
-			ConfigurationCircuitTypeRaw:                circuitType,
-			StateValveStatusRaw:                        zoneValve,
+			OperatingMode:       operatingMode,
+			Preset:              preset,
+			HvacAction:          hvacAction,
+			AllowedModes:        allowedModes,
+			CurrentTempC:        currentPtr,
+			TargetTempC:         targetPtr,
+			HumidityPct:         humidity,
+			StateValveStatusRaw: zoneValve,
 		}
 		if zoneOpMode != nil {
 			incoming.ConfigurationHeatingOperationMode = formatUintToken(*zoneOpMode)
@@ -2953,7 +3044,7 @@ func (p *vaillantSemanticPoller) refreshState(ctx context.Context) {
 
 		p.mu.Lock()
 		if entry := p.zones[instance]; entry != nil {
-			mergeZoneSnapshotFields(entry, incoming, semanticSnapshotSourceLive, zoneStateFieldSet)
+			mergeZoneSnapshotFields(entry, incoming, semanticSnapshotSourceLive, zoneFastStateFieldSet)
 		}
 		p.mu.Unlock()
 	}
@@ -3247,31 +3338,13 @@ func (p *vaillantSemanticPoller) refreshDHW(ctx context.Context) semanticSnapsho
 		attempted[dhwFieldSpecialFunctionRaw] = struct{}{}
 	}
 
-	var dhwHolidayStartDate, dhwHolidayEndDate string
-	if raw, ok := p.readB524Value(ctx, localDHW.opcode, localDHW.group, dhwInstance, dhw_holiday_start_date); ok && len(raw) >= 3 {
-		if date := decodeB524DateSuppressSentinel(raw); date != "" {
-			dhwHolidayStartDate = date
-		}
-		liveReadSuccess = true
-		attempted[dhwFieldHolidayStartDate] = struct{}{}
-	}
-	if raw, ok := p.readB524Value(ctx, localDHW.opcode, localDHW.group, dhwInstance, dhw_holiday_end_date); ok && len(raw) >= 3 {
-		if date := decodeB524DateSuppressSentinel(raw); date != "" {
-			dhwHolidayEndDate = date
-		}
-		liveReadSuccess = true
-		attempted[dhwFieldHolidayEndDate] = struct{}{}
-	}
-
 	if !liveReadSuccess {
 		return p.sourceFromEbusdGrab(p.refreshDHWFromEbusdGrab(ctx))
 	}
 
 	status := &vaillantDhwSnapshot{
-		CurrentTempC:     currentPtr,
-		TargetTempC:      targetPtr,
-		HolidayStartDate: dhwHolidayStartDate,
-		HolidayEndDate:   dhwHolidayEndDate,
+		CurrentTempC: currentPtr,
+		TargetTempC:  targetPtr,
 	}
 	if attempted.has(dhwFieldOperatingMode) || attempted.has(dhwFieldPreset) {
 		status.OperatingMode, status.Preset = deriveDhwModeAndPreset(opModeRaw, sfModeRaw)
@@ -4251,18 +4324,40 @@ func (p *vaillantSemanticPoller) refreshBoilerStatusB524(ctx context.Context, ti
 		return updated
 	}
 
-	if value := p.readDhwFloat(ctx, dhw_current_temp); value != nil {
-		snapshot.DhwTemperatureC = value
+	updated = p.mergeBoilerDHWFieldsFromSnapshot(snapshot) || updated
+	return updated
+}
+
+func (p *vaillantSemanticPoller) mergeBoilerDHWFieldsFromSnapshot(snapshot *vaillantBoilerSnapshot) bool {
+	if p == nil || snapshot == nil {
+		return false
+	}
+
+	p.mu.Lock()
+	dhw := p.dhw
+	if dhw == nil {
+		p.mu.Unlock()
+		return false
+	}
+	current := cloneFloat64Ptr(dhw.CurrentTempC)
+	target := cloneFloat64Ptr(dhw.TargetTempC)
+	operationMode := strings.TrimSpace(dhw.ConfigurationDHWOperationMode)
+	p.mu.Unlock()
+
+	updated := false
+	if current != nil {
+		snapshot.DhwTemperatureC = current
 		updated = true
 	}
-	if value := p.readDhwFloat(ctx, dhw_target_temp); value != nil {
-		snapshot.DhwTargetTemperatureC = value
+	if target != nil {
+		snapshot.DhwTargetTemperatureC = target
 		updated = true
 	}
-	if raw, ok := p.readDhwUint16(ctx, dhw_operation_mode); ok && raw != nil {
-		value := int(*raw)
-		snapshot.DhwOperatingMode = &value
-		updated = true
+	if operationMode != "" {
+		if parsed, err := strconv.Atoi(operationMode); err == nil {
+			snapshot.DhwOperatingMode = &parsed
+			updated = true
+		}
 	}
 	return updated
 }
@@ -7179,7 +7274,7 @@ func (p *vaillantSemanticPoller) readB509UCHFloat(ctx context.Context, target by
 }
 
 func (p *vaillantSemanticPoller) readB524Value(ctx context.Context, opcode, group, instance byte, addr uint16) ([]byte, bool) {
-	if p == nil || p.bus == nil {
+	if p == nil || (p.bus == nil && p.sendFrameFn == nil) {
 		return nil, false
 	}
 	if ctx == nil {
@@ -7216,7 +7311,7 @@ func (p *vaillantSemanticPoller) readB524Value(ctx context.Context, opcode, grou
 				Secondary: vaillantExtRegisterSecondary,
 				Data:      buildB524ReadSelector(opcode, group, instance, addr),
 			}
-			response, err := p.bus.Send(reqCtx, request)
+			response, err := p.sendSemanticFrame(reqCtx, request)
 			cancel()
 			p.readMu.Unlock()
 

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -2773,18 +2773,18 @@ func (p *vaillantSemanticPoller) refreshConfig(ctx context.Context) {
 		return
 	}
 
-	liveReadSuccess := false
+	zoneLiveReadSuccess := false
 	for _, instance := range zones {
 		primaryName, primaryOK := p.readB524ZoneNamePart(ctx, instance, zone_name)
 		prefix, prefixOK := p.readB524ZoneNamePart(ctx, instance, zone_name_prefix)
 		suffix, suffixOK := p.readB524ZoneNamePart(ctx, instance, zone_name_suffix)
 		if primaryOK || prefixOK || suffixOK {
-			liveReadSuccess = true
+			zoneLiveReadSuccess = true
 		}
 
 		incoming, slowOK := p.refreshZoneSlowConfigFields(ctx, instance)
 		if slowOK {
-			liveReadSuccess = true
+			zoneLiveReadSuccess = true
 		}
 		if incoming == nil {
 			incoming = &vaillantZoneSnapshot{}
@@ -2799,18 +2799,15 @@ func (p *vaillantSemanticPoller) refreshConfig(ctx context.Context) {
 	}
 
 	dhwSource := p.refreshDHWSlowConfig(ctx)
-	if dhwSource == semanticSnapshotSourceLive {
-		liveReadSuccess = true
-	}
-	if !liveReadSuccess && p.tryRefreshFromEbusdGrab(ctx) {
+	if !zoneLiveReadSuccess && p.tryRefreshFromEbusdGrab(ctx) {
 		grabHydrated = true
 	}
 
-	source := semanticSnapshotSourceCache
-	if liveReadSuccess || grabHydrated {
-		source = semanticSnapshotSourceLive
+	zoneSource := semanticSnapshotSourceCache
+	if zoneLiveReadSuccess || grabHydrated {
+		zoneSource = semanticSnapshotSourceLive
 	}
-	p.publishZones(source)
+	p.publishZones(zoneSource)
 	p.publishDHW(dhwSource)
 }
 
@@ -4324,7 +4321,7 @@ func (p *vaillantSemanticPoller) refreshBoilerStatusB524(ctx context.Context, ti
 		return updated
 	}
 
-	updated = p.mergeBoilerDHWFieldsFromSnapshot(snapshot) || updated
+	p.mergeBoilerDHWFieldsFromSnapshot(snapshot)
 	return updated
 }
 

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -2770,6 +2770,9 @@ func (p *vaillantSemanticPoller) refreshConfig(ctx context.Context) {
 		}
 	}
 	if controller == 0 || len(zones) == 0 {
+		if controller != 0 {
+			p.publishDHW(p.refreshDHWSlowConfig(ctx))
+		}
 		return
 	}
 

--- a/cmd/gateway/semantic_vaillant_test.go
+++ b/cmd/gateway/semantic_vaillant_test.go
@@ -477,6 +477,175 @@ func TestReadB524StartupUsesLivePathWithoutScheduler(t *testing.T) {
 	}
 }
 
+func TestRefreshStateSkipsSlowZoneAndDHWB524Selectors(t *testing.T) {
+	t.Parallel()
+
+	var selectors [][]byte
+	poller := &vaillantSemanticPoller{
+		scheduler:      ebusgateway.NewSemanticReadScheduler(),
+		provider:       graphql.NewLiveSemanticProvider(),
+		source:         0x7F,
+		controller:     0x15,
+		requestTimeout: 50 * time.Millisecond,
+		zones: map[byte]*vaillantZoneSnapshot{
+			0x00: {
+				Instance:                    0x00,
+				Present:                     true,
+				ConfigurationCircuitTypeRaw: uint16Ptr(1),
+			},
+		},
+		circuits: map[byte]*vaillantCircuitSnapshot{
+			0x00: {Instance: 0x00, Active: true, CircuitTypeRaw: uint16Ptr(1)},
+		},
+	}
+	poller.sendFrameFn = func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+		selectors = append(selectors, slices.Clone(frame.Data))
+		return testB524ResponseForSelector(frame.Data), nil
+	}
+
+	poller.refreshState(context.Background())
+
+	requireB524Selector(t, selectors, localZones.group, 0x00, zone_current_temp)
+	requireB524Selector(t, selectors, localZones.group, 0x00, zone_target_temp)
+	requireB524Selector(t, selectors, localZones.group, 0x00, zone_heating_op_mode)
+	requireB524Selector(t, selectors, localZones.group, 0x00, zone_valve_status)
+	requireB524Selector(t, selectors, localDHW.group, dhwInstance, dhw_current_temp)
+	requireB524Selector(t, selectors, localDHW.group, dhwInstance, dhw_operation_mode)
+
+	for _, forbidden := range []struct {
+		group    byte
+		instance byte
+		addr     uint16
+	}{
+		{localZones.group, 0x00, zone_quick_veto_temp},
+		{localZones.group, 0x00, zone_quick_veto_end_time},
+		{localZones.group, 0x00, zone_holiday_start_date},
+		{localZones.group, 0x00, zone_room_temperature_zone_mapping_raw},
+		{localCircuits.group, 0x00, circuit_type},
+		{localDHW.group, dhwInstance, dhw_holiday_start_date},
+		{localDHW.group, dhwInstance, dhw_holiday_end_date},
+	} {
+		if hasB524Selector(selectors, forbidden.group, forbidden.instance, forbidden.addr) {
+			t.Fatalf("refreshState read slow selector group=0x%02x instance=0x%02x addr=0x%04x", forbidden.group, forbidden.instance, forbidden.addr)
+		}
+	}
+}
+
+func TestRefreshConfigReadsSlowZoneAndDHWB524Selectors(t *testing.T) {
+	t.Parallel()
+
+	var selectors [][]byte
+	poller := &vaillantSemanticPoller{
+		scheduler:      ebusgateway.NewSemanticReadScheduler(),
+		provider:       graphql.NewLiveSemanticProvider(),
+		source:         0x7F,
+		controller:     0x15,
+		requestTimeout: 50 * time.Millisecond,
+		zones: map[byte]*vaillantZoneSnapshot{
+			0x00: {Instance: 0x00, Present: true},
+		},
+		circuits: make(map[byte]*vaillantCircuitSnapshot),
+	}
+	poller.sendFrameFn = func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+		selectors = append(selectors, slices.Clone(frame.Data))
+		return testB524ResponseForSelector(frame.Data), nil
+	}
+
+	poller.refreshConfig(context.Background())
+
+	requireB524Selector(t, selectors, localZones.group, 0x00, zone_quick_veto_temp)
+	requireB524Selector(t, selectors, localZones.group, 0x00, zone_quick_veto_end_time)
+	requireB524Selector(t, selectors, localZones.group, 0x00, zone_holiday_start_date)
+	requireB524Selector(t, selectors, localZones.group, 0x00, zone_room_temperature_zone_mapping_raw)
+	requireB524Selector(t, selectors, localCircuits.group, 0x00, circuit_type)
+	requireB524Selector(t, selectors, localDHW.group, dhwInstance, dhw_holiday_start_date)
+	requireB524Selector(t, selectors, localDHW.group, dhwInstance, dhw_holiday_end_date)
+
+	if hasB524Selector(selectors, localZones.group, 0x00, zone_current_temp) {
+		t.Fatal("refreshConfig read fast zone current temperature selector")
+	}
+	if hasB524Selector(selectors, localDHW.group, dhwInstance, dhw_current_temp) {
+		t.Fatal("refreshConfig read fast DHW current temperature selector")
+	}
+}
+
+func hasB524Selector(selectors [][]byte, group, instance byte, addr uint16) bool {
+	for _, selector := range selectors {
+		if len(selector) != 6 {
+			continue
+		}
+		gotAddr := uint16(selector[4]) | uint16(selector[5])<<8
+		if selector[2] == group && selector[3] == instance && gotAddr == addr {
+			return true
+		}
+	}
+	return false
+}
+
+func requireB524Selector(t *testing.T, selectors [][]byte, group, instance byte, addr uint16) {
+	t.Helper()
+	if !hasB524Selector(selectors, group, instance, addr) {
+		t.Fatalf("missing selector group=0x%02x instance=0x%02x addr=0x%04x in % x", group, instance, addr, selectors)
+	}
+}
+
+func testB524ResponseForSelector(selector []byte) *protocol.Frame {
+	if len(selector) != 6 {
+		return &protocol.Frame{Data: []byte{0x00}}
+	}
+	group := selector[2]
+	instance := selector[3]
+	addr := uint16(selector[4]) | uint16(selector[5])<<8
+	payload := testB524PayloadForSelector(group, addr)
+	data := []byte{0x01, instance, group, byte(addr), byte(addr >> 8)}
+	data = append(data, payload...)
+	return &protocol.Frame{Data: data}
+}
+
+func testB524PayloadForSelector(group byte, addr uint16) []byte {
+	switch {
+	case group == localZones.group && (addr == zone_current_temp ||
+		addr == zone_target_temp ||
+		addr == zone_fallback_manual_temp ||
+		addr == zone_current_humidity ||
+		addr == zone_quick_veto_temp ||
+		addr == zone_quick_veto_duration ||
+		addr == zone_holiday_setpoint):
+		return testB524Float32Payload(21.5)
+	case group == localDHW.group && (addr == dhw_current_temp || addr == dhw_target_temp):
+		return testB524Float32Payload(48.5)
+	case group == localRegulator.group && addr == system_flow_temperature:
+		return testB524Float32Payload(42.5)
+	case group == localZones.group && (addr == zone_quick_veto_end_time ||
+		addr == zone_holiday_start_time ||
+		addr == zone_holiday_end_time):
+		return []byte{6, 30}
+	case group == localZones.group && (addr == zone_quick_veto_end_date ||
+		addr == zone_holiday_start_date ||
+		addr == zone_holiday_end_date):
+		return []byte{2, 1, 24}
+	case group == localDHW.group && (addr == dhw_holiday_start_date || addr == dhw_holiday_end_date):
+		return []byte{2, 1, 24}
+	case group == localZones.group && (addr == zone_heating_op_mode ||
+		addr == zone_special_function ||
+		addr == zone_valve_status ||
+		addr == zone_room_temperature_zone_mapping_raw):
+		return []byte{1, 0}
+	case group == localCircuits.group && (addr == circuit_type ||
+		addr == circuit_pump_status ||
+		addr == circuit_circuit_state):
+		return []byte{1, 0}
+	default:
+		return []byte{'T', 'e', 's', 't', 0, 0}
+	}
+}
+
+func testB524Float32Payload(value float64) []byte {
+	payload := make([]byte, 4)
+	binary.LittleEndian.PutUint32(payload, math.Float32bits(float32(value)))
+	return payload
+}
+
 func TestRefreshDiscoveryPrimesDHWBeforeStartupZoneScan(t *testing.T) {
 	t.Parallel()
 
@@ -2552,6 +2721,50 @@ func TestRefreshBoilerStatusTier_NoSuccessfulReadsPreservesSnapshot(t *testing.T
 	}
 }
 
+func TestRefreshBoilerStatusFastUsesCachedDHWWithoutB524DHWReads(t *testing.T) {
+	t.Parallel()
+
+	current := 47.5
+	target := 50.0
+	var selectors [][]byte
+	poller := &vaillantSemanticPoller{
+		scheduler:      ebusgateway.NewSemanticReadScheduler(),
+		provider:       graphql.NewLiveSemanticProvider(),
+		source:         0x7F,
+		controller:     0x15,
+		requestTimeout: 50 * time.Millisecond,
+		dhw: &vaillantDhwSnapshot{
+			CurrentTempC:                  &current,
+			TargetTempC:                   &target,
+			ConfigurationDHWOperationMode: "1",
+		},
+	}
+	poller.sendFrameFn = func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+		selectors = append(selectors, slices.Clone(frame.Data))
+		return testB524ResponseForSelector(frame.Data), nil
+	}
+
+	poller.refreshBoilerStatusTier(context.Background(), boilerStatusTierFast)
+
+	for _, selector := range selectors {
+		if len(selector) == 6 && selector[2] == localDHW.group {
+			t.Fatalf("boiler fast issued duplicate DHW B524 selector % x", selector)
+		}
+	}
+	if poller.boiler == nil {
+		t.Fatal("poller.boiler = nil; want merged boiler snapshot")
+	}
+	if poller.boiler.DhwTemperatureC == nil || *poller.boiler.DhwTemperatureC != current {
+		t.Fatalf("boiler DhwTemperatureC = %v; want cached %.1f", poller.boiler.DhwTemperatureC, current)
+	}
+	if poller.boiler.DhwTargetTemperatureC == nil || *poller.boiler.DhwTargetTemperatureC != target {
+		t.Fatalf("boiler DhwTargetTemperatureC = %v; want cached %.1f", poller.boiler.DhwTargetTemperatureC, target)
+	}
+	if poller.boiler.DhwOperatingMode == nil || *poller.boiler.DhwOperatingMode != 1 {
+		t.Fatalf("boiler DhwOperatingMode = %v; want cached 1", poller.boiler.DhwOperatingMode)
+	}
+}
+
 func TestDeriveCircuitManagingDevice(t *testing.T) {
 	t.Parallel()
 
@@ -3775,7 +3988,30 @@ func TestMergeZoneSnapshotFields_PartialLiveUpdatePreservesLastKnownAndFreshness
 		CurrentTempC:                      &updatedCurrent,
 		ConfigurationHeatingOperationMode: "2",
 	}
-	mergeZoneSnapshotFields(entry, incoming, semanticSnapshotSourceLive, zoneStateFieldSet)
+	mergeZoneSnapshotFields(entry, incoming, semanticSnapshotSourceLive, newSemanticFieldSet(
+		zoneFieldOperatingMode,
+		zoneFieldPreset,
+		zoneFieldHvacAction,
+		zoneFieldAllowedModes,
+		zoneFieldCurrentTempC,
+		zoneFieldTargetTempC,
+		zoneFieldCurrentHumidityPct,
+		zoneFieldZoneOperationModeRaw,
+		zoneFieldSpecialFunctionRaw,
+		zoneFieldRoomTemperatureZoneMappingRaw,
+		zoneFieldZoneCircuitIndexRaw,
+		zoneFieldZoneValveStatusRaw,
+		zoneFieldCircuitTypeRaw,
+		zoneFieldQuickVetoTempC,
+		zoneFieldQuickVetoDurationH,
+		zoneFieldQuickVetoEndTime,
+		zoneFieldQuickVetoEndDate,
+		zoneFieldHolidayStartDate,
+		zoneFieldHolidayEndDate,
+		zoneFieldHolidaySetpointC,
+		zoneFieldHolidayStartTime,
+		zoneFieldHolidayEndTime,
+	))
 
 	if entry.CurrentTempC == nil || *entry.CurrentTempC != 21.8 {
 		t.Fatalf("entry.CurrentTempC = %v; want 21.8", entry.CurrentTempC)

--- a/cmd/gateway/semantic_vaillant_test.go
+++ b/cmd/gateway/semantic_vaillant_test.go
@@ -601,6 +601,51 @@ func TestRefreshConfigDHWOnlySuccessKeepsZonesCacheSource(t *testing.T) {
 	}
 }
 
+func TestRefreshConfigNoZonesStillRefreshesDHWSlowConfig(t *testing.T) {
+	t.Parallel()
+
+	provider := graphql.NewLiveSemanticProvider()
+	poller := &vaillantSemanticPoller{
+		scheduler:             ebusgateway.NewSemanticReadScheduler(),
+		provider:              provider,
+		reg:                   newTestRegistry(registry.DeviceInfo{Address: 0x15, Manufacturer: "Vaillant", DeviceID: "BASV"}),
+		source:                0x7F,
+		controller:            0x15,
+		requestTimeout:        50 * time.Millisecond,
+		zones:                 make(map[byte]*vaillantZoneSnapshot),
+		presence:              make(map[byte]*zonePresenceRecord),
+		circuits:              make(map[byte]*vaillantCircuitSnapshot),
+		radioDevices:          make(map[radioDeviceKey]*vaillantRadioDeviceSnapshot),
+		solarCylinders:        make(map[byte]*vaillantCylinderSnapshot),
+		startupSemanticPrimed: true,
+		b524ProbeFn: func(context.Context, byte, byte, byte, byte, uint16) bool {
+			return true
+		},
+	}
+	poller.sendFrameFn = func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+		if len(frame.Data) == 6 && frame.Data[2] == localDHW.group {
+			return testB524ResponseForSelector(frame.Data), nil
+		}
+		if len(frame.Data) == 6 && frame.Data[2] == localZones.group && (uint16(frame.Data[4])|uint16(frame.Data[5])<<8) == zone_index {
+			group := frame.Data[2]
+			instance := frame.Data[3]
+			addr := uint16(frame.Data[4]) | uint16(frame.Data[5])<<8
+			return &protocol.Frame{Data: []byte{0x01, instance, group, byte(addr), byte(addr >> 8), 0xFF}}, nil
+		}
+		return nil, errors.New("non-DHW read unavailable")
+	}
+
+	poller.refreshConfig(context.Background())
+
+	dhw := provider.DHW()
+	if dhw == nil {
+		t.Fatal("DHW = nil; want no-zone config refresh to publish DHW slow fields")
+	}
+	if dhw.Config.HolidayStartDate == "" || dhw.Config.HolidayEndDate == "" {
+		t.Fatalf("DHW holiday dates = %q/%q; want slow config values", dhw.Config.HolidayStartDate, dhw.Config.HolidayEndDate)
+	}
+}
+
 func hasB524Selector(selectors [][]byte, group, instance byte, addr uint16) bool {
 	for _, selector := range selectors {
 		if len(selector) != 6 {

--- a/cmd/gateway/semantic_vaillant_test.go
+++ b/cmd/gateway/semantic_vaillant_test.go
@@ -569,6 +569,38 @@ func TestRefreshConfigReadsSlowZoneAndDHWB524Selectors(t *testing.T) {
 	}
 }
 
+func TestRefreshConfigDHWOnlySuccessKeepsZonesCacheSource(t *testing.T) {
+	t.Parallel()
+
+	provider := graphql.NewLiveSemanticProvider()
+	poller := &vaillantSemanticPoller{
+		scheduler:      ebusgateway.NewSemanticReadScheduler(),
+		provider:       provider,
+		source:         0x7F,
+		controller:     0x15,
+		requestTimeout: 50 * time.Millisecond,
+		zones: map[byte]*vaillantZoneSnapshot{
+			0x00: {Instance: 0x00, Present: true, Name: "Zone 1"},
+		},
+		circuits: make(map[byte]*vaillantCircuitSnapshot),
+	}
+	poller.sendFrameFn = func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+		if len(frame.Data) == 6 && frame.Data[2] == localDHW.group {
+			return testB524ResponseForSelector(frame.Data), nil
+		}
+		return nil, errors.New("zone read unavailable")
+	}
+
+	poller.refreshConfig(context.Background())
+
+	if dhw := provider.DHW(); dhw == nil {
+		t.Fatal("DHW = nil; want DHW slow config to publish")
+	}
+	if cacheEpoch, liveEpoch := provider.StartupEpochs(); liveEpoch != 1 || cacheEpoch != 1 {
+		t.Fatalf("StartupEpochs() = cache=%d live=%d; want zone cache=1 and DHW live=1", cacheEpoch, liveEpoch)
+	}
+}
+
 func hasB524Selector(selectors [][]byte, group, instance byte, addr uint16) bool {
 	for _, selector := range selectors {
 		if len(selector) != 6 {
@@ -2762,6 +2794,35 @@ func TestRefreshBoilerStatusFastUsesCachedDHWWithoutB524DHWReads(t *testing.T) {
 	}
 	if poller.boiler.DhwOperatingMode == nil || *poller.boiler.DhwOperatingMode != 1 {
 		t.Fatalf("boiler DhwOperatingMode = %v; want cached 1", poller.boiler.DhwOperatingMode)
+	}
+}
+
+func TestRefreshBoilerStatusFastCachedDHWOnlyDoesNotPublishLive(t *testing.T) {
+	t.Parallel()
+
+	current := 47.5
+	target := 50.0
+	provider := graphql.NewLiveSemanticProvider()
+	poller := &vaillantSemanticPoller{
+		scheduler:      ebusgateway.NewSemanticReadScheduler(),
+		provider:       provider,
+		source:         0x7F,
+		controller:     0x15,
+		requestTimeout: 50 * time.Millisecond,
+		dhw: &vaillantDhwSnapshot{
+			CurrentTempC:                  &current,
+			TargetTempC:                   &target,
+			ConfigurationDHWOperationMode: "1",
+		},
+	}
+	poller.sendFrameFn = func(context.Context, protocol.Frame) (*protocol.Frame, error) {
+		return nil, errors.New("boiler fast unavailable")
+	}
+
+	poller.refreshBoilerStatusTier(context.Background(), boilerStatusTierFast)
+
+	if got := provider.BoilerStatus(); got != nil {
+		t.Fatalf("BoilerStatus() = %+v; want nil without live boiler/B524 success", got)
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -114,49 +114,49 @@ type Config struct {
 	DiagnosticFullRangeRetry bool
 	// SemanticInterval is a legacy single-interval semantic polling configuration.
 	// Prefer SemanticDiscoveryInterval / SemanticConfigInterval / SemanticStateInterval.
-	SemanticInterval                        time.Duration
-	SemanticDiscoveryInterval               time.Duration
-	SemanticConfigInterval                  time.Duration
-	SemanticStateInterval                   time.Duration
-	SemanticEnergyInterval                  time.Duration
-	SemanticRequestTimeout                  time.Duration
-	SemanticReadBreakerFailureBudget        int
-	SemanticReadBreakerFailureBudgetSet     bool
-	SemanticReadBreakerOpenCooldown         time.Duration
-	SemanticReadBreakerHalfOpenProbeLimit   int
-	SemanticZonePresenceMissThreshold       int
-	SemanticZonePresenceHitThreshold        int
-	SemanticDHWStaleTTL                     time.Duration
-	SemanticRegulatorRecheckInterval        time.Duration
-	SemanticRegulatorAbsenceGrace           time.Duration
-	SemanticCachePath                       string
-	BroadcastListen                         bool
-	PassiveAbsenceThreshold                 time.Duration
-	PassiveTransactionWatchdog              time.Duration
-	PassiveReconnectInitialDelay            time.Duration
-	PassiveReconnectMaxDelay                time.Duration
-	PassiveDedupActivePublishBudget         time.Duration
-	PassiveDedupPassiveDeliveryBudget       time.Duration
-	PassiveDedupPendingGraceTimeout         time.Duration
-	PassiveDedupActiveFingerprintRetention  time.Duration
-	PassiveDedupPendingCapacity             int
-	PassiveDedupRecoveryHysteresis          time.Duration
-	PassiveDedupRecoveryEventThreshold      int
-	LocalAddressSnapshotter                 LocalBusAddressSnapshotter
-	AdmittedSource                          func() byte
-	WatchObserver                           WatchObserver
-	WatchEfficiencyObserver                 WatchEfficiencyObserver
-	HTTPAddr                                string
-	MetricsPath                             string
-	GraphQLPath                             string
-	SnapshotPath                            string
-	SubscriptionPath                        string
-	MCPPath                                 string
-	UIPath                                  string
-	PortalPath                              string
-	MDNSAdvertise                           bool
-	MDNSInstance                            string
-	InstanceGUID                            string
+	SemanticInterval                       time.Duration
+	SemanticDiscoveryInterval              time.Duration
+	SemanticConfigInterval                 time.Duration
+	SemanticStateInterval                  time.Duration
+	SemanticEnergyInterval                 time.Duration
+	SemanticRequestTimeout                 time.Duration
+	SemanticReadBreakerFailureBudget       int
+	SemanticReadBreakerFailureBudgetSet    bool
+	SemanticReadBreakerOpenCooldown        time.Duration
+	SemanticReadBreakerHalfOpenProbeLimit  int
+	SemanticZonePresenceMissThreshold      int
+	SemanticZonePresenceHitThreshold       int
+	SemanticDHWStaleTTL                    time.Duration
+	SemanticRegulatorRecheckInterval       time.Duration
+	SemanticRegulatorAbsenceGrace          time.Duration
+	SemanticCachePath                      string
+	BroadcastListen                        bool
+	PassiveAbsenceThreshold                time.Duration
+	PassiveTransactionWatchdog             time.Duration
+	PassiveReconnectInitialDelay           time.Duration
+	PassiveReconnectMaxDelay               time.Duration
+	PassiveDedupActivePublishBudget        time.Duration
+	PassiveDedupPassiveDeliveryBudget      time.Duration
+	PassiveDedupPendingGraceTimeout        time.Duration
+	PassiveDedupActiveFingerprintRetention time.Duration
+	PassiveDedupPendingCapacity            int
+	PassiveDedupRecoveryHysteresis         time.Duration
+	PassiveDedupRecoveryEventThreshold     int
+	LocalAddressSnapshotter                LocalBusAddressSnapshotter
+	AdmittedSource                         func() byte
+	WatchObserver                          WatchObserver
+	WatchEfficiencyObserver                WatchEfficiencyObserver
+	HTTPAddr                               string
+	MetricsPath                            string
+	GraphQLPath                            string
+	SnapshotPath                           string
+	SubscriptionPath                       string
+	MCPPath                                string
+	UIPath                                 string
+	PortalPath                             string
+	MDNSAdvertise                          bool
+	MDNSInstance                           string
+	InstanceGUID                           string
 	// InstanceGUIDSource is the AD27 provenance tag passed by the
 	// add-on alongside InstanceGUID. One of: "runtime_state",
 	// "legacy_migrated", "generated", "cli-override". Empty when the
@@ -166,7 +166,7 @@ type Config struct {
 	InstanceGUIDSource string
 	// RuntimeStatePath overrides /data/runtime_state.json for tests +
 	// alternate deployments. Empty uses the runtimestate package default.
-	RuntimeStatePath string
+	RuntimeStatePath                        string
 	DumpOutputDir                           string
 	DumpUploadPath                          string
 	DumpUploadURL                           string

--- a/internal/adaptermux/absorb_debounce_test.go
+++ b/internal/adaptermux/absorb_debounce_test.go
@@ -81,7 +81,7 @@ func TestAbsorbSkipLog_RateLimitedWithSuppressedSuffix(t *testing.T) {
 	})
 
 	mock := newP3MockTransport()
-	defer mock.Close()
+	defer func() { _ = mock.Close() }()
 	mux.connMu.Lock()
 	mux.upstream = mock
 	mux.connMu.Unlock()
@@ -169,7 +169,7 @@ func TestAbsorbSkipLog_NoCarryoverAcrossAbsorbEpisodes(t *testing.T) {
 	})
 
 	mock := newP3MockTransport()
-	defer mock.Close()
+	defer func() { _ = mock.Close() }()
 	mux.connMu.Lock()
 	mux.upstream = mock
 	mux.connMu.Unlock()

--- a/internal/adaptermux/e2e_test.go
+++ b/internal/adaptermux/e2e_test.go
@@ -193,8 +193,8 @@ func TestE2E_ScanB504_ToTarget0x08_SuccessFullFlow(t *testing.T) {
 		t.Logf("Phase-3 timeout after %d/%d bytes consumed", len(gotSnapshot), totalExpected)
 		t.Logf("bytes consumed: % X", gotSnapshot)
 		dumpSynDiag(t, mux)
-		t.Fatalf("Phase-3 timeout: terminator SYN never delivered to activeCh after explicit "+
-			"sendEndOfMessage. Round-6 regression — the hasPendingEcho+SymbolSyn branch of "+
+		t.Fatalf("Phase-3 timeout: terminator SYN never delivered to activeCh after explicit " +
+			"sendEndOfMessage. Round-6 regression — the hasPendingEcho+SymbolSyn branch of " +
 			"the terminator gate failed to fire.")
 	}
 

--- a/internal/adaptermux/echo_passthrough_test.go
+++ b/internal/adaptermux/echo_passthrough_test.go
@@ -490,7 +490,7 @@ func TestDeliverToSessions_NoReorderUnderBurst(t *testing.T) {
 //  4. Assert at each step:
 //     a. Owner session receives each byte (F-18 contract).
 //     b. Ownership held until the trailing SYN (NOT the final ACK,
-//        per F-21).
+//     per F-21).
 //     c. Ownership released exactly at the SYN observation.
 //     d. After release, m.phase is back at Idle.
 //

--- a/internal/adaptermux/f15_am8_deadline_reconnect_test.go
+++ b/internal/adaptermux/f15_am8_deadline_reconnect_test.go
@@ -360,4 +360,3 @@ func TestF22_AbsorbTimerResetsCounterWithoutReconnect(t *testing.T) {
 		t.Fatalf("pendingStartAbsorb = %d after safety-net fire; want 0 (reset must clear the barrier)", stillBlocked)
 	}
 }
-

--- a/internal/adaptermux/f17_cancelled_result_flag_test.go
+++ b/internal/adaptermux/f17_cancelled_result_flag_test.go
@@ -32,7 +32,7 @@ import (
 func TestArbitrator_SameSessionReplace_StartResultCarriesCancelledFlag(t *testing.T) {
 	t.Run("external_session_replace", func(t *testing.T) {
 		arb := newArbitrator()
-		arb.setPolicy(24 * time.Hour, 0, 0) // disable C3 TTL for this test
+		arb.setPolicy(24*time.Hour, 0, 0) // disable C3 TTL for this test
 
 		chOld := arb.requestStart(1, 0x31)
 		_ = arb.requestStart(1, 0x32) // replaces chOld in pendingExternal
@@ -55,7 +55,7 @@ func TestArbitrator_SameSessionReplace_StartResultCarriesCancelledFlag(t *testin
 
 	t.Run("gateway_session_replace", func(t *testing.T) {
 		arb := newArbitrator()
-		arb.setPolicy(24 * time.Hour, 0, 0)
+		arb.setPolicy(24*time.Hour, 0, 0)
 
 		chOld := arb.requestStart(gatewaySessionID, 0x71)
 		_ = arb.requestStart(gatewaySessionID, 0x72) // replaces pendingGateway
@@ -84,7 +84,7 @@ func TestArbitrator_SameSessionReplace_StartResultCarriesCancelledFlag(t *testin
 // is not regressed.
 func TestArbitrator_SameSessionReplace_StructFlagAlsoSet(t *testing.T) {
 	arb := newArbitrator()
-	arb.setPolicy(24 * time.Hour, 0, 0)
+	arb.setPolicy(24*time.Hour, 0, 0)
 
 	_ = arb.requestStart(1, 0x31)
 	arb.mu.Lock()

--- a/internal/adaptermux/f17_review_round1_test.go
+++ b/internal/adaptermux/f17_review_round1_test.go
@@ -180,7 +180,7 @@ func TestHandleArbitrationResponse_InFlightCancelled_FAILED_LogMarksSuppression(
 // cancelled=true so handleStart silent-returns.
 func TestArbitrator_CancelStart_ExternalSession_SetsCancelledFlag(t *testing.T) {
 	arb := newArbitrator()
-	arb.setPolicy(24 * time.Hour, 0, 0)
+	arb.setPolicy(24*time.Hour, 0, 0)
 
 	ch := arb.requestStart(1, 0x31)
 	if !arb.cancelStart(1) {
@@ -207,7 +207,7 @@ func TestArbitrator_CancelStart_ExternalSession_SetsCancelledFlag(t *testing.T) 
 // for the gateway-session path. Same contract as the external path.
 func TestArbitrator_CancelStart_GatewaySession_SetsCancelledFlag(t *testing.T) {
 	arb := newArbitrator()
-	arb.setPolicy(24 * time.Hour, 0, 0)
+	arb.setPolicy(24*time.Hour, 0, 0)
 
 	ch := arb.requestStart(gatewaySessionID, 0x71)
 	if !arb.cancelStart(gatewaySessionID) {
@@ -310,7 +310,7 @@ func TestHandleArbitrationResponse_InFlightCancelled_AM56Mismatch_SuppressedSile
 // late-STARTED suppression path), so cancelStart must set both flags.
 func TestArbitrator_CancelStart_AlsoSetsStructFlag(t *testing.T) {
 	arb := newArbitrator()
-	arb.setPolicy(24 * time.Hour, 0, 0)
+	arb.setPolicy(24*time.Hour, 0, 0)
 
 	_ = arb.requestStart(1, 0x31)
 	arb.mu.Lock()

--- a/internal/adaptermux/f17_review_round3_test.go
+++ b/internal/adaptermux/f17_review_round3_test.go
@@ -266,10 +266,10 @@ func TestRequestStartErr_InFlightCancelled_ResetErr_DeliversReset(t *testing.T) 
 // a fixed error from RequestStart. Used to exercise M2's
 // non-blocking-half err branch deterministically.
 type requestStartErrTransport struct {
-	eventCh    chan transport.StreamEvent
-	err        error
-	calls      atomic.Int32
-	closed     atomic.Bool
+	eventCh chan transport.StreamEvent
+	err     error
+	calls   atomic.Int32
+	closed  atomic.Bool
 }
 
 func (t *requestStartErrTransport) RequestStart(initiator byte) error {

--- a/internal/adaptermux/listener_test.go
+++ b/internal/adaptermux/listener_test.go
@@ -75,13 +75,13 @@ func newTestMux(t *testing.T) (*Mux, context.CancelFunc, func()) {
 	adapterAddr, adapterClose := fakeAdapterServer(t)
 
 	cfg := Config{
-		Protocol:    "enh",
-		Network:     "tcp",
-		Address:     adapterAddr,
-		DialTimeout: 2 * time.Second,
-		ReadTimeout: 200 * time.Millisecond,
-	PendingStartTTL: 24 * time.Hour,  // disable C3 TTL drain in legacy tests
-	SYNInterval: time.Hour,  // disable C1 idle fast path in legacy tests
+		Protocol:        "enh",
+		Network:         "tcp",
+		Address:         adapterAddr,
+		DialTimeout:     2 * time.Second,
+		ReadTimeout:     200 * time.Millisecond,
+		PendingStartTTL: 24 * time.Hour, // disable C3 TTL drain in legacy tests
+		SYNInterval:     time.Hour,      // disable C1 idle fast path in legacy tests
 	}
 
 	mux := New(cfg)
@@ -327,13 +327,13 @@ func TestConnect_INITRetrySucceeds(t *testing.T) {
 	defer adapterClose()
 
 	cfg := Config{
-		Protocol:    "enh",
-		Network:     "tcp",
-		Address:     adapterAddr,
-		DialTimeout: 2 * time.Second,
-		ReadTimeout: 200 * time.Millisecond,
-	PendingStartTTL: 24 * time.Hour,  // disable C3 TTL drain in legacy tests
-	SYNInterval: time.Hour,  // disable C1 idle fast path in legacy tests
+		Protocol:        "enh",
+		Network:         "tcp",
+		Address:         adapterAddr,
+		DialTimeout:     2 * time.Second,
+		ReadTimeout:     200 * time.Millisecond,
+		PendingStartTTL: 24 * time.Hour, // disable C3 TTL drain in legacy tests
+		SYNInterval:     time.Hour,      // disable C1 idle fast path in legacy tests
 	}
 
 	mux := New(cfg)

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -2085,7 +2085,7 @@ func (m *Mux) onReceived(symbol byte, wasEscaped bool) {
 	// decoded payload 0xAA (wasEscaped=true) is genuine bus traffic
 	// from a third-party frame and MUST refresh the activity clock;
 	// only a real un-escaped wire SYN counts as bus-idle.
-	if !(symbol == protocol.SymbolSyn && !wasEscaped) {
+	if symbol != protocol.SymbolSyn || wasEscaped {
 		m.lastWireActivity = now
 	}
 
@@ -2573,7 +2573,7 @@ func (m *Mux) onSYNLocked(phaseEvent wirePhaseEvent, ownerID uint64, hasOwner bo
 	// structural flag the predicate now treats case (b) the same as
 	// case (c): midWriteSyn=true → wire SYN suppressed.
 	nextExpectedEcho, nextStructural, hasPendingEcho := m.gatewayEcho.peekNextExpectedWithFlags()
-	midWriteSyn := hasPendingEcho && !(nextExpectedEcho == protocol.SymbolSyn && nextStructural)
+	midWriteSyn := hasPendingEcho && (nextExpectedEcho != protocol.SymbolSyn || !nextStructural)
 
 	// batch-26 round-7 — Attack 3 closure (inter-write empty-queue SYN
 	// leak). The peek-based P10.2 gate (midWriteSyn) cannot suppress a

--- a/internal/adaptermux/pacer_wiring_test.go
+++ b/internal/adaptermux/pacer_wiring_test.go
@@ -67,7 +67,7 @@ func TestSessionPacer_AddSession_CreatesPacer(t *testing.T) {
 	defer cleanup()
 
 	clientConn, serverConn := net.Pipe()
-	defer clientConn.Close()
+	defer func() { _ = clientConn.Close() }()
 	sid := mux.AddSession(serverConn)
 	if sid == 0 {
 		t.Fatal("AddSession returned 0")
@@ -96,7 +96,7 @@ func TestSessionPacer_RemoveSession_DropsEntry(t *testing.T) {
 	defer cleanup()
 
 	clientConn, serverConn := net.Pipe()
-	defer clientConn.Close()
+	defer func() { _ = clientConn.Close() }()
 	sid := mux.AddSession(serverConn)
 	if sid == 0 {
 		t.Fatal("AddSession returned 0")
@@ -465,7 +465,7 @@ func TestSessionPacer_OutputPacer_SchedulesFrameEgress(t *testing.T) {
 	defer cleanup()
 
 	clientConn, serverConn := net.Pipe()
-	defer clientConn.Close()
+	defer func() { _ = clientConn.Close() }()
 	sid := mux.AddSession(serverConn)
 	if sid == 0 {
 		t.Fatal("AddSession returned 0")
@@ -556,7 +556,7 @@ func TestSessionPacer_OutputPacer_OffMode_NoSchedule(t *testing.T) {
 	defer cleanup()
 
 	clientConn, serverConn := net.Pipe()
-	defer clientConn.Close()
+	defer func() { _ = clientConn.Close() }()
 	sid := mux.AddSession(serverConn)
 	if sid == 0 {
 		t.Fatal("AddSession returned 0")
@@ -618,7 +618,7 @@ func TestSessionPacer_OutputPacer_FrameAtomicEgress(t *testing.T) {
 	defer cleanup()
 
 	clientConn, pipeServerConn := net.Pipe()
-	defer clientConn.Close()
+	defer func() { _ = clientConn.Close() }()
 	// Wrap the server side of the pipe with a writeCounter so we
 	// can assert the per-frame Write count (Codex round-2 MAJOR #1).
 	recorder := &writeCountingConn{Conn: pipeServerConn}

--- a/internal/adaptermux/phantom_collision_filter_test.go
+++ b/internal/adaptermux/phantom_collision_filter_test.go
@@ -58,7 +58,7 @@ func TestReadLoop_PhantomCollisionByteNotMirrored(t *testing.T) {
 	// directly via AddSession to keep the scope contained to the
 	// readLoop → mirror-delivery path.
 	clientConn, serverConn := net.Pipe()
-	defer clientConn.Close()
+	defer func() { _ = clientConn.Close() }()
 	sid := mux.AddSession(serverConn)
 	if sid == 0 {
 		t.Fatal("AddSession returned 0")
@@ -116,7 +116,7 @@ func TestReadLoop_RealMasterByteStillMirrored(t *testing.T) {
 		ReadTimeout: 200 * time.Millisecond,
 		// Treat every byte as a known initiator — C5 must be a no-op.
 		IsKnownInitiatorByte: func(b byte) bool { return true },
-		PendingStartTTL:   24 * time.Hour,
+		PendingStartTTL:      24 * time.Hour,
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -139,7 +139,7 @@ func TestReadLoop_RealMasterByteStillMirrored(t *testing.T) {
 	}()
 
 	clientConn, serverConn := net.Pipe()
-	defer clientConn.Close()
+	defer func() { _ = clientConn.Close() }()
 	sid := mux.AddSession(serverConn)
 	if sid == 0 {
 		t.Fatal("AddSession returned 0")

--- a/internal/adaptermux/pr502_review_test.go
+++ b/internal/adaptermux/pr502_review_test.go
@@ -337,7 +337,7 @@ func TestBlockingArbDeadline_NoOverlap(t *testing.T) {
 		// drain (default 50 ms would reject the external pending
 		// during the test's 150 ms deadline window).
 		PendingStartTTL: 24 * time.Hour,
-	SYNInterval: time.Hour,  // disable C1 idle fast path in legacy tests
+		SYNInterval:     time.Hour, // disable C1 idle fast path in legacy tests
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1132,7 +1132,7 @@ func TestBlockingArbDeadline_TriggersReconnect_NoOverlap(t *testing.T) {
 		StartDeadline: 120 * time.Millisecond,
 		// C1/C3 test isolation (see paired test above).
 		PendingStartTTL: 24 * time.Hour,
-	SYNInterval: time.Hour,  // disable C1 idle fast path in legacy tests
+		SYNInterval:     time.Hour, // disable C1 idle fast path in legacy tests
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/adaptermux/pre_echo_syn_p102_test.go
+++ b/internal/adaptermux/pre_echo_syn_p102_test.go
@@ -171,7 +171,6 @@ func TestPreEchoSyn_LegitimateTerminator_Delivered(t *testing.T) {
 	}
 }
 
-
 // TestPreEchoSyn_BetweenWritesSyn_Suppress (batch-26 round-7 — Attack 3
 // closure). Verifies that a wire SYN arriving in the inter-write window
 // (matchEcho consumed echo K, recordSent of K+1 not yet armed) is
@@ -191,7 +190,7 @@ func TestPreEchoSyn_LegitimateTerminator_Delivered(t *testing.T) {
 //     gatewayTxnActive=true, bytesDeliveredToActive>0
 //     → betweenWritesSyn=true, preEchoMidFrameSuppress=true
 //     → terminator branch does NOT fire (gated on
-//       !preEchoMidFrameSuppress)
+//     !preEchoMidFrameSuppress)
 //     → synSuppressedBetweenWrites counter increments
 //     → flushOnSYN does NOT fire (queueJustDrained preserved)
 //     → idle release does NOT fire (suppressIdleRelease gates).

--- a/internal/adaptermux/syn_diag_test.go
+++ b/internal/adaptermux/syn_diag_test.go
@@ -298,7 +298,6 @@ func TestOnSYNLocked_NoTerminatorDeliveryWhenBytesReadZero(t *testing.T) {
 	}
 }
 
-
 // TestEchoMismatch_SYNAfterWriteBeforeFirstEcho is the exact scenario
 // Codex flagged on PR #502 (commit 30c3dcd / finding at mux.go:1210):
 // the terminator gate keying off bytesWritten>0 allows a queued idle SYN

--- a/internal/adaptermux/v8classifier/classifier.go
+++ b/internal/adaptermux/v8classifier/classifier.go
@@ -942,16 +942,16 @@ func (c *Classifier) EnforceDropsAppliedTotal() uint64 {
 //   - nil classifier: returns 0.
 //
 // Operator usage (canary rollout):
-//   1. Deploy with HELIANTHUS_V8_CLASSIFIER_MODE=shadow.
-//   2. Monitor this counter during a representative production
-//      window (e.g. 24h of bus activity).
-//   3. If the counter stays at 0 or stays bounded (no growth
-//      under normal load), the classifier's enforce-mode impact
-//      would be zero (or bounded). Promote to enforce.
-//   4. If the counter grows under normal load, the classifier
-//      is flagging legitimate bytes — investigate before
-//      promoting (likely a false-positive AA-injection
-//      classification).
+//  1. Deploy with HELIANTHUS_V8_CLASSIFIER_MODE=shadow.
+//  2. Monitor this counter during a representative production
+//     window (e.g. 24h of bus activity).
+//  3. If the counter stays at 0 or stays bounded (no growth
+//     under normal load), the classifier's enforce-mode impact
+//     would be zero (or bounded). Promote to enforce.
+//  4. If the counter grows under normal load, the classifier
+//     is flagging legitimate bytes — investigate before
+//     promoting (likely a false-positive AA-injection
+//     classification).
 //
 // Prometheus alert (deployment/prometheus-alerts.md):
 //

--- a/internal/adaptermux/wire_phase_test.go
+++ b/internal/adaptermux/wire_phase_test.go
@@ -546,9 +546,9 @@ func TestWirePhase_ResponseDoubleNACK(t *testing.T) {
 	tracker.advance(protocol.SymbolNack) // first NACK -> retry
 
 	// Retry response + second NACK.
-	tracker.advance(0x01)                       // LEN
-	tracker.advance(0xAB)                       // DATA
-	tracker.advance(0xEE)                       // CRC -> ResponseDone
+	tracker.advance(0x01) // LEN
+	tracker.advance(0xAB) // DATA
+	tracker.advance(0xEE) // CRC -> ResponseDone
 	// F-21 (batch-20): second response NACK defers to trailing SYN.
 	got := tracker.advance(protocol.SymbolNack)
 	if got != wirePhaseEventNone {

--- a/internal/runtimestate/revalidate_test.go
+++ b/internal/runtimestate/revalidate_test.go
@@ -47,7 +47,7 @@ func TestRevalidator_OrdersByLastSeenAtDescThenAddrAsc(t *testing.T) {
 	members := []KnownBusMember{
 		makeMember(0x08, t0.Add(-3*time.Minute)),
 		makeMember(0x15, t0),
-		makeMember(0xF6, t0),                  // tie with 0x15 → addr ASC means 0x15 first
+		makeMember(0xF6, t0), // tie with 0x15 → addr ASC means 0x15 first
 		makeMember(0x26, t0.Add(-1*time.Minute)),
 		makeMember(0x04, t0.Add(-3*time.Minute)), // tie with 0x08 → addr ASC means 0x04 first
 	}
@@ -210,7 +210,7 @@ func TestRevalidator_PassivelyRefreshedMembersDoNotConsumeCap(t *testing.T) {
 func TestRevalidator_NoReplyOutcomeReportedAndCounted(t *testing.T) {
 	t0 := time.Date(2026, 5, 10, 19, 0, 0, 0, time.UTC)
 	members := []KnownBusMember{
-		makeMember(0x08, t0),                  // responder
+		makeMember(0x08, t0),                     // responder
 		makeMember(0x15, t0.Add(-1*time.Second)), // no-reply
 		makeMember(0xF6, t0.Add(-2*time.Second)), // responder
 	}

--- a/internal/runtimestate/runtimestate.go
+++ b/internal/runtimestate/runtimestate.go
@@ -665,4 +665,3 @@ func (m *Manager) atomicWrite(snap *State) error {
 	m.opts.Metrics.OnWrite("ok")
 	return nil
 }
-


### PR DESCRIPTION
## What
Fixes #670 by splitting steady-state semantic B524 reads into fast and slow slices.

- Keeps the 60s state task focused on live-critical zone and DHW values
- Moves quick-veto, holiday, room mapping, associated circuit type, and DHW holiday reads to config cadence
- Projects boiler-status DHW fields from the semantic DHW snapshot instead of duplicating DHW B524 reads in boiler-fast
- Includes a mechanical gofmt/errcheck/staticcheck cleanup required for local CI

## Why
Post-deploy metrics showed gateway-originated `0x7f -> 0x15` B524 traffic at about 5k/hour after passive-cache recovery. Code inspection matched the observed magnitude: the 60s state loop was reading broad slow zone fields, and boiler-fast duplicated DHW reads every 30s.

## Doc Gate
- Project-Helianthus/helianthus-docs-ebus#321

## Validation
- `go test ./cmd/gateway`
- `go test ./internal/adaptermux`
- `go test ./...`
- `golangci-lint run ./...`
- `PATH="/Users/razvan/go/bin:$PATH" make ci-local` in docs repo
- `TRANSPORT_GATE_OWNER_OVERRIDE=OVERRIDE_TRANSPORT_GATE_BY_OWNER TRANSPORT_GATE_OWNER_REASON="issue #670 touches adaptermux only for gofmt/errcheck/staticcheck cleanup required by local CI; no transport behavior change" PASSIVE_SMOKE_GATE_OWNER_OVERRIDE=OVERRIDE_PASSIVE_SMOKE_GATE_BY_OWNER PASSIVE_SMOKE_GATE_OWNER_REASON="issue #670 touches config.go only for gofmt cleanup required by local CI; no passive smoke behavior change" ./scripts/ci_local.sh`
