### PR TITLE
Stop refreshing empty B524 radio slots every config tick

### DIFF
--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -349,7 +349,7 @@ type vaillantSemanticPoller struct {
 	lastCircuitFullScanAt       time.Time
 	lastCircuitFullScanComplete bool
 	radioDevices                map[radioDeviceKey]*vaillantRadioDeviceSnapshot
-	deviceSlotCache             map[deviceSlotKey]bool // OP=0x06 slots where device_connected responded
+	deviceSlotCache             map[deviceSlotKey]bool // OP=0x06 slots retained for steady-state detail refresh
 	deviceSlotDiscoveryDone     bool
 	deviceSlotDiscoveryAt       time.Time
 	startupSemanticPrimed       bool
@@ -4751,22 +4751,38 @@ func (p *vaillantSemanticPoller) refreshSystem(ctx context.Context) {
 }
 
 // discoverDeviceSlots probes all OP=0x06 device slot groups to find which
-// slots have a connected device. Returns the set of (group, instance) pairs
-// where device_connected (RR=0x0001) responded with a non-nil value.
+// slots should be retained for steady-state detail refresh. Connected slots
+// are retained. Disconnected functional module slots are retained only when
+// identity registers prove inventory, preserving FM5 evidence without
+// refreshing empty regulator/thermostat slots every config tick.
 // This runs at startup and every deviceSlotRediscoveryTTL to avoid
 // probing empty slots on every poll cycle (~30 timeouts eliminated).
-func (p *vaillantSemanticPoller) discoverDeviceSlots(ctx context.Context) map[deviceSlotKey]bool {
+func (p *vaillantSemanticPoller) discoverDeviceSlots(ctx context.Context) (map[deviceSlotKey]bool, bool) {
 	active := make(map[deviceSlotKey]bool)
+	observedAny := false
 	for _, grp := range remoteDeviceGroups {
 		for instance := byte(0x00); instance <= 0x0A; instance++ {
 			connectedRaw := p.readB524U8(ctx, grp.opcode, grp.group, instance, device_slot_connected)
 			if connectedRaw == nil {
-				continue // timeout — slot empty
+				continue
 			}
-			active[deviceSlotKey{Group: grp.group, Instance: instance}] = true
+			observedAny = true
+			if *connectedRaw == 1 {
+				active[deviceSlotKey{Group: grp.group, Instance: instance}] = true
+				continue
+			}
+			if grp.group != remoteFunctionalModules.group {
+				continue
+			}
+			classAddress := p.readB524U8(ctx, grp.opcode, grp.group, instance, device_slot_class_address)
+			firmware := p.readB524Firmware(ctx, grp.opcode, grp.group, instance, device_slot_firmware)
+			hardware := p.readB524U16(ctx, grp.opcode, grp.group, instance, device_slot_hardware_identifier)
+			if hasRemoteIdentityEvidence(classAddress, firmware, hardware) {
+				active[deviceSlotKey{Group: grp.group, Instance: instance}] = true
+			}
 		}
 	}
-	return active
+	return active, observedAny
 }
 
 func (p *vaillantSemanticPoller) refreshRadioDevices(ctx context.Context) {
@@ -4785,13 +4801,17 @@ func (p *vaillantSemanticPoller) refreshRadioDevices(ctx context.Context) {
 
 	// Phase 1: Device slot discovery — full scan of all OP=0x06 groups.
 	// Runs at startup and every deviceSlotRediscoveryTTL (30min default).
+	discoveryObserved := false
 	if needsDiscovery {
-		activeSlots := p.discoverDeviceSlots(ctx)
-		p.mu.Lock()
-		p.deviceSlotCache = activeSlots
-		p.deviceSlotDiscoveryDone = true
-		p.deviceSlotDiscoveryAt = p.now()
-		p.mu.Unlock()
+		activeSlots, observedAny := p.discoverDeviceSlots(ctx)
+		discoveryObserved = observedAny
+		if observedAny {
+			p.mu.Lock()
+			p.deviceSlotCache = activeSlots
+			p.deviceSlotDiscoveryDone = true
+			p.deviceSlotDiscoveryAt = p.now()
+			p.mu.Unlock()
+		}
 	}
 
 	p.mu.Lock()
@@ -4799,6 +4819,13 @@ func (p *vaillantSemanticPoller) refreshRadioDevices(ctx context.Context) {
 	p.mu.Unlock()
 
 	if len(slots) == 0 {
+		if discoveryObserved {
+			p.mu.Lock()
+			p.radioDevices = make(map[radioDeviceKey]*vaillantRadioDeviceSnapshot)
+			p.mu.Unlock()
+			p.publishRadioDevices(semanticSnapshotSourceLive)
+			p.refreshFM5Semantic(ctx)
+		}
 		return
 	}
 

--- a/cmd/gateway/semantic_vaillant_test.go
+++ b/cmd/gateway/semantic_vaillant_test.go
@@ -679,6 +679,18 @@ func testB524ResponseForSelector(selector []byte) *protocol.Frame {
 	return &protocol.Frame{Data: data}
 }
 
+func testB524ResponseForSelectorPayload(selector []byte, payload ...byte) *protocol.Frame {
+	if len(selector) != 6 {
+		return &protocol.Frame{Data: []byte{0x00}}
+	}
+	group := selector[2]
+	instance := selector[3]
+	addr := uint16(selector[4]) | uint16(selector[5])<<8
+	data := []byte{0x01, instance, group, byte(addr), byte(addr >> 8)}
+	data = append(data, payload...)
+	return &protocol.Frame{Data: data}
+}
+
 func testB524PayloadForSelector(group byte, addr uint16) []byte {
 	switch {
 	case group == localZones.group && (addr == zone_current_temp ||
@@ -6465,6 +6477,174 @@ func TestB524GroupDef_OpcodeGroupBindingIsCorrect(t *testing.T) {
 		if g.opcode != vaillantB524OpcodeRead {
 			t.Errorf("remote group %q (GG=0x%02X) has opcode 0x%02X; want 0x06", g.name, g.group, g.opcode)
 		}
+	}
+}
+
+func TestDiscoverDeviceSlotsExcludesDisconnectedRegulatorAndThermostatSlots(t *testing.T) {
+	t.Parallel()
+
+	var selectors [][]byte
+	poller := &vaillantSemanticPoller{
+		scheduler:      ebusgateway.NewSemanticReadScheduler(),
+		source:         0x7F,
+		controller:     0x15,
+		requestTimeout: 50 * time.Millisecond,
+	}
+	poller.sendFrameFn = func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+		selectors = append(selectors, slices.Clone(frame.Data))
+		if len(frame.Data) != 6 {
+			return nil, errors.New("invalid B524 selector")
+		}
+		group := frame.Data[2]
+		instance := frame.Data[3]
+		addr := uint16(frame.Data[4]) | uint16(frame.Data[5])<<8
+		if addr == device_slot_connected {
+			switch {
+			case group == remoteRegulators.group && instance == 0x01:
+				return testB524ResponseForSelectorPayload(frame.Data, 0x00), nil
+			case group == remoteThermostats.group && instance == 0x01:
+				return testB524ResponseForSelectorPayload(frame.Data, 0x00), nil
+			case group == remoteThermostats.group && instance == 0x02:
+				return testB524ResponseForSelectorPayload(frame.Data, 0x01), nil
+			}
+		}
+		return testB524ResponseForSelectorPayload(frame.Data, 0xFF), nil
+	}
+
+	active, observedAny := poller.discoverDeviceSlots(context.Background())
+
+	if !observedAny {
+		t.Fatal("discoverDeviceSlots observedAny = false; want true for responsive disconnected/connected slots")
+	}
+	if active[deviceSlotKey{Group: remoteRegulators.group, Instance: 0x01}] {
+		t.Fatal("disconnected regulator slot was retained for steady-state detail refresh")
+	}
+	if active[deviceSlotKey{Group: remoteThermostats.group, Instance: 0x01}] {
+		t.Fatal("disconnected thermostat slot was retained for steady-state detail refresh")
+	}
+	if !active[deviceSlotKey{Group: remoteThermostats.group, Instance: 0x02}] {
+		t.Fatal("connected thermostat slot was not retained for steady-state detail refresh")
+	}
+	if hasB524Selector(selectors, remoteRegulators.group, 0x01, device_slot_class_address) {
+		t.Fatal("disconnected regulator slot should not receive identity-detail probes")
+	}
+	if hasB524Selector(selectors, remoteThermostats.group, 0x01, device_slot_class_address) {
+		t.Fatal("disconnected thermostat slot should not receive identity-detail probes")
+	}
+}
+
+func TestDiscoverDeviceSlotsKeepsDisconnectedFunctionalModuleIdentityEvidence(t *testing.T) {
+	t.Parallel()
+
+	var selectors [][]byte
+	poller := &vaillantSemanticPoller{
+		scheduler:      ebusgateway.NewSemanticReadScheduler(),
+		source:         0x7F,
+		controller:     0x15,
+		requestTimeout: 50 * time.Millisecond,
+	}
+	poller.sendFrameFn = func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+		selectors = append(selectors, slices.Clone(frame.Data))
+		if len(frame.Data) != 6 {
+			return nil, errors.New("invalid B524 selector")
+		}
+		group := frame.Data[2]
+		instance := frame.Data[3]
+		addr := uint16(frame.Data[4]) | uint16(frame.Data[5])<<8
+		if group == remoteFunctionalModules.group && instance == 0x04 {
+			switch addr {
+			case device_slot_connected:
+				return testB524ResponseForSelectorPayload(frame.Data, 0x00), nil
+			case device_slot_class_address:
+				return testB524ResponseForSelectorPayload(frame.Data, 0x26), nil
+			}
+		}
+		return testB524ResponseForSelectorPayload(frame.Data, 0xFF), nil
+	}
+
+	active, observedAny := poller.discoverDeviceSlots(context.Background())
+
+	if !observedAny {
+		t.Fatal("discoverDeviceSlots observedAny = false; want true for responsive functional module slot")
+	}
+	if !active[deviceSlotKey{Group: remoteFunctionalModules.group, Instance: 0x04}] {
+		t.Fatal("disconnected functional module identity evidence was not retained")
+	}
+	requireB524Selector(t, selectors, remoteFunctionalModules.group, 0x04, device_slot_class_address)
+}
+
+func TestRefreshRadioDevicesClearsStaleSnapshotsWhenDiscoveryFindsNoRefreshableSlots(t *testing.T) {
+	t.Parallel()
+
+	poller := &vaillantSemanticPoller{
+		scheduler:      ebusgateway.NewSemanticReadScheduler(),
+		provider:       graphql.NewLiveSemanticProvider(),
+		source:         0x7F,
+		controller:     0x15,
+		requestTimeout: 50 * time.Millisecond,
+		radioDevices: map[radioDeviceKey]*vaillantRadioDeviceSnapshot{
+			{Group: remoteRegulators.group, Instance: 0x01}: {
+				Group:    remoteRegulators.group,
+				Instance: 0x01,
+				SlotMode: "active",
+			},
+		},
+	}
+	poller.sendFrameFn = func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+		if len(frame.Data) != 6 {
+			return nil, errors.New("invalid B524 selector")
+		}
+		return testB524ResponseForSelectorPayload(frame.Data, 0x00), nil
+	}
+
+	poller.refreshRadioDevices(context.Background())
+
+	poller.mu.Lock()
+	got := len(poller.radioDevices)
+	poller.mu.Unlock()
+	if got != 0 {
+		t.Fatalf("radioDevices length = %d; want stale snapshots cleared", got)
+	}
+}
+
+func TestRefreshRadioDevicesPreservesSnapshotsWhenRediscoveryOnlyTimesOut(t *testing.T) {
+	t.Parallel()
+
+	poller := &vaillantSemanticPoller{
+		scheduler:                ebusgateway.NewSemanticReadScheduler(),
+		provider:                 graphql.NewLiveSemanticProvider(),
+		source:                   0x7F,
+		controller:               0x15,
+		requestTimeout:           50 * time.Millisecond,
+		deviceSlotRediscoveryTTL: time.Millisecond,
+		deviceSlotCache: map[deviceSlotKey]bool{
+			{Group: remoteRegulators.group, Instance: 0x01}: true,
+		},
+		deviceSlotDiscoveryDone: true,
+		deviceSlotDiscoveryAt:   time.Now().Add(-time.Second),
+		radioDevices: map[radioDeviceKey]*vaillantRadioDeviceSnapshot{
+			{Group: remoteRegulators.group, Instance: 0x01}: {
+				Group:    remoteRegulators.group,
+				Instance: 0x01,
+				SlotMode: "active",
+			},
+		},
+	}
+	poller.sendFrameFn = func(context.Context, protocol.Frame) (*protocol.Frame, error) {
+		return nil, errors.New("temporary rediscovery timeout")
+	}
+
+	poller.refreshRadioDevices(context.Background())
+
+	poller.mu.Lock()
+	radioDevices := len(poller.radioDevices)
+	cachedSlots := len(poller.deviceSlotCache)
+	poller.mu.Unlock()
+	if radioDevices != 1 {
+		t.Fatalf("radioDevices length = %d; want stale snapshot preserved through all-timeout rediscovery", radioDevices)
+	}
+	if cachedSlots != 1 {
+		t.Fatalf("deviceSlotCache length = %d; want existing cache preserved through all-timeout rediscovery", cachedSlots)
 	}
 }
 


### PR DESCRIPTION
## What
Cache only genuinely active B524 remote radio slots for steady-state radio-device detail refresh.

## Why
Live verification after PR #671 still showed high 0x7f to 0x15 B524 pressure. The residual burst came from refreshRadioDevices caching explicit device_connected=false slots, then rereading their detail registers every config tick. Empty regulator/thermostat slots should be bounded to rediscovery, not refreshed every 5 minutes.

## Changes
- Retain connected 0x09/0x0A/0x0C slots for detail refresh.
- Exclude disconnected 0x09 regulator and 0x0A thermostat slots from steady-state detail refresh.
- Keep disconnected 0x0C functional module slots only when identity evidence exists, preserving FM5 inventory.
- Add regressions for disconnected exclusion and FM identity retention.

## Validation
- go test ./cmd/gateway -run 'TestDiscoverDeviceSlots|TestDeviceSlotCacheGating'
- go test ./cmd/gateway
- go test ./internal/adaptermux

Closes #672