### PR TITLE
Skip unknown FM startup radio inventory

### DIFF
--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -1802,7 +1802,7 @@ func startupRadioDeviceInclude(group byte, connected bool, classAddress *uint8) 
 		if connected {
 			return true, "startup"
 		}
-		if classAddress != nil {
+		if classAddress != nil && *classAddress == circuitManagingDeviceVR71Address {
 			return true, "inventory"
 		}
 		return false, "startup"

--- a/cmd/gateway/semantic_vaillant_test.go
+++ b/cmd/gateway/semantic_vaillant_test.go
@@ -5424,6 +5424,10 @@ func TestStartupRadioDeviceInclude_SkipsDisconnectedRegulatorSlots(t *testing.T)
 	if include, mode := startupRadioDeviceInclude(remoteFunctionalModules.group, false, &classAddress); !include || mode != "inventory" {
 		t.Fatalf("functional module identity evidence include=%v mode=%q; want inventory include", include, mode)
 	}
+	unknownClassAddress := uint8(0x00)
+	if include, _ := startupRadioDeviceInclude(remoteFunctionalModules.group, false, &unknownClassAddress); include {
+		t.Fatal("unknown disconnected functional module slot included; want skipped")
+	}
 	if include, _ := startupRadioDeviceInclude(remoteFunctionalModules.group, false, nil); include {
 		t.Fatal("empty functional module slot included; want skipped")
 	}


### PR DESCRIPTION
## What
Do not publish disconnected 0x0C functional-module radio slots as startup inventory when the only evidence is an unknown class address such as 0x00.

## Why
Post-#673 live verification showed MCP radio_devices still included disconnected 0x0C inventory entries with device_class_address=0 and model Unknown (0x00). Those are not identity evidence and should not become semantic radio devices.

## Changes
- Startup FM inventory now requires VR71/FM5 class identity for disconnected 0x0C slots.
- Added regression coverage for disconnected 0x0C class 0x00 exclusion.

## Validation
- go test ./cmd/gateway -run 'TestStartupRadioDeviceInclude_SkipsDisconnectedRegulatorSlots|TestDiscoverDeviceSlotsKeepsDisconnectedFunctionalModuleIdentityEvidence|TestRefreshRadioDevices'
- go test ./cmd/gateway

Closes #674