### PR TITLE
Reduce B524 semantic active traffic

### DIFF
--- a/active_passive_deduplicator.go
+++ b/active_passive_deduplicator.go
@@ -322,6 +322,15 @@ func (deduplicator *ActivePassiveDeduplicator) LocalAddressSnapshot() LocalAddre
 	return deduplicator.localAddr
 }
 
+func (deduplicator *ActivePassiveDeduplicator) SetWatchObserver(observer WatchObserver) {
+	if deduplicator == nil {
+		return
+	}
+	deduplicator.mu.Lock()
+	defer deduplicator.mu.Unlock()
+	deduplicator.cfg.WatchObserver = observer
+}
+
 func (deduplicator *ActivePassiveDeduplicator) Subscribe(name string, priority DedupSubscriberPriority, buffer int) (*AdjudicatedPassiveSubscription, error) {
 	if deduplicator == nil {
 		return nil, fmt.Errorf("deduplicator missing: %w", ebuserrors.ErrInvalidPayload)

--- a/active_passive_deduplicator_test.go
+++ b/active_passive_deduplicator_test.go
@@ -251,6 +251,127 @@ func TestActivePassiveDeduplicator_B524CorrelatedReadUsesRuntimeObserverFallback
 	}
 }
 
+func TestActivePassiveDeduplicator_B524CorrelatedReadUsesShadowWatchObserver(t *testing.T) {
+	deduplicator := newTestDeduplicator(t)
+	subscription, err := deduplicator.Subscribe("test", DedupSubscriberCritical, 16)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	forceHealthyDedup(deduplicator)
+	stateKey := NewB524WatchKey(0x15, 0x06, 0x03, 0x01, 0x001C)
+	catalog, activations := testShadowCatalogAndActivations(t, nil, WatchActivationSourceTooling)
+	shadow := newTestShadowCache(t, catalog, activations, time.Unix(0, 0), ShadowCacheOptions{})
+	if err := shadow.BootstrapRuntimeDescriptor(WatchDescriptor{
+		Key:               stateKey,
+		SemanticClass:     WatchSemanticClassState,
+		FreshnessProfile:  WatchFreshnessProfileStateFast,
+		DecoderID:         "test.semantic",
+		CorrelationPolicy: WatchCorrelationPolicyRequestResponse,
+		DirectApplyPolicy: WatchDirectApplyPolicyStateDefault,
+	}, WatchActivationSourcePoller); err != nil {
+		t.Fatalf("BootstrapRuntimeDescriptor() error = %v", err)
+	}
+	deduplicator.SetWatchObserver(shadow)
+
+	base := time.Unix(0, 0)
+	deduplicator.nowFunc = func() time.Time { return base }
+
+	request := protocol.Frame{
+		Source:    0x31,
+		Target:    0x15,
+		Primary:   0xB5,
+		Secondary: 0x24,
+		Data:      []byte{0x06, 0x00, 0x03, 0x01, 0x1C, 0x00},
+	}
+	response := protocol.Frame{
+		Source:    request.Target,
+		Target:    request.Source,
+		Primary:   request.Primary,
+		Secondary: request.Secondary,
+		Data:      []byte{0x42, 0x01, 0x03, 0x1C, 0x00, 0x22},
+	}
+
+	deduplicator.OnPassiveClassifiedEvent(passiveTransactionEvent(base, request, response))
+	assertNoAdjudicatedEvent(t, subscription, 25*time.Millisecond)
+
+	deduplicator.nowFunc = func() time.Time {
+		return base.Add(deduplicator.budgets.PendingGraceTimeout + time.Millisecond)
+	}
+	deduplicator.publishAll(deduplicator.releaseExpiredPending(deduplicator.now()))
+
+	event := requireAdjudicatedEvent(t, subscription, DedupDispositionUnmatchedThirdParty)
+	if !event.ThirdPartyEligible {
+		t.Fatal("ThirdPartyEligible = false; want true with semantic shadow watch observer")
+	}
+	if event.FamilyPolicy.DirectApplyPolicy != ObserveFirstDirectApplyPolicyStateDefault {
+		t.Fatalf("DirectApplyPolicy = %q; want %q", event.FamilyPolicy.DirectApplyPolicy, ObserveFirstDirectApplyPolicyStateDefault)
+	}
+	if event.Fingerprint.SharedWatchKey == nil || event.Fingerprint.SharedWatchKey.Canonical() != stateKey.Canonical() {
+		t.Fatalf("SharedWatchKey = %v; want %s", event.Fingerprint.SharedWatchKey, stateKey.Canonical())
+	}
+}
+
+func TestActivePassiveDeduplicator_B524ConfigShadowObserverDoesNotPromoteToStateDefault(t *testing.T) {
+	deduplicator := newTestDeduplicator(t)
+	subscription, err := deduplicator.Subscribe("test", DedupSubscriberCritical, 16)
+	if err != nil {
+		t.Fatalf("Subscribe error = %v", err)
+	}
+	defer subscription.Close()
+
+	forceHealthyDedup(deduplicator)
+	configKey := NewB524WatchKey(0x15, 0x06, 0x03, 0x01, 0x0005)
+	catalog, activations := testShadowCatalogAndActivations(t, nil, WatchActivationSourceTooling)
+	shadow := newTestShadowCache(t, catalog, activations, time.Unix(0, 0), ShadowCacheOptions{})
+	if err := shadow.BootstrapRuntimeDescriptor(WatchDescriptor{
+		Key:               configKey,
+		SemanticClass:     WatchSemanticClassConfig,
+		FreshnessProfile:  WatchFreshnessProfileConfig,
+		DecoderID:         "test.semantic.config",
+		CorrelationPolicy: WatchCorrelationPolicyRequestResponse,
+		DirectApplyPolicy: WatchDirectApplyPolicyConfigOptIn,
+	}, WatchActivationSourcePoller); err != nil {
+		t.Fatalf("BootstrapRuntimeDescriptor() error = %v", err)
+	}
+	deduplicator.SetWatchObserver(shadow)
+
+	base := time.Unix(0, 0)
+	deduplicator.nowFunc = func() time.Time { return base }
+
+	request := protocol.Frame{
+		Source:    0x31,
+		Target:    0x15,
+		Primary:   0xB5,
+		Secondary: 0x24,
+		Data:      []byte{0x06, 0x00, 0x03, 0x01, 0x05, 0x00},
+	}
+	response := protocol.Frame{
+		Source:    request.Target,
+		Target:    request.Source,
+		Primary:   request.Primary,
+		Secondary: request.Secondary,
+		Data:      []byte{0x42, 0x01, 0x03, 0x05, 0x00, 0x22},
+	}
+
+	deduplicator.OnPassiveClassifiedEvent(passiveTransactionEvent(base, request, response))
+	assertNoAdjudicatedEvent(t, subscription, 25*time.Millisecond)
+
+	deduplicator.nowFunc = func() time.Time {
+		return base.Add(deduplicator.budgets.PendingGraceTimeout + time.Millisecond)
+	}
+	deduplicator.publishAll(deduplicator.releaseExpiredPending(deduplicator.now()))
+
+	event := requireAdjudicatedEvent(t, subscription, DedupDispositionObservabilityOnly)
+	if event.ThirdPartyEligible {
+		t.Fatal("ThirdPartyEligible = true; want false for config-class B524 shadow observation")
+	}
+	if event.FamilyPolicy.DirectApplyPolicy == ObserveFirstDirectApplyPolicyStateDefault {
+		t.Fatalf("DirectApplyPolicy = %q; config-class B524 must not promote to state_default", event.FamilyPolicy.DirectApplyPolicy)
+	}
+}
+
 func TestActivePassiveDeduplicator_B524ConfigPolicyNotPromotedToStateDefault(t *testing.T) {
 	deduplicator := newTestDeduplicator(t)
 	forceHealthyDedup(deduplicator)

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -761,6 +761,12 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 		builder.SetScheduleWriter(gatedGraphQLWriter)
 		builder.SetWatchSummaryProvider(newGraphQLWatchSummaryProvider(semanticPoller.shadow))
 	}
+	if semanticPoller != nil && semanticPoller.shadow != nil && deduplicator != nil {
+		// Use the semantic shadow directly here. The broader runtime observer can
+		// fall back to the deduplicator itself, which would re-enter dedup locks
+		// while passive fingerprints are being built.
+		deduplicator.SetWatchObserver(semanticPoller.shadow)
+	}
 	observeFirstFlags := ebusgateway.NormalizeObserveFirstFeatureFlags(
 		cfg.ObserveFirstEnabled,
 		cfg.PassiveStateDirectApply,

--- a/shadow_cache.go
+++ b/shadow_cache.go
@@ -318,6 +318,20 @@ func (cache *ShadowCache) FeatureFlags() ObserveFirstFeatureFlags {
 	return cache.featureFlags
 }
 
+func (cache *ShadowCache) Observe(key WatchKey) WatchObservation {
+	if cache == nil || key == nil {
+		return WatchObservation{State: WatchObservationStateCatalogMiss}
+	}
+
+	cache.mu.Lock()
+	activations := cache.activations
+	cache.mu.Unlock()
+	if activations == nil {
+		return WatchObservation{State: WatchObservationStateCatalogMiss}
+	}
+	return activations.Observe(key)
+}
+
 func (cache *ShadowCache) StartCompactor() {
 	if cache == nil || cache.compactorCadence <= 0 {
 		return

--- a/shadow_cache_test.go
+++ b/shadow_cache_test.go
@@ -760,6 +760,44 @@ func TestShadowCacheBootstrapRuntimeDescriptorUpgradesPassiveFallbackDescriptor(
 	}
 }
 
+func TestShadowCacheObserveReturnsRuntimeDescriptorActivation(t *testing.T) {
+	t.Parallel()
+
+	key := NewB524WatchKey(0x15, 0x06, 0x03, 0x01, 0x001C)
+	missingKey := NewB524WatchKey(0x15, 0x06, 0x03, 0x02, 0x001C)
+	catalog, activations := testShadowCatalogAndActivations(t, nil, WatchActivationSourceTooling)
+	cache := newTestShadowCache(t, catalog, activations, time.Unix(100, 0), ShadowCacheOptions{})
+
+	descriptor := WatchDescriptor{
+		Key:               key,
+		SemanticClass:     WatchSemanticClassState,
+		FreshnessProfile:  WatchFreshnessProfileStateFast,
+		DecoderID:         "test.semantic",
+		CorrelationPolicy: WatchCorrelationPolicyRequestResponse,
+		DirectApplyPolicy: WatchDirectApplyPolicyStateDefault,
+	}
+	if err := cache.BootstrapRuntimeDescriptor(descriptor, WatchActivationSourcePoller); err != nil {
+		t.Fatalf("BootstrapRuntimeDescriptor() error = %v", err)
+	}
+
+	observation := cache.Observe(key)
+	if observation.State != WatchObservationStateActive {
+		t.Fatalf("Observe(key).State = %q; want %q", observation.State, WatchObservationStateActive)
+	}
+	if !observation.HasDescriptor {
+		t.Fatal("Observe(key).HasDescriptor = false; want true")
+	}
+	if observation.Descriptor.DirectApplyPolicy != WatchDirectApplyPolicyStateDefault {
+		t.Fatalf("DirectApplyPolicy = %q; want %q", observation.Descriptor.DirectApplyPolicy, WatchDirectApplyPolicyStateDefault)
+	}
+	if got, want := observation.Sources, []WatchActivationSource{WatchActivationSourcePoller}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("Observe(key).Sources = %v; want %v", got, want)
+	}
+	if missing := cache.Observe(missingKey); missing.State != WatchObservationStateCatalogMiss {
+		t.Fatalf("Observe(missing).State = %q; want %q", missing.State, WatchObservationStateCatalogMiss)
+	}
+}
+
 func TestShadowCacheBootstrapRuntimeDescriptorExistingKeyPromotionRecomputesBudgetAndPins(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What
- Wire the passive deduplicator to the semantic shadow cache after the semantic poller is created so B524 passive reads can see runtime watch descriptors.
- Expose ShadowCache as a read-only WatchObserver and add a deduplicator observer setter that avoids the recursive runtime observer fallback.
- Add positive and negative B524 tests proving only state-class shadow descriptors promote to state_default; config-class B524 remains observability-only.

## Why
Post-#673 live evidence showed B524 passive traffic was reconstructed, but B524 direct-apply/avoidance stayed at zero while active 7f->15 B524 remained about 3.3k/hour. B524 policy requires active state descriptor evidence; production dedup wiring only had nil/static observers plus its own active fingerprint fallback, so semantic shadow runtime descriptors were invisible.

Fixes #676.

## Validation
- go test . -run 'TestActivePassiveDeduplicator_B524CorrelatedReadUsesShadowWatchObserver|TestActivePassiveDeduplicator_B524ConfigShadowObserverDoesNotPromoteToStateDefault|TestActivePassiveDeduplicator_B524CorrelatedReadUsesRuntimeObserverFallback|TestActivePassiveDeduplicator_B524ConfigPolicyNotPromotedToStateDefault|TestShadowCacheObserveReturnsRuntimeDescriptorActivation|TestShadowCacheBootstrapRuntimeDescriptor'
- go test ./cmd/gateway
- go test ./...
- git diff --check

Smoke test required: YES