### PR TITLE
Reduce semantic B524 active polling

### DIFF
--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -4866,20 +4866,22 @@ func (p *vaillantSemanticPoller) refreshRadioDevices(ctx context.Context) {
 		}
 
 		device := &vaillantRadioDeviceSnapshot{
-			Group:                group,
-			Instance:             instance,
-			SlotMode:             slotMode,
-			DeviceConnected:      cloneBoilerBoolPtr(&connected),
-			DeviceClassAddress:   cloneUint8Ptr(classAddress),
-			DeviceModel:          decodeRadioDeviceModel(classAddress),
-			FirmwareVersion:      cloneStringPtr(firmware),
-			HardwareIdentifier:   cloneUint16Ptr(hardware),
-			RemoteControlAddress: p.readB524U8(ctx, opcode, group, instance, device_slot_remote_control_address),
-			DevicePaired:         p.readB524Bool(ctx, opcode, group, instance, device_slot_paired),
-			ReceptionStrength:    p.readB524U8(ctx, opcode, group, instance, device_slot_reception_strength),
-			ZoneAssignment:       p.readB524U8(ctx, opcode, group, instance, device_slot_zone_assignment),
-			RoomTemperatureC:     p.readB524F32(ctx, opcode, group, instance, device_slot_room_temperature),
-			RoomHumidityPct:      p.readB524F32(ctx, opcode, group, instance, device_slot_room_humidity),
+			Group:              group,
+			Instance:           instance,
+			SlotMode:           slotMode,
+			DeviceConnected:    cloneBoilerBoolPtr(&connected),
+			DeviceClassAddress: cloneUint8Ptr(classAddress),
+			DeviceModel:        decodeRadioDeviceModel(classAddress),
+			FirmwareVersion:    cloneStringPtr(firmware),
+			HardwareIdentifier: cloneUint16Ptr(hardware),
+		}
+		if connected {
+			device.RemoteControlAddress = p.readB524U8(ctx, opcode, group, instance, device_slot_remote_control_address)
+			device.DevicePaired = p.readB524Bool(ctx, opcode, group, instance, device_slot_paired)
+			device.ReceptionStrength = p.readB524U8(ctx, opcode, group, instance, device_slot_reception_strength)
+			device.ZoneAssignment = p.readB524U8(ctx, opcode, group, instance, device_slot_zone_assignment)
+			device.RoomTemperatureC = p.readB524F32(ctx, opcode, group, instance, device_slot_room_temperature)
+			device.RoomHumidityPct = p.readB524F32(ctx, opcode, group, instance, device_slot_room_humidity)
 		}
 		discovered[radioDeviceKey{Group: group, Instance: instance}] = device
 	}
@@ -6451,13 +6453,230 @@ func semanticReadWatchDescriptorPassiveFallback(key ebusgateway.WatchKey) ebusga
 }
 
 func semanticReadWatchDescriptorWithDecoderID(key ebusgateway.WatchKey, decoderID string) ebusgateway.WatchDescriptor {
+	semanticClass, freshnessProfile, directApplyPolicy := semanticReadWatchDescriptorPolicy(key)
 	return ebusgateway.WatchDescriptor{
 		Key:               key,
-		SemanticClass:     ebusgateway.WatchSemanticClassState,
-		FreshnessProfile:  ebusgateway.WatchFreshnessProfileStateFast,
+		SemanticClass:     semanticClass,
+		FreshnessProfile:  freshnessProfile,
 		DecoderID:         decoderID,
 		CorrelationPolicy: ebusgateway.WatchCorrelationPolicyRequestResponse,
-		DirectApplyPolicy: ebusgateway.WatchDirectApplyPolicyStateDefault,
+		DirectApplyPolicy: directApplyPolicy,
+	}
+}
+
+func semanticReadWatchDescriptorPolicy(key ebusgateway.WatchKey) (ebusgateway.WatchSemanticClass, ebusgateway.WatchFreshnessProfile, ebusgateway.WatchDirectApplyPolicy) {
+	switch typed := key.(type) {
+	case ebusgateway.B524WatchKey:
+		return semanticReadB524WatchDescriptorPolicy(typed)
+	case *ebusgateway.B524WatchKey:
+		if typed != nil {
+			return semanticReadB524WatchDescriptorPolicy(*typed)
+		}
+	}
+	return semanticReadStateFastDescriptorPolicy()
+}
+
+func semanticReadStateFastDescriptorPolicy() (ebusgateway.WatchSemanticClass, ebusgateway.WatchFreshnessProfile, ebusgateway.WatchDirectApplyPolicy) {
+	return ebusgateway.WatchSemanticClassState, ebusgateway.WatchFreshnessProfileStateFast, ebusgateway.WatchDirectApplyPolicyStateDefault
+}
+
+func semanticReadStateSlowDescriptorPolicy() (ebusgateway.WatchSemanticClass, ebusgateway.WatchFreshnessProfile, ebusgateway.WatchDirectApplyPolicy) {
+	return ebusgateway.WatchSemanticClassState, ebusgateway.WatchFreshnessProfileStateSlow, ebusgateway.WatchDirectApplyPolicyStateDefault
+}
+
+func semanticReadConfigDescriptorPolicy() (ebusgateway.WatchSemanticClass, ebusgateway.WatchFreshnessProfile, ebusgateway.WatchDirectApplyPolicy) {
+	return ebusgateway.WatchSemanticClassConfig, ebusgateway.WatchFreshnessProfileConfig, ebusgateway.WatchDirectApplyPolicyConfigOptIn
+}
+
+func semanticReadDiscoveryDescriptorPolicy() (ebusgateway.WatchSemanticClass, ebusgateway.WatchFreshnessProfile, ebusgateway.WatchDirectApplyPolicy) {
+	return ebusgateway.WatchSemanticClassDiscovery, ebusgateway.WatchFreshnessProfileDiscovery, ebusgateway.WatchDirectApplyPolicyNever
+}
+
+func semanticReadB524WatchDescriptorPolicy(key ebusgateway.B524WatchKey) (ebusgateway.WatchSemanticClass, ebusgateway.WatchFreshnessProfile, ebusgateway.WatchDirectApplyPolicy) {
+	switch key.Opcode {
+	case vaillantB524OpcodeLocal:
+		return semanticReadB524LocalDescriptorPolicy(key.Group, key.RegisterAddress)
+	case vaillantB524OpcodeRead:
+		return semanticReadB524RemoteDescriptorPolicy(key.Group, key.RegisterAddress)
+	default:
+		return semanticReadStateFastDescriptorPolicy()
+	}
+}
+
+func semanticReadB524LocalDescriptorPolicy(group byte, addr uint16) (ebusgateway.WatchSemanticClass, ebusgateway.WatchFreshnessProfile, ebusgateway.WatchDirectApplyPolicy) {
+	switch group {
+	case localZones.group:
+		return semanticReadB524ZoneDescriptorPolicy(addr)
+	case localDHW.group:
+		return semanticReadB524DHWDescriptorPolicy(addr)
+	case localCircuits.group:
+		return semanticReadB524CircuitDescriptorPolicy(addr)
+	case localRegulator.group:
+		return semanticReadB524RegulatorDescriptorPolicy(addr)
+	case localSolar.group:
+		return semanticReadB524SolarDescriptorPolicy(addr)
+	case localCylinders.group:
+		return semanticReadB524CylinderDescriptorPolicy(addr)
+	default:
+		return semanticReadStateFastDescriptorPolicy()
+	}
+}
+
+func semanticReadB524RegulatorDescriptorPolicy(addr uint16) (ebusgateway.WatchSemanticClass, ebusgateway.WatchFreshnessProfile, ebusgateway.WatchDirectApplyPolicy) {
+	switch addr {
+	case system_off,
+		system_water_pressure,
+		system_flow_temperature,
+		system_outdoor_temperature,
+		system_maintenance_due,
+		system_hwc_cylinder_temperature_top,
+		system_hwc_cylinder_temperature_bottom:
+		return semanticReadStateFastDescriptorPolicy()
+	case system_outdoor_temperature_avg_24h,
+		energy_fuel_sum_hc,
+		energy_electricity_sum_hc,
+		energy_electricity_sum_hwc,
+		energy_fuel_sum_hwc,
+		energy_fuel_sum_hc_this_month,
+		energy_electricity_sum_hc_this_month,
+		energy_electricity_sum_hwc_this_month,
+		energy_fuel_sum_hwc_this_month,
+		energy_fuel_sum_hc_last_month,
+		energy_electricity_sum_hc_last_month,
+		energy_electricity_sum_hwc_last_month,
+		energy_fuel_sum_hwc_last_month:
+		return semanticReadStateSlowDescriptorPolicy()
+	case system_adaptive_heating_curve,
+		system_alternative_point,
+		system_heating_circuit_bivalence_point,
+		system_dhw_bivalence_point,
+		system_hc_emergency_temperature,
+		system_hwc_max_flow_temp_desired,
+		system_max_room_humidity,
+		system_maintenance_date,
+		system_installer_name_1,
+		system_installer_name_2,
+		system_installer_phone_1,
+		system_installer_phone_2,
+		system_installer_menu_code:
+		return semanticReadConfigDescriptorPolicy()
+	case system_scheme, system_module_configuration_vr71:
+		return semanticReadDiscoveryDescriptorPolicy()
+	default:
+		return semanticReadStateFastDescriptorPolicy()
+	}
+}
+
+func semanticReadB524ZoneDescriptorPolicy(addr uint16) (ebusgateway.WatchSemanticClass, ebusgateway.WatchFreshnessProfile, ebusgateway.WatchDirectApplyPolicy) {
+	switch addr {
+	case zone_current_temp, zone_special_function, zone_valve_status:
+		return semanticReadStateFastDescriptorPolicy()
+	case zone_current_humidity, zone_quick_veto_end_time, zone_quick_veto_end_date:
+		return semanticReadStateSlowDescriptorPolicy()
+	case zone_heating_op_mode,
+		zone_target_temp,
+		zone_fallback_manual_temp,
+		zone_room_temperature_zone_mapping_raw,
+		zone_quick_veto_temp,
+		zone_quick_veto_duration,
+		zone_holiday_start_date,
+		zone_holiday_end_date,
+		zone_holiday_setpoint,
+		zone_holiday_end_time,
+		zone_holiday_start_time:
+		return semanticReadConfigDescriptorPolicy()
+	case zone_name, zone_name_prefix, zone_name_suffix, zone_index:
+		return semanticReadDiscoveryDescriptorPolicy()
+	default:
+		return semanticReadStateFastDescriptorPolicy()
+	}
+}
+
+func semanticReadB524DHWDescriptorPolicy(addr uint16) (ebusgateway.WatchSemanticClass, ebusgateway.WatchFreshnessProfile, ebusgateway.WatchDirectApplyPolicy) {
+	switch addr {
+	case dhw_current_temp, dhw_special_function:
+		return semanticReadStateFastDescriptorPolicy()
+	case dhw_operation_mode, dhw_target_temp, dhw_holiday_start_date, dhw_holiday_end_date:
+		return semanticReadConfigDescriptorPolicy()
+	default:
+		return semanticReadStateFastDescriptorPolicy()
+	}
+}
+
+func semanticReadB524CircuitDescriptorPolicy(addr uint16) (ebusgateway.WatchSemanticClass, ebusgateway.WatchFreshnessProfile, ebusgateway.WatchDirectApplyPolicy) {
+	switch addr {
+	case circuit_flow_setpoint,
+		circuit_flow_temp,
+		circuit_circuit_state,
+		circuit_pump_status,
+		circuit_calc_flow_temp,
+		circuit_mixer_position:
+		return semanticReadStateFastDescriptorPolicy()
+	case circuit_humidity,
+		circuit_dew_point,
+		circuit_pump_hours,
+		circuit_pump_starts:
+		return semanticReadStateSlowDescriptorPolicy()
+	case circuit_type,
+		circuit_cooling_enabled,
+		circuit_heating_curve,
+		circuit_flow_temp_max,
+		circuit_flow_temp_min,
+		circuit_summer_limit,
+		circuit_room_temp_control,
+		circuit_frost_protection:
+		return semanticReadConfigDescriptorPolicy()
+	default:
+		return semanticReadStateFastDescriptorPolicy()
+	}
+}
+
+func semanticReadB524SolarDescriptorPolicy(addr uint16) (ebusgateway.WatchSemanticClass, ebusgateway.WatchFreshnessProfile, ebusgateway.WatchDirectApplyPolicy) {
+	switch addr {
+	case solar_collector_temp, solar_return_temp, solar_pump_active, solar_current_yield:
+		return semanticReadStateFastDescriptorPolicy()
+	case solar_pump_hours:
+		return semanticReadStateSlowDescriptorPolicy()
+	case solar_enabled, solar_function_mode:
+		return semanticReadConfigDescriptorPolicy()
+	default:
+		return semanticReadStateFastDescriptorPolicy()
+	}
+}
+
+func semanticReadB524CylinderDescriptorPolicy(addr uint16) (ebusgateway.WatchSemanticClass, ebusgateway.WatchFreshnessProfile, ebusgateway.WatchDirectApplyPolicy) {
+	switch addr {
+	case cylinder_temperature:
+		return semanticReadStateFastDescriptorPolicy()
+	case cylinder_max_setpoint, cylinder_charge_hysteresis, cylinder_charge_offset:
+		return semanticReadConfigDescriptorPolicy()
+	default:
+		return semanticReadStateFastDescriptorPolicy()
+	}
+}
+
+func semanticReadB524RemoteDescriptorPolicy(group byte, addr uint16) (ebusgateway.WatchSemanticClass, ebusgateway.WatchFreshnessProfile, ebusgateway.WatchDirectApplyPolicy) {
+	switch group {
+	case remoteRegulators.group, remoteThermostats.group, remoteFunctionalModules.group:
+		switch addr {
+		case device_slot_connected:
+			return semanticReadStateSlowDescriptorPolicy()
+		case device_slot_room_humidity,
+			device_slot_room_temperature,
+			device_slot_paired,
+			device_slot_reception_strength:
+			return semanticReadStateSlowDescriptorPolicy()
+		case device_slot_class_address,
+			device_slot_firmware,
+			device_slot_remote_control_address,
+			device_slot_hardware_identifier,
+			device_slot_zone_assignment:
+			return semanticReadDiscoveryDescriptorPolicy()
+		default:
+			return semanticReadStateFastDescriptorPolicy()
+		}
+	default:
+		return semanticReadStateFastDescriptorPolicy()
 	}
 }
 

--- a/cmd/gateway/semantic_vaillant_test.go
+++ b/cmd/gateway/semantic_vaillant_test.go
@@ -2431,6 +2431,149 @@ func TestPrepareSemanticReadWatch_UsesObserverDescriptorFreshness(t *testing.T) 
 	}
 }
 
+func TestSemanticReadWatchDescriptorWithDecoderID_ClassifiesB524Cadence(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		key         ebusgateway.WatchKey
+		wantClass   ebusgateway.WatchSemanticClass
+		wantProfile ebusgateway.WatchFreshnessProfile
+		wantPolicy  ebusgateway.WatchDirectApplyPolicy
+		wantTTL     time.Duration
+	}{
+		{
+			name:        "zone current temp stays fast state",
+			key:         ebusgateway.NewB524WatchKey(0x15, vaillantB524OpcodeLocal, localZones.group, 0x00, zone_current_temp),
+			wantClass:   ebusgateway.WatchSemanticClassState,
+			wantProfile: ebusgateway.WatchFreshnessProfileStateFast,
+			wantPolicy:  ebusgateway.WatchDirectApplyPolicyStateDefault,
+			wantTTL:     30 * time.Second,
+		},
+		{
+			name:        "zone humidity is slow state",
+			key:         ebusgateway.NewB524WatchKey(0x15, vaillantB524OpcodeLocal, localZones.group, 0x00, zone_current_humidity),
+			wantClass:   ebusgateway.WatchSemanticClassState,
+			wantProfile: ebusgateway.WatchFreshnessProfileStateSlow,
+			wantPolicy:  ebusgateway.WatchDirectApplyPolicyStateDefault,
+			wantTTL:     120 * time.Second,
+		},
+		{
+			name:        "zone target temp is config opt in",
+			key:         ebusgateway.NewB524WatchKey(0x15, vaillantB524OpcodeLocal, localZones.group, 0x00, zone_target_temp),
+			wantClass:   ebusgateway.WatchSemanticClassConfig,
+			wantProfile: ebusgateway.WatchFreshnessProfileConfig,
+			wantPolicy:  ebusgateway.WatchDirectApplyPolicyConfigOptIn,
+			wantTTL:     5 * time.Minute,
+		},
+		{
+			name:        "zone index is discovery",
+			key:         ebusgateway.NewB524WatchKey(0x15, vaillantB524OpcodeLocal, localZones.group, 0x00, zone_index),
+			wantClass:   ebusgateway.WatchSemanticClassDiscovery,
+			wantProfile: ebusgateway.WatchFreshnessProfileDiscovery,
+			wantPolicy:  ebusgateway.WatchDirectApplyPolicyNever,
+			wantTTL:     time.Hour,
+		},
+		{
+			name:        "regulator flow temperature stays fast state",
+			key:         ebusgateway.NewB524WatchKey(0x15, vaillantB524OpcodeLocal, localRegulator.group, regulatorInstance, system_flow_temperature),
+			wantClass:   ebusgateway.WatchSemanticClassState,
+			wantProfile: ebusgateway.WatchFreshnessProfileStateFast,
+			wantPolicy:  ebusgateway.WatchDirectApplyPolicyStateDefault,
+			wantTTL:     30 * time.Second,
+		},
+		{
+			name:        "regulator energy totals are slow state",
+			key:         ebusgateway.NewB524WatchKey(0x15, vaillantB524OpcodeLocal, localRegulator.group, regulatorInstance, energy_fuel_sum_hc),
+			wantClass:   ebusgateway.WatchSemanticClassState,
+			wantProfile: ebusgateway.WatchFreshnessProfileStateSlow,
+			wantPolicy:  ebusgateway.WatchDirectApplyPolicyStateDefault,
+			wantTTL:     120 * time.Second,
+		},
+		{
+			name:        "regulator installer field is config",
+			key:         ebusgateway.NewB524WatchKey(0x15, vaillantB524OpcodeLocal, localRegulator.group, regulatorInstance, system_installer_menu_code),
+			wantClass:   ebusgateway.WatchSemanticClassConfig,
+			wantProfile: ebusgateway.WatchFreshnessProfileConfig,
+			wantPolicy:  ebusgateway.WatchDirectApplyPolicyConfigOptIn,
+			wantTTL:     5 * time.Minute,
+		},
+		{
+			name:        "regulator module configuration is discovery",
+			key:         ebusgateway.NewB524WatchKey(0x15, vaillantB524OpcodeLocal, localRegulator.group, regulatorInstance, system_module_configuration_vr71),
+			wantClass:   ebusgateway.WatchSemanticClassDiscovery,
+			wantProfile: ebusgateway.WatchFreshnessProfileDiscovery,
+			wantPolicy:  ebusgateway.WatchDirectApplyPolicyNever,
+			wantTTL:     time.Hour,
+		},
+		{
+			name:        "circuit type is config",
+			key:         ebusgateway.NewB524WatchKey(0x15, vaillantB524OpcodeLocal, localCircuits.group, 0x00, circuit_type),
+			wantClass:   ebusgateway.WatchSemanticClassConfig,
+			wantProfile: ebusgateway.WatchFreshnessProfileConfig,
+			wantPolicy:  ebusgateway.WatchDirectApplyPolicyConfigOptIn,
+			wantTTL:     5 * time.Minute,
+		},
+		{
+			name:        "remote slot connected is slow state liveness",
+			key:         ebusgateway.NewB524WatchKey(0x15, vaillantB524OpcodeRead, remoteFunctionalModules.group, 0x01, device_slot_connected),
+			wantClass:   ebusgateway.WatchSemanticClassState,
+			wantProfile: ebusgateway.WatchFreshnessProfileStateSlow,
+			wantPolicy:  ebusgateway.WatchDirectApplyPolicyStateDefault,
+			wantTTL:     120 * time.Second,
+		},
+		{
+			name:        "remote slot humidity is slow state",
+			key:         ebusgateway.NewB524WatchKey(0x15, vaillantB524OpcodeRead, remoteFunctionalModules.group, 0x01, device_slot_room_humidity),
+			wantClass:   ebusgateway.WatchSemanticClassState,
+			wantProfile: ebusgateway.WatchFreshnessProfileStateSlow,
+			wantPolicy:  ebusgateway.WatchDirectApplyPolicyStateDefault,
+			wantTTL:     120 * time.Second,
+		},
+		{
+			name:        "remote slot hardware identity is discovery",
+			key:         ebusgateway.NewB524WatchKey(0x15, vaillantB524OpcodeRead, remoteFunctionalModules.group, 0x01, device_slot_hardware_identifier),
+			wantClass:   ebusgateway.WatchSemanticClassDiscovery,
+			wantProfile: ebusgateway.WatchFreshnessProfileDiscovery,
+			wantPolicy:  ebusgateway.WatchDirectApplyPolicyNever,
+			wantTTL:     time.Hour,
+		},
+		{
+			name:        "non B524 keeps prior fast state fallback",
+			key:         ebusgateway.NewB509WatchKey(0x08, 0x0200),
+			wantClass:   ebusgateway.WatchSemanticClassState,
+			wantProfile: ebusgateway.WatchFreshnessProfileStateFast,
+			wantPolicy:  ebusgateway.WatchDirectApplyPolicyStateDefault,
+			wantTTL:     30 * time.Second,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			descriptor := semanticReadWatchDescriptorWithDecoderID(test.key, "test.decoder")
+			if descriptor.SemanticClass != test.wantClass {
+				t.Fatalf("SemanticClass = %q; want %q", descriptor.SemanticClass, test.wantClass)
+			}
+			if descriptor.FreshnessProfile != test.wantProfile {
+				t.Fatalf("FreshnessProfile = %q; want %q", descriptor.FreshnessProfile, test.wantProfile)
+			}
+			if descriptor.DirectApplyPolicy != test.wantPolicy {
+				t.Fatalf("DirectApplyPolicy = %q; want %q", descriptor.DirectApplyPolicy, test.wantPolicy)
+			}
+			ttl, err := descriptor.EffectiveFreshnessTTL()
+			if err != nil {
+				t.Fatalf("EffectiveFreshnessTTL() error = %v", err)
+			}
+			if ttl != test.wantTTL {
+				t.Fatalf("EffectiveFreshnessTTL() = %s; want %s", ttl, test.wantTTL)
+			}
+		})
+	}
+}
+
 func TestPrepareSemanticReadWatchRuntime_FallbackDescriptorB524DiscoveryBucketsCorrectly(t *testing.T) {
 	t.Parallel()
 
@@ -2461,8 +2604,8 @@ func TestPrepareSemanticReadWatchRuntime_FallbackDescriptorB524DiscoveryBucketsC
 	if strings.Contains(metrics, `ambiguous_total{family="B524",reason="missing_runtime_descriptor"}`) {
 		t.Fatalf("RenderPrometheus incorrectly classified fallback-descriptor B524 read as ambiguous:\n%s", metrics)
 	}
-	if !strings.Contains(metrics, `passive_hits_total{family="B524",freshness_profile="state_fast"} 0`) {
-		t.Fatalf("RenderPrometheus missing bucketed B524 state_fast entry:\n%s", metrics)
+	if !strings.Contains(metrics, `passive_hits_total{family="B524",freshness_profile="discovery"} 0`) {
+		t.Fatalf("RenderPrometheus missing bucketed B524 discovery entry:\n%s", metrics)
 	}
 }
 
@@ -6575,6 +6718,82 @@ func TestDiscoverDeviceSlotsKeepsDisconnectedFunctionalModuleIdentityEvidence(t 
 		t.Fatal("disconnected functional module identity evidence was not retained")
 	}
 	requireB524Selector(t, selectors, remoteFunctionalModules.group, 0x04, device_slot_class_address)
+}
+
+func TestRefreshRadioDevicesSkipsVolatileDetailsForDisconnectedFunctionalModuleInventory(t *testing.T) {
+	t.Parallel()
+
+	var selectors [][]byte
+	poller := &vaillantSemanticPoller{
+		scheduler:                ebusgateway.NewSemanticReadScheduler(),
+		provider:                 graphql.NewLiveSemanticProvider(),
+		reg:                      newTestRegistry(),
+		source:                   0x7F,
+		controller:               0x15,
+		requestTimeout:           50 * time.Millisecond,
+		deviceSlotRediscoveryTTL: 30 * time.Minute,
+		deviceSlotDiscoveryDone:  true,
+		deviceSlotDiscoveryAt:    time.Now(),
+		deviceSlotCache: map[deviceSlotKey]bool{
+			{Group: remoteFunctionalModules.group, Instance: 0x04}: true,
+		},
+		nowFn: time.Now,
+	}
+	poller.sendFrameFn = func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+		selectors = append(selectors, slices.Clone(frame.Data))
+		if len(frame.Data) != 6 {
+			return nil, errors.New("invalid B524 selector")
+		}
+		group := frame.Data[2]
+		instance := frame.Data[3]
+		addr := uint16(frame.Data[4]) | uint16(frame.Data[5])<<8
+		if group == remoteFunctionalModules.group && instance == 0x04 {
+			switch addr {
+			case device_slot_connected:
+				return testB524ResponseForSelectorPayload(frame.Data, 0x00), nil
+			case device_slot_class_address:
+				return testB524ResponseForSelectorPayload(frame.Data, 0x26), nil
+			case device_slot_firmware:
+				return testB524ResponseForSelectorPayload(frame.Data, 0x01, 0x02, 0x03), nil
+			case device_slot_hardware_identifier:
+				return testB524ResponseForSelectorPayload(frame.Data, 0x34, 0x12), nil
+			}
+		}
+		return testB524ResponseForSelectorPayload(frame.Data, 0xFF), nil
+	}
+
+	poller.refreshRadioDevices(context.Background())
+
+	requireB524Selector(t, selectors, remoteFunctionalModules.group, 0x04, device_slot_connected)
+	requireB524Selector(t, selectors, remoteFunctionalModules.group, 0x04, device_slot_class_address)
+	requireB524Selector(t, selectors, remoteFunctionalModules.group, 0x04, device_slot_firmware)
+	requireB524Selector(t, selectors, remoteFunctionalModules.group, 0x04, device_slot_hardware_identifier)
+
+	for _, forbidden := range []uint16{
+		device_slot_remote_control_address,
+		device_slot_paired,
+		device_slot_reception_strength,
+		device_slot_zone_assignment,
+		device_slot_room_temperature,
+		device_slot_room_humidity,
+	} {
+		if hasB524Selector(selectors, remoteFunctionalModules.group, 0x04, forbidden) {
+			t.Fatalf("disconnected functional-module inventory read volatile addr=0x%04x; want identity-only detail refresh", forbidden)
+		}
+	}
+
+	poller.mu.Lock()
+	device := poller.radioDevices[radioDeviceKey{Group: remoteFunctionalModules.group, Instance: 0x04}]
+	poller.mu.Unlock()
+	if device == nil {
+		t.Fatal("radioDevices missing disconnected functional-module inventory snapshot")
+	}
+	if device.SlotMode != "inventory" {
+		t.Fatalf("SlotMode = %q; want inventory", device.SlotMode)
+	}
+	if device.RoomTemperatureC != nil || device.RoomHumidityPct != nil || device.ReceptionStrength != nil || device.DevicePaired != nil {
+		t.Fatalf("volatile fields populated for disconnected inventory snapshot: %+v", device)
+	}
 }
 
 func TestRefreshRadioDevicesClearsStaleSnapshotsWhenDiscoveryFindsNoRefreshableSlots(t *testing.T) {


### PR DESCRIPTION
## What
Reduce gateway-originated B524 active polling demand after passive cache recovery.

## Why
Live post-#677 metrics showed passive B524 direct apply working, but active 0x7f->0x15 B524 remained high because every semantic B524 runtime descriptor fell back to state_fast/state_default and disconnected FM inventory slots still probed volatile detail fields.

## Changes
- Classify B524 semantic fallback descriptors as fast state, slow state, config, or discovery by selector.
- Keep config reads on config_opt_in instead of state_default direct apply.
- Keep discovery/identity selectors out of state_default direct apply.
- Treat device_slot_connected as state_slow liveness, not 1h discovery.
- Preserve disconnected functional-module inventory identity while skipping volatile detail reads until connected.

## Validation
- `go test ./cmd/gateway -run 'TestSemanticReadWatchDescriptorWithDecoderID_ClassifiesB524Cadence|TestPrepareSemanticReadWatchRuntime_FallbackDescriptorB524DiscoveryBucketsCorrectly|TestRefreshRadioDevicesSkipsVolatileDetailsForDisconnectedFunctionalModuleInventory'`\n- `go test ./cmd/gateway`\n- `go test ./...`\n- `git diff --check`\n- Fresh reviewer PASS after liveness blocker fix.\n\n## Docs\n- Companion docs PR: Project-Helianthus/helianthus-docs-ebus#323\n\n## Links\n- Closes #678