### PR TITLE
Project mapped radio room state into zones

### DIFF
--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -3185,12 +3185,23 @@ func (p *vaillantSemanticPoller) publishZones(source semanticSnapshotSource) {
 		if quickVetoActive && entry.QuickVetoEndDate != "" && entry.QuickVetoEndTime != "" {
 			qvExpiry = entry.QuickVetoEndDate + "T" + entry.QuickVetoEndTime
 		}
+		currentTempC := entry.CurrentTempC
+		currentHumidityPct := entry.HumidityPct
+		if currentTempC == nil || currentHumidityPct == nil {
+			radioTempC, radioHumidityPct := p.mappedRadioRoomStateForZoneLocked(entry)
+			if currentTempC == nil {
+				currentTempC = radioTempC
+			}
+			if currentHumidityPct == nil {
+				currentHumidityPct = radioHumidityPct
+			}
+		}
 		zone := graphql.Zone{
 			ID:   fmt.Sprintf("zone-%d", instance+1),
 			Name: name,
 			State: graphql.ZoneState{
-				CurrentTempC:       entry.CurrentTempC,
-				CurrentHumidityPct: entry.HumidityPct,
+				CurrentTempC:       currentTempC,
+				CurrentHumidityPct: currentHumidityPct,
 				HvacAction:         entry.HvacAction,
 				SpecialFunction:    entry.StateSpecialFunction,
 				ValvePositionPct:   decodeValvePositionPct(entry.StateValveStatusRaw),
@@ -3241,6 +3252,56 @@ func (p *vaillantSemanticPoller) publishZones(source semanticSnapshotSource) {
 		}
 	}
 	p.persistSemanticCache(source)
+}
+
+func (p *vaillantSemanticPoller) mappedRadioRoomStateForZoneLocked(entry *vaillantZoneSnapshot) (*float64, *float64) {
+	if p == nil || entry == nil || entry.ConfigurationRoomTemperatureZoneMappingRaw == nil {
+		return nil, nil
+	}
+	mapping := *entry.ConfigurationRoomTemperatureZoneMappingRaw
+	if mapping == 0 || mapping == 0xFFFF {
+		return nil, nil
+	}
+	if decodeRoomTemperatureZoneMapping(&mapping) == nil {
+		return nil, nil
+	}
+
+	var snapshot *vaillantRadioDeviceSnapshot
+	switch mapping {
+	case 1:
+		snapshot = p.firstConnectedRadioDeviceLocked(remoteRegulators.group)
+	default:
+		if mapping > 0x100 {
+			return nil, nil
+		}
+		snapshot = p.radioDevices[radioDeviceKey{Group: remoteThermostats.group, Instance: byte(mapping - 1)}]
+	}
+	if snapshot == nil || !radioDeviceConnected(snapshot) {
+		return nil, nil
+	}
+	return cloneFloat64Ptr(snapshot.RoomTemperatureC), cloneFloat64Ptr(snapshot.RoomHumidityPct)
+}
+
+func (p *vaillantSemanticPoller) firstConnectedRadioDeviceLocked(group byte) *vaillantRadioDeviceSnapshot {
+	if p == nil {
+		return nil
+	}
+	var selected *vaillantRadioDeviceSnapshot
+	var selectedInstance byte
+	for key, snapshot := range p.radioDevices {
+		if key.Group != group || snapshot == nil || !radioDeviceConnected(snapshot) {
+			continue
+		}
+		if selected == nil || key.Instance < selectedInstance {
+			selected = snapshot
+			selectedInstance = key.Instance
+		}
+	}
+	return selected
+}
+
+func radioDeviceConnected(snapshot *vaillantRadioDeviceSnapshot) bool {
+	return snapshot != nil && snapshot.DeviceConnected != nil && *snapshot.DeviceConnected
 }
 
 func zoneEquals(a, b graphql.Zone) bool {
@@ -6163,11 +6224,27 @@ func (p *vaillantSemanticPoller) persistSemanticSnapshot() {
 	if p == nil || p.cache == nil || p.provider == nil {
 		return
 	}
+	p.mu.Lock()
+	zones := p.cacheZonesLocked(p.provider.Zones())
+	p.mu.Unlock()
 	_ = p.cache.Save(semanticCacheSnapshot{
-		Zones:  p.provider.Zones(),
+		Zones:  zones,
 		DHW:    p.provider.DHW(),
 		Boiler: p.provider.BoilerStatus(),
 	})
+}
+
+func (p *vaillantSemanticPoller) cacheZonesLocked(published []graphql.Zone) []graphql.Zone {
+	out := make([]graphql.Zone, 0, len(published))
+	for idx, zone := range published {
+		instance := zoneInstanceFromSemanticID(zone.ID, idx)
+		if entry := p.zones[instance]; entry != nil {
+			zone.State.CurrentTempC = cloneFloat64Ptr(entry.CurrentTempC)
+			zone.State.CurrentHumidityPct = cloneFloat64Ptr(entry.HumidityPct)
+		}
+		out = append(out, zone)
+	}
+	return out
 }
 
 func dhwEquals(a, b *graphql.DhwStatus) bool {

--- a/cmd/gateway/semantic_vaillant_test.go
+++ b/cmd/gateway/semantic_vaillant_test.go
@@ -4376,6 +4376,217 @@ func TestVaillantSemanticPoller_PublishZones_SeparatesRoomTemperatureZoneMapping
 	}
 }
 
+func TestVaillantSemanticPoller_PublishZones_FillsRoomStateFromMappedRadioSensors(t *testing.T) {
+	t.Parallel()
+
+	provider := graphql.NewLiveSemanticProvider()
+	regulatorMapping := uint16(1)
+	thermostatMapping := uint16(2)
+	regulatorConnected := true
+	thermostatConnected := true
+	regulatorTemp := 14.8125
+	regulatorHumidity := 62.0
+	thermostatTemp := 17.6875
+	thermostatHumidity := 53.0
+
+	poller := &vaillantSemanticPoller{
+		provider: provider,
+		zones: map[byte]*vaillantZoneSnapshot{
+			0x00: {
+				Instance: 0x00,
+				Present:  true,
+				Name:     "Parter",
+				ConfigurationRoomTemperatureZoneMappingRaw: &regulatorMapping,
+			},
+			0x01: {
+				Instance: 0x01,
+				Present:  true,
+				Name:     "Etaj",
+				ConfigurationRoomTemperatureZoneMappingRaw: &thermostatMapping,
+			},
+		},
+		radioDevices: map[radioDeviceKey]*vaillantRadioDeviceSnapshot{
+			{Group: remoteRegulators.group, Instance: 0x01}: {
+				Group:            remoteRegulators.group,
+				Instance:         0x01,
+				DeviceConnected:  &regulatorConnected,
+				RoomTemperatureC: &regulatorTemp,
+				RoomHumidityPct:  &regulatorHumidity,
+			},
+			{Group: remoteThermostats.group, Instance: 0x01}: {
+				Group:            remoteThermostats.group,
+				Instance:         0x01,
+				DeviceConnected:  &thermostatConnected,
+				RoomTemperatureC: &thermostatTemp,
+				RoomHumidityPct:  &thermostatHumidity,
+			},
+		},
+	}
+
+	poller.publishZones(semanticSnapshotSourceLive)
+
+	zones := provider.Zones()
+	if len(zones) != 2 {
+		t.Fatalf("len(provider.Zones()) = %d; want 2", len(zones))
+	}
+	if zones[0].State.CurrentTempC == nil || *zones[0].State.CurrentTempC != regulatorTemp {
+		t.Fatalf("zone 1 current temp = %#v; want %.4f", zones[0].State.CurrentTempC, regulatorTemp)
+	}
+	if zones[0].State.CurrentHumidityPct == nil || *zones[0].State.CurrentHumidityPct != regulatorHumidity {
+		t.Fatalf("zone 1 humidity = %#v; want %.1f", zones[0].State.CurrentHumidityPct, regulatorHumidity)
+	}
+	if zones[1].State.CurrentTempC == nil || *zones[1].State.CurrentTempC != thermostatTemp {
+		t.Fatalf("zone 2 current temp = %#v; want %.4f", zones[1].State.CurrentTempC, thermostatTemp)
+	}
+	if zones[1].State.CurrentHumidityPct == nil || *zones[1].State.CurrentHumidityPct != thermostatHumidity {
+		t.Fatalf("zone 2 humidity = %#v; want %.1f", zones[1].State.CurrentHumidityPct, thermostatHumidity)
+	}
+}
+
+func TestVaillantSemanticPoller_PublishZones_KeepsDirectRoomStateOverRadioFallback(t *testing.T) {
+	t.Parallel()
+
+	provider := graphql.NewLiveSemanticProvider()
+	mapping := uint16(2)
+	connected := true
+	directTemp := 21.0
+	directHumidity := 44.0
+	radioTemp := 17.6875
+	radioHumidity := 53.0
+
+	poller := &vaillantSemanticPoller{
+		provider: provider,
+		zones: map[byte]*vaillantZoneSnapshot{
+			0x01: {
+				Instance:     0x01,
+				Present:      true,
+				Name:         "Etaj",
+				CurrentTempC: &directTemp,
+				HumidityPct:  &directHumidity,
+				ConfigurationRoomTemperatureZoneMappingRaw: &mapping,
+			},
+		},
+		radioDevices: map[radioDeviceKey]*vaillantRadioDeviceSnapshot{
+			{Group: remoteThermostats.group, Instance: 0x01}: {
+				Group:            remoteThermostats.group,
+				Instance:         0x01,
+				DeviceConnected:  &connected,
+				RoomTemperatureC: &radioTemp,
+				RoomHumidityPct:  &radioHumidity,
+			},
+		},
+	}
+
+	poller.publishZones(semanticSnapshotSourceLive)
+
+	zones := provider.Zones()
+	if len(zones) != 1 {
+		t.Fatalf("len(provider.Zones()) = %d; want 1", len(zones))
+	}
+	if zones[0].State.CurrentTempC == nil || *zones[0].State.CurrentTempC != directTemp {
+		t.Fatalf("zone current temp = %#v; want direct %.1f", zones[0].State.CurrentTempC, directTemp)
+	}
+	if zones[0].State.CurrentHumidityPct == nil || *zones[0].State.CurrentHumidityPct != directHumidity {
+		t.Fatalf("zone humidity = %#v; want direct %.1f", zones[0].State.CurrentHumidityPct, directHumidity)
+	}
+}
+
+func TestVaillantSemanticPoller_PublishZones_RadioFallbackDoesNotPersistAsDirectState(t *testing.T) {
+	t.Parallel()
+
+	provider := graphql.NewLiveSemanticProvider()
+	cache := &semanticSnapshotCaptureSpy{}
+	mapping := uint16(2)
+	connected := true
+	radioTemp := 17.6875
+	radioHumidity := 53.0
+
+	poller := &vaillantSemanticPoller{
+		provider: provider,
+		cache:    cache,
+		zones: map[byte]*vaillantZoneSnapshot{
+			0x01: {
+				Instance: 0x01,
+				Present:  true,
+				Name:     "Etaj",
+				ConfigurationRoomTemperatureZoneMappingRaw: &mapping,
+			},
+		},
+		radioDevices: map[radioDeviceKey]*vaillantRadioDeviceSnapshot{
+			{Group: remoteThermostats.group, Instance: 0x01}: {
+				Group:            remoteThermostats.group,
+				Instance:         0x01,
+				DeviceConnected:  &connected,
+				RoomTemperatureC: &radioTemp,
+				RoomHumidityPct:  &radioHumidity,
+			},
+		},
+	}
+
+	poller.publishZones(semanticSnapshotSourceLive)
+
+	published := provider.Zones()
+	if len(published) != 1 {
+		t.Fatalf("len(provider.Zones()) = %d; want 1", len(published))
+	}
+	if published[0].State.CurrentTempC == nil || *published[0].State.CurrentTempC != radioTemp {
+		t.Fatalf("published current temp = %#v; want radio fallback %.4f", published[0].State.CurrentTempC, radioTemp)
+	}
+	if cache.calls == 0 || len(cache.last.Zones) != 1 {
+		t.Fatalf("cache calls=%d zones=%d; want persisted zone snapshot", cache.calls, len(cache.last.Zones))
+	}
+	if cache.last.Zones[0].State.CurrentTempC != nil {
+		t.Fatalf("cached current temp = %#v; want nil direct zone value", cache.last.Zones[0].State.CurrentTempC)
+	}
+	if cache.last.Zones[0].State.CurrentHumidityPct != nil {
+		t.Fatalf("cached humidity = %#v; want nil direct zone value", cache.last.Zones[0].State.CurrentHumidityPct)
+	}
+}
+
+func TestVaillantSemanticPoller_PublishZones_SkipsUnknownRoomSensorMappingFallback(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []uint16{0, 0xFF, 0xFFFF} {
+		raw := raw
+		t.Run(fmt.Sprintf("mapping_0x%04x", raw), func(t *testing.T) {
+			t.Parallel()
+
+			provider := graphql.NewLiveSemanticProvider()
+			connected := true
+			radioTemp := 17.6875
+			poller := &vaillantSemanticPoller{
+				provider: provider,
+				zones: map[byte]*vaillantZoneSnapshot{
+					0x01: {
+						Instance: 0x01,
+						Present:  true,
+						Name:     "Etaj",
+						ConfigurationRoomTemperatureZoneMappingRaw: &raw,
+					},
+				},
+				radioDevices: map[radioDeviceKey]*vaillantRadioDeviceSnapshot{
+					{Group: remoteThermostats.group, Instance: 0xFE}: {
+						Group:            remoteThermostats.group,
+						Instance:         0xFE,
+						DeviceConnected:  &connected,
+						RoomTemperatureC: &radioTemp,
+					},
+				},
+			}
+
+			poller.publishZones(semanticSnapshotSourceLive)
+
+			zones := provider.Zones()
+			if len(zones) != 1 {
+				t.Fatalf("len(provider.Zones()) = %d; want 1", len(zones))
+			}
+			if zones[0].State.CurrentTempC != nil {
+				t.Fatalf("zone current temp = %#v; want nil for unknown mapping 0x%04x", zones[0].State.CurrentTempC, raw)
+			}
+		})
+	}
+}
+
 func TestMergeDhwSnapshotFields_PartialLiveUpdatePreservesLastKnownAndFreshness(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Fill zone current temperature and humidity from the mapped regulator/thermostat radio-device snapshot when direct zone state is absent.
- Preserve direct zone room-state values as authoritative when present.
- Cover regulator mapping (1) and thermostat mapping (>=2 -> instance mapping-1) with regression tests.

## Validation
- go test ./cmd/gateway -run 'TestVaillantSemanticPoller_PublishZones_(FillsRoomStateFromMappedRadioSensors|KeepsDirectRoomStateOverRadioFallback|SeparatesRoomTemperatureZoneMappingFromAssociatedCircuit)'
- go test ./cmd/gateway
- go test ./...
- golangci-lint run
- git diff --check

Fixes #682
Docs: Project-Helianthus/helianthus-docs-ebus#328