### PR TITLE
Reduce active B524 semantic mirror reads

### DIFF
--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -455,8 +455,9 @@ type vaillantDhwSnapshot struct {
 }
 
 type vaillantCircuitSnapshot struct {
-	Instance byte
-	Active   bool
+	Instance   byte
+	Active     bool
+	Controller byte
 
 	CircuitTypeRaw     *uint16
 	CoolingEnabledRaw  *uint16
@@ -468,8 +469,10 @@ type vaillantCircuitSnapshot struct {
 	SummerLimitC       *float64
 	RoomTempControlRaw *uint16
 	CircuitStateRaw    *uint16
+	CircuitStateLiveAt time.Time
 	FrostProtectionC   *float64
 	PumpStatusRaw      *uint16
+	PumpStatusLiveAt   time.Time
 	CalcFlowTempC      *float64
 	MixerPositionPct   *float64
 	HumidityPct        *float64
@@ -1617,6 +1620,9 @@ func (p *vaillantSemanticPoller) refreshCircuitsStartup(ctx context.Context) {
 		return
 	}
 
+	p.mu.Lock()
+	controller := p.controller
+	p.mu.Unlock()
 	instances := allCircuitRefreshInstances()
 	updates := make(map[byte]*vaillantCircuitSnapshot)
 	inactive := make(map[byte]struct{})
@@ -1633,6 +1639,7 @@ func (p *vaillantSemanticPoller) refreshCircuitsStartup(ctx context.Context) {
 			updates[instance] = &vaillantCircuitSnapshot{
 				Instance:       instance,
 				Active:         true,
+				Controller:     controller,
 				CircuitTypeRaw: cloneUint16Ptr(circuitTypeRaw),
 			}
 		}
@@ -1655,6 +1662,12 @@ func (p *vaillantSemanticPoller) refreshCircuitsStartup(ctx context.Context) {
 		delete(p.circuits, instance)
 	}
 	for instance, incoming := range updates {
+		if incoming.CircuitStateRaw != nil {
+			incoming.CircuitStateLiveAt = p.now()
+		}
+		if incoming.PumpStatusRaw != nil {
+			incoming.PumpStatusLiveAt = p.now()
+		}
 		p.circuits[instance] = mergeCircuitSnapshotNonDestructive(p.circuits[instance], incoming)
 	}
 	p.lastCircuitFullScanAt = p.now()
@@ -1668,7 +1681,10 @@ func (p *vaillantSemanticPoller) refreshSystemStartup(ctx context.Context) {
 		return
 	}
 
-	snapshot := &vaillantSystemSnapshot{}
+	p.mu.Lock()
+	controller := p.controller
+	p.mu.Unlock()
+	snapshot := &vaillantSystemSnapshot{Controller: controller}
 	readAny := false
 	if raw, ok := p.readB524Uint16Startup(ctx, localRegulator.opcode, localRegulator.group, regulatorInstance, system_scheme); ok && raw != nil {
 		snapshot.SystemScheme = cloneUint16Ptr(raw)
@@ -1688,6 +1704,9 @@ func (p *vaillantSemanticPoller) refreshSystemStartup(ctx context.Context) {
 	p.mu.Lock()
 	source := semanticSnapshotSourceCache
 	if readAny {
+		if snapshot.SystemFlowTemperature != nil {
+			snapshot.SystemFlowTemperatureLiveAt = p.now()
+		}
 		p.system = mergeSystemSnapshotNonDestructive(p.system, snapshot)
 		source = semanticSnapshotSourceLive
 	}
@@ -3196,6 +3215,15 @@ func (p *vaillantSemanticPoller) publishZones(source semanticSnapshotSource) {
 				currentHumidityPct = radioHumidityPct
 			}
 		}
+		roomMappingRaw := entry.ConfigurationRoomTemperatureZoneMappingRaw
+		if roomMappingRaw == nil {
+			roomMappingRaw = p.inferRadioRoomMappingForZoneLocked(entry.Instance)
+		}
+		associatedCircuitRaw := entry.ConfigurationAssociatedCircuitRaw
+		if associatedCircuitRaw == nil && roomMappingRaw != nil {
+			value := uint16(resolveAssociatedCircuitInstance(roomMappingRaw, entry.Instance))
+			associatedCircuitRaw = &value
+		}
 		zone := graphql.Zone{
 			ID:   fmt.Sprintf("zone-%d", instance+1),
 			Name: name,
@@ -3212,8 +3240,8 @@ func (p *vaillantSemanticPoller) publishZones(source semanticSnapshotSource) {
 				TargetTempC:                entry.TargetTempC,
 				AllowedModes:               append([]string(nil), entry.AllowedModes...),
 				CircuitType:                decodeCircuitType(entry.ConfigurationCircuitTypeRaw),
-				AssociatedCircuit:          decodeAssociatedCircuit(entry.ConfigurationAssociatedCircuitRaw),
-				RoomTemperatureZoneMapping: decodeRoomTemperatureZoneMapping(entry.ConfigurationRoomTemperatureZoneMappingRaw),
+				AssociatedCircuit:          decodeAssociatedCircuit(associatedCircuitRaw),
+				RoomTemperatureZoneMapping: decodeRoomTemperatureZoneMapping(roomMappingRaw),
 				QuickVeto:                  quickVetoActive,
 				QuickVetoSetpointC:         entry.QuickVetoTempC,
 				QuickVetoDurationH:         entry.QuickVetoDurationH,
@@ -3255,10 +3283,17 @@ func (p *vaillantSemanticPoller) publishZones(source semanticSnapshotSource) {
 }
 
 func (p *vaillantSemanticPoller) mappedRadioRoomStateForZoneLocked(entry *vaillantZoneSnapshot) (*float64, *float64) {
-	if p == nil || entry == nil || entry.ConfigurationRoomTemperatureZoneMappingRaw == nil {
+	if p == nil || entry == nil {
 		return nil, nil
 	}
-	mapping := *entry.ConfigurationRoomTemperatureZoneMappingRaw
+	mappingRaw := entry.ConfigurationRoomTemperatureZoneMappingRaw
+	if mappingRaw == nil {
+		mappingRaw = p.inferRadioRoomMappingForZoneLocked(entry.Instance)
+	}
+	if mappingRaw == nil {
+		return nil, nil
+	}
+	mapping := *mappingRaw
 	if mapping == 0 || mapping == 0xFFFF {
 		return nil, nil
 	}
@@ -3280,6 +3315,28 @@ func (p *vaillantSemanticPoller) mappedRadioRoomStateForZoneLocked(entry *vailla
 		return nil, nil
 	}
 	return cloneFloat64Ptr(snapshot.RoomTemperatureC), cloneFloat64Ptr(snapshot.RoomHumidityPct)
+}
+
+func (p *vaillantSemanticPoller) inferRadioRoomMappingForZoneLocked(instance byte) *uint16 {
+	if p == nil {
+		return nil
+	}
+	zoneNumber := int(instance) + 1
+	matches := make([]byte, 0, 1)
+	for key, snapshot := range p.radioDevices {
+		if key.Group != remoteThermostats.group || snapshot == nil || !radioDeviceConnected(snapshot) || snapshot.ZoneAssignment == nil {
+			continue
+		}
+		if int(*snapshot.ZoneAssignment) != zoneNumber {
+			continue
+		}
+		matches = append(matches, key.Instance)
+	}
+	if len(matches) != 1 {
+		return nil
+	}
+	mapping := uint16(matches[0]) + 1
+	return &mapping
 }
 
 func (p *vaillantSemanticPoller) firstConnectedRadioDeviceLocked(group byte) *vaillantRadioDeviceSnapshot {
@@ -3638,10 +3695,10 @@ func (p *vaillantSemanticPoller) refreshCircuits(ctx context.Context) {
 
 	now := p.now()
 	p.mu.Lock()
-	controllerPresent := p.controller != 0
+	controller := p.controller
 	instances, fullScan := p.circuitRefreshInstancesLocked(now)
 	p.mu.Unlock()
-	if !controllerPresent {
+	if controller == 0 {
 		return
 	}
 
@@ -3678,6 +3735,7 @@ func (p *vaillantSemanticPoller) refreshCircuits(ctx context.Context) {
 		snapshot := &vaillantCircuitSnapshot{
 			Instance:       instance,
 			Active:         true,
+			Controller:     controller,
 			CircuitTypeRaw: cloneUint16Ptr(circuitTypeRaw),
 		}
 		anyRead = true
@@ -3722,6 +3780,7 @@ func (p *vaillantSemanticPoller) refreshCircuits(ctx context.Context) {
 		}
 		if raw, ok := p.readB524Uint16(ctx, localCircuits.opcode, localCircuits.group, instance, circuit_circuit_state); ok && raw != nil {
 			snapshot.CircuitStateRaw = cloneUint16Ptr(raw)
+			snapshot.CircuitStateLiveAt = now
 			anyRead = true
 		}
 		if value, ok := p.readB524Float32LE(ctx, localCircuits.opcode, localCircuits.group, instance, circuit_frost_protection); ok {
@@ -3731,6 +3790,7 @@ func (p *vaillantSemanticPoller) refreshCircuits(ctx context.Context) {
 		}
 		if raw, ok := p.readB524Uint16(ctx, localCircuits.opcode, localCircuits.group, instance, circuit_pump_status); ok && raw != nil {
 			snapshot.PumpStatusRaw = cloneUint16Ptr(raw)
+			snapshot.PumpStatusLiveAt = now
 			anyRead = true
 		}
 		if value, ok := p.readB524Float32LE(ctx, localCircuits.opcode, localCircuits.group, instance, circuit_calc_flow_temp); ok {
@@ -3838,6 +3898,18 @@ func mergeCircuitSnapshotNonDestructive(existing, incoming *vaillantCircuitSnaps
 
 	merged.Instance = incoming.Instance
 	merged.Active = merged.Active || incoming.Active
+	controllerChanged := incoming.Controller != 0 && incoming.Controller != merged.Controller
+	if controllerChanged && incoming.CircuitStateRaw == nil {
+		merged.CircuitStateRaw = nil
+		merged.CircuitStateLiveAt = time.Time{}
+	}
+	if controllerChanged && incoming.PumpStatusRaw == nil {
+		merged.PumpStatusRaw = nil
+		merged.PumpStatusLiveAt = time.Time{}
+	}
+	if incoming.Controller != 0 {
+		merged.Controller = incoming.Controller
+	}
 	if incoming.CircuitTypeRaw != nil {
 		merged.CircuitTypeRaw = cloneUint16Ptr(incoming.CircuitTypeRaw)
 	}
@@ -3867,12 +3939,14 @@ func mergeCircuitSnapshotNonDestructive(existing, incoming *vaillantCircuitSnaps
 	}
 	if incoming.CircuitStateRaw != nil {
 		merged.CircuitStateRaw = cloneUint16Ptr(incoming.CircuitStateRaw)
+		merged.CircuitStateLiveAt = incoming.CircuitStateLiveAt
 	}
 	if incoming.FrostProtectionC != nil {
 		merged.FrostProtectionC = cloneFloat64Ptr(incoming.FrostProtectionC)
 	}
 	if incoming.PumpStatusRaw != nil {
 		merged.PumpStatusRaw = cloneUint16Ptr(incoming.PumpStatusRaw)
+		merged.PumpStatusLiveAt = incoming.PumpStatusLiveAt
 	}
 	if incoming.CalcFlowTempC != nil {
 		merged.CalcFlowTempC = cloneFloat64Ptr(incoming.CalcFlowTempC)
@@ -3902,6 +3976,7 @@ func cloneCircuitSnapshot(snapshot *vaillantCircuitSnapshot) *vaillantCircuitSna
 	return &vaillantCircuitSnapshot{
 		Instance:           snapshot.Instance,
 		Active:             snapshot.Active,
+		Controller:         snapshot.Controller,
 		CircuitTypeRaw:     cloneUint16Ptr(snapshot.CircuitTypeRaw),
 		CoolingEnabledRaw:  cloneUint16Ptr(snapshot.CoolingEnabledRaw),
 		FlowSetpointC:      cloneFloat64Ptr(snapshot.FlowSetpointC),
@@ -3912,8 +3987,10 @@ func cloneCircuitSnapshot(snapshot *vaillantCircuitSnapshot) *vaillantCircuitSna
 		SummerLimitC:       cloneFloat64Ptr(snapshot.SummerLimitC),
 		RoomTempControlRaw: cloneUint16Ptr(snapshot.RoomTempControlRaw),
 		CircuitStateRaw:    cloneUint16Ptr(snapshot.CircuitStateRaw),
+		CircuitStateLiveAt: snapshot.CircuitStateLiveAt,
 		FrostProtectionC:   cloneFloat64Ptr(snapshot.FrostProtectionC),
 		PumpStatusRaw:      cloneUint16Ptr(snapshot.PumpStatusRaw),
+		PumpStatusLiveAt:   snapshot.PumpStatusLiveAt,
 		CalcFlowTempC:      cloneFloat64Ptr(snapshot.CalcFlowTempC),
 		MixerPositionPct:   cloneFloat64Ptr(snapshot.MixerPositionPct),
 		HumidityPct:        cloneFloat64Ptr(snapshot.HumidityPct),
@@ -4277,10 +4354,13 @@ type vaillantBoilerSnapshot struct {
 }
 
 type vaillantSystemSnapshot struct {
+	Controller byte
+
 	// State
 	SystemOff                    *bool
 	SystemWaterPressure          *float64
 	SystemFlowTemperature        *float64
+	SystemFlowTemperatureLiveAt  time.Time
 	OutdoorTemperature           *float64
 	OutdoorTemperatureAvg24h     *float64
 	MaintenanceDue               *bool
@@ -4400,9 +4480,18 @@ func (p *vaillantSemanticPoller) refreshBoilerStatusTier(ctx context.Context, ti
 	if boilerAddress != 0 {
 		updated = p.refreshBoilerStatusB509(ctx, boilerAddress, tier, snapshot) || updated
 	}
+	dhwUpdated := false
+	if tier == boilerStatusTierFast {
+		dhwUpdated = p.mergeBoilerDHWFieldsFromSnapshot(snapshot)
+	}
 
 	// Preserve last-known values on transient/partial failures.
 	if !updated {
+		if dhwUpdated {
+			p.mu.Lock()
+			p.boiler = mergeBoilerSnapshotNonDestructive(p.boiler, snapshot)
+			p.mu.Unlock()
+		}
 		return
 	}
 
@@ -4416,6 +4505,10 @@ func (p *vaillantSemanticPoller) refreshBoilerStatusTier(ctx context.Context, ti
 func (p *vaillantSemanticPoller) refreshBoilerStatusB524(ctx context.Context, tier boilerStatusTier, snapshot *vaillantBoilerSnapshot) bool {
 	if p == nil || snapshot == nil {
 		return false
+	}
+
+	if tier == boilerStatusTierFast {
+		return p.mergeBoilerMirrorFieldsFromSnapshots(snapshot)
 	}
 
 	updated := false
@@ -4457,12 +4550,71 @@ func (p *vaillantSemanticPoller) refreshBoilerStatusB524(ctx context.Context, ti
 		}
 	}
 
-	if tier != boilerStatusTierFast {
-		return updated
+	return updated
+}
+
+func (p *vaillantSemanticPoller) mergeBoilerMirrorFieldsFromSnapshots(snapshot *vaillantBoilerSnapshot) bool {
+	if p == nil || snapshot == nil {
+		return false
 	}
 
-	p.mergeBoilerDHWFieldsFromSnapshot(snapshot)
+	p.mu.Lock()
+	controller := p.controller
+	system := cloneSystemSnapshot(p.system)
+	circuit := cloneCircuitSnapshot(p.circuits[0x00])
+	p.mu.Unlock()
+	if controller == 0 {
+		return false
+	}
+
+	now := p.now()
+	maxAge := p.boilerMirrorMaxAge()
+	updated := false
+	if system != nil && system.Controller == controller && system.SystemFlowTemperature != nil && semanticSnapshotObservedWithin(system.SystemFlowTemperatureLiveAt, now, maxAge) {
+		snapshot.FlowTemperatureC = cloneFloat64Ptr(system.SystemFlowTemperature)
+		updated = true
+	}
+	if circuit != nil && circuit.Controller == controller {
+		if circuit.PumpStatusRaw != nil && semanticSnapshotObservedWithin(circuit.PumpStatusLiveAt, now, maxAge) {
+			active := *circuit.PumpStatusRaw != 0
+			snapshot.CentralHeatingPumpActive = &active
+			updated = true
+		}
+		if circuit.CircuitStateRaw != nil && semanticSnapshotObservedWithin(circuit.CircuitStateLiveAt, now, maxAge) {
+			status := int(*circuit.CircuitStateRaw)
+			snapshot.HeatingStatusRaw = &status
+			updated = true
+		}
+	}
+	if updated {
+		p.mergeBoilerDHWFieldsFromSnapshot(snapshot)
+	}
 	return updated
+}
+
+func (p *vaillantSemanticPoller) boilerMirrorMaxAge() time.Duration {
+	interval := p.configInterval
+	if interval <= 0 {
+		interval = ebusgateway.DefaultConfig().SemanticConfigInterval
+	}
+	fastInterval := p.boilerFastInterval
+	if fastInterval <= 0 {
+		fastInterval = 30 * time.Second
+	}
+	return interval + fastInterval
+}
+
+func semanticSnapshotObservedWithin(observedAt, now time.Time, maxAge time.Duration) bool {
+	if observedAt.IsZero() {
+		return false
+	}
+	if maxAge <= 0 {
+		return true
+	}
+	if now.Before(observedAt) {
+		return true
+	}
+	return now.Sub(observedAt) <= maxAge
 }
 
 func (p *vaillantSemanticPoller) mergeBoilerDHWFieldsFromSnapshot(snapshot *vaillantBoilerSnapshot) bool {
@@ -4754,7 +4906,7 @@ func (p *vaillantSemanticPoller) refreshSystem(ctx context.Context) {
 		return
 	}
 
-	snapshot := &vaillantSystemSnapshot{}
+	snapshot := &vaillantSystemSnapshot{Controller: controller}
 	updated := false
 
 	if raw, ok := p.readB524Uint16(ctx, localRegulator.opcode, localRegulator.group, regulatorInstance, system_off); ok && raw != nil {
@@ -4768,6 +4920,7 @@ func (p *vaillantSemanticPoller) refreshSystem(ctx context.Context) {
 	}
 	if value, ok := p.readB524Float32LE(ctx, localRegulator.opcode, localRegulator.group, regulatorInstance, system_flow_temperature); ok {
 		snapshot.SystemFlowTemperature = &value
+		snapshot.SystemFlowTemperatureLiveAt = p.now()
 		updated = true
 	}
 	if value, ok := p.readB524Float32LE(ctx, localRegulator.opcode, localRegulator.group, regulatorInstance, system_outdoor_temperature); ok {
@@ -5676,6 +5829,14 @@ func mergeSystemSnapshotNonDestructive(existing, incoming *vaillantSystemSnapsho
 		return merged
 	}
 
+	controllerChanged := incoming.Controller != 0 && incoming.Controller != merged.Controller
+	if controllerChanged && incoming.SystemFlowTemperature == nil {
+		merged.SystemFlowTemperature = nil
+		merged.SystemFlowTemperatureLiveAt = time.Time{}
+	}
+	if incoming.Controller != 0 {
+		merged.Controller = incoming.Controller
+	}
 	if incoming.SystemOff != nil {
 		merged.SystemOff = cloneBoilerBoolPtr(incoming.SystemOff)
 	}
@@ -5684,6 +5845,7 @@ func mergeSystemSnapshotNonDestructive(existing, incoming *vaillantSystemSnapsho
 	}
 	if incoming.SystemFlowTemperature != nil {
 		merged.SystemFlowTemperature = cloneFloat64Ptr(incoming.SystemFlowTemperature)
+		merged.SystemFlowTemperatureLiveAt = incoming.SystemFlowTemperatureLiveAt
 	}
 	if incoming.OutdoorTemperature != nil {
 		merged.OutdoorTemperature = cloneFloat64Ptr(incoming.OutdoorTemperature)
@@ -5750,9 +5912,11 @@ func cloneSystemSnapshot(snapshot *vaillantSystemSnapshot) *vaillantSystemSnapsh
 		return nil
 	}
 	return &vaillantSystemSnapshot{
+		Controller:                   snapshot.Controller,
 		SystemOff:                    cloneBoilerBoolPtr(snapshot.SystemOff),
 		SystemWaterPressure:          cloneFloat64Ptr(snapshot.SystemWaterPressure),
 		SystemFlowTemperature:        cloneFloat64Ptr(snapshot.SystemFlowTemperature),
+		SystemFlowTemperatureLiveAt:  snapshot.SystemFlowTemperatureLiveAt,
 		OutdoorTemperature:           cloneFloat64Ptr(snapshot.OutdoorTemperature),
 		OutdoorTemperatureAvg24h:     cloneFloat64Ptr(snapshot.OutdoorTemperatureAvg24h),
 		MaintenanceDue:               cloneBoilerBoolPtr(snapshot.MaintenanceDue),
@@ -6241,6 +6405,8 @@ func (p *vaillantSemanticPoller) cacheZonesLocked(published []graphql.Zone) []gr
 		if entry := p.zones[instance]; entry != nil {
 			zone.State.CurrentTempC = cloneFloat64Ptr(entry.CurrentTempC)
 			zone.State.CurrentHumidityPct = cloneFloat64Ptr(entry.HumidityPct)
+			zone.Config.RoomTemperatureZoneMapping = decodeRoomTemperatureZoneMapping(entry.ConfigurationRoomTemperatureZoneMappingRaw)
+			zone.Config.AssociatedCircuit = decodeAssociatedCircuit(entry.ConfigurationAssociatedCircuitRaw)
 		}
 		out = append(out, zone)
 	}

--- a/cmd/gateway/semantic_vaillant_test.go
+++ b/cmd/gateway/semantic_vaillant_test.go
@@ -597,6 +597,220 @@ func TestRefreshConfigReadsSlowZoneAndDHWB524Selectors(t *testing.T) {
 	}
 }
 
+func TestRefreshBoilerStatusFastProjectsB524MirrorsWithoutActiveB524Reads(t *testing.T) {
+	t.Parallel()
+
+	var selectors [][]byte
+	observedAt := time.Unix(100, 0)
+	flowTemp := 42.5
+	dhwTemp := 48.5
+	pumpRaw := uint16(1)
+	heatingRaw := uint16(2)
+	poller := &vaillantSemanticPoller{
+		scheduler:      ebusgateway.NewSemanticReadScheduler(),
+		source:         0x7F,
+		controller:     0x15,
+		requestTimeout: 50 * time.Millisecond,
+		nowFn:          func() time.Time { return observedAt.Add(30 * time.Second) },
+		system: &vaillantSystemSnapshot{
+			Controller:                  0x15,
+			SystemFlowTemperature:       &flowTemp,
+			SystemFlowTemperatureLiveAt: observedAt,
+		},
+		circuits: map[byte]*vaillantCircuitSnapshot{
+			0x00: {
+				Instance:           0x00,
+				Active:             true,
+				Controller:         0x15,
+				PumpStatusRaw:      &pumpRaw,
+				PumpStatusLiveAt:   observedAt,
+				CircuitStateRaw:    &heatingRaw,
+				CircuitStateLiveAt: observedAt,
+			},
+		},
+		dhw: &vaillantDhwSnapshot{CurrentTempC: &dhwTemp},
+	}
+	poller.sendFrameFn = func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+		selectors = append(selectors, slices.Clone(frame.Data))
+		return testB524ResponseForSelector(frame.Data), nil
+	}
+
+	snapshot := &vaillantBoilerSnapshot{}
+	if !poller.refreshBoilerStatusB524(context.Background(), boilerStatusTierFast, snapshot) {
+		t.Fatal("refreshBoilerStatusB524(fast) updated = false; want projected snapshot update")
+	}
+	if len(selectors) != 0 {
+		t.Fatalf("refreshBoilerStatusB524(fast) performed %d active reads; want zero", len(selectors))
+	}
+	if snapshot.FlowTemperatureC == nil || *snapshot.FlowTemperatureC != flowTemp {
+		t.Fatalf("flow temperature = %#v; want %.1f", snapshot.FlowTemperatureC, flowTemp)
+	}
+	if snapshot.CentralHeatingPumpActive == nil || !*snapshot.CentralHeatingPumpActive {
+		t.Fatalf("pump active = %#v; want true", snapshot.CentralHeatingPumpActive)
+	}
+	if snapshot.HeatingStatusRaw == nil || *snapshot.HeatingStatusRaw != int(heatingRaw) {
+		t.Fatalf("heating status = %#v; want %d", snapshot.HeatingStatusRaw, heatingRaw)
+	}
+	if snapshot.DhwTemperatureC == nil || *snapshot.DhwTemperatureC != dhwTemp {
+		t.Fatalf("dhw temperature = %#v; want %.1f", snapshot.DhwTemperatureC, dhwTemp)
+	}
+}
+
+func TestRefreshBoilerStatusFastIgnoresStaleB524Mirrors(t *testing.T) {
+	t.Parallel()
+
+	observedAt := time.Unix(100, 0)
+	flowTemp := 42.5
+	pumpRaw := uint16(1)
+	heatingRaw := uint16(2)
+	poller := &vaillantSemanticPoller{
+		scheduler:          ebusgateway.NewSemanticReadScheduler(),
+		provider:           graphql.NewLiveSemanticProvider(),
+		source:             0x7F,
+		controller:         0x15,
+		configInterval:     5 * time.Minute,
+		boilerFastInterval: 30 * time.Second,
+		requestTimeout:     50 * time.Millisecond,
+		nowFn:              func() time.Time { return observedAt.Add(6 * time.Minute) },
+		system: &vaillantSystemSnapshot{
+			Controller:                  0x15,
+			SystemFlowTemperature:       &flowTemp,
+			SystemFlowTemperatureLiveAt: observedAt,
+		},
+		circuits: map[byte]*vaillantCircuitSnapshot{
+			0x00: {
+				Instance:           0x00,
+				Active:             true,
+				Controller:         0x15,
+				PumpStatusRaw:      &pumpRaw,
+				PumpStatusLiveAt:   observedAt,
+				CircuitStateRaw:    &heatingRaw,
+				CircuitStateLiveAt: observedAt,
+			},
+		},
+	}
+
+	snapshot := &vaillantBoilerSnapshot{}
+	if poller.refreshBoilerStatusB524(context.Background(), boilerStatusTierFast, snapshot) {
+		t.Fatal("refreshBoilerStatusB524(fast) updated = true; want stale mirrors ignored")
+	}
+	if snapshot.FlowTemperatureC != nil || snapshot.CentralHeatingPumpActive != nil || snapshot.HeatingStatusRaw != nil {
+		t.Fatalf("stale mirror snapshot = %+v; want no projected fields", snapshot)
+	}
+}
+
+func TestRefreshBoilerStatusFastIgnoresDifferentControllerB524Mirrors(t *testing.T) {
+	t.Parallel()
+
+	observedAt := time.Unix(100, 0)
+	flowTemp := 42.5
+	pumpRaw := uint16(1)
+	heatingRaw := uint16(2)
+	poller := &vaillantSemanticPoller{
+		scheduler:          ebusgateway.NewSemanticReadScheduler(),
+		provider:           graphql.NewLiveSemanticProvider(),
+		source:             0x7F,
+		controller:         0x26,
+		configInterval:     5 * time.Minute,
+		boilerFastInterval: 30 * time.Second,
+		requestTimeout:     50 * time.Millisecond,
+		nowFn:              func() time.Time { return observedAt.Add(30 * time.Second) },
+		system: &vaillantSystemSnapshot{
+			Controller:                  0x15,
+			SystemFlowTemperature:       &flowTemp,
+			SystemFlowTemperatureLiveAt: observedAt,
+		},
+		circuits: map[byte]*vaillantCircuitSnapshot{
+			0x00: {
+				Instance:           0x00,
+				Active:             true,
+				Controller:         0x15,
+				PumpStatusRaw:      &pumpRaw,
+				PumpStatusLiveAt:   observedAt,
+				CircuitStateRaw:    &heatingRaw,
+				CircuitStateLiveAt: observedAt,
+			},
+		},
+	}
+
+	snapshot := &vaillantBoilerSnapshot{}
+	if poller.refreshBoilerStatusB524(context.Background(), boilerStatusTierFast, snapshot) {
+		t.Fatal("refreshBoilerStatusB524(fast) updated = true; want different-controller mirrors ignored")
+	}
+	if snapshot.FlowTemperatureC != nil || snapshot.CentralHeatingPumpActive != nil || snapshot.HeatingStatusRaw != nil {
+		t.Fatalf("different-controller mirror snapshot = %+v; want no projected fields", snapshot)
+	}
+}
+
+func TestRefreshBoilerStatusFastIgnoresRestampedPartialMirrorSnapshots(t *testing.T) {
+	t.Parallel()
+
+	observedAt := time.Unix(100, 0)
+	flowTemp := 42.5
+	pressure := 1.4
+	pumpRaw := uint16(1)
+	heatingRaw := uint16(2)
+	circuitType := uint16(1)
+
+	system := mergeSystemSnapshotNonDestructive(
+		&vaillantSystemSnapshot{
+			Controller:                  0x15,
+			SystemFlowTemperature:       &flowTemp,
+			SystemFlowTemperatureLiveAt: observedAt,
+		},
+		&vaillantSystemSnapshot{
+			Controller:          0x26,
+			SystemWaterPressure: &pressure,
+		},
+	)
+	circuit := mergeCircuitSnapshotNonDestructive(
+		&vaillantCircuitSnapshot{
+			Instance:           0x00,
+			Active:             true,
+			Controller:         0x15,
+			PumpStatusRaw:      &pumpRaw,
+			PumpStatusLiveAt:   observedAt,
+			CircuitStateRaw:    &heatingRaw,
+			CircuitStateLiveAt: observedAt,
+		},
+		&vaillantCircuitSnapshot{
+			Instance:       0x00,
+			Active:         true,
+			Controller:     0x26,
+			CircuitTypeRaw: &circuitType,
+		},
+	)
+	if system.SystemFlowTemperature != nil || !system.SystemFlowTemperatureLiveAt.IsZero() {
+		t.Fatalf("merged system mirror = (%v, %s); want cleared on controller change", system.SystemFlowTemperature, system.SystemFlowTemperatureLiveAt)
+	}
+	if circuit.PumpStatusRaw != nil || !circuit.PumpStatusLiveAt.IsZero() {
+		t.Fatalf("merged pump mirror = (%v, %s); want cleared on controller change", circuit.PumpStatusRaw, circuit.PumpStatusLiveAt)
+	}
+	if circuit.CircuitStateRaw != nil || !circuit.CircuitStateLiveAt.IsZero() {
+		t.Fatalf("merged state mirror = (%v, %s); want cleared on controller change", circuit.CircuitStateRaw, circuit.CircuitStateLiveAt)
+	}
+
+	poller := &vaillantSemanticPoller{
+		scheduler:          ebusgateway.NewSemanticReadScheduler(),
+		provider:           graphql.NewLiveSemanticProvider(),
+		source:             0x7F,
+		controller:         0x26,
+		configInterval:     5 * time.Minute,
+		boilerFastInterval: 30 * time.Second,
+		requestTimeout:     50 * time.Millisecond,
+		nowFn:              func() time.Time { return observedAt.Add(30 * time.Second) },
+		system:             system,
+		circuits: map[byte]*vaillantCircuitSnapshot{
+			0x00: circuit,
+		},
+	}
+
+	snapshot := &vaillantBoilerSnapshot{}
+	if poller.refreshBoilerStatusB524(context.Background(), boilerStatusTierFast, snapshot) {
+		t.Fatal("refreshBoilerStatusB524(fast) updated = true; want partial restamped mirrors ignored")
+	}
+}
+
 func TestRefreshConfigDHWOnlySuccessKeepsZonesCacheSource(t *testing.T) {
 	t.Parallel()
 
@@ -3057,6 +3271,61 @@ func TestRefreshBoilerStatusFastCachedDHWOnlyDoesNotPublishLive(t *testing.T) {
 	}
 }
 
+func TestRefreshBoilerStatusFastMergesCachedDHWWhenB509UpdatesWithoutB524Mirrors(t *testing.T) {
+	t.Parallel()
+
+	current := 47.5
+	target := 50.0
+	flow := 42.5
+	provider := graphql.NewLiveSemanticProvider()
+	poller := &vaillantSemanticPoller{
+		scheduler:      ebusgateway.NewSemanticReadScheduler(),
+		provider:       provider,
+		source:         0x7F,
+		controller:     0x15,
+		boilerAddress:  0x08,
+		requestTimeout: 50 * time.Millisecond,
+		dhw: &vaillantDhwSnapshot{
+			CurrentTempC:                  &current,
+			TargetTempC:                   &target,
+			ConfigurationDHWOperationMode: "1",
+		},
+	}
+	poller.sendFrameFn = func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+		if frame.Primary != vaillantB509Primary || frame.Secondary != vaillantB509Secondary {
+			t.Fatalf("unexpected non-B509 active read: primary=0x%02x secondary=0x%02x data=% x", frame.Primary, frame.Secondary, frame.Data)
+		}
+		if len(frame.Data) < 3 || frame.Data[0] != vaillantB509OpcodeRead {
+			t.Fatalf("unexpected B509 request data % x", frame.Data)
+		}
+		addr := uint16(frame.Data[1])<<8 | uint16(frame.Data[2])
+		payload := append([]byte{vaillantB509OpcodeRead, byte(addr >> 8), byte(addr)}, encodeTempDATA2c(flow)...)
+		return &protocol.Frame{Data: payload}, nil
+	}
+
+	poller.refreshBoilerStatusTier(context.Background(), boilerStatusTierFast)
+
+	if poller.boiler == nil {
+		t.Fatal("poller.boiler = nil; want merged boiler snapshot")
+	}
+	if poller.boiler.FlowTemperatureC == nil || *poller.boiler.FlowTemperatureC != flow {
+		t.Fatalf("boiler FlowTemperatureC = %v; want B509 %.1f", poller.boiler.FlowTemperatureC, flow)
+	}
+	if poller.boiler.DhwTemperatureC == nil || *poller.boiler.DhwTemperatureC != current {
+		t.Fatalf("boiler DhwTemperatureC = %v; want cached %.1f", poller.boiler.DhwTemperatureC, current)
+	}
+	if poller.boiler.DhwTargetTemperatureC == nil || *poller.boiler.DhwTargetTemperatureC != target {
+		t.Fatalf("boiler DhwTargetTemperatureC = %v; want cached %.1f", poller.boiler.DhwTargetTemperatureC, target)
+	}
+	if poller.boiler.DhwOperatingMode == nil || *poller.boiler.DhwOperatingMode != 1 {
+		t.Fatalf("boiler DhwOperatingMode = %v; want cached 1", poller.boiler.DhwOperatingMode)
+	}
+	status := provider.BoilerStatus()
+	if status == nil || status.State.DhwTemperatureC == nil || *status.State.DhwTemperatureC != current {
+		t.Fatalf("published boiler status = %+v; want cached DHW on live B509 update", status)
+	}
+}
+
 func TestDeriveCircuitManagingDevice(t *testing.T) {
 	t.Parallel()
 
@@ -4440,6 +4709,134 @@ func TestVaillantSemanticPoller_PublishZones_FillsRoomStateFromMappedRadioSensor
 	}
 	if zones[1].State.CurrentHumidityPct == nil || *zones[1].State.CurrentHumidityPct != thermostatHumidity {
 		t.Fatalf("zone 2 humidity = %#v; want %.1f", zones[1].State.CurrentHumidityPct, thermostatHumidity)
+	}
+}
+
+func TestVaillantSemanticPoller_PublishZones_InfersThermostatMappingFromRadioAssignment(t *testing.T) {
+	t.Parallel()
+
+	provider := graphql.NewLiveSemanticProvider()
+	cache := &semanticSnapshotCaptureSpy{}
+	connected := true
+	zoneAssignment := uint8(2)
+	radioTemp := 17.8125
+	radioHumidity := 53.0
+
+	poller := &vaillantSemanticPoller{
+		provider: provider,
+		cache:    cache,
+		zones: map[byte]*vaillantZoneSnapshot{
+			0x01: {
+				Instance: 0x01,
+				Present:  true,
+				Name:     "Etaj",
+			},
+		},
+		radioDevices: map[radioDeviceKey]*vaillantRadioDeviceSnapshot{
+			{Group: remoteThermostats.group, Instance: 0x01}: {
+				Group:            remoteThermostats.group,
+				Instance:         0x01,
+				DeviceConnected:  &connected,
+				ZoneAssignment:   &zoneAssignment,
+				RoomTemperatureC: &radioTemp,
+				RoomHumidityPct:  &radioHumidity,
+			},
+		},
+	}
+
+	poller.publishZones(semanticSnapshotSourceLive)
+
+	zones := provider.Zones()
+	if len(zones) != 1 {
+		t.Fatalf("len(provider.Zones()) = %d; want 1", len(zones))
+	}
+	if zones[0].State.CurrentTempC == nil || *zones[0].State.CurrentTempC != radioTemp {
+		t.Fatalf("zone current temp = %#v; want radio %.4f", zones[0].State.CurrentTempC, radioTemp)
+	}
+	if zones[0].State.CurrentHumidityPct == nil || *zones[0].State.CurrentHumidityPct != radioHumidity {
+		t.Fatalf("zone humidity = %#v; want radio %.1f", zones[0].State.CurrentHumidityPct, radioHumidity)
+	}
+	if zones[0].Config.RoomTemperatureZoneMapping == nil || *zones[0].Config.RoomTemperatureZoneMapping != 2 {
+		t.Fatalf("roomTemperatureZoneMapping = %#v; want inferred 2", zones[0].Config.RoomTemperatureZoneMapping)
+	}
+	if zones[0].Config.AssociatedCircuit == nil || *zones[0].Config.AssociatedCircuit != 1 {
+		t.Fatalf("associatedCircuit = %#v; want inferred 1", zones[0].Config.AssociatedCircuit)
+	}
+	if cache.calls == 0 || len(cache.last.Zones) != 1 {
+		t.Fatalf("cache calls=%d zones=%d; want persisted zone snapshot", cache.calls, len(cache.last.Zones))
+	}
+	if cache.last.Zones[0].State.CurrentTempC != nil {
+		t.Fatalf("cached current temp = %#v; want nil direct zone value", cache.last.Zones[0].State.CurrentTempC)
+	}
+	if cache.last.Zones[0].Config.RoomTemperatureZoneMapping != nil {
+		t.Fatalf("cached inferred mapping = %#v; want nil direct zone mapping", cache.last.Zones[0].Config.RoomTemperatureZoneMapping)
+	}
+	if cache.last.Zones[0].Config.AssociatedCircuit != nil {
+		t.Fatalf("cached inferred associated circuit = %#v; want nil direct associated circuit", cache.last.Zones[0].Config.AssociatedCircuit)
+	}
+}
+
+func TestVaillantSemanticPoller_PublishZones_DoesNotInferAmbiguousThermostatAssignment(t *testing.T) {
+	t.Parallel()
+
+	provider := graphql.NewLiveSemanticProvider()
+	cache := &semanticSnapshotCaptureSpy{}
+	connected := true
+	zoneAssignment := uint8(2)
+	firstTemp := 17.8125
+	secondTemp := 18.25
+
+	poller := &vaillantSemanticPoller{
+		provider: provider,
+		cache:    cache,
+		zones: map[byte]*vaillantZoneSnapshot{
+			0x01: {
+				Instance: 0x01,
+				Present:  true,
+				Name:     "Etaj",
+			},
+		},
+		radioDevices: map[radioDeviceKey]*vaillantRadioDeviceSnapshot{
+			{Group: remoteThermostats.group, Instance: 0x01}: {
+				Group:            remoteThermostats.group,
+				Instance:         0x01,
+				DeviceConnected:  &connected,
+				ZoneAssignment:   &zoneAssignment,
+				RoomTemperatureC: &firstTemp,
+			},
+			{Group: remoteThermostats.group, Instance: 0x02}: {
+				Group:            remoteThermostats.group,
+				Instance:         0x02,
+				DeviceConnected:  &connected,
+				ZoneAssignment:   &zoneAssignment,
+				RoomTemperatureC: &secondTemp,
+			},
+		},
+	}
+
+	poller.publishZones(semanticSnapshotSourceLive)
+
+	zones := provider.Zones()
+	if len(zones) != 1 {
+		t.Fatalf("len(provider.Zones()) = %d; want 1", len(zones))
+	}
+	if zones[0].State.CurrentTempC != nil {
+		t.Fatalf("zone current temp = %#v; want nil for ambiguous inferred mapping", zones[0].State.CurrentTempC)
+	}
+	if zones[0].Config.RoomTemperatureZoneMapping != nil {
+		t.Fatalf("roomTemperatureZoneMapping = %#v; want nil for ambiguous inferred mapping", zones[0].Config.RoomTemperatureZoneMapping)
+	}
+	if zones[0].Config.AssociatedCircuit != nil {
+		t.Fatalf("associatedCircuit = %#v; want nil for ambiguous inferred mapping", zones[0].Config.AssociatedCircuit)
+	}
+	if cache.calls == 0 || len(cache.last.Zones) != 1 {
+		t.Fatalf("cache calls=%d zones=%d; want persisted zone snapshot", cache.calls, len(cache.last.Zones))
+	}
+	if cache.last.Zones[0].Config.RoomTemperatureZoneMapping != nil {
+		t.Fatalf("cached ambiguous mapping = %#v; want nil", cache.last.Zones[0].Config.RoomTemperatureZoneMapping)
+	}
+	if cache.last.Zones[0].Config.AssociatedCircuit != nil {
+		t.Fatalf("cached ambiguous associated circuit = %#v; want nil", cache.last.Zones[0].Config.AssociatedCircuit)
 	}
 }
 


### PR DESCRIPTION
## What
Reduce active B524 reads from the fast boiler/status path and keep zone radio-room projection complete when direct zone mapping is missing.

## Why
Live proxy traffic showed passive-cache performance improved, but Helianthus 0x7f traffic remained higher than expected. The remaining high-rate reads were semantic mirror reads that can be projected from already-cached system/circuit/DHW state instead of actively re-reading B524 on every fast boiler_status refresh.

## Changes
- Fast boiler_status B524 refresh now projects mirrored fields from existing system/circuit/DHW snapshots without active B524 reads.
- Cached DHW can update the internal boiler snapshot without publishing a live boiler_status when no actual boiler mirror field is present.
- Zone publication can infer thermostat room mapping from connected remote thermostat zone assignment, but inferred mapping is not persisted back into the semantic cache.
- Add regression coverage for zero-read fast boiler projection and inferred radio thermostat zone mapping.

## Validation
- go test ./cmd/gateway
- ./scripts/ci_local.sh

Refs #680