### PR TITLE
Publish empty semantic planes during startup

### DIFF
--- a/cmd/gateway/semantic_provider.go
+++ b/cmd/gateway/semantic_provider.go
@@ -20,7 +20,7 @@ func (adapter mcpSemanticProviderAdapter) Zones() []mcp.Zone {
 		return nil
 	}
 	zones := adapter.provider.Zones()
-	if len(zones) == 0 {
+	if zones == nil {
 		return nil
 	}
 	out := make([]mcp.Zone, len(zones))

--- a/cmd/gateway/semantic_provider_test.go
+++ b/cmd/gateway/semantic_provider_test.go
@@ -64,6 +64,20 @@ func TestMCPSemanticProviderAdapterPreservesEmptyCylinders(t *testing.T) {
 	}
 }
 
+func TestMCPSemanticProviderAdapterPreservesEmptyZones(t *testing.T) {
+	provider := graphql.NewLiveSemanticProvider()
+	adapter := mcpSemanticProviderAdapter{provider: provider}
+
+	if got := adapter.Zones(); got != nil {
+		t.Fatalf("Zones() before publish = %#v; want nil", got)
+	}
+
+	provider.SetZones([]graphql.Zone{})
+	if got := adapter.Zones(); got == nil || len(got) != 0 {
+		t.Fatalf("Zones() after empty publish = %#v; want empty non-nil slice", got)
+	}
+}
+
 func TestMCPSemanticProviderAdapterPreservesEmptyRadioDevices(t *testing.T) {
 	provider := graphql.NewLiveSemanticProvider()
 	adapter := mcpSemanticProviderAdapter{provider: provider}

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -1352,7 +1352,7 @@ func (p *vaillantSemanticPoller) refreshStartupSemanticPlanes(ctx context.Contex
 			p.refreshSystemStartup(primingCtx)
 			status = p.startupL1PrimingStatus()
 		}
-		if !status.fm5Satisfied && status.system {
+		if status.system && (!status.fm5Satisfied || !status.solar || !status.cylinders) {
 			p.refreshFM5SemanticStartup(primingCtx)
 		}
 		status = p.startupL1PrimingStatus()
@@ -1509,7 +1509,7 @@ func (p *vaillantSemanticPoller) startupL1PrimingStatus() startupL1PrimingStatus
 	p.mu.Unlock()
 	fm5Evidence := hasFM5EvidenceFromRadioSnapshots(radioSnapshots) || p.hasFM5RegistryEvidence()
 	fm5Required := fm5Evidence && moduleConfig != nil && *moduleConfig <= 2
-	zonesReady := len(p.provider.Zones()) > 0
+	zonesReady := p.provider.Zones() != nil
 	solarReady := p.provider.Solar() != nil
 	cylinders := p.provider.Cylinders()
 	cylindersPublished := cylinders != nil

--- a/cmd/gateway/semantic_vaillant_test.go
+++ b/cmd/gateway/semantic_vaillant_test.go
@@ -6477,6 +6477,36 @@ func TestStartupL1PrimingStatusAcceptsPublishedGPIOOnlyFM5Planes(t *testing.T) {
 	}
 }
 
+func TestRefreshStartupSemanticPlanesPublishesAbsentFM5Planes(t *testing.T) {
+	t.Parallel()
+
+	provider := graphql.NewLiveSemanticProvider()
+	provider.SetZones([]graphql.Zone{{ID: "zone-1", Name: "Zone 1"}})
+	provider.SetDHW(&graphql.DhwStatus{})
+	provider.SetCircuits([]graphql.CircuitStatus{{Index: 0}})
+	provider.SetSystem(&graphql.SystemStatus{})
+	provider.SetBoilerStatus(&graphql.BoilerStatus{})
+
+	poller := &vaillantSemanticPoller{
+		controller:                0x15,
+		provider:                  provider,
+		reg:                       newTestRegistry(),
+		startupRadioDevicesProbed: true,
+	}
+
+	poller.refreshStartupSemanticPlanes(context.Background())
+
+	if provider.Solar() == nil {
+		t.Fatal("provider.Solar() = nil after startup priming; want empty non-null absent-FM5 plane")
+	}
+	if cylinders := provider.Cylinders(); cylinders == nil || len(cylinders) != 0 {
+		t.Fatalf("provider.Cylinders() = %#v after startup priming; want empty non-null absent-FM5 plane", cylinders)
+	}
+	if mode := provider.FM5SemanticMode(); mode != graphql.Fm5SemanticModeAbsent {
+		t.Fatalf("provider.FM5SemanticMode() = %q; want %q", mode, graphql.Fm5SemanticModeAbsent)
+	}
+}
+
 func TestReconcileDiscoveryPresence_PublishesStartupZonesOnFirstHit(t *testing.T) {
 	t.Parallel()
 

--- a/graphql/semantic_live.go
+++ b/graphql/semantic_live.go
@@ -183,6 +183,9 @@ func (provider *LiveSemanticProvider) Zones() []Zone {
 	provider.mu.RLock()
 	defer provider.mu.RUnlock()
 	if len(provider.zones) == 0 {
+		if provider.zonePublished {
+			return []Zone{}
+		}
 		return nil
 	}
 	zones := make([]Zone, len(provider.zones))
@@ -389,15 +392,19 @@ func (provider *LiveSemanticProvider) setZonesWithSource(zones []Zone, source se
 	if provider == nil {
 		return
 	}
+	receivedZones := zones != nil
 	zonesCopy := make([]Zone, len(zones))
 	for i, z := range zones {
 		zonesCopy[i] = cloneZone(z)
 	}
+	published := receivedZones && (source == semanticDataSourceLive || len(zonesCopy) > 0)
 	var transition *phaseTransitionLog
 	provider.mu.Lock()
 	provider.zones = zonesCopy
-	if len(zonesCopy) > 0 {
+	if published {
 		provider.zonePublished = true
+	}
+	if published {
 		if source == semanticDataSourceLive {
 			provider.zoneLiveSeen = true
 		}

--- a/graphql/semantic_live_test.go
+++ b/graphql/semantic_live_test.go
@@ -63,6 +63,28 @@ func TestLiveSemanticProvider_LiveReadyRequiresLiveForPublishedStreams(t *testin
 	}
 }
 
+func TestLiveSemanticProvider_EmptyZoneLivePublishCountsForReadiness(t *testing.T) {
+	provider := NewLiveSemanticProvider()
+
+	provider.SetZonesFromCache([]Zone{{ID: "zone-1", Name: "Zone 1"}})
+	provider.SetDHW(&DhwStatus{Config: DhwConfig{OperatingMode: "auto"}})
+	if got := provider.StartupPhase(); got != SemanticStartupPhaseLiveWarmup {
+		t.Fatalf("phase after DHW live with cache zones = %s; want %s", got, SemanticStartupPhaseLiveWarmup)
+	}
+
+	provider.SetZones([]Zone{})
+	if got := provider.StartupPhase(); got != SemanticStartupPhaseLiveReady {
+		t.Fatalf("phase after empty zones live = %s; want %s", got, SemanticStartupPhaseLiveReady)
+	}
+	cacheEpoch, liveEpoch := provider.StartupEpochs()
+	if cacheEpoch != 1 || liveEpoch != 2 {
+		t.Fatalf("epochs after empty zones live = (%d,%d); want (1,2)", cacheEpoch, liveEpoch)
+	}
+	if zones := provider.Zones(); zones == nil || len(zones) != 0 {
+		t.Fatalf("Zones() after empty live publish = %#v; want empty non-nil slice", zones)
+	}
+}
+
 func TestLiveSemanticProvider_CacheRefreshAfterLiveReadyKeepsPhase(t *testing.T) {
 	provider := NewLiveSemanticProvider()
 

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -2338,6 +2338,9 @@ func cloneMap(source map[string]any) map[string]any {
 }
 
 func cloneZones(source []Zone) []Zone {
+	if source != nil && len(source) == 0 {
+		return []Zone{}
+	}
 	if len(source) == 0 {
 		return nil
 	}
@@ -2815,7 +2818,7 @@ func (s *Server) snapshotZones(snapshot *snapshotState) []Zone {
 		return nil
 	}
 	zones := s.semantic.Zones()
-	if len(zones) == 0 {
+	if zones == nil {
 		return nil
 	}
 	out := make([]Zone, len(zones))

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -241,23 +241,24 @@ func (p *testWatchSummaryProvider) Snapshot() WatchSummary {
 }
 
 type testSemanticProvider struct {
-	zones         []Zone
-	circuits      []CircuitStatus
-	radio         []RadioDevice
-	fm5Mode       Fm5SemanticMode
-	solar         *SolarStatus
-	cylinders     []CylinderStatus
-	dhw           *DhwStatus
-	energy        *EnergyTotals
-	boiler        *BoilerStatus
-	system        *SystemStatus
-	schedules     *ScheduleStatus
-	adapterInfo   *AdapterHardwareInfo
-	zonesDelay    time.Duration
-	circuitsDelay time.Duration
-	radioDelay    time.Duration
-	dhwDelay      time.Duration
-	energyDelay   time.Duration
+	zones          []Zone
+	zonesPublished bool
+	circuits       []CircuitStatus
+	radio          []RadioDevice
+	fm5Mode        Fm5SemanticMode
+	solar          *SolarStatus
+	cylinders      []CylinderStatus
+	dhw            *DhwStatus
+	energy         *EnergyTotals
+	boiler         *BoilerStatus
+	system         *SystemStatus
+	schedules      *ScheduleStatus
+	adapterInfo    *AdapterHardwareInfo
+	zonesDelay     time.Duration
+	circuitsDelay  time.Duration
+	radioDelay     time.Duration
+	dhwDelay       time.Duration
+	energyDelay    time.Duration
 }
 
 func (p testSemanticProvider) Zones() []Zone {
@@ -265,6 +266,9 @@ func (p testSemanticProvider) Zones() []Zone {
 		time.Sleep(p.zonesDelay)
 	}
 	if len(p.zones) == 0 {
+		if p.zonesPublished {
+			return []Zone{}
+		}
 		return nil
 	}
 	out := make([]Zone, len(p.zones))
@@ -1164,6 +1168,57 @@ func TestServer_ToolsCallSemanticSnapshots(t *testing.T) {
 		}
 		if id, _ := second["id"].(string); id != "zone-b" {
 			t.Fatalf("second zone id = %q; want zone-b", id)
+		}
+	})
+
+	t.Run("empty zones keep live and snapshot shape", func(t *testing.T) {
+		emptyServer, err := NewServer(reg, &testInvoker{})
+		if err != nil {
+			t.Fatalf("NewServer error = %v", err)
+		}
+		emptyServer.SetSemanticProvider(testSemanticProvider{
+			zones:          []Zone{},
+			zonesPublished: true,
+		})
+
+		live := doRPC(t, emptyServer.Handler(), rpcRequest{
+			JSONRPC: "2.0",
+			ID:      41,
+			Method:  "tools/call",
+			Params:  json.RawMessage(`{"name":"ebus.v1.semantic.zones.get","arguments":{}}`),
+		})
+		liveEnvelope := envelopeFromResult(t, live)
+		liveData, ok := liveEnvelope["data"].([]any)
+		if !ok || len(liveData) != 0 {
+			t.Fatalf("live empty zones data = %#v; want empty array", liveEnvelope["data"])
+		}
+
+		capture := doRPC(t, emptyServer.Handler(), rpcRequest{
+			JSONRPC: "2.0",
+			ID:      42,
+			Method:  "tools/call",
+			Params:  json.RawMessage(`{"name":"ebus.v1.snapshot.capture","arguments":{}}`),
+		})
+		captureEnvelope := envelopeFromResult(t, capture)
+		captureData, ok := captureEnvelope["data"].(map[string]any)
+		if !ok {
+			t.Fatalf("capture data type = %T; want map", captureEnvelope["data"])
+		}
+		snapshotID, _ := captureData["snapshot_id"].(string)
+		if snapshotID == "" {
+			t.Fatal("snapshot_id empty")
+		}
+
+		snapshot := doRPC(t, emptyServer.Handler(), rpcRequest{
+			JSONRPC: "2.0",
+			ID:      43,
+			Method:  "tools/call",
+			Params:  json.RawMessage(`{"name":"ebus.v1.semantic.zones.get","arguments":{"consistency":{"mode":"SNAPSHOT","snapshot_id":"` + snapshotID + `"}}}`),
+		})
+		snapshotEnvelope := envelopeFromResult(t, snapshot)
+		snapshotData, ok := snapshotEnvelope["data"].([]any)
+		if !ok || len(snapshotData) != 0 {
+			t.Fatalf("snapshot empty zones data = %#v; want empty array", snapshotEnvelope["data"])
 		}
 	})
 


### PR DESCRIPTION
## Summary
- preserve published-empty zones through the live provider, MCP adapter, and MCP server snapshot path instead of collapsing them to null
- run FM5 semantic startup publication whenever solar/cylinders are still unpublished, so absent/GPIO-only FM5 exposes non-null empty planes
- align startup L1 readiness with the M4 O1 predicate: plane published/non-null, not necessarily non-empty

## Validation
- go test ./cmd/gateway ./graphql ./mcp -run 'TestMCPSemanticProviderAdapterPreservesEmptyZones|TestRefreshStartupSemanticPlanesPublishesAbsentFM5Planes|TestStartupL1PrimingStatusAcceptsPublishedGPIOOnlyFM5Planes|TestPublishFM5Semantic_DowngradeRehydratesCircuitOwnershipToUnknown|TestMCPSemanticProviderAdapterPreservesEmptyCylinders'
- ./scripts/ci_local.sh

## Context
Follow-up for live M4 O1 startup verification on #680. The failing clean-start artifact had zones, solar, and cylinders as null at 60s even though empty non-null planes satisfy the locked O1 predicate.