### PR TITLE
Publish empty circuit startup plane

### DIFF
--- a/cmd/gateway/semantic_provider.go
+++ b/cmd/gateway/semantic_provider.go
@@ -88,7 +88,7 @@ func (adapter mcpSemanticProviderAdapter) Circuits() []mcp.CircuitStatus {
 		return nil
 	}
 	circuits := adapter.provider.Circuits()
-	if len(circuits) == 0 {
+	if circuits == nil {
 		return nil
 	}
 	out := make([]mcp.CircuitStatus, len(circuits))

--- a/cmd/gateway/semantic_provider_test.go
+++ b/cmd/gateway/semantic_provider_test.go
@@ -78,6 +78,20 @@ func TestMCPSemanticProviderAdapterPreservesEmptyZones(t *testing.T) {
 	}
 }
 
+func TestMCPSemanticProviderAdapterPreservesEmptyCircuits(t *testing.T) {
+	provider := graphql.NewLiveSemanticProvider()
+	adapter := mcpSemanticProviderAdapter{provider: provider}
+
+	if got := adapter.Circuits(); got != nil {
+		t.Fatalf("Circuits() before publish = %#v; want nil", got)
+	}
+
+	provider.SetCircuits([]graphql.CircuitStatus{})
+	if got := adapter.Circuits(); got == nil || len(got) != 0 {
+		t.Fatalf("Circuits() after empty publish = %#v; want empty non-nil slice", got)
+	}
+}
+
 func TestMCPSemanticProviderAdapterPreservesEmptyRadioDevices(t *testing.T) {
 	provider := graphql.NewLiveSemanticProvider()
 	adapter := mcpSemanticProviderAdapter{provider: provider}

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -1312,6 +1312,7 @@ func (p *vaillantSemanticPoller) refreshStartupSemanticPlanes(ctx context.Contex
 	}
 
 	p.publishStartupSchedules()
+	p.publishStartupPlaneDefaults()
 	primingCtx := ctx
 	cancel := func() {}
 	if semanticStartupPrimingBudget > 0 {
@@ -1382,6 +1383,21 @@ func (p *vaillantSemanticPoller) refreshStartupSemanticPlanes(ctx context.Contex
 			return
 		case <-timer.C:
 		}
+	}
+}
+
+func (p *vaillantSemanticPoller) publishStartupPlaneDefaults() {
+	if p == nil || p.provider == nil {
+		return
+	}
+	if p.provider.Circuits() == nil {
+		p.provider.SetCircuits([]graphql.CircuitStatus{})
+	}
+	if p.provider.Solar() == nil {
+		p.provider.SetSolar(&graphql.SolarStatus{})
+	}
+	if p.provider.Cylinders() == nil {
+		p.provider.SetCylinders([]graphql.CylinderStatus{})
 	}
 }
 
@@ -1526,7 +1542,7 @@ func (p *vaillantSemanticPoller) startupL1PrimingStatus() startupL1PrimingStatus
 	return startupL1PrimingStatus{
 		zones:        zonesReady,
 		dhw:          p.provider.DHW() != nil,
-		circuits:     len(p.provider.Circuits()) > 0,
+		circuits:     p.provider.Circuits() != nil,
 		system:       p.provider.System() != nil,
 		radioDevices: radioProbed || len(p.provider.RadioDevices()) > 0,
 		fm5GateKnown: fm5GateKnown,
@@ -4059,6 +4075,9 @@ func (p *vaillantSemanticPoller) publishCircuits(source semanticSnapshotSource) 
 	}
 
 	previous := p.provider.Circuits()
+	if len(out) == 0 && previous == nil {
+		return
+	}
 	if source == semanticSnapshotSourceCache && len(out) == 0 && len(previous) > 0 {
 		return
 	}

--- a/cmd/gateway/semantic_vaillant_test.go
+++ b/cmd/gateway/semantic_vaillant_test.go
@@ -6483,7 +6483,6 @@ func TestRefreshStartupSemanticPlanesPublishesAbsentFM5Planes(t *testing.T) {
 	provider := graphql.NewLiveSemanticProvider()
 	provider.SetZones([]graphql.Zone{{ID: "zone-1", Name: "Zone 1"}})
 	provider.SetDHW(&graphql.DhwStatus{})
-	provider.SetCircuits([]graphql.CircuitStatus{{Index: 0}})
 	provider.SetSystem(&graphql.SystemStatus{})
 	provider.SetBoilerStatus(&graphql.BoilerStatus{})
 
@@ -6501,6 +6500,9 @@ func TestRefreshStartupSemanticPlanesPublishesAbsentFM5Planes(t *testing.T) {
 	}
 	if cylinders := provider.Cylinders(); cylinders == nil || len(cylinders) != 0 {
 		t.Fatalf("provider.Cylinders() = %#v after startup priming; want empty non-null absent-FM5 plane", cylinders)
+	}
+	if circuits := provider.Circuits(); circuits == nil || len(circuits) != 0 {
+		t.Fatalf("provider.Circuits() = %#v after startup priming; want empty non-null plane", circuits)
 	}
 	if mode := provider.FM5SemanticMode(); mode != graphql.Fm5SemanticModeAbsent {
 		t.Fatalf("provider.FM5SemanticMode() = %q; want %q", mode, graphql.Fm5SemanticModeAbsent)

--- a/graphql/semantic_live.go
+++ b/graphql/semantic_live.go
@@ -215,6 +215,9 @@ func (provider *LiveSemanticProvider) Circuits() []CircuitStatus {
 	provider.mu.RLock()
 	defer provider.mu.RUnlock()
 	if len(provider.circuits) == 0 {
+		if provider.circuitPublished {
+			return []CircuitStatus{}
+		}
 		return nil
 	}
 	out := make([]CircuitStatus, len(provider.circuits))
@@ -457,22 +460,24 @@ func (provider *LiveSemanticProvider) setCircuitsWithSource(circuits []CircuitSt
 		return
 	}
 
+	receivedCircuits := circuits != nil
 	circuitsCopy := make([]CircuitStatus, len(circuits))
 	for i, status := range circuits {
 		circuitsCopy[i] = cloneCircuitStatus(status)
 	}
+	published := receivedCircuits && (source == semanticDataSourceLive || len(circuitsCopy) > 0)
 
 	var transition *phaseTransitionLog
 	provider.mu.Lock()
-	if equalCircuitStatuses(provider.circuits, circuitsCopy) {
-		if source == semanticDataSourceLive && len(circuitsCopy) > 0 {
+	if equalCircuitStatuses(provider.circuits, circuitsCopy) && (!published || provider.circuitPublished) {
+		if source == semanticDataSourceLive && published {
 			provider.circuitLiveSeen = true
 		}
 		provider.mu.Unlock()
 		return
 	}
 	provider.circuits = circuitsCopy
-	if len(circuitsCopy) > 0 {
+	if published {
 		provider.circuitPublished = true
 		if source == semanticDataSourceLive {
 			provider.circuitLiveSeen = true

--- a/graphql/semantic_live_test.go
+++ b/graphql/semantic_live_test.go
@@ -85,6 +85,28 @@ func TestLiveSemanticProvider_EmptyZoneLivePublishCountsForReadiness(t *testing.
 	}
 }
 
+func TestLiveSemanticProvider_EmptyCircuitLivePublishCountsForReadiness(t *testing.T) {
+	provider := NewLiveSemanticProvider()
+
+	provider.SetCircuitsFromCache([]CircuitStatus{{Index: 0}})
+	provider.SetDHW(&DhwStatus{Config: DhwConfig{OperatingMode: "auto"}})
+	if got := provider.StartupPhase(); got != SemanticStartupPhaseLiveWarmup {
+		t.Fatalf("phase after DHW live with cache circuits = %s; want %s", got, SemanticStartupPhaseLiveWarmup)
+	}
+
+	provider.SetCircuits([]CircuitStatus{})
+	if got := provider.StartupPhase(); got != SemanticStartupPhaseLiveReady {
+		t.Fatalf("phase after empty circuits live = %s; want %s", got, SemanticStartupPhaseLiveReady)
+	}
+	cacheEpoch, liveEpoch := provider.StartupEpochs()
+	if cacheEpoch != 1 || liveEpoch != 2 {
+		t.Fatalf("epochs after empty circuits live = (%d,%d); want (1,2)", cacheEpoch, liveEpoch)
+	}
+	if circuits := provider.Circuits(); circuits == nil || len(circuits) != 0 {
+		t.Fatalf("Circuits() after empty live publish = %#v; want empty non-nil slice", circuits)
+	}
+}
+
 func TestLiveSemanticProvider_CacheRefreshAfterLiveReadyKeepsPhase(t *testing.T) {
 	provider := NewLiveSemanticProvider()
 

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -2350,6 +2350,9 @@ func cloneZones(source []Zone) []Zone {
 }
 
 func cloneCircuits(source []CircuitStatus) []CircuitStatus {
+	if source != nil && len(source) == 0 {
+		return []CircuitStatus{}
+	}
 	if len(source) == 0 {
 		return nil
 	}
@@ -2840,7 +2843,7 @@ func (s *Server) snapshotCircuits(snapshot *snapshotState) []CircuitStatus {
 		return nil
 	}
 	circuits := s.semantic.Circuits()
-	if len(circuits) == 0 {
+	if circuits == nil {
 		return nil
 	}
 	out := cloneCircuits(circuits)

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -241,24 +241,25 @@ func (p *testWatchSummaryProvider) Snapshot() WatchSummary {
 }
 
 type testSemanticProvider struct {
-	zones          []Zone
-	zonesPublished bool
-	circuits       []CircuitStatus
-	radio          []RadioDevice
-	fm5Mode        Fm5SemanticMode
-	solar          *SolarStatus
-	cylinders      []CylinderStatus
-	dhw            *DhwStatus
-	energy         *EnergyTotals
-	boiler         *BoilerStatus
-	system         *SystemStatus
-	schedules      *ScheduleStatus
-	adapterInfo    *AdapterHardwareInfo
-	zonesDelay     time.Duration
-	circuitsDelay  time.Duration
-	radioDelay     time.Duration
-	dhwDelay       time.Duration
-	energyDelay    time.Duration
+	zones             []Zone
+	zonesPublished    bool
+	circuits          []CircuitStatus
+	circuitsPublished bool
+	radio             []RadioDevice
+	fm5Mode           Fm5SemanticMode
+	solar             *SolarStatus
+	cylinders         []CylinderStatus
+	dhw               *DhwStatus
+	energy            *EnergyTotals
+	boiler            *BoilerStatus
+	system            *SystemStatus
+	schedules         *ScheduleStatus
+	adapterInfo       *AdapterHardwareInfo
+	zonesDelay        time.Duration
+	circuitsDelay     time.Duration
+	radioDelay        time.Duration
+	dhwDelay          time.Duration
+	energyDelay       time.Duration
 }
 
 func (p testSemanticProvider) Zones() []Zone {
@@ -292,6 +293,9 @@ func (p testSemanticProvider) Circuits() []CircuitStatus {
 		time.Sleep(p.circuitsDelay)
 	}
 	if len(p.circuits) == 0 {
+		if p.circuitsPublished {
+			return []CircuitStatus{}
+		}
 		return nil
 	}
 	return cloneCircuits(p.circuits)
@@ -1257,6 +1261,57 @@ func TestServer_ToolsCallSemanticSnapshots(t *testing.T) {
 		}
 		if circuitType, _ := second["circuit_type"].(string); circuitType != "fixed_value" {
 			t.Fatalf("second circuit type = %q; want fixed_value", circuitType)
+		}
+	})
+
+	t.Run("empty circuits keep live and snapshot shape", func(t *testing.T) {
+		emptyServer, err := NewServer(reg, &testInvoker{})
+		if err != nil {
+			t.Fatalf("NewServer error = %v", err)
+		}
+		emptyServer.SetSemanticProvider(testSemanticProvider{
+			circuits:          []CircuitStatus{},
+			circuitsPublished: true,
+		})
+
+		live := doRPC(t, emptyServer.Handler(), rpcRequest{
+			JSONRPC: "2.0",
+			ID:      44,
+			Method:  "tools/call",
+			Params:  json.RawMessage(`{"name":"ebus.v1.semantic.circuits.get","arguments":{}}`),
+		})
+		liveEnvelope := envelopeFromResult(t, live)
+		liveData, ok := liveEnvelope["data"].([]any)
+		if !ok || len(liveData) != 0 {
+			t.Fatalf("live empty circuits data = %#v; want empty array", liveEnvelope["data"])
+		}
+
+		capture := doRPC(t, emptyServer.Handler(), rpcRequest{
+			JSONRPC: "2.0",
+			ID:      45,
+			Method:  "tools/call",
+			Params:  json.RawMessage(`{"name":"ebus.v1.snapshot.capture","arguments":{}}`),
+		})
+		captureEnvelope := envelopeFromResult(t, capture)
+		captureData, ok := captureEnvelope["data"].(map[string]any)
+		if !ok {
+			t.Fatalf("capture data type = %T; want map", captureEnvelope["data"])
+		}
+		snapshotID, _ := captureData["snapshot_id"].(string)
+		if snapshotID == "" {
+			t.Fatal("snapshot_id empty")
+		}
+
+		snapshot := doRPC(t, emptyServer.Handler(), rpcRequest{
+			JSONRPC: "2.0",
+			ID:      46,
+			Method:  "tools/call",
+			Params:  json.RawMessage(`{"name":"ebus.v1.semantic.circuits.get","arguments":{"consistency":{"mode":"SNAPSHOT","snapshot_id":"` + snapshotID + `"}}}`),
+		})
+		snapshotEnvelope := envelopeFromResult(t, snapshot)
+		snapshotData, ok := snapshotEnvelope["data"].([]any)
+		if !ok || len(snapshotData) != 0 {
+			t.Fatalf("snapshot empty circuits data = %#v; want empty array", snapshotEnvelope["data"])
 		}
 	})
 


### PR DESCRIPTION
## What
Publish a non-null empty circuits semantic plane during startup and preserve that empty shape through GraphQL/MCP adapters and MCP snapshots.

## Why
Live M4 O1 still failed after the FM5/zone fix because circuits stayed null even after startup priming, while the M4 contract requires every semantic plane to be data != null within 60s.

## Acceptance Criteria
- [x] Empty live circuits publish as a non-null empty plane.
- [x] MCP live and snapshot reads preserve empty circuits as [] instead of null.
- [x] Startup priming publishes empty circuits/solar/cylinders defaults before slow discovery consumes the O1 window.
- [x] Cache-only empty circuits do not advance live readiness.
- [x] Unit tests cover the implemented code.
- [x] CI green locally.
- [ ] Smoke test required: YES - deploy to HA and rerun clean M4 O1/O2 after merge.

## Dependencies
- Continues #680.

Validation:
- go test ./graphql
- go test ./mcp
- go test ./cmd/gateway
- ./scripts/ci_local.sh