### PR TITLE
Recognize B524 II=0x09 DHW pseudo-circuit

### DIFF
--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -1652,9 +1652,11 @@ func (p *vaillantSemanticPoller) refreshCircuitsStartup(ctx context.Context) {
 		}
 		switch *circuitTypeRaw {
 		case 0x0000, 0x00FF, 0xFFFF:
-			if snapshot := p.readDhwPseudoCircuitStartupEvidence(ctx, instance); snapshot != nil {
+			if snapshot, known := p.readDhwPseudoCircuitStartupEvidence(ctx, instance); snapshot != nil {
 				snapshot.Controller = controller
 				updates[instance] = snapshot
+				continue
+			} else if !known && instance == dhwPseudoCircuitInstance {
 				continue
 			}
 			inactive[instance] = struct{}{}
@@ -1700,25 +1702,31 @@ func (p *vaillantSemanticPoller) refreshCircuitsStartup(ctx context.Context) {
 	p.publishCircuits(semanticSnapshotSourceLive)
 }
 
-func (p *vaillantSemanticPoller) readDhwPseudoCircuitStartupEvidence(ctx context.Context, instance byte) *vaillantCircuitSnapshot {
+func (p *vaillantSemanticPoller) readDhwPseudoCircuitStartupEvidence(ctx context.Context, instance byte) (*vaillantCircuitSnapshot, bool) {
 	if p == nil || instance != dhwPseudoCircuitInstance {
-		return nil
+		return nil, false
 	}
 	snapshot := newDhwPseudoCircuitSnapshot(instance)
-	if raw, ok := p.readB524Startup(ctx, localCircuits.opcode, localCircuits.group, instance, circuit_flow_temp); ok {
-		if value := decodeB524Float32FromRaw(raw); isDhwPseudoCircuitTemperatureEvidence(value) {
-			snapshot.FlowTemperatureC = value
-		}
+	flow, flowKnown := p.readDhwPseudoCircuitStartupTemperatureEvidence(ctx, instance, circuit_flow_temp)
+	if isDhwPseudoCircuitTemperatureEvidence(flow) {
+		snapshot.FlowTemperatureC = flow
 	}
-	if raw, ok := p.readB524Startup(ctx, localCircuits.opcode, localCircuits.group, instance, circuit_calc_flow_temp); ok {
-		if value := decodeB524Float32FromRaw(raw); isDhwPseudoCircuitTemperatureEvidence(value) {
-			snapshot.CalcFlowTempC = value
-		}
+	calc, calcKnown := p.readDhwPseudoCircuitStartupTemperatureEvidence(ctx, instance, circuit_calc_flow_temp)
+	if isDhwPseudoCircuitTemperatureEvidence(calc) {
+		snapshot.CalcFlowTempC = calc
 	}
 	if snapshot.FlowTemperatureC == nil && snapshot.CalcFlowTempC == nil {
-		return nil
+		return nil, flowKnown && calcKnown
 	}
-	return snapshot
+	return snapshot, true
+}
+
+func (p *vaillantSemanticPoller) readDhwPseudoCircuitStartupTemperatureEvidence(ctx context.Context, instance byte, addr uint16) (*float64, bool) {
+	raw, ok := p.readB524Startup(ctx, localCircuits.opcode, localCircuits.group, instance, addr)
+	if !ok {
+		return nil, false
+	}
+	return decodeB524Float32FromRaw(raw), true
 }
 
 func (p *vaillantSemanticPoller) refreshSystemStartup(ctx context.Context) {
@@ -3759,9 +3767,11 @@ func (p *vaillantSemanticPoller) refreshCircuits(ctx context.Context) {
 		probeSuccess = true
 		switch *circuitTypeRaw {
 		case 0x0000, 0x00FF, 0xFFFF:
-			if snapshot := p.readDhwPseudoCircuitEvidence(ctx, instance); snapshot != nil {
+			if snapshot, known := p.readDhwPseudoCircuitEvidence(ctx, instance); snapshot != nil {
 				snapshot.Controller = controller
 				discovered[instance] = snapshot
+				continue
+			} else if !known && instance == dhwPseudoCircuitInstance {
 				continue
 			}
 			inactive[instance] = struct{}{}
@@ -3903,27 +3913,31 @@ func (p *vaillantSemanticPoller) refreshCircuits(ctx context.Context) {
 	p.publishCircuits(source)
 }
 
-func (p *vaillantSemanticPoller) readDhwPseudoCircuitEvidence(ctx context.Context, instance byte) *vaillantCircuitSnapshot {
+func (p *vaillantSemanticPoller) readDhwPseudoCircuitEvidence(ctx context.Context, instance byte) (*vaillantCircuitSnapshot, bool) {
 	if p == nil || instance != dhwPseudoCircuitInstance {
-		return nil
+		return nil, false
 	}
 	snapshot := newDhwPseudoCircuitSnapshot(instance)
-	if value, ok := p.readB524Float32LE(ctx, localCircuits.opcode, localCircuits.group, instance, circuit_flow_temp); ok {
-		v := value
-		if isDhwPseudoCircuitTemperatureEvidence(&v) {
-			snapshot.FlowTemperatureC = &v
-		}
+	flow, flowKnown := p.readDhwPseudoCircuitTemperatureEvidence(ctx, instance, circuit_flow_temp)
+	if isDhwPseudoCircuitTemperatureEvidence(flow) {
+		snapshot.FlowTemperatureC = flow
 	}
-	if value, ok := p.readB524Float32LE(ctx, localCircuits.opcode, localCircuits.group, instance, circuit_calc_flow_temp); ok {
-		v := value
-		if isDhwPseudoCircuitTemperatureEvidence(&v) {
-			snapshot.CalcFlowTempC = &v
-		}
+	calc, calcKnown := p.readDhwPseudoCircuitTemperatureEvidence(ctx, instance, circuit_calc_flow_temp)
+	if isDhwPseudoCircuitTemperatureEvidence(calc) {
+		snapshot.CalcFlowTempC = calc
 	}
 	if snapshot.FlowTemperatureC == nil && snapshot.CalcFlowTempC == nil {
-		return nil
+		return nil, flowKnown && calcKnown
 	}
-	return snapshot
+	return snapshot, true
+}
+
+func (p *vaillantSemanticPoller) readDhwPseudoCircuitTemperatureEvidence(ctx context.Context, instance byte, addr uint16) (*float64, bool) {
+	raw, ok := p.readB524Value(ctx, localCircuits.opcode, localCircuits.group, instance, addr)
+	if !ok {
+		return nil, false
+	}
+	return decodeB524Float32FromRaw(raw), true
 }
 
 func newDhwPseudoCircuitSnapshot(instance byte) *vaillantCircuitSnapshot {

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -89,6 +89,9 @@ const (
 	circuit_room_temp_control = uint16(0x0015) // room_temperature_control_mode
 	circuit_frost_protection  = uint16(0x001D) // frost_protection_threshold
 
+	dhwPseudoCircuitInstance = byte(0x09)
+	dhwPseudoCircuitTypeRaw  = uint16(0x0003)
+
 	CircuitStateStandby = "standby"
 	CircuitStateHeating = "heating"
 	CircuitStateCooling = "cooling"
@@ -1649,6 +1652,11 @@ func (p *vaillantSemanticPoller) refreshCircuitsStartup(ctx context.Context) {
 		}
 		switch *circuitTypeRaw {
 		case 0x0000, 0x00FF, 0xFFFF:
+			if snapshot := p.readDhwPseudoCircuitStartupEvidence(ctx, instance); snapshot != nil {
+				snapshot.Controller = controller
+				updates[instance] = snapshot
+				continue
+			}
 			inactive[instance] = struct{}{}
 			continue
 		default:
@@ -1690,6 +1698,27 @@ func (p *vaillantSemanticPoller) refreshCircuitsStartup(ctx context.Context) {
 	p.lastCircuitFullScanComplete = len(updates)+len(inactive) == len(instances)
 	p.mu.Unlock()
 	p.publishCircuits(semanticSnapshotSourceLive)
+}
+
+func (p *vaillantSemanticPoller) readDhwPseudoCircuitStartupEvidence(ctx context.Context, instance byte) *vaillantCircuitSnapshot {
+	if p == nil || instance != dhwPseudoCircuitInstance {
+		return nil
+	}
+	snapshot := newDhwPseudoCircuitSnapshot(instance)
+	if raw, ok := p.readB524Startup(ctx, localCircuits.opcode, localCircuits.group, instance, circuit_flow_temp); ok {
+		if value := decodeB524Float32FromRaw(raw); isDhwPseudoCircuitTemperatureEvidence(value) {
+			snapshot.FlowTemperatureC = value
+		}
+	}
+	if raw, ok := p.readB524Startup(ctx, localCircuits.opcode, localCircuits.group, instance, circuit_calc_flow_temp); ok {
+		if value := decodeB524Float32FromRaw(raw); isDhwPseudoCircuitTemperatureEvidence(value) {
+			snapshot.CalcFlowTempC = value
+		}
+	}
+	if snapshot.FlowTemperatureC == nil && snapshot.CalcFlowTempC == nil {
+		return nil
+	}
+	return snapshot
 }
 
 func (p *vaillantSemanticPoller) refreshSystemStartup(ctx context.Context) {
@@ -3718,7 +3747,7 @@ func (p *vaillantSemanticPoller) refreshCircuits(ctx context.Context) {
 		return
 	}
 
-	discovered := make(map[byte]*uint16, 4)
+	discovered := make(map[byte]*vaillantCircuitSnapshot, 4)
 	inactive := make(map[byte]struct{})
 	probeSuccess := false
 
@@ -3730,9 +3759,19 @@ func (p *vaillantSemanticPoller) refreshCircuits(ctx context.Context) {
 		probeSuccess = true
 		switch *circuitTypeRaw {
 		case 0x0000, 0x00FF, 0xFFFF:
+			if snapshot := p.readDhwPseudoCircuitEvidence(ctx, instance); snapshot != nil {
+				snapshot.Controller = controller
+				discovered[instance] = snapshot
+				continue
+			}
 			inactive[instance] = struct{}{}
 		default:
-			discovered[instance] = cloneUint16Ptr(circuitTypeRaw)
+			discovered[instance] = &vaillantCircuitSnapshot{
+				Instance:       instance,
+				Active:         true,
+				Controller:     controller,
+				CircuitTypeRaw: cloneUint16Ptr(circuitTypeRaw),
+			}
 		}
 	}
 	if !probeSuccess {
@@ -3747,12 +3786,10 @@ func (p *vaillantSemanticPoller) refreshCircuits(ctx context.Context) {
 
 	updates := make(map[byte]*vaillantCircuitSnapshot, len(discovered))
 	anyRead := false
-	for instance, circuitTypeRaw := range discovered {
-		snapshot := &vaillantCircuitSnapshot{
-			Instance:       instance,
-			Active:         true,
-			Controller:     controller,
-			CircuitTypeRaw: cloneUint16Ptr(circuitTypeRaw),
+	for instance, discoveredSnapshot := range discovered {
+		snapshot := cloneCircuitSnapshot(discoveredSnapshot)
+		if snapshot == nil {
+			continue
 		}
 		anyRead = true
 
@@ -3864,6 +3901,45 @@ func (p *vaillantSemanticPoller) refreshCircuits(ctx context.Context) {
 		source = semanticSnapshotSourceLive
 	}
 	p.publishCircuits(source)
+}
+
+func (p *vaillantSemanticPoller) readDhwPseudoCircuitEvidence(ctx context.Context, instance byte) *vaillantCircuitSnapshot {
+	if p == nil || instance != dhwPseudoCircuitInstance {
+		return nil
+	}
+	snapshot := newDhwPseudoCircuitSnapshot(instance)
+	if value, ok := p.readB524Float32LE(ctx, localCircuits.opcode, localCircuits.group, instance, circuit_flow_temp); ok {
+		v := value
+		if isDhwPseudoCircuitTemperatureEvidence(&v) {
+			snapshot.FlowTemperatureC = &v
+		}
+	}
+	if value, ok := p.readB524Float32LE(ctx, localCircuits.opcode, localCircuits.group, instance, circuit_calc_flow_temp); ok {
+		v := value
+		if isDhwPseudoCircuitTemperatureEvidence(&v) {
+			snapshot.CalcFlowTempC = &v
+		}
+	}
+	if snapshot.FlowTemperatureC == nil && snapshot.CalcFlowTempC == nil {
+		return nil
+	}
+	return snapshot
+}
+
+func newDhwPseudoCircuitSnapshot(instance byte) *vaillantCircuitSnapshot {
+	circuitType := dhwPseudoCircuitTypeRaw
+	return &vaillantCircuitSnapshot{
+		Instance:       instance,
+		Active:         true,
+		CircuitTypeRaw: &circuitType,
+	}
+}
+
+func isDhwPseudoCircuitTemperatureEvidence(value *float64) bool {
+	if value == nil {
+		return false
+	}
+	return *value >= 5 && *value <= 95
 }
 
 func allCircuitRefreshInstances() []byte {

--- a/cmd/gateway/semantic_vaillant_test.go
+++ b/cmd/gateway/semantic_vaillant_test.go
@@ -3763,6 +3763,132 @@ func TestRefreshCircuits_NoSuccessfulReadsPreservesSnapshot(t *testing.T) {
 	}
 }
 
+func TestRefreshCircuits_PromotesDhwPseudoCircuitWithTemperatureEvidence(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(1000, 0)
+	existingType := uint16(1)
+	provider := graphql.NewLiveSemanticProvider()
+	poller := &vaillantSemanticPoller{
+		controller:                  0x15,
+		source:                      0x7F,
+		provider:                    provider,
+		scheduler:                   ebusgateway.NewSemanticReadScheduler(),
+		requestTimeout:              50 * time.Millisecond,
+		circuitFullScanInterval:     semanticCircuitFullScanInterval,
+		lastCircuitFullScanAt:       now.Add(-5 * time.Minute),
+		lastCircuitFullScanComplete: true,
+		nowFn:                       func() time.Time { return now },
+		circuits: map[byte]*vaillantCircuitSnapshot{
+			0x09: {
+				Instance:       0x09,
+				Active:         true,
+				CircuitTypeRaw: &existingType,
+			},
+		},
+		sendFrameFn: func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+			if len(frame.Data) != 6 {
+				return testB524ResponseForSelectorPayload(frame.Data), nil
+			}
+			group := frame.Data[2]
+			instance := frame.Data[3]
+			addr := uint16(frame.Data[4]) | uint16(frame.Data[5])<<8
+			if group != localCircuits.group || instance != 0x09 {
+				return testB524ResponseForSelectorPayload(frame.Data), nil
+			}
+			switch addr {
+			case circuit_type:
+				return testB524ResponseForSelectorPayload(frame.Data, 0x00, 0x00), nil
+			case circuit_flow_temp:
+				return testB524ResponseForSelectorPayload(frame.Data, testB524Float32Payload(47.5)...), nil
+			case circuit_calc_flow_temp:
+				return testB524ResponseForSelectorPayload(frame.Data, testB524Float32Payload(46.25)...), nil
+			case circuit_flow_setpoint,
+				circuit_heating_curve,
+				circuit_flow_temp_max,
+				circuit_flow_temp_min,
+				circuit_summer_limit,
+				circuit_frost_protection,
+				circuit_mixer_position,
+				circuit_humidity,
+				circuit_dew_point:
+				return testB524ResponseForSelectorPayload(frame.Data, testB524Float32Payload(0)...), nil
+			case circuit_pump_hours,
+				circuit_pump_starts:
+				return testB524ResponseForSelectorPayload(frame.Data, 0x00, 0x00, 0x00, 0x00), nil
+			default:
+				return testB524ResponseForSelectorPayload(frame.Data, 0x00), nil
+			}
+		},
+	}
+
+	poller.refreshCircuits(context.Background())
+
+	entry, ok := poller.circuits[0x09]
+	if !ok || entry == nil {
+		t.Fatal("DHW pseudo-circuit snapshot missing after refresh")
+	}
+	if entry.CircuitTypeRaw == nil || *entry.CircuitTypeRaw != 3 {
+		t.Fatalf("entry.CircuitTypeRaw = %v; want 3 (dhw)", entry.CircuitTypeRaw)
+	}
+	if entry.FlowTemperatureC == nil || *entry.FlowTemperatureC != 47.5 {
+		t.Fatalf("entry.FlowTemperatureC = %v; want 47.5", entry.FlowTemperatureC)
+	}
+
+	status := provider.Circuits()
+	if len(status) != 1 {
+		t.Fatalf("provider.Circuits() = %d entries; want 1", len(status))
+	}
+	if status[0].Index != 9 || status[0].CircuitType != "dhw" {
+		t.Fatalf("provider.Circuits()[0] = %#v; want index 9 type dhw", status[0])
+	}
+}
+
+func TestRefreshCircuits_DoesNotPromoteDhwPseudoCircuitWithoutTemperatureEvidence(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(1000, 0)
+	existingType := uint16(1)
+	poller := &vaillantSemanticPoller{
+		controller:                  0x15,
+		source:                      0x7F,
+		provider:                    graphql.NewLiveSemanticProvider(),
+		scheduler:                   ebusgateway.NewSemanticReadScheduler(),
+		requestTimeout:              50 * time.Millisecond,
+		circuitFullScanInterval:     semanticCircuitFullScanInterval,
+		lastCircuitFullScanAt:       now.Add(-5 * time.Minute),
+		lastCircuitFullScanComplete: true,
+		nowFn:                       func() time.Time { return now },
+		circuits: map[byte]*vaillantCircuitSnapshot{
+			0x09: {
+				Instance:       0x09,
+				Active:         true,
+				CircuitTypeRaw: &existingType,
+			},
+		},
+		sendFrameFn: func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+			if len(frame.Data) != 6 {
+				return testB524ResponseForSelectorPayload(frame.Data), nil
+			}
+			addr := uint16(frame.Data[4]) | uint16(frame.Data[5])<<8
+			switch addr {
+			case circuit_type:
+				return testB524ResponseForSelectorPayload(frame.Data, 0x00, 0x00), nil
+			case circuit_flow_temp, circuit_calc_flow_temp:
+				return testB524ResponseForSelectorPayload(frame.Data, testB524Float32Payload(math.NaN())...), nil
+			default:
+				return testB524ResponseForSelectorPayload(frame.Data, 0x00), nil
+			}
+		},
+	}
+
+	poller.refreshCircuits(context.Background())
+
+	if entry := poller.circuits[0x09]; entry != nil {
+		t.Fatalf("poller.circuits[0x09] = %#v; want removed without DHW temperature evidence", entry)
+	}
+}
+
 func TestRefreshCircuits_TargetedProbeFailureForcesNextFullScan(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/gateway/semantic_vaillant_test.go
+++ b/cmd/gateway/semantic_vaillant_test.go
@@ -3889,6 +3889,60 @@ func TestRefreshCircuits_DoesNotPromoteDhwPseudoCircuitWithoutTemperatureEvidenc
 	}
 }
 
+func TestRefreshCircuits_PreservesDhwPseudoCircuitWhenEvidenceReadsFail(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(1000, 0)
+	existingType := uint16(3)
+	existingFlow := 47.5
+	poller := &vaillantSemanticPoller{
+		controller:                  0x15,
+		source:                      0x7F,
+		provider:                    graphql.NewLiveSemanticProvider(),
+		scheduler:                   ebusgateway.NewSemanticReadScheduler(),
+		requestTimeout:              50 * time.Millisecond,
+		circuitFullScanInterval:     semanticCircuitFullScanInterval,
+		lastCircuitFullScanAt:       now.Add(-5 * time.Minute),
+		lastCircuitFullScanComplete: true,
+		nowFn:                       func() time.Time { return now },
+		circuits: map[byte]*vaillantCircuitSnapshot{
+			0x09: {
+				Instance:         0x09,
+				Active:           true,
+				CircuitTypeRaw:   &existingType,
+				FlowTemperatureC: &existingFlow,
+			},
+		},
+		sendFrameFn: func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+			if len(frame.Data) != 6 {
+				return testB524ResponseForSelectorPayload(frame.Data), nil
+			}
+			addr := uint16(frame.Data[4]) | uint16(frame.Data[5])<<8
+			switch addr {
+			case circuit_type:
+				return testB524ResponseForSelectorPayload(frame.Data, 0x00, 0x00), nil
+			case circuit_flow_temp, circuit_calc_flow_temp:
+				return &protocol.Frame{Data: []byte{0x00}}, nil
+			default:
+				return testB524ResponseForSelectorPayload(frame.Data, 0x00), nil
+			}
+		},
+	}
+
+	poller.refreshCircuits(context.Background())
+
+	entry, ok := poller.circuits[0x09]
+	if !ok || entry == nil {
+		t.Fatal("DHW pseudo-circuit snapshot missing after transient evidence read failures")
+	}
+	if entry.CircuitTypeRaw == nil || *entry.CircuitTypeRaw != 3 {
+		t.Fatalf("entry.CircuitTypeRaw = %v; want preserved 3", entry.CircuitTypeRaw)
+	}
+	if entry.FlowTemperatureC == nil || *entry.FlowTemperatureC != 47.5 {
+		t.Fatalf("entry.FlowTemperatureC = %v; want preserved 47.5", entry.FlowTemperatureC)
+	}
+}
+
 func TestRefreshCircuits_TargetedProbeFailureForcesNextFullScan(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What
Promotes B524 local circuit instance `0x09` to a DHW circuit when `circuit_type` reports inactive but live circuit temperature evidence is present.

## Why
Community VRC Explorer evidence shows `GG=0x02 II=0x09` can represent an additional-cylinder/DHW pseudo-circuit. Without this exception, the gateway deletes the slot as inactive and Home Assistant never sees the semantic child.

## Details
- Adds an evidence-gated `II=0x09` pseudo-circuit classifier for startup and steady refresh.
- Uses `RR=0x0008` or `RR=0x0020` plausible temperature evidence before publishing `mctype=3` / `dhw`.
- Leaves all other inactive circuit slots gated by the existing inactive markers.

## Verification
- `go test ./cmd/gateway -run 'TestRefreshCircuits_.*DhwPseudo|TestDecodeHeatingCircuitTypeToken' -count=1`\n- `go test ./cmd/gateway -count=1`\n- `go test ./... -count=1`\n- `git diff --check`\n\nDocs: Project-Helianthus/helianthus-docs-ebus#331\n\nCloses #687.\n