### PR TITLE
test(matrix): mark T65/T66 UDP proxy cases passing

### DIFF
--- a/internal/matrix/runner.go
+++ b/internal/matrix/runner.go
@@ -588,6 +588,10 @@ func defaultExpectedFailure(testCase TopologyCase) string {
 	}
 	if testCase.Kind == TopologyProxyDual {
 		if testCase.ProxyTransport == TransportUDPPlain {
+			if testCase.GatewayTransport == TransportUDPPlain &&
+				(testCase.EbusdTransport == TransportENS || testCase.EbusdTransport == TransportENH) {
+				return ""
+			}
 			return "proxy dual-client with southbound udp reports no signal (ens/enh clients also show host comm framing)"
 		}
 		if testCase.ProxyTransport == TransportTCPPlain {

--- a/internal/matrix/runner_test.go
+++ b/internal/matrix/runner_test.go
@@ -376,6 +376,9 @@ func TestDefaultExpectedFailureCoverage(t *testing.T) {
 	checkReason("T27", "proxy dual-client with ebusd northbound udp reports no signal")
 	checkReason("T33", "proxy dual-client with southbound udp reports no signal (ens/enh clients also show host comm framing)")
 	checkReason("T37", "proxy dual-client with southbound tcp reports no signal (ens/enh clients also show host comm framing)")
+	checkReason("T65", "")
+	checkReason("T66", "")
+	checkReason("T67", "proxy dual-client with southbound udp reports no signal (ens/enh clients also show host comm framing)")
 	checkReason("T26", "")
 
 	defaultFailCount := 0
@@ -384,7 +387,7 @@ func TestDefaultExpectedFailureCoverage(t *testing.T) {
 			defaultFailCount++
 		}
 	}
-	if defaultFailCount != 42 {
-		t.Fatalf("default expected-failure count = %d; want 42", defaultFailCount)
+	if defaultFailCount != 40 {
+		t.Fatalf("default expected-failure count = %d; want 40", defaultFailCount)
 	}
 }


### PR DESCRIPTION
## Summary
- updates default matrix expectations so T65/T66 are no longer expected failures
- keeps T67+ southbound UDP no-signal expectations intact
- reflects live PR #106 full88 run where T65/T66 passed while other southbound UDP cases remained adapter_no_signal or xfail

## Validation
- TRANSPORT_MATRIX_REPORT=/Users/razvan/Desktop/Helianthus Project/helianthus-ebusgateway/results-matrix-ha/20260525T060617Z-pr106-full88/index.json PASSIVE_SMOKE_REPORT=/Users/razvan/Desktop/Helianthus Project/helianthus-ebusgateway/results-matrix-ha/20260312T094435Z-pr354-parent-passive-p01-p06/index.json ./scripts/ci_local.sh
- full88 live matrix: results-matrix-ha/20260525T060617Z-pr106-full88/index.json (46 pass, 7 xfail, 2 xpass under pre-patch metadata, 33 adapter_no_signal blocked)
