### PR TITLE
MSP-05A: add disabled eeBUS config scaffold

### DIFF
--- a/cmd/gateway/eebus_config_flags.go
+++ b/cmd/gateway/eebus_config_flags.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"net/netip"
+	"sort"
+	"strconv"
+	"strings"
+
+	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
+)
+
+func bindEEBusFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) {
+	fs.BoolVar(&cfg.EEBusConfig.Enabled, "eebus-enabled", cfg.EEBusConfig.Enabled, "record intent to activate the eeBUS runtime sidecar (M5A does not start it)")
+	fs.Func("eebus-listen-port", "eeBUS SHIP listen port (0 remains unconfigured)", func(value string) error {
+		parsed, err := strconv.ParseUint(strings.TrimSpace(value), 10, 16)
+		if err != nil {
+			return fmt.Errorf("invalid eebus-listen-port %q", value)
+		}
+		cfg.EEBusConfig.ListenPort = uint16(parsed)
+		return nil
+	})
+	fs.Func("eebus-interfaces", "comma-separated explicit eeBUS network interfaces", func(value string) error {
+		cfg.EEBusConfig.Interfaces = normalizeEEBusInterfaces(value)
+		return nil
+	})
+	fs.Func("eebus-subnets", "comma-separated explicit eeBUS network prefixes", func(value string) error {
+		subnets, err := normalizeEEBusSubnets(value)
+		if err != nil {
+			return err
+		}
+		cfg.EEBusConfig.Subnets = subnets
+		return nil
+	})
+	fs.Func("eebus-certificate-path", "eeBUS certificate file path", func(value string) error {
+		path, err := normalizeEEBusPath("eebus-certificate-path", value)
+		if err != nil {
+			return err
+		}
+		cfg.EEBusConfig.CertificatePath = path
+		return nil
+	})
+	fs.Func("eebus-private-key-path", "eeBUS private-key file path", func(value string) error {
+		path, err := normalizeEEBusPath("eebus-private-key-path", value)
+		if err != nil {
+			return err
+		}
+		cfg.EEBusConfig.PrivateKeyPath = path
+		return nil
+	})
+	fs.Func("eebus-trust-store-path", "eeBUS trust-store file path", func(value string) error {
+		path, err := normalizeEEBusPath("eebus-trust-store-path", value)
+		if err != nil {
+			return err
+		}
+		cfg.EEBusConfig.TrustStorePath = path
+		return nil
+	})
+	fs.Func("eebus-remote-ski-allowlist", "comma-separated remote eeBUS SKI allowlist", func(value string) error {
+		allowlist, err := normalizeEEBusRemoteSKIAllowlist(value)
+		if err != nil {
+			return err
+		}
+		cfg.EEBusConfig.RemoteSKIAllowlist = allowlist
+		return nil
+	})
+	fs.Func("eebus-pairing-window-mode", "eeBUS pairing-window mode (M5A: closed only)", func(value string) error {
+		mode := ebusgateway.EEBusPairingWindowMode(strings.ToLower(strings.TrimSpace(value)))
+		if mode != ebusgateway.EEBusPairingWindowClosed {
+			return fmt.Errorf("invalid eebus-pairing-window-mode %q", value)
+		}
+		cfg.EEBusConfig.PairingWindowMode = mode
+		return nil
+	})
+}
+
+func normalizeEEBusInterfaces(value string) []string {
+	return normalizeEEBusList(value, false)
+}
+
+func normalizeEEBusSubnets(value string) ([]string, error) {
+	items := normalizeEEBusList(value, false)
+	seen := make(map[string]struct{}, len(items))
+	normalized := make([]string, 0, len(items))
+	for _, item := range items {
+		prefix, err := netip.ParsePrefix(item)
+		if err != nil {
+			return nil, fmt.Errorf("invalid eebus-subnets prefix %q", item)
+		}
+		canonical := prefix.Masked().String()
+		if _, ok := seen[canonical]; ok {
+			continue
+		}
+		seen[canonical] = struct{}{}
+		normalized = append(normalized, canonical)
+	}
+	sort.Strings(normalized)
+	return normalized, nil
+}
+
+func normalizeEEBusRemoteSKIAllowlist(value string) ([]string, error) {
+	items := normalizeEEBusList(value, true)
+	for _, item := range items {
+		decoded, err := hex.DecodeString(item)
+		if err != nil || len(decoded) != 20 {
+			return nil, fmt.Errorf("invalid eebus-remote-ski-allowlist entry %q", item)
+		}
+	}
+	sort.Strings(items)
+	return items, nil
+}
+
+func normalizeEEBusPath(flagName, value string) (string, error) {
+	if strings.ContainsRune(value, '\x00') {
+		return "", fmt.Errorf("invalid %s: path contains NUL", flagName)
+	}
+	return strings.TrimSpace(value), nil
+}
+
+func normalizeEEBusList(value string, lowercase bool) []string {
+	parts := strings.Split(value, ",")
+	seen := make(map[string]struct{}, len(parts))
+	normalized := make([]string, 0, len(parts))
+	for _, part := range parts {
+		item := strings.TrimSpace(part)
+		if lowercase {
+			item = strings.ToLower(item)
+		}
+		if item == "" {
+			continue
+		}
+		if _, ok := seen[item]; ok {
+			continue
+		}
+		seen[item] = struct{}{}
+		normalized = append(normalized, item)
+	}
+	return normalized
+}

--- a/cmd/gateway/eebus_config_flags_test.go
+++ b/cmd/gateway/eebus_config_flags_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"flag"
+	"reflect"
+	"strings"
+	"testing"
+
+	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
+)
+
+func TestBindFlags_EEBusScaffoldNormalizesExplicitValues(t *testing.T) {
+	cfg := ebusgateway.DefaultConfig()
+	fs := flag.NewFlagSet("gateway-test", flag.ContinueOnError)
+	bindFlags(fs, &cfg)
+	err := fs.Parse([]string{
+		"-eebus-enabled",
+		"-eebus-listen-port", "4712",
+		"-eebus-interfaces", " en0, en1,en0 ,,en2 ",
+		"-eebus-subnets", "2001:db8::42/64,192.0.2.17/24,192.0.2.0/24",
+		"-eebus-certificate-path", " /data/eebus/cert.pem ",
+		"-eebus-private-key-path", " /data/eebus/key.pem ",
+		"-eebus-trust-store-path", " /data/eebus/trust.json ",
+		"-eebus-remote-ski-allowlist", strings.Repeat("B", 40) + "," + strings.Repeat("a", 40) + "," + strings.Repeat("b", 40),
+		"-eebus-pairing-window-mode", " CLOSED ",
+	})
+	if err != nil {
+		t.Fatalf("parse eeBUS flags: %v", err)
+	}
+
+	got := cfg.EEBusConfig
+	if !got.Enabled || got.ListenPort != 4712 {
+		t.Fatalf("Enabled/ListenPort = %v/%d; want true/4712", got.Enabled, got.ListenPort)
+	}
+	if want := []string{"en0", "en1", "en2"}; !reflect.DeepEqual(got.Interfaces, want) {
+		t.Fatalf("Interfaces = %v; want %v", got.Interfaces, want)
+	}
+	if want := []string{"192.0.2.0/24", "2001:db8::/64"}; !reflect.DeepEqual(got.Subnets, want) {
+		t.Fatalf("Subnets = %v; want %v", got.Subnets, want)
+	}
+	if got.CertificatePath != "/data/eebus/cert.pem" ||
+		got.PrivateKeyPath != "/data/eebus/key.pem" ||
+		got.TrustStorePath != "/data/eebus/trust.json" {
+		t.Fatalf("paths not trimmed: %+v", got)
+	}
+	if want := []string{strings.Repeat("a", 40), strings.Repeat("b", 40)}; !reflect.DeepEqual(got.RemoteSKIAllowlist, want) {
+		t.Fatalf("RemoteSKIAllowlist = %v; want %v", got.RemoteSKIAllowlist, want)
+	}
+	if got.PairingWindowMode != ebusgateway.EEBusPairingWindowClosed {
+		t.Fatalf("PairingWindowMode = %q; want closed", got.PairingWindowMode)
+	}
+}
+
+func TestBindFlags_EEBusListFlagsLastOccurrenceWins(t *testing.T) {
+	cfg := ebusgateway.DefaultConfig()
+	fs := flag.NewFlagSet("gateway-test", flag.ContinueOnError)
+	bindFlags(fs, &cfg)
+	err := fs.Parse([]string{
+		"-eebus-interfaces", "en0,en1",
+		"-eebus-interfaces", "eth0",
+		"-eebus-subnets", "192.0.2.0/24",
+		"-eebus-subnets", "2001:db8::/64",
+	})
+	if err != nil {
+		t.Fatalf("parse repeated eeBUS list flags: %v", err)
+	}
+	if want := []string{"eth0"}; !reflect.DeepEqual(cfg.EEBusConfig.Interfaces, want) {
+		t.Fatalf("Interfaces = %v; want %v", cfg.EEBusConfig.Interfaces, want)
+	}
+	if want := []string{"2001:db8::/64"}; !reflect.DeepEqual(cfg.EEBusConfig.Subnets, want) {
+		t.Fatalf("Subnets = %v; want %v", cfg.EEBusConfig.Subnets, want)
+	}
+}
+
+func TestBindFlags_EEBusRejectsInvalidValuesWithoutMutation(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "negative port", args: []string{"-eebus-listen-port", "-1"}},
+		{name: "overflow port", args: []string{"-eebus-listen-port", "65536"}},
+		{name: "non-decimal port", args: []string{"-eebus-listen-port", "0x1268"}},
+		{name: "invalid subnet", args: []string{"-eebus-subnets", "not-a-prefix"}},
+		{name: "short ski", args: []string{"-eebus-remote-ski-allowlist", "abcd"}},
+		{name: "non-hex ski", args: []string{"-eebus-remote-ski-allowlist", strings.Repeat("z", 40)}},
+		{name: "future pairing mode", args: []string{"-eebus-pairing-window-mode", "manual"}},
+		{name: "certificate path NUL", args: []string{"-eebus-certificate-path", "cert\x00.pem"}},
+		{name: "private key path NUL", args: []string{"-eebus-private-key-path", "key\x00.pem"}},
+		{name: "trust store path NUL", args: []string{"-eebus-trust-store-path", "trust\x00.json"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := ebusgateway.DefaultConfig()
+			before := cfg.EEBusConfig
+			fs := flag.NewFlagSet("gateway-test", flag.ContinueOnError)
+			bindFlags(fs, &cfg)
+			if err := fs.Parse(test.args); err == nil {
+				t.Fatalf("Parse(%q) error = nil; want deterministic rejection", test.args)
+			}
+			if !reflect.DeepEqual(cfg.EEBusConfig, before) {
+				t.Fatalf("invalid input mutated config: before=%+v after=%+v", before, cfg.EEBusConfig)
+			}
+		})
+	}
+}
+
+func TestBindFlags_EEBusEmptyListsRemainExplicitlyEmpty(t *testing.T) {
+	cfg := ebusgateway.DefaultConfig()
+	fs := flag.NewFlagSet("gateway-test", flag.ContinueOnError)
+	bindFlags(fs, &cfg)
+	if err := fs.Parse([]string{
+		"-eebus-interfaces", " , , ",
+		"-eebus-subnets", " , ",
+		"-eebus-remote-ski-allowlist", " , ",
+	}); err != nil {
+		t.Fatalf("parse explicit empty lists: %v", err)
+	}
+	if len(cfg.EEBusConfig.Interfaces) != 0 || len(cfg.EEBusConfig.Subnets) != 0 || len(cfg.EEBusConfig.RemoteSKIAllowlist) != 0 {
+		t.Fatalf("empty list flags widened config: %+v", cfg.EEBusConfig)
+	}
+}

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"expvar"
 	"flag"
@@ -9,9 +10,11 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/netip"
 	"os"
 	"os/signal"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -1216,6 +1219,67 @@ func bindFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) {
 	fs.DurationVar(&cfg.TransportConfig.ReadTimeout, "read-timeout", cfg.TransportConfig.ReadTimeout, "transport read timeout")
 	fs.DurationVar(&cfg.TransportConfig.WriteTimeout, "write-timeout", cfg.TransportConfig.WriteTimeout, "transport write timeout")
 	fs.DurationVar(&cfg.TransportConfig.DialTimeout, "dial-timeout", cfg.TransportConfig.DialTimeout, "transport dial timeout")
+	fs.BoolVar(&cfg.EEBusConfig.Enabled, "eebus-enabled", cfg.EEBusConfig.Enabled, "enable the eeBUS runtime sidecar (M5A stores configuration only)")
+	fs.Func("eebus-listen-port", "eeBUS SHIP listen port (0 remains unconfigured)", func(value string) error {
+		parsed, err := strconv.ParseUint(strings.TrimSpace(value), 10, 16)
+		if err != nil {
+			return fmt.Errorf("invalid eebus-listen-port %q", value)
+		}
+		cfg.EEBusConfig.ListenPort = uint16(parsed)
+		return nil
+	})
+	fs.Func("eebus-interfaces", "comma-separated explicit eeBUS network interfaces", func(value string) error {
+		cfg.EEBusConfig.Interfaces = normalizeEEBusInterfaces(value)
+		return nil
+	})
+	fs.Func("eebus-subnets", "comma-separated explicit eeBUS network prefixes", func(value string) error {
+		subnets, err := normalizeEEBusSubnets(value)
+		if err != nil {
+			return err
+		}
+		cfg.EEBusConfig.Subnets = subnets
+		return nil
+	})
+	fs.Func("eebus-certificate-path", "eeBUS certificate file path", func(value string) error {
+		path, err := normalizeEEBusPath("eebus-certificate-path", value)
+		if err != nil {
+			return err
+		}
+		cfg.EEBusConfig.CertificatePath = path
+		return nil
+	})
+	fs.Func("eebus-private-key-path", "eeBUS private-key file path", func(value string) error {
+		path, err := normalizeEEBusPath("eebus-private-key-path", value)
+		if err != nil {
+			return err
+		}
+		cfg.EEBusConfig.PrivateKeyPath = path
+		return nil
+	})
+	fs.Func("eebus-trust-store-path", "eeBUS trust-store file path", func(value string) error {
+		path, err := normalizeEEBusPath("eebus-trust-store-path", value)
+		if err != nil {
+			return err
+		}
+		cfg.EEBusConfig.TrustStorePath = path
+		return nil
+	})
+	fs.Func("eebus-remote-ski-allowlist", "comma-separated remote eeBUS SKI allowlist", func(value string) error {
+		allowlist, err := normalizeEEBusRemoteSKIAllowlist(value)
+		if err != nil {
+			return err
+		}
+		cfg.EEBusConfig.RemoteSKIAllowlist = allowlist
+		return nil
+	})
+	fs.Func("eebus-pairing-window-mode", "eeBUS pairing-window mode (M5A: closed only)", func(value string) error {
+		mode := ebusgateway.EEBusPairingWindowMode(strings.ToLower(strings.TrimSpace(value)))
+		if mode != ebusgateway.EEBusPairingWindowClosed {
+			return fmt.Errorf("invalid eebus-pairing-window-mode %q", value)
+		}
+		cfg.EEBusConfig.PairingWindowMode = mode
+		return nil
+	})
 	fs.IntVar(&cfg.QueueCapacity, "queue-capacity", cfg.QueueCapacity, "bus queue capacity (0 uses protocol default)")
 	fs.BoolVar(&cfg.ScanOnStart, "scan", cfg.ScanOnStart, "scan bus on startup")
 	fs.DurationVar(&cfg.ScanTimeout, "scan-timeout", cfg.ScanTimeout, "startup scan timeout")
@@ -1346,6 +1410,70 @@ func bindFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) {
 		return nil
 	})
 	fs.BoolVar(&cfg.StartupSource.Validate, "startup-source-override-validate", cfg.StartupSource.Validate, "run source-address selector in advisory-only mode alongside startup-source-override")
+}
+
+func normalizeEEBusInterfaces(value string) []string {
+	return normalizeEEBusList(value, false)
+}
+
+func normalizeEEBusSubnets(value string) ([]string, error) {
+	items := normalizeEEBusList(value, false)
+	seen := make(map[string]struct{}, len(items))
+	normalized := make([]string, 0, len(items))
+	for _, item := range items {
+		prefix, err := netip.ParsePrefix(item)
+		if err != nil {
+			return nil, fmt.Errorf("invalid eebus-subnets prefix %q", item)
+		}
+		canonical := prefix.Masked().String()
+		if _, ok := seen[canonical]; ok {
+			continue
+		}
+		seen[canonical] = struct{}{}
+		normalized = append(normalized, canonical)
+	}
+	sort.Strings(normalized)
+	return normalized, nil
+}
+
+func normalizeEEBusRemoteSKIAllowlist(value string) ([]string, error) {
+	items := normalizeEEBusList(value, true)
+	for _, item := range items {
+		decoded, err := hex.DecodeString(item)
+		if err != nil || len(decoded) != 20 {
+			return nil, fmt.Errorf("invalid eebus-remote-ski-allowlist entry %q", item)
+		}
+	}
+	sort.Strings(items)
+	return items, nil
+}
+
+func normalizeEEBusPath(flagName, value string) (string, error) {
+	if strings.ContainsRune(value, '\x00') {
+		return "", fmt.Errorf("invalid %s: path contains NUL", flagName)
+	}
+	return strings.TrimSpace(value), nil
+}
+
+func normalizeEEBusList(value string, lowercase bool) []string {
+	parts := strings.Split(value, ",")
+	seen := make(map[string]struct{}, len(parts))
+	normalized := make([]string, 0, len(parts))
+	for _, part := range parts {
+		item := strings.TrimSpace(part)
+		if lowercase {
+			item = strings.ToLower(item)
+		}
+		if item == "" {
+			continue
+		}
+		if _, ok := seen[item]; ok {
+			continue
+		}
+		seen[item] = struct{}{}
+		normalized = append(normalized, item)
+	}
+	return normalized
 }
 
 // parseHexByteList parses a comma-separated list of hex byte literals

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/hex"
 	"encoding/json"
 	"expvar"
 	"flag"
@@ -10,11 +9,9 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"net/netip"
 	"os"
 	"os/signal"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -1219,67 +1216,7 @@ func bindFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) {
 	fs.DurationVar(&cfg.TransportConfig.ReadTimeout, "read-timeout", cfg.TransportConfig.ReadTimeout, "transport read timeout")
 	fs.DurationVar(&cfg.TransportConfig.WriteTimeout, "write-timeout", cfg.TransportConfig.WriteTimeout, "transport write timeout")
 	fs.DurationVar(&cfg.TransportConfig.DialTimeout, "dial-timeout", cfg.TransportConfig.DialTimeout, "transport dial timeout")
-	fs.BoolVar(&cfg.EEBusConfig.Enabled, "eebus-enabled", cfg.EEBusConfig.Enabled, "enable the eeBUS runtime sidecar (M5A stores configuration only)")
-	fs.Func("eebus-listen-port", "eeBUS SHIP listen port (0 remains unconfigured)", func(value string) error {
-		parsed, err := strconv.ParseUint(strings.TrimSpace(value), 10, 16)
-		if err != nil {
-			return fmt.Errorf("invalid eebus-listen-port %q", value)
-		}
-		cfg.EEBusConfig.ListenPort = uint16(parsed)
-		return nil
-	})
-	fs.Func("eebus-interfaces", "comma-separated explicit eeBUS network interfaces", func(value string) error {
-		cfg.EEBusConfig.Interfaces = normalizeEEBusInterfaces(value)
-		return nil
-	})
-	fs.Func("eebus-subnets", "comma-separated explicit eeBUS network prefixes", func(value string) error {
-		subnets, err := normalizeEEBusSubnets(value)
-		if err != nil {
-			return err
-		}
-		cfg.EEBusConfig.Subnets = subnets
-		return nil
-	})
-	fs.Func("eebus-certificate-path", "eeBUS certificate file path", func(value string) error {
-		path, err := normalizeEEBusPath("eebus-certificate-path", value)
-		if err != nil {
-			return err
-		}
-		cfg.EEBusConfig.CertificatePath = path
-		return nil
-	})
-	fs.Func("eebus-private-key-path", "eeBUS private-key file path", func(value string) error {
-		path, err := normalizeEEBusPath("eebus-private-key-path", value)
-		if err != nil {
-			return err
-		}
-		cfg.EEBusConfig.PrivateKeyPath = path
-		return nil
-	})
-	fs.Func("eebus-trust-store-path", "eeBUS trust-store file path", func(value string) error {
-		path, err := normalizeEEBusPath("eebus-trust-store-path", value)
-		if err != nil {
-			return err
-		}
-		cfg.EEBusConfig.TrustStorePath = path
-		return nil
-	})
-	fs.Func("eebus-remote-ski-allowlist", "comma-separated remote eeBUS SKI allowlist", func(value string) error {
-		allowlist, err := normalizeEEBusRemoteSKIAllowlist(value)
-		if err != nil {
-			return err
-		}
-		cfg.EEBusConfig.RemoteSKIAllowlist = allowlist
-		return nil
-	})
-	fs.Func("eebus-pairing-window-mode", "eeBUS pairing-window mode (M5A: closed only)", func(value string) error {
-		mode := ebusgateway.EEBusPairingWindowMode(strings.ToLower(strings.TrimSpace(value)))
-		if mode != ebusgateway.EEBusPairingWindowClosed {
-			return fmt.Errorf("invalid eebus-pairing-window-mode %q", value)
-		}
-		cfg.EEBusConfig.PairingWindowMode = mode
-		return nil
-	})
+	bindEEBusFlags(fs, cfg)
 	fs.IntVar(&cfg.QueueCapacity, "queue-capacity", cfg.QueueCapacity, "bus queue capacity (0 uses protocol default)")
 	fs.BoolVar(&cfg.ScanOnStart, "scan", cfg.ScanOnStart, "scan bus on startup")
 	fs.DurationVar(&cfg.ScanTimeout, "scan-timeout", cfg.ScanTimeout, "startup scan timeout")
@@ -1410,70 +1347,6 @@ func bindFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) {
 		return nil
 	})
 	fs.BoolVar(&cfg.StartupSource.Validate, "startup-source-override-validate", cfg.StartupSource.Validate, "run source-address selector in advisory-only mode alongside startup-source-override")
-}
-
-func normalizeEEBusInterfaces(value string) []string {
-	return normalizeEEBusList(value, false)
-}
-
-func normalizeEEBusSubnets(value string) ([]string, error) {
-	items := normalizeEEBusList(value, false)
-	seen := make(map[string]struct{}, len(items))
-	normalized := make([]string, 0, len(items))
-	for _, item := range items {
-		prefix, err := netip.ParsePrefix(item)
-		if err != nil {
-			return nil, fmt.Errorf("invalid eebus-subnets prefix %q", item)
-		}
-		canonical := prefix.Masked().String()
-		if _, ok := seen[canonical]; ok {
-			continue
-		}
-		seen[canonical] = struct{}{}
-		normalized = append(normalized, canonical)
-	}
-	sort.Strings(normalized)
-	return normalized, nil
-}
-
-func normalizeEEBusRemoteSKIAllowlist(value string) ([]string, error) {
-	items := normalizeEEBusList(value, true)
-	for _, item := range items {
-		decoded, err := hex.DecodeString(item)
-		if err != nil || len(decoded) != 20 {
-			return nil, fmt.Errorf("invalid eebus-remote-ski-allowlist entry %q", item)
-		}
-	}
-	sort.Strings(items)
-	return items, nil
-}
-
-func normalizeEEBusPath(flagName, value string) (string, error) {
-	if strings.ContainsRune(value, '\x00') {
-		return "", fmt.Errorf("invalid %s: path contains NUL", flagName)
-	}
-	return strings.TrimSpace(value), nil
-}
-
-func normalizeEEBusList(value string, lowercase bool) []string {
-	parts := strings.Split(value, ",")
-	seen := make(map[string]struct{}, len(parts))
-	normalized := make([]string, 0, len(parts))
-	for _, part := range parts {
-		item := strings.TrimSpace(part)
-		if lowercase {
-			item = strings.ToLower(item)
-		}
-		if item == "" {
-			continue
-		}
-		if _, ok := seen[item]; ok {
-			continue
-		}
-		seen[item] = struct{}{}
-		normalized = append(normalized, item)
-	}
-	return normalized
 }
 
 // parseHexByteList parses a comma-separated list of hex byte literals

--- a/config.go
+++ b/config.go
@@ -70,6 +70,33 @@ type TransportConfig struct {
 	Dial         func(ctx context.Context, network, address string, timeout time.Duration) (net.Conn, error)
 }
 
+type EEBusPairingWindowMode string
+
+const EEBusPairingWindowClosed EEBusPairingWindowMode = "closed"
+
+// EEBusConfig is the inert M5A configuration boundary for the future eeBUS
+// runtime sidecar. No runtime consumes this value in M5A.
+type EEBusConfig struct {
+	Enabled            bool
+	ListenPort         uint16
+	Interfaces         []string
+	Subnets            []string
+	CertificatePath    string
+	PrivateKeyPath     string
+	TrustStorePath     string
+	RemoteSKIAllowlist []string
+	PairingWindowMode  EEBusPairingWindowMode
+}
+
+func DefaultEEBusConfig() EEBusConfig {
+	return EEBusConfig{
+		Interfaces:         []string{},
+		Subnets:            []string{},
+		RemoteSKIAllowlist: []string{},
+		PairingWindowMode:  EEBusPairingWindowClosed,
+	}
+}
+
 type WatchObserver interface {
 	Observe(key WatchKey) WatchObservation
 }
@@ -96,6 +123,7 @@ type Config struct {
 	PassiveTransport         transport.RawTransport // pre-configured passive transport (adapter-direct mode)
 	ProxyListenAddr          string                 // TCP listen address for ENH proxy clients (empty disables)
 	TransportConfig          TransportConfig
+	EEBusConfig              EEBusConfig
 	BusConfig                protocol.BusConfig
 	QueueCapacity            int
 	Providers                []registry.PlaneProvider
@@ -232,6 +260,7 @@ func DefaultConfig() Config {
 			WriteTimeout: 5 * time.Second,
 			DialTimeout:  5 * time.Second,
 		},
+		EEBusConfig: DefaultEEBusConfig(),
 		BusConfig:   protocol.DefaultBusConfig(),
 		Providers:   vaillantproviders.Default(),
 		ScanOnStart: true,

--- a/eebus_config_test.go
+++ b/eebus_config_test.go
@@ -64,7 +64,7 @@ func TestM5AEEBusScaffold_HasNoRuntimeOrModuleCoupling(t *testing.T) {
 	}
 
 	allowedReferences := []string{
-		"cmd/gateway/main.go",
+		"cmd/gateway/eebus_config_flags.go",
 		"config.go",
 	}
 	var unexpected []string

--- a/eebus_config_test.go
+++ b/eebus_config_test.go
@@ -1,0 +1,103 @@
+package ebusgateway
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestDefaultConfig_DisablesEEBusScaffold(t *testing.T) {
+	cfg := DefaultConfig().EEBusConfig
+	if cfg.Enabled {
+		t.Fatal("EEBusConfig.Enabled = true; want false")
+	}
+	if cfg.ListenPort != 0 {
+		t.Fatalf("EEBusConfig.ListenPort = %d; want 0", cfg.ListenPort)
+	}
+	if len(cfg.Interfaces) != 0 || len(cfg.Subnets) != 0 || len(cfg.RemoteSKIAllowlist) != 0 {
+		t.Fatalf(
+			"EEBusConfig lists = interfaces:%v subnets:%v allowlist:%v; want empty",
+			cfg.Interfaces,
+			cfg.Subnets,
+			cfg.RemoteSKIAllowlist,
+		)
+	}
+	if cfg.CertificatePath != "" || cfg.PrivateKeyPath != "" || cfg.TrustStorePath != "" {
+		t.Fatalf(
+			"EEBusConfig paths = cert:%q key:%q store:%q; want empty",
+			cfg.CertificatePath,
+			cfg.PrivateKeyPath,
+			cfg.TrustStorePath,
+		)
+	}
+	if cfg.PairingWindowMode != EEBusPairingWindowClosed {
+		t.Fatalf(
+			"EEBusConfig.PairingWindowMode = %q; want %q",
+			cfg.PairingWindowMode,
+			EEBusPairingWindowClosed,
+		)
+	}
+}
+
+func TestDefaultEEBusConfig_ReturnsIndependentEmptySlices(t *testing.T) {
+	first := DefaultEEBusConfig()
+	second := DefaultEEBusConfig()
+	first.Interfaces = append(first.Interfaces, "en0")
+	first.Subnets = append(first.Subnets, "192.0.2.0/24")
+	first.RemoteSKIAllowlist = append(first.RemoteSKIAllowlist, strings.Repeat("a", 40))
+
+	if len(second.Interfaces) != 0 || len(second.Subnets) != 0 || len(second.RemoteSKIAllowlist) != 0 {
+		t.Fatalf("defaults share list backing state: %+v", second)
+	}
+}
+
+func TestM5AEEBusScaffold_HasNoRuntimeOrModuleCoupling(t *testing.T) {
+	const forbiddenImport = "github.com/Project-Helianthus/helianthus-eebusreg"
+	goMod, err := os.ReadFile("go.mod")
+	if err != nil {
+		t.Fatalf("read go.mod: %v", err)
+	}
+	if strings.Contains(string(goMod), forbiddenImport) {
+		t.Fatalf("go.mod contains forbidden M5A dependency %q", forbiddenImport)
+	}
+
+	allowedReferences := []string{
+		"cmd/gateway/main.go",
+		"config.go",
+	}
+	var unexpected []string
+	err = filepath.WalkDir(".", func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			if path == ".git" || strings.HasPrefix(path, ".git"+string(filepath.Separator)) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if filepath.Ext(path) != ".go" || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		normalized := filepath.ToSlash(strings.TrimPrefix(path, "."+string(filepath.Separator)))
+		if strings.Contains(string(content), forbiddenImport) {
+			unexpected = append(unexpected, normalized+": forbidden import")
+		}
+		if strings.Contains(string(content), "EEBusConfig") && !slices.Contains(allowedReferences, normalized) {
+			unexpected = append(unexpected, normalized+": runtime reference outside config scaffold")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk production Go files: %v", err)
+	}
+	if len(unexpected) != 0 {
+		t.Fatalf("M5A eeBUS boundary violations: %v", unexpected)
+	}
+}


### PR DESCRIPTION
## Summary
- add the inert `EEBusConfig` sibling without importing or starting the eeBUS runtime
- freeze disabled defaults and deterministic CLI parsing for M5A
- reject invalid ports, subnets, SKIs, pairing modes, and NUL-bearing paths without mutation
- isolate eeBUS CLI parsing so the anti-leak test can enforce a narrow production boundary

## TDD evidence
- tests-only RED: `7e99126f4ea189fe046902a36b58c2ecf8a9f864`
- RED CI: [29603497231](https://github.com/Project-Helianthus/helianthus-ebusgateway/actions/runs/29603497231)
- intended missing-symbol failures: build `87960996416`, lint `87960996475`, test `87960996489`
- initial GREEN: `422256a6d39de63787b3a486973f51fd31cbe7a4`
- focused review fix: `ba43bc1abf4e6b95fe65a8ec66b29894a8805c13`

## Validation
- local `./scripts/ci_local.sh`: PASS on initial GREEN and focused review fix
- transport gate owner override: M5A is config-only; no runtime import, socket, transport, protocol, router, registry, or semantic path
- passive smoke owner override: existing passive eBUS path is unchanged and no runtime consumes `EEBusConfig`
- initial GREEN GitHub CI: [29605133593](https://github.com/Project-Helianthus/helianthus-ebusgateway/actions/runs/29605133593) PASS
- final exact-head GitHub CI: [29606329914](https://github.com/Project-Helianthus/helianthus-ebusgateway/actions/runs/29606329914) (running)

## Review closure
- P1 gate evidence: closed by documented owner overrides and full local CI exit 0
- P2 anti-leak scope: closed by moving parser code to `cmd/gateway/eebus_config_flags.go` and narrowing the whitelist
- P3 CLI wording: closed by stating that M5A records activation intent and starts no runtime
- no second broad audit per operator direction; targeted normal/race tests and full CI passed

## Documentation gate
- docs PR: Project-Helianthus/helianthus-docs-eebus#35
- merge SHA: `f9aedb371c7b910cbca0667aa35b099d254da4c1`
- post-main docs CI: [29603339397](https://github.com/Project-Helianthus/helianthus-docs-eebus/actions/runs/29603339397) PASS

Closes #691
