### PR TITLE
MSP-05A-R2: harden gateway lifecycle prerequisites

### DIFF
--- a/cmd/gateway/eebus_runtime_config.go
+++ b/cmd/gateway/eebus_runtime_config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/netip"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
@@ -146,7 +147,7 @@ func validateEEBusSubnets(subnets []string) ([]netip.Prefix, error) {
 func mapEEBusRemotes(allowlist []string) ([]eebusruntime.Remote, error) {
 	var remotes []eebusruntime.Remote
 	if allowlist != nil {
-		remotes = make([]eebusruntime.Remote, len(allowlist))
+		remotes = make([]eebusruntime.Remote, 0, len(allowlist))
 	}
 	seen := make(map[string]struct{}, len(allowlist))
 	for index, ski := range allowlist {
@@ -161,8 +162,11 @@ func mapEEBusRemotes(allowlist []string) ([]eebusruntime.Remote, error) {
 			return nil, fmt.Errorf("duplicate eeBUS remote SKI at index %d", index)
 		}
 		seen[identity] = struct{}{}
-		remotes[index] = eebusruntime.Remote{SKI: ski}
+		remotes = append(remotes, eebusruntime.Remote{SKI: identity})
 	}
+	sort.Slice(remotes, func(left, right int) bool {
+		return remotes[left].SKI < remotes[right].SKI
+	})
 	return remotes, nil
 }
 

--- a/cmd/gateway/eebus_runtime_config_test.go
+++ b/cmd/gateway/eebus_runtime_config_test.go
@@ -108,7 +108,7 @@ func TestMapEEBusRuntimeConfig_DisabledRejectsActiveInputBeforeResolver(t *testi
 	}
 }
 
-func TestMapEEBusRuntimeConfig_MapsEnabledProductLosslessly(t *testing.T) {
+func TestMapEEBusRuntimeConfig_NormalizesAndSortsRemotes(t *testing.T) {
 	firstSKI := strings.Repeat("B", 40)
 	secondSKI := strings.Repeat("a", 40)
 	cfg := validEEBusRuntimeGatewayConfig()
@@ -128,8 +128,8 @@ func TestMapEEBusRuntimeConfig_MapsEnabledProductLosslessly(t *testing.T) {
 		ListenAddress:    netip.AddrPortFrom(address, 4712),
 		DiscoveryEnabled: true,
 		Remotes: []eebusruntime.Remote{
-			{SKI: firstSKI},
 			{SKI: secondSKI},
+			{SKI: strings.ToLower(firstSKI)},
 		},
 		PairingPolicy: eebusruntime.PairingPolicyClosed,
 	}
@@ -186,7 +186,7 @@ func TestMapEEBusRuntimeConfig_RejectsIncompleteEnabledProductBeforeResolver(t *
 		{name: "invalid remote SKI", mutate: func(cfg *ebusgateway.EEBusConfig) { cfg.RemoteSKIAllowlist = []string{"abcd"} }},
 		{name: "duplicate remote SKI", mutate: func(cfg *ebusgateway.EEBusConfig) {
 			remoteSKI := strings.Repeat("a", 40)
-			cfg.RemoteSKIAllowlist = []string{remoteSKI, remoteSKI}
+			cfg.RemoteSKIAllowlist = []string{remoteSKI, strings.ToUpper(remoteSKI)}
 		}},
 	}
 

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -215,7 +215,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 	metrics := ebusgateway.GetOrInitStartupSourceSelectionMetrics()
 	artifactBuilder := ebusgateway.NewSourceSelectionArtifactBuilder(string(cfg.TransportConfig.Protocol))
 	if err := artifactBuilder.SetSourceSelectionMode("degraded_no_events"); err != nil {
-		log.Fatalf("FATAL: AD23 enum violation at startup: %v", err)
+		return fmt.Errorf("set startup source-selection mode: %w", err)
 	}
 	overrideSet := admissionPath == ebusgateway.TransportAdmissionSourceSelectionCapable && cfg.StartupSource.Source != nil
 	overrideSource := byte(0x00)
@@ -226,7 +226,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 		metrics.RecordExplicitValidateOnly()
 		artifactBuilder.SetExplicitSource(overrideSource)
 		if err := artifactBuilder.SetSourceSelectionMode("explicit_validate_only"); err != nil {
-			log.Fatalf("FATAL: SAS M4 enum violation on explicit source path: %v", err)
+			return fmt.Errorf("set explicit source-selection mode: %w", err)
 		}
 		// Exact source is configured: state immediately becomes "active" because
 		// the explicit source is in use from the first active frame. The selector
@@ -524,7 +524,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 			artifactBuilder.SetPromotedSuspects(len(startupProbeTargets(cfg)))
 			artifactBuilder.SetSourceSelection(result.Source, result.Companion, result.Metrics.WarmupDurationActual)
 			if perr := artifactBuilder.SetSourceSelectionMode("source_selection"); perr != nil {
-				log.Fatalf("FATAL: SAS M4 enum violation on source-selection default-policy path: %v", perr)
+				return fmt.Errorf("set default-policy source-selection mode: %w", perr)
 			}
 			log.Printf("startup source selection candidate source=0x%02X companion_target=0x%02X provenance=source_selection_default_policy", result.Source, result.Companion)
 			recordBusAdmissionTransitionWithStabilityRefresh(ctx, busObservability, "pending", result.Source, result.Companion, "active_probe_pending")
@@ -541,7 +541,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 			artifactBuilder.SetPromotedSuspects(len(startupProbeTargets(cfg)))
 			artifactBuilder.SetSourceSelection(result.Source, result.Companion, 0)
 			if perr := artifactBuilder.SetSourceSelectionMode("source_selection"); perr != nil {
-				log.Fatalf("FATAL: SAS M4 enum violation on configured source validation path: %v", perr)
+				return fmt.Errorf("set configured source-selection mode: %w", perr)
 			}
 			log.Printf("startup source selection candidate source=0x%02X companion_target=0x%02X provenance=configured_source", result.Source, result.Companion)
 			recordBusAdmissionTransitionWithStabilityRefresh(ctx, busObservability, "pending", result.Source, result.Companion, "active_probe_pending")
@@ -686,7 +686,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 			metrics.MarkDegraded(time.Now())
 			artifactBuilder.SetDegraded("source_selection_failed")
 			if perr := artifactBuilder.SetSourceSelectionMode("degraded_no_events"); perr != nil {
-				log.Fatalf("FATAL: AD23 enum violation on source-address selector-fail path: %v", perr)
+				return fmt.Errorf("set degraded source-selection mode: %w", perr)
 			}
 		} else {
 			if overrideSet {
@@ -700,7 +700,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) error {
 				artifactBuilder.SetPromotedSuspects(len(startupProbeTargets(cfg)))
 				artifactBuilder.SetSourceSelection(result.Source, result.Companion, time.Since(warmupStartedAt))
 				if perr := artifactBuilder.SetSourceSelectionMode("source_selection"); perr != nil {
-					log.Fatalf("FATAL: AD23 enum violation on source-selection path: %v", perr)
+					return fmt.Errorf("set selected source-selection mode: %w", perr)
 				}
 				log.Printf("startup source selection candidate source=0x%02X companion_target=0x%02X", result.Source, result.Companion)
 				recordBusAdmissionTransitionWithStabilityRefresh(ctx, busObservability, "pending", result.Source, result.Companion, "active_probe_pending")
@@ -1576,7 +1576,7 @@ func wireAdapterDirect(ctx context.Context, cfg *ebusgateway.Config) (func() err
 	if envMode := os.Getenv(v8classifier.EnvVarName); envMode != "" {
 		parsedMode, err := v8classifier.ParseMode(envMode)
 		if err != nil {
-			log.Fatalf("invalid %s=%q: %v (expected off|shadow|enforce)", v8classifier.EnvVarName, envMode, err)
+			return nil, nil, fmt.Errorf("invalid %s=%q (expected off|shadow|enforce): %w", v8classifier.EnvVarName, envMode, err)
 		}
 		muxCfg.V8ClassifierMode = parsedMode
 		if parsedMode != v8classifier.ModeOff {

--- a/cmd/gateway/main_test.go
+++ b/cmd/gateway/main_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Project-Helianthus/helianthus-ebusgateway"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/graphql"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/adaptermux/v8classifier"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mdns"
 	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
@@ -1381,6 +1382,25 @@ func TestWireAdapterDirect_NonAdapterDirect_ReturnsNil(t *testing.T) {
 	}
 	if closer != nil {
 		t.Fatal("closer should be nil for non-adapter-direct protocol")
+	}
+}
+
+func TestWireAdapterDirect_InvalidClassifierModeReturnsError(t *testing.T) {
+	t.Setenv(v8classifier.EnvVarName, "invalid-mode")
+	cfg := ebusgateway.DefaultConfig()
+	cfg.TransportConfig.Protocol = ebusgateway.TransportAdapterDirect
+	cfg.TransportConfig.Network = "tcp"
+	cfg.TransportConfig.Address = "192.0.2.1:9999"
+
+	closer, classifier, err := wireAdapterDirect(context.Background(), &cfg)
+	if err == nil {
+		t.Fatal("invalid classifier mode error = nil; want rejection")
+	}
+	if closer != nil || classifier != nil {
+		t.Fatalf("invalid classifier mode returned resources: closer=%v classifier=%v", closer != nil, classifier != nil)
+	}
+	if !strings.Contains(err.Error(), v8classifier.EnvVarName) || !strings.Contains(err.Error(), "invalid-mode") {
+		t.Fatalf("invalid classifier mode error = %q; want environment name and value", err)
 	}
 }
 

--- a/cmd/gateway/process_exit_boundary_test.go
+++ b/cmd/gateway/process_exit_boundary_test.go
@@ -47,10 +47,19 @@ func processExitViolations(filename string, source any) ([]processExitViolation,
 	}
 
 	var mainBody *ast.BlockStmt
+	var nestedMainFunctions []*ast.FuncLit
 	for _, declaration := range parsed.Decls {
 		function, ok := declaration.(*ast.FuncDecl)
 		if ok && function.Recv == nil && function.Name.Name == "main" {
 			mainBody = function.Body
+			ast.Inspect(mainBody, func(node ast.Node) bool {
+				literal, ok := node.(*ast.FuncLit)
+				if !ok {
+					return true
+				}
+				nestedMainFunctions = append(nestedMainFunctions, literal)
+				return false
+			})
 			break
 		}
 	}
@@ -61,22 +70,32 @@ func processExitViolations(filename string, source any) ([]processExitViolation,
 		if !ok {
 			return true
 		}
-		qualifier, ok := selector.X.(*ast.Ident)
-		if !ok {
-			return true
+		qualifier, qualified := selector.X.(*ast.Ident)
+		path := ""
+		call := selector.Sel.Name
+		if qualified {
+			path = aliases[qualifier.Name]
+			call = qualifier.Name + "." + selector.Sel.Name
 		}
-		path := aliases[qualifier.Name]
 		terminates := path == "os" && selector.Sel.Name == "Exit"
-		terminates = terminates || path == "log" && (selector.Sel.Name == "Fatal" || selector.Sel.Name == "Fatalf" || selector.Sel.Name == "Fatalln")
+		terminates = terminates || selector.Sel.Name == "Fatal" || selector.Sel.Name == "Fatalf" || selector.Sel.Name == "Fatalln"
 		if !terminates {
 			return true
 		}
-		if mainBody != nil && selector.Pos() >= mainBody.Pos() && selector.End() <= mainBody.End() {
+		insideMain := mainBody != nil && selector.Pos() >= mainBody.Pos() && selector.End() <= mainBody.End()
+		insideNestedFunction := false
+		for _, literal := range nestedMainFunctions {
+			if selector.Pos() >= literal.Pos() && selector.End() <= literal.End() {
+				insideNestedFunction = true
+				break
+			}
+		}
+		if insideMain && !insideNestedFunction {
 			return true
 		}
 		violations = append(violations, processExitViolation{
 			position: files.Position(selector.Pos()),
-			call:     qualifier.Name + "." + selector.Sel.Name,
+			call:     call,
 		})
 		return true
 	})
@@ -84,27 +103,50 @@ func processExitViolations(filename string, source any) ([]processExitViolation,
 }
 
 func TestGatewayWorkerCodeCannotTerminateProcess(t *testing.T) {
-	entries, err := os.ReadDir(".")
-	if err != nil {
-		t.Fatalf("read gateway package: %v", err)
-	}
-
 	var findings []string
-	for _, entry := range entries {
-		name := entry.Name()
-		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
-			continue
-		}
-		violations, err := processExitViolations(name, nil)
+	for _, directory := range []string{".", "../.."} {
+		entries, err := os.ReadDir(directory)
 		if err != nil {
-			t.Fatalf("inspect %s: %v", name, err)
+			t.Fatalf("read gateway package %s: %v", directory, err)
 		}
-		for _, violation := range violations {
-			findings = append(findings, fmt.Sprintf("%s: %s", violation.position, violation.call))
+		for _, entry := range entries {
+			name := entry.Name()
+			if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+				continue
+			}
+			filename := filepath.Join(directory, name)
+			violations, err := processExitViolations(filename, nil)
+			if err != nil {
+				t.Fatalf("inspect %s: %v", filename, err)
+			}
+			for _, violation := range violations {
+				findings = append(findings, fmt.Sprintf("%s: %s", violation.position, violation.call))
+			}
 		}
 	}
 	if len(findings) != 0 {
 		t.Fatalf("gateway process termination is allowed only inside main():\n%s", strings.Join(findings, "\n"))
+	}
+}
+
+func TestProcessExitGuardRejectsLoggerReceiversAndNestedMainWorkers(t *testing.T) {
+	const source = `package fixture
+import "log"
+func main() {
+  log.Fatalf("top-level termination")
+  worker := func() {
+    logger := log.Default()
+    logger.Fatal("nested termination")
+  }
+  _ = worker
+}
+`
+	violations, err := processExitViolations("fixture.go", source)
+	if err != nil {
+		t.Fatalf("inspect receiver fixture: %v", err)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("receiver/nested process-exit violations = %v; want 1", violations)
 	}
 }
 

--- a/cmd/gateway/process_exit_boundary_test.go
+++ b/cmd/gateway/process_exit_boundary_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+type processExitViolation struct {
+	position token.Position
+	call     string
+}
+
+func processExitViolations(filename string, source any) ([]processExitViolation, error) {
+	files := token.NewFileSet()
+	parsed, err := parser.ParseFile(files, filename, source, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	aliases := make(map[string]string)
+	for _, imported := range parsed.Imports {
+		path, err := strconv.Unquote(imported.Path.Value)
+		if err != nil {
+			return nil, fmt.Errorf("unquote import %s: %w", imported.Path.Value, err)
+		}
+		if path != "log" && path != "os" {
+			continue
+		}
+		alias := filepath.Base(path)
+		if imported.Name != nil {
+			alias = imported.Name.Name
+		}
+		if alias == "_" {
+			continue
+		}
+		if alias == "." {
+			return nil, fmt.Errorf("dot import of process-termination package %q is forbidden", path)
+		}
+		aliases[alias] = path
+	}
+
+	var mainBody *ast.BlockStmt
+	for _, declaration := range parsed.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if ok && function.Recv == nil && function.Name.Name == "main" {
+			mainBody = function.Body
+			break
+		}
+	}
+
+	var violations []processExitViolation
+	ast.Inspect(parsed, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		qualifier, ok := selector.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		path := aliases[qualifier.Name]
+		terminates := path == "os" && selector.Sel.Name == "Exit"
+		terminates = terminates || path == "log" && (selector.Sel.Name == "Fatal" || selector.Sel.Name == "Fatalf" || selector.Sel.Name == "Fatalln")
+		if !terminates {
+			return true
+		}
+		if mainBody != nil && call.Pos() >= mainBody.Pos() && call.End() <= mainBody.End() {
+			return true
+		}
+		violations = append(violations, processExitViolation{
+			position: files.Position(call.Pos()),
+			call:     qualifier.Name + "." + selector.Sel.Name,
+		})
+		return true
+	})
+	return violations, nil
+}
+
+func TestGatewayWorkerCodeCannotTerminateProcess(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read gateway package: %v", err)
+	}
+
+	var findings []string
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		violations, err := processExitViolations(name, nil)
+		if err != nil {
+			t.Fatalf("inspect %s: %v", name, err)
+		}
+		for _, violation := range violations {
+			findings = append(findings, fmt.Sprintf("%s: %s", violation.position, violation.call))
+		}
+	}
+	if len(findings) != 0 {
+		t.Fatalf("gateway process termination is allowed only inside main():\n%s", strings.Join(findings, "\n"))
+	}
+}
+
+func TestProcessExitGuardResolvesStdlibAliases(t *testing.T) {
+	const source = `package fixture
+import (
+  logging "log"
+  system "os"
+)
+func worker() {
+  logging.Fatalf("stop")
+  system.Exit(1)
+}
+`
+	violations, err := processExitViolations("fixture.go", source)
+	if err != nil {
+		t.Fatalf("inspect aliased fixture: %v", err)
+	}
+	if len(violations) != 2 {
+		t.Fatalf("aliased process-exit violations = %v; want 2", violations)
+	}
+}

--- a/cmd/gateway/process_exit_boundary_test.go
+++ b/cmd/gateway/process_exit_boundary_test.go
@@ -57,11 +57,7 @@ func processExitViolations(filename string, source any) ([]processExitViolation,
 
 	var violations []processExitViolation
 	ast.Inspect(parsed, func(node ast.Node) bool {
-		call, ok := node.(*ast.CallExpr)
-		if !ok {
-			return true
-		}
-		selector, ok := call.Fun.(*ast.SelectorExpr)
+		selector, ok := node.(*ast.SelectorExpr)
 		if !ok {
 			return true
 		}
@@ -75,11 +71,11 @@ func processExitViolations(filename string, source any) ([]processExitViolation,
 		if !terminates {
 			return true
 		}
-		if mainBody != nil && call.Pos() >= mainBody.Pos() && call.End() <= mainBody.End() {
+		if mainBody != nil && selector.Pos() >= mainBody.Pos() && selector.End() <= mainBody.End() {
 			return true
 		}
 		violations = append(violations, processExitViolation{
-			position: files.Position(call.Pos()),
+			position: files.Position(selector.Pos()),
 			call:     qualifier.Name + "." + selector.Sel.Name,
 		})
 		return true
@@ -120,7 +116,8 @@ import (
 )
 func worker() {
   logging.Fatalf("stop")
-  system.Exit(1)
+  terminate := system.Exit
+  terminate(1)
 }
 `
 	violations, err := processExitViolations("fixture.go", source)

--- a/config.go
+++ b/config.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"net"
 	"strings"
 	"time"
@@ -367,13 +366,6 @@ func applyDefaults(cfg Config) Config {
 	if cfg.StateMinStabilitySeconds == 0 {
 		cfg.StateMinStabilitySeconds = StartupAdmissionStateMinStabilitySecondsDefault
 	}
-	// AD22 invariant enforcement at config-load (per Codex-bot review on M2):
-	// non-zero invalid values (e.g. -1, 120, or any value violating
-	// state_min_stability_s × 5 ≤ continuous_threshold_s) MUST be rejected
-	// FATALly here, not just exercised in tests.
-	if err := ValidateStartupAdmissionStability(cfg.StateMinStabilitySeconds); err != nil {
-		log.Fatalf("FATAL: %v", err)
-	}
 	if cfg.SemanticInterval == 0 {
 		cfg.SemanticInterval = 1 * time.Minute
 	}
@@ -556,7 +548,8 @@ func applyDefaults(cfg Config) Config {
 // ValidateStartupAdmissionStability enforces AD22.
 func ValidateStartupAdmissionStability(stateMinStabilitySeconds int) error {
 	if stateMinStabilitySeconds < StartupAdmissionStateMinStabilitySecondsMin || stateMinStabilitySeconds > StartupAdmissionStateMinStabilitySecondsMax {
-		return fmt.Errorf("startup admission: state_min_stability_s=%d out of range [%d, %d]",
+		return fmt.Errorf("%w: state_min_stability_s=%d out of range [%d, %d]",
+			ErrStartupAdmissionStabilityInvariant,
 			stateMinStabilitySeconds,
 			StartupAdmissionStateMinStabilitySecondsMin,
 			StartupAdmissionStateMinStabilitySecondsMax)

--- a/gateway.go
+++ b/gateway.go
@@ -29,6 +29,9 @@ type Gateway struct {
 
 func New(ctx context.Context, cfg Config) (*Gateway, error) {
 	cfg = applyDefaults(cfg)
+	if err := ValidateStartupAdmissionStability(cfg.StateMinStabilitySeconds); err != nil {
+		return nil, fmt.Errorf("validate gateway config: %w", err)
+	}
 
 	transportLayer, closeFn, err := resolveTransport(ctx, cfg)
 	if err != nil {

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -2,8 +2,11 @@ package ebusgateway
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net"
+	"os"
+	"os/exec"
 	"sync"
 	"testing"
 	"time"
@@ -13,6 +16,36 @@ import (
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
 	"github.com/Project-Helianthus/helianthus-ebusreg/router"
 )
+
+func TestNewGateway_InvalidAdmissionStabilityReturnsBeforeDial(t *testing.T) {
+	if os.Getenv("HELIANTHUS_TEST_INVALID_ADMISSION_STABILITY") == "1" {
+		cfg := Config{
+			StateMinStabilitySeconds: 120,
+			TransportConfig: TransportConfig{
+				Protocol: TransportENH,
+				Network:  "tcp",
+				Address:  "192.0.2.1:9999",
+				Dial: func(context.Context, string, string, time.Duration) (net.Conn, error) {
+					panic("transport dialed before admission stability validation")
+				},
+			},
+		}
+		gateway, err := New(context.Background(), cfg)
+		if gateway != nil {
+			t.Fatalf("New() gateway = %v; want nil", gateway)
+		}
+		if !errors.Is(err, ErrStartupAdmissionStabilityInvariant) {
+			t.Fatalf("New() error = %v; want ErrStartupAdmissionStabilityInvariant", err)
+		}
+		return
+	}
+
+	command := exec.Command(os.Args[0], "-test.run=^TestNewGateway_InvalidAdmissionStabilityReturnsBeforeDial$")
+	command.Env = append(os.Environ(), "HELIANTHUS_TEST_INVALID_ADMISSION_STABILITY=1")
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("invalid admission stability terminated the helper process: %v\n%s", err, output)
+	}
+}
 
 func TestNewGateway_UsesProvidedTransport(t *testing.T) {
 	loopback := transport.NewLoopback()


### PR DESCRIPTION
## Summary
GREEN implementation for MSP-05A-R2, including one focused review repair cycle.

- keeps `main` as the sole process-exit boundary across the gateway command and root runtime package
- returns wrapped worker/helper and gateway-configuration errors so deferred shutdown executes
- rejects invalid admission stability before transport resolution/dial while preserving `ErrStartupAdmissionStabilityInvariant`
- canonicalizes eeBUS remote SKIs as lowercase ascending identities while preserving nil versus explicit empty
- rejects case-insensitive duplicate SKIs
- preserves the disabled-by-default eeBUS configuration boundary and existing eBUS runtime behavior

## TDD State
- Initial tests-only RED: `3eaf719b82b8f3970dee643be4018e5e9179fd54`; external run `29652107055`
- Initial GREEN: `d7b231c94930f6311d4dc7507d0fb6621ea76f96`; exact-head run `29652547842` 4/4 PASS
- Fresh Sol/xhigh review: FAIL with one P1 and one P2 process-exit finding
- Focused tests-only RED: `9cfc5224e2392128f3dee025bea22f8678a819ac`; external run `29652915260` expected RED, other 3 jobs PASS
- Focused GREEN: `8944f4a205a5fcd6a0c095c84610378d302b45a1`
- Targeted normal/race, root + `cmd/gateway` normal/race, and full `./scripts/ci_local.sh`: PASS
- Exact-head external GREEN: run `29653315950` in progress

## Gates
- Execution-plan authority: `Project-Helianthus/helianthus-execution-plans@6088a67c67c2b4e335505bb7b8f19f31e49d239a`
- Doc gate: existing `helianthus-docs-eebus` architecture contract remains authoritative; this prerequisite adds no protocol/API behavior
- Transport gate: EEBUS-G00/G05 targeted mapper evidence PASS; full eBUS no-drift local CI PASS
- Security gate: process termination cannot bypass deferred cleanup; invalid classifier and gateway configuration return errors without leaking acquired resources
- Review policy: all two findings fixed in one focused cycle; no second broad audit per operator direction

Closes #695 after exact-head CI and merge gates pass.