### PR TITLE
MSP-05B: add disabled eeBUS sibling runtime lifecycle

### DIFF
--- a/cmd/gateway/eebus_interface_resolver.go
+++ b/cmd/gateway/eebus_interface_resolver.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"net/netip"
+)
+
+var eebusInterfaceByNameFn = net.InterfaceByName
+
+func resolveEEBusInterfaceAddresses(interfaceName string) ([]netip.Addr, error) {
+	networkInterface, err := eebusInterfaceByNameFn(interfaceName)
+	if err != nil {
+		return nil, fmt.Errorf("look up eeBUS interface %q: %w", interfaceName, err)
+	}
+	if networkInterface == nil {
+		return nil, fmt.Errorf("look up eeBUS interface %q: resolver returned nil", interfaceName)
+	}
+	addresses, err := networkInterface.Addrs()
+	if err != nil {
+		return nil, fmt.Errorf("list eeBUS interface %q addresses: %w", interfaceName, err)
+	}
+	return convertEEBusInterfaceAddresses(interfaceName, addresses)
+}
+
+func convertEEBusInterfaceAddresses(interfaceName string, addresses []net.Addr) ([]netip.Addr, error) {
+	converted := make([]netip.Addr, 0, len(addresses))
+	for index, source := range addresses {
+		var ip net.IP
+		switch address := source.(type) {
+		case *net.IPNet:
+			if address == nil {
+				return nil, fmt.Errorf("eeBUS interface address %d is a nil *net.IPNet", index)
+			}
+			ip = address.IP
+		case *net.IPAddr:
+			if address == nil {
+				return nil, fmt.Errorf("eeBUS interface address %d is a nil *net.IPAddr", index)
+			}
+			ip = address.IP
+		default:
+			return nil, fmt.Errorf("eeBUS interface address %d has unsupported type %T", index, source)
+		}
+
+		address, ok := netip.AddrFromSlice(ip)
+		if !ok {
+			return nil, fmt.Errorf("eeBUS interface address %d has invalid IP bytes", index)
+		}
+		address = address.Unmap().WithZone("")
+		if address.Is6() && address.IsLinkLocalUnicast() {
+			address = address.WithZone(interfaceName)
+		}
+		converted = append(converted, address)
+	}
+	return converted, nil
+}

--- a/cmd/gateway/eebus_interface_resolver_test.go
+++ b/cmd/gateway/eebus_interface_resolver_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"errors"
+	"net"
+	"net/netip"
+	"testing"
+)
+
+type msp05bUnknownAddr struct{}
+
+func (msp05bUnknownAddr) Network() string { return "msp05b" }
+func (msp05bUnknownAddr) String() string  { return "unsupported" }
+
+func TestMSP05BConvertEEBusInterfaceAddresses(t *testing.T) {
+	interfaceName := "fixture0"
+	tests := []struct {
+		name string
+		addr net.Addr
+		want netip.Addr
+	}{
+		{
+			name: "IPNet IPv4 is unmapped and unzoned",
+			addr: &net.IPNet{IP: net.ParseIP("192.0.2.42"), Mask: net.CIDRMask(24, 32)},
+			want: netip.MustParseAddr("192.0.2.42"),
+		},
+		{
+			name: "IPAddr IPv4 discards an inapplicable zone",
+			addr: &net.IPAddr{IP: net.ParseIP("192.0.2.43"), Zone: "stale0"},
+			want: netip.MustParseAddr("192.0.2.43"),
+		},
+		{
+			name: "IPNet link local IPv6 gains the selected interface zone",
+			addr: &net.IPNet{IP: net.ParseIP("fe80::1234"), Mask: net.CIDRMask(64, 128)},
+			want: netip.MustParseAddr("fe80::1234%fixture0"),
+		},
+		{
+			name: "IPAddr link local IPv6 replaces the reported zone",
+			addr: &net.IPAddr{IP: net.ParseIP("fe80::5678"), Zone: "stale0"},
+			want: netip.MustParseAddr("fe80::5678%fixture0"),
+		},
+		{
+			name: "global IPv6 remains unzoned",
+			addr: &net.IPAddr{IP: net.ParseIP("2001:db8::42"), Zone: "stale0"},
+			want: netip.MustParseAddr("2001:db8::42"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := convertEEBusInterfaceAddresses(interfaceName, []net.Addr{test.addr})
+			if err != nil {
+				t.Fatalf("convert address: %v", err)
+			}
+			if len(got) != 1 || got[0] != test.want {
+				t.Fatalf("converted addresses = %v; want [%v]", got, test.want)
+			}
+		})
+	}
+}
+
+func TestMSP05BConvertEEBusInterfaceAddressesRejectsUnknownType(t *testing.T) {
+	got, err := convertEEBusInterfaceAddresses("fixture0", []net.Addr{
+		&net.IPAddr{IP: net.ParseIP("192.0.2.42")},
+		msp05bUnknownAddr{},
+	})
+	if err == nil {
+		t.Fatal("unknown net.Addr conversion error = nil; want rejection")
+	}
+	if got != nil {
+		t.Fatalf("addresses after unknown type = %v; want nil fail-closed result", got)
+	}
+}
+
+func TestMSP05BConvertEEBusInterfaceAddressesRejectsTypedNil(t *testing.T) {
+	tests := []struct {
+		name string
+		addr net.Addr
+	}{
+		{name: "nil IPNet", addr: (*net.IPNet)(nil)},
+		{name: "nil IPAddr", addr: (*net.IPAddr)(nil)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := convertEEBusInterfaceAddresses("fixture0", []net.Addr{test.addr})
+			if err == nil {
+				t.Fatal("typed-nil conversion error = nil; want rejection")
+			}
+			if got != nil {
+				t.Fatalf("addresses after typed nil = %v; want nil fail-closed result", got)
+			}
+		})
+	}
+}
+
+func TestMSP05BResolveEEBusInterfaceAddressesUsesInterfaceByName(t *testing.T) {
+	original := eebusInterfaceByNameFn
+	t.Cleanup(func() { eebusInterfaceByNameFn = original })
+
+	wantErr := errors.New("interface lookup failed")
+	calledWith := ""
+	eebusInterfaceByNameFn = func(name string) (*net.Interface, error) {
+		calledWith = name
+		return nil, wantErr
+	}
+
+	got, err := resolveEEBusInterfaceAddresses("fixture0")
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("resolver error = %v; want interface lookup cause", err)
+	}
+	if got != nil {
+		t.Fatalf("resolver addresses = %v; want nil", got)
+	}
+	if calledWith != "fixture0" {
+		t.Fatalf("InterfaceByName argument = %q; want fixture0", calledWith)
+	}
+}

--- a/cmd/gateway/eebus_runtime_adapter.go
+++ b/cmd/gateway/eebus_runtime_adapter.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
+	eebusruntime "github.com/Project-Helianthus/helianthus-eebusreg"
+)
+
+type eebusRuntimeFactory func(eebusruntime.Config) (eebusruntime.Runtime, error)
+
+var (
+	resolveEEBusInterfaceAddressesFn eebusInterfaceAddressResolver = resolveEEBusInterfaceAddresses
+	newEEBusRuntimeFn                eebusRuntimeFactory           = eebusruntime.New
+)
+
+type eebusRuntimeAdapter struct {
+	runtime eebusruntime.Runtime
+
+	shutdownOnce sync.Once
+	shutdownErr  error
+}
+
+func startEEBusRuntime(
+	ctx context.Context,
+	config ebusgateway.EEBusConfig,
+	resolve eebusInterfaceAddressResolver,
+	factory eebusRuntimeFactory,
+) (*eebusRuntimeAdapter, error) {
+	runtimeConfig, err := mapEEBusRuntimeConfig(config, resolve)
+	if err != nil {
+		return nil, fmt.Errorf("map eeBUS runtime configuration: %w", err)
+	}
+	if !config.Enabled {
+		return nil, nil
+	}
+	if factory == nil {
+		return nil, errors.New("enabled eeBUS configuration requires a runtime factory")
+	}
+
+	runtime, factoryErr := factory(runtimeConfig)
+	if runtime == nil {
+		if factoryErr != nil {
+			return nil, fmt.Errorf("construct eeBUS runtime: %w", factoryErr)
+		}
+		return nil, errors.New("construct eeBUS runtime: factory returned nil")
+	}
+	adapter := &eebusRuntimeAdapter{runtime: runtime}
+	if factoryErr != nil {
+		return nil, fmt.Errorf("construct eeBUS runtime: %w", errors.Join(factoryErr, adapter.Shutdown()))
+	}
+	if err := runtime.Start(ctx); err != nil {
+		return nil, fmt.Errorf("start eeBUS runtime: %w", errors.Join(err, adapter.Shutdown()))
+	}
+	return adapter, nil
+}
+
+func (adapter *eebusRuntimeAdapter) Shutdown() error {
+	if adapter == nil || adapter.runtime == nil {
+		return nil
+	}
+	adapter.shutdownOnce.Do(func() {
+		adapter.shutdownErr = adapter.runtime.Shutdown()
+	})
+	return adapter.shutdownErr
+}

--- a/cmd/gateway/eebus_runtime_adapter_test.go
+++ b/cmd/gateway/eebus_runtime_adapter_test.go
@@ -3,10 +3,16 @@ package main
 import (
 	"context"
 	"errors"
+	"net/http"
 	"net/netip"
+	"path/filepath"
 	"testing"
 
 	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/graphql"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/mdns"
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
 	eebusruntime "github.com/Project-Helianthus/helianthus-eebusreg"
 )
 
@@ -118,6 +124,45 @@ func TestMSP05BStartEEBusRuntimeFailureShutsConstructedRuntimeOnce(t *testing.T)
 	}
 }
 
+func TestMSP05BStartEEBusRuntimeRejectsMissingFactoryAndNilRuntime(t *testing.T) {
+	resolver := func(string) ([]netip.Addr, error) {
+		return []netip.Addr{netip.MustParseAddr("192.0.2.42")}, nil
+	}
+	factoryErr := errors.New("runtime factory failed")
+	tests := []struct {
+		name    string
+		factory eebusRuntimeFactory
+		wantErr error
+	}{
+		{name: "nil factory", factory: nil},
+		{
+			name: "nil runtime with error",
+			factory: func(eebusruntime.Config) (eebusruntime.Runtime, error) {
+				return nil, factoryErr
+			},
+			wantErr: factoryErr,
+		},
+		{
+			name: "nil runtime without error",
+			factory: func(eebusruntime.Config) (eebusruntime.Runtime, error) {
+				return nil, nil
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			adapter, err := startEEBusRuntime(context.Background(), msp05bEnabledConfig(), resolver, test.factory)
+			if adapter != nil || err == nil {
+				t.Fatalf("start result = (%v, %v); want nil adapter and error", adapter, err)
+			}
+			if test.wantErr != nil && !errors.Is(err, test.wantErr) {
+				t.Fatalf("start error = %v; want factory cause", err)
+			}
+		})
+	}
+}
+
 func TestMSP05BStartedAdapterShutdownIsIdempotent(t *testing.T) {
 	runtime := &msp05bRuntime{shutdownErr: errors.New("sidecar shutdown failed")}
 	adapter, err := startEEBusRuntime(
@@ -174,4 +219,97 @@ func TestMSP05BRunJoinsLaterErrorWithSidecarShutdown(t *testing.T) {
 	if runtime.startCalls != 1 || runtime.stopCalls != 1 {
 		t.Fatalf("calls start=%d shutdown=%d; want exactly one each", runtime.startCalls, runtime.stopCalls)
 	}
+}
+
+func TestMSP05BRunJoinsHTTPStartupErrorWithSidecarShutdown(t *testing.T) {
+	originalResolver := resolveEEBusInterfaceAddressesFn
+	originalFactory := newEEBusRuntimeFn
+	originalWire := wireObserveFirstObserversFn
+	originalDiscovery := startDiscoveryScanLoopFn
+	originalSemantic := startVaillantSemanticPollingFn
+	originalHTTP := startHTTPServerFn
+	t.Cleanup(func() {
+		resolveEEBusInterfaceAddressesFn = originalResolver
+		newEEBusRuntimeFn = originalFactory
+		wireObserveFirstObserversFn = originalWire
+		startDiscoveryScanLoopFn = originalDiscovery
+		startVaillantSemanticPollingFn = originalSemantic
+		startHTTPServerFn = originalHTTP
+	})
+
+	runtime := &msp05bRuntime{shutdownErr: errors.New("sidecar shutdown failed")}
+	httpErr := errors.New("HTTP startup failed")
+	installMSP05BRunDependencies(runtime)
+	startHTTPServerFn = func(context.Context, ebusgateway.Config, *ebusgateway.Gateway, *graphql.Builder, *graphql.BroadcastHub, graphql.SemanticProvider, mcp.ScheduleWriter, mcp.ConfigWriter, *ebusgateway.BusObservabilityStore, *ebusgateway.ShadowCache) (*http.Server, mdns.Advertiser, error) {
+		return nil, nil, httpErr
+	}
+
+	err := run(context.Background(), msp05bGatewayRunConfig(t))
+	if !errors.Is(err, httpErr) || !errors.Is(err, runtime.shutdownErr) {
+		t.Fatalf("run error = %v; want HTTP and sidecar shutdown causes", err)
+	}
+	if runtime.startCalls != 1 || runtime.stopCalls != 1 {
+		t.Fatalf("calls start=%d shutdown=%d; want exactly one each", runtime.startCalls, runtime.stopCalls)
+	}
+}
+
+func TestMSP05BRunCleanCancellationReturnsSidecarShutdownError(t *testing.T) {
+	originalResolver := resolveEEBusInterfaceAddressesFn
+	originalFactory := newEEBusRuntimeFn
+	originalWire := wireObserveFirstObserversFn
+	originalDiscovery := startDiscoveryScanLoopFn
+	originalSemantic := startVaillantSemanticPollingFn
+	originalHTTP := startHTTPServerFn
+	t.Cleanup(func() {
+		resolveEEBusInterfaceAddressesFn = originalResolver
+		newEEBusRuntimeFn = originalFactory
+		wireObserveFirstObserversFn = originalWire
+		startDiscoveryScanLoopFn = originalDiscovery
+		startVaillantSemanticPollingFn = originalSemantic
+		startHTTPServerFn = originalHTTP
+	})
+
+	runtime := &msp05bRuntime{shutdownErr: errors.New("sidecar shutdown failed")}
+	installMSP05BRunDependencies(runtime)
+	ctx, cancel := context.WithCancel(context.Background())
+	startHTTPServerFn = func(context.Context, ebusgateway.Config, *ebusgateway.Gateway, *graphql.Builder, *graphql.BroadcastHub, graphql.SemanticProvider, mcp.ScheduleWriter, mcp.ConfigWriter, *ebusgateway.BusObservabilityStore, *ebusgateway.ShadowCache) (*http.Server, mdns.Advertiser, error) {
+		cancel()
+		return nil, nil, nil
+	}
+
+	err := run(ctx, msp05bGatewayRunConfig(t))
+	if !errors.Is(err, runtime.shutdownErr) {
+		t.Fatalf("run error = %v; want sidecar shutdown cause after clean cancellation", err)
+	}
+	if runtime.startCalls != 1 || runtime.stopCalls != 1 {
+		t.Fatalf("calls start=%d shutdown=%d; want exactly one each", runtime.startCalls, runtime.stopCalls)
+	}
+}
+
+func installMSP05BRunDependencies(runtime eebusruntime.Runtime) {
+	resolveEEBusInterfaceAddressesFn = func(string) ([]netip.Addr, error) {
+		return []netip.Addr{netip.MustParseAddr("192.0.2.42")}, nil
+	}
+	newEEBusRuntimeFn = func(eebusruntime.Config) (eebusruntime.Runtime, error) {
+		return runtime, nil
+	}
+	wireObserveFirstObserversFn = func(*ebusgateway.Config) (*ebusgateway.BusObservabilityStore, *ebusgateway.ActivePassiveDeduplicator, error) {
+		return nil, nil, nil
+	}
+	startDiscoveryScanLoopFn = func(context.Context, ebusgateway.Config, *ebusgateway.Gateway, *graphql.Builder, activeTxnClassifier) startupScanSignals {
+		return startupScanSignals{}
+	}
+	startVaillantSemanticPollingFn = func(context.Context, ebusgateway.Config, *ebusgateway.Gateway, *graphql.LiveSemanticProvider, *graphql.BroadcastHub, <-chan struct{}) *vaillantSemanticPoller {
+		return nil
+	}
+}
+
+func msp05bGatewayRunConfig(t *testing.T) ebusgateway.Config {
+	t.Helper()
+	cfg := ebusgateway.DefaultConfig()
+	cfg.EEBusConfig = msp05bEnabledConfig()
+	cfg.Transport = transport.NewLoopback()
+	cfg.BroadcastListen = false
+	cfg.RuntimeStatePath = filepath.Join(t.TempDir(), "runtime-state.json")
+	return cfg
 }

--- a/cmd/gateway/eebus_runtime_adapter_test.go
+++ b/cmd/gateway/eebus_runtime_adapter_test.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"testing"
+
+	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
+	eebusruntime "github.com/Project-Helianthus/helianthus-eebusreg"
+)
+
+type msp05bRuntime struct {
+	startErr    error
+	shutdownErr error
+	startCalls  int
+	stopCalls   int
+}
+
+func (runtime *msp05bRuntime) Start(context.Context) error {
+	runtime.startCalls++
+	return runtime.startErr
+}
+
+func (runtime *msp05bRuntime) Shutdown() error {
+	runtime.stopCalls++
+	return runtime.shutdownErr
+}
+
+func (*msp05bRuntime) Snapshot() (eebusruntime.SnapshotV1, error) {
+	return eebusruntime.SnapshotV1{}, nil
+}
+
+func (*msp05bRuntime) PairingState() ([]eebusruntime.PairingObservationV1, error) {
+	return nil, nil
+}
+
+func msp05bEnabledConfig() ebusgateway.EEBusConfig {
+	return ebusgateway.EEBusConfig{
+		Enabled:            true,
+		ListenPort:         4712,
+		Interfaces:         []string{"fixture0"},
+		Subnets:            []string{"192.0.2.0/24"},
+		StateRoot:          "/var/lib/helianthus/eebus",
+		RemoteSKIAllowlist: []string{},
+		PairingWindowMode:  ebusgateway.EEBusPairingWindowClosed,
+	}
+}
+
+func TestMSP05BStartEEBusRuntimeDisabledMakesZeroCalls(t *testing.T) {
+	resolverCalls := 0
+	factoryCalls := 0
+	runtime := &msp05bRuntime{}
+
+	adapter, err := startEEBusRuntime(
+		context.Background(),
+		ebusgateway.DefaultEEBusConfig(),
+		func(string) ([]netip.Addr, error) {
+			resolverCalls++
+			return []netip.Addr{netip.MustParseAddr("192.0.2.42")}, nil
+		},
+		func(eebusruntime.Config) (eebusruntime.Runtime, error) {
+			factoryCalls++
+			return runtime, nil
+		},
+	)
+	if err != nil || adapter != nil {
+		t.Fatalf("disabled start = (%v, %v); want (nil, nil)", adapter, err)
+	}
+	if resolverCalls != 0 || factoryCalls != 0 || runtime.startCalls != 0 || runtime.stopCalls != 0 {
+		t.Fatalf("disabled calls resolver=%d factory=%d start=%d shutdown=%d; want all zero",
+			resolverCalls, factoryCalls, runtime.startCalls, runtime.stopCalls)
+	}
+}
+
+func TestMSP05BStartEEBusRuntimeFailureShutsConstructedRuntimeOnce(t *testing.T) {
+	resolver := func(string) ([]netip.Addr, error) {
+		return []netip.Addr{netip.MustParseAddr("192.0.2.42")}, nil
+	}
+	shutdownErr := errors.New("sidecar shutdown failed")
+	tests := []struct {
+		name       string
+		factoryErr error
+		startErr   error
+	}{
+		{name: "factory failure", factoryErr: errors.New("runtime factory failed")},
+		{name: "start failure", startErr: errors.New("runtime start failed")},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runtime := &msp05bRuntime{startErr: test.startErr, shutdownErr: shutdownErr}
+			adapter, err := startEEBusRuntime(
+				context.Background(),
+				msp05bEnabledConfig(),
+				resolver,
+				func(eebusruntime.Config) (eebusruntime.Runtime, error) {
+					return runtime, test.factoryErr
+				},
+			)
+			primaryErr := test.factoryErr
+			wantStartCalls := 0
+			if primaryErr == nil {
+				primaryErr = test.startErr
+				wantStartCalls = 1
+			}
+			if adapter != nil {
+				t.Fatalf("adapter = %v; want nil after failure", adapter)
+			}
+			if !errors.Is(err, primaryErr) || !errors.Is(err, shutdownErr) {
+				t.Fatalf("error = %v; want primary and shutdown causes", err)
+			}
+			if runtime.startCalls != wantStartCalls || runtime.stopCalls != 1 {
+				t.Fatalf("calls start=%d shutdown=%d; want start=%d shutdown=1",
+					runtime.startCalls, runtime.stopCalls, wantStartCalls)
+			}
+		})
+	}
+}
+
+func TestMSP05BStartedAdapterShutdownIsIdempotent(t *testing.T) {
+	runtime := &msp05bRuntime{shutdownErr: errors.New("sidecar shutdown failed")}
+	adapter, err := startEEBusRuntime(
+		context.Background(),
+		msp05bEnabledConfig(),
+		func(string) ([]netip.Addr, error) {
+			return []netip.Addr{netip.MustParseAddr("192.0.2.42")}, nil
+		},
+		func(eebusruntime.Config) (eebusruntime.Runtime, error) {
+			return runtime, nil
+		},
+	)
+	if err != nil || adapter == nil {
+		t.Fatalf("start adapter = (%v, %v); want non-nil and nil error", adapter, err)
+	}
+	firstErr := adapter.Shutdown()
+	secondErr := adapter.Shutdown()
+	if !errors.Is(firstErr, runtime.shutdownErr) || !errors.Is(secondErr, runtime.shutdownErr) {
+		t.Fatalf("shutdown errors = (%v, %v); want retained shutdown cause", firstErr, secondErr)
+	}
+	if runtime.startCalls != 1 || runtime.stopCalls != 1 {
+		t.Fatalf("calls start=%d shutdown=%d; want exactly one each", runtime.startCalls, runtime.stopCalls)
+	}
+}
+
+func TestMSP05BRunJoinsLaterErrorWithSidecarShutdown(t *testing.T) {
+	originalResolver := resolveEEBusInterfaceAddressesFn
+	originalFactory := newEEBusRuntimeFn
+	originalWire := wireObserveFirstObserversFn
+	t.Cleanup(func() {
+		resolveEEBusInterfaceAddressesFn = originalResolver
+		newEEBusRuntimeFn = originalFactory
+		wireObserveFirstObserversFn = originalWire
+	})
+
+	runtime := &msp05bRuntime{shutdownErr: errors.New("sidecar shutdown failed")}
+	laterErr := errors.New("later gateway startup failed")
+	resolveEEBusInterfaceAddressesFn = func(string) ([]netip.Addr, error) {
+		return []netip.Addr{netip.MustParseAddr("192.0.2.42")}, nil
+	}
+	newEEBusRuntimeFn = func(eebusruntime.Config) (eebusruntime.Runtime, error) {
+		return runtime, nil
+	}
+	wireObserveFirstObserversFn = func(*ebusgateway.Config) (*ebusgateway.BusObservabilityStore, *ebusgateway.ActivePassiveDeduplicator, error) {
+		return nil, nil, laterErr
+	}
+
+	cfg := ebusgateway.DefaultConfig()
+	cfg.EEBusConfig = msp05bEnabledConfig()
+	err := run(context.Background(), cfg)
+	if !errors.Is(err, laterErr) || !errors.Is(err, runtime.shutdownErr) {
+		t.Fatalf("run error = %v; want later gateway and sidecar shutdown causes", err)
+	}
+	if runtime.startCalls != 1 || runtime.stopCalls != 1 {
+		t.Fatalf("calls start=%d shutdown=%d; want exactly one each", runtime.startCalls, runtime.stopCalls)
+	}
+}

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"expvar"
 	"flag"
 	"fmt"
@@ -154,11 +155,23 @@ func recordBusAdmissionTransitionWithStabilityRefresh(ctx context.Context, store
 	}()
 }
 
-func run(ctx context.Context, cfg ebusgateway.Config) error {
+func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 	applyTransportSourcePolicy(&cfg)
 
 	if len(cfg.Providers) == 0 {
 		cfg.Providers = vaillantproviders.Default()
+	}
+
+	eebusAdapter, err := startEEBusRuntime(ctx, cfg.EEBusConfig, resolveEEBusInterfaceAddressesFn, newEEBusRuntimeFn)
+	if err != nil {
+		return fmt.Errorf("eeBUS sidecar: %w", err)
+	}
+	if eebusAdapter != nil {
+		defer func() {
+			if err := eebusAdapter.Shutdown(); err != nil {
+				result = errors.Join(result, fmt.Errorf("shutdown eeBUS sidecar: %w", err))
+			}
+		}()
 	}
 
 	// Initialize the runtime-state Manager early so the cached

--- a/eebus_config_test.go
+++ b/eebus_config_test.go
@@ -59,7 +59,7 @@ func TestDefaultEEBusConfig_ReturnsIndependentEmptySlices(t *testing.T) {
 	}
 }
 
-func TestM5AR1EEBusConfig_RuntimeCouplingIsConfinedToPrivateMapper(t *testing.T) {
+func TestMSP05BEEBusRuntimeCouplingIsConfinedToPrivateGatewaySeams(t *testing.T) {
 	const runtimeImport = "github.com/Project-Helianthus/helianthus-eebusreg"
 	goMod, err := os.ReadFile("go.mod")
 	if err != nil {
@@ -71,11 +71,15 @@ func TestM5AR1EEBusConfig_RuntimeCouplingIsConfinedToPrivateMapper(t *testing.T)
 
 	allowedConfigReferences := []string{
 		"cmd/gateway/eebus_config_flags.go",
+		"cmd/gateway/eebus_runtime_adapter.go",
 		"cmd/gateway/eebus_runtime_config.go",
+		"cmd/gateway/main.go",
 		"config.go",
 	}
-	const allowedRuntimeImport = "cmd/gateway/eebus_runtime_config.go"
-	foundRuntimeImport := false
+	allowedRuntimeImports := map[string]bool{
+		"cmd/gateway/eebus_runtime_adapter.go": false,
+		"cmd/gateway/eebus_runtime_config.go":  false,
+	}
 	var unexpected []string
 	err = filepath.WalkDir(".", func(path string, entry os.DirEntry, walkErr error) error {
 		if walkErr != nil {
@@ -96,14 +100,14 @@ func TestM5AR1EEBusConfig_RuntimeCouplingIsConfinedToPrivateMapper(t *testing.T)
 		}
 		normalized := filepath.ToSlash(strings.TrimPrefix(path, "."+string(filepath.Separator)))
 		if strings.Contains(string(content), runtimeImport) {
-			if normalized != allowedRuntimeImport {
-				unexpected = append(unexpected, normalized+": runtime import outside private mapper")
+			if _, allowed := allowedRuntimeImports[normalized]; !allowed {
+				unexpected = append(unexpected, normalized+": runtime import outside private gateway seams")
 			} else {
-				foundRuntimeImport = true
+				allowedRuntimeImports[normalized] = true
 			}
 		}
 		if strings.Contains(string(content), "EEBusConfig") && !slices.Contains(allowedConfigReferences, normalized) {
-			unexpected = append(unexpected, normalized+": runtime reference outside config scaffold")
+			unexpected = append(unexpected, normalized+": eeBUS config reference outside private gateway seams")
 		}
 		return nil
 	})
@@ -113,7 +117,9 @@ func TestM5AR1EEBusConfig_RuntimeCouplingIsConfinedToPrivateMapper(t *testing.T)
 	if len(unexpected) != 0 {
 		t.Fatalf("MSP-05A-R1 eeBUS boundary violations: %v", unexpected)
 	}
-	if !foundRuntimeImport {
-		t.Fatalf("%s does not import %q", allowedRuntimeImport, runtimeImport)
+	for path, found := range allowedRuntimeImports {
+		if !found {
+			t.Errorf("%s does not import %q", path, runtimeImport)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
Wire the eeBUS runtime as a disabled-by-default sibling sidecar in the gateway process.

- maps the frozen gateway config into the raw runtime before construction
- resolves selected interface addresses into typed `netip.Addr` values with fail-closed handling
- starts the eeBUS runtime synchronously before the existing gateway runtime
- guarantees exactly-once sidecar shutdown and preserves multiple failure causes with `errors.Join`
- leaves eBUS transport, router, registry, GraphQL, Portal, HA, and semantic surfaces unchanged

## TDD Evidence
- Tests-only RED: `8fd506004f73599bb81273a6f90bf71d4d8c8f32`
- External expected RED: Actions run `29654191052`; terminology passed and build/lint/test failed only on absent MSP-05B seams
- GREEN implementation: `943d391d6aee21be35a166fd90fa9fc67551bfb2`
- Focused review fixes add HTTP-start/cancellation error-join coverage and nil factory/runtime coverage; no production defect was found

## Validation
- `go test ./cmd/gateway -count=1` PASS (`47.956s`)
- `go test -race ./cmd/gateway -count=1` PASS (`49.821s`)
- targeted MSP-05B normal/race tests PASS after focused review fixes
- `./scripts/ci_local.sh` PASS: formatting, assets, vet, build, race suite, 168+5+7+5 Python tests, lint (`0 issues`), transport and passive-smoke gates
- transport/passive owner overrides are scoped to this sibling-sidecar-only change; no eBUS transport or capture path changes

## Gates
- Plan: `Project-Helianthus/helianthus-execution-plans@6088a67c67c2b4e335505bb7b8f19f31e49d239a`
- Predecessor: `MSP-05A-R2@9e174d1da434923d6537b5cf9aad4011e0ef8ea8`
- Runtime: `Project-Helianthus/helianthus-eebusreg@7a5852e009bbdcba47f0a34ba866070a4ab35ef8`
- Doc gate: `helianthus-docs-eebus@81cf193b`, `architecture/_candidate/msp-05p-production-activation.md`
- Transport/security: EEBUS-G00/G05, exact binding, disabled no-effect, eBUS anti-leak/no-drift

Closes #697 after exact-head CI, final review, merge, and post-main verification.
