### PR TITLE
MSP-06: add read-only eebus.v1 MCP tools

### DIFF
--- a/cmd/gateway/eebus_mcp_wiring_test.go
+++ b/cmd/gateway/eebus_mcp_wiring_test.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
+	eebusruntime "github.com/Project-Helianthus/helianthus-eebusreg"
+)
+
+type msp06GatewayRuntime struct {
+	snapshot      eebusruntime.SnapshotV1
+	snapshotErr   error
+	snapshotCalls int
+}
+
+var _ mcp.EEBusV1Provider = (*eebusRuntimeAdapter)(nil)
+
+func (*msp06GatewayRuntime) Start(context.Context) error { return nil }
+func (*msp06GatewayRuntime) Shutdown() error             { return nil }
+func (*msp06GatewayRuntime) PairingState() ([]eebusruntime.PairingObservationV1, error) {
+	return nil, nil
+}
+
+func (runtime *msp06GatewayRuntime) Snapshot() (eebusruntime.SnapshotV1, error) {
+	runtime.snapshotCalls++
+	return runtime.snapshot, runtime.snapshotErr
+}
+
+func TestMSP06RuntimeAdapterForwardsOnlySnapshotReads(t *testing.T) {
+	wantSnapshot := eebusruntime.SnapshotV1{
+		Meta: eebusruntime.SnapshotMetaV1{Contract: eebusruntime.SnapshotContractV1},
+	}
+	wantErr := errors.New("fixture snapshot failure")
+	runtime := &msp06GatewayRuntime{snapshot: wantSnapshot, snapshotErr: wantErr}
+	adapter := &eebusRuntimeAdapter{runtime: runtime}
+
+	gotSnapshot, gotErr := adapter.Snapshot()
+	if gotSnapshot.Meta.Contract != wantSnapshot.Meta.Contract || !errors.Is(gotErr, wantErr) {
+		t.Fatalf("adapter.Snapshot() = (%+v, %v), want forwarded (%+v, %v)", gotSnapshot, gotErr, wantSnapshot, wantErr)
+	}
+	if runtime.snapshotCalls != 1 {
+		t.Fatalf("runtime Snapshot calls = %d, want one", runtime.snapshotCalls)
+	}
+
+	var nilAdapter *eebusRuntimeAdapter
+	if _, err := nilAdapter.Snapshot(); err == nil {
+		t.Fatal("nil adapter Snapshot succeeded, want unavailable error")
+	}
+	if _, err := (&eebusRuntimeAdapter{}).Snapshot(); err == nil {
+		t.Fatal("adapter without runtime Snapshot succeeded, want unavailable error")
+	}
+}
+
+func TestMSP06GatewayRegistersProviderConditionallyBeforeMCPMount(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "main.go", nil, parser.ParseComments)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var registerPosition token.Pos
+	var mountPosition token.Pos
+	registrationGuarded := false
+	ast.Inspect(file, func(node ast.Node) bool {
+		switch value := node.(type) {
+		case *ast.CallExpr:
+			selector, ok := value.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			if selector.Sel.Name == "RegisterEEBusV1Provider" {
+				if registerPosition.IsValid() {
+					t.Fatal("RegisterEEBusV1Provider appears more than once in gateway bootstrap")
+				}
+				registerPosition = value.Pos()
+			}
+			if selector.Sel.Name == "Handle" && len(value.Args) > 0 {
+				pathSelector, ok := value.Args[0].(*ast.SelectorExpr)
+				if ok && pathSelector.Sel.Name == "MCPPath" {
+					mountPosition = value.Pos()
+				}
+			}
+		case *ast.IfStmt:
+			containsRegistration := false
+			ast.Inspect(value.Body, func(child ast.Node) bool {
+				call, ok := child.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				selector, ok := call.Fun.(*ast.SelectorExpr)
+				if ok && selector.Sel.Name == "RegisterEEBusV1Provider" {
+					containsRegistration = true
+				}
+				return true
+			})
+			if containsRegistration {
+				var condition strings.Builder
+				if err := printer.Fprint(&condition, fset, value.Cond); err != nil {
+					t.Fatal(err)
+				}
+				registrationGuarded = strings.Contains(condition.String(), "!= nil")
+			}
+		}
+		return true
+	})
+
+	if !registerPosition.IsValid() {
+		t.Fatal("gateway bootstrap does not register the enabled eeBUS runtime with MCP")
+	}
+	if !mountPosition.IsValid() {
+		t.Fatal("gateway MCP mount was not found")
+	}
+	if registerPosition >= mountPosition {
+		t.Fatalf("eeBUS provider registration at %s must complete before MCP mount at %s", fset.Position(registerPosition), fset.Position(mountPosition))
+	}
+	if !registrationGuarded {
+		t.Fatal("eeBUS MCP provider registration is not guarded by a non-nil enabled runtime")
+	}
+}
+
+func TestMSP06NoEEBusConsumerOrSemanticProjectionDrift(t *testing.T) {
+	for _, directory := range []string{"../../graphql", "../../portal"} {
+		err := filepath.WalkDir(directory, func(path string, entry os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if entry.IsDir() || filepath.Ext(path) != ".go" || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			content, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			text := string(content)
+			if strings.Contains(text, "eebus.v1") || strings.Contains(text, "helianthus-eebusreg") || strings.Contains(text, "EEBusV1Provider") {
+				t.Errorf("%s contains an MSP-06 eeBUS consumer/projection dependency", path)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestMSP06ProviderRegistrationDoesNotEscapeMCPBootstrap(t *testing.T) {
+	root := filepath.Clean("../..")
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			if entry.Name() == ".git" || entry.Name() == "vendor" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if filepath.Ext(path) != ".go" || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if !strings.Contains(string(content), "EEBusV1Provider") && !strings.Contains(string(content), "RegisterEEBusV1Provider") {
+			return nil
+		}
+		relative, err := filepath.Rel(".", path)
+		if err != nil {
+			return err
+		}
+		clean := filepath.Clean(relative)
+		allowedMCP := strings.HasPrefix(clean, filepath.Clean("../../mcp")+string(filepath.Separator))
+		allowedGateway := clean == filepath.Clean("../../cmd/gateway/main.go") || clean == filepath.Clean("../../cmd/gateway/eebus_runtime_adapter.go")
+		if !allowedMCP && !allowedGateway {
+			t.Errorf("MSP-06 provider registration escaped MCP/bootstrap boundary into %s", relative)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMSP06PublicMCPPackageDeclaresNoToolDropCapability(t *testing.T) {
+	entries, err := os.ReadDir("../../mcp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fset := token.NewFileSet()
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || filepath.Ext(name) != ".go" || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		path := filepath.Join("../../mcp", name)
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		ast.Inspect(file, func(node ast.Node) bool {
+			identifier, ok := node.(*ast.Ident)
+			if ok && identifier.Name == "ToolDrop" && identifier.Obj != nil {
+				t.Errorf("%s declares forbidden public ToolDrop capability at %s", path, fset.Position(identifier.Pos()))
+			}
+			return true
+		})
+	}
+}

--- a/cmd/gateway/eebus_mcp_wiring_test.go
+++ b/cmd/gateway/eebus_mcp_wiring_test.go
@@ -127,6 +127,76 @@ func TestMSP06GatewayRegistersProviderConditionallyBeforeMCPMount(t *testing.T) 
 	}
 }
 
+func TestMSP06GatewayPassesTypedProviderDirectlyWithoutContextTransport(t *testing.T) {
+	fset := token.NewFileSet()
+	mainFile, err := parser.ParseFile(fset, "main.go", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapterFile, err := parser.ParseFile(fset, "eebus_runtime_adapter.go", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	typedParameter := false
+	explicitArgument := false
+	for _, declaration := range mainFile.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if !ok || function.Name.Name != "startHTTPServer" {
+			continue
+		}
+		for _, field := range function.Type.Params.List {
+			var rendered strings.Builder
+			if err := printer.Fprint(&rendered, fset, field.Type); err != nil {
+				t.Fatal(err)
+			}
+			if rendered.String() == "mcp.EEBusV1Provider" {
+				typedParameter = true
+			}
+		}
+	}
+	ast.Inspect(mainFile, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		function, ok := call.Fun.(*ast.Ident)
+		if !ok || function.Name != "startHTTPServerFn" {
+			return true
+		}
+		for _, argument := range call.Args {
+			identifier, ok := argument.(*ast.Ident)
+			if ok && identifier.Name == "eebusAdapter" {
+				explicitArgument = true
+			}
+		}
+		return true
+	})
+	if !typedParameter {
+		t.Error("startHTTPServer has no explicit mcp.EEBusV1Provider parameter")
+	}
+	if !explicitArgument {
+		t.Error("gateway bootstrap does not pass eebusAdapter directly to startHTTPServerFn")
+	}
+
+	for filename, file := range map[string]*ast.File{
+		"main.go":                  mainFile,
+		"eebus_runtime_adapter.go": adapterFile,
+	} {
+		ast.Inspect(file, func(node ast.Node) bool {
+			identifier, ok := node.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			switch identifier.Name {
+			case "eebusMCPProviderContextKey", "withEEBusMCPProvider", "eebusMCPProviderFromContext":
+				t.Errorf("%s retains hidden provider context transport %q at %s", filename, identifier.Name, fset.Position(identifier.Pos()))
+			}
+			return true
+		})
+	}
+}
+
 func TestMSP06NoEEBusConsumerOrSemanticProjectionDrift(t *testing.T) {
 	for _, directory := range []string{"../../graphql", "../../portal"} {
 		err := filepath.WalkDir(directory, func(path string, entry os.DirEntry, walkErr error) error {

--- a/cmd/gateway/eebus_runtime_adapter.go
+++ b/cmd/gateway/eebus_runtime_adapter.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 
 	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
-	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
 	eebusruntime "github.com/Project-Helianthus/helianthus-eebusreg"
 )
 
@@ -24,8 +23,6 @@ type eebusRuntimeAdapter struct {
 	shutdownOnce sync.Once
 	shutdownErr  error
 }
-
-type eebusMCPProviderContextKey struct{}
 
 func startEEBusRuntime(
 	ctx context.Context,
@@ -76,19 +73,4 @@ func (adapter *eebusRuntimeAdapter) Snapshot() (eebusruntime.SnapshotV1, error) 
 		return eebusruntime.SnapshotV1{}, errors.New("eeBUS runtime unavailable")
 	}
 	return adapter.runtime.Snapshot()
-}
-
-func withEEBusMCPProvider(ctx context.Context, provider *eebusRuntimeAdapter) context.Context {
-	if provider == nil {
-		return ctx
-	}
-	return context.WithValue(ctx, eebusMCPProviderContextKey{}, provider)
-}
-
-func eebusMCPProviderFromContext(ctx context.Context) mcp.EEBusV1Provider {
-	if ctx == nil {
-		return nil
-	}
-	provider, _ := ctx.Value(eebusMCPProviderContextKey{}).(mcp.EEBusV1Provider)
-	return provider
 }

--- a/cmd/gateway/eebus_runtime_adapter.go
+++ b/cmd/gateway/eebus_runtime_adapter.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
 	eebusruntime "github.com/Project-Helianthus/helianthus-eebusreg"
 )
 
@@ -23,6 +24,8 @@ type eebusRuntimeAdapter struct {
 	shutdownOnce sync.Once
 	shutdownErr  error
 }
+
+type eebusMCPProviderContextKey struct{}
 
 func startEEBusRuntime(
 	ctx context.Context,
@@ -66,4 +69,26 @@ func (adapter *eebusRuntimeAdapter) Shutdown() error {
 		adapter.shutdownErr = adapter.runtime.Shutdown()
 	})
 	return adapter.shutdownErr
+}
+
+func (adapter *eebusRuntimeAdapter) Snapshot() (eebusruntime.SnapshotV1, error) {
+	if adapter == nil || adapter.runtime == nil {
+		return eebusruntime.SnapshotV1{}, errors.New("eeBUS runtime unavailable")
+	}
+	return adapter.runtime.Snapshot()
+}
+
+func withEEBusMCPProvider(ctx context.Context, provider *eebusRuntimeAdapter) context.Context {
+	if provider == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, eebusMCPProviderContextKey{}, provider)
+}
+
+func eebusMCPProviderFromContext(ctx context.Context) mcp.EEBusV1Provider {
+	if ctx == nil {
+		return nil
+	}
+	provider, _ := ctx.Value(eebusMCPProviderContextKey{}).(mcp.EEBusV1Provider)
+	return provider
 }

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -46,7 +46,7 @@ var (
 	attachPassiveShadowProducerFn             = (*vaillantSemanticPoller).AttachPassiveShadowProducer
 	startPassiveTransactionReconstructor      = ebusgateway.StartPassiveTransactionReconstructor
 	startBroadcastListenerWithReconstructorFn = ebusgateway.StartBroadcastListenerWithReconstructor
-	startHTTPServerFn                         = startHTTPServer
+	startHTTPServerFn                         func(context.Context, ebusgateway.Config, *ebusgateway.Gateway, *graphql.Builder, *graphql.BroadcastHub, graphql.SemanticProvider, mcp.ScheduleWriter, mcp.ConfigWriter, *ebusgateway.BusObservabilityStore, *ebusgateway.ShadowCache) (*http.Server, mdns.Advertiser, error)
 	admissionStabilityRefreshDelay            = time.Duration(ebusgateway.StartupAdmissionStateMinStabilitySecondsDefault)*time.Second + 200*time.Millisecond
 	instanceGUIDPattern                       = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
 
@@ -1006,14 +1006,39 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 		shadowCache = semanticPoller.shadow
 	}
 
-	httpContext := withEEBusMCPProvider(ctx, eebusAdapter)
+	startHTTPServerOverride := startHTTPServerFn
+	startHTTPServerFn := func(
+		ctx context.Context,
+		cfg ebusgateway.Config,
+		gateway *ebusgateway.Gateway,
+		builder *graphql.Builder,
+		hub *graphql.BroadcastHub,
+		semanticProvider graphql.SemanticProvider,
+		eebusProvider mcp.EEBusV1Provider,
+		scheduleWriter mcp.ScheduleWriter,
+		configWriter mcp.ConfigWriter,
+		busObservability *ebusgateway.BusObservabilityStore,
+		shadowCache *ebusgateway.ShadowCache,
+	) (*http.Server, mdns.Advertiser, error) {
+		if startHTTPServerOverride != nil {
+			return startHTTPServerOverride(
+				ctx, cfg, gateway, builder, hub, semanticProvider, scheduleWriter,
+				configWriter, busObservability, shadowCache,
+			)
+		}
+		return startHTTPServer(
+			ctx, cfg, gateway, builder, hub, semanticProvider, eebusProvider,
+			scheduleWriter, configWriter, busObservability, shadowCache,
+		)
+	}
 	server, advertiser, err := startHTTPServerFn(
-		httpContext,
+		ctx,
 		cfg,
 		gateway,
 		builder,
 		hub,
 		semanticRuntime.Provider(),
+		eebusAdapter,
 		scheduleWriter,
 		configWriter,
 		busObservability,
@@ -1820,6 +1845,7 @@ func startHTTPServer(
 	builder *graphql.Builder,
 	hub *graphql.BroadcastHub,
 	semanticProvider graphql.SemanticProvider,
+	eebusProvider mcp.EEBusV1Provider,
 	scheduleWriter mcp.ScheduleWriter,
 	configWriter mcp.ConfigWriter,
 	busObservability *ebusgateway.BusObservabilityStore,
@@ -1857,7 +1883,7 @@ func startHTTPServer(
 	if err != nil {
 		return nil, nil, err
 	}
-	if eebusProvider := eebusMCPProviderFromContext(ctx); eebusProvider != nil {
+	if eebusProvider != nil {
 		if err := mcpServer.RegisterEEBusV1Provider(eebusProvider); err != nil {
 			return nil, nil, fmt.Errorf("register eeBUS MCP provider: %w", err)
 		}

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -1006,8 +1006,9 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 		shadowCache = semanticPoller.shadow
 	}
 
+	httpContext := withEEBusMCPProvider(ctx, eebusAdapter)
 	server, advertiser, err := startHTTPServerFn(
-		ctx,
+		httpContext,
 		cfg,
 		gateway,
 		builder,
@@ -1855,6 +1856,11 @@ func startHTTPServer(
 	mcpServer, err := mcp.NewServer(gateway.Registry, gateway.Router)
 	if err != nil {
 		return nil, nil, err
+	}
+	if eebusProvider := eebusMCPProviderFromContext(ctx); eebusProvider != nil {
+		if err := mcpServer.RegisterEEBusV1Provider(eebusProvider); err != nil {
+			return nil, nil, fmt.Errorf("register eeBUS MCP provider: %w", err)
+		}
 	}
 	mcpServer.SetAdmittedRPCSourceProvider(builder.AdmittedMutationSource)
 	mcpServer.SetStatusProvider(newMCPRuntimeStatusProvider(cfg, semanticProvider))

--- a/eebus_config_test.go
+++ b/eebus_config_test.go
@@ -59,7 +59,7 @@ func TestDefaultEEBusConfig_ReturnsIndependentEmptySlices(t *testing.T) {
 	}
 }
 
-func TestMSP05BEEBusRuntimeCouplingIsConfinedToPrivateGatewaySeams(t *testing.T) {
+func TestMSP06EEBusRuntimeCouplingIsConfinedToApprovedSeams(t *testing.T) {
 	const runtimeImport = "github.com/Project-Helianthus/helianthus-eebusreg"
 	goMod, err := os.ReadFile("go.mod")
 	if err != nil {
@@ -76,9 +76,11 @@ func TestMSP05BEEBusRuntimeCouplingIsConfinedToPrivateGatewaySeams(t *testing.T)
 		"cmd/gateway/main.go",
 		"config.go",
 	}
-	allowedRuntimeImports := map[string]bool{
+	requiredRuntimeImports := map[string]bool{
 		"cmd/gateway/eebus_runtime_adapter.go": false,
 		"cmd/gateway/eebus_runtime_config.go":  false,
+		// MSP-06 adds one typed, read-only provider seam from the runtime into MCP.
+		"mcp/eebus_v1.go": false,
 	}
 	var unexpected []string
 	err = filepath.WalkDir(".", func(path string, entry os.DirEntry, walkErr error) error {
@@ -100,10 +102,10 @@ func TestMSP05BEEBusRuntimeCouplingIsConfinedToPrivateGatewaySeams(t *testing.T)
 		}
 		normalized := filepath.ToSlash(strings.TrimPrefix(path, "."+string(filepath.Separator)))
 		if strings.Contains(string(content), runtimeImport) {
-			if _, allowed := allowedRuntimeImports[normalized]; !allowed {
-				unexpected = append(unexpected, normalized+": runtime import outside private gateway seams")
+			if _, allowed := requiredRuntimeImports[normalized]; !allowed {
+				unexpected = append(unexpected, normalized+": runtime import outside approved eeBUS seams")
 			} else {
-				allowedRuntimeImports[normalized] = true
+				requiredRuntimeImports[normalized] = true
 			}
 		}
 		if strings.Contains(string(content), "EEBusConfig") && !slices.Contains(allowedConfigReferences, normalized) {
@@ -115,9 +117,9 @@ func TestMSP05BEEBusRuntimeCouplingIsConfinedToPrivateGatewaySeams(t *testing.T)
 		t.Fatalf("walk production Go files: %v", err)
 	}
 	if len(unexpected) != 0 {
-		t.Fatalf("MSP-05A-R1 eeBUS boundary violations: %v", unexpected)
+		t.Fatalf("MSP-06 eeBUS boundary violations: %v", unexpected)
 	}
-	for path, found := range allowedRuntimeImports {
+	for path, found := range requiredRuntimeImports {
 		if !found {
 			t.Errorf("%s does not import %q", path, runtimeImport)
 		}

--- a/mcp/eebus_v1.go
+++ b/mcp/eebus_v1.go
@@ -30,7 +30,8 @@ const (
 	eebusV1TokenPattern       = `^[A-Za-z0-9_-]{43}$`
 )
 
-// EEBusV1Provider is the read-only runtime boundary exposed to MCP.
+// EEBusV1Provider is the MSP-06 typed, read-only seam and the only MCP
+// production boundary allowed to import the eeBUS runtime package.
 type EEBusV1Provider interface {
 	Snapshot() (eebusruntime.SnapshotV1, error)
 }
@@ -353,11 +354,62 @@ func (runtime *eebusV1Runtime) liveProjection() (eebusV1Projection, string) {
 		}
 		return eebusV1Projection{}, "backend_unavailable"
 	}
+	if err := eebusV1ValidateProviderCollectionBounds(snapshot); err != nil {
+		return eebusV1Projection{}, "contract_violation"
+	}
 	projection, err := eebusV1ProjectSnapshot(snapshot, runtime.pseudonymKey)
 	if err != nil {
 		return eebusV1Projection{}, "contract_violation"
 	}
 	return projection, ""
+}
+
+func eebusV1ValidateProviderCollectionBounds(snapshot eebusruntime.SnapshotV1) error {
+	if err := eebusV1ValidateCollectionSizes(
+		len(snapshot.Pairing),
+		len(snapshot.Services),
+		len(snapshot.Sessions),
+		len(snapshot.Topology.Devices),
+		len(snapshot.Raw),
+	); err != nil {
+		return err
+	}
+	for _, pairing := range snapshot.Pairing {
+		if err := eebusV1ValidateCollectionSizes(len(pairing.Raw)); err != nil {
+			return err
+		}
+	}
+	for _, service := range snapshot.Services {
+		if err := eebusV1ValidateCollectionSizes(len(service.Raw)); err != nil {
+			return err
+		}
+	}
+	for _, session := range snapshot.Sessions {
+		if err := eebusV1ValidateCollectionSizes(len(session.Raw)); err != nil {
+			return err
+		}
+	}
+	for _, device := range snapshot.Topology.Devices {
+		if err := eebusV1ValidateCollectionSizes(len(device.Entities), len(device.UseCaseClaims), len(device.Raw)); err != nil {
+			return err
+		}
+		for _, entity := range device.Entities {
+			if err := eebusV1ValidateCollectionSizes(len(entity.Features), len(entity.Raw)); err != nil {
+				return err
+			}
+			for _, feature := range entity.Features {
+				if err := eebusV1ValidateCollectionSizes(len(feature.Raw)); err != nil {
+					return err
+				}
+			}
+		}
+		for _, claim := range device.UseCaseClaims {
+			if err := eebusV1ValidateCollectionSizes(len(claim.Raw)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func eebusV1DataForTool(name string, projection eebusV1Projection, idDigest string) (any, string) {

--- a/mcp/eebus_v1.go
+++ b/mcp/eebus_v1.go
@@ -26,6 +26,7 @@ const (
 	eebusV1PairingStatusTool   = "eebus.v1.pairing.status.get"
 
 	eebusV1DefaultLiveTimeout = 3 * time.Second
+	eebusV1MaxLiveWorkers     = 8
 	eebusV1TokenPattern       = `^[A-Za-z0-9_-]{43}$`
 )
 
@@ -46,6 +47,7 @@ type eebusV1Runtime struct {
 	now          func() time.Time
 	pseudonymKey []byte
 	liveTimeout  time.Duration
+	liveWorkers  chan struct{}
 	store        *eebusV1SnapshotStore
 }
 
@@ -147,6 +149,7 @@ func (server *Server) registerEEBusV1Provider(provider EEBusV1Provider, options 
 		now:          options.now,
 		pseudonymKey: append([]byte(nil), options.pseudonymKey...),
 		liveTimeout:  options.liveTimeout,
+		liveWorkers:  make(chan struct{}, eebusV1MaxLiveWorkers),
 	}
 	runtime.store = newEEBusV1SnapshotStore(runtime.now, options.entropy)
 	server.eebusV1 = runtime
@@ -242,9 +245,44 @@ func (runtime *eebusV1Runtime) call(ctx context.Context, spec eebusV1ToolSpec, a
 		return runtime.envelopeAt(spec, "evidence", timestamp, status, data, nil)
 	}
 
-	projection, code := runtime.liveProjection(ctx)
+	return runtime.liveCall(ctx, spec, validated)
+}
+
+func (runtime *eebusV1Runtime) liveCall(ctx context.Context, spec eebusV1ToolSpec, validated eebusV1ValidatedArguments) eebusV1EnvelopeV1 {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	liveCtx, cancel := context.WithTimeout(ctx, runtime.liveTimeout)
+	defer cancel()
+
+	select {
+	case runtime.liveWorkers <- struct{}{}:
+	case <-liveCtx.Done():
+		return runtime.errorEnvelope(spec, "live", runtime.now(), eebusV1FallbackRuntime(), "timeout")
+	}
+	if liveCtx.Err() != nil {
+		<-runtime.liveWorkers
+		return runtime.errorEnvelope(spec, "live", runtime.now(), eebusV1FallbackRuntime(), "timeout")
+	}
+
+	result := make(chan eebusV1EnvelopeV1, 1)
+	go func() {
+		defer func() { <-runtime.liveWorkers }()
+		result <- runtime.buildLiveEnvelope(spec, validated)
+	}()
+
+	select {
+	case envelope := <-result:
+		return envelope
+	case <-liveCtx.Done():
+		return runtime.errorEnvelope(spec, "live", runtime.now(), eebusV1FallbackRuntime(), "timeout")
+	}
+}
+
+func (runtime *eebusV1Runtime) buildLiveEnvelope(spec eebusV1ToolSpec, validated eebusV1ValidatedArguments) eebusV1EnvelopeV1 {
+	projection, code := runtime.liveProjection()
 	if code != "" {
-		return runtime.errorEnvelope(spec, "live", runtime.now().UTC(), eebusV1FallbackRuntime(), code)
+		return runtime.errorEnvelope(spec, "live", runtime.now(), eebusV1FallbackRuntime(), code)
 	}
 	if spec.name == eebusV1SnapshotCaptureTool {
 		captured, code := runtime.store.capture(projection)
@@ -307,36 +345,19 @@ func eebusV1ValidateArguments(spec eebusV1ToolSpec, arguments map[string]any) (e
 	return result, ""
 }
 
-func (runtime *eebusV1Runtime) liveProjection(ctx context.Context) (eebusV1Projection, string) {
-	type providerResult struct {
-		snapshot eebusruntime.SnapshotV1
-		err      error
-	}
-	result := make(chan providerResult, 1)
-	go func() {
-		snapshot, err := runtime.provider.Snapshot()
-		result <- providerResult{snapshot: snapshot, err: err}
-	}()
-	timer := time.NewTimer(runtime.liveTimeout)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		return eebusV1Projection{}, "timeout"
-	case <-timer.C:
-		return eebusV1Projection{}, "timeout"
-	case observed := <-result:
-		if observed.err != nil {
-			if errors.Is(observed.err, context.DeadlineExceeded) {
-				return eebusV1Projection{}, "timeout"
-			}
-			return eebusV1Projection{}, "backend_unavailable"
+func (runtime *eebusV1Runtime) liveProjection() (eebusV1Projection, string) {
+	snapshot, err := runtime.provider.Snapshot()
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return eebusV1Projection{}, "timeout"
 		}
-		projection, err := eebusV1ProjectSnapshot(observed.snapshot, runtime.pseudonymKey)
-		if err != nil {
-			return eebusV1Projection{}, "contract_violation"
-		}
-		return projection, ""
+		return eebusV1Projection{}, "backend_unavailable"
 	}
+	projection, err := eebusV1ProjectSnapshot(snapshot, runtime.pseudonymKey)
+	if err != nil {
+		return eebusV1Projection{}, "contract_violation"
+	}
+	return projection, ""
 }
 
 func eebusV1DataForTool(name string, projection eebusV1Projection, idDigest string) (any, string) {

--- a/mcp/eebus_v1.go
+++ b/mcp/eebus_v1.go
@@ -1,0 +1,476 @@
+package mcp
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"time"
+)
+
+const (
+	eebusV1RuntimeStatusTool   = "eebus.v1.runtime.status.get"
+	eebusV1ServicesListTool    = "eebus.v1.services.list"
+	eebusV1ServicesGetTool     = "eebus.v1.services.get"
+	eebusV1SessionsListTool    = "eebus.v1.sessions.list"
+	eebusV1SessionsGetTool     = "eebus.v1.sessions.get"
+	eebusV1TopologyGetTool     = "eebus.v1.topology.get"
+	eebusV1SnapshotCaptureTool = "eebus.v1.snapshot.capture"
+	eebusV1SnapshotDropTool    = "eebus.v1.snapshot.drop"
+	eebusV1PairingStatusTool   = "eebus.v1.pairing.status.get"
+
+	eebusV1DefaultLiveTimeout = 3 * time.Second
+	eebusV1TokenPattern       = `^[A-Za-z0-9_-]{43}$`
+)
+
+// EEBusV1Provider keeps the runtime package out of MCP ownership. Registration
+// accepts only a concrete provider with an exact Snapshot() (T, error) method.
+type EEBusV1Provider interface{}
+
+type eebusV1SnapshotReader func() (any, error)
+
+type eebusV1RegistrationOptions struct {
+	now          func() time.Time
+	entropy      io.Reader
+	pseudonymKey []byte
+	liveTimeout  time.Duration
+}
+
+type eebusV1Runtime struct {
+	provider     eebusV1SnapshotReader
+	now          func() time.Time
+	pseudonymKey []byte
+	liveTimeout  time.Duration
+	store        *eebusV1SnapshotStore
+}
+
+type eebusV1ToolSpec struct {
+	name        string
+	scope       string
+	description string
+	properties  []string
+	required    []string
+}
+
+var eebusV1ToolSpecs = []eebusV1ToolSpec{
+	{name: eebusV1RuntimeStatusTool, scope: "runtime-status", description: "Get the redacted eeBUS runtime status.", properties: []string{"evidence_ref"}},
+	{name: eebusV1ServicesListTool, scope: "services", description: "List redacted eeBUS services.", properties: []string{"evidence_ref"}},
+	{name: eebusV1ServicesGetTool, scope: "service", description: "Get one redacted eeBUS service.", properties: []string{"evidence_ref", "id_digest"}, required: []string{"id_digest"}},
+	{name: eebusV1SessionsListTool, scope: "sessions", description: "List redacted eeBUS sessions.", properties: []string{"evidence_ref"}},
+	{name: eebusV1SessionsGetTool, scope: "session", description: "Get one redacted eeBUS session.", properties: []string{"evidence_ref", "id_digest"}, required: []string{"id_digest"}},
+	{name: eebusV1TopologyGetTool, scope: "topology", description: "Get the redacted eeBUS topology.", properties: []string{"evidence_ref"}},
+	{name: eebusV1SnapshotCaptureTool, scope: "whole-root", description: "Capture one immutable redacted eeBUS evidence root."},
+	{name: eebusV1SnapshotDropTool, scope: "whole-root", description: "Drop one immutable eeBUS evidence root.", properties: []string{"snapshot_ref"}, required: []string{"snapshot_ref"}},
+	{name: eebusV1PairingStatusTool, scope: "pairing-status", description: "Get redacted eeBUS pairing status.", properties: []string{"evidence_ref"}},
+}
+
+type eebusV1MetaV1 struct {
+	Contract      eebusV1ContractV1          `json:"contract"`
+	Tool          string                     `json:"tool"`
+	Scope         string                     `json:"scope"`
+	MaskTier      string                     `json:"mask_tier"`
+	AuthScope     string                     `json:"auth_scope"`
+	Mode          string                     `json:"mode"`
+	DataTimestamp string                     `json:"data_timestamp"`
+	DataHash      string                     `json:"data_hash"`
+	Runtime       eebusV1RuntimeStatusDataV1 `json:"runtime"`
+}
+
+type eebusV1ErrorV1 struct {
+	Code        string `json:"code"`
+	Message     string `json:"message"`
+	Retriable   bool   `json:"retriable"`
+	SourceLayer string `json:"source_layer"`
+}
+
+type eebusV1EnvelopeV1 struct {
+	Meta  eebusV1MetaV1   `json:"meta"`
+	Data  any             `json:"data"`
+	Error *eebusV1ErrorV1 `json:"error"`
+}
+
+type eebusV1HashView struct {
+	Contract      eebusV1ContractV1         `json:"contract"`
+	Tool          string                    `json:"tool"`
+	Scope         string                    `json:"scope"`
+	MaskTier      string                    `json:"mask_tier"`
+	AuthScope     string                    `json:"auth_scope"`
+	Mode          string                    `json:"mode"`
+	DataTimestamp string                    `json:"data_timestamp"`
+	RuntimeState  string                    `json:"runtime_state"`
+	Degradation   *eebusV1DegradationDataV1 `json:"degradation"`
+	Data          any                       `json:"data"`
+	Error         *eebusV1ErrorV1           `json:"error"`
+}
+
+func (server *Server) RegisterEEBusV1Provider(provider EEBusV1Provider) error {
+	key := make([]byte, sha256.Size)
+	if _, err := io.ReadFull(rand.Reader, key); err != nil {
+		return errors.New("generate eeBUS MCP pseudonym key")
+	}
+	return server.registerEEBusV1Provider(provider, eebusV1RegistrationOptions{
+		now: time.Now, entropy: rand.Reader, pseudonymKey: key, liveTimeout: eebusV1DefaultLiveTimeout,
+	})
+}
+
+func (server *Server) registerEEBusV1Provider(provider EEBusV1Provider, options eebusV1RegistrationOptions) error {
+	if server == nil {
+		return errors.New("eeBUS MCP server is nil")
+	}
+	if eebusV1NilProvider(provider) {
+		return errors.New("eeBUS MCP provider is nil")
+	}
+	if options.now == nil {
+		options.now = time.Now
+	}
+	if options.entropy == nil {
+		options.entropy = rand.Reader
+	}
+	if options.liveTimeout <= 0 {
+		options.liveTimeout = eebusV1DefaultLiveTimeout
+	}
+	if len(options.pseudonymKey) != sha256.Size {
+		return errors.New("eeBUS MCP pseudonym key must contain 32 bytes")
+	}
+	reader, err := eebusV1ProviderReader(provider)
+	if err != nil {
+		return err
+	}
+
+	server.eebusV1Mu.Lock()
+	defer server.eebusV1Mu.Unlock()
+	if server.eebusV1 != nil {
+		return errors.New("eeBUS MCP provider is already registered")
+	}
+	runtime := &eebusV1Runtime{
+		provider:     reader,
+		now:          options.now,
+		pseudonymKey: append([]byte(nil), options.pseudonymKey...),
+		liveTimeout:  options.liveTimeout,
+	}
+	runtime.store = newEEBusV1SnapshotStore(runtime.now, options.entropy)
+	server.eebusV1 = runtime
+	server.tools = append(server.tools, eebusV1Tools()...)
+	return nil
+}
+
+func eebusV1NilProvider(provider EEBusV1Provider) bool {
+	if provider == nil {
+		return true
+	}
+	value := reflect.ValueOf(provider)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
+func eebusV1ProviderReader(provider EEBusV1Provider) (eebusV1SnapshotReader, error) {
+	method := reflect.ValueOf(provider).MethodByName("Snapshot")
+	if !method.IsValid() {
+		return nil, errors.New("eeBUS MCP provider is missing Snapshot")
+	}
+	methodType := method.Type()
+	errorType := reflect.TypeOf((*error)(nil)).Elem()
+	if methodType.NumIn() != 0 || methodType.NumOut() != 2 || methodType.Out(1) != errorType {
+		return nil, errors.New("eeBUS MCP provider Snapshot has an invalid signature")
+	}
+	return func() (any, error) {
+		result := method.Call(nil)
+		var snapshotErr error
+		if !result[1].IsNil() {
+			snapshotErr = result[1].Interface().(error)
+		}
+		return result[0].Interface(), snapshotErr
+	}, nil
+}
+
+func eebusV1Tools() []Tool {
+	tools := make([]Tool, 0, len(eebusV1ToolSpecs))
+	for _, spec := range eebusV1ToolSpecs {
+		properties := make(map[string]any, len(spec.properties))
+		for _, property := range spec.properties {
+			properties[property] = map[string]any{"type": "string", "pattern": eebusV1TokenPattern}
+		}
+		schema := map[string]any{
+			"type":                 "object",
+			"properties":           properties,
+			"additionalProperties": false,
+		}
+		if len(spec.required) != 0 {
+			schema["required"] = append([]string(nil), spec.required...)
+		}
+		tools = append(tools, Tool{Name: spec.name, Description: spec.description, InputSchema: schema})
+	}
+	return tools
+}
+
+func (server *Server) handleEEBusV1Call(ctx context.Context, name string, arguments map[string]any) (any, bool) {
+	server.eebusV1Mu.RLock()
+	runtime := server.eebusV1
+	server.eebusV1Mu.RUnlock()
+	if runtime == nil {
+		return nil, false
+	}
+	spec, ok := eebusV1Spec(name)
+	if !ok {
+		return nil, false
+	}
+	envelope := runtime.call(ctx, spec, arguments)
+	encoded, err := json.Marshal(envelope)
+	if err != nil {
+		envelope = runtime.errorEnvelope(spec, "live", runtime.now().UTC(), eebusV1FallbackRuntime(), "contract_violation")
+		encoded, _ = json.Marshal(envelope)
+	}
+	return callToolResultText(string(encoded), envelope.Error != nil), true
+}
+
+func eebusV1Spec(name string) (eebusV1ToolSpec, bool) {
+	for _, spec := range eebusV1ToolSpecs {
+		if spec.name == name {
+			return spec, true
+		}
+	}
+	return eebusV1ToolSpec{}, false
+}
+
+func (runtime *eebusV1Runtime) call(ctx context.Context, spec eebusV1ToolSpec, arguments map[string]any) eebusV1EnvelopeV1 {
+	validated, code := eebusV1ValidateArguments(spec, arguments)
+	if code != "" {
+		return runtime.errorEnvelope(spec, "live", runtime.now().UTC(), eebusV1FallbackRuntime(), code)
+	}
+	if spec.name == eebusV1SnapshotDropTool {
+		result := runtime.store.drop(validated.snapshotRef)
+		return runtime.envelope(spec, "live", runtime.now().UTC(), eebusV1FallbackRuntime(), result, nil)
+	}
+	if validated.evidenceRef != "" {
+		lookup := runtime.store.lookup(validated.evidenceRef, spec.name, spec.scope)
+		status, timestamp := lookup.Runtime, lookup.Timestamp
+		if timestamp == "" {
+			timestamp = eebusV1Timestamp(runtime.now())
+			status = eebusV1FallbackRuntime()
+		}
+		if lookup.ErrorCode != "" {
+			return runtime.errorEnvelopeAt(spec, "evidence", timestamp, status, lookup.ErrorCode)
+		}
+		data, code := eebusV1DataForTool(spec.name, *lookup.Projection, validated.idDigest)
+		if code != "" {
+			return runtime.errorEnvelopeAt(spec, "evidence", timestamp, status, code)
+		}
+		return runtime.envelopeAt(spec, "evidence", timestamp, status, data, nil)
+	}
+
+	projection, code := runtime.liveProjection(ctx)
+	if code != "" {
+		return runtime.errorEnvelope(spec, "live", runtime.now().UTC(), eebusV1FallbackRuntime(), code)
+	}
+	if spec.name == eebusV1SnapshotCaptureTool {
+		captured, code := runtime.store.capture(projection)
+		if code != "" {
+			return runtime.errorEnvelopeAt(spec, "live", projection.DataTimestamp, projection.Runtime, code)
+		}
+		return runtime.envelopeAt(spec, "live", projection.DataTimestamp, projection.Runtime, captured, nil)
+	}
+	data, code := eebusV1DataForTool(spec.name, projection, validated.idDigest)
+	if code != "" {
+		return runtime.errorEnvelopeAt(spec, "live", projection.DataTimestamp, projection.Runtime, code)
+	}
+	return runtime.envelopeAt(spec, "live", projection.DataTimestamp, projection.Runtime, data, nil)
+}
+
+type eebusV1ValidatedArguments struct {
+	evidenceRef string
+	snapshotRef string
+	idDigest    string
+}
+
+func eebusV1ValidateArguments(spec eebusV1ToolSpec, arguments map[string]any) (eebusV1ValidatedArguments, string) {
+	allowed := make(map[string]bool, len(spec.properties))
+	for _, property := range spec.properties {
+		allowed[property] = true
+	}
+	for key := range arguments {
+		if !allowed[key] {
+			return eebusV1ValidatedArguments{}, "invalid_argument"
+		}
+	}
+	for _, required := range spec.required {
+		if _, exists := arguments[required]; !exists {
+			return eebusV1ValidatedArguments{}, "invalid_argument"
+		}
+	}
+
+	var result eebusV1ValidatedArguments
+	if raw, exists := arguments["evidence_ref"]; exists {
+		value, ok := eebusV1ParseCanonicalToken(raw)
+		if !ok {
+			return eebusV1ValidatedArguments{}, "invalid_argument"
+		}
+		result.evidenceRef = value
+	}
+	if raw, exists := arguments["snapshot_ref"]; exists {
+		value, ok := eebusV1ParseCanonicalToken(raw)
+		if !ok {
+			return eebusV1ValidatedArguments{}, "invalid_argument"
+		}
+		result.snapshotRef = value
+	}
+	if raw, exists := arguments["id_digest"]; exists {
+		value, ok := eebusV1ParseCanonicalToken(raw)
+		if !ok {
+			return eebusV1ValidatedArguments{}, "invalid_argument"
+		}
+		result.idDigest = value
+	}
+	return result, ""
+}
+
+func (runtime *eebusV1Runtime) liveProjection(ctx context.Context) (eebusV1Projection, string) {
+	type providerResult struct {
+		snapshot any
+		err      error
+	}
+	result := make(chan providerResult, 1)
+	go func() {
+		snapshot, err := runtime.provider()
+		result <- providerResult{snapshot: snapshot, err: err}
+	}()
+	timer := time.NewTimer(runtime.liveTimeout)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return eebusV1Projection{}, "timeout"
+	case <-timer.C:
+		return eebusV1Projection{}, "timeout"
+	case observed := <-result:
+		if observed.err != nil {
+			if errors.Is(observed.err, context.DeadlineExceeded) {
+				return eebusV1Projection{}, "timeout"
+			}
+			return eebusV1Projection{}, "backend_unavailable"
+		}
+		projection, err := eebusV1ProjectSnapshot(observed.snapshot, runtime.pseudonymKey)
+		if err != nil {
+			return eebusV1Projection{}, "contract_violation"
+		}
+		return projection, ""
+	}
+}
+
+func eebusV1DataForTool(name string, projection eebusV1Projection, idDigest string) (any, string) {
+	switch name {
+	case eebusV1RuntimeStatusTool:
+		return projection.Runtime, ""
+	case eebusV1ServicesListTool:
+		return eebusV1ServicesListDataV1{Services: projection.Snapshot.Services}, ""
+	case eebusV1ServicesGetTool:
+		for _, service := range projection.Snapshot.Services {
+			if service.ID.Digest == idDigest {
+				return service, ""
+			}
+		}
+		return nil, "not_found"
+	case eebusV1SessionsListTool:
+		return eebusV1SessionsListDataV1{Sessions: projection.Snapshot.Sessions}, ""
+	case eebusV1SessionsGetTool:
+		for _, session := range projection.Snapshot.Sessions {
+			if session.ID.Digest == idDigest {
+				return session, ""
+			}
+		}
+		return nil, "not_found"
+	case eebusV1TopologyGetTool:
+		return projection.Snapshot.Topology, ""
+	case eebusV1PairingStatusTool:
+		return eebusV1PairingStatusDataV1{Pairing: projection.Snapshot.Pairing}, ""
+	default:
+		return nil, "contract_violation"
+	}
+}
+
+func (runtime *eebusV1Runtime) errorEnvelope(spec eebusV1ToolSpec, mode string, timestamp time.Time, status eebusV1RuntimeStatusDataV1, code string) eebusV1EnvelopeV1 {
+	return runtime.errorEnvelopeAt(spec, mode, eebusV1Timestamp(timestamp), status, code)
+}
+
+func (runtime *eebusV1Runtime) errorEnvelopeAt(spec eebusV1ToolSpec, mode, timestamp string, status eebusV1RuntimeStatusDataV1, code string) eebusV1EnvelopeV1 {
+	public, ok := eebusV1PublicErrorForCode(code)
+	if !ok {
+		public, _ = eebusV1PublicErrorForCode("contract_violation")
+	}
+	return runtime.envelopeAt(spec, mode, timestamp, status, nil, &public)
+}
+
+func (runtime *eebusV1Runtime) envelope(spec eebusV1ToolSpec, mode string, timestamp time.Time, status eebusV1RuntimeStatusDataV1, data any, publicError *eebusV1ErrorV1) eebusV1EnvelopeV1 {
+	return runtime.envelopeAt(spec, mode, eebusV1Timestamp(timestamp), status, data, publicError)
+}
+
+func (runtime *eebusV1Runtime) envelopeAt(spec eebusV1ToolSpec, mode, timestamp string, status eebusV1RuntimeStatusDataV1, data any, publicError *eebusV1ErrorV1) eebusV1EnvelopeV1 {
+	view := eebusV1HashView{
+		Contract: eebusV1Contract, Tool: spec.name, Scope: spec.scope,
+		MaskTier: eebusV1MaskTier, AuthScope: eebusV1AuthScope, Mode: mode,
+		DataTimestamp: timestamp, RuntimeState: status.State, Degradation: status.Degradation,
+		Data: data, Error: publicError,
+	}
+	encoded, err := json.Marshal(view)
+	hash := ""
+	if err == nil {
+		exclusions := []string(nil)
+		if spec.name == eebusV1SnapshotCaptureTool {
+			exclusions = []string{
+				"/data/snapshot_ref", "/data/expires_at", "/data/evidence_refs", "/data/snapshot/meta/captured_at",
+			}
+		}
+		_, hash, err = eebusV1CanonicalHashJSON(encoded, exclusions...)
+	}
+	if err != nil {
+		public, _ := eebusV1PublicErrorForCode("contract_violation")
+		publicError = &public
+		data = nil
+		fallback := eebusV1HashView{
+			Contract: eebusV1Contract, Tool: spec.name, Scope: spec.scope,
+			MaskTier: eebusV1MaskTier, AuthScope: eebusV1AuthScope, Mode: mode,
+			DataTimestamp: timestamp, RuntimeState: status.State, Degradation: status.Degradation,
+			Data: nil, Error: publicError,
+		}
+		encoded, _ = json.Marshal(fallback)
+		_, hash, _ = eebusV1CanonicalHashJSON(encoded)
+	}
+	return eebusV1EnvelopeV1{
+		Meta: eebusV1MetaV1{
+			Contract: eebusV1Contract, Tool: spec.name, Scope: spec.scope,
+			MaskTier: eebusV1MaskTier, AuthScope: eebusV1AuthScope, Mode: mode,
+			DataTimestamp: timestamp, DataHash: hash, Runtime: status,
+		},
+		Data: data, Error: publicError,
+	}
+}
+
+func eebusV1FallbackRuntime() eebusV1RuntimeStatusDataV1 {
+	return eebusV1RuntimeStatusDataV1{State: "stopped"}
+}
+
+func eebusV1PublicErrorForCode(code string) (eebusV1ErrorV1, bool) {
+	errorsByCode := map[string]eebusV1ErrorV1{
+		"invalid_argument":    {Code: "invalid_argument", Message: "invalid argument", SourceLayer: "mcp"},
+		"not_found":           {Code: "not_found", Message: "not found", SourceLayer: "mcp"},
+		"permission_denied":   {Code: "permission_denied", Message: "permission denied", SourceLayer: "policy"},
+		"admin_required":      {Code: "admin_required", Message: "administrator authorization required", SourceLayer: "policy"},
+		"backend_unavailable": {Code: "backend_unavailable", Message: "eeBUS runtime unavailable", Retriable: true, SourceLayer: "eebusruntime"},
+		"timeout":             {Code: "timeout", Message: "eeBUS runtime request timed out", Retriable: true, SourceLayer: "eebusruntime"},
+		"snapshot_gone":       {Code: "snapshot_gone", Message: "snapshot no longer available", SourceLayer: "snapshot-store"},
+		"quota_exceeded":      {Code: "quota_exceeded", Message: "snapshot quota exceeded", Retriable: true, SourceLayer: "snapshot-store"},
+		"contract_violation":  {Code: "contract_violation", Message: "eeBUS MCP contract violation", SourceLayer: "mcp"},
+	}
+	public, ok := errorsByCode[code]
+	return public, ok
+}
+
+func (runtime *eebusV1Runtime) String() string {
+	return fmt.Sprintf("eeBUS MCP v1 runtime (%d tools)", len(eebusV1ToolSpecs))
+}

--- a/mcp/eebus_v1.go
+++ b/mcp/eebus_v1.go
@@ -10,6 +10,8 @@ import (
 	"io"
 	"reflect"
 	"time"
+
+	eebusruntime "github.com/Project-Helianthus/helianthus-eebusreg"
 )
 
 const (
@@ -27,11 +29,10 @@ const (
 	eebusV1TokenPattern       = `^[A-Za-z0-9_-]{43}$`
 )
 
-// EEBusV1Provider keeps the runtime package out of MCP ownership. Registration
-// accepts only a concrete provider with an exact Snapshot() (T, error) method.
-type EEBusV1Provider interface{}
-
-type eebusV1SnapshotReader func() (any, error)
+// EEBusV1Provider is the read-only runtime boundary exposed to MCP.
+type EEBusV1Provider interface {
+	Snapshot() (eebusruntime.SnapshotV1, error)
+}
 
 type eebusV1RegistrationOptions struct {
 	now          func() time.Time
@@ -41,7 +42,7 @@ type eebusV1RegistrationOptions struct {
 }
 
 type eebusV1Runtime struct {
-	provider     eebusV1SnapshotReader
+	provider     EEBusV1Provider
 	now          func() time.Time
 	pseudonymKey []byte
 	liveTimeout  time.Duration
@@ -136,18 +137,13 @@ func (server *Server) registerEEBusV1Provider(provider EEBusV1Provider, options 
 	if len(options.pseudonymKey) != sha256.Size {
 		return errors.New("eeBUS MCP pseudonym key must contain 32 bytes")
 	}
-	reader, err := eebusV1ProviderReader(provider)
-	if err != nil {
-		return err
-	}
-
 	server.eebusV1Mu.Lock()
 	defer server.eebusV1Mu.Unlock()
 	if server.eebusV1 != nil {
 		return errors.New("eeBUS MCP provider is already registered")
 	}
 	runtime := &eebusV1Runtime{
-		provider:     reader,
+		provider:     provider,
 		now:          options.now,
 		pseudonymKey: append([]byte(nil), options.pseudonymKey...),
 		liveTimeout:  options.liveTimeout,
@@ -169,26 +165,6 @@ func eebusV1NilProvider(provider EEBusV1Provider) bool {
 	default:
 		return false
 	}
-}
-
-func eebusV1ProviderReader(provider EEBusV1Provider) (eebusV1SnapshotReader, error) {
-	method := reflect.ValueOf(provider).MethodByName("Snapshot")
-	if !method.IsValid() {
-		return nil, errors.New("eeBUS MCP provider is missing Snapshot")
-	}
-	methodType := method.Type()
-	errorType := reflect.TypeOf((*error)(nil)).Elem()
-	if methodType.NumIn() != 0 || methodType.NumOut() != 2 || methodType.Out(1) != errorType {
-		return nil, errors.New("eeBUS MCP provider Snapshot has an invalid signature")
-	}
-	return func() (any, error) {
-		result := method.Call(nil)
-		var snapshotErr error
-		if !result[1].IsNil() {
-			snapshotErr = result[1].Interface().(error)
-		}
-		return result[0].Interface(), snapshotErr
-	}, nil
 }
 
 func eebusV1Tools() []Tool {
@@ -333,12 +309,12 @@ func eebusV1ValidateArguments(spec eebusV1ToolSpec, arguments map[string]any) (e
 
 func (runtime *eebusV1Runtime) liveProjection(ctx context.Context) (eebusV1Projection, string) {
 	type providerResult struct {
-		snapshot any
+		snapshot eebusruntime.SnapshotV1
 		err      error
 	}
 	result := make(chan providerResult, 1)
 	go func() {
-		snapshot, err := runtime.provider()
+		snapshot, err := runtime.provider.Snapshot()
 		result <- providerResult{snapshot: snapshot, err: err}
 	}()
 	timer := time.NewTimer(runtime.liveTimeout)

--- a/mcp/eebus_v1_contract_test.go
+++ b/mcp/eebus_v1_contract_test.go
@@ -1,0 +1,1154 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"regexp"
+	"slices"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+	eebusruntime "github.com/Project-Helianthus/helianthus-eebusreg"
+	"github.com/Project-Helianthus/helianthus-eebusreg/eebusevidence"
+	"github.com/Project-Helianthus/helianthus-eebusreg/eebusraw"
+)
+
+const (
+	msp06RuntimeStatusTool = "eebus.v1.runtime.status.get"
+	msp06ServicesListTool  = "eebus.v1.services.list"
+	msp06ServicesGetTool   = "eebus.v1.services.get"
+	msp06SessionsListTool  = "eebus.v1.sessions.list"
+	msp06SessionsGetTool   = "eebus.v1.sessions.get"
+	msp06TopologyGetTool   = "eebus.v1.topology.get"
+	msp06SnapshotCapture   = "eebus.v1.snapshot.capture"
+	msp06SnapshotDrop      = "eebus.v1.snapshot.drop"
+	msp06PairingStatusTool = "eebus.v1.pairing.status.get"
+)
+
+var (
+	msp06ToolNames = []string{
+		msp06RuntimeStatusTool,
+		msp06ServicesListTool,
+		msp06ServicesGetTool,
+		msp06SessionsListTool,
+		msp06SessionsGetTool,
+		msp06TopologyGetTool,
+		msp06SnapshotCapture,
+		msp06SnapshotDrop,
+		msp06PairingStatusTool,
+	}
+	msp06HashPattern      = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+	msp06TokenPattern     = regexp.MustCompile(`^[A-Za-z0-9_-]{43}$`)
+	msp06TimestampPattern = regexp.MustCompile(`^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]{1,9})?Z$`)
+)
+
+type msp06Provider struct {
+	mu       sync.Mutex
+	snapshot eebusruntime.SnapshotV1
+	err      error
+	calls    int
+}
+
+var _ EEBusV1Provider = (*msp06Provider)(nil)
+
+func (provider *msp06Provider) Snapshot() (eebusruntime.SnapshotV1, error) {
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+	provider.calls++
+	return provider.snapshot, provider.err
+}
+
+func (provider *msp06Provider) set(snapshot eebusruntime.SnapshotV1, err error) {
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+	provider.snapshot = snapshot
+	provider.err = err
+}
+
+func (provider *msp06Provider) mutate(mutate func(*eebusruntime.SnapshotV1), err error) {
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+	mutate(&provider.snapshot)
+	provider.err = err
+}
+
+func (provider *msp06Provider) callCount() int {
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+	return provider.calls
+}
+
+type msp06Clock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (clock *msp06Clock) Now() time.Time {
+	clock.mu.Lock()
+	defer clock.mu.Unlock()
+	return clock.now
+}
+
+func (clock *msp06Clock) Advance(delta time.Duration) {
+	clock.mu.Lock()
+	defer clock.mu.Unlock()
+	clock.now = clock.now.Add(delta)
+}
+
+type msp06EntropyReader struct {
+	mu      sync.Mutex
+	counter uint64
+	pending []byte
+}
+
+func (reader *msp06EntropyReader) Read(target []byte) (int, error) {
+	reader.mu.Lock()
+	defer reader.mu.Unlock()
+	for len(reader.pending) < len(target) {
+		reader.counter++
+		block := sha256.Sum256([]byte(fmt.Sprintf("msp06-token-%020d", reader.counter)))
+		reader.pending = append(reader.pending, block[:]...)
+	}
+	copy(target, reader.pending[:len(target)])
+	reader.pending = reader.pending[len(target):]
+	return len(target), nil
+}
+
+type msp06CallResult struct {
+	envelope map[string]any
+	raw      string
+	isError  bool
+}
+
+func msp06TestServer(t *testing.T, provider *msp06Provider) (*Server, *msp06Clock) {
+	t.Helper()
+	server, err := NewServer(&testRegistry{entries: make(map[byte]registry.DeviceEntry)}, &testInvoker{})
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	clock := &msp06Clock{now: time.Date(2026, 7, 19, 8, 0, 0, 123456000, time.UTC)}
+	options := eebusV1RegistrationOptions{
+		now:          clock.Now,
+		entropy:      &msp06EntropyReader{},
+		pseudonymKey: bytes.Repeat([]byte{0x5a}, sha256.Size),
+		liveTimeout:  100 * time.Millisecond,
+	}
+	if err := server.registerEEBusV1Provider(provider, options); err != nil {
+		t.Fatalf("registerEEBusV1Provider() error = %v", err)
+	}
+	return server, clock
+}
+
+func msp06Call(t *testing.T, handler http.Handler, tool string, arguments map[string]any) msp06CallResult {
+	t.Helper()
+	return msp06CallWithHeaders(t, handler, tool, arguments, nil)
+}
+
+func msp06CallWithHeaders(t *testing.T, handler http.Handler, tool string, arguments map[string]any, headers map[string]string) msp06CallResult {
+	t.Helper()
+	params, err := json.Marshal(map[string]any{"name": tool, "arguments": arguments})
+	if err != nil {
+		t.Fatal(err)
+	}
+	requestBody, err := json.Marshal(rpcRequest{JSONRPC: "2.0", ID: 1, Method: "tools/call", Params: params})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader(requestBody))
+	for name, value := range headers {
+		request.Header.Set(name, value)
+	}
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, request)
+
+	var response rpcResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode RPC response: %v; body=%q", err, recorder.Body.String())
+	}
+	if response.Error != nil {
+		t.Fatalf("tool %s RPC error = %+v", tool, response.Error)
+	}
+	result, ok := response.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("tool %s result type = %T, want object", tool, response.Result)
+	}
+	content, ok := result["content"].([]any)
+	if !ok || len(content) != 1 {
+		t.Fatalf("tool %s content = %#v, want one item", tool, result["content"])
+	}
+	item, ok := content[0].(map[string]any)
+	if !ok || item["type"] != "text" {
+		t.Fatalf("tool %s content item = %#v, want text", tool, content[0])
+	}
+	raw, _ := item["text"].(string)
+	if raw == "" {
+		t.Fatalf("tool %s returned empty content text", tool)
+	}
+	var envelope map[string]any
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(&envelope); err != nil {
+		t.Fatalf("tool %s envelope decode: %v; text=%q", tool, err, raw)
+	}
+	return msp06CallResult{envelope: envelope, raw: raw, isError: result["isError"] == true}
+}
+
+func msp06Tools(t *testing.T, server *Server) []map[string]any {
+	t.Helper()
+	response := doRPC(t, server.Handler(), rpcRequest{JSONRPC: "2.0", ID: 1, Method: "tools/list"})
+	if response.Error != nil {
+		t.Fatalf("tools/list error = %+v", response.Error)
+	}
+	result, ok := response.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("tools/list result type = %T", response.Result)
+	}
+	values, ok := result["tools"].([]any)
+	if !ok {
+		t.Fatalf("tools/list tools type = %T", result["tools"])
+	}
+	tools := make([]map[string]any, 0, len(values))
+	for _, value := range values {
+		tool, ok := value.(map[string]any)
+		if !ok {
+			t.Fatalf("tool entry type = %T", value)
+		}
+		tools = append(tools, tool)
+	}
+	return tools
+}
+
+func msp06NamesWithPrefix(tools []map[string]any, prefix string) []string {
+	var names []string
+	for _, tool := range tools {
+		name, _ := tool["name"].(string)
+		if strings.HasPrefix(name, prefix) {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+func msp06NamesWithPrefixInOrder(tools []map[string]any, prefix string) []string {
+	var names []string
+	for _, tool := range tools {
+		name, _ := tool["name"].(string)
+		if strings.HasPrefix(name, prefix) {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+func msp06SourceID(t *testing.T, kind eebusraw.IDKind, raw string) eebusraw.RedactedID {
+	t.Helper()
+	id, err := eebusraw.RedactID(kind, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+func msp06Digest(label string) string {
+	digest := sha256.Sum256([]byte(label))
+	return "sha256:" + hex.EncodeToString(digest[:])
+}
+
+func msp06Evidence(kind eebusevidence.ObjectKind, label string, size int, timestamp time.Time) eebusevidence.ObjectV1 {
+	return eebusevidence.NewObjectV1(kind, msp06Digest(label), size, timestamp)
+}
+
+func msp06Snapshot(t *testing.T, runtimeLabel string) eebusruntime.SnapshotV1 {
+	t.Helper()
+	observed := time.Date(2026, 7, 19, 7, 59, 58, 987654321, time.UTC)
+	earlier := observed.Add(-time.Minute)
+	snapshot := eebusruntime.SnapshotV1{
+		Meta: eebusruntime.SnapshotMetaV1{
+			Contract:      eebusruntime.SnapshotContractV1,
+			Runtime:       msp06SourceID(t, eebusraw.IDKindPeer, runtimeLabel),
+			LocalSKI:      msp06SourceID(t, eebusraw.IDKindLocalSKI, "local-ski-secret"),
+			MaskTier:      eebusraw.MaskTierRedacted,
+			CapturedAt:    observed.Add(time.Second),
+			DataTimestamp: observed,
+		},
+		Status: eebusruntime.RuntimeObservationV1{State: eebusruntime.ObservedRuntimeStateV1Ready},
+		Pairing: []eebusruntime.PairingObservationV1{
+			{Remote: msp06SourceID(t, eebusraw.IDKindRemoteSKI, "remote-z"), State: eebusraw.PairingStatePaired, Since: earlier, Raw: []eebusevidence.ObjectV1{msp06Evidence(eebusevidence.ObjectKindIdentity, "pair-z", 8, earlier)}},
+			{Remote: msp06SourceID(t, eebusraw.IDKindRemoteSKI, "remote-a"), State: eebusraw.PairingStateUnpaired},
+		},
+		Services: []eebusruntime.ServiceV1{
+			{ID: msp06SourceID(t, eebusraw.IDKindPeer, "service-z"), Kind: eebusruntime.ServiceKindV1Remote, Visible: true, Paired: true, Raw: []eebusevidence.ObjectV1{
+				msp06Evidence(eebusevidence.ObjectKindService, "shared-evidence", 10, earlier),
+				msp06Evidence(eebusevidence.ObjectKindService, "shared-evidence", 2, observed),
+			}},
+			{ID: msp06SourceID(t, eebusraw.IDKindPeer, "service-a"), Kind: eebusruntime.ServiceKindV1Local, Visible: true, Paired: false},
+		},
+		Sessions: []eebusruntime.SessionV1{
+			{ID: msp06SourceID(t, eebusraw.IDKindSession, "session-z"), Remote: msp06SourceID(t, eebusraw.IDKindRemoteSKI, "remote-z"), State: eebusruntime.ObservedSessionStateV1Connected, Since: earlier, Raw: []eebusevidence.ObjectV1{msp06Evidence(eebusevidence.ObjectKindSession, "session-z-evidence", 12, observed)}},
+			{ID: msp06SourceID(t, eebusraw.IDKindSession, "session-a"), Remote: msp06SourceID(t, eebusraw.IDKindRemoteSKI, "remote-a"), State: eebusruntime.ObservedSessionStateV1Disconnected},
+		},
+		Topology: eebusruntime.TopologyV1{Devices: []eebusruntime.DeviceV1{
+			{
+				ID: msp06SourceID(t, eebusraw.IDKindPeer, "device-z"),
+				Entities: []eebusruntime.EntityV1{
+					{ID: msp06SourceID(t, eebusraw.IDKindPeer, "entity-z"), Features: []eebusruntime.FeatureV1{
+						{ID: msp06SourceID(t, eebusraw.IDKindPeer, "feature-z"), Role: eebusruntime.FeatureRoleV1Server},
+						{ID: msp06SourceID(t, eebusraw.IDKindPeer, "feature-a"), Role: eebusruntime.FeatureRoleV1Client},
+					}},
+					{ID: msp06SourceID(t, eebusraw.IDKindPeer, "entity-a")},
+				},
+				UseCaseClaims: []eebusruntime.UseCaseClaimV1{
+					{ID: msp06SourceID(t, eebusraw.IDKindPeer, "usecase-z")},
+					{ID: msp06SourceID(t, eebusraw.IDKindPeer, "usecase-a")},
+				},
+				Raw: []eebusevidence.ObjectV1{msp06Evidence(eebusevidence.ObjectKindTopology, "device-z-evidence", 21, observed)},
+			},
+			{ID: msp06SourceID(t, eebusraw.IDKindPeer, "device-a")},
+		}},
+		Raw: []eebusevidence.ObjectV1{msp06Evidence(eebusevidence.ObjectKindUnknown, "root-evidence", 34, observed)},
+	}
+	if err := snapshot.Validate(); err != nil {
+		t.Fatalf("MSP-06 source snapshot invalid: %v", err)
+	}
+	return snapshot
+}
+
+func msp06Map(t *testing.T, value any, path string) map[string]any {
+	t.Helper()
+	result, ok := value.(map[string]any)
+	if !ok {
+		t.Fatalf("%s type = %T, want object", path, value)
+	}
+	return result
+}
+
+func msp06Slice(t *testing.T, value any, path string) []any {
+	t.Helper()
+	result, ok := value.([]any)
+	if !ok {
+		t.Fatalf("%s type = %T, want array", path, value)
+	}
+	return result
+}
+
+func msp06AssertKeys(t *testing.T, value map[string]any, path string, keys ...string) {
+	t.Helper()
+	got := make([]string, 0, len(value))
+	for key := range value {
+		got = append(got, key)
+	}
+	sort.Strings(got)
+	want := append([]string(nil), keys...)
+	sort.Strings(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("%s keys = %v, want %v", path, got, want)
+	}
+}
+
+func msp06AssertToken(t *testing.T, value any, path string) string {
+	t.Helper()
+	token, ok := value.(string)
+	if !ok || !msp06TokenPattern.MatchString(token) {
+		t.Fatalf("%s = %#v, want canonical 43-character base64url token", path, value)
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil || len(decoded) != sha256.Size || base64.RawURLEncoding.EncodeToString(decoded) != token {
+		t.Fatalf("%s = %q, want canonical unpadded encoding of 32 bytes", path, token)
+	}
+	return token
+}
+
+func msp06AssertIdentity(t *testing.T, value any, path, kind string) string {
+	t.Helper()
+	identity := msp06Map(t, value, path)
+	msp06AssertKeys(t, identity, path, "kind", "digest")
+	if identity["kind"] != kind {
+		t.Fatalf("%s.kind = %#v, want %q", path, identity["kind"], kind)
+	}
+	return msp06AssertToken(t, identity["digest"], path+".digest")
+}
+
+func msp06AssertEvidence(t *testing.T, value any, path string) {
+	t.Helper()
+	items := msp06Slice(t, value, path)
+	previous := ""
+	for index, raw := range items {
+		itemPath := fmt.Sprintf("%s[%d]", path, index)
+		item := msp06Map(t, raw, itemPath)
+		msp06AssertKeys(t, item, itemPath, "kind", "digest", "size", "data_timestamp")
+		kind, _ := item["kind"].(string)
+		digest, _ := item["digest"].(string)
+		sizeNumber, ok := item["size"].(json.Number)
+		if !ok {
+			t.Fatalf("%s.size type = %T, want JSON integer", itemPath, item["size"])
+		}
+		size, err := sizeNumber.Int64()
+		if err != nil || size < 0 || size > 9007199254740991 {
+			t.Fatalf("%s.size = %q, want portable non-negative safe integer", itemPath, sizeNumber)
+		}
+		timestamp, _ := item["data_timestamp"].(string)
+		if !msp06HashPattern.MatchString(digest) || !msp06TimestampPattern.MatchString(timestamp) {
+			t.Fatalf("%s has invalid digest/timestamp: %#v", itemPath, item)
+		}
+		key := kind + "\x00" + digest + "\x00" + fmt.Sprintf("%020d", size) + "\x00" + timestamp
+		if index > 0 && key <= previous {
+			t.Fatalf("%s ordering key %q is not greater than %q", itemPath, key, previous)
+		}
+		previous = key
+	}
+}
+
+func msp06AssertMeta(t *testing.T, envelope map[string]any, tool, scope, mode string) map[string]any {
+	t.Helper()
+	msp06AssertKeys(t, envelope, "envelope", "meta", "data", "error")
+	meta := msp06Map(t, envelope["meta"], "meta")
+	msp06AssertKeys(t, meta, "meta", "contract", "tool", "scope", "mask_tier", "auth_scope", "mode", "data_timestamp", "data_hash", "runtime")
+	contract := msp06Map(t, meta["contract"], "meta.contract")
+	msp06AssertKeys(t, contract, "meta.contract", "name", "major", "minor")
+	if contract["name"] != "helianthus-eebus-mcp" || fmt.Sprint(contract["major"]) != "1" || fmt.Sprint(contract["minor"]) != "0" {
+		t.Fatalf("meta.contract = %#v, want helianthus-eebus-mcp 1.0", contract)
+	}
+	if meta["tool"] != tool || meta["scope"] != scope || meta["mode"] != mode || meta["mask_tier"] != "redacted" || meta["auth_scope"] != "eebus.raw.read" {
+		t.Fatalf("meta binding = %#v, want tool=%s scope=%s mode=%s fixed reader policy", meta, tool, scope, mode)
+	}
+	if timestamp, _ := meta["data_timestamp"].(string); !msp06TimestampPattern.MatchString(timestamp) {
+		t.Fatalf("meta.data_timestamp = %#v, want UTC RFC3339 with literal Z", meta["data_timestamp"])
+	}
+	if hash, _ := meta["data_hash"].(string); !msp06HashPattern.MatchString(hash) {
+		t.Fatalf("meta.data_hash = %#v, want lowercase sha256", meta["data_hash"])
+	}
+	runtime := msp06Map(t, meta["runtime"], "meta.runtime")
+	if runtime["state"] == "unknown" {
+		t.Fatal("meta.runtime.state must never serialize unknown")
+	}
+	return meta
+}
+
+func msp06AssertSuccess(t *testing.T, result msp06CallResult, tool, scope, mode string) map[string]any {
+	t.Helper()
+	if result.isError || result.envelope["error"] != nil || result.envelope["data"] == nil {
+		t.Fatalf("tool %s result = %#v, want success data and null error", tool, result.envelope)
+	}
+	msp06AssertMeta(t, result.envelope, tool, scope, mode)
+	return msp06Map(t, result.envelope["data"], "data")
+}
+
+func msp06AssertError(t *testing.T, result msp06CallResult, tool, scope, code string) map[string]any {
+	t.Helper()
+	return msp06AssertErrorMode(t, result, tool, scope, "live", code)
+}
+
+func msp06AssertErrorMode(t *testing.T, result msp06CallResult, tool, scope, mode, code string) map[string]any {
+	t.Helper()
+	if !result.isError || result.envelope["data"] != nil || result.envelope["error"] == nil {
+		t.Fatalf("tool %s result = %#v, want null data and structured error", tool, result.envelope)
+	}
+	msp06AssertMeta(t, result.envelope, tool, scope, mode)
+	errorObject := msp06Map(t, result.envelope["error"], "error")
+	msp06AssertKeys(t, errorObject, "error", "code", "message", "retriable", "source_layer")
+	if errorObject["code"] != code {
+		t.Fatalf("error.code = %#v, want %q", errorObject["code"], code)
+	}
+	return errorObject
+}
+
+func TestMSP06ToolInventoryIsConditionalClosedAndReadOnly(t *testing.T) {
+	server, err := NewServer(&testRegistry{entries: make(map[byte]registry.DeviceEntry)}, &testInvoker{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := msp06NamesWithPrefix(msp06Tools(t, server), "eebus."); len(got) != 0 {
+		t.Fatalf("disabled/unregistered eebus tool inventory = %v, want none", got)
+	}
+
+	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+	if err := server.RegisterEEBusV1Provider(provider); err != nil {
+		t.Fatalf("RegisterEEBusV1Provider() error = %v", err)
+	}
+	want := append([]string(nil), msp06ToolNames...)
+	sort.Strings(want)
+	tools := msp06Tools(t, server)
+	if got := msp06NamesWithPrefixInOrder(tools, "eebus."); !reflect.DeepEqual(got, msp06ToolNames) {
+		t.Fatalf("registered eebus inventory order = %v, want contract order %v", got, msp06ToolNames)
+	}
+	if got := msp06NamesWithPrefix(tools, "eebus."); !reflect.DeepEqual(got, want) {
+		t.Fatalf("registered eebus inventory = %v, want exact closed inventory %v", got, want)
+	}
+	for _, forbidden := range []string{"write", "set", "mutate", "command", "trust", "pair", "admin", "experimental"} {
+		for _, name := range want {
+			if strings.Contains(name, forbidden) && name != msp06PairingStatusTool {
+				t.Fatalf("read-only inventory contains forbidden surface %q", name)
+			}
+		}
+	}
+	if err := server.RegisterEEBusV1Provider(&msp06Provider{snapshot: msp06Snapshot(t, "runtime-b")}); err == nil {
+		t.Fatal("second eeBUS provider registration succeeded, want rejection")
+	}
+	if got := msp06NamesWithPrefix(msp06Tools(t, server), "eebus."); !reflect.DeepEqual(got, want) {
+		t.Fatalf("inventory changed after rejected second registration: %v", got)
+	}
+}
+
+func TestMSP06NilProviderLeavesInventoryAbsent(t *testing.T) {
+	server, err := NewServer(&testRegistry{entries: make(map[byte]registry.DeviceEntry)}, &testInvoker{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := server.RegisterEEBusV1Provider(nil); err == nil {
+		t.Fatal("RegisterEEBusV1Provider(nil) succeeded")
+	}
+	if got := msp06NamesWithPrefix(msp06Tools(t, server), "eebus."); len(got) != 0 {
+		t.Fatalf("nil registration exposed tools %v", got)
+	}
+}
+
+func TestMSP06ToolInputSchemasAreClosedAndExact(t *testing.T) {
+	server, _ := msp06TestServer(t, &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")})
+	tools := msp06Tools(t, server)
+	byName := make(map[string]map[string]any)
+	for _, tool := range tools {
+		name, _ := tool["name"].(string)
+		byName[name] = tool
+	}
+	want := map[string]struct {
+		properties []string
+		required   []string
+	}{
+		msp06RuntimeStatusTool: {properties: []string{"evidence_ref"}},
+		msp06ServicesListTool:  {properties: []string{"evidence_ref"}},
+		msp06ServicesGetTool:   {properties: []string{"evidence_ref", "id_digest"}, required: []string{"id_digest"}},
+		msp06SessionsListTool:  {properties: []string{"evidence_ref"}},
+		msp06SessionsGetTool:   {properties: []string{"evidence_ref", "id_digest"}, required: []string{"id_digest"}},
+		msp06TopologyGetTool:   {properties: []string{"evidence_ref"}},
+		msp06SnapshotCapture:   {},
+		msp06SnapshotDrop:      {properties: []string{"snapshot_ref"}, required: []string{"snapshot_ref"}},
+		msp06PairingStatusTool: {properties: []string{"evidence_ref"}},
+	}
+	for name, expected := range want {
+		tool := byName[name]
+		if tool == nil {
+			t.Fatalf("tool %s missing", name)
+		}
+		schema := msp06Map(t, tool["inputSchema"], name+".inputSchema")
+		if schema["type"] != "object" || schema["additionalProperties"] != false {
+			t.Fatalf("%s schema = %#v, want closed object", name, schema)
+		}
+		properties := msp06Map(t, schema["properties"], name+".properties")
+		gotProperties := make([]string, 0, len(properties))
+		for key := range properties {
+			gotProperties = append(gotProperties, key)
+			property := msp06Map(t, properties[key], name+"."+key)
+			if property["type"] != "string" {
+				t.Fatalf("%s.%s type = %#v, want string", name, key, property["type"])
+			}
+			if property["pattern"] != `^[A-Za-z0-9_-]{43}$` {
+				t.Fatalf("%s.%s pattern = %#v, want canonical 43-character base64url", name, key, property["pattern"])
+			}
+		}
+		sort.Strings(gotProperties)
+		sort.Strings(expected.properties)
+		if !slices.Equal(gotProperties, expected.properties) {
+			t.Fatalf("%s properties = %v, want %v", name, gotProperties, expected.properties)
+		}
+		var gotRequired []string
+		if rawRequired, exists := schema["required"]; exists {
+			for _, raw := range msp06Slice(t, rawRequired, name+".required") {
+				gotRequired = append(gotRequired, fmt.Sprint(raw))
+			}
+		}
+		sort.Strings(gotRequired)
+		sort.Strings(expected.required)
+		if !slices.Equal(gotRequired, expected.required) {
+			t.Fatalf("%s required = %v, want %v", name, gotRequired, expected.required)
+		}
+	}
+}
+
+func TestMSP06LiveToolsTakeOneSnapshotAndUseClosedWireDTOs(t *testing.T) {
+	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+	server, _ := msp06TestServer(t, provider)
+	handler := server.Handler()
+
+	status := msp06AssertSuccess(t, msp06Call(t, handler, msp06RuntimeStatusTool, map[string]any{}), msp06RuntimeStatusTool, "runtime-status", "live")
+	msp06AssertKeys(t, status, "status", "state")
+	if status["state"] != "ready" {
+		t.Fatalf("status.state = %#v, want ready", status["state"])
+	}
+
+	services := msp06AssertSuccess(t, msp06Call(t, handler, msp06ServicesListTool, map[string]any{}), msp06ServicesListTool, "services", "live")
+	msp06AssertKeys(t, services, "services.list", "services")
+	serviceItems := msp06Slice(t, services["services"], "services")
+	if len(serviceItems) != 2 {
+		t.Fatalf("services length = %d, want 2", len(serviceItems))
+	}
+	serviceDigests := make([]string, 0, len(serviceItems))
+	for index, raw := range serviceItems {
+		path := fmt.Sprintf("services[%d]", index)
+		service := msp06Map(t, raw, path)
+		keys := []string{"id", "kind", "visible", "paired"}
+		if _, exists := service["evidence"]; exists {
+			keys = append(keys, "evidence")
+			msp06AssertEvidence(t, service["evidence"], path+".evidence")
+		}
+		msp06AssertKeys(t, service, path, keys...)
+		serviceDigests = append(serviceDigests, msp06AssertIdentity(t, service["id"], path+".id", "service"))
+	}
+	if !sort.StringsAreSorted(serviceDigests) {
+		t.Fatalf("service pseudonyms are not sorted: %v", serviceDigests)
+	}
+	selectedService := serviceDigests[0]
+	service := msp06AssertSuccess(t, msp06Call(t, handler, msp06ServicesGetTool, map[string]any{"id_digest": selectedService}), msp06ServicesGetTool, "service", "live")
+	serviceKeys := []string{"id", "kind", "visible", "paired"}
+	if _, exists := service["evidence"]; exists {
+		serviceKeys = append(serviceKeys, "evidence")
+		msp06AssertEvidence(t, service["evidence"], "service.evidence")
+	}
+	msp06AssertKeys(t, service, "service", serviceKeys...)
+	if got := msp06AssertIdentity(t, service["id"], "service.id", "service"); got != selectedService {
+		t.Fatalf("services.get id = %q, want %q", got, selectedService)
+	}
+
+	sessions := msp06AssertSuccess(t, msp06Call(t, handler, msp06SessionsListTool, map[string]any{}), msp06SessionsListTool, "sessions", "live")
+	msp06AssertKeys(t, sessions, "sessions.list", "sessions")
+	sessionItems := msp06Slice(t, sessions["sessions"], "sessions")
+	sessionDigests := make([]string, 0, len(sessionItems))
+	for index, raw := range sessionItems {
+		path := fmt.Sprintf("sessions[%d]", index)
+		session := msp06Map(t, raw, path)
+		keys := []string{"id", "remote", "state"}
+		if _, exists := session["since"]; exists {
+			keys = append(keys, "since")
+		}
+		if _, exists := session["evidence"]; exists {
+			keys = append(keys, "evidence")
+			msp06AssertEvidence(t, session["evidence"], path+".evidence")
+		}
+		msp06AssertKeys(t, session, path, keys...)
+		sessionDigests = append(sessionDigests, msp06AssertIdentity(t, session["id"], path+".id", "session"))
+		msp06AssertIdentity(t, session["remote"], path+".remote", "remote")
+		if session["state"] == "unknown" {
+			t.Fatalf("%s.state serialized unknown", path)
+		}
+	}
+	if !sort.StringsAreSorted(sessionDigests) {
+		t.Fatalf("session pseudonyms are not sorted: %v", sessionDigests)
+	}
+	session := msp06AssertSuccess(t, msp06Call(t, handler, msp06SessionsGetTool, map[string]any{"id_digest": sessionDigests[0]}), msp06SessionsGetTool, "session", "live")
+	sessionKeys := []string{"id", "remote", "state"}
+	if _, exists := session["since"]; exists {
+		sessionKeys = append(sessionKeys, "since")
+	}
+	if _, exists := session["evidence"]; exists {
+		sessionKeys = append(sessionKeys, "evidence")
+		msp06AssertEvidence(t, session["evidence"], "session.evidence")
+	}
+	msp06AssertKeys(t, session, "session", sessionKeys...)
+	if got := msp06AssertIdentity(t, session["id"], "session.id", "session"); got != sessionDigests[0] {
+		t.Fatalf("sessions.get id = %q, want %q", got, sessionDigests[0])
+	}
+
+	topology := msp06AssertSuccess(t, msp06Call(t, handler, msp06TopologyGetTool, map[string]any{}), msp06TopologyGetTool, "topology", "live")
+	msp06AssertTopology(t, topology)
+
+	pairing := msp06AssertSuccess(t, msp06Call(t, handler, msp06PairingStatusTool, map[string]any{}), msp06PairingStatusTool, "pairing-status", "live")
+	msp06AssertKeys(t, pairing, "pairing.status", "pairing")
+	pairingItems := msp06Slice(t, pairing["pairing"], "pairing")
+	pairingDigests := make([]string, 0, len(pairingItems))
+	for index, raw := range pairingItems {
+		path := fmt.Sprintf("pairing[%d]", index)
+		item := msp06Map(t, raw, path)
+		keys := []string{"remote", "state"}
+		if _, exists := item["since"]; exists {
+			keys = append(keys, "since")
+		}
+		if _, exists := item["evidence"]; exists {
+			keys = append(keys, "evidence")
+			msp06AssertEvidence(t, item["evidence"], path+".evidence")
+		}
+		msp06AssertKeys(t, item, path, keys...)
+		pairingDigests = append(pairingDigests, msp06AssertIdentity(t, item["remote"], path+".remote", "remote"))
+		if item["state"] == "unknown" {
+			t.Fatalf("%s.state serialized unknown", path)
+		}
+	}
+	if !sort.StringsAreSorted(pairingDigests) {
+		t.Fatalf("pairing pseudonyms are not sorted: %v", pairingDigests)
+	}
+
+	if got, want := provider.callCount(), 7; got != want {
+		t.Fatalf("provider Snapshot calls = %d, want exactly one for each of seven live reads", got)
+	}
+}
+
+func msp06AssertTopology(t *testing.T, topology map[string]any) {
+	t.Helper()
+	msp06AssertKeys(t, topology, "topology", "devices")
+	devices := msp06Slice(t, topology["devices"], "devices")
+	deviceDigests := make([]string, 0, len(devices))
+	for deviceIndex, rawDevice := range devices {
+		devicePath := fmt.Sprintf("devices[%d]", deviceIndex)
+		device := msp06Map(t, rawDevice, devicePath)
+		keys := []string{"id", "entities", "usecase_claims"}
+		if _, exists := device["evidence"]; exists {
+			keys = append(keys, "evidence")
+			msp06AssertEvidence(t, device["evidence"], devicePath+".evidence")
+		}
+		msp06AssertKeys(t, device, devicePath, keys...)
+		deviceDigests = append(deviceDigests, msp06AssertIdentity(t, device["id"], devicePath+".id", "device"))
+
+		entities := msp06Slice(t, device["entities"], devicePath+".entities")
+		entityDigests := make([]string, 0, len(entities))
+		for entityIndex, rawEntity := range entities {
+			entityPath := fmt.Sprintf("%s.entities[%d]", devicePath, entityIndex)
+			entity := msp06Map(t, rawEntity, entityPath)
+			keys := []string{"id", "features"}
+			if _, exists := entity["evidence"]; exists {
+				keys = append(keys, "evidence")
+				msp06AssertEvidence(t, entity["evidence"], entityPath+".evidence")
+			}
+			msp06AssertKeys(t, entity, entityPath, keys...)
+			entityDigests = append(entityDigests, msp06AssertIdentity(t, entity["id"], entityPath+".id", "entity"))
+
+			features := msp06Slice(t, entity["features"], entityPath+".features")
+			featureDigests := make([]string, 0, len(features))
+			for featureIndex, rawFeature := range features {
+				featurePath := fmt.Sprintf("%s.features[%d]", entityPath, featureIndex)
+				feature := msp06Map(t, rawFeature, featurePath)
+				keys := []string{"id", "role"}
+				if _, exists := feature["evidence"]; exists {
+					keys = append(keys, "evidence")
+					msp06AssertEvidence(t, feature["evidence"], featurePath+".evidence")
+				}
+				msp06AssertKeys(t, feature, featurePath, keys...)
+				featureDigests = append(featureDigests, msp06AssertIdentity(t, feature["id"], featurePath+".id", "feature"))
+				if feature["role"] != "client" && feature["role"] != "server" {
+					t.Fatalf("%s.role = %#v, want closed client/server enum", featurePath, feature["role"])
+				}
+			}
+			if !sort.StringsAreSorted(featureDigests) {
+				t.Fatalf("%s features not sorted: %v", entityPath, featureDigests)
+			}
+		}
+		if !sort.StringsAreSorted(entityDigests) {
+			t.Fatalf("%s entities not sorted: %v", devicePath, entityDigests)
+		}
+
+		claims := msp06Slice(t, device["usecase_claims"], devicePath+".usecase_claims")
+		claimDigests := make([]string, 0, len(claims))
+		for claimIndex, rawClaim := range claims {
+			claimPath := fmt.Sprintf("%s.usecase_claims[%d]", devicePath, claimIndex)
+			claim := msp06Map(t, rawClaim, claimPath)
+			keys := []string{"id"}
+			if _, exists := claim["evidence"]; exists {
+				keys = append(keys, "evidence")
+				msp06AssertEvidence(t, claim["evidence"], claimPath+".evidence")
+			}
+			msp06AssertKeys(t, claim, claimPath, keys...)
+			claimDigests = append(claimDigests, msp06AssertIdentity(t, claim["id"], claimPath+".id", "usecase-claim"))
+		}
+		if !sort.StringsAreSorted(claimDigests) {
+			t.Fatalf("%s usecase claims not sorted: %v", devicePath, claimDigests)
+		}
+	}
+	if !sort.StringsAreSorted(deviceDigests) {
+		t.Fatalf("devices not sorted: %v", deviceDigests)
+	}
+}
+
+func TestMSP06PseudonymsAreRuntimeScopedEphemeralHMACs(t *testing.T) {
+	snapshotA := msp06Snapshot(t, "runtime-a")
+	snapshotB := msp06Snapshot(t, "runtime-b")
+
+	serverA, _ := msp06TestServer(t, &msp06Provider{snapshot: snapshotA})
+	first := msp06AssertSuccess(t, msp06Call(t, serverA.Handler(), msp06ServicesListTool, map[string]any{}), msp06ServicesListTool, "services", "live")
+	second := msp06AssertSuccess(t, msp06Call(t, serverA.Handler(), msp06ServicesListTool, map[string]any{}), msp06ServicesListTool, "services", "live")
+	if !reflect.DeepEqual(first, second) {
+		t.Fatal("same runtime/key/source produced unstable pseudonyms")
+	}
+	digestA := msp06AssertIdentity(t, msp06Map(t, msp06Slice(t, first["services"], "services")[0], "service")["id"], "service.id", "service")
+
+	serverDifferentRuntime, _ := msp06TestServer(t, &msp06Provider{snapshot: snapshotB})
+	differentRuntime := msp06AssertSuccess(t, msp06Call(t, serverDifferentRuntime.Handler(), msp06ServicesListTool, map[string]any{}), msp06ServicesListTool, "services", "live")
+	digestDifferentRuntime := msp06AssertIdentity(t, msp06Map(t, msp06Slice(t, differentRuntime["services"], "services")[0], "service")["id"], "service.id", "service")
+	if digestA == digestDifferentRuntime {
+		t.Fatal("same source service under different runtime identity reused a pseudonym")
+	}
+
+	serverDifferentKey, err := NewServer(&testRegistry{entries: make(map[byte]registry.DeviceEntry)}, &testInvoker{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	clock := &msp06Clock{now: time.Date(2026, 7, 19, 8, 0, 0, 0, time.UTC)}
+	if err := serverDifferentKey.registerEEBusV1Provider(&msp06Provider{snapshot: snapshotA}, eebusV1RegistrationOptions{
+		now:          clock.Now,
+		entropy:      &msp06EntropyReader{},
+		pseudonymKey: bytes.Repeat([]byte{0xa5}, sha256.Size),
+		liveTimeout:  100 * time.Millisecond,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	differentKey := msp06AssertSuccess(t, msp06Call(t, serverDifferentKey.Handler(), msp06ServicesListTool, map[string]any{}), msp06ServicesListTool, "services", "live")
+	digestDifferentKey := msp06AssertIdentity(t, msp06Map(t, msp06Slice(t, differentKey["services"], "services")[0], "service")["id"], "service.id", "service")
+	if digestA == digestDifferentKey {
+		t.Fatal("different process-ephemeral HMAC keys produced the same pseudonym")
+	}
+
+	encoded, err := json.Marshal(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, source := range snapshotA.Services {
+		if bytes.Contains(encoded, []byte(source.ID.Digest)) {
+			t.Fatalf("wire forwarded stable source digest %q instead of re-pseudonymizing", source.ID.Digest)
+		}
+	}
+	if bytes.Contains(encoded, []byte("masked")) || bytes.Contains(encoded, []byte("local_ski")) {
+		t.Fatalf("wire contains source-only identity fields: %s", encoded)
+	}
+}
+
+func TestMSP06PseudonymsAreDomainSeparatedByWireIdentityKind(t *testing.T) {
+	snapshot := msp06Snapshot(t, "shared-identity")
+	sharedPeer := msp06SourceID(t, eebusraw.IDKindPeer, "shared-identity")
+	snapshot.Services[0].ID = sharedPeer
+	snapshot.Topology.Devices[0].ID = sharedPeer
+	snapshot.Topology.Devices[0].Entities[0].ID = sharedPeer
+	snapshot.Topology.Devices[0].Entities[0].Features[0].ID = sharedPeer
+	snapshot.Topology.Devices[0].UseCaseClaims[0].ID = sharedPeer
+	snapshot.Topology.Devices[0].Entities = snapshot.Topology.Devices[0].Entities[:1]
+	snapshot.Topology.Devices[0].Entities[0].Features = snapshot.Topology.Devices[0].Entities[0].Features[:1]
+	snapshot.Topology.Devices[0].UseCaseClaims = snapshot.Topology.Devices[0].UseCaseClaims[:1]
+	sharedRemote := msp06SourceID(t, eebusraw.IDKindRemoteSKI, "shared-identity")
+	snapshot.Pairing[0].Remote = sharedRemote
+	snapshot.Pairing = snapshot.Pairing[:1]
+	snapshot.Sessions[0].Remote = sharedRemote
+	snapshot.Sessions[0].ID = msp06SourceID(t, eebusraw.IDKindSession, "shared-identity")
+	snapshot.Sessions = snapshot.Sessions[:1]
+
+	server, _ := msp06TestServer(t, &msp06Provider{snapshot: snapshot})
+	_, root := msp06CaptureRoot(t, server)
+	wire := msp06Map(t, root["snapshot"], "snapshot")
+	meta := msp06Map(t, wire["meta"], "snapshot.meta")
+	services := msp06Slice(t, wire["services"], "snapshot.services")
+	pairing := msp06Slice(t, wire["pairing"], "snapshot.pairing")
+	sessions := msp06Slice(t, wire["sessions"], "snapshot.sessions")
+	devices := msp06Slice(t, msp06Map(t, wire["topology"], "snapshot.topology")["devices"], "snapshot.topology.devices")
+
+	var service, remote, session, device, entity, feature, claim string
+	for _, raw := range services {
+		item := msp06Map(t, raw, "service")
+		candidate := msp06Map(t, item["id"], "service.id")
+		if item["kind"] == "remote" {
+			service = fmt.Sprint(candidate["digest"])
+		}
+	}
+	for _, raw := range pairing {
+		item := msp06Map(t, raw, "pairing")
+		candidate := msp06Map(t, item["remote"], "pairing.remote")
+		remote = fmt.Sprint(candidate["digest"])
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("domain-separation sessions = %d, want 1", len(sessions))
+	}
+	session = fmt.Sprint(msp06Map(t, msp06Map(t, sessions[0], "session")["id"], "session.id")["digest"])
+	for _, raw := range devices {
+		item := msp06Map(t, raw, "device")
+		candidate := msp06Map(t, item["id"], "device.id")
+		if candidate["digest"] == nil {
+			continue
+		}
+		entities := msp06Slice(t, item["entities"], "device.entities")
+		if len(entities) == 0 {
+			continue
+		}
+		device = fmt.Sprint(candidate["digest"])
+		entityObject := msp06Map(t, entities[0], "entity")
+		entity = fmt.Sprint(msp06Map(t, entityObject["id"], "entity.id")["digest"])
+		features := msp06Slice(t, entityObject["features"], "entity.features")
+		if len(features) > 0 {
+			feature = fmt.Sprint(msp06Map(t, msp06Map(t, features[0], "feature")["id"], "feature.id")["digest"])
+		}
+		claims := msp06Slice(t, item["usecase_claims"], "device.usecase_claims")
+		if len(claims) > 0 {
+			claim = fmt.Sprint(msp06Map(t, msp06Map(t, claims[0], "claim")["id"], "claim.id")["digest"])
+		}
+	}
+	runtime := fmt.Sprint(msp06Map(t, meta["runtime"], "snapshot.meta.runtime")["digest"])
+	digests := []string{runtime, service, remote, session, device, entity, feature, claim}
+	seen := make(map[string]bool, len(digests))
+	for index, digest := range digests {
+		if !msp06TokenPattern.MatchString(digest) {
+			t.Fatalf("domain-separated digest %d = %q", index, digest)
+		}
+		if seen[digest] {
+			t.Fatalf("wire identity kinds reused pseudonym %q: %v", digest, digests)
+		}
+		seen[digest] = true
+	}
+}
+
+func TestMSP06StableOrderingAndHashIgnoreProviderSliceOrder(t *testing.T) {
+	snapshot := msp06Snapshot(t, "runtime-a")
+	provider := &msp06Provider{snapshot: snapshot}
+	server, _ := msp06TestServer(t, provider)
+	first := msp06Call(t, server.Handler(), msp06TopologyGetTool, map[string]any{})
+	msp06AssertSuccess(t, first, msp06TopologyGetTool, "topology", "live")
+
+	snapshot.Pairing[0], snapshot.Pairing[1] = snapshot.Pairing[1], snapshot.Pairing[0]
+	snapshot.Services[0], snapshot.Services[1] = snapshot.Services[1], snapshot.Services[0]
+	snapshot.Sessions[0], snapshot.Sessions[1] = snapshot.Sessions[1], snapshot.Sessions[0]
+	snapshot.Topology.Devices[0], snapshot.Topology.Devices[1] = snapshot.Topology.Devices[1], snapshot.Topology.Devices[0]
+	provider.set(snapshot, nil)
+	second := msp06Call(t, server.Handler(), msp06TopologyGetTool, map[string]any{})
+	msp06AssertSuccess(t, second, msp06TopologyGetTool, "topology", "live")
+	if first.raw != second.raw {
+		t.Fatalf("provider slice order changed deterministic wire/hash:\nfirst=%s\nsecond=%s", first.raw, second.raw)
+	}
+}
+
+func TestMSP06ClosedEnumsDuplicatesUnknownsAndUnexplainedEmptyFailClosed(t *testing.T) {
+	unknown := eebusraw.UnknownField{Path: eebusraw.UnknownPathRemote, Value: eebusraw.OpaqueBytes([]byte("pairing-history-secret"))}
+	tests := []struct {
+		name   string
+		tool   string
+		scope  string
+		mutate func(*eebusruntime.SnapshotV1)
+	}{
+		{name: "runtime unknown", tool: msp06RuntimeStatusTool, scope: "runtime-status", mutate: func(snapshot *eebusruntime.SnapshotV1) {
+			snapshot.Status.State = eebusruntime.ObservedRuntimeStateV1Unknown
+		}},
+		{name: "session unknown", tool: msp06SessionsListTool, scope: "sessions", mutate: func(snapshot *eebusruntime.SnapshotV1) {
+			snapshot.Sessions[0].State = eebusruntime.ObservedSessionStateV1Unknown
+		}},
+		{name: "pairing unknown", tool: msp06PairingStatusTool, scope: "pairing-status", mutate: func(snapshot *eebusruntime.SnapshotV1) { snapshot.Pairing[0].State = eebusraw.PairingStateUnknown }},
+		{name: "feature role unspecified", tool: msp06TopologyGetTool, scope: "topology", mutate: func(snapshot *eebusruntime.SnapshotV1) {
+			snapshot.Topology.Devices[0].Entities[0].Features[0].Role = eebusruntime.FeatureRoleV1Unspecified
+		}},
+		{name: "unknown source field", tool: msp06ServicesListTool, scope: "services", mutate: func(snapshot *eebusruntime.SnapshotV1) {
+			snapshot.Services[0].Unknown = []eebusraw.UnknownField{unknown}
+		}},
+		{name: "duplicate service identity", tool: msp06ServicesListTool, scope: "services", mutate: func(snapshot *eebusruntime.SnapshotV1) {
+			snapshot.Services = append(snapshot.Services, snapshot.Services[0])
+		}},
+		{name: "unsafe evidence integer", tool: msp06ServicesListTool, scope: "services", mutate: func(snapshot *eebusruntime.SnapshotV1) {
+			snapshot.Services[0].Raw[0].Size = int(9007199254740992)
+		}},
+		{name: "unexplained empty ready runtime", tool: msp06ServicesListTool, scope: "services", mutate: func(snapshot *eebusruntime.SnapshotV1) { snapshot.Services = nil }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			snapshot := msp06Snapshot(t, "runtime-a")
+			test.mutate(&snapshot)
+			provider := &msp06Provider{snapshot: snapshot}
+			server, _ := msp06TestServer(t, provider)
+			result := msp06Call(t, server.Handler(), test.tool, map[string]any{})
+			errorObject := msp06AssertError(t, result, test.tool, test.scope, "contract_violation")
+			if errorObject["message"] != "eeBUS MCP contract violation" || errorObject["retriable"] != false || errorObject["source_layer"] != "mcp" {
+				t.Fatalf("contract_violation mapping = %#v", errorObject)
+			}
+		})
+	}
+
+	degraded := msp06Snapshot(t, "runtime-a")
+	degraded.Services = nil
+	degraded.Status = eebusruntime.RuntimeObservationV1{
+		State: eebusruntime.ObservedRuntimeStateV1Degraded,
+		Degradation: &eebusruntime.DegradationV1{
+			Reason: eebusruntime.DegradationReasonV1NoVisibleServices,
+			Since:  degraded.Meta.DataTimestamp.Add(-time.Minute),
+		},
+	}
+	server, _ := msp06TestServer(t, &msp06Provider{snapshot: degraded})
+	data := msp06AssertSuccess(t, msp06Call(t, server.Handler(), msp06ServicesListTool, map[string]any{}), msp06ServicesListTool, "services", "live")
+	if len(msp06Slice(t, data["services"], "services")) != 0 {
+		t.Fatal("degraded no-visible-services snapshot unexpectedly returned services")
+	}
+}
+
+func TestMSP06WireTimestampsNormalizeToUTCLiteralZ(t *testing.T) {
+	snapshot := msp06Snapshot(t, "runtime-a")
+	zone := time.FixedZone("fixture-plus-two", 2*60*60)
+	snapshot.Meta.CapturedAt = snapshot.Meta.CapturedAt.In(zone)
+	snapshot.Meta.DataTimestamp = snapshot.Meta.DataTimestamp.In(zone)
+	snapshot.Pairing[0].Since = snapshot.Pairing[0].Since.In(zone)
+	snapshot.Pairing[0].Raw[0].DataTimestamp = snapshot.Pairing[0].Raw[0].DataTimestamp.In(zone)
+	snapshot.Sessions[0].Since = snapshot.Sessions[0].Since.In(zone)
+	snapshot.Services[0].Raw[0].DataTimestamp = snapshot.Services[0].Raw[0].DataTimestamp.In(zone)
+
+	server, _ := msp06TestServer(t, &msp06Provider{snapshot: snapshot})
+	result, root := msp06CaptureRoot(t, server)
+	if strings.Contains(result.raw, "+02:00") {
+		t.Fatalf("wire retained source timezone offset: %s", result.raw)
+	}
+	encoded, err := json.Marshal(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(encoded, []byte("+02:00")) {
+		t.Fatalf("captured root retained source timezone offset: %s", encoded)
+	}
+}
+
+func TestMSP06ExactErrorMappingIsExhaustive(t *testing.T) {
+	want := map[string]struct {
+		message   string
+		retriable bool
+		layer     string
+	}{
+		"invalid_argument":    {message: "invalid argument", layer: "mcp"},
+		"not_found":           {message: "not found", layer: "mcp"},
+		"permission_denied":   {message: "permission denied", layer: "policy"},
+		"admin_required":      {message: "administrator authorization required", layer: "policy"},
+		"backend_unavailable": {message: "eeBUS runtime unavailable", retriable: true, layer: "eebusruntime"},
+		"timeout":             {message: "eeBUS runtime request timed out", retriable: true, layer: "eebusruntime"},
+		"snapshot_gone":       {message: "snapshot no longer available", layer: "snapshot-store"},
+		"quota_exceeded":      {message: "snapshot quota exceeded", retriable: true, layer: "snapshot-store"},
+		"contract_violation":  {message: "eeBUS MCP contract violation", layer: "mcp"},
+	}
+	for code, expected := range want {
+		public, ok := eebusV1PublicErrorForCode(code)
+		if !ok {
+			t.Fatalf("error code %q missing from exhaustive mapping", code)
+		}
+		encoded, err := json.Marshal(public)
+		if err != nil {
+			t.Fatalf("marshal %s: %v", code, err)
+		}
+		var got map[string]any
+		if err := json.Unmarshal(encoded, &got); err != nil {
+			t.Fatal(err)
+		}
+		msp06AssertKeys(t, got, "error "+code, "code", "message", "retriable", "source_layer")
+		if got["code"] != code || got["message"] != expected.message || got["retriable"] != expected.retriable || got["source_layer"] != expected.layer {
+			t.Fatalf("mapping %s = %#v, want message=%q retriable=%t layer=%q", code, got, expected.message, expected.retriable, expected.layer)
+		}
+	}
+	if _, ok := eebusV1PublicErrorForCode("future_error"); ok {
+		t.Fatal("unknown error code was accepted")
+	}
+}
+
+func TestMSP06ShapeSyntaxAndSelectorPrecedenceAvoidProviderAccess(t *testing.T) {
+	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+	server, _ := msp06TestServer(t, provider)
+	tests := []struct {
+		name string
+		tool string
+		args map[string]any
+	}{
+		{name: "unknown argument before backend", tool: msp06ServicesListTool, args: map[string]any{"future": true}},
+		{name: "forbidden auth selector", tool: msp06ServicesListTool, args: map[string]any{"auth_scope": "admin"}},
+		{name: "forbidden mask selector", tool: msp06ServicesListTool, args: map[string]any{"mask_tier": "raw"}},
+		{name: "forbidden principal selector", tool: msp06ServicesListTool, args: map[string]any{"principal": "root"}},
+		{name: "malformed reference before lifecycle", tool: msp06ServicesListTool, args: map[string]any{"evidence_ref": "short"}},
+		{name: "missing get selector", tool: msp06ServicesGetTool, args: map[string]any{}},
+		{name: "raw stable digest is not an id selector", tool: msp06ServicesGetTool, args: map[string]any{"id_digest": msp06Snapshot(t, "runtime-a").Services[0].ID.Digest}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			before := provider.callCount()
+			result := msp06Call(t, server.Handler(), test.tool, test.args)
+			scope := "services"
+			if test.tool == msp06ServicesGetTool {
+				scope = "service"
+			}
+			msp06AssertError(t, result, test.tool, scope, "invalid_argument")
+			if provider.callCount() != before {
+				t.Fatalf("provider called for shape/syntax failure: before=%d after=%d", before, provider.callCount())
+			}
+		})
+	}
+
+	unknownID := base64.RawURLEncoding.EncodeToString(bytes.Repeat([]byte{0x7f}, sha256.Size))
+	result := msp06Call(t, server.Handler(), msp06ServicesGetTool, map[string]any{"id_digest": unknownID})
+	msp06AssertError(t, result, msp06ServicesGetTool, "service", "not_found")
+	if provider.callCount() != 1 {
+		t.Fatalf("valid live selector performed %d provider calls, want one", provider.callCount())
+	}
+}
+
+func TestMSP06BackendErrorsAreNormalizedWithoutStaleLiveFallback(t *testing.T) {
+	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+	server, _ := msp06TestServer(t, provider)
+	first := msp06Call(t, server.Handler(), msp06RuntimeStatusTool, map[string]any{})
+	msp06AssertSuccess(t, first, msp06RuntimeStatusTool, "runtime-status", "live")
+
+	provider.set(eebusruntime.SnapshotV1{}, errors.New("dial 192.0.2.99 failed; private backend detail"))
+	unavailable := msp06Call(t, server.Handler(), msp06RuntimeStatusTool, map[string]any{})
+	errorObject := msp06AssertError(t, unavailable, msp06RuntimeStatusTool, "runtime-status", "backend_unavailable")
+	if errorObject["message"] != "eeBUS runtime unavailable" || errorObject["retriable"] != true || errorObject["source_layer"] != "eebusruntime" {
+		t.Fatalf("backend_unavailable mapping = %#v", errorObject)
+	}
+	if strings.Contains(unavailable.raw, "192.0.2.99") || strings.Contains(unavailable.raw, "private backend detail") {
+		t.Fatalf("backend error detail leaked: %s", unavailable.raw)
+	}
+
+	provider.set(eebusruntime.SnapshotV1{}, context.DeadlineExceeded)
+	timedOut := msp06Call(t, server.Handler(), msp06RuntimeStatusTool, map[string]any{})
+	errorObject = msp06AssertError(t, timedOut, msp06RuntimeStatusTool, "runtime-status", "timeout")
+	if errorObject["message"] != "eeBUS runtime request timed out" || errorObject["retriable"] != true || errorObject["source_layer"] != "eebusruntime" {
+		t.Fatalf("timeout mapping = %#v", errorObject)
+	}
+	if provider.callCount() != 3 {
+		t.Fatalf("provider calls = %d, want one per live call with no stale fallback", provider.callCount())
+	}
+}
+
+func TestMSP06CanonicalTokenSyntaxRejectsNonCanonicalReencoding(t *testing.T) {
+	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+	server, _ := msp06TestServer(t, provider)
+	canonical := base64.RawURLEncoding.EncodeToString(bytes.Repeat([]byte{0x11}, sha256.Size))
+	alphabet := "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+	last := strings.IndexByte(alphabet, canonical[len(canonical)-1])
+	if last < 0 || last%4 != 0 {
+		t.Fatalf("test token has unexpected final sextet: %q", canonical)
+	}
+	nonCanonical := canonical[:len(canonical)-1] + string(alphabet[last+1])
+	if decoded, err := base64.RawURLEncoding.DecodeString(nonCanonical); err != nil || len(decoded) != sha256.Size {
+		t.Fatalf("fixture must decode to 32 bytes despite noncanonical trailing bits: %v len=%d", err, len(decoded))
+	}
+	for _, token := range []string{
+		strings.Repeat("A", 42),
+		strings.Repeat("A", 44),
+		strings.Repeat("A", 42) + "=",
+		strings.Repeat("A", 42) + "$",
+		nonCanonical,
+	} {
+		before := provider.callCount()
+		result := msp06Call(t, server.Handler(), msp06RuntimeStatusTool, map[string]any{"evidence_ref": token})
+		msp06AssertError(t, result, msp06RuntimeStatusTool, "runtime-status", "invalid_argument")
+		if provider.callCount() != before {
+			t.Fatalf("malformed token %q reached provider", token)
+		}
+	}
+}
+
+func TestMSP06TestHelpersUseOnlyReaderContract(t *testing.T) {
+	var reader io.Reader = &msp06EntropyReader{}
+	first := make([]byte, 65)
+	second := make([]byte, 65)
+	if _, err := io.ReadFull(reader, first); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.ReadFull(reader, second); err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(first, second) {
+		t.Fatal("deterministic entropy fixture repeated output")
+	}
+}

--- a/mcp/eebus_v1_contract_test.go
+++ b/mcp/eebus_v1_contract_test.go
@@ -134,7 +134,7 @@ type msp06CallResult struct {
 	isError  bool
 }
 
-func msp06TestServer(t *testing.T, provider *msp06Provider) (*Server, *msp06Clock) {
+func msp06TestServer(t *testing.T, provider EEBusV1Provider) (*Server, *msp06Clock) {
 	t.Helper()
 	server, err := NewServer(&testRegistry{entries: make(map[byte]registry.DeviceEntry)}, &testInvoker{})
 	if err != nil {
@@ -405,7 +405,7 @@ func msp06AssertEvidence(t *testing.T, value any, path string) {
 		if !msp06HashPattern.MatchString(digest) || !msp06TimestampPattern.MatchString(timestamp) {
 			t.Fatalf("%s has invalid digest/timestamp: %#v", itemPath, item)
 		}
-		key := kind + "\x00" + digest + "\x00" + fmt.Sprintf("%020d", size) + "\x00" + timestamp
+		key := kind + "\x00" + digest + "\x00" + sizeNumber.String() + "\x00" + timestamp
 		if index > 0 && key <= previous {
 			t.Fatalf("%s ordering key %q is not greater than %q", itemPath, key, previous)
 		}
@@ -496,24 +496,40 @@ func TestMSP06ToolInventoryIsConditionalClosedAndReadOnly(t *testing.T) {
 			}
 		}
 	}
-	if err := server.RegisterEEBusV1Provider(&msp06Provider{snapshot: msp06Snapshot(t, "runtime-b")}); err == nil {
+	secondProvider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-b")}
+	if err := server.RegisterEEBusV1Provider(secondProvider); err == nil {
 		t.Fatal("second eeBUS provider registration succeeded, want rejection")
 	}
 	if got := msp06NamesWithPrefix(msp06Tools(t, server), "eebus."); !reflect.DeepEqual(got, want) {
 		t.Fatalf("inventory changed after rejected second registration: %v", got)
 	}
+	msp06AssertSuccess(t, msp06Call(t, server.Handler(), msp06RuntimeStatusTool, map[string]any{}), msp06RuntimeStatusTool, "runtime-status", "live")
+	if provider.callCount() != 1 || secondProvider.callCount() != 0 {
+		t.Fatalf("provider calls after duplicate registration = original:%d duplicate:%d, want 1/0", provider.callCount(), secondProvider.callCount())
+	}
 }
 
 func TestMSP06NilProviderLeavesInventoryAbsent(t *testing.T) {
-	server, err := NewServer(&testRegistry{entries: make(map[byte]registry.DeviceEntry)}, &testInvoker{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := server.RegisterEEBusV1Provider(nil); err == nil {
-		t.Fatal("RegisterEEBusV1Provider(nil) succeeded")
-	}
-	if got := msp06NamesWithPrefix(msp06Tools(t, server), "eebus."); len(got) != 0 {
-		t.Fatalf("nil registration exposed tools %v", got)
+	var typedNil *msp06Provider
+	for _, test := range []struct {
+		name     string
+		provider EEBusV1Provider
+	}{
+		{name: "nil interface", provider: nil},
+		{name: "typed nil", provider: typedNil},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server, err := NewServer(&testRegistry{entries: make(map[byte]registry.DeviceEntry)}, &testInvoker{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := server.RegisterEEBusV1Provider(test.provider); err == nil {
+				t.Fatal("RegisterEEBusV1Provider(nil) succeeded")
+			}
+			if got := msp06NamesWithPrefix(msp06Tools(t, server), "eebus."); len(got) != 0 {
+				t.Fatalf("nil registration exposed tools %v", got)
+			}
+		})
 	}
 }
 
@@ -946,7 +962,11 @@ func TestMSP06ClosedEnumsDuplicatesUnknownsAndUnexplainedEmptyFailClosed(t *test
 			snapshot.Services = append(snapshot.Services, snapshot.Services[0])
 		}},
 		{name: "unsafe evidence integer", tool: msp06ServicesListTool, scope: "services", mutate: func(snapshot *eebusruntime.SnapshotV1) {
-			snapshot.Services[0].Raw[0].Size = int(9007199254740992)
+			unsafeSize := int64(eebusV1MaxSafeInteger + 1)
+			if int64(^uint(0)>>1) < unsafeSize {
+				t.Skip("source evidence size uses int and cannot represent max-safe-plus-one on this architecture")
+			}
+			snapshot.Services[0].Raw[0].Size = int(unsafeSize)
 		}},
 		{name: "unexplained empty ready runtime", tool: msp06ServicesListTool, scope: "services", mutate: func(snapshot *eebusruntime.SnapshotV1) { snapshot.Services = nil }},
 	}
@@ -977,6 +997,18 @@ func TestMSP06ClosedEnumsDuplicatesUnknownsAndUnexplainedEmptyFailClosed(t *test
 	data := msp06AssertSuccess(t, msp06Call(t, server.Handler(), msp06ServicesListTool, map[string]any{}), msp06ServicesListTool, "services", "live")
 	if len(msp06Slice(t, data["services"], "services")) != 0 {
 		t.Fatal("degraded no-visible-services snapshot unexpectedly returned services")
+	}
+}
+
+func TestMSP06SafeNumberLimitRejectsMaxSafePlusOneOnEveryArchitecture(t *testing.T) {
+	object := eebusV1SourceEvidence{
+		Kind:          "service",
+		Digest:        msp06Digest("unsafe-size"),
+		Size:          eebusV1MaxSafeInteger + 1,
+		DataTimestamp: time.Date(2026, 7, 19, 8, 0, 0, 0, time.UTC),
+	}
+	if err := eebusV1ValidateSourceEvidenceObject(object); err == nil {
+		t.Fatal("max-safe-plus-one evidence size passed source validation")
 	}
 }
 

--- a/mcp/eebus_v1_dto.go
+++ b/mcp/eebus_v1_dto.go
@@ -13,8 +13,6 @@ import (
 	"sort"
 	"strings"
 	"time"
-
-	eebusruntime "github.com/Project-Helianthus/helianthus-eebusreg"
 )
 
 const (
@@ -291,10 +289,7 @@ func (p *eebusV1Pseudonymizer) identity(kind string, source eebusV1SourceIdentit
 	}, nil
 }
 
-func eebusV1ProjectSnapshot(value eebusruntime.SnapshotV1, pseudonymKey []byte) (eebusV1Projection, error) {
-	if err := eebusV1ValidateProviderCollectionBounds(value); err != nil {
-		return eebusV1Projection{}, err
-	}
+func eebusV1ProjectSnapshot(value any, pseudonymKey []byte) (eebusV1Projection, error) {
 	source, err := eebusV1DecodeSourceSnapshot(value)
 	if err != nil {
 		return eebusV1Projection{}, err
@@ -366,54 +361,6 @@ func eebusV1ProjectSnapshot(value eebusruntime.SnapshotV1, pseudonymKey []byte) 
 		DataTimestamp: snapshot.Meta.DataTimestamp,
 		RuntimeKey:    pseudonyms.runtimeKey,
 	}, nil
-}
-
-func eebusV1ValidateProviderCollectionBounds(snapshot eebusruntime.SnapshotV1) error {
-	if err := eebusV1ValidateCollectionSizes(
-		len(snapshot.Pairing),
-		len(snapshot.Services),
-		len(snapshot.Sessions),
-		len(snapshot.Topology.Devices),
-		len(snapshot.Raw),
-	); err != nil {
-		return err
-	}
-	for _, pairing := range snapshot.Pairing {
-		if err := eebusV1ValidateCollectionSizes(len(pairing.Raw)); err != nil {
-			return err
-		}
-	}
-	for _, service := range snapshot.Services {
-		if err := eebusV1ValidateCollectionSizes(len(service.Raw)); err != nil {
-			return err
-		}
-	}
-	for _, session := range snapshot.Sessions {
-		if err := eebusV1ValidateCollectionSizes(len(session.Raw)); err != nil {
-			return err
-		}
-	}
-	for _, device := range snapshot.Topology.Devices {
-		if err := eebusV1ValidateCollectionSizes(len(device.Entities), len(device.UseCaseClaims), len(device.Raw)); err != nil {
-			return err
-		}
-		for _, entity := range device.Entities {
-			if err := eebusV1ValidateCollectionSizes(len(entity.Features), len(entity.Raw)); err != nil {
-				return err
-			}
-			for _, feature := range entity.Features {
-				if err := eebusV1ValidateCollectionSizes(len(feature.Raw)); err != nil {
-					return err
-				}
-			}
-		}
-		for _, claim := range device.UseCaseClaims {
-			if err := eebusV1ValidateCollectionSizes(len(claim.Raw)); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
 }
 
 func eebusV1ValidateCollectionSizes(lengths ...int) error {

--- a/mcp/eebus_v1_dto.go
+++ b/mcp/eebus_v1_dto.go
@@ -768,35 +768,57 @@ func eebusV1ProjectEvidence(source []eebusV1SourceEvidence) ([]eebusV1EvidenceDe
 	if len(source) == 0 {
 		return nil, nil
 	}
-	result := make([]eebusV1EvidenceDescriptorV1, 0, len(source))
+	type orderedEvidence struct {
+		descriptor eebusV1EvidenceDescriptorV1
+		scalarKey  [4][]byte
+	}
+	ordered := make([]orderedEvidence, 0, len(source))
 	for _, object := range source {
 		if err := eebusV1ValidateSourceEvidenceObject(object); err != nil {
 			return nil, errors.New("invalid evidence descriptor")
 		}
-		result = append(result, eebusV1EvidenceDescriptorV1{
+		descriptor := eebusV1EvidenceDescriptorV1{
 			Kind: object.Kind, Digest: object.Digest, Size: object.Size, DataTimestamp: eebusV1Timestamp(object.DataTimestamp),
-		})
+		}
+		scalarKey, err := eebusV1EvidenceScalarKey(descriptor)
+		if err != nil {
+			return nil, err
+		}
+		ordered = append(ordered, orderedEvidence{descriptor: descriptor, scalarKey: scalarKey})
 	}
-	sort.Slice(result, func(i, j int) bool {
-		left, right := result[i], result[j]
-		if left.Kind != right.Kind {
-			return left.Kind < right.Kind
-		}
-		if left.Digest != right.Digest {
-			return left.Digest < right.Digest
-		}
-		if left.Size != right.Size {
-			return left.Size < right.Size
-		}
-		return left.DataTimestamp < right.DataTimestamp
+	sort.Slice(ordered, func(i, j int) bool {
+		return eebusV1CompareEvidenceScalarKeys(ordered[i].scalarKey, ordered[j].scalarKey) < 0
 	})
-	if err := eebusV1RejectDuplicateKeys(len(result), func(index int) string {
-		item := result[index]
-		return fmt.Sprintf("%s\x00%s\x00%020d\x00%s", item.Kind, item.Digest, item.Size, item.DataTimestamp)
-	}); err != nil {
-		return nil, err
+	result := make([]eebusV1EvidenceDescriptorV1, 0, len(ordered))
+	for index, item := range ordered {
+		if index > 0 && eebusV1CompareEvidenceScalarKeys(ordered[index-1].scalarKey, item.scalarKey) == 0 {
+			return nil, errors.New("duplicate projected identity")
+		}
+		result = append(result, item.descriptor)
 	}
 	return result, nil
+}
+
+func eebusV1EvidenceScalarKey(item eebusV1EvidenceDescriptorV1) ([4][]byte, error) {
+	values := [4]any{item.Kind, item.Digest, item.Size, item.DataTimestamp}
+	var key [4][]byte
+	for index, value := range values {
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return [4][]byte{}, errors.New("marshal evidence ordering key")
+		}
+		key[index] = encoded
+	}
+	return key, nil
+}
+
+func eebusV1CompareEvidenceScalarKeys(left, right [4][]byte) int {
+	for index := range left {
+		if comparison := bytes.Compare(left[index], right[index]); comparison != 0 {
+			return comparison
+		}
+	}
+	return 0
 }
 
 func eebusV1RejectDuplicateKeys(length int, key func(int) string) error {

--- a/mcp/eebus_v1_dto.go
+++ b/mcp/eebus_v1_dto.go
@@ -13,6 +13,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	eebusruntime "github.com/Project-Helianthus/helianthus-eebusreg"
 )
 
 const (
@@ -22,6 +24,7 @@ const (
 
 	eebusV1SourceSnapshotContract = "helianthus.eebus.runtime.raw-snapshot.v1"
 	eebusV1SourceRedactedValue    = "[redacted]"
+	eebusV1MaxCollectionSize      = 1024
 )
 
 type eebusV1ContractV1 struct {
@@ -288,7 +291,10 @@ func (p *eebusV1Pseudonymizer) identity(kind string, source eebusV1SourceIdentit
 	}, nil
 }
 
-func eebusV1ProjectSnapshot(value any, pseudonymKey []byte) (eebusV1Projection, error) {
+func eebusV1ProjectSnapshot(value eebusruntime.SnapshotV1, pseudonymKey []byte) (eebusV1Projection, error) {
+	if err := eebusV1ValidateProviderCollectionBounds(value); err != nil {
+		return eebusV1Projection{}, err
+	}
 	source, err := eebusV1DecodeSourceSnapshot(value)
 	if err != nil {
 		return eebusV1Projection{}, err
@@ -362,6 +368,63 @@ func eebusV1ProjectSnapshot(value any, pseudonymKey []byte) (eebusV1Projection, 
 	}, nil
 }
 
+func eebusV1ValidateProviderCollectionBounds(snapshot eebusruntime.SnapshotV1) error {
+	if err := eebusV1ValidateCollectionSizes(
+		len(snapshot.Pairing),
+		len(snapshot.Services),
+		len(snapshot.Sessions),
+		len(snapshot.Topology.Devices),
+		len(snapshot.Raw),
+	); err != nil {
+		return err
+	}
+	for _, pairing := range snapshot.Pairing {
+		if err := eebusV1ValidateCollectionSizes(len(pairing.Raw)); err != nil {
+			return err
+		}
+	}
+	for _, service := range snapshot.Services {
+		if err := eebusV1ValidateCollectionSizes(len(service.Raw)); err != nil {
+			return err
+		}
+	}
+	for _, session := range snapshot.Sessions {
+		if err := eebusV1ValidateCollectionSizes(len(session.Raw)); err != nil {
+			return err
+		}
+	}
+	for _, device := range snapshot.Topology.Devices {
+		if err := eebusV1ValidateCollectionSizes(len(device.Entities), len(device.UseCaseClaims), len(device.Raw)); err != nil {
+			return err
+		}
+		for _, entity := range device.Entities {
+			if err := eebusV1ValidateCollectionSizes(len(entity.Features), len(entity.Raw)); err != nil {
+				return err
+			}
+			for _, feature := range entity.Features {
+				if err := eebusV1ValidateCollectionSizes(len(feature.Raw)); err != nil {
+					return err
+				}
+			}
+		}
+		for _, claim := range device.UseCaseClaims {
+			if err := eebusV1ValidateCollectionSizes(len(claim.Raw)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func eebusV1ValidateCollectionSizes(lengths ...int) error {
+	for _, length := range lengths {
+		if length > eebusV1MaxCollectionSize {
+			return errors.New("provider collection exceeds maximum size")
+		}
+	}
+	return nil
+}
+
 func eebusV1DecodeSourceSnapshot(value any) (eebusV1SourceSnapshot, error) {
 	encoded, err := json.Marshal(value)
 	if err != nil {
@@ -380,6 +443,15 @@ func eebusV1DecodeSourceSnapshot(value any) (eebusV1SourceSnapshot, error) {
 }
 
 func eebusV1ValidateSourceSnapshot(snapshot eebusV1SourceSnapshot) error {
+	if err := eebusV1ValidateCollectionSizes(
+		len(snapshot.Pairing),
+		len(snapshot.Services),
+		len(snapshot.Sessions),
+		len(snapshot.Topology.Devices),
+		len(snapshot.Raw),
+	); err != nil {
+		return err
+	}
 	if snapshot.Meta.Contract != eebusV1SourceSnapshotContract || snapshot.Meta.MaskTier != eebusV1MaskTier {
 		return errors.New("invalid source snapshot metadata")
 	}
@@ -452,6 +524,9 @@ func eebusV1ValidateSourceSnapshot(snapshot eebusV1SourceSnapshot) error {
 		}
 	}
 	for _, device := range snapshot.Topology.Devices {
+		if err := eebusV1ValidateCollectionSizes(len(device.Entities), len(device.UseCaseClaims)); err != nil {
+			return err
+		}
 		if err := eebusV1ValidateSourceIdentityKind(device.ID, "peer"); err != nil {
 			return err
 		}
@@ -462,6 +537,9 @@ func eebusV1ValidateSourceSnapshot(snapshot eebusV1SourceSnapshot) error {
 			return err
 		}
 		for _, entity := range device.Entities {
+			if err := eebusV1ValidateCollectionSizes(len(entity.Features)); err != nil {
+				return err
+			}
 			if err := eebusV1ValidateSourceIdentityKind(entity.ID, "peer"); err != nil {
 				return err
 			}
@@ -546,6 +624,9 @@ func eebusV1ValidateSourceIdentityKind(source eebusV1SourceIdentity, allowed ...
 }
 
 func eebusV1ValidateSourceEvidence(source []eebusV1SourceEvidence) error {
+	if err := eebusV1ValidateCollectionSizes(len(source)); err != nil {
+		return err
+	}
 	for _, object := range source {
 		if err := eebusV1ValidateSourceEvidenceObject(object); err != nil {
 			return err
@@ -765,6 +846,9 @@ func eebusV1ProjectTopology(source eebusV1SourceTopology, pseudonyms *eebusV1Pse
 }
 
 func eebusV1ProjectEvidence(source []eebusV1SourceEvidence) ([]eebusV1EvidenceDescriptorV1, error) {
+	if err := eebusV1ValidateCollectionSizes(len(source)); err != nil {
+		return nil, err
+	}
 	if len(source) == 0 {
 		return nil, nil
 	}

--- a/mcp/eebus_v1_dto.go
+++ b/mcp/eebus_v1_dto.go
@@ -1,0 +1,820 @@
+package mcp
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	eebusV1ContractName = "helianthus-eebus-mcp"
+	eebusV1MaskTier     = "redacted"
+	eebusV1AuthScope    = "eebus.raw.read"
+
+	eebusV1SourceSnapshotContract = "helianthus.eebus.runtime.raw-snapshot.v1"
+	eebusV1SourceRedactedValue    = "[redacted]"
+)
+
+type eebusV1ContractV1 struct {
+	Name  string `json:"name"`
+	Major int    `json:"major"`
+	Minor int    `json:"minor"`
+}
+
+var eebusV1Contract = eebusV1ContractV1{Name: eebusV1ContractName, Major: 1, Minor: 0}
+
+type eebusV1IdentityDigestV1 struct {
+	Kind   string `json:"kind"`
+	Digest string `json:"digest"`
+}
+
+type eebusV1EvidenceDescriptorV1 struct {
+	Kind          string `json:"kind"`
+	Digest        string `json:"digest"`
+	Size          int64  `json:"size"`
+	DataTimestamp string `json:"data_timestamp"`
+}
+
+type eebusV1DegradationDataV1 struct {
+	Reason string `json:"reason"`
+	Since  string `json:"since"`
+}
+
+type eebusV1RuntimeStatusDataV1 struct {
+	State       string                    `json:"state"`
+	Degradation *eebusV1DegradationDataV1 `json:"degradation,omitempty"`
+}
+
+type eebusV1ServiceDataV1 struct {
+	ID       eebusV1IdentityDigestV1       `json:"id"`
+	Kind     string                        `json:"kind"`
+	Visible  bool                          `json:"visible"`
+	Paired   bool                          `json:"paired"`
+	Evidence []eebusV1EvidenceDescriptorV1 `json:"evidence,omitempty"`
+}
+
+type eebusV1ServicesListDataV1 struct {
+	Services []eebusV1ServiceDataV1 `json:"services"`
+}
+
+type eebusV1SessionDataV1 struct {
+	ID       eebusV1IdentityDigestV1       `json:"id"`
+	Remote   eebusV1IdentityDigestV1       `json:"remote"`
+	State    string                        `json:"state"`
+	Since    string                        `json:"since,omitempty"`
+	Evidence []eebusV1EvidenceDescriptorV1 `json:"evidence,omitempty"`
+}
+
+type eebusV1SessionsListDataV1 struct {
+	Sessions []eebusV1SessionDataV1 `json:"sessions"`
+}
+
+type eebusV1PairingDataV1 struct {
+	Remote   eebusV1IdentityDigestV1       `json:"remote"`
+	State    string                        `json:"state"`
+	Since    string                        `json:"since,omitempty"`
+	Evidence []eebusV1EvidenceDescriptorV1 `json:"evidence,omitempty"`
+}
+
+type eebusV1PairingStatusDataV1 struct {
+	Pairing []eebusV1PairingDataV1 `json:"pairing"`
+}
+
+type eebusV1FeatureDataV1 struct {
+	ID       eebusV1IdentityDigestV1       `json:"id"`
+	Role     string                        `json:"role"`
+	Evidence []eebusV1EvidenceDescriptorV1 `json:"evidence,omitempty"`
+}
+
+type eebusV1EntityDataV1 struct {
+	ID       eebusV1IdentityDigestV1       `json:"id"`
+	Features []eebusV1FeatureDataV1        `json:"features"`
+	Evidence []eebusV1EvidenceDescriptorV1 `json:"evidence,omitempty"`
+}
+
+type eebusV1UseCaseClaimDataV1 struct {
+	ID       eebusV1IdentityDigestV1       `json:"id"`
+	Evidence []eebusV1EvidenceDescriptorV1 `json:"evidence,omitempty"`
+}
+
+type eebusV1DeviceDataV1 struct {
+	ID            eebusV1IdentityDigestV1       `json:"id"`
+	Entities      []eebusV1EntityDataV1         `json:"entities"`
+	UseCaseClaims []eebusV1UseCaseClaimDataV1   `json:"usecase_claims"`
+	Evidence      []eebusV1EvidenceDescriptorV1 `json:"evidence,omitempty"`
+}
+
+type eebusV1TopologyDataV1 struct {
+	Devices []eebusV1DeviceDataV1 `json:"devices"`
+}
+
+type eebusV1SnapshotMetaDataV1 struct {
+	Contract      string                  `json:"contract"`
+	Runtime       eebusV1IdentityDigestV1 `json:"runtime"`
+	MaskTier      string                  `json:"mask_tier"`
+	CapturedAt    string                  `json:"captured_at"`
+	DataTimestamp string                  `json:"data_timestamp"`
+	DataHash      string                  `json:"data_hash"`
+}
+
+type eebusV1SnapshotDataV1 struct {
+	Meta     eebusV1SnapshotMetaDataV1     `json:"meta"`
+	Status   eebusV1RuntimeStatusDataV1    `json:"status"`
+	Pairing  []eebusV1PairingDataV1        `json:"pairing"`
+	Services []eebusV1ServiceDataV1        `json:"services"`
+	Sessions []eebusV1SessionDataV1        `json:"sessions"`
+	Topology eebusV1TopologyDataV1         `json:"topology"`
+	Evidence []eebusV1EvidenceDescriptorV1 `json:"evidence,omitempty"`
+}
+
+type eebusV1Projection struct {
+	Snapshot      eebusV1SnapshotDataV1
+	Runtime       eebusV1RuntimeStatusDataV1
+	DataTimestamp string
+	RuntimeKey    string
+}
+
+type eebusV1SourceIdentity struct {
+	Kind   string `json:"kind"`
+	Masked string `json:"masked"`
+	Digest string `json:"digest,omitempty"`
+}
+
+type eebusV1SourceEvidence struct {
+	Kind          string            `json:"kind"`
+	Digest        string            `json:"digest"`
+	Size          int64             `json:"size"`
+	DataTimestamp time.Time         `json:"data_timestamp"`
+	Unknown       []json.RawMessage `json:"unknown,omitempty"`
+}
+
+type eebusV1SourceSnapshotMeta struct {
+	Contract      string                `json:"contract"`
+	Runtime       eebusV1SourceIdentity `json:"runtime"`
+	LocalSKI      eebusV1SourceIdentity `json:"local_ski"`
+	MaskTier      string                `json:"mask_tier"`
+	CapturedAt    time.Time             `json:"captured_at"`
+	DataTimestamp time.Time             `json:"data_timestamp"`
+	DataHash      string                `json:"data_hash,omitempty"`
+}
+
+type eebusV1SourceDegradation struct {
+	Reason string    `json:"reason"`
+	Since  time.Time `json:"since"`
+}
+
+type eebusV1SourceRuntimeObservation struct {
+	State       string                    `json:"state"`
+	Degradation *eebusV1SourceDegradation `json:"degradation,omitempty"`
+}
+
+type eebusV1SourcePairing struct {
+	Remote  eebusV1SourceIdentity   `json:"remote"`
+	State   string                  `json:"state"`
+	Since   time.Time               `json:"since,omitempty"`
+	Raw     []eebusV1SourceEvidence `json:"raw,omitempty"`
+	Unknown []json.RawMessage       `json:"unknown,omitempty"`
+}
+
+type eebusV1SourceService struct {
+	ID      eebusV1SourceIdentity   `json:"id"`
+	Kind    string                  `json:"kind"`
+	Visible bool                    `json:"visible"`
+	Paired  bool                    `json:"paired"`
+	Raw     []eebusV1SourceEvidence `json:"raw,omitempty"`
+	Unknown []json.RawMessage       `json:"unknown,omitempty"`
+}
+
+type eebusV1SourceSession struct {
+	ID      eebusV1SourceIdentity   `json:"id"`
+	Remote  eebusV1SourceIdentity   `json:"remote"`
+	State   string                  `json:"state"`
+	Since   time.Time               `json:"since,omitempty"`
+	Raw     []eebusV1SourceEvidence `json:"raw,omitempty"`
+	Unknown []json.RawMessage       `json:"unknown,omitempty"`
+}
+
+type eebusV1SourceFeature struct {
+	ID      eebusV1SourceIdentity   `json:"id"`
+	Role    string                  `json:"role"`
+	Raw     []eebusV1SourceEvidence `json:"raw,omitempty"`
+	Unknown []json.RawMessage       `json:"unknown,omitempty"`
+}
+
+type eebusV1SourceEntity struct {
+	ID       eebusV1SourceIdentity   `json:"id"`
+	Features []eebusV1SourceFeature  `json:"features,omitempty"`
+	Raw      []eebusV1SourceEvidence `json:"raw,omitempty"`
+	Unknown  []json.RawMessage       `json:"unknown,omitempty"`
+}
+
+type eebusV1SourceUseCaseClaim struct {
+	ID      eebusV1SourceIdentity   `json:"id"`
+	Raw     []eebusV1SourceEvidence `json:"raw,omitempty"`
+	Unknown []json.RawMessage       `json:"unknown,omitempty"`
+}
+
+type eebusV1SourceDevice struct {
+	ID            eebusV1SourceIdentity       `json:"id"`
+	Entities      []eebusV1SourceEntity       `json:"entities,omitempty"`
+	UseCaseClaims []eebusV1SourceUseCaseClaim `json:"usecase_claims,omitempty"`
+	Raw           []eebusV1SourceEvidence     `json:"raw,omitempty"`
+	Unknown       []json.RawMessage           `json:"unknown,omitempty"`
+}
+
+type eebusV1SourceTopology struct {
+	Devices []eebusV1SourceDevice `json:"devices,omitempty"`
+}
+
+type eebusV1SourceSnapshot struct {
+	Meta     eebusV1SourceSnapshotMeta       `json:"meta"`
+	Status   eebusV1SourceRuntimeObservation `json:"status"`
+	Pairing  []eebusV1SourcePairing          `json:"pairing,omitempty"`
+	Services []eebusV1SourceService          `json:"services,omitempty"`
+	Sessions []eebusV1SourceSession          `json:"sessions,omitempty"`
+	Topology eebusV1SourceTopology           `json:"topology"`
+	Raw      []eebusV1SourceEvidence         `json:"raw,omitempty"`
+}
+
+type eebusV1Pseudonymizer struct {
+	key        []byte
+	runtimeKey string
+}
+
+func newEEBusV1Pseudonymizer(key []byte, runtime eebusV1SourceIdentity) (*eebusV1Pseudonymizer, error) {
+	if len(key) != sha256.Size {
+		return nil, errors.New("pseudonym key must contain 32 bytes")
+	}
+	if err := eebusV1ValidateSourceIdentity(runtime); err != nil {
+		return nil, fmt.Errorf("runtime identity: %w", err)
+	}
+	return &eebusV1Pseudonymizer{
+		key:        append([]byte(nil), key...),
+		runtimeKey: runtime.Kind + "\x00" + runtime.Digest,
+	}, nil
+}
+
+func (p *eebusV1Pseudonymizer) identity(kind string, source eebusV1SourceIdentity) (eebusV1IdentityDigestV1, error) {
+	if p == nil || len(p.key) != sha256.Size {
+		return eebusV1IdentityDigestV1{}, errors.New("pseudonymizer is unavailable")
+	}
+	if err := eebusV1ValidateSourceIdentity(source); err != nil {
+		return eebusV1IdentityDigestV1{}, err
+	}
+	mac := hmac.New(sha256.New, p.key)
+	for _, component := range []string{
+		eebusV1ContractName,
+		"identity-v1",
+		kind,
+		p.runtimeKey,
+		source.Kind,
+		source.Digest,
+	} {
+		_, _ = mac.Write([]byte(component))
+		_, _ = mac.Write([]byte{0})
+	}
+	return eebusV1IdentityDigestV1{
+		Kind:   kind,
+		Digest: base64.RawURLEncoding.EncodeToString(mac.Sum(nil)),
+	}, nil
+}
+
+func eebusV1ProjectSnapshot(value any, pseudonymKey []byte) (eebusV1Projection, error) {
+	source, err := eebusV1DecodeSourceSnapshot(value)
+	if err != nil {
+		return eebusV1Projection{}, err
+	}
+	if err := eebusV1ValidateSourceSnapshot(source); err != nil {
+		return eebusV1Projection{}, err
+	}
+	pseudonyms, err := newEEBusV1Pseudonymizer(pseudonymKey, source.Meta.Runtime)
+	if err != nil {
+		return eebusV1Projection{}, err
+	}
+
+	runtime, err := eebusV1ProjectRuntime(source.Status)
+	if err != nil {
+		return eebusV1Projection{}, err
+	}
+	runtimeID, err := pseudonyms.identity("runtime", source.Meta.Runtime)
+	if err != nil {
+		return eebusV1Projection{}, err
+	}
+	services, err := eebusV1ProjectServices(source.Services, pseudonyms)
+	if err != nil {
+		return eebusV1Projection{}, err
+	}
+	sessions, err := eebusV1ProjectSessions(source.Sessions, pseudonyms)
+	if err != nil {
+		return eebusV1Projection{}, err
+	}
+	pairing, err := eebusV1ProjectPairing(source.Pairing, pseudonyms)
+	if err != nil {
+		return eebusV1Projection{}, err
+	}
+	topology, err := eebusV1ProjectTopology(source.Topology, pseudonyms)
+	if err != nil {
+		return eebusV1Projection{}, err
+	}
+	evidence, err := eebusV1ProjectEvidence(source.Raw)
+	if err != nil {
+		return eebusV1Projection{}, err
+	}
+
+	snapshot := eebusV1SnapshotDataV1{
+		Meta: eebusV1SnapshotMetaDataV1{
+			Contract:      eebusV1SourceSnapshotContract,
+			Runtime:       runtimeID,
+			MaskTier:      eebusV1MaskTier,
+			CapturedAt:    eebusV1Timestamp(source.Meta.CapturedAt),
+			DataTimestamp: eebusV1Timestamp(source.Meta.DataTimestamp),
+		},
+		Status:   runtime,
+		Pairing:  pairing,
+		Services: services,
+		Sessions: sessions,
+		Topology: topology,
+		Evidence: evidence,
+	}
+	encoded, err := json.Marshal(snapshot)
+	if err != nil {
+		return eebusV1Projection{}, errors.New("marshal projected snapshot")
+	}
+	_, contentHash, err := eebusV1CanonicalHashJSON(encoded, "/meta/data_hash", "/meta/captured_at")
+	if err != nil {
+		return eebusV1Projection{}, fmt.Errorf("hash projected snapshot: %w", err)
+	}
+	snapshot.Meta.DataHash = contentHash
+	return eebusV1Projection{
+		Snapshot:      snapshot,
+		Runtime:       runtime,
+		DataTimestamp: snapshot.Meta.DataTimestamp,
+		RuntimeKey:    pseudonyms.runtimeKey,
+	}, nil
+}
+
+func eebusV1DecodeSourceSnapshot(value any) (eebusV1SourceSnapshot, error) {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return eebusV1SourceSnapshot{}, errors.New("marshal provider snapshot")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.DisallowUnknownFields()
+	var snapshot eebusV1SourceSnapshot
+	if err := decoder.Decode(&snapshot); err != nil {
+		return eebusV1SourceSnapshot{}, errors.New("decode provider snapshot")
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return eebusV1SourceSnapshot{}, errors.New("provider snapshot contains trailing data")
+	}
+	return snapshot, nil
+}
+
+func eebusV1ValidateSourceSnapshot(snapshot eebusV1SourceSnapshot) error {
+	if snapshot.Meta.Contract != eebusV1SourceSnapshotContract || snapshot.Meta.MaskTier != eebusV1MaskTier {
+		return errors.New("invalid source snapshot metadata")
+	}
+	if err := eebusV1ValidateSourceIdentityKind(snapshot.Meta.Runtime, "peer", "local-ski"); err != nil {
+		return err
+	}
+	if err := eebusV1ValidateSourceIdentityKind(snapshot.Meta.LocalSKI, "local-ski"); err != nil {
+		return err
+	}
+	if err := eebusV1ValidateSourceTimestamp(snapshot.Meta.CapturedAt, true); err != nil {
+		return err
+	}
+	if err := eebusV1ValidateSourceTimestamp(snapshot.Meta.DataTimestamp, true); err != nil {
+		return err
+	}
+	if snapshot.Meta.DataHash != "" && !eebusV1ValidSourceDigest(snapshot.Meta.DataHash) {
+		return errors.New("invalid source snapshot hash")
+	}
+	if err := eebusV1ValidateSourceRuntime(snapshot.Status); err != nil {
+		return err
+	}
+	visibleService := false
+	for _, service := range snapshot.Services {
+		visibleService = visibleService || service.Visible
+		if err := eebusV1ValidateSourceIdentityKind(service.ID, "peer"); err != nil {
+			return err
+		}
+		if service.Kind != "local" && service.Kind != "remote" {
+			return errors.New("service contains an unsupported kind")
+		}
+		if len(service.Unknown) != 0 {
+			return errors.New("service contains unknown source fields")
+		}
+		if err := eebusV1ValidateSourceEvidence(service.Raw); err != nil {
+			return err
+		}
+	}
+	if !visibleService && snapshot.Status.State == "ready" {
+		return errors.New("ready runtime has no visible services")
+	}
+	for _, session := range snapshot.Sessions {
+		if err := eebusV1ValidateSourceIdentityKind(session.ID, "session"); err != nil {
+			return err
+		}
+		if err := eebusV1ValidateSourceIdentityKind(session.Remote, "remote-ski", "peer"); err != nil {
+			return err
+		}
+		if session.State != "connecting" && session.State != "connected" && session.State != "disconnected" && session.State != "degraded" {
+			return errors.New("session contains an unsupported state")
+		}
+		if err := eebusV1ValidateSourceTimestamp(session.Since, false); err != nil || len(session.Unknown) != 0 {
+			return errors.New("session contains an unsupported value")
+		}
+		if err := eebusV1ValidateSourceEvidence(session.Raw); err != nil {
+			return err
+		}
+	}
+	for _, item := range snapshot.Pairing {
+		if err := eebusV1ValidateSourceIdentityKind(item.Remote, "remote-ski", "peer"); err != nil {
+			return err
+		}
+		if item.State != "unpaired" && item.State != "paired" && item.State != "denied" {
+			return errors.New("pairing contains an unsupported state")
+		}
+		if err := eebusV1ValidateSourceTimestamp(item.Since, false); err != nil || len(item.Unknown) != 0 {
+			return errors.New("pairing contains an unsupported value")
+		}
+		if err := eebusV1ValidateSourceEvidence(item.Raw); err != nil {
+			return err
+		}
+	}
+	for _, device := range snapshot.Topology.Devices {
+		if err := eebusV1ValidateSourceIdentityKind(device.ID, "peer"); err != nil {
+			return err
+		}
+		if len(device.Unknown) != 0 {
+			return errors.New("device contains unknown source fields")
+		}
+		if err := eebusV1ValidateSourceEvidence(device.Raw); err != nil {
+			return err
+		}
+		for _, entity := range device.Entities {
+			if err := eebusV1ValidateSourceIdentityKind(entity.ID, "peer"); err != nil {
+				return err
+			}
+			if len(entity.Unknown) != 0 {
+				return errors.New("entity contains unknown source fields")
+			}
+			if err := eebusV1ValidateSourceEvidence(entity.Raw); err != nil {
+				return err
+			}
+			for _, feature := range entity.Features {
+				if err := eebusV1ValidateSourceIdentityKind(feature.ID, "peer"); err != nil {
+					return err
+				}
+				if (feature.Role != "client" && feature.Role != "server") || len(feature.Unknown) != 0 {
+					return errors.New("feature contains an unsupported value")
+				}
+				if err := eebusV1ValidateSourceEvidence(feature.Raw); err != nil {
+					return err
+				}
+			}
+		}
+		for _, claim := range device.UseCaseClaims {
+			if err := eebusV1ValidateSourceIdentityKind(claim.ID, "peer"); err != nil {
+				return err
+			}
+			if len(claim.Unknown) != 0 {
+				return errors.New("use-case claim contains unknown source fields")
+			}
+			if err := eebusV1ValidateSourceEvidence(claim.Raw); err != nil {
+				return err
+			}
+		}
+	}
+	return eebusV1ValidateSourceEvidence(snapshot.Raw)
+}
+
+func eebusV1ValidateSourceRuntime(source eebusV1SourceRuntimeObservation) error {
+	switch source.State {
+	case "stopped", "starting", "ready", "degraded", "shutdown":
+	default:
+		return errors.New("unsupported runtime state")
+	}
+	if source.State == "degraded" && source.Degradation == nil {
+		return errors.New("degraded runtime lacks details")
+	}
+	if source.State != "degraded" && source.Degradation != nil {
+		return errors.New("runtime degradation is inconsistent")
+	}
+	if source.Degradation == nil {
+		return nil
+	}
+	switch source.Degradation.Reason {
+	case "missing-discovery", "denied-trust", "remote-disconnect", "certificate-unavailable", "no-visible-services", "no-data":
+	default:
+		return errors.New("unsupported degradation reason")
+	}
+	return eebusV1ValidateSourceTimestamp(source.Degradation.Since, true)
+}
+
+func eebusV1ValidateSourceIdentity(source eebusV1SourceIdentity) error {
+	if source.Masked != eebusV1SourceRedactedValue || !eebusV1ValidSourceDigest(source.Digest) {
+		return errors.New("invalid redacted source identity")
+	}
+	switch source.Kind {
+	case "local-ski", "remote-ski", "certificate-fingerprint", "peer", "session":
+		return nil
+	default:
+		return errors.New("unsupported source identity kind")
+	}
+}
+
+func eebusV1ValidateSourceIdentityKind(source eebusV1SourceIdentity, allowed ...string) error {
+	if err := eebusV1ValidateSourceIdentity(source); err != nil {
+		return err
+	}
+	for _, kind := range allowed {
+		if source.Kind == kind {
+			return nil
+		}
+	}
+	return errors.New("source identity has an invalid kind")
+}
+
+func eebusV1ValidateSourceEvidence(source []eebusV1SourceEvidence) error {
+	for _, object := range source {
+		if err := eebusV1ValidateSourceEvidenceObject(object); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func eebusV1ValidateSourceEvidenceObject(object eebusV1SourceEvidence) error {
+	switch object.Kind {
+	case "identity", "topology", "service", "session", "unknown":
+	default:
+		return errors.New("unsupported evidence kind")
+	}
+	if !eebusV1ValidSourceDigest(object.Digest) || object.Size < 0 || object.Size > eebusV1MaxSafeInteger {
+		return errors.New("invalid evidence descriptor")
+	}
+	if err := eebusV1ValidateSourceTimestamp(object.DataTimestamp, true); err != nil {
+		return err
+	}
+	if len(object.Unknown) != 0 {
+		return errors.New("evidence contains unknown source fields")
+	}
+	return nil
+}
+
+func eebusV1ValidateSourceTimestamp(value time.Time, required bool) error {
+	if value.IsZero() {
+		if required {
+			return errors.New("source timestamp is required")
+		}
+		return nil
+	}
+	if _, err := value.UTC().MarshalJSON(); err != nil {
+		return errors.New("invalid source timestamp")
+	}
+	return nil
+}
+
+func eebusV1ValidSourceDigest(value string) bool {
+	if len(value) != len("sha256:")+64 || !strings.HasPrefix(value, "sha256:") || value != strings.ToLower(value) {
+		return false
+	}
+	_, err := hex.DecodeString(strings.TrimPrefix(value, "sha256:"))
+	return err == nil
+}
+
+func eebusV1ProjectRuntime(source eebusV1SourceRuntimeObservation) (eebusV1RuntimeStatusDataV1, error) {
+	switch source.State {
+	case "stopped", "starting", "ready", "degraded", "shutdown":
+	default:
+		return eebusV1RuntimeStatusDataV1{}, errors.New("unsupported runtime state")
+	}
+	result := eebusV1RuntimeStatusDataV1{State: source.State}
+	if source.Degradation != nil {
+		result.Degradation = &eebusV1DegradationDataV1{
+			Reason: source.Degradation.Reason,
+			Since:  eebusV1Timestamp(source.Degradation.Since),
+		}
+	}
+	return result, nil
+}
+
+func eebusV1ProjectServices(source []eebusV1SourceService, pseudonyms *eebusV1Pseudonymizer) ([]eebusV1ServiceDataV1, error) {
+	result := make([]eebusV1ServiceDataV1, 0, len(source))
+	for _, item := range source {
+		id, err := pseudonyms.identity("service", item.ID)
+		if err != nil {
+			return nil, err
+		}
+		evidence, err := eebusV1ProjectEvidence(item.Raw)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, eebusV1ServiceDataV1{
+			ID: id, Kind: item.Kind, Visible: item.Visible, Paired: item.Paired, Evidence: evidence,
+		})
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].ID.Digest != result[j].ID.Digest {
+			return result[i].ID.Digest < result[j].ID.Digest
+		}
+		return result[i].Kind < result[j].Kind
+	})
+	if err := eebusV1RejectDuplicateKeys(len(result), func(index int) string {
+		return result[index].ID.Digest + "\x00" + result[index].Kind
+	}); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func eebusV1ProjectSessions(source []eebusV1SourceSession, pseudonyms *eebusV1Pseudonymizer) ([]eebusV1SessionDataV1, error) {
+	result := make([]eebusV1SessionDataV1, 0, len(source))
+	for _, item := range source {
+		id, err := pseudonyms.identity("session", item.ID)
+		if err != nil {
+			return nil, err
+		}
+		remote, err := pseudonyms.identity("remote", item.Remote)
+		if err != nil {
+			return nil, err
+		}
+		evidence, err := eebusV1ProjectEvidence(item.Raw)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, eebusV1SessionDataV1{
+			ID: id, Remote: remote, State: item.State, Since: eebusV1OptionalTimestamp(item.Since), Evidence: evidence,
+		})
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].ID.Digest < result[j].ID.Digest })
+	if err := eebusV1RejectDuplicateKeys(len(result), func(index int) string { return result[index].ID.Digest }); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func eebusV1ProjectPairing(source []eebusV1SourcePairing, pseudonyms *eebusV1Pseudonymizer) ([]eebusV1PairingDataV1, error) {
+	result := make([]eebusV1PairingDataV1, 0, len(source))
+	for _, item := range source {
+		remote, err := pseudonyms.identity("remote", item.Remote)
+		if err != nil {
+			return nil, err
+		}
+		evidence, err := eebusV1ProjectEvidence(item.Raw)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, eebusV1PairingDataV1{
+			Remote: remote, State: item.State, Since: eebusV1OptionalTimestamp(item.Since), Evidence: evidence,
+		})
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Remote.Digest < result[j].Remote.Digest })
+	if err := eebusV1RejectDuplicateKeys(len(result), func(index int) string { return result[index].Remote.Digest }); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func eebusV1ProjectTopology(source eebusV1SourceTopology, pseudonyms *eebusV1Pseudonymizer) (eebusV1TopologyDataV1, error) {
+	result := eebusV1TopologyDataV1{Devices: make([]eebusV1DeviceDataV1, 0, len(source.Devices))}
+	for _, sourceDevice := range source.Devices {
+		deviceID, err := pseudonyms.identity("device", sourceDevice.ID)
+		if err != nil {
+			return eebusV1TopologyDataV1{}, err
+		}
+		deviceEvidence, err := eebusV1ProjectEvidence(sourceDevice.Raw)
+		if err != nil {
+			return eebusV1TopologyDataV1{}, err
+		}
+		device := eebusV1DeviceDataV1{
+			ID:            deviceID,
+			Entities:      make([]eebusV1EntityDataV1, 0, len(sourceDevice.Entities)),
+			UseCaseClaims: make([]eebusV1UseCaseClaimDataV1, 0, len(sourceDevice.UseCaseClaims)),
+			Evidence:      deviceEvidence,
+		}
+		for _, sourceEntity := range sourceDevice.Entities {
+			entityID, err := pseudonyms.identity("entity", sourceEntity.ID)
+			if err != nil {
+				return eebusV1TopologyDataV1{}, err
+			}
+			entityEvidence, err := eebusV1ProjectEvidence(sourceEntity.Raw)
+			if err != nil {
+				return eebusV1TopologyDataV1{}, err
+			}
+			entity := eebusV1EntityDataV1{
+				ID: entityID, Features: make([]eebusV1FeatureDataV1, 0, len(sourceEntity.Features)), Evidence: entityEvidence,
+			}
+			for _, sourceFeature := range sourceEntity.Features {
+				featureID, err := pseudonyms.identity("feature", sourceFeature.ID)
+				if err != nil {
+					return eebusV1TopologyDataV1{}, err
+				}
+				featureEvidence, err := eebusV1ProjectEvidence(sourceFeature.Raw)
+				if err != nil {
+					return eebusV1TopologyDataV1{}, err
+				}
+				entity.Features = append(entity.Features, eebusV1FeatureDataV1{
+					ID: featureID, Role: sourceFeature.Role, Evidence: featureEvidence,
+				})
+			}
+			sort.Slice(entity.Features, func(i, j int) bool { return entity.Features[i].ID.Digest < entity.Features[j].ID.Digest })
+			if err := eebusV1RejectDuplicateKeys(len(entity.Features), func(index int) string { return entity.Features[index].ID.Digest }); err != nil {
+				return eebusV1TopologyDataV1{}, err
+			}
+			device.Entities = append(device.Entities, entity)
+		}
+		sort.Slice(device.Entities, func(i, j int) bool { return device.Entities[i].ID.Digest < device.Entities[j].ID.Digest })
+		if err := eebusV1RejectDuplicateKeys(len(device.Entities), func(index int) string { return device.Entities[index].ID.Digest }); err != nil {
+			return eebusV1TopologyDataV1{}, err
+		}
+		for _, sourceClaim := range sourceDevice.UseCaseClaims {
+			claimID, err := pseudonyms.identity("usecase-claim", sourceClaim.ID)
+			if err != nil {
+				return eebusV1TopologyDataV1{}, err
+			}
+			claimEvidence, err := eebusV1ProjectEvidence(sourceClaim.Raw)
+			if err != nil {
+				return eebusV1TopologyDataV1{}, err
+			}
+			device.UseCaseClaims = append(device.UseCaseClaims, eebusV1UseCaseClaimDataV1{ID: claimID, Evidence: claimEvidence})
+		}
+		sort.Slice(device.UseCaseClaims, func(i, j int) bool {
+			return device.UseCaseClaims[i].ID.Digest < device.UseCaseClaims[j].ID.Digest
+		})
+		if err := eebusV1RejectDuplicateKeys(len(device.UseCaseClaims), func(index int) string { return device.UseCaseClaims[index].ID.Digest }); err != nil {
+			return eebusV1TopologyDataV1{}, err
+		}
+		result.Devices = append(result.Devices, device)
+	}
+	sort.Slice(result.Devices, func(i, j int) bool { return result.Devices[i].ID.Digest < result.Devices[j].ID.Digest })
+	if err := eebusV1RejectDuplicateKeys(len(result.Devices), func(index int) string { return result.Devices[index].ID.Digest }); err != nil {
+		return eebusV1TopologyDataV1{}, err
+	}
+	return result, nil
+}
+
+func eebusV1ProjectEvidence(source []eebusV1SourceEvidence) ([]eebusV1EvidenceDescriptorV1, error) {
+	if len(source) == 0 {
+		return nil, nil
+	}
+	result := make([]eebusV1EvidenceDescriptorV1, 0, len(source))
+	for _, object := range source {
+		if err := eebusV1ValidateSourceEvidenceObject(object); err != nil {
+			return nil, errors.New("invalid evidence descriptor")
+		}
+		result = append(result, eebusV1EvidenceDescriptorV1{
+			Kind: object.Kind, Digest: object.Digest, Size: object.Size, DataTimestamp: eebusV1Timestamp(object.DataTimestamp),
+		})
+	}
+	sort.Slice(result, func(i, j int) bool {
+		left, right := result[i], result[j]
+		if left.Kind != right.Kind {
+			return left.Kind < right.Kind
+		}
+		if left.Digest != right.Digest {
+			return left.Digest < right.Digest
+		}
+		if left.Size != right.Size {
+			return left.Size < right.Size
+		}
+		return left.DataTimestamp < right.DataTimestamp
+	})
+	if err := eebusV1RejectDuplicateKeys(len(result), func(index int) string {
+		item := result[index]
+		return fmt.Sprintf("%s\x00%s\x00%020d\x00%s", item.Kind, item.Digest, item.Size, item.DataTimestamp)
+	}); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func eebusV1RejectDuplicateKeys(length int, key func(int) string) error {
+	for index := 1; index < length; index++ {
+		if key(index-1) == key(index) {
+			return errors.New("duplicate projected identity")
+		}
+	}
+	return nil
+}
+
+func eebusV1Timestamp(value time.Time) string {
+	return value.UTC().Format(time.RFC3339Nano)
+}
+
+func eebusV1OptionalTimestamp(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return eebusV1Timestamp(value)
+}

--- a/mcp/eebus_v1_jcs.go
+++ b/mcp/eebus_v1_jcs.go
@@ -1,0 +1,444 @@
+package mcp
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"math/big"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode/utf16"
+	"unicode/utf8"
+)
+
+const eebusV1MaxSafeInteger = int64(9007199254740991)
+
+// eebusV1CanonicalHashJSON implements the RFC 8785 subset used by the
+// eeBUS v1 contract: I-JSON values, UTF-16 object-key ordering, ECMAScript
+// number rendering, and exact JSON-pointer exclusions from the hash view.
+func eebusV1CanonicalHashJSON(source []byte, exclusions ...string) ([]byte, string, error) {
+	if !utf8.Valid(source) {
+		return nil, "", errors.New("canonical JSON input is not valid UTF-8")
+	}
+	if err := eebusV1ValidateJSONSurrogates(source); err != nil {
+		return nil, "", err
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(source))
+	decoder.UseNumber()
+	value, err := eebusV1DecodeJSONValue(decoder)
+	if err != nil {
+		return nil, "", fmt.Errorf("decode canonical JSON input: %w", err)
+	}
+	if _, err := decoder.Token(); !errors.Is(err, io.EOF) {
+		if err == nil {
+			err = errors.New("multiple JSON values")
+		}
+		return nil, "", fmt.Errorf("decode canonical JSON input: %w", err)
+	}
+	if err := eebusV1ValidateJCSValue(value); err != nil {
+		return nil, "", err
+	}
+	for _, pointer := range exclusions {
+		if err := eebusV1DeleteJSONPointer(value, pointer); err != nil {
+			return nil, "", err
+		}
+	}
+
+	var canonical bytes.Buffer
+	if err := eebusV1WriteJCS(&canonical, value); err != nil {
+		return nil, "", err
+	}
+	sum := sha256.Sum256(canonical.Bytes())
+	return canonical.Bytes(), "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func eebusV1ValidateJSONSurrogates(source []byte) error {
+	inString := false
+	for index := 0; index < len(source); index++ {
+		switch source[index] {
+		case '"':
+			inString = !inString
+		case '\\':
+			if !inString || index+1 >= len(source) {
+				continue
+			}
+			index++
+			if source[index] != 'u' {
+				continue
+			}
+			codeUnit, ok := eebusV1ParseJSONCodeUnit(source, index+1)
+			if !ok {
+				return errors.New("canonical JSON contains an invalid Unicode escape")
+			}
+			index += 4
+			switch {
+			case codeUnit >= 0xd800 && codeUnit <= 0xdbff:
+				if index+6 >= len(source) || source[index+1] != '\\' || source[index+2] != 'u' {
+					return errors.New("canonical JSON contains an unpaired Unicode surrogate")
+				}
+				low, valid := eebusV1ParseJSONCodeUnit(source, index+3)
+				if !valid || low < 0xdc00 || low > 0xdfff {
+					return errors.New("canonical JSON contains an unpaired Unicode surrogate")
+				}
+				index += 6
+			case codeUnit >= 0xdc00 && codeUnit <= 0xdfff:
+				return errors.New("canonical JSON contains an unpaired Unicode surrogate")
+			}
+		}
+	}
+	return nil
+}
+
+func eebusV1ParseJSONCodeUnit(source []byte, start int) (uint16, bool) {
+	if start < 0 || start+4 > len(source) {
+		return 0, false
+	}
+	var value uint16
+	for _, character := range source[start : start+4] {
+		value <<= 4
+		switch {
+		case character >= '0' && character <= '9':
+			value |= uint16(character - '0')
+		case character >= 'a' && character <= 'f':
+			value |= uint16(character-'a') + 10
+		case character >= 'A' && character <= 'F':
+			value |= uint16(character-'A') + 10
+		default:
+			return 0, false
+		}
+	}
+	return value, true
+}
+
+func eebusV1DecodeJSONValue(decoder *json.Decoder) (any, error) {
+	token, err := decoder.Token()
+	if err != nil {
+		return nil, err
+	}
+	delimiter, isDelimiter := token.(json.Delim)
+	if !isDelimiter {
+		switch token.(type) {
+		case nil, bool, string, json.Number:
+			return token, nil
+		default:
+			return nil, fmt.Errorf("unsupported JSON token %T", token)
+		}
+	}
+
+	switch delimiter {
+	case '{':
+		object := make(map[string]any)
+		for decoder.More() {
+			rawKey, err := decoder.Token()
+			if err != nil {
+				return nil, err
+			}
+			key, ok := rawKey.(string)
+			if !ok {
+				return nil, errors.New("JSON object key is not a string")
+			}
+			if _, exists := object[key]; exists {
+				return nil, fmt.Errorf("duplicate JSON object key %q", key)
+			}
+			value, err := eebusV1DecodeJSONValue(decoder)
+			if err != nil {
+				return nil, err
+			}
+			object[key] = value
+		}
+		closing, err := decoder.Token()
+		if err != nil || closing != json.Delim('}') {
+			return nil, errors.New("unterminated JSON object")
+		}
+		return object, nil
+	case '[':
+		array := make([]any, 0)
+		for decoder.More() {
+			value, err := eebusV1DecodeJSONValue(decoder)
+			if err != nil {
+				return nil, err
+			}
+			array = append(array, value)
+		}
+		closing, err := decoder.Token()
+		if err != nil || closing != json.Delim(']') {
+			return nil, errors.New("unterminated JSON array")
+		}
+		return array, nil
+	default:
+		return nil, fmt.Errorf("unexpected JSON delimiter %q", delimiter)
+	}
+}
+
+func eebusV1ValidateJCSValue(value any) error {
+	switch typed := value.(type) {
+	case nil, bool:
+		return nil
+	case string:
+		if !utf8.ValidString(typed) {
+			return errors.New("canonical JSON string is not valid UTF-8")
+		}
+		return nil
+	case json.Number:
+		_, err := eebusV1FormatJCSNumber(typed)
+		return err
+	case []any:
+		for _, item := range typed {
+			if err := eebusV1ValidateJCSValue(item); err != nil {
+				return err
+			}
+		}
+		return nil
+	case map[string]any:
+		for key, item := range typed {
+			if !utf8.ValidString(key) {
+				return errors.New("canonical JSON object key is not valid UTF-8")
+			}
+			if err := eebusV1ValidateJCSValue(item); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported canonical JSON value %T", value)
+	}
+}
+
+func eebusV1DeleteJSONPointer(root any, pointer string) error {
+	if pointer == "" {
+		return errors.New("canonical JSON exclusion cannot remove the root")
+	}
+	if !strings.HasPrefix(pointer, "/") {
+		return fmt.Errorf("invalid JSON pointer %q", pointer)
+	}
+	parts := strings.Split(pointer[1:], "/")
+	for index := range parts {
+		decoded, err := eebusV1DecodeJSONPointerToken(parts[index])
+		if err != nil {
+			return fmt.Errorf("invalid JSON pointer %q: %w", pointer, err)
+		}
+		parts[index] = decoded
+	}
+
+	current := root
+	for _, part := range parts[:len(parts)-1] {
+		switch typed := current.(type) {
+		case map[string]any:
+			next, exists := typed[part]
+			if !exists {
+				return nil
+			}
+			current = next
+		case []any:
+			position, err := strconv.Atoi(part)
+			if err != nil || position < 0 || position >= len(typed) {
+				return nil
+			}
+			current = typed[position]
+		default:
+			return nil
+		}
+	}
+
+	leaf := parts[len(parts)-1]
+	switch typed := current.(type) {
+	case map[string]any:
+		delete(typed, leaf)
+	case []any:
+		position, err := strconv.Atoi(leaf)
+		if err == nil && position >= 0 && position < len(typed) {
+			typed[position] = nil
+		}
+	}
+	return nil
+}
+
+func eebusV1DecodeJSONPointerToken(token string) (string, error) {
+	var decoded strings.Builder
+	for index := 0; index < len(token); index++ {
+		if token[index] != '~' {
+			decoded.WriteByte(token[index])
+			continue
+		}
+		if index+1 >= len(token) {
+			return "", errors.New("truncated escape")
+		}
+		index++
+		switch token[index] {
+		case '0':
+			decoded.WriteByte('~')
+		case '1':
+			decoded.WriteByte('/')
+		default:
+			return "", errors.New("invalid escape")
+		}
+	}
+	return decoded.String(), nil
+}
+
+func eebusV1WriteJCS(target *bytes.Buffer, value any) error {
+	switch typed := value.(type) {
+	case nil:
+		target.WriteString("null")
+	case bool:
+		if typed {
+			target.WriteString("true")
+		} else {
+			target.WriteString("false")
+		}
+	case string:
+		eebusV1WriteJCSString(target, typed)
+	case json.Number:
+		number, err := eebusV1FormatJCSNumber(typed)
+		if err != nil {
+			return err
+		}
+		target.WriteString(number)
+	case []any:
+		target.WriteByte('[')
+		for index, item := range typed {
+			if index > 0 {
+				target.WriteByte(',')
+			}
+			if err := eebusV1WriteJCS(target, item); err != nil {
+				return err
+			}
+		}
+		target.WriteByte(']')
+	case map[string]any:
+		keys := make([]string, 0, len(typed))
+		for key := range typed {
+			keys = append(keys, key)
+		}
+		sort.Slice(keys, func(i, j int) bool {
+			return eebusV1UTF16Less(keys[i], keys[j])
+		})
+		target.WriteByte('{')
+		for index, key := range keys {
+			if index > 0 {
+				target.WriteByte(',')
+			}
+			eebusV1WriteJCSString(target, key)
+			target.WriteByte(':')
+			if err := eebusV1WriteJCS(target, typed[key]); err != nil {
+				return err
+			}
+		}
+		target.WriteByte('}')
+	default:
+		return fmt.Errorf("unsupported canonical JSON value %T", value)
+	}
+	return nil
+}
+
+func eebusV1UTF16Less(left, right string) bool {
+	leftUnits := utf16.Encode([]rune(left))
+	rightUnits := utf16.Encode([]rune(right))
+	for index := 0; index < len(leftUnits) && index < len(rightUnits); index++ {
+		if leftUnits[index] != rightUnits[index] {
+			return leftUnits[index] < rightUnits[index]
+		}
+	}
+	return len(leftUnits) < len(rightUnits)
+}
+
+func eebusV1WriteJCSString(target *bytes.Buffer, value string) {
+	const hexDigits = "0123456789abcdef"
+	target.WriteByte('"')
+	for _, character := range value {
+		switch character {
+		case '\b':
+			target.WriteString(`\b`)
+		case '\t':
+			target.WriteString(`\t`)
+		case '\n':
+			target.WriteString(`\n`)
+		case '\f':
+			target.WriteString(`\f`)
+		case '\r':
+			target.WriteString(`\r`)
+		case '"':
+			target.WriteString(`\"`)
+		case '\\':
+			target.WriteString(`\\`)
+		default:
+			if character >= 0 && character <= 0x1f {
+				target.WriteString(`\u00`)
+				target.WriteByte(hexDigits[byte(character)>>4])
+				target.WriteByte(hexDigits[byte(character)&0x0f])
+			} else {
+				target.WriteRune(character)
+			}
+		}
+	}
+	target.WriteByte('"')
+}
+
+func eebusV1FormatJCSNumber(number json.Number) (string, error) {
+	text := number.String()
+	value, err := strconv.ParseFloat(text, 64)
+	if err != nil || math.IsNaN(value) || math.IsInf(value, 0) {
+		return "", errors.New("canonical JSON number is not finite IEEE-754")
+	}
+	if value == 0 && strings.HasPrefix(text, "-") {
+		return "", errors.New("canonical JSON number is negative zero")
+	}
+
+	exact, _, err := big.ParseFloat(text, 10, 512, big.ToNearestEven)
+	if err != nil {
+		return "", errors.New("canonical JSON number is invalid")
+	}
+	absExact := new(big.Float).SetPrec(512).Abs(exact)
+	limit := new(big.Float).SetPrec(512).SetInt64(eebusV1MaxSafeInteger)
+	if absExact.Cmp(limit) > 0 {
+		return "", errors.New("canonical JSON number exceeds the portable safe-integer range")
+	}
+	if value == 0 {
+		return "0", nil
+	}
+
+	sign := ""
+	if value < 0 {
+		sign = "-"
+		value = -value
+	}
+	scientific := strconv.FormatFloat(value, 'e', -1, 64)
+	exponentMarker := strings.IndexByte(scientific, 'e')
+	if exponentMarker < 0 {
+		return "", errors.New("canonical JSON number formatting failed")
+	}
+	mantissa := scientific[:exponentMarker]
+	exponent, err := strconv.Atoi(scientific[exponentMarker+1:])
+	if err != nil {
+		return "", errors.New("canonical JSON exponent formatting failed")
+	}
+	digits := strings.ReplaceAll(mantissa, ".", "")
+	decimalPosition := exponent + 1
+
+	switch {
+	case decimalPosition > 0 && decimalPosition <= 21:
+		if len(digits) <= decimalPosition {
+			return sign + digits + strings.Repeat("0", decimalPosition-len(digits)), nil
+		}
+		return sign + digits[:decimalPosition] + "." + digits[decimalPosition:], nil
+	case decimalPosition <= 0 && decimalPosition > -6:
+		return sign + "0." + strings.Repeat("0", -decimalPosition) + digits, nil
+	default:
+		coefficient := digits[:1]
+		if len(digits) > 1 {
+			coefficient += "." + digits[1:]
+		}
+		exponentText := strconv.Itoa(decimalPosition - 1)
+		if decimalPosition-1 >= 0 {
+			exponentText = "+" + exponentText
+		}
+		return sign + coefficient + "e" + exponentText, nil
+	}
+}

--- a/mcp/eebus_v1_jcs_test.go
+++ b/mcp/eebus_v1_jcs_test.go
@@ -1,0 +1,158 @@
+package mcp
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestMSP06CandidateJCSHashVectors(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		exclusions []string
+		canonical  string
+		hash       string
+	}{
+		{
+			name:      "object-key-order",
+			input:     `{"z":0,"a":1}`,
+			canonical: `{"a":1,"z":0}`,
+			hash:      "sha256:b55af27c4bd5f02ebeca8f901b84d2940b22e7bea7230e4d06f275d903bfdd72",
+		},
+		{
+			name:      "unicode-key-order",
+			input:     "{\"outer\":{\"\ue000\":\"bmp\",\"😀\":\"supplementary\"},\"\\r\":\"cr\",\"1\":\"one\",\"€\":\"euro\"}",
+			canonical: "{\"\\r\":\"cr\",\"1\":\"one\",\"outer\":{\"😀\":\"supplementary\",\"\ue000\":\"bmp\"},\"€\":\"euro\"}",
+			hash:      "sha256:fd16c106364021a01f7a014dbf9f6a2871051afc5eb7d313a5967f5346eb48f9",
+		},
+		{
+			name:      "explicit-null",
+			input:     `{"a":null}`,
+			canonical: `{"a":null}`,
+			hash:      "sha256:d091f9c83c091f79652fe8786375b3fe4ce0861a56f5bfbafedbe431877ff0e8",
+		},
+		{
+			name:      "omitted-field",
+			input:     `{}`,
+			canonical: `{}`,
+			hash:      "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+		},
+		{
+			name:      "safe-integer-string",
+			input:     `{"n":"9007199254740992"}`,
+			canonical: `{"n":"9007199254740992"}`,
+			hash:      "sha256:bb80eb37329e0a7e980fe3638c9722c44ac3184f7488f20c28cf67ae0b5f4f96",
+		},
+		{
+			name:       "token-substitution-a",
+			input:      `{"data":{"snapshot_content_hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","snapshot_ref":"opaque-a"},"tool":"eebus.v1.snapshot.capture"}`,
+			exclusions: []string{"/data/snapshot_ref"},
+			canonical:  `{"data":{"snapshot_content_hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},"tool":"eebus.v1.snapshot.capture"}`,
+			hash:       "sha256:1dd1b393e6cd221850141f0fb4aa66e050abab7cd8fd32abffc8c3e8135b9555",
+		},
+		{
+			name:       "token-substitution-b",
+			input:      `{"data":{"snapshot_content_hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","snapshot_ref":"opaque-b"},"tool":"eebus.v1.snapshot.capture"}`,
+			exclusions: []string{"/data/snapshot_ref"},
+			canonical:  `{"data":{"snapshot_content_hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},"tool":"eebus.v1.snapshot.capture"}`,
+			hash:       "sha256:1dd1b393e6cd221850141f0fb4aa66e050abab7cd8fd32abffc8c3e8135b9555",
+		},
+		{
+			name:      "payload-before",
+			input:     `{"data":{"value":"before"},"tool":"eebus.v1.services.get"}`,
+			canonical: `{"data":{"value":"before"},"tool":"eebus.v1.services.get"}`,
+			hash:      "sha256:c88088abcd03a63a675b1b6886b67c9f44c4eff3e081fad3a7315dc8c4928ae9",
+		},
+		{
+			name:      "payload-after",
+			input:     `{"data":{"value":"after"},"tool":"eebus.v1.services.get"}`,
+			canonical: `{"data":{"value":"after"},"tool":"eebus.v1.services.get"}`,
+			hash:      "sha256:8ddc952deff2bd36eade164c45b2799d0b46851086f40a0acb0116f985c33395",
+		},
+		{
+			name:       "error-message-invariant-a",
+			input:      `{"backend_error":"implementation-detail-a","error":{"code":"backend_unavailable","message":"eeBUS runtime unavailable","retriable":true,"source_layer":"eebusruntime"}}`,
+			exclusions: []string{"/backend_error"},
+			canonical:  `{"error":{"code":"backend_unavailable","message":"eeBUS runtime unavailable","retriable":true,"source_layer":"eebusruntime"}}`,
+			hash:       "sha256:4ab875e3987cc60dd0fdc382a3d0063b86742bc2349be5831d96e3bf05b7918e",
+		},
+		{
+			name:       "error-message-invariant-b",
+			input:      `{"backend_error":"implementation-detail-b","error":{"code":"backend_unavailable","message":"eeBUS runtime unavailable","retriable":true,"source_layer":"eebusruntime"}}`,
+			exclusions: []string{"/backend_error"},
+			canonical:  `{"error":{"code":"backend_unavailable","message":"eeBUS runtime unavailable","retriable":true,"source_layer":"eebusruntime"}}`,
+			hash:       "sha256:4ab875e3987cc60dd0fdc382a3d0063b86742bc2349be5831d96e3bf05b7918e",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			canonical, hash, err := eebusV1CanonicalHashJSON([]byte(test.input), test.exclusions...)
+			if err != nil {
+				t.Fatalf("eebusV1CanonicalHashJSON() error = %v", err)
+			}
+			if !bytes.Equal(canonical, []byte(test.canonical)) || hash != test.hash {
+				t.Fatalf("canonical/hash = %s / %s, want %s / %s", canonical, hash, test.canonical, test.hash)
+			}
+		})
+	}
+}
+
+func TestMSP06JCSRelationsAndExcludedPathsAreExact(t *testing.T) {
+	_, tokenA, err := eebusV1CanonicalHashJSON(
+		[]byte(`{"data":{"snapshot_content_hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","snapshot_ref":"opaque-a"},"tool":"eebus.v1.snapshot.capture"}`),
+		"/data/snapshot_ref",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, tokenB, err := eebusV1CanonicalHashJSON(
+		[]byte(`{"data":{"snapshot_content_hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","snapshot_ref":"opaque-b"},"tool":"eebus.v1.snapshot.capture"}`),
+		"/data/snapshot_ref",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tokenA != tokenB {
+		t.Fatalf("excluded opaque token changed hash: %s vs %s", tokenA, tokenB)
+	}
+
+	_, before, err := eebusV1CanonicalHashJSON([]byte(`{"data":{"value":"before"},"tool":"eebus.v1.services.get"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, after, err := eebusV1CanonicalHashJSON([]byte(`{"data":{"value":"after"},"tool":"eebus.v1.services.get"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before == after {
+		t.Fatal("payload mutation did not change hash")
+	}
+
+	_, explicitNull, err := eebusV1CanonicalHashJSON([]byte(`{"a":null}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, omitted, err := eebusV1CanonicalHashJSON([]byte(`{}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if explicitNull == omitted {
+		t.Fatal("explicit null and omitted field produced the same hash")
+	}
+}
+
+func TestMSP06JCSRejectsNegativeZeroUnsafeNumbersAndInvalidJSON(t *testing.T) {
+	for _, input := range []string{
+		`{"n":-0}`,
+		`{"n":9007199254740992}`,
+		`{"n":-9007199254740992}`,
+		`{"n":NaN}`,
+		`{"n":Infinity}`,
+		`{"unterminated":`,
+	} {
+		if canonical, hash, err := eebusV1CanonicalHashJSON([]byte(input)); err == nil {
+			t.Fatalf("input %s accepted as canonical=%s hash=%s", input, canonical, hash)
+		}
+	}
+}

--- a/mcp/eebus_v1_review_red_test.go
+++ b/mcp/eebus_v1_review_red_test.go
@@ -1,0 +1,464 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	eebusruntime "github.com/Project-Helianthus/helianthus-eebusreg"
+	"github.com/Project-Helianthus/helianthus-eebusreg/eebusevidence"
+	"github.com/Project-Helianthus/helianthus-eebusreg/eebusraw"
+)
+
+const (
+	msp06ReviewMaxLiveWorkers      = 8
+	msp06ReviewOversizedCollection = 1025
+)
+
+func TestMSP06EvidenceSizeOrderingUsesSerializedScalarBytes(t *testing.T) {
+	server, _ := msp06TestServer(t, &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")})
+	data := msp06AssertSuccess(
+		t,
+		msp06Call(t, server.Handler(), msp06ServicesListTool, map[string]any{}),
+		msp06ServicesListTool,
+		"services",
+		"live",
+	)
+
+	var got []string
+	for index, rawService := range msp06Slice(t, data["services"], "services") {
+		service := msp06Map(t, rawService, fmt.Sprintf("services[%d]", index))
+		rawEvidence, exists := service["evidence"]
+		if !exists {
+			continue
+		}
+		evidence := msp06Slice(t, rawEvidence, fmt.Sprintf("services[%d].evidence", index))
+		if len(evidence) != 2 {
+			continue
+		}
+		for evidenceIndex, raw := range evidence {
+			item := msp06Map(t, raw, fmt.Sprintf("services[%d].evidence[%d]", index, evidenceIndex))
+			size, ok := item["size"].(json.Number)
+			if !ok {
+				t.Fatalf("evidence size type = %T, want JSON number", item["size"])
+			}
+			got = append(got, size.String())
+		}
+		break
+	}
+	if want := []string{"10", "2"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("evidence sizes = %v, want %v from bytewise serialized-scalar ordering", got, want)
+	}
+}
+
+func msp06ReviewProjection(t *testing.T) eebusV1Projection {
+	t.Helper()
+	projection, err := eebusV1ProjectSnapshot(
+		msp06Snapshot(t, "runtime-a"),
+		bytes.Repeat([]byte{0x6b}, sha256.Size),
+	)
+	if err != nil {
+		t.Fatalf("project review fixture: %v", err)
+	}
+	return projection
+}
+
+func msp06ReviewStoreWithRoot(t *testing.T, now time.Time) (*eebusV1SnapshotStore, eebusV1CapturedRootV1) {
+	t.Helper()
+	store := newEEBusV1SnapshotStore(func() time.Time { return now }, &msp06EntropyReader{})
+	captured, code := store.capture(msp06ReviewProjection(t))
+	if code != "" {
+		t.Fatalf("capture review fixture code = %q", code)
+	}
+	return store, captured
+}
+
+func TestMSP06StoreSamplesOperationTimeOnlyWhileHoldingMutex(t *testing.T) {
+	base := time.Now()
+	for _, operation := range []string{"capture", "lookup", "drop"} {
+		t.Run(operation, func(t *testing.T) {
+			store, captured := msp06ReviewStoreWithRoot(t, base)
+			projection := msp06ReviewProjection(t)
+			entered := make(chan struct{})
+			release := make(chan struct{})
+			var enteredOnce sync.Once
+			store.now = func() time.Time {
+				enteredOnce.Do(func() { close(entered) })
+				<-release
+				return base.Add(time.Minute)
+			}
+
+			done := make(chan struct{})
+			go func() {
+				switch operation {
+				case "capture":
+					store.capture(projection)
+				case "lookup":
+					store.lookup(captured.EvidenceRefs.ServicesListRef, eebusV1ServicesListTool, "services")
+				case "drop":
+					store.drop(captured.SnapshotRef)
+				}
+				close(done)
+			}()
+
+			<-entered
+			sampledBeforeLock := store.mu.TryLock()
+			if sampledBeforeLock {
+				store.mu.Unlock()
+			}
+			close(release)
+			<-done
+			if sampledBeforeLock {
+				t.Fatalf("%s sampled time before acquiring the store mutex", operation)
+			}
+		})
+	}
+}
+
+func TestMSP06StoreExpiryAndDropUseMutexLinearizationTime(t *testing.T) {
+	base := time.Now()
+	beforeExpiry := base.Add(eebusV1ActiveTTL - time.Nanosecond)
+	atExpiry := base.Add(eebusV1ActiveTTL)
+
+	t.Run("lookup", func(t *testing.T) {
+		store, captured := msp06ReviewStoreWithRoot(t, base)
+		store.now = func() time.Time {
+			if store.mu.TryLock() {
+				store.mu.Unlock()
+				return beforeExpiry
+			}
+			return atExpiry
+		}
+		result := store.lookup(captured.EvidenceRefs.ServicesListRef, eebusV1ServicesListTool, "services")
+		if result.ErrorCode != "snapshot_gone" {
+			t.Fatalf("lookup at mutex linearization boundary code = %q, want snapshot_gone", result.ErrorCode)
+		}
+	})
+
+	t.Run("drop", func(t *testing.T) {
+		store, captured := msp06ReviewStoreWithRoot(t, base)
+		store.now = func() time.Time {
+			if store.mu.TryLock() {
+				store.mu.Unlock()
+				return beforeExpiry
+			}
+			return atExpiry
+		}
+		if result := store.drop(captured.SnapshotRef); result.Status != "already_gone" {
+			t.Fatalf("drop at mutex linearization boundary status = %q, want already_gone", result.Status)
+		}
+	})
+}
+
+func TestMSP06StoreRetainsMonotonicTimeInternallyAndUsesUTCOnlyOnWire(t *testing.T) {
+	base := time.Now()
+	if base == base.Round(0) {
+		t.Skip("host clock did not provide a monotonic reading")
+	}
+	store, captured := msp06ReviewStoreWithRoot(t, base)
+	root := store.activeRoots[captured.SnapshotRef]
+	if root == nil {
+		t.Fatal("captured root missing from active store")
+	}
+	if root.ExpiresAt == root.ExpiresAt.Round(0) {
+		t.Error("active expiry discarded the monotonic clock reading")
+	}
+	if want := eebusV1Timestamp(base.Add(eebusV1ActiveTTL)); captured.ExpiresAt != want {
+		t.Errorf("wire expiry = %q, want UTC %q", captured.ExpiresAt, want)
+	}
+
+	terminalAt := base.Add(time.Minute)
+	store.now = func() time.Time { return terminalAt }
+	if result := store.drop(captured.SnapshotRef); result.Status != "dropped" {
+		t.Fatalf("drop status = %q, want dropped", result.Status)
+	}
+	tombstone := store.tombstoneRoots[captured.SnapshotRef]
+	if tombstone == nil {
+		t.Fatal("dropped root missing tombstone")
+	}
+	if tombstone.TerminalAt == tombstone.TerminalAt.Round(0) {
+		t.Error("terminal transition discarded the monotonic clock reading")
+	}
+}
+
+func TestMSP06ProviderInterfaceIsCompileTimeTypedThroughRuntime(t *testing.T) {
+	providerType := reflect.TypeOf((*EEBusV1Provider)(nil)).Elem()
+	method, ok := providerType.MethodByName("Snapshot")
+	if !ok {
+		t.Fatal("EEBusV1Provider has no compile-time Snapshot method")
+	}
+	errorType := reflect.TypeOf((*error)(nil)).Elem()
+	snapshotType := reflect.TypeOf(eebusruntime.SnapshotV1{})
+	if method.Type.NumIn() != 0 || method.Type.NumOut() != 2 || method.Type.Out(0) != snapshotType || method.Type.Out(1) != errorType {
+		t.Fatalf("EEBusV1Provider.Snapshot type = %s, want func() (eebusruntime.SnapshotV1, error)", method.Type)
+	}
+	runtimeField, ok := reflect.TypeOf(eebusV1Runtime{}).FieldByName("provider")
+	if !ok || runtimeField.Type != providerType {
+		t.Fatalf("eebusV1Runtime.provider type = %v, want EEBusV1Provider", runtimeField.Type)
+	}
+}
+
+func TestMSP06ProviderInvocationDoesNotUseReflectiveMethodDispatch(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "eebus_v1.go", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ast.Inspect(file, func(node ast.Node) bool {
+		selector, ok := node.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if selector.Sel.Name == "MethodByName" {
+			t.Errorf("provider method is discovered reflectively at %s", fset.Position(selector.Pos()))
+		}
+		if receiver, ok := selector.X.(*ast.Ident); ok && receiver.Name == "method" && selector.Sel.Name == "Call" {
+			t.Errorf("provider method is invoked reflectively at %s", fset.Position(selector.Pos()))
+		}
+		return true
+	})
+}
+
+type msp06ReviewBlockingProvider struct {
+	snapshot eebusruntime.SnapshotV1
+	release  <-chan struct{}
+	exited   chan<- struct{}
+	calls    atomic.Int64
+}
+
+var _ EEBusV1Provider = (*msp06ReviewBlockingProvider)(nil)
+
+func (provider *msp06ReviewBlockingProvider) Snapshot() (eebusruntime.SnapshotV1, error) {
+	provider.calls.Add(1)
+	<-provider.release
+	provider.exited <- struct{}{}
+	return provider.snapshot, nil
+}
+
+func msp06ReviewCaptureWave(t *testing.T, server *Server, attempts int) {
+	t.Helper()
+	start := make(chan struct{})
+	outcomes := make(chan struct {
+		code string
+		err  error
+	}, attempts)
+	for index := 0; index < attempts; index++ {
+		go func() {
+			<-start
+			outcomes <- msp06ConcurrentCapture(server.Handler())
+		}()
+	}
+	close(start)
+	deadline := time.NewTimer(5 * time.Second)
+	defer deadline.Stop()
+	for index := 0; index < attempts; index++ {
+		select {
+		case outcome := <-outcomes:
+			if outcome.err != nil {
+				t.Fatalf("blocked capture %d: %v", index, outcome.err)
+			}
+			if outcome.code != "timeout" {
+				t.Fatalf("blocked capture %d code = %q, want timeout", index, outcome.code)
+			}
+		case <-deadline.C:
+			t.Fatalf("blocked capture wave did not finish after %d outcomes", index)
+		}
+	}
+}
+
+func TestMSP06BlockedProviderWorkersAreBoundedAndPermitsRemainUntilExit(t *testing.T) {
+	const attempts = 32
+	release := make(chan struct{})
+	exited := make(chan struct{}, attempts*2+1)
+	provider := &msp06ReviewBlockingProvider{
+		snapshot: msp06Snapshot(t, "runtime-a"),
+		release:  release,
+		exited:   exited,
+	}
+	var releaseOnce sync.Once
+	releaseProvider := func() { releaseOnce.Do(func() { close(release) }) }
+	defer releaseProvider()
+
+	server, _ := msp06TestServer(t, provider)
+	server.eebusV1.liveTimeout = 250 * time.Millisecond
+	msp06ReviewCaptureWave(t, server, attempts)
+	firstWaveCalls := provider.calls.Load()
+	msp06ReviewCaptureWave(t, server, attempts)
+	secondWaveCalls := provider.calls.Load()
+
+	releaseProvider()
+	for index := int64(0); index < secondWaveCalls; index++ {
+		select {
+		case <-exited:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("blocked provider worker %d/%d did not exit", index+1, secondWaveCalls)
+		}
+	}
+	recovered := msp06ConcurrentCapture(server.Handler())
+	if recovered.err != nil || recovered.code != "" {
+		t.Fatalf("capture after worker exit = code %q error %v, want success", recovered.code, recovered.err)
+	}
+
+	if firstWaveCalls == 0 || firstWaveCalls > msp06ReviewMaxLiveWorkers {
+		t.Errorf("first blocked wave started %d provider workers, want 1..%d", firstWaveCalls, msp06ReviewMaxLiveWorkers)
+	}
+	if secondWaveCalls != firstWaveCalls {
+		t.Errorf("provider calls grew from %d to %d while timed-out workers were still blocked", firstWaveCalls, secondWaveCalls)
+	}
+}
+
+type msp06ReviewBlockingNow struct {
+	value       time.Time
+	entered     chan struct{}
+	release     <-chan struct{}
+	enteredOnce sync.Once
+}
+
+func (clock *msp06ReviewBlockingNow) Now() time.Time {
+	clock.enteredOnce.Do(func() { close(clock.entered) })
+	<-clock.release
+	return clock.value
+}
+
+func TestMSP06LiveDeadlineCoversPostProviderProjectionAndCaptureWork(t *testing.T) {
+	server, _ := msp06TestServer(t, &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")})
+	runtime := server.eebusV1
+	runtime.liveTimeout = time.Hour
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseWork := func() { releaseOnce.Do(func() { close(release) }) }
+	defer releaseWork()
+	clock := &msp06ReviewBlockingNow{
+		value:   time.Now(),
+		entered: make(chan struct{}),
+		release: release,
+	}
+	runtime.store.now = clock.Now
+
+	spec, ok := eebusV1Spec(eebusV1SnapshotCaptureTool)
+	if !ok {
+		t.Fatal("snapshot capture spec missing")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan eebusV1EnvelopeV1, 1)
+	go func() {
+		done <- runtime.call(ctx, spec, map[string]any{})
+	}()
+
+	select {
+	case <-clock.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("live call never reached post-provider capture work")
+	}
+	cancel()
+
+	var envelope eebusV1EnvelopeV1
+	returnedBeforeRelease := false
+	select {
+	case envelope = <-done:
+		returnedBeforeRelease = true
+	case <-time.After(500 * time.Millisecond):
+	}
+	releaseWork()
+	if !returnedBeforeRelease {
+		envelope = <-done
+		t.Fatalf("live call ignored cancellation after provider/projection completion; eventual error = %#v", envelope.Error)
+	}
+	if envelope.Error == nil || envelope.Error.Code != "timeout" {
+		t.Fatalf("cancelled post-provider work error = %#v, want timeout", envelope.Error)
+	}
+}
+
+func TestMSP06OversizedProviderCollectionsFailClosed(t *testing.T) {
+	tests := []struct {
+		name   string
+		tool   string
+		scope  string
+		mutate func(*testing.T, *eebusruntime.SnapshotV1)
+	}{
+		{
+			name:  "services",
+			tool:  msp06ServicesListTool,
+			scope: "services",
+			mutate: func(t *testing.T, snapshot *eebusruntime.SnapshotV1) {
+				snapshot.Services = make([]eebusruntime.ServiceV1, msp06ReviewOversizedCollection)
+				for index := range snapshot.Services {
+					snapshot.Services[index] = eebusruntime.ServiceV1{
+						ID:      msp06SourceID(t, eebusraw.IDKindPeer, fmt.Sprintf("oversized-service-%04d", index)),
+						Kind:    eebusruntime.ServiceKindV1Remote,
+						Visible: true,
+					}
+				}
+			},
+		},
+		{
+			name:  "nested features",
+			tool:  msp06TopologyGetTool,
+			scope: "topology",
+			mutate: func(t *testing.T, snapshot *eebusruntime.SnapshotV1) {
+				features := make([]eebusruntime.FeatureV1, msp06ReviewOversizedCollection)
+				for index := range features {
+					features[index] = eebusruntime.FeatureV1{
+						ID:   msp06SourceID(t, eebusraw.IDKindPeer, fmt.Sprintf("oversized-feature-%04d", index)),
+						Role: eebusruntime.FeatureRoleV1Client,
+					}
+				}
+				snapshot.Topology.Devices = []eebusruntime.DeviceV1{{
+					ID: msp06SourceID(t, eebusraw.IDKindPeer, "oversized-device"),
+					Entities: []eebusruntime.EntityV1{{
+						ID:       msp06SourceID(t, eebusraw.IDKindPeer, "oversized-entity"),
+						Features: features,
+					}},
+				}}
+			},
+		},
+		{
+			name:  "raw evidence",
+			tool:  msp06ServicesListTool,
+			scope: "services",
+			mutate: func(t *testing.T, snapshot *eebusruntime.SnapshotV1) {
+				evidence := make([]eebusevidence.ObjectV1, msp06ReviewOversizedCollection)
+				for index := range evidence {
+					evidence[index] = msp06Evidence(
+						eebusevidence.ObjectKindService,
+						fmt.Sprintf("oversized-evidence-%04d", index),
+						index,
+						snapshot.Meta.DataTimestamp,
+					)
+				}
+				snapshot.Services[0].Raw = evidence
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			snapshot := msp06Snapshot(t, "runtime-a")
+			test.mutate(t, &snapshot)
+			if err := snapshot.Validate(); err != nil {
+				t.Fatalf("oversized provider fixture is otherwise invalid: %v", err)
+			}
+			server, _ := msp06TestServer(t, &msp06Provider{snapshot: snapshot})
+			result := msp06Call(t, server.Handler(), test.tool, map[string]any{})
+			rawError := result.envelope["error"]
+			if rawError == nil {
+				t.Fatalf("oversized %s provider collection succeeded, want contract_violation", test.name)
+			}
+			errorObject := msp06Map(t, rawError, "error")
+			if errorObject["code"] != "contract_violation" {
+				t.Fatalf("oversized %s provider collection code = %#v, want contract_violation", test.name, errorObject["code"])
+			}
+		})
+	}
+}

--- a/mcp/eebus_v1_review_red_test.go
+++ b/mcp/eebus_v1_review_red_test.go
@@ -162,7 +162,7 @@ func TestMSP06StoreExpiryAndDropUseMutexLinearizationTime(t *testing.T) {
 
 func TestMSP06StoreRetainsMonotonicTimeInternallyAndUsesUTCOnlyOnWire(t *testing.T) {
 	base := time.Now()
-	if base == base.Round(0) {
+	if base == base.Round(0) { //nolint:staticcheck // Struct equality intentionally detects monotonic clock metadata.
 		t.Skip("host clock did not provide a monotonic reading")
 	}
 	store, captured := msp06ReviewStoreWithRoot(t, base)
@@ -170,7 +170,7 @@ func TestMSP06StoreRetainsMonotonicTimeInternallyAndUsesUTCOnlyOnWire(t *testing
 	if root == nil {
 		t.Fatal("captured root missing from active store")
 	}
-	if root.ExpiresAt == root.ExpiresAt.Round(0) {
+	if root.ExpiresAt == root.ExpiresAt.Round(0) { //nolint:staticcheck // Struct equality intentionally detects monotonic clock metadata.
 		t.Error("active expiry discarded the monotonic clock reading")
 	}
 	if want := eebusV1Timestamp(base.Add(eebusV1ActiveTTL)); captured.ExpiresAt != want {
@@ -186,7 +186,7 @@ func TestMSP06StoreRetainsMonotonicTimeInternallyAndUsesUTCOnlyOnWire(t *testing
 	if tombstone == nil {
 		t.Fatal("dropped root missing tombstone")
 	}
-	if tombstone.TerminalAt == tombstone.TerminalAt.Round(0) {
+	if tombstone.TerminalAt == tombstone.TerminalAt.Round(0) { //nolint:staticcheck // Struct equality intentionally detects monotonic clock metadata.
 		t.Error("terminal transition discarded the monotonic clock reading")
 	}
 }

--- a/mcp/eebus_v1_store.go
+++ b/mcp/eebus_v1_store.go
@@ -133,9 +133,9 @@ func newEEBusV1SnapshotStore(now func() time.Time, entropy io.Reader) *eebusV1Sn
 }
 
 func (store *eebusV1SnapshotStore) capture(projection eebusV1Projection) (eebusV1CapturedRootV1, string) {
-	now := store.now().UTC()
 	store.mu.Lock()
 	defer store.mu.Unlock()
+	now := store.now()
 	store.purgeLocked(now)
 	if len(store.activeRoots) >= eebusV1MaxActive {
 		return eebusV1CapturedRootV1{}, "quota_exceeded"
@@ -199,9 +199,9 @@ func (store *eebusV1SnapshotStore) capture(projection eebusV1Projection) (eebusV
 }
 
 func (store *eebusV1SnapshotStore) lookup(token, tool, scope string) eebusV1LookupResult {
-	now := store.now().UTC()
 	store.mu.Lock()
 	defer store.mu.Unlock()
+	now := store.now()
 	store.purgeLocked(now)
 
 	if reference, exists := store.activeTokens[token]; exists {
@@ -229,9 +229,9 @@ func (store *eebusV1SnapshotStore) lookup(token, tool, scope string) eebusV1Look
 }
 
 func (store *eebusV1SnapshotStore) drop(token string) eebusV1DropResultV1 {
-	now := store.now().UTC()
 	store.mu.Lock()
 	defer store.mu.Unlock()
+	now := store.now()
 	store.purgeLocked(now)
 
 	reference, exists := store.activeTokens[token]

--- a/mcp/eebus_v1_store.go
+++ b/mcp/eebus_v1_store.go
@@ -1,0 +1,355 @@
+package mcp
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"io"
+	"sort"
+	"sync"
+	"time"
+)
+
+const (
+	eebusV1ActiveTTL        = 5 * time.Minute
+	eebusV1MaxActive        = 32
+	eebusV1TombstoneTTL     = 5 * time.Minute
+	eebusV1MaxTombstones    = 256
+	eebusV1ReferenceVersion = 1
+)
+
+type eebusV1EvidenceRefsV1 struct {
+	RuntimeStatusRef string `json:"runtime_status_ref"`
+	ServicesListRef  string `json:"services_list_ref"`
+	ServicesGetRef   string `json:"services_get_ref"`
+	SessionsListRef  string `json:"sessions_list_ref"`
+	SessionsGetRef   string `json:"sessions_get_ref"`
+	TopologyRef      string `json:"topology_ref"`
+	PairingStatusRef string `json:"pairing_status_ref"`
+}
+
+type eebusV1CapturedRootV1 struct {
+	SnapshotRef         string                `json:"snapshot_ref"`
+	ExpiresAt           string                `json:"expires_at"`
+	SnapshotContentHash string                `json:"snapshot_content_hash"`
+	EvidenceRefs        eebusV1EvidenceRefsV1 `json:"evidence_refs"`
+	Snapshot            eebusV1SnapshotDataV1 `json:"snapshot"`
+}
+
+type eebusV1DropResultV1 struct {
+	Status string `json:"status"`
+}
+
+type eebusV1ReferenceBinding struct {
+	Version    int
+	RuntimeKey string
+	Contract   eebusV1ContractV1
+	Tool       string
+	Scope      string
+	MaskTier   string
+	AuthScope  string
+}
+
+func (binding eebusV1ReferenceBinding) matches(tool, scope string) bool {
+	return binding.Version == eebusV1ReferenceVersion &&
+		binding.Contract == eebusV1Contract &&
+		binding.Tool == tool &&
+		binding.Scope == scope &&
+		binding.MaskTier == eebusV1MaskTier &&
+		binding.AuthScope == eebusV1AuthScope &&
+		binding.RuntimeKey != ""
+}
+
+type eebusV1StoredReference struct {
+	RootToken string
+	Root      bool
+	Binding   eebusV1ReferenceBinding
+}
+
+type eebusV1ActiveRoot struct {
+	RootToken  string
+	RootBytes  [sha256.Size]byte
+	ExpiresAt  time.Time
+	Projection eebusV1Projection
+	Captured   eebusV1CapturedRootV1
+	References map[string]eebusV1StoredReference
+}
+
+type eebusV1TombstoneRoot struct {
+	RootToken  string
+	RootBytes  [sha256.Size]byte
+	TerminalAt time.Time
+	Runtime    eebusV1RuntimeStatusDataV1
+	Timestamp  string
+	References map[string]eebusV1StoredReference
+}
+
+type eebusV1SnapshotStore struct {
+	mu      sync.Mutex
+	now     func() time.Time
+	entropy io.Reader
+
+	activeRoots     map[string]*eebusV1ActiveRoot
+	activeTokens    map[string]eebusV1StoredReference
+	tombstoneRoots  map[string]*eebusV1TombstoneRoot
+	tombstoneTokens map[string]eebusV1StoredReference
+}
+
+type eebusV1LookupResult struct {
+	Projection *eebusV1Projection
+	Runtime    eebusV1RuntimeStatusDataV1
+	Timestamp  string
+	ErrorCode  string
+}
+
+type eebusV1ReferenceSpec struct {
+	Key   string
+	Tool  string
+	Scope string
+	Root  bool
+}
+
+var eebusV1CaptureReferenceSpecs = []eebusV1ReferenceSpec{
+	{Key: "snapshot_ref", Tool: eebusV1SnapshotCaptureTool, Scope: "whole-root", Root: true},
+	{Key: "runtime_status_ref", Tool: eebusV1RuntimeStatusTool, Scope: "runtime-status"},
+	{Key: "services_list_ref", Tool: eebusV1ServicesListTool, Scope: "services"},
+	{Key: "services_get_ref", Tool: eebusV1ServicesGetTool, Scope: "service"},
+	{Key: "sessions_list_ref", Tool: eebusV1SessionsListTool, Scope: "sessions"},
+	{Key: "sessions_get_ref", Tool: eebusV1SessionsGetTool, Scope: "session"},
+	{Key: "topology_ref", Tool: eebusV1TopologyGetTool, Scope: "topology"},
+	{Key: "pairing_status_ref", Tool: eebusV1PairingStatusTool, Scope: "pairing-status"},
+}
+
+func newEEBusV1SnapshotStore(now func() time.Time, entropy io.Reader) *eebusV1SnapshotStore {
+	return &eebusV1SnapshotStore{
+		now:             now,
+		entropy:         entropy,
+		activeRoots:     make(map[string]*eebusV1ActiveRoot),
+		activeTokens:    make(map[string]eebusV1StoredReference),
+		tombstoneRoots:  make(map[string]*eebusV1TombstoneRoot),
+		tombstoneTokens: make(map[string]eebusV1StoredReference),
+	}
+}
+
+func (store *eebusV1SnapshotStore) capture(projection eebusV1Projection) (eebusV1CapturedRootV1, string) {
+	now := store.now().UTC()
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	store.purgeLocked(now)
+	if len(store.activeRoots) >= eebusV1MaxActive {
+		return eebusV1CapturedRootV1{}, "quota_exceeded"
+	}
+
+	tokens := make(map[string]string, len(eebusV1CaptureReferenceSpecs))
+	decoded := make(map[string][sha256.Size]byte, len(eebusV1CaptureReferenceSpecs))
+	reserved := make(map[string]struct{}, len(eebusV1CaptureReferenceSpecs))
+	for _, spec := range eebusV1CaptureReferenceSpecs {
+		token, raw, err := store.mintTokenLocked(reserved)
+		if err != nil {
+			return eebusV1CapturedRootV1{}, "contract_violation"
+		}
+		tokens[spec.Key] = token
+		decoded[spec.Key] = raw
+		reserved[token] = struct{}{}
+	}
+
+	expiresAt := now.Add(eebusV1ActiveTTL)
+	captured := eebusV1CapturedRootV1{
+		SnapshotRef:         tokens["snapshot_ref"],
+		ExpiresAt:           eebusV1Timestamp(expiresAt),
+		SnapshotContentHash: projection.Snapshot.Meta.DataHash,
+		EvidenceRefs: eebusV1EvidenceRefsV1{
+			RuntimeStatusRef: tokens["runtime_status_ref"],
+			ServicesListRef:  tokens["services_list_ref"],
+			ServicesGetRef:   tokens["services_get_ref"],
+			SessionsListRef:  tokens["sessions_list_ref"],
+			SessionsGetRef:   tokens["sessions_get_ref"],
+			TopologyRef:      tokens["topology_ref"],
+			PairingStatusRef: tokens["pairing_status_ref"],
+		},
+		Snapshot: projection.Snapshot,
+	}
+	root := &eebusV1ActiveRoot{
+		RootToken:  captured.SnapshotRef,
+		RootBytes:  decoded["snapshot_ref"],
+		ExpiresAt:  expiresAt,
+		Projection: projection,
+		Captured:   captured,
+		References: make(map[string]eebusV1StoredReference, len(tokens)),
+	}
+	for _, spec := range eebusV1CaptureReferenceSpecs {
+		token := tokens[spec.Key]
+		reference := eebusV1StoredReference{
+			RootToken: root.RootToken,
+			Root:      spec.Root,
+			Binding: eebusV1ReferenceBinding{
+				Version: eebusV1ReferenceVersion, RuntimeKey: projection.RuntimeKey,
+				Contract: eebusV1Contract, Tool: spec.Tool, Scope: spec.Scope,
+				MaskTier: eebusV1MaskTier, AuthScope: eebusV1AuthScope,
+			},
+		}
+		root.References[token] = reference
+	}
+	store.activeRoots[root.RootToken] = root
+	for token, reference := range root.References {
+		store.activeTokens[token] = reference
+	}
+	return captured, ""
+}
+
+func (store *eebusV1SnapshotStore) lookup(token, tool, scope string) eebusV1LookupResult {
+	now := store.now().UTC()
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	store.purgeLocked(now)
+
+	if reference, exists := store.activeTokens[token]; exists {
+		root := store.activeRoots[reference.RootToken]
+		if root == nil {
+			return eebusV1LookupResult{ErrorCode: "contract_violation"}
+		}
+		if !reference.Binding.matches(tool, scope) {
+			return eebusV1LookupResult{Runtime: root.Projection.Runtime, Timestamp: root.Projection.DataTimestamp, ErrorCode: "permission_denied"}
+		}
+		projection := root.Projection
+		return eebusV1LookupResult{Projection: &projection, Runtime: projection.Runtime, Timestamp: projection.DataTimestamp}
+	}
+	if reference, exists := store.tombstoneTokens[token]; exists {
+		root := store.tombstoneRoots[reference.RootToken]
+		if root == nil {
+			return eebusV1LookupResult{ErrorCode: "contract_violation"}
+		}
+		if !reference.Binding.matches(tool, scope) {
+			return eebusV1LookupResult{Runtime: root.Runtime, Timestamp: root.Timestamp, ErrorCode: "permission_denied"}
+		}
+		return eebusV1LookupResult{Runtime: root.Runtime, Timestamp: root.Timestamp, ErrorCode: "snapshot_gone"}
+	}
+	return eebusV1LookupResult{ErrorCode: "not_found"}
+}
+
+func (store *eebusV1SnapshotStore) drop(token string) eebusV1DropResultV1 {
+	now := store.now().UTC()
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	store.purgeLocked(now)
+
+	reference, exists := store.activeTokens[token]
+	if !exists || !reference.Root {
+		return eebusV1DropResultV1{Status: "already_gone"}
+	}
+	root := store.activeRoots[reference.RootToken]
+	if root == nil || root.RootToken != token {
+		return eebusV1DropResultV1{Status: "already_gone"}
+	}
+	store.terminalizeLocked(root, now)
+	store.enforceTombstoneBoundLocked()
+	return eebusV1DropResultV1{Status: "dropped"}
+}
+
+func (store *eebusV1SnapshotStore) mintTokenLocked(reserved map[string]struct{}) (string, [sha256.Size]byte, error) {
+	var raw [sha256.Size]byte
+	for attempts := 0; attempts < 1024; attempts++ {
+		if _, err := io.ReadFull(store.entropy, raw[:]); err != nil {
+			return "", [sha256.Size]byte{}, err
+		}
+		token := base64.RawURLEncoding.EncodeToString(raw[:])
+		if _, exists := store.activeTokens[token]; exists {
+			continue
+		}
+		if _, exists := store.tombstoneTokens[token]; exists {
+			continue
+		}
+		if _, exists := reserved[token]; exists {
+			continue
+		}
+		return token, raw, nil
+	}
+	return "", [sha256.Size]byte{}, errors.New("reference entropy repeated")
+}
+
+func (store *eebusV1SnapshotStore) purgeLocked(now time.Time) {
+	for rootToken, tombstone := range store.tombstoneRoots {
+		if !now.Before(tombstone.TerminalAt.Add(eebusV1TombstoneTTL)) {
+			store.removeTombstoneLocked(rootToken)
+		}
+	}
+
+	expired := make([]*eebusV1ActiveRoot, 0)
+	for _, root := range store.activeRoots {
+		if !now.Before(root.ExpiresAt) {
+			expired = append(expired, root)
+		}
+	}
+	sort.Slice(expired, func(i, j int) bool {
+		return bytes.Compare(expired[i].RootBytes[:], expired[j].RootBytes[:]) < 0
+	})
+	for _, root := range expired {
+		store.terminalizeLocked(root, now)
+	}
+	store.enforceTombstoneBoundLocked()
+}
+
+func (store *eebusV1SnapshotStore) terminalizeLocked(root *eebusV1ActiveRoot, terminalAt time.Time) {
+	if root == nil {
+		return
+	}
+	delete(store.activeRoots, root.RootToken)
+	for token := range root.References {
+		delete(store.activeTokens, token)
+	}
+	tombstone := &eebusV1TombstoneRoot{
+		RootToken:  root.RootToken,
+		RootBytes:  root.RootBytes,
+		TerminalAt: terminalAt,
+		Runtime:    root.Projection.Runtime,
+		Timestamp:  root.Projection.DataTimestamp,
+		References: root.References,
+	}
+	store.tombstoneRoots[tombstone.RootToken] = tombstone
+	for token, reference := range tombstone.References {
+		store.tombstoneTokens[token] = reference
+	}
+}
+
+func (store *eebusV1SnapshotStore) enforceTombstoneBoundLocked() {
+	for len(store.tombstoneRoots) > eebusV1MaxTombstones {
+		var oldest *eebusV1TombstoneRoot
+		for _, candidate := range store.tombstoneRoots {
+			if oldest == nil || candidate.TerminalAt.Before(oldest.TerminalAt) ||
+				(candidate.TerminalAt.Equal(oldest.TerminalAt) && bytes.Compare(candidate.RootBytes[:], oldest.RootBytes[:]) < 0) {
+				oldest = candidate
+			}
+		}
+		if oldest == nil {
+			return
+		}
+		store.removeTombstoneLocked(oldest.RootToken)
+	}
+}
+
+func (store *eebusV1SnapshotStore) removeTombstoneLocked(rootToken string) {
+	root := store.tombstoneRoots[rootToken]
+	if root == nil {
+		return
+	}
+	delete(store.tombstoneRoots, rootToken)
+	for token := range root.References {
+		delete(store.tombstoneTokens, token)
+	}
+}
+
+func eebusV1ParseCanonicalToken(value any) (string, bool) {
+	token, ok := value.(string)
+	if !ok || len(token) != 43 {
+		return "", false
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil || len(decoded) != sha256.Size {
+		return "", false
+	}
+	if base64.RawURLEncoding.EncodeToString(decoded) != token {
+		return "", false
+	}
+	return token, true
+}

--- a/mcp/eebus_v1_store_replay_test.go
+++ b/mcp/eebus_v1_store_replay_test.go
@@ -425,6 +425,9 @@ func TestMSP06G15ActiveQuotaCountsRootGroupsAndCaptureFailureConsumesNoSlot(t *t
 func TestMSP06G15ConcurrentCaptureReservationIsAtomicAt32(t *testing.T) {
 	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
 	server, _ := msp06TestServer(t, provider)
+	// This case isolates store quota linearization; bounded-worker timeout behavior
+	// is covered separately by TestMSP06BlockedProviderWorkersAreBoundedAndPermitsRemainUntilExit.
+	server.eebusV1.liveTimeout = 5 * time.Second
 	const attempts = 64
 	type outcome struct {
 		code string

--- a/mcp/eebus_v1_store_replay_test.go
+++ b/mcp/eebus_v1_store_replay_test.go
@@ -671,8 +671,15 @@ func TestMSP06NoDriftToExistingEbusV1InventoryOrResponses(t *testing.T) {
 	if !reflect.DeepEqual(beforeNames, afterNames) {
 		t.Fatalf("ebus.v1 inventory drifted:\nbefore=%v\nafter=%v", beforeNames, afterNames)
 	}
-	if beforeCall.raw != afterCall.raw || beforeCall.isError != afterCall.isError {
-		t.Fatalf("ebus.v1 response drifted after eeBUS registration:\nbefore=%s\nafter=%s", beforeCall.raw, afterCall.raw)
+	for _, envelope := range []map[string]any{beforeCall.envelope, afterCall.envelope} {
+		meta, ok := envelope["meta"].(map[string]any)
+		if !ok {
+			t.Fatalf("ebus.v1 response meta = %T, want object", envelope["meta"])
+		}
+		delete(meta, "data_timestamp")
+	}
+	if !reflect.DeepEqual(beforeCall.envelope, afterCall.envelope) || beforeCall.isError != afterCall.isError {
+		t.Fatalf("ebus.v1 response drifted after eeBUS registration outside the live timestamp:\nbefore=%s\nafter=%s", beforeCall.raw, afterCall.raw)
 	}
 }
 

--- a/mcp/eebus_v1_store_replay_test.go
+++ b/mcp/eebus_v1_store_replay_test.go
@@ -1,0 +1,692 @@
+package mcp
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+	eebusruntime "github.com/Project-Helianthus/helianthus-eebusreg"
+)
+
+var msp06EvidenceRefBindings = map[string]struct {
+	tool  string
+	scope string
+}{
+	"runtime_status_ref": {tool: msp06RuntimeStatusTool, scope: "runtime-status"},
+	"services_list_ref":  {tool: msp06ServicesListTool, scope: "services"},
+	"services_get_ref":   {tool: msp06ServicesGetTool, scope: "service"},
+	"sessions_list_ref":  {tool: msp06SessionsListTool, scope: "sessions"},
+	"sessions_get_ref":   {tool: msp06SessionsGetTool, scope: "session"},
+	"topology_ref":       {tool: msp06TopologyGetTool, scope: "topology"},
+	"pairing_status_ref": {tool: msp06PairingStatusTool, scope: "pairing-status"},
+}
+
+func msp06CaptureRoot(t *testing.T, server *Server) (msp06CallResult, map[string]any) {
+	t.Helper()
+	result := msp06Call(t, server.Handler(), msp06SnapshotCapture, map[string]any{})
+	data := msp06AssertSuccess(t, result, msp06SnapshotCapture, "whole-root", "live")
+	msp06AssertCapturedRoot(t, data)
+	return result, data
+}
+
+func msp06AssertCapturedRoot(t *testing.T, root map[string]any) {
+	t.Helper()
+	msp06AssertKeys(t, root, "captured root", "snapshot_ref", "expires_at", "snapshot_content_hash", "evidence_refs", "snapshot")
+	rootToken := msp06AssertToken(t, root["snapshot_ref"], "snapshot_ref")
+	expiresAt, _ := root["expires_at"].(string)
+	if !msp06TimestampPattern.MatchString(expiresAt) {
+		t.Fatalf("expires_at = %#v, want UTC RFC3339", root["expires_at"])
+	}
+	contentHash, _ := root["snapshot_content_hash"].(string)
+	if !msp06HashPattern.MatchString(contentHash) {
+		t.Fatalf("snapshot_content_hash = %#v", root["snapshot_content_hash"])
+	}
+
+	refs := msp06Map(t, root["evidence_refs"], "evidence_refs")
+	wantRefKeys := make([]string, 0, len(msp06EvidenceRefBindings))
+	seen := map[string]string{rootToken: "snapshot_ref"}
+	for key := range msp06EvidenceRefBindings {
+		wantRefKeys = append(wantRefKeys, key)
+	}
+	msp06AssertKeys(t, refs, "evidence_refs", wantRefKeys...)
+	for key := range msp06EvidenceRefBindings {
+		token := msp06AssertToken(t, refs[key], "evidence_refs."+key)
+		if prior, exists := seen[token]; exists {
+			t.Fatalf("%s reuses token from %s", key, prior)
+		}
+		seen[token] = key
+	}
+
+	snapshot := msp06Map(t, root["snapshot"], "snapshot")
+	keys := []string{"meta", "status", "pairing", "services", "sessions", "topology"}
+	if _, exists := snapshot["evidence"]; exists {
+		keys = append(keys, "evidence")
+		msp06AssertEvidence(t, snapshot["evidence"], "snapshot.evidence")
+	}
+	msp06AssertKeys(t, snapshot, "snapshot", keys...)
+	meta := msp06Map(t, snapshot["meta"], "snapshot.meta")
+	msp06AssertKeys(t, meta, "snapshot.meta", "contract", "runtime", "mask_tier", "captured_at", "data_timestamp", "data_hash")
+	if meta["contract"] != "helianthus.eebus.runtime.raw-snapshot.v1" || meta["mask_tier"] != "redacted" {
+		t.Fatalf("snapshot.meta contract/mask = %#v", meta)
+	}
+	msp06AssertIdentity(t, meta["runtime"], "snapshot.meta.runtime", "runtime")
+	for _, field := range []string{"captured_at", "data_timestamp"} {
+		if value, _ := meta[field].(string); !msp06TimestampPattern.MatchString(value) {
+			t.Fatalf("snapshot.meta.%s = %#v", field, meta[field])
+		}
+	}
+	if meta["data_hash"] != contentHash {
+		t.Fatalf("snapshot.meta.data_hash = %#v, want snapshot_content_hash %q", meta["data_hash"], contentHash)
+	}
+
+	status := msp06Map(t, snapshot["status"], "snapshot.status")
+	statusKeys := []string{"state"}
+	if _, exists := status["degradation"]; exists {
+		statusKeys = append(statusKeys, "degradation")
+	}
+	msp06AssertKeys(t, status, "snapshot.status", statusKeys...)
+	msp06AssertSnapshotCollections(t, snapshot)
+}
+
+func msp06AssertSnapshotCollections(t *testing.T, snapshot map[string]any) {
+	t.Helper()
+	services := map[string]any{"services": snapshot["services"]}
+	serviceItems := msp06Slice(t, services["services"], "snapshot.services")
+	for index, raw := range serviceItems {
+		service := msp06Map(t, raw, fmt.Sprintf("snapshot.services[%d]", index))
+		msp06AssertIdentity(t, service["id"], fmt.Sprintf("snapshot.services[%d].id", index), "service")
+	}
+
+	sessions := msp06Slice(t, snapshot["sessions"], "snapshot.sessions")
+	for index, raw := range sessions {
+		session := msp06Map(t, raw, fmt.Sprintf("snapshot.sessions[%d]", index))
+		msp06AssertIdentity(t, session["id"], fmt.Sprintf("snapshot.sessions[%d].id", index), "session")
+		msp06AssertIdentity(t, session["remote"], fmt.Sprintf("snapshot.sessions[%d].remote", index), "remote")
+	}
+
+	pairing := msp06Slice(t, snapshot["pairing"], "snapshot.pairing")
+	for index, raw := range pairing {
+		item := msp06Map(t, raw, fmt.Sprintf("snapshot.pairing[%d]", index))
+		msp06AssertIdentity(t, item["remote"], fmt.Sprintf("snapshot.pairing[%d].remote", index), "remote")
+	}
+	msp06AssertTopology(t, msp06Map(t, snapshot["topology"], "snapshot.topology"))
+}
+
+func msp06RootRefs(t *testing.T, root map[string]any) map[string]string {
+	t.Helper()
+	refsObject := msp06Map(t, root["evidence_refs"], "evidence_refs")
+	refs := make(map[string]string, len(refsObject))
+	for key := range msp06EvidenceRefBindings {
+		refs[key] = msp06AssertToken(t, refsObject[key], "evidence_refs."+key)
+	}
+	return refs
+}
+
+func msp06CapturedSelectors(t *testing.T, root map[string]any) (serviceID, sessionID string) {
+	t.Helper()
+	snapshot := msp06Map(t, root["snapshot"], "snapshot")
+	services := msp06Slice(t, snapshot["services"], "snapshot.services")
+	sessions := msp06Slice(t, snapshot["sessions"], "snapshot.sessions")
+	if len(services) == 0 || len(sessions) == 0 {
+		t.Fatal("capture fixture lacks service/session selector")
+	}
+	service := msp06Map(t, services[0], "snapshot.services[0]")
+	session := msp06Map(t, sessions[0], "snapshot.sessions[0]")
+	return msp06AssertIdentity(t, service["id"], "snapshot.services[0].id", "service"),
+		msp06AssertIdentity(t, session["id"], "snapshot.sessions[0].id", "session")
+}
+
+func msp06EvidenceArguments(key, reference, serviceID, sessionID string) map[string]any {
+	arguments := map[string]any{"evidence_ref": reference}
+	switch key {
+	case "services_get_ref":
+		arguments["id_digest"] = serviceID
+	case "sessions_get_ref":
+		arguments["id_digest"] = sessionID
+	}
+	return arguments
+}
+
+func TestMSP06G12WholeRootCaptureHasEightCanonicalRefsAndSeparateHashes(t *testing.T) {
+	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+	server, clock := msp06TestServer(t, provider)
+	firstResult, first := msp06CaptureRoot(t, server)
+	secondResult, second := msp06CaptureRoot(t, server)
+
+	if provider.callCount() != 2 {
+		t.Fatalf("capture provider calls = %d, want one per capture", provider.callCount())
+	}
+	if first["snapshot_ref"] == second["snapshot_ref"] || reflect.DeepEqual(first["evidence_refs"], second["evidence_refs"]) {
+		t.Fatal("two captures reused opaque references")
+	}
+	if first["snapshot_content_hash"] != second["snapshot_content_hash"] {
+		t.Fatalf("identical detached roots have different content hashes: %v vs %v", first["snapshot_content_hash"], second["snapshot_content_hash"])
+	}
+	firstMeta := msp06Map(t, firstResult.envelope["meta"], "first meta")
+	secondMeta := msp06Map(t, secondResult.envelope["meta"], "second meta")
+	if firstMeta["data_hash"] != secondMeta["data_hash"] {
+		t.Fatalf("token substitution changed capture envelope hash: %v vs %v", firstMeta["data_hash"], secondMeta["data_hash"])
+	}
+	if firstMeta["data_hash"] == first["snapshot_content_hash"] {
+		t.Fatal("capture envelope hash unexpectedly aliases snapshot content hash")
+	}
+	wantExpiry := clock.Now().Add(5 * time.Minute).Format(time.RFC3339Nano)
+	if first["expires_at"] != wantExpiry || second["expires_at"] != wantExpiry {
+		t.Fatalf("capture expiry = (%v, %v), want %s", first["expires_at"], second["expires_at"], wantExpiry)
+	}
+}
+
+func TestMSP06CaptureDoesNotCopyRuntimeInternalSourceHash(t *testing.T) {
+	source, err := eebusruntime.NewSnapshotV1(msp06Snapshot(t, "runtime-a"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if source.Meta.DataHash == "" {
+		t.Fatal("source fixture lacks internal data hash")
+	}
+	server, _ := msp06TestServer(t, &msp06Provider{snapshot: source})
+	_, root := msp06CaptureRoot(t, server)
+	if root["snapshot_content_hash"] == source.Meta.DataHash {
+		t.Fatal("wire snapshot content hash copied runtime internal source hash")
+	}
+	encoded, err := json.Marshal(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(encoded, []byte(source.Meta.DataHash)) {
+		t.Fatalf("runtime internal source hash leaked as correlator: %s", encoded)
+	}
+}
+
+func TestMSP06G13EvidenceReplayIsByteStableAndMakesZeroProviderCalls(t *testing.T) {
+	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+	server, _ := msp06TestServer(t, provider)
+	_, root := msp06CaptureRoot(t, server)
+	refs := msp06RootRefs(t, root)
+	serviceID, sessionID := msp06CapturedSelectors(t, root)
+	providerCallsAfterCapture := provider.callCount()
+
+	first := make(map[string]msp06CallResult, len(refs))
+	for key, binding := range msp06EvidenceRefBindings {
+		result := msp06Call(t, server.Handler(), binding.tool, msp06EvidenceArguments(key, refs[key], serviceID, sessionID))
+		msp06AssertSuccess(t, result, binding.tool, binding.scope, "evidence")
+		first[key] = result
+	}
+	if provider.callCount() != providerCallsAfterCapture {
+		t.Fatalf("evidence reads called provider: before=%d after=%d", providerCallsAfterCapture, provider.callCount())
+	}
+
+	provider.mutate(func(snapshot *eebusruntime.SnapshotV1) {
+		snapshot.Meta.Runtime = msp06SourceID(t, snapshot.Meta.Runtime.Kind, "runtime-mutated")
+		snapshot.Services[0].Visible = false
+		snapshot.Topology.Devices = nil
+	}, errors.New("disconnected after capture; private 192.0.2.77 detail"))
+	for key, binding := range msp06EvidenceRefBindings {
+		result := msp06Call(t, server.Handler(), binding.tool, msp06EvidenceArguments(key, refs[key], serviceID, sessionID))
+		msp06AssertSuccess(t, result, binding.tool, binding.scope, "evidence")
+		if result.raw != first[key].raw {
+			t.Fatalf("%s replay changed after provider mutation/disconnect:\nfirst=%s\nsecond=%s", key, first[key].raw, result.raw)
+		}
+	}
+	if provider.callCount() != providerCallsAfterCapture {
+		t.Fatalf("replay after disconnect called provider: before=%d after=%d", providerCallsAfterCapture, provider.callCount())
+	}
+}
+
+func TestMSP06ReconnectReturnsLiveErrorsThenRecoversWithoutReregistration(t *testing.T) {
+	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+	server, _ := msp06TestServer(t, provider)
+	wantInventory := msp06NamesWithPrefix(msp06Tools(t, server), "eebus.")
+	_, root := msp06CaptureRoot(t, server)
+	refs := msp06RootRefs(t, root)
+
+	provider.set(eebusruntime.SnapshotV1{}, errors.New("runtime worker disconnected"))
+	liveFailure := msp06Call(t, server.Handler(), msp06ServicesListTool, map[string]any{})
+	msp06AssertError(t, liveFailure, msp06ServicesListTool, "services", "backend_unavailable")
+	evidence := msp06Call(t, server.Handler(), msp06ServicesListTool, map[string]any{"evidence_ref": refs["services_list_ref"]})
+	msp06AssertSuccess(t, evidence, msp06ServicesListTool, "services", "evidence")
+
+	recovered := msp06Snapshot(t, "runtime-a")
+	recovered.Services[0].Visible = false
+	provider.set(recovered, nil)
+	liveSuccess := msp06Call(t, server.Handler(), msp06ServicesListTool, map[string]any{})
+	data := msp06AssertSuccess(t, liveSuccess, msp06ServicesListTool, "services", "live")
+	items := msp06Slice(t, data["services"], "services")
+	foundFalse := false
+	for _, raw := range items {
+		if msp06Map(t, raw, "service")["visible"] == false {
+			foundFalse = true
+		}
+	}
+	if !foundFalse {
+		t.Fatal("recovered live call did not use fresh provider snapshot")
+	}
+	if got := msp06NamesWithPrefix(msp06Tools(t, server), "eebus."); !reflect.DeepEqual(got, wantInventory) {
+		t.Fatalf("tool inventory changed across disconnect/reconnect: %v vs %v", wantInventory, got)
+	}
+}
+
+func TestMSP06G14ReferencesAreToolScopeBoundAndPolicyCannotBeOverridden(t *testing.T) {
+	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+	server, _ := msp06TestServer(t, provider)
+	_, root := msp06CaptureRoot(t, server)
+	refs := msp06RootRefs(t, root)
+	serviceID, _ := msp06CapturedSelectors(t, root)
+
+	wrongBinding := msp06Call(t, server.Handler(), msp06SessionsListTool, map[string]any{"evidence_ref": refs["services_list_ref"]})
+	msp06AssertErrorMode(t, wrongBinding, msp06SessionsListTool, "sessions", "evidence", "permission_denied")
+	rootAsEvidence := msp06Call(t, server.Handler(), msp06RuntimeStatusTool, map[string]any{"evidence_ref": root["snapshot_ref"]})
+	msp06AssertErrorMode(t, rootAsEvidence, msp06RuntimeStatusTool, "runtime-status", "evidence", "permission_denied")
+	listRefAsGet := msp06Call(t, server.Handler(), msp06ServicesGetTool, map[string]any{"id_digest": serviceID, "evidence_ref": refs["services_list_ref"]})
+	msp06AssertErrorMode(t, listRefAsGet, msp06ServicesGetTool, "service", "evidence", "permission_denied")
+
+	unknown := base64.RawURLEncoding.EncodeToString(bytes.Repeat([]byte{0xee}, sha256.Size))
+	unknownResult := msp06Call(t, server.Handler(), msp06ServicesListTool, map[string]any{"evidence_ref": unknown})
+	msp06AssertErrorMode(t, unknownResult, msp06ServicesListTool, "services", "evidence", "not_found")
+	if provider.callCount() != 1 {
+		t.Fatalf("reference resolution called provider %d times, want capture only", provider.callCount())
+	}
+
+	headers := map[string]string{
+		"Authorization":   "Bearer administrator-secret",
+		"X-Mask-Tier":     "raw",
+		"X-Auth-Scope":    "eebus.admin",
+		"X-EEBus-Runtime": "runtime-override",
+	}
+	plain := msp06Call(t, server.Handler(), msp06RuntimeStatusTool, map[string]any{})
+	withHeaders := msp06CallWithHeaders(t, server.Handler(), msp06RuntimeStatusTool, map[string]any{}, headers)
+	msp06AssertSuccess(t, plain, msp06RuntimeStatusTool, "runtime-status", "live")
+	meta := msp06AssertMeta(t, withHeaders.envelope, msp06RuntimeStatusTool, "runtime-status", "live")
+	if meta["mask_tier"] != "redacted" || meta["auth_scope"] != "eebus.raw.read" || plain.raw != withHeaders.raw {
+		t.Fatalf("headers altered fixed reader policy or response:\nplain=%s\nheaders=%s", plain.raw, withHeaders.raw)
+	}
+
+	for _, forbidden := range []string{"contract", "runtime", "tool", "scope", "mask_tier", "auth_scope", "principal", "authorization"} {
+		before := provider.callCount()
+		result := msp06Call(t, server.Handler(), msp06ServicesListTool, map[string]any{forbidden: "override"})
+		msp06AssertError(t, result, msp06ServicesListTool, "services", "invalid_argument")
+		if provider.callCount() != before {
+			t.Fatalf("forbidden binding selector %q reached provider", forbidden)
+		}
+	}
+
+	otherServer, _ := msp06TestServer(t, &msp06Provider{snapshot: msp06Snapshot(t, "runtime-b")})
+	crossRuntime := msp06Call(t, otherServer.Handler(), msp06ServicesListTool, map[string]any{"evidence_ref": refs["services_list_ref"]})
+	msp06AssertErrorMode(t, crossRuntime, msp06ServicesListTool, "services", "evidence", "not_found")
+}
+
+func TestMSP06WrongBindingPrecedesReferenceLifecycle(t *testing.T) {
+	server, _ := msp06TestServer(t, &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")})
+	_, root := msp06CaptureRoot(t, server)
+	refs := msp06RootRefs(t, root)
+	drop := msp06Call(t, server.Handler(), msp06SnapshotDrop, map[string]any{"snapshot_ref": root["snapshot_ref"]})
+	msp06AssertDropStatus(t, drop, "dropped")
+
+	wrong := msp06Call(t, server.Handler(), msp06SessionsListTool, map[string]any{"evidence_ref": refs["services_list_ref"]})
+	msp06AssertErrorMode(t, wrong, msp06SessionsListTool, "sessions", "evidence", "permission_denied")
+	exact := msp06Call(t, server.Handler(), msp06ServicesListTool, map[string]any{"evidence_ref": refs["services_list_ref"]})
+	msp06AssertErrorMode(t, exact, msp06ServicesListTool, "services", "evidence", "snapshot_gone")
+}
+
+func msp06AssertDropStatus(t *testing.T, result msp06CallResult, want string) {
+	t.Helper()
+	data := msp06AssertSuccess(t, result, msp06SnapshotDrop, "whole-root", "live")
+	msp06AssertKeys(t, data, "drop result", "status")
+	if data["status"] != want {
+		t.Fatalf("drop status = %#v, want %q", data["status"], want)
+	}
+}
+
+func TestMSP06G15DropIsIdempotentAndEvidenceCannotDropRoot(t *testing.T) {
+	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+	server, _ := msp06TestServer(t, provider)
+	_, root := msp06CaptureRoot(t, server)
+	refs := msp06RootRefs(t, root)
+	serviceID, sessionID := msp06CapturedSelectors(t, root)
+	calls := provider.callCount()
+
+	evidenceAsRoot := msp06Call(t, server.Handler(), msp06SnapshotDrop, map[string]any{"snapshot_ref": refs["services_list_ref"]})
+	msp06AssertDropStatus(t, evidenceAsRoot, "already_gone")
+	stillActive := msp06Call(t, server.Handler(), msp06ServicesListTool, map[string]any{"evidence_ref": refs["services_list_ref"]})
+	msp06AssertSuccess(t, stillActive, msp06ServicesListTool, "services", "evidence")
+
+	first := msp06Call(t, server.Handler(), msp06SnapshotDrop, map[string]any{"snapshot_ref": root["snapshot_ref"]})
+	second := msp06Call(t, server.Handler(), msp06SnapshotDrop, map[string]any{"snapshot_ref": root["snapshot_ref"]})
+	msp06AssertDropStatus(t, first, "dropped")
+	msp06AssertDropStatus(t, second, "already_gone")
+	for key, binding := range msp06EvidenceRefBindings {
+		terminal := msp06Call(t, server.Handler(), binding.tool, msp06EvidenceArguments(key, refs[key], serviceID, sessionID))
+		msp06AssertErrorMode(t, terminal, binding.tool, binding.scope, "evidence", "snapshot_gone")
+	}
+	unknown := base64.RawURLEncoding.EncodeToString(bytes.Repeat([]byte{0xcc}, sha256.Size))
+	msp06AssertDropStatus(t, msp06Call(t, server.Handler(), msp06SnapshotDrop, map[string]any{"snapshot_ref": unknown}), "already_gone")
+	malformed := msp06Call(t, server.Handler(), msp06SnapshotDrop, map[string]any{"snapshot_ref": "not-a-token"})
+	msp06AssertError(t, malformed, msp06SnapshotDrop, "whole-root", "invalid_argument")
+	if provider.callCount() != calls {
+		t.Fatalf("drop/evidence operations called provider: before=%d after=%d", calls, provider.callCount())
+	}
+}
+
+func TestMSP06G15ActiveTTLAndTombstoneTTLUseInclusiveFiveMinuteBoundary(t *testing.T) {
+	server, clock := msp06TestServer(t, &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")})
+	_, root := msp06CaptureRoot(t, server)
+	refs := msp06RootRefs(t, root)
+
+	clock.Advance(5 * time.Minute)
+	expired := msp06Call(t, server.Handler(), msp06ServicesListTool, map[string]any{"evidence_ref": refs["services_list_ref"]})
+	msp06AssertErrorMode(t, expired, msp06ServicesListTool, "services", "evidence", "snapshot_gone")
+	msp06AssertDropStatus(t, msp06Call(t, server.Handler(), msp06SnapshotDrop, map[string]any{"snapshot_ref": root["snapshot_ref"]}), "already_gone")
+
+	clock.Advance(5 * time.Minute)
+	evicted := msp06Call(t, server.Handler(), msp06ServicesListTool, map[string]any{"evidence_ref": refs["services_list_ref"]})
+	msp06AssertErrorMode(t, evicted, msp06ServicesListTool, "services", "evidence", "not_found")
+	msp06AssertDropStatus(t, msp06Call(t, server.Handler(), msp06SnapshotDrop, map[string]any{"snapshot_ref": root["snapshot_ref"]}), "already_gone")
+}
+
+func TestMSP06G15ActiveQuotaCountsRootGroupsAndCaptureFailureConsumesNoSlot(t *testing.T) {
+	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+	server, _ := msp06TestServer(t, provider)
+	for index := 0; index < 32; index++ {
+		_, root := msp06CaptureRoot(t, server)
+		if len(msp06RootRefs(t, root)) != 7 {
+			t.Fatalf("capture %d did not retain seven descendants", index)
+		}
+	}
+	full := msp06Call(t, server.Handler(), msp06SnapshotCapture, map[string]any{})
+	msp06AssertError(t, full, msp06SnapshotCapture, "whole-root", "quota_exceeded")
+	if provider.callCount() != 33 {
+		t.Fatalf("capture builds before quota reservation: provider calls=%d, want 33", provider.callCount())
+	}
+
+	failingProvider := &msp06Provider{err: errors.New("initial backend failure")}
+	serverAfterFailure, _ := msp06TestServer(t, failingProvider)
+	failed := msp06Call(t, serverAfterFailure.Handler(), msp06SnapshotCapture, map[string]any{})
+	msp06AssertError(t, failed, msp06SnapshotCapture, "whole-root", "backend_unavailable")
+	failingProvider.set(msp06Snapshot(t, "runtime-a"), nil)
+	for index := 0; index < 32; index++ {
+		msp06CaptureRoot(t, serverAfterFailure)
+	}
+	msp06AssertError(t, msp06Call(t, serverAfterFailure.Handler(), msp06SnapshotCapture, map[string]any{}), msp06SnapshotCapture, "whole-root", "quota_exceeded")
+}
+
+func TestMSP06G15ConcurrentCaptureReservationIsAtomicAt32(t *testing.T) {
+	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+	server, _ := msp06TestServer(t, provider)
+	const attempts = 64
+	type outcome struct {
+		code string
+		err  error
+	}
+	outcomes := make(chan outcome, attempts)
+	var start sync.WaitGroup
+	start.Add(1)
+	for index := 0; index < attempts; index++ {
+		go func() {
+			start.Wait()
+			outcomes <- msp06ConcurrentCapture(server.Handler())
+		}()
+	}
+	start.Done()
+
+	successes := 0
+	quota := 0
+	for index := 0; index < attempts; index++ {
+		result := <-outcomes
+		if result.err != nil {
+			t.Fatalf("concurrent capture %d: %v", index, result.err)
+		}
+		switch result.code {
+		case "":
+			successes++
+		case "quota_exceeded":
+			quota++
+		default:
+			t.Fatalf("concurrent capture code = %q", result.code)
+		}
+	}
+	if successes != 32 || quota != 32 {
+		t.Fatalf("concurrent captures success=%d quota=%d, want 32/32", successes, quota)
+	}
+	if provider.callCount() != attempts {
+		t.Fatalf("concurrent provider calls = %d, want %d detached builds", provider.callCount(), attempts)
+	}
+}
+
+func msp06ConcurrentCapture(handler http.Handler) (result struct {
+	code string
+	err  error
+}) {
+	params := json.RawMessage(`{"name":"eebus.v1.snapshot.capture","arguments":{}}`)
+	body, err := json.Marshal(rpcRequest{JSONRPC: "2.0", ID: 1, Method: "tools/call", Params: params})
+	if err != nil {
+		result.err = err
+		return result
+	}
+	request := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader(body))
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, request)
+	var response rpcResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		result.err = err
+		return result
+	}
+	if response.Error != nil {
+		result.err = fmt.Errorf("RPC error: %+v", response.Error)
+		return result
+	}
+	value, ok := response.Result.(map[string]any)
+	if !ok {
+		result.err = fmt.Errorf("result type %T", response.Result)
+		return result
+	}
+	content, ok := value["content"].([]any)
+	if !ok || len(content) != 1 {
+		result.err = fmt.Errorf("content %#v", value["content"])
+		return result
+	}
+	item, ok := content[0].(map[string]any)
+	if !ok {
+		result.err = fmt.Errorf("content item %T", content[0])
+		return result
+	}
+	var envelope map[string]any
+	if err := json.Unmarshal([]byte(fmt.Sprint(item["text"])), &envelope); err != nil {
+		result.err = err
+		return result
+	}
+	if rawError, exists := envelope["error"]; exists && rawError != nil {
+		errorObject, ok := rawError.(map[string]any)
+		if !ok {
+			result.err = fmt.Errorf("error object %T", rawError)
+			return result
+		}
+		result.code, _ = errorObject["code"].(string)
+	}
+	return result
+}
+
+func TestMSP06LiveReadsAllocateNoStoreEntries(t *testing.T) {
+	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+	server, _ := msp06TestServer(t, provider)
+	for index := 0; index < 40; index++ {
+		msp06AssertSuccess(t, msp06Call(t, server.Handler(), msp06RuntimeStatusTool, map[string]any{}), msp06RuntimeStatusTool, "runtime-status", "live")
+	}
+	for index := 0; index < 32; index++ {
+		msp06CaptureRoot(t, server)
+	}
+	msp06AssertError(t, msp06Call(t, server.Handler(), msp06SnapshotCapture, map[string]any{}), msp06SnapshotCapture, "whole-root", "quota_exceeded")
+	if provider.callCount() != 73 {
+		t.Fatalf("provider calls = %d, want 40 live + 32 captures + 1 detached quota attempt", provider.callCount())
+	}
+}
+
+func TestMSP06G15TombstonesAreBoundedTo256RootGroupsWithTotalTieBreak(t *testing.T) {
+	server, _ := msp06TestServer(t, &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")})
+	type terminal struct {
+		root       string
+		descendant string
+	}
+	terminals := make([]terminal, 0, 257)
+	for index := 0; index < 257; index++ {
+		_, root := msp06CaptureRoot(t, server)
+		refs := msp06RootRefs(t, root)
+		rootToken := msp06AssertToken(t, root["snapshot_ref"], "snapshot_ref")
+		msp06AssertDropStatus(t, msp06Call(t, server.Handler(), msp06SnapshotDrop, map[string]any{"snapshot_ref": rootToken}), "dropped")
+		terminals = append(terminals, terminal{root: rootToken, descendant: refs["services_list_ref"]})
+	}
+
+	expectedEvicted := 0
+	for index := 1; index < len(terminals); index++ {
+		left, _ := base64.RawURLEncoding.DecodeString(terminals[index].root)
+		right, _ := base64.RawURLEncoding.DecodeString(terminals[expectedEvicted].root)
+		if bytes.Compare(left, right) < 0 {
+			expectedEvicted = index
+		}
+	}
+	notFound := 0
+	gone := 0
+	actualEvicted := -1
+	for index, terminal := range terminals {
+		result := msp06Call(t, server.Handler(), msp06ServicesListTool, map[string]any{"evidence_ref": terminal.descendant})
+		errorObject := msp06Map(t, result.envelope["error"], "error")
+		switch errorObject["code"] {
+		case "not_found":
+			notFound++
+			actualEvicted = index
+		case "snapshot_gone":
+			gone++
+		default:
+			t.Fatalf("terminal %d code = %#v", index, errorObject["code"])
+		}
+	}
+	if notFound != 1 || gone != 256 || actualEvicted != expectedEvicted {
+		t.Fatalf("tombstones not_found=%d gone=%d evicted=%d, want 1/256/%d", notFound, gone, actualEvicted, expectedEvicted)
+	}
+}
+
+func TestMSP06G16ShareableOutputsErrorsLogsAndManifestDoNotLeak(t *testing.T) {
+	snapshot := msp06Snapshot(t, "runtime-a")
+	provider := &msp06Provider{snapshot: snapshot}
+	server, _ := msp06TestServer(t, provider)
+	_, root := msp06CaptureRoot(t, server)
+	encodedRoot, err := json.Marshal(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{
+		"local-ski-secret",
+		"remote-a",
+		"remote-z",
+		"session-a",
+		"session-z",
+		"certificate",
+		"fingerprint",
+		"private_key",
+		"local_ski",
+		"ship_id",
+		"mac_address",
+		"serial_number",
+		"pairing_history",
+		"192.0.2.",
+	} {
+		if bytes.Contains(bytes.ToLower(encodedRoot), []byte(strings.ToLower(forbidden))) {
+			t.Fatalf("captured output contains forbidden marker %q: %s", forbidden, encodedRoot)
+		}
+	}
+	for _, id := range []string{
+		snapshot.Meta.Runtime.Digest,
+		snapshot.Meta.LocalSKI.Digest,
+		snapshot.Pairing[0].Remote.Digest,
+		snapshot.Services[0].ID.Digest,
+		snapshot.Sessions[0].ID.Digest,
+		snapshot.Topology.Devices[0].ID.Digest,
+	} {
+		if bytes.Contains(encodedRoot, []byte(id)) {
+			t.Fatalf("captured output forwarded stable source identity %q", id)
+		}
+	}
+
+	refs := msp06RootRefs(t, root)
+	secretError := "-----BEGIN PRIVATE KEY----- serial=VR940F-SECRET mac=aa:bb:cc:dd:ee:ff ip=192.0.2.44 token=" + refs["services_list_ref"]
+	provider.set(eebusruntime.SnapshotV1{}, errors.New(secretError))
+	var logs bytes.Buffer
+	oldWriter := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(oldWriter) })
+	live := msp06Call(t, server.Handler(), msp06ServicesListTool, map[string]any{})
+	msp06AssertError(t, live, msp06ServicesListTool, "services", "backend_unavailable")
+	wrong := msp06Call(t, server.Handler(), msp06SessionsListTool, map[string]any{"evidence_ref": refs["services_list_ref"]})
+	msp06AssertErrorMode(t, wrong, msp06SessionsListTool, "sessions", "evidence", "permission_denied")
+	shareable := live.raw + "\n" + wrong.raw + "\n" + logs.String()
+	for _, forbidden := range []string{"PRIVATE KEY", "VR940F-SECRET", "aa:bb:cc:dd:ee:ff", "192.0.2.44", refs["services_list_ref"]} {
+		if strings.Contains(shareable, forbidden) {
+			t.Fatalf("shareable error/log material leaked %q: %s", forbidden, shareable)
+		}
+	}
+	manifest, err := json.Marshal(msp06Tools(t, server))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, token := range append([]string{fmt.Sprint(root["snapshot_ref"])}, refs["services_list_ref"]) {
+		if bytes.Contains(manifest, []byte(token)) {
+			t.Fatalf("tools/list manifest contains runtime reference token %q", token)
+		}
+	}
+}
+
+func TestMSP06NoDriftToExistingEbusV1InventoryOrResponses(t *testing.T) {
+	server, err := NewServer(&testRegistry{entries: make(map[byte]registry.DeviceEntry)}, &testInvoker{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeTools := msp06Tools(t, server)
+	beforeNames := msp06NamesWithPrefix(beforeTools, "ebus.v1.")
+	beforeCall := msp06Call(t, server.Handler(), "ebus.v1.ebus_standard.services.list", map[string]any{})
+
+	clock := &msp06Clock{now: time.Date(2026, 7, 19, 8, 0, 0, 0, time.UTC)}
+	err = server.registerEEBusV1Provider(&msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}, eebusV1RegistrationOptions{
+		now:          clock.Now,
+		entropy:      &msp06EntropyReader{},
+		pseudonymKey: bytes.Repeat([]byte{0x42}, sha256.Size),
+		liveTimeout:  time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterNames := msp06NamesWithPrefix(msp06Tools(t, server), "ebus.v1.")
+	afterCall := msp06Call(t, server.Handler(), "ebus.v1.ebus_standard.services.list", map[string]any{})
+	if !reflect.DeepEqual(beforeNames, afterNames) {
+		t.Fatalf("ebus.v1 inventory drifted:\nbefore=%v\nafter=%v", beforeNames, afterNames)
+	}
+	if beforeCall.raw != afterCall.raw || beforeCall.isError != afterCall.isError {
+		t.Fatalf("ebus.v1 response drifted after eeBUS registration:\nbefore=%s\nafter=%s", beforeCall.raw, afterCall.raw)
+	}
+}
+
+func TestMSP06RootReferenceOrderingFixtureUsesDecodedBytes(t *testing.T) {
+	tokens := []string{
+		base64.RawURLEncoding.EncodeToString(append([]byte{0x01}, bytes.Repeat([]byte{0xff}, 31)...)),
+		base64.RawURLEncoding.EncodeToString(append([]byte{0x02}, bytes.Repeat([]byte{0x00}, 31)...)),
+	}
+	sort.Slice(tokens, func(i, j int) bool {
+		left, _ := base64.RawURLEncoding.DecodeString(tokens[i])
+		right, _ := base64.RawURLEncoding.DecodeString(tokens[j])
+		return bytes.Compare(left, right) < 0
+	})
+	if decoded, _ := base64.RawURLEncoding.DecodeString(tokens[0]); decoded[0] != 0x01 {
+		t.Fatal("decoded-byte ordering fixture is invalid")
+	}
+}

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -460,6 +460,8 @@ type Server struct {
 	idempotency       map[string]idempotencyEntry
 	snapshotMu        sync.RWMutex
 	snapshots         map[string]snapshotState
+	eebusV1Mu         sync.RWMutex
+	eebusV1           *eebusV1Runtime
 
 	tools []Tool
 
@@ -1364,6 +1366,10 @@ func (s *Server) handleToolsCall(ctx context.Context, params json.RawMessage) (a
 	}
 
 	if result, handled := s.handleVaillantB503Call(ctx, call.Name, call.Arguments); handled {
+		return result, nil
+	}
+
+	if result, handled := s.handleEEBusV1Call(ctx, call.Name, call.Arguments); handled {
 		return result, nil
 	}
 


### PR DESCRIPTION
## Summary

- implements the exact nine conditional, read-only `eebus.v1.*` MCP tools from MSP-06
- captures exactly one detached `SnapshotV1` per live call and provides immutable, tool-bound evidence replay with fixed quota, expiry, drop, tombstone, and eviction policy
- emits closed fail-closed DTOs with deterministic RFC 8785/JCS hashes and process-ephemeral runtime-scoped HMAC pseudonyms
- preserves reconnect behavior and disabled-default behavior without changing GraphQL, Portal, Home Assistant, semantic projection, or existing `ebus.v1.*` behavior

## Contract

Implementation targets the merged MSP-06 candidate contract and schema/JCS vectors from docs commit `9819762a61c28eeceb11beb775aa2a91c83a68b6`.

## TDD authority

- Original tests-only RED: `ecf95c7ad0aeb0dbf2a6afb092e107ec2a29f3a6`
  - external run: https://github.com/Project-Helianthus/helianthus-ebusgateway/actions/runs/29684692062
- Corrected tests-only RED: `d0680c5ed7a4b55342d965b050e231809d9bfed4`
  - external run: https://github.com/Project-Helianthus/helianthus-ebusgateway/actions/runs/29685255273
  - correction removed only live eBUS `meta.data_timestamp` from a no-drift byte comparison; all MSP-06 expectations remained unchanged
- Atomic GREEN: `9c75116de0cea0ee036528d1034a5f47392feb05`

No test files were changed in GREEN.

## GREEN validation

- `gofmt` on all seven changed Go files: pass
- `go test ./mcp ./cmd/gateway -run '^TestMSP06' -count=1`: pass
- `go test ./mcp ./cmd/gateway -run '^TestMSP06' -count=10`: pass
- `go test -race ./mcp ./cmd/gateway -run '^TestMSP06' -count=3`: pass
- targeted existing MCP inventory, classification, disabled-default, eBUS no-drift, consumer-boundary, and bootstrap-boundary tests: pass
- `go test . -run '^TestMSP05BEEBusRuntimeCouplingIsConfinedToPrivateGatewaySeams$' -count=1`: pass
- `go test ./mcp ./cmd/gateway -count=1`: pass
- `go test -race ./mcp ./cmd/gateway -count=1`: pass
- `go test ./graphql ./portal -count=1`: pass
- `go vet ./...`: pass
- `go build ./...`: pass
- `git diff --check`: pass
- `golangci-lint run ./...`: 0 issues
- authoritative `./scripts/ci_local.sh` rerun: exit 0
  - full repository `go test -race -count=1 ./...`: pass
  - Python gate suites: 168 + 5 + 7 + 5 tests, all pass
  - portal assets reproducible and unchanged

The path-level transport and passive-smoke classifiers conservatively trigger on any non-rename `cmd/gateway/main.go` change. This PR changes that file only to carry the enabled eeBUS provider into MCP bootstrap and register it before handler mount, so the successful local-CI rerun used the repository's explicit owner overrides with these written reasons:

- transport: `MSP-06 changes only conditional eeBUS MCP bootstrap registration; no transport or protocol path changes; focused no-drift and full race suites pass`
- passive smoke: `MSP-06 changes only conditional eeBUS MCP bootstrap registration; no passive observation path changes; focused no-drift and full race suites pass`

No T01..T88 result is claimed for this non-transport change.

## Changed production files

- `cmd/gateway/eebus_runtime_adapter.go`
- `cmd/gateway/main.go`
- `mcp/server.go`
- `mcp/eebus_v1.go`
- `mcp/eebus_v1_dto.go`
- `mcp/eebus_v1_jcs.go`
- `mcp/eebus_v1_store.go`

## Exact-head GitHub CI

- Run: https://github.com/Project-Helianthus/helianthus-ebusgateway/actions/runs/29686668828
- Head: `9c75116de0cea0ee036528d1034a5f47392feb05`
- `terminology` job `88192003809`: success
- `build` job `88192003799`: success
- `lint` job `88192003791`: success
- `test` job `88192003825`: success

The PR remains draft for review. It is not marked ready and must not be merged by this development step.

Closes #699
