### PR TITLE
MSP-07: close sampled comparator outcome mappings

### DIFF
--- a/internal/candidatefacts/artifacts.go
+++ b/internal/candidatefacts/artifacts.go
@@ -14,7 +14,7 @@ var artifactFiles embed.FS
 func PinnedContractV1() ContractBindingV1 {
 	return ContractBindingV1{
 		OwnerRepository:      "Project-Helianthus/helianthus-docs-ebus",
-		OwnerCommit:          "58a91574a637d9be101f9011220c509eabb0ef53",
+		OwnerCommit:          "ea88fef23ecb154b08f70e7f94b36e1738ed08bf",
 		GraphSchemaPath:      "docs/platform/schemas/draft-candidate-fact-graph-v1.schema.json",
 		GraphSchemaSHA256:    "ab5f65a527633c3c5f60119cf0071a6ffdd3ee66d6e210f78bf17a03e438069a",
 		ReplaySchemaPath:     "docs/platform/schemas/draft-candidate-fact-replay-v1.schema.json",

--- a/internal/candidatefacts/comparator.go
+++ b/internal/candidatefacts/comparator.go
@@ -118,11 +118,11 @@ func evaluateNumericWindow(
 			conflictRun = 0
 		}
 	}
-	if conflict {
-		return "CONFLICT", lastRight, nil
-	}
 	if unavailable > maximumMissing || present < minimumSamples {
 		return "INDETERMINATE", lastRight, nil
+	}
+	if conflict {
+		return "CONFLICT", lastRight, nil
 	}
 	if mismatch {
 		return "MISMATCH", lastRight, nil

--- a/internal/candidatefacts/contract_red_test.go
+++ b/internal/candidatefacts/contract_red_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	docsMergeV1         = "58a91574a637d9be101f9011220c509eabb0ef53"
+	docsMergeV1         = "ea88fef23ecb154b08f70e7f94b36e1738ed08bf"
 	sourceOwnerCommitV1 = "4d7747730be023acb251b20a22d796545a9f3688"
 )
 

--- a/internal/candidatefacts/outcome_matrix_red_test.go
+++ b/internal/candidatefacts/outcome_matrix_red_test.go
@@ -1,0 +1,257 @@
+package candidatefacts
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestOutcomeMatrixPinsCorrectiveDocsMerge(t *testing.T) {
+	const want = "ea88fef23ecb154b08f70e7f94b36e1738ed08bf"
+	if got := PinnedContractV1().OwnerCommit; got != want {
+		t.Fatalf("OwnerCommit = %q; want %q", got, want)
+	}
+}
+
+func TestOutcomeMatrixAcceptsIntegratedSampledMappings(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		status     string
+		terminal   any
+		outcome    string
+		leftValue  any
+		rightValue any
+		state      string
+	}{
+		{
+			name:   "mismatch is an active conflict",
+			status: "CONFLICTED", outcome: "MISMATCH",
+			leftValue: "10", rightValue: "10.5", state: "PRESENT",
+		},
+		{
+			name:   "indeterminate is not tested for this bundle",
+			status: "WITHHELD", terminal: "NOT_TESTED", outcome: "INDETERMINATE",
+			leftValue: nil, rightValue: "10", state: "MISSING",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			graph, source, sourceReplay := outcomeMatrixVector(t, test.status, test.terminal, test.outcome, test.leftValue, test.rightValue, test.state)
+			if err := verifyOutcomeMatrixVector(graph, source, sourceReplay); err != nil {
+				t.Fatalf("integrated %s mapping: %v", test.outcome, err)
+			}
+		})
+	}
+}
+
+func TestOutcomeMatrixRejectsSwappedSampledMappings(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		status     string
+		terminal   any
+		outcome    string
+		leftValue  any
+		rightValue any
+		state      string
+	}{
+		{
+			name:   "mismatch is not a terminal bundle conflict",
+			status: "WITHHELD", terminal: "CONFLICT", outcome: "MISMATCH",
+			leftValue: "10", rightValue: "10.5", state: "PRESENT",
+		},
+		{
+			name:   "indeterminate is not an active conflict",
+			status: "CONFLICTED", outcome: "INDETERMINATE",
+			leftValue: nil, rightValue: "10", state: "MISSING",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			graph, source, sourceReplay := outcomeMatrixVector(t, test.status, test.terminal, test.outcome, test.leftValue, test.rightValue, test.state)
+			assertCategory(t, verifyOutcomeMatrixVector(graph, source, sourceReplay), "state.terminal")
+		})
+	}
+}
+
+func TestOutcomeMatrixAvailabilityFailurePrecedesConflict(t *testing.T) {
+	left := correctiveArtifact("EBUS", "availability-left", "7", "10", "degC", 2_000_000_000)
+	missingLeft := correctiveArtifact("EBUS", "availability-missing", "8", "10", "degC", 2_000_000_000)
+	missingObservation := missingLeft["normalized_evidence"].(map[string]any)["observation"].(map[string]any)
+	missingObservation["value"] = nil
+	missingObservation["unit"] = nil
+	right := correctiveArtifact("EEBUS", "availability-right", "9", "11", "degC", 2_000_000_000)
+	parameters := correctiveParameters()
+	parameters["minimum_samples"] = number(1)
+	parameters["maximum_missing_samples"] = number(0)
+	parameters["conflict_threshold"] = map[string]any{
+		"absolute_decimal": "1", "consecutive_samples": number(1),
+	}
+	outcome, _, err := evaluateNumericWindow(parameters, []map[string]any{
+		correctiveSample(left, right, 3_000_000_000, "PRESENT"),
+		correctiveSample(missingLeft, right, 4_000_000_000, "MISSING"),
+	}, correctiveArtifactIndex(left, missingLeft, right), nil)
+	if err != nil || outcome != "INDETERMINATE" {
+		t.Fatalf("availability plus conflict = (%q, %v); want INDETERMINATE", outcome, err)
+	}
+}
+
+func outcomeMatrixVector(t *testing.T, status string, terminal any, outcome string, leftValue, rightValue any, state string) (map[string]any, map[string]any, map[string]any) {
+	t.Helper()
+	artifacts := pinnedTestArtifactsV1()
+	graph := decodeObject(t, artifacts.PositiveGraph)
+	source := decodeObject(t, artifacts.SourceBundle)
+	sourceReplay := decodeObject(t, artifacts.SourceReplay)
+
+	var target map[string]any
+	for _, raw := range arrayAt(t, graph, "facts") {
+		fact := raw.(map[string]any)
+		provenance := objectAt(t, fact, "provenance")
+		identity, _ := provenance["ebus"].(map[string]any)
+		if identity != nil && identity["family"] == "B524" && fact["status"] == "RAW_ONLY" {
+			target = fact
+			break
+		}
+	}
+	if target == nil {
+		t.Fatal("canonical graph has no B524 RAW_ONLY fact")
+	}
+
+	left := correctiveArtifact("EBUS", "outcome-left", "7", "10", "degC", 2_000_000_000)
+	right := correctiveArtifact("EEBUS", "outcome-right", "8", "10", "degC", 2_000_000_000)
+	setOutcomeObservation(left, leftValue)
+	setOutcomeObservation(right, rightValue)
+
+	provenance := objectAt(t, target, "provenance")
+	left["ebus_identity"] = cloneObject(provenance["ebus"].(map[string]any))
+	eebusPath := map[string]any{
+		"service": "service-" + repeatByte('a', 32),
+		"entity":  "entity-" + repeatByte('b', 32),
+		"feature": "feature-" + repeatByte('c', 32),
+		"feature_path": []any{
+			map[string]any{"kind": "SERVICE", "selector": "service-" + repeatByte('a', 32)},
+			map[string]any{"kind": "ENTITY", "selector": "entity-" + repeatByte('b', 32)},
+			map[string]any{"kind": "FEATURE", "selector": "feature-" + repeatByte('c', 32)},
+		},
+	}
+	rightNormalized := right["normalized_evidence"].(map[string]any)
+	rightNormalized["data"] = map[string]any{
+		"services":      []any{map[string]any{"id": map[string]any{"digest": eebusPath["service"]}}},
+		"feature_paths": []any{cloneObject(eebusPath)},
+	}
+
+	leftRef := left["evidence_refs"].([]any)[0]
+	rightRef := right["evidence_refs"].([]any)[0]
+	refs := []any{leftRef, rightRef}
+	sort.Slice(refs, func(i, j int) bool { return evidenceRefLess(refs[i], refs[j]) })
+	provenance["native_evidence_refs"] = refs
+	provenance["ebus_source_id"] = left["source_id"]
+	provenance["ebus_artifact_id"] = left["artifact_id"]
+	provenance["eebus_source_id"] = right["source_id"]
+	provenance["eebus_artifact_id"] = right["artifact_id"]
+	provenance["eebus_service"] = eebusPath["service"]
+	provenance["eebus"] = eebusPath
+
+	target["status"] = status
+	target["terminal_negative_state"] = terminal
+	target["draft_value"] = nil
+	target["draft_unit"] = nil
+	target["comparator"] = map[string]any{
+		"draft_id": "NUMERIC_WINDOW_V1_DRAFT",
+		"samples": []any{
+			correctiveSample(left, right, 3_000_000_000, state),
+			correctiveSample(left, right, 4_000_000_000, state),
+		},
+		"outcome": outcome,
+	}
+
+	source["sources"] = append(arrayAt(t, source, "sources"),
+		map[string]any{"source_id": left["source_id"], "source_kind": "EBUS", "artifact_ids": []any{left["artifact_id"]}},
+		map[string]any{"source_id": right["source_id"], "source_kind": "EEBUS", "artifact_ids": []any{right["artifact_id"]}},
+	)
+	source["artifacts"] = append(arrayAt(t, source, "artifacts"), left, right)
+	rootRefs := append(arrayAt(t, source, "evidence_refs"), leftRef, rightRef)
+	sort.Slice(rootRefs, func(i, j int) bool { return evidenceRefLess(rootRefs[i], rootRefs[j]) })
+	source["evidence_refs"] = rootRefs
+	objectAt(t, graph, "source_bundle")["evidence_refs"] = cloneArray(rootRefs)
+	normalizeBuildOrdering(graph)
+	rehashOutcomeMatrixGraph(t, graph)
+	return graph, source, sourceReplay
+}
+
+func setOutcomeObservation(artifact map[string]any, value any) {
+	observation := artifact["normalized_evidence"].(map[string]any)["observation"].(map[string]any)
+	observation["value"] = value
+	if value == nil {
+		observation["unit"] = nil
+	}
+}
+
+func rehashOutcomeMatrixGraph(t *testing.T, graph map[string]any) {
+	t.Helper()
+	for _, raw := range arrayAt(t, graph, "facts") {
+		fact := raw.(map[string]any)
+		view := cloneObject(fact)
+		delete(view, "fact_hash")
+		canonical, err := canonicalJSON(view)
+		if err != nil {
+			t.Fatal(err)
+		}
+		fact["fact_hash"] = "sha256:" + domainHex(factDomainV1, canonical)
+	}
+	view := cloneObject(graph)
+	delete(view, "graph_id")
+	delete(view, "graph_hash")
+	canonical, err := canonicalJSON(view)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := domainHex(graphDomainV1, canonical)
+	graph["graph_id"] = "dcfgv1:sha256:" + digest
+	graph["graph_hash"] = "sha256:" + digest
+}
+
+func verifyOutcomeMatrixVector(graph, source, sourceReplay map[string]any) error {
+	registry, registryRaw, err := loadRegistryV1()
+	if err != nil {
+		return err
+	}
+	if err := schemaCheck(graph); err != nil {
+		return err
+	}
+	encoded, err := canonicalJSON(graph)
+	if err != nil {
+		return err
+	}
+	if err := checkLimits(graph, len(encoded)); err != nil {
+		return err
+	}
+	if err := checkRegistryBinding(graph, registry, registryRaw); err != nil {
+		return err
+	}
+	return verifyGraphAfterRegistry(graph, registry, source, sourceReplay)
+}
+
+func cloneArray(values []any) []any {
+	result := make([]any, len(values))
+	for index, value := range values {
+		switch typed := value.(type) {
+		case map[string]any:
+			result[index] = cloneObject(typed)
+		default:
+			result[index] = typed
+		}
+	}
+	return result
+}
+
+func TestOutcomeMatrixPreservesFourTerminalStatesAndV1(t *testing.T) {
+	registry, _, err := loadRegistryV1()
+	if err != nil {
+		t.Fatal(err)
+	}
+	terminals, ok := stringArray(registry["terminal_negative_states"])
+	if !ok || !reflect.DeepEqual(terminals, []string{"NO_SIGNAL", "CLOUD_ONLY", "CONFLICT", "NOT_TESTED"}) {
+		t.Fatalf("terminal states = %v; want exact V1 set", terminals)
+	}
+	if PinnedContractV1().GraphSchemaPath != "docs/platform/schemas/draft-candidate-fact-graph-v1.schema.json" {
+		t.Fatal("outcome correction introduced a non-V1 graph schema")
+	}
+}

--- a/internal/candidatefacts/remediation_test.go
+++ b/internal/candidatefacts/remediation_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestCorrectiveContractPinAndCanonicalGraphAreCurrent(t *testing.T) {
-	if got := PinnedContractV1().OwnerCommit; got != "58a91574a637d9be101f9011220c509eabb0ef53" {
+	if got := PinnedContractV1().OwnerCommit; got != "ea88fef23ecb154b08f70e7f94b36e1738ed08bf" {
 		t.Fatalf("OwnerCommit = %q; want corrective docs merge", got)
 	}
 	artifacts := pinnedTestArtifactsV1()

--- a/internal/candidatefacts/validation.go
+++ b/internal/candidatefacts/validation.go
@@ -329,7 +329,7 @@ func checkProvenance(graph, registry, sourceBundle, sourceReplay map[string]any)
 		terminal, _ := optionalString(fact["terminal_negative_state"])
 		comparator, _ := objectValue(fact["comparator"])
 		samples, _ := arrayValue(comparator["samples"])
-		if status == "CANDIDATE" || status == "CONFLICTED" || terminal == "CONFLICT" {
+		if len(samples) > 0 || status == "CANDIDATE" || status == "CONFLICTED" || terminal == "CONFLICT" {
 			if provenance["ebus"] == nil || provenance["eebus"] == nil ||
 				provenance["ebus_source_id"] == nil || provenance["eebus_source_id"] == nil ||
 				len(samples) == 0 {

--- a/internal/candidatefacts/validation_native.go
+++ b/internal/candidatefacts/validation_native.go
@@ -294,6 +294,8 @@ func checkStates(graph, registry map[string]any) error {
 		comparator, _ := objectValue(fact["comparator"])
 		samples, _ := arrayValue(comparator["samples"])
 		outcome := asString(comparator["outcome"])
+		validNotTested := len(samples) == 0 && outcome == "NOT_EVALUATED" ||
+			len(samples) > 0 && outcome == "INDETERMINATE" && nativeKinds["EBUS"] && nativeKinds["EEBUS"]
 
 		if cloudOnly && (status != "WITHHELD" || terminal != "CLOUD_ONLY") {
 			return fail("state.terminal")
@@ -306,20 +308,24 @@ func checkStates(graph, registry map[string]any) error {
 			}
 		case "CANDIDATE":
 			if terminal != "" || fact["draft_value"] == nil || fact["draft_unit"] == nil ||
-				outcome != "MATCH" || !nativeKinds["EBUS"] || !nativeKinds["EEBUS"] {
+				len(samples) == 0 || outcome != "MATCH" || !nativeKinds["EBUS"] || !nativeKinds["EEBUS"] {
 				return fail("state.terminal")
 			}
 		case "CONFLICTED":
 			if terminal != "" || fact["draft_value"] != nil || fact["draft_unit"] != nil ||
-				outcome != "CONFLICT" || !nativeKinds["EBUS"] || !nativeKinds["EEBUS"] {
+				len(samples) == 0 || !member(outcome, "MISMATCH", "CONFLICT") ||
+				!nativeKinds["EBUS"] || !nativeKinds["EEBUS"] {
 				return fail("state.terminal")
 			}
 		case "WITHHELD":
 			if terminal == "" || fact["draft_value"] != nil || fact["draft_unit"] != nil {
 				return fail("state.terminal")
 			}
-			if (terminal == "CLOUD_ONLY" || terminal == "NO_SIGNAL" || terminal == "NOT_TESTED") &&
+			if (terminal == "CLOUD_ONLY" || terminal == "NO_SIGNAL") &&
 				(len(samples) != 0 || outcome != "NOT_EVALUATED") {
+				return fail("state.terminal")
+			}
+			if terminal == "NOT_TESTED" && !validNotTested {
 				return fail("state.terminal")
 			}
 			if terminal == "CLOUD_ONLY" && !cloudOnly {
@@ -416,13 +422,17 @@ func checkComparators(graph, registry, sourceBundle map[string]any) error {
 			return fail("comparator.invalid")
 		}
 		status := asString(fact["status"])
+		terminal, _ := optionalString(fact["terminal_negative_state"])
 		allowedOutcomes := map[string]map[string]bool{
-			"RAW_ONLY":   {"NOT_EVALUATED": true},
-			"CANDIDATE":  {"MATCH": true},
-			"CONFLICTED": {"CONFLICT": true},
-			"WITHHELD":   {"NOT_EVALUATED": true, "CONFLICT": true, "INDETERMINATE": true},
+			"RAW_ONLY\x00":           {"NOT_EVALUATED": true},
+			"CANDIDATE\x00":          {"MATCH": true},
+			"CONFLICTED\x00":         {"MISMATCH": true, "CONFLICT": true},
+			"WITHHELD\x00CLOUD_ONLY": {"NOT_EVALUATED": true},
+			"WITHHELD\x00NO_SIGNAL":  {"NOT_EVALUATED": true},
+			"WITHHELD\x00NOT_TESTED": {"NOT_EVALUATED": true, "INDETERMINATE": true},
+			"WITHHELD\x00CONFLICT":   {"CONFLICT": true},
 		}
-		if !allowedOutcomes[status][computed] {
+		if !allowedOutcomes[status+"\x00"+terminal][computed] {
 			return fail("comparator.invalid")
 		}
 		if status == "CANDIDATE" {
@@ -432,9 +442,8 @@ func checkComparators(graph, registry, sourceBundle map[string]any) error {
 				return fail("comparator.invalid")
 			}
 		}
-		terminal, _ := optionalString(fact["terminal_negative_state"])
 		if terminal == "CONFLICT" && computed != "CONFLICT" ||
-			(terminal == "NO_SIGNAL" || terminal == "CLOUD_ONLY" || terminal == "NOT_TESTED") &&
+			(terminal == "NO_SIGNAL" || terminal == "CLOUD_ONLY") &&
 				computed != "NOT_EVALUATED" {
 			return fail("comparator.invalid")
 		}


### PR DESCRIPTION
## Summary

- close the internal candidate fact graph V1 sampled outcome/state matrix from docs merge `ea88fef23ecb154b08f70e7f94b36e1738ed08bf`
- map `MATCH -> CANDIDATE/null`, `MISMATCH -> CONFLICTED/null`, active `CONFLICT -> CONFLICTED/null`, terminal bundle `CONFLICT -> WITHHELD/CONFLICT`, sampled `INDETERMINATE -> WITHHELD/NOT_TESTED`, and empty `NOT_EVALUATED -> WITHHELD/NOT_TESTED`
- require complete direct eBUS and eeBUS provenance for every sampled fact and preserve availability-before-conflict precedence
- preserve exactly four terminal states, V1, candidate-only visibility, and all existing artifact digests

Refs #705 and #703. Addresses post-merge review comment `3611412004` from #704.
Canonical docs: Project-Helianthus/helianthus-docs-ebus#363 / PR #364, squash merge `ea88fef23ecb154b08f70e7f94b36e1738ed08bf`, tree `7a22395b5d894de00db0cae167c45d475e31a103`.

## Strict TDD

RED: `080aba7d5d11b185d8de8eb425e8ce87abd2d782` (tests only).

- local focused/full RED: only `internal/candidatefacts` failed on stale OwnerCommit, sampled `MISMATCH` and `INDETERMINATE` representability, and availability-before-conflict
- external RED: Actions `29705839794`; test failed on those four assertions while build, lint, and terminology passed

GREEN: `d788fdd861ee3efb6ae0403bba2d0ead6d62599e`.

- `go test -count=1 ./internal/candidatefacts`
- `go test -race -count=1 ./internal/candidatefacts`
- `go test -count=1 ./...`
- `go test -race -count=1 ./...`
- `go vet ./...`
- `golangci-lint run ./...` (0 issues)
- Linux `amd64` and `arm64`, `CGO_ENABLED=0`: full build and compile-only test matrix passed
- `./scripts/ci_local.sh`: passed, including 185 Python gate tests; transport and passive smoke gates correctly not triggered because the diff is internal/pure; no override used
- exact-head Actions `29706294706`: 4/4 green (test, build, lint, terminology)

## Scope

No V2, config, runtime, transport, network, socket, filesystem, MCP, GraphQL, Portal, HA, command, or stable semantic registry changes.