### PR TITLE
LIVE-EEBUS: consume reentrancy-safe eebusreg v0.1.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260521144203-f9919f4b1007
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2
-	github.com/Project-Helianthus/helianthus-eebusreg v0.1.0
+	github.com/Project-Helianthus/helianthus-eebusreg v0.1.1
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e4
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
 github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.3 h1:lYe48Ve3wDRd9/Ov4kKd2HY5kOF0HUqlS9P7Zse02Vs=
 github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.3/go.mod h1:zW+AbkkhwLmzoCeybd62m6fqDks29vY+zJF9oIGIQ88=
-github.com/Project-Helianthus/helianthus-eebusreg v0.1.0 h1:6EZPtvLgqMD9FbJlrEZwQZQntL0hqWmfoz5ofpgAu/E=
-github.com/Project-Helianthus/helianthus-eebusreg v0.1.0/go.mod h1:rtHtQ2bDxQ/7T+nHBUzAPPc+XPIgNeCF1diJM3CaJ5E=
+github.com/Project-Helianthus/helianthus-eebusreg v0.1.1 h1:iKd6614SEEprHW5XLjmUzk8zvHiWNC989g6Uo0XMjpQ=
+github.com/Project-Helianthus/helianthus-eebusreg v0.1.1/go.mod h1:rtHtQ2bDxQ/7T+nHBUzAPPc+XPIgNeCF1diJM3CaJ5E=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.4 h1:aVUEhbflEwU7G1+E3WfIuVsWlVy42fZdmwh+K4Wkf+E=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.4/go.mod h1:qPqQTDqmPjyOJCr0JMNjhSC1XW1k3h5P/EZqRGy80Vs=
 github.com/Project-Helianthus/helianthus-spine-go v0.7.1-helianthus.1 h1:4OdB3ijVUA3SDJGUYp8I62kXOTX+96ghAiVqsvQV8yw=


### PR DESCRIPTION
## Summary
- bump only `github.com/Project-Helianthus/helianthus-eebusreg` from `v0.1.0` to `v0.1.1`
- consume the public reentrant trust-effect deadlock fix from eebusreg PR #49
- keep the gateway endpoint contract and all existing eBUS paths unchanged

## Evidence
- dependency RED: eebusreg `34cb87a55ddbd864576c95241cef54ff85224063`, CI `29787272925`
- dependency GREEN: eebusreg `3ee451b5eeb2b2edbff8753c7f5f5fb11a1c38fa`, CI `29787833613`
- public tag: `v0.1.1`, tag object `57b36b93bfc27145091cb5bbcd4912b53f7698b2`, commit `1768979512d1fab11fc6d07fc7320f2dcc47cbbb`
- gateway local `./scripts/ci_local.sh`: green; all Go race suites, 185 Python tests, zero lint issues; transport/passive gates not triggered
- `go mod verify`: all modules verified

## Scope
Only `go.mod` and `go.sum`; no replace directive and no compatibility layer.

Closes #715