### PR TITLE
LIVE-EEBUS: consume repeated-window eebusreg v0.1.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260521144203-f9919f4b1007
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2
-	github.com/Project-Helianthus/helianthus-eebusreg v0.1.1
+	github.com/Project-Helianthus/helianthus-eebusreg v0.1.2
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e4
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
 github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.3 h1:lYe48Ve3wDRd9/Ov4kKd2HY5kOF0HUqlS9P7Zse02Vs=
 github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.3/go.mod h1:zW+AbkkhwLmzoCeybd62m6fqDks29vY+zJF9oIGIQ88=
-github.com/Project-Helianthus/helianthus-eebusreg v0.1.1 h1:iKd6614SEEprHW5XLjmUzk8zvHiWNC989g6Uo0XMjpQ=
-github.com/Project-Helianthus/helianthus-eebusreg v0.1.1/go.mod h1:rtHtQ2bDxQ/7T+nHBUzAPPc+XPIgNeCF1diJM3CaJ5E=
+github.com/Project-Helianthus/helianthus-eebusreg v0.1.2 h1:/1j1JiArkT5vdf0b7ns4bAtyFHuOmosafnGxHySzBJk=
+github.com/Project-Helianthus/helianthus-eebusreg v0.1.2/go.mod h1:rtHtQ2bDxQ/7T+nHBUzAPPc+XPIgNeCF1diJM3CaJ5E=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.4 h1:aVUEhbflEwU7G1+E3WfIuVsWlVy42fZdmwh+K4Wkf+E=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.4/go.mod h1:qPqQTDqmPjyOJCr0JMNjhSC1XW1k3h5P/EZqRGy80Vs=
 github.com/Project-Helianthus/helianthus-spine-go v0.7.1-helianthus.1 h1:4OdB3ijVUA3SDJGUYp8I62kXOTX+96ghAiVqsvQV8yw=


### PR DESCRIPTION
## Summary
- bump only `github.com/Project-Helianthus/helianthus-eebusreg` from `v0.1.1` to `v0.1.2`
- consume cancelled-generation retirement and repeated-window reconnect fix from eebusreg PR #51
- leave gateway endpoint and existing eBUS behavior unchanged

## Evidence
- dependency RED `e7d753dd63261643c91c45308ff08150429f2bd4`, CI `29789285695`
- dependency GREEN `6ac6ff98b6460e63c815ed7b0ebd7c333660bc37`, CI `29789574826`
- tag `v0.1.2`, tag object `e9fb0a4f41c28820147a0406f040903720855356`, commit `a5e1d37f843fd77248a58cbf0483a752f364f2e6`
- gateway full `./scripts/ci_local.sh` green: all Go race suites, 185 Python tests, zero lint issues; transport/passive gates not triggered
- `go mod verify`: all modules verified

## Scope
Only `go.mod` and `go.sum`; no replace directive, public API change, or compatibility layer.

Closes #717