### PR TITLE
LIVE-EEBUS: consume connected-retirement eebusreg v0.1.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260521144203-f9919f4b1007
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2
-	github.com/Project-Helianthus/helianthus-eebusreg v0.1.2
+	github.com/Project-Helianthus/helianthus-eebusreg v0.1.3
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e4
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
 github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.3 h1:lYe48Ve3wDRd9/Ov4kKd2HY5kOF0HUqlS9P7Zse02Vs=
 github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.3/go.mod h1:zW+AbkkhwLmzoCeybd62m6fqDks29vY+zJF9oIGIQ88=
-github.com/Project-Helianthus/helianthus-eebusreg v0.1.2 h1:/1j1JiArkT5vdf0b7ns4bAtyFHuOmosafnGxHySzBJk=
-github.com/Project-Helianthus/helianthus-eebusreg v0.1.2/go.mod h1:rtHtQ2bDxQ/7T+nHBUzAPPc+XPIgNeCF1diJM3CaJ5E=
+github.com/Project-Helianthus/helianthus-eebusreg v0.1.3 h1:Ffe+Z1uafvcxA7Zl2HFeZdY/y6bwHhL8f4joPf/Y4t4=
+github.com/Project-Helianthus/helianthus-eebusreg v0.1.3/go.mod h1:rtHtQ2bDxQ/7T+nHBUzAPPc+XPIgNeCF1diJM3CaJ5E=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.4 h1:aVUEhbflEwU7G1+E3WfIuVsWlVy42fZdmwh+K4Wkf+E=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.4/go.mod h1:qPqQTDqmPjyOJCr0JMNjhSC1XW1k3h5P/EZqRGy80Vs=
 github.com/Project-Helianthus/helianthus-spine-go v0.7.1-helianthus.1 h1:4OdB3ijVUA3SDJGUYp8I62kXOTX+96ghAiVqsvQV8yw=


### PR DESCRIPTION
Closes #719.

Pins `helianthus-eebusreg v0.1.3`, which closes connected pending SHIP transports during pairing cancellation so immediate expiry/reopen can create a fresh generation.

No gateway API, configuration, fork, or compatibility layer changes.

Validation:
- `./scripts/ci_local.sh` GREEN
- Go race suites GREEN
- Python tests 168 + 5 + 7 + 5 GREEN
- golangci-lint 0 issues
- transport/passive gates not triggered by dependency-only pin
- `git diff --check` GREEN

Live acceptance follows after merge on exact published main SHA.