### PR TITLE
Runtime: consume durable eeBUS pre-dial gate release

### DIFF
--- a/eebusreg_v016_contract_test.go
+++ b/eebusreg_v016_contract_test.go
@@ -20,7 +20,7 @@ const (
 	shipgoModule   = "github.com/Project-Helianthus/helianthus-ship-go"
 )
 
-func TestEEBusregV015ModuleClosure(t *testing.T) {
+func TestEEBusregV016ModuleClosure(t *testing.T) {
 	contents, err := os.ReadFile("go.mod")
 	if err != nil {
 		t.Fatalf("read go.mod: %v", err)
@@ -34,7 +34,7 @@ func TestEEBusregV015ModuleClosure(t *testing.T) {
 	}
 
 	want := map[string]string{
-		eebusregModule: "v0.1.5",
+		eebusregModule: "v0.1.6",
 		eebusgoModule:  "v0.7.1-helianthus.6",
 		shipgoModule:   "v0.6.1-helianthus.6",
 	}
@@ -52,7 +52,7 @@ func TestEEBusregV015ModuleClosure(t *testing.T) {
 	}
 }
 
-func TestEEBusregV015RuntimeAndGatewayBoundary(t *testing.T) {
+func TestEEBusregV016RuntimeAndGatewayBoundary(t *testing.T) {
 	remoteType := reflect.TypeOf(eebusruntime.Remote{})
 	if remoteType.NumField() != 1 || remoteType.Field(0).Name != "SKI" {
 		t.Fatalf("eebusruntime.Remote fields = %d/%v; want exactly SKI", remoteType.NumField(), remoteFieldNames(remoteType))
@@ -84,7 +84,7 @@ func TestEEBusregV015RuntimeAndGatewayBoundary(t *testing.T) {
 	}
 }
 
-func TestEEBusregV015CandidateFlowStaysPrivate(t *testing.T) {
+func TestEEBusregV016CandidateFlowStaysPrivate(t *testing.T) {
 	forbidden := []string{
 		"candidate_ref",
 		"CandidateRef",

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260521144203-f9919f4b1007
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2
-	github.com/Project-Helianthus/helianthus-eebusreg v0.1.5
+	github.com/Project-Helianthus/helianthus-eebusreg v0.1.6
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e4
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
 github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.6 h1:eT97Driadu8nHUotVS1BvYr25D4YfiqxnXR3rWOjRcs=
 github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.6/go.mod h1:1xamWuuuqsRRQLWm4Z0thn3YZqgXb19kpBtWDb3sJDk=
-github.com/Project-Helianthus/helianthus-eebusreg v0.1.5 h1:qZVUaXjk6f4WO9q+sks65sum60GcoykHtNh6JTaI8Uo=
-github.com/Project-Helianthus/helianthus-eebusreg v0.1.5/go.mod h1:zvFsei/fOLZPenZfRzn6K6Az2dmMdGPlMAnveeOj4oQ=
+github.com/Project-Helianthus/helianthus-eebusreg v0.1.6 h1:2opjxtNko8ocVLpM7Kxvdnim+cmemJvsJpBwjeB2awY=
+github.com/Project-Helianthus/helianthus-eebusreg v0.1.6/go.mod h1:zvFsei/fOLZPenZfRzn6K6Az2dmMdGPlMAnveeOj4oQ=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.6 h1:U59HyBu97w3DSaiM8/YTJrVNLZsHR6umMheL9Bi114I=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.6/go.mod h1:qPqQTDqmPjyOJCr0JMNjhSC1XW1k3h5P/EZqRGy80Vs=
 github.com/Project-Helianthus/helianthus-spine-go v0.7.1-helianthus.1 h1:4OdB3ijVUA3SDJGUYp8I62kXOTX+96ghAiVqsvQV8yw=


### PR DESCRIPTION
## What
Pin `helianthus-eebusreg v0.1.6`, the release that restores durable selected-candidate pre-dial authorization.

## Why
The deployed v0.1.5 runtime discovers the VR940 but its private candidate snapshot terminates as `candidate_queue_failed` / `transport_gate_unavailable`. This release restores the production OutgoingAttemptGate composition without exposing candidate internals through stable APIs.

## Acceptance Criteria
- [x] Pin v0.1.6 without replace directives
- [x] Contract tests and local CI green
- [x] Existing eBUS behavior unchanged by the dependency-only gateway diff
- [ ] Deploy linux/arm64 build to 192.168.100.4
- [ ] Bind only VR940 SKI `b1b7197b064084e4cfef2365105d8d36ff185e5b`
- [ ] Verify restart persistence and stable `eebus.v1` MCP

## TDD
- RED: `1687df4` failed GitHub CI run `30143652994` at `go test -race -count=1 ./...` because the contract required v0.1.6 while `go.mod` still pinned v0.1.5.
- GREEN: `0726ea6` pins v0.1.6; `GOWORK=off ./scripts/ci_local.sh` passed, including full race tests, 185 Python tests, golangci-lint, and gate classification.

## Dependencies
- Project-Helianthus/helianthus-docs-eebus#55 merged as `bc5c84a36cb67c169f6e5b2023e2c78554de30bf`
- Project-Helianthus/helianthus-eebusreg#59 merged as `bd980708ab5101dc5b8a24ce1dbd8305880c2dab`, released as `v0.1.6`

Closes #727