### PR TITLE
Runtime: consume eeBUS transient-trust module

### DIFF
--- a/eebusreg_v017_contract_test.go
+++ b/eebusreg_v017_contract_test.go
@@ -20,7 +20,7 @@ const (
 	shipgoModule   = "github.com/Project-Helianthus/helianthus-ship-go"
 )
 
-func TestEEBusregV016ModuleClosure(t *testing.T) {
+func TestEEBusregV017ModuleClosure(t *testing.T) {
 	contents, err := os.ReadFile("go.mod")
 	if err != nil {
 		t.Fatalf("read go.mod: %v", err)
@@ -34,7 +34,7 @@ func TestEEBusregV016ModuleClosure(t *testing.T) {
 	}
 
 	want := map[string]string{
-		eebusregModule: "v0.1.6",
+		eebusregModule: "v0.1.7",
 		eebusgoModule:  "v0.7.1-helianthus.6",
 		shipgoModule:   "v0.6.1-helianthus.6",
 	}
@@ -52,7 +52,7 @@ func TestEEBusregV016ModuleClosure(t *testing.T) {
 	}
 }
 
-func TestEEBusregV016RuntimeAndGatewayBoundary(t *testing.T) {
+func TestEEBusregV017RuntimeAndGatewayBoundary(t *testing.T) {
 	remoteType := reflect.TypeOf(eebusruntime.Remote{})
 	if remoteType.NumField() != 1 || remoteType.Field(0).Name != "SKI" {
 		t.Fatalf("eebusruntime.Remote fields = %d/%v; want exactly SKI", remoteType.NumField(), remoteFieldNames(remoteType))
@@ -84,7 +84,7 @@ func TestEEBusregV016RuntimeAndGatewayBoundary(t *testing.T) {
 	}
 }
 
-func TestEEBusregV016CandidateFlowStaysPrivate(t *testing.T) {
+func TestEEBusregV017CandidateFlowStaysPrivate(t *testing.T) {
 	forbidden := []string{
 		"candidate_ref",
 		"CandidateRef",

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260521144203-f9919f4b1007
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2
-	github.com/Project-Helianthus/helianthus-eebusreg v0.1.6
+	github.com/Project-Helianthus/helianthus-eebusreg v0.1.7
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e4
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
 github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.6 h1:eT97Driadu8nHUotVS1BvYr25D4YfiqxnXR3rWOjRcs=
 github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.6/go.mod h1:1xamWuuuqsRRQLWm4Z0thn3YZqgXb19kpBtWDb3sJDk=
-github.com/Project-Helianthus/helianthus-eebusreg v0.1.6 h1:2opjxtNko8ocVLpM7Kxvdnim+cmemJvsJpBwjeB2awY=
-github.com/Project-Helianthus/helianthus-eebusreg v0.1.6/go.mod h1:zvFsei/fOLZPenZfRzn6K6Az2dmMdGPlMAnveeOj4oQ=
+github.com/Project-Helianthus/helianthus-eebusreg v0.1.7 h1:9LBAJw0Ss5A5aGwPSxyNzrL5WwMavPZEKZlMnUxI9WA=
+github.com/Project-Helianthus/helianthus-eebusreg v0.1.7/go.mod h1:zvFsei/fOLZPenZfRzn6K6Az2dmMdGPlMAnveeOj4oQ=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.6 h1:U59HyBu97w3DSaiM8/YTJrVNLZsHR6umMheL9Bi114I=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.6/go.mod h1:qPqQTDqmPjyOJCr0JMNjhSC1XW1k3h5P/EZqRGy80Vs=
 github.com/Project-Helianthus/helianthus-spine-go v0.7.1-helianthus.1 h1:4OdB3ijVUA3SDJGUYp8I62kXOTX+96ghAiVqsvQV8yw=


### PR DESCRIPTION
## Summary

- pin `helianthus-eebusreg` from `v0.1.6` to annotated module tag `v0.1.7`
- rename/update the module-closure guard to the exact consumed tag
- keep the gateway public surface, eBUS behavior, and initial `eebus.v1.*` namespace unchanged

## Publication Proof

- module tag: `v0.1.7`
- peeled runtime commit: `efc0af88f820e5260b4596980bcc96592555ff34`
- module sum: `h1:9LBAJw0Ss5A5aGwPSxyNzrL5WwMavPZEKZlMnUxI9WA=`
- documentation main: `7c183b35ed960268ead063355e04ffb420ad5943`

## Validation

- `GOWORK=off go mod verify`: PASS
- exact module closure test: PASS
- stale `v0.1.6`/`V016` source scan: clean
- `GOWORK=off ./scripts/ci_local.sh`: PASS
- race tests: PASS
- `golangci-lint`: 0 issues
- transport/passive smoke gates: not triggered by dependency-only change

Closes #729
