### PR TITLE
Runtime: consume eeBUS pre-confirm ordering fix

### DIFF
--- a/eebusreg_v018_contract_test.go
+++ b/eebusreg_v018_contract_test.go
@@ -20,7 +20,7 @@ const (
 	shipgoModule   = "github.com/Project-Helianthus/helianthus-ship-go"
 )
 
-func TestEEBusregV017ModuleClosure(t *testing.T) {
+func TestEEBusregV018ModuleClosure(t *testing.T) {
 	contents, err := os.ReadFile("go.mod")
 	if err != nil {
 		t.Fatalf("read go.mod: %v", err)
@@ -34,7 +34,7 @@ func TestEEBusregV017ModuleClosure(t *testing.T) {
 	}
 
 	want := map[string]string{
-		eebusregModule: "v0.1.7",
+		eebusregModule: "v0.1.8",
 		eebusgoModule:  "v0.7.1-helianthus.6",
 		shipgoModule:   "v0.6.1-helianthus.6",
 	}
@@ -52,7 +52,7 @@ func TestEEBusregV017ModuleClosure(t *testing.T) {
 	}
 }
 
-func TestEEBusregV017RuntimeAndGatewayBoundary(t *testing.T) {
+func TestEEBusregV018RuntimeAndGatewayBoundary(t *testing.T) {
 	remoteType := reflect.TypeOf(eebusruntime.Remote{})
 	if remoteType.NumField() != 1 || remoteType.Field(0).Name != "SKI" {
 		t.Fatalf("eebusruntime.Remote fields = %d/%v; want exactly SKI", remoteType.NumField(), remoteFieldNames(remoteType))
@@ -84,7 +84,7 @@ func TestEEBusregV017RuntimeAndGatewayBoundary(t *testing.T) {
 	}
 }
 
-func TestEEBusregV017CandidateFlowStaysPrivate(t *testing.T) {
+func TestEEBusregV018CandidateFlowStaysPrivate(t *testing.T) {
 	forbidden := []string{
 		"candidate_ref",
 		"CandidateRef",

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260521144203-f9919f4b1007
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2
-	github.com/Project-Helianthus/helianthus-eebusreg v0.1.7
+	github.com/Project-Helianthus/helianthus-eebusreg v0.1.8
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e4
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
 github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.6 h1:eT97Driadu8nHUotVS1BvYr25D4YfiqxnXR3rWOjRcs=
 github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.6/go.mod h1:1xamWuuuqsRRQLWm4Z0thn3YZqgXb19kpBtWDb3sJDk=
-github.com/Project-Helianthus/helianthus-eebusreg v0.1.7 h1:9LBAJw0Ss5A5aGwPSxyNzrL5WwMavPZEKZlMnUxI9WA=
-github.com/Project-Helianthus/helianthus-eebusreg v0.1.7/go.mod h1:zvFsei/fOLZPenZfRzn6K6Az2dmMdGPlMAnveeOj4oQ=
+github.com/Project-Helianthus/helianthus-eebusreg v0.1.8 h1:SEpiTBrRAvt8jVKFZyiuyiujGRNSVtKfltWPIfFXxgA=
+github.com/Project-Helianthus/helianthus-eebusreg v0.1.8/go.mod h1:zvFsei/fOLZPenZfRzn6K6Az2dmMdGPlMAnveeOj4oQ=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.6 h1:U59HyBu97w3DSaiM8/YTJrVNLZsHR6umMheL9Bi114I=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.6/go.mod h1:qPqQTDqmPjyOJCr0JMNjhSC1XW1k3h5P/EZqRGy80Vs=
 github.com/Project-Helianthus/helianthus-spine-go v0.7.1-helianthus.1 h1:4OdB3ijVUA3SDJGUYp8I62kXOTX+96ghAiVqsvQV8yw=


### PR DESCRIPTION
## Summary

- pin `helianthus-eebusreg` from `v0.1.7` to annotated module tag `v0.1.8`
- rename/update the module-closure guard to the exact consumed tag
- keep gateway behavior and the initial `eebus.v1.*` namespace unchanged

## Publication Proof

- module tag: `v0.1.8`
- tag object: `f1a7a3953c19413f8eb36488cfeb6069c63f7569`
- peeled runtime commit: `e7e18c997ca4ccdd10938bc9c857298c18c5d4c3`
- module sum: `h1:SEpiTBrRAvt8jVKFZyiuyiujGRNSVtKfltWPIfFXxgA=`
- documentation main: `70c9089ffa386cc4efe34005e4bf0f527c27ca76`
- docs publication CI: `30161102978`
- runtime main CI: `30162677684`

## Validation

- exact module closure test: PASS
- `GOWORK=off go mod verify`: PASS
- stale `v0.1.7`/`V017` source scan: clean
- `GOWORK=off ./scripts/ci_local.sh`: PASS
- race tests: PASS
- Python tests: 168 + 5 + 7 + 5 PASS
- `golangci-lint`: 0 issues
- transport/passive smoke gates: not triggered by dependency-only change

Closes #731
