### PR TITLE
Pin durable eeBUS trust restart fix

### DIFF
--- a/cmd/gateway/eebus_mcp_wiring_test.go
+++ b/cmd/gateway/eebus_mcp_wiring_test.go
@@ -127,7 +127,9 @@ func TestMSP06GatewayRegistersProviderConditionallyBeforeMCPMount(t *testing.T) 
 	}
 }
 
-func TestMSP06GatewayPassesTypedProviderDirectlyWithoutContextTransport(t *testing.T) {
+// This AST check is retained because the process bootstrap cannot be invoked
+// behaviorally without constructing the unrelated eBUS transport lifecycle.
+func TestMSP06GatewayNormalizesTypedProviderBeforeHTTPBootstrap(t *testing.T) {
 	fset := token.NewFileSet()
 	mainFile, err := parser.ParseFile(fset, "main.go", nil, 0)
 	if err != nil {
@@ -165,10 +167,16 @@ func TestMSP06GatewayPassesTypedProviderDirectlyWithoutContextTransport(t *testi
 			return true
 		}
 		for _, argument := range call.Args {
-			identifier, ok := argument.(*ast.Ident)
-			if ok && identifier.Name == "eebusAdapter" {
-				explicitArgument = true
+			conversion, ok := argument.(*ast.CallExpr)
+			if !ok {
+				continue
 			}
+			function, ok := conversion.Fun.(*ast.Ident)
+			if !ok || function.Name != "eebusMCPProvider" || len(conversion.Args) != 1 {
+				continue
+			}
+			identifier, ok := conversion.Args[0].(*ast.Ident)
+			explicitArgument = ok && identifier.Name == "eebusAdapter"
 		}
 		return true
 	})
@@ -176,7 +184,7 @@ func TestMSP06GatewayPassesTypedProviderDirectlyWithoutContextTransport(t *testi
 		t.Error("startHTTPServer has no explicit mcp.EEBusV1Provider parameter")
 	}
 	if !explicitArgument {
-		t.Error("gateway bootstrap does not pass eebusAdapter directly to startHTTPServerFn")
+		t.Error("gateway bootstrap does not normalize eebusAdapter before startHTTPServerFn")
 	}
 
 	for filename, file := range map[string]*ast.File{

--- a/cmd/gateway/eebus_runtime_adapter.go
+++ b/cmd/gateway/eebus_runtime_adapter.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
 	eebusruntime "github.com/Project-Helianthus/helianthus-eebusreg"
 )
 
@@ -22,6 +23,13 @@ type eebusRuntimeAdapter struct {
 
 	shutdownOnce sync.Once
 	shutdownErr  error
+}
+
+func eebusMCPProvider(adapter *eebusRuntimeAdapter) mcp.EEBusV1Provider {
+	if adapter == nil {
+		return nil
+	}
+	return adapter
 }
 
 func startEEBusRuntime(

--- a/cmd/gateway/issue737_disabled_eebus_provider_red_test.go
+++ b/cmd/gateway/issue737_disabled_eebus_provider_red_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestIssue737DisabledEEBusAdapterProducesNilMCPProvider(t *testing.T) {
+	var adapter *eebusRuntimeAdapter
+	if provider := eebusMCPProvider(adapter); provider != nil {
+		t.Fatalf("disabled eeBUS provider = %#v, want nil", provider)
+	}
+}
+
+func TestIssue737EnabledEEBusAdapterPreservesMCPProvider(t *testing.T) {
+	adapter := &eebusRuntimeAdapter{}
+	provider := eebusMCPProvider(adapter)
+	if provider == nil {
+		t.Fatal("enabled eeBUS provider is nil")
+	}
+	if provider != adapter {
+		t.Fatalf("enabled eeBUS provider = %#v, want original adapter", provider)
+	}
+}

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -1065,7 +1065,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 		builder,
 		hub,
 		semanticRuntime.Provider(),
-		eebusAdapter,
+		eebusMCPProvider(eebusAdapter),
 		scheduleWriter,
 		configWriter,
 		busObservability,

--- a/eebusreg_v0111_contract_test.go
+++ b/eebusreg_v0111_contract_test.go
@@ -20,7 +20,7 @@ const (
 	shipgoModule   = "github.com/Project-Helianthus/helianthus-ship-go"
 )
 
-func TestEEBusregV0110ModuleClosure(t *testing.T) {
+func TestEEBusregV0111ModuleClosure(t *testing.T) {
 	contents, err := os.ReadFile("go.mod")
 	if err != nil {
 		t.Fatalf("read go.mod: %v", err)
@@ -34,7 +34,7 @@ func TestEEBusregV0110ModuleClosure(t *testing.T) {
 	}
 
 	want := map[string]string{
-		eebusregModule: "v0.1.10",
+		eebusregModule: "v0.1.11",
 		eebusgoModule:  "v0.7.1-helianthus.8",
 		shipgoModule:   "v0.6.1-helianthus.8",
 	}
@@ -52,7 +52,7 @@ func TestEEBusregV0110ModuleClosure(t *testing.T) {
 	}
 }
 
-func TestEEBusregV0110RuntimeAndGatewayBoundary(t *testing.T) {
+func TestEEBusregV0111RuntimeAndGatewayBoundary(t *testing.T) {
 	remoteType := reflect.TypeOf(eebusruntime.Remote{})
 	if remoteType.NumField() != 1 || remoteType.Field(0).Name != "SKI" {
 		t.Fatalf("eebusruntime.Remote fields = %d/%v; want exactly SKI", remoteType.NumField(), remoteFieldNames(remoteType))
@@ -84,7 +84,7 @@ func TestEEBusregV0110RuntimeAndGatewayBoundary(t *testing.T) {
 	}
 }
 
-func TestEEBusregV0110CandidateFlowStaysPrivate(t *testing.T) {
+func TestEEBusregV0111CandidateFlowStaysPrivate(t *testing.T) {
 	forbidden := []string{
 		"candidate_ref",
 		"CandidateRef",

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260521144203-f9919f4b1007
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2
-	github.com/Project-Helianthus/helianthus-eebusreg v0.1.10
+	github.com/Project-Helianthus/helianthus-eebusreg v0.1.11
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e4
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
 github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.8 h1:hQwm5y2U1sRRn6hfn7QBAEh1iBho63ATz7YIj82GdgQ=
 github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.8/go.mod h1:goAjnkNNvMfE+7XI1v4P5Vsx0WnojEHi5hLMv7a/gJ4=
-github.com/Project-Helianthus/helianthus-eebusreg v0.1.10 h1:Y7Nx1dYnFrcIxVqRdLL3Jro3SKXW4xLLvK8/D9Qer9A=
-github.com/Project-Helianthus/helianthus-eebusreg v0.1.10/go.mod h1:3C4h69+Foy4KJutpSsMzpOsYRbcaTvkjVK6RU2I8I8I=
+github.com/Project-Helianthus/helianthus-eebusreg v0.1.11 h1:ONARACSZPbibXOQtd6AaZilmzOgys6QUVmI68SKuuqY=
+github.com/Project-Helianthus/helianthus-eebusreg v0.1.11/go.mod h1:3C4h69+Foy4KJutpSsMzpOsYRbcaTvkjVK6RU2I8I8I=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.8 h1:v0eQK7XX3VbDpolJwwR4NHgn9czT3/p1xAlVWBt/I5M=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.8/go.mod h1:qPqQTDqmPjyOJCr0JMNjhSC1XW1k3h5P/EZqRGy80Vs=
 github.com/Project-Helianthus/helianthus-spine-go v0.7.1-helianthus.1 h1:4OdB3ijVUA3SDJGUYp8I62kXOTX+96ghAiVqsvQV8yw=


### PR DESCRIPTION
## Summary
- pin `helianthus-eebusreg v0.1.11`
- preserve a genuinely nil MCP provider when the eeBUS adapter is disabled
- retain the enabled eeBUS nine-tool MCP wiring

## TDD
- RED commit: `b4cff9b`
- CI-observed RED: run `30173924684`
- GREEN commit: `802070e`
- Local focused Go tests green
- Full local race, Python, assets, vet, build, and lint green

## Documentation gate
Not triggered: dependency propagation and correction of the already-documented disabled-by-default behavior.

## Transport gate
Owner override: T01-T88 validates the eBUS transport matrix. This PR changes only typed-nil eeBUS MCP bootstrap wiring and consumes the eeBUS trust persistence fix. Exact-SKI VR940 live bind plus restart persistence is the required protocol proof.

Closes #737
