### PR TITLE
Consume live eeBUS SPINE topology runtime

### DIFF
--- a/eebusreg_v0113_contract_test.go
+++ b/eebusreg_v0113_contract_test.go
@@ -20,7 +20,7 @@ const (
 	shipgoModule   = "github.com/Project-Helianthus/helianthus-ship-go"
 )
 
-func TestEEBusregV0111ModuleClosure(t *testing.T) {
+func TestEEBusregV0113ModuleClosure(t *testing.T) {
 	contents, err := os.ReadFile("go.mod")
 	if err != nil {
 		t.Fatalf("read go.mod: %v", err)
@@ -34,7 +34,7 @@ func TestEEBusregV0111ModuleClosure(t *testing.T) {
 	}
 
 	want := map[string]string{
-		eebusregModule: "v0.1.11",
+		eebusregModule: "v0.1.13",
 		eebusgoModule:  "v0.7.1-helianthus.8",
 		shipgoModule:   "v0.6.1-helianthus.8",
 	}
@@ -52,7 +52,7 @@ func TestEEBusregV0111ModuleClosure(t *testing.T) {
 	}
 }
 
-func TestEEBusregV0111RuntimeAndGatewayBoundary(t *testing.T) {
+func TestEEBusregV0113RuntimeAndGatewayBoundary(t *testing.T) {
 	remoteType := reflect.TypeOf(eebusruntime.Remote{})
 	if remoteType.NumField() != 1 || remoteType.Field(0).Name != "SKI" {
 		t.Fatalf("eebusruntime.Remote fields = %d/%v; want exactly SKI", remoteType.NumField(), remoteFieldNames(remoteType))
@@ -84,7 +84,7 @@ func TestEEBusregV0111RuntimeAndGatewayBoundary(t *testing.T) {
 	}
 }
 
-func TestEEBusregV0111CandidateFlowStaysPrivate(t *testing.T) {
+func TestEEBusregV0113CandidateFlowStaysPrivate(t *testing.T) {
 	forbidden := []string{
 		"candidate_ref",
 		"CandidateRef",

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260521144203-f9919f4b1007
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2
-	github.com/Project-Helianthus/helianthus-eebusreg v0.1.11
+	github.com/Project-Helianthus/helianthus-eebusreg v0.1.13
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4
@@ -18,7 +18,7 @@ require (
 require (
 	github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.8 // indirect
 	github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.8 // indirect
-	github.com/Project-Helianthus/helianthus-spine-go v0.7.1-helianthus.1 // indirect
+	github.com/Project-Helianthus/helianthus-spine-go v0.7.1-helianthus.4 // indirect
 	github.com/ahmetb/go-linq/v3 v3.2.0 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/enbility/go-avahi v0.0.0-20240909195612-d5de6b280d7a // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,12 +4,12 @@ github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e4
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
 github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.8 h1:hQwm5y2U1sRRn6hfn7QBAEh1iBho63ATz7YIj82GdgQ=
 github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.8/go.mod h1:goAjnkNNvMfE+7XI1v4P5Vsx0WnojEHi5hLMv7a/gJ4=
-github.com/Project-Helianthus/helianthus-eebusreg v0.1.11 h1:ONARACSZPbibXOQtd6AaZilmzOgys6QUVmI68SKuuqY=
-github.com/Project-Helianthus/helianthus-eebusreg v0.1.11/go.mod h1:3C4h69+Foy4KJutpSsMzpOsYRbcaTvkjVK6RU2I8I8I=
+github.com/Project-Helianthus/helianthus-eebusreg v0.1.13 h1:GExLojZC1as3UYVmEu0LxNg6M8MqNER+5nPNo7GTzMI=
+github.com/Project-Helianthus/helianthus-eebusreg v0.1.13/go.mod h1:DF2xP996ICq6xdrfo1fOP5oiB5i2BiYRh4EfYuzw/9w=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.8 h1:v0eQK7XX3VbDpolJwwR4NHgn9czT3/p1xAlVWBt/I5M=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.8/go.mod h1:qPqQTDqmPjyOJCr0JMNjhSC1XW1k3h5P/EZqRGy80Vs=
-github.com/Project-Helianthus/helianthus-spine-go v0.7.1-helianthus.1 h1:4OdB3ijVUA3SDJGUYp8I62kXOTX+96ghAiVqsvQV8yw=
-github.com/Project-Helianthus/helianthus-spine-go v0.7.1-helianthus.1/go.mod h1:+F0QhC19FMgBmHqbTDyG/G0lwnAQDEnxcMhP3xjX/5s=
+github.com/Project-Helianthus/helianthus-spine-go v0.7.1-helianthus.4 h1:krfz1llILo/li3nwSA6LaCSyxx8eiKDJS9Hn3I5Jwxo=
+github.com/Project-Helianthus/helianthus-spine-go v0.7.1-helianthus.4/go.mod h1:+F0QhC19FMgBmHqbTDyG/G0lwnAQDEnxcMhP3xjX/5s=
 github.com/ahmetb/go-linq/v3 v3.2.0 h1:BEuMfp+b59io8g5wYzNoFe9pWPalRklhlhbiU3hYZDE=
 github.com/ahmetb/go-linq/v3 v3.2.0/go.mod h1:haQ3JfOeWK8HpVxMtHHEMPVgBKiYyQ+f1/kLZh/cj9U=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=

--- a/mcp/eebus_v1_contract_test.go
+++ b/mcp/eebus_v1_contract_test.go
@@ -309,6 +309,7 @@ func msp06Snapshot(t *testing.T, runtimeLabel string) eebusruntime.SnapshotV1 {
 					{ID: msp06SourceID(t, eebusraw.IDKindPeer, "entity-z"), Features: []eebusruntime.FeatureV1{
 						{ID: msp06SourceID(t, eebusraw.IDKindPeer, "feature-z"), Role: eebusruntime.FeatureRoleV1Server},
 						{ID: msp06SourceID(t, eebusraw.IDKindPeer, "feature-a"), Role: eebusruntime.FeatureRoleV1Client},
+						{ID: msp06SourceID(t, eebusraw.IDKindPeer, "feature-m"), Role: eebusruntime.FeatureRoleV1Special},
 					}},
 					{ID: msp06SourceID(t, eebusraw.IDKindPeer, "entity-a")},
 				},
@@ -752,8 +753,8 @@ func msp06AssertTopology(t *testing.T, topology map[string]any) {
 				}
 				msp06AssertKeys(t, feature, featurePath, keys...)
 				featureDigests = append(featureDigests, msp06AssertIdentity(t, feature["id"], featurePath+".id", "feature"))
-				if feature["role"] != "client" && feature["role"] != "server" {
-					t.Fatalf("%s.role = %#v, want closed client/server enum", featurePath, feature["role"])
+				if feature["role"] != "client" && feature["role"] != "server" && feature["role"] != "special" {
+					t.Fatalf("%s.role = %#v, want closed client/server/special enum", featurePath, feature["role"])
 				}
 			}
 			if !sort.StringsAreSorted(featureDigests) {

--- a/mcp/eebus_v1_dto.go
+++ b/mcp/eebus_v1_dto.go
@@ -500,7 +500,7 @@ func eebusV1ValidateSourceSnapshot(snapshot eebusV1SourceSnapshot) error {
 				if err := eebusV1ValidateSourceIdentityKind(feature.ID, "peer"); err != nil {
 					return err
 				}
-				if (feature.Role != "client" && feature.Role != "server") || len(feature.Unknown) != 0 {
+				if (feature.Role != "client" && feature.Role != "server" && feature.Role != "special") || len(feature.Unknown) != 0 {
 					return errors.New("feature contains an unsupported value")
 				}
 				if err := eebusV1ValidateSourceEvidence(feature.Raw); err != nil {


### PR DESCRIPTION
## Summary
- pin `helianthus-eebusreg v0.1.13` and transitive `helianthus-spine-go v0.7.1-helianthus.4`
- preserve the raw SPINE `special` feature role in stable `eebus.v1` topology output
- keep semantic, GraphQL, Portal, HA, and `ebus.v1` surfaces unchanged
- remove all temporary live diagnostic logging and local module replacement

Closes #739

## TDD
- RED commit: `d9c75b390d4f34137df9dad25ff89cfaabff2e6d`
- GitHub-observed RED: run `30180643106`, test job failed on the valid raw `special` role and stale `.11` module closure
- GREEN commit: `58dd7eefa87c9010f7985f90e89f62d252e1abf9`

## Validation
- `./scripts/ci_local.sh` GREEN
- full Go race suite GREEN
- 168 + 5 + 7 + 5 Python tests GREEN
- golangci-lint: 0 issues
- transport/passive smoke gates: not triggered
- exact VR940 live bind, restart persistence, and all nine MCP tools remain the deploy acceptance

## Documentation gate
Satisfied by helianthus-docs-eebus PR #63, merge `3ff44d15a005495810bb9859fa56d376b90d811e`. No docs are added to this code repository.

## Transport gate
No eBUS transport path changes. Exact VR940 live bind, restart persistence, and stable MCP validation are the required protocol proof.