### PR TITLE
MSP-0625-GW-MCP: register exact raw feature and mutation tools

### DIFF
--- a/cmd/gateway/eebus_mcp_wiring_test.go
+++ b/cmd/gateway/eebus_mcp_wiring_test.go
@@ -21,6 +21,7 @@ type msp06GatewayRuntime struct {
 	snapshot      eebusruntime.SnapshotV1
 	snapshotErr   error
 	snapshotCalls int
+	featuresCalls int
 }
 
 var _ mcp.EEBusV1Provider = (*eebusRuntimeAdapter)(nil)
@@ -31,11 +32,12 @@ func (*msp06GatewayRuntime) PairingState() ([]eebusruntime.PairingObservationV1,
 	return nil, nil
 }
 
-func (*msp06GatewayRuntime) FeaturesGet(
+func (runtime *msp06GatewayRuntime) FeaturesGet(
 	context.Context,
 	eebusraw.ReadAuthorizationV1,
 	eebusraw.FeaturesGetRequestV1,
 ) (eebusraw.FeaturesGetDataV1, *eebusraw.ErrorV1) {
+	runtime.featuresCalls++
 	return eebusraw.FeaturesGetDataV1{}, nil
 }
 
@@ -77,6 +79,37 @@ func TestMSP06RuntimeAdapterForwardsOnlySnapshotReads(t *testing.T) {
 	}
 }
 
+func TestIssue749GatewayCommandRouterUsesAdapterRuntime(t *testing.T) {
+	runtime := &msp06GatewayRuntime{}
+	adapter := &eebusRuntimeAdapter{runtime: runtime}
+	router := eebusMCPCommandRouter(adapter)
+	if router == nil {
+		t.Fatal("enabled eeBUS adapter produced no MCP command router")
+	}
+	if _, terminal := router.FeaturesGet(
+		context.Background(),
+		eebusraw.ReadAuthorizationV1{
+			PrincipalClass: "owner",
+			Scope:          eebusraw.AuthScopeV1RawRead,
+			Tool:           eebusraw.ToolV1FeaturesGet,
+			MaskTier:       eebusraw.MaskTierRaw,
+		},
+		eebusraw.FeaturesGetRequestV1{},
+	); terminal != nil {
+		t.Fatalf("same-runtime command route failed: %v", terminal)
+	}
+	if runtime.featuresCalls != 1 {
+		t.Fatalf("adapter runtime feature calls = %d, want 1", runtime.featuresCalls)
+	}
+
+	if router := eebusMCPCommandRouter(nil); router != nil {
+		t.Fatalf("disabled eeBUS adapter produced command router %T", router)
+	}
+	if router := eebusMCPCommandRouter(&eebusRuntimeAdapter{}); router != nil {
+		t.Fatalf("adapter without runtime produced command router %T", router)
+	}
+}
+
 func TestMSP06GatewayRegistersProviderConditionallyBeforeMCPMount(t *testing.T) {
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, "main.go", nil, parser.ParseComments)
@@ -85,8 +118,10 @@ func TestMSP06GatewayRegistersProviderConditionallyBeforeMCPMount(t *testing.T) 
 	}
 
 	var registerPosition token.Pos
+	var commandRegisterPosition token.Pos
 	var mountPosition token.Pos
 	registrationGuarded := false
+	commandRegistrationGuarded := false
 	ast.Inspect(file, func(node ast.Node) bool {
 		switch value := node.(type) {
 		case *ast.CallExpr:
@@ -100,6 +135,12 @@ func TestMSP06GatewayRegistersProviderConditionallyBeforeMCPMount(t *testing.T) 
 				}
 				registerPosition = value.Pos()
 			}
+			if selector.Sel.Name == "RegisterEEBusV1CommandRouter" {
+				if commandRegisterPosition.IsValid() {
+					t.Fatal("RegisterEEBusV1CommandRouter appears more than once in gateway bootstrap")
+				}
+				commandRegisterPosition = value.Pos()
+			}
 			if selector.Sel.Name == "Handle" && len(value.Args) > 0 {
 				pathSelector, ok := value.Args[0].(*ast.SelectorExpr)
 				if ok && pathSelector.Sel.Name == "MCPPath" {
@@ -108,6 +149,7 @@ func TestMSP06GatewayRegistersProviderConditionallyBeforeMCPMount(t *testing.T) 
 			}
 		case *ast.IfStmt:
 			containsRegistration := false
+			containsCommandRegistration := false
 			ast.Inspect(value.Body, func(child ast.Node) bool {
 				call, ok := child.(*ast.CallExpr)
 				if !ok {
@@ -117,6 +159,9 @@ func TestMSP06GatewayRegistersProviderConditionallyBeforeMCPMount(t *testing.T) 
 				if ok && selector.Sel.Name == "RegisterEEBusV1Provider" {
 					containsRegistration = true
 				}
+				if ok && selector.Sel.Name == "RegisterEEBusV1CommandRouter" {
+					containsCommandRegistration = true
+				}
 				return true
 			})
 			if containsRegistration {
@@ -125,6 +170,13 @@ func TestMSP06GatewayRegistersProviderConditionallyBeforeMCPMount(t *testing.T) 
 					t.Fatal(err)
 				}
 				registrationGuarded = strings.Contains(condition.String(), "!= nil")
+			}
+			if containsCommandRegistration {
+				var condition strings.Builder
+				if err := printer.Fprint(&condition, fset, value.Cond); err != nil {
+					t.Fatal(err)
+				}
+				commandRegistrationGuarded = strings.Contains(condition.String(), "!= nil")
 			}
 		}
 		return true
@@ -136,11 +188,21 @@ func TestMSP06GatewayRegistersProviderConditionallyBeforeMCPMount(t *testing.T) 
 	if !mountPosition.IsValid() {
 		t.Fatal("gateway MCP mount was not found")
 	}
+	if !commandRegisterPosition.IsValid() {
+		t.Fatal("gateway bootstrap does not register the enabled eeBUS command router with MCP")
+	}
 	if registerPosition >= mountPosition {
 		t.Fatalf("eeBUS provider registration at %s must complete before MCP mount at %s", fset.Position(registerPosition), fset.Position(mountPosition))
 	}
 	if !registrationGuarded {
 		t.Fatal("eeBUS MCP provider registration is not guarded by a non-nil enabled runtime")
+	}
+	if commandRegisterPosition >= mountPosition {
+		t.Fatalf("eeBUS command router registration at %s must complete before MCP mount at %s",
+			fset.Position(commandRegisterPosition), fset.Position(mountPosition))
+	}
+	if !commandRegistrationGuarded {
+		t.Fatal("eeBUS MCP command router registration is not guarded by a non-nil enabled runtime")
 	}
 }
 
@@ -158,7 +220,9 @@ func TestMSP06GatewayNormalizesTypedProviderBeforeHTTPBootstrap(t *testing.T) {
 	}
 
 	typedParameter := false
+	typedCommandParameter := false
 	explicitArgument := false
+	explicitCommandArgument := false
 	for _, declaration := range mainFile.Decls {
 		function, ok := declaration.(*ast.FuncDecl)
 		if !ok || function.Name.Name != "startHTTPServer" {
@@ -171,6 +235,9 @@ func TestMSP06GatewayNormalizesTypedProviderBeforeHTTPBootstrap(t *testing.T) {
 			}
 			if rendered.String() == "mcp.EEBusV1Provider" {
 				typedParameter = true
+			}
+			if rendered.String() == "mcp.EEBusV1CommandRouter" {
+				typedCommandParameter = true
 			}
 		}
 	}
@@ -189,11 +256,16 @@ func TestMSP06GatewayNormalizesTypedProviderBeforeHTTPBootstrap(t *testing.T) {
 				continue
 			}
 			function, ok := conversion.Fun.(*ast.Ident)
-			if !ok || function.Name != "eebusMCPProvider" || len(conversion.Args) != 1 {
+			if !ok || len(conversion.Args) != 1 {
 				continue
 			}
 			identifier, ok := conversion.Args[0].(*ast.Ident)
-			explicitArgument = ok && identifier.Name == "eebusAdapter"
+			switch function.Name {
+			case "eebusMCPProvider":
+				explicitArgument = ok && identifier.Name == "eebusAdapter"
+			case "eebusMCPCommandRouter":
+				explicitCommandArgument = ok && identifier.Name == "eebusAdapter"
+			}
 		}
 		return true
 	})
@@ -202,6 +274,12 @@ func TestMSP06GatewayNormalizesTypedProviderBeforeHTTPBootstrap(t *testing.T) {
 	}
 	if !explicitArgument {
 		t.Error("gateway bootstrap does not normalize eebusAdapter before startHTTPServerFn")
+	}
+	if !typedCommandParameter {
+		t.Error("startHTTPServer has no explicit mcp.EEBusV1CommandRouter parameter")
+	}
+	if !explicitCommandArgument {
+		t.Error("gateway bootstrap does not create the command router from eebusAdapter before startHTTPServerFn")
 	}
 
 	for filename, file := range map[string]*ast.File{

--- a/cmd/gateway/eebus_operator_boundary_red_test.go
+++ b/cmd/gateway/eebus_operator_boundary_red_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 )
 
-func TestIssue747DependencyClosurePinsEEBusregV0118(t *testing.T) {
+func TestIssue749DependencyClosurePinsEEBusregV0119(t *testing.T) {
 	goMod, err := os.Open("../../go.mod")
 	if err != nil {
 		t.Fatal(err)
@@ -33,8 +33,8 @@ func TestIssue747DependencyClosurePinsEEBusregV0118(t *testing.T) {
 	if err := scanner.Err(); err != nil {
 		t.Fatal(err)
 	}
-	if len(versions) != 1 || versions[0] != "v0.1.18" {
-		t.Fatalf("%s versions = %v, want exactly [v0.1.18]", module, versions)
+	if len(versions) != 1 || versions[0] != "v0.1.19" {
+		t.Fatalf("%s versions = %v, want exactly [v0.1.19]", module, versions)
 	}
 }
 

--- a/cmd/gateway/eebus_runtime_adapter.go
+++ b/cmd/gateway/eebus_runtime_adapter.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/eebuscommand"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
 	eebusruntime "github.com/Project-Helianthus/helianthus-eebusreg"
 )
@@ -30,6 +31,13 @@ func eebusMCPProvider(adapter *eebusRuntimeAdapter) mcp.EEBusV1Provider {
 		return nil
 	}
 	return adapter
+}
+
+func eebusMCPCommandRouter(adapter *eebusRuntimeAdapter) mcp.EEBusV1CommandRouter {
+	if adapter == nil || adapter.runtime == nil {
+		return nil
+	}
+	return eebuscommand.New(adapter.runtime)
 }
 
 func startEEBusRuntime(

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -1043,6 +1043,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 		hub *graphql.BroadcastHub,
 		semanticProvider graphql.SemanticProvider,
 		eebusProvider mcp.EEBusV1Provider,
+		eebusCommandRouter mcp.EEBusV1CommandRouter,
 		scheduleWriter mcp.ScheduleWriter,
 		configWriter mcp.ConfigWriter,
 		busObservability *ebusgateway.BusObservabilityStore,
@@ -1055,7 +1056,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 			)
 		}
 		return startHTTPServer(
-			ctx, cfg, gateway, builder, hub, semanticProvider, eebusProvider,
+			ctx, cfg, gateway, builder, hub, semanticProvider, eebusProvider, eebusCommandRouter,
 			scheduleWriter, configWriter, busObservability, shadowCache,
 		)
 	}
@@ -1067,6 +1068,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 		hub,
 		semanticRuntime.Provider(),
 		eebusMCPProvider(eebusAdapter),
+		eebusMCPCommandRouter(eebusAdapter),
 		scheduleWriter,
 		configWriter,
 		busObservability,
@@ -1874,6 +1876,7 @@ func startHTTPServer(
 	hub *graphql.BroadcastHub,
 	semanticProvider graphql.SemanticProvider,
 	eebusProvider mcp.EEBusV1Provider,
+	eebusCommandRouter mcp.EEBusV1CommandRouter,
 	scheduleWriter mcp.ScheduleWriter,
 	configWriter mcp.ConfigWriter,
 	busObservability *ebusgateway.BusObservabilityStore,
@@ -1914,6 +1917,11 @@ func startHTTPServer(
 	if eebusProvider != nil {
 		if err := mcpServer.RegisterEEBusV1Provider(eebusProvider); err != nil {
 			return nil, nil, fmt.Errorf("register eeBUS MCP provider: %w", err)
+		}
+	}
+	if eebusCommandRouter != nil {
+		if err := mcpServer.RegisterEEBusV1CommandRouter(eebusCommandRouter); err != nil {
+			return nil, nil, fmt.Errorf("register eeBUS MCP command router: %w", err)
 		}
 	}
 	mcpServer.SetAdmittedRPCSourceProvider(builder.AdmittedMutationSource)

--- a/eebus_config_test.go
+++ b/eebus_config_test.go
@@ -84,6 +84,7 @@ func TestMSP06EEBusRuntimeCouplingIsConfinedToApprovedSeams(t *testing.T) {
 		// Issue #747 adds one isolated command router over the canonical runtime.
 		"internal/eebuscommand/router.go": false,
 		"mcp/eebus_v1_dto.go":             false,
+		"mcp/eebus_v1_commands.go":        false,
 	}
 	var unexpected []string
 	err = filepath.WalkDir(".", func(path string, entry os.DirEntry, walkErr error) error {

--- a/eebusreg_v0114_contract_test.go
+++ b/eebusreg_v0114_contract_test.go
@@ -22,7 +22,7 @@ const (
 	spinegoModule  = "github.com/Project-Helianthus/helianthus-spine-go"
 )
 
-func TestEEBusregV0118ModuleClosure(t *testing.T) {
+func TestEEBusregV0119ModuleClosure(t *testing.T) {
 	contents, err := os.ReadFile("go.mod")
 	if err != nil {
 		t.Fatalf("read go.mod: %v", err)
@@ -36,7 +36,7 @@ func TestEEBusregV0118ModuleClosure(t *testing.T) {
 	}
 
 	want := map[string]string{
-		eebusregModule: "v0.1.18",
+		eebusregModule: "v0.1.19",
 		eebusgoModule:  "v0.7.1-helianthus.11",
 		shipgoModule:   "v0.6.1-helianthus.9",
 		spinegoModule:  "v0.7.1-helianthus.7",

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260521144203-f9919f4b1007
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2
-	github.com/Project-Helianthus/helianthus-eebusreg v0.1.18
+	github.com/Project-Helianthus/helianthus-eebusreg v0.1.19
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e4
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
 github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.11 h1:LHakALyx1j+ctwRaOHyaDUM/wQQI4mnQbnTeS+/qWY8=
 github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.11/go.mod h1:2lvj0o5lhqdif9khZQkIA9bCGEQCcSfWQ+EIjk78j14=
-github.com/Project-Helianthus/helianthus-eebusreg v0.1.18 h1:WXNXQBSFc+mpDHXtdH8hDItIUw12rAu8djPdwGvnJNo=
-github.com/Project-Helianthus/helianthus-eebusreg v0.1.18/go.mod h1:1kTJXsmP7SLQA4XGyIxF6CLt/Hd3h1AkZHl4a29X0No=
+github.com/Project-Helianthus/helianthus-eebusreg v0.1.19 h1:O5Fjb97D6AMk/OJl4ssPKUZ7Ww9Fn/mRWiXinYLHvjI=
+github.com/Project-Helianthus/helianthus-eebusreg v0.1.19/go.mod h1:1kTJXsmP7SLQA4XGyIxF6CLt/Hd3h1AkZHl4a29X0No=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.9 h1:oaM8JhTHWmDldVPmdJrTOFU3ZpOwEgPpEMUil51cDac=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.9/go.mod h1:qPqQTDqmPjyOJCr0JMNjhSC1XW1k3h5P/EZqRGy80Vs=
 github.com/Project-Helianthus/helianthus-spine-go v0.7.1-helianthus.7 h1:TYoM9+9qgf1MAytCeYIt9OphbaXvSN7KtbabGMZBYuw=

--- a/mcp/eebus_command_router_boundary_test.go
+++ b/mcp/eebus_command_router_boundary_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
@@ -9,101 +10,220 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
+
+	"github.com/Project-Helianthus/helianthus-eebusreg/eebusraw"
 )
 
-const issue747MainEEBusManifestSHA256 = "2d28e20a07d6338ca8873907be284de92701b18b5140023e875a8d14136acec6"
+const issue749FrozenM6ManifestSHA256 = "2d28e20a07d6338ca8873907be284de92701b18b5140023e875a8d14136acec6"
 
-func TestIssue747CurrentEEBusMCPInventoryRemainsUnchanged(t *testing.T) {
+var issue749AdditiveToolNames = []string{
+	"eebus.v1.features.get",
+	"eebus.v1.features.data.get",
+	"eebus.v1.features.data.set",
+	"eebus.v1.mutations.get",
+	"eebus.v1.mutations.rollback",
+}
+
+type issue749CommandRuntime struct {
+	mu    sync.Mutex
+	calls []eebusraw.ToolV1
+}
+
+func TestIssue749ExactAdditiveInventoryPreservesPublicM6(t *testing.T) {
 	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
 	server, _ := msp06TestServer(t, provider)
+	commandRuntime := &issue749CommandRuntime{}
+	issue749RegisterCommandRouter(t, server, commandRuntime)
 
 	beforePublicList := provider.callCount()
-	publicTools := issue747EEBusTools(t, server.Handler())
+	publicTools := issue749EEBusTools(t, server.Handler())
 	if after := provider.callCount(); after != beforePublicList {
 		t.Fatalf("public tools/list contacted provider: %d -> %d", beforePublicList, after)
 	}
 	beforeOperatorList := provider.callCount()
-	operatorTools := issue747EEBusTools(t, issue743OperatorHandler(t, server))
+	operatorTools := issue749EEBusTools(t, issue743OperatorHandler(t, server))
 	if after := provider.callCount(); after != beforeOperatorList {
 		t.Fatalf("operator tools/list contacted provider: %d -> %d", beforeOperatorList, after)
 	}
-	publicNames := issue747ToolNames(publicTools)
-	operatorNames := issue747ToolNames(operatorTools)
-	wantNames := append([]string(nil), msp06ToolNames...)
-	sort.Strings(wantNames)
-
-	if !reflect.DeepEqual(publicNames, wantNames) {
-		t.Fatalf("public eeBUS tools = %v, want exact existing inventory %v", publicNames, wantNames)
+	if calls := commandRuntime.callCount(); calls != 0 {
+		t.Fatalf("tools/list contacted command runtime %d times", calls)
 	}
-	if !reflect.DeepEqual(operatorNames, wantNames) {
-		t.Fatalf("operator eeBUS tools = %v, want exact existing inventory %v", operatorNames, wantNames)
+
+	publicNames := issue749ToolNames(publicTools)
+	wantPublicNames := append([]string(nil), msp06ToolNames...)
+	sort.Strings(wantPublicNames)
+
+	if !reflect.DeepEqual(publicNames, wantPublicNames) {
+		t.Fatalf("public eeBUS tools = %v, want exact frozen M6 inventory %v", publicNames, wantPublicNames)
 	}
 
 	publicManifest, err := json.Marshal(publicTools)
 	if err != nil {
 		t.Fatal(err)
 	}
+	gotDigest := sha256.Sum256(publicManifest)
+	if got := fmt.Sprintf("%x", gotDigest); got != issue749FrozenM6ManifestSHA256 {
+		t.Fatalf("public M6 manifest SHA-256 = %s, want frozen %s\nmanifest: %s",
+			got, issue749FrozenM6ManifestSHA256, publicManifest)
+	}
+
+	operatorM6Manifest, err := json.Marshal(issue749SelectTools(operatorTools, msp06ToolNames))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(publicManifest, operatorM6Manifest) {
+		t.Fatalf("operator changed the frozen M6 tools:\npublic: %s\noperator M6: %s",
+			publicManifest, operatorM6Manifest)
+	}
+
+	wantOperatorNames := append(append([]string(nil), msp06ToolNames...), issue749AdditiveToolNames...)
+	sort.Strings(wantOperatorNames)
+	operatorNames := issue749ToolNames(operatorTools)
+	if !reflect.DeepEqual(operatorNames, wantOperatorNames) {
+		t.Fatalf("operator eeBUS tools = %v, want exact 14-tool inventory %v",
+			operatorNames, wantOperatorNames)
+	}
+
 	operatorManifest, err := json.Marshal(operatorTools)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !bytes.Equal(publicManifest, operatorManifest) {
-		t.Fatalf("public and operator eeBUS manifests differ:\npublic: %s\noperator: %s",
-			publicManifest, operatorManifest)
-	}
-	gotDigest := sha256.Sum256(publicManifest)
-	if got := fmt.Sprintf("%x", gotDigest); got != issue747MainEEBusManifestSHA256 {
-		t.Fatalf("eeBUS manifest SHA-256 = %s, want main golden %s\nmanifest: %s",
-			got, issue747MainEEBusManifestSHA256, publicManifest)
-	}
-	if bytes.Contains(publicManifest, []byte("candidate_ref")) {
-		t.Fatalf("current eeBUS manifest exposes candidate_ref: %s", publicManifest)
+	for _, forbidden := range [][]byte{
+		[]byte("candidate_ref"),
+		[]byte("eebus.v2."),
+		[]byte("eebus.v1.features.read"),
+	} {
+		if bytes.Contains(operatorManifest, forbidden) {
+			t.Fatalf("operator manifest exposes forbidden token %q: %s", forbidden, operatorManifest)
+		}
 	}
 }
 
-func TestIssue747MCPHasNoDirectFeatureWriteOrRollbackPath(t *testing.T) {
+func TestIssue749PublicBoundaryDeniesCommandsBeforeProvider(t *testing.T) {
 	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
 	server, _ := msp06TestServer(t, provider)
+	commandRuntime := &issue749CommandRuntime{}
+	issue749RegisterCommandRouter(t, server, commandRuntime)
 
-	for boundary, handler := range map[string]http.Handler{
-		"public":   server.Handler(),
-		"operator": issue743OperatorHandler(t, server),
-	} {
-		t.Run(boundary, func(t *testing.T) {
-			for _, tool := range []string{
-				"eebus.v1.features.get",
-				"eebus.v1.features.data.get",
-				"eebus.v1.features.data.set",
-				"eebus.v1.mutations.get",
-				"eebus.v1.mutations.rollback",
-			} {
-				before := provider.callCount()
-				params, err := json.Marshal(map[string]any{
-					"name":      tool,
-					"arguments": map[string]any{},
-				})
-				if err != nil {
-					t.Fatal(err)
-				}
-				response := doRPC(t, handler, rpcRequest{
-					JSONRPC: "2.0",
-					ID:      1,
-					Method:  "tools/call",
-					Params:  params,
-				})
-				if response.Error == nil || !strings.Contains(response.Error.Message, "unknown tool") {
-					t.Fatalf("%s call to %q error = %+v, want unknown tool", boundary, tool, response.Error)
-				}
-				if after := provider.callCount(); after != before {
-					t.Fatalf("%s call to %q contacted provider: %d -> %d", boundary, tool, before, after)
-				}
+	for _, test := range issue749CommandCases(t) {
+		t.Run(test.tool, func(t *testing.T) {
+			before := provider.callCount()
+			params, err := json.Marshal(map[string]any{
+				"name":      test.tool,
+				"arguments": test.arguments,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			response := doRPC(t, server.Handler(), rpcRequest{
+				JSONRPC: "2.0",
+				ID:      1,
+				Method:  "tools/call",
+				Params:  params,
+			})
+			if response.Error != nil {
+				t.Fatalf("public call returned RPC error %+v, want content-level permission_denied", response.Error)
+			}
+			result := msp06Map(t, response.Result, "public command result")
+			if isError, _ := result["isError"].(bool); !isError {
+				t.Fatal("public denial did not set isError=true")
+			}
+			content := msp06Slice(t, result["content"], "public command content")
+			if len(content) != 1 {
+				t.Fatalf("public command content count = %d, want 1", len(content))
+			}
+			text, _ := msp06Map(t, content[0], "public command content[0]")["text"].(string)
+			var envelope map[string]any
+			if err := json.Unmarshal([]byte(text), &envelope); err != nil {
+				t.Fatalf("decode public denial envelope: %v; text=%q", err, text)
+			}
+			meta := msp06Map(t, envelope["meta"], "public command meta")
+			if got, _ := meta["tool"].(string); got != test.tool {
+				t.Fatalf("public command meta.tool = %q, want %q", got, test.tool)
+			}
+			if got, _ := meta["scope"].(string); got != test.scope {
+				t.Fatalf("public command meta.scope = %q, want %q", got, test.scope)
+			}
+			if got, _ := meta["auth_scope"].(string); got != test.scope {
+				t.Fatalf("public command meta.auth_scope = %q, want %q", got, test.scope)
+			}
+			if got, _ := meta["mask_tier"].(string); got != "raw" {
+				t.Fatalf("public command meta.mask_tier = %q, want raw", got)
+			}
+			if envelope["data"] != nil {
+				t.Fatalf("public denial data = %#v, want null", envelope["data"])
+			}
+			publicError := msp06Map(t, envelope["error"], "public command error")
+			if code, _ := publicError["code"].(string); code != "permission_denied" {
+				t.Fatalf("public command error code = %q, want permission_denied", code)
+			}
+			if calls := commandRuntime.callCount(); calls != 0 {
+				t.Fatalf("public call reached command runtime %d times", calls)
+			}
+			if after := provider.callCount(); after != before {
+				t.Fatalf("public call contacted provider: %d -> %d", before, after)
 			}
 		})
 	}
 }
 
-func issue747EEBusTools(t *testing.T, handler http.Handler) []map[string]any {
+func TestIssue749OperatorCommandsRouteOnlyThroughCommandRouter(t *testing.T) {
+	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+	server, _ := msp06TestServer(t, provider)
+	commandRuntime := &issue749CommandRuntime{}
+	issue749RegisterCommandRouter(t, server, commandRuntime)
+	operator := issue743OperatorHandler(t, server)
+
+	for index, test := range issue749CommandCases(t) {
+		t.Run(test.tool, func(t *testing.T) {
+			beforeProvider := provider.callCount()
+			result := msp06Call(t, operator, test.tool, test.arguments)
+			if !result.isError {
+				t.Fatal("recording runtime terminal response did not set isError=true")
+			}
+			publicError := msp06Map(t, result.envelope["error"], "operator command error")
+			if code, _ := publicError["code"].(string); code != "invalid_argument" {
+				t.Fatalf("operator command error code = %q, want recording invalid_argument", code)
+			}
+			if got := commandRuntime.callCount(); got != index+1 {
+				t.Fatalf("command runtime calls = %d, want %d", got, index+1)
+			}
+			if got := commandRuntime.lastCall(); got != eebusraw.ToolV1(test.tool) {
+				t.Fatalf("command runtime last call = %q, want %q", got, test.tool)
+			}
+			if after := provider.callCount(); after != beforeProvider {
+				t.Fatalf("operator command contacted snapshot provider: %d -> %d", beforeProvider, after)
+			}
+		})
+	}
+}
+
+func TestIssue749ServerExposesTypedCommandRouterRegistration(t *testing.T) {
+	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+	server, _ := msp06TestServer(t, provider)
+	if method := reflect.ValueOf(server).MethodByName("RegisterEEBusV1CommandRouter"); !method.IsValid() {
+		t.Fatal("MCP server lacks RegisterEEBusV1CommandRouter(EEBusV1CommandRouter) registration boundary")
+	}
+}
+
+func issue749RegisterCommandRouter(t *testing.T, server *Server, router any) {
+	t.Helper()
+	method := reflect.ValueOf(server).MethodByName("RegisterEEBusV1CommandRouter")
+	if !method.IsValid() {
+		t.Fatal("MCP server lacks RegisterEEBusV1CommandRouter(EEBusV1CommandRouter) registration boundary")
+	}
+	results := method.Call([]reflect.Value{reflect.ValueOf(router)})
+	if len(results) != 1 {
+		t.Fatalf("RegisterEEBusV1CommandRouter result count = %d, want 1", len(results))
+	}
+	if !results[0].IsNil() {
+		t.Fatalf("register eeBUS command router: %v", results[0].Interface())
+	}
+}
+
+func issue749EEBusTools(t *testing.T, handler http.Handler) []map[string]any {
 	t.Helper()
 	response := doRPC(t, handler, rpcRequest{JSONRPC: "2.0", ID: 1, Method: "tools/list"})
 	if response.Error != nil {
@@ -118,7 +238,7 @@ func issue747EEBusTools(t *testing.T, handler http.Handler) []map[string]any {
 		t.Fatalf("tools/list tools type = %T, want []any", result["tools"])
 	}
 
-	tools := make([]map[string]any, 0, len(msp06ToolNames))
+	tools := make([]map[string]any, 0, len(msp06ToolNames)+len(issue749AdditiveToolNames))
 	for _, rawTool := range rawTools {
 		tool, ok := rawTool.(map[string]any)
 		if !ok {
@@ -137,11 +257,173 @@ func issue747EEBusTools(t *testing.T, handler http.Handler) []map[string]any {
 	return tools
 }
 
-func issue747ToolNames(tools []map[string]any) []string {
+func issue749ToolNames(tools []map[string]any) []string {
 	names := make([]string, 0, len(tools))
 	for _, tool := range tools {
 		name, _ := tool["name"].(string)
 		names = append(names, name)
 	}
 	return names
+}
+
+func issue749SelectTools(tools []map[string]any, names []string) []map[string]any {
+	selectedNames := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		selectedNames[name] = struct{}{}
+	}
+	selected := make([]map[string]any, 0, len(names))
+	for _, tool := range tools {
+		name, _ := tool["name"].(string)
+		if _, ok := selectedNames[name]; ok {
+			selected = append(selected, tool)
+		}
+	}
+	return selected
+}
+
+type issue749CommandCase struct {
+	tool      string
+	scope     string
+	arguments map[string]any
+}
+
+func issue749CommandCases(t *testing.T) []issue749CommandCase {
+	t.Helper()
+	locator := eebusraw.FeatureLocatorV1{
+		RemoteSKI: "fixture-remote-ski", SHIPID: "fixture-ship-id",
+		DeviceAddress: "0", EntityAddress: []uint64{1}, FeatureAddress: 2,
+		FeatureType: "Measurement", FeatureRole: eebusraw.FeatureRoleV1Server,
+	}
+	readTarget := eebusraw.FeatureTargetV1{
+		RemoteSKI: locator.RemoteSKI, SHIPID: locator.SHIPID,
+		DeviceAddress: locator.DeviceAddress, EntityAddress: locator.EntityAddress,
+		FeatureAddress: locator.FeatureAddress, FeatureType: locator.FeatureType,
+		FeatureRole: locator.FeatureRole, Function: "measurementListData",
+		Operation: eebusraw.OperationV1Read,
+	}
+	writeTarget := readTarget.Clone()
+	writeTarget.Operation = eebusraw.OperationV1Write
+	value, err := eebusraw.NewTypedValueV1("fixture-value")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return []issue749CommandCase{
+		{
+			tool:  string(eebusraw.ToolV1FeaturesGet),
+			scope: string(eebusraw.AuthScopeV1RawRead),
+			arguments: issue749Arguments(t, eebusraw.FeaturesGetRequestV1{
+				Target: locator,
+			}),
+		},
+		{
+			tool:  string(eebusraw.ToolV1FeaturesDataGet),
+			scope: string(eebusraw.AuthScopeV1RawRead),
+			arguments: issue749Arguments(t, eebusraw.FeatureDataGetRequestV1{
+				Targets: []eebusraw.FeatureTargetV1{readTarget},
+			}),
+		},
+		{
+			tool:  string(eebusraw.ToolV1FeaturesDataSet),
+			scope: string(eebusraw.AuthScopeV1RawWrite),
+			arguments: issue749Arguments(t, eebusraw.FeatureDataSetRequestV1{
+				Target: writeTarget, Value: value, ReadToken: "fixture-read-token",
+				IdempotencyKey: "fixture-set-key", Mode: eebusraw.ModeV1Apply,
+			}),
+		},
+		{
+			tool:  string(eebusraw.ToolV1MutationsGet),
+			scope: string(eebusraw.AuthScopeV1RawRead),
+			arguments: issue749Arguments(t, eebusraw.MutationGetRequestV1{
+				MutationRef: "fixture-mutation-ref",
+			}),
+		},
+		{
+			tool:  string(eebusraw.ToolV1MutationsRollback),
+			scope: string(eebusraw.AuthScopeV1RawWrite),
+			arguments: issue749Arguments(t, eebusraw.MutationRollbackRequestV1{
+				MutationRef: "fixture-mutation-ref", IdempotencyKey: "fixture-rollback-key",
+			}),
+		},
+	}
+}
+
+func issue749Arguments(t *testing.T, request any) map[string]any {
+	t.Helper()
+	encoded, err := json.Marshal(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var arguments map[string]any
+	if err := json.Unmarshal(encoded, &arguments); err != nil {
+		t.Fatal(err)
+	}
+	return arguments
+}
+
+func (runtime *issue749CommandRuntime) terminal(tool eebusraw.ToolV1) *eebusraw.ErrorV1 {
+	runtime.mu.Lock()
+	runtime.calls = append(runtime.calls, tool)
+	runtime.mu.Unlock()
+	return eebusraw.NewErrorV1(
+		eebusraw.ErrorCodeV1InvalidArgument,
+		"recording command runtime terminal",
+		false,
+		eebusraw.SourceLayerV1Validation,
+	)
+}
+
+func (runtime *issue749CommandRuntime) callCount() int {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	return len(runtime.calls)
+}
+
+func (runtime *issue749CommandRuntime) lastCall() eebusraw.ToolV1 {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	if len(runtime.calls) == 0 {
+		return ""
+	}
+	return runtime.calls[len(runtime.calls)-1]
+}
+
+func (runtime *issue749CommandRuntime) FeaturesGet(
+	_ context.Context,
+	_ eebusraw.ReadAuthorizationV1,
+	_ eebusraw.FeaturesGetRequestV1,
+) (eebusraw.FeaturesGetDataV1, *eebusraw.ErrorV1) {
+	return eebusraw.FeaturesGetDataV1{}, runtime.terminal(eebusraw.ToolV1FeaturesGet)
+}
+
+func (runtime *issue749CommandRuntime) FeaturesDataGet(
+	_ context.Context,
+	_ eebusraw.ReadAuthorizationV1,
+	_ eebusraw.FeatureDataGetRequestV1,
+) (eebusraw.FeatureDataGetDataV1, *eebusraw.ErrorV1) {
+	return eebusraw.FeatureDataGetDataV1{}, runtime.terminal(eebusraw.ToolV1FeaturesDataGet)
+}
+
+func (runtime *issue749CommandRuntime) FeaturesDataSet(
+	_ context.Context,
+	_ eebusraw.WriteAuthorizationV1,
+	_ eebusraw.FeatureDataSetRequestV1,
+) (eebusraw.MutationV1, *eebusraw.ErrorV1) {
+	return eebusraw.MutationV1{}, runtime.terminal(eebusraw.ToolV1FeaturesDataSet)
+}
+
+func (runtime *issue749CommandRuntime) MutationsGet(
+	_ context.Context,
+	_ eebusraw.ReadAuthorizationV1,
+	_ eebusraw.MutationGetRequestV1,
+) (eebusraw.MutationV1, *eebusraw.ErrorV1) {
+	return eebusraw.MutationV1{}, runtime.terminal(eebusraw.ToolV1MutationsGet)
+}
+
+func (runtime *issue749CommandRuntime) MutationsRollback(
+	_ context.Context,
+	_ eebusraw.WriteAuthorizationV1,
+	_ eebusraw.MutationRollbackRequestV1,
+) (eebusraw.MutationV1, *eebusraw.ErrorV1) {
+	return eebusraw.MutationV1{}, runtime.terminal(eebusraw.ToolV1MutationsRollback)
 }

--- a/mcp/eebus_command_router_boundary_test.go
+++ b/mcp/eebus_command_router_boundary_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/Project-Helianthus/helianthus-eebusreg/eebusraw"
 )
 
-const issue749FrozenM6ManifestSHA256 = "2d28e20a07d6338ca8873907be284de92701b18b5140023e875a8d14136acec6"
+const issue749FrozenM6ManifestSHA256 = "4bbbe92ba4a0294b82092d6b735261725fd45bb1f7b1fef76aca54894ec921b4"
 
 var issue749AdditiveToolNames = []string{
 	"eebus.v1.features.get",
@@ -290,7 +290,7 @@ type issue749CommandCase struct {
 func issue749CommandCases(t *testing.T) []issue749CommandCase {
 	t.Helper()
 	locator := eebusraw.FeatureLocatorV1{
-		RemoteSKI: "fixture-remote-ski", SHIPID: "fixture-ship-id",
+		RemoteSKI: strings.Repeat("a", 40), SHIPID: "fixture-ship-id",
 		DeviceAddress: "0", EntityAddress: []uint64{1}, FeatureAddress: 2,
 		FeatureType: "Measurement", FeatureRole: eebusraw.FeatureRoleV1Server,
 	}
@@ -327,22 +327,22 @@ func issue749CommandCases(t *testing.T) []issue749CommandCase {
 			tool:  string(eebusraw.ToolV1FeaturesDataSet),
 			scope: string(eebusraw.AuthScopeV1RawWrite),
 			arguments: issue749Arguments(t, eebusraw.FeatureDataSetRequestV1{
-				Target: writeTarget, Value: value, ReadToken: "fixture-read-token",
-				IdempotencyKey: "fixture-set-key", Mode: eebusraw.ModeV1Apply,
+				Target: writeTarget, Value: value, ReadToken: strings.Repeat("E", 43),
+				IdempotencyKey: "fixture-set-key-01", Mode: eebusraw.ModeV1Apply,
 			}),
 		},
 		{
 			tool:  string(eebusraw.ToolV1MutationsGet),
 			scope: string(eebusraw.AuthScopeV1RawRead),
 			arguments: issue749Arguments(t, eebusraw.MutationGetRequestV1{
-				MutationRef: "fixture-mutation-ref",
+				MutationRef: strings.Repeat("M", 43),
 			}),
 		},
 		{
 			tool:  string(eebusraw.ToolV1MutationsRollback),
 			scope: string(eebusraw.AuthScopeV1RawWrite),
 			arguments: issue749Arguments(t, eebusraw.MutationRollbackRequestV1{
-				MutationRef: "fixture-mutation-ref", IdempotencyKey: "fixture-rollback-key",
+				MutationRef: strings.Repeat("M", 43), IdempotencyKey: "fixture-rollback-key-01",
 			}),
 		},
 	}

--- a/mcp/eebus_v1.go
+++ b/mcp/eebus_v1.go
@@ -29,8 +29,8 @@ const (
 
 	eebusV1DefaultLiveTimeout = 3 * time.Second
 	eebusV1MaxLiveWorkers     = 8
-	eebusV1TokenPattern       = `^[A-Za-z0-9_-]{43}$`
-	eebusV1IDDigestPattern    = `^(?:[A-Za-z0-9_-]{43}|sha256:[0-9a-f]{64})$`
+	eebusV1TokenPattern       = `^[A-Za-z0-9_-]{42}[AEIMQUYcgkosw048]$`
+	eebusV1IDDigestPattern    = `^(?:[A-Za-z0-9_-]{42}[AEIMQUYcgkosw048]|sha256:[0-9a-f]{64})$`
 )
 
 // EEBusV1Provider is the MSP-06 typed, read-only seam and the only MCP

--- a/mcp/eebus_v1_commands.go
+++ b/mcp/eebus_v1_commands.go
@@ -1,0 +1,928 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"reflect"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/Project-Helianthus/helianthus-eebusreg/eebusraw"
+)
+
+const eebusV1RawFeatureContract = "helianthus.eebus.raw-feature-runtime.v1"
+
+const (
+	eebusV1SourceLayerMCP           = eebusraw.SourceLayerV1("mcp")
+	eebusV1SourceLayerGatewayRouter = eebusraw.SourceLayerV1("gateway-router")
+	eebusV1MaximumSafeInteger       = uint64(9007199254740991)
+)
+
+// EEBusV1CommandRouter is the sole MCP dependency for typed raw eeBUS
+// feature reads, mutations, status, and rollback.
+type EEBusV1CommandRouter interface {
+	FeaturesGet(context.Context, eebusraw.ReadAuthorizationV1, eebusraw.FeaturesGetRequestV1) (eebusraw.FeaturesGetDataV1, *eebusraw.ErrorV1)
+	FeaturesDataGet(context.Context, eebusraw.ReadAuthorizationV1, eebusraw.FeatureDataGetRequestV1) (eebusraw.FeatureDataGetDataV1, *eebusraw.ErrorV1)
+	FeaturesDataSet(context.Context, eebusraw.WriteAuthorizationV1, eebusraw.FeatureDataSetRequestV1) (eebusraw.MutationV1, *eebusraw.ErrorV1)
+	MutationsGet(context.Context, eebusraw.ReadAuthorizationV1, eebusraw.MutationGetRequestV1) (eebusraw.MutationV1, *eebusraw.ErrorV1)
+	MutationsRollback(context.Context, eebusraw.WriteAuthorizationV1, eebusraw.MutationRollbackRequestV1) (eebusraw.MutationV1, *eebusraw.ErrorV1)
+}
+
+type eebusV1CommandSpec struct {
+	tool        eebusraw.ToolV1
+	scope       eebusraw.AuthScopeV1
+	description string
+	inputSchema map[string]any
+}
+
+var eebusV1CommandSpecs = []eebusV1CommandSpec{
+	{
+		tool: eebusraw.ToolV1FeaturesGet, scope: eebusraw.AuthScopeV1RawRead,
+		description: "Get one exact raw eeBUS feature and its full function declarations.",
+		inputSchema: eebusV1FeaturesGetSchema(),
+	},
+	{
+		tool: eebusraw.ToolV1FeaturesDataGet, scope: eebusraw.AuthScopeV1RawRead,
+		description: "Read complete typed data from one to sixteen exact raw eeBUS feature functions.",
+		inputSchema: eebusV1FeaturesDataGetSchema(),
+	},
+	{
+		tool: eebusraw.ToolV1FeaturesDataSet, scope: eebusraw.AuthScopeV1RawWrite,
+		description: "Apply one guarded complete typed raw eeBUS feature mutation.",
+		inputSchema: eebusV1FeaturesDataSetSchema(),
+	},
+	{
+		tool: eebusraw.ToolV1MutationsGet, scope: eebusraw.AuthScopeV1RawRead,
+		description: "Get one durable raw eeBUS mutation record.",
+		inputSchema: eebusV1MutationsGetSchema(),
+	},
+	{
+		tool: eebusraw.ToolV1MutationsRollback, scope: eebusraw.AuthScopeV1RawWrite,
+		description: "Rollback one durable raw eeBUS mutation through the guarded command path.",
+		inputSchema: eebusV1MutationsRollbackSchema(),
+	},
+}
+
+type eebusV1CommandMeta struct {
+	Contract      string               `json:"contract"`
+	Tool          eebusraw.ToolV1      `json:"tool"`
+	Scope         eebusraw.AuthScopeV1 `json:"scope"`
+	MaskTier      eebusraw.MaskTier    `json:"mask_tier"`
+	AuthScope     eebusraw.AuthScopeV1 `json:"auth_scope"`
+	DataTimestamp string               `json:"data_timestamp"`
+	DataHash      eebusraw.HashV1      `json:"data_hash"`
+	// Nil is reserved for failures that occur before any runtime binding is known.
+	Runtime *eebusraw.RuntimeBindingV1 `json:"runtime"`
+}
+
+type eebusV1CommandEnvelope struct {
+	Meta    eebusV1CommandMeta `json:"meta"`
+	Request any                `json:"request"`
+	Data    any                `json:"data"`
+	Error   *eebusraw.ErrorV1  `json:"error"`
+}
+
+type eebusV1CommandHashView struct {
+	Contract  string                     `json:"contract"`
+	Tool      eebusraw.ToolV1            `json:"tool"`
+	Scope     eebusraw.AuthScopeV1       `json:"scope"`
+	MaskTier  eebusraw.MaskTier          `json:"mask_tier"`
+	AuthScope eebusraw.AuthScopeV1       `json:"auth_scope"`
+	Runtime   *eebusraw.RuntimeBindingV1 `json:"runtime"`
+	Request   any                        `json:"request"`
+	Data      any                        `json:"data"`
+	Error     *eebusraw.ErrorV1          `json:"error"`
+}
+
+func (server *Server) RegisterEEBusV1CommandRouter(router EEBusV1CommandRouter) error {
+	if server == nil {
+		return errors.New("eeBUS MCP server is nil")
+	}
+	if eebusV1NilCommandRouter(router) {
+		return errors.New("eeBUS MCP command router is nil")
+	}
+	server.eebusV1Mu.Lock()
+	defer server.eebusV1Mu.Unlock()
+	if server.eebusV1CommandRouter != nil {
+		return errors.New("eeBUS MCP command router is already registered")
+	}
+	server.eebusV1CommandRouter = router
+	return nil
+}
+
+func eebusV1NilCommandRouter(router EEBusV1CommandRouter) bool {
+	if router == nil {
+		return true
+	}
+	value := reflect.ValueOf(router)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
+func eebusV1CommandSpecForName(name string) (eebusV1CommandSpec, bool) {
+	for _, spec := range eebusV1CommandSpecs {
+		if string(spec.tool) == name {
+			return spec, true
+		}
+	}
+	return eebusV1CommandSpec{}, false
+}
+
+func eebusV1CommandTools() []Tool {
+	tools := make([]Tool, 0, len(eebusV1CommandSpecs))
+	for _, spec := range eebusV1CommandSpecs {
+		tools = append(tools, Tool{
+			Name: string(spec.tool), Description: spec.description, InputSchema: spec.inputSchema,
+		})
+	}
+	return tools
+}
+
+func (server *Server) handleEEBusV1CommandRawCall(
+	ctx context.Context,
+	spec eebusV1CommandSpec,
+	arguments json.RawMessage,
+) any {
+	request, terminal := eebusV1DecodeCommandRequest(spec.tool, arguments)
+	if terminal != nil {
+		return eebusV1CommandResult(spec, nil, nil, terminal, nil)
+	}
+
+	if eebusV1BoundaryFromContext(ctx) != eebusV1OperatorBoundary {
+		terminal = eebusraw.NewErrorV1(
+			eebusraw.ErrorCodeV1PermissionDenied,
+			"raw eeBUS commands require the owner-only operator boundary",
+			false,
+			eebusV1SourceLayerGatewayRouter,
+		)
+		return eebusV1CommandResult(spec, request, nil, terminal, nil)
+	}
+
+	server.eebusV1Mu.RLock()
+	router := server.eebusV1CommandRouter
+	server.eebusV1Mu.RUnlock()
+	if eebusV1NilCommandRouter(router) {
+		terminal = eebusraw.NewErrorV1(
+			eebusraw.ErrorCodeV1Internal,
+			"raw eeBUS command router is unavailable",
+			false,
+			eebusV1SourceLayerGatewayRouter,
+		)
+		return eebusV1CommandResult(spec, request, nil, terminal, nil)
+	}
+
+	data, terminal, runtime := eebusV1DispatchCommand(ctx, router, spec, request)
+	if terminal != nil &&
+		(spec.tool != eebusraw.ToolV1FeaturesDataGet ||
+			terminal.Code != eebusraw.ErrorCodeV1PartialResult) {
+		data = nil
+	}
+	return eebusV1CommandResult(spec, request, data, terminal, runtime)
+}
+
+func eebusV1MalformedCommandResult(spec eebusV1CommandSpec) any {
+	return eebusV1CommandResult(
+		spec,
+		nil,
+		nil,
+		eebusraw.NewErrorV1(
+			eebusraw.ErrorCodeV1InvalidArgument,
+			"command request does not match the closed tool shape",
+			false,
+			eebusV1SourceLayerMCP,
+		),
+		nil,
+	)
+}
+
+func eebusV1DecodeCommandRequest(
+	tool eebusraw.ToolV1,
+	arguments json.RawMessage,
+) (any, *eebusraw.ErrorV1) {
+	invalid := func() (any, *eebusraw.ErrorV1) {
+		return nil, eebusraw.NewErrorV1(
+			eebusraw.ErrorCodeV1InvalidArgument,
+			"command request does not match the closed tool shape",
+			false,
+			eebusV1SourceLayerMCP,
+		)
+	}
+	if len(arguments) == 0 || eebusV1JSONHasDuplicateKeys(arguments) {
+		return invalid()
+	}
+	decode := func(request any) (any, *eebusraw.ErrorV1) {
+		decoder := json.NewDecoder(bytes.NewReader(arguments))
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(request); err != nil {
+			return invalid()
+		}
+		if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+			return invalid()
+		}
+		typed := reflect.ValueOf(request).Elem().Interface()
+		if terminal := eebusV1ValidateCommandRequest(tool, typed); terminal != nil {
+			if terminal.Code == eebusraw.ErrorCodeV1SecretDetected {
+				return nil, eebusraw.NewErrorV1(
+					eebusraw.ErrorCodeV1InvalidArgument,
+					"command request was rejected by the protected input boundary",
+					false,
+					eebusV1SourceLayerMCP,
+				)
+			}
+			cloned := terminal.Clone()
+			cloned.SourceLayer = eebusV1SourceLayerMCP
+			cloned.Message = "command request failed canonical validation"
+			return typed, &cloned
+		}
+		return typed, nil
+	}
+	switch tool {
+	case eebusraw.ToolV1FeaturesGet:
+		return decode(&eebusraw.FeaturesGetRequestV1{})
+	case eebusraw.ToolV1FeaturesDataGet:
+		return decode(&eebusraw.FeatureDataGetRequestV1{})
+	case eebusraw.ToolV1FeaturesDataSet:
+		return decode(&eebusraw.FeatureDataSetRequestV1{})
+	case eebusraw.ToolV1MutationsGet:
+		return decode(&eebusraw.MutationGetRequestV1{})
+	case eebusraw.ToolV1MutationsRollback:
+		return decode(&eebusraw.MutationRollbackRequestV1{})
+	default:
+		return invalid()
+	}
+}
+
+func eebusV1JSONHasDuplicateKeys(document []byte) bool {
+	decoder := json.NewDecoder(bytes.NewReader(document))
+	decoder.UseNumber()
+	duplicate, err := eebusV1WalkJSONValue(decoder)
+	if err != nil {
+		return false
+	}
+	if duplicate {
+		return true
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return false
+	}
+	return false
+}
+
+func eebusV1WalkJSONValue(decoder *json.Decoder) (bool, error) {
+	token, err := decoder.Token()
+	if err != nil {
+		return false, err
+	}
+	delimiter, ok := token.(json.Delim)
+	if !ok {
+		return false, nil
+	}
+	switch delimiter {
+	case '{':
+		seen := make(map[string]struct{})
+		for decoder.More() {
+			rawKey, err := decoder.Token()
+			if err != nil {
+				return false, err
+			}
+			key, ok := rawKey.(string)
+			if !ok {
+				return false, errors.New("JSON object key is not a string")
+			}
+			if _, exists := seen[key]; exists {
+				return true, nil
+			}
+			seen[key] = struct{}{}
+			duplicate, err := eebusV1WalkJSONValue(decoder)
+			if err != nil || duplicate {
+				return duplicate, err
+			}
+		}
+		_, err := decoder.Token()
+		return false, err
+	case '[':
+		for decoder.More() {
+			duplicate, err := eebusV1WalkJSONValue(decoder)
+			if err != nil || duplicate {
+				return duplicate, err
+			}
+		}
+		_, err := decoder.Token()
+		return false, err
+	default:
+		return false, errors.New("unexpected JSON delimiter")
+	}
+}
+
+func eebusV1ValidateCommandRequest(tool eebusraw.ToolV1, request any) *eebusraw.ErrorV1 {
+	switch tool {
+	case eebusraw.ToolV1FeaturesGet:
+		typed, ok := request.(eebusraw.FeaturesGetRequestV1)
+		if !ok {
+			return eebusraw.NewErrorV1(eebusraw.ErrorCodeV1InvalidArgument, "invalid request", false, eebusV1SourceLayerMCP)
+		}
+		return eebusraw.ValidateFeaturesGetRequestV1(typed)
+	case eebusraw.ToolV1FeaturesDataGet:
+		typed, ok := request.(eebusraw.FeatureDataGetRequestV1)
+		if !ok {
+			return eebusraw.NewErrorV1(eebusraw.ErrorCodeV1InvalidArgument, "invalid request", false, eebusV1SourceLayerMCP)
+		}
+		return eebusraw.ValidateFeatureDataGetRequestV1(typed)
+	case eebusraw.ToolV1FeaturesDataSet:
+		typed, ok := request.(eebusraw.FeatureDataSetRequestV1)
+		if !ok {
+			return eebusraw.NewErrorV1(eebusraw.ErrorCodeV1InvalidArgument, "invalid request", false, eebusV1SourceLayerMCP)
+		}
+		return eebusraw.ValidateFeatureDataSetRequestV1(typed)
+	case eebusraw.ToolV1MutationsGet:
+		typed, ok := request.(eebusraw.MutationGetRequestV1)
+		if !ok {
+			return eebusraw.NewErrorV1(eebusraw.ErrorCodeV1InvalidArgument, "invalid request", false, eebusV1SourceLayerMCP)
+		}
+		return eebusraw.ValidateMutationGetRequestV1(typed)
+	case eebusraw.ToolV1MutationsRollback:
+		typed, ok := request.(eebusraw.MutationRollbackRequestV1)
+		if !ok {
+			return eebusraw.NewErrorV1(eebusraw.ErrorCodeV1InvalidArgument, "invalid request", false, eebusV1SourceLayerMCP)
+		}
+		return eebusraw.ValidateMutationRollbackRequestV1(typed)
+	default:
+		return eebusraw.NewErrorV1(eebusraw.ErrorCodeV1InvalidArgument, "unknown raw eeBUS command", false, eebusV1SourceLayerMCP)
+	}
+}
+
+func eebusV1DispatchCommand(
+	ctx context.Context,
+	router EEBusV1CommandRouter,
+	spec eebusV1CommandSpec,
+	request any,
+) (any, *eebusraw.ErrorV1, *eebusraw.RuntimeBindingV1) {
+	var data any
+	var terminal *eebusraw.ErrorV1
+	switch spec.tool {
+	case eebusraw.ToolV1FeaturesGet:
+		typedRequest := request.(eebusraw.FeaturesGetRequestV1)
+		typedData, typedTerminal := router.FeaturesGet(ctx, eebusV1ReadAuthorization(spec), typedRequest)
+		data, terminal = typedData, typedTerminal
+	case eebusraw.ToolV1FeaturesDataGet:
+		typedRequest := request.(eebusraw.FeatureDataGetRequestV1)
+		typedData, typedTerminal := router.FeaturesDataGet(ctx, eebusV1ReadAuthorization(spec), typedRequest)
+		data, terminal = typedData, typedTerminal
+	case eebusraw.ToolV1FeaturesDataSet:
+		typedRequest := request.(eebusraw.FeatureDataSetRequestV1)
+		typedData, typedTerminal := router.FeaturesDataSet(ctx, eebusV1WriteAuthorization(spec), typedRequest)
+		data, terminal = typedData, typedTerminal
+	case eebusraw.ToolV1MutationsGet:
+		typedRequest := request.(eebusraw.MutationGetRequestV1)
+		typedData, typedTerminal := router.MutationsGet(ctx, eebusV1ReadAuthorization(spec), typedRequest)
+		data, terminal = typedData, typedTerminal
+	case eebusraw.ToolV1MutationsRollback:
+		typedRequest := request.(eebusraw.MutationRollbackRequestV1)
+		typedData, typedTerminal := router.MutationsRollback(ctx, eebusV1WriteAuthorization(spec), typedRequest)
+		data, terminal = typedData, typedTerminal
+	default:
+		return nil, eebusraw.NewErrorV1(
+			eebusraw.ErrorCodeV1Internal,
+			"raw eeBUS command dispatch failed",
+			false,
+			eebusV1SourceLayerGatewayRouter,
+		), nil
+	}
+
+	safeTerminal, terminalFailure := eebusV1ValidateRouterTerminal(terminal)
+	if terminalFailure != nil {
+		return nil, terminalFailure, nil
+	}
+	terminal = safeTerminal
+	runtime, validationFailure := eebusV1ValidateCommandOutcome(spec.tool, request, data, terminal)
+	if validationFailure != nil {
+		return nil, validationFailure, nil
+	}
+	if runtime == nil && terminal != nil {
+		if eebusV1TerminalRequiresRuntime(terminal.Code) {
+			return nil, eebusV1ContractViolation(), nil
+		}
+		terminal.SourceLayer = eebusV1SourceLayerGatewayRouter
+	}
+	return data, terminal, runtime
+}
+
+func eebusV1ReadAuthorization(spec eebusV1CommandSpec) eebusraw.ReadAuthorizationV1 {
+	return eebusraw.ReadAuthorizationV1{
+		PrincipalClass: "owner",
+		Scope:          eebusraw.AuthScopeV1RawRead,
+		Tool:           spec.tool,
+		MaskTier:       eebusraw.MaskTierRaw,
+	}
+}
+
+func eebusV1WriteAuthorization(spec eebusV1CommandSpec) eebusraw.WriteAuthorizationV1 {
+	return eebusraw.WriteAuthorizationV1{
+		PrincipalClass: "owner",
+		Scope:          eebusraw.AuthScopeV1RawWrite,
+		Tool:           spec.tool,
+		MaskTier:       eebusraw.MaskTierRaw,
+	}
+}
+
+func eebusV1FeatureDataRuntime(data eebusraw.FeatureDataGetDataV1) *eebusraw.RuntimeBindingV1 {
+	var binding *eebusraw.RuntimeBindingV1
+	for _, result := range data.Results {
+		current := eebusV1BoundRuntime(result.Runtime)
+		if current == nil {
+			return nil
+		}
+		if binding == nil {
+			binding = current
+			continue
+		}
+		if *binding != *current {
+			return nil
+		}
+	}
+	return binding
+}
+
+func eebusV1BoundRuntime(runtime eebusraw.RuntimeBindingV1) *eebusraw.RuntimeBindingV1 {
+	if runtime.RuntimeEpoch == 0 ||
+		runtime.RuntimeEpoch > eebusV1MaximumSafeInteger ||
+		runtime.ConnectionGeneration == 0 ||
+		runtime.ConnectionGeneration > eebusV1MaximumSafeInteger {
+		return nil
+	}
+	bound := runtime
+	return &bound
+}
+
+func eebusV1ValidateCommandOutcome(
+	tool eebusraw.ToolV1,
+	request any,
+	data any,
+	terminal *eebusraw.ErrorV1,
+) (*eebusraw.RuntimeBindingV1, *eebusraw.ErrorV1) {
+	switch tool {
+	case eebusraw.ToolV1FeaturesGet:
+		typedRequest := request.(eebusraw.FeaturesGetRequestV1)
+		typedData := data.(eebusraw.FeaturesGetDataV1)
+		if reflect.ValueOf(typedData).IsZero() {
+			if terminal == nil {
+				return nil, eebusV1ContractViolation()
+			}
+			return nil, nil
+		}
+		if failure := eebusraw.ValidateFeaturesGetDataV1(typedRequest, typedData); failure != nil {
+			return nil, eebusV1CanonicalValidationFailure(failure)
+		}
+		runtime := eebusV1BoundRuntime(typedData.Runtime)
+		if runtime == nil {
+			return nil, eebusV1ContractViolation()
+		}
+		return runtime, nil
+	case eebusraw.ToolV1FeaturesDataGet:
+		typedRequest := request.(eebusraw.FeatureDataGetRequestV1)
+		typedData := data.(eebusraw.FeatureDataGetDataV1)
+		if terminal != nil && terminal.Code != eebusraw.ErrorCodeV1PartialResult {
+			if !reflect.ValueOf(typedData).IsZero() {
+				return nil, eebusV1ContractViolation()
+			}
+			return nil, nil
+		}
+		if failure := eebusraw.ValidateFeatureDataGetDataV1(typedRequest, typedData, terminal); failure != nil {
+			return nil, eebusV1CanonicalValidationFailure(failure)
+		}
+		runtime := eebusV1FeatureDataRuntime(typedData)
+		if runtime == nil {
+			return nil, eebusV1ContractViolation()
+		}
+		return runtime, nil
+	case eebusraw.ToolV1FeaturesDataSet,
+		eebusraw.ToolV1MutationsGet,
+		eebusraw.ToolV1MutationsRollback:
+		typedData := data.(eebusraw.MutationV1)
+		if reflect.ValueOf(typedData).IsZero() {
+			if terminal == nil {
+				return nil, eebusV1ContractViolation()
+			}
+			return nil, nil
+		}
+		if failure := eebusraw.ValidateMutationV1(typedData); failure != nil {
+			return nil, eebusV1CanonicalValidationFailure(failure)
+		}
+		if !eebusV1MutationMatchesRequest(tool, request, typedData) {
+			return nil, eebusV1ContractViolation()
+		}
+		runtime := eebusV1BoundRuntime(typedData.Runtime)
+		if runtime == nil {
+			return nil, eebusV1ContractViolation()
+		}
+		return runtime, nil
+	default:
+		return nil, eebusV1ContractViolation()
+	}
+}
+
+func eebusV1MutationMatchesRequest(
+	tool eebusraw.ToolV1,
+	request any,
+	mutation eebusraw.MutationV1,
+) bool {
+	switch tool {
+	case eebusraw.ToolV1FeaturesDataSet:
+		typed := request.(eebusraw.FeatureDataSetRequestV1)
+		if !reflect.DeepEqual(typed.Target, mutation.Target) {
+			return false
+		}
+		requestedHash, requestErr := typed.Value.ComputeHash()
+		mutationHash, mutationErr := mutation.Requested.ComputeHash()
+		return requestErr == nil && mutationErr == nil && requestedHash == mutationHash
+	case eebusraw.ToolV1MutationsGet:
+		return request.(eebusraw.MutationGetRequestV1).MutationRef == mutation.MutationRef
+	case eebusraw.ToolV1MutationsRollback:
+		return request.(eebusraw.MutationRollbackRequestV1).MutationRef == mutation.MutationRef
+	default:
+		return false
+	}
+}
+
+func eebusV1ValidateRouterTerminal(
+	terminal *eebusraw.ErrorV1,
+) (*eebusraw.ErrorV1, *eebusraw.ErrorV1) {
+	if terminal == nil {
+		return nil, nil
+	}
+	cloned := terminal.Clone()
+	if _, err := eebusraw.CanonicalSHA256V1(cloned); err != nil {
+		if errors.Is(err, eebusraw.ErrSecretDetected) {
+			return nil, eebusV1SecretFailure()
+		}
+		return nil, eebusV1ContractViolation()
+	}
+	if !eebusV1KnownErrorCode(cloned.Code) ||
+		!eebusV1KnownSourceLayer(cloned.SourceLayer) ||
+		!eebusV1BoundedString(cloned.Message, 512) {
+		return nil, eebusV1ContractViolation()
+	}
+	if cloned.Details != nil {
+		if cloned.Details.TargetIndex != nil && *cloned.Details.TargetIndex > 15 ||
+			!eebusV1OptionalBoundedString(cloned.Details.Classification, 128) ||
+			len(cloned.Details.Unknown) > 256 {
+			return nil, eebusV1ContractViolation()
+		}
+		for _, unknown := range cloned.Details.Unknown {
+			if !eebusV1BoundedString(unknown.Path, 1024) ||
+				!eebusV1BoundedString(unknown.Source, 256) ||
+				unknown.Value.Validate() != nil {
+				return nil, eebusV1ContractViolation()
+			}
+		}
+	}
+	return &cloned, nil
+}
+
+func eebusV1BoundedString(value string, maximum int) bool {
+	trimmed := strings.TrimSpace(value)
+	return trimmed != "" &&
+		utf8.ValidString(trimmed) &&
+		utf8.RuneCountInString(trimmed) <= maximum
+}
+
+func eebusV1OptionalBoundedString(value string, maximum int) bool {
+	return value == "" || eebusV1BoundedString(value, maximum)
+}
+
+func eebusV1CanonicalValidationFailure(terminal *eebusraw.ErrorV1) *eebusraw.ErrorV1 {
+	if terminal != nil && terminal.Code == eebusraw.ErrorCodeV1SecretDetected {
+		return eebusV1SecretFailure()
+	}
+	return eebusV1ContractViolation()
+}
+
+func eebusV1SecretFailure() *eebusraw.ErrorV1 {
+	return eebusraw.NewErrorV1(
+		eebusraw.ErrorCodeV1SecretDetected,
+		"raw eeBUS response was rejected by the protected output boundary",
+		false,
+		eebusV1SourceLayerGatewayRouter,
+	)
+}
+
+func eebusV1ContractViolation() *eebusraw.ErrorV1 {
+	return eebusraw.NewErrorV1(
+		eebusraw.ErrorCodeV1Internal,
+		"raw eeBUS command router returned an invalid contract result",
+		false,
+		eebusV1SourceLayerGatewayRouter,
+	)
+}
+
+func eebusV1TerminalRequiresRuntime(code eebusraw.ErrorCodeV1) bool {
+	switch code {
+	case eebusraw.ErrorCodeV1ConstraintsUnknown,
+		eebusraw.ErrorCodeV1ConstraintFailure,
+		eebusraw.ErrorCodeV1StaleReadToken,
+		eebusraw.ErrorCodeV1CASMismatch,
+		eebusraw.ErrorCodeV1RuntimeEpochMismatch,
+		eebusraw.ErrorCodeV1ConnectionGenerationMismatch,
+		eebusraw.ErrorCodeV1IdempotencyConflict,
+		eebusraw.ErrorCodeV1WriterBusy,
+		eebusraw.ErrorCodeV1Disconnected,
+		eebusraw.ErrorCodeV1Timeout,
+		eebusraw.ErrorCodeV1Cancelled,
+		eebusraw.ErrorCodeV1RemoteError,
+		eebusraw.ErrorCodeV1DecodeError,
+		eebusraw.ErrorCodeV1PartialResult,
+		eebusraw.ErrorCodeV1NoEffect,
+		eebusraw.ErrorCodeV1OutcomeUnknown,
+		eebusraw.ErrorCodeV1Conflict,
+		eebusraw.ErrorCodeV1RollbackFailed,
+		eebusraw.ErrorCodeV1NotFound:
+		return true
+	default:
+		return false
+	}
+}
+
+func eebusV1KnownErrorCode(code eebusraw.ErrorCodeV1) bool {
+	switch code {
+	case eebusraw.ErrorCodeV1PermissionDenied,
+		eebusraw.ErrorCodeV1InvalidArgument,
+		eebusraw.ErrorCodeV1UnsupportedOperation,
+		eebusraw.ErrorCodeV1PartialOperationForbidden,
+		eebusraw.ErrorCodeV1ConstraintsUnknown,
+		eebusraw.ErrorCodeV1ConstraintFailure,
+		eebusraw.ErrorCodeV1StaleReadToken,
+		eebusraw.ErrorCodeV1CASMismatch,
+		eebusraw.ErrorCodeV1RuntimeEpochMismatch,
+		eebusraw.ErrorCodeV1ConnectionGenerationMismatch,
+		eebusraw.ErrorCodeV1IdempotencyConflict,
+		eebusraw.ErrorCodeV1WriterBusy,
+		eebusraw.ErrorCodeV1Disconnected,
+		eebusraw.ErrorCodeV1Timeout,
+		eebusraw.ErrorCodeV1Cancelled,
+		eebusraw.ErrorCodeV1RemoteError,
+		eebusraw.ErrorCodeV1DecodeError,
+		eebusraw.ErrorCodeV1PartialResult,
+		eebusraw.ErrorCodeV1OutcomeUnknown,
+		eebusraw.ErrorCodeV1Conflict,
+		eebusraw.ErrorCodeV1RollbackFailed,
+		eebusraw.ErrorCodeV1NoEffect,
+		eebusraw.ErrorCodeV1NotFound,
+		eebusraw.ErrorCodeV1SecretDetected,
+		eebusraw.ErrorCodeV1Internal:
+		return true
+	default:
+		return false
+	}
+}
+
+func eebusV1KnownSourceLayer(layer eebusraw.SourceLayerV1) bool {
+	switch string(layer) {
+	case "mcp",
+		"gateway-router",
+		"eebusreg-runtime",
+		"eebusreg-coordinator",
+		"eebus-go-executor",
+		"spine-go-round-trip",
+		"ship-session",
+		"remote":
+		return true
+	default:
+		return false
+	}
+}
+
+func eebusV1CommandResult(
+	spec eebusV1CommandSpec,
+	request any,
+	data any,
+	terminal *eebusraw.ErrorV1,
+	runtime *eebusraw.RuntimeBindingV1,
+) any {
+	if terminal != nil {
+		cloned := terminal.Clone()
+		terminal = &cloned
+	}
+	if terminal != nil && terminal.Code == eebusraw.ErrorCodeV1SecretDetected {
+		request = nil
+		data = nil
+		runtime = nil
+	}
+	hashView := eebusV1CommandHashView{
+		Contract: eebusV1RawFeatureContract,
+		Tool:     spec.tool, Scope: spec.scope, MaskTier: eebusraw.MaskTierRaw,
+		AuthScope: spec.scope, Runtime: runtime, Request: request, Data: data, Error: terminal,
+	}
+	hash, err := eebusraw.CanonicalSHA256V1(hashView)
+	if err != nil {
+		request = nil
+		data = nil
+		runtime = nil
+		if errors.Is(err, eebusraw.ErrSecretDetected) {
+			terminal = eebusV1SecretFailure()
+		} else {
+			terminal = eebusV1ContractViolation()
+		}
+		hashView.Runtime = nil
+		hashView.Request = nil
+		hashView.Data = nil
+		hashView.Error = terminal
+		hash, _ = eebusraw.CanonicalSHA256V1(hashView)
+	}
+	envelope := eebusV1CommandEnvelope{
+		Meta: eebusV1CommandMeta{
+			Contract: eebusV1RawFeatureContract,
+			Tool:     spec.tool, Scope: spec.scope, MaskTier: eebusraw.MaskTierRaw,
+			AuthScope: spec.scope, DataTimestamp: time.Now().UTC().Format(time.RFC3339Nano),
+			DataHash: hash, Runtime: runtime,
+		},
+		Request: request, Data: data, Error: terminal,
+	}
+	encoded, err := json.Marshal(envelope)
+	if err != nil {
+		fallbackTerminal := eebusraw.NewErrorV1(
+			eebusraw.ErrorCodeV1Internal,
+			"raw eeBUS response encoding failed",
+			false,
+			eebusV1SourceLayerGatewayRouter,
+		)
+		fallbackView := eebusV1CommandHashView{
+			Contract: eebusV1RawFeatureContract,
+			Tool:     spec.tool, Scope: spec.scope, MaskTier: eebusraw.MaskTierRaw,
+			AuthScope: spec.scope, Error: fallbackTerminal,
+		}
+		fallbackHash, _ := eebusraw.CanonicalSHA256V1(fallbackView)
+		fallbackEnvelope := eebusV1CommandEnvelope{
+			Meta: eebusV1CommandMeta{
+				Contract: eebusV1RawFeatureContract,
+				Tool:     spec.tool, Scope: spec.scope, MaskTier: eebusraw.MaskTierRaw,
+				AuthScope: spec.scope, DataTimestamp: time.Now().UTC().Format(time.RFC3339Nano),
+				DataHash: fallbackHash,
+			},
+			Error: fallbackTerminal,
+		}
+		encoded, _ = json.Marshal(fallbackEnvelope)
+		return callToolResultText(string(encoded), true)
+	}
+	return callToolResultText(string(encoded), terminal != nil)
+}
+
+func eebusV1FeaturesGetSchema() map[string]any {
+	return eebusV1ClosedSchema(
+		map[string]any{"target": eebusV1FeatureLocatorSchema()},
+		[]string{"target"},
+	)
+}
+
+func eebusV1FeaturesDataGetSchema() map[string]any {
+	return eebusV1ClosedSchema(
+		map[string]any{
+			"targets": map[string]any{
+				"type": "array", "minItems": 1, "maxItems": 16,
+				"items": eebusV1FeatureTargetSchema(eebusraw.OperationV1Read),
+			},
+			"timeout_ms": map[string]any{"type": "integer", "minimum": 1, "maximum": 30000},
+		},
+		[]string{"targets"},
+	)
+}
+
+func eebusV1FeaturesDataSetSchema() map[string]any {
+	schema := eebusV1ClosedSchema(
+		map[string]any{
+			"target": eebusV1FeatureTargetSchema(eebusraw.OperationV1Write),
+			"value":  eebusV1TypedValueSchema(1),
+			"read_token": map[string]any{
+				"type": "string", "pattern": eebusV1TokenPattern,
+			},
+			"expected_current": eebusV1TypedValueSchema(1),
+			"idempotency_key": map[string]any{
+				"type": "string", "minLength": 16, "maxLength": 128,
+				"pattern": `^[A-Za-z0-9._~-]+$`,
+			},
+			"mode":              map[string]any{"type": "string", "enum": []string{"apply", "probe"}},
+			"probe_ttl_seconds": map[string]any{"type": "integer", "minimum": 1, "maximum": 900},
+			"constraints_override": eebusV1ClosedSchema(
+				map[string]any{
+					"profile_id":    map[string]any{"type": "string", "minLength": 1, "maxLength": 128},
+					"justification": map[string]any{"type": "string", "minLength": 1, "maxLength": 1024},
+					"expires_at":    map[string]any{"type": "string", "format": "date-time", "pattern": `Z$`},
+				},
+				[]string{"profile_id", "justification", "expires_at"},
+			),
+		},
+		[]string{"target", "value", "read_token", "idempotency_key", "mode"},
+	)
+	schema["allOf"] = []any{
+		map[string]any{
+			"if": map[string]any{
+				"properties": map[string]any{"mode": map[string]any{"const": "probe"}},
+				"required":   []string{"mode"},
+			},
+			"then": map[string]any{"required": []string{"probe_ttl_seconds"}},
+			"else": map[string]any{"not": map[string]any{"required": []string{"probe_ttl_seconds"}}},
+		},
+	}
+	return schema
+}
+
+func eebusV1MutationsGetSchema() map[string]any {
+	return eebusV1ClosedSchema(
+		map[string]any{"mutation_ref": map[string]any{"type": "string", "pattern": eebusV1TokenPattern}},
+		[]string{"mutation_ref"},
+	)
+}
+
+func eebusV1MutationsRollbackSchema() map[string]any {
+	return eebusV1ClosedSchema(
+		map[string]any{
+			"mutation_ref": map[string]any{"type": "string", "pattern": eebusV1TokenPattern},
+			"idempotency_key": map[string]any{
+				"type": "string", "minLength": 16, "maxLength": 128,
+				"pattern": `^[A-Za-z0-9._~-]+$`,
+			},
+		},
+		[]string{"mutation_ref", "idempotency_key"},
+	)
+}
+
+func eebusV1FeatureLocatorSchema() map[string]any {
+	return eebusV1ClosedSchema(
+		map[string]any{
+			"remote_ski":      map[string]any{"type": "string", "minLength": 40, "maxLength": 40, "pattern": `^[0-9a-f]{40}$`},
+			"ship_id":         map[string]any{"type": "string", "minLength": 1, "maxLength": 256},
+			"device_address":  map[string]any{"type": "string", "minLength": 1, "maxLength": 64},
+			"entity_address":  map[string]any{"type": "array", "minItems": 1, "maxItems": 16, "items": eebusV1SafeIntegerSchema(0)},
+			"feature_address": eebusV1SafeIntegerSchema(0),
+			"feature_type":    map[string]any{"type": "string", "minLength": 1, "maxLength": 128},
+			"feature_role":    map[string]any{"type": "string", "enum": []string{"client", "server", "special"}},
+		},
+		[]string{
+			"remote_ski", "ship_id", "device_address", "entity_address",
+			"feature_address", "feature_type", "feature_role",
+		},
+	)
+}
+
+func eebusV1FeatureTargetSchema(operation eebusraw.OperationV1) map[string]any {
+	locator := eebusV1FeatureLocatorSchema()
+	properties := locator["properties"].(map[string]any)
+	properties["function"] = map[string]any{"type": "string", "minLength": 1, "maxLength": 256}
+	properties["operation"] = map[string]any{"type": "string", "const": string(operation)}
+	required := append(locator["required"].([]string), "function", "operation")
+	locator["required"] = required
+	return locator
+}
+
+func eebusV1ClosedSchema(properties map[string]any, required []string) map[string]any {
+	schema := map[string]any{
+		"type":                 "object",
+		"properties":           properties,
+		"additionalProperties": false,
+		"x-secret-classifier":  "eebusraw.canonical.v1",
+	}
+	if len(required) != 0 {
+		schema["required"] = required
+	}
+	return schema
+}
+
+func eebusV1SafeIntegerSchema(minimum int64) map[string]any {
+	return map[string]any{
+		"type": "integer", "minimum": minimum, "maximum": int64(9007199254740991),
+	}
+}
+
+func eebusV1TypedValueSchema(depth int) map[string]any {
+	scalar := map[string]any{
+		"oneOf": []any{
+			map[string]any{"type": "null"},
+			map[string]any{"type": "boolean"},
+			eebusV1SafeIntegerSchema(-9007199254740991),
+			map[string]any{"type": "string", "maxLength": 16384},
+		},
+	}
+	if depth > 4 {
+		return scalar
+	}
+	return map[string]any{
+		"oneOf": []any{
+			scalar,
+			map[string]any{
+				"type": "array", "maxItems": 256, "items": eebusV1TypedValueSchema(depth + 1),
+			},
+			map[string]any{
+				"type": "object", "maxProperties": 256,
+				"propertyNames":        map[string]any{"type": "string", "maxLength": 256},
+				"additionalProperties": eebusV1TypedValueSchema(depth + 1),
+			},
+		},
+	}
+}

--- a/mcp/eebus_v1_commands.go
+++ b/mcp/eebus_v1_commands.go
@@ -642,8 +642,7 @@ func eebusV1TerminalRequiresRuntime(code eebusraw.ErrorCodeV1) bool {
 		eebusraw.ErrorCodeV1NoEffect,
 		eebusraw.ErrorCodeV1OutcomeUnknown,
 		eebusraw.ErrorCodeV1Conflict,
-		eebusraw.ErrorCodeV1RollbackFailed,
-		eebusraw.ErrorCodeV1NotFound:
+		eebusraw.ErrorCodeV1RollbackFailed:
 		return true
 	default:
 		return false

--- a/mcp/eebus_v1_commands_test.go
+++ b/mcp/eebus_v1_commands_test.go
@@ -1,0 +1,943 @@
+package mcp
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+	"github.com/Project-Helianthus/helianthus-eebusreg/eebusraw"
+)
+
+type issue749TypedRouter struct {
+	mu sync.Mutex
+
+	calls []eebusraw.ToolV1
+
+	readAuth  eebusraw.ReadAuthorizationV1
+	writeAuth eebusraw.WriteAuthorizationV1
+
+	featuresGetData  eebusraw.FeaturesGetDataV1
+	featuresGetError *eebusraw.ErrorV1
+	dataGetData      eebusraw.FeatureDataGetDataV1
+	dataGetError     *eebusraw.ErrorV1
+	mutationData     eebusraw.MutationV1
+	mutationError    *eebusraw.ErrorV1
+}
+
+func (router *issue749TypedRouter) record(tool eebusraw.ToolV1) {
+	router.calls = append(router.calls, tool)
+}
+
+func (router *issue749TypedRouter) FeaturesGet(
+	_ context.Context,
+	auth eebusraw.ReadAuthorizationV1,
+	_ eebusraw.FeaturesGetRequestV1,
+) (eebusraw.FeaturesGetDataV1, *eebusraw.ErrorV1) {
+	router.mu.Lock()
+	defer router.mu.Unlock()
+	router.record(eebusraw.ToolV1FeaturesGet)
+	router.readAuth = auth
+	return router.featuresGetData, router.featuresGetError
+}
+
+func (router *issue749TypedRouter) FeaturesDataGet(
+	_ context.Context,
+	auth eebusraw.ReadAuthorizationV1,
+	_ eebusraw.FeatureDataGetRequestV1,
+) (eebusraw.FeatureDataGetDataV1, *eebusraw.ErrorV1) {
+	router.mu.Lock()
+	defer router.mu.Unlock()
+	router.record(eebusraw.ToolV1FeaturesDataGet)
+	router.readAuth = auth
+	return router.dataGetData, router.dataGetError
+}
+
+func (router *issue749TypedRouter) FeaturesDataSet(
+	_ context.Context,
+	auth eebusraw.WriteAuthorizationV1,
+	_ eebusraw.FeatureDataSetRequestV1,
+) (eebusraw.MutationV1, *eebusraw.ErrorV1) {
+	router.mu.Lock()
+	defer router.mu.Unlock()
+	router.record(eebusraw.ToolV1FeaturesDataSet)
+	router.writeAuth = auth
+	return router.mutationData, router.mutationError
+}
+
+func (router *issue749TypedRouter) MutationsGet(
+	_ context.Context,
+	auth eebusraw.ReadAuthorizationV1,
+	_ eebusraw.MutationGetRequestV1,
+) (eebusraw.MutationV1, *eebusraw.ErrorV1) {
+	router.mu.Lock()
+	defer router.mu.Unlock()
+	router.record(eebusraw.ToolV1MutationsGet)
+	router.readAuth = auth
+	return router.mutationData, router.mutationError
+}
+
+func (router *issue749TypedRouter) MutationsRollback(
+	_ context.Context,
+	auth eebusraw.WriteAuthorizationV1,
+	_ eebusraw.MutationRollbackRequestV1,
+) (eebusraw.MutationV1, *eebusraw.ErrorV1) {
+	router.mu.Lock()
+	defer router.mu.Unlock()
+	router.record(eebusraw.ToolV1MutationsRollback)
+	router.writeAuth = auth
+	return router.mutationData, router.mutationError
+}
+
+func (router *issue749TypedRouter) callCount() int {
+	router.mu.Lock()
+	defer router.mu.Unlock()
+	return len(router.calls)
+}
+
+func TestIssue749CommandRouterRegistrationRejectsNilAndDuplicate(t *testing.T) {
+	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+	server, _ := msp06TestServer(t, provider)
+
+	if err := server.RegisterEEBusV1CommandRouter(nil); err == nil {
+		t.Fatal("nil command router registration succeeded")
+	}
+	var typedNil *issue749TypedRouter
+	if err := server.RegisterEEBusV1CommandRouter(typedNil); err == nil {
+		t.Fatal("typed-nil command router registration succeeded")
+	}
+
+	router := &issue749TypedRouter{}
+	if err := server.RegisterEEBusV1CommandRouter(router); err != nil {
+		t.Fatalf("register command router: %v", err)
+	}
+	if err := server.RegisterEEBusV1CommandRouter(&issue749TypedRouter{}); err == nil {
+		t.Fatal("duplicate command router registration succeeded")
+	}
+}
+
+func TestIssue749ProviderAndTypedNilRouterFailClosed(t *testing.T) {
+	server, err := NewServer(
+		&testRegistry{entries: make(map[byte]registry.DeviceEntry)},
+		&testInvoker{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var typedNilProvider *msp06Provider
+	if err := server.registerEEBusV1Provider(typedNilProvider, eebusV1RegistrationOptions{}); err == nil {
+		t.Fatal("typed-nil eeBUS provider registration succeeded")
+	}
+
+	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+	server, _ = msp06TestServer(t, provider)
+	var typedNilRouter *issue749TypedRouter
+	server.eebusV1CommandRouter = typedNilRouter
+	want := append([]string(nil), msp06ToolNames...)
+	sort.Strings(want)
+	if got := issue749ToolNames(issue749EEBusTools(t, issue743OperatorHandler(t, server))); !reflect.DeepEqual(got, want) {
+		t.Fatalf("typed-nil router exposed command tools: got %v, want frozen public tools %v", got, want)
+	}
+}
+
+func TestIssue749TypedSuccessErrorAndPartialResultEnvelopes(t *testing.T) {
+	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+	server, _ := msp06TestServer(t, provider)
+	binding := eebusraw.RuntimeBindingV1{RuntimeEpoch: 7, ConnectionGeneration: 3}
+	cases := issue749CommandCases(t)
+	featuresRequest := issue749DecodeArguments[eebusraw.FeaturesGetRequestV1](t, cases[0].arguments)
+	router := &issue749TypedRouter{
+		featuresGetData: issue749FeaturesGetData(t, featuresRequest, binding),
+	}
+	if err := server.RegisterEEBusV1CommandRouter(router); err != nil {
+		t.Fatal(err)
+	}
+	operator := issue743OperatorHandler(t, server)
+
+	success := msp06Call(t, operator, cases[0].tool, cases[0].arguments)
+	if success.isError || success.envelope["error"] != nil || success.envelope["data"] == nil {
+		t.Fatalf("typed success envelope = %#v", success.envelope)
+	}
+	assertIssue749CommandMeta(t, success.envelope, cases[0].tool, cases[0].scope, binding)
+	if router.readAuth != (eebusraw.ReadAuthorizationV1{
+		PrincipalClass: "owner", Scope: eebusraw.AuthScopeV1RawRead,
+		Tool: eebusraw.ToolV1FeaturesGet, MaskTier: eebusraw.MaskTierRaw,
+	}) {
+		t.Fatalf("server-owned read authorization = %#v", router.readAuth)
+	}
+
+	router.mu.Lock()
+	setRequest := issue749DecodeArguments[eebusraw.FeatureDataSetRequestV1](t, cases[2].arguments)
+	router.mutationData = issue749PreparedMutation(t, setRequest, binding)
+	router.mutationError = eebusraw.NewErrorV1(
+		eebusraw.ErrorCodeV1Internal, "fixed admitted failure", false, eebusraw.SourceLayerV1Runtime,
+	)
+	router.mu.Unlock()
+	typedError := msp06Call(t, operator, cases[2].tool, cases[2].arguments)
+	if !typedError.isError || typedError.envelope["data"] != nil {
+		t.Fatalf("typed error envelope = %#v", typedError.envelope)
+	}
+	if code := issue749EnvelopeErrorCode(t, typedError.envelope); code != string(eebusraw.ErrorCodeV1Internal) {
+		t.Fatalf("typed error code = %q", code)
+	}
+	assertIssue749CommandMeta(t, typedError.envelope, cases[2].tool, cases[2].scope, binding)
+	if router.writeAuth != (eebusraw.WriteAuthorizationV1{
+		PrincipalClass: "owner", Scope: eebusraw.AuthScopeV1RawWrite,
+		Tool: eebusraw.ToolV1FeaturesDataSet, MaskTier: eebusraw.MaskTierRaw,
+	}) {
+		t.Fatalf("server-owned write authorization = %#v", router.writeAuth)
+	}
+
+	partialArguments := cloneIssue749Arguments(t, cases[1].arguments)
+	targets := partialArguments["targets"].([]any)
+	secondTarget := cloneIssue749Arguments(t, targets[0].(map[string]any))
+	secondTarget["feature_address"] = float64(3)
+	partialArguments["targets"] = append(targets, secondTarget)
+	partialRequest := issue749DecodeArguments[eebusraw.FeatureDataGetRequestV1](t, partialArguments)
+	partialData := issue749PartialData(t, partialRequest, binding)
+	router.mu.Lock()
+	router.dataGetData = partialData
+	router.dataGetError = eebusraw.NewErrorV1(
+		eebusraw.ErrorCodeV1PartialResult, "fixed partial result", true, eebusraw.SourceLayerV1Runtime,
+	)
+	router.mu.Unlock()
+	partial := msp06Call(t, operator, cases[1].tool, partialArguments)
+	if !partial.isError || partial.envelope["data"] == nil ||
+		issue749EnvelopeErrorCode(t, partial.envelope) != string(eebusraw.ErrorCodeV1PartialResult) {
+		t.Fatalf("partial-result envelope = %#v", partial.envelope)
+	}
+	if got := router.callCount(); got != 3 {
+		t.Fatalf("router calls = %d, want exactly 3", got)
+	}
+}
+
+func TestIssue749ShapeAndBoundaryErrorPrecedence(t *testing.T) {
+	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+	server, _ := msp06TestServer(t, provider)
+	router := &issue749TypedRouter{}
+	if err := server.RegisterEEBusV1CommandRouter(router); err != nil {
+		t.Fatal(err)
+	}
+	test := issue749CommandCases(t)[0]
+	malformed := cloneIssue749Arguments(t, test.arguments)
+	malformed["unknown"] = true
+
+	beforeProvider := provider.callCount()
+	for _, endpoint := range []struct {
+		name    string
+		handler http.Handler
+	}{
+		{name: "public", handler: server.Handler()},
+		{name: "operator", handler: issue743OperatorHandler(t, server)},
+	} {
+		t.Run(endpoint.name, func(t *testing.T) {
+			result := msp06Call(t, endpoint.handler, test.tool, malformed)
+			if code := issue749EnvelopeErrorCode(t, result.envelope); code != string(eebusraw.ErrorCodeV1InvalidArgument) {
+				t.Fatalf("malformed request error = %q, want invalid_argument", code)
+			}
+		})
+	}
+	if router.callCount() != 0 || provider.callCount() != beforeProvider {
+		t.Fatalf("malformed calls contacted router/provider: router=%d provider=%d->%d",
+			router.callCount(), beforeProvider, provider.callCount())
+	}
+
+	public := msp06Call(t, server.Handler(), test.tool, test.arguments)
+	if code := issue749EnvelopeErrorCode(t, public.envelope); code != string(eebusraw.ErrorCodeV1PermissionDenied) {
+		t.Fatalf("valid public request error = %q, want permission_denied", code)
+	}
+	publicAgain := msp06Call(t, server.Handler(), test.tool, test.arguments)
+	publicMeta := msp06Map(t, public.envelope["meta"], "public command meta")
+	publicAgainMeta := msp06Map(t, publicAgain.envelope["meta"], "repeated public command meta")
+	if publicMeta["runtime"] != nil {
+		t.Fatalf("zero-contact public denial fabricated runtime identity: %#v", publicMeta["runtime"])
+	}
+	if publicMeta["data_hash"] != publicAgainMeta["data_hash"] {
+		t.Fatalf("zero-contact public denial hash is unstable: %v != %v",
+			publicMeta["data_hash"], publicAgainMeta["data_hash"])
+	}
+	if router.callCount() != 0 || provider.callCount() != beforeProvider {
+		t.Fatalf("public denial contacted router/provider: router=%d provider=%d->%d",
+			router.callCount(), beforeProvider, provider.callCount())
+	}
+}
+
+func TestIssue749DuplicateJSONKeysFailBeforeDispatch(t *testing.T) {
+	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+	server, _ := msp06TestServer(t, provider)
+	router := &issue749TypedRouter{}
+	if err := server.RegisterEEBusV1CommandRouter(router); err != nil {
+		t.Fatal(err)
+	}
+	operator := issue743OperatorHandler(t, server)
+	test := issue749CommandCases(t)[0]
+	encodedArguments, err := json.Marshal(test.arguments)
+	if err != nil {
+		t.Fatal(err)
+	}
+	remoteSKI := strings.Repeat("a", 40)
+	duplicateArguments := strings.Replace(
+		string(encodedArguments),
+		`"remote_ski":`,
+		`"remote_ski":"`+remoteSKI+`","remote_ski":`,
+		1,
+	)
+
+	for _, rawParams := range []string{
+		`{"name":` + mustJSON(test.tool) + `,"arguments":` + duplicateArguments + `}`,
+		`{"name":` + mustJSON(test.tool) + `,"name":` + mustJSON(test.tool) +
+			`,"arguments":` + string(encodedArguments) + `}`,
+	} {
+		result := issue749RawCommandCall(t, operator, json.RawMessage(rawParams))
+		if code := issue749EnvelopeErrorCode(t, result.envelope); code != string(eebusraw.ErrorCodeV1InvalidArgument) {
+			t.Fatalf("duplicate-key error = %q, want invalid_argument", code)
+		}
+		assertIssue749PreRuntimeFailure(t, result.envelope, true)
+	}
+	if router.callCount() != 0 {
+		t.Fatalf("duplicate-key requests dispatched %d router calls", router.callCount())
+	}
+}
+
+func TestIssue749SecretRequestFailsBeforeDispatchWithoutEcho(t *testing.T) {
+	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+	server, _ := msp06TestServer(t, provider)
+	router := &issue749TypedRouter{}
+	if err := server.RegisterEEBusV1CommandRouter(router); err != nil {
+		t.Fatal(err)
+	}
+	test := issue749CommandCases(t)[0]
+	arguments := cloneIssue749Arguments(t, test.arguments)
+	target := arguments["target"].(map[string]any)
+	target["ship_id"] = "Bearer fixture-secret"
+
+	result := msp06Call(t, issue743OperatorHandler(t, server), test.tool, arguments)
+	if code := issue749EnvelopeErrorCode(t, result.envelope); code != string(eebusraw.ErrorCodeV1InvalidArgument) {
+		t.Fatalf("secret request error = %q, want protected invalid_argument", code)
+	}
+	if strings.Contains(result.raw, "fixture-secret") {
+		t.Fatalf("secret request was echoed in response: %s", result.raw)
+	}
+	assertIssue749PreRuntimeFailure(t, result.envelope, true)
+	if router.callCount() != 0 {
+		t.Fatalf("secret-bearing request dispatched %d router calls", router.callCount())
+	}
+}
+
+func TestIssue749RouterOutputsAreValidatedBeforePublication(t *testing.T) {
+	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+	server, _ := msp06TestServer(t, provider)
+	binding := eebusraw.RuntimeBindingV1{RuntimeEpoch: 7, ConnectionGeneration: 3}
+	test := issue749CommandCases(t)[0]
+	request := issue749DecodeArguments[eebusraw.FeaturesGetRequestV1](t, test.arguments)
+	invalid := issue749FeaturesGetData(t, request, binding)
+	invalid.DataHash = eebusraw.HashV1("sha256:" + strings.Repeat("0", 64))
+	router := &issue749TypedRouter{featuresGetData: invalid}
+	if err := server.RegisterEEBusV1CommandRouter(router); err != nil {
+		t.Fatal(err)
+	}
+
+	result := msp06Call(t, issue743OperatorHandler(t, server), test.tool, test.arguments)
+	if code := issue749EnvelopeErrorCode(t, result.envelope); code != string(eebusraw.ErrorCodeV1Internal) {
+		t.Fatalf("invalid router output error = %q, want internal", code)
+	}
+	if result.envelope["data"] != nil {
+		t.Fatalf("invalid router output was published: %#v", result.envelope["data"])
+	}
+	assertIssue749PreRuntimeFailure(t, result.envelope, false)
+	if router.callCount() != 1 {
+		t.Fatalf("router calls = %d, want one rejected output", router.callCount())
+	}
+}
+
+func TestIssue749ZeroDataRouterErrorValidatesOpaqueDetails(t *testing.T) {
+	opaqueValue, err := eebusraw.NewTypedValueV1(map[string]any{"status": "opaque"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	test := issue749CommandCases(t)[0]
+	cases := []struct {
+		name           string
+		message        string
+		classification string
+		unknown        eebusraw.OpaqueObservationV1
+		wantCode       eebusraw.ErrorCodeV1
+	}{
+		{
+			name: "valid",
+			unknown: eebusraw.OpaqueObservationV1{
+				Path: "/remote/error", Source: "runtime", Value: opaqueValue,
+			},
+			wantCode: eebusraw.ErrorCodeV1InvalidArgument,
+		},
+		{
+			name: "empty path",
+			unknown: eebusraw.OpaqueObservationV1{
+				Source: "runtime", Value: opaqueValue,
+			},
+			wantCode: eebusraw.ErrorCodeV1Internal,
+		},
+		{
+			name: "blank source",
+			unknown: eebusraw.OpaqueObservationV1{
+				Path: "/remote/error", Source: "  ", Value: opaqueValue,
+			},
+			wantCode: eebusraw.ErrorCodeV1Internal,
+		},
+		{
+			name:           "blank classification",
+			classification: " ",
+			unknown: eebusraw.OpaqueObservationV1{
+				Path: "/remote/error", Source: "runtime", Value: opaqueValue,
+			},
+			wantCode: eebusraw.ErrorCodeV1Internal,
+		},
+		{
+			name:    "invalid message utf8",
+			message: string([]byte{0xff}),
+			unknown: eebusraw.OpaqueObservationV1{
+				Path: "/remote/error", Source: "runtime", Value: opaqueValue,
+			},
+			wantCode: eebusraw.ErrorCodeV1Internal,
+		},
+	}
+
+	for _, current := range cases {
+		t.Run(current.name, func(t *testing.T) {
+			provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+			server, _ := msp06TestServer(t, provider)
+			message := current.message
+			if message == "" {
+				message = "fixed router error"
+			}
+			terminal := eebusraw.NewErrorV1(
+				eebusraw.ErrorCodeV1InvalidArgument,
+				message,
+				false,
+				eebusraw.SourceLayerV1Runtime,
+			)
+			terminal.Details = &eebusraw.ErrorDetailsV1{
+				Classification: current.classification,
+				Unknown:        []eebusraw.OpaqueObservationV1{current.unknown},
+			}
+			router := &issue749TypedRouter{featuresGetError: terminal}
+			if err := server.RegisterEEBusV1CommandRouter(router); err != nil {
+				t.Fatal(err)
+			}
+
+			result := msp06Call(
+				t,
+				issue743OperatorHandler(t, server),
+				test.tool,
+				test.arguments,
+			)
+			if code := issue749EnvelopeErrorCode(t, result.envelope); code != string(current.wantCode) {
+				t.Fatalf("zero-data router error = %q, want %q; envelope=%#v",
+					code, current.wantCode, result.envelope)
+			}
+			if result.envelope["data"] != nil {
+				t.Fatalf("zero-data router error published data: %#v", result.envelope["data"])
+			}
+			assertIssue749PreRuntimeFailure(t, result.envelope, false)
+		})
+	}
+}
+
+func TestIssue749BatchRuntimeBindingRejectsMixedGenerations(t *testing.T) {
+	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+	server, _ := msp06TestServer(t, provider)
+	test := issue749CommandCases(t)[1]
+	arguments := cloneIssue749Arguments(t, test.arguments)
+	targets := arguments["targets"].([]any)
+	secondTarget := cloneIssue749Arguments(t, targets[0].(map[string]any))
+	secondTarget["feature_address"] = float64(3)
+	arguments["targets"] = append(targets, secondTarget)
+	request := issue749DecodeArguments[eebusraw.FeatureDataGetRequestV1](t, arguments)
+	now := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	router := &issue749TypedRouter{
+		dataGetData: eebusraw.FeatureDataGetDataV1{
+			Results: []eebusraw.ReadObservationV1{
+				issue749Observation(t, request.Targets[0], eebusraw.RuntimeBindingV1{
+					RuntimeEpoch: 7, ConnectionGeneration: 3,
+				}, now),
+				issue749Observation(t, request.Targets[1], eebusraw.RuntimeBindingV1{
+					RuntimeEpoch: 7, ConnectionGeneration: 4,
+				}, now),
+			},
+			Complete: true,
+		},
+	}
+	if err := server.RegisterEEBusV1CommandRouter(router); err != nil {
+		t.Fatal(err)
+	}
+
+	result := msp06Call(t, issue743OperatorHandler(t, server), test.tool, arguments)
+	if code := issue749EnvelopeErrorCode(t, result.envelope); code != string(eebusraw.ErrorCodeV1Internal) {
+		t.Fatalf("mixed-runtime output error = %q, want internal", code)
+	}
+	if result.envelope["data"] != nil {
+		t.Fatalf("mixed-runtime output was published: %#v", result.envelope["data"])
+	}
+	assertIssue749PreRuntimeFailure(t, result.envelope, false)
+}
+
+func TestIssue749CommandSchemasAreClosedBoundedAndSecretAware(t *testing.T) {
+	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+	server, _ := msp06TestServer(t, provider)
+	if err := server.RegisterEEBusV1CommandRouter(&issue749TypedRouter{}); err != nil {
+		t.Fatal(err)
+	}
+	tools := issue749EEBusTools(t, issue743OperatorHandler(t, server))
+	byName := make(map[string]map[string]any, len(tools))
+	for _, tool := range tools {
+		name, _ := tool["name"].(string)
+		byName[name] = tool
+	}
+
+	for _, name := range issue749AdditiveToolNames {
+		schema := msp06Map(t, byName[name]["inputSchema"], name+".inputSchema")
+		if schema["additionalProperties"] != false ||
+			schema["x-secret-classifier"] != "eebusraw.canonical.v1" {
+			t.Fatalf("%s schema is not closed and secret-aware: %#v", name, schema)
+		}
+	}
+
+	dataGetProperties := issue749SchemaProperties(t, byName[string(eebusraw.ToolV1FeaturesDataGet)])
+	targets := msp06Map(t, dataGetProperties["targets"], "features.data.get.targets")
+	if fmt.Sprint(targets["minItems"]) != "1" || fmt.Sprint(targets["maxItems"]) != "16" {
+		t.Fatalf("features.data.get target bounds = %#v", targets)
+	}
+	readTarget := msp06Map(t, targets["items"], "features.data.get.target")
+	issue749AssertTargetSchema(t, readTarget, eebusraw.OperationV1Read)
+
+	dataSetProperties := issue749SchemaProperties(t, byName[string(eebusraw.ToolV1FeaturesDataSet)])
+	writeTarget := msp06Map(t, dataSetProperties["target"], "features.data.set.target")
+	issue749AssertTargetSchema(t, writeTarget, eebusraw.OperationV1Write)
+	if msp06Map(t, dataSetProperties["read_token"], "features.data.set.read_token")["pattern"] != eebusV1TokenPattern {
+		t.Fatal("features.data.set read_token schema does not enforce one canonical opaque reference")
+	}
+	idempotency := msp06Map(t, dataSetProperties["idempotency_key"], "features.data.set.idempotency_key")
+	if fmt.Sprint(idempotency["minLength"]) != "16" || fmt.Sprint(idempotency["maxLength"]) != "128" {
+		t.Fatalf("idempotency key bounds = %#v", idempotency)
+	}
+}
+
+func TestIssue749TypedValueSchemaMatchesCanonicalDepthFour(t *testing.T) {
+	depthFour := map[string]any{
+		"one": []any{
+			map[string]any{
+				"two": []any{
+					int64(4),
+				},
+			},
+		},
+	}
+	depthFive := map[string]any{"zero": depthFour}
+	if _, err := eebusraw.NewTypedValueV1(depthFour); err != nil {
+		t.Fatalf("canonical depth-four value rejected: %v", err)
+	}
+	if _, err := eebusraw.NewTypedValueV1(depthFive); err == nil {
+		t.Fatal("canonical validator accepted depth-five containers")
+	}
+
+	schema := eebusV1TypedValueSchema(1)
+	for depth := 1; depth <= 4; depth++ {
+		if !issue749TypedValueSchemaAllowsContainers(t, schema) {
+			t.Fatalf("TypedValue schema rejects canonical container depth %d", depth)
+		}
+		schema = issue749TypedValueObjectChildSchema(t, schema)
+	}
+	if issue749TypedValueSchemaAllowsContainers(t, schema) {
+		t.Fatal("TypedValue schema permits a fifth container depth")
+	}
+}
+
+func TestIssue749OpaqueReferenceSchemaEnforcesCanonicalPadBits(t *testing.T) {
+	canonical := base64.RawURLEncoding.EncodeToString(make([]byte, 32))
+	nonCanonical := strings.Repeat("A", 42) + "B"
+	if terminal := eebusraw.ValidateMutationGetRequestV1(
+		eebusraw.MutationGetRequestV1{MutationRef: canonical},
+	); terminal != nil {
+		t.Fatalf("canonical reference rejected by eebusraw: %+v", terminal)
+	}
+	if terminal := eebusraw.ValidateMutationGetRequestV1(
+		eebusraw.MutationGetRequestV1{MutationRef: nonCanonical},
+	); terminal == nil {
+		t.Fatal("non-canonical reference accepted by eebusraw")
+	}
+
+	pattern := regexp.MustCompile(eebusV1TokenPattern)
+	if !pattern.MatchString(canonical) {
+		t.Fatalf("schema pattern rejected canonical reference %q", canonical)
+	}
+	if pattern.MatchString(nonCanonical) {
+		t.Fatalf("schema pattern accepted non-canonical pad bits %q", nonCanonical)
+	}
+	idPattern := regexp.MustCompile(eebusV1IDDigestPattern)
+	if !idPattern.MatchString(canonical) ||
+		!idPattern.MatchString("sha256:"+strings.Repeat("a", 64)) {
+		t.Fatal("id_digest schema rejected a canonical opaque reference or SHA-256 digest")
+	}
+	if idPattern.MatchString(nonCanonical) {
+		t.Fatalf("id_digest schema accepted non-canonical pad bits %q", nonCanonical)
+	}
+
+	for name, schema := range map[string]map[string]any{
+		"read_token":        eebusV1FeaturesDataSetSchema(),
+		"mutation_get":      eebusV1MutationsGetSchema(),
+		"mutation_rollback": eebusV1MutationsRollbackSchema(),
+	} {
+		properties := msp06Map(t, schema["properties"], name+".properties")
+		field := "mutation_ref"
+		if name == "read_token" {
+			field = "read_token"
+		}
+		if got := msp06Map(t, properties[field], name+"."+field)["pattern"]; got != eebusV1TokenPattern {
+			t.Fatalf("%s pattern = %v, want %s", name, got, eebusV1TokenPattern)
+		}
+	}
+}
+
+func TestIssue749CommandEnvelopeJCSHashIsStable(t *testing.T) {
+	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+	server, _ := msp06TestServer(t, provider)
+	router := &issue749TypedRouter{
+		mutationData: eebusraw.MutationV1{
+			MutationRef: "fixture", State: eebusraw.MutationStateV1Prepared,
+			Runtime: eebusraw.RuntimeBindingV1{RuntimeEpoch: 7, ConnectionGeneration: 3},
+		},
+	}
+	if err := server.RegisterEEBusV1CommandRouter(router); err != nil {
+		t.Fatal(err)
+	}
+	operator := issue743OperatorHandler(t, server)
+	test := issue749CommandCases(t)[2]
+	first := cloneIssue749Arguments(t, test.arguments)
+	first["value"] = map[string]any{"z": int64(2), "a": int64(1)}
+	second := cloneIssue749Arguments(t, test.arguments)
+	second["value"] = map[string]any{"a": int64(1), "z": int64(2)}
+
+	firstResult := msp06Call(t, operator, test.tool, first)
+	secondResult := msp06Call(t, operator, test.tool, second)
+	firstMeta := msp06Map(t, firstResult.envelope["meta"], "first meta")
+	secondMeta := msp06Map(t, secondResult.envelope["meta"], "second meta")
+	if firstMeta["data_hash"] != secondMeta["data_hash"] {
+		t.Fatalf("JCS data hashes differ: %v != %v", firstMeta["data_hash"], secondMeta["data_hash"])
+	}
+}
+
+func TestIssue749CommandEnvelopeRejectsSecretBearingRouterOutput(t *testing.T) {
+	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+	server, _ := msp06TestServer(t, provider)
+	router := &issue749TypedRouter{
+		featuresGetError: eebusraw.NewErrorV1(
+			eebusraw.ErrorCodeV1Internal,
+			"Bearer fixture-secret",
+			false,
+			eebusraw.SourceLayerV1Runtime,
+		),
+	}
+	if err := server.RegisterEEBusV1CommandRouter(router); err != nil {
+		t.Fatal(err)
+	}
+	test := issue749CommandCases(t)[0]
+	result := msp06Call(t, issue743OperatorHandler(t, server), test.tool, test.arguments)
+	encoded, err := json.Marshal(result.envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "fixture-secret") ||
+		issue749EnvelopeErrorCode(t, result.envelope) != string(eebusraw.ErrorCodeV1SecretDetected) {
+		t.Fatalf("secret-bearing router output was not failed closed: %s", encoded)
+	}
+	assertIssue749PreRuntimeFailure(t, result.envelope, true)
+}
+
+func assertIssue749CommandMeta(
+	t *testing.T,
+	envelope map[string]any,
+	tool string,
+	scope string,
+	runtime eebusraw.RuntimeBindingV1,
+) {
+	t.Helper()
+	meta := msp06Map(t, envelope["meta"], "command meta")
+	if meta["contract"] != eebusV1RawFeatureContract ||
+		meta["tool"] != tool ||
+		meta["scope"] != scope ||
+		meta["auth_scope"] != scope ||
+		meta["mask_tier"] != string(eebusraw.MaskTierRaw) {
+		t.Fatalf("command meta = %#v", meta)
+	}
+	gotRuntime := msp06Map(t, meta["runtime"], "command runtime")
+	if fmt.Sprint(gotRuntime["runtime_epoch"]) != fmt.Sprint(runtime.RuntimeEpoch) ||
+		fmt.Sprint(gotRuntime["connection_generation"]) != fmt.Sprint(runtime.ConnectionGeneration) {
+		t.Fatalf("command runtime = %#v, want %#v", gotRuntime, runtime)
+	}
+}
+
+func issue749EnvelopeErrorCode(t *testing.T, envelope map[string]any) string {
+	t.Helper()
+	publicError := msp06Map(t, envelope["error"], "command error")
+	code, _ := publicError["code"].(string)
+	return code
+}
+
+func issue749RawCommandCall(
+	t *testing.T,
+	handler http.Handler,
+	params json.RawMessage,
+) msp06CallResult {
+	t.Helper()
+	response := doRPC(t, handler, rpcRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "tools/call",
+		Params:  params,
+	})
+	if response.Error != nil {
+		t.Fatalf("raw command RPC error = %+v", response.Error)
+	}
+	result := msp06Map(t, response.Result, "raw command result")
+	content := msp06Slice(t, result["content"], "raw command content")
+	if len(content) != 1 {
+		t.Fatalf("raw command content count = %d, want 1", len(content))
+	}
+	raw, _ := msp06Map(t, content[0], "raw command content[0]")["text"].(string)
+	var envelope map[string]any
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(&envelope); err != nil {
+		t.Fatalf("decode raw command envelope: %v; text=%q", err, raw)
+	}
+	return msp06CallResult{envelope: envelope, raw: raw, isError: result["isError"] == true}
+}
+
+func assertIssue749PreRuntimeFailure(
+	t *testing.T,
+	envelope map[string]any,
+	requestMustBeNil bool,
+) {
+	t.Helper()
+	meta := msp06Map(t, envelope["meta"], "pre-runtime meta")
+	if meta["runtime"] != nil {
+		t.Fatalf("pre-runtime failure fabricated runtime: %#v", meta["runtime"])
+	}
+	if requestMustBeNil && envelope["request"] != nil {
+		t.Fatalf("protected or undecodable request was retained: %#v", envelope["request"])
+	}
+}
+
+func issue749SchemaProperties(t *testing.T, tool map[string]any) map[string]any {
+	t.Helper()
+	schema := msp06Map(t, tool["inputSchema"], "command inputSchema")
+	return msp06Map(t, schema["properties"], "command inputSchema.properties")
+}
+
+func issue749AssertTargetSchema(
+	t *testing.T,
+	target map[string]any,
+	operation eebusraw.OperationV1,
+) {
+	t.Helper()
+	if target["additionalProperties"] != false ||
+		target["x-secret-classifier"] != "eebusraw.canonical.v1" {
+		t.Fatalf("target schema is not closed and secret-aware: %#v", target)
+	}
+	properties := msp06Map(t, target["properties"], "target.properties")
+	remoteSKI := msp06Map(t, properties["remote_ski"], "target.remote_ski")
+	if fmt.Sprint(remoteSKI["minLength"]) != "40" ||
+		fmt.Sprint(remoteSKI["maxLength"]) != "40" ||
+		remoteSKI["pattern"] != `^[0-9a-f]{40}$` {
+		t.Fatalf("remote_ski schema = %#v", remoteSKI)
+	}
+	if msp06Map(t, properties["operation"], "target.operation")["const"] != string(operation) {
+		t.Fatalf("target operation is not fixed to %s: %#v", operation, properties["operation"])
+	}
+}
+
+func issue749TypedValueSchemaAllowsContainers(t *testing.T, schema map[string]any) bool {
+	t.Helper()
+	for _, raw := range msp06Slice(t, schema["oneOf"], "TypedValue.oneOf") {
+		branch := msp06Map(t, raw, "TypedValue.oneOf branch")
+		if branch["type"] == "array" || branch["type"] == "object" {
+			return true
+		}
+	}
+	return false
+}
+
+func issue749TypedValueObjectChildSchema(t *testing.T, schema map[string]any) map[string]any {
+	t.Helper()
+	for _, raw := range msp06Slice(t, schema["oneOf"], "TypedValue.oneOf") {
+		branch := msp06Map(t, raw, "TypedValue.oneOf branch")
+		if branch["type"] == "object" {
+			return msp06Map(t, branch["additionalProperties"], "TypedValue object child")
+		}
+	}
+	t.Fatal("TypedValue schema omitted object container branch")
+	return nil
+}
+
+func cloneIssue749Arguments(t *testing.T, arguments map[string]any) map[string]any {
+	t.Helper()
+	encoded, err := json.Marshal(arguments)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cloned map[string]any
+	if err := json.Unmarshal(encoded, &cloned); err != nil {
+		t.Fatal(err)
+	}
+	return cloned
+}
+
+func issue749DecodeArguments[T any](t *testing.T, arguments map[string]any) T {
+	t.Helper()
+	encoded, err := json.Marshal(arguments)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var request T
+	if err := json.Unmarshal(encoded, &request); err != nil {
+		t.Fatal(err)
+	}
+	return request
+}
+
+func issue749FeaturesGetData(
+	t *testing.T,
+	request eebusraw.FeaturesGetRequestV1,
+	binding eebusraw.RuntimeBindingV1,
+) eebusraw.FeaturesGetDataV1 {
+	t.Helper()
+	data := eebusraw.FeaturesGetDataV1{
+		Feature: request.Target, Description: "fixture feature",
+		Runtime: binding, DataTimestamp: time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC),
+		Source: eebusraw.ObservationSourceV1Live,
+	}
+	hash, err := data.ComputeDataHash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data.DataHash = hash
+	return data
+}
+
+func issue749PartialData(
+	t *testing.T,
+	request eebusraw.FeatureDataGetRequestV1,
+	binding eebusraw.RuntimeBindingV1,
+) eebusraw.FeatureDataGetDataV1 {
+	t.Helper()
+	now := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	observation := issue749Observation(t, request.Targets[0], binding, now)
+	return eebusraw.FeatureDataGetDataV1{
+		Results: []eebusraw.ReadObservationV1{observation},
+		Failures: []eebusraw.ReadFailureV1{{
+			TargetIndex: 1,
+			Target:      request.Targets[1],
+			Error: *eebusraw.NewErrorV1(
+				eebusraw.ErrorCodeV1Timeout,
+				"fixture timeout",
+				true,
+				eebusraw.SourceLayerV1SpineRoundTrip,
+			),
+		}},
+		Complete: false,
+	}
+}
+
+func issue749Observation(
+	t *testing.T,
+	target eebusraw.FeatureTargetV1,
+	binding eebusraw.RuntimeBindingV1,
+	now time.Time,
+) eebusraw.ReadObservationV1 {
+	t.Helper()
+	value, err := eebusraw.NewTypedValueV1(int64(18))
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation := eebusraw.ReadObservationV1{
+		Target: target, Runtime: binding,
+		RawRequest: eebusraw.ProtocolMessageV1{
+			Classifier: "READ", CorrelationKey: 1, Function: target.Function,
+		},
+		RawResponse: eebusraw.ProtocolMessageV1{
+			Classifier: "REPLY", CorrelationKey: 1, Function: target.Function, Data: &value,
+		},
+		Value: value, RequestedAt: now, ReceivedAt: now.Add(time.Millisecond),
+		DataTimestamp: now.Add(time.Millisecond), Source: eebusraw.ObservationSourceV1Live,
+		ReadToken: eebusraw.ReadTokenV1{
+			ReadToken: strings.Repeat("E", 43), ExpiresAt: now.Add(time.Minute),
+			BindingHash: eebusraw.HashV1("sha256:" + strings.Repeat("1", 64)),
+		},
+	}
+	hash, err := observation.ComputeDataHash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation.DataHash = hash
+	return observation
+}
+
+func issue749PreparedMutation(
+	t *testing.T,
+	request eebusraw.FeatureDataSetRequestV1,
+	binding eebusraw.RuntimeBindingV1,
+) eebusraw.MutationV1 {
+	t.Helper()
+	now := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	before, err := eebusraw.NewTypedValueV1(int64(18))
+	if err != nil {
+		t.Fatal(err)
+	}
+	transition := eebusraw.AuditTransitionV1{
+		Sequence: 1, State: eebusraw.MutationStateV1Prepared, TransitionedAt: now,
+	}
+	transition.TransitionHash = issue749TransitionHash(t, transition)
+	return eebusraw.MutationV1{
+		MutationRef: strings.Repeat("M", 43),
+		State:       eebusraw.MutationStateV1Prepared,
+		Mode:        request.Mode,
+		Target:      request.Target,
+		Runtime:     binding,
+		Before:      before,
+		Requested:   request.Value,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		Audit:       []eebusraw.AuditTransitionV1{transition},
+	}
+}
+
+func issue749TransitionHash(
+	t *testing.T,
+	transition eebusraw.AuditTransitionV1,
+) eebusraw.HashV1 {
+	t.Helper()
+	hash, err := eebusraw.CanonicalSHA256V1(struct {
+		Sequence       uint64                   `json:"sequence"`
+		State          eebusraw.MutationStateV1 `json:"state"`
+		TransitionedAt time.Time                `json:"transitioned_at"`
+		Classification string                   `json:"classification,omitempty"`
+		PreviousHash   *eebusraw.HashV1         `json:"previous_hash"`
+	}{
+		Sequence: transition.Sequence, State: transition.State,
+		TransitionedAt: transition.TransitionedAt,
+		Classification: transition.Classification, PreviousHash: transition.PreviousHash,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return hash
+}

--- a/mcp/eebus_v1_commands_test.go
+++ b/mcp/eebus_v1_commands_test.go
@@ -359,6 +359,68 @@ func TestIssue749RouterOutputsAreValidatedBeforePublication(t *testing.T) {
 	}
 }
 
+func TestIssue749MutationGetNotFoundWithoutRuntimeIsPreserved(t *testing.T) {
+	commandCases := issue749CommandCases(t)
+	test := commandCases[3]
+	notFound := eebusraw.NewErrorV1(
+		eebusraw.ErrorCodeV1NotFound,
+		"raw mutation was not found",
+		false,
+		eebusraw.SourceLayerV1Runtime,
+	)
+	malformed := notFound.Clone()
+	malformed.Message = " "
+	incoherent := issue749PreparedMutation(
+		t,
+		issue749DecodeArguments[eebusraw.FeatureDataSetRequestV1](t, commandCases[2].arguments),
+		eebusraw.RuntimeBindingV1{RuntimeEpoch: 7, ConnectionGeneration: 3},
+	)
+	incoherent.MutationRef = strings.Repeat("Q", 43)
+	if terminal := eebusraw.ValidateMutationV1(incoherent); terminal != nil {
+		t.Fatalf("incoherent fixture is not independently valid: %+v", terminal)
+	}
+
+	cases := []struct {
+		name     string
+		data     eebusraw.MutationV1
+		terminal *eebusraw.ErrorV1
+		wantCode eebusraw.ErrorCodeV1
+	}{
+		{name: "unknown reference", terminal: notFound, wantCode: eebusraw.ErrorCodeV1NotFound},
+		{name: "malformed terminal", terminal: &malformed, wantCode: eebusraw.ErrorCodeV1Internal},
+		{name: "incoherent data", data: incoherent, terminal: notFound, wantCode: eebusraw.ErrorCodeV1Internal},
+	}
+	for _, current := range cases {
+		t.Run(current.name, func(t *testing.T) {
+			provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+			server, _ := msp06TestServer(t, provider)
+			router := &issue749TypedRouter{
+				mutationData:  current.data,
+				mutationError: current.terminal,
+			}
+			if err := server.RegisterEEBusV1CommandRouter(router); err != nil {
+				t.Fatal(err)
+			}
+
+			result := msp06Call(t, issue743OperatorHandler(t, server), test.tool, test.arguments)
+			publicError := msp06Map(t, result.envelope["error"], "command error")
+			if code := publicError["code"]; code != string(current.wantCode) {
+				t.Fatalf("mutation get error = %q, want %q; envelope=%#v",
+					code, current.wantCode, result.envelope)
+			}
+			if result.envelope["data"] != nil {
+				t.Fatalf("mutation get error published data: %#v", result.envelope["data"])
+			}
+			assertIssue749PreRuntimeFailure(t, result.envelope, false)
+			if current.wantCode == eebusraw.ErrorCodeV1NotFound &&
+				(publicError["message"] != notFound.Message ||
+					publicError["source_layer"] != string(eebusV1SourceLayerGatewayRouter)) {
+				t.Fatalf("actionable not_found was not preserved: %#v", publicError)
+			}
+		})
+	}
+}
+
 func TestIssue749ZeroDataRouterErrorValidatesOpaqueDetails(t *testing.T) {
 	opaqueValue, err := eebusraw.NewTypedValueV1(map[string]any{"status": "opaque"})
 	if err != nil {

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -445,23 +445,24 @@ type SemanticProvider interface {
 }
 
 type Server struct {
-	registry          Registry
-	invoker           Invoker
-	statusProvider    StatusProvider
-	bus               BusObservabilityProvider
-	watch             WatchSummaryProvider
-	semantic          SemanticProvider
-	scheduleWriter    ScheduleWriter
-	configWriter      ConfigWriter
-	rpcSource         byte
-	rpcSourceAdmitted bool
-	rpcSourceProvider func() (byte, bool)
-	idempotencyMu     sync.Mutex
-	idempotency       map[string]idempotencyEntry
-	snapshotMu        sync.RWMutex
-	snapshots         map[string]snapshotState
-	eebusV1Mu         sync.RWMutex
-	eebusV1           *eebusV1Runtime
+	registry             Registry
+	invoker              Invoker
+	statusProvider       StatusProvider
+	bus                  BusObservabilityProvider
+	watch                WatchSummaryProvider
+	semantic             SemanticProvider
+	scheduleWriter       ScheduleWriter
+	configWriter         ConfigWriter
+	rpcSource            byte
+	rpcSourceAdmitted    bool
+	rpcSourceProvider    func() (byte, bool)
+	idempotencyMu        sync.Mutex
+	idempotency          map[string]idempotencyEntry
+	snapshotMu           sync.RWMutex
+	snapshots            map[string]snapshotState
+	eebusV1Mu            sync.RWMutex
+	eebusV1              *eebusV1Runtime
+	eebusV1CommandRouter EEBusV1CommandRouter
 
 	tools []Tool
 
@@ -1118,6 +1119,9 @@ func (s *Server) hasToolNamed(name string) bool {
 	if s == nil {
 		return false
 	}
+	if _, ok := eebusV1CommandSpecForName(name); ok {
+		return true
+	}
 	for _, tool := range s.tools {
 		if tool.Name == name {
 			return true
@@ -1302,7 +1306,7 @@ func (s *Server) dispatch(ctx context.Context, method string, params json.RawMes
 	case "initialize":
 		return s.handleInitialize(params)
 	case "tools/list":
-		return s.handleToolsList()
+		return s.handleToolsList(ctx)
 	case "tools/call":
 		return s.handleToolsCall(ctx, params)
 	case "ping":
@@ -1338,9 +1342,18 @@ func (s *Server) handleInitialize(params json.RawMessage) (any, *rpcError) {
 	}, nil
 }
 
-func (s *Server) handleToolsList() (any, *rpcError) {
+func (s *Server) handleToolsList(ctx context.Context) (any, *rpcError) {
+	tools := s.tools
+	if eebusV1BoundaryFromContext(ctx) == eebusV1OperatorBoundary {
+		s.eebusV1Mu.RLock()
+		registered := !eebusV1NilCommandRouter(s.eebusV1CommandRouter)
+		s.eebusV1Mu.RUnlock()
+		if registered {
+			tools = append(append([]Tool(nil), tools...), eebusV1CommandTools()...)
+		}
+	}
 	return map[string]any{
-		"tools": s.tools,
+		"tools": tools,
 	}, nil
 }
 
@@ -1349,16 +1362,36 @@ type callToolParams struct {
 	Arguments map[string]any `json:"arguments"`
 }
 
+type rawCallToolParams struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
 func (s *Server) handleToolsCall(ctx context.Context, params json.RawMessage) (any, *rpcError) {
+	hasDuplicateKeys := eebusV1JSONHasDuplicateKeys(params)
+	var rawCall rawCallToolParams
+	if err := json.Unmarshal(params, &rawCall); err != nil {
+		return nil, rpcErrorInvalidParams("tools/call params invalid")
+	}
+	if rawCall.Name == "" {
+		return nil, rpcErrorInvalidParams("tools/call missing name")
+	}
+	if !s.hasToolNamed(rawCall.Name) {
+		return nil, rpcErrorInvalidParams(fmt.Sprintf("unknown tool %q", rawCall.Name))
+	}
+	if spec, ok := eebusV1CommandSpecForName(rawCall.Name); ok {
+		if hasDuplicateKeys {
+			return eebusV1MalformedCommandResult(spec), nil
+		}
+		return s.handleEEBusV1CommandRawCall(ctx, spec, rawCall.Arguments), nil
+	}
+	if hasDuplicateKeys {
+		return nil, rpcErrorInvalidParams("tools/call params contain duplicate object keys")
+	}
+
 	var call callToolParams
 	if err := json.Unmarshal(params, &call); err != nil {
 		return nil, rpcErrorInvalidParams("tools/call params invalid")
-	}
-	if call.Name == "" {
-		return nil, rpcErrorInvalidParams("tools/call missing name")
-	}
-	if !s.hasToolNamed(call.Name) {
-		return nil, rpcErrorInvalidParams(fmt.Sprintf("unknown tool %q", call.Name))
 	}
 
 	if result, handled := s.handleEbusStandardCall(call.Name, call.Arguments); handled {

--- a/mcp/tool_classification_test.go
+++ b/mcp/tool_classification_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/vaillant/b503session"
 	estd "github.com/Project-Helianthus/helianthus-ebusgateway/mcp/ebus_standard"
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+	"github.com/Project-Helianthus/helianthus-eebusreg/eebusraw"
 )
 
 type toolClass string
@@ -55,6 +56,13 @@ func toolClassificationPolicy() map[string]toolClass {
 		estd.ToolCommandsList:            toolClassCoreStable,
 		estd.ToolCommandGet:              toolClassCoreStable,
 		estd.ToolDecode:                  toolClassCoreStable,
+
+		// Owner-only raw eeBUS command surface (execution-plans#71).
+		string(eebusraw.ToolV1FeaturesGet):       toolClassCoreStable,
+		string(eebusraw.ToolV1FeaturesDataGet):   toolClassCoreStable,
+		string(eebusraw.ToolV1FeaturesDataSet):   toolClassCoreStable,
+		string(eebusraw.ToolV1MutationsGet):      toolClassCoreStable,
+		string(eebusraw.ToolV1MutationsRollback): toolClassCoreStable,
 		// Vaillant B503 surface (M2a_GATEWAY_MCP / execution-plans#19).
 		// Provider-scoped namespace parallel to ebus_standard; tools surface
 		// a dedicated capability signal (meta.capabilities.vaillant_b503).
@@ -98,13 +106,14 @@ func TestToolClassificationPolicy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewServer error = %v", err)
 	}
-	// Install B503 tools so the classification policy check covers them too
-	// (production wiring does this in cmd/gateway/main.go). Without this
-	// explicit registration here, the test would only check the default
-	// NewServer inventory and leave ebus.v1.vaillant.* without CI coverage.
+	// Install production-wired dynamic tools so the policy check covers the
+	// registered operator inventory, not only the default NewServer tools.
 	testInstallB503ForClassification(server)
+	if err := server.RegisterEEBusV1CommandRouter(&issue749TypedRouter{}); err != nil {
+		t.Fatalf("RegisterEEBusV1CommandRouter error = %v", err)
+	}
 
-	res := doRPC(t, server.Handler(), rpcRequest{JSONRPC: "2.0", ID: 1, Method: "tools/list", Params: nil})
+	res := doRPC(t, issue743OperatorHandler(t, server), rpcRequest{JSONRPC: "2.0", ID: 1, Method: "tools/list", Params: nil})
 	if res.Error != nil {
 		t.Fatalf("tools/list error = %+v", res.Error)
 	}


### PR DESCRIPTION
## Summary
- register the exact five additive M6.25 command tools while preserving the public nine-tool and owner fourteen-tool inventories
- decode duplicate-safe closed JSON and validate all request/result DTOs through `helianthus-eebusreg v0.1.19`
- keep public callers read-only/zero-contact and expose raw command tools only on the owner `AF_UNIX` endpoint
- bind envelopes to auth scope, tool, runtime, request, contract, raw tier and deterministic data hash
- reject secret input before dispatch and validate router terminals, batch runtimes, typed-nil providers, and tools/list schemas fail-closed
- add no v2, aliases, `candidate_ref`, GraphQL, Portal, HA, `ebus.v1`, or semantic-registry exposure

## Strict TDD
- RED: `a307064c6ca5ed8b306fe781c12fd87b6a0e1a03`, hosted run `30383720543` / test job `90357637564`
- GREEN: `36eadeda052b1cce101b5a1da1dddae9007845dd`

## Gates
- canonical docs: Project-Helianthus/helianthus-docs-eebus#83 (`f9b422351331f10e13f4c35bb8f1d4d83d97165e`)
- validator dependency: `helianthus-eebusreg v0.1.19`, merge `19874f0ebd57be7d1cf3ab9b7ee7aaac175a2dd9`, tag object `debc7e0dbf9c344861945860b0a772da1e44d934`
- local CI: full race, vet/build, 185 Python tests, lint, and explicit no-eBUS-transport-impact owner gate reasons pass
- focused closure review findings repaired and focused race green
- no live write until MSP-0625-LAB

Tracks Project-Helianthus/helianthus-execution-plans#58. Closes #749.
