### PR TITLE
chore(eebus): pin eebusreg v0.1.20

### DIFF
--- a/cmd/gateway/eebus_operator_boundary_red_test.go
+++ b/cmd/gateway/eebus_operator_boundary_red_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 )
 
-func TestIssue749DependencyClosurePinsEEBusregV0119(t *testing.T) {
+func TestIssue751DependencyClosurePinsEEBusregV0120(t *testing.T) {
 	goMod, err := os.Open("../../go.mod")
 	if err != nil {
 		t.Fatal(err)
@@ -33,8 +33,8 @@ func TestIssue749DependencyClosurePinsEEBusregV0119(t *testing.T) {
 	if err := scanner.Err(); err != nil {
 		t.Fatal(err)
 	}
-	if len(versions) != 1 || versions[0] != "v0.1.19" {
-		t.Fatalf("%s versions = %v, want exactly [v0.1.19]", module, versions)
+	if len(versions) != 1 || versions[0] != "v0.1.20" {
+		t.Fatalf("%s versions = %v, want exactly [v0.1.20]", module, versions)
 	}
 }
 

--- a/eebusreg_v0114_contract_test.go
+++ b/eebusreg_v0114_contract_test.go
@@ -22,7 +22,7 @@ const (
 	spinegoModule  = "github.com/Project-Helianthus/helianthus-spine-go"
 )
 
-func TestEEBusregV0119ModuleClosure(t *testing.T) {
+func TestEEBusregV0120ModuleClosure(t *testing.T) {
 	contents, err := os.ReadFile("go.mod")
 	if err != nil {
 		t.Fatalf("read go.mod: %v", err)
@@ -36,7 +36,7 @@ func TestEEBusregV0119ModuleClosure(t *testing.T) {
 	}
 
 	want := map[string]string{
-		eebusregModule: "v0.1.19",
+		eebusregModule: "v0.1.20",
 		eebusgoModule:  "v0.7.1-helianthus.11",
 		shipgoModule:   "v0.6.1-helianthus.9",
 		spinegoModule:  "v0.7.1-helianthus.7",

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260521144203-f9919f4b1007
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2
-	github.com/Project-Helianthus/helianthus-eebusreg v0.1.19
+	github.com/Project-Helianthus/helianthus-eebusreg v0.1.20
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.11 h1:LHakAL
 github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.11/go.mod h1:2lvj0o5lhqdif9khZQkIA9bCGEQCcSfWQ+EIjk78j14=
 github.com/Project-Helianthus/helianthus-eebusreg v0.1.19 h1:O5Fjb97D6AMk/OJl4ssPKUZ7Ww9Fn/mRWiXinYLHvjI=
 github.com/Project-Helianthus/helianthus-eebusreg v0.1.19/go.mod h1:1kTJXsmP7SLQA4XGyIxF6CLt/Hd3h1AkZHl4a29X0No=
+github.com/Project-Helianthus/helianthus-eebusreg v0.1.20 h1:up+VToeM0aXuutJG10XezUrJ9mZLihmdEVTGWk6go7g=
+github.com/Project-Helianthus/helianthus-eebusreg v0.1.20/go.mod h1:1kTJXsmP7SLQA4XGyIxF6CLt/Hd3h1AkZHl4a29X0No=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.9 h1:oaM8JhTHWmDldVPmdJrTOFU3ZpOwEgPpEMUil51cDac=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.9/go.mod h1:qPqQTDqmPjyOJCr0JMNjhSC1XW1k3h5P/EZqRGy80Vs=
 github.com/Project-Helianthus/helianthus-spine-go v0.7.1-helianthus.7 h1:TYoM9+9qgf1MAytCeYIt9OphbaXvSN7KtbabGMZBYuw=


### PR DESCRIPTION
## Summary
- pin `helianthus-eebusreg v0.1.20`
- update the two dependency-closure assertions
- preserve the single unreleased `eebus.v1.*` contract with no aliases or runtime code changes

## Validation
- `GOWORK=off go test ./cmd/gateway -run 'TestIssue751DependencyClosurePinsEEBusregV0120|TestIssue743' -count=1`\n- `GOWORK=off go test . -run TestEEBusregV0120ModuleClosure -count=1`\n- `GOWORK=off go test ./internal/eebuscommand ./mcp -run 'EEBus|Issue749|Issue751' -count=1`\n- `./scripts/ci_local.sh`\n\nAll passed. Transport and passive-smoke gates were correctly not triggered because this PR changes only the published dependency pin and its closure tests.\n\nCloses #751.\nTracks Project-Helianthus/helianthus-execution-plans#58.\nDepends on Project-Helianthus/helianthus-eebusreg#90 and Project-Helianthus/helianthus-docs-eebus#85.