### PR TITLE
M6.25 LAB: load owner-only mutation profile

### DIFF
--- a/cmd/gateway/eebus_mutation_lab_profile.go
+++ b/cmd/gateway/eebus_mutation_lab_profile.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+
+	"github.com/Project-Helianthus/helianthus-eebusreg/eebusraw"
+)
+
+const eebusMutationLabProfileBasename = "mutation-lab-profile-v1.json"
+
+var errEEBusMutationLabProfileLoad = errors.New("eeBUS mutation lab profile load failed")
+
+func loadEEBusMutationLabProfile(
+	stateRoot string,
+) (*eebusraw.MutationLabProfileV1, error) {
+	raw, present, err := readEEBusMutationLabProfileFile(stateRoot)
+	if err != nil {
+		return nil, errEEBusMutationLabProfileLoad
+	}
+	if !present {
+		return nil, nil
+	}
+	defer clear(raw)
+
+	profile, err := decodeEEBusMutationLabProfile(raw)
+	if err != nil {
+		return nil, errEEBusMutationLabProfileLoad
+	}
+	cloned := profile.Clone()
+	return &cloned, nil
+}
+
+func decodeEEBusMutationLabProfile(
+	raw []byte,
+) (eebusraw.MutationLabProfileV1, error) {
+	if err := validateSingleEEBusMutationLabJSONObject(raw); err != nil {
+		return eebusraw.MutationLabProfileV1{}, err
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	var profile eebusraw.MutationLabProfileV1
+	if err := decoder.Decode(&profile); err != nil {
+		return eebusraw.MutationLabProfileV1{}, err
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return eebusraw.MutationLabProfileV1{}, errors.New("profile JSON has trailing content")
+	}
+	if terminal := eebusraw.ValidateMutationLabProfileV1(profile); terminal != nil {
+		return eebusraw.MutationLabProfileV1{}, errors.New("profile validation failed")
+	}
+	return profile, nil
+}
+
+func validateSingleEEBusMutationLabJSONObject(raw []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delimiter, ok := token.(json.Delim)
+	if !ok || delimiter != '{' {
+		return errors.New("profile JSON root is not an object")
+	}
+	if err := walkEEBusMutationLabJSONObject(decoder); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return errors.New("profile JSON has trailing content")
+	}
+	return nil
+}
+
+func walkEEBusMutationLabJSONValue(decoder *json.Decoder) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delimiter, ok := token.(json.Delim)
+	if !ok {
+		return nil
+	}
+	switch delimiter {
+	case '{':
+		return walkEEBusMutationLabJSONObject(decoder)
+	case '[':
+		for decoder.More() {
+			if err := walkEEBusMutationLabJSONValue(decoder); err != nil {
+				return err
+			}
+		}
+		closing, err := decoder.Token()
+		if err != nil || closing != json.Delim(']') {
+			return errors.New("profile JSON array is unterminated")
+		}
+		return nil
+	default:
+		return errors.New("profile JSON has an unexpected delimiter")
+	}
+}
+
+func walkEEBusMutationLabJSONObject(decoder *json.Decoder) error {
+	seen := make(map[string]struct{})
+	for decoder.More() {
+		rawKey, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		key, ok := rawKey.(string)
+		if !ok {
+			return errors.New("profile JSON object key is invalid")
+		}
+		if _, duplicate := seen[key]; duplicate {
+			return errors.New("profile JSON object key is duplicated")
+		}
+		seen[key] = struct{}{}
+		if err := walkEEBusMutationLabJSONValue(decoder); err != nil {
+			return err
+		}
+	}
+	closing, err := decoder.Token()
+	if err != nil || closing != json.Delim('}') {
+		return errors.New("profile JSON object is unterminated")
+	}
+	return nil
+}

--- a/cmd/gateway/eebus_mutation_lab_profile.go
+++ b/cmd/gateway/eebus_mutation_lab_profile.go
@@ -13,6 +13,32 @@ const eebusMutationLabProfileBasename = "mutation-lab-profile-v1.json"
 
 var errEEBusMutationLabProfileLoad = errors.New("eeBUS mutation lab profile load failed")
 
+type eebusMutationLabJSONObjectSchema map[string]eebusMutationLabJSONObjectSchema
+
+var eebusMutationLabProfileJSONSchema = eebusMutationLabJSONObjectSchema{
+	"contract":                  nil,
+	"profile_id":                nil,
+	"target":                    eebusMutationLabTargetJSONSchema,
+	"allowed_value_hashes":      nil,
+	"rollback_value_hash":       nil,
+	"maximum_probe_ttl_seconds": nil,
+	"safety_predicates":         nil,
+	"evidence_hashes":           nil,
+	"expires_at":                nil,
+}
+
+var eebusMutationLabTargetJSONSchema = eebusMutationLabJSONObjectSchema{
+	"remote_ski":      nil,
+	"ship_id":         nil,
+	"device_address":  nil,
+	"entity_address":  nil,
+	"feature_address": nil,
+	"feature_type":    nil,
+	"feature_role":    nil,
+	"function":        nil,
+	"operation":       nil,
+}
+
 func loadEEBusMutationLabProfile(
 	stateRoot string,
 ) (*eebusraw.MutationLabProfileV1, error) {
@@ -66,7 +92,10 @@ func validateSingleEEBusMutationLabJSONObject(raw []byte) error {
 	if !ok || delimiter != '{' {
 		return errors.New("profile JSON root is not an object")
 	}
-	if err := walkEEBusMutationLabJSONObject(decoder); err != nil {
+	if err := walkEEBusMutationLabJSONObject(
+		decoder,
+		eebusMutationLabProfileJSONSchema,
+	); err != nil {
 		return err
 	}
 	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
@@ -75,7 +104,10 @@ func validateSingleEEBusMutationLabJSONObject(raw []byte) error {
 	return nil
 }
 
-func walkEEBusMutationLabJSONValue(decoder *json.Decoder) error {
+func walkEEBusMutationLabJSONValue(
+	decoder *json.Decoder,
+	schema eebusMutationLabJSONObjectSchema,
+) error {
 	token, err := decoder.Token()
 	if err != nil {
 		return err
@@ -86,10 +118,10 @@ func walkEEBusMutationLabJSONValue(decoder *json.Decoder) error {
 	}
 	switch delimiter {
 	case '{':
-		return walkEEBusMutationLabJSONObject(decoder)
+		return walkEEBusMutationLabJSONObject(decoder, schema)
 	case '[':
 		for decoder.More() {
-			if err := walkEEBusMutationLabJSONValue(decoder); err != nil {
+			if err := walkEEBusMutationLabJSONValue(decoder, nil); err != nil {
 				return err
 			}
 		}
@@ -103,7 +135,10 @@ func walkEEBusMutationLabJSONValue(decoder *json.Decoder) error {
 	}
 }
 
-func walkEEBusMutationLabJSONObject(decoder *json.Decoder) error {
+func walkEEBusMutationLabJSONObject(
+	decoder *json.Decoder,
+	schema eebusMutationLabJSONObjectSchema,
+) error {
 	seen := make(map[string]struct{})
 	for decoder.More() {
 		rawKey, err := decoder.Token()
@@ -118,7 +153,11 @@ func walkEEBusMutationLabJSONObject(decoder *json.Decoder) error {
 			return errors.New("profile JSON object key is duplicated")
 		}
 		seen[key] = struct{}{}
-		if err := walkEEBusMutationLabJSONValue(decoder); err != nil {
+		childSchema, allowed := schema[key]
+		if schema != nil && !allowed {
+			return errors.New("profile JSON object key is unknown")
+		}
+		if err := walkEEBusMutationLabJSONValue(decoder, childSchema); err != nil {
 			return err
 		}
 	}

--- a/cmd/gateway/eebus_mutation_lab_profile_linux.go
+++ b/cmd/gateway/eebus_mutation_lab_profile_linux.go
@@ -1,0 +1,166 @@
+//go:build linux
+
+package main
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+const eebusMutationLabProfileMaximumBytes = 65536
+
+type eebusMutationLabFileIdentity struct {
+	device       uint64
+	inode        uint64
+	mode         uint32
+	uid          uint32
+	linkCount    uint64
+	size         int64
+	changeSec    int64
+	changeNsec   int64
+	modifiedSec  int64
+	modifiedNsec int64
+}
+
+func readEEBusMutationLabProfileFile(stateRoot string) ([]byte, bool, error) {
+	rootFD, present, err := openEEBusMutationLabStateRoot(stateRoot)
+	if err != nil || !present {
+		return nil, false, err
+	}
+	defer func() { _ = unix.Close(rootFD) }()
+
+	fd, err := unix.Openat(
+		rootFD,
+		eebusMutationLabProfileBasename,
+		unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW|unix.O_NONBLOCK,
+		0,
+	)
+	if errors.Is(err, unix.ENOENT) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, errEEBusMutationLabProfileLoad
+	}
+	file := os.NewFile(uintptr(fd), eebusMutationLabProfileBasename)
+	if file == nil {
+		_ = unix.Close(fd)
+		return nil, false, errEEBusMutationLabProfileLoad
+	}
+
+	var before unix.Stat_t
+	if err := unix.Fstat(fd, &before); err != nil ||
+		!mutationLabFileMetadataValid(
+			before.Mode,
+			before.Uid,
+			uint64(before.Nlink),
+			before.Size,
+			uint32(os.Geteuid()),
+		) {
+		_ = file.Close()
+		return nil, false, errEEBusMutationLabProfileLoad
+	}
+	beforeIdentity := mutationLabFileIdentity(before)
+
+	raw, readErr := io.ReadAll(io.LimitReader(file, eebusMutationLabProfileMaximumBytes+1))
+	var after unix.Stat_t
+	statErr := unix.Fstat(fd, &after)
+	closeErr := file.Close()
+	if readErr != nil || statErr != nil || closeErr != nil ||
+		len(raw) == 0 || len(raw) > eebusMutationLabProfileMaximumBytes ||
+		int64(len(raw)) != before.Size ||
+		beforeIdentity != mutationLabFileIdentity(after) {
+		clear(raw)
+		return nil, false, errEEBusMutationLabProfileLoad
+	}
+	return raw, true, nil
+}
+
+func openEEBusMutationLabStateRoot(stateRoot string) (int, bool, error) {
+	if stateRoot == "" || !filepath.IsAbs(stateRoot) ||
+		filepath.Clean(stateRoot) != stateRoot ||
+		stateRoot == string(filepath.Separator) {
+		return -1, false, errEEBusMutationLabProfileLoad
+	}
+
+	current, err := unix.Open(
+		string(filepath.Separator),
+		unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+		0,
+	)
+	if err != nil {
+		return -1, false, errEEBusMutationLabProfileLoad
+	}
+	components := strings.Split(
+		strings.TrimPrefix(stateRoot, string(filepath.Separator)),
+		string(filepath.Separator),
+	)
+	for _, component := range components {
+		if component == "" || component == "." || component == ".." {
+			_ = unix.Close(current)
+			return -1, false, errEEBusMutationLabProfileLoad
+		}
+		next, openErr := unix.Openat(
+			current,
+			component,
+			unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+			0,
+		)
+		_ = unix.Close(current)
+		if errors.Is(openErr, unix.ENOENT) {
+			return -1, false, nil
+		}
+		if openErr != nil {
+			return -1, false, errEEBusMutationLabProfileLoad
+		}
+		current = next
+	}
+
+	var stat unix.Stat_t
+	if err := unix.Fstat(current, &stat); err != nil ||
+		!mutationLabRootMetadataValid(stat.Mode, stat.Uid, uint32(os.Geteuid())) {
+		_ = unix.Close(current)
+		return -1, false, errEEBusMutationLabProfileLoad
+	}
+	return current, true, nil
+}
+
+func mutationLabRootMetadataValid(mode, uid, euid uint32) bool {
+	return mode&unix.S_IFMT == unix.S_IFDIR &&
+		mode&0o7777 == 0o700 &&
+		uid == euid
+}
+
+func mutationLabFileMetadataValid(
+	mode uint32,
+	uid uint32,
+	linkCount uint64,
+	size int64,
+	euid uint32,
+) bool {
+	return mode&unix.S_IFMT == unix.S_IFREG &&
+		mode&0o7777 == 0o600 &&
+		uid == euid &&
+		linkCount == 1 &&
+		size >= 1 &&
+		size <= eebusMutationLabProfileMaximumBytes
+}
+
+func mutationLabFileIdentity(stat unix.Stat_t) eebusMutationLabFileIdentity {
+	return eebusMutationLabFileIdentity{
+		device:       uint64(stat.Dev),
+		inode:        stat.Ino,
+		mode:         stat.Mode,
+		uid:          stat.Uid,
+		linkCount:    uint64(stat.Nlink),
+		size:         stat.Size,
+		changeSec:    stat.Ctim.Sec,
+		changeNsec:   stat.Ctim.Nsec,
+		modifiedSec:  stat.Mtim.Sec,
+		modifiedNsec: stat.Mtim.Nsec,
+	}
+}

--- a/cmd/gateway/eebus_mutation_lab_profile_linux_test.go
+++ b/cmd/gateway/eebus_mutation_lab_profile_linux_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestIssue755ValidProfileHandoffIsOneImmutableSnapshot(t *testing.T) {
-	stateRoot := t.TempDir()
+	stateRoot := issue755SecureStateRoot(t)
 	profile := issue755ValidMutationLabProfile(t)
 	expected := issue755CloneProfile(profile)
 	raw := issue755ValidMutationLabProfileJSON(t)
@@ -76,7 +76,7 @@ func TestIssue755RejectsUnsafeRootAndFileBoundariesBeforeFactory(t *testing.T) {
 		{
 			name: "root mode",
 			setup: func(t *testing.T) string {
-				root := t.TempDir()
+				root := issue755SecureStateRoot(t)
 				if err := os.Chmod(root, 0o750); err != nil {
 					t.Fatal(err)
 				}
@@ -119,7 +119,7 @@ func TestIssue755RejectsUnsafeRootAndFileBoundariesBeforeFactory(t *testing.T) {
 		{
 			name: "file symlink",
 			setup: func(t *testing.T) string {
-				root := t.TempDir()
+				root := issue755SecureStateRoot(t)
 				target := filepath.Join(t.TempDir(), "profile.json")
 				if err := os.WriteFile(target, valid, 0o600); err != nil {
 					t.Fatal(err)
@@ -133,7 +133,7 @@ func TestIssue755RejectsUnsafeRootAndFileBoundariesBeforeFactory(t *testing.T) {
 		{
 			name: "nonregular file",
 			setup: func(t *testing.T) string {
-				root := t.TempDir()
+				root := issue755SecureStateRoot(t)
 				if err := os.Mkdir(filepath.Join(root, issue755ProfileBasename), 0o600); err != nil {
 					t.Fatal(err)
 				}
@@ -143,7 +143,7 @@ func TestIssue755RejectsUnsafeRootAndFileBoundariesBeforeFactory(t *testing.T) {
 		{
 			name: "file mode",
 			setup: func(t *testing.T) string {
-				root := t.TempDir()
+				root := issue755SecureStateRoot(t)
 				path := issue755WriteProfile(t, root, valid)
 				if err := os.Chmod(path, 0o640); err != nil {
 					t.Fatal(err)
@@ -154,7 +154,7 @@ func TestIssue755RejectsUnsafeRootAndFileBoundariesBeforeFactory(t *testing.T) {
 		{
 			name: "hardlink",
 			setup: func(t *testing.T) string {
-				root := t.TempDir()
+				root := issue755SecureStateRoot(t)
 				original := filepath.Join(root, "original.json")
 				if err := os.WriteFile(original, valid, 0o600); err != nil {
 					t.Fatal(err)
@@ -228,7 +228,7 @@ func TestIssue755ProfileSizeBoundary(t *testing.T) {
 	}
 
 	t.Run("65536 accepted", func(t *testing.T) {
-		root := t.TempDir()
+		root := issue755SecureStateRoot(t)
 		raw := append(append([]byte(nil), valid...), []byte(strings.Repeat(" ", 65536-len(valid)))...)
 		issue755WriteProfile(t, root, raw)
 		runtime := &msp05bRuntime{}
@@ -254,7 +254,7 @@ func TestIssue755ProfileSizeBoundary(t *testing.T) {
 	})
 
 	t.Run("65537 rejected", func(t *testing.T) {
-		root := t.TempDir()
+		root := issue755SecureStateRoot(t)
 		raw := append(append([]byte(nil), valid...), []byte(strings.Repeat(" ", 65537-len(valid)))...)
 		issue755WriteProfile(t, root, raw)
 		issue755AssertGenericLoadFailure(t, root, "")
@@ -301,7 +301,7 @@ func TestIssue755RejectsMalformedOrInvalidProfileBeforeFactory(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			root := t.TempDir()
+			root := issue755SecureStateRoot(t)
 			issue755WriteProfile(t, root, test.raw)
 			issue755AssertGenericLoadFailure(t, root, "secret-marker")
 		})

--- a/cmd/gateway/eebus_mutation_lab_profile_linux_test.go
+++ b/cmd/gateway/eebus_mutation_lab_profile_linux_test.go
@@ -1,0 +1,313 @@
+//go:build linux
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	eebusruntime "github.com/Project-Helianthus/helianthus-eebusreg"
+	"golang.org/x/sys/unix"
+)
+
+func TestIssue755ValidProfileHandoffIsOneImmutableSnapshot(t *testing.T) {
+	stateRoot := t.TempDir()
+	profile := issue755ValidMutationLabProfile(t)
+	expected := issue755CloneProfile(profile)
+	raw := issue755ValidMutationLabProfileJSON(t)
+	path := issue755WriteProfile(t, stateRoot, raw)
+	runtime := &msp05bRuntime{}
+	factoryCalls := 0
+
+	adapter, err := startEEBusRuntime(
+		context.Background(),
+		issue755EnabledConfig(stateRoot),
+		issue755Resolver,
+		func(got eebusruntime.Config) (eebusruntime.Runtime, error) {
+			factoryCalls++
+			if len(got.MutationLabProfiles) != 1 {
+				t.Fatalf("MutationLabProfiles = %#v; want exactly one", got.MutationLabProfiles)
+			}
+			if !issue755ProfilesEqual(got.MutationLabProfiles[0], expected) {
+				t.Fatalf("loaded profile mismatch: got %#v", got.MutationLabProfiles[0])
+			}
+
+			replacement := issue755CloneProfile(profile)
+			replacement.ProfileID = "replacement-after-load"
+			replacementRaw, marshalErr := jsonMarshalIssue755(replacement)
+			if marshalErr != nil {
+				t.Fatal(marshalErr)
+			}
+			if writeErr := os.WriteFile(path, replacementRaw, 0o600); writeErr != nil {
+				t.Fatal(writeErr)
+			}
+			if !issue755ProfilesEqual(got.MutationLabProfiles[0], expected) {
+				t.Fatal("runtime config profile changed after backing file replacement")
+			}
+			return runtime, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("start with valid profile: %v", err)
+	}
+	if adapter == nil {
+		t.Fatal("adapter = nil; want started runtime")
+	}
+	t.Cleanup(func() {
+		if err := adapter.Shutdown(); err != nil {
+			t.Error(err)
+		}
+	})
+	if factoryCalls != 1 || runtime.startCalls != 1 {
+		t.Fatalf("calls factory=%d start=%d; want one each", factoryCalls, runtime.startCalls)
+	}
+}
+
+func TestIssue755RejectsUnsafeRootAndFileBoundariesBeforeFactory(t *testing.T) {
+	valid := issue755ValidMutationLabProfileJSON(t)
+	tests := []struct {
+		name  string
+		setup func(*testing.T) string
+	}{
+		{
+			name: "root mode",
+			setup: func(t *testing.T) string {
+				root := t.TempDir()
+				if err := os.Chmod(root, 0o750); err != nil {
+					t.Fatal(err)
+				}
+				issue755WriteProfile(t, root, valid)
+				return root
+			},
+		},
+		{
+			name: "root symlink",
+			setup: func(t *testing.T) string {
+				parent := t.TempDir()
+				actual := filepath.Join(parent, "actual")
+				if err := os.Mkdir(actual, 0o700); err != nil {
+					t.Fatal(err)
+				}
+				issue755WriteProfile(t, actual, valid)
+				link := filepath.Join(parent, "linked")
+				if err := os.Symlink(actual, link); err != nil {
+					t.Fatal(err)
+				}
+				return link
+			},
+		},
+		{
+			name: "intermediate symlink",
+			setup: func(t *testing.T) string {
+				parent := t.TempDir()
+				actual := filepath.Join(parent, "actual")
+				if err := os.Mkdir(actual, 0o700); err != nil {
+					t.Fatal(err)
+				}
+				issue755WriteProfile(t, actual, valid)
+				link := filepath.Join(parent, "component")
+				if err := os.Symlink(actual, link); err != nil {
+					t.Fatal(err)
+				}
+				return link
+			},
+		},
+		{
+			name: "file symlink",
+			setup: func(t *testing.T) string {
+				root := t.TempDir()
+				target := filepath.Join(t.TempDir(), "profile.json")
+				if err := os.WriteFile(target, valid, 0o600); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(target, filepath.Join(root, issue755ProfileBasename)); err != nil {
+					t.Fatal(err)
+				}
+				return root
+			},
+		},
+		{
+			name: "nonregular file",
+			setup: func(t *testing.T) string {
+				root := t.TempDir()
+				if err := os.Mkdir(filepath.Join(root, issue755ProfileBasename), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				return root
+			},
+		},
+		{
+			name: "file mode",
+			setup: func(t *testing.T) string {
+				root := t.TempDir()
+				path := issue755WriteProfile(t, root, valid)
+				if err := os.Chmod(path, 0o640); err != nil {
+					t.Fatal(err)
+				}
+				return root
+			},
+		},
+		{
+			name: "hardlink",
+			setup: func(t *testing.T) string {
+				root := t.TempDir()
+				original := filepath.Join(root, "original.json")
+				if err := os.WriteFile(original, valid, 0o600); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Link(original, filepath.Join(root, issue755ProfileBasename)); err != nil {
+					t.Fatal(err)
+				}
+				return root
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			issue755AssertGenericLoadFailure(t, test.setup(t), "")
+		})
+	}
+}
+
+func TestIssue755MetadataValidationRejectsOwnerTypeModeLinksAndSize(t *testing.T) {
+	euid := uint32(os.Geteuid())
+	if !mutationLabRootMetadataValid(unix.S_IFDIR|0o700, euid, euid) {
+		t.Fatal("valid root metadata rejected")
+	}
+	for _, test := range []struct {
+		name string
+		mode uint32
+		uid  uint32
+	}{
+		{name: "owner", mode: unix.S_IFDIR | 0o700, uid: euid + 1},
+		{name: "type", mode: unix.S_IFREG | 0o700, uid: euid},
+		{name: "mode", mode: unix.S_IFDIR | 0o750, uid: euid},
+	} {
+		t.Run("root "+test.name, func(t *testing.T) {
+			if mutationLabRootMetadataValid(test.mode, test.uid, euid) {
+				t.Fatal("unsafe root metadata accepted")
+			}
+		})
+	}
+
+	if !mutationLabFileMetadataValid(unix.S_IFREG|0o600, euid, 1, 1, euid) ||
+		!mutationLabFileMetadataValid(unix.S_IFREG|0o600, euid, 1, 65536, euid) {
+		t.Fatal("valid boundary file metadata rejected")
+	}
+	for _, test := range []struct {
+		name  string
+		mode  uint32
+		uid   uint32
+		links uint64
+		size  int64
+	}{
+		{name: "owner", mode: unix.S_IFREG | 0o600, uid: euid + 1, links: 1, size: 1},
+		{name: "type", mode: unix.S_IFDIR | 0o600, uid: euid, links: 1, size: 1},
+		{name: "mode", mode: unix.S_IFREG | 0o640, uid: euid, links: 1, size: 1},
+		{name: "hardlink", mode: unix.S_IFREG | 0o600, uid: euid, links: 2, size: 1},
+		{name: "empty", mode: unix.S_IFREG | 0o600, uid: euid, links: 1, size: 0},
+		{name: "too large", mode: unix.S_IFREG | 0o600, uid: euid, links: 1, size: 65537},
+	} {
+		t.Run("file "+test.name, func(t *testing.T) {
+			if mutationLabFileMetadataValid(test.mode, test.uid, test.links, test.size, euid) {
+				t.Fatal("unsafe file metadata accepted")
+			}
+		})
+	}
+}
+
+func TestIssue755ProfileSizeBoundary(t *testing.T) {
+	valid := issue755ValidMutationLabProfileJSON(t)
+	if len(valid) >= 65536 {
+		t.Fatalf("valid fixture size = %d; want room for boundary padding", len(valid))
+	}
+
+	t.Run("65536 accepted", func(t *testing.T) {
+		root := t.TempDir()
+		raw := append(append([]byte(nil), valid...), []byte(strings.Repeat(" ", 65536-len(valid)))...)
+		issue755WriteProfile(t, root, raw)
+		runtime := &msp05bRuntime{}
+		adapter, err := startEEBusRuntime(
+			context.Background(),
+			issue755EnabledConfig(root),
+			issue755Resolver,
+			func(config eebusruntime.Config) (eebusruntime.Runtime, error) {
+				if len(config.MutationLabProfiles) != 1 {
+					t.Fatalf("profile count = %d, want 1", len(config.MutationLabProfiles))
+				}
+				return runtime, nil
+			},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			if err := adapter.Shutdown(); err != nil {
+				t.Error(err)
+			}
+		})
+	})
+
+	t.Run("65537 rejected", func(t *testing.T) {
+		root := t.TempDir()
+		raw := append(append([]byte(nil), valid...), []byte(strings.Repeat(" ", 65537-len(valid)))...)
+		issue755WriteProfile(t, root, raw)
+		issue755AssertGenericLoadFailure(t, root, "")
+	})
+}
+
+func TestIssue755RejectsMalformedOrInvalidProfileBeforeFactory(t *testing.T) {
+	valid := issue755ValidMutationLabProfileJSON(t)
+	invalidTyped := issue755ValidMutationLabProfile(t)
+	invalidTyped.MaximumProbeTTLSeconds = 0
+	invalidTypedRaw, err := jsonMarshalIssue755(invalidTyped)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name string
+		raw  []byte
+	}{
+		{name: "empty", raw: nil},
+		{name: "null", raw: []byte("null")},
+		{name: "array", raw: []byte("[]")},
+		{name: "multiple objects", raw: append(append([]byte(nil), valid...), []byte("{}")...)},
+		{name: "nested duplicate", raw: []byte(strings.Replace(
+			string(valid),
+			`"entity_address":[1]`,
+			`"entity_address":[1],"entity_address":[2]`,
+			1,
+		))},
+		{name: "top-level duplicate", raw: []byte(strings.Replace(
+			string(valid),
+			`"profile_id":"issue755-lab-profile"`,
+			`"profile_id":"duplicate-marker","profile_id":"issue755-lab-profile"`,
+			1,
+		))},
+		{name: "unknown field", raw: []byte(strings.Replace(
+			string(valid),
+			`"profile_id":"issue755-lab-profile"`,
+			`"profile_id":"issue755-lab-profile","unknown_marker":"secret-marker"`,
+			1,
+		))},
+		{name: "trailing", raw: append(append([]byte(nil), valid...), []byte("secret-marker")...)},
+		{name: "invalid typed profile", raw: invalidTypedRaw},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			issue755WriteProfile(t, root, test.raw)
+			issue755AssertGenericLoadFailure(t, root, "secret-marker")
+		})
+	}
+}
+
+func jsonMarshalIssue755(value any) ([]byte, error) {
+	return json.Marshal(value)
+}

--- a/cmd/gateway/eebus_mutation_lab_profile_linux_test.go
+++ b/cmd/gateway/eebus_mutation_lab_profile_linux_test.go
@@ -5,8 +5,10 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -17,7 +19,7 @@ import (
 func TestIssue755ValidProfileHandoffIsOneImmutableSnapshot(t *testing.T) {
 	stateRoot := issue755SecureStateRoot(t)
 	profile := issue755ValidMutationLabProfile(t)
-	expected := issue755CloneProfile(profile)
+	expected := profile.Clone()
 	raw := issue755ValidMutationLabProfileJSON(t)
 	path := issue755WriteProfile(t, stateRoot, raw)
 	runtime := &msp05bRuntime{}
@@ -32,11 +34,11 @@ func TestIssue755ValidProfileHandoffIsOneImmutableSnapshot(t *testing.T) {
 			if len(got.MutationLabProfiles) != 1 {
 				t.Fatalf("MutationLabProfiles = %#v; want exactly one", got.MutationLabProfiles)
 			}
-			if !issue755ProfilesEqual(got.MutationLabProfiles[0], expected) {
+			if !reflect.DeepEqual(got.MutationLabProfiles[0], expected) {
 				t.Fatalf("loaded profile mismatch: got %#v", got.MutationLabProfiles[0])
 			}
 
-			replacement := issue755CloneProfile(profile)
+			replacement := profile.Clone()
 			replacement.ProfileID = "replacement-after-load"
 			replacementRaw, marshalErr := jsonMarshalIssue755(replacement)
 			if marshalErr != nil {
@@ -45,7 +47,7 @@ func TestIssue755ValidProfileHandoffIsOneImmutableSnapshot(t *testing.T) {
 			if writeErr := os.WriteFile(path, replacementRaw, 0o600); writeErr != nil {
 				t.Fatal(writeErr)
 			}
-			if !issue755ProfilesEqual(got.MutationLabProfiles[0], expected) {
+			if !reflect.DeepEqual(got.MutationLabProfiles[0], expected) {
 				t.Fatal("runtime config profile changed after backing file replacement")
 			}
 			return runtime, nil
@@ -310,4 +312,41 @@ func TestIssue755RejectsMalformedOrInvalidProfileBeforeFactory(t *testing.T) {
 
 func jsonMarshalIssue755(value any) ([]byte, error) {
 	return json.Marshal(value)
+}
+
+func issue755AssertGenericLoadFailure(
+	t *testing.T,
+	stateRoot string,
+	contentMarker string,
+) {
+	t.Helper()
+	runtime := &msp05bRuntime{}
+	factoryCalls := 0
+	adapter, err := startEEBusRuntime(
+		context.Background(),
+		issue755EnabledConfig(stateRoot),
+		issue755Resolver,
+		func(eebusruntime.Config) (eebusruntime.Runtime, error) {
+			factoryCalls++
+			return runtime, nil
+		},
+	)
+	if adapter != nil || err == nil {
+		t.Fatalf("invalid profile startup = (%v, %v); want nil adapter and error", adapter, err)
+	}
+	if factoryCalls != 0 || runtime.startCalls != 0 {
+		t.Fatalf("invalid profile calls factory=%d start=%d; want zero", factoryCalls, runtime.startCalls)
+	}
+	const generic = "eeBUS mutation lab profile load failed"
+	if !strings.Contains(err.Error(), generic) {
+		t.Fatalf("startup error = %q; want generic profile load failure", err)
+	}
+	for _, secret := range []string{stateRoot, contentMarker, issue755RemoteSKI} {
+		if secret != "" && strings.Contains(err.Error(), secret) {
+			t.Fatalf("startup error leaked protected profile detail %q: %v", secret, err)
+		}
+	}
+	if errors.Unwrap(errors.Unwrap(err)) != nil {
+		t.Fatalf("startup error exposes an implementation cause chain: %v", err)
+	}
 }

--- a/cmd/gateway/eebus_mutation_lab_profile_linux_test.go
+++ b/cmd/gateway/eebus_mutation_lab_profile_linux_test.go
@@ -297,6 +297,30 @@ func TestIssue755RejectsMalformedOrInvalidProfileBeforeFactory(t *testing.T) {
 			`"profile_id":"issue755-lab-profile","unknown_marker":"secret-marker"`,
 			1,
 		))},
+		{name: "root case alias", raw: []byte(strings.Replace(
+			string(valid),
+			`"profile_id":"issue755-lab-profile"`,
+			`"PROFILE_ID":"issue755-lab-profile"`,
+			1,
+		))},
+		{name: "root canonical and case alias collision", raw: []byte(strings.Replace(
+			string(valid),
+			`"profile_id":"issue755-lab-profile"`,
+			`"profile_id":"issue755-lab-profile","PROFILE_ID":"issue755-lab-profile"`,
+			1,
+		))},
+		{name: "target case alias", raw: []byte(strings.Replace(
+			string(valid),
+			`"remote_ski":"`+issue755RemoteSKI+`"`,
+			`"REMOTE_SKI":"`+issue755RemoteSKI+`"`,
+			1,
+		))},
+		{name: "target canonical and case alias collision", raw: []byte(strings.Replace(
+			string(valid),
+			`"remote_ski":"`+issue755RemoteSKI+`"`,
+			`"remote_ski":"`+issue755RemoteSKI+`","REMOTE_SKI":"`+issue755RemoteSKI+`"`,
+			1,
+		))},
 		{name: "trailing", raw: append(append([]byte(nil), valid...), []byte("secret-marker")...)},
 		{name: "invalid typed profile", raw: invalidTypedRaw},
 	}

--- a/cmd/gateway/eebus_mutation_lab_profile_test.go
+++ b/cmd/gateway/eebus_mutation_lab_profile_test.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
+	eebusruntime "github.com/Project-Helianthus/helianthus-eebusreg"
+	"github.com/Project-Helianthus/helianthus-eebusreg/eebusraw"
+)
+
+const issue755ProfileBasename = "mutation-lab-profile-v1.json"
+
+func TestIssue755AbsentMutationLabProfileLeavesRuntimeConfigNil(t *testing.T) {
+	tests := []struct {
+		name      string
+		stateRoot func(*testing.T) string
+	}{
+		{
+			name: "root absent",
+			stateRoot: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), "absent")
+			},
+		},
+		{
+			name: "file absent",
+			stateRoot: func(t *testing.T) string {
+				return t.TempDir()
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := issue755EnabledConfig(test.stateRoot(t))
+			runtime := &msp05bRuntime{}
+			factoryCalls := 0
+
+			adapter, err := startEEBusRuntime(
+				context.Background(),
+				cfg,
+				issue755Resolver,
+				func(got eebusruntime.Config) (eebusruntime.Runtime, error) {
+					factoryCalls++
+					if got.MutationLabProfiles != nil {
+						t.Fatalf("MutationLabProfiles = %#v; want nil when profile is absent", got.MutationLabProfiles)
+					}
+					return runtime, nil
+				},
+			)
+			if err != nil {
+				t.Fatalf("start with absent profile: %v", err)
+			}
+			if adapter == nil {
+				t.Fatal("adapter = nil; want started runtime")
+			}
+			t.Cleanup(func() {
+				if err := adapter.Shutdown(); err != nil {
+					t.Error(err)
+				}
+			})
+			if factoryCalls != 1 || runtime.startCalls != 1 {
+				t.Fatalf("calls factory=%d start=%d; want one each", factoryCalls, runtime.startCalls)
+			}
+		})
+	}
+}
+
+func TestIssue755LoaderProductionSurfaceIsFixedAndNonLeaking(t *testing.T) {
+	files, err := filepath.Glob("eebus_mutation_lab_profile*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var production []string
+	var source strings.Builder
+	for _, name := range files {
+		if strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		production = append(production, name)
+		raw, readErr := os.ReadFile(name)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		source.Write(raw)
+		source.WriteByte('\n')
+	}
+	if len(production) == 0 {
+		t.Fatal("mutation lab profile loader production files are missing")
+	}
+
+	text := source.String()
+	if count := strings.Count(text, issue755ProfileBasename); count != 1 {
+		t.Fatalf("fixed profile basename occurrences = %d, want exactly one", count)
+	}
+	for _, forbidden := range []string{
+		"os.Getenv",
+		"os.LookupEnv",
+		"os.Args",
+		"flag.",
+		"log.",
+		"slog.",
+		"candidate" + "_ref",
+		"mutation-lab-profile-v" + "2",
+		"mutation_lab_profile_v" + "2",
+		"legacy",
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("loader production source contains forbidden surface %q", forbidden)
+		}
+	}
+}
+
+func issue755EnabledConfig(stateRoot string) ebusgateway.EEBusConfig {
+	cfg := msp05bEnabledConfig()
+	cfg.StateRoot = stateRoot
+	cfg.RemoteSKIAllowlist = []string{issue755RemoteSKI}
+	return cfg
+}
+
+func issue755Resolver(string) ([]netip.Addr, error) {
+	return []netip.Addr{netip.MustParseAddr("192.0.2.42")}, nil
+}
+
+const issue755RemoteSKI = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+func issue755ValidMutationLabProfile(t *testing.T) eebusraw.MutationLabProfileV1 {
+	t.Helper()
+	requested, err := eebusraw.NewTypedValueV1(int64(21))
+	if err != nil {
+		t.Fatal(err)
+	}
+	requestedHash, err := requested.ComputeHash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := eebusraw.NewTypedValueV1(int64(20))
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeHash, err := before.ComputeHash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return eebusraw.MutationLabProfileV1{
+		Contract:  eebusraw.MutationLabProfileContractV1,
+		ProfileID: "issue755-lab-profile",
+		Target: eebusraw.FeatureTargetV1{
+			RemoteSKI:      issue755RemoteSKI,
+			SHIPID:         "issue755-ship",
+			DeviceAddress:  "issue755-device",
+			EntityAddress:  []uint64{1},
+			FeatureAddress: 7,
+			FeatureType:    "measurement",
+			FeatureRole:    eebusraw.FeatureRoleV1Server,
+			Function:       "measurementListData",
+			Operation:      eebusraw.OperationV1Write,
+		},
+		AllowedValueHashes:     []eebusraw.HashV1{requestedHash},
+		RollbackValueHash:      beforeHash,
+		MaximumProbeTTLSeconds: 60,
+		SafetyPredicates: []string{
+			"exact-target-capability-current",
+			"rollback-representable",
+		},
+		EvidenceHashes: []eebusraw.HashV1{
+			eebusraw.HashV1("sha256:" + strings.Repeat("3", 64)),
+		},
+		ExpiresAt: time.Unix(1_900_000_000, 0).UTC(),
+	}
+}
+
+func issue755ValidMutationLabProfileJSON(t *testing.T) []byte {
+	t.Helper()
+	raw, err := json.Marshal(issue755ValidMutationLabProfile(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func issue755WriteProfile(t *testing.T, stateRoot string, raw []byte) string {
+	t.Helper()
+	path := filepath.Join(stateRoot, issue755ProfileBasename)
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func issue755AssertGenericLoadFailure(
+	t *testing.T,
+	stateRoot string,
+	contentMarker string,
+) {
+	t.Helper()
+	runtime := &msp05bRuntime{}
+	factoryCalls := 0
+	adapter, err := startEEBusRuntime(
+		context.Background(),
+		issue755EnabledConfig(stateRoot),
+		issue755Resolver,
+		func(eebusruntime.Config) (eebusruntime.Runtime, error) {
+			factoryCalls++
+			return runtime, nil
+		},
+	)
+	if adapter != nil || err == nil {
+		t.Fatalf("invalid profile startup = (%v, %v); want nil adapter and error", adapter, err)
+	}
+	if factoryCalls != 0 || runtime.startCalls != 0 {
+		t.Fatalf("invalid profile calls factory=%d start=%d; want zero", factoryCalls, runtime.startCalls)
+	}
+	const generic = "eeBUS mutation lab profile load failed"
+	if !strings.Contains(err.Error(), generic) {
+		t.Fatalf("startup error = %q; want generic profile load failure", err)
+	}
+	for _, secret := range []string{stateRoot, contentMarker, issue755RemoteSKI} {
+		if secret != "" && strings.Contains(err.Error(), secret) {
+			t.Fatalf("startup error leaked protected profile detail %q: %v", secret, err)
+		}
+	}
+	if errors.Unwrap(errors.Unwrap(err)) != nil {
+		t.Fatalf("startup error exposes an implementation cause chain: %v", err)
+	}
+}
+
+func issue755CloneProfile(profile eebusraw.MutationLabProfileV1) eebusraw.MutationLabProfileV1 {
+	return profile.Clone()
+}
+
+func issue755ProfilesEqual(left, right eebusraw.MutationLabProfileV1) bool {
+	return reflect.DeepEqual(left, right)
+}

--- a/cmd/gateway/eebus_mutation_lab_profile_test.go
+++ b/cmd/gateway/eebus_mutation_lab_profile_test.go
@@ -3,11 +3,9 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"net/netip"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -206,49 +204,4 @@ func issue755SecureStateRoot(t *testing.T) string {
 		t.Fatal(err)
 	}
 	return root
-}
-
-func issue755AssertGenericLoadFailure(
-	t *testing.T,
-	stateRoot string,
-	contentMarker string,
-) {
-	t.Helper()
-	runtime := &msp05bRuntime{}
-	factoryCalls := 0
-	adapter, err := startEEBusRuntime(
-		context.Background(),
-		issue755EnabledConfig(stateRoot),
-		issue755Resolver,
-		func(eebusruntime.Config) (eebusruntime.Runtime, error) {
-			factoryCalls++
-			return runtime, nil
-		},
-	)
-	if adapter != nil || err == nil {
-		t.Fatalf("invalid profile startup = (%v, %v); want nil adapter and error", adapter, err)
-	}
-	if factoryCalls != 0 || runtime.startCalls != 0 {
-		t.Fatalf("invalid profile calls factory=%d start=%d; want zero", factoryCalls, runtime.startCalls)
-	}
-	const generic = "eeBUS mutation lab profile load failed"
-	if !strings.Contains(err.Error(), generic) {
-		t.Fatalf("startup error = %q; want generic profile load failure", err)
-	}
-	for _, secret := range []string{stateRoot, contentMarker, issue755RemoteSKI} {
-		if secret != "" && strings.Contains(err.Error(), secret) {
-			t.Fatalf("startup error leaked protected profile detail %q: %v", secret, err)
-		}
-	}
-	if errors.Unwrap(errors.Unwrap(err)) != nil {
-		t.Fatalf("startup error exposes an implementation cause chain: %v", err)
-	}
-}
-
-func issue755CloneProfile(profile eebusraw.MutationLabProfileV1) eebusraw.MutationLabProfileV1 {
-	return profile.Clone()
-}
-
-func issue755ProfilesEqual(left, right eebusraw.MutationLabProfileV1) bool {
-	return reflect.DeepEqual(left, right)
 }

--- a/cmd/gateway/eebus_mutation_lab_profile_test.go
+++ b/cmd/gateway/eebus_mutation_lab_profile_test.go
@@ -33,7 +33,7 @@ func TestIssue755AbsentMutationLabProfileLeavesRuntimeConfigNil(t *testing.T) {
 		{
 			name: "file absent",
 			stateRoot: func(t *testing.T) string {
-				return t.TempDir()
+				return issue755SecureStateRoot(t)
 			},
 		},
 	}
@@ -197,6 +197,15 @@ func issue755WriteProfile(t *testing.T, stateRoot string, raw []byte) string {
 		t.Fatal(err)
 	}
 	return path
+}
+
+func issue755SecureStateRoot(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.Chmod(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return root
 }
 
 func issue755AssertGenericLoadFailure(

--- a/cmd/gateway/eebus_mutation_lab_profile_test.go
+++ b/cmd/gateway/eebus_mutation_lab_profile_test.go
@@ -185,6 +185,48 @@ func issue755ValidMutationLabProfileJSON(t *testing.T) []byte {
 	return raw
 }
 
+func TestIssue755RejectsCaseAliasedMutationLabProfileKeys(t *testing.T) {
+	valid := string(issue755ValidMutationLabProfileJSON(t))
+	tests := []struct {
+		name        string
+		oldFragment string
+		newFragment string
+	}{
+		{
+			name:        "root case alias",
+			oldFragment: `"profile_id":"issue755-lab-profile"`,
+			newFragment: `"PROFILE_ID":"issue755-lab-profile"`,
+		},
+		{
+			name:        "root canonical and case alias collision",
+			oldFragment: `"profile_id":"issue755-lab-profile"`,
+			newFragment: `"profile_id":"issue755-lab-profile","PROFILE_ID":"issue755-lab-profile"`,
+		},
+		{
+			name:        "target case alias",
+			oldFragment: `"remote_ski":"` + issue755RemoteSKI + `"`,
+			newFragment: `"REMOTE_SKI":"` + issue755RemoteSKI + `"`,
+		},
+		{
+			name:        "target canonical and case alias collision",
+			oldFragment: `"remote_ski":"` + issue755RemoteSKI + `"`,
+			newFragment: `"remote_ski":"` + issue755RemoteSKI + `","REMOTE_SKI":"` + issue755RemoteSKI + `"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			raw := strings.Replace(valid, test.oldFragment, test.newFragment, 1)
+			if raw == valid {
+				t.Fatal("test fixture did not replace the expected canonical key")
+			}
+			if _, err := decodeEEBusMutationLabProfile([]byte(raw)); err == nil {
+				t.Fatal("case-aliased profile key was accepted")
+			}
+		})
+	}
+}
+
 func issue755WriteProfile(t *testing.T, stateRoot string, raw []byte) string {
 	t.Helper()
 	path := filepath.Join(stateRoot, issue755ProfileBasename)

--- a/cmd/gateway/eebus_mutation_lab_profile_unsupported.go
+++ b/cmd/gateway/eebus_mutation_lab_profile_unsupported.go
@@ -1,0 +1,24 @@
+//go:build !linux
+
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+func readEEBusMutationLabProfileFile(stateRoot string) ([]byte, bool, error) {
+	root, err := os.Lstat(stateRoot)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, false, nil
+	}
+	if err != nil || root.Mode()&os.ModeSymlink != 0 || !root.IsDir() {
+		return nil, false, errEEBusMutationLabProfileLoad
+	}
+	_, err = os.Lstat(filepath.Join(stateRoot, eebusMutationLabProfileBasename))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, false, nil
+	}
+	return nil, false, errEEBusMutationLabProfileLoad
+}

--- a/cmd/gateway/eebus_mutation_lab_profile_unsupported_test.go
+++ b/cmd/gateway/eebus_mutation_lab_profile_unsupported_test.go
@@ -1,0 +1,33 @@
+//go:build !linux
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	eebusruntime "github.com/Project-Helianthus/helianthus-eebusreg"
+)
+
+func TestIssue755NonLinuxPresentProfileFailsClosedBeforeFactory(t *testing.T) {
+	root := t.TempDir()
+	issue755WriteProfile(t, root, issue755ValidMutationLabProfileJSON(t))
+	runtime := &msp05bRuntime{}
+	factoryCalls := 0
+
+	adapter, err := startEEBusRuntime(
+		context.Background(),
+		issue755EnabledConfig(root),
+		issue755Resolver,
+		func(eebusruntime.Config) (eebusruntime.Runtime, error) {
+			factoryCalls++
+			return runtime, nil
+		},
+	)
+	if adapter != nil || err == nil {
+		t.Fatalf("non-Linux present profile startup = (%v, %v); want nil adapter and error", adapter, err)
+	}
+	if factoryCalls != 0 || runtime.startCalls != 0 {
+		t.Fatalf("calls factory=%d start=%d; want zero", factoryCalls, runtime.startCalls)
+	}
+}

--- a/cmd/gateway/eebus_operator_boundary_red_test.go
+++ b/cmd/gateway/eebus_operator_boundary_red_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 )
 
-func TestIssue753DependencyClosurePinsEEBusregV0121(t *testing.T) {
+func TestIssue755DependencyClosurePinsEEBusregV0122(t *testing.T) {
 	goMod, err := os.Open("../../go.mod")
 	if err != nil {
 		t.Fatal(err)
@@ -33,8 +33,8 @@ func TestIssue753DependencyClosurePinsEEBusregV0121(t *testing.T) {
 	if err := scanner.Err(); err != nil {
 		t.Fatal(err)
 	}
-	if len(versions) != 1 || versions[0] != "v0.1.21" {
-		t.Fatalf("%s versions = %v, want exactly [v0.1.21]", module, versions)
+	if len(versions) != 1 || versions[0] != "v0.1.22" {
+		t.Fatalf("%s versions = %v, want exactly [v0.1.22]", module, versions)
 	}
 }
 

--- a/cmd/gateway/eebus_runtime_adapter.go
+++ b/cmd/gateway/eebus_runtime_adapter.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/eebuscommand"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
 	eebusruntime "github.com/Project-Helianthus/helianthus-eebusreg"
+	"github.com/Project-Helianthus/helianthus-eebusreg/eebusraw"
 )
 
 type eebusRuntimeFactory func(eebusruntime.Config) (eebusruntime.Runtime, error)
@@ -55,6 +56,15 @@ func startEEBusRuntime(
 	}
 	if factory == nil {
 		return nil, errors.New("enabled eeBUS configuration requires a runtime factory")
+	}
+	profile, err := loadEEBusMutationLabProfile(runtimeConfig.StateRoot)
+	if err != nil {
+		return nil, fmt.Errorf("load eeBUS mutation lab profile: %w", err)
+	}
+	if profile != nil {
+		runtimeConfig.MutationLabProfiles = []eebusraw.MutationLabProfileV1{
+			profile.Clone(),
+		}
 	}
 
 	runtime, factoryErr := factory(runtimeConfig)

--- a/eebus_config_test.go
+++ b/eebus_config_test.go
@@ -77,8 +77,9 @@ func TestMSP06EEBusRuntimeCouplingIsConfinedToApprovedSeams(t *testing.T) {
 		"config.go",
 	}
 	requiredRuntimeImports := map[string]bool{
-		"cmd/gateway/eebus_runtime_adapter.go": false,
-		"cmd/gateway/eebus_runtime_config.go":  false,
+		"cmd/gateway/eebus_mutation_lab_profile.go": false,
+		"cmd/gateway/eebus_runtime_adapter.go":      false,
+		"cmd/gateway/eebus_runtime_config.go":       false,
 		// MSP-06 adds one typed, read-only provider seam from the runtime into MCP.
 		"mcp/eebus_v1.go": false,
 		// Issue #747 adds one isolated command router over the canonical runtime.

--- a/eebusreg_v0114_contract_test.go
+++ b/eebusreg_v0114_contract_test.go
@@ -22,7 +22,7 @@ const (
 	spinegoModule  = "github.com/Project-Helianthus/helianthus-spine-go"
 )
 
-func TestEEBusregV0121ModuleClosure(t *testing.T) {
+func TestEEBusregV0122ModuleClosure(t *testing.T) {
 	contents, err := os.ReadFile("go.mod")
 	if err != nil {
 		t.Fatalf("read go.mod: %v", err)
@@ -36,7 +36,7 @@ func TestEEBusregV0121ModuleClosure(t *testing.T) {
 	}
 
 	want := map[string]string{
-		eebusregModule: "v0.1.21",
+		eebusregModule: "v0.1.22",
 		eebusgoModule:  "v0.7.1-helianthus.11",
 		shipgoModule:   "v0.6.1-helianthus.9",
 		spinegoModule:  "v0.7.1-helianthus.7",

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260521144203-f9919f4b1007
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2
-	github.com/Project-Helianthus/helianthus-eebusreg v0.1.21
+	github.com/Project-Helianthus/helianthus-eebusreg v0.1.22
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/Project-Helianthus/helianthus-eebusreg v0.1.20 h1:up+VToeM0aXuutJG10X
 github.com/Project-Helianthus/helianthus-eebusreg v0.1.20/go.mod h1:1kTJXsmP7SLQA4XGyIxF6CLt/Hd3h1AkZHl4a29X0No=
 github.com/Project-Helianthus/helianthus-eebusreg v0.1.21 h1:PcgZK36E3u6IV/PZhSZNgyZH8cIBiwIVU6F79CMBarI=
 github.com/Project-Helianthus/helianthus-eebusreg v0.1.21/go.mod h1:1kTJXsmP7SLQA4XGyIxF6CLt/Hd3h1AkZHl4a29X0No=
+github.com/Project-Helianthus/helianthus-eebusreg v0.1.22 h1:yAXy81nVAlGDrrnQLcRzn0vQgTAi220PjiukEhKHtMM=
+github.com/Project-Helianthus/helianthus-eebusreg v0.1.22/go.mod h1:1kTJXsmP7SLQA4XGyIxF6CLt/Hd3h1AkZHl4a29X0No=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.9 h1:oaM8JhTHWmDldVPmdJrTOFU3ZpOwEgPpEMUil51cDac=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.9/go.mod h1:qPqQTDqmPjyOJCr0JMNjhSC1XW1k3h5P/EZqRGy80Vs=
 github.com/Project-Helianthus/helianthus-spine-go v0.7.1-helianthus.7 h1:TYoM9+9qgf1MAytCeYIt9OphbaXvSN7KtbabGMZBYuw=


### PR DESCRIPTION
## What
Load the fixed owner-only M6.25 mutation lab profile before eeBUS runtime construction and start.

## Why
Issue #755 requires a protected local profile handoff without adding a public, CLI, environment, alias, or legacy configuration surface.

## Acceptance Criteria
- [x] Exact `v0.1.22` eebusreg dependency pin
- [x] Tests cover absence, filesystem safety, exact-key strict JSON, typed validation, and immutable runtime handoff
- [x] Linux descriptor-relative loader and non-Linux fail-closed behavior pass validation
- [x] Public HTTP and owner AF_UNIX contracts remain unchanged
- [x] Focused security review findings fixed and re-review PASS
- [x] Exact-head CI green
- [ ] Smoke test required: YES (after merge and protected live profile preparation)

## TDD Evidence
- Tests-only RED head: `9a16af3e62b0cb8d0fdc5303302eff8e32cfe166`
- RED CI: https://github.com/Project-Helianthus/helianthus-ebusgateway/actions/runs/30424378025
- RED jobs: test `90487499602`, lint `90487499613`, build `90487499639`; failures were only undefined loader metadata validators
- Final GREEN head: `10bdf81e3aed0e9a38400da21cfb95b1df5b9549`
- Final GREEN CI: https://github.com/Project-Helianthus/helianthus-ebusgateway/actions/runs/30426295365 (4/4 jobs green)
- Strict-key bypass was reproduced pre-fix and closed for root/nested aliases and collisions

## Local Validation
- `GOWORK=off go test ./...`
- `GOWORK=off go test -race -count=1 ./cmd/gateway`
- `GOWORK=off go vet ./...`
- `GOWORK=off ./scripts/ci_local.sh`
- Linux arm64 focused loader test execution in an isolated temporary Ubuntu VM

## Dependencies
- Project-Helianthus/helianthus-docs-eebus#89
- Project-Helianthus/helianthus-eebusreg#94

Companion docs: Project-Helianthus/helianthus-docs-eebus#89

Tracks #755.

No live profile was created and no live deployment/write was performed by the PR implementation cycle. Live bounded proof follows the merge.