### PR TITLE
M6.25 LAB: load profile from protected mutation subtree

### DIFF
--- a/cmd/gateway/eebus_mutation_lab_profile.go
+++ b/cmd/gateway/eebus_mutation_lab_profile.go
@@ -9,7 +9,10 @@ import (
 	"github.com/Project-Helianthus/helianthus-eebusreg/eebusraw"
 )
 
-const eebusMutationLabProfileBasename = "mutation-lab-profile-v1.json"
+const (
+	eebusMutationLabProfileDirectory = "eebusmutation"
+	eebusMutationLabProfileBasename  = "mutation-lab-profile-v1.json"
+)
 
 var errEEBusMutationLabProfileLoad = errors.New("eeBUS mutation lab profile load failed")
 

--- a/cmd/gateway/eebus_mutation_lab_profile_linux.go
+++ b/cmd/gateway/eebus_mutation_lab_profile_linux.go
@@ -34,8 +34,17 @@ func readEEBusMutationLabProfileFile(stateRoot string) ([]byte, bool, error) {
 	}
 	defer func() { _ = unix.Close(rootFD) }()
 
+	if err := rejectEEBusMutationLabRootLevelProfile(rootFD); err != nil {
+		return nil, false, err
+	}
+	directoryFD, present, err := openEEBusMutationLabProfileDirectory(rootFD)
+	if err != nil || !present {
+		return nil, false, err
+	}
+	defer func() { _ = unix.Close(directoryFD) }()
+
 	fd, err := unix.Openat(
-		rootFD,
+		directoryFD,
 		eebusMutationLabProfileBasename,
 		unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW|unix.O_NONBLOCK,
 		0,
@@ -78,6 +87,43 @@ func readEEBusMutationLabProfileFile(stateRoot string) ([]byte, bool, error) {
 		return nil, false, errEEBusMutationLabProfileLoad
 	}
 	return raw, true, nil
+}
+
+func rejectEEBusMutationLabRootLevelProfile(rootFD int) error {
+	var stat unix.Stat_t
+	err := unix.Fstatat(
+		rootFD,
+		eebusMutationLabProfileBasename,
+		&stat,
+		unix.AT_SYMLINK_NOFOLLOW,
+	)
+	if errors.Is(err, unix.ENOENT) {
+		return nil
+	}
+	return errEEBusMutationLabProfileLoad
+}
+
+func openEEBusMutationLabProfileDirectory(rootFD int) (int, bool, error) {
+	fd, err := unix.Openat(
+		rootFD,
+		eebusMutationLabProfileDirectory,
+		unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+		0,
+	)
+	if errors.Is(err, unix.ENOENT) {
+		return -1, false, nil
+	}
+	if err != nil {
+		return -1, false, errEEBusMutationLabProfileLoad
+	}
+
+	var stat unix.Stat_t
+	if err := unix.Fstat(fd, &stat); err != nil ||
+		!mutationLabRootMetadataValid(stat.Mode, stat.Uid, uint32(os.Geteuid())) {
+		_ = unix.Close(fd)
+		return -1, false, errEEBusMutationLabProfileLoad
+	}
+	return fd, true, nil
 }
 
 func openEEBusMutationLabStateRoot(stateRoot string) (int, bool, error) {

--- a/cmd/gateway/eebus_mutation_lab_profile_linux_test.go
+++ b/cmd/gateway/eebus_mutation_lab_profile_linux_test.go
@@ -5,7 +5,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -119,14 +118,68 @@ func TestIssue755RejectsUnsafeRootAndFileBoundariesBeforeFactory(t *testing.T) {
 			},
 		},
 		{
+			name: "child symlink",
+			setup: func(t *testing.T) string {
+				root := issue755SecureStateRoot(t)
+				actual := filepath.Join(t.TempDir(), "actual")
+				if err := os.Mkdir(actual, 0o700); err != nil {
+					t.Fatal(err)
+				}
+				issue755WriteProfileAt(
+					t,
+					filepath.Join(actual, issue755ProfileBasename),
+					valid,
+				)
+				if err := os.Symlink(
+					actual,
+					filepath.Join(root, issue755ProfileDirectory),
+				); err != nil {
+					t.Fatal(err)
+				}
+				return root
+			},
+		},
+		{
+			name: "child non-directory",
+			setup: func(t *testing.T) string {
+				root := issue755SecureStateRoot(t)
+				issue755WriteProfileAt(
+					t,
+					filepath.Join(root, issue755ProfileDirectory),
+					valid,
+				)
+				return root
+			},
+		},
+		{
+			name: "child mode",
+			setup: func(t *testing.T) string {
+				root := issue755SecureStateRoot(t)
+				child := filepath.Join(root, issue755ProfileDirectory)
+				if err := os.Mkdir(child, 0o750); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Chmod(child, 0o750); err != nil {
+					t.Fatal(err)
+				}
+				issue755WriteProfileAt(
+					t,
+					filepath.Join(child, issue755ProfileBasename),
+					valid,
+				)
+				return root
+			},
+		},
+		{
 			name: "file symlink",
 			setup: func(t *testing.T) string {
 				root := issue755SecureStateRoot(t)
+				child := issue755SecureProfileDirectory(t, root)
 				target := filepath.Join(t.TempDir(), "profile.json")
 				if err := os.WriteFile(target, valid, 0o600); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.Symlink(target, filepath.Join(root, issue755ProfileBasename)); err != nil {
+				if err := os.Symlink(target, filepath.Join(child, issue755ProfileBasename)); err != nil {
 					t.Fatal(err)
 				}
 				return root
@@ -136,7 +189,8 @@ func TestIssue755RejectsUnsafeRootAndFileBoundariesBeforeFactory(t *testing.T) {
 			name: "nonregular file",
 			setup: func(t *testing.T) string {
 				root := issue755SecureStateRoot(t)
-				if err := os.Mkdir(filepath.Join(root, issue755ProfileBasename), 0o600); err != nil {
+				child := issue755SecureProfileDirectory(t, root)
+				if err := os.Mkdir(filepath.Join(child, issue755ProfileBasename), 0o600); err != nil {
 					t.Fatal(err)
 				}
 				return root
@@ -157,11 +211,12 @@ func TestIssue755RejectsUnsafeRootAndFileBoundariesBeforeFactory(t *testing.T) {
 			name: "hardlink",
 			setup: func(t *testing.T) string {
 				root := issue755SecureStateRoot(t)
-				original := filepath.Join(root, "original.json")
+				child := issue755SecureProfileDirectory(t, root)
+				original := filepath.Join(child, "original.json")
 				if err := os.WriteFile(original, valid, 0o600); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.Link(original, filepath.Join(root, issue755ProfileBasename)); err != nil {
+				if err := os.Link(original, filepath.Join(child, issue755ProfileBasename)); err != nil {
 					t.Fatal(err)
 				}
 				return root
@@ -176,10 +231,10 @@ func TestIssue755RejectsUnsafeRootAndFileBoundariesBeforeFactory(t *testing.T) {
 	}
 }
 
-func TestIssue755MetadataValidationRejectsOwnerTypeModeLinksAndSize(t *testing.T) {
+func TestIssue755MetadataValidationRejectsRootChildAndFileBoundaries(t *testing.T) {
 	euid := uint32(os.Geteuid())
 	if !mutationLabRootMetadataValid(unix.S_IFDIR|0o700, euid, euid) {
-		t.Fatal("valid root metadata rejected")
+		t.Fatal("valid root or child metadata rejected")
 	}
 	for _, test := range []struct {
 		name string
@@ -190,9 +245,9 @@ func TestIssue755MetadataValidationRejectsOwnerTypeModeLinksAndSize(t *testing.T
 		{name: "type", mode: unix.S_IFREG | 0o700, uid: euid},
 		{name: "mode", mode: unix.S_IFDIR | 0o750, uid: euid},
 	} {
-		t.Run("root "+test.name, func(t *testing.T) {
+		t.Run("root or child "+test.name, func(t *testing.T) {
 			if mutationLabRootMetadataValid(test.mode, test.uid, euid) {
-				t.Fatal("unsafe root metadata accepted")
+				t.Fatal("unsafe root or child metadata accepted")
 			}
 		})
 	}
@@ -336,41 +391,4 @@ func TestIssue755RejectsMalformedOrInvalidProfileBeforeFactory(t *testing.T) {
 
 func jsonMarshalIssue755(value any) ([]byte, error) {
 	return json.Marshal(value)
-}
-
-func issue755AssertGenericLoadFailure(
-	t *testing.T,
-	stateRoot string,
-	contentMarker string,
-) {
-	t.Helper()
-	runtime := &msp05bRuntime{}
-	factoryCalls := 0
-	adapter, err := startEEBusRuntime(
-		context.Background(),
-		issue755EnabledConfig(stateRoot),
-		issue755Resolver,
-		func(eebusruntime.Config) (eebusruntime.Runtime, error) {
-			factoryCalls++
-			return runtime, nil
-		},
-	)
-	if adapter != nil || err == nil {
-		t.Fatalf("invalid profile startup = (%v, %v); want nil adapter and error", adapter, err)
-	}
-	if factoryCalls != 0 || runtime.startCalls != 0 {
-		t.Fatalf("invalid profile calls factory=%d start=%d; want zero", factoryCalls, runtime.startCalls)
-	}
-	const generic = "eeBUS mutation lab profile load failed"
-	if !strings.Contains(err.Error(), generic) {
-		t.Fatalf("startup error = %q; want generic profile load failure", err)
-	}
-	for _, secret := range []string{stateRoot, contentMarker, issue755RemoteSKI} {
-		if secret != "" && strings.Contains(err.Error(), secret) {
-			t.Fatalf("startup error leaked protected profile detail %q: %v", secret, err)
-		}
-	}
-	if errors.Unwrap(errors.Unwrap(err)) != nil {
-		t.Fatalf("startup error exposes an implementation cause chain: %v", err)
-	}
 }

--- a/cmd/gateway/eebus_mutation_lab_profile_test.go
+++ b/cmd/gateway/eebus_mutation_lab_profile_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/netip"
 	"os"
 	"path/filepath"
@@ -15,7 +16,10 @@ import (
 	"github.com/Project-Helianthus/helianthus-eebusreg/eebusraw"
 )
 
-const issue755ProfileBasename = "mutation-lab-profile-v1.json"
+const (
+	issue755ProfileDirectory = "eebusmutation"
+	issue755ProfileBasename  = "mutation-lab-profile-v1.json"
+)
 
 func TestIssue755AbsentMutationLabProfileLeavesRuntimeConfigNil(t *testing.T) {
 	tests := []struct {
@@ -29,9 +33,17 @@ func TestIssue755AbsentMutationLabProfileLeavesRuntimeConfigNil(t *testing.T) {
 			},
 		},
 		{
-			name: "file absent",
+			name: "child absent",
 			stateRoot: func(t *testing.T) string {
 				return issue755SecureStateRoot(t)
+			},
+		},
+		{
+			name: "file absent",
+			stateRoot: func(t *testing.T) string {
+				root := issue755SecureStateRoot(t)
+				issue755SecureProfileDirectory(t, root)
+				return root
 			},
 		},
 	}
@@ -99,6 +111,9 @@ func TestIssue755LoaderProductionSurfaceIsFixedAndNonLeaking(t *testing.T) {
 	if count := strings.Count(text, issue755ProfileBasename); count != 1 {
 		t.Fatalf("fixed profile basename occurrences = %d, want exactly one", count)
 	}
+	if count := strings.Count(text, issue755ProfileDirectory); count != 1 {
+		t.Fatalf("fixed profile directory occurrences = %d, want exactly one", count)
+	}
 	for _, forbidden := range []string{
 		"os.Getenv",
 		"os.LookupEnv",
@@ -115,6 +130,16 @@ func TestIssue755LoaderProductionSurfaceIsFixedAndNonLeaking(t *testing.T) {
 			t.Fatalf("loader production source contains forbidden surface %q", forbidden)
 		}
 	}
+}
+
+func TestIssue755RejectsRootLevelMutationLabProfileBeforeFactory(t *testing.T) {
+	root := issue755SecureStateRoot(t)
+	issue755WriteProfileAt(
+		t,
+		filepath.Join(root, issue755ProfileBasename),
+		issue755ValidMutationLabProfileJSON(t),
+	)
+	issue755AssertGenericLoadFailure(t, root, "")
 }
 
 func issue755EnabledConfig(stateRoot string) ebusgateway.EEBusConfig {
@@ -229,7 +254,16 @@ func TestIssue755RejectsCaseAliasedMutationLabProfileKeys(t *testing.T) {
 
 func issue755WriteProfile(t *testing.T, stateRoot string, raw []byte) string {
 	t.Helper()
-	path := filepath.Join(stateRoot, issue755ProfileBasename)
+	directory := issue755SecureProfileDirectory(t, stateRoot)
+	return issue755WriteProfileAt(
+		t,
+		filepath.Join(directory, issue755ProfileBasename),
+		raw,
+	)
+}
+
+func issue755WriteProfileAt(t *testing.T, path string, raw []byte) string {
+	t.Helper()
 	if err := os.WriteFile(path, raw, 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -246,4 +280,53 @@ func issue755SecureStateRoot(t *testing.T) string {
 		t.Fatal(err)
 	}
 	return root
+}
+
+func issue755SecureProfileDirectory(t *testing.T, stateRoot string) string {
+	t.Helper()
+	directory := filepath.Join(stateRoot, issue755ProfileDirectory)
+	if err := os.Mkdir(directory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(directory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return directory
+}
+
+func issue755AssertGenericLoadFailure(
+	t *testing.T,
+	stateRoot string,
+	contentMarker string,
+) {
+	t.Helper()
+	runtime := &msp05bRuntime{}
+	factoryCalls := 0
+	adapter, err := startEEBusRuntime(
+		context.Background(),
+		issue755EnabledConfig(stateRoot),
+		issue755Resolver,
+		func(eebusruntime.Config) (eebusruntime.Runtime, error) {
+			factoryCalls++
+			return runtime, nil
+		},
+	)
+	if adapter != nil || err == nil {
+		t.Fatalf("invalid profile startup = (%v, %v); want nil adapter and error", adapter, err)
+	}
+	if factoryCalls != 0 || runtime.startCalls != 0 {
+		t.Fatalf("invalid profile calls factory=%d start=%d; want zero", factoryCalls, runtime.startCalls)
+	}
+	const generic = "eeBUS mutation lab profile load failed"
+	if !strings.Contains(err.Error(), generic) {
+		t.Fatalf("startup error = %q; want generic profile load failure", err)
+	}
+	for _, secret := range []string{stateRoot, contentMarker, issue755RemoteSKI} {
+		if secret != "" && strings.Contains(err.Error(), secret) {
+			t.Fatalf("startup error leaked protected profile detail %q: %v", secret, err)
+		}
+	}
+	if errors.Unwrap(errors.Unwrap(err)) != nil {
+		t.Fatalf("startup error exposes an implementation cause chain: %v", err)
+	}
 }

--- a/cmd/gateway/eebus_mutation_lab_profile_unsupported.go
+++ b/cmd/gateway/eebus_mutation_lab_profile_unsupported.go
@@ -16,7 +16,25 @@ func readEEBusMutationLabProfileFile(stateRoot string) ([]byte, bool, error) {
 	if err != nil || root.Mode()&os.ModeSymlink != 0 || !root.IsDir() {
 		return nil, false, errEEBusMutationLabProfileLoad
 	}
+
 	_, err = os.Lstat(filepath.Join(stateRoot, eebusMutationLabProfileBasename))
+	if err == nil || !errors.Is(err, os.ErrNotExist) {
+		return nil, false, errEEBusMutationLabProfileLoad
+	}
+
+	directory, err := os.Lstat(filepath.Join(stateRoot, eebusMutationLabProfileDirectory))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, false, nil
+	}
+	if err != nil || directory.Mode()&os.ModeSymlink != 0 || !directory.IsDir() {
+		return nil, false, errEEBusMutationLabProfileLoad
+	}
+
+	_, err = os.Lstat(filepath.Join(
+		stateRoot,
+		eebusMutationLabProfileDirectory,
+		eebusMutationLabProfileBasename,
+	))
 	if errors.Is(err, os.ErrNotExist) {
 		return nil, false, nil
 	}


### PR DESCRIPTION
## What
Move the M6.25 mutation profile loader from the rejected state-root file into the existing protected raw-mutation subtree.

## Why
Live acceptance of `defe6b5d0ba0cfce4174e21429dbf23e3eae1a6a` falsified the root-level path: eebusreg correctly rejected the unexpected state-root leaf before network startup. The loader now uses `/data/eebus/eebusmutation/mutation-lab-profile-v1.json` without weakening the association-store whitelist.

## Acceptance
- Canonical path only; no legacy/v2 alias.
- Root-level stale file fails closed.
- Root and child are owner-only `0700`.
- Linux traversal is descriptor-relative with `openat`/`O_NOFOLLOW`.
- Leaf remains owner-only regular `0600`, one-link, bounded, identity-stable.
- Missing child/file remains disabled.
- Non-Linux canonical presence fails closed.
- No public, GraphQL, Portal, HA, or semantic surface.
- Exact live VR940 probe/rollback acceptance remains tracked by issue #755 after merge.

## TDD and validation
- RED: `44cc3c9e5146b9996d1bdd1dc7a76df318a9193f`
- Hosted RED: Actions run `30428931997`, expected issue #755 test failures.
- GREEN: `b2e13524ab17636e0d00b4b68b0fc9350e52cfba`
- Hosted GREEN: Actions run `30429127698`, all four jobs green including `go test -race -count=1 ./...`.
- Local focused tests, focused race, `go vet ./cmd/gateway`, and full `./scripts/ci_local.sh`: green.
- Independent security/portability review: PASS, no findings.

## Docs
Canonical contract merged first in Project-Helianthus/helianthus-docs-eebus#91 at `7e29d1253b7c2257e940fb66dbc0bc21de42172d`; exact source-head docs CI completion is retained as the gate before this PR merges.

Continues #755.