### PR TITLE
M6.25: preserve stage-bound raw command terminals

### DIFF
--- a/cmd/gateway/eebus_operator_boundary_red_test.go
+++ b/cmd/gateway/eebus_operator_boundary_red_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 )
 
-func TestIssue755DependencyClosurePinsEEBusregV0122(t *testing.T) {
+func TestIssue755DependencyClosurePinsEEBusregV0123(t *testing.T) {
 	goMod, err := os.Open("../../go.mod")
 	if err != nil {
 		t.Fatal(err)
@@ -33,8 +33,8 @@ func TestIssue755DependencyClosurePinsEEBusregV0122(t *testing.T) {
 	if err := scanner.Err(); err != nil {
 		t.Fatal(err)
 	}
-	if len(versions) != 1 || versions[0] != "v0.1.22" {
-		t.Fatalf("%s versions = %v, want exactly [v0.1.22]", module, versions)
+	if len(versions) != 1 || versions[0] != "v0.1.23" {
+		t.Fatalf("%s versions = %v, want exactly [v0.1.23]", module, versions)
 	}
 }
 

--- a/eebusreg_v0114_contract_test.go
+++ b/eebusreg_v0114_contract_test.go
@@ -22,7 +22,7 @@ const (
 	spinegoModule  = "github.com/Project-Helianthus/helianthus-spine-go"
 )
 
-func TestEEBusregV0122ModuleClosure(t *testing.T) {
+func TestEEBusregV0123ModuleClosure(t *testing.T) {
 	contents, err := os.ReadFile("go.mod")
 	if err != nil {
 		t.Fatalf("read go.mod: %v", err)
@@ -36,7 +36,7 @@ func TestEEBusregV0122ModuleClosure(t *testing.T) {
 	}
 
 	want := map[string]string{
-		eebusregModule: "v0.1.22",
+		eebusregModule: "v0.1.23",
 		eebusgoModule:  "v0.7.1-helianthus.11",
 		shipgoModule:   "v0.6.1-helianthus.9",
 		spinegoModule:  "v0.7.1-helianthus.7",

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260521144203-f9919f4b1007
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2
-	github.com/Project-Helianthus/helianthus-eebusreg v0.1.22
+	github.com/Project-Helianthus/helianthus-eebusreg v0.1.23
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/Project-Helianthus/helianthus-eebusreg v0.1.21 h1:PcgZK36E3u6IV/PZhSZ
 github.com/Project-Helianthus/helianthus-eebusreg v0.1.21/go.mod h1:1kTJXsmP7SLQA4XGyIxF6CLt/Hd3h1AkZHl4a29X0No=
 github.com/Project-Helianthus/helianthus-eebusreg v0.1.22 h1:yAXy81nVAlGDrrnQLcRzn0vQgTAi220PjiukEhKHtMM=
 github.com/Project-Helianthus/helianthus-eebusreg v0.1.22/go.mod h1:1kTJXsmP7SLQA4XGyIxF6CLt/Hd3h1AkZHl4a29X0No=
+github.com/Project-Helianthus/helianthus-eebusreg v0.1.23 h1:g3WCp5XY2qm2611gKa/8lJ5HdAx3sQpBOEewgQSr0GI=
+github.com/Project-Helianthus/helianthus-eebusreg v0.1.23/go.mod h1:1kTJXsmP7SLQA4XGyIxF6CLt/Hd3h1AkZHl4a29X0No=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.9 h1:oaM8JhTHWmDldVPmdJrTOFU3ZpOwEgPpEMUil51cDac=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.9/go.mod h1:qPqQTDqmPjyOJCr0JMNjhSC1XW1k3h5P/EZqRGy80Vs=
 github.com/Project-Helianthus/helianthus-spine-go v0.7.1-helianthus.7 h1:TYoM9+9qgf1MAytCeYIt9OphbaXvSN7KtbabGMZBYuw=

--- a/internal/eebuscommand/router.go
+++ b/internal/eebuscommand/router.go
@@ -52,13 +52,13 @@ func (router *Router) FeaturesDataSet(
 	ctx context.Context,
 	auth eebusraw.WriteAuthorizationV1,
 	request eebusraw.FeatureDataSetRequestV1,
-) (eebusraw.MutationV1, *eebusraw.ErrorV1) {
+) (eebusruntime.RawMutationOutcomeV1, *eebusraw.ErrorV1) {
 	if terminal := eebusraw.ValidateWriteAuthorizationV1(auth, eebusraw.ToolV1FeaturesDataSet); terminal != nil {
-		return eebusraw.MutationV1{}, terminal
+		return eebusruntime.RawMutationOutcomeV1{}, terminal
 	}
 	runtime, terminal := router.mutationRuntime()
 	if terminal != nil {
-		return eebusraw.MutationV1{}, terminal
+		return eebusruntime.RawMutationOutcomeV1{}, terminal
 	}
 	return runtime.FeaturesDataSet(ctx, auth, request)
 }
@@ -68,13 +68,13 @@ func (router *Router) MutationsGet(
 	ctx context.Context,
 	auth eebusraw.ReadAuthorizationV1,
 	request eebusraw.MutationGetRequestV1,
-) (eebusraw.MutationV1, *eebusraw.ErrorV1) {
+) (eebusruntime.RawMutationOutcomeV1, *eebusraw.ErrorV1) {
 	if terminal := eebusraw.ValidateReadAuthorizationV1(auth, eebusraw.ToolV1MutationsGet); terminal != nil {
-		return eebusraw.MutationV1{}, terminal
+		return eebusruntime.RawMutationOutcomeV1{}, terminal
 	}
 	runtime, terminal := router.mutationRuntime()
 	if terminal != nil {
-		return eebusraw.MutationV1{}, terminal
+		return eebusruntime.RawMutationOutcomeV1{}, terminal
 	}
 	return runtime.MutationsGet(ctx, auth, request)
 }
@@ -84,13 +84,13 @@ func (router *Router) MutationsRollback(
 	ctx context.Context,
 	auth eebusraw.WriteAuthorizationV1,
 	request eebusraw.MutationRollbackRequestV1,
-) (eebusraw.MutationV1, *eebusraw.ErrorV1) {
+) (eebusruntime.RawMutationOutcomeV1, *eebusraw.ErrorV1) {
 	if terminal := eebusraw.ValidateWriteAuthorizationV1(auth, eebusraw.ToolV1MutationsRollback); terminal != nil {
-		return eebusraw.MutationV1{}, terminal
+		return eebusruntime.RawMutationOutcomeV1{}, terminal
 	}
 	runtime, terminal := router.mutationRuntime()
 	if terminal != nil {
-		return eebusraw.MutationV1{}, terminal
+		return eebusruntime.RawMutationOutcomeV1{}, terminal
 	}
 	return runtime.MutationsRollback(ctx, auth, request)
 }

--- a/internal/eebuscommand/router_test.go
+++ b/internal/eebuscommand/router_test.go
@@ -147,21 +147,21 @@ type issue747MutationRuntime struct {
 	featuresDataSetContext context.Context
 	featuresDataSetAuth    eebusraw.WriteAuthorizationV1
 	featuresDataSetRequest eebusraw.FeatureDataSetRequestV1
-	featuresDataSetResult  eebusraw.MutationV1
+	featuresDataSetResult  eebusruntime.RawMutationOutcomeV1
 	featuresDataSetError   *eebusraw.ErrorV1
 
 	mutationsGetCalls   int
 	mutationsGetContext context.Context
 	mutationsGetAuth    eebusraw.ReadAuthorizationV1
 	mutationsGetRequest eebusraw.MutationGetRequestV1
-	mutationsGetResult  eebusraw.MutationV1
+	mutationsGetResult  eebusruntime.RawMutationOutcomeV1
 	mutationsGetError   *eebusraw.ErrorV1
 
 	mutationsRollbackCalls   int
 	mutationsRollbackContext context.Context
 	mutationsRollbackAuth    eebusraw.WriteAuthorizationV1
 	mutationsRollbackRequest eebusraw.MutationRollbackRequestV1
-	mutationsRollbackResult  eebusraw.MutationV1
+	mutationsRollbackResult  eebusruntime.RawMutationOutcomeV1
 	mutationsRollbackError   *eebusraw.ErrorV1
 }
 
@@ -171,7 +171,7 @@ func (runtime *issue747MutationRuntime) FeaturesDataSet(
 	ctx context.Context,
 	auth eebusraw.WriteAuthorizationV1,
 	request eebusraw.FeatureDataSetRequestV1,
-) (eebusraw.MutationV1, *eebusraw.ErrorV1) {
+) (eebusruntime.RawMutationOutcomeV1, *eebusraw.ErrorV1) {
 	runtime.featuresDataSetCalls++
 	runtime.featuresDataSetContext = ctx
 	runtime.featuresDataSetAuth = auth
@@ -183,7 +183,7 @@ func (runtime *issue747MutationRuntime) MutationsGet(
 	ctx context.Context,
 	auth eebusraw.ReadAuthorizationV1,
 	request eebusraw.MutationGetRequestV1,
-) (eebusraw.MutationV1, *eebusraw.ErrorV1) {
+) (eebusruntime.RawMutationOutcomeV1, *eebusraw.ErrorV1) {
 	runtime.mutationsGetCalls++
 	runtime.mutationsGetContext = ctx
 	runtime.mutationsGetAuth = auth
@@ -195,7 +195,7 @@ func (runtime *issue747MutationRuntime) MutationsRollback(
 	ctx context.Context,
 	auth eebusraw.WriteAuthorizationV1,
 	request eebusraw.MutationRollbackRequestV1,
-) (eebusraw.MutationV1, *eebusraw.ErrorV1) {
+) (eebusruntime.RawMutationOutcomeV1, *eebusraw.ErrorV1) {
 	runtime.mutationsRollbackCalls++
 	runtime.mutationsRollbackContext = ctx
 	runtime.mutationsRollbackAuth = auth
@@ -356,27 +356,27 @@ func (*issue747TypedNilRuntime) FeaturesDataSet(
 	context.Context,
 	eebusraw.WriteAuthorizationV1,
 	eebusraw.FeatureDataSetRequestV1,
-) (eebusraw.MutationV1, *eebusraw.ErrorV1) {
+) (eebusruntime.RawMutationOutcomeV1, *eebusraw.ErrorV1) {
 	issue747TypedNilCalls.FeaturesDataSet++
-	return eebusraw.MutationV1{}, nil
+	return eebusruntime.RawMutationOutcomeV1{}, nil
 }
 
 func (*issue747TypedNilRuntime) MutationsGet(
 	context.Context,
 	eebusraw.ReadAuthorizationV1,
 	eebusraw.MutationGetRequestV1,
-) (eebusraw.MutationV1, *eebusraw.ErrorV1) {
+) (eebusruntime.RawMutationOutcomeV1, *eebusraw.ErrorV1) {
 	issue747TypedNilCalls.MutationsGet++
-	return eebusraw.MutationV1{}, nil
+	return eebusruntime.RawMutationOutcomeV1{}, nil
 }
 
 func (*issue747TypedNilRuntime) MutationsRollback(
 	context.Context,
 	eebusraw.WriteAuthorizationV1,
 	eebusraw.MutationRollbackRequestV1,
-) (eebusraw.MutationV1, *eebusraw.ErrorV1) {
+) (eebusruntime.RawMutationOutcomeV1, *eebusraw.ErrorV1) {
 	issue747TypedNilCalls.MutationsRollback++
-	return eebusraw.MutationV1{}, nil
+	return eebusruntime.RawMutationOutcomeV1{}, nil
 }
 
 func TestRouterReadOperationsDelegateExactlyOnce(t *testing.T) {
@@ -445,19 +445,25 @@ func TestRouterMutationOperationsDelegateExactlyOnce(t *testing.T) {
 	rollbackError := &eebusraw.ErrorV1{Message: "rollback-sentinel"}
 	runtime := &issue747MutationRuntime{
 		issue747ReadRuntime: &issue747ReadRuntime{},
-		featuresDataSetResult: eebusraw.MutationV1{
-			MutationRef: "mutation-set",
-			State:       "applied",
+		featuresDataSetResult: eebusruntime.RawMutationOutcomeV1{
+			Mutation: eebusraw.MutationV1{
+				MutationRef: "mutation-set",
+				State:       "applied",
+			},
 		},
 		featuresDataSetError: setError,
-		mutationsGetResult: eebusraw.MutationV1{
-			MutationRef: "mutation-status",
-			State:       "verify_pending",
+		mutationsGetResult: eebusruntime.RawMutationOutcomeV1{
+			Mutation: eebusraw.MutationV1{
+				MutationRef: "mutation-status",
+				State:       "verify_pending",
+			},
 		},
 		mutationsGetError: statusError,
-		mutationsRollbackResult: eebusraw.MutationV1{
-			MutationRef: "mutation-rollback",
-			State:       "rolled_back",
+		mutationsRollbackResult: eebusruntime.RawMutationOutcomeV1{
+			Mutation: eebusraw.MutationV1{
+				MutationRef: "mutation-rollback",
+				State:       "rolled_back",
+			},
 		},
 		mutationsRollbackError: rollbackError,
 	}
@@ -587,11 +593,11 @@ func TestRouterMutationCapabilityFailsClosedBeforeRuntimeContact(t *testing.T) {
 
 			operations := []struct {
 				name string
-				call func() (eebusraw.MutationV1, *eebusraw.ErrorV1)
+				call func() (eebusruntime.RawMutationOutcomeV1, *eebusraw.ErrorV1)
 			}{
 				{
 					name: "FeaturesDataSet",
-					call: func() (eebusraw.MutationV1, *eebusraw.ErrorV1) {
+					call: func() (eebusruntime.RawMutationOutcomeV1, *eebusraw.ErrorV1) {
 						return router.FeaturesDataSet(
 							context.Background(),
 							eebusraw.WriteAuthorizationV1{},
@@ -601,7 +607,7 @@ func TestRouterMutationCapabilityFailsClosedBeforeRuntimeContact(t *testing.T) {
 				},
 				{
 					name: "MutationsGet",
-					call: func() (eebusraw.MutationV1, *eebusraw.ErrorV1) {
+					call: func() (eebusruntime.RawMutationOutcomeV1, *eebusraw.ErrorV1) {
 						return router.MutationsGet(
 							context.Background(),
 							eebusraw.ReadAuthorizationV1{},
@@ -611,7 +617,7 @@ func TestRouterMutationCapabilityFailsClosedBeforeRuntimeContact(t *testing.T) {
 				},
 				{
 					name: "MutationsRollback",
-					call: func() (eebusraw.MutationV1, *eebusraw.ErrorV1) {
+					call: func() (eebusruntime.RawMutationOutcomeV1, *eebusraw.ErrorV1) {
 						return router.MutationsRollback(
 							context.Background(),
 							eebusraw.WriteAuthorizationV1{},
@@ -629,7 +635,7 @@ func TestRouterMutationCapabilityFailsClosedBeforeRuntimeContact(t *testing.T) {
 					if terminal == nil {
 						t.Fatalf("%s succeeded without the complete RawMutationRuntimeV1", operation.name)
 					}
-					if !reflect.DeepEqual(result, eebusraw.MutationV1{}) {
+					if !reflect.DeepEqual(result, eebusruntime.RawMutationOutcomeV1{}) {
 						t.Fatalf("%s result = %+v, want zero mutation", operation.name, result)
 					}
 				})
@@ -644,11 +650,11 @@ func TestRouterMutationAuthorizationFailsBeforeRuntimeContact(t *testing.T) {
 
 	operations := []struct {
 		name string
-		call func() (eebusraw.MutationV1, *eebusraw.ErrorV1)
+		call func() (eebusruntime.RawMutationOutcomeV1, *eebusraw.ErrorV1)
 	}{
 		{
 			name: "FeaturesDataSet requires write authorization for its tool",
-			call: func() (eebusraw.MutationV1, *eebusraw.ErrorV1) {
+			call: func() (eebusruntime.RawMutationOutcomeV1, *eebusraw.ErrorV1) {
 				return router.FeaturesDataSet(
 					context.Background(),
 					eebusraw.WriteAuthorizationV1{
@@ -663,7 +669,7 @@ func TestRouterMutationAuthorizationFailsBeforeRuntimeContact(t *testing.T) {
 		},
 		{
 			name: "MutationsGet requires read authorization for its tool",
-			call: func() (eebusraw.MutationV1, *eebusraw.ErrorV1) {
+			call: func() (eebusruntime.RawMutationOutcomeV1, *eebusraw.ErrorV1) {
 				return router.MutationsGet(
 					context.Background(),
 					eebusraw.ReadAuthorizationV1{
@@ -678,7 +684,7 @@ func TestRouterMutationAuthorizationFailsBeforeRuntimeContact(t *testing.T) {
 		},
 		{
 			name: "MutationsRollback requires write authorization for its tool",
-			call: func() (eebusraw.MutationV1, *eebusraw.ErrorV1) {
+			call: func() (eebusruntime.RawMutationOutcomeV1, *eebusraw.ErrorV1) {
 				return router.MutationsRollback(
 					context.Background(),
 					eebusraw.WriteAuthorizationV1{
@@ -701,7 +707,7 @@ func TestRouterMutationAuthorizationFailsBeforeRuntimeContact(t *testing.T) {
 			if terminal == nil || terminal.Code != eebusraw.ErrorCodeV1PermissionDenied {
 				t.Fatalf("terminal error = %+v, want permission_denied", terminal)
 			}
-			if !reflect.DeepEqual(result, eebusraw.MutationV1{}) {
+			if !reflect.DeepEqual(result, eebusruntime.RawMutationOutcomeV1{}) {
 				t.Fatalf("result = %+v, want zero mutation", result)
 			}
 		})

--- a/mcp/eebus_command_router_boundary_test.go
+++ b/mcp/eebus_command_router_boundary_test.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"testing"
 
+	eebusruntime "github.com/Project-Helianthus/helianthus-eebusreg"
 	"github.com/Project-Helianthus/helianthus-eebusreg/eebusraw"
 )
 
@@ -408,22 +409,22 @@ func (runtime *issue749CommandRuntime) FeaturesDataSet(
 	_ context.Context,
 	_ eebusraw.WriteAuthorizationV1,
 	_ eebusraw.FeatureDataSetRequestV1,
-) (eebusraw.MutationV1, *eebusraw.ErrorV1) {
-	return eebusraw.MutationV1{}, runtime.terminal(eebusraw.ToolV1FeaturesDataSet)
+) (eebusruntime.RawMutationOutcomeV1, *eebusraw.ErrorV1) {
+	return eebusruntime.RawMutationOutcomeV1{}, runtime.terminal(eebusraw.ToolV1FeaturesDataSet)
 }
 
 func (runtime *issue749CommandRuntime) MutationsGet(
 	_ context.Context,
 	_ eebusraw.ReadAuthorizationV1,
 	_ eebusraw.MutationGetRequestV1,
-) (eebusraw.MutationV1, *eebusraw.ErrorV1) {
-	return eebusraw.MutationV1{}, runtime.terminal(eebusraw.ToolV1MutationsGet)
+) (eebusruntime.RawMutationOutcomeV1, *eebusraw.ErrorV1) {
+	return eebusruntime.RawMutationOutcomeV1{}, runtime.terminal(eebusraw.ToolV1MutationsGet)
 }
 
 func (runtime *issue749CommandRuntime) MutationsRollback(
 	_ context.Context,
 	_ eebusraw.WriteAuthorizationV1,
 	_ eebusraw.MutationRollbackRequestV1,
-) (eebusraw.MutationV1, *eebusraw.ErrorV1) {
-	return eebusraw.MutationV1{}, runtime.terminal(eebusraw.ToolV1MutationsRollback)
+) (eebusruntime.RawMutationOutcomeV1, *eebusraw.ErrorV1) {
+	return eebusruntime.RawMutationOutcomeV1{}, runtime.terminal(eebusraw.ToolV1MutationsRollback)
 }

--- a/mcp/eebus_v1_commands.go
+++ b/mcp/eebus_v1_commands.go
@@ -11,6 +11,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	eebusruntime "github.com/Project-Helianthus/helianthus-eebusreg"
 	"github.com/Project-Helianthus/helianthus-eebusreg/eebusraw"
 )
 
@@ -27,9 +28,9 @@ const (
 type EEBusV1CommandRouter interface {
 	FeaturesGet(context.Context, eebusraw.ReadAuthorizationV1, eebusraw.FeaturesGetRequestV1) (eebusraw.FeaturesGetDataV1, *eebusraw.ErrorV1)
 	FeaturesDataGet(context.Context, eebusraw.ReadAuthorizationV1, eebusraw.FeatureDataGetRequestV1) (eebusraw.FeatureDataGetDataV1, *eebusraw.ErrorV1)
-	FeaturesDataSet(context.Context, eebusraw.WriteAuthorizationV1, eebusraw.FeatureDataSetRequestV1) (eebusraw.MutationV1, *eebusraw.ErrorV1)
-	MutationsGet(context.Context, eebusraw.ReadAuthorizationV1, eebusraw.MutationGetRequestV1) (eebusraw.MutationV1, *eebusraw.ErrorV1)
-	MutationsRollback(context.Context, eebusraw.WriteAuthorizationV1, eebusraw.MutationRollbackRequestV1) (eebusraw.MutationV1, *eebusraw.ErrorV1)
+	FeaturesDataSet(context.Context, eebusraw.WriteAuthorizationV1, eebusraw.FeatureDataSetRequestV1) (eebusruntime.RawMutationOutcomeV1, *eebusraw.ErrorV1)
+	MutationsGet(context.Context, eebusraw.ReadAuthorizationV1, eebusraw.MutationGetRequestV1) (eebusruntime.RawMutationOutcomeV1, *eebusraw.ErrorV1)
+	MutationsRollback(context.Context, eebusraw.WriteAuthorizationV1, eebusraw.MutationRollbackRequestV1) (eebusruntime.RawMutationOutcomeV1, *eebusraw.ErrorV1)
 }
 
 type eebusV1CommandSpec struct {
@@ -367,6 +368,7 @@ func eebusV1DispatchCommand(
 ) (any, *eebusraw.ErrorV1, *eebusraw.RuntimeBindingV1) {
 	var data any
 	var terminal *eebusraw.ErrorV1
+	var outcomeRuntime *eebusraw.RuntimeBindingV1
 	switch spec.tool {
 	case eebusraw.ToolV1FeaturesGet:
 		typedRequest := request.(eebusraw.FeaturesGetRequestV1)
@@ -378,16 +380,16 @@ func eebusV1DispatchCommand(
 		data, terminal = typedData, typedTerminal
 	case eebusraw.ToolV1FeaturesDataSet:
 		typedRequest := request.(eebusraw.FeatureDataSetRequestV1)
-		typedData, typedTerminal := router.FeaturesDataSet(ctx, eebusV1WriteAuthorization(spec), typedRequest)
-		data, terminal = typedData, typedTerminal
+		outcome, typedTerminal := router.FeaturesDataSet(ctx, eebusV1WriteAuthorization(spec), typedRequest)
+		data, outcomeRuntime, terminal = outcome.Mutation, outcome.Runtime, typedTerminal
 	case eebusraw.ToolV1MutationsGet:
 		typedRequest := request.(eebusraw.MutationGetRequestV1)
-		typedData, typedTerminal := router.MutationsGet(ctx, eebusV1ReadAuthorization(spec), typedRequest)
-		data, terminal = typedData, typedTerminal
+		outcome, typedTerminal := router.MutationsGet(ctx, eebusV1ReadAuthorization(spec), typedRequest)
+		data, outcomeRuntime, terminal = outcome.Mutation, outcome.Runtime, typedTerminal
 	case eebusraw.ToolV1MutationsRollback:
 		typedRequest := request.(eebusraw.MutationRollbackRequestV1)
-		typedData, typedTerminal := router.MutationsRollback(ctx, eebusV1WriteAuthorization(spec), typedRequest)
-		data, terminal = typedData, typedTerminal
+		outcome, typedTerminal := router.MutationsRollback(ctx, eebusV1WriteAuthorization(spec), typedRequest)
+		data, outcomeRuntime, terminal = outcome.Mutation, outcome.Runtime, typedTerminal
 	default:
 		return nil, eebusraw.NewErrorV1(
 			eebusraw.ErrorCodeV1Internal,
@@ -402,15 +404,15 @@ func eebusV1DispatchCommand(
 		return nil, terminalFailure, nil
 	}
 	terminal = safeTerminal
-	runtime, validationFailure := eebusV1ValidateCommandOutcome(spec.tool, request, data, terminal)
+	runtime, validationFailure := eebusV1ValidateCommandOutcome(
+		spec.tool,
+		request,
+		data,
+		terminal,
+		outcomeRuntime,
+	)
 	if validationFailure != nil {
 		return nil, validationFailure, nil
-	}
-	if runtime == nil && terminal != nil {
-		if eebusV1TerminalRequiresRuntime(terminal.Code) {
-			return nil, eebusV1ContractViolation(), nil
-		}
-		terminal.SourceLayer = eebusV1SourceLayerGatewayRouter
 	}
 	return data, terminal, runtime
 }
@@ -462,14 +464,27 @@ func eebusV1BoundRuntime(runtime eebusraw.RuntimeBindingV1) *eebusraw.RuntimeBin
 	return &bound
 }
 
+func eebusV1BoundOutcomeRuntime(
+	runtime *eebusraw.RuntimeBindingV1,
+) *eebusraw.RuntimeBindingV1 {
+	if runtime == nil {
+		return nil
+	}
+	return eebusV1BoundRuntime(*runtime)
+}
+
 func eebusV1ValidateCommandOutcome(
 	tool eebusraw.ToolV1,
 	request any,
 	data any,
 	terminal *eebusraw.ErrorV1,
+	outcomeRuntime *eebusraw.RuntimeBindingV1,
 ) (*eebusraw.RuntimeBindingV1, *eebusraw.ErrorV1) {
 	switch tool {
 	case eebusraw.ToolV1FeaturesGet:
+		if outcomeRuntime != nil {
+			return nil, eebusV1ContractViolation()
+		}
 		typedRequest := request.(eebusraw.FeaturesGetRequestV1)
 		typedData := data.(eebusraw.FeaturesGetDataV1)
 		if reflect.ValueOf(typedData).IsZero() {
@@ -487,6 +502,9 @@ func eebusV1ValidateCommandOutcome(
 		}
 		return runtime, nil
 	case eebusraw.ToolV1FeaturesDataGet:
+		if outcomeRuntime != nil {
+			return nil, eebusV1ContractViolation()
+		}
 		typedRequest := request.(eebusraw.FeatureDataGetRequestV1)
 		typedData := data.(eebusraw.FeatureDataGetDataV1)
 		if terminal != nil && terminal.Code != eebusraw.ErrorCodeV1PartialResult {
@@ -507,11 +525,18 @@ func eebusV1ValidateCommandOutcome(
 		eebusraw.ToolV1MutationsGet,
 		eebusraw.ToolV1MutationsRollback:
 		typedData := data.(eebusraw.MutationV1)
+		runtime := eebusV1BoundOutcomeRuntime(outcomeRuntime)
+		if outcomeRuntime != nil && runtime == nil {
+			return nil, eebusV1ContractViolation()
+		}
 		if reflect.ValueOf(typedData).IsZero() {
 			if terminal == nil {
 				return nil, eebusV1ContractViolation()
 			}
-			return nil, nil
+			if runtime == nil && !eebusV1UnboundTerminalSourceAllowed(terminal.SourceLayer) {
+				return nil, eebusV1ContractViolation()
+			}
+			return runtime, nil
 		}
 		if failure := eebusraw.ValidateMutationV1(typedData); failure != nil {
 			return nil, eebusV1CanonicalValidationFailure(failure)
@@ -519,13 +544,27 @@ func eebusV1ValidateCommandOutcome(
 		if !eebusV1MutationMatchesRequest(tool, request, typedData) {
 			return nil, eebusV1ContractViolation()
 		}
-		runtime := eebusV1BoundRuntime(typedData.Runtime)
-		if runtime == nil {
+		mutationRuntime := eebusV1BoundRuntime(typedData.Runtime)
+		if mutationRuntime == nil ||
+			runtime == nil ||
+			*runtime != *mutationRuntime {
 			return nil, eebusV1ContractViolation()
 		}
 		return runtime, nil
 	default:
 		return nil, eebusV1ContractViolation()
+	}
+}
+
+func eebusV1UnboundTerminalSourceAllowed(layer eebusraw.SourceLayerV1) bool {
+	switch string(layer) {
+	case "mcp",
+		"gateway-router",
+		"eebusreg-runtime",
+		"eebusreg-coordinator":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -621,32 +660,6 @@ func eebusV1ContractViolation() *eebusraw.ErrorV1 {
 		false,
 		eebusV1SourceLayerGatewayRouter,
 	)
-}
-
-func eebusV1TerminalRequiresRuntime(code eebusraw.ErrorCodeV1) bool {
-	switch code {
-	case eebusraw.ErrorCodeV1ConstraintsUnknown,
-		eebusraw.ErrorCodeV1ConstraintFailure,
-		eebusraw.ErrorCodeV1StaleReadToken,
-		eebusraw.ErrorCodeV1CASMismatch,
-		eebusraw.ErrorCodeV1RuntimeEpochMismatch,
-		eebusraw.ErrorCodeV1ConnectionGenerationMismatch,
-		eebusraw.ErrorCodeV1IdempotencyConflict,
-		eebusraw.ErrorCodeV1WriterBusy,
-		eebusraw.ErrorCodeV1Disconnected,
-		eebusraw.ErrorCodeV1Timeout,
-		eebusraw.ErrorCodeV1Cancelled,
-		eebusraw.ErrorCodeV1RemoteError,
-		eebusraw.ErrorCodeV1DecodeError,
-		eebusraw.ErrorCodeV1PartialResult,
-		eebusraw.ErrorCodeV1NoEffect,
-		eebusraw.ErrorCodeV1OutcomeUnknown,
-		eebusraw.ErrorCodeV1Conflict,
-		eebusraw.ErrorCodeV1RollbackFailed:
-		return true
-	default:
-		return false
-	}
 }
 
 func eebusV1KnownErrorCode(code eebusraw.ErrorCodeV1) bool {

--- a/mcp/eebus_v1_commands.go
+++ b/mcp/eebus_v1_commands.go
@@ -511,6 +511,9 @@ func eebusV1ValidateCommandOutcome(
 			if !reflect.ValueOf(typedData).IsZero() {
 				return nil, eebusV1ContractViolation()
 			}
+			if !eebusV1UnboundTerminalSourceAllowed(terminal.SourceLayer) {
+				return nil, eebusV1ContractViolation()
+			}
 			return nil, nil
 		}
 		if failure := eebusraw.ValidateFeatureDataGetDataV1(typedRequest, typedData, terminal); failure != nil {
@@ -524,6 +527,9 @@ func eebusV1ValidateCommandOutcome(
 	case eebusraw.ToolV1FeaturesDataSet,
 		eebusraw.ToolV1MutationsGet,
 		eebusraw.ToolV1MutationsRollback:
+		if terminal != nil && terminal.Code == eebusraw.ErrorCodeV1PartialResult {
+			return nil, eebusV1ContractViolation()
+		}
 		typedData := data.(eebusraw.MutationV1)
 		runtime := eebusV1BoundOutcomeRuntime(outcomeRuntime)
 		if outcomeRuntime != nil && runtime == nil {

--- a/mcp/eebus_v1_commands_test.go
+++ b/mcp/eebus_v1_commands_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+	eebusruntime "github.com/Project-Helianthus/helianthus-eebusreg"
 	"github.com/Project-Helianthus/helianthus-eebusreg/eebusraw"
 )
 
@@ -66,36 +67,47 @@ func (router *issue749TypedRouter) FeaturesDataSet(
 	_ context.Context,
 	auth eebusraw.WriteAuthorizationV1,
 	_ eebusraw.FeatureDataSetRequestV1,
-) (eebusraw.MutationV1, *eebusraw.ErrorV1) {
+) (eebusruntime.RawMutationOutcomeV1, *eebusraw.ErrorV1) {
 	router.mu.Lock()
 	defer router.mu.Unlock()
 	router.record(eebusraw.ToolV1FeaturesDataSet)
 	router.writeAuth = auth
-	return router.mutationData, router.mutationError
+	return issue749MutationOutcome(router.mutationData), router.mutationError
 }
 
 func (router *issue749TypedRouter) MutationsGet(
 	_ context.Context,
 	auth eebusraw.ReadAuthorizationV1,
 	_ eebusraw.MutationGetRequestV1,
-) (eebusraw.MutationV1, *eebusraw.ErrorV1) {
+) (eebusruntime.RawMutationOutcomeV1, *eebusraw.ErrorV1) {
 	router.mu.Lock()
 	defer router.mu.Unlock()
 	router.record(eebusraw.ToolV1MutationsGet)
 	router.readAuth = auth
-	return router.mutationData, router.mutationError
+	return issue749MutationOutcome(router.mutationData), router.mutationError
 }
 
 func (router *issue749TypedRouter) MutationsRollback(
 	_ context.Context,
 	auth eebusraw.WriteAuthorizationV1,
 	_ eebusraw.MutationRollbackRequestV1,
-) (eebusraw.MutationV1, *eebusraw.ErrorV1) {
+) (eebusruntime.RawMutationOutcomeV1, *eebusraw.ErrorV1) {
 	router.mu.Lock()
 	defer router.mu.Unlock()
 	router.record(eebusraw.ToolV1MutationsRollback)
 	router.writeAuth = auth
-	return router.mutationData, router.mutationError
+	return issue749MutationOutcome(router.mutationData), router.mutationError
+}
+
+func issue749MutationOutcome(
+	mutation eebusraw.MutationV1,
+) eebusruntime.RawMutationOutcomeV1 {
+	outcome := eebusruntime.RawMutationOutcomeV1{Mutation: mutation}
+	if !reflect.ValueOf(mutation).IsZero() {
+		runtime := mutation.Runtime
+		outcome.Runtime = &runtime
+	}
+	return outcome
 }
 
 func (router *issue749TypedRouter) callCount() int {
@@ -414,7 +426,7 @@ func TestIssue749MutationGetNotFoundWithoutRuntimeIsPreserved(t *testing.T) {
 			assertIssue749PreRuntimeFailure(t, result.envelope, false)
 			if current.wantCode == eebusraw.ErrorCodeV1NotFound &&
 				(publicError["message"] != notFound.Message ||
-					publicError["source_layer"] != string(eebusV1SourceLayerGatewayRouter)) {
+					publicError["source_layer"] != string(eebusraw.SourceLayerV1Runtime)) {
 				t.Fatalf("actionable not_found was not preserved: %#v", publicError)
 			}
 		})

--- a/mcp/eebus_v1_stage_bound_mutation_outcomes_red_test.go
+++ b/mcp/eebus_v1_stage_bound_mutation_outcomes_red_test.go
@@ -1,0 +1,337 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	eebusruntime "github.com/Project-Helianthus/helianthus-eebusreg"
+	"github.com/Project-Helianthus/helianthus-eebusreg/eebusraw"
+)
+
+type issue755StageBoundRouter struct {
+	outcome  eebusruntime.RawMutationOutcomeV1
+	terminal *eebusraw.ErrorV1
+}
+
+var _ EEBusV1CommandRouter = (*issue755StageBoundRouter)(nil)
+
+func (*issue755StageBoundRouter) FeaturesGet(
+	context.Context,
+	eebusraw.ReadAuthorizationV1,
+	eebusraw.FeaturesGetRequestV1,
+) (eebusraw.FeaturesGetDataV1, *eebusraw.ErrorV1) {
+	return eebusraw.FeaturesGetDataV1{}, eebusraw.NewErrorV1(
+		eebusraw.ErrorCodeV1Internal,
+		"unexpected feature lookup",
+		false,
+		eebusraw.SourceLayerV1Runtime,
+	)
+}
+
+func (*issue755StageBoundRouter) FeaturesDataGet(
+	context.Context,
+	eebusraw.ReadAuthorizationV1,
+	eebusraw.FeatureDataGetRequestV1,
+) (eebusraw.FeatureDataGetDataV1, *eebusraw.ErrorV1) {
+	return eebusraw.FeatureDataGetDataV1{}, eebusraw.NewErrorV1(
+		eebusraw.ErrorCodeV1Internal,
+		"unexpected feature data lookup",
+		false,
+		eebusraw.SourceLayerV1Runtime,
+	)
+}
+
+func (router *issue755StageBoundRouter) FeaturesDataSet(
+	context.Context,
+	eebusraw.WriteAuthorizationV1,
+	eebusraw.FeatureDataSetRequestV1,
+) (eebusruntime.RawMutationOutcomeV1, *eebusraw.ErrorV1) {
+	return router.outcome.Clone(), issue755CloneTerminal(router.terminal)
+}
+
+func (router *issue755StageBoundRouter) MutationsGet(
+	context.Context,
+	eebusraw.ReadAuthorizationV1,
+	eebusraw.MutationGetRequestV1,
+) (eebusruntime.RawMutationOutcomeV1, *eebusraw.ErrorV1) {
+	return router.outcome.Clone(), issue755CloneTerminal(router.terminal)
+}
+
+func (router *issue755StageBoundRouter) MutationsRollback(
+	context.Context,
+	eebusraw.WriteAuthorizationV1,
+	eebusraw.MutationRollbackRequestV1,
+) (eebusruntime.RawMutationOutcomeV1, *eebusraw.ErrorV1) {
+	return router.outcome.Clone(), issue755CloneTerminal(router.terminal)
+}
+
+func issue755CloneTerminal(terminal *eebusraw.ErrorV1) *eebusraw.ErrorV1 {
+	if terminal == nil {
+		return nil
+	}
+	cloned := terminal.Clone()
+	return &cloned
+}
+
+func TestIssue755LiveExpiredTokenKeepsCapturedRuntimeAndStableHash(t *testing.T) {
+	binding := eebusraw.RuntimeBindingV1{
+		RuntimeEpoch:         2,
+		ConnectionGeneration: 10,
+	}
+	router := &issue755StageBoundRouter{
+		outcome: eebusruntime.RawMutationOutcomeV1{Runtime: &binding},
+		terminal: eebusraw.NewErrorV1(
+			eebusraw.ErrorCodeV1StaleReadToken,
+			"read token expired",
+			false,
+			eebusraw.SourceLayerV1("eebusreg-coordinator"),
+		),
+	}
+	test := issue749CommandCases(t)[2]
+	first := issue755CallCommand(t, router, test)
+	second := issue755CallCommand(t, router, test)
+
+	issue755AssertTerminalEnvelope(
+		t,
+		first.envelope,
+		eebusraw.ErrorCodeV1StaleReadToken,
+		eebusraw.SourceLayerV1("eebusreg-coordinator"),
+		&binding,
+	)
+	firstMeta := msp06Map(t, first.envelope["meta"], "first meta")
+	secondMeta := msp06Map(t, second.envelope["meta"], "second meta")
+	if firstMeta["data_hash"] != secondMeta["data_hash"] {
+		t.Fatalf("bound stale-token hash changed with data_timestamp: %v != %v",
+			firstMeta["data_hash"], secondMeta["data_hash"])
+	}
+}
+
+func TestIssue755SameStaleTokenCodeMayBeBoundOrUnbound(t *testing.T) {
+	binding := eebusraw.RuntimeBindingV1{
+		RuntimeEpoch:         2,
+		ConnectionGeneration: 10,
+	}
+	test := issue749CommandCases(t)[2]
+	bound := issue755CallCommand(t, &issue755StageBoundRouter{
+		outcome: eebusruntime.RawMutationOutcomeV1{Runtime: &binding},
+		terminal: eebusraw.NewErrorV1(
+			eebusraw.ErrorCodeV1StaleReadToken,
+			"authenticated read token expired",
+			false,
+			eebusraw.SourceLayerV1Runtime,
+		),
+	}, test)
+	unbound := issue755CallCommand(t, &issue755StageBoundRouter{
+		terminal: eebusraw.NewErrorV1(
+			eebusraw.ErrorCodeV1StaleReadToken,
+			"unknown read token",
+			false,
+			eebusraw.SourceLayerV1Runtime,
+		),
+	}, test)
+
+	issue755AssertTerminalEnvelope(
+		t,
+		bound.envelope,
+		eebusraw.ErrorCodeV1StaleReadToken,
+		eebusraw.SourceLayerV1Runtime,
+		&binding,
+	)
+	issue755AssertTerminalEnvelope(
+		t,
+		unbound.envelope,
+		eebusraw.ErrorCodeV1StaleReadToken,
+		eebusraw.SourceLayerV1Runtime,
+		nil,
+	)
+	boundHash := msp06Map(t, bound.envelope["meta"], "bound meta")["data_hash"]
+	unboundHash := msp06Map(t, unbound.envelope["meta"], "unbound meta")["data_hash"]
+	if boundHash == unboundHash {
+		t.Fatalf("bound and unbound terminal envelopes share hash %v", boundHash)
+	}
+}
+
+func TestIssue755MutationTerminalBindingAppliesToEveryMutationTool(t *testing.T) {
+	binding := eebusraw.RuntimeBindingV1{
+		RuntimeEpoch:         7,
+		ConnectionGeneration: 3,
+	}
+	cases := issue749CommandCases(t)
+	for _, index := range []int{2, 3, 4} {
+		test := cases[index]
+		t.Run(test.tool, func(t *testing.T) {
+			result := issue755CallCommand(t, &issue755StageBoundRouter{
+				outcome: eebusruntime.RawMutationOutcomeV1{Runtime: &binding},
+				terminal: eebusraw.NewErrorV1(
+					eebusraw.ErrorCodeV1Disconnected,
+					"operation lost its admitted SHIP session",
+					true,
+					eebusraw.SourceLayerV1("eebusreg-coordinator"),
+				),
+			}, test)
+			issue755AssertTerminalEnvelope(
+				t,
+				result.envelope,
+				eebusraw.ErrorCodeV1Disconnected,
+				eebusraw.SourceLayerV1("eebusreg-coordinator"),
+				&binding,
+			)
+		})
+	}
+}
+
+func TestIssue755MutationGetNotFoundStaysCanonicalAndUnbound(t *testing.T) {
+	test := issue749CommandCases(t)[3]
+	result := issue755CallCommand(t, &issue755StageBoundRouter{
+		terminal: eebusraw.NewErrorV1(
+			eebusraw.ErrorCodeV1NotFound,
+			"mutation reference was not found",
+			false,
+			eebusraw.SourceLayerV1Runtime,
+		),
+	}, test)
+	issue755AssertTerminalEnvelope(
+		t,
+		result.envelope,
+		eebusraw.ErrorCodeV1NotFound,
+		eebusraw.SourceLayerV1Runtime,
+		nil,
+	)
+}
+
+func TestIssue755PostDispatchTerminalWithoutRuntimeFailsClosed(t *testing.T) {
+	postDispatchSources := []eebusraw.SourceLayerV1{
+		eebusraw.SourceLayerV1("eebus-go-executor"),
+		eebusraw.SourceLayerV1SpineRoundTrip,
+		eebusraw.SourceLayerV1("ship-session"),
+		eebusraw.SourceLayerV1Remote,
+	}
+	test := issue749CommandCases(t)[2]
+	for _, source := range postDispatchSources {
+		t.Run(string(source), func(t *testing.T) {
+			result := issue755CallCommand(t, &issue755StageBoundRouter{
+				terminal: eebusraw.NewErrorV1(
+					eebusraw.ErrorCodeV1Disconnected,
+					"post-dispatch terminal omitted its runtime",
+					true,
+					source,
+				),
+			}, test)
+			issue755AssertTerminalEnvelope(
+				t,
+				result.envelope,
+				eebusraw.ErrorCodeV1Internal,
+				eebusV1SourceLayerGatewayRouter,
+				nil,
+			)
+		})
+	}
+}
+
+func TestIssue755MutationAndOutcomeRuntimeMustMatch(t *testing.T) {
+	binding := eebusraw.RuntimeBindingV1{
+		RuntimeEpoch:         7,
+		ConnectionGeneration: 3,
+	}
+	test := issue749CommandCases(t)[2]
+	request := issue749DecodeArguments[eebusraw.FeatureDataSetRequestV1](t, test.arguments)
+	mutation := issue749PreparedMutation(t, request, binding)
+
+	cases := []struct {
+		name    string
+		runtime *eebusraw.RuntimeBindingV1
+	}{
+		{name: "missing"},
+		{
+			name: "different",
+			runtime: &eebusraw.RuntimeBindingV1{
+				RuntimeEpoch:         binding.RuntimeEpoch,
+				ConnectionGeneration: binding.ConnectionGeneration + 1,
+			},
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			result := issue755CallCommand(t, &issue755StageBoundRouter{
+				outcome: eebusruntime.RawMutationOutcomeV1{
+					Mutation: mutation,
+					Runtime:  testCase.runtime,
+				},
+			}, test)
+			issue755AssertTerminalEnvelope(
+				t,
+				result.envelope,
+				eebusraw.ErrorCodeV1Internal,
+				eebusV1SourceLayerGatewayRouter,
+				nil,
+			)
+		})
+	}
+
+	result := issue755CallCommand(t, &issue755StageBoundRouter{
+		outcome: eebusruntime.RawMutationOutcomeV1{
+			Mutation: mutation,
+			Runtime:  &binding,
+		},
+	}, test)
+	if result.isError || result.envelope["error"] != nil || result.envelope["data"] == nil {
+		t.Fatalf("matching mutation outcome failed: %#v", result.envelope)
+	}
+	assertIssue749CommandMeta(t, result.envelope, test.tool, test.scope, binding)
+}
+
+func issue755CallCommand(
+	t *testing.T,
+	router EEBusV1CommandRouter,
+	test issue749CommandCase,
+) msp06CallResult {
+	t.Helper()
+	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+	server, _ := msp06TestServer(t, provider)
+	if err := server.RegisterEEBusV1CommandRouter(router); err != nil {
+		t.Fatal(err)
+	}
+	return msp06Call(
+		t,
+		issue743OperatorHandler(t, server),
+		test.tool,
+		cloneIssue749Arguments(t, test.arguments),
+	)
+}
+
+func issue755AssertTerminalEnvelope(
+	t *testing.T,
+	envelope map[string]any,
+	code eebusraw.ErrorCodeV1,
+	source eebusraw.SourceLayerV1,
+	runtime *eebusraw.RuntimeBindingV1,
+) {
+	t.Helper()
+	if envelope["data"] != nil {
+		t.Fatalf("terminal envelope exposed data: %#v", envelope["data"])
+	}
+	publicError := msp06Map(t, envelope["error"], "terminal error")
+	if publicError["code"] != string(code) ||
+		publicError["source_layer"] != string(source) {
+		t.Fatalf("terminal error = %#v, want code=%s source=%s",
+			publicError, code, source)
+	}
+	meta := msp06Map(t, envelope["meta"], "terminal meta")
+	hash, _ := meta["data_hash"].(string)
+	if !strings.HasPrefix(hash, "sha256:") || len(hash) != len("sha256:")+64 {
+		t.Fatalf("terminal data_hash = %q", hash)
+	}
+	if runtime == nil {
+		if meta["runtime"] != nil {
+			t.Fatalf("unbound terminal fabricated runtime: %#v", meta["runtime"])
+		}
+		return
+	}
+	got := msp06Map(t, meta["runtime"], "terminal runtime")
+	if fmt.Sprint(got["runtime_epoch"]) != fmt.Sprint(runtime.RuntimeEpoch) ||
+		fmt.Sprint(got["connection_generation"]) != fmt.Sprint(runtime.ConnectionGeneration) {
+		t.Fatalf("terminal runtime = %#v, want %#v", got, runtime)
+	}
+}

--- a/mcp/eebus_v1_stage_bound_mutation_outcomes_red_test.go
+++ b/mcp/eebus_v1_stage_bound_mutation_outcomes_red_test.go
@@ -148,8 +148,18 @@ func TestIssue755SameStaleTokenCodeMayBeBoundOrUnbound(t *testing.T) {
 	)
 	boundHash := msp06Map(t, bound.envelope["meta"], "bound meta")["data_hash"]
 	unboundHash := msp06Map(t, unbound.envelope["meta"], "unbound meta")["data_hash"]
-	if boundHash == unboundHash {
-		t.Fatalf("bound and unbound terminal envelopes share hash %v", boundHash)
+	const (
+		wantBoundHash   = "sha256:53f6b7f26272d6d955a3cbde49077d200703faca5f15384165e2d2b9c9dc265e"
+		wantUnboundHash = "sha256:ac70761fdce6e5a750d811711189b82c09cd49e33451b09c00af6ecac72299ba"
+	)
+	if boundHash != wantBoundHash || unboundHash != wantUnboundHash {
+		t.Fatalf(
+			"terminal hash known-answer mismatch: bound=%v want=%s unbound=%v want=%s",
+			boundHash,
+			wantBoundHash,
+			unboundHash,
+			wantUnboundHash,
+		)
 	}
 }
 
@@ -202,6 +212,10 @@ func TestIssue755MutationGetNotFoundStaysCanonicalAndUnbound(t *testing.T) {
 }
 
 func TestIssue755PostDispatchTerminalWithoutRuntimeFailsClosed(t *testing.T) {
+	binding := eebusraw.RuntimeBindingV1{
+		RuntimeEpoch:         7,
+		ConnectionGeneration: 3,
+	}
 	postDispatchSources := []eebusraw.SourceLayerV1{
 		eebusraw.SourceLayerV1("eebus-go-executor"),
 		eebusraw.SourceLayerV1SpineRoundTrip,
@@ -225,6 +239,23 @@ func TestIssue755PostDispatchTerminalWithoutRuntimeFailsClosed(t *testing.T) {
 				eebusraw.ErrorCodeV1Internal,
 				eebusV1SourceLayerGatewayRouter,
 				nil,
+			)
+
+			bound := issue755CallCommand(t, &issue755StageBoundRouter{
+				outcome: eebusruntime.RawMutationOutcomeV1{Runtime: &binding},
+				terminal: eebusraw.NewErrorV1(
+					eebusraw.ErrorCodeV1Disconnected,
+					"post-dispatch terminal retained its runtime",
+					true,
+					source,
+				),
+			}, test)
+			issue755AssertTerminalEnvelope(
+				t,
+				bound.envelope,
+				eebusraw.ErrorCodeV1Disconnected,
+				source,
+				&binding,
 			)
 		})
 	}
@@ -309,16 +340,39 @@ func issue755AssertTerminalEnvelope(
 	runtime *eebusraw.RuntimeBindingV1,
 ) {
 	t.Helper()
+	msp06AssertKeys(t, envelope, "terminal envelope", "meta", "request", "data", "error")
 	if envelope["data"] != nil {
 		t.Fatalf("terminal envelope exposed data: %#v", envelope["data"])
 	}
 	publicError := msp06Map(t, envelope["error"], "terminal error")
+	msp06AssertKeys(
+		t,
+		publicError,
+		"terminal error",
+		"code",
+		"message",
+		"retriable",
+		"source_layer",
+	)
 	if publicError["code"] != string(code) ||
 		publicError["source_layer"] != string(source) {
 		t.Fatalf("terminal error = %#v, want code=%s source=%s",
 			publicError, code, source)
 	}
 	meta := msp06Map(t, envelope["meta"], "terminal meta")
+	msp06AssertKeys(
+		t,
+		meta,
+		"terminal meta",
+		"contract",
+		"tool",
+		"scope",
+		"mask_tier",
+		"auth_scope",
+		"data_timestamp",
+		"data_hash",
+		"runtime",
+	)
 	hash, _ := meta["data_hash"].(string)
 	if !strings.HasPrefix(hash, "sha256:") || len(hash) != len("sha256:")+64 {
 		t.Fatalf("terminal data_hash = %q", hash)
@@ -330,6 +384,13 @@ func issue755AssertTerminalEnvelope(
 		return
 	}
 	got := msp06Map(t, meta["runtime"], "terminal runtime")
+	msp06AssertKeys(
+		t,
+		got,
+		"terminal runtime",
+		"runtime_epoch",
+		"connection_generation",
+	)
 	if fmt.Sprint(got["runtime_epoch"]) != fmt.Sprint(runtime.RuntimeEpoch) ||
 		fmt.Sprint(got["connection_generation"]) != fmt.Sprint(runtime.ConnectionGeneration) {
 		t.Fatalf("terminal runtime = %#v, want %#v", got, runtime)

--- a/mcp/eebus_v1_stage_bound_mutation_outcomes_red_test.go
+++ b/mcp/eebus_v1_stage_bound_mutation_outcomes_red_test.go
@@ -11,8 +11,10 @@ import (
 )
 
 type issue755StageBoundRouter struct {
-	outcome  eebusruntime.RawMutationOutcomeV1
-	terminal *eebusraw.ErrorV1
+	dataGetData     eebusraw.FeatureDataGetDataV1
+	dataGetTerminal *eebusraw.ErrorV1
+	outcome         eebusruntime.RawMutationOutcomeV1
+	terminal        *eebusraw.ErrorV1
 }
 
 var _ EEBusV1CommandRouter = (*issue755StageBoundRouter)(nil)
@@ -30,17 +32,12 @@ func (*issue755StageBoundRouter) FeaturesGet(
 	)
 }
 
-func (*issue755StageBoundRouter) FeaturesDataGet(
+func (router *issue755StageBoundRouter) FeaturesDataGet(
 	context.Context,
 	eebusraw.ReadAuthorizationV1,
 	eebusraw.FeatureDataGetRequestV1,
 ) (eebusraw.FeatureDataGetDataV1, *eebusraw.ErrorV1) {
-	return eebusraw.FeatureDataGetDataV1{}, eebusraw.NewErrorV1(
-		eebusraw.ErrorCodeV1Internal,
-		"unexpected feature data lookup",
-		false,
-		eebusraw.SourceLayerV1Runtime,
-	)
+	return router.dataGetData.Clone(), issue755CloneTerminal(router.dataGetTerminal)
 }
 
 func (router *issue755StageBoundRouter) FeaturesDataSet(
@@ -311,6 +308,181 @@ func TestIssue755MutationAndOutcomeRuntimeMustMatch(t *testing.T) {
 		t.Fatalf("matching mutation outcome failed: %#v", result.envelope)
 	}
 	assertIssue749CommandMeta(t, result.envelope, test.tool, test.scope, binding)
+}
+
+func TestIssue755FeatureDataGetZeroDataEnforcesSourcePartition(t *testing.T) {
+	sourceCases := []struct {
+		source     eebusraw.SourceLayerV1
+		wantCode   eebusraw.ErrorCodeV1
+		wantSource eebusraw.SourceLayerV1
+	}{
+		{
+			source:     eebusV1SourceLayerMCP,
+			wantCode:   eebusraw.ErrorCodeV1Disconnected,
+			wantSource: eebusV1SourceLayerMCP,
+		},
+		{
+			source:     eebusV1SourceLayerGatewayRouter,
+			wantCode:   eebusraw.ErrorCodeV1Disconnected,
+			wantSource: eebusV1SourceLayerGatewayRouter,
+		},
+		{
+			source:     eebusraw.SourceLayerV1Runtime,
+			wantCode:   eebusraw.ErrorCodeV1Disconnected,
+			wantSource: eebusraw.SourceLayerV1Runtime,
+		},
+		{
+			source:     eebusraw.SourceLayerV1("eebusreg-coordinator"),
+			wantCode:   eebusraw.ErrorCodeV1Disconnected,
+			wantSource: eebusraw.SourceLayerV1("eebusreg-coordinator"),
+		},
+		{
+			source:     eebusraw.SourceLayerV1Executor,
+			wantCode:   eebusraw.ErrorCodeV1Internal,
+			wantSource: eebusV1SourceLayerGatewayRouter,
+		},
+		{
+			source:     eebusraw.SourceLayerV1SpineRoundTrip,
+			wantCode:   eebusraw.ErrorCodeV1Internal,
+			wantSource: eebusV1SourceLayerGatewayRouter,
+		},
+		{
+			source:     eebusraw.SourceLayerV1("ship-session"),
+			wantCode:   eebusraw.ErrorCodeV1Internal,
+			wantSource: eebusV1SourceLayerGatewayRouter,
+		},
+		{
+			source:     eebusraw.SourceLayerV1Remote,
+			wantCode:   eebusraw.ErrorCodeV1Internal,
+			wantSource: eebusV1SourceLayerGatewayRouter,
+		},
+	}
+	test := issue749CommandCases(t)[1]
+	for _, testCase := range sourceCases {
+		t.Run(string(testCase.source), func(t *testing.T) {
+			result := issue755CallCommand(t, &issue755StageBoundRouter{
+				dataGetTerminal: eebusraw.NewErrorV1(
+					eebusraw.ErrorCodeV1Disconnected,
+					"feature data read ended without a captured runtime",
+					true,
+					testCase.source,
+				),
+			}, test)
+			issue755AssertTerminalEnvelope(
+				t,
+				result.envelope,
+				testCase.wantCode,
+				testCase.wantSource,
+				nil,
+			)
+		})
+	}
+}
+
+func TestIssue755FeatureDataGetPartialResultWithBoundDataRemainsLegal(t *testing.T) {
+	binding := eebusraw.RuntimeBindingV1{
+		RuntimeEpoch:         7,
+		ConnectionGeneration: 3,
+	}
+	test := issue749CommandCases(t)[1]
+	arguments := cloneIssue749Arguments(t, test.arguments)
+	targets := arguments["targets"].([]any)
+	secondTarget := cloneIssue749Arguments(t, targets[0].(map[string]any))
+	secondTarget["feature_address"] = float64(3)
+	arguments["targets"] = append(targets, secondTarget)
+	test.arguments = arguments
+	request := issue749DecodeArguments[eebusraw.FeatureDataGetRequestV1](t, arguments)
+
+	result := issue755CallCommand(t, &issue755StageBoundRouter{
+		dataGetData: issue749PartialData(t, request, binding),
+		dataGetTerminal: eebusraw.NewErrorV1(
+			eebusraw.ErrorCodeV1PartialResult,
+			"one bound read target timed out",
+			true,
+			eebusraw.SourceLayerV1SpineRoundTrip,
+		),
+	}, test)
+	if !result.isError || result.envelope["data"] == nil {
+		t.Fatalf("bound partial read was not retained: %#v", result.envelope)
+	}
+	publicError := msp06Map(t, result.envelope["error"], "partial read error")
+	if publicError["code"] != string(eebusraw.ErrorCodeV1PartialResult) ||
+		publicError["source_layer"] != string(eebusraw.SourceLayerV1SpineRoundTrip) {
+		t.Fatalf("partial read terminal = %#v", publicError)
+	}
+	assertIssue749CommandMeta(t, result.envelope, test.tool, test.scope, binding)
+}
+
+func TestIssue755MutationToolsRejectPartialResultCategorically(t *testing.T) {
+	binding := eebusraw.RuntimeBindingV1{
+		RuntimeEpoch:         7,
+		ConnectionGeneration: 3,
+	}
+	commandCases := issue749CommandCases(t)
+	setRequest := issue749DecodeArguments[eebusraw.FeatureDataSetRequestV1](
+		t,
+		commandCases[2].arguments,
+	)
+	mutation := issue749PreparedMutation(t, setRequest, binding)
+	sources := []eebusraw.SourceLayerV1{
+		eebusV1SourceLayerMCP,
+		eebusV1SourceLayerGatewayRouter,
+		eebusraw.SourceLayerV1Runtime,
+		eebusraw.SourceLayerV1("eebusreg-coordinator"),
+		eebusraw.SourceLayerV1Executor,
+		eebusraw.SourceLayerV1SpineRoundTrip,
+		eebusraw.SourceLayerV1("ship-session"),
+		eebusraw.SourceLayerV1Remote,
+	}
+	outcomes := []struct {
+		name    string
+		outcome eebusruntime.RawMutationOutcomeV1
+	}{
+		{name: "zero-unbound"},
+		{
+			name: "zero-bound",
+			outcome: eebusruntime.RawMutationOutcomeV1{
+				Runtime: &binding,
+			},
+		},
+		{
+			name: "mutation-bound",
+			outcome: eebusruntime.RawMutationOutcomeV1{
+				Mutation: mutation,
+				Runtime:  &binding,
+			},
+		},
+	}
+
+	for _, commandIndex := range []int{2, 3, 4} {
+		test := commandCases[commandIndex]
+		t.Run(test.tool, func(t *testing.T) {
+			for _, source := range sources {
+				t.Run(string(source), func(t *testing.T) {
+					for _, outcome := range outcomes {
+						t.Run(outcome.name, func(t *testing.T) {
+							result := issue755CallCommand(t, &issue755StageBoundRouter{
+								outcome: outcome.outcome,
+								terminal: eebusraw.NewErrorV1(
+									eebusraw.ErrorCodeV1PartialResult,
+									"partial mutation results are forbidden",
+									true,
+									source,
+								),
+							}, test)
+							issue755AssertTerminalEnvelope(
+								t,
+								result.envelope,
+								eebusraw.ErrorCodeV1Internal,
+								eebusV1SourceLayerGatewayRouter,
+								nil,
+							)
+						})
+					}
+				})
+			}
+		})
+	}
 }
 
 func issue755CallCommand(


### PR DESCRIPTION
## What
Consume `helianthus-eebusreg v0.1.23` typed mutation outcomes and publish raw command terminal envelopes with the operation-captured runtime binding.

## Why
The live stale-token probe proved that zero-mutation terminals cannot derive binding from `MutationV1` or error-code classes. The gateway must preserve bound/unbound stage truth without a post-error runtime lookup.

## Acceptance Criteria
- [x] Same `stale_read_token` code may be bound or unbound by operation stage
- [x] Mutation data requires an equal positive outcome runtime
- [x] Post-dispatch sources without runtime fail closed
- [x] Canonical unbound `not_found` remains actionable
- [x] `partial_result` is accepted only for bound feature-data reads
- [x] Source layer is preserved; no error-code inference or fabricated mutation
- [x] No v2, legacy alias, candidate_ref, GraphQL, semantic, or ebus.v1 leakage
- [x] Unit, full race, vet, lint, Python, and local CI gates pass
- [ ] Live bounded probe, restart rollback, and profile removal proof after merge

## Dependencies
- Docs: Project-Helianthus/helianthus-docs-eebus#93 merged at `1ea36df153f9fac7cd4e17d44fd947525711ddc0`
- Runtime: Project-Helianthus/helianthus-eebusreg#96 merged at `5528b436f814f1867138a1d7da9354c665916f28`, tag `v0.1.23`
- Tracks issue #755

## Validation
- `GOWORK=off go test ./mcp ./internal/eebuscommand`
- `GOWORK=off go test ./...`
- `go test -race ./mcp ./internal/eebuscommand`
- `go vet ./...`
- `./scripts/ci_local.sh`

RED: `f5d387b80b2077728f160e2d6027252b0da5441a`
GREEN: `b84ce469faa1b04d845af30111a19f9bf78f1440`
Review fix: `8952deb9c918b21ff6cd48a4dfed6e8faa613cd9`