### PR TITLE
M6.25 LAB: pin released reconnect dependency chain

### DIFF
--- a/cmd/gateway/eebus_operator_boundary_red_test.go
+++ b/cmd/gateway/eebus_operator_boundary_red_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 )
 
-func TestIssue759DependencyClosurePinsEEBusregV0124(t *testing.T) {
+func TestIssue755ReleasedDependencyClosurePinsEEBusregV0125(t *testing.T) {
 	goMod, err := os.Open("../../go.mod")
 	if err != nil {
 		t.Fatal(err)
@@ -33,8 +33,8 @@ func TestIssue759DependencyClosurePinsEEBusregV0124(t *testing.T) {
 	if err := scanner.Err(); err != nil {
 		t.Fatal(err)
 	}
-	if len(versions) != 1 || versions[0] != "v0.1.24" {
-		t.Fatalf("%s versions = %v, want exactly [v0.1.24]", module, versions)
+	if len(versions) != 1 || versions[0] != "v0.1.25" {
+		t.Fatalf("%s versions = %v, want exactly [v0.1.25]", module, versions)
 	}
 }
 

--- a/eebusreg_v0114_contract_test.go
+++ b/eebusreg_v0114_contract_test.go
@@ -22,7 +22,7 @@ const (
 	spinegoModule  = "github.com/Project-Helianthus/helianthus-spine-go"
 )
 
-func TestEEBusregV0124ModuleClosure(t *testing.T) {
+func TestIssue755ReleasedEEBusDependencyClosure(t *testing.T) {
 	contents, err := os.ReadFile("go.mod")
 	if err != nil {
 		t.Fatalf("read go.mod: %v", err)
@@ -36,9 +36,9 @@ func TestEEBusregV0124ModuleClosure(t *testing.T) {
 	}
 
 	want := map[string]string{
-		eebusregModule: "v0.1.24",
+		eebusregModule: "v0.1.25",
 		eebusgoModule:  "v0.7.1-helianthus.11",
-		shipgoModule:   "v0.6.1-helianthus.9",
+		shipgoModule:   "v0.6.1-helianthus.10",
 		spinegoModule:  "v0.7.1-helianthus.7",
 	}
 	declared := make(map[string]string, len(want))

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260521144203-f9919f4b1007
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2
-	github.com/Project-Helianthus/helianthus-eebusreg v0.1.24
+	github.com/Project-Helianthus/helianthus-eebusreg v0.1.25
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4
@@ -17,7 +17,7 @@ require (
 
 require (
 	github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.11 // indirect
-	github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.9 // indirect
+	github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.10 // indirect
 	github.com/Project-Helianthus/helianthus-spine-go v0.7.1-helianthus.7 // indirect
 	github.com/ahmetb/go-linq/v3 v3.2.0 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,10 +4,10 @@ github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e4
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
 github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.11 h1:LHakALyx1j+ctwRaOHyaDUM/wQQI4mnQbnTeS+/qWY8=
 github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.11/go.mod h1:2lvj0o5lhqdif9khZQkIA9bCGEQCcSfWQ+EIjk78j14=
-github.com/Project-Helianthus/helianthus-eebusreg v0.1.24 h1:KDw4lvB+q9nRSR68tHEYje6QeKoN7n9e6F5iKbaB/QM=
-github.com/Project-Helianthus/helianthus-eebusreg v0.1.24/go.mod h1:1kTJXsmP7SLQA4XGyIxF6CLt/Hd3h1AkZHl4a29X0No=
-github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.9 h1:oaM8JhTHWmDldVPmdJrTOFU3ZpOwEgPpEMUil51cDac=
-github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.9/go.mod h1:qPqQTDqmPjyOJCr0JMNjhSC1XW1k3h5P/EZqRGy80Vs=
+github.com/Project-Helianthus/helianthus-eebusreg v0.1.25 h1:fXGEW1v1NZQJ1dYGnZr+fFI6K2Q5GCigVRSImb8x99Y=
+github.com/Project-Helianthus/helianthus-eebusreg v0.1.25/go.mod h1:kmZjDC3L21SoMjXaflTHjikQprld9AdZ95rwBXV5Sk8=
+github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.10 h1:b3qVTiG808qS5v0NdUNwZHzWhHFUjvbzxYMGSCPun1g=
+github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.10/go.mod h1:qPqQTDqmPjyOJCr0JMNjhSC1XW1k3h5P/EZqRGy80Vs=
 github.com/Project-Helianthus/helianthus-spine-go v0.7.1-helianthus.7 h1:TYoM9+9qgf1MAytCeYIt9OphbaXvSN7KtbabGMZBYuw=
 github.com/Project-Helianthus/helianthus-spine-go v0.7.1-helianthus.7/go.mod h1:+F0QhC19FMgBmHqbTDyG/G0lwnAQDEnxcMhP3xjX/5s=
 github.com/ahmetb/go-linq/v3 v3.2.0 h1:BEuMfp+b59io8g5wYzNoFe9pWPalRklhlhbiU3hYZDE=


### PR DESCRIPTION
## What
Pin the final released SHIP reconnect-collision chain through `helianthus-eebusreg v0.1.25` before repeating the no-write VR940 restart-persistence proof.

## Why
Issue #755 remains open only until the exact released SHIP -> eebusreg -> gateway chain is deployed and the read-only acceptance is repeated.

## Acceptance Criteria
- [x] Strict test-only RED commit `5c1bd0cdf03195efb9486ad87778ddac367febf2` exists.
- [x] Hosted RED run `30466633014` failed only on unpublished `v0.1.25` / SHIP `.10`; terminology/build/lint passed.
- [x] SHIP `.10` and eebusreg `v0.1.25` are published annotated releases.
- [x] Gateway pins exact released closure `.25/.11/.10/.7` with no replace or pseudo-version.
- [x] Focused release-pin tests pass.
- [x] Full `./scripts/ci_local.sh` passes, including race, 168+5+7+5 Python tests, lint, and gates.
- [ ] Focused review passes.
- [ ] Hosted CI passes.
- [ ] Merge and deploy exact released chain to 192.168.100.4.
- [ ] Two read-only proof captures across restart preserve trust/topology/raw MCP/public redaction/eBUS coexistence.

## Dependencies
- Project-Helianthus/helianthus-ship-go#23 merged at `3e4be608d4a024e34e52747e78fc75f83cf9f762`; tag `.10` published.
- Project-Helianthus/helianthus-eebusreg#102 merged at `c8b6645d343fa4186e87793b17a83b0c0ff52707`; tag `v0.1.25` published.
- Tracks and closes #755 after final live proof.
