### PR TITLE
M6.25: record one-shot synchronized eeBUS evidence

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -1924,6 +1924,15 @@ func startHTTPServer(
 			return nil, nil, fmt.Errorf("register eeBUS MCP command router: %w", err)
 		}
 	}
+	oneShotRuntime, err := newSynchronizedEvidenceOneShotRuntime(eebusProvider, eebusCommandRouter)
+	if err != nil {
+		return nil, nil, err
+	}
+	if oneShotRuntime != nil {
+		if err := mcpServer.RegisterSynchronizedEvidenceCapture(oneShotRuntime); err != nil {
+			return nil, nil, fmt.Errorf("register synchronized evidence capture: %w", err)
+		}
+	}
 	mcpServer.SetAdmittedRPCSourceProvider(builder.AdmittedMutationSource)
 	mcpServer.SetStatusProvider(newMCPRuntimeStatusProvider(cfg, semanticProvider))
 	if busObservability != nil {

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -158,6 +158,9 @@ func recordBusAdmissionTransitionWithStabilityRefresh(ctx context.Context, store
 
 func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 	applyTransportSourcePolicy(&cfg)
+	if err := ebusgateway.ValidateSynchronizedEvidenceConfig(cfg); err != nil {
+		return fmt.Errorf("validate synchronized evidence config: %w", err)
+	}
 
 	if len(cfg.Providers) == 0 {
 		cfg.Providers = vaillantproviders.Default()
@@ -1286,6 +1289,12 @@ func bindFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) {
 	fs.DurationVar(&cfg.TransportConfig.WriteTimeout, "write-timeout", cfg.TransportConfig.WriteTimeout, "transport write timeout")
 	fs.DurationVar(&cfg.TransportConfig.DialTimeout, "dial-timeout", cfg.TransportConfig.DialTimeout, "transport dial timeout")
 	bindEEBusFlags(fs, cfg)
+	fs.BoolVar(
+		&cfg.EvidenceOneShotEnabled,
+		"synchronized-evidence-one-shot-enabled",
+		cfg.EvidenceOneShotEnabled,
+		"enable the fixed owner-only synchronized evidence one-shot control",
+	)
 	fs.IntVar(&cfg.QueueCapacity, "queue-capacity", cfg.QueueCapacity, "bus queue capacity (0 uses protocol default)")
 	fs.BoolVar(&cfg.ScanOnStart, "scan", cfg.ScanOnStart, "scan bus on startup")
 	fs.DurationVar(&cfg.ScanTimeout, "scan-timeout", cfg.ScanTimeout, "startup scan timeout")
@@ -1924,7 +1933,11 @@ func startHTTPServer(
 			return nil, nil, fmt.Errorf("register eeBUS MCP command router: %w", err)
 		}
 	}
-	oneShotRuntime, err := newSynchronizedEvidenceOneShotRuntime(eebusProvider, eebusCommandRouter)
+	oneShotRuntime, err := newSynchronizedEvidenceOneShotRuntime(
+		cfg.EvidenceOneShotEnabled,
+		eebusProvider,
+		eebusCommandRouter,
+	)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/gateway/synchronized_evidence_flags_test.go
+++ b/cmd/gateway/synchronized_evidence_flags_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"testing"
+
+	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/syncevidence"
+)
+
+func TestIssue764SynchronizedEvidenceOneShotFlagIsExplicitOptIn(t *testing.T) {
+	cfg := ebusgateway.DefaultConfig()
+	fs := flag.NewFlagSet("synchronized-evidence-one-shot-test", flag.ContinueOnError)
+	bindFlags(fs, &cfg)
+	if err := fs.Parse([]string{"-synchronized-evidence-one-shot-enabled=true"}); err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.EvidenceOneShotEnabled {
+		t.Fatal("one-shot control was not enabled")
+	}
+	if cfg.EvidenceRecorderConfig != ebusgateway.DefaultEvidenceRecorderConfig() {
+		t.Fatalf("generic recorder config changed: %#v", cfg.EvidenceRecorderConfig)
+	}
+	if err := ebusgateway.ValidateSynchronizedEvidenceConfig(cfg); err != nil {
+		t.Fatalf("parsed one-shot config is invalid: %v", err)
+	}
+	adapter := &eebusRuntimeAdapter{runtime: &msp06GatewayRuntime{}}
+	runtime, err := newSynchronizedEvidenceOneShotRuntime(
+		cfg.EvidenceOneShotEnabled,
+		eebusMCPProvider(adapter),
+		eebusMCPCommandRouter(adapter),
+	)
+	if err != nil || runtime == nil {
+		t.Fatalf("construct enabled one-shot runtime = %#v, %v", runtime, err)
+	}
+	runtime.execute = func(_ context.Context, options syncevidence.OneShotExecutionOptions) syncevidence.OneShotReceiptV1 {
+		if options.Root != synchronizedEvidenceOneShotRoot {
+			t.Fatalf("one-shot root = %q", options.Root)
+		}
+		return syncevidence.OneShotReceiptV1{Category: syncevidence.OneShotExisting}
+	}
+	if receipt := runtime.CaptureSynchronizedEvidence(context.Background()); receipt.Category != syncevidence.OneShotExisting {
+		t.Fatalf("capture receipt = %#v", receipt)
+	}
+}
+
+func TestIssue764SynchronizedEvidenceOneShotDefaultIsInert(t *testing.T) {
+	cfg := ebusgateway.DefaultConfig()
+	fs := flag.NewFlagSet("synchronized-evidence-one-shot-default-test", flag.ContinueOnError)
+	bindFlags(fs, &cfg)
+	if err := fs.Parse(nil); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.EvidenceOneShotEnabled {
+		t.Fatal("one-shot control enabled by default")
+	}
+	if cfg.EvidenceRecorderConfig != ebusgateway.DefaultEvidenceRecorderConfig() {
+		t.Fatalf("default generic recorder config changed: %#v", cfg.EvidenceRecorderConfig)
+	}
+	adapter := &eebusRuntimeAdapter{runtime: &msp06GatewayRuntime{}}
+	runtime, err := newSynchronizedEvidenceOneShotRuntime(
+		cfg.EvidenceOneShotEnabled,
+		eebusMCPProvider(adapter),
+		eebusMCPCommandRouter(adapter),
+	)
+	if err != nil || runtime != nil {
+		t.Fatalf("default one-shot runtime = %#v, %v", runtime, err)
+	}
+}

--- a/cmd/gateway/synchronized_evidence_runtime.go
+++ b/cmd/gateway/synchronized_evidence_runtime.go
@@ -100,9 +100,13 @@ func (reader *gatewayEEBusEvidenceReader) ListServices(context.Context, syncevid
 }
 
 func newSynchronizedEvidenceOneShotRuntime(
+	enabled bool,
 	provider synchronizedEvidenceSnapshotProvider,
 	router mcp.EEBusV1CommandRouter,
 ) (*synchronizedEvidenceOneShotRuntime, error) {
+	if !enabled {
+		return nil, nil
+	}
 	if synchronizedEvidenceNilInterface(provider) || synchronizedEvidenceNilInterface(router) {
 		return nil, nil
 	}

--- a/cmd/gateway/synchronized_evidence_runtime.go
+++ b/cmd/gateway/synchronized_evidence_runtime.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"reflect"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -14,9 +15,13 @@ import (
 
 	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/syncevidence"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
+	eebusruntime "github.com/Project-Helianthus/helianthus-eebusreg"
+	"github.com/Project-Helianthus/helianthus-eebusreg/eebusraw"
 )
 
 const synchronizedEvidenceSourceVersion = "git:520b6439441cb6e8ef9ff291bde28f4efa4db254"
+const synchronizedEvidenceOneShotRoot = "/data/synchronized-evidence"
 
 type synchronizedEvidenceRuntime struct {
 	store     *syncevidence.FileStore
@@ -24,6 +29,25 @@ type synchronizedEvidenceRuntime struct {
 	config    ebusgateway.EvidenceRecorderConfig
 	closeOnce sync.Once
 	closeErr  error
+}
+
+type synchronizedEvidenceOneShotRuntime struct {
+	mu            sync.Mutex
+	root          string
+	reader        syncevidence.EEBusM625Reader
+	clockFactory  func() syncevidence.Clock
+	entropy       io.Reader
+	buildIdentity func() (syncevidence.OneShotBuildIdentity, error)
+	execute       func(context.Context, syncevidence.OneShotExecutionOptions) syncevidence.OneShotReceiptV1
+}
+
+type synchronizedEvidenceM625Runtime struct {
+	provider synchronizedEvidenceSnapshotProvider
+	router   mcp.EEBusV1CommandRouter
+}
+
+type synchronizedEvidenceSnapshotProvider interface {
+	Snapshot() (eebusruntime.SnapshotV1, error)
 }
 
 type synchronizedEvidenceClock struct {
@@ -73,6 +97,83 @@ func (reader *gatewayEEBusEvidenceReader) ListServices(context.Context, syncevid
 		return syncevidence.AcquiredEvidence{}, err
 	}
 	return syncevidence.AcquiredEvidence{SourceObservedAt: observedAt, NormalizedEvidence: payload}, nil
+}
+
+func newSynchronizedEvidenceOneShotRuntime(
+	provider synchronizedEvidenceSnapshotProvider,
+	router mcp.EEBusV1CommandRouter,
+) (*synchronizedEvidenceOneShotRuntime, error) {
+	if synchronizedEvidenceNilInterface(provider) || synchronizedEvidenceNilInterface(router) {
+		return nil, nil
+	}
+	reader, err := syncevidence.NewM625EEBusReader(&synchronizedEvidenceM625Runtime{
+		provider: provider,
+		router:   router,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("construct synchronized evidence M6.25 reader: %w", err)
+	}
+	return &synchronizedEvidenceOneShotRuntime{
+		root:          synchronizedEvidenceOneShotRoot,
+		reader:        reader,
+		clockFactory:  func() syncevidence.Clock { return newSynchronizedEvidenceClock() },
+		entropy:       synchronizedEvidenceEntropy,
+		buildIdentity: synchronizedEvidenceOneShotBuildIdentity,
+		execute:       syncevidence.ExecuteOneShot,
+	}, nil
+}
+
+func synchronizedEvidenceNilInterface(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}
+
+func (runtime *synchronizedEvidenceOneShotRuntime) CaptureSynchronizedEvidence(
+	ctx context.Context,
+) syncevidence.OneShotReceiptV1 {
+	if runtime == nil {
+		return syncevidence.OneShotReceiptV1{Category: syncevidence.OneShotInternal}
+	}
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	if runtime.execute == nil {
+		return syncevidence.OneShotReceiptV1{Category: syncevidence.OneShotInternal}
+	}
+	return runtime.execute(ctx, syncevidence.OneShotExecutionOptions{
+		Root:          runtime.root,
+		Reader:        runtime.reader,
+		ClockFactory:  runtime.clockFactory,
+		Entropy:       runtime.entropy,
+		BuildIdentity: runtime.buildIdentity,
+	})
+}
+
+func (runtime *synchronizedEvidenceM625Runtime) Snapshot() (eebusruntime.SnapshotV1, error) {
+	return runtime.provider.Snapshot()
+}
+
+func (runtime *synchronizedEvidenceM625Runtime) FeaturesGet(
+	ctx context.Context,
+	auth eebusraw.ReadAuthorizationV1,
+	request eebusraw.FeaturesGetRequestV1,
+) (eebusraw.FeaturesGetDataV1, *eebusraw.ErrorV1) {
+	return runtime.router.FeaturesGet(ctx, auth, request)
+}
+
+func (runtime *synchronizedEvidenceM625Runtime) FeaturesDataGet(
+	ctx context.Context,
+	auth eebusraw.ReadAuthorizationV1,
+	request eebusraw.FeatureDataGetRequestV1,
+) (eebusraw.FeatureDataGetDataV1, *eebusraw.ErrorV1) {
+	return runtime.router.FeaturesDataGet(ctx, auth, request)
 }
 
 func openSynchronizedEvidenceRuntime(config ebusgateway.EvidenceRecorderConfig) (*synchronizedEvidenceRuntime, error) {
@@ -201,13 +302,34 @@ func contentEvidenceRef(digest string) syncevidence.EvidenceRefV1 {
 }
 
 func synchronizedEvidenceBuildVersion() (string, error) {
+	revision, err := synchronizedEvidenceBuildRevision()
+	if err != nil {
+		return "", err
+	}
+	return buildVersion + "+git." + revision, nil
+}
+
+func synchronizedEvidenceOneShotBuildIdentity() (syncevidence.OneShotBuildIdentity, error) {
+	revision, err := synchronizedEvidenceBuildRevision()
+	if err != nil {
+		return syncevidence.OneShotBuildIdentity{}, err
+	}
+	version := buildVersion + "+git." + revision
+	return syncevidence.OneShotBuildIdentity{
+		RecorderVersion:  version,
+		ReplayVersion:    version,
+		OperationVersion: "git:" + revision,
+	}, nil
+}
+
+func synchronizedEvidenceBuildRevision() (string, error) {
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
 		return "", errors.New("read build information")
 	}
 	for _, setting := range info.Settings {
 		if setting.Key == "vcs.revision" && len(setting.Value) == 40 && strings.Trim(setting.Value, "0123456789abcdef") == "" {
-			return buildVersion + "+git." + setting.Value, nil
+			return setting.Value, nil
 		}
 	}
 	return "", errors.New("full build revision unavailable")
@@ -216,5 +338,7 @@ func synchronizedEvidenceBuildVersion() (string, error) {
 var _ syncevidence.EBusSnapshotReader = unavailableEBusEvidenceReader{}
 var _ syncevidence.EEBusServicesReader = unavailableEEBusEvidenceReader{}
 var _ syncevidence.EEBusServicesReader = (*gatewayEEBusEvidenceReader)(nil)
+var _ syncevidence.M625EEBusRuntime = (*synchronizedEvidenceM625Runtime)(nil)
+var _ mcp.SynchronizedEvidenceCapture = (*synchronizedEvidenceOneShotRuntime)(nil)
 
 var synchronizedEvidenceEntropy io.Reader = rand.Reader

--- a/cmd/gateway/synchronized_evidence_runtime_test.go
+++ b/cmd/gateway/synchronized_evidence_runtime_test.go
@@ -124,6 +124,30 @@ func TestMSP065EvidenceStoreLockFailsBeforeTransportDial(t *testing.T) {
 	}
 }
 
+func TestIssue764DuplicateEvidenceStoreOwnersFailBeforeOpenOrDial(t *testing.T) {
+	config := enabledSynchronizedEvidenceConfig(t)
+	gatewayConfig := ebusgateway.DefaultConfig()
+	gatewayConfig.EvidenceRecorderConfig = config
+	gatewayConfig.EvidenceOneShotEnabled = true
+	dialed := false
+	gatewayConfig.TransportConfig.Network = "tcp"
+	gatewayConfig.TransportConfig.Address = "127.0.0.1:9999"
+	gatewayConfig.TransportConfig.Dial = func(context.Context, string, string, time.Duration) (net.Conn, error) {
+		dialed = true
+		return nil, errors.New("unexpected dial")
+	}
+
+	if err := run(context.Background(), gatewayConfig); !errors.Is(err, ebusgateway.ErrSynchronizedEvidenceOwnership) {
+		t.Fatalf("run() error = %v, want %v", err, ebusgateway.ErrSynchronizedEvidenceOwnership)
+	}
+	if dialed {
+		t.Fatal("transport dialed before duplicate ownership was rejected")
+	}
+	if _, err := os.Stat(config.StateRoot); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("duplicate ownership opened store: %v", err)
+	}
+}
+
 func TestMSP065SynchronizedEvidenceRuntimeRejectsSecondConfigurationAndClosesOnce(t *testing.T) {
 	config := enabledSynchronizedEvidenceConfig(t)
 	runtime, err := openSynchronizedEvidenceRuntime(config)
@@ -148,6 +172,7 @@ func TestIssue764GatewayOneShotRuntimeIsFixedReadOnlyAndSerialized(t *testing.T)
 	eebusRuntime := &msp06GatewayRuntime{}
 	adapter := &eebusRuntimeAdapter{runtime: eebusRuntime}
 	runtime, err := newSynchronizedEvidenceOneShotRuntime(
+		true,
 		eebusMCPProvider(adapter),
 		eebusMCPCommandRouter(adapter),
 	)
@@ -196,8 +221,15 @@ func TestIssue764GatewayOneShotRuntimeIsFixedReadOnlyAndSerialized(t *testing.T)
 		t.Fatalf("calls/maximum concurrency = %d/%d", calls, maximum)
 	}
 
-	if absent, err := newSynchronizedEvidenceOneShotRuntime(nil, nil); err != nil || absent != nil {
+	if absent, err := newSynchronizedEvidenceOneShotRuntime(true, nil, nil); err != nil || absent != nil {
 		t.Fatalf("disabled one-shot runtime = %#v, %v", absent, err)
+	}
+	if absent, err := newSynchronizedEvidenceOneShotRuntime(
+		false,
+		eebusMCPProvider(adapter),
+		eebusMCPCommandRouter(adapter),
+	); err != nil || absent != nil {
+		t.Fatalf("explicitly disabled one-shot runtime = %#v, %v", absent, err)
 	}
 }
 

--- a/cmd/gateway/synchronized_evidence_runtime_test.go
+++ b/cmd/gateway/synchronized_evidence_runtime_test.go
@@ -5,15 +5,20 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"net"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/syncevidence"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
 )
 
 const synchronizedEvidenceTestVersion = "1.0.0+git.61bc62fa1d08dcf7b677c3dc08855beb5c68ceb1"
@@ -136,5 +141,96 @@ func TestMSP065SynchronizedEvidenceRuntimeRejectsSecondConfigurationAndClosesOnc
 	}
 	if err := runtime.Close(); err != nil {
 		t.Fatalf("second Close() error = %v", err)
+	}
+}
+
+func TestIssue764GatewayOneShotRuntimeIsFixedReadOnlyAndSerialized(t *testing.T) {
+	eebusRuntime := &msp06GatewayRuntime{}
+	adapter := &eebusRuntimeAdapter{runtime: eebusRuntime}
+	runtime, err := newSynchronizedEvidenceOneShotRuntime(
+		eebusMCPProvider(adapter),
+		eebusMCPCommandRouter(adapter),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime == nil || runtime.root != synchronizedEvidenceOneShotRoot || runtime.reader == nil {
+		t.Fatalf("one-shot runtime = %#v", runtime)
+	}
+	if _, ok := any(runtime).(mcp.SynchronizedEvidenceCapture); !ok {
+		t.Fatal("one-shot runtime does not implement the private MCP owner seam")
+	}
+
+	var stateMu sync.Mutex
+	active, maximum, calls := 0, 0, 0
+	runtime.execute = func(_ context.Context, options syncevidence.OneShotExecutionOptions) syncevidence.OneShotReceiptV1 {
+		if options.Root != synchronizedEvidenceOneShotRoot || options.Reader == nil ||
+			options.ClockFactory == nil || options.BuildIdentity == nil {
+			t.Fatalf("execution options = %#v", options)
+		}
+		stateMu.Lock()
+		active++
+		calls++
+		if active > maximum {
+			maximum = active
+		}
+		stateMu.Unlock()
+		time.Sleep(20 * time.Millisecond)
+		stateMu.Lock()
+		active--
+		stateMu.Unlock()
+		return syncevidence.OneShotReceiptV1{Category: syncevidence.OneShotExisting}
+	}
+	var wait sync.WaitGroup
+	wait.Add(2)
+	for range 2 {
+		go func() {
+			defer wait.Done()
+			if receipt := runtime.CaptureSynchronizedEvidence(context.Background()); receipt.Category != syncevidence.OneShotExisting {
+				t.Errorf("receipt = %#v", receipt)
+			}
+		}()
+	}
+	wait.Wait()
+	if calls != 2 || maximum != 1 {
+		t.Fatalf("calls/maximum concurrency = %d/%d", calls, maximum)
+	}
+
+	if absent, err := newSynchronizedEvidenceOneShotRuntime(nil, nil); err != nil || absent != nil {
+		t.Fatalf("disabled one-shot runtime = %#v, %v", absent, err)
+	}
+}
+
+func TestIssue764GatewayRegistersPrivateCaptureExactlyOnceBeforeMCPMount(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "main.go", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var registration token.Pos
+	var mount token.Pos
+	count := 0
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if selector.Sel.Name == "RegisterSynchronizedEvidenceCapture" {
+			count++
+			registration = call.Pos()
+		}
+		if selector.Sel.Name == "Handle" && len(call.Args) > 0 {
+			if path, ok := call.Args[0].(*ast.SelectorExpr); ok && path.Sel.Name == "MCPPath" {
+				mount = call.Pos()
+			}
+		}
+		return true
+	})
+	if count != 1 || !registration.IsValid() || !mount.IsValid() || registration >= mount {
+		t.Fatalf("private registration count/positions = %d/%d/%d", count, registration, mount)
 	}
 }

--- a/config.go
+++ b/config.go
@@ -126,6 +126,7 @@ type Config struct {
 	TransportConfig          TransportConfig
 	EEBusConfig              EEBusConfig
 	EvidenceRecorderConfig   EvidenceRecorderConfig
+	EvidenceOneShotEnabled   bool
 	BusConfig                protocol.BusConfig
 	QueueCapacity            int
 	Providers                []registry.PlaneProvider

--- a/eebus_config_test.go
+++ b/eebus_config_test.go
@@ -86,6 +86,10 @@ func TestMSP06EEBusRuntimeCouplingIsConfinedToApprovedSeams(t *testing.T) {
 		"internal/eebuscommand/router.go": false,
 		"mcp/eebus_v1_dto.go":             false,
 		"mcp/eebus_v1_commands.go":        false,
+		// Issue #764 adds one bounded read-only M6.25 evidence consumer and its
+		// private gateway owner wiring. Neither seam is a consumer projection.
+		"internal/syncevidence/m625_acquisition.go":    false,
+		"cmd/gateway/synchronized_evidence_runtime.go": false,
 	}
 	var unexpected []string
 	err = filepath.WalkDir(".", func(path string, entry os.DirEntry, walkErr error) error {

--- a/evidence_recorder_config.go
+++ b/evidence_recorder_config.go
@@ -34,6 +34,7 @@ var (
 	ErrEvidenceRecorderRetention     = errors.New("evidence recorder config: retention must be positive")
 	ErrEvidenceRecorderQuota         = errors.New("evidence recorder config: quota cannot hold one maximum bundle")
 	ErrEvidenceRecorderLimits        = errors.New("evidence recorder config: limits must be positive and within V1 ceilings")
+	ErrSynchronizedEvidenceOwnership = errors.New("synchronized evidence: generic recorder and one-shot control cannot both be enabled")
 )
 
 // EvidenceRecorderLimits records the effective, hash-bound V1 capture limits.
@@ -76,6 +77,16 @@ func DefaultEvidenceRecorderLimits() EvidenceRecorderLimits {
 		MaxCaptureDuration: 15 * time.Minute,
 		MaxSourceDuration:  time.Minute,
 	}
+}
+
+func ValidateSynchronizedEvidenceConfig(cfg Config) error {
+	if err := ValidateEvidenceRecorderConfig(cfg.EvidenceRecorderConfig); err != nil {
+		return err
+	}
+	if cfg.EvidenceRecorderConfig.Enabled && cfg.EvidenceOneShotEnabled {
+		return ErrSynchronizedEvidenceOwnership
+	}
+	return nil
 }
 
 func ValidateEvidenceRecorderConfig(cfg EvidenceRecorderConfig) error {

--- a/evidence_recorder_config_test.go
+++ b/evidence_recorder_config_test.go
@@ -89,3 +89,25 @@ func TestGatewayRejectsUnsafeEvidenceRecorderBeforeTransportDial(t *testing.T) {
 		t.Fatal("transport dialed before evidence recorder configuration was rejected")
 	}
 }
+
+func TestSynchronizedEvidenceConfigRejectsDuplicateStoreOwners(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.EvidenceOneShotEnabled = true
+	cfg.EvidenceRecorderConfig = EvidenceRecorderConfig{
+		Version:    EvidenceRecorderConfigVersion,
+		Enabled:    true,
+		Scope:      EvidenceRecorderScopeV1,
+		StateRoot:  "/data/evidence",
+		Retention:  DefaultEvidenceRecorderRetention,
+		QuotaBytes: DefaultEvidenceRecorderQuotaBytes,
+		Limits:     DefaultEvidenceRecorderLimits(),
+	}
+
+	if err := ValidateSynchronizedEvidenceConfig(cfg); !errors.Is(err, ErrSynchronizedEvidenceOwnership) {
+		t.Fatalf("ValidateSynchronizedEvidenceConfig() error = %v, want %v", err, ErrSynchronizedEvidenceOwnership)
+	}
+	cfg.EvidenceRecorderConfig = DefaultEvidenceRecorderConfig()
+	if err := ValidateSynchronizedEvidenceConfig(cfg); err != nil {
+		t.Fatalf("one-shot-only config rejected: %v", err)
+	}
+}

--- a/gateway.go
+++ b/gateway.go
@@ -32,7 +32,7 @@ func New(ctx context.Context, cfg Config) (*Gateway, error) {
 	if err := ValidateStartupAdmissionStability(cfg.StateMinStabilitySeconds); err != nil {
 		return nil, fmt.Errorf("validate gateway config: %w", err)
 	}
-	if err := ValidateEvidenceRecorderConfig(cfg.EvidenceRecorderConfig); err != nil {
+	if err := ValidateSynchronizedEvidenceConfig(cfg); err != nil {
 		return nil, fmt.Errorf("validate gateway config: %w", err)
 	}
 

--- a/internal/syncevidence/canonical.go
+++ b/internal/syncevidence/canonical.go
@@ -8,8 +8,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/big"
 	"sort"
-	"strconv"
 	"strings"
 	"unicode/utf16"
 	"unicode/utf8"
@@ -194,19 +194,67 @@ func validateJSONString(value string, maximum uint64) error {
 }
 
 func isSafeInteger(value string) bool {
-	if value == "0" {
-		return true
+	_, ok := safeIntegerValue(value)
+	return ok
+}
+
+func safeIntegerValue(value string) (uint64, bool) {
+	if !isJSONNumberLexeme(value) {
+		return 0, false
 	}
-	if value == "" || value[0] < '1' || value[0] > '9' {
+	rational, ok := new(big.Rat).SetString(value)
+	if !ok || !rational.IsInt() || rational.Sign() < 0 || !rational.Num().IsUint64() {
+		return 0, false
+	}
+	parsed := rational.Num().Uint64()
+	if parsed > MaxSafeIntegerV1 {
+		return 0, false
+	}
+	return parsed, true
+}
+
+func isJSONNumberLexeme(value string) bool {
+	index := 0
+	if index < len(value) && value[index] == '-' {
+		index++
+	}
+	if index >= len(value) {
 		return false
 	}
-	for _, char := range value[1:] {
-		if char < '0' || char > '9' {
+	if value[index] == '0' {
+		index++
+	} else {
+		if value[index] < '1' || value[index] > '9' {
+			return false
+		}
+		for index < len(value) && value[index] >= '0' && value[index] <= '9' {
+			index++
+		}
+	}
+	if index < len(value) && value[index] == '.' {
+		index++
+		fractionStart := index
+		for index < len(value) && value[index] >= '0' && value[index] <= '9' {
+			index++
+		}
+		if index == fractionStart {
 			return false
 		}
 	}
-	parsed, err := strconv.ParseUint(value, 10, 64)
-	return err == nil && parsed <= MaxSafeIntegerV1
+	if index < len(value) && (value[index] == 'e' || value[index] == 'E') {
+		index++
+		if index < len(value) && (value[index] == '+' || value[index] == '-') {
+			index++
+		}
+		exponentStart := index
+		for index < len(value) && value[index] >= '0' && value[index] <= '9' {
+			index++
+		}
+		if index == exponentStart {
+			return false
+		}
+	}
+	return index == len(value)
 }
 
 func appendCanonical(out *bytes.Buffer, value any) error {
@@ -222,10 +270,11 @@ func appendCanonical(out *bytes.Buffer, value any) error {
 	case string:
 		appendJSONString(out, current)
 	case json.Number:
-		if !isSafeInteger(string(current)) {
+		integer, ok := safeIntegerValue(string(current))
+		if !ok {
 			return ErrContractViolation
 		}
-		out.WriteString(string(current))
+		fmt.Fprint(out, integer)
 	case []any:
 		out.WriteByte('[')
 		for index, item := range current {

--- a/internal/syncevidence/contracts/helianthus.eebus.m625.public-redacted-evidence.v1.schema.json
+++ b/internal/syncevidence/contracts/helianthus.eebus.m625.public-redacted-evidence.v1.schema.json
@@ -1,0 +1,612 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Project-Helianthus/helianthus-docs-eebus/raw/main/api/_candidate/msp-0625/helianthus.eebus.m625.public-redacted-evidence.v1.schema.json",
+  "title": "Helianthus M6.25 public-redacted eeBUS normalized evidence V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "contract",
+    "schema_version",
+    "source_observed_at",
+    "services",
+    "feature_paths",
+    "observations"
+  ],
+  "properties": {
+    "contract": {
+      "const": "helianthus.eebus.m625.public-redacted-evidence.v1"
+    },
+    "schema_version": {
+      "const": 1
+    },
+    "source_observed_at": {
+      "$ref": "#/$defs/TimestampV1"
+    },
+    "services": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 64,
+      "items": {
+        "$ref": "#/$defs/PseudonymV1"
+      }
+    },
+    "feature_paths": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 4096,
+      "items": {
+        "$ref": "#/$defs/EEBusPathV1"
+      }
+    },
+    "observations": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 4096,
+      "items": {
+        "$ref": "#/$defs/ObservationV1"
+      }
+    }
+  },
+  "$defs": {
+    "TimestampV1": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-([0-2][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\\.[0-9]{0,8}[1-9])?Z$"
+    },
+    "SafeIntegerV1": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "PseudonymV1": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_-]{43}$"
+    },
+    "ObservationRefV1": {
+      "type": "string",
+      "pattern": "^obs-[A-Za-z0-9_-]{43}$"
+    },
+    "IdentifierV1": {
+      "type": "string",
+      "pattern": "^[A-Za-z][A-Za-z0-9]{0,127}$"
+    },
+    "DecimalV1": {
+      "type": "string",
+      "pattern": "^(0(\\.0+)?|0\\.[0-9]*[1-9][0-9]*|[1-9][0-9]*(\\.[0-9]+)?|-(0\\.[0-9]*[1-9][0-9]*|[1-9][0-9]*(\\.[0-9]+)?))$",
+      "maxLength": 64
+    },
+    "BooleanV1": {
+      "type": "string",
+      "enum": [
+        "false",
+        "true"
+      ]
+    },
+    "EnumValueV1": {
+      "type": "string",
+      "pattern": "^ID_(0|[1-9][0-9]{0,9})$"
+    },
+    "UnitV1": {
+      "type": "string",
+      "enum": [
+        "unknown",
+        "1",
+        "m",
+        "kg",
+        "s",
+        "A",
+        "K",
+        "mol",
+        "cd",
+        "V",
+        "W",
+        "Wh",
+        "VA",
+        "VAh",
+        "var",
+        "varh",
+        "degC",
+        "degF",
+        "Lm",
+        "lx",
+        "Ohm",
+        "Hz",
+        "dB",
+        "dBm",
+        "pct",
+        "ppm",
+        "l",
+        "l/s",
+        "l/h",
+        "deg",
+        "rad",
+        "rad/s",
+        "sr",
+        "Gy",
+        "Bq",
+        "Bq/m^3",
+        "Sv",
+        "Rd",
+        "C",
+        "F",
+        "H",
+        "J",
+        "N",
+        "N_m",
+        "N_s",
+        "Wb",
+        "T",
+        "Pa",
+        "bar",
+        "atm",
+        "psi",
+        "mmHg",
+        "m^2",
+        "m^3",
+        "m^3/h",
+        "m/s",
+        "m/s^2",
+        "m^3/s",
+        "m/m^3",
+        "kg/m^3",
+        "kg_m",
+        "m^2/s",
+        "W/m_K",
+        "J/K",
+        "1/s",
+        "W/m^2",
+        "J/m^2",
+        "S",
+        "S/m",
+        "K/s",
+        "Pa/s",
+        "J/kg_K",
+        "Vs",
+        "V/m",
+        "V/Hz",
+        "As",
+        "A/m",
+        "Hz/s",
+        "kg/s",
+        "kg_m^2",
+        "J/Wh",
+        "W/s",
+        "ft^3",
+        "ft^3/h",
+        "ccf",
+        "ccf/h",
+        "US.liq.gal",
+        "US.liq.gal/h",
+        "Imp.gal",
+        "Imp.gal/h",
+        "Btu",
+        "Btu/h",
+        "Ah",
+        "kg/Wh"
+      ]
+    },
+    "NullableUnitV1": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/$defs/UnitV1"
+        }
+      ]
+    },
+    "NullableQualityV1": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "enum": [
+            "OBSERVED",
+            "STALE"
+          ]
+        }
+      ]
+    },
+    "TerminalClassificationV1": {
+      "enum": [
+        "SUCCESS",
+        "INVALID_ARGUMENT",
+        "PERMISSION_DENIED",
+        "UNSUPPORTED_OPERATION",
+        "PARTIAL_OPERATION_FORBIDDEN",
+        "CONSTRAINTS_UNKNOWN",
+        "CONSTRAINT_FAILURE",
+        "STALE_READ_TOKEN",
+        "CAS_MISMATCH",
+        "RUNTIME_EPOCH_MISMATCH",
+        "CONNECTION_GENERATION_MISMATCH",
+        "IDEMPOTENCY_CONFLICT",
+        "WRITER_BUSY",
+        "TIMEOUT",
+        "CANCELLED",
+        "DISCONNECTED",
+        "REMOTE_ERROR",
+        "DECODE_ERROR",
+        "PARTIAL_RESULT",
+        "NO_EFFECT",
+        "OUTCOME_UNKNOWN",
+        "CONFLICT",
+        "ROLLBACK_FAILED",
+        "NOT_FOUND",
+        "SECRET_DETECTED",
+        "INTERNAL"
+      ]
+    },
+    "PathSegmentV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "selector"
+      ],
+      "properties": {
+        "kind": {
+          "enum": [
+            "SERVICE",
+            "ENTITY",
+            "FEATURE",
+            "FIELD"
+          ]
+        },
+        "selector": {
+          "$ref": "#/$defs/PseudonymV1"
+        }
+      }
+    },
+    "EEBusPathV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "service",
+        "entity",
+        "feature",
+        "feature_path"
+      ],
+      "properties": {
+        "service": {
+          "$ref": "#/$defs/PseudonymV1"
+        },
+        "entity": {
+          "$ref": "#/$defs/PseudonymV1"
+        },
+        "feature": {
+          "$ref": "#/$defs/PseudonymV1"
+        },
+        "feature_path": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 32,
+          "items": {
+            "$ref": "#/$defs/PathSegmentV1"
+          }
+        }
+      }
+    },
+    "NullableValueTypeV1": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "enum": [
+            "BOOLEAN",
+            "DECIMAL",
+            "ENUM"
+          ]
+        }
+      ]
+    },
+    "NullableValueV1": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/$defs/DecimalV1"
+        },
+        {
+          "$ref": "#/$defs/BooleanV1"
+        },
+        {
+          "$ref": "#/$defs/EnumValueV1"
+        }
+      ]
+    },
+    "ObservationV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "observation_ref",
+        "path_index",
+        "feature_type",
+        "feature_role",
+        "function",
+        "source_observed_at",
+        "terminal_classification",
+        "value_type",
+        "value",
+        "unit",
+        "quality"
+      ],
+      "properties": {
+        "observation_ref": {
+          "$ref": "#/$defs/ObservationRefV1"
+        },
+        "path_index": {
+          "$ref": "#/$defs/SafeIntegerV1"
+        },
+        "feature_type": {
+          "$ref": "#/$defs/IdentifierV1"
+        },
+        "feature_role": {
+          "enum": [
+            "client",
+            "server",
+            "special"
+          ]
+        },
+        "function": {
+          "$ref": "#/$defs/IdentifierV1"
+        },
+        "source_observed_at": {
+          "$ref": "#/$defs/TimestampV1"
+        },
+        "terminal_classification": {
+          "$ref": "#/$defs/TerminalClassificationV1"
+        },
+        "value_type": {
+          "$ref": "#/$defs/NullableValueTypeV1"
+        },
+        "value": {
+          "$ref": "#/$defs/NullableValueV1"
+        },
+        "unit": {
+          "$ref": "#/$defs/NullableUnitV1"
+        },
+        "quality": {
+          "$ref": "#/$defs/NullableQualityV1"
+        }
+      },
+      "allOf": [
+        {
+          "oneOf": [
+            {
+              "properties": {
+                "feature_type": {
+                  "const": "Measurement"
+                },
+                "function": {
+                  "const": "measurementListData"
+                },
+                "value_type": {
+                  "enum": [
+                    null,
+                    "DECIMAL"
+                  ]
+                }
+              }
+            },
+            {
+              "properties": {
+                "feature_type": {
+                  "const": "Setpoint"
+                },
+                "function": {
+                  "const": "setpointListData"
+                },
+                "value_type": {
+                  "enum": [
+                    null,
+                    "BOOLEAN",
+                    "DECIMAL"
+                  ]
+                }
+              }
+            },
+            {
+              "properties": {
+                "feature_type": {
+                  "const": "HVAC"
+                },
+                "function": {
+                  "const": "hvacSystemFunctionListData"
+                },
+                "value_type": {
+                  "enum": [
+                    null,
+                    "BOOLEAN",
+                    "ENUM"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "oneOf": [
+            {
+              "properties": {
+                "terminal_classification": {
+                  "const": "SUCCESS"
+                },
+                "value_type": {
+                  "const": "DECIMAL"
+                },
+                "value": {
+                  "$ref": "#/$defs/DecimalV1"
+                },
+                "quality": {
+                  "enum": [
+                    "OBSERVED",
+                    "STALE"
+                  ]
+                }
+              }
+            },
+            {
+              "properties": {
+                "terminal_classification": {
+                  "const": "SUCCESS"
+                },
+                "value_type": {
+                  "const": "BOOLEAN"
+                },
+                "value": {
+                  "$ref": "#/$defs/BooleanV1"
+                },
+                "unit": {
+                  "type": "null"
+                },
+                "quality": {
+                  "enum": [
+                    "OBSERVED",
+                    "STALE"
+                  ]
+                }
+              }
+            },
+            {
+              "properties": {
+                "terminal_classification": {
+                  "const": "SUCCESS"
+                },
+                "value_type": {
+                  "const": "ENUM"
+                },
+                "value": {
+                  "$ref": "#/$defs/EnumValueV1"
+                },
+                "unit": {
+                  "type": "null"
+                },
+                "quality": {
+                  "enum": [
+                    "OBSERVED",
+                    "STALE"
+                  ]
+                }
+              }
+            },
+            {
+              "properties": {
+                "terminal_classification": {
+                  "enum": [
+                    "INVALID_ARGUMENT",
+                    "PERMISSION_DENIED",
+                    "UNSUPPORTED_OPERATION",
+                    "PARTIAL_OPERATION_FORBIDDEN",
+                    "CONSTRAINTS_UNKNOWN",
+                    "CONSTRAINT_FAILURE",
+                    "STALE_READ_TOKEN",
+                    "CAS_MISMATCH",
+                    "RUNTIME_EPOCH_MISMATCH",
+                    "CONNECTION_GENERATION_MISMATCH",
+                    "IDEMPOTENCY_CONFLICT",
+                    "WRITER_BUSY",
+                    "TIMEOUT",
+                    "CANCELLED",
+                    "DISCONNECTED",
+                    "REMOTE_ERROR",
+                    "DECODE_ERROR",
+                    "PARTIAL_RESULT",
+                    "NO_EFFECT",
+                    "OUTCOME_UNKNOWN",
+                    "CONFLICT",
+                    "ROLLBACK_FAILED",
+                    "NOT_FOUND",
+                    "SECRET_DETECTED",
+                    "INTERNAL"
+                  ]
+                },
+                "value_type": {
+                  "type": "null"
+                },
+                "value": {
+                  "type": "null"
+                },
+                "unit": {
+                  "type": "null"
+                },
+                "quality": {
+                  "type": "null"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "x-public-value-allowlist": [
+    {
+      "feature_type": "Measurement",
+      "function": "measurementListData",
+      "value_types": [
+        "DECIMAL"
+      ]
+    },
+    {
+      "feature_type": "Setpoint",
+      "function": "setpointListData",
+      "value_types": [
+        "BOOLEAN",
+        "DECIMAL"
+      ]
+    },
+    {
+      "feature_type": "HVAC",
+      "function": "hvacSystemFunctionListData",
+      "value_types": [
+        "BOOLEAN",
+        "ENUM"
+      ]
+    }
+  ],
+  "x-msp065-adapter": {
+    "source_kind": "EEBUS",
+    "operation_id": "eebus.v1.features.data.get",
+    "normalized_evidence_root": "$",
+    "value_pointer_pattern": "/observations/{index}/value",
+    "unit_pointer_pattern": "/observations/{index}/unit",
+    "envelope_owned_fields": [
+      "bundle_id",
+      "source_id",
+      "artifact_id",
+      "phase",
+      "source_binding",
+      "auth_scope",
+      "evidence_refs",
+      "recorder_ingested_at",
+      "recorder_ingested_offset_ns",
+      "remasking",
+      "item_count",
+      "byte_count",
+      "redacted_hash",
+      "generated_replay_hash"
+    ]
+  },
+  "x-privacy-boundary": {
+    "pseudonyms": "minted and remasked per MSP-065 bundle",
+    "values": "bounded normalized scalar comparison values only",
+    "forbidden": [
+      "stable identity",
+      "SKI",
+      "SHIP ID",
+      "native SPINE address",
+      "raw request or response",
+      "purpose-bound token",
+      "private network coordinate",
+      "label",
+      "schedule",
+      "secret",
+      "remapping table",
+      "candidate reference"
+    ]
+  }
+}

--- a/internal/syncevidence/contracts/synchronized-evidence-one-shot-control-v1.schema.json
+++ b/internal/syncevidence/contracts/synchronized-evidence-one-shot-control-v1.schema.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Project-Helianthus/helianthus-docs-ebus/raw/main/docs/platform/schemas/synchronized-evidence-one-shot-control-v1.schema.json",
+  "title": "Helianthus synchronized-evidence one-shot request V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "contract",
+    "schema_version",
+    "action_evidence_ref",
+    "cloud_app_action"
+  ],
+  "properties": {
+    "contract": {
+      "const": "helianthus.platform.synchronized-evidence.one-shot-request.v1"
+    },
+    "schema_version": {
+      "const": 1
+    },
+    "action_evidence_ref": {
+      "$ref": "#/$defs/EvidenceRefV1"
+    },
+    "cloud_app_action": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "evidence_ref",
+        "normalized_evidence"
+      ],
+      "properties": {
+        "evidence_ref": {
+          "$ref": "#/$defs/EvidenceRefV1"
+        },
+        "normalized_evidence": {
+          "$ref": "synchronized-evidence-source-cloud-app-v1.schema.json"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "EmptyArgsV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "maxProperties": 0
+    },
+    "EvidenceRefV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "digest_algorithm",
+        "digest",
+        "repository",
+        "commit",
+        "path"
+      ],
+      "properties": {
+        "kind": {
+          "const": "CONTENT"
+        },
+        "digest_algorithm": {
+          "const": "SHA256_CONTENT_BYTES"
+        },
+        "digest": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "repository": {
+          "type": "null"
+        },
+        "commit": {
+          "type": "null"
+        },
+        "path": {
+          "type": "null"
+        }
+      }
+    },
+    "ReceiptV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "category"
+      ],
+      "properties": {
+        "category": {
+          "enum": [
+            "PUBLISHED",
+            "EXISTING",
+            "INVALID_REQUEST",
+            "PERMISSION_DENIED",
+            "CONFLICT",
+            "ACQUISITION_FAILED",
+            "REPLAY_MISMATCH",
+            "PUBLISH_FAILED",
+            "INTERNAL"
+          ]
+        }
+      }
+    }
+  },
+  "x-helianthus-one-shot-control": {
+    "tool": "helianthus.v1.synchronized_evidence.capture",
+    "arguments": "#/$defs/EmptyArgsV1",
+    "transport": "AF_UNIX",
+    "socket_boundary": "EXISTING_OPERATOR_SOCKET",
+    "peer_uid": "SAME_UID",
+    "visibility": "OWNER_ONLY_PRIVATE",
+    "public_tools_list": "OMITTED",
+    "request_path": "/data/synchronized-evidence/one-shot-request-v1.json",
+    "request_mode": "0600",
+    "request_loading": "DESCRIPTOR_RELATIVE_NO_SYMLINK_NO_TRAVERSAL",
+    "store_directory": "/data/synchronized-evidence/store",
+    "store_loading": "DESCRIPTOR_RELATIVE_NO_SYMLINK_NO_TRAVERSAL",
+    "selection": "ALL_SERVER_MEASUREMENT_SETPOINT_HVAC",
+    "sort_key": "COMPLETE_NATIVE_TUPLE",
+    "batch_max": 16,
+    "caller_targets": "FORBIDDEN",
+    "action_input": "PRECAPTURED_CLOUD_APP",
+    "source_kind": "EEBUS",
+    "source_contract": "helianthus.eebus.m625.public-redacted-evidence.v1",
+    "source_schema_version": 1,
+    "idempotency_key": "ACTION_EVIDENCE_REF_PLUS_SOURCE_TUPLE",
+    "prepublish_replay_count": 2,
+    "prepublish_replay_input": "FINALIZED_CANONICAL_STAGING_BYTES",
+    "prepublish_replay_equality": "BYTE_IDENTICAL",
+    "postpublish_verification": "REOPEN_VALIDATE_REPLAY_MATCH",
+    "receipt_after": "ATOMIC_PUBLISH_REOPEN_VALIDATE_REPLAY",
+    "repeat_result": "EXISTING_NO_RUNTIME_NETWORK_SOURCE_ACQUISITION_IO",
+    "repeat_allowed_io": "REQUEST_STORE_READ_RETAINED_VALIDATION_OFFLINE_REPLAY",
+    "repeat_forbidden_new": "TIMESTAMPS_BUNDLE_PSEUDONYMS_STAGING"
+  }
+}

--- a/internal/syncevidence/contracts/synchronized-evidence-source-registry-v1.json
+++ b/internal/syncevidence/contracts/synchronized-evidence-source-registry-v1.json
@@ -43,6 +43,16 @@
       "embedded_schema": null
     },
     {
+      "source_kind": "EEBUS",
+      "source_contract": "helianthus.eebus.m625.public-redacted-evidence.v1",
+      "source_schema_version": 1,
+      "owner_repository": "Project-Helianthus/helianthus-docs-eebus",
+      "owner_path": "api/_candidate/msp-0625/helianthus.eebus.m625.public-redacted-evidence.v1.schema.json",
+      "owner_commit": "a09e3a77153204bc3117e233c71e77ef1859834e",
+      "schema_sha256": "0a2885d01d6703389541e246db59bcd845a332e7ed296abca2d49b4f8de31811",
+      "embedded_schema": "docs/platform/schemas/vendor/helianthus.eebus.m625.public-redacted-evidence.v1.schema.json"
+    },
+    {
       "source_kind": "CLOUD_APP",
       "source_contract": "helianthus.cloud-app.precaptured.evidence.v1",
       "source_schema_version": 1,

--- a/internal/syncevidence/issue764_m625_acquisition_test.go
+++ b/internal/syncevidence/issue764_m625_acquisition_test.go
@@ -3,6 +3,7 @@ package syncevidence
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -214,6 +215,25 @@ func TestIssue764M625AcquisitionSelectsOrdersBatchesAndRedacts(t *testing.T) {
 	}
 	if got := len(payload["observations"].([]any)); got != 17 {
 		t.Fatalf("observation count = %d, want 17", got)
+	}
+	observations := payload["observations"].([]any)
+	observationRefs := make([]string, len(observations))
+	nativeBase := time.Date(2026, 7, 30, 12, 0, 1, 0, time.UTC)
+	for index, raw := range observations {
+		observation := raw.(map[string]any)
+		wantObservedAt := nativeBase.Add(time.Duration(index+1) * time.Millisecond).Format(time.RFC3339Nano)
+		if got := observation["source_observed_at"]; got != wantObservedAt {
+			t.Fatalf(
+				"emitted observation %d source_observed_at = %v, want native feature order timestamp %q",
+				index,
+				got,
+				wantObservedAt,
+			)
+		}
+		observationRefs[index] = observation["observation_ref"].(string)
+	}
+	if sort.StringsAreSorted(observationRefs) {
+		t.Fatalf("native feature order unexpectedly equals pseudonym lexical order: %v", observationRefs)
 	}
 
 	runtime.mu.Lock()

--- a/internal/syncevidence/issue764_m625_acquisition_test.go
+++ b/internal/syncevidence/issue764_m625_acquisition_test.go
@@ -1,6 +1,7 @@
 package syncevidence
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"sort"
@@ -216,25 +217,50 @@ func TestIssue764M625AcquisitionSelectsOrdersBatchesAndRedacts(t *testing.T) {
 	if got := len(payload["observations"].([]any)); got != 17 {
 		t.Fatalf("observation count = %d, want 17", got)
 	}
-	observations := payload["observations"].([]any)
-	observationRefs := make([]string, len(observations))
 	nativeBase := time.Date(2026, 7, 30, 12, 0, 1, 0, time.UTC)
-	for index, raw := range observations {
-		observation := raw.(map[string]any)
-		wantObservedAt := nativeBase.Add(time.Duration(index+1) * time.Millisecond).Format(time.RFC3339Nano)
-		if got := observation["source_observed_at"]; got != wantObservedAt {
-			t.Fatalf(
-				"emitted observation %d source_observed_at = %v, want native feature order timestamp %q",
-				index,
-				got,
-				wantObservedAt,
-			)
+	assertNativeOrder := func(label string, payload map[string]any) {
+		t.Helper()
+		observations := payload["observations"].([]any)
+		observationRefs := make([]string, len(observations))
+		for index, raw := range observations {
+			observation := raw.(map[string]any)
+			wantObservedAt := nativeBase.Add(time.Duration(index+1) * time.Millisecond).Format(time.RFC3339Nano)
+			if got := observation["source_observed_at"]; got != wantObservedAt {
+				t.Fatalf(
+					"%s observation %d source_observed_at = %v, want native feature order timestamp %q",
+					label,
+					index,
+					got,
+					wantObservedAt,
+				)
+			}
+			observationRefs[index] = observation["observation_ref"].(string)
 		}
-		observationRefs[index] = observation["observation_ref"].(string)
+		if sort.StringsAreSorted(observationRefs) {
+			t.Fatalf("%s native feature order unexpectedly equals pseudonym lexical order: %v", label, observationRefs)
+		}
 	}
-	if sort.StringsAreSorted(observationRefs) {
-		t.Fatalf("native feature order unexpectedly equals pseudonym lexical order: %v", observationRefs)
+	assertNativeOrder("acquired", payload)
+
+	recorder := &Recorder{
+		entropy: bytes.NewReader(bytes.Repeat([]byte{0x71}, 1<<20)),
+		limits:  DefaultLimitsV1(),
 	}
+	remasked, _, _, err := recorder.prepareEvidence(sourceCapture{
+		sourceKind:          SourceEEBus,
+		sourceContract:      M625EEBusContractV1,
+		sourceSchemaVersion: 1,
+		sourceObservedAt:    evidence.SourceObservedAt,
+		normalizedEvidence:  evidence.NormalizedEvidence,
+	}, nil, strings.Repeat("S", 43), make(map[string]struct{}))
+	if err != nil {
+		t.Fatalf("prepare final M6.25 evidence: %v", err)
+	}
+	finalValue, _, err := parseJSON(remasked, DefaultLimitsV1(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertNativeOrder("final remasked", finalValue.(map[string]any))
 
 	runtime.mu.Lock()
 	defer runtime.mu.Unlock()

--- a/internal/syncevidence/issue764_m625_acquisition_test.go
+++ b/internal/syncevidence/issue764_m625_acquisition_test.go
@@ -1,0 +1,303 @@
+package syncevidence
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	eebusruntime "github.com/Project-Helianthus/helianthus-eebusreg"
+	"github.com/Project-Helianthus/helianthus-eebusreg/eebusraw"
+)
+
+type issue764M625Runtime struct {
+	mu sync.Mutex
+
+	snapshot eebusruntime.SnapshotV1
+	binding  eebusraw.RuntimeBindingV1
+	driftAt  uint64
+
+	snapshotCalls int
+	featureCalls  []eebusraw.FeaturesGetRequestV1
+	dataCalls     []eebusraw.FeatureDataGetRequestV1
+	auth          []eebusraw.ReadAuthorizationV1
+}
+
+func (runtime *issue764M625Runtime) Snapshot() (eebusruntime.SnapshotV1, error) {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	runtime.snapshotCalls++
+	return runtime.snapshot, nil
+}
+
+func (runtime *issue764M625Runtime) FeaturesGet(
+	_ context.Context,
+	auth eebusraw.ReadAuthorizationV1,
+	request eebusraw.FeaturesGetRequestV1,
+) (eebusraw.FeaturesGetDataV1, *eebusraw.ErrorV1) {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	runtime.auth = append(runtime.auth, auth)
+	runtime.featureCalls = append(runtime.featureCalls, request.Clone())
+	binding := runtime.binding
+	if request.Target.FeatureAddress == runtime.driftAt {
+		binding.ConnectionGeneration++
+	}
+	data := eebusraw.FeaturesGetDataV1{
+		Feature: request.Target.Clone(),
+		Functions: []eebusraw.FunctionDescriptorV1{{
+			Function:           "measurementListData",
+			PossibleOperations: eebusraw.FullOperationsV1{Read: true},
+			Changeable:         eebusraw.ChangeabilityV1False,
+			Constraints: eebusraw.ConstraintSetV1{
+				Status: eebusraw.ConstraintStatusV1Known,
+				Unit:   "degC",
+			},
+		}},
+		Runtime:       binding,
+		DataTimestamp: time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC),
+		Source:        eebusraw.ObservationSourceV1Cache,
+	}
+	hash, err := data.ComputeDataHash()
+	if err != nil {
+		panic(err)
+	}
+	data.DataHash = hash
+	if terminal := eebusraw.ValidateFeaturesGetDataV1(request, data); terminal != nil {
+		panic(fmt.Sprintf("invalid features data: %#v", terminal))
+	}
+	return data, nil
+}
+
+func (runtime *issue764M625Runtime) FeaturesDataGet(
+	_ context.Context,
+	auth eebusraw.ReadAuthorizationV1,
+	request eebusraw.FeatureDataGetRequestV1,
+) (eebusraw.FeatureDataGetDataV1, *eebusraw.ErrorV1) {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	runtime.auth = append(runtime.auth, auth)
+	runtime.dataCalls = append(runtime.dataCalls, request.Clone())
+	results := make([]eebusraw.ReadObservationV1, 0, len(request.Targets))
+	base := time.Date(2026, 7, 30, 12, 0, 1, 0, time.UTC)
+	for index, target := range request.Targets {
+		value, err := eebusraw.NewTypedValueV1(map[string]any{
+			"measurementData": []any{map[string]any{
+				"measurementId": int64(target.FeatureAddress),
+				"value": map[string]any{
+					"number": int64(215 + index),
+					"scale":  int64(-1),
+				},
+			}},
+		})
+		if err != nil {
+			panic(err)
+		}
+		observedAt := base.Add(time.Duration(target.FeatureAddress) * time.Millisecond)
+		observation := eebusraw.ReadObservationV1{
+			Target: target.Clone(), Runtime: runtime.binding,
+			RawRequest: eebusraw.ProtocolMessageV1{
+				Classifier: "READ", CorrelationKey: target.FeatureAddress, Function: target.Function,
+			},
+			RawResponse: eebusraw.ProtocolMessageV1{
+				Classifier: "REPLY", CorrelationKey: target.FeatureAddress, Function: target.Function, Data: &value,
+			},
+			Value: value, RequestedAt: observedAt, ReceivedAt: observedAt,
+			DataTimestamp: observedAt, Source: eebusraw.ObservationSourceV1Live,
+			ReadToken: eebusraw.ReadTokenV1{
+				ReadToken: strings.Repeat("E", 43), Reusable: true,
+				ExpiresAt: observedAt.Add(time.Minute),
+				BindingHash: eebusraw.HashV1(
+					"sha256:" + strings.Repeat("1", 64),
+				),
+			},
+		}
+		hash, err := observation.ComputeDataHash()
+		if err != nil {
+			panic(err)
+		}
+		observation.DataHash = hash
+		results = append(results, observation)
+	}
+	data := eebusraw.FeatureDataGetDataV1{Results: results, Complete: true}
+	if terminal := eebusraw.ValidateFeatureDataGetDataV1(request, data, nil); terminal != nil {
+		panic(fmt.Sprintf("invalid read data: %#v", terminal))
+	}
+	return data, nil
+}
+
+func issue764RawSnapshot(t *testing.T, eligible int) eebusruntime.SnapshotV1 {
+	t.Helper()
+	runtimeID, err := eebusraw.RedactID(eebusraw.IDKindPeer, "issue764-runtime")
+	if err != nil {
+		t.Fatal(err)
+	}
+	shipID := "issue764-ship"
+	remoteSKI := strings.Repeat("a", 40)
+	observed := time.Date(2026, 7, 30, 11, 59, 59, 0, time.UTC)
+	features := make([]eebusruntime.FeatureV1, 0, eligible+2)
+	for address := eligible; address >= 1; address-- {
+		features = append(features, eebusruntime.FeatureV1{
+			DeviceAddress:  "device-1",
+			EntityAddress:  "device-1:[1]:",
+			FeatureAddress: fmt.Sprintf("device-1:[1]:%d", address),
+			Type:           "Measurement",
+			Role:           "server",
+		})
+	}
+	features = append(features,
+		eebusruntime.FeatureV1{
+			DeviceAddress: "device-1", EntityAddress: "device-1:[1]:",
+			FeatureAddress: "device-1:[1]:99", Type: "Measurement", Role: "client",
+		},
+		eebusruntime.FeatureV1{
+			DeviceAddress: "device-1", EntityAddress: "device-1:[1]:",
+			FeatureAddress: "device-1:[1]:100", Type: "DeviceConfiguration", Role: "server",
+		},
+	)
+	snapshot, err := eebusruntime.NewSnapshotV1(eebusruntime.SnapshotV1{
+		Meta: eebusruntime.SnapshotMetaV1{
+			Contract:   eebusruntime.SnapshotContractV1,
+			Runtime:    runtimeID,
+			LocalSKI:   strings.Repeat("b", 40),
+			MaskTier:   eebusraw.MaskTierRaw,
+			CapturedAt: observed.Add(time.Second), DataTimestamp: observed,
+		},
+		Status: eebusruntime.RuntimeObservationV1{State: eebusruntime.ObservedRuntimeStateV1Ready},
+		Services: []eebusruntime.ServiceV1{{
+			SKI: remoteSKI, SHIPID: &shipID, Kind: eebusruntime.ServiceKindV1Remote,
+			Visible: true, Paired: true,
+		}},
+		Devices: []eebusruntime.DeviceV1{{
+			SKI: remoteSKI, SHIPID: &shipID, Address: "device-1", Type: "heating",
+		}},
+		Entities: []eebusruntime.EntityV1{{
+			DeviceAddress: "device-1", EntityAddress: "device-1:[1]:", Type: "zone",
+		}},
+		Features: features,
+	})
+	if err != nil {
+		t.Fatalf("construct raw snapshot: %v", err)
+	}
+	return snapshot
+}
+
+func TestIssue764M625AcquisitionSelectsOrdersBatchesAndRedacts(t *testing.T) {
+	runtime := &issue764M625Runtime{
+		snapshot: issue764RawSnapshot(t, 17),
+		binding:  eebusraw.RuntimeBindingV1{RuntimeEpoch: 7, ConnectionGeneration: 3},
+	}
+	reader, err := NewM625EEBusReader(runtime)
+	if err != nil {
+		t.Fatalf("NewM625EEBusReader: %v", err)
+	}
+	evidence, err := reader.ReadFeatureData(context.Background(), SourceRequest{
+		Phase: PhasePre, Limits: DefaultLimitsV1(),
+		OperationID: "eebus.v1.features.data.get", OperationScope: "feature-data", MaskTier: "redacted",
+		AuthScope: AuthScopeV1{Authority: "effective", Permissions: []string{"eebus.raw.read"}},
+	})
+	if err != nil {
+		t.Fatalf("ReadFeatureData: %v", err)
+	}
+	value, _, err := parseJSON(evidence.NormalizedEvidence, DefaultLimitsV1(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := value.(map[string]any)
+	if err := validateM625Payload(payload, sourceCapture{
+		sourceKind: SourceEEBus, sourceContract: M625EEBusContractV1, sourceSchemaVersion: 1,
+		sourceObservedAt: evidence.SourceObservedAt,
+	}); err != nil {
+		t.Fatalf("normalized M6.25 payload: %v\n%s", err, evidence.NormalizedEvidence)
+	}
+	if got := len(payload["observations"].([]any)); got != 17 {
+		t.Fatalf("observation count = %d, want 17", got)
+	}
+
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	if runtime.snapshotCalls != 1 || len(runtime.featureCalls) != 17 || len(runtime.dataCalls) != 2 {
+		t.Fatalf("snapshot/features/data calls = %d/%d/%d, want 1/17/2",
+			runtime.snapshotCalls, len(runtime.featureCalls), len(runtime.dataCalls))
+	}
+	if len(runtime.dataCalls[0].Targets) != 16 || len(runtime.dataCalls[1].Targets) != 1 {
+		t.Fatalf("batch sizes = %d/%d, want 16/1", len(runtime.dataCalls[0].Targets), len(runtime.dataCalls[1].Targets))
+	}
+	for index, call := range runtime.featureCalls {
+		if call.Target.FeatureAddress != uint64(index+1) {
+			t.Fatalf("feature call %d address = %d, want complete native order", index, call.Target.FeatureAddress)
+		}
+	}
+	for _, auth := range runtime.auth {
+		if auth != (eebusraw.ReadAuthorizationV1{
+			PrincipalClass: "owner",
+			Scope:          eebusraw.AuthScopeV1RawRead,
+			Tool:           auth.Tool,
+			MaskTier:       eebusraw.MaskTierRaw,
+		}) || (auth.Tool != eebusraw.ToolV1FeaturesGet && auth.Tool != eebusraw.ToolV1FeaturesDataGet) {
+			t.Fatalf("runtime authorization = %#v", auth)
+		}
+	}
+	for _, forbidden := range []string{
+		strings.Repeat("a", 40),
+		"issue764-ship",
+		"device-1",
+		"read_token",
+		"raw_request",
+		"candidate_ref",
+	} {
+		if strings.Contains(string(evidence.NormalizedEvidence), forbidden) {
+			t.Fatalf("normalized evidence leaks %q: %s", forbidden, evidence.NormalizedEvidence)
+		}
+	}
+}
+
+func TestIssue764M625AcquisitionFailsWithoutEligibleServerRead(t *testing.T) {
+	runtime := &issue764M625Runtime{
+		snapshot: issue764RawSnapshot(t, 0),
+		binding:  eebusraw.RuntimeBindingV1{RuntimeEpoch: 7, ConnectionGeneration: 3},
+	}
+	reader, err := NewM625EEBusReader(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reader.ReadFeatureData(context.Background(), SourceRequest{
+		Phase: PhasePre, Limits: DefaultLimitsV1(),
+		OperationID: "eebus.v1.features.data.get", OperationScope: "feature-data", MaskTier: "redacted",
+		AuthScope: AuthScopeV1{Authority: "effective", Permissions: []string{"eebus.raw.read"}},
+	}); err == nil {
+		t.Fatal("zero eligible server READ features succeeded")
+	}
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	if len(runtime.featureCalls) != 0 || len(runtime.dataCalls) != 0 {
+		t.Fatalf("zero-selection runtime calls = %d/%d, want 0/0", len(runtime.featureCalls), len(runtime.dataCalls))
+	}
+}
+
+func TestIssue764M625AcquisitionRejectsRuntimeBindingSubstitutionBeforeRead(t *testing.T) {
+	runtime := &issue764M625Runtime{
+		snapshot: issue764RawSnapshot(t, 3),
+		binding:  eebusraw.RuntimeBindingV1{RuntimeEpoch: 7, ConnectionGeneration: 3},
+		driftAt:  2,
+	}
+	reader, err := NewM625EEBusReader(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reader.ReadFeatureData(context.Background(), SourceRequest{
+		Phase: PhasePre, Limits: DefaultLimitsV1(),
+		OperationID: "eebus.v1.features.data.get", OperationScope: "feature-data", MaskTier: "redacted",
+		AuthScope: AuthScopeV1{Authority: "effective", Permissions: []string{"eebus.raw.read"}},
+	}); err == nil {
+		t.Fatal("cross-generation feature inventory succeeded")
+	}
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	if len(runtime.featureCalls) != 2 || len(runtime.dataCalls) != 0 {
+		t.Fatalf("binding substitution calls = features:%d data:%d, want 2/0",
+			len(runtime.featureCalls), len(runtime.dataCalls))
+	}
+}

--- a/internal/syncevidence/issue764_m625_recorder_test.go
+++ b/internal/syncevidence/issue764_m625_recorder_test.go
@@ -1,0 +1,272 @@
+package syncevidence
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+type issue764M625ReaderFunc func(context.Context, SourceRequest) (AcquiredEvidence, error)
+
+const issue764OperationVersion = "git:61bc62fa1d08dcf7b677c3dc08855beb5c68ceb1"
+
+func (reader issue764M625ReaderFunc) ReadFeatureData(ctx context.Context, request SourceRequest) (AcquiredEvidence, error) {
+	return reader(ctx, request)
+}
+
+func issue764M625Payload() json.RawMessage {
+	return json.RawMessage(`{
+		"contract":"helianthus.eebus.m625.public-redacted-evidence.v1",
+		"schema_version":1,
+		"source_observed_at":"2026-07-30T12:00:02Z",
+		"services":["BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"],
+		"feature_paths":[
+			{
+				"service":"BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+				"entity":"CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+				"feature":"DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD",
+				"feature_path":[
+					{"kind":"SERVICE","selector":"BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"},
+					{"kind":"ENTITY","selector":"CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"},
+					{"kind":"FEATURE","selector":"DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD"},
+					{"kind":"FIELD","selector":"EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE"}
+				]
+			},
+			{
+				"service":"BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+				"entity":"FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+				"feature":"GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG",
+				"feature_path":[
+					{"kind":"SERVICE","selector":"BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"},
+					{"kind":"ENTITY","selector":"FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"},
+					{"kind":"FEATURE","selector":"GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG"}
+				]
+			}
+		],
+		"observations":[
+			{
+				"observation_ref":"obs-HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH",
+				"path_index":0,
+				"feature_type":"Measurement",
+				"feature_role":"server",
+				"function":"measurementListData",
+				"source_observed_at":"2026-07-30T12:00:01Z",
+				"terminal_classification":"SUCCESS",
+				"value_type":"DECIMAL",
+				"value":"21.5",
+				"unit":"degC",
+				"quality":"OBSERVED"
+			},
+			{
+				"observation_ref":"obs-IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII",
+				"path_index":1,
+				"feature_type":"HVAC",
+				"feature_role":"server",
+				"function":"hvacSystemFunctionListData",
+				"source_observed_at":"2026-07-30T12:00:02Z",
+				"terminal_classification":"DECODE_ERROR",
+				"value_type":null,
+				"value":null,
+				"unit":null,
+				"quality":null
+			}
+		]
+	}`)
+}
+
+func issue764ExactIdentity(kind SourceKind) *EBusSourceIdentityV1 {
+	switch kind {
+	case SourceEBusB509:
+		return &EBusSourceIdentityV1{
+			Family: EBusFamilyB509, TargetAddress: 0x15, SourceAddress: 0xf7,
+			TargetProduct: "BASV2", RegisterFamily: "status", RegisterID: 1,
+			UnitScaleSource: "catalog-v1", EvidenceRole: "AUTHORITATIVE",
+		}
+	case SourceEBusB524:
+		return &EBusSourceIdentityV1{
+			Family: EBusFamilyB524, TargetAddress: 0x15, SourceAddress: 0xf7,
+			Opcode: 2, GG: 3, II: 0, RR: 28, GroupMeaning: "zones",
+			InstanceGate: "index-not-ff", RegisterCategory: "STATE",
+			UnitScaleSource: "catalog-v1",
+		}
+	case SourceEBusB555:
+		return &EBusSourceIdentityV1{
+			Family: EBusFamilyB555, TargetAddress: 0x15, SourceAddress: 0xf7,
+			DeviceFamily: "BASV2", ScheduleProgram: "heating", SlotIndex: 0,
+			DayOfWeek: "MONDAY", TimeIdentity: "06:00:00",
+			OperationModeContext: "AUTO", UnitScaleSource: "catalog-v1",
+		}
+	default:
+		return nil
+	}
+}
+
+func issue764TerminalEBusSource(kind SourceKind, phase Phase, scope, digest string) RegisteredSource {
+	return RegisteredSource{
+		Phase: phase, SourceKind: kind, RuntimeInstance: "ebus-runtime",
+		OperationVersion: issue764OperationVersion, OperationScope: scope,
+		Admission:    allowedAdmission("ebus.read"),
+		EvidenceRefs: []EvidenceRefV1{contentEvidenceRefForTest(digest)},
+		EBusIdentity: issue764ExactIdentity(kind),
+		EBusReader: ebusReaderFunc(func(context.Context, SourceRequest) (AcquiredEvidence, error) {
+			return AcquiredEvidence{}, ErrBackendUnavailable
+		}),
+	}
+}
+
+func contentEvidenceRefForTest(digest string) EvidenceRefV1 {
+	return EvidenceRefV1{
+		Kind:            EvidenceKindContent,
+		DigestAlgorithm: DigestAlgorithmContentBytes,
+		Digest:          "sha256:" + digest,
+	}
+}
+
+func TestIssue764M625FiveSourceCaptureRemasksAndReplays(t *testing.T) {
+	observed := time.Date(2026, 7, 30, 12, 0, 2, 0, time.UTC)
+	m625Reader := issue764M625ReaderFunc(func(_ context.Context, request SourceRequest) (AcquiredEvidence, error) {
+		if request.OperationID != "eebus.v1.features.data.get" ||
+			request.OperationScope != "feature-data" ||
+			request.MaskTier != "redacted" ||
+			!permissionsContain(request.AuthScope.Permissions, []string{"eebus.raw.read"}) {
+			t.Fatalf("M6.25 request binding = %#v", request)
+		}
+		return AcquiredEvidence{SourceObservedAt: observed, NormalizedEvidence: issue764M625Payload()}, nil
+	})
+	actionRef := redEvidenceRef('a')
+	sources := []RegisteredSource{
+		issue764TerminalEBusSource(SourceEBusB509, PhasePre, "ebus-b509", "dbe91a10a208613183f890849c634f8d13661194aad937a03ae2a4143070bf2d"),
+		{
+			Phase: PhasePre, SourceKind: SourceEEBus, SourceContract: M625EEBusContractV1, SourceVersion: 1,
+			RuntimeInstance: "eebus-runtime", OperationVersion: issue764OperationVersion, OperationScope: "feature-data",
+			Admission: allowedAdmission("eebus.raw.read"),
+			EvidenceRefs: []EvidenceRefV1{
+				contentEvidenceRefForTest("0a2885d01d6703389541e246db59bcd845a332e7ed296abca2d49b4f8de31811"),
+			},
+			EEBusM625Reader: m625Reader,
+		},
+		issue764TerminalEBusSource(SourceEBusB524, PhaseAction, "ebus-b524", "1002e09890801c9032548af407b13b58d889217dfc83e58bfe2a28df6bc33b78"),
+		cloudRegistration(PrecapturedCloudInput{
+			SourceObservedAt: observed,
+			NormalizedEvidence: cloudPayload(
+				observed,
+				strings.Repeat("J", 43),
+				"21.5",
+			),
+			EvidenceRef: actionRef,
+		}, PhaseAction, "cloud-runtime"),
+		issue764TerminalEBusSource(SourceEBusB555, PhasePost, "ebus-b555", "a3237e344f5c3582ceaf1ca947eabf200bede8fe9388ec85cf647331f026c72d"),
+	}
+	recorder := testRecorder(t, sources, func(options *RecorderOptions) {
+		options.Entropy = bytes.NewReader(bytes.Repeat([]byte{0x61}, 1<<20))
+	})
+	raw, err := recorder.Capture(context.Background(), ActionMarker{EvidenceRef: actionRef})
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+	if _, err := Replay(raw); err != nil {
+		t.Fatalf("Replay: %v", err)
+	}
+
+	var bundle SynchronizedEvidenceBundleV1
+	if err := json.Unmarshal(raw, &bundle); err != nil {
+		t.Fatal(err)
+	}
+	if len(bundle.Sources) != 5 || len(bundle.Artifacts) != 2 {
+		t.Fatalf("source/artifact count = %d/%d, want 5/2", len(bundle.Sources), len(bundle.Artifacts))
+	}
+	for _, source := range bundle.Sources {
+		switch source.SourceContract {
+		case M625EEBusContractV1:
+			if source.State != StatePresent || source.SourceSchemaVersion != 1 ||
+				source.SourceBinding.OperationID != "eebus.v1.features.data.get" {
+				t.Fatalf("M6.25 source = %#v", source)
+			}
+		case "helianthus.cloud-app.precaptured.evidence.v1":
+			if source.State != StatePresent {
+				t.Fatalf("cloud source = %#v", source)
+			}
+		default:
+			if source.State != StateUnavailable || source.EBusIdentity == nil {
+				t.Fatalf("eBUS terminal source = %#v", source)
+			}
+		}
+	}
+
+	var m625 json.RawMessage
+	for _, artifact := range bundle.Artifacts {
+		if artifact.SourceContract == M625EEBusContractV1 {
+			m625 = artifact.NormalizedEvidence
+			if len(artifact.Remasking.Entries) != 16 {
+				t.Fatalf("M6.25 remasking entry count = %d, want 16", len(artifact.Remasking.Entries))
+			}
+		}
+	}
+	if len(m625) == 0 {
+		t.Fatal("M6.25 artifact absent")
+	}
+	for _, forbidden := range []string{
+		"BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+		"CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+		"obs-HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH",
+		"candidate_ref",
+		"remote_ski",
+		"ship_id",
+		"device_address",
+		"raw_request",
+	} {
+		if bytes.Contains(m625, []byte(forbidden)) {
+			t.Fatalf("M6.25 artifact leaks %q: %s", forbidden, m625)
+		}
+	}
+}
+
+func TestIssue764M625ValidatorRejectsWrongOrderingAndRawMetadata(t *testing.T) {
+	observed := time.Date(2026, 7, 30, 12, 0, 2, 0, time.UTC)
+	base := sourceCapture{
+		sourceKind:          SourceEEBus,
+		sourceContract:      M625EEBusContractV1,
+		sourceSchemaVersion: 1,
+		sourceObservedAt:    observed,
+		operationID:         "eebus.v1.features.data.get",
+		operationScope:      "feature-data",
+	}
+	valid, _, err := parseJSON(issue764M625Payload(), DefaultLimitsV1(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateSourcePayload(valid.(map[string]any), base); err != nil {
+		t.Fatalf("valid M6.25 payload rejected: %v", err)
+	}
+
+	for name, mutate := range map[string]func(map[string]any){
+		"raw identity": func(root map[string]any) {
+			root["remote_ski"] = strings.Repeat("a", 40)
+		},
+		"wrong ordering": func(root map[string]any) {
+			paths := root["feature_paths"].([]any)
+			paths[0], paths[1] = paths[1], paths[0]
+		},
+		"wrong value matrix": func(root map[string]any) {
+			observation := root["observations"].([]any)[0].(map[string]any)
+			observation["value_type"] = "BOOLEAN"
+			observation["value"] = "true"
+			observation["unit"] = nil
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			value, _, err := parseJSON(issue764M625Payload(), DefaultLimitsV1(), false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			root := value.(map[string]any)
+			mutate(root)
+			if err := validateSourcePayload(root, base); err == nil {
+				t.Fatal("invalid M6.25 payload accepted")
+			}
+		})
+	}
+}

--- a/internal/syncevidence/issue764_m625_recorder_test.go
+++ b/internal/syncevidence/issue764_m625_recorder_test.go
@@ -266,3 +266,94 @@ func TestIssue764M625ValidatorRejectsRawMetadataAndWrongValueMatrix(t *testing.T
 		})
 	}
 }
+
+func TestIssue764M625AcceptsIntegralNumericFormsAndRepeatedPathObservations(t *testing.T) {
+	observed := time.Date(2026, 7, 30, 12, 0, 2, 0, time.UTC)
+	value, _, err := parseJSON(issue764M625Payload(), DefaultLimitsV1(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := value.(map[string]any)
+	root["schema_version"] = json.Number("1.0")
+	observations := root["observations"].([]any)
+	observations[0].(map[string]any)["path_index"] = json.Number("0.0")
+	observations[1].(map[string]any)["path_index"] = json.Number("0e0")
+	capture := sourceCapture{
+		sourceKind:          SourceEEBus,
+		sourceContract:      M625EEBusContractV1,
+		sourceSchemaVersion: 1,
+		sourceObservedAt:    observed,
+		operationID:         "eebus.v1.features.data.get",
+		operationScope:      "feature-data",
+	}
+	if err := validateM625Payload(root, capture); err != nil {
+		t.Fatalf("schema-valid repeated-path payload rejected: %v", err)
+	}
+
+	encoded, err := canonicalJSONValue(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	capture.normalizedEvidence = encoded
+	recorder := &Recorder{
+		limits:  DefaultLimitsV1(),
+		entropy: bytes.NewReader(bytes.Repeat([]byte{0x63}, 1<<20)),
+	}
+	remasked, remasking, itemCount, err := recorder.prepareEvidence(
+		capture,
+		nil,
+		"remask-"+strings.Repeat("a", 32),
+		make(map[string]struct{}),
+	)
+	if err != nil {
+		t.Fatalf("prepare repeated-path evidence: %v", err)
+	}
+	if itemCount != 2 {
+		t.Fatalf("item count = %d, want 2", itemCount)
+	}
+	var observationPseudonyms []string
+	for _, entry := range remasking.Entries {
+		if strings.HasPrefix(entry.Path, "/observations/") {
+			observationPseudonyms = append(observationPseudonyms, entry.Pseudonym)
+		}
+	}
+	if len(observationPseudonyms) != 2 || observationPseudonyms[0] == observationPseudonyms[1] {
+		t.Fatalf("observation remasking = %#v", observationPseudonyms)
+	}
+	remaskedValue, _, err := parseJSON(remasked, DefaultLimitsV1(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateM625Payload(remaskedValue.(map[string]any), capture); err != nil {
+		t.Fatalf("remasked repeated-path payload rejected: %v", err)
+	}
+
+	observations[1].(map[string]any)["observation_ref"] = observations[0].(map[string]any)["observation_ref"]
+	if err := validateM625Payload(root, capture); err == nil {
+		t.Fatal("duplicate observation_ref accepted")
+	}
+}
+
+func TestIssue764M625SafeIntegerMatchesJSONSchemaIntegerSemantics(t *testing.T) {
+	for _, test := range []struct {
+		number string
+		want   uint64
+		ok     bool
+	}{
+		{number: "0", want: 0, ok: true},
+		{number: "1.0", want: 1, ok: true},
+		{number: "1e0", want: 1, ok: true},
+		{number: "9007199254740991.0", want: 9_007_199_254_740_991, ok: true},
+		{number: "1.5", ok: false},
+		{number: "-1.0", ok: false},
+		{number: "9007199254740992", ok: false},
+		{number: "1/1", ok: false},
+		{number: "01", ok: false},
+		{number: "+1", ok: false},
+	} {
+		got, ok := m625SafeInteger(json.Number(test.number))
+		if got != test.want || ok != test.ok {
+			t.Errorf("m625SafeInteger(%q) = (%d, %t), want (%d, %t)", test.number, got, ok, test.want, test.ok)
+		}
+	}
+}

--- a/internal/syncevidence/issue764_m625_recorder_test.go
+++ b/internal/syncevidence/issue764_m625_recorder_test.go
@@ -224,7 +224,7 @@ func TestIssue764M625FiveSourceCaptureRemasksAndReplays(t *testing.T) {
 	}
 }
 
-func TestIssue764M625ValidatorRejectsWrongOrderingAndRawMetadata(t *testing.T) {
+func TestIssue764M625ValidatorRejectsRawMetadataAndWrongValueMatrix(t *testing.T) {
 	observed := time.Date(2026, 7, 30, 12, 0, 2, 0, time.UTC)
 	base := sourceCapture{
 		sourceKind:          SourceEEBus,
@@ -245,10 +245,6 @@ func TestIssue764M625ValidatorRejectsWrongOrderingAndRawMetadata(t *testing.T) {
 	for name, mutate := range map[string]func(map[string]any){
 		"raw identity": func(root map[string]any) {
 			root["remote_ski"] = strings.Repeat("a", 40)
-		},
-		"wrong ordering": func(root map[string]any) {
-			paths := root["feature_paths"].([]any)
-			paths[0], paths[1] = paths[1], paths[0]
 		},
 		"wrong value matrix": func(root map[string]any) {
 			observation := root["observations"].([]any)[0].(map[string]any)

--- a/internal/syncevidence/issue764_oneshot_test.go
+++ b/internal/syncevidence/issue764_oneshot_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -118,6 +119,39 @@ func TestIssue764OneShotPublishesThenRepeatsAndRestartsWithoutAcquisition(t *tes
 	}
 	if len(bundle.Sources) != 5 {
 		t.Fatalf("source count = %d", len(bundle.Sources))
+	}
+	exactIdentities := map[SourceKind]*EBusSourceIdentityV1{
+		SourceEBusB509: {
+			Family: EBusFamilyB509, TargetAddress: 0x08, TargetProduct: "BAI00",
+			RegisterFamily: "system", RegisterID: 512, UnitScaleSource: "gateway-catalog-v1",
+			EvidenceRole: "AUTHORITATIVE",
+		},
+		SourceEBusB524: {
+			Family: EBusFamilyB524, TargetAddress: 0x15, SourceAddress: 0xf7,
+			Opcode: 2, GG: 3, II: 0, RR: 28, GroupMeaning: "zones",
+			InstanceGate: "index-not-ff", RegisterCategory: "STATE",
+			UnitScaleSource: "vrc-explorer-v1",
+		},
+		SourceEBusB555: {
+			Family: EBusFamilyB555, DeviceFamily: "VRC",
+			ScheduleProgram: "heating-program-1", SlotIndex: 0, DayOfWeek: "MONDAY",
+			TimeIdentity: "06:00:00", OperationModeContext: "AUTO",
+			UnitScaleSource: "source-native",
+		},
+	}
+	for _, source := range bundle.Sources {
+		want := exactIdentities[source.SourceBinding.SourceKind]
+		if want == nil {
+			continue
+		}
+		got := cloneIdentity(source.EBusIdentity)
+		if got == nil || got.TargetPseudonym == "" {
+			t.Fatalf("exact identity missing for %s", source.SourceBinding.SourceKind)
+		}
+		got.TargetPseudonym = ""
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("identity for %s = %#v, want %#v", source.SourceBinding.SourceKind, got, want)
+		}
 	}
 	lockPath := filepath.Join(storeRoot, storeLockName)
 	lockBefore, err := os.ReadFile(lockPath)
@@ -230,5 +264,41 @@ func TestIssue764OneShotInvalidRequestIsCategoryOnlyAndDoesNotOpenStore(t *testi
 	}
 	if _, err := os.Stat(filepath.Join(root, "store")); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("invalid request opened store: %v", err)
+	}
+}
+
+func TestIssue764OneShotRejectsStoreSymlinkBeforeAnyNewCaptureWork(t *testing.T) {
+	base := issue764SecureTempDir(t)
+	root := filepath.Join(base, "synchronized-evidence")
+	issue764WriteRequest(t, root, issue764RequestBytes(t, 'd'), 0o600)
+	target := filepath.Join(base, "store-target")
+	if err := os.Mkdir(target, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(root, "store")); err != nil {
+		t.Fatal(err)
+	}
+	receipt := ExecuteOneShot(context.Background(), OneShotExecutionOptions{
+		Root:    root,
+		Entropy: issue764RejectEntropy{},
+		Reader: issue764M625ReaderFunc(func(context.Context, SourceRequest) (AcquiredEvidence, error) {
+			t.Fatal("unsafe store triggered acquisition")
+			return AcquiredEvidence{}, nil
+		}),
+		ClockFactory: func() Clock {
+			t.Fatal("unsafe store created a clock")
+			return nil
+		},
+		BuildIdentity: func() (OneShotBuildIdentity, error) {
+			t.Fatal("unsafe store resolved build identity")
+			return OneShotBuildIdentity{}, nil
+		},
+	})
+	if receipt != (OneShotReceiptV1{Category: OneShotPublishFailed}) {
+		t.Fatalf("receipt = %#v", receipt)
+	}
+	entries, err := os.ReadDir(target)
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("symlink target entries = %v, %v", entries, err)
 	}
 }

--- a/internal/syncevidence/issue764_oneshot_test.go
+++ b/internal/syncevidence/issue764_oneshot_test.go
@@ -185,6 +185,20 @@ func TestIssue764OneShotPublishesThenRepeatsAndRestartsWithoutAcquisition(t *tes
 		t.Fatalf("repeat rewrote store lock proof")
 	}
 
+	mutatedRequest := issue764MutateRequestCloudValue(t, requestBytes)
+	issue764WriteRequest(t, root, mutatedRequest, 0o600)
+	receipt = ExecuteOneShot(context.Background(), options)
+	if receipt != (OneShotReceiptV1{Category: OneShotInvalidRequest}) {
+		t.Fatalf("mutated retained-ref receipt = %#v", receipt)
+	}
+	if readerCalls != 1 || clockCalls != 1 || versionCalls != 1 || replayCalls != 2 || entropy.bytes != firstEntropy {
+		t.Fatalf(
+			"mutated retained-ref request performed work reader=%d clock=%d version=%d replay=%d entropy=%d/%d",
+			readerCalls, clockCalls, versionCalls, replayCalls, entropy.bytes, firstEntropy,
+		)
+	}
+	issue764WriteRequest(t, root, requestBytes, 0o600)
+
 	restartOptions := options
 	restartOptions.Reader = issue764M625ReaderFunc(func(context.Context, SourceRequest) (AcquiredEvidence, error) {
 		t.Fatal("restart acquired a source")

--- a/internal/syncevidence/issue764_oneshot_test.go
+++ b/internal/syncevidence/issue764_oneshot_test.go
@@ -117,6 +117,9 @@ func TestIssue764OneShotPublishesThenRepeatsAndRestartsWithoutAcquisition(t *tes
 	if err := validateOneShotBundle(bundle, options.sourceTuple()); err != nil {
 		t.Fatalf("published bundle: %v", err)
 	}
+	if bundle.Limits != oneShotCaptureLimits() {
+		t.Fatalf("one-shot limits = %#v, want %#v", bundle.Limits, oneShotCaptureLimits())
+	}
 	if len(bundle.Sources) != 5 {
 		t.Fatalf("source count = %d", len(bundle.Sources))
 	}
@@ -224,6 +227,71 @@ func TestIssue764OneShotPublishesThenRepeatsAndRestartsWithoutAcquisition(t *tes
 	entries, err = os.ReadDir(storeRoot)
 	if err != nil || len(entries) != 2 {
 		t.Fatalf("restart entries = %v, %v", entries, err)
+	}
+}
+
+func TestIssue764OneShotRetainedCloudMismatchConflictsWithoutAcquisition(t *testing.T) {
+	root := filepath.Join(issue764SecureTempDir(t), "synchronized-evidence")
+	requestBytes := issue764RequestBytes(t, 'a')
+	issue764WriteRequest(t, root, requestBytes, 0o600)
+	request, err := parseOneShotRequest(requestBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cloudRef := redEvidenceRef('f')
+	if evidenceRefKey(cloudRef) == evidenceRefKey(request.ActionEvidenceRef) {
+		t.Fatal("cloud mismatch fixture unexpectedly matches the action ref")
+	}
+	retained := issue764FiveSourceBundleWithCloudRefAt(
+		t,
+		request.ActionEvidenceRef,
+		cloudRef,
+		0x61,
+		time.Now().UTC().Add(-time.Hour),
+	)
+	store, err := OpenFileStore(FileStoreConfig{
+		Root:       filepath.Join(root, "store"),
+		QuotaBytes: oneShotStoreQuota,
+		Retention:  oneShotStoreRetention,
+		LockProof:  oneShotStoreLockProof,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Publish(retained); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	receipt := ExecuteOneShot(context.Background(), OneShotExecutionOptions{
+		Root:    root,
+		Entropy: issue764RejectEntropy{},
+		Reader: issue764M625ReaderFunc(func(context.Context, SourceRequest) (AcquiredEvidence, error) {
+			t.Fatal("conflicting retained bundle triggered source acquisition")
+			return AcquiredEvidence{}, errors.New("unreachable")
+		}),
+		ClockFactory: func() Clock {
+			t.Fatal("conflicting retained bundle created a clock")
+			return nil
+		},
+		BuildIdentity: func() (OneShotBuildIdentity, error) {
+			t.Fatal("conflicting retained bundle resolved build identity")
+			return OneShotBuildIdentity{}, errors.New("unreachable")
+		},
+	})
+	if receipt != (OneShotReceiptV1{Category: OneShotConflict}) {
+		t.Fatalf("receipt = %#v", receipt)
+	}
+	entries, err := os.ReadDir(filepath.Join(root, "store"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if entry.Name() != storeLockName && !strings.HasSuffix(entry.Name(), ".json") {
+			t.Fatalf("conflict created store entry %q", entry.Name())
+		}
 	}
 }
 

--- a/internal/syncevidence/issue764_oneshot_test.go
+++ b/internal/syncevidence/issue764_oneshot_test.go
@@ -1,0 +1,234 @@
+package syncevidence
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+type issue764CountingReader struct {
+	reader io.Reader
+	bytes  int
+}
+
+func (reader *issue764CountingReader) Read(target []byte) (int, error) {
+	count, err := reader.reader.Read(target)
+	reader.bytes += count
+	return count, err
+}
+
+func issue764OneShotOptions(
+	t *testing.T,
+	root string,
+	reader EEBusM625Reader,
+	entropy io.Reader,
+	clockCalls *int,
+	versionCalls *int,
+) OneShotExecutionOptions {
+	t.Helper()
+	return OneShotExecutionOptions{
+		Root:    root,
+		Reader:  reader,
+		Entropy: entropy,
+		ClockFactory: func() Clock {
+			*clockCalls++
+			return &redClock{wall: time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)}
+		},
+		BuildIdentity: func() (OneShotBuildIdentity, error) {
+			*versionCalls++
+			return OneShotBuildIdentity{
+				RecorderVersion:  testBuildVersion,
+				ReplayVersion:    testBuildVersion,
+				OperationVersion: issue764OperationVersion,
+			}, nil
+		},
+	}
+}
+
+func TestIssue764OneShotPublishesThenRepeatsAndRestartsWithoutAcquisition(t *testing.T) {
+	root := filepath.Join(issue764SecureTempDir(t), "synchronized-evidence")
+	requestBytes := issue764RequestBytes(t, 'a')
+	issue764WriteRequest(t, root, requestBytes, 0o600)
+	readerCalls := 0
+	reader := issue764M625ReaderFunc(func(context.Context, SourceRequest) (AcquiredEvidence, error) {
+		readerCalls++
+		return AcquiredEvidence{
+			SourceObservedAt:   time.Date(2026, 7, 30, 12, 0, 2, 0, time.UTC),
+			NormalizedEvidence: issue764M625Payload(),
+		}, nil
+	})
+	entropy := &issue764CountingReader{
+		reader: bytes.NewReader(bytes.Repeat([]byte{0x61}, 1<<20)),
+	}
+	clockCalls := 0
+	versionCalls := 0
+	options := issue764OneShotOptions(t, root, reader, entropy, &clockCalls, &versionCalls)
+	replayCalls := 0
+	options.replay = func(bundle []byte) ([]byte, error) {
+		replayCalls++
+		return Replay(bundle)
+	}
+
+	receipt := ExecuteOneShot(context.Background(), options)
+	if receipt != (OneShotReceiptV1{Category: OneShotPublished}) {
+		t.Fatalf("first receipt = %#v", receipt)
+	}
+	if readerCalls != 1 || clockCalls != 1 || versionCalls != 1 || replayCalls != 2 || entropy.bytes == 0 {
+		t.Fatalf(
+			"first calls reader=%d clock=%d version=%d replay=%d entropy=%d",
+			readerCalls, clockCalls, versionCalls, replayCalls, entropy.bytes,
+		)
+	}
+	firstEntropy := entropy.bytes
+	storeRoot := filepath.Join(root, "store")
+	entries, err := os.ReadDir(storeRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var bundlePath string
+	for _, entry := range entries {
+		switch {
+		case entry.Name() == storeLockName:
+		case strings.HasSuffix(entry.Name(), ".json"):
+			if bundlePath != "" {
+				t.Fatalf("multiple published bundles: %q and %q", bundlePath, entry.Name())
+			}
+			bundlePath = filepath.Join(storeRoot, entry.Name())
+		default:
+			t.Fatalf("unexpected durable entry %q", entry.Name())
+		}
+	}
+	raw, err := os.ReadFile(bundlePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle, err := verifyBundle(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateOneShotBundle(bundle, options.sourceTuple()); err != nil {
+		t.Fatalf("published bundle: %v", err)
+	}
+	if len(bundle.Sources) != 5 {
+		t.Fatalf("source count = %d", len(bundle.Sources))
+	}
+	lockPath := filepath.Join(storeRoot, storeLockName)
+	lockBefore, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lockInfoBefore, err := os.Stat(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	receipt = ExecuteOneShot(context.Background(), options)
+	if receipt != (OneShotReceiptV1{Category: OneShotExisting}) {
+		t.Fatalf("repeat receipt = %#v", receipt)
+	}
+	if readerCalls != 1 || clockCalls != 1 || versionCalls != 1 || replayCalls != 2 || entropy.bytes != firstEntropy {
+		t.Fatalf(
+			"repeat performed work reader=%d clock=%d version=%d replay=%d entropy=%d/%d",
+			readerCalls, clockCalls, versionCalls, replayCalls, entropy.bytes, firstEntropy,
+		)
+	}
+	lockAfter, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lockInfoAfter, err := os.Stat(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(lockAfter, lockBefore) || !lockInfoAfter.ModTime().Equal(lockInfoBefore.ModTime()) {
+		t.Fatalf("repeat rewrote store lock proof")
+	}
+
+	restartOptions := options
+	restartOptions.Reader = issue764M625ReaderFunc(func(context.Context, SourceRequest) (AcquiredEvidence, error) {
+		t.Fatal("restart acquired a source")
+		return AcquiredEvidence{}, errors.New("unreachable")
+	})
+	restartOptions.Entropy = issue764RejectEntropy{}
+	restartOptions.ClockFactory = func() Clock {
+		t.Fatal("restart created a clock")
+		return nil
+	}
+	restartOptions.BuildIdentity = func() (OneShotBuildIdentity, error) {
+		t.Fatal("restart resolved build identity")
+		return OneShotBuildIdentity{}, errors.New("unreachable")
+	}
+	restartOptions.replay = func([]byte) ([]byte, error) {
+		t.Fatal("restart ran a new-capture replay")
+		return nil, errors.New("unreachable")
+	}
+	receipt = ExecuteOneShot(context.Background(), restartOptions)
+	if receipt != (OneShotReceiptV1{Category: OneShotExisting}) {
+		t.Fatalf("restart receipt = %#v", receipt)
+	}
+	entries, err = os.ReadDir(storeRoot)
+	if err != nil || len(entries) != 2 {
+		t.Fatalf("restart entries = %v, %v", entries, err)
+	}
+}
+
+func TestIssue764OneShotReplayMismatchPublishesNothing(t *testing.T) {
+	root := filepath.Join(issue764SecureTempDir(t), "synchronized-evidence")
+	issue764WriteRequest(t, root, issue764RequestBytes(t, 'b'), 0o600)
+	reader := issue764M625ReaderFunc(func(context.Context, SourceRequest) (AcquiredEvidence, error) {
+		return AcquiredEvidence{
+			SourceObservedAt:   time.Date(2026, 7, 30, 12, 0, 2, 0, time.UTC),
+			NormalizedEvidence: issue764M625Payload(),
+		}, nil
+	})
+	clockCalls, versionCalls := 0, 0
+	options := issue764OneShotOptions(
+		t,
+		root,
+		reader,
+		bytes.NewReader(bytes.Repeat([]byte{0x62}, 1<<20)),
+		&clockCalls,
+		&versionCalls,
+	)
+	replayCalls := 0
+	options.replay = func([]byte) ([]byte, error) {
+		replayCalls++
+		return []byte{byte(replayCalls)}, nil
+	}
+	receipt := ExecuteOneShot(context.Background(), options)
+	if receipt != (OneShotReceiptV1{Category: OneShotReplayMismatch}) || replayCalls != 2 {
+		t.Fatalf("receipt/calls = %#v/%d", receipt, replayCalls)
+	}
+	entries, err := os.ReadDir(filepath.Join(root, "store"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if entry.Name() != storeLockName {
+			t.Fatalf("replay mismatch left %q", entry.Name())
+		}
+	}
+}
+
+func TestIssue764OneShotInvalidRequestIsCategoryOnlyAndDoesNotOpenStore(t *testing.T) {
+	root := filepath.Join(issue764SecureTempDir(t), "synchronized-evidence")
+	issue764WriteRequest(t, root, issue764RequestBytes(t, 'c'), 0o640)
+	receipt := ExecuteOneShot(context.Background(), OneShotExecutionOptions{Root: root})
+	if receipt != (OneShotReceiptV1{Category: OneShotInvalidRequest}) {
+		t.Fatalf("receipt = %#v", receipt)
+	}
+	raw, err := json.Marshal(receipt)
+	if err != nil || string(raw) != `{"category":"INVALID_REQUEST"}` {
+		t.Fatalf("receipt JSON = %q, %v", raw, err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "store")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("invalid request opened store: %v", err)
+	}
+}

--- a/internal/syncevidence/issue764_registry_red_test.go
+++ b/internal/syncevidence/issue764_registry_red_test.go
@@ -1,0 +1,98 @@
+package syncevidence
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+const (
+	issue764HistoricalEEBusContract = "helianthus-eebus-mcp"
+	issue764M625EEBusContract       = "helianthus.eebus.m625.public-redacted-evidence.v1"
+)
+
+func TestIssue764EEBusAuthoritiesAreKeyedByFullSourceTuple(t *testing.T) {
+	historicalKey := sourceAuthorityKey{
+		kind:     SourceEEBus,
+		contract: issue764HistoricalEEBusContract,
+		version:  1,
+	}
+	m625Key := sourceAuthorityKey{
+		kind:     SourceEEBus,
+		contract: issue764M625EEBusContract,
+		version:  1,
+	}
+
+	if len(sourceAuthorities) != 6 {
+		t.Fatalf("source authority count = %d, want 6", len(sourceAuthorities))
+	}
+	historical, ok := sourceAuthorities[historicalKey]
+	if !ok {
+		t.Fatalf("historical EEBUS authority missing for key %#v", historicalKey)
+	}
+	if historical.contract != issue764HistoricalEEBusContract ||
+		historical.version != 1 ||
+		historical.ownerCommit != "9819762a61c28eeceb11beb775aa2a91c83a68b6" ||
+		historical.schemaSHA256 != "7f10fa6860e8ccee1af7f155e03d5ac208b5a6fb30518aa3145122a9a1dc0a1c" {
+		t.Fatalf("historical EEBUS authority changed: %#v", historical)
+	}
+	m625, ok := sourceAuthorities[m625Key]
+	if !ok {
+		t.Fatalf("M6.25 EEBUS authority missing for key %#v", m625Key)
+	}
+	if m625.contract != issue764M625EEBusContract ||
+		m625.version != 1 ||
+		m625.ownerCommit != "a09e3a77153204bc3117e233c71e77ef1859834e" ||
+		m625.schemaSHA256 != "0a2885d01d6703389541e246db59bcd845a332e7ed296abca2d49b4f8de31811" {
+		t.Fatalf("M6.25 EEBUS authority = %#v", m625)
+	}
+}
+
+func TestIssue764HistoricalEEBusRegistryEntryRemainsByteIdentical(t *testing.T) {
+	var registry struct {
+		Entries []json.RawMessage `json:"entries"`
+	}
+	if err := json.Unmarshal(mustReadContract("synchronized-evidence-source-registry-v1.json"), &registry); err != nil {
+		t.Fatalf("decode registry: %v", err)
+	}
+
+	var historical json.RawMessage
+	for _, raw := range registry.Entries {
+		var identity struct {
+			SourceKind     SourceKind `json:"source_kind"`
+			SourceContract string     `json:"source_contract"`
+		}
+		if err := json.Unmarshal(raw, &identity); err != nil {
+			t.Fatalf("decode registry entry: %v", err)
+		}
+		if identity.SourceKind == SourceEEBus && identity.SourceContract == issue764HistoricalEEBusContract {
+			historical = raw
+			break
+		}
+	}
+	if historical == nil {
+		t.Fatal("historical EEBUS registry entry is absent")
+	}
+
+	want := []byte(`{
+      "source_kind": "EEBUS",
+      "source_contract": "helianthus-eebus-mcp",
+      "source_schema_version": 1,
+      "owner_repository": "Project-Helianthus/helianthus-docs-eebus",
+      "owner_path": "api/_candidate/msp-06/helianthus.eebus.mcp.v1.schema.json",
+      "owner_commit": "9819762a61c28eeceb11beb775aa2a91c83a68b6",
+      "schema_sha256": "7f10fa6860e8ccee1af7f155e03d5ac208b5a6fb30518aa3145122a9a1dc0a1c",
+      "embedded_schema": null
+    }`)
+	historicalCompact := new(bytes.Buffer)
+	wantCompact := new(bytes.Buffer)
+	if err := json.Compact(historicalCompact, historical); err != nil {
+		t.Fatalf("compact historical entry: %v", err)
+	}
+	if err := json.Compact(wantCompact, want); err != nil {
+		t.Fatalf("compact expected historical entry: %v", err)
+	}
+	if !bytes.Equal(historicalCompact.Bytes(), wantCompact.Bytes()) {
+		t.Fatalf("historical EEBUS registry entry changed:\n got: %s\nwant: %s", historicalCompact.Bytes(), wantCompact.Bytes())
+	}
+}

--- a/internal/syncevidence/issue764_registry_red_test.go
+++ b/internal/syncevidence/issue764_registry_red_test.go
@@ -84,15 +84,7 @@ func TestIssue764HistoricalEEBusRegistryEntryRemainsByteIdentical(t *testing.T) 
       "schema_sha256": "7f10fa6860e8ccee1af7f155e03d5ac208b5a6fb30518aa3145122a9a1dc0a1c",
       "embedded_schema": null
     }`)
-	historicalCompact := new(bytes.Buffer)
-	wantCompact := new(bytes.Buffer)
-	if err := json.Compact(historicalCompact, historical); err != nil {
-		t.Fatalf("compact historical entry: %v", err)
-	}
-	if err := json.Compact(wantCompact, want); err != nil {
-		t.Fatalf("compact expected historical entry: %v", err)
-	}
-	if !bytes.Equal(historicalCompact.Bytes(), wantCompact.Bytes()) {
-		t.Fatalf("historical EEBUS registry entry changed:\n got: %s\nwant: %s", historicalCompact.Bytes(), wantCompact.Bytes())
+	if !bytes.Equal(historical, want) {
+		t.Fatalf("historical EEBUS registry entry changed byte-for-byte:\n got: %q\nwant: %q", historical, want)
 	}
 }

--- a/internal/syncevidence/issue764_request_test.go
+++ b/internal/syncevidence/issue764_request_test.go
@@ -1,0 +1,165 @@
+package syncevidence
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func issue764RequestBytes(t *testing.T, digit byte) []byte {
+	t.Helper()
+	observed := time.Date(2026, 7, 30, 11, 12, 13, 456000000, time.UTC)
+	ref := redEvidenceRef(digit)
+	raw, err := json.Marshal(map[string]any{
+		"contract":            OneShotRequestContractV1,
+		"schema_version":      1,
+		"action_evidence_ref": ref,
+		"cloud_app_action": map[string]any{
+			"evidence_ref":        ref,
+			"normalized_evidence": json.RawMessage(cloudPayload(observed, strings.Repeat("A", 43), "21.5")),
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	return raw
+}
+
+func issue764SecureTempDir(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("resolve temp directory: %v", err)
+	}
+	return root
+}
+
+func issue764WriteRequest(t *testing.T, root string, raw []byte, mode os.FileMode) string {
+	t.Helper()
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("mkdir request root: %v", err)
+	}
+	if err := os.Chmod(root, 0o700); err != nil {
+		t.Fatalf("chmod request root: %v", err)
+	}
+	path := filepath.Join(root, OneShotRequestFileV1)
+	if err := os.WriteFile(path, raw, mode); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatalf("chmod request: %v", err)
+	}
+	return path
+}
+
+func TestIssue764RequestLoaderAcceptsOnlyFixedClosedRequest(t *testing.T) {
+	root := filepath.Join(issue764SecureTempDir(t), "synchronized-evidence")
+	raw := issue764RequestBytes(t, 'a')
+	issue764WriteRequest(t, root, raw, 0o600)
+	if _, err := parseOneShotRequest(raw); err != nil {
+		t.Fatalf("parse request fixture: %v\n%s", err, raw)
+	}
+	request, err := loadOneShotRequestAt(root, nil)
+	if err != nil {
+		t.Fatalf("load request: %v", err)
+	}
+	if request.Contract != OneShotRequestContractV1 || request.SchemaVersion != 1 {
+		t.Fatalf("request identity = %#v", request)
+	}
+	if !reflect.DeepEqual(request.ActionEvidenceRef, request.CloudAppAction.EvidenceRef) {
+		t.Fatalf("request refs differ: %#v", request)
+	}
+	wantCloud, err := CanonicalizeJSON(cloudPayload(
+		time.Date(2026, 7, 30, 11, 12, 13, 456000000, time.UTC),
+		strings.Repeat("A", 43),
+		"21.5",
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(request.CloudAppAction.NormalizedEvidence, wantCloud) {
+		t.Fatalf("cloud evidence = %s, want canonical %s", request.CloudAppAction.NormalizedEvidence, wantCloud)
+	}
+}
+
+func TestIssue764RequestLoaderRejectsModeSymlinkMutationAndSelectors(t *testing.T) {
+	t.Run("mode", func(t *testing.T) {
+		root := filepath.Join(issue764SecureTempDir(t), "synchronized-evidence")
+		issue764WriteRequest(t, root, issue764RequestBytes(t, 'a'), 0o640)
+		if _, err := loadOneShotRequestAt(root, nil); err == nil {
+			t.Fatal("accepted request without exact mode 0600")
+		}
+	})
+
+	t.Run("leaf symlink", func(t *testing.T) {
+		base := issue764SecureTempDir(t)
+		root := filepath.Join(base, "synchronized-evidence")
+		target := filepath.Join(base, "request.json")
+		if err := os.WriteFile(target, issue764RequestBytes(t, 'a'), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Mkdir(root, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(target, filepath.Join(root, OneShotRequestFileV1)); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := loadOneShotRequestAt(root, nil); err == nil {
+			t.Fatal("followed request symlink")
+		}
+	})
+
+	t.Run("parent symlink", func(t *testing.T) {
+		base := issue764SecureTempDir(t)
+		actual := filepath.Join(base, "actual")
+		issue764WriteRequest(t, actual, issue764RequestBytes(t, 'a'), 0o600)
+		link := filepath.Join(base, "synchronized-evidence")
+		if err := os.Symlink(actual, link); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := loadOneShotRequestAt(link, nil); err == nil {
+			t.Fatal("followed request parent symlink")
+		}
+	})
+
+	t.Run("changed after metadata", func(t *testing.T) {
+		root := filepath.Join(issue764SecureTempDir(t), "synchronized-evidence")
+		path := issue764WriteRequest(t, root, issue764RequestBytes(t, 'a'), 0o600)
+		if _, err := loadOneShotRequestAt(root, func() {
+			if writeErr := os.WriteFile(path, issue764RequestBytes(t, 'b'), 0o600); writeErr != nil {
+				t.Fatalf("mutate request: %v", writeErr)
+			}
+		}); err == nil {
+			t.Fatal("accepted request changed between metadata verification and read")
+		}
+	})
+
+	t.Run("caller selector", func(t *testing.T) {
+		root := filepath.Join(issue764SecureTempDir(t), "synchronized-evidence")
+		raw := bytes.TrimSuffix(issue764RequestBytes(t, 'a'), []byte("}"))
+		raw = append(raw, []byte(`,"targets":[]}`)...)
+		issue764WriteRequest(t, root, raw, 0o600)
+		if _, err := loadOneShotRequestAt(root, nil); err == nil {
+			t.Fatal("accepted caller-supplied targets")
+		}
+	})
+
+	t.Run("different refs", func(t *testing.T) {
+		root := filepath.Join(issue764SecureTempDir(t), "synchronized-evidence")
+		raw := bytes.Replace(
+			issue764RequestBytes(t, 'a'),
+			[]byte("sha256:"+strings.Repeat("a", 64)),
+			[]byte("sha256:"+strings.Repeat("b", 64)),
+			1,
+		)
+		issue764WriteRequest(t, root, raw, 0o600)
+		if _, err := loadOneShotRequestAt(root, nil); err == nil {
+			t.Fatal("accepted non-identical action and cloud evidence refs")
+		}
+	})
+}

--- a/internal/syncevidence/issue764_request_test.go
+++ b/internal/syncevidence/issue764_request_test.go
@@ -14,20 +14,41 @@ import (
 func issue764RequestBytes(t *testing.T, digit byte) []byte {
 	t.Helper()
 	observed := time.Date(2026, 7, 30, 11, 12, 13, 456000000, time.UTC)
-	ref := redEvidenceRef(digit)
+	normalized, err := CanonicalizeJSON(cloudPayload(
+		observed,
+		strings.Repeat(strings.ToUpper(string(digit)), 43),
+		"21.5",
+	))
+	if err != nil {
+		t.Fatalf("canonicalize cloud evidence: %v", err)
+	}
+	ref := EvidenceRefV1{
+		Kind:            EvidenceKindContent,
+		DigestAlgorithm: DigestAlgorithmContentBytes,
+		Digest:          HashContentBytes(normalized),
+	}
 	raw, err := json.Marshal(map[string]any{
 		"contract":            OneShotRequestContractV1,
 		"schema_version":      1,
 		"action_evidence_ref": ref,
 		"cloud_app_action": map[string]any{
 			"evidence_ref":        ref,
-			"normalized_evidence": json.RawMessage(cloudPayload(observed, strings.Repeat("A", 43), "21.5")),
+			"normalized_evidence": json.RawMessage(normalized),
 		},
 	})
 	if err != nil {
 		t.Fatalf("marshal request: %v", err)
 	}
 	return raw
+}
+
+func issue764MutateRequestCloudValue(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	mutated := bytes.Replace(raw, []byte(`"value":"21.5"`), []byte(`"value":"22.5"`), 1)
+	if bytes.Equal(mutated, raw) || len(mutated) != len(raw) {
+		t.Fatalf("cloud mutation did not preserve request size")
+	}
+	return mutated
 }
 
 func issue764SecureTempDir(t *testing.T) string {
@@ -84,6 +105,13 @@ func TestIssue764RequestLoaderAcceptsOnlyFixedClosedRequest(t *testing.T) {
 	}
 	if !bytes.Equal(request.CloudAppAction.NormalizedEvidence, wantCloud) {
 		t.Fatalf("cloud evidence = %s, want canonical %s", request.CloudAppAction.NormalizedEvidence, wantCloud)
+	}
+}
+
+func TestIssue764RequestRejectsCloudContentDigestMismatch(t *testing.T) {
+	raw := issue764MutateRequestCloudValue(t, issue764RequestBytes(t, 'a'))
+	if _, err := parseOneShotRequest(raw); err == nil {
+		t.Fatal("accepted mutated canonical cloud evidence with retained content digest")
 	}
 }
 
@@ -184,12 +212,15 @@ func TestIssue764RequestLoaderRejectsModeSymlinkMutationAndSelectors(t *testing.
 
 	t.Run("different refs", func(t *testing.T) {
 		root := filepath.Join(issue764SecureTempDir(t), "synchronized-evidence")
-		raw := bytes.Replace(
-			issue764RequestBytes(t, 'a'),
-			[]byte("sha256:"+strings.Repeat("a", 64)),
-			[]byte("sha256:"+strings.Repeat("b", 64)),
-			1,
-		)
+		var request map[string]any
+		if err := json.Unmarshal(issue764RequestBytes(t, 'a'), &request); err != nil {
+			t.Fatal(err)
+		}
+		request["action_evidence_ref"].(map[string]any)["digest"] = "sha256:" + strings.Repeat("f", 64)
+		raw, err := json.Marshal(request)
+		if err != nil {
+			t.Fatal(err)
+		}
 		issue764WriteRequest(t, root, raw, 0o600)
 		if _, err := loadOneShotRequestAt(root, nil); err == nil {
 			t.Fatal("accepted non-identical action and cloud evidence refs")

--- a/internal/syncevidence/issue764_request_test.go
+++ b/internal/syncevidence/issue764_request_test.go
@@ -163,6 +163,10 @@ func TestIssue764RequestLoaderRejectsModeSymlinkMutationAndSelectors(t *testing.
 			if closeErr := file.Close(); closeErr != nil {
 				t.Fatalf("close in-place mutation: %v", closeErr)
 			}
+			changedAt := time.Date(2030, 1, 2, 3, 4, 5, 6, time.UTC)
+			if chtimesErr := os.Chtimes(path, changedAt, changedAt); chtimesErr != nil {
+				t.Fatalf("set deterministic mutation time: %v", chtimesErr)
+			}
 		}, nil); err == nil {
 			t.Fatal("accepted same-size in-place mutation after initial fstat")
 		}

--- a/internal/syncevidence/issue764_request_test.go
+++ b/internal/syncevidence/issue764_request_test.go
@@ -162,4 +162,30 @@ func TestIssue764RequestLoaderRejectsModeSymlinkMutationAndSelectors(t *testing.
 			t.Fatal("accepted non-identical action and cloud evidence refs")
 		}
 	})
+
+	t.Run("git blob evidence ref", func(t *testing.T) {
+		root := filepath.Join(issue764SecureTempDir(t), "synchronized-evidence")
+		var request map[string]any
+		if err := json.Unmarshal(issue764RequestBytes(t, 'a'), &request); err != nil {
+			t.Fatal(err)
+		}
+		ref := map[string]any{
+			"kind":             EvidenceKindGitBlob,
+			"digest_algorithm": DigestAlgorithmGitBlobV1,
+			"digest":           "sha256:" + strings.Repeat("a", 64),
+			"repository":       "Project-Helianthus/private-evidence",
+			"commit":           strings.Repeat("b", 40),
+			"path":             "evidence.json",
+		}
+		request["action_evidence_ref"] = ref
+		request["cloud_app_action"].(map[string]any)["evidence_ref"] = ref
+		raw, err := json.Marshal(request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		issue764WriteRequest(t, root, raw, 0o600)
+		if _, err := loadOneShotRequestAt(root, nil); err == nil {
+			t.Fatal("one-shot request accepted a Git-blob evidence ref")
+		}
+	})
 }

--- a/internal/syncevidence/issue764_request_test.go
+++ b/internal/syncevidence/issue764_request_test.go
@@ -139,6 +139,35 @@ func TestIssue764RequestLoaderRejectsModeSymlinkMutationAndSelectors(t *testing.
 		}
 	})
 
+	t.Run("same-size in-place changed after initial fstat", func(t *testing.T) {
+		root := filepath.Join(issue764SecureTempDir(t), "synchronized-evidence")
+		initial := issue764RequestBytes(t, 'a')
+		mutated := issue764RequestBytes(t, 'b')
+		if len(mutated) != len(initial) {
+			t.Fatalf("mutation fixture sizes differ: %d != %d", len(mutated), len(initial))
+		}
+		path := issue764WriteRequest(t, root, initial, 0o600)
+		if _, err := loadOneShotRequestAtWithHooks(root, func() {
+			file, openErr := os.OpenFile(path, os.O_WRONLY, 0)
+			if openErr != nil {
+				t.Fatalf("open request for in-place mutation: %v", openErr)
+			}
+			if _, writeErr := file.WriteAt(mutated, 0); writeErr != nil {
+				_ = file.Close()
+				t.Fatalf("mutate request in place: %v", writeErr)
+			}
+			if syncErr := file.Sync(); syncErr != nil {
+				_ = file.Close()
+				t.Fatalf("sync in-place mutation: %v", syncErr)
+			}
+			if closeErr := file.Close(); closeErr != nil {
+				t.Fatalf("close in-place mutation: %v", closeErr)
+			}
+		}, nil); err == nil {
+			t.Fatal("accepted same-size in-place mutation after initial fstat")
+		}
+	})
+
 	t.Run("caller selector", func(t *testing.T) {
 		root := filepath.Join(issue764SecureTempDir(t), "synchronized-evidence")
 		raw := bytes.TrimSuffix(issue764RequestBytes(t, 'a'), []byte("}"))

--- a/internal/syncevidence/issue764_store_test.go
+++ b/internal/syncevidence/issue764_store_test.go
@@ -3,10 +3,12 @@ package syncevidence
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -27,6 +29,23 @@ func issue764FiveSourceBundleWithCloudRef(
 	actionRef EvidenceRefV1,
 	cloudRef EvidenceRefV1,
 	entropy byte,
+) []byte {
+	t.Helper()
+	return issue764FiveSourceBundleWithCloudRefAt(
+		t,
+		actionRef,
+		cloudRef,
+		entropy,
+		time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC),
+	)
+}
+
+func issue764FiveSourceBundleWithCloudRefAt(
+	t *testing.T,
+	actionRef EvidenceRefV1,
+	cloudRef EvidenceRefV1,
+	entropy byte,
+	captureStartedAt time.Time,
 ) []byte {
 	t.Helper()
 	observed := time.Date(2026, 7, 30, 12, 0, 2, 0, time.UTC)
@@ -59,6 +78,7 @@ func issue764FiveSourceBundleWithCloudRef(
 	}
 	recorder := testRecorder(t, sources, func(options *RecorderOptions) {
 		options.Entropy = bytes.NewReader(bytes.Repeat([]byte{entropy}, 1<<20))
+		options.Clock = &redClock{wall: captureStartedAt}
 	})
 	bundle, err := recorder.Capture(context.Background(), ActionMarker{EvidenceRef: actionRef})
 	if err != nil {
@@ -75,15 +95,74 @@ func issue764RetainedCloudContentRef(t *testing.T, raw []byte) EvidenceRefV1 {
 	}
 	for _, artifact := range bundle.Artifacts {
 		if artifact.SourceBinding.SourceKind == SourceCloudApp {
-			return EvidenceRefV1{
-				Kind:            EvidenceKindContent,
-				DigestAlgorithm: DigestAlgorithmContentBytes,
-				Digest:          HashContentBytes(artifact.NormalizedEvidence),
+			if len(artifact.EvidenceRefs) != 1 {
+				t.Fatalf("retained cloud artifact refs = %#v", artifact.EvidenceRefs)
 			}
+			return artifact.EvidenceRefs[0]
 		}
 	}
 	t.Fatal("retained bundle has no cloud artifact")
 	return EvidenceRefV1{}
+}
+
+func issue764CloudSubject(t *testing.T, raw []byte) string {
+	t.Helper()
+	bundle, err := verifyBundle(raw)
+	if err != nil {
+		t.Fatalf("verify cloud bundle: %v", err)
+	}
+	for _, artifact := range bundle.Artifacts {
+		if artifact.SourceBinding.SourceKind != SourceCloudApp {
+			continue
+		}
+		var payload struct {
+			SubjectPseudonym string `json:"subject_pseudonym"`
+		}
+		if err := json.Unmarshal(artifact.NormalizedEvidence, &payload); err != nil {
+			t.Fatal(err)
+		}
+		if len(artifact.Remasking.Entries) != 1 ||
+			artifact.Remasking.Entries[0] != (RemaskedPseudonymV1{
+				Path: "/subject_pseudonym", Pseudonym: payload.SubjectPseudonym,
+			}) {
+			t.Fatalf("cloud remasking = %#v", artifact.Remasking)
+		}
+		return payload.SubjectPseudonym
+	}
+	t.Fatal("bundle has no cloud artifact")
+	return ""
+}
+
+func TestIssue764PublishedBundlesRemaskCloudSubjectPerBundle(t *testing.T) {
+	root := filepath.Join(storeTestRoot(t), "store")
+	store, err := OpenFileStore(FileStoreConfig{
+		Root: root, QuotaBytes: 1 << 27, LockProof: bytes.Repeat([]byte{0x4c}, 32),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	callerSubject := strings.Repeat("J", 43)
+	var subjects []string
+	for _, fixture := range []struct {
+		ref     EvidenceRefV1
+		entropy byte
+	}{
+		{ref: redEvidenceRef('a'), entropy: 0x61},
+		{ref: redEvidenceRef('b'), entropy: 0x62},
+	} {
+		bundle := issue764FiveSourceBundle(t, fixture.ref, fixture.entropy)
+		if bytes.Contains(bundle, []byte(callerSubject)) {
+			t.Fatalf("published candidate leaks caller cloud subject: %s", bundle)
+		}
+		if _, err := store.Publish(bundle); err != nil {
+			t.Fatal(err)
+		}
+		subjects = append(subjects, issue764CloudSubject(t, bundle))
+	}
+	if subjects[0] == callerSubject || subjects[1] == callerSubject || subjects[0] == subjects[1] {
+		t.Fatalf("cloud subjects preserve correlation: %#v", subjects)
+	}
 }
 
 func TestIssue764RetainedLookupSurvivesRestartWithoutEntropyOrStaging(t *testing.T) {
@@ -175,7 +254,7 @@ func TestIssue764RetainedLookupConflictsOnMultipleCandidates(t *testing.T) {
 	}
 }
 
-func TestIssue764RetainedLookupRejectsLegacyCloudContentMismatch(t *testing.T) {
+func TestIssue764RetainedLookupConflictsOnCloudContentMismatch(t *testing.T) {
 	root := filepath.Join(storeTestRoot(t), "store")
 	request, err := parseOneShotRequest(issue764RequestBytes(t, 'a'))
 	if err != nil {
@@ -219,7 +298,7 @@ func TestIssue764RetainedLookupRejectsLegacyCloudContentMismatch(t *testing.T) {
 	retained, err := restarted.lookupOneShot(actionRef, SourceTupleV1{
 		SourceKind: SourceEEBus, Contract: M625EEBusContractV1, Version: 1,
 	})
-	if err != nil || retained.Status != OneShotLookupNone ||
+	if err != nil || retained.Status != OneShotLookupConflict ||
 		retained.Bundle != nil || retained.Replay != nil {
 		t.Fatalf("legacy mismatch lookup = %#v, %v", retained, err)
 	}

--- a/internal/syncevidence/issue764_store_test.go
+++ b/internal/syncevidence/issue764_store_test.go
@@ -1,0 +1,179 @@
+package syncevidence
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+type issue764RejectEntropy struct{}
+
+func (issue764RejectEntropy) Read([]byte) (int, error) {
+	return 0, errors.New("unexpected entropy read")
+}
+
+func issue764FiveSourceBundle(t *testing.T, actionRef EvidenceRefV1, entropy byte) []byte {
+	t.Helper()
+	observed := time.Date(2026, 7, 30, 12, 0, 2, 0, time.UTC)
+	sources := []RegisteredSource{
+		issue764TerminalEBusSource(SourceEBusB509, PhasePre, "ebus-b509", "dbe91a10a208613183f890849c634f8d13661194aad937a03ae2a4143070bf2d"),
+		{
+			Phase: PhasePre, SourceKind: SourceEEBus, SourceContract: M625EEBusContractV1, SourceVersion: 1,
+			RuntimeInstance: "eebus-runtime", OperationVersion: issue764OperationVersion, OperationScope: "feature-data",
+			Admission: allowedAdmission("eebus.raw.read"),
+			EvidenceRefs: []EvidenceRefV1{
+				contentEvidenceRefForTest("0a2885d01d6703389541e246db59bcd845a332e7ed296abca2d49b4f8de31811"),
+			},
+			EEBusM625Reader: issue764M625ReaderFunc(func(context.Context, SourceRequest) (AcquiredEvidence, error) {
+				return AcquiredEvidence{SourceObservedAt: observed, NormalizedEvidence: issue764M625Payload()}, nil
+			}),
+		},
+		issue764TerminalEBusSource(SourceEBusB524, PhaseAction, "ebus-b524", "1002e09890801c9032548af407b13b58d889217dfc83e58bfe2a28df6bc33b78"),
+		cloudRegistration(PrecapturedCloudInput{
+			SourceObservedAt: observed,
+			NormalizedEvidence: cloudPayload(
+				observed,
+				"JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ",
+				"21.5",
+			),
+			EvidenceRef: actionRef,
+		}, PhaseAction, "cloud-runtime"),
+		issue764TerminalEBusSource(SourceEBusB555, PhasePost, "ebus-b555", "a3237e344f5c3582ceaf1ca947eabf200bede8fe9388ec85cf647331f026c72d"),
+	}
+	recorder := testRecorder(t, sources, func(options *RecorderOptions) {
+		options.Entropy = bytes.NewReader(bytes.Repeat([]byte{entropy}, 1<<20))
+	})
+	bundle, err := recorder.Capture(context.Background(), ActionMarker{EvidenceRef: actionRef})
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+	return bundle
+}
+
+func TestIssue764RetainedLookupSurvivesRestartWithoutEntropyOrStaging(t *testing.T) {
+	root := filepath.Join(storeTestRoot(t), "store")
+	actionRef := redEvidenceRef('a')
+	bundle := issue764FiveSourceBundle(t, actionRef, 0x61)
+	replay, err := Replay(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lockProof := bytes.Repeat([]byte{0x4c}, 32)
+	store, err := OpenFileStore(FileStoreConfig{
+		Root: root, QuotaBytes: 1 << 27, LockProof: lockProof,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reservation, err := store.ReserveCapture(int64(DefaultLimitsV1().MaxBundleBytes))
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, err := reservation.PublishVerified(bundle, replay)
+	if err != nil {
+		t.Fatalf("PublishVerified: %v", err)
+	}
+	if id != bundleIDFromBytes(t, bundle) {
+		t.Fatalf("published id = %q", id)
+	}
+	retained, err := store.lookupOneShot(actionRef, SourceTupleV1{
+		SourceKind: SourceEEBus, Contract: M625EEBusContractV1, Version: 1,
+	})
+	if err != nil || retained.Status != OneShotLookupExisting ||
+		!bytes.Equal(retained.Bundle, bundle) || !bytes.Equal(retained.Replay, replay) {
+		t.Fatalf("first lookup = %#v, %v", retained, err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	restarted, err := OpenFileStore(FileStoreConfig{
+		Root: root, QuotaBytes: 1 << 27, Entropy: issue764RejectEntropy{}, LockProof: lockProof,
+	})
+	if err != nil {
+		t.Fatalf("restart requested entropy or failed: %v", err)
+	}
+	t.Cleanup(func() { _ = restarted.Close() })
+	retained, err = restarted.lookupOneShot(actionRef, SourceTupleV1{
+		SourceKind: SourceEEBus, Contract: M625EEBusContractV1, Version: 1,
+	})
+	if err != nil || retained.Status != OneShotLookupExisting ||
+		!bytes.Equal(retained.Bundle, bundle) || !bytes.Equal(retained.Replay, replay) {
+		t.Fatalf("restart lookup = %#v, %v", retained, err)
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if entry.Name() != storeLockName && entry.Name() != id+".json" {
+			t.Fatalf("repeat created unexpected store entry %q", entry.Name())
+		}
+	}
+}
+
+func TestIssue764RetainedLookupConflictsOnMultipleCandidates(t *testing.T) {
+	root := filepath.Join(storeTestRoot(t), "store")
+	actionRef := redEvidenceRef('b')
+	store, err := OpenFileStore(FileStoreConfig{
+		Root: root, QuotaBytes: 1 << 27, LockProof: bytes.Repeat([]byte{0x4c}, 32),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	for _, entropy := range []byte{0x61, 0x62} {
+		bundle := issue764FiveSourceBundle(t, actionRef, entropy)
+		if _, err := store.Publish(bundle); err != nil {
+			t.Fatal(err)
+		}
+	}
+	retained, err := store.lookupOneShot(actionRef, SourceTupleV1{
+		SourceKind: SourceEEBus, Contract: M625EEBusContractV1, Version: 1,
+	})
+	if err != nil || retained.Status != OneShotLookupConflict ||
+		retained.Bundle != nil || retained.Replay != nil {
+		t.Fatalf("conflicting lookup = %#v, %v", retained, err)
+	}
+}
+
+func TestIssue764VerifiedPublishReopensExactFinalBytes(t *testing.T) {
+	root := filepath.Join(storeTestRoot(t), "store")
+	store, err := OpenFileStore(FileStoreConfig{
+		Root: root, QuotaBytes: 1 << 27, LockProof: bytes.Repeat([]byte{0x4c}, 32),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	bundle := issue764FiveSourceBundle(t, redEvidenceRef('c'), 0x61)
+	replay, err := Replay(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.beforePublishedReopen = func(name string) {
+		path := filepath.Join(root, name)
+		raw, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		raw[len(raw)-1] ^= 1
+		if writeErr := os.WriteFile(path, raw, 0o600); writeErr != nil {
+			t.Fatal(writeErr)
+		}
+	}
+	reservation, err := store.ReserveCapture(int64(DefaultLimitsV1().MaxBundleBytes))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reservation.PublishVerified(bundle, replay); !errors.Is(err, ErrDurability) {
+		t.Fatalf("replaced final publish error = %v", err)
+	}
+}
+
+var _ io.Reader = issue764RejectEntropy{}

--- a/internal/syncevidence/issue764_store_test.go
+++ b/internal/syncevidence/issue764_store_test.go
@@ -30,6 +30,16 @@ func issue764FiveSourceBundleWithCloudRef(
 ) []byte {
 	t.Helper()
 	observed := time.Date(2026, 7, 30, 12, 0, 2, 0, time.UTC)
+	cloud := cloudRegistration(PrecapturedCloudInput{
+		SourceObservedAt: observed,
+		NormalizedEvidence: cloudPayload(
+			observed,
+			"JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ",
+			"21.5",
+		),
+		EvidenceRef: cloudRef,
+	}, PhaseAction, "cloud-runtime")
+	cloud.cloudBound = true
 	sources := []RegisteredSource{
 		issue764TerminalEBusSource(SourceEBusB509, PhasePre, "ebus-b509", "dbe91a10a208613183f890849c634f8d13661194aad937a03ae2a4143070bf2d"),
 		{
@@ -44,15 +54,7 @@ func issue764FiveSourceBundleWithCloudRef(
 			}),
 		},
 		issue764TerminalEBusSource(SourceEBusB524, PhaseAction, "ebus-b524", "1002e09890801c9032548af407b13b58d889217dfc83e58bfe2a28df6bc33b78"),
-		cloudRegistration(PrecapturedCloudInput{
-			SourceObservedAt: observed,
-			NormalizedEvidence: cloudPayload(
-				observed,
-				"JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ",
-				"21.5",
-			),
-			EvidenceRef: cloudRef,
-		}, PhaseAction, "cloud-runtime"),
+		cloud,
 		issue764TerminalEBusSource(SourceEBusB555, PhasePost, "ebus-b555", "a3237e344f5c3582ceaf1ca947eabf200bede8fe9388ec85cf647331f026c72d"),
 	}
 	recorder := testRecorder(t, sources, func(options *RecorderOptions) {
@@ -86,7 +88,8 @@ func issue764RetainedCloudContentRef(t *testing.T, raw []byte) EvidenceRefV1 {
 
 func TestIssue764RetainedLookupSurvivesRestartWithoutEntropyOrStaging(t *testing.T) {
 	root := filepath.Join(storeTestRoot(t), "store")
-	actionRef := redEvidenceRef('a')
+	provisional := issue764FiveSourceBundle(t, redEvidenceRef('a'), 0x61)
+	actionRef := issue764RetainedCloudContentRef(t, provisional)
 	bundle := issue764FiveSourceBundle(t, actionRef, 0x61)
 	replay, err := Replay(bundle)
 	if err != nil {
@@ -148,7 +151,8 @@ func TestIssue764RetainedLookupSurvivesRestartWithoutEntropyOrStaging(t *testing
 
 func TestIssue764RetainedLookupConflictsOnMultipleCandidates(t *testing.T) {
 	root := filepath.Join(storeTestRoot(t), "store")
-	actionRef := redEvidenceRef('b')
+	provisional := issue764FiveSourceBundle(t, redEvidenceRef('b'), 0x61)
+	actionRef := issue764RetainedCloudContentRef(t, provisional)
 	store, err := OpenFileStore(FileStoreConfig{
 		Root: root, QuotaBytes: 1 << 27, LockProof: bytes.Repeat([]byte{0x4c}, 32),
 	})

--- a/internal/syncevidence/issue764_store_test.go
+++ b/internal/syncevidence/issue764_store_test.go
@@ -19,6 +19,16 @@ func (issue764RejectEntropy) Read([]byte) (int, error) {
 
 func issue764FiveSourceBundle(t *testing.T, actionRef EvidenceRefV1, entropy byte) []byte {
 	t.Helper()
+	return issue764FiveSourceBundleWithCloudRef(t, actionRef, actionRef, entropy)
+}
+
+func issue764FiveSourceBundleWithCloudRef(
+	t *testing.T,
+	actionRef EvidenceRefV1,
+	cloudRef EvidenceRefV1,
+	entropy byte,
+) []byte {
+	t.Helper()
 	observed := time.Date(2026, 7, 30, 12, 0, 2, 0, time.UTC)
 	sources := []RegisteredSource{
 		issue764TerminalEBusSource(SourceEBusB509, PhasePre, "ebus-b509", "dbe91a10a208613183f890849c634f8d13661194aad937a03ae2a4143070bf2d"),
@@ -41,7 +51,7 @@ func issue764FiveSourceBundle(t *testing.T, actionRef EvidenceRefV1, entropy byt
 				"JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ",
 				"21.5",
 			),
-			EvidenceRef: actionRef,
+			EvidenceRef: cloudRef,
 		}, PhaseAction, "cloud-runtime"),
 		issue764TerminalEBusSource(SourceEBusB555, PhasePost, "ebus-b555", "a3237e344f5c3582ceaf1ca947eabf200bede8fe9388ec85cf647331f026c72d"),
 	}
@@ -53,6 +63,25 @@ func issue764FiveSourceBundle(t *testing.T, actionRef EvidenceRefV1, entropy byt
 		t.Fatalf("Capture: %v", err)
 	}
 	return bundle
+}
+
+func issue764RetainedCloudContentRef(t *testing.T, raw []byte) EvidenceRefV1 {
+	t.Helper()
+	bundle, err := verifyBundle(raw)
+	if err != nil {
+		t.Fatalf("verify retained bundle: %v", err)
+	}
+	for _, artifact := range bundle.Artifacts {
+		if artifact.SourceBinding.SourceKind == SourceCloudApp {
+			return EvidenceRefV1{
+				Kind:            EvidenceKindContent,
+				DigestAlgorithm: DigestAlgorithmContentBytes,
+				Digest:          HashContentBytes(artifact.NormalizedEvidence),
+			}
+		}
+	}
+	t.Fatal("retained bundle has no cloud artifact")
+	return EvidenceRefV1{}
 }
 
 func TestIssue764RetainedLookupSurvivesRestartWithoutEntropyOrStaging(t *testing.T) {
@@ -139,6 +168,56 @@ func TestIssue764RetainedLookupConflictsOnMultipleCandidates(t *testing.T) {
 	if err != nil || retained.Status != OneShotLookupConflict ||
 		retained.Bundle != nil || retained.Replay != nil {
 		t.Fatalf("conflicting lookup = %#v, %v", retained, err)
+	}
+}
+
+func TestIssue764RetainedLookupRejectsLegacyCloudContentMismatch(t *testing.T) {
+	root := filepath.Join(storeTestRoot(t), "store")
+	request, err := parseOneShotRequest(issue764RequestBytes(t, 'a'))
+	if err != nil {
+		t.Fatal(err)
+	}
+	actionRef := request.ActionEvidenceRef
+	const entropy = byte(0x61)
+	provisional := issue764FiveSourceBundle(t, redEvidenceRef('f'), entropy)
+	cloudRef := issue764RetainedCloudContentRef(t, provisional)
+	if evidenceRefKey(cloudRef) == evidenceRefKey(actionRef) {
+		t.Fatal("legacy mismatch fixture refs unexpectedly match")
+	}
+	legacy := issue764FiveSourceBundleWithCloudRef(t, actionRef, cloudRef, entropy)
+	if got := issue764RetainedCloudContentRef(t, legacy); evidenceRefKey(got) != evidenceRefKey(cloudRef) {
+		t.Fatalf("legacy cloud digest = %#v, want %#v", got, cloudRef)
+	}
+	if _, err := Replay(legacy); err != nil {
+		t.Fatalf("legacy bundle no longer satisfies replay contract: %v", err)
+	}
+	lockProof := bytes.Repeat([]byte{0x4c}, 32)
+	store, err := OpenFileStore(FileStoreConfig{
+		Root: root, QuotaBytes: 1 << 27, LockProof: lockProof,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Publish(legacy); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	restarted, err := OpenFileStore(FileStoreConfig{
+		Root: root, QuotaBytes: 1 << 27, Entropy: issue764RejectEntropy{}, LockProof: lockProof,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = restarted.Close() })
+	retained, err := restarted.lookupOneShot(actionRef, SourceTupleV1{
+		SourceKind: SourceEEBus, Contract: M625EEBusContractV1, Version: 1,
+	})
+	if err != nil || retained.Status != OneShotLookupNone ||
+		retained.Bundle != nil || retained.Replay != nil {
+		t.Fatalf("legacy mismatch lookup = %#v, %v", retained, err)
 	}
 }
 

--- a/internal/syncevidence/m625.go
+++ b/internal/syncevidence/m625.go
@@ -45,9 +45,10 @@ func mustM625SchemaEnum(definition string) map[string]bool {
 }
 
 func validateM625Payload(object map[string]any, capture sourceCapture) error {
+	schemaVersion, schemaVersionOK := m625SafeInteger(object["schema_version"])
 	if !exactKeys(object, "contract", "schema_version", "source_observed_at", "services", "feature_paths", "observations") ||
 		object["contract"] != M625EEBusContractV1 ||
-		object["schema_version"] != json.Number("1") ||
+		!schemaVersionOK || schemaVersion != 1 ||
 		capture.sourceContract != M625EEBusContractV1 ||
 		capture.sourceSchemaVersion != 1 {
 		return contractError("schema.bundle")
@@ -107,7 +108,6 @@ func validateM625Payload(object map[string]any, capture sourceCapture) error {
 		return contractError("schema.bundle")
 	}
 	refs := make(map[string]bool, len(observations))
-	pathIndexes := make(map[uint64]bool, len(observations))
 	var latest time.Time
 	for _, raw := range observations {
 		observation, ok := raw.(map[string]any)
@@ -133,10 +133,9 @@ func validateM625Payload(object map[string]any, capture sourceCapture) error {
 		}
 		refs[ref] = true
 		pathIndex, ok := m625SafeInteger(observation["path_index"])
-		if !ok || pathIndex >= uint64(len(paths)) || pathIndexes[pathIndex] {
+		if !ok || pathIndex >= uint64(len(paths)) {
 			return contractError("schema.bundle")
 		}
-		pathIndexes[pathIndex] = true
 		observedAt, ok := m625Timestamp(observation["source_observed_at"])
 		if !ok || validateM625Observation(observation) != nil {
 			return contractError("schema.bundle")
@@ -270,11 +269,10 @@ func m625Timestamp(value any) (time.Time, bool) {
 
 func m625SafeInteger(value any) (uint64, bool) {
 	number, ok := value.(json.Number)
-	if !ok || !isSafeInteger(string(number)) {
+	if !ok {
 		return 0, false
 	}
-	parsed, err := strconv.ParseUint(string(number), 10, 64)
-	return parsed, err == nil
+	return safeIntegerValue(string(number))
 }
 
 func m625RemaskingRequirements(object map[string]any) (map[string]m625RemaskingRequirement, error) {
@@ -345,13 +343,9 @@ func m625RemaskingRequirements(object map[string]any) (map[string]m625RemaskingR
 		if !ok || pathIndex >= uint64(len(paths)) {
 			return nil, contractError("privacy.remask")
 		}
-		pathBytes, err := canonicalJSONValue(paths[pathIndex])
-		if err != nil {
-			return nil, err
-		}
 		result["/observations/"+strconv.Itoa(index)+"/observation_ref"] = m625RemaskingRequirement{
 			pseudonym: ref[4:],
-			identity:  "OBSERVATION\x00" + string(pathBytes),
+			identity:  "OBSERVATION\x00" + ref,
 		}
 	}
 	return result, nil

--- a/internal/syncevidence/m625.go
+++ b/internal/syncevidence/m625.go
@@ -1,0 +1,408 @@
+package syncevidence
+
+import (
+	"encoding/json"
+	"regexp"
+	"sort"
+	"strconv"
+	"time"
+)
+
+var (
+	m625ObservationRefPattern = regexp.MustCompile(`^obs-[A-Za-z0-9_-]{43}$`)
+	m625IdentifierPattern     = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]{0,127}$`)
+	m625DecimalPattern        = regexp.MustCompile(`^(0(\.0+)?|0\.[0-9]*[1-9][0-9]*|[1-9][0-9]*(\.[0-9]+)?|-(0\.[0-9]*[1-9][0-9]*|[1-9][0-9]*(\.[0-9]+)?))$`)
+	m625EnumPattern           = regexp.MustCompile(`^ID_(0|[1-9][0-9]{0,9})$`)
+	m625Units                 = mustM625SchemaEnum("UnitV1")
+	m625Terminals             = mustM625SchemaEnum("TerminalClassificationV1")
+)
+
+type m625RemaskingRequirement struct {
+	pseudonym string
+	identity  string
+}
+
+func mustM625SchemaEnum(definition string) map[string]bool {
+	var document struct {
+		Definitions map[string]struct {
+			Enum []string `json:"enum"`
+		} `json:"$defs"`
+	}
+	if err := json.Unmarshal(mustReadContract("helianthus.eebus.m625.public-redacted-evidence.v1.schema.json"), &document); err != nil {
+		panic("syncevidence: invalid M6.25 source schema")
+	}
+	values := document.Definitions[definition].Enum
+	if len(values) == 0 {
+		panic("syncevidence: incomplete M6.25 source schema")
+	}
+	result := make(map[string]bool, len(values))
+	for _, value := range values {
+		if value == "" || result[value] {
+			panic("syncevidence: invalid M6.25 source enum")
+		}
+		result[value] = true
+	}
+	return result
+}
+
+func validateM625Payload(object map[string]any, capture sourceCapture) error {
+	if !exactKeys(object, "contract", "schema_version", "source_observed_at", "services", "feature_paths", "observations") ||
+		object["contract"] != M625EEBusContractV1 ||
+		object["schema_version"] != json.Number("1") ||
+		capture.sourceContract != M625EEBusContractV1 ||
+		capture.sourceSchemaVersion != 1 {
+		return contractError("schema.bundle")
+	}
+	rootTimestamp, ok := m625Timestamp(object["source_observed_at"])
+	if !ok || !rootTimestamp.Equal(capture.sourceObservedAt) {
+		return contractError("schema.bundle")
+	}
+
+	services, ok := object["services"].([]any)
+	if !ok || len(services) < 1 || len(services) > 64 {
+		return contractError("schema.bundle")
+	}
+	serviceSet := make(map[string]bool, len(services))
+	lastService := ""
+	for _, raw := range services {
+		service, ok := raw.(string)
+		if !ok || !remaskedValuePattern.MatchString(service) || serviceSet[service] ||
+			lastService != "" && service < lastService {
+			return contractError("schema.bundle")
+		}
+		serviceSet[service] = true
+		lastService = service
+	}
+
+	paths, ok := object["feature_paths"].([]any)
+	if !ok || len(paths) < 1 || len(paths) > 4096 {
+		return contractError("schema.bundle")
+	}
+	referencedServices := make(map[string]bool)
+	pathEncodings := make(map[string]bool, len(paths))
+	lastPath := ""
+	for _, raw := range paths {
+		path, ok := raw.(map[string]any)
+		if !ok || validateM625Path(path, serviceSet) != nil {
+			return contractError("schema.bundle")
+		}
+		service := path["service"].(string)
+		referencedServices[service] = true
+		encoded, err := canonicalJSONValue(path)
+		if err != nil {
+			return contractError("schema.bundle")
+		}
+		key := string(encoded)
+		if pathEncodings[key] || lastPath != "" && key < lastPath {
+			return contractError("ordering.invalid")
+		}
+		pathEncodings[key] = true
+		lastPath = key
+	}
+	if len(referencedServices) != len(serviceSet) {
+		return contractError("schema.bundle")
+	}
+	for service := range serviceSet {
+		if !referencedServices[service] {
+			return contractError("schema.bundle")
+		}
+	}
+
+	observations, ok := object["observations"].([]any)
+	if !ok || len(observations) < 1 || len(observations) > 4096 {
+		return contractError("schema.bundle")
+	}
+	refs := make(map[string]bool, len(observations))
+	pathIndexes := make(map[uint64]bool, len(observations))
+	lastRef := ""
+	var latest time.Time
+	for _, raw := range observations {
+		observation, ok := raw.(map[string]any)
+		if !ok || !exactKeys(
+			observation,
+			"observation_ref",
+			"path_index",
+			"feature_type",
+			"feature_role",
+			"function",
+			"source_observed_at",
+			"terminal_classification",
+			"value_type",
+			"value",
+			"unit",
+			"quality",
+		) {
+			return contractError("schema.bundle")
+		}
+		ref, ok := observation["observation_ref"].(string)
+		if !ok || !m625ObservationRefPattern.MatchString(ref) || refs[ref] ||
+			lastRef != "" && ref < lastRef {
+			return contractError("ordering.invalid")
+		}
+		refs[ref] = true
+		lastRef = ref
+		pathIndex, ok := m625SafeInteger(observation["path_index"])
+		if !ok || pathIndex >= uint64(len(paths)) || pathIndexes[pathIndex] {
+			return contractError("schema.bundle")
+		}
+		pathIndexes[pathIndex] = true
+		observedAt, ok := m625Timestamp(observation["source_observed_at"])
+		if !ok || validateM625Observation(observation) != nil {
+			return contractError("schema.bundle")
+		}
+		if latest.IsZero() || observedAt.After(latest) {
+			latest = observedAt
+		}
+	}
+	if !rootTimestamp.Equal(latest) {
+		return contractError("schema.bundle")
+	}
+	return nil
+}
+
+func validateM625Path(path map[string]any, services map[string]bool) error {
+	if !exactKeys(path, "service", "entity", "feature", "feature_path") {
+		return contractError("schema.bundle")
+	}
+	service, serviceOK := path["service"].(string)
+	entity, entityOK := path["entity"].(string)
+	feature, featureOK := path["feature"].(string)
+	if !serviceOK || !entityOK || !featureOK ||
+		!remaskedValuePattern.MatchString(service) ||
+		!remaskedValuePattern.MatchString(entity) ||
+		!remaskedValuePattern.MatchString(feature) ||
+		!services[service] {
+		return contractError("schema.bundle")
+	}
+	segments, ok := path["feature_path"].([]any)
+	if !ok || len(segments) < 3 || len(segments) > 32 {
+		return contractError("schema.bundle")
+	}
+	selectors := make(map[string]bool, len(segments))
+	baseKinds := []string{"SERVICE", "ENTITY", "FEATURE"}
+	baseSelectors := []string{service, entity, feature}
+	for index, raw := range segments {
+		segment, ok := raw.(map[string]any)
+		if !ok || !exactKeys(segment, "kind", "selector") {
+			return contractError("schema.bundle")
+		}
+		kind, kindOK := segment["kind"].(string)
+		selector, selectorOK := segment["selector"].(string)
+		if !kindOK || !selectorOK || !remaskedValuePattern.MatchString(selector) || selectors[selector] {
+			return contractError("schema.bundle")
+		}
+		selectors[selector] = true
+		if index < 3 {
+			if kind != baseKinds[index] || selector != baseSelectors[index] {
+				return contractError("schema.bundle")
+			}
+		} else if kind != "FIELD" {
+			return contractError("schema.bundle")
+		}
+	}
+	return nil
+}
+
+func validateM625Observation(observation map[string]any) error {
+	featureType, typeOK := observation["feature_type"].(string)
+	role, roleOK := observation["feature_role"].(string)
+	function, functionOK := observation["function"].(string)
+	terminal, terminalOK := observation["terminal_classification"].(string)
+	if !typeOK || !roleOK || !functionOK || !terminalOK ||
+		!m625IdentifierPattern.MatchString(featureType) ||
+		!m625IdentifierPattern.MatchString(function) ||
+		role != "server" ||
+		!m625Terminals[terminal] {
+		return contractError("schema.bundle")
+	}
+	allowed := map[string]bool{}
+	switch {
+	case featureType == "Measurement" && function == "measurementListData":
+		allowed["DECIMAL"] = true
+	case featureType == "Setpoint" && function == "setpointListData":
+		allowed["DECIMAL"], allowed["BOOLEAN"] = true, true
+	case featureType == "HVAC" && function == "hvacSystemFunctionListData":
+		allowed["BOOLEAN"], allowed["ENUM"] = true, true
+	default:
+		return contractError("schema.bundle")
+	}
+	valueType := observation["value_type"]
+	value := observation["value"]
+	unit := observation["unit"]
+	quality := observation["quality"]
+	if terminal != "SUCCESS" {
+		if valueType != nil || value != nil || unit != nil || quality != nil {
+			return contractError("schema.bundle")
+		}
+		return nil
+	}
+	valueTypeText, typeOK := valueType.(string)
+	valueText, valueOK := value.(string)
+	qualityText, qualityOK := quality.(string)
+	if !typeOK || !valueOK || !qualityOK || !allowed[valueTypeText] ||
+		(qualityText != "OBSERVED" && qualityText != "STALE") {
+		return contractError("schema.bundle")
+	}
+	switch valueTypeText {
+	case "DECIMAL":
+		if len(valueText) > 64 || !m625DecimalPattern.MatchString(valueText) {
+			return contractError("schema.bundle")
+		}
+		if unit != nil {
+			unitText, ok := unit.(string)
+			if !ok || !m625Units[unitText] {
+				return contractError("schema.bundle")
+			}
+		}
+	case "BOOLEAN":
+		if (valueText != "false" && valueText != "true") || unit != nil {
+			return contractError("schema.bundle")
+		}
+	case "ENUM":
+		if !m625EnumPattern.MatchString(valueText) || unit != nil {
+			return contractError("schema.bundle")
+		}
+	default:
+		return contractError("schema.bundle")
+	}
+	return nil
+}
+
+func m625Timestamp(value any) (time.Time, bool) {
+	text, ok := value.(string)
+	if !ok || !canonicalTimestamp(text) {
+		return time.Time{}, false
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, text)
+	return parsed, err == nil
+}
+
+func m625SafeInteger(value any) (uint64, bool) {
+	number, ok := value.(json.Number)
+	if !ok || !isSafeInteger(string(number)) {
+		return 0, false
+	}
+	parsed, err := strconv.ParseUint(string(number), 10, 64)
+	return parsed, err == nil
+}
+
+func sortM625Payload(object map[string]any) error {
+	paths := object["feature_paths"].([]any)
+	type indexedPath struct {
+		oldIndex int
+		encoded  string
+		value    any
+	}
+	indexed := make([]indexedPath, len(paths))
+	for index, path := range paths {
+		encoded, err := canonicalJSONValue(path)
+		if err != nil {
+			return err
+		}
+		indexed[index] = indexedPath{oldIndex: index, encoded: string(encoded), value: path}
+	}
+	sort.Slice(indexed, func(left, right int) bool { return indexed[left].encoded < indexed[right].encoded })
+	oldToNew := make(map[uint64]uint64, len(indexed))
+	for newIndex, path := range indexed {
+		paths[newIndex] = path.value
+		oldToNew[uint64(path.oldIndex)] = uint64(newIndex)
+	}
+	observations := object["observations"].([]any)
+	for _, raw := range observations {
+		observation := raw.(map[string]any)
+		oldIndex, ok := m625SafeInteger(observation["path_index"])
+		if !ok {
+			return contractError("schema.bundle")
+		}
+		observation["path_index"] = json.Number(strconv.FormatUint(oldToNew[oldIndex], 10))
+	}
+	sort.Slice(observations, func(left, right int) bool {
+		return observations[left].(map[string]any)["observation_ref"].(string) <
+			observations[right].(map[string]any)["observation_ref"].(string)
+	})
+	services := object["services"].([]any)
+	sort.Slice(services, func(left, right int) bool {
+		return services[left].(string) < services[right].(string)
+	})
+	return nil
+}
+
+func m625RemaskingRequirements(object map[string]any) (map[string]m625RemaskingRequirement, error) {
+	result := make(map[string]m625RemaskingRequirement)
+	services, ok := object["services"].([]any)
+	if !ok {
+		return nil, contractError("privacy.remask")
+	}
+	for index, raw := range services {
+		service, ok := raw.(string)
+		if !ok {
+			return nil, contractError("privacy.remask")
+		}
+		result["/services/"+strconv.Itoa(index)] = m625RemaskingRequirement{
+			pseudonym: service,
+			identity:  "SERVICE\x00" + service,
+		}
+	}
+	paths, ok := object["feature_paths"].([]any)
+	if !ok {
+		return nil, contractError("privacy.remask")
+	}
+	for pathIndex, raw := range paths {
+		path, ok := raw.(map[string]any)
+		if !ok {
+			return nil, contractError("privacy.remask")
+		}
+		service := path["service"].(string)
+		entity := path["entity"].(string)
+		feature := path["feature"].(string)
+		prefix := "/feature_paths/" + strconv.Itoa(pathIndex)
+		serviceIdentity := "SERVICE\x00" + service
+		entityIdentity := serviceIdentity + "\x00ENTITY\x00" + entity
+		featureIdentity := entityIdentity + "\x00FEATURE\x00" + feature
+		result[prefix+"/service"] = m625RemaskingRequirement{pseudonym: service, identity: serviceIdentity}
+		result[prefix+"/entity"] = m625RemaskingRequirement{pseudonym: entity, identity: entityIdentity}
+		result[prefix+"/feature"] = m625RemaskingRequirement{pseudonym: feature, identity: featureIdentity}
+		segments := path["feature_path"].([]any)
+		identity := ""
+		for segmentIndex, rawSegment := range segments {
+			segment := rawSegment.(map[string]any)
+			kind := segment["kind"].(string)
+			selector := segment["selector"].(string)
+			switch segmentIndex {
+			case 0:
+				identity = serviceIdentity
+			case 1:
+				identity = entityIdentity
+			case 2:
+				identity = featureIdentity
+			default:
+				identity += "\x00" + kind + "\x00" + selector
+			}
+			result[prefix+"/feature_path/"+strconv.Itoa(segmentIndex)+"/selector"] = m625RemaskingRequirement{
+				pseudonym: selector,
+				identity:  identity,
+			}
+		}
+	}
+	observations, ok := object["observations"].([]any)
+	if !ok {
+		return nil, contractError("privacy.remask")
+	}
+	for index, raw := range observations {
+		observation := raw.(map[string]any)
+		ref := observation["observation_ref"].(string)
+		pathIndex, ok := m625SafeInteger(observation["path_index"])
+		if !ok || pathIndex >= uint64(len(paths)) {
+			return nil, contractError("privacy.remask")
+		}
+		pathBytes, err := canonicalJSONValue(paths[pathIndex])
+		if err != nil {
+			return nil, err
+		}
+		result["/observations/"+strconv.Itoa(index)+"/observation_ref"] = m625RemaskingRequirement{
+			pseudonym: ref[4:],
+			identity:  "OBSERVATION\x00" + string(pathBytes),
+		}
+	}
+	return result, nil
+}

--- a/internal/syncevidence/m625.go
+++ b/internal/syncevidence/m625.go
@@ -3,7 +3,6 @@ package syncevidence
 import (
 	"encoding/json"
 	"regexp"
-	"sort"
 	"strconv"
 	"time"
 )
@@ -63,15 +62,12 @@ func validateM625Payload(object map[string]any, capture sourceCapture) error {
 		return contractError("schema.bundle")
 	}
 	serviceSet := make(map[string]bool, len(services))
-	lastService := ""
 	for _, raw := range services {
 		service, ok := raw.(string)
-		if !ok || !remaskedValuePattern.MatchString(service) || serviceSet[service] ||
-			lastService != "" && service < lastService {
+		if !ok || !remaskedValuePattern.MatchString(service) || serviceSet[service] {
 			return contractError("schema.bundle")
 		}
 		serviceSet[service] = true
-		lastService = service
 	}
 
 	paths, ok := object["feature_paths"].([]any)
@@ -80,7 +76,6 @@ func validateM625Payload(object map[string]any, capture sourceCapture) error {
 	}
 	referencedServices := make(map[string]bool)
 	pathEncodings := make(map[string]bool, len(paths))
-	lastPath := ""
 	for _, raw := range paths {
 		path, ok := raw.(map[string]any)
 		if !ok || validateM625Path(path, serviceSet) != nil {
@@ -93,11 +88,10 @@ func validateM625Payload(object map[string]any, capture sourceCapture) error {
 			return contractError("schema.bundle")
 		}
 		key := string(encoded)
-		if pathEncodings[key] || lastPath != "" && key < lastPath {
-			return contractError("ordering.invalid")
+		if pathEncodings[key] {
+			return contractError("schema.bundle")
 		}
 		pathEncodings[key] = true
-		lastPath = key
 	}
 	if len(referencedServices) != len(serviceSet) {
 		return contractError("schema.bundle")
@@ -114,7 +108,6 @@ func validateM625Payload(object map[string]any, capture sourceCapture) error {
 	}
 	refs := make(map[string]bool, len(observations))
 	pathIndexes := make(map[uint64]bool, len(observations))
-	lastRef := ""
 	var latest time.Time
 	for _, raw := range observations {
 		observation, ok := raw.(map[string]any)
@@ -135,12 +128,10 @@ func validateM625Payload(object map[string]any, capture sourceCapture) error {
 			return contractError("schema.bundle")
 		}
 		ref, ok := observation["observation_ref"].(string)
-		if !ok || !m625ObservationRefPattern.MatchString(ref) || refs[ref] ||
-			lastRef != "" && ref < lastRef {
-			return contractError("ordering.invalid")
+		if !ok || !m625ObservationRefPattern.MatchString(ref) || refs[ref] {
+			return contractError("schema.bundle")
 		}
 		refs[ref] = true
-		lastRef = ref
 		pathIndex, ok := m625SafeInteger(observation["path_index"])
 		if !ok || pathIndex >= uint64(len(paths)) || pathIndexes[pathIndex] {
 			return contractError("schema.bundle")
@@ -284,47 +275,6 @@ func m625SafeInteger(value any) (uint64, bool) {
 	}
 	parsed, err := strconv.ParseUint(string(number), 10, 64)
 	return parsed, err == nil
-}
-
-func sortM625Payload(object map[string]any) error {
-	paths := object["feature_paths"].([]any)
-	type indexedPath struct {
-		oldIndex int
-		encoded  string
-		value    any
-	}
-	indexed := make([]indexedPath, len(paths))
-	for index, path := range paths {
-		encoded, err := canonicalJSONValue(path)
-		if err != nil {
-			return err
-		}
-		indexed[index] = indexedPath{oldIndex: index, encoded: string(encoded), value: path}
-	}
-	sort.Slice(indexed, func(left, right int) bool { return indexed[left].encoded < indexed[right].encoded })
-	oldToNew := make(map[uint64]uint64, len(indexed))
-	for newIndex, path := range indexed {
-		paths[newIndex] = path.value
-		oldToNew[uint64(path.oldIndex)] = uint64(newIndex)
-	}
-	observations := object["observations"].([]any)
-	for _, raw := range observations {
-		observation := raw.(map[string]any)
-		oldIndex, ok := m625SafeInteger(observation["path_index"])
-		if !ok {
-			return contractError("schema.bundle")
-		}
-		observation["path_index"] = json.Number(strconv.FormatUint(oldToNew[oldIndex], 10))
-	}
-	sort.Slice(observations, func(left, right int) bool {
-		return observations[left].(map[string]any)["observation_ref"].(string) <
-			observations[right].(map[string]any)["observation_ref"].(string)
-	})
-	services := object["services"].([]any)
-	sort.Slice(services, func(left, right int) bool {
-		return services[left].(string) < services[right].(string)
-	})
-	return nil
 }
 
 func m625RemaskingRequirements(object map[string]any) (map[string]m625RemaskingRequirement, error) {

--- a/internal/syncevidence/m625_acquisition.go
+++ b/internal/syncevidence/m625_acquisition.go
@@ -1,0 +1,685 @@
+package syncevidence
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	eebusruntime "github.com/Project-Helianthus/helianthus-eebusreg"
+	"github.com/Project-Helianthus/helianthus-eebusreg/eebusraw"
+)
+
+type M625EEBusRuntime interface {
+	Snapshot() (eebusruntime.SnapshotV1, error)
+	FeaturesGet(context.Context, eebusraw.ReadAuthorizationV1, eebusraw.FeaturesGetRequestV1) (eebusraw.FeaturesGetDataV1, *eebusraw.ErrorV1)
+	FeaturesDataGet(context.Context, eebusraw.ReadAuthorizationV1, eebusraw.FeatureDataGetRequestV1) (eebusraw.FeatureDataGetDataV1, *eebusraw.ErrorV1)
+}
+
+type m625EEBusReader struct {
+	runtime M625EEBusRuntime
+}
+
+type m625Target struct {
+	target        eebusraw.FeatureTargetV1
+	unit          string
+	fallbackTime  time.Time
+	nativeService []string
+}
+
+type m625ProjectedObservation struct {
+	target        eebusraw.FeatureTargetV1
+	nativeService []string
+	fieldPath     []string
+	observedAt    time.Time
+	terminal      string
+	valueType     any
+	value         any
+	unit          any
+	quality       any
+}
+
+func NewM625EEBusReader(runtime M625EEBusRuntime) (EEBusM625Reader, error) {
+	if runtime == nil || reflect.ValueOf(runtime).Kind() == reflect.Ptr && reflect.ValueOf(runtime).IsNil() {
+		return nil, ErrInvalidArgument
+	}
+	return &m625EEBusReader{runtime: runtime}, nil
+}
+
+func (reader *m625EEBusReader) ReadFeatureData(ctx context.Context, request SourceRequest) (AcquiredEvidence, error) {
+	if reader == nil || reader.runtime == nil || ctx == nil ||
+		request.Phase != PhasePre ||
+		request.OperationID != string(eebusraw.ToolV1FeaturesDataGet) ||
+		request.OperationScope != "feature-data" ||
+		request.MaskTier != "redacted" ||
+		request.AuthScope.Authority != "effective" ||
+		!permissionsContain(request.AuthScope.Permissions, []string{"eebus.raw.read"}) ||
+		ValidateLimitsV1(request.Limits) != nil {
+		return AcquiredEvidence{}, ErrInvalidArgument
+	}
+	snapshot, err := reader.runtime.Snapshot()
+	if err != nil || snapshot.Validate() != nil ||
+		snapshot.Meta.MaskTier != eebusraw.MaskTierRaw ||
+		snapshot.Status.State != eebusruntime.ObservedRuntimeStateV1Ready {
+		return AcquiredEvidence{}, ErrBackendUnavailable
+	}
+	locators, err := m625SnapshotLocators(snapshot)
+	if err != nil {
+		return AcquiredEvidence{}, err
+	}
+	if len(locators) == 0 {
+		return AcquiredEvidence{}, ErrContractViolation
+	}
+	if uint64(len(locators)) > request.Limits.MaxItemsPerSource {
+		return AcquiredEvidence{}, ErrLimitsExceeded
+	}
+
+	featureAuth := eebusraw.ReadAuthorizationV1{
+		PrincipalClass: "owner",
+		Scope:          eebusraw.AuthScopeV1RawRead,
+		Tool:           eebusraw.ToolV1FeaturesGet,
+		MaskTier:       eebusraw.MaskTierRaw,
+	}
+	targets := make([]m625Target, 0, len(locators))
+	var binding eebusraw.RuntimeBindingV1
+	for _, locator := range locators {
+		if err := ctx.Err(); err != nil {
+			return AcquiredEvidence{}, err
+		}
+		featuresRequest := eebusraw.FeaturesGetRequestV1{Target: locator.Clone()}
+		if terminal := eebusraw.ValidateFeaturesGetRequestV1(featuresRequest); terminal != nil {
+			return AcquiredEvidence{}, ErrContractViolation
+		}
+		data, terminal := reader.runtime.FeaturesGet(ctx, featureAuth, featuresRequest)
+		if terminal != nil || eebusraw.ValidateFeaturesGetDataV1(featuresRequest, data) != nil {
+			return AcquiredEvidence{}, ErrContractViolation
+		}
+		if binding == (eebusraw.RuntimeBindingV1{}) {
+			binding = data.Runtime
+		} else if data.Runtime != binding {
+			return AcquiredEvidence{}, ErrContractViolation
+		}
+		function := m625FunctionForType(locator.FeatureType)
+		var descriptor *eebusraw.FunctionDescriptorV1
+		for index := range data.Functions {
+			if data.Functions[index].Function == function {
+				descriptor = &data.Functions[index]
+				break
+			}
+		}
+		if descriptor == nil || !descriptor.PossibleOperations.Read {
+			continue
+		}
+		unit := descriptor.Constraints.Unit
+		if unit == "" || !m625Units[unit] {
+			unit = "unknown"
+		}
+		targets = append(targets, m625Target{
+			target: eebusraw.FeatureTargetV1{
+				RemoteSKI: locator.RemoteSKI, SHIPID: locator.SHIPID,
+				DeviceAddress: locator.DeviceAddress, EntityAddress: append([]uint64(nil), locator.EntityAddress...),
+				FeatureAddress: locator.FeatureAddress, FeatureType: locator.FeatureType,
+				FeatureRole: locator.FeatureRole, Function: function, Operation: eebusraw.OperationV1Read,
+			},
+			unit: unit, fallbackTime: data.DataTimestamp,
+			nativeService: []string{locator.RemoteSKI, locator.SHIPID},
+		})
+	}
+	if len(targets) == 0 {
+		return AcquiredEvidence{}, ErrContractViolation
+	}
+
+	dataAuth := eebusraw.ReadAuthorizationV1{
+		PrincipalClass: "owner",
+		Scope:          eebusraw.AuthScopeV1RawRead,
+		Tool:           eebusraw.ToolV1FeaturesDataGet,
+		MaskTier:       eebusraw.MaskTierRaw,
+	}
+	projected := make([]m625ProjectedObservation, 0, len(targets))
+	for begin := 0; begin < len(targets); begin += eebusraw.MaximumReadTargetsV1 {
+		end := begin + eebusraw.MaximumReadTargetsV1
+		if end > len(targets) {
+			end = len(targets)
+		}
+		batch := targets[begin:end]
+		rawTargets := make([]eebusraw.FeatureTargetV1, len(batch))
+		for index := range batch {
+			rawTargets[index] = batch[index].target.Clone()
+		}
+		readRequest := eebusraw.FeatureDataGetRequestV1{Targets: rawTargets}
+		if terminal := eebusraw.ValidateFeatureDataGetRequestV1(readRequest); terminal != nil {
+			return AcquiredEvidence{}, ErrContractViolation
+		}
+		data, terminal := reader.runtime.FeaturesDataGet(ctx, dataAuth, readRequest)
+		if terminal != nil && len(data.Results) == 0 && len(data.Failures) == 0 {
+			for _, target := range batch {
+				projected = append(projected, m625TerminalObservation(target, terminal.Code))
+			}
+			continue
+		}
+		if eebusraw.ValidateFeatureDataGetDataV1(readRequest, data, terminal) != nil {
+			return AcquiredEvidence{}, ErrContractViolation
+		}
+		resultIndex := 0
+		failureByIndex := make(map[uint64]eebusraw.ReadFailureV1, len(data.Failures))
+		for _, failure := range data.Failures {
+			failureByIndex[failure.TargetIndex] = failure
+		}
+		for targetIndex, target := range batch {
+			if failure, failed := failureByIndex[uint64(targetIndex)]; failed {
+				projected = append(projected, m625TerminalObservation(target, failure.Error.Code))
+				continue
+			}
+			if resultIndex >= len(data.Results) || data.Results[resultIndex].Runtime != binding {
+				return AcquiredEvidence{}, ErrContractViolation
+			}
+			normalized := m625NormalizeRead(target, data.Results[resultIndex])
+			if len(normalized) == 0 {
+				normalized = []m625ProjectedObservation{m625TerminalObservation(target, eebusraw.ErrorCodeV1DecodeError)}
+			}
+			projected = append(projected, normalized...)
+			resultIndex++
+		}
+	}
+	if len(projected) == 0 || uint64(len(projected)) > request.Limits.MaxItemsPerSource {
+		return AcquiredEvidence{}, ErrLimitsExceeded
+	}
+	return m625BuildEvidence(projected, request.Limits)
+}
+
+func m625SnapshotLocators(snapshot eebusruntime.SnapshotV1) ([]eebusraw.FeatureLocatorV1, error) {
+	devices := make(map[string]eebusruntime.DeviceV1, len(snapshot.Devices))
+	for _, device := range snapshot.Devices {
+		if _, duplicate := devices[device.Address]; duplicate || device.SHIPID == nil {
+			return nil, ErrContractViolation
+		}
+		devices[device.Address] = device
+	}
+	locators := make([]eebusraw.FeatureLocatorV1, 0)
+	for _, feature := range snapshot.Features {
+		if feature.Role != string(eebusraw.FeatureRoleV1Server) || m625FunctionForType(feature.Type) == "" {
+			continue
+		}
+		device, ok := devices[feature.DeviceAddress]
+		if !ok || device.SHIPID == nil || *device.SHIPID == "" {
+			return nil, ErrContractViolation
+		}
+		entity, featureAddress, err := m625ParseSnapshotAddress(
+			feature.DeviceAddress,
+			feature.EntityAddress,
+			feature.FeatureAddress,
+		)
+		if err != nil {
+			return nil, err
+		}
+		locator := eebusraw.FeatureLocatorV1{
+			RemoteSKI: device.SKI, SHIPID: *device.SHIPID,
+			DeviceAddress: feature.DeviceAddress, EntityAddress: entity,
+			FeatureAddress: featureAddress, FeatureType: feature.Type,
+			FeatureRole: eebusraw.FeatureRoleV1Server,
+		}
+		if terminal := eebusraw.ValidateFeaturesGetRequestV1(eebusraw.FeaturesGetRequestV1{Target: locator}); terminal != nil {
+			return nil, ErrContractViolation
+		}
+		locators = append(locators, locator)
+	}
+	sort.Slice(locators, func(left, right int) bool {
+		return m625CompareLocator(locators[left], locators[right]) < 0
+	})
+	for index := 1; index < len(locators); index++ {
+		if m625CompareLocator(locators[index-1], locators[index]) == 0 {
+			return nil, ErrContractViolation
+		}
+	}
+	return locators, nil
+}
+
+func m625ParseSnapshotAddress(device, entityText, featureText string) ([]uint64, uint64, error) {
+	prefix := device + ":["
+	if device == "" || !strings.HasPrefix(entityText, prefix) || !strings.HasSuffix(entityText, "]:") {
+		return nil, 0, ErrContractViolation
+	}
+	entityBody := strings.TrimSuffix(strings.TrimPrefix(entityText, prefix), "]:")
+	if entityBody == "" {
+		return nil, 0, ErrContractViolation
+	}
+	parts := strings.Split(entityBody, ",")
+	entity := make([]uint64, len(parts))
+	for index, part := range parts {
+		value, ok := m625ParseAddressInteger(part)
+		if !ok {
+			return nil, 0, ErrContractViolation
+		}
+		entity[index] = value
+	}
+	if !strings.HasPrefix(featureText, entityText) {
+		return nil, 0, ErrContractViolation
+	}
+	feature, ok := m625ParseAddressInteger(strings.TrimPrefix(featureText, entityText))
+	if !ok {
+		return nil, 0, ErrContractViolation
+	}
+	return entity, feature, nil
+}
+
+func m625ParseAddressInteger(value string) (uint64, bool) {
+	if value == "" || len(value) > 16 || len(value) > 1 && value[0] == '0' {
+		return 0, false
+	}
+	for _, char := range value {
+		if char < '0' || char > '9' {
+			return 0, false
+		}
+	}
+	parsed, err := strconv.ParseUint(value, 10, 64)
+	return parsed, err == nil && parsed <= MaxSafeIntegerV1
+}
+
+func m625CompareLocator(left, right eebusraw.FeatureLocatorV1) int {
+	for _, pair := range [][2]string{
+		{left.RemoteSKI, right.RemoteSKI},
+		{left.SHIPID, right.SHIPID},
+		{left.DeviceAddress, right.DeviceAddress},
+	} {
+		if pair[0] < pair[1] {
+			return -1
+		}
+		if pair[0] > pair[1] {
+			return 1
+		}
+	}
+	for index := 0; index < len(left.EntityAddress) && index < len(right.EntityAddress); index++ {
+		if left.EntityAddress[index] < right.EntityAddress[index] {
+			return -1
+		}
+		if left.EntityAddress[index] > right.EntityAddress[index] {
+			return 1
+		}
+	}
+	if len(left.EntityAddress) < len(right.EntityAddress) {
+		return -1
+	}
+	if len(left.EntityAddress) > len(right.EntityAddress) {
+		return 1
+	}
+	if left.FeatureAddress < right.FeatureAddress {
+		return -1
+	}
+	if left.FeatureAddress > right.FeatureAddress {
+		return 1
+	}
+	if left.FeatureType < right.FeatureType {
+		return -1
+	}
+	if left.FeatureType > right.FeatureType {
+		return 1
+	}
+	return strings.Compare(string(left.FeatureRole), string(right.FeatureRole))
+}
+
+func m625FunctionForType(featureType string) string {
+	switch featureType {
+	case "Measurement":
+		return "measurementListData"
+	case "Setpoint":
+		return "setpointListData"
+	case "HVAC":
+		return "hvacSystemFunctionListData"
+	default:
+		return ""
+	}
+}
+
+func m625TerminalObservation(target m625Target, code eebusraw.ErrorCodeV1) m625ProjectedObservation {
+	terminal := strings.ToUpper(string(code))
+	if !m625Terminals[terminal] || terminal == "SUCCESS" {
+		terminal = "INTERNAL"
+	}
+	return m625ProjectedObservation{
+		target: target.target, nativeService: append([]string(nil), target.nativeService...),
+		observedAt: target.fallbackTime, terminal: terminal,
+	}
+}
+
+func m625NormalizeRead(target m625Target, observation eebusraw.ReadObservationV1) []m625ProjectedObservation {
+	root, ok := observation.Value.Value().(map[string]any)
+	if !ok {
+		return nil
+	}
+	switch target.target.Function {
+	case "measurementListData":
+		return m625NormalizeMeasurement(target, observation.DataTimestamp, root)
+	case "setpointListData":
+		return m625NormalizeSetpoint(target, observation.DataTimestamp, root)
+	case "hvacSystemFunctionListData":
+		return m625NormalizeHVAC(target, observation.DataTimestamp, root)
+	default:
+		return nil
+	}
+}
+
+func m625NormalizeMeasurement(target m625Target, observedAt time.Time, root map[string]any) []m625ProjectedObservation {
+	items, ok := root["measurementData"].([]any)
+	if !ok || len(items) == 0 {
+		return nil
+	}
+	result := make([]m625ProjectedObservation, 0, len(items))
+	for index, raw := range items {
+		item, ok := raw.(map[string]any)
+		path := m625ItemPath("measurementData", index, item, "measurementId")
+		if !ok {
+			result = append(result, m625DecodeFailure(target, observedAt, path))
+			continue
+		}
+		decimal, ok := m625ScaledDecimal(item["value"])
+		if !ok {
+			result = append(result, m625DecodeFailure(target, observedAt, append(path, "value")))
+			continue
+		}
+		result = append(result, m625Success(target, observedAt, append(path, "value"), "DECIMAL", decimal, target.unit))
+	}
+	return result
+}
+
+func m625NormalizeSetpoint(target m625Target, observedAt time.Time, root map[string]any) []m625ProjectedObservation {
+	items, ok := root["setpointData"].([]any)
+	if !ok || len(items) == 0 {
+		return nil
+	}
+	result := make([]m625ProjectedObservation, 0)
+	decimalFields := []string{"value", "valueMin", "valueMax", "valueToleranceAbsolute", "valueTolerancePercentage"}
+	booleanFields := []string{"isSetpointChangeable", "isSetpointActive"}
+	for index, raw := range items {
+		item, ok := raw.(map[string]any)
+		path := m625ItemPath("setpointData", index, item, "setpointId")
+		if !ok {
+			result = append(result, m625DecodeFailure(target, observedAt, path))
+			continue
+		}
+		for _, field := range decimalFields {
+			if _, exists := item[field]; !exists {
+				continue
+			}
+			decimal, valid := m625ScaledDecimal(item[field])
+			if !valid {
+				result = append(result, m625DecodeFailure(target, observedAt, append(path, field)))
+				continue
+			}
+			result = append(result, m625Success(target, observedAt, append(path, field), "DECIMAL", decimal, target.unit))
+		}
+		for _, field := range booleanFields {
+			if _, exists := item[field]; !exists {
+				continue
+			}
+			value, valid := item[field].(bool)
+			if !valid {
+				result = append(result, m625DecodeFailure(target, observedAt, append(path, field)))
+				continue
+			}
+			result = append(result, m625Success(target, observedAt, append(path, field), "BOOLEAN", strconv.FormatBool(value), nil))
+		}
+	}
+	return result
+}
+
+func m625NormalizeHVAC(target m625Target, observedAt time.Time, root map[string]any) []m625ProjectedObservation {
+	items, ok := root["hvacSystemFunctionData"].([]any)
+	if !ok || len(items) == 0 {
+		return nil
+	}
+	result := make([]m625ProjectedObservation, 0)
+	enumFields := []string{"currentOperationModeId", "currentSetpointId"}
+	booleanFields := []string{"isOperationModeIdChangeable", "isSetpointIdChangeable", "isOverrunActive"}
+	for index, raw := range items {
+		item, ok := raw.(map[string]any)
+		path := m625ItemPath("hvacSystemFunctionData", index, item, "systemFunctionId")
+		if !ok {
+			result = append(result, m625DecodeFailure(target, observedAt, path))
+			continue
+		}
+		for _, field := range enumFields {
+			if _, exists := item[field]; !exists {
+				continue
+			}
+			value, valid := m625UnsignedInteger(item[field])
+			if !valid || value > 9_999_999_999 {
+				result = append(result, m625DecodeFailure(target, observedAt, append(path, field)))
+				continue
+			}
+			result = append(result, m625Success(target, observedAt, append(path, field), "ENUM", "ID_"+strconv.FormatUint(value, 10), nil))
+		}
+		for _, field := range booleanFields {
+			if _, exists := item[field]; !exists {
+				continue
+			}
+			value, valid := item[field].(bool)
+			if !valid {
+				result = append(result, m625DecodeFailure(target, observedAt, append(path, field)))
+				continue
+			}
+			result = append(result, m625Success(target, observedAt, append(path, field), "BOOLEAN", strconv.FormatBool(value), nil))
+		}
+	}
+	return result
+}
+
+func m625ItemPath(root string, index int, item map[string]any, identityField string) []string {
+	path := []string{root, fmt.Sprintf("%020d", index)}
+	if item != nil {
+		if identity, ok := m625UnsignedInteger(item[identityField]); ok {
+			path = append(path, identityField+"="+strconv.FormatUint(identity, 10))
+		}
+	}
+	return path
+}
+
+func m625Success(target m625Target, observedAt time.Time, path []string, valueType, value string, unit any) m625ProjectedObservation {
+	return m625ProjectedObservation{
+		target: target.target, nativeService: append([]string(nil), target.nativeService...),
+		fieldPath: append([]string(nil), path...), observedAt: observedAt, terminal: "SUCCESS",
+		valueType: valueType, value: value, unit: unit, quality: "OBSERVED",
+	}
+}
+
+func m625DecodeFailure(target m625Target, observedAt time.Time, path []string) m625ProjectedObservation {
+	return m625ProjectedObservation{
+		target: target.target, nativeService: append([]string(nil), target.nativeService...),
+		fieldPath: append([]string(nil), path...), observedAt: observedAt, terminal: "DECODE_ERROR",
+	}
+}
+
+func m625ScaledDecimal(value any) (string, bool) {
+	scaled, ok := value.(map[string]any)
+	if !ok {
+		return "", false
+	}
+	number, numberOK := m625SignedInteger(scaled["number"])
+	scale, scaleOK := m625SignedInteger(scaled["scale"])
+	if !numberOK || !scaleOK || scale < -128 || scale > 127 {
+		return "", false
+	}
+	if number == 0 {
+		if scale >= 0 {
+			return "0", true
+		}
+		result := "0." + strings.Repeat("0", int(-scale))
+		return result, len(result) <= 64
+	}
+	negative := number < 0
+	digits := strconv.FormatInt(number, 10)
+	if negative {
+		digits = digits[1:]
+	}
+	var result string
+	switch {
+	case scale >= 0:
+		result = digits + strings.Repeat("0", int(scale))
+	case int64(len(digits))+scale > 0:
+		point := int64(len(digits)) + scale
+		result = digits[:point] + "." + digits[point:]
+	default:
+		result = "0." + strings.Repeat("0", int(-scale)-len(digits)) + digits
+	}
+	if negative {
+		result = "-" + result
+	}
+	return result, len(result) <= 64 && m625DecimalPattern.MatchString(result)
+}
+
+func m625SignedInteger(value any) (int64, bool) {
+	switch current := value.(type) {
+	case int:
+		return int64(current), true
+	case int8:
+		return int64(current), true
+	case int16:
+		return int64(current), true
+	case int32:
+		return int64(current), true
+	case int64:
+		return current, true
+	case uint:
+		if uint64(current) <= uint64(^uint64(0)>>1) {
+			return int64(current), true
+		}
+	case uint8:
+		return int64(current), true
+	case uint16:
+		return int64(current), true
+	case uint32:
+		return int64(current), true
+	case uint64:
+		if current <= uint64(^uint64(0)>>1) {
+			return int64(current), true
+		}
+	case json.Number:
+		parsed, err := strconv.ParseInt(string(current), 10, 64)
+		return parsed, err == nil
+	}
+	return 0, false
+}
+
+func m625UnsignedInteger(value any) (uint64, bool) {
+	signed, ok := m625SignedInteger(value)
+	return uint64(signed), ok && signed >= 0
+}
+
+func m625BuildEvidence(observations []m625ProjectedObservation, limits CaptureLimitsV1) (AcquiredEvidence, error) {
+	sort.Slice(observations, func(left, right int) bool {
+		return m625ObservationNativeKey(observations[left]) < m625ObservationNativeKey(observations[right])
+	})
+	services := make(map[string]string)
+	paths := make([]any, 0, len(observations))
+	rows := make([]any, 0, len(observations))
+	pathKeys := make(map[string]bool, len(observations))
+	var latest time.Time
+	for index, observation := range observations {
+		serviceIdentity := strings.Join(observation.nativeService, "\x00")
+		service := services[serviceIdentity]
+		if service == "" {
+			service = m625OpaquePseudonym("service\x00" + serviceIdentity)
+			services[serviceIdentity] = service
+		}
+		entityIdentity := serviceIdentity + "\x00" + observation.target.DeviceAddress + "\x00" + m625UintPath(observation.target.EntityAddress)
+		entity := m625OpaquePseudonym("entity\x00" + entityIdentity)
+		featureIdentity := entityIdentity + "\x00" + strconv.FormatUint(observation.target.FeatureAddress, 10)
+		feature := m625OpaquePseudonym("feature\x00" + featureIdentity)
+		segments := []any{
+			map[string]any{"kind": "SERVICE", "selector": service},
+			map[string]any{"kind": "ENTITY", "selector": entity},
+			map[string]any{"kind": "FEATURE", "selector": feature},
+		}
+		fieldIdentity := featureIdentity
+		for _, component := range observation.fieldPath {
+			fieldIdentity += "\x00" + component
+			segments = append(segments, map[string]any{
+				"kind": "FIELD", "selector": m625OpaquePseudonym("field\x00" + fieldIdentity),
+			})
+		}
+		path := map[string]any{
+			"service": service, "entity": entity, "feature": feature, "feature_path": segments,
+		}
+		pathBytes, err := canonicalJSONValue(path)
+		if err != nil || pathKeys[string(pathBytes)] {
+			return AcquiredEvidence{}, ErrContractViolation
+		}
+		pathKeys[string(pathBytes)] = true
+		paths = append(paths, path)
+		observationKey := m625ObservationNativeKey(observation)
+		rows = append(rows, map[string]any{
+			"observation_ref":         "obs-" + m625OpaquePseudonym("observation\x00"+observationKey),
+			"path_index":              json.Number(strconv.Itoa(index)),
+			"feature_type":            observation.target.FeatureType,
+			"feature_role":            string(observation.target.FeatureRole),
+			"function":                observation.target.Function,
+			"source_observed_at":      observation.observedAt.UTC().Format(time.RFC3339Nano),
+			"terminal_classification": observation.terminal,
+			"value_type":              observation.valueType,
+			"value":                   observation.value,
+			"unit":                    observation.unit,
+			"quality":                 observation.quality,
+		})
+		if latest.IsZero() || observation.observedAt.After(latest) {
+			latest = observation.observedAt
+		}
+	}
+	serviceRows := make([]any, 0, len(services))
+	for _, service := range services {
+		serviceRows = append(serviceRows, service)
+	}
+	payload := map[string]any{
+		"contract":           M625EEBusContractV1,
+		"schema_version":     json.Number("1"),
+		"source_observed_at": latest.UTC().Format(time.RFC3339Nano),
+		"services":           serviceRows,
+		"feature_paths":      paths,
+		"observations":       rows,
+	}
+	if err := sortM625Payload(payload); err != nil {
+		return AcquiredEvidence{}, err
+	}
+	if err := validateM625Payload(payload, sourceCapture{
+		sourceKind: SourceEEBus, sourceContract: M625EEBusContractV1, sourceSchemaVersion: 1,
+		sourceObservedAt: latest,
+	}); err != nil {
+		return AcquiredEvidence{}, err
+	}
+	encoded, err := canonicalJSONValue(payload)
+	if err != nil || uint64(len(encoded)) > limits.MaxArtifactBytes {
+		return AcquiredEvidence{}, ErrLimitsExceeded
+	}
+	return AcquiredEvidence{SourceObservedAt: latest, NormalizedEvidence: encoded}, nil
+}
+
+func m625ObservationNativeKey(observation m625ProjectedObservation) string {
+	parts := append([]string(nil), observation.nativeService...)
+	parts = append(parts, observation.target.DeviceAddress)
+	for _, entity := range observation.target.EntityAddress {
+		parts = append(parts, fmt.Sprintf("%020d", entity))
+	}
+	parts = append(parts, fmt.Sprintf("%020d", observation.target.FeatureAddress))
+	parts = append(parts, observation.fieldPath...)
+	parts = append(parts, observation.target.FeatureType, observation.target.Function)
+	return strings.Join(parts, "\x00")
+}
+
+func m625UintPath(values []uint64) string {
+	parts := make([]string, len(values))
+	for index, value := range values {
+		parts[index] = strconv.FormatUint(value, 10)
+	}
+	return strings.Join(parts, ",")
+}
+
+func m625OpaquePseudonym(identity string) string {
+	digest := sha256.Sum256([]byte("HELIANTHUS:M625:EPHEMERAL:V1\x00" + identity))
+	return base64.RawURLEncoding.EncodeToString(digest[:])
+}
+
+var _ EEBusM625Reader = (*m625EEBusReader)(nil)

--- a/internal/syncevidence/m625_acquisition.go
+++ b/internal/syncevidence/m625_acquisition.go
@@ -575,6 +575,7 @@ func m625BuildEvidence(observations []m625ProjectedObservation, limits CaptureLi
 		return m625ObservationNativeKey(observations[left]) < m625ObservationNativeKey(observations[right])
 	})
 	services := make(map[string]string)
+	serviceRows := make([]any, 0)
 	paths := make([]any, 0, len(observations))
 	rows := make([]any, 0, len(observations))
 	pathKeys := make(map[string]bool, len(observations))
@@ -585,6 +586,7 @@ func m625BuildEvidence(observations []m625ProjectedObservation, limits CaptureLi
 		if service == "" {
 			service = m625OpaquePseudonym("service\x00" + serviceIdentity)
 			services[serviceIdentity] = service
+			serviceRows = append(serviceRows, service)
 		}
 		entityIdentity := serviceIdentity + "\x00" + observation.target.DeviceAddress + "\x00" + m625UintPath(observation.target.EntityAddress)
 		entity := m625OpaquePseudonym("entity\x00" + entityIdentity)
@@ -629,10 +631,6 @@ func m625BuildEvidence(observations []m625ProjectedObservation, limits CaptureLi
 			latest = observation.observedAt
 		}
 	}
-	serviceRows := make([]any, 0, len(services))
-	for _, service := range services {
-		serviceRows = append(serviceRows, service)
-	}
 	payload := map[string]any{
 		"contract":           M625EEBusContractV1,
 		"schema_version":     json.Number("1"),
@@ -640,9 +638,6 @@ func m625BuildEvidence(observations []m625ProjectedObservation, limits CaptureLi
 		"services":           serviceRows,
 		"feature_paths":      paths,
 		"observations":       rows,
-	}
-	if err := sortM625Payload(payload); err != nil {
-		return AcquiredEvidence{}, err
 	}
 	if err := validateM625Payload(payload, sourceCapture{
 		sourceKind: SourceEEBus, sourceContract: M625EEBusContractV1, sourceSchemaVersion: 1,

--- a/internal/syncevidence/oneshot.go
+++ b/internal/syncevidence/oneshot.go
@@ -10,7 +10,10 @@ import (
 	"time"
 )
 
-const oneShotStoreQuota = int64(1 << 28)
+const (
+	oneShotStoreQuota     = int64(1 << 28)
+	oneShotStoreRetention = 7 * 24 * time.Hour
+)
 
 var oneShotStoreLockProof = bytes.Repeat([]byte{0x4c}, 32)
 
@@ -76,6 +79,7 @@ func ExecuteOneShot(ctx context.Context, options OneShotExecutionOptions) OneSho
 	store, err := openOneShotFileStore(parent, FileStoreConfig{
 		Root:       filepath.Join(options.Root, "store"),
 		QuotaBytes: oneShotStoreQuota,
+		Retention:  oneShotStoreRetention,
 		Entropy:    options.Entropy,
 		LockProof:  oneShotStoreLockProof,
 	})
@@ -103,8 +107,7 @@ func ExecuteOneShot(ctx context.Context, options OneShotExecutionOptions) OneSho
 	if options.Reader == nil || options.ClockFactory == nil || options.BuildIdentity == nil {
 		return oneShotReceipt(OneShotInternal)
 	}
-	limits := DefaultLimitsV1()
-	limits.MaxSources = 5
+	limits := oneShotCaptureLimits()
 	reservation, err := store.ReserveCapture(int64(limits.MaxBundleBytes))
 	if err != nil {
 		return oneShotReceipt(OneShotPublishFailed)
@@ -153,6 +156,12 @@ func ExecuteOneShot(ctx context.Context, options OneShotExecutionOptions) OneSho
 		return oneShotReceipt(OneShotPublishFailed)
 	}
 	return oneShotReceipt(OneShotPublished)
+}
+
+func oneShotCaptureLimits() CaptureLimitsV1 {
+	limits := DefaultLimitsV1()
+	limits.MaxSources = 5
+	return limits
 }
 
 func oneShotReceipt(category OneShotReceiptCategory) OneShotReceiptV1 {

--- a/internal/syncevidence/oneshot.go
+++ b/internal/syncevidence/oneshot.go
@@ -65,7 +65,9 @@ func ExecuteOneShot(ctx context.Context, options OneShotExecutionOptions) OneSho
 	if err != nil {
 		return oneShotReceipt(OneShotInvalidRequest)
 	}
-	defer parent.Close()
+	defer func() {
+		_ = parent.Close()
+	}()
 	request, err := loadOneShotRequestFromDirectory(parent, nil)
 	if err != nil {
 		return oneShotReceipt(OneShotInvalidRequest)
@@ -80,7 +82,9 @@ func ExecuteOneShot(ctx context.Context, options OneShotExecutionOptions) OneSho
 	if err != nil {
 		return oneShotReceipt(OneShotPublishFailed)
 	}
-	defer store.Close()
+	defer func() {
+		_ = store.Close()
+	}()
 
 	retained, err := store.lookupOneShot(request.ActionEvidenceRef, options.sourceTuple())
 	if err != nil {

--- a/internal/syncevidence/oneshot.go
+++ b/internal/syncevidence/oneshot.go
@@ -210,6 +210,7 @@ func oneShotSources(
 			Phase: PhaseAction, SourceKind: SourceCloudApp,
 			RuntimeInstance: "cloud-app-precaptured", OperationVersion: operationVersion,
 			OperationScope: "cloud-app", Admission: oneShotAdmission("cloud.read", BackendUnknown),
+			cloudBound: true,
 			PrecapturedCloud: &PrecapturedCloudInput{
 				SourceObservedAt: cloudObservedAt,
 				NormalizedEvidence: append(

--- a/internal/syncevidence/oneshot.go
+++ b/internal/syncevidence/oneshot.go
@@ -1,0 +1,332 @@
+package syncevidence
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"path/filepath"
+	"reflect"
+	"time"
+)
+
+const oneShotStoreQuota = int64(1 << 28)
+
+var oneShotStoreLockProof = bytes.Repeat([]byte{0x4c}, 32)
+
+type OneShotReceiptCategory string
+
+const (
+	OneShotPublished         OneShotReceiptCategory = "PUBLISHED"
+	OneShotExisting          OneShotReceiptCategory = "EXISTING"
+	OneShotInvalidRequest    OneShotReceiptCategory = "INVALID_REQUEST"
+	OneShotPermissionDenied  OneShotReceiptCategory = "PERMISSION_DENIED"
+	OneShotConflict          OneShotReceiptCategory = "CONFLICT"
+	OneShotAcquisitionFailed OneShotReceiptCategory = "ACQUISITION_FAILED"
+	OneShotReplayMismatch    OneShotReceiptCategory = "REPLAY_MISMATCH"
+	OneShotPublishFailed     OneShotReceiptCategory = "PUBLISH_FAILED"
+	OneShotInternal          OneShotReceiptCategory = "INTERNAL"
+)
+
+type OneShotReceiptV1 struct {
+	Category OneShotReceiptCategory `json:"category"`
+}
+
+type OneShotBuildIdentity struct {
+	RecorderVersion  string
+	ReplayVersion    string
+	OperationVersion string
+}
+
+type OneShotExecutionOptions struct {
+	Root          string
+	Reader        EEBusM625Reader
+	ClockFactory  func() Clock
+	Entropy       io.Reader
+	BuildIdentity func() (OneShotBuildIdentity, error)
+	replay        func([]byte) ([]byte, error)
+}
+
+type oneShotUnavailableEBusReader struct{}
+
+func (oneShotUnavailableEBusReader) ReadSnapshot(context.Context, SourceRequest) (AcquiredEvidence, error) {
+	return AcquiredEvidence{}, ErrBackendUnavailable
+}
+
+func (options OneShotExecutionOptions) sourceTuple() SourceTupleV1 {
+	return SourceTupleV1{SourceKind: SourceEEBus, Contract: M625EEBusContractV1, Version: 1}
+}
+
+func ExecuteOneShot(ctx context.Context, options OneShotExecutionOptions) OneShotReceiptV1 {
+	if ctx == nil {
+		return oneShotReceipt(OneShotInternal)
+	}
+	parent, err := openOneShotRequestDirectory(options.Root)
+	if err != nil {
+		return oneShotReceipt(OneShotInvalidRequest)
+	}
+	defer parent.Close()
+	request, err := loadOneShotRequestFromDirectory(parent, nil)
+	if err != nil {
+		return oneShotReceipt(OneShotInvalidRequest)
+	}
+
+	store, err := openOneShotFileStore(parent, FileStoreConfig{
+		Root:       filepath.Join(options.Root, "store"),
+		QuotaBytes: oneShotStoreQuota,
+		Entropy:    options.Entropy,
+		LockProof:  oneShotStoreLockProof,
+	})
+	if err != nil {
+		return oneShotReceipt(OneShotPublishFailed)
+	}
+	defer store.Close()
+
+	retained, err := store.lookupOneShot(request.ActionEvidenceRef, options.sourceTuple())
+	if err != nil {
+		return oneShotReceipt(OneShotInternal)
+	}
+	switch retained.Status {
+	case OneShotLookupExisting:
+		return oneShotReceipt(OneShotExisting)
+	case OneShotLookupConflict:
+		return oneShotReceipt(OneShotConflict)
+	case OneShotLookupNone:
+	default:
+		return oneShotReceipt(OneShotInternal)
+	}
+
+	if options.Reader == nil || options.ClockFactory == nil || options.BuildIdentity == nil {
+		return oneShotReceipt(OneShotInternal)
+	}
+	limits := DefaultLimitsV1()
+	limits.MaxSources = 5
+	reservation, err := store.ReserveCapture(int64(limits.MaxBundleBytes))
+	if err != nil {
+		return oneShotReceipt(OneShotPublishFailed)
+	}
+	defer reservation.Release()
+
+	build, err := options.BuildIdentity()
+	if err != nil {
+		return oneShotReceipt(OneShotInternal)
+	}
+	clock := options.ClockFactory()
+	if clock == nil {
+		return oneShotReceipt(OneShotInternal)
+	}
+	cloudObservedAt, err := oneShotCloudObservedAt(request.CloudAppAction.NormalizedEvidence)
+	if err != nil {
+		return oneShotReceipt(OneShotInvalidRequest)
+	}
+	recorder, err := NewRecorder(RecorderOptions{
+		Clock: clock, Entropy: options.Entropy, Limits: limits,
+		Sources:         oneShotSources(request, options.Reader, build.OperationVersion, cloudObservedAt),
+		RecorderVersion: build.RecorderVersion, ReplayVersion: build.ReplayVersion,
+	})
+	if err != nil {
+		return oneShotReceipt(OneShotInternal)
+	}
+	bundleBytes, err := recorder.Capture(ctx, ActionMarker{EvidenceRef: request.ActionEvidenceRef})
+	if err != nil {
+		return oneShotReceipt(OneShotAcquisitionFailed)
+	}
+	bundle, err := verifyBundle(bundleBytes)
+	if err != nil || validateOneShotBundle(bundle, options.sourceTuple()) != nil {
+		return oneShotReceipt(OneShotAcquisitionFailed)
+	}
+
+	replay := options.replay
+	if replay == nil {
+		replay = Replay
+	}
+	firstReplay, firstErr := replay(bundleBytes)
+	secondReplay, secondErr := replay(bundleBytes)
+	if firstErr != nil || secondErr != nil || !bytes.Equal(firstReplay, secondReplay) {
+		return oneShotReceipt(OneShotReplayMismatch)
+	}
+	if _, err := reservation.PublishVerified(bundleBytes, firstReplay); err != nil {
+		return oneShotReceipt(OneShotPublishFailed)
+	}
+	return oneShotReceipt(OneShotPublished)
+}
+
+func oneShotReceipt(category OneShotReceiptCategory) OneShotReceiptV1 {
+	return OneShotReceiptV1{Category: category}
+}
+
+func oneShotCloudObservedAt(raw json.RawMessage) (time.Time, error) {
+	var payload struct {
+		SourceObservedAt string `json:"source_observed_at"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil || !canonicalTimestamp(payload.SourceObservedAt) {
+		return time.Time{}, ErrInvalidArgument
+	}
+	observedAt, err := time.Parse(time.RFC3339Nano, payload.SourceObservedAt)
+	if err != nil {
+		return time.Time{}, ErrInvalidArgument
+	}
+	return observedAt, nil
+}
+
+func oneShotSources(
+	request OneShotRequestV1,
+	reader EEBusM625Reader,
+	operationVersion string,
+	cloudObservedAt time.Time,
+) []RegisteredSource {
+	return []RegisteredSource{
+		oneShotTerminalEBusSource(
+			SourceEBusB509,
+			PhasePre,
+			"ebus-b509",
+			"dbe91a10a208613183f890849c634f8d13661194aad937a03ae2a4143070bf2d",
+			operationVersion,
+			oneShotB509Identity(),
+		),
+		{
+			Phase: PhasePre, SourceKind: SourceEEBus,
+			SourceContract: M625EEBusContractV1, SourceVersion: 1,
+			RuntimeInstance: "eebus-runtime", OperationVersion: operationVersion,
+			OperationScope: "feature-data", Admission: oneShotAdmission("eebus.raw.read", BackendUnknown),
+			EvidenceRefs: []EvidenceRefV1{
+				oneShotContentRef("0a2885d01d6703389541e246db59bcd845a332e7ed296abca2d49b4f8de31811"),
+			},
+			EEBusM625Reader: reader,
+		},
+		oneShotTerminalEBusSource(
+			SourceEBusB524,
+			PhaseAction,
+			"ebus-b524",
+			"1002e09890801c9032548af407b13b58d889217dfc83e58bfe2a28df6bc33b78",
+			operationVersion,
+			oneShotB524Identity(),
+		),
+		{
+			Phase: PhaseAction, SourceKind: SourceCloudApp,
+			RuntimeInstance: "cloud-app-precaptured", OperationVersion: operationVersion,
+			OperationScope: "cloud-app", Admission: oneShotAdmission("cloud.read", BackendUnknown),
+			PrecapturedCloud: &PrecapturedCloudInput{
+				SourceObservedAt: cloudObservedAt,
+				NormalizedEvidence: append(
+					json.RawMessage(nil),
+					request.CloudAppAction.NormalizedEvidence...,
+				),
+				EvidenceRef: request.CloudAppAction.EvidenceRef,
+			},
+		},
+		oneShotTerminalEBusSource(
+			SourceEBusB555,
+			PhasePost,
+			"ebus-b555",
+			"a3237e344f5c3582ceaf1ca947eabf200bede8fe9388ec85cf647331f026c72d",
+			operationVersion,
+			oneShotB555Identity(),
+		),
+	}
+}
+
+func oneShotTerminalEBusSource(
+	kind SourceKind,
+	phase Phase,
+	scope string,
+	schemaDigest string,
+	operationVersion string,
+	identity *EBusSourceIdentityV1,
+) RegisteredSource {
+	return RegisteredSource{
+		Phase: phase, SourceKind: kind, RuntimeInstance: "ebus-runtime",
+		OperationVersion: operationVersion, OperationScope: scope,
+		Admission:    oneShotAdmission("ebus.read", BackendUnreachable),
+		EvidenceRefs: []EvidenceRefV1{oneShotContentRef(schemaDigest)},
+		EBusIdentity: identity,
+		EBusReader:   oneShotUnavailableEBusReader{},
+	}
+}
+
+func oneShotAdmission(permission string, backend BackendDecision) SourceAdmission {
+	return SourceAdmission{
+		Selection: SelectionIncluded, Policy: PolicyAllowed, Backend: backend,
+		EffectivePermissions: []string{permission}, RequiredPermissions: []string{permission},
+	}
+}
+
+func oneShotContentRef(digest string) EvidenceRefV1 {
+	return EvidenceRefV1{
+		Kind: EvidenceKindContent, DigestAlgorithm: DigestAlgorithmContentBytes,
+		Digest: "sha256:" + digest,
+	}
+}
+
+func oneShotB509Identity() *EBusSourceIdentityV1 {
+	return &EBusSourceIdentityV1{
+		Family: EBusFamilyB509, TargetAddress: 0x08, TargetProduct: "BAI00",
+		RegisterFamily: "system", RegisterID: 512, UnitScaleSource: "gateway-catalog-v1",
+		EvidenceRole: "AUTHORITATIVE",
+	}
+}
+
+func oneShotB524Identity() *EBusSourceIdentityV1 {
+	return &EBusSourceIdentityV1{
+		Family: EBusFamilyB524, TargetAddress: 0x15, SourceAddress: 0xf7,
+		Opcode: 2, GG: 3, II: 0, RR: 28, GroupMeaning: "zones",
+		InstanceGate: "index-not-ff", RegisterCategory: "STATE",
+		UnitScaleSource: "vrc-explorer-v1",
+	}
+}
+
+func oneShotB555Identity() *EBusSourceIdentityV1 {
+	return &EBusSourceIdentityV1{
+		Family: EBusFamilyB555, DeviceFamily: "VRC",
+		ScheduleProgram: "heating-program-1", SlotIndex: 0, DayOfWeek: "MONDAY",
+		TimeIdentity: "06:00:00", OperationModeContext: "AUTO",
+		UnitScaleSource: "source-native",
+	}
+}
+
+func validateOneShotBundle(bundle SynchronizedEvidenceBundleV1, tuple SourceTupleV1) error {
+	if len(bundle.Sources) != 5 {
+		return ErrContractViolation
+	}
+	expected := map[SourceKind]struct {
+		phase    Phase
+		contract string
+		state    SourceState
+		identity *EBusSourceIdentityV1
+	}{
+		SourceEBusB509: {PhasePre, "helianthus.ebus.b509.evidence.v1", StateUnavailable, oneShotB509Identity()},
+		SourceEEBus:    {PhasePre, tuple.Contract, StatePresent, nil},
+		SourceEBusB524: {PhaseAction, "helianthus.ebus.b524.evidence.v1", StateUnavailable, oneShotB524Identity()},
+		SourceCloudApp: {PhaseAction, "helianthus.cloud-app.precaptured.evidence.v1", StatePresent, nil},
+		SourceEBusB555: {PhasePost, "helianthus.ebus.b555.evidence.v1", StateUnavailable, oneShotB555Identity()},
+	}
+	seen := make(map[SourceKind]bool, len(expected))
+	for _, source := range bundle.Sources {
+		kind := source.SourceBinding.SourceKind
+		want, ok := expected[kind]
+		if !ok || seen[kind] || source.Phase != want.phase ||
+			source.SourceContract != want.contract || source.State != want.state {
+			return ErrContractViolation
+		}
+		if kind == tuple.SourceKind && source.SourceSchemaVersion != tuple.Version {
+			return ErrContractViolation
+		}
+		if want.identity != nil {
+			got := cloneIdentity(source.EBusIdentity)
+			if got == nil {
+				return ErrContractViolation
+			}
+			got.TargetPseudonym = ""
+			if !reflect.DeepEqual(got, want.identity) {
+				return ErrContractViolation
+			}
+		}
+		seen[kind] = true
+	}
+	if len(seen) != len(expected) {
+		return ErrContractViolation
+	}
+	return nil
+}
+
+var _ EBusSnapshotReader = oneShotUnavailableEBusReader{}

--- a/internal/syncevidence/oneshot_request.go
+++ b/internal/syncevidence/oneshot_request.go
@@ -234,6 +234,10 @@ func parseOneShotRequest(raw []byte) (OneShotRequestV1, error) {
 	if err != nil {
 		return OneShotRequestV1{}, ErrInvalidArgument
 	}
+	contentDigest := HashContentBytes(normalizedCanonical)
+	if actionRef.Digest != contentDigest || cloudRef.Digest != contentDigest {
+		return OneShotRequestV1{}, ErrInvalidArgument
+	}
 	observedAtText, ok := normalized["source_observed_at"].(string)
 	if !ok || !canonicalTimestamp(observedAtText) {
 		return OneShotRequestV1{}, ErrInvalidArgument

--- a/internal/syncevidence/oneshot_request.go
+++ b/internal/syncevidence/oneshot_request.go
@@ -243,7 +243,13 @@ func parseOneShotEvidenceRef(value map[string]any) (EvidenceRefV1, []byte, error
 		return EvidenceRefV1{}, nil, ErrInvalidArgument
 	}
 	var ref EvidenceRefV1
-	if err := json.Unmarshal(canonical, &ref); err != nil || validateEvidenceRef(ref) != nil {
+	if err := json.Unmarshal(canonical, &ref); err != nil ||
+		validateEvidenceRef(ref) != nil ||
+		ref.Kind != EvidenceKindContent ||
+		ref.DigestAlgorithm != DigestAlgorithmContentBytes ||
+		ref.Repository != nil ||
+		ref.Commit != nil ||
+		ref.Path != nil {
 		return EvidenceRefV1{}, nil, ErrInvalidArgument
 	}
 	return ref, canonical, nil

--- a/internal/syncevidence/oneshot_request.go
+++ b/internal/syncevidence/oneshot_request.go
@@ -33,15 +33,27 @@ type OneShotRequestV1 struct {
 }
 
 type oneShotFileIdentity struct {
-	device uint64
-	inode  uint64
-	mode   uint32
-	uid    uint32
-	links  uint64
-	size   int64
+	device    uint64
+	inode     uint64
+	mode      uint32
+	uid       uint32
+	links     uint64
+	size      int64
+	mtimeSec  int64
+	mtimeNSec int64
+	ctimeSec  int64
+	ctimeNSec int64
 }
 
 func loadOneShotRequestAt(root string, afterFirstRead func()) (OneShotRequestV1, error) {
+	return loadOneShotRequestAtWithHooks(root, nil, afterFirstRead)
+}
+
+func loadOneShotRequestAtWithHooks(
+	root string,
+	afterInitialStat func(),
+	afterFirstRead func(),
+) (OneShotRequestV1, error) {
 	if digestHex(mustReadContract("synchronized-evidence-one-shot-control-v1.schema.json")) != oneShotRequestSchemaDigest {
 		panic("syncevidence: pinned one-shot request schema digest mismatch")
 	}
@@ -52,10 +64,18 @@ func loadOneShotRequestAt(root string, afterFirstRead func()) (OneShotRequestV1,
 	defer func() {
 		_ = parent.Close()
 	}()
-	return loadOneShotRequestFromDirectory(parent, afterFirstRead)
+	return loadOneShotRequestFromDirectoryWithHooks(parent, afterInitialStat, afterFirstRead)
 }
 
 func loadOneShotRequestFromDirectory(parent *os.File, afterFirstRead func()) (OneShotRequestV1, error) {
+	return loadOneShotRequestFromDirectoryWithHooks(parent, nil, afterFirstRead)
+}
+
+func loadOneShotRequestFromDirectoryWithHooks(
+	parent *os.File,
+	afterInitialStat func(),
+	afterFirstRead func(),
+) (OneShotRequestV1, error) {
 	if parent == nil || verifyDirectoryFD(int(parent.Fd())) != nil {
 		return OneShotRequestV1{}, ErrUnsafeStore
 	}
@@ -76,6 +96,9 @@ func loadOneShotRequestFromDirectory(parent *os.File, afterFirstRead func()) (On
 	before, err := verifiedOneShotRequestIdentity(fd)
 	if err != nil {
 		return OneShotRequestV1{}, err
+	}
+	if afterInitialStat != nil {
+		afterInitialStat()
 	}
 	first, err := readOneShotRequest(file)
 	if err != nil {
@@ -154,13 +177,18 @@ func oneShotRequestIdentity(stat unix.Stat_t) (oneShotFileIdentity, error) {
 		stat.Size < 0 {
 		return oneShotFileIdentity{}, ErrUnsafeStore
 	}
+	mtimeSec, mtimeNSec, ctimeSec, ctimeNSec := oneShotRequestChangeTimes(stat)
 	return oneShotFileIdentity{
-		device: uint64(stat.Dev),
-		inode:  uint64(stat.Ino),
-		mode:   uint32(stat.Mode),
-		uid:    stat.Uid,
-		links:  uint64(stat.Nlink),
-		size:   stat.Size,
+		device:    uint64(stat.Dev),
+		inode:     uint64(stat.Ino),
+		mode:      uint32(stat.Mode),
+		uid:       stat.Uid,
+		links:     uint64(stat.Nlink),
+		size:      stat.Size,
+		mtimeSec:  mtimeSec,
+		mtimeNSec: mtimeNSec,
+		ctimeSec:  ctimeSec,
+		ctimeNSec: ctimeNSec,
 	}, nil
 }
 

--- a/internal/syncevidence/oneshot_request.go
+++ b/internal/syncevidence/oneshot_request.go
@@ -49,7 +49,9 @@ func loadOneShotRequestAt(root string, afterFirstRead func()) (OneShotRequestV1,
 	if err != nil {
 		return OneShotRequestV1{}, err
 	}
-	defer parent.Close()
+	defer func() {
+		_ = parent.Close()
+	}()
 	return loadOneShotRequestFromDirectory(parent, afterFirstRead)
 }
 
@@ -67,7 +69,9 @@ func loadOneShotRequestFromDirectory(parent *os.File, afterFirstRead func()) (On
 		return OneShotRequestV1{}, ErrInvalidArgument
 	}
 	file := os.NewFile(uintptr(fd), OneShotRequestFileV1)
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	before, err := verifiedOneShotRequestIdentity(fd)
 	if err != nil {

--- a/internal/syncevidence/oneshot_request.go
+++ b/internal/syncevidence/oneshot_request.go
@@ -1,0 +1,244 @@
+package syncevidence
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	OneShotRequestContractV1 = "helianthus.platform.synchronized-evidence.one-shot-request.v1"
+	OneShotRequestFileV1     = "one-shot-request-v1.json"
+
+	oneShotRequestSchemaDigest = "0a17427656c4a5b81b9f7aceb3d6c1f3445a626c7ce2846953e5ccd29a774227"
+)
+
+type OneShotCloudActionV1 struct {
+	EvidenceRef        EvidenceRefV1   `json:"evidence_ref"`
+	NormalizedEvidence json.RawMessage `json:"normalized_evidence"`
+}
+
+type OneShotRequestV1 struct {
+	Contract          string               `json:"contract"`
+	SchemaVersion     uint64               `json:"schema_version"`
+	ActionEvidenceRef EvidenceRefV1        `json:"action_evidence_ref"`
+	CloudAppAction    OneShotCloudActionV1 `json:"cloud_app_action"`
+}
+
+type oneShotFileIdentity struct {
+	device uint64
+	inode  uint64
+	mode   uint32
+	uid    uint32
+	links  uint64
+	size   int64
+}
+
+func loadOneShotRequestAt(root string, afterFirstRead func()) (OneShotRequestV1, error) {
+	if digestHex(mustReadContract("synchronized-evidence-one-shot-control-v1.schema.json")) != oneShotRequestSchemaDigest {
+		panic("syncevidence: pinned one-shot request schema digest mismatch")
+	}
+	parent, err := openOneShotRequestDirectory(root)
+	if err != nil {
+		return OneShotRequestV1{}, err
+	}
+	defer parent.Close()
+
+	fd, err := unix.Openat(
+		int(parent.Fd()),
+		OneShotRequestFileV1,
+		unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW|unix.O_NONBLOCK,
+		0,
+	)
+	if err != nil {
+		return OneShotRequestV1{}, ErrInvalidArgument
+	}
+	file := os.NewFile(uintptr(fd), OneShotRequestFileV1)
+	defer file.Close()
+
+	before, err := verifiedOneShotRequestIdentity(fd)
+	if err != nil {
+		return OneShotRequestV1{}, err
+	}
+	first, err := readOneShotRequest(file)
+	if err != nil {
+		return OneShotRequestV1{}, err
+	}
+	if afterFirstRead != nil {
+		afterFirstRead()
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return OneShotRequestV1{}, ErrInvalidArgument
+	}
+	second, err := readOneShotRequest(file)
+	if err != nil {
+		return OneShotRequestV1{}, err
+	}
+	after, err := verifiedOneShotRequestIdentity(fd)
+	if err != nil {
+		return OneShotRequestV1{}, err
+	}
+	var linked unix.Stat_t
+	if err := unix.Fstatat(int(parent.Fd()), OneShotRequestFileV1, &linked, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return OneShotRequestV1{}, ErrInvalidArgument
+	}
+	linkedIdentity, err := oneShotRequestIdentity(linked)
+	if err != nil || before != after || before != linkedIdentity || !bytes.Equal(first, second) {
+		return OneShotRequestV1{}, ErrInvalidArgument
+	}
+	return parseOneShotRequest(second)
+}
+
+func openOneShotRequestDirectory(root string) (*os.File, error) {
+	if root == "" || !filepath.IsAbs(root) || filepath.Clean(root) != root || root == string(filepath.Separator) {
+		return nil, ErrInvalidArgument
+	}
+	components := strings.Split(strings.TrimPrefix(root, string(filepath.Separator)), string(filepath.Separator))
+	fd, err := unix.Open(string(filepath.Separator), unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, ErrInvalidArgument
+	}
+	for _, component := range components {
+		if component == "" || component == "." || component == ".." {
+			_ = unix.Close(fd)
+			return nil, ErrInvalidArgument
+		}
+		next, openErr := unix.Openat(fd, component, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+		_ = unix.Close(fd)
+		if openErr != nil {
+			return nil, ErrInvalidArgument
+		}
+		fd = next
+	}
+	var stat unix.Stat_t
+	if err := unix.Fstat(fd, &stat); err != nil ||
+		stat.Mode&unix.S_IFMT != unix.S_IFDIR ||
+		uint32(stat.Mode)&0o777 != 0o700 ||
+		stat.Uid != uint32(os.Geteuid()) {
+		_ = unix.Close(fd)
+		return nil, ErrUnsafeStore
+	}
+	return os.NewFile(uintptr(fd), root), nil
+}
+
+func verifiedOneShotRequestIdentity(fd int) (oneShotFileIdentity, error) {
+	var stat unix.Stat_t
+	if err := unix.Fstat(fd, &stat); err != nil {
+		return oneShotFileIdentity{}, ErrInvalidArgument
+	}
+	return oneShotRequestIdentity(stat)
+}
+
+func oneShotRequestIdentity(stat unix.Stat_t) (oneShotFileIdentity, error) {
+	if stat.Mode&unix.S_IFMT != unix.S_IFREG ||
+		uint32(stat.Mode)&0o777 != 0o600 ||
+		stat.Uid != uint32(os.Geteuid()) ||
+		uint64(stat.Nlink) != 1 ||
+		stat.Size < 0 {
+		return oneShotFileIdentity{}, ErrUnsafeStore
+	}
+	return oneShotFileIdentity{
+		device: uint64(stat.Dev),
+		inode:  uint64(stat.Ino),
+		mode:   uint32(stat.Mode),
+		uid:    stat.Uid,
+		links:  uint64(stat.Nlink),
+		size:   stat.Size,
+	}, nil
+}
+
+func readOneShotRequest(file *os.File) ([]byte, error) {
+	maximum := int64(DefaultLimitsV1().MaxArtifactBytes)
+	raw, err := io.ReadAll(io.LimitReader(file, maximum+1))
+	if err != nil || len(raw) == 0 || int64(len(raw)) > maximum {
+		return nil, ErrInvalidArgument
+	}
+	return raw, nil
+}
+
+func parseOneShotRequest(raw []byte) (OneShotRequestV1, error) {
+	value, _, err := parseJSON(raw, DefaultLimitsV1(), false)
+	if err != nil {
+		return OneShotRequestV1{}, ErrInvalidArgument
+	}
+	root, ok := value.(map[string]any)
+	if !ok || !exactKeys(root, "contract", "schema_version", "action_evidence_ref", "cloud_app_action") ||
+		root["contract"] != OneShotRequestContractV1 ||
+		root["schema_version"] != json.Number("1") {
+		return OneShotRequestV1{}, ErrInvalidArgument
+	}
+	actionMap, actionOK := root["action_evidence_ref"].(map[string]any)
+	cloudMap, cloudOK := root["cloud_app_action"].(map[string]any)
+	if !actionOK || !cloudOK || !exactKeys(cloudMap, "evidence_ref", "normalized_evidence") {
+		return OneShotRequestV1{}, ErrInvalidArgument
+	}
+	cloudRefMap, refOK := cloudMap["evidence_ref"].(map[string]any)
+	normalized, evidenceOK := cloudMap["normalized_evidence"].(map[string]any)
+	if !refOK || !evidenceOK {
+		return OneShotRequestV1{}, ErrInvalidArgument
+	}
+	actionRef, actionCanonical, err := parseOneShotEvidenceRef(actionMap)
+	if err != nil {
+		return OneShotRequestV1{}, err
+	}
+	cloudRef, cloudCanonical, err := parseOneShotEvidenceRef(cloudRefMap)
+	if err != nil || !bytes.Equal(actionCanonical, cloudCanonical) || !reflect.DeepEqual(actionRef, cloudRef) {
+		return OneShotRequestV1{}, ErrInvalidArgument
+	}
+	normalizedCanonical, err := canonicalJSONValue(normalized)
+	if err != nil {
+		return OneShotRequestV1{}, ErrInvalidArgument
+	}
+	observedAtText, ok := normalized["source_observed_at"].(string)
+	if !ok || !canonicalTimestamp(observedAtText) {
+		return OneShotRequestV1{}, ErrInvalidArgument
+	}
+	observedAt, err := time.Parse(time.RFC3339Nano, observedAtText)
+	if err != nil {
+		return OneShotRequestV1{}, ErrInvalidArgument
+	}
+	authority, ok := boundSourceAuthority(
+		SourceCloudApp,
+		"helianthus.cloud-app.precaptured.evidence.v1",
+		1,
+	)
+	if !ok || validateSourcePayload(normalized, sourceCapture{
+		sourceKind:          SourceCloudApp,
+		sourceContract:      authority.contract,
+		sourceSchemaVersion: authority.version,
+		sourceObservedAt:    observedAt,
+	}) != nil {
+		return OneShotRequestV1{}, ErrInvalidArgument
+	}
+	return OneShotRequestV1{
+		Contract:          OneShotRequestContractV1,
+		SchemaVersion:     1,
+		ActionEvidenceRef: actionRef,
+		CloudAppAction: OneShotCloudActionV1{
+			EvidenceRef:        cloudRef,
+			NormalizedEvidence: normalizedCanonical,
+		},
+	}, nil
+}
+
+func parseOneShotEvidenceRef(value map[string]any) (EvidenceRefV1, []byte, error) {
+	if !exactKeys(value, "kind", "digest_algorithm", "digest", "repository", "commit", "path") {
+		return EvidenceRefV1{}, nil, ErrInvalidArgument
+	}
+	canonical, err := canonicalJSONValue(value)
+	if err != nil {
+		return EvidenceRefV1{}, nil, ErrInvalidArgument
+	}
+	var ref EvidenceRefV1
+	if err := json.Unmarshal(canonical, &ref); err != nil || validateEvidenceRef(ref) != nil {
+		return EvidenceRefV1{}, nil, ErrInvalidArgument
+	}
+	return ref, canonical, nil
+}

--- a/internal/syncevidence/oneshot_request.go
+++ b/internal/syncevidence/oneshot_request.go
@@ -50,7 +50,13 @@ func loadOneShotRequestAt(root string, afterFirstRead func()) (OneShotRequestV1,
 		return OneShotRequestV1{}, err
 	}
 	defer parent.Close()
+	return loadOneShotRequestFromDirectory(parent, afterFirstRead)
+}
 
+func loadOneShotRequestFromDirectory(parent *os.File, afterFirstRead func()) (OneShotRequestV1, error) {
+	if parent == nil || verifyDirectoryFD(int(parent.Fd())) != nil {
+		return OneShotRequestV1{}, ErrUnsafeStore
+	}
 	fd, err := unix.Openat(
 		int(parent.Fd()),
 		OneShotRequestFileV1,

--- a/internal/syncevidence/oneshot_request_times_darwin.go
+++ b/internal/syncevidence/oneshot_request_times_darwin.go
@@ -1,0 +1,9 @@
+//go:build darwin
+
+package syncevidence
+
+import "golang.org/x/sys/unix"
+
+func oneShotRequestChangeTimes(stat unix.Stat_t) (int64, int64, int64, int64) {
+	return stat.Mtim.Sec, stat.Mtim.Nsec, stat.Ctim.Sec, stat.Ctim.Nsec
+}

--- a/internal/syncevidence/oneshot_request_times_linux.go
+++ b/internal/syncevidence/oneshot_request_times_linux.go
@@ -1,0 +1,9 @@
+//go:build linux
+
+package syncevidence
+
+import "golang.org/x/sys/unix"
+
+func oneShotRequestChangeTimes(stat unix.Stat_t) (int64, int64, int64, int64) {
+	return stat.Mtim.Sec, stat.Mtim.Nsec, stat.Ctim.Sec, stat.Ctim.Nsec
+}

--- a/internal/syncevidence/recorder.go
+++ b/internal/syncevidence/recorder.go
@@ -811,9 +811,6 @@ func (recorder *Recorder) prepareEvidence(capture sourceCapture, identity *EBusS
 		if err := recorder.remaskM625Payload(object, usedValues); err != nil {
 			return nil, RemaskingV1{}, 0, err
 		}
-		if err := sortM625Payload(object); err != nil {
-			return nil, RemaskingV1{}, 0, err
-		}
 		requirements, err := m625RemaskingRequirements(object)
 		if err != nil {
 			return nil, RemaskingV1{}, 0, err

--- a/internal/syncevidence/recorder.go
+++ b/internal/syncevidence/recorder.go
@@ -259,7 +259,11 @@ func (recorder *Recorder) Capture(ctx context.Context, marker ActionMarker) ([]b
 			if base.errorCategory != ErrorBackendUnavailable {
 				var hitTotal bool
 				var rootErr error
-				result, hitTotal, rootErr = recorder.captureSource(ctx, registered, SourceRequest{Phase: phase, Limits: recorder.limits}, totalTimer.C())
+				result, hitTotal, rootErr = recorder.captureSource(ctx, registered, SourceRequest{
+					Phase: phase, Limits: recorder.limits,
+					OperationID: base.operationID, OperationScope: base.operationScope, MaskTier: "redacted",
+					AuthScope: AuthScopeV1{Authority: "effective", Permissions: append([]string(nil), permissions...)},
+				}, totalTimer.C())
 				if rootErr != nil {
 					return rootErr
 				}
@@ -505,7 +509,15 @@ func (recorder *Recorder) captureSource(ctx context.Context, registered Register
 		case SourceEBusB509, SourceEBusB524, SourceEBusB555:
 			outcome.evidence, outcome.err = registered.EBusReader.ReadSnapshot(sourceCtx, request)
 		case SourceEEBus:
-			outcome.evidence, outcome.err = registered.EEBusReader.ListServices(sourceCtx, request)
+			authority, ok := registeredSourceAuthority(registered)
+			switch {
+			case !ok:
+				outcome.err = ErrContractViolation
+			case authority.contract == M625EEBusContractV1:
+				outcome.evidence, outcome.err = registered.EEBusM625Reader.ReadFeatureData(sourceCtx, request)
+			default:
+				outcome.evidence, outcome.err = registered.EEBusReader.ListServices(sourceCtx, request)
+			}
 		case SourceCloudApp:
 			outcome.evidence = AcquiredEvidence{SourceObservedAt: registered.PrecapturedCloud.SourceObservedAt, NormalizedEvidence: append(json.RawMessage(nil), registered.PrecapturedCloud.NormalizedEvidence...)}
 		default:
@@ -555,7 +567,7 @@ func (recorder *Recorder) sourcePrecedence(registered RegisteredSource) (sourceC
 	if err != nil {
 		return sourceCapture{}, sourceAuthority{}, nil, false, err
 	}
-	operationID, snapshotMode := expectedSourceOperation(runtimeKind)
+	operationID, snapshotMode := expectedSourceOperation(runtimeKind, authority.contract)
 	refs := append([]EvidenceRefV1(nil), registered.EvidenceRefs...)
 	if registered.SourceKind == SourceCloudApp {
 		refs = []EvidenceRefV1{registered.PrecapturedCloud.EvidenceRef}
@@ -795,10 +807,24 @@ func (recorder *Recorder) prepareEvidence(capture sourceCapture, identity *EBusS
 		return nil, RemaskingV1{}, 0, err
 	}
 	entries := make([]RemaskedPseudonymV1, 0)
-	if err := recorder.remaskPayload(object, capture.sourceKind, identity, "", &entries, usedValues); err != nil {
+	if capture.sourceKind == SourceEEBus && capture.sourceContract == M625EEBusContractV1 {
+		if err := recorder.remaskM625Payload(object, usedValues); err != nil {
+			return nil, RemaskingV1{}, 0, err
+		}
+		if err := sortM625Payload(object); err != nil {
+			return nil, RemaskingV1{}, 0, err
+		}
+		requirements, err := m625RemaskingRequirements(object)
+		if err != nil {
+			return nil, RemaskingV1{}, 0, err
+		}
+		for path, requirement := range requirements {
+			entries = append(entries, RemaskedPseudonymV1{Path: path, Pseudonym: requirement.pseudonym})
+		}
+	} else if err := recorder.remaskPayload(object, capture.sourceKind, identity, "", &entries, usedValues); err != nil {
 		return nil, RemaskingV1{}, 0, err
 	}
-	if capture.sourceKind == SourceEEBus {
+	if capture.sourceKind == SourceEEBus && capture.sourceContract == HistoricalEEBusContractV1 {
 		sortEEBusPayload(object)
 		if err := recomputeEEBusDataHash(object); err != nil {
 			return nil, RemaskingV1{}, 0, err
@@ -890,6 +916,9 @@ func validateSourcePayload(object map[string]any, capture sourceCapture) error {
 			return contractError("schema.bundle")
 		}
 	case SourceEEBus:
+		if capture.sourceContract == M625EEBusContractV1 {
+			return validateM625Payload(object, capture)
+		}
 		return validateEEBusServicesPayload(object, capture)
 	default:
 		return contractError("binding.registry")
@@ -1259,6 +1288,85 @@ func (recorder *Recorder) remaskPayload(value any, kind SourceKind, identity *EB
 	return nil
 }
 
+func (recorder *Recorder) remaskM625Payload(object map[string]any, usedValues map[string]struct{}) error {
+	assignments := make(map[string]string)
+	assign := func(identity string) (string, error) {
+		if pseudonym := assignments[identity]; pseudonym != "" {
+			return pseudonym, nil
+		}
+		pseudonym, err := recorder.mintUniqueRemask(usedValues)
+		if err != nil {
+			return "", err
+		}
+		assignments[identity] = pseudonym
+		return pseudonym, nil
+	}
+
+	services := object["services"].([]any)
+	servicePseudonyms := make(map[string]string, len(services))
+	for index, raw := range services {
+		service := raw.(string)
+		pseudonym, err := assign("SERVICE\x00" + service)
+		if err != nil {
+			return err
+		}
+		servicePseudonyms[service] = pseudonym
+		services[index] = pseudonym
+	}
+	paths := object["feature_paths"].([]any)
+	for _, raw := range paths {
+		path := raw.(map[string]any)
+		service := path["service"].(string)
+		entity := path["entity"].(string)
+		feature := path["feature"].(string)
+		serviceIdentity := "SERVICE\x00" + service
+		entityIdentity := serviceIdentity + "\x00ENTITY\x00" + entity
+		featureIdentity := entityIdentity + "\x00FEATURE\x00" + feature
+		servicePseudonym := servicePseudonyms[service]
+		entityPseudonym, err := assign(entityIdentity)
+		if err != nil {
+			return err
+		}
+		featurePseudonym, err := assign(featureIdentity)
+		if err != nil {
+			return err
+		}
+		path["service"] = servicePseudonym
+		path["entity"] = entityPseudonym
+		path["feature"] = featurePseudonym
+		segments := path["feature_path"].([]any)
+		for index, rawSegment := range segments {
+			segment := rawSegment.(map[string]any)
+			switch index {
+			case 0:
+				segment["selector"] = servicePseudonym
+			case 1:
+				segment["selector"] = entityPseudonym
+			case 2:
+				segment["selector"] = featurePseudonym
+			default:
+				selector := segment["selector"].(string)
+				featureIdentity += "\x00FIELD\x00" + selector
+				pseudonym, err := assign(featureIdentity)
+				if err != nil {
+					return err
+				}
+				segment["selector"] = pseudonym
+			}
+		}
+	}
+	for _, raw := range object["observations"].([]any) {
+		observation := raw.(map[string]any)
+		ref := observation["observation_ref"].(string)
+		pseudonym, err := assign("OBSERVATION\x00" + ref)
+		if err != nil {
+			return err
+		}
+		observation["observation_ref"] = "obs-" + pseudonym
+	}
+	return nil
+}
+
 func sourceItemCount(object map[string]any, kind SourceKind) uint64 {
 	switch kind {
 	case SourceEBusB509, SourceEBusB524, SourceEBusB555:
@@ -1268,6 +1376,9 @@ func sourceItemCount(object map[string]any, kind SourceKind) uint64 {
 	case SourceCloudApp:
 		return 1
 	case SourceEEBus:
+		if rows, ok := object["observations"].([]any); ok {
+			return uint64(len(rows))
+		}
 		if data, ok := object["data"].(map[string]any); ok {
 			if rows, ok := data["services"].([]any); ok {
 				return uint64(len(rows))

--- a/internal/syncevidence/recorder.go
+++ b/internal/syncevidence/recorder.go
@@ -57,6 +57,7 @@ type sourceCapture struct {
 	ebusIdentity        *EBusSourceIdentityV1
 	evidenceRefs        []EvidenceRefV1
 	normalizedEvidence  json.RawMessage
+	cloudBound          bool
 }
 
 type acquisitionOutcome struct {
@@ -583,6 +584,7 @@ func (recorder *Recorder) sourcePrecedence(registered RegisteredSource) (sourceC
 		snapshotMode:        snapshotMode,
 		ebusIdentity:        cloneIdentity(registered.EBusIdentity),
 		evidenceRefs:        refs,
+		cloudBound:          registered.cloudBound,
 	}
 	switch {
 	case registered.Admission.Selection == SelectionExcluded:
@@ -807,7 +809,19 @@ func (recorder *Recorder) prepareEvidence(capture sourceCapture, identity *EBusS
 		return nil, RemaskingV1{}, 0, err
 	}
 	entries := make([]RemaskedPseudonymV1, 0)
-	if capture.sourceKind == SourceEEBus && capture.sourceContract == M625EEBusContractV1 {
+	if capture.sourceKind == SourceCloudApp && capture.cloudBound {
+		pseudonym, ok := object["subject_pseudonym"].(string)
+		if !ok || !remaskedValuePattern.MatchString(pseudonym) {
+			return nil, RemaskingV1{}, 0, contractError("privacy.remask")
+		}
+		if _, duplicate := usedValues[pseudonym]; duplicate {
+			return nil, RemaskingV1{}, 0, contractError("privacy.remask")
+		}
+		usedValues[pseudonym] = struct{}{}
+		entries = append(entries, RemaskedPseudonymV1{
+			Path: "/subject_pseudonym", Pseudonym: pseudonym,
+		})
+	} else if capture.sourceKind == SourceEEBus && capture.sourceContract == M625EEBusContractV1 {
 		if err := recorder.remaskM625Payload(object, usedValues); err != nil {
 			return nil, RemaskingV1{}, 0, err
 		}

--- a/internal/syncevidence/recorder.go
+++ b/internal/syncevidence/recorder.go
@@ -546,7 +546,10 @@ func (recorder *Recorder) hasPendingSource() bool {
 }
 
 func (recorder *Recorder) sourcePrecedence(registered RegisteredSource) (sourceCapture, sourceAuthority, []string, bool, error) {
-	authority := sourceAuthorities[registered.SourceKind]
+	authority, exists := registeredSourceAuthority(registered)
+	if !exists {
+		return sourceCapture{}, sourceAuthority{}, nil, false, ErrInvalidArgument
+	}
 	runtimeKind, _ := runtimeForSource(registered.SourceKind)
 	permissions, err := normalizePermissions(registered.Admission.EffectivePermissions)
 	if err != nil {

--- a/internal/syncevidence/recorder.go
+++ b/internal/syncevidence/recorder.go
@@ -810,14 +810,14 @@ func (recorder *Recorder) prepareEvidence(capture sourceCapture, identity *EBusS
 	}
 	entries := make([]RemaskedPseudonymV1, 0)
 	if capture.sourceKind == SourceCloudApp && capture.cloudBound {
-		pseudonym, ok := object["subject_pseudonym"].(string)
-		if !ok || !remaskedValuePattern.MatchString(pseudonym) {
+		if _, ok := object["subject_pseudonym"].(string); !ok {
 			return nil, RemaskingV1{}, 0, contractError("privacy.remask")
 		}
-		if _, duplicate := usedValues[pseudonym]; duplicate {
-			return nil, RemaskingV1{}, 0, contractError("privacy.remask")
+		pseudonym, err := recorder.mintUniqueRemask(usedValues)
+		if err != nil {
+			return nil, RemaskingV1{}, 0, err
 		}
-		usedValues[pseudonym] = struct{}{}
+		object["subject_pseudonym"] = pseudonym
 		entries = append(entries, RemaskedPseudonymV1{
 			Path: "/subject_pseudonym", Pseudonym: pseudonym,
 		})

--- a/internal/syncevidence/registry.go
+++ b/internal/syncevidence/registry.go
@@ -39,9 +39,15 @@ type embeddedRegistryEntry struct {
 	EmbeddedSchema      *string    `json:"embedded_schema"`
 }
 
-func mustLoadSourceAuthorities() map[SourceKind]sourceAuthority {
+type sourceAuthorityKey struct {
+	kind     SourceKind
+	contract string
+	version  uint64
+}
+
+func mustLoadSourceAuthorities() map[sourceAuthorityKey]sourceAuthority {
 	raw := mustReadContract("synchronized-evidence-source-registry-v1.json")
-	if digestHex(raw) != "a91b2106076c3ef0f70578e9fc1c85925dd085af323c5889f809b5b2ef1a2488" {
+	if digestHex(raw) != "bfc105545bcbe96b528928ac5893c2273057d18bae4dc7d1f81fb6291f94045c" {
 		panic("syncevidence: pinned source registry digest mismatch")
 	}
 	decoder := json.NewDecoder(bytes.NewReader(raw))
@@ -53,12 +59,17 @@ func mustLoadSourceAuthorities() map[SourceKind]sourceAuthority {
 	if token, err := decoder.Token(); err != io.EOF || token != nil {
 		panic("syncevidence: trailing embedded source registry data")
 	}
-	if registry.Contract != registryContractV1 || registry.Version != registryVersionV1 || len(registry.Entries) != 5 {
+	if registry.Contract != registryContractV1 || registry.Version != registryVersionV1 || len(registry.Entries) != 6 {
 		panic("syncevidence: unsupported embedded source registry")
 	}
-	result := make(map[SourceKind]sourceAuthority, len(registry.Entries))
+	result := make(map[sourceAuthorityKey]sourceAuthority, len(registry.Entries))
 	for _, entry := range registry.Entries {
-		if _, duplicate := result[entry.SourceKind]; duplicate || !validRegistryEntry(entry) {
+		key := sourceAuthorityKey{
+			kind:     entry.SourceKind,
+			contract: entry.SourceContract,
+			version:  entry.SourceSchemaVersion,
+		}
+		if _, duplicate := result[key]; duplicate || !validRegistryEntry(entry) {
 			panic("syncevidence: invalid embedded source registry entry")
 		}
 		schemaName := "helianthus.eebus.mcp.v1.schema.json"
@@ -68,7 +79,7 @@ func mustLoadSourceAuthorities() map[SourceKind]sourceAuthority {
 		if digestHex(mustReadContract(schemaName)) != entry.SchemaSHA256 {
 			panic("syncevidence: embedded source schema digest mismatch")
 		}
-		result[entry.SourceKind] = sourceAuthority{
+		result[key] = sourceAuthority{
 			kind:            entry.SourceKind,
 			contract:        entry.SourceContract,
 			version:         entry.SourceSchemaVersion,
@@ -79,11 +90,65 @@ func mustLoadSourceAuthorities() map[SourceKind]sourceAuthority {
 		}
 	}
 	for _, kind := range []SourceKind{SourceEBusB509, SourceEBusB524, SourceEBusB555, SourceEEBus, SourceCloudApp} {
-		if _, ok := result[kind]; !ok {
+		key, ok := defaultSourceAuthorityKey(kind)
+		if !ok {
+			panic("syncevidence: invalid default source authority")
+		}
+		if _, ok := result[key]; !ok {
 			panic("syncevidence: incomplete embedded source registry")
 		}
 	}
+	if _, ok := result[sourceAuthorityKey{kind: SourceEEBus, contract: M625EEBusContractV1, version: 1}]; !ok {
+		panic("syncevidence: incomplete M6.25 source registry")
+	}
 	return result
+}
+
+func defaultSourceAuthorityKey(kind SourceKind) (sourceAuthorityKey, bool) {
+	var contract string
+	switch kind {
+	case SourceEBusB509:
+		contract = "helianthus.ebus.b509.evidence.v1"
+	case SourceEBusB524:
+		contract = "helianthus.ebus.b524.evidence.v1"
+	case SourceEBusB555:
+		contract = "helianthus.ebus.b555.evidence.v1"
+	case SourceEEBus:
+		contract = HistoricalEEBusContractV1
+	case SourceCloudApp:
+		contract = "helianthus.cloud-app.precaptured.evidence.v1"
+	default:
+		return sourceAuthorityKey{}, false
+	}
+	return sourceAuthorityKey{kind: kind, contract: contract, version: 1}, true
+}
+
+func registeredSourceAuthority(source RegisteredSource) (sourceAuthority, bool) {
+	key, ok := defaultSourceAuthorityKey(source.SourceKind)
+	if !ok {
+		return sourceAuthority{}, false
+	}
+	if source.SourceContract != "" || source.SourceVersion != 0 {
+		if source.SourceContract == "" || source.SourceVersion == 0 {
+			return sourceAuthority{}, false
+		}
+		key = sourceAuthorityKey{
+			kind:     source.SourceKind,
+			contract: source.SourceContract,
+			version:  source.SourceVersion,
+		}
+	}
+	authority, ok := sourceAuthorities[key]
+	return authority, ok
+}
+
+func boundSourceAuthority(kind SourceKind, contract string, version uint64) (sourceAuthority, bool) {
+	authority, ok := sourceAuthorities[sourceAuthorityKey{
+		kind:     kind,
+		contract: contract,
+		version:  version,
+	}]
+	return authority, ok
 }
 
 func validRegistryEntry(entry embeddedRegistryEntry) bool {

--- a/internal/syncevidence/replay.go
+++ b/internal/syncevidence/replay.go
@@ -518,7 +518,7 @@ func validateSources(bundle *SynchronizedEvidenceBundleV1, rootPermissions map[s
 }
 
 func validateBinding(binding SourceBindingV1, source *SourceRecordV1, permissions map[string]bool) error {
-	authority, exists := sourceAuthorities[binding.SourceKind]
+	authority, exists := boundSourceAuthority(binding.SourceKind, binding.SourceContract, binding.SourceSchemaVersion)
 	expectedRuntime, validKind := runtimeForSource(binding.SourceKind)
 	if !exists || !validKind || binding.RuntimeKind != expectedRuntime || binding.RuntimeKind != source.SourceKind ||
 		!runtimeIDPattern.MatchString(binding.RuntimePseudonym) || !operationVersionExpr.MatchString(binding.OperationVersion) ||

--- a/internal/syncevidence/replay.go
+++ b/internal/syncevidence/replay.go
@@ -533,7 +533,7 @@ func validateBinding(binding SourceBindingV1, source *SourceRecordV1, permission
 		!reflect.DeepEqual(binding.EBusIdentity, source.EBusIdentity) {
 		return contractError("binding.registry")
 	}
-	expectedOperation, expectedMode := expectedSourceOperation(source.SourceKind)
+	expectedOperation, expectedMode := expectedSourceOperation(source.SourceKind, binding.SourceContract)
 	if binding.OperationID != expectedOperation || binding.SnapshotScope.Mode != expectedMode {
 		return contractError("binding.registry")
 	}
@@ -717,23 +717,53 @@ func validateRemasking(artifact *SourceArtifactV1, value any, bundle *Synchroniz
 	}
 	last := ""
 	paths := make(map[string]string)
+	var m625Requirements map[string]m625RemaskingRequirement
+	if artifact.SourceContract == M625EEBusContractV1 {
+		object, ok := value.(map[string]any)
+		if !ok {
+			return contractError("privacy.remask")
+		}
+		var err error
+		m625Requirements, err = m625RemaskingRequirements(object)
+		if err != nil {
+			return err
+		}
+	}
 	for _, entry := range artifact.Remasking.Entries {
 		if entry.Path == "" || !remaskedValuePattern.MatchString(entry.Pseudonym) || (last != "" && (entry.Path < last || entry.Path == last)) {
 			return contractError("privacy.remask")
 		}
 		resolved, ok := resolveJSONPointer(value, entry.Path)
-		if !ok || resolved != entry.Pseudonym {
+		observationRef := artifact.SourceContract == M625EEBusContractV1 &&
+			strings.HasPrefix(entry.Path, "/observations/") &&
+			strings.HasSuffix(entry.Path, "/observation_ref") &&
+			resolved == "obs-"+entry.Pseudonym
+		if !ok || resolved != entry.Pseudonym && !observationRef {
 			return contractError("privacy.remask")
 		}
-		if prior, duplicate := assignments[entry.Pseudonym]; duplicate && prior != artifact.ArtifactID+"\x00"+entry.Path {
+		assignment := artifact.ArtifactID + "\x00" + entry.Path
+		if m625Requirements != nil {
+			requirement, exists := m625Requirements[entry.Path]
+			if !exists || requirement.pseudonym != entry.Pseudonym {
+				return contractError("privacy.remask")
+			}
+			assignment = artifact.ArtifactID + "\x00" + requirement.identity
+		}
+		if prior, duplicate := assignments[entry.Pseudonym]; duplicate && prior != assignment {
 			return contractError("privacy.remask")
 		}
-		assignments[entry.Pseudonym] = artifact.ArtifactID + "\x00" + entry.Path
+		assignments[entry.Pseudonym] = assignment
 		paths[entry.Path] = entry.Pseudonym
 		last = entry.Path
 	}
 	required := make(map[string]string)
-	collectRemaskedPaths(value, artifact.SourceBinding.SourceKind, "", required)
+	if m625Requirements != nil {
+		for path, requirement := range m625Requirements {
+			required[path] = requirement.pseudonym
+		}
+	} else {
+		collectRemaskedPaths(value, artifact.SourceBinding.SourceKind, "", required)
+	}
 	if !reflect.DeepEqual(required, paths) {
 		return contractError("privacy.remask")
 	}

--- a/internal/syncevidence/store.go
+++ b/internal/syncevidence/store.go
@@ -838,6 +838,9 @@ func (store *FileStore) lookupOneShot(actionRef EvidenceRefV1, tuple SourceTuple
 		if evidenceRefKey(bundle.CaptureWindow.Action.EvidenceRef) != actionKey {
 			continue
 		}
+		if !retainedOneShotCloudContentMatches(bundle, actionRef) {
+			continue
+		}
 		replay, err := Replay(raw)
 		if err != nil {
 			return OneShotLookupResult{}, err
@@ -864,6 +867,23 @@ func (store *FileStore) lookupOneShot(actionRef EvidenceRefV1, tuple SourceTuple
 		return OneShotLookupResult{Status: OneShotLookupConflict}, nil
 	}
 	return result, nil
+}
+
+func retainedOneShotCloudContentMatches(
+	bundle SynchronizedEvidenceBundleV1,
+	actionRef EvidenceRefV1,
+) bool {
+	matches := 0
+	for _, artifact := range bundle.Artifacts {
+		if artifact.SourceBinding.SourceKind != SourceCloudApp {
+			continue
+		}
+		matches++
+		if HashContentBytes(artifact.NormalizedEvidence) != actionRef.Digest {
+			return false
+		}
+	}
+	return matches == 1
 }
 
 func (store *FileStore) createExclusive(prefix string) (string, *os.File, error) {

--- a/internal/syncevidence/store.go
+++ b/internal/syncevidence/store.go
@@ -68,15 +68,34 @@ type journalRecord struct {
 }
 
 func OpenFileStore(config FileStoreConfig) (*FileStore, error) {
-	if config.Root == "" || !filepath.IsAbs(config.Root) || filepath.Clean(config.Root) != config.Root ||
-		config.Root == string(filepath.Separator) || config.QuotaBytes <= journalReserveBytes || config.Retention < 0 ||
-		config.LockProof != nil && len(config.LockProof) != 32 {
+	if !validFileStoreConfig(config) {
 		return nil, ErrUnsafeStore
 	}
 	rootFile, err := openOrCreateStoreRoot(config.Root)
 	if err != nil {
 		return nil, err
 	}
+	return openFileStore(config, rootFile)
+}
+
+func openOneShotFileStore(parent *os.File, config FileStoreConfig) (*FileStore, error) {
+	if parent == nil || !validFileStoreConfig(config) || verifyDirectoryFD(int(parent.Fd())) != nil {
+		return nil, ErrUnsafeStore
+	}
+	rootFile, err := openOrCreateStoreDirectoryAt(parent, "store", config.Root)
+	if err != nil {
+		return nil, err
+	}
+	return openFileStore(config, rootFile)
+}
+
+func validFileStoreConfig(config FileStoreConfig) bool {
+	return config.Root != "" && filepath.IsAbs(config.Root) && filepath.Clean(config.Root) == config.Root &&
+		config.Root != string(filepath.Separator) && config.QuotaBytes > journalReserveBytes &&
+		config.Retention >= 0 && (config.LockProof == nil || len(config.LockProof) == 32)
+}
+
+func openFileStore(config FileStoreConfig, rootFile *os.File) (*FileStore, error) {
 	fail := func(result error) (*FileStore, error) {
 		_ = rootFile.Close()
 		return nil, result
@@ -113,7 +132,7 @@ func OpenFileStore(config FileStoreConfig) (*FileStore, error) {
 		retention: config.Retention, now: now, entropy: entropy,
 		lockProof: append([]byte(nil), config.LockProof...), reservations: make(map[uint64]int64),
 	}
-	if err := store.verifyLockOwnership(); err != nil {
+	if err := store.verifyLockOwnership(created); err != nil {
 		_ = store.Close()
 		return nil, err
 	}
@@ -122,6 +141,45 @@ func OpenFileStore(config FileStoreConfig) (*FileStore, error) {
 		return nil, err
 	}
 	return store, nil
+}
+
+func openOrCreateStoreDirectoryAt(parent *os.File, name, label string) (*os.File, error) {
+	if parent == nil || name != "store" || verifyDirectoryFD(int(parent.Fd())) != nil {
+		return nil, ErrUnsafeStore
+	}
+	fd, err := unix.Openat(
+		int(parent.Fd()),
+		name,
+		unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+		0,
+	)
+	created := false
+	if errors.Is(err, unix.ENOENT) {
+		if err := unix.Mkdirat(int(parent.Fd()), name, 0o700); err != nil {
+			return nil, ErrUnsafeStore
+		}
+		created = true
+		if err := syncDirectory(parent); err != nil {
+			return nil, err
+		}
+		fd, err = unix.Openat(
+			int(parent.Fd()),
+			name,
+			unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+			0,
+		)
+	}
+	if err != nil {
+		return nil, ErrUnsafeStore
+	}
+	if created {
+		err = unix.Fchmod(fd, 0o700)
+	}
+	if err != nil || verifyDirectoryFD(fd) != nil {
+		_ = unix.Close(fd)
+		return nil, ErrUnsafeStore
+	}
+	return os.NewFile(uintptr(fd), label), nil
 }
 
 func openOrCreateStoreRoot(root string) (*os.File, error) {
@@ -214,13 +272,22 @@ func verifyRegularFD(fd int, wantedMode uint32) error {
 	return nil
 }
 
-func (store *FileStore) verifyLockOwnership() error {
+func (store *FileStore) verifyLockOwnership(created bool) error {
 	token := append([]byte(nil), store.lockProof...)
 	if len(token) == 0 {
 		token = make([]byte, 32)
 		if _, err := io.ReadFull(store.entropy, token); err != nil {
 			return ErrUnsafeStore
 		}
+	} else if !created {
+		if _, err := store.lockFile.Seek(0, io.SeekStart); err != nil {
+			return ErrUnsafeStore
+		}
+		readBack, err := io.ReadAll(io.LimitReader(store.lockFile, int64(len(token))+1))
+		if err != nil || !bytes.Equal(readBack, token) {
+			return ErrUnsafeStore
+		}
+		return nil
 	}
 	if err := store.lockFile.Truncate(0); err != nil {
 		return ErrUnsafeStore
@@ -252,6 +319,7 @@ func (store *FileStore) recoverAndMeasure() error {
 	if err != nil {
 		return err
 	}
+	changed := false
 	for _, entry := range entries {
 		name := entry.Name()
 		switch {
@@ -266,6 +334,7 @@ func (store *FileStore) recoverAndMeasure() error {
 			if err := unix.Unlinkat(int(store.rootFile.Fd()), name, 0); err != nil {
 				return ErrUnsafeStore
 			}
+			changed = true
 		case strings.HasPrefix(name, journalPrefix), strings.HasPrefix(name, dropPrefix):
 			return ErrUnsafeStore
 		case strings.HasSuffix(name, ".json"):
@@ -273,13 +342,16 @@ func (store *FileStore) recoverAndMeasure() error {
 				if err := store.quarantine(name); err != nil {
 					return err
 				}
+				changed = true
 			}
 		default:
 			return ErrUnsafeStore
 		}
 	}
-	if err := syncDirectory(store.rootFile); err != nil {
-		return err
+	if changed {
+		if err := syncDirectory(store.rootFile); err != nil {
+			return err
+		}
 	}
 	if err := store.remeasure(); err != nil {
 		return err

--- a/internal/syncevidence/store.go
+++ b/internal/syncevidence/store.go
@@ -838,12 +838,13 @@ func (store *FileStore) lookupOneShot(actionRef EvidenceRefV1, tuple SourceTuple
 		if evidenceRefKey(bundle.CaptureWindow.Action.EvidenceRef) != actionKey {
 			continue
 		}
-		if !retainedOneShotCloudContentMatches(bundle, actionRef) {
-			continue
-		}
 		replay, err := Replay(raw)
 		if err != nil {
 			return OneShotLookupResult{}, err
+		}
+		if !retainedOneShotCloudContentMatches(bundle, actionRef) {
+			conflict = true
+			continue
 		}
 		matches := 0
 		for _, source := range bundle.Sources {
@@ -874,12 +875,13 @@ func retainedOneShotCloudContentMatches(
 	actionRef EvidenceRefV1,
 ) bool {
 	matches := 0
+	actionKey := evidenceRefKey(actionRef)
 	for _, artifact := range bundle.Artifacts {
 		if artifact.SourceBinding.SourceKind != SourceCloudApp {
 			continue
 		}
 		matches++
-		if HashContentBytes(artifact.NormalizedEvidence) != actionRef.Digest {
+		if len(artifact.EvidenceRefs) != 1 || evidenceRefKey(artifact.EvidenceRefs[0]) != actionKey {
 			return false
 		}
 	}

--- a/internal/syncevidence/store.go
+++ b/internal/syncevidence/store.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -31,23 +32,26 @@ type FileStoreConfig struct {
 	Retention  time.Duration
 	Now        func() time.Time
 	Entropy    io.Reader
+	LockProof  []byte
 }
 
 type FileStore struct {
-	mu               sync.Mutex
-	root             string
-	rootFile         *os.File
-	lockFile         *os.File
-	quota            int64
-	used             int64
-	reserved         int64
-	retention        time.Duration
-	now              func() time.Time
-	entropy          io.Reader
-	reservations     map[uint64]int64
-	nextReserve      uint64
-	beforeDropRename func()
-	closed           bool
+	mu                    sync.Mutex
+	root                  string
+	rootFile              *os.File
+	lockFile              *os.File
+	quota                 int64
+	used                  int64
+	reserved              int64
+	retention             time.Duration
+	now                   func() time.Time
+	entropy               io.Reader
+	lockProof             []byte
+	reservations          map[uint64]int64
+	nextReserve           uint64
+	beforeDropRename      func()
+	beforePublishedReopen func(string)
+	closed                bool
 }
 
 type CaptureReservation struct {
@@ -65,7 +69,8 @@ type journalRecord struct {
 
 func OpenFileStore(config FileStoreConfig) (*FileStore, error) {
 	if config.Root == "" || !filepath.IsAbs(config.Root) || filepath.Clean(config.Root) != config.Root ||
-		config.Root == string(filepath.Separator) || config.QuotaBytes <= journalReserveBytes || config.Retention < 0 {
+		config.Root == string(filepath.Separator) || config.QuotaBytes <= journalReserveBytes || config.Retention < 0 ||
+		config.LockProof != nil && len(config.LockProof) != 32 {
 		return nil, ErrUnsafeStore
 	}
 	rootFile, err := openOrCreateStoreRoot(config.Root)
@@ -105,7 +110,8 @@ func OpenFileStore(config FileStoreConfig) (*FileStore, error) {
 	}
 	store := &FileStore{
 		root: config.Root, rootFile: rootFile, lockFile: lockFile, quota: config.QuotaBytes,
-		retention: config.Retention, now: now, entropy: entropy, reservations: make(map[uint64]int64),
+		retention: config.Retention, now: now, entropy: entropy,
+		lockProof: append([]byte(nil), config.LockProof...), reservations: make(map[uint64]int64),
 	}
 	if err := store.verifyLockOwnership(); err != nil {
 		_ = store.Close()
@@ -191,7 +197,8 @@ func openStoreLock(rootFD int) (int, bool, error) {
 
 func verifyDirectoryFD(fd int) error {
 	var stat unix.Stat_t
-	if err := unix.Fstat(fd, &stat); err != nil || stat.Mode&unix.S_IFMT != unix.S_IFDIR || uint32(stat.Mode)&0o777 != 0o700 {
+	if err := unix.Fstat(fd, &stat); err != nil || stat.Mode&unix.S_IFMT != unix.S_IFDIR ||
+		uint32(stat.Mode)&0o777 != 0o700 || stat.Uid != uint32(os.Geteuid()) {
 		return ErrUnsafeStore
 	}
 	return nil
@@ -200,16 +207,20 @@ func verifyDirectoryFD(fd int) error {
 func verifyRegularFD(fd int, wantedMode uint32) error {
 	var stat unix.Stat_t
 	if err := unix.Fstat(fd, &stat); err != nil || stat.Mode&unix.S_IFMT != unix.S_IFREG ||
-		uint64(stat.Nlink) != 1 || uint32(stat.Mode)&0o777 != wantedMode {
+		uint64(stat.Nlink) != 1 || uint32(stat.Mode)&0o777 != wantedMode ||
+		stat.Uid != uint32(os.Geteuid()) {
 		return ErrUnsafeStore
 	}
 	return nil
 }
 
 func (store *FileStore) verifyLockOwnership() error {
-	token := make([]byte, 32)
-	if _, err := io.ReadFull(store.entropy, token); err != nil {
-		return ErrUnsafeStore
+	token := append([]byte(nil), store.lockProof...)
+	if len(token) == 0 {
+		token = make([]byte, 32)
+		if _, err := io.ReadFull(store.entropy, token); err != nil {
+			return ErrUnsafeStore
+		}
 	}
 	if err := store.lockFile.Truncate(0); err != nil {
 		return ErrUnsafeStore
@@ -553,6 +564,17 @@ func (store *FileStore) ReserveCapture(maxBundleBytes int64) (*CaptureReservatio
 }
 
 func (reservation *CaptureReservation) Publish(bundle []byte) (string, error) {
+	return reservation.publish(bundle, nil)
+}
+
+func (reservation *CaptureReservation) PublishVerified(bundle, expectedReplay []byte) (string, error) {
+	if len(expectedReplay) == 0 {
+		return "", ErrInvalidArgument
+	}
+	return reservation.publish(bundle, expectedReplay)
+}
+
+func (reservation *CaptureReservation) publish(bundle, expectedReplay []byte) (string, error) {
 	if reservation == nil || reservation.store == nil {
 		return "", ErrInvalidArgument
 	}
@@ -571,7 +593,14 @@ func (reservation *CaptureReservation) Publish(bundle []byte) (string, error) {
 	if int64(len(bundle)) > reservation.max {
 		return "", ErrQuotaExceeded
 	}
-	return store.publishLocked(bundle)
+	id, err := store.publishLocked(bundle)
+	if err != nil || expectedReplay == nil {
+		return id, err
+	}
+	if err := store.verifyPublishedLocked(id, bundle, expectedReplay); err != nil {
+		return "", err
+	}
+	return id, nil
 }
 
 func (reservation *CaptureReservation) Release() {
@@ -673,6 +702,96 @@ func (store *FileStore) publishLocked(bundle []byte) (string, error) {
 	}
 	published = true
 	return id, nil
+}
+
+func (store *FileStore) verifyPublishedLocked(id string, bundle, expectedReplay []byte) error {
+	name := id + ".json"
+	if store.beforePublishedReopen != nil {
+		store.beforePublishedReopen(name)
+	}
+	reopened, err := store.readEntry(name, DefaultLimitsV1().MaxBundleBytes)
+	if err != nil || !bytes.Equal(reopened, bundle) {
+		return ErrDurability
+	}
+	reopenedID, err := extractBundleID(reopened)
+	if err != nil || reopenedID != id {
+		return ErrDurability
+	}
+	replayed, err := Replay(reopened)
+	if err != nil || !bytes.Equal(replayed, expectedReplay) {
+		return ErrDurability
+	}
+	return syncDirectory(store.rootFile)
+}
+
+func (store *FileStore) lookupOneShot(actionRef EvidenceRefV1, tuple SourceTupleV1) (OneShotLookupResult, error) {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if store.closed {
+		return OneShotLookupResult{}, ErrStoreClosed
+	}
+	if validateEvidenceRef(actionRef) != nil {
+		return OneShotLookupResult{}, ErrInvalidArgument
+	}
+	authority, ok := boundSourceAuthority(tuple.SourceKind, tuple.Contract, tuple.Version)
+	if !ok || authority.kind != tuple.SourceKind || authority.contract != tuple.Contract || authority.version != tuple.Version {
+		return OneShotLookupResult{}, ErrInvalidArgument
+	}
+	entries, err := store.listEntries()
+	if err != nil {
+		return OneShotLookupResult{}, err
+	}
+	sort.Slice(entries, func(left, right int) bool {
+		return entries[left].Name() < entries[right].Name()
+	})
+	result := OneShotLookupResult{Status: OneShotLookupNone}
+	conflict := false
+	actionKey := evidenceRefKey(actionRef)
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".json") {
+			continue
+		}
+		if err := store.verifyFinal(name); err != nil {
+			return OneShotLookupResult{}, err
+		}
+		raw, err := store.readEntry(name, DefaultLimitsV1().MaxBundleBytes)
+		if err != nil {
+			return OneShotLookupResult{}, err
+		}
+		bundle, err := verifyBundle(raw)
+		if err != nil {
+			return OneShotLookupResult{}, err
+		}
+		if evidenceRefKey(bundle.CaptureWindow.Action.EvidenceRef) != actionKey {
+			continue
+		}
+		replay, err := Replay(raw)
+		if err != nil {
+			return OneShotLookupResult{}, err
+		}
+		matches := 0
+		for _, source := range bundle.Sources {
+			if source.SourceBinding.SourceKind == tuple.SourceKind &&
+				source.SourceContract == tuple.Contract &&
+				source.SourceSchemaVersion == tuple.Version {
+				matches++
+			}
+		}
+		if matches != 1 || result.Status == OneShotLookupExisting {
+			conflict = true
+			continue
+		}
+		result = OneShotLookupResult{
+			Status: OneShotLookupExisting,
+			Bundle: append([]byte(nil), raw...),
+			Replay: append([]byte(nil), replay...),
+		}
+	}
+	if conflict {
+		return OneShotLookupResult{Status: OneShotLookupConflict}, nil
+	}
+	return result, nil
 }
 
 func (store *FileStore) createExclusive(prefix string) (string, *os.File, error) {

--- a/internal/syncevidence/types.go
+++ b/internal/syncevidence/types.go
@@ -517,6 +517,7 @@ type RegisteredSource struct {
 	EEBusReader      EEBusServicesReader
 	EEBusM625Reader  EEBusM625Reader
 	PrecapturedCloud *PrecapturedCloudInput
+	cloudBound       bool
 }
 
 type StoppableTimer interface {

--- a/internal/syncevidence/types.go
+++ b/internal/syncevidence/types.go
@@ -436,8 +436,12 @@ type ActionMarker struct {
 }
 
 type SourceRequest struct {
-	Phase  Phase
-	Limits CaptureLimitsV1
+	Phase          Phase
+	Limits         CaptureLimitsV1
+	OperationID    string
+	OperationScope string
+	MaskTier       string
+	AuthScope      AuthScopeV1
 }
 
 type SourceAdmission struct {
@@ -464,6 +468,11 @@ type EEBusServicesReader interface {
 	ListServices(context.Context, SourceRequest) (AcquiredEvidence, error)
 }
 
+// EEBusM625Reader exposes only the bounded public-redacted feature-data read.
+type EEBusM625Reader interface {
+	ReadFeatureData(context.Context, SourceRequest) (AcquiredEvidence, error)
+}
+
 // PrecapturedCloudInput is a value-only local seam. It has no callback, client,
 // endpoint, credential, retry, or refresh capability.
 type PrecapturedCloudInput struct {
@@ -486,6 +495,7 @@ type RegisteredSource struct {
 	EBusIdentity     *EBusSourceIdentityV1
 	EBusReader       EBusSnapshotReader
 	EEBusReader      EEBusServicesReader
+	EEBusM625Reader  EEBusM625Reader
 	PrecapturedCloud *PrecapturedCloudInput
 }
 

--- a/internal/syncevidence/types.go
+++ b/internal/syncevidence/types.go
@@ -54,6 +54,11 @@ const (
 	SourceCloudApp SourceKind = "CLOUD_APP"
 )
 
+const (
+	HistoricalEEBusContractV1 = "helianthus-eebus-mcp"
+	M625EEBusContractV1       = "helianthus.eebus.m625.public-redacted-evidence.v1"
+)
+
 type Phase string
 
 const (
@@ -470,6 +475,8 @@ type PrecapturedCloudInput struct {
 type RegisteredSource struct {
 	Phase            Phase
 	SourceKind       SourceKind
+	SourceContract   string
+	SourceVersion    uint64
 	RuntimeInstance  string
 	SourceID         string // Deprecated compatibility alias for RuntimeInstance; never serialized.
 	OperationVersion string

--- a/internal/syncevidence/types.go
+++ b/internal/syncevidence/types.go
@@ -140,6 +140,26 @@ const (
 	DropStatusAlreadyGone DropStatus = "ALREADY_GONE"
 )
 
+type SourceTupleV1 struct {
+	SourceKind SourceKind
+	Contract   string
+	Version    uint64
+}
+
+type OneShotLookupStatus string
+
+const (
+	OneShotLookupNone     OneShotLookupStatus = "NONE"
+	OneShotLookupExisting OneShotLookupStatus = "EXISTING"
+	OneShotLookupConflict OneShotLookupStatus = "CONFLICT"
+)
+
+type OneShotLookupResult struct {
+	Status OneShotLookupStatus
+	Bundle []byte
+	Replay []byte
+}
+
 type EBusFamily string
 
 const (

--- a/internal/syncevidence/validation.go
+++ b/internal/syncevidence/validation.go
@@ -276,7 +276,7 @@ func oneOfError(value ErrorCategory, allowed ...ErrorCategory) bool {
 }
 
 func validateRegisteredSource(source RegisteredSource) error {
-	authority, exists := sourceAuthorities[source.SourceKind]
+	authority, exists := registeredSourceAuthority(source)
 	runtimeKind, validKind := runtimeForSource(source.SourceKind)
 	if !exists || !validKind || authority.kind != source.SourceKind || !validPhase(source.Phase) ||
 		!operationVersionExpr.MatchString(source.OperationVersion) || source.OperationScope != expectedOperationScope(source.SourceKind) {

--- a/internal/syncevidence/validation.go
+++ b/internal/syncevidence/validation.go
@@ -279,7 +279,7 @@ func validateRegisteredSource(source RegisteredSource) error {
 	authority, exists := registeredSourceAuthority(source)
 	runtimeKind, validKind := runtimeForSource(source.SourceKind)
 	if !exists || !validKind || authority.kind != source.SourceKind || !validPhase(source.Phase) ||
-		!operationVersionExpr.MatchString(source.OperationVersion) || source.OperationScope != expectedOperationScope(source.SourceKind) {
+		!operationVersionExpr.MatchString(source.OperationVersion) || source.OperationScope != expectedOperationScope(authority) {
 		return ErrInvalidArgument
 	}
 	if source.RuntimeInstance != "" && source.SourceID != "" && source.RuntimeInstance != source.SourceID {
@@ -309,7 +309,7 @@ func validateRegisteredSource(source RegisteredSource) error {
 		}
 	}
 	if runtimeKind == RuntimeEBus {
-		if source.EBusReader == nil || source.EEBusReader != nil || source.PrecapturedCloud != nil {
+		if source.EBusReader == nil || source.EEBusReader != nil || source.EEBusM625Reader != nil || source.PrecapturedCloud != nil {
 			return ErrInvalidArgument
 		}
 		if source.EBusIdentity != nil {
@@ -328,11 +328,13 @@ func validateRegisteredSource(source RegisteredSource) error {
 	} else if source.EBusIdentity != nil {
 		return ErrInvalidArgument
 	} else if runtimeKind == RuntimeEEBus {
-		if source.EEBusReader == nil || source.EBusReader != nil || source.PrecapturedCloud != nil || len(source.EvidenceRefs) == 0 {
+		historical := authority.contract == HistoricalEEBusContractV1 && source.EEBusReader != nil && source.EEBusM625Reader == nil
+		m625 := authority.contract == M625EEBusContractV1 && source.EEBusReader == nil && source.EEBusM625Reader != nil
+		if (!historical && !m625) || source.EBusReader != nil || source.PrecapturedCloud != nil || len(source.EvidenceRefs) == 0 {
 			return ErrInvalidArgument
 		}
 	} else {
-		if source.PrecapturedCloud == nil || source.EBusReader != nil || source.EEBusReader != nil || len(source.EvidenceRefs) != 0 {
+		if source.PrecapturedCloud == nil || source.EBusReader != nil || source.EEBusReader != nil || source.EEBusM625Reader != nil || len(source.EvidenceRefs) != 0 {
 			return ErrInvalidArgument
 		}
 		if err := validateEvidenceRef(source.PrecapturedCloud.EvidenceRef); err != nil {
@@ -347,8 +349,8 @@ func validateRegisteredSource(source RegisteredSource) error {
 	return nil
 }
 
-func expectedOperationScope(kind SourceKind) string {
-	switch kind {
+func expectedOperationScope(authority sourceAuthority) string {
+	switch authority.kind {
 	case SourceEBusB509:
 		return "ebus-b509"
 	case SourceEBusB524:
@@ -356,6 +358,9 @@ func expectedOperationScope(kind SourceKind) string {
 	case SourceEBusB555:
 		return "ebus-b555"
 	case SourceEEBus:
+		if authority.contract == M625EEBusContractV1 {
+			return "feature-data"
+		}
 		return "services"
 	case SourceCloudApp:
 		return "cloud-app"
@@ -364,11 +369,14 @@ func expectedOperationScope(kind SourceKind) string {
 	}
 }
 
-func expectedSourceOperation(kind RuntimeKind) (string, SnapshotMode) {
+func expectedSourceOperation(kind RuntimeKind, contract string) (string, SnapshotMode) {
 	switch kind {
 	case RuntimeEBus:
 		return "ebus.v1.snapshot.capture", SnapshotFrozen
 	case RuntimeEEBus:
+		if contract == M625EEBusContractV1 {
+			return "eebus.v1.features.data.get", SnapshotLiveRead
+		}
 		return "eebus.v1.services.list", SnapshotLiveRead
 	case RuntimeCloudApp:
 		return "cloud.precaptured.import", SnapshotPrecaptured

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -1273,12 +1273,17 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handlePost(w http.ResponseWriter, r *http.Request) {
-	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	const maximumRequestBodyBytes = 1 << 20
+	body, err := io.ReadAll(io.LimitReader(r.Body, maximumRequestBodyBytes+1))
 	if err != nil {
 		http.Error(w, "read failed", http.StatusBadRequest)
 		return
 	}
 	defer func() { _ = r.Body.Close() }()
+	if len(body) > maximumRequestBodyBytes {
+		s.writeRPCError(w, nil, rpcErrorInvalidRequest("request body too large"))
+		return
+	}
 
 	var req rpcRequest
 	if err := json.Unmarshal(body, &req); err != nil {
@@ -1385,7 +1390,8 @@ func (s *Server) handleToolsCall(ctx context.Context, params json.RawMessage) (a
 		return nil, rpcErrorInvalidParams("tools/call missing name")
 	}
 	if rawCall.Name == synchronizedEvidenceCaptureToolName {
-		return s.handleSynchronizedEvidenceCaptureRaw(ctx, rawCall.Arguments, hasDuplicateKeys)
+		invalidCallParams := hasDuplicateKeys || !synchronizedEvidenceCallParamsClosed(params)
+		return s.handleSynchronizedEvidenceCaptureRaw(ctx, rawCall.Arguments, invalidCallParams)
 	}
 	if !s.hasToolNamed(rawCall.Name) {
 		return nil, rpcErrorInvalidParams(fmt.Sprintf("unknown tool %q", rawCall.Name))

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -445,24 +445,25 @@ type SemanticProvider interface {
 }
 
 type Server struct {
-	registry             Registry
-	invoker              Invoker
-	statusProvider       StatusProvider
-	bus                  BusObservabilityProvider
-	watch                WatchSummaryProvider
-	semantic             SemanticProvider
-	scheduleWriter       ScheduleWriter
-	configWriter         ConfigWriter
-	rpcSource            byte
-	rpcSourceAdmitted    bool
-	rpcSourceProvider    func() (byte, bool)
-	idempotencyMu        sync.Mutex
-	idempotency          map[string]idempotencyEntry
-	snapshotMu           sync.RWMutex
-	snapshots            map[string]snapshotState
-	eebusV1Mu            sync.RWMutex
-	eebusV1              *eebusV1Runtime
-	eebusV1CommandRouter EEBusV1CommandRouter
+	registry                    Registry
+	invoker                     Invoker
+	statusProvider              StatusProvider
+	bus                         BusObservabilityProvider
+	watch                       WatchSummaryProvider
+	semantic                    SemanticProvider
+	scheduleWriter              ScheduleWriter
+	configWriter                ConfigWriter
+	rpcSource                   byte
+	rpcSourceAdmitted           bool
+	rpcSourceProvider           func() (byte, bool)
+	idempotencyMu               sync.Mutex
+	idempotency                 map[string]idempotencyEntry
+	snapshotMu                  sync.RWMutex
+	snapshots                   map[string]snapshotState
+	eebusV1Mu                   sync.RWMutex
+	eebusV1                     *eebusV1Runtime
+	eebusV1CommandRouter        EEBusV1CommandRouter
+	synchronizedEvidenceCapture SynchronizedEvidenceCapture
 
 	tools []Tool
 
@@ -1346,10 +1347,17 @@ func (s *Server) handleToolsList(ctx context.Context) (any, *rpcError) {
 	tools := s.tools
 	if eebusV1BoundaryFromContext(ctx) == eebusV1OperatorBoundary {
 		s.eebusV1Mu.RLock()
-		registered := !eebusV1NilCommandRouter(s.eebusV1CommandRouter)
+		commandsRegistered := !eebusV1NilCommandRouter(s.eebusV1CommandRouter)
+		captureRegistered := !nilSynchronizedEvidenceCapture(s.synchronizedEvidenceCapture)
 		s.eebusV1Mu.RUnlock()
-		if registered {
-			tools = append(append([]Tool(nil), tools...), eebusV1CommandTools()...)
+		if commandsRegistered || captureRegistered {
+			tools = append([]Tool(nil), tools...)
+		}
+		if commandsRegistered {
+			tools = append(tools, eebusV1CommandTools()...)
+		}
+		if captureRegistered {
+			tools = append(tools, synchronizedEvidenceCaptureTool())
 		}
 	}
 	return map[string]any{
@@ -1375,6 +1383,9 @@ func (s *Server) handleToolsCall(ctx context.Context, params json.RawMessage) (a
 	}
 	if rawCall.Name == "" {
 		return nil, rpcErrorInvalidParams("tools/call missing name")
+	}
+	if rawCall.Name == synchronizedEvidenceCaptureToolName {
+		return s.handleSynchronizedEvidenceCaptureRaw(ctx, rawCall.Arguments, hasDuplicateKeys)
 	}
 	if !s.hasToolNamed(rawCall.Name) {
 		return nil, rpcErrorInvalidParams(fmt.Sprintf("unknown tool %q", rawCall.Name))

--- a/mcp/synchronized_evidence.go
+++ b/mcp/synchronized_evidence.go
@@ -63,7 +63,7 @@ func synchronizedEvidenceCaptureTool() Tool {
 func (server *Server) handleSynchronizedEvidenceCaptureRaw(
 	ctx context.Context,
 	arguments json.RawMessage,
-	hasDuplicateKeys bool,
+	invalidCallParams bool,
 ) (any, *rpcError) {
 	if eebusV1BoundaryFromContext(ctx) != eebusV1OperatorBoundary {
 		return nil, rpcErrorInvalidParams(fmt.Sprintf("unknown tool %q", synchronizedEvidenceCaptureToolName))
@@ -74,7 +74,7 @@ func (server *Server) handleSynchronizedEvidenceCaptureRaw(
 	if nilSynchronizedEvidenceCapture(capture) {
 		return nil, rpcErrorInvalidParams(fmt.Sprintf("unknown tool %q", synchronizedEvidenceCaptureToolName))
 	}
-	if hasDuplicateKeys || !synchronizedEvidenceEmptyArgs(arguments) {
+	if invalidCallParams || !synchronizedEvidenceEmptyArgs(arguments) {
 		receipt := syncevidence.OneShotReceiptV1{Category: syncevidence.OneShotInvalidRequest}
 		return callToolResultText(mustJSON(receipt), true), nil
 	}
@@ -98,6 +98,16 @@ func synchronizedEvidenceEmptyArgs(raw json.RawMessage) bool {
 		return false
 	}
 	return errors.Is(decoder.Decode(&struct{}{}), io.EOF)
+}
+
+func synchronizedEvidenceCallParamsClosed(raw json.RawMessage) bool {
+	var value map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &value); err != nil || len(value) != 2 {
+		return false
+	}
+	_, hasName := value["name"]
+	_, hasArguments := value["arguments"]
+	return hasName && hasArguments
 }
 
 func callSynchronizedEvidenceCapture(

--- a/mcp/synchronized_evidence.go
+++ b/mcp/synchronized_evidence.go
@@ -1,0 +1,131 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/syncevidence"
+)
+
+const synchronizedEvidenceCaptureToolName = "helianthus.v1.synchronized_evidence.capture"
+
+type SynchronizedEvidenceCapture interface {
+	CaptureSynchronizedEvidence(context.Context) syncevidence.OneShotReceiptV1
+}
+
+func (server *Server) RegisterSynchronizedEvidenceCapture(capture SynchronizedEvidenceCapture) error {
+	if server == nil {
+		return errors.New("MCP server is nil")
+	}
+	if nilSynchronizedEvidenceCapture(capture) {
+		return errors.New("synchronized evidence capture is nil")
+	}
+	server.eebusV1Mu.Lock()
+	defer server.eebusV1Mu.Unlock()
+	if server.synchronizedEvidenceCapture != nil {
+		return errors.New("synchronized evidence capture is already registered")
+	}
+	server.synchronizedEvidenceCapture = capture
+	return nil
+}
+
+func nilSynchronizedEvidenceCapture(capture SynchronizedEvidenceCapture) bool {
+	if capture == nil {
+		return true
+	}
+	value := reflect.ValueOf(capture)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
+func synchronizedEvidenceCaptureTool() Tool {
+	return Tool{
+		Name:        synchronizedEvidenceCaptureToolName,
+		Description: "Capture the fixed owner-only synchronized evidence request.",
+		InputSchema: map[string]any{
+			"type":                 "object",
+			"properties":           map[string]any{},
+			"additionalProperties": false,
+			"maxProperties":        0,
+		},
+	}
+}
+
+func (server *Server) handleSynchronizedEvidenceCaptureRaw(
+	ctx context.Context,
+	arguments json.RawMessage,
+	hasDuplicateKeys bool,
+) (any, *rpcError) {
+	if eebusV1BoundaryFromContext(ctx) != eebusV1OperatorBoundary {
+		return nil, rpcErrorInvalidParams(fmt.Sprintf("unknown tool %q", synchronizedEvidenceCaptureToolName))
+	}
+	server.eebusV1Mu.RLock()
+	capture := server.synchronizedEvidenceCapture
+	server.eebusV1Mu.RUnlock()
+	if nilSynchronizedEvidenceCapture(capture) {
+		return nil, rpcErrorInvalidParams(fmt.Sprintf("unknown tool %q", synchronizedEvidenceCaptureToolName))
+	}
+	if hasDuplicateKeys || !synchronizedEvidenceEmptyArgs(arguments) {
+		receipt := syncevidence.OneShotReceiptV1{Category: syncevidence.OneShotInvalidRequest}
+		return callToolResultText(mustJSON(receipt), true), nil
+	}
+	receipt := callSynchronizedEvidenceCapture(ctx, capture)
+	if !validSynchronizedEvidenceReceipt(receipt.Category) {
+		receipt = syncevidence.OneShotReceiptV1{Category: syncevidence.OneShotInternal}
+	}
+	isError := receipt.Category != syncevidence.OneShotPublished &&
+		receipt.Category != syncevidence.OneShotExisting
+	return callToolResultText(mustJSON(receipt), isError), nil
+}
+
+func synchronizedEvidenceEmptyArgs(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	var value map[string]json.RawMessage
+	if err := decoder.Decode(&value); err != nil || value == nil || len(value) != 0 {
+		return false
+	}
+	return errors.Is(decoder.Decode(&struct{}{}), io.EOF)
+}
+
+func callSynchronizedEvidenceCapture(
+	ctx context.Context,
+	capture SynchronizedEvidenceCapture,
+) (receipt syncevidence.OneShotReceiptV1) {
+	receipt = syncevidence.OneShotReceiptV1{Category: syncevidence.OneShotInternal}
+	defer func() {
+		if recover() != nil {
+			receipt = syncevidence.OneShotReceiptV1{Category: syncevidence.OneShotInternal}
+		}
+	}()
+	return capture.CaptureSynchronizedEvidence(ctx)
+}
+
+func validSynchronizedEvidenceReceipt(category syncevidence.OneShotReceiptCategory) bool {
+	switch category {
+	case syncevidence.OneShotPublished,
+		syncevidence.OneShotExisting,
+		syncevidence.OneShotInvalidRequest,
+		syncevidence.OneShotPermissionDenied,
+		syncevidence.OneShotConflict,
+		syncevidence.OneShotAcquisitionFailed,
+		syncevidence.OneShotReplayMismatch,
+		syncevidence.OneShotPublishFailed,
+		syncevidence.OneShotInternal:
+		return true
+	default:
+		return false
+	}
+}

--- a/mcp/synchronized_evidence_one_shot_test.go
+++ b/mcp/synchronized_evidence_one_shot_test.go
@@ -1,8 +1,11 @@
 package mcp
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"strings"
 	"testing"
@@ -18,6 +21,30 @@ type issue764CaptureProvider struct {
 func (provider *issue764CaptureProvider) CaptureSynchronizedEvidence(context.Context) syncevidence.OneShotReceiptV1 {
 	provider.calls++
 	return provider.receipt
+}
+
+func issue764RawCaptureCall(
+	t *testing.T,
+	handler http.Handler,
+	params json.RawMessage,
+) msp06CallResult {
+	t.Helper()
+	response := doRPC(t, handler, rpcRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "tools/call",
+		Params:  params,
+	})
+	if response.Error != nil {
+		t.Fatalf("capture RPC error = %+v", response.Error)
+	}
+	result := msp06Map(t, response.Result, "result")
+	content := msp06Slice(t, result["content"], "result.content")
+	if len(content) != 1 {
+		t.Fatalf("capture content count = %d", len(content))
+	}
+	raw, _ := msp06Map(t, content[0], "content[0]")["text"].(string)
+	return msp06CallResult{raw: raw, isError: result["isError"] == true}
 }
 
 func TestIssue764PrivateCaptureToolIsAbsentFromPublicInventoryAndDispatch(t *testing.T) {
@@ -82,6 +109,62 @@ func TestIssue764PrivateCaptureToolAcceptsOnlyEmptyArgsAndReturnsCategoryOnly(t 
 	invalid := msp06Call(t, operator, synchronizedEvidenceCaptureToolName, map[string]any{"target": "forbidden"})
 	if invalid.raw != `{"category":"INVALID_REQUEST"}` || !invalid.isError || provider.calls != 1 {
 		t.Fatalf("invalid call result=%q error=%v calls=%d", invalid.raw, invalid.isError, provider.calls)
+	}
+}
+
+func TestIssue764PrivateCaptureToolRejectsUnknownCallParams(t *testing.T) {
+	server, _ := msp06TestServer(t, &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")})
+	provider := &issue764CaptureProvider{
+		receipt: syncevidence.OneShotReceiptV1{Category: syncevidence.OneShotPublished},
+	}
+	if err := server.RegisterSynchronizedEvidenceCapture(provider); err != nil {
+		t.Fatal(err)
+	}
+	params, err := json.Marshal(map[string]any{
+		"name":          synchronizedEvidenceCaptureToolName,
+		"arguments":     map[string]any{},
+		"candidate_ref": "forbidden",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := issue764RawCaptureCall(t, issue743OperatorHandler(t, server), params)
+	if result.raw != `{"category":"INVALID_REQUEST"}` || !result.isError || provider.calls != 0 {
+		t.Fatalf("unknown-param result=%q error=%v calls=%d", result.raw, result.isError, provider.calls)
+	}
+}
+
+func TestIssue764PrivateCaptureToolRejectsBodyLargerThanOneMiB(t *testing.T) {
+	server, _ := msp06TestServer(t, &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")})
+	provider := &issue764CaptureProvider{
+		receipt: syncevidence.OneShotReceiptV1{Category: syncevidence.OneShotPublished},
+	}
+	if err := server.RegisterSynchronizedEvidenceCapture(provider); err != nil {
+		t.Fatal(err)
+	}
+	params, err := json.Marshal(map[string]any{
+		"name": synchronizedEvidenceCaptureToolName, "arguments": map[string]any{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := json.Marshal(rpcRequest{
+		JSONRPC: "2.0", ID: 1, Method: "tools/call", Params: params,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const oversizedBodyBytes = (1 << 20) + 1
+	body = append(body, bytes.Repeat([]byte{' '}, oversizedBodyBytes-len(body))...)
+	request := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader(body))
+	recorder := httptest.NewRecorder()
+	issue743OperatorHandler(t, server).ServeHTTP(recorder, request)
+	var response rpcResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode oversized response: %v; body=%q", err, recorder.Body.String())
+	}
+	if response.Error == nil || provider.calls != 0 {
+		t.Fatalf("oversized response=%#v provider_calls=%d", response, provider.calls)
 	}
 }
 

--- a/mcp/synchronized_evidence_one_shot_test.go
+++ b/mcp/synchronized_evidence_one_shot_test.go
@@ -1,0 +1,115 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/syncevidence"
+)
+
+type issue764CaptureProvider struct {
+	calls   int
+	receipt syncevidence.OneShotReceiptV1
+}
+
+func (provider *issue764CaptureProvider) CaptureSynchronizedEvidence(context.Context) syncevidence.OneShotReceiptV1 {
+	provider.calls++
+	return provider.receipt
+}
+
+func TestIssue764PrivateCaptureToolIsAbsentFromPublicInventoryAndDispatch(t *testing.T) {
+	server, _ := msp06TestServer(t, &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")})
+	publicBefore := doRPC(t, server.Handler(), rpcRequest{JSONRPC: "2.0", ID: 1, Method: "tools/list"})
+	provider := &issue764CaptureProvider{
+		receipt: syncevidence.OneShotReceiptV1{Category: syncevidence.OneShotPublished},
+	}
+	if err := server.RegisterSynchronizedEvidenceCapture(provider); err != nil {
+		t.Fatalf("register capture: %v", err)
+	}
+	publicAfter := doRPC(t, server.Handler(), rpcRequest{JSONRPC: "2.0", ID: 1, Method: "tools/list"})
+	if !reflect.DeepEqual(publicAfter.Result, publicBefore.Result) {
+		t.Fatal("private registration changed public tools/list")
+	}
+	publicRaw, err := json.Marshal(publicAfter.Result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(publicRaw), synchronizedEvidenceCaptureToolName) {
+		t.Fatalf("public tools/list leaked private tool: %s", publicRaw)
+	}
+
+	params, err := json.Marshal(map[string]any{
+		"name": synchronizedEvidenceCaptureToolName, "arguments": map[string]any{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	publicCall := doRPC(t, server.Handler(), rpcRequest{
+		JSONRPC: "2.0", ID: 2, Method: "tools/call", Params: params,
+	})
+	if publicCall.Error == nil || provider.calls != 0 {
+		t.Fatalf("public dispatch response=%#v provider_calls=%d", publicCall, provider.calls)
+	}
+
+	operatorList := doRPC(t, issue743OperatorHandler(t, server), rpcRequest{
+		JSONRPC: "2.0", ID: 3, Method: "tools/list",
+	})
+	operatorRaw, err := json.Marshal(operatorList.Result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count := strings.Count(string(operatorRaw), synchronizedEvidenceCaptureToolName); count != 1 {
+		t.Fatalf("operator tool count = %d: %s", count, operatorRaw)
+	}
+}
+
+func TestIssue764PrivateCaptureToolAcceptsOnlyEmptyArgsAndReturnsCategoryOnly(t *testing.T) {
+	server, _ := msp06TestServer(t, &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")})
+	provider := &issue764CaptureProvider{
+		receipt: syncevidence.OneShotReceiptV1{Category: syncevidence.OneShotExisting},
+	}
+	if err := server.RegisterSynchronizedEvidenceCapture(provider); err != nil {
+		t.Fatal(err)
+	}
+	operator := issue743OperatorHandler(t, server)
+	result := msp06Call(t, operator, synchronizedEvidenceCaptureToolName, map[string]any{})
+	if result.raw != `{"category":"EXISTING"}` || result.isError || provider.calls != 1 {
+		t.Fatalf("valid call result=%q error=%v calls=%d", result.raw, result.isError, provider.calls)
+	}
+	invalid := msp06Call(t, operator, synchronizedEvidenceCaptureToolName, map[string]any{"target": "forbidden"})
+	if invalid.raw != `{"category":"INVALID_REQUEST"}` || !invalid.isError || provider.calls != 1 {
+		t.Fatalf("invalid call result=%q error=%v calls=%d", invalid.raw, invalid.isError, provider.calls)
+	}
+}
+
+func TestIssue764PrivateCaptureRegistrationAndReceiptFailClosed(t *testing.T) {
+	server, _ := msp06TestServer(t, &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")})
+	var typedNil *issue764CaptureProvider
+	if err := server.RegisterSynchronizedEvidenceCapture(nil); err == nil {
+		t.Fatal("nil capture provider registered")
+	}
+	if err := server.RegisterSynchronizedEvidenceCapture(typedNil); err == nil {
+		t.Fatal("typed-nil capture provider registered")
+	}
+	provider := &issue764CaptureProvider{
+		receipt: syncevidence.OneShotReceiptV1{Category: "raw-evidence-forbidden"},
+	}
+	if err := server.RegisterSynchronizedEvidenceCapture(provider); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.RegisterSynchronizedEvidenceCapture(&issue764CaptureProvider{}); err == nil {
+		t.Fatal("second capture provider registered")
+	}
+	result := msp06Call(
+		t,
+		issue743OperatorHandler(t, server),
+		synchronizedEvidenceCaptureToolName,
+		map[string]any{},
+	)
+	if result.raw != `{"category":"INTERNAL"}` || !result.isError {
+		t.Fatalf("invalid provider receipt escaped: %q", result.raw)
+	}
+}

--- a/smoke.go
+++ b/smoke.go
@@ -628,7 +628,7 @@ func smokeMethodNeedsParams(method registry.Method) bool {
 
 func newGatewayWithTransport(ctx context.Context, cfg Config, wrap func(transport.RawTransport) transport.RawTransport) (*Gateway, error) {
 	cfg = applyDefaults(cfg)
-	if err := ValidateEvidenceRecorderConfig(cfg.EvidenceRecorderConfig); err != nil {
+	if err := ValidateSynchronizedEvidenceConfig(cfg); err != nil {
 		return nil, fmt.Errorf("validate gateway config: %w", err)
 	}
 


### PR DESCRIPTION
## What
Implement the M6.25 one-shot synchronized evidence recorder for gateway issue #764.

## Why
This consumes the frozen public-redacted M6.25 tuple and the canonical one-shot control contract after raw eeBUS/SPINE acquisition, without exposing the private capture tool on public HTTP/LAN surfaces.

## Changes
- preserve the historical source-registry entry byte-for-byte while adding tuple-keyed M6.25 authority
- securely load the fixed owner-provisioned request from `/data/synchronized-evidence/one-shot-request-v1.json`
- acquire eligible eeBUS server READ features in native order, with bounded 16-target batches
- produce the five-source synchronized bundle and deterministic replay artifacts
- publish restart-safe/idempotent receipts and reject incompatible retained legacy bundles
- expose `helianthus.v1.synchronized_evidence.capture` only through the same-UID AF_UNIX operator boundary
- keep GraphQL, Portal, HA, semantic registry, eBUS transport/protocol, and public MCP inventory unchanged

## Security and correctness
- exact `0700/0600`, owner, regular-file, link-count and descriptor-relative no-follow checks
- metadata/content TOCTOU binding across both Darwin and Linux
- cloud `SHA256_CONTENT_BYTES` recomputed from exact canonical normalized evidence
- native tuple order retained through pseudonymization/remasking
- unknown fields, `candidate_ref`, and bodies over 1 MiB rejected on the private closed tool
- retained `EXISTING` bundles revalidate cloud bytes against the action digest

## Validation
- strict RED/GREEN history retained
- `./scripts/ci_local.sh`: PASS on `02e2e72543f89259fbbe84a9358733c71af1eac4`
- full `go test -race -count=1 ./...`: PASS
- `go vet ./...`, `go build ./...`, portal assets: PASS
- Python gates: 168 + 5 + 7 + 5 PASS
- `golangci-lint run ./...`: 0 issues
- Linux ARM64 cross-compilation for the changed runtime packages: PASS
- embedded schemas are byte-identical to docs merge `777954d1dea586409827116f2a0eb887ee5cd4f4`

The repository transport/passive gates conservatively trigger on any non-rename `cmd/gateway/main.go` diff. The owner overrides were used with written reasons: this PR adds only owner-only synchronized-evidence MCP/runtime registration and changes no transport, protocol, framing, adaptermux, passive acquisition, deduplication, or bus behavior.

## Dependencies
- Execution-plan main: `87dbd047d930894c80bb029f98ba900f8343fa8d`
- Canonical docs: Project-Helianthus/helianthus-docs-ebus#384, merge `777954d1dea586409827116f2a0eb887ee5cd4f4`
- eeBUS/SPINE runtime baseline: #763, merge `1a02388170a1ee6befeed1529956a7104aa94e21`

## Remaining acceptance
- [ ] restore physical `ens://192.168.100.2:9999` and active eBUS registry
- [ ] deploy exact ARM64 PR head to `192.168.100.4`
- [ ] run one fresh myVaillant cloud capture and owner-only one-shot invocation
- [ ] prove five-source bundle/replay hashes and public anti-leak
- [ ] restart and prove `EXISTING` without new acquisition

Closes #764 after live acceptance.