### PR TITLE
M6.25: preserve typed-empty raw read terminal (#766)

### DIFF
--- a/cmd/gateway/eebus_operator_boundary_red_test.go
+++ b/cmd/gateway/eebus_operator_boundary_red_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 )
 
-func TestIssue762ReleasedDependencyClosurePinsEEBusregV0126(t *testing.T) {
+func TestIssue762ReleasedDependencyClosurePinsEEBusregV0127(t *testing.T) {
 	goMod, err := os.Open("../../go.mod")
 	if err != nil {
 		t.Fatal(err)
@@ -33,8 +33,8 @@ func TestIssue762ReleasedDependencyClosurePinsEEBusregV0126(t *testing.T) {
 	if err := scanner.Err(); err != nil {
 		t.Fatal(err)
 	}
-	if len(versions) != 1 || versions[0] != "v0.1.26" {
-		t.Fatalf("%s versions = %v, want exactly [v0.1.26]", module, versions)
+	if len(versions) != 1 || versions[0] != "v0.1.27" {
+		t.Fatalf("%s versions = %v, want exactly [v0.1.27]", module, versions)
 	}
 }
 

--- a/eebusreg_v0114_contract_test.go
+++ b/eebusreg_v0114_contract_test.go
@@ -36,7 +36,7 @@ func TestIssue762ReleasedEEBusDependencyClosure(t *testing.T) {
 	}
 
 	want := map[string]string{
-		eebusregModule: "v0.1.26",
+		eebusregModule: "v0.1.27",
 		eebusgoModule:  "v0.7.1-helianthus.12",
 		shipgoModule:   "v0.6.1-helianthus.10",
 		spinegoModule:  "v0.7.1-helianthus.8",

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260521144203-f9919f4b1007
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2
-	github.com/Project-Helianthus/helianthus-eebusreg v0.1.26
+	github.com/Project-Helianthus/helianthus-eebusreg v0.1.27
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e4
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
 github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.12 h1:gC32YG1YLUy4dIzLlpVnB6axwvCMhKz4ZL2ldi5oWTY=
 github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.12/go.mod h1:52AWmDxL2xEtgH7nd94RnuH7L104naGtKMr1ksmO1ZI=
-github.com/Project-Helianthus/helianthus-eebusreg v0.1.26 h1:JCSf3aITaDOZCG/kMP0fls8Fiz70sDl+WTmMuY61iT0=
-github.com/Project-Helianthus/helianthus-eebusreg v0.1.26/go.mod h1:XKQ7wjc5lA9xda7oFeBOx9pq+HOUqy2Dm7Bpli5p9mA=
+github.com/Project-Helianthus/helianthus-eebusreg v0.1.27 h1:/GFDYQyqsELj+WvXmdEK3Cp19WEQiguen+x+0VKVk5k=
+github.com/Project-Helianthus/helianthus-eebusreg v0.1.27/go.mod h1:XKQ7wjc5lA9xda7oFeBOx9pq+HOUqy2Dm7Bpli5p9mA=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.10 h1:b3qVTiG808qS5v0NdUNwZHzWhHFUjvbzxYMGSCPun1g=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.10/go.mod h1:qPqQTDqmPjyOJCr0JMNjhSC1XW1k3h5P/EZqRGy80Vs=
 github.com/Project-Helianthus/helianthus-spine-go v0.7.1-helianthus.8 h1:afLO/7dI9y8KoZgt0pgA4KemD8AH9Vi0rw7QOvYOm34=

--- a/mcp/eebus_v1_commands.go
+++ b/mcp/eebus_v1_commands.go
@@ -480,6 +480,11 @@ func eebusV1ValidateCommandOutcome(
 	terminal *eebusraw.ErrorV1,
 	outcomeRuntime *eebusraw.RuntimeBindingV1,
 ) (*eebusraw.RuntimeBindingV1, *eebusraw.ErrorV1) {
+	if terminal != nil &&
+		terminal.Code == eebusraw.ErrorCodeV1TypedEmpty &&
+		tool != eebusraw.ToolV1FeaturesDataGet {
+		return nil, eebusV1ContractViolation()
+	}
 	switch tool {
 	case eebusraw.ToolV1FeaturesGet:
 		if outcomeRuntime != nil {

--- a/mcp/eebus_v1_commands.go
+++ b/mcp/eebus_v1_commands.go
@@ -511,7 +511,9 @@ func eebusV1ValidateCommandOutcome(
 			if !reflect.ValueOf(typedData).IsZero() {
 				return nil, eebusV1ContractViolation()
 			}
-			if !eebusV1UnboundTerminalSourceAllowed(terminal.SourceLayer) {
+			if !eebusV1UnboundTerminalSourceAllowed(terminal.SourceLayer) &&
+				!(terminal.Code == eebusraw.ErrorCodeV1TypedEmpty &&
+					terminal.SourceLayer == eebusraw.SourceLayerV1Remote) {
 				return nil, eebusV1ContractViolation()
 			}
 			return nil, nil
@@ -567,8 +569,7 @@ func eebusV1UnboundTerminalSourceAllowed(layer eebusraw.SourceLayerV1) bool {
 	case "mcp",
 		"gateway-router",
 		"eebusreg-runtime",
-		"eebusreg-coordinator",
-		"remote":
+		"eebusreg-coordinator":
 		return true
 	default:
 		return false

--- a/mcp/eebus_v1_commands.go
+++ b/mcp/eebus_v1_commands.go
@@ -511,9 +511,14 @@ func eebusV1ValidateCommandOutcome(
 			if !reflect.ValueOf(typedData).IsZero() {
 				return nil, eebusV1ContractViolation()
 			}
-			if !eebusV1UnboundTerminalSourceAllowed(terminal.SourceLayer) &&
-				!(terminal.Code == eebusraw.ErrorCodeV1TypedEmpty &&
-					terminal.SourceLayer == eebusraw.SourceLayerV1Remote) {
+			if terminal.Code == eebusraw.ErrorCodeV1TypedEmpty {
+				if terminal.SourceLayer != eebusraw.SourceLayerV1Remote ||
+					terminal.Retriable {
+					return nil, eebusV1ContractViolation()
+				}
+				return nil, nil
+			}
+			if !eebusV1UnboundTerminalSourceAllowed(terminal.SourceLayer) {
 				return nil, eebusV1ContractViolation()
 			}
 			return nil, nil

--- a/mcp/eebus_v1_commands.go
+++ b/mcp/eebus_v1_commands.go
@@ -567,7 +567,8 @@ func eebusV1UnboundTerminalSourceAllowed(layer eebusraw.SourceLayerV1) bool {
 	case "mcp",
 		"gateway-router",
 		"eebusreg-runtime",
-		"eebusreg-coordinator":
+		"eebusreg-coordinator",
+		"remote":
 		return true
 	default:
 		return false
@@ -686,6 +687,7 @@ func eebusV1KnownErrorCode(code eebusraw.ErrorCodeV1) bool {
 		eebusraw.ErrorCodeV1Timeout,
 		eebusraw.ErrorCodeV1Cancelled,
 		eebusraw.ErrorCodeV1RemoteError,
+		eebusraw.ErrorCodeV1TypedEmpty,
 		eebusraw.ErrorCodeV1DecodeError,
 		eebusraw.ErrorCodeV1PartialResult,
 		eebusraw.ErrorCodeV1OutcomeUnknown,

--- a/mcp/eebus_v1_typed_empty_red_test.go
+++ b/mcp/eebus_v1_typed_empty_red_test.go
@@ -1,0 +1,94 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-eebusreg/eebusraw"
+)
+
+func TestIssue766TypedEmptyKeepsTheReleasedRawReadTerminalContract(t *testing.T) {
+	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+	server, _ := msp06TestServer(t, provider)
+	router := &issue749TypedRouter{
+		dataGetError: eebusraw.NewErrorV1(
+			eebusraw.ErrorCodeV1TypedEmpty,
+			"raw READ response contained valid empty typed data",
+			false,
+			eebusraw.SourceLayerV1Remote,
+		),
+	}
+	if err := server.RegisterEEBusV1CommandRouter(router); err != nil {
+		t.Fatal(err)
+	}
+
+	command := issue749CommandCases(t)[1]
+	result := msp06Call(t, issue743OperatorHandler(t, server), command.tool, command.arguments)
+	if !result.isError || result.envelope["data"] != nil {
+		t.Fatalf("typed-empty envelope = %#v", result.envelope)
+	}
+	errorData := msp06Map(t, result.envelope["error"], "typed-empty error")
+	if errorData["code"] != string(eebusraw.ErrorCodeV1TypedEmpty) ||
+		errorData["retriable"] != false ||
+		errorData["source_layer"] != string(eebusraw.SourceLayerV1Remote) {
+		t.Fatalf("typed-empty terminal = %#v", errorData)
+	}
+	for _, forbidden := range []string{"read_token", "before", "mutation_ref", "continuation"} {
+		if strings.Contains(result.raw, forbidden) {
+			t.Fatalf("typed-empty terminal leaked %q: %s", forbidden, result.raw)
+		}
+	}
+}
+
+func TestIssue766MixedTypedEmptyRemainsPartialResult(t *testing.T) {
+	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+	server, _ := msp06TestServer(t, provider)
+	command := issue749CommandCases(t)[1]
+	arguments := cloneIssue749Arguments(t, command.arguments)
+	targets := arguments["targets"].([]any)
+	second := cloneIssue749Arguments(t, targets[0].(map[string]any))
+	second["feature_address"] = float64(3)
+	arguments["targets"] = append(targets, second)
+	request := issue749DecodeArguments[eebusraw.FeatureDataGetRequestV1](t, arguments)
+	binding := eebusraw.RuntimeBindingV1{RuntimeEpoch: 7, ConnectionGeneration: 3}
+	data := issue749PartialData(t, request, binding)
+	data.Failures[0].Error = *eebusraw.NewErrorV1(
+		eebusraw.ErrorCodeV1TypedEmpty,
+		"raw READ response contained valid empty typed data",
+		false,
+		eebusraw.SourceLayerV1Remote,
+	)
+	router := &issue749TypedRouter{
+		dataGetData: data,
+		dataGetError: eebusraw.NewErrorV1(
+			eebusraw.ErrorCodeV1PartialResult,
+			"fixed partial result",
+			false,
+			eebusraw.SourceLayerV1Runtime,
+		),
+	}
+	if err := server.RegisterEEBusV1CommandRouter(router); err != nil {
+		t.Fatal(err)
+	}
+
+	result := msp06Call(t, issue743OperatorHandler(t, server), command.tool, arguments)
+	if !result.isError || result.envelope["data"] == nil ||
+		issue749EnvelopeErrorCode(t, result.envelope) != string(eebusraw.ErrorCodeV1PartialResult) {
+		t.Fatalf("mixed typed-empty envelope = %#v", result.envelope)
+	}
+	dataEnvelope := msp06Map(t, result.envelope["data"], "mixed typed-empty data")
+	if dataEnvelope["complete"] != false {
+		t.Fatalf("mixed typed-empty complete = %#v, want false", dataEnvelope["complete"])
+	}
+	failures, ok := dataEnvelope["failures"].([]any)
+	if !ok || len(failures) != 1 {
+		t.Fatalf("mixed typed-empty failures = %#v", dataEnvelope["failures"])
+	}
+	failure := msp06Map(t, failures[0], "mixed typed-empty failure")
+	failureError := msp06Map(t, failure["error"], "mixed typed-empty failure error")
+	if failureError["code"] != string(eebusraw.ErrorCodeV1TypedEmpty) ||
+		failureError["retriable"] != false ||
+		failureError["source_layer"] != string(eebusraw.SourceLayerV1Remote) {
+		t.Fatalf("mixed typed-empty failure terminal = %#v", failureError)
+	}
+}

--- a/mcp/eebus_v1_typed_empty_red_test.go
+++ b/mcp/eebus_v1_typed_empty_red_test.go
@@ -40,6 +40,53 @@ func TestIssue766TypedEmptyKeepsTheReleasedRawReadTerminalContract(t *testing.T)
 	}
 }
 
+func TestIssue766TypedEmptyFailsClosedUnlessNonRetriableRemote(t *testing.T) {
+	command := issue749CommandCases(t)[1]
+	tests := []struct {
+		name      string
+		retriable bool
+		source    eebusraw.SourceLayerV1
+	}{
+		{
+			name:   "runtime source",
+			source: eebusraw.SourceLayerV1Runtime,
+		},
+		{
+			name:      "retriable remote",
+			retriable: true,
+			source:    eebusraw.SourceLayerV1Remote,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+			server, _ := msp06TestServer(t, provider)
+			router := &issue749TypedRouter{
+				dataGetError: eebusraw.NewErrorV1(
+					eebusraw.ErrorCodeV1TypedEmpty,
+					"raw READ response contained valid empty typed data",
+					test.retriable,
+					test.source,
+				),
+			}
+			if err := server.RegisterEEBusV1CommandRouter(router); err != nil {
+				t.Fatal(err)
+			}
+
+			result := msp06Call(t, issue743OperatorHandler(t, server), command.tool, command.arguments)
+			if !result.isError || result.envelope["data"] != nil {
+				t.Fatalf("malformed typed-empty envelope = %#v", result.envelope)
+			}
+			errorData := msp06Map(t, result.envelope["error"], "malformed typed-empty error")
+			if errorData["code"] != string(eebusraw.ErrorCodeV1Internal) ||
+				errorData["retriable"] != false ||
+				errorData["source_layer"] != string(eebusV1SourceLayerGatewayRouter) {
+				t.Fatalf("malformed typed-empty terminal = %#v", errorData)
+			}
+		})
+	}
+}
+
 func TestIssue766MixedTypedEmptyRemainsPartialResult(t *testing.T) {
 	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
 	server, _ := msp06TestServer(t, provider)

--- a/mcp/eebus_v1_typed_empty_red_test.go
+++ b/mcp/eebus_v1_typed_empty_red_test.go
@@ -87,6 +87,60 @@ func TestIssue766TypedEmptyFailsClosedUnlessNonRetriableRemote(t *testing.T) {
 	}
 }
 
+func TestIssue766TypedEmptyIsFeatureDataGetOnly(t *testing.T) {
+	commandCases := issue749CommandCases(t)
+	tests := []struct {
+		name      string
+		command   issue749CommandCase
+		configure func(*issue749TypedRouter, *eebusraw.ErrorV1)
+	}{
+		{
+			name:    "features get",
+			command: commandCases[0],
+			configure: func(router *issue749TypedRouter, terminal *eebusraw.ErrorV1) {
+				router.featuresGetError = terminal
+			},
+		},
+		{
+			name:    "mutation get",
+			command: commandCases[3],
+			configure: func(router *issue749TypedRouter, terminal *eebusraw.ErrorV1) {
+				router.mutationError = terminal
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
+			server, _ := msp06TestServer(t, provider)
+			router := &issue749TypedRouter{}
+			test.configure(router, eebusraw.NewErrorV1(
+				eebusraw.ErrorCodeV1TypedEmpty,
+				"typed-empty is invalid for this tool",
+				false,
+				eebusraw.SourceLayerV1Runtime,
+			))
+			if err := server.RegisterEEBusV1CommandRouter(router); err != nil {
+				t.Fatal(err)
+			}
+
+			result := msp06Call(
+				t,
+				issue743OperatorHandler(t, server),
+				test.command.tool,
+				test.command.arguments,
+			)
+			issue755AssertTerminalEnvelope(
+				t,
+				result.envelope,
+				eebusraw.ErrorCodeV1Internal,
+				eebusV1SourceLayerGatewayRouter,
+				nil,
+			)
+		})
+	}
+}
+
 func TestIssue766MixedTypedEmptyRemainsPartialResult(t *testing.T) {
 	provider := &msp06Provider{snapshot: msp06Snapshot(t, "runtime-a")}
 	server, _ := msp06TestServer(t, provider)


### PR DESCRIPTION
## What

Tests the released typed-empty raw eeBUS read terminal contract at the gateway boundary.

## Why

M6.25-R-TYPED-EMPTY requires the gateway to consume the eebusreg v0.1.27 typed-empty result without widening the public surface.

## Acceptance Criteria

- [x] Tests-only RED commit proves v0.1.26 lacks the released typed-empty contract
- [ ] Pin exactly `github.com/Project-Helianthus/helianthus-eebusreg v0.1.27` after RED authorization
- [ ] Focused contract tests green
- [ ] CI green
- [ ] Smoke test required: NO

## Dependencies

- Refs #766

RED evidence: `GOWORK=off go test ./mcp -run '^TestIssue766' -count=1` fails to compile because v0.1.26 does not export `eebusraw.ErrorCodeV1TypedEmpty`.