### PR TITLE
Restore Linux 32-bit timestamp compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,10 @@ jobs:
       - run: ./scripts/check_portal_assets.sh
       - run: go vet ./...
       - run: go build ./...
+      - name: Compile Linux 32-bit sync evidence
+        run: |
+          GOOS=linux GOARCH=386 go test -c -o /dev/null ./internal/syncevidence
+          GOOS=linux GOARCH=arm GOARM=7 go test -c -o /dev/null ./internal/syncevidence
 
   test:
     runs-on: ubuntu-latest

--- a/internal/syncevidence/oneshot_request_times_linux.go
+++ b/internal/syncevidence/oneshot_request_times_linux.go
@@ -5,5 +5,5 @@ package syncevidence
 import "golang.org/x/sys/unix"
 
 func oneShotRequestChangeTimes(stat unix.Stat_t) (int64, int64, int64, int64) {
-	return stat.Mtim.Sec, stat.Mtim.Nsec, stat.Ctim.Sec, stat.Ctim.Nsec
+	return int64(stat.Mtim.Sec), int64(stat.Mtim.Nsec), int64(stat.Ctim.Sec), int64(stat.Ctim.Nsec)
 }

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -32,6 +32,10 @@ go vet ./...
 echo "==> go build"
 go build ./...
 
+echo "==> linux 32-bit build"
+GOOS=linux GOARCH=386 go test -c -o /dev/null ./internal/syncevidence
+GOOS=linux GOARCH=arm GOARM=7 go test -c -o /dev/null ./internal/syncevidence
+
 echo "==> go test (race)"
 go test -race -count=1 ./...
 


### PR DESCRIPTION
Closes #774.

## Change

- Convert Linux `Stat_t` timestamp components explicitly to `int64`, preserving the existing helper contract on both 32-bit and 64-bit targets.
- Add Linux/386 and Linux/armv7 compile guards to the authoritative local CI.

## Validation

- RED reproduced on `GOOS=linux GOARCH=386` before the fix.
- Linux/386, Linux/armv6, and Linux/armv7 cross-compiles pass.
- Native `internal/syncevidence` tests pass.
- Full `./scripts/ci_local.sh` passes, including race tests, 185 Python tests, lint, and the new cross-build gate.
- Transport gate: not triggered.
- Docs gate: not triggered; this is a portability-only implementation correction with no protocol, semantic, API, or architecture contract change.

Downstream failure: Home Assistant add-on build run `31341083048`.