### PR TITLE
Complete full gateway Linux 32-bit compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,11 @@ jobs:
       - run: ./scripts/check_portal_assets.sh
       - run: go vet ./...
       - run: go build ./...
-      - name: Compile Linux 32-bit sync evidence
+      - name: Compile Linux 32-bit gateway
         run: |
-          GOOS=linux GOARCH=386 go test -c -o /dev/null ./internal/syncevidence
-          GOOS=linux GOARCH=arm GOARM=7 go test -c -o /dev/null ./internal/syncevidence
+          GOOS=linux GOARCH=386 go build -o /dev/null ./cmd/gateway
+          GOOS=linux GOARCH=arm GOARM=7 go build -o /dev/null ./cmd/gateway
+          GOOS=linux GOARCH=arm GOARM=6 go build -o /dev/null ./cmd/gateway
 
   test:
     runs-on: ubuntu-latest

--- a/cmd/gateway/eebus_mutation_lab_profile_linux.go
+++ b/cmd/gateway/eebus_mutation_lab_profile_linux.go
@@ -204,9 +204,9 @@ func mutationLabFileIdentity(stat unix.Stat_t) eebusMutationLabFileIdentity {
 		uid:          stat.Uid,
 		linkCount:    uint64(stat.Nlink),
 		size:         stat.Size,
-		changeSec:    stat.Ctim.Sec,
-		changeNsec:   stat.Ctim.Nsec,
-		modifiedSec:  stat.Mtim.Sec,
-		modifiedNsec: stat.Mtim.Nsec,
+		changeSec:    int64(stat.Ctim.Sec),
+		changeNsec:   int64(stat.Ctim.Nsec),
+		modifiedSec:  int64(stat.Mtim.Sec),
+		modifiedNsec: int64(stat.Mtim.Nsec),
 	}
 }

--- a/mcp/eebus_v1_socket_linux.go
+++ b/mcp/eebus_v1_socket_linux.go
@@ -170,7 +170,7 @@ func (parent *eebusV1PinnedParent) statChild() (eebusV1SocketIdentity, error) {
 	}
 	return eebusV1SocketIdentity{
 		device: uint64(stat.Dev), inode: stat.Ino, mode: stat.Mode, uid: stat.Uid,
-		ctimeS: stat.Ctim.Sec, ctimeN: stat.Ctim.Nsec,
+		ctimeS: int64(stat.Ctim.Sec), ctimeN: int64(stat.Ctim.Nsec),
 	}, nil
 }
 

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -33,8 +33,9 @@ echo "==> go build"
 go build ./...
 
 echo "==> linux 32-bit build"
-GOOS=linux GOARCH=386 go test -c -o /dev/null ./internal/syncevidence
-GOOS=linux GOARCH=arm GOARM=7 go test -c -o /dev/null ./internal/syncevidence
+GOOS=linux GOARCH=386 go build -o /dev/null ./cmd/gateway
+GOOS=linux GOARCH=arm GOARM=7 go build -o /dev/null ./cmd/gateway
+GOOS=linux GOARCH=arm GOARM=6 go build -o /dev/null ./cmd/gateway
 
 echo "==> go test (race)"
 go test -race -count=1 ./...


### PR DESCRIPTION
Closes #776.

## Change

- Preserve Linux socket and mutation-lab file ctime/mtime identity values through explicit `int64` conversion on 32-bit targets.
- Replace package-only cross-compile guards with full `cmd/gateway` builds for Linux/386, ARMv7, and ARMv6 in both local and hosted CI.

## Validation

- RED: full Linux/386 gateway build failed first in operator socket identity, then exposed the mutation-lab identity mismatch.
- GREEN: full gateway binary cross-builds for Linux/386, ARMv7, and ARMv6.
- Native focused MCP/sync-evidence tests pass.
- `actionlint .github/workflows/ci.yml`: PASS.
- Full `./scripts/ci_local.sh`: PASS, including race, 185 Python tests, lint, and full Linux32 gateway builds.
- Docs gate: not triggered.
- Transport gate: not triggered.

Downstream evidence: add-on build run `31342750518` reached the operator-socket mismatch after the earlier package-only fix.