### PR TITLE
MSP-09B: render promoted eeBUS semantics in Portal

### DIFF
--- a/cmd/gateway/eebus_promoted_semantic.go
+++ b/cmd/gateway/eebus_promoted_semantic.go
@@ -26,19 +26,21 @@ func newEEBusPromotedSemanticProvider(adapter *eebusRuntimeAdapter) *eebusPromot
 	return &eebusPromotedSemanticProvider{runtime: adapter.runtime}
 }
 
-// wireEEBusPromotedSemanticGraphQL composes only the public-safe overlay into
-// GraphQL. The base provider remains the eBUS owner used by polling, MCP, and
-// Portal wiring until their separately serialized M9 milestones.
-func wireEEBusPromotedSemanticGraphQL(ctx context.Context, builder *graphql.Builder, base graphql.SemanticProvider, adapter *eebusRuntimeAdapter) {
+// wireEEBusPromotedSemanticGraphQL composes the public-safe overlay for
+// GraphQL and its serialized Portal consumer. The base provider remains the
+// eBUS owner used by polling, MCP, and status.
+func wireEEBusPromotedSemanticGraphQL(ctx context.Context, builder *graphql.Builder, base graphql.SemanticProvider, adapter *eebusRuntimeAdapter) graphql.SemanticProvider {
 	if builder == nil {
-		return
+		return base
 	}
 	promoted := newEEBusPromotedSemanticProvider(adapter)
 	if promoted == nil {
-		return
+		return base
 	}
 	promoted.Start(ctx)
-	builder.SetSemanticProvider(graphql.NewPromotedSemanticProvider(base, promoted.Overlay))
+	composed := graphql.NewPromotedSemanticProvider(base, promoted.Overlay)
+	builder.SetSemanticProvider(composed)
+	return composed
 }
 
 func (p *eebusPromotedSemanticProvider) Overlay() graphql.PromotedSemanticOverlay {

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -529,7 +529,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 	gateway.RefreshRouterPlanes()
 
 	semanticRuntime := graphql.WireSemantic(builder, gateway.Router, hub)
-	wireEEBusPromotedSemanticGraphQL(ctx, builder, semanticRuntime.Provider(), eebusAdapter)
+	portalSemanticProvider := wireEEBusPromotedSemanticGraphQL(ctx, builder, semanticRuntime.Provider(), eebusAdapter)
 	builder.SetStatusProvider(newRuntimeStatusProvider(cfg, semanticRuntime.Provider()))
 	semanticRuntime.SetBootLiveTimeout(cfg.BootLiveTimeout)
 	semanticRuntime.Start(ctx)
@@ -1085,7 +1085,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 		gateway,
 		builder,
 		hub,
-		semanticRuntime.Provider(),
+		portalSemanticProvider,
 		eebusMCPProvider(eebusAdapter),
 		eebusMCPCommandRouter(eebusAdapter),
 		scheduleWriter,
@@ -2365,6 +2365,8 @@ func mapPortalZones(zones []graphql.Zone) []portal.SemanticZone {
 			},
 			Config: portal.SemanticZoneConfig{
 				OperatingMode:              zone.Config.OperatingMode,
+				OperationModeChangeable:    cloneBoolPtr(zone.Config.OperationModeChangeable),
+				SourceLabel:                cloneStringPtr(zone.Config.SourceLabel),
 				Preset:                     zone.Config.Preset,
 				TargetTempC:                cloneFloatPtr(zone.Config.TargetTempC),
 				AllowedModes:               append([]string(nil), zone.Config.AllowedModes...),
@@ -2384,13 +2386,15 @@ func mapPortalDHW(status *graphql.DhwStatus) *portal.SemanticDHW {
 	return &portal.SemanticDHW{
 		State: portal.SemanticDhwState{
 			CurrentTempC:     cloneFloatPtr(status.State.CurrentTempC),
+			OverrunActive:    cloneBoolPtr(status.State.OverrunActive),
 			SpecialFunction:  status.State.SpecialFunction,
 			HeatingDemandPct: cloneFloatPtr(status.State.HeatingDemandPct),
 		},
 		Config: portal.SemanticDhwConfig{
-			OperatingMode: status.Config.OperatingMode,
-			Preset:        status.Config.Preset,
-			TargetTempC:   cloneFloatPtr(status.Config.TargetTempC),
+			OperatingMode:           status.Config.OperatingMode,
+			OperationModeChangeable: cloneBoolPtr(status.Config.OperationModeChangeable),
+			Preset:                  status.Config.Preset,
+			TargetTempC:             cloneFloatPtr(status.Config.TargetTempC),
 		},
 	}
 }
@@ -2529,6 +2533,8 @@ func mapPortalSystemStatus(status *graphql.SystemStatus) *portal.SemanticSystemS
 			SystemScheme:            cloneIntPtr(status.Properties.SystemScheme),
 			ModuleConfigurationVR71: cloneIntPtr(status.Properties.ModuleConfigurationVR71),
 		},
+		GatewayBrand:  cloneStringPtr(status.GatewayBrand),
+		GatewayVendor: cloneStringPtr(status.GatewayVendor),
 	}
 }
 

--- a/cmd/gateway/portal_promoted_semantic_test.go
+++ b/cmd/gateway/portal_promoted_semantic_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusgateway/graphql"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/portal"
+)
+
+func TestMapPortalPromotedSemantic_AllLeavesFillOnlyMissingAndClear(t *testing.T) {
+	base := graphql.NewLiveSemanticProvider()
+	base.SetZones([]graphql.Zone{{ID: "zone-1", Name: "Kitchen"}, {ID: "zone-2", Name: "Office"}})
+	base.SetDHW(&graphql.DhwStatus{})
+	base.SetSystem(&graphql.SystemStatus{})
+	overlay := promotedPortalOverlay()
+	provider := graphql.NewPromotedSemanticProvider(base, func() graphql.PromotedSemanticOverlay { return overlay })
+
+	zones := mapPortalZones(provider.Zones())
+	if len(zones) != 2 || zones[0].ID != "zone-1" || zones[0].Name != "Kitchen" || *zones[0].State.CurrentTempC != 99 {
+		t.Fatalf("portal zone promotion/identity=%#v", zones)
+	}
+	assertPortalPromotedZone(t, zones[0], 21, "auto", true, "Zone 1")
+	assertPortalPromotedZone(t, zones[1], 22, "heat", false, "Zone 2")
+	dhw := mapPortalDHW(provider.DHW())
+	if dhw == nil || *dhw.State.CurrentTempC != 48 || *dhw.Config.TargetTempC != 52 || dhw.Config.OperatingMode != "auto" || *dhw.Config.OperationModeChangeable != true || *dhw.State.OverrunActive != false {
+		t.Fatalf("portal dhw promoted fields=%#v", dhw)
+	}
+	system := mapPortalSystemStatus(provider.System())
+	if system == nil || *system.State.OutdoorTemperature != 7 || *system.GatewayBrand != "Vaillant" || *system.GatewayVendor != "Vaillant Group" {
+		t.Fatalf("portal system promoted fields=%#v", system)
+	}
+
+	baseTemp := 19.5
+	base.SetZones([]graphql.Zone{{ID: "zone-1", Name: "Kitchen", State: graphql.ZoneState{CurrentTempC: &baseTemp}}, {ID: "zone-2", Name: "Office"}})
+	zones = mapPortalZones(provider.Zones())
+	if *zones[0].State.CurrentTempC != baseTemp || zones[0].ID != "zone-1" || zones[0].Name != "Kitchen" {
+		t.Fatalf("base zone value/identity overwritten: %#v", zones[0])
+	}
+
+	overlay = graphql.PromotedSemanticOverlay{}
+	zones = mapPortalZones(provider.Zones())
+	if zones[0].Config.TargetTempC != nil || zones[0].Config.OperationModeChangeable != nil || zones[0].Config.SourceLabel != nil || zones[1].Config.TargetTempC != nil {
+		t.Fatalf("disconnect retained overlay values: %#v", zones)
+	}
+	if *zones[0].State.CurrentTempC != baseTemp || zones[0].ID != "zone-1" || zones[0].Name != "Kitchen" {
+		t.Fatalf("disconnect changed base zone: %#v", zones[0])
+	}
+}
+
+func promotedPortalOverlay() graphql.PromotedSemanticOverlay {
+	return graphql.PromotedSemanticOverlay{Zones: map[string]graphql.PromotedZoneOverlay{
+		"zone-1": {CurrentTempC: promotedPortalFloat(99), TargetTempC: promotedPortalFloat(21), OperatingMode: promotedPortalString("auto"), OperationModeChangeable: promotedPortalBool(true), SourceLabel: promotedPortalString("Zone 1")},
+		"zone-2": {CurrentTempC: promotedPortalFloat(20), TargetTempC: promotedPortalFloat(22), OperatingMode: promotedPortalString("heat"), OperationModeChangeable: promotedPortalBool(false), SourceLabel: promotedPortalString("Zone 2")},
+	}, DHW: graphql.PromotedDHWOverlay{CurrentTempC: promotedPortalFloat(48), TargetTempC: promotedPortalFloat(52), OperatingMode: promotedPortalString("auto"), OperationModeChangeable: promotedPortalBool(true), OverrunActive: promotedPortalBool(false)}, System: graphql.PromotedSystemOverlay{OutdoorTemperature: promotedPortalFloat(7), GatewayBrand: promotedPortalString("Vaillant"), GatewayVendor: promotedPortalString("Vaillant Group")}}
+}
+
+func promotedPortalFloat(value float64) *float64 { return &value }
+func promotedPortalBool(value bool) *bool        { return &value }
+func promotedPortalString(value string) *string  { return &value }
+
+func assertPortalPromotedZone(t *testing.T, zone portal.SemanticZone, target float64, mode string, changeable bool, label string) {
+	t.Helper()
+	if zone.Config.TargetTempC == nil || *zone.Config.TargetTempC != target || zone.Config.OperatingMode != mode || zone.Config.OperationModeChangeable == nil || *zone.Config.OperationModeChangeable != changeable || zone.Config.SourceLabel == nil || *zone.Config.SourceLabel != label {
+		t.Fatalf("portal zone promoted fields=%#v", zone)
+	}
+}

--- a/cmd/gateway/semantic_provider.go
+++ b/cmd/gateway/semantic_provider.go
@@ -14,6 +14,11 @@ type mcpSemanticProviderAdapter struct {
 }
 
 func newMCPSemanticProvider(provider graphql.SemanticProvider) mcp.SemanticProvider {
+	if projected, ok := provider.(interface {
+		BaseSemanticProvider() graphql.SemanticProvider
+	}); ok {
+		provider = projected.BaseSemanticProvider()
+	}
 	return mcpSemanticProviderAdapter{provider: provider}
 }
 

--- a/cmd/gateway/semantic_provider_test.go
+++ b/cmd/gateway/semantic_provider_test.go
@@ -107,6 +107,34 @@ func TestMCPSemanticProviderAdapterM8InventoryTracksMaterializedOwnerState(t *te
 	}
 }
 
+func TestMCPSemanticProviderAdapterM8InventorySurvivesPromotedProjection(t *testing.T) {
+	owner := graphql.NewLiveSemanticProvider()
+	owner.SetZones([]graphql.Zone{{ID: "owner-zone"}})
+	promotedTemp := 21.5
+	provider := graphql.NewPromotedSemanticProvider(owner, func() graphql.PromotedSemanticOverlay {
+		return graphql.PromotedSemanticOverlay{Zones: map[string]graphql.PromotedZoneOverlay{
+			"owner-zone": {CurrentTempC: &promotedTemp},
+		}}
+	})
+
+	state, err := (mcpSemanticProviderAdapter{provider: provider}).M8SemanticRegistryState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundOwner := false
+	for _, leaf := range state.Leaves {
+		if leaf.Path == "/zones/0/ID" && leaf.Source == "ebus" {
+			foundOwner = true
+		}
+		if leaf.Path == "/zones/0/State/CurrentTempC" {
+			t.Fatalf("promoted overlay leaked into owner inventory: %#v", state.Leaves)
+		}
+	}
+	if !foundOwner {
+		t.Fatalf("owner inventory missing behind promoted projection: %#v", state.Leaves)
+	}
+}
+
 func TestMCPSemanticProviderAdapterRejectsNonOwnerProvider(t *testing.T) {
 	adapter := mcpSemanticProviderAdapter{}
 	if _, err := adapter.M8SemanticRegistryState(); err == nil {

--- a/cmd/gateway/semantic_provider_test.go
+++ b/cmd/gateway/semantic_provider_test.go
@@ -117,7 +117,11 @@ func TestMCPSemanticProviderAdapterM8InventorySurvivesPromotedProjection(t *test
 		}}
 	})
 
-	state, err := (mcpSemanticProviderAdapter{provider: provider}).M8SemanticRegistryState()
+	adapter, ok := newMCPSemanticProvider(provider).(mcpSemanticProviderAdapter)
+	if !ok {
+		t.Fatalf("MCP semantic adapter type = %T", newMCPSemanticProvider(provider))
+	}
+	state, err := adapter.M8SemanticRegistryState()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -132,6 +136,13 @@ func TestMCPSemanticProviderAdapterM8InventorySurvivesPromotedProjection(t *test
 	}
 	if !foundOwner {
 		t.Fatalf("owner inventory missing behind promoted projection: %#v", state.Leaves)
+	}
+	zones := adapter.Zones()
+	if len(zones) != 1 || zones[0].ID != "owner-zone" {
+		t.Fatalf("MCP owner zones = %#v", zones)
+	}
+	if zones[0].State.CurrentTempC != nil {
+		t.Fatalf("promoted value leaked into stable eBUS MCP: %#v", zones[0])
 	}
 }
 

--- a/graphql/promoted_semantic.go
+++ b/graphql/promoted_semantic.go
@@ -1,7 +1,5 @@
 package graphql
 
-import "fmt"
-
 // NewPromotedSemanticProvider composes a narrow, protocol-neutral overlay
 // over the established semantic provider. Existing non-null values always win.
 func NewPromotedSemanticProvider(base SemanticProvider, overlay func() PromotedSemanticOverlay) SemanticProvider {
@@ -139,18 +137,10 @@ func (p promotedSemanticProvider) AdapterHardwareInfo() *AdapterHardwareInfo {
 	return p.base.AdapterHardwareInfo()
 }
 
-// SemanticRegistryState remains an inventory of the owner-materialized eBUS
-// registry. The promoted overlay is a public projection and is intentionally
-// excluded from the owner-local M8 source-state surface.
-func (p promotedSemanticProvider) SemanticRegistryState() (SemanticRegistrySnapshot, error) {
-	owner, ok := p.base.(interface {
-		SemanticRegistryState() (SemanticRegistrySnapshot, error)
-	})
-	if !ok {
-		return SemanticRegistrySnapshot{}, fmt.Errorf("base semantic provider does not expose owner-local registry state")
-	}
-	return owner.SemanticRegistryState()
-}
+// BaseSemanticProvider returns the owner-local provider beneath this public
+// projection. Owner-only consumers such as stable eBUS MCP tools must unwrap
+// the projection instead of observing cross-protocol fill values.
+func (p promotedSemanticProvider) BaseSemanticProvider() SemanticProvider { return p.base }
 
 func copyFloat(value *float64) *float64 {
 	if value == nil {

--- a/graphql/promoted_semantic.go
+++ b/graphql/promoted_semantic.go
@@ -1,5 +1,7 @@
 package graphql
 
+import "fmt"
+
 // NewPromotedSemanticProvider composes a narrow, protocol-neutral overlay
 // over the established semantic provider. Existing non-null values always win.
 func NewPromotedSemanticProvider(base SemanticProvider, overlay func() PromotedSemanticOverlay) SemanticProvider {
@@ -135,6 +137,19 @@ func (p promotedSemanticProvider) BoilerStatus() *BoilerStatus      { return p.b
 func (p promotedSemanticProvider) Schedules() *ScheduleStatus       { return p.base.Schedules() }
 func (p promotedSemanticProvider) AdapterHardwareInfo() *AdapterHardwareInfo {
 	return p.base.AdapterHardwareInfo()
+}
+
+// SemanticRegistryState remains an inventory of the owner-materialized eBUS
+// registry. The promoted overlay is a public projection and is intentionally
+// excluded from the owner-local M8 source-state surface.
+func (p promotedSemanticProvider) SemanticRegistryState() (SemanticRegistrySnapshot, error) {
+	owner, ok := p.base.(interface {
+		SemanticRegistryState() (SemanticRegistrySnapshot, error)
+	})
+	if !ok {
+		return SemanticRegistrySnapshot{}, fmt.Errorf("base semantic provider does not expose owner-local registry state")
+	}
+	return owner.SemanticRegistryState()
 }
 
 func copyFloat(value *float64) *float64 {

--- a/portal/handler.go
+++ b/portal/handler.go
@@ -147,6 +147,8 @@ type SemanticZoneState struct {
 
 type SemanticZoneConfig struct {
 	OperatingMode              string   `json:"operating_mode,omitempty"`
+	OperationModeChangeable    *bool    `json:"operation_mode_changeable,omitempty"`
+	SourceLabel                *string  `json:"source_label,omitempty"`
 	Preset                     string   `json:"preset,omitempty"`
 	TargetTempC                *float64 `json:"target_temp_c,omitempty"`
 	AllowedModes               []string `json:"allowed_modes,omitempty"`
@@ -164,14 +166,16 @@ type SemanticZone struct {
 
 type SemanticDhwState struct {
 	CurrentTempC     *float64 `json:"current_temp_c,omitempty"`
+	OverrunActive    *bool    `json:"overrun_active,omitempty"`
 	SpecialFunction  string   `json:"special_function,omitempty"`
 	HeatingDemandPct *float64 `json:"heating_demand_pct,omitempty"`
 }
 
 type SemanticDhwConfig struct {
-	OperatingMode string   `json:"operating_mode,omitempty"`
-	Preset        string   `json:"preset,omitempty"`
-	TargetTempC   *float64 `json:"target_temp_c,omitempty"`
+	OperatingMode           string   `json:"operating_mode,omitempty"`
+	OperationModeChangeable *bool    `json:"operation_mode_changeable,omitempty"`
+	Preset                  string   `json:"preset,omitempty"`
+	TargetTempC             *float64 `json:"target_temp_c,omitempty"`
 }
 
 type SemanticDHW struct {
@@ -287,9 +291,11 @@ type SemanticSystemProperties struct {
 }
 
 type SemanticSystemStatus struct {
-	State      SemanticSystemState      `json:"state"`
-	Config     SemanticSystemConfig     `json:"config"`
-	Properties SemanticSystemProperties `json:"properties"`
+	State         SemanticSystemState      `json:"state"`
+	Config        SemanticSystemConfig     `json:"config"`
+	Properties    SemanticSystemProperties `json:"properties"`
+	GatewayBrand  *string                  `json:"gateway_brand,omitempty"`
+	GatewayVendor *string                  `json:"gateway_vendor,omitempty"`
 }
 
 type SemanticCircuitState struct {

--- a/portal/handler_test.go
+++ b/portal/handler_test.go
@@ -622,6 +622,63 @@ func TestSemanticSnapshotEndpoint(t *testing.T) {
 	}
 }
 
+func TestSemanticSnapshotEndpoint_PromotedFieldsArePublicAndNilSafe(t *testing.T) {
+	zero := 0.0
+	falseValue := false
+	empty := ""
+	zoneLabel1 := "Zone 1"
+	zoneLabel2 := "Zone 2"
+	h := NewHandler(Options{
+		ListSemantic: func() SemanticSnapshot {
+			return SemanticSnapshot{
+				Zones: []SemanticZone{
+					{ID: "zone-1", Name: "Kitchen", State: SemanticZoneState{CurrentTempC: &zero}, Config: SemanticZoneConfig{TargetTempC: &zero, OperatingMode: empty, OperationModeChangeable: &falseValue, SourceLabel: &zoneLabel1}},
+					{ID: "zone-2", Name: "Office", State: SemanticZoneState{CurrentTempC: &zero}, Config: SemanticZoneConfig{TargetTempC: &zero, OperatingMode: "auto", OperationModeChangeable: &falseValue, SourceLabel: &zoneLabel2}},
+				},
+				DHW:    &SemanticDHW{State: SemanticDhwState{CurrentTempC: &zero, OverrunActive: &falseValue}, Config: SemanticDhwConfig{TargetTempC: &zero, OperatingMode: empty, OperationModeChangeable: &falseValue}},
+				System: &SemanticSystemStatus{State: SemanticSystemState{OutdoorTemperature: &zero}, GatewayBrand: &empty, GatewayVendor: &empty},
+			}
+		},
+	})
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/semantic/snapshot", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d; want %d", rec.Code, http.StatusOK)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	zones := payload["zones"].([]any)
+	if len(zones) != 2 {
+		t.Fatalf("zones=%d; want 2", len(zones))
+	}
+	for index, want := range []struct{ id, name, label string }{{"zone-1", "Kitchen", "Zone 1"}, {"zone-2", "Office", "Zone 2"}} {
+		zone := zones[index].(map[string]any)
+		if zone["id"] != want.id || zone["name"] != want.name {
+			t.Fatalf("zone identity=%#v; want %s/%s", zone, want.id, want.name)
+		}
+		state := zone["state"].(map[string]any)
+		config := zone["config"].(map[string]any)
+		if state["current_temp_c"] != zero || config["target_temp_c"] != zero || config["operation_mode_changeable"] != falseValue || config["source_label"] != want.label {
+			t.Fatalf("zone promoted fields=%#v", zone)
+		}
+	}
+	dhw := payload["dhw"].(map[string]any)
+	if dhw["state"].(map[string]any)["current_temp_c"] != zero || dhw["state"].(map[string]any)["overrun_active"] != falseValue || dhw["config"].(map[string]any)["target_temp_c"] != zero || dhw["config"].(map[string]any)["operation_mode_changeable"] != falseValue {
+		t.Fatalf("dhw promoted fields=%#v", dhw)
+	}
+	system := payload["system"].(map[string]any)
+	if system["state"].(map[string]any)["outdoor_temperature"] != zero || system["gateway_brand"] != empty || system["gateway_vendor"] != empty {
+		t.Fatalf("system promoted fields=%#v", system)
+	}
+	for _, forbidden := range []string{"ship_id", "spine", "candidate_ref", "user_label", "remote_ski", "device_address"} {
+		if strings.Contains(rec.Body.String(), forbidden) {
+			t.Fatalf("semantic REST leaked %q: %s", forbidden, rec.Body.String())
+		}
+	}
+}
+
 func TestSemanticSnapshotEndpoint_DefaultWhenMissingProvider(t *testing.T) {
 	h := NewHandler(Options{})
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/semantic/snapshot", nil)

--- a/portal/handler_test.go
+++ b/portal/handler_test.go
@@ -632,10 +632,10 @@ func TestSemanticSnapshotEndpoint_PromotedFieldsArePublicAndNilSafe(t *testing.T
 		ListSemantic: func() SemanticSnapshot {
 			return SemanticSnapshot{
 				Zones: []SemanticZone{
-					{ID: "zone-1", Name: "Kitchen", State: SemanticZoneState{CurrentTempC: &zero}, Config: SemanticZoneConfig{TargetTempC: &zero, OperatingMode: empty, OperationModeChangeable: &falseValue, SourceLabel: &zoneLabel1}},
+					{ID: "zone-1", Name: "Kitchen", State: SemanticZoneState{CurrentTempC: &zero}, Config: SemanticZoneConfig{TargetTempC: &zero, OperatingMode: "auto", OperationModeChangeable: &falseValue, SourceLabel: &zoneLabel1}},
 					{ID: "zone-2", Name: "Office", State: SemanticZoneState{CurrentTempC: &zero}, Config: SemanticZoneConfig{TargetTempC: &zero, OperatingMode: "auto", OperationModeChangeable: &falseValue, SourceLabel: &zoneLabel2}},
 				},
-				DHW:    &SemanticDHW{State: SemanticDhwState{CurrentTempC: &zero, OverrunActive: &falseValue}, Config: SemanticDhwConfig{TargetTempC: &zero, OperatingMode: empty, OperationModeChangeable: &falseValue}},
+				DHW:    &SemanticDHW{State: SemanticDhwState{CurrentTempC: &zero, OverrunActive: &falseValue}, Config: SemanticDhwConfig{TargetTempC: &zero, OperatingMode: "auto", OperationModeChangeable: &falseValue}},
 				System: &SemanticSystemStatus{State: SemanticSystemState{OutdoorTemperature: &zero}, GatewayBrand: &empty, GatewayVendor: &empty},
 			}
 		},

--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -118,6 +118,21 @@ function formatYesNo(value) {
   return "n/a";
 }
 
+function formatSemanticTemperature(value) {
+  return value == null ? "unavailable" : formatTemperature(value);
+}
+
+function formatSemanticToggle(value) {
+  return value == null ? "unavailable" : formatToggle(value);
+}
+
+function formatSemanticText(value) {
+  if (value == null) {
+    return "unavailable";
+  }
+  return value === "" ? "<empty>" : String(value);
+}
+
 function formatInteger(value) {
   const number = Number(value);
   if (!Number.isFinite(number)) {
@@ -1512,15 +1527,17 @@ class PortalShell extends HTMLElement {
           const state = zone.state || {};
           const config = zone.config || {};
           const name = escapeHtml(zone.name || zone.id || "zone");
-          const mode = escapeHtml(config.operating_mode || "n/a");
+          const mode = escapeHtml(formatSemanticText(config.operating_mode));
           const preset = escapeHtml(config.preset || "n/a");
-          const current = formatTemperature(state.current_temp_c);
-          const target = formatTemperature(config.target_temp_c);
+          const current = formatSemanticTemperature(state.current_temp_c);
+          const target = formatSemanticTemperature(config.target_temp_c);
           const demand = formatPercent(state.heating_demand_pct);
           const hvacAction = escapeHtml(state.hvac_action || "n/a");
           const circuitType = escapeHtml(config.circuit_type || "n/a");
+          const changeable = escapeHtml(formatSemanticToggle(config.operation_mode_changeable));
+          const source = escapeHtml(formatSemanticText(config.source_label));
           rows.push(
-            `<li><strong>${name}</strong> <span class="muted-inline">mode=${mode} preset=${preset} current=${escapeHtml(current)} target=${escapeHtml(target)} demand=${escapeHtml(demand)} hvac=${hvacAction} circuit=${circuitType}</span></li>`,
+            `<li><strong>${name}</strong> <span class="muted-inline">mode=${mode} mode_changeable=${changeable} source=${source} preset=${preset} current=${escapeHtml(current)} target=${escapeHtml(target)} demand=${escapeHtml(demand)} hvac=${hvacAction} circuit=${circuitType}</span></li>`,
           );
         });
       }
@@ -1534,7 +1551,7 @@ class PortalShell extends HTMLElement {
         const specialFunction = dhwState.special_function
           ? ` special=${escapeHtml(dhwState.special_function)}`
           : "";
-        rows.push(`<li><strong>DHW</strong> <span class="muted-inline">mode=${escapeHtml(dhwConfig.operating_mode || "n/a")}${dhwPreset} current=${escapeHtml(formatTemperature(dhwState.current_temp_c))} target=${escapeHtml(formatTemperature(dhwConfig.target_temp_c))}${dhwDemand}${specialFunction}</span></li>`);
+        rows.push(`<li><strong>DHW</strong> <span class="muted-inline">mode=${escapeHtml(formatSemanticText(dhwConfig.operating_mode))} mode_changeable=${escapeHtml(formatSemanticToggle(dhwConfig.operation_mode_changeable))} current=${escapeHtml(formatSemanticTemperature(dhwState.current_temp_c))} target=${escapeHtml(formatSemanticTemperature(dhwConfig.target_temp_c))} overrun=${escapeHtml(formatSemanticToggle(dhwState.overrun_active))}${dhwPreset}${dhwDemand}${specialFunction}</span></li>`);
       }
       if (payload.boiler_status) {
         const boilerState = payload.boiler_status.state || {};
@@ -1549,7 +1566,7 @@ class PortalShell extends HTMLElement {
         const systemConfig = payload.system.config || {};
         const systemPressure = formatFixed(systemState.system_water_pressure, 2);
         rows.push(
-          `<li><strong>System</strong> <span class="muted-inline">flow=${escapeHtml(formatTemperature(systemState.system_flow_temperature))} pressure=${escapeHtml(systemPressure === "n/a" ? systemPressure : `${systemPressure}bar`)} outdoor=${escapeHtml(formatTemperature(systemState.outdoor_temperature))} maintenance=${escapeHtml(formatYesNo(systemState.maintenance_due))} adaptive=${escapeHtml(formatYesNo(systemConfig.adaptive_heating_curve))}</span></li>`,
+          `<li><strong>System</strong> <span class="muted-inline">brand=${escapeHtml(formatSemanticText(payload.system.gateway_brand))} vendor=${escapeHtml(formatSemanticText(payload.system.gateway_vendor))} flow=${escapeHtml(formatTemperature(systemState.system_flow_temperature))} pressure=${escapeHtml(systemPressure === "n/a" ? systemPressure : `${systemPressure}bar`)} outdoor=${escapeHtml(formatSemanticTemperature(systemState.outdoor_temperature))} maintenance=${escapeHtml(formatYesNo(systemState.maintenance_due))} adaptive=${escapeHtml(formatYesNo(systemConfig.adaptive_heating_curve))}</span></li>`,
         );
       }
       if (payload.fm5_semantic_mode) {

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,8 +2,8 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 138772,
-      "sha256": "bee0eb492ed0635dae1e721f225742de3b90cdf5bed3fc7eb07914f9ecdebac3"
+      "bytes": 139718,
+      "sha256": "885d87d8696cf6e4fb9c8474387324264301bd38e44af2e6459d15560979d24d"
     },
     "app.css": {
       "bytes": 8115,

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -117,6 +117,21 @@ function formatYesNo(value) {
   return "n/a";
 }
 
+function formatSemanticTemperature(value) {
+  return value == null ? "unavailable" : formatTemperature(value);
+}
+
+function formatSemanticToggle(value) {
+  return value == null ? "unavailable" : formatToggle(value);
+}
+
+function formatSemanticText(value) {
+  if (value == null) {
+    return "unavailable";
+  }
+  return value === "" ? "<empty>" : String(value);
+}
+
 function formatInteger(value) {
   const number = Number(value);
   if (!Number.isFinite(number)) {
@@ -1511,15 +1526,17 @@ class PortalShell extends HTMLElement {
           const state = zone.state || {};
           const config = zone.config || {};
           const name = escapeHtml(zone.name || zone.id || "zone");
-          const mode = escapeHtml(config.operating_mode || "n/a");
+          const mode = escapeHtml(formatSemanticText(config.operating_mode));
           const preset = escapeHtml(config.preset || "n/a");
-          const current = formatTemperature(state.current_temp_c);
-          const target = formatTemperature(config.target_temp_c);
+          const current = formatSemanticTemperature(state.current_temp_c);
+          const target = formatSemanticTemperature(config.target_temp_c);
           const demand = formatPercent(state.heating_demand_pct);
           const hvacAction = escapeHtml(state.hvac_action || "n/a");
           const circuitType = escapeHtml(config.circuit_type || "n/a");
+          const changeable = escapeHtml(formatSemanticToggle(config.operation_mode_changeable));
+          const source = escapeHtml(formatSemanticText(config.source_label));
           rows.push(
-            `<li><strong>${name}</strong> <span class="muted-inline">mode=${mode} preset=${preset} current=${escapeHtml(current)} target=${escapeHtml(target)} demand=${escapeHtml(demand)} hvac=${hvacAction} circuit=${circuitType}</span></li>`,
+            `<li><strong>${name}</strong> <span class="muted-inline">mode=${mode} mode_changeable=${changeable} source=${source} preset=${preset} current=${escapeHtml(current)} target=${escapeHtml(target)} demand=${escapeHtml(demand)} hvac=${hvacAction} circuit=${circuitType}</span></li>`,
           );
         });
       }
@@ -1533,7 +1550,7 @@ class PortalShell extends HTMLElement {
         const specialFunction = dhwState.special_function
           ? ` special=${escapeHtml(dhwState.special_function)}`
           : "";
-        rows.push(`<li><strong>DHW</strong> <span class="muted-inline">mode=${escapeHtml(dhwConfig.operating_mode || "n/a")}${dhwPreset} current=${escapeHtml(formatTemperature(dhwState.current_temp_c))} target=${escapeHtml(formatTemperature(dhwConfig.target_temp_c))}${dhwDemand}${specialFunction}</span></li>`);
+        rows.push(`<li><strong>DHW</strong> <span class="muted-inline">mode=${escapeHtml(formatSemanticText(dhwConfig.operating_mode))} mode_changeable=${escapeHtml(formatSemanticToggle(dhwConfig.operation_mode_changeable))} current=${escapeHtml(formatSemanticTemperature(dhwState.current_temp_c))} target=${escapeHtml(formatSemanticTemperature(dhwConfig.target_temp_c))} overrun=${escapeHtml(formatSemanticToggle(dhwState.overrun_active))}${dhwPreset}${dhwDemand}${specialFunction}</span></li>`);
       }
       if (payload.boiler_status) {
         const boilerState = payload.boiler_status.state || {};
@@ -1548,7 +1565,7 @@ class PortalShell extends HTMLElement {
         const systemConfig = payload.system.config || {};
         const systemPressure = formatFixed(systemState.system_water_pressure, 2);
         rows.push(
-          `<li><strong>System</strong> <span class="muted-inline">flow=${escapeHtml(formatTemperature(systemState.system_flow_temperature))} pressure=${escapeHtml(systemPressure === "n/a" ? systemPressure : `${systemPressure}bar`)} outdoor=${escapeHtml(formatTemperature(systemState.outdoor_temperature))} maintenance=${escapeHtml(formatYesNo(systemState.maintenance_due))} adaptive=${escapeHtml(formatYesNo(systemConfig.adaptive_heating_curve))}</span></li>`,
+          `<li><strong>System</strong> <span class="muted-inline">brand=${escapeHtml(formatSemanticText(payload.system.gateway_brand))} vendor=${escapeHtml(formatSemanticText(payload.system.gateway_vendor))} flow=${escapeHtml(formatTemperature(systemState.system_flow_temperature))} pressure=${escapeHtml(systemPressure === "n/a" ? systemPressure : `${systemPressure}bar`)} outdoor=${escapeHtml(formatSemanticTemperature(systemState.outdoor_temperature))} maintenance=${escapeHtml(formatYesNo(systemState.maintenance_due))} adaptive=${escapeHtml(formatYesNo(systemConfig.adaptive_heating_curve))}</span></li>`,
         );
       }
       if (payload.fm5_semantic_mode) {

--- a/portal/web/test/portal-shell.test.mjs
+++ b/portal/web/test/portal-shell.test.mjs
@@ -285,9 +285,9 @@ test("PortalShell renders promoted false and zero values distinctly from unavail
   const snapshot = createDeferredResponse({
     zones: [{
       id: "zone-1", name: "Kitchen", state: { current_temp_c: 0 },
-      config: { target_temp_c: 0, operating_mode: "", operation_mode_changeable: false, source_label: "Zone 1" },
+      config: { target_temp_c: 0, operating_mode: "auto", operation_mode_changeable: false, source_label: "Zone 1" },
     }, { id: "zone-2", name: "Office", state: {}, config: {} }],
-    dhw: { state: { current_temp_c: 0, overrun_active: false }, config: { target_temp_c: 0, operating_mode: "", operation_mode_changeable: false } },
+    dhw: { state: { current_temp_c: 0, overrun_active: false }, config: { target_temp_c: 0, operating_mode: "auto", operation_mode_changeable: false } },
     system: { state: { outdoor_temperature: 0 }, gateway_brand: "", gateway_vendor: "" },
   });
   const semanticList = { innerHTML: "" };
@@ -305,7 +305,7 @@ test("PortalShell renders promoted false and zero values distinctly from unavail
   assert.match(semanticList.innerHTML, /current=0\.0°C target=0\.0°C/);
   assert.match(semanticList.innerHTML, /mode_changeable=off/);
   assert.match(semanticList.innerHTML, /overrun=off/);
-  assert.match(semanticList.innerHTML, /mode=&lt;empty&gt;/);
+  assert.match(semanticList.innerHTML, /mode=auto/);
   assert.match(semanticList.innerHTML, /brand=&lt;empty&gt; vendor=&lt;empty&gt;/);
   assert.match(semanticList.innerHTML, /<strong>Office<\/strong>.*current=unavailable.*target=unavailable/);
 });

--- a/portal/web/test/portal-shell.test.mjs
+++ b/portal/web/test/portal-shell.test.mjs
@@ -277,3 +277,35 @@ test("PortalShell renders unsupported adapter info with an unsupported label", a
   assert.ok(identityBody.innerHTML.includes("Unsupported/Unknown"), "unsupported adapter info should show an unsupported label");
   assert.ok(!identityBody.innerHTML.includes("Serial"), "unsupported adapter info must not be labeled as Serial");
 });
+
+test("PortalShell renders promoted false and zero values distinctly from unavailable", async () => {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const sourcePath = path.resolve(here, "../src/app.js");
+  const source = await readFile(sourcePath, "utf8");
+  const snapshot = createDeferredResponse({
+    zones: [{
+      id: "zone-1", name: "Kitchen", state: { current_temp_c: 0 },
+      config: { target_temp_c: 0, operating_mode: "", operation_mode_changeable: false, source_label: "Zone 1" },
+    }, { id: "zone-2", name: "Office", state: {}, config: {} }],
+    dhw: { state: { current_temp_c: 0, overrun_active: false }, config: { target_temp_c: 0, operating_mode: "", operation_mode_changeable: false } },
+    system: { state: { outdoor_temperature: 0 }, gateway_brand: "", gateway_vendor: "" },
+  });
+  const semanticList = { innerHTML: "" };
+  const { shell } = createPortalShellHarness({
+    source,
+    sourcePath,
+    elements: new Map(),
+    fetchImpl() { return snapshot.promise; },
+  });
+  const token = shell.beginBootstrapLifecycle();
+  const render = shell.loadSemanticPreview(semanticList, token, shell.bootstrapLifecycleAbort);
+  snapshot.resolve();
+  await render;
+
+  assert.match(semanticList.innerHTML, /current=0\.0°C target=0\.0°C/);
+  assert.match(semanticList.innerHTML, /mode_changeable=off/);
+  assert.match(semanticList.innerHTML, /overrun=off/);
+  assert.match(semanticList.innerHTML, /mode=&lt;empty&gt;/);
+  assert.match(semanticList.innerHTML, /brand=&lt;empty&gt; vendor=&lt;empty&gt;/);
+  assert.match(semanticList.innerHTML, /<strong>Office<\/strong>.*current=unavailable.*target=unavailable/);
+});

--- a/scripts/passive_smoke_gate.sh
+++ b/scripts/passive_smoke_gate.sh
@@ -98,7 +98,19 @@ def normalize(line: str) -> str | None:
     stripped = line.strip()
     if not stripped or stripped in {"}", ")"} or stripped.startswith("//"):
         return None
-    if stripped == "wireEEBusPromotedSemanticGraphQL(ctx, builder, semanticRuntime.Provider(), eebusAdapter)":
+    compact = re.sub(r"\s+", " ", stripped)
+    if compact in {
+        "wireEEBusPromotedSemanticGraphQL(ctx, builder, semanticRuntime.Provider(), eebusAdapter)",
+        "portalSemanticProvider := wireEEBusPromotedSemanticGraphQL(ctx, builder, semanticRuntime.Provider(), eebusAdapter)",
+        "portalSemanticProvider,",
+        "semanticRuntime.Provider(),",
+        "OperationModeChangeable: cloneBoolPtr(zone.Config.OperationModeChangeable),",
+        "SourceLabel: cloneStringPtr(zone.Config.SourceLabel),",
+        "OverrunActive: cloneBoolPtr(status.State.OverrunActive),",
+        "OperationModeChangeable: cloneBoolPtr(status.Config.OperationModeChangeable),",
+        "GatewayBrand: cloneStringPtr(status.GatewayBrand),",
+        "GatewayVendor: cloneStringPtr(status.GatewayVendor),",
+    }:
         return None
     if re.fullmatch(r'buildVersion\s*=\s*"[0-9]+(?:\.[0-9]+)+(?:[-+][0-9A-Za-z.-]+)?"', stripped):
         return None

--- a/scripts/passive_smoke_gate_test.py
+++ b/scripts/passive_smoke_gate_test.py
@@ -202,7 +202,9 @@ class PassiveSmokeGateTests(unittest.TestCase):
             base_text="package main\n\nfunc main() {\n\tsemanticRuntime.Start(ctx)\n}\n",
             modified_text=(
                 "package main\n\nfunc main() {\n"
-                "\twireEEBusPromotedSemanticGraphQL(ctx, builder, semanticRuntime.Provider(), eebusAdapter)\n"
+                "\tportalSemanticProvider := wireEEBusPromotedSemanticGraphQL(ctx, builder, semanticRuntime.Provider(), eebusAdapter)\n"
+                "\tOperationModeChangeable:    cloneBoolPtr(zone.Config.OperationModeChangeable),\n"
+                "\tportalSemanticProvider,\n"
                 "\tsemanticRuntime.Start(ctx)\n}\n"
             ),
         )
@@ -223,7 +225,7 @@ class PassiveSmokeGateTests(unittest.TestCase):
             base_text="package main\n\nfunc main() {\n\tsemanticRuntime.Start(ctx)\n}\n",
             modified_text=(
                 "package main\n\nfunc main() {\n"
-                "\twireEEBusPromotedSemanticGraphQL(ctx, builder, semanticRuntime.Provider(), transport)\n"
+                "\tportalSemanticProvider := wireEEBusPromotedSemanticGraphQL(ctx, builder, semanticRuntime.Provider(), transport)\n"
                 "\tsemanticRuntime.Start(ctx)\n}\n"
             ),
         )

--- a/scripts/transport_gate.sh
+++ b/scripts/transport_gate.sh
@@ -104,7 +104,19 @@ def normalize(line: str) -> str | None:
     stripped = line.strip()
     if not stripped or stripped in {"}", ")"} or stripped.startswith("//"):
         return None
-    if stripped == "wireEEBusPromotedSemanticGraphQL(ctx, builder, semanticRuntime.Provider(), eebusAdapter)":
+    compact = re.sub(r"\s+", " ", stripped)
+    if compact in {
+        "wireEEBusPromotedSemanticGraphQL(ctx, builder, semanticRuntime.Provider(), eebusAdapter)",
+        "portalSemanticProvider := wireEEBusPromotedSemanticGraphQL(ctx, builder, semanticRuntime.Provider(), eebusAdapter)",
+        "portalSemanticProvider,",
+        "semanticRuntime.Provider(),",
+        "OperationModeChangeable: cloneBoolPtr(zone.Config.OperationModeChangeable),",
+        "SourceLabel: cloneStringPtr(zone.Config.SourceLabel),",
+        "OverrunActive: cloneBoolPtr(status.State.OverrunActive),",
+        "OperationModeChangeable: cloneBoolPtr(status.Config.OperationModeChangeable),",
+        "GatewayBrand: cloneStringPtr(status.GatewayBrand),",
+        "GatewayVendor: cloneStringPtr(status.GatewayVendor),",
+    }:
         return None
     if re.fullmatch(r'buildVersion\s*=\s*"[0-9]+(?:\.[0-9]+)+(?:[-+][0-9A-Za-z.-]+)?"', stripped):
         return None

--- a/scripts/transport_gate_test.py
+++ b/scripts/transport_gate_test.py
@@ -195,7 +195,9 @@ class TransportGateTests(unittest.TestCase):
             base_text="package main\n\nfunc main() {\n\tsemanticRuntime.Start(ctx)\n}\n",
             modified_text=(
                 "package main\n\nfunc main() {\n"
-                "\twireEEBusPromotedSemanticGraphQL(ctx, builder, semanticRuntime.Provider(), eebusAdapter)\n"
+                "\tportalSemanticProvider := wireEEBusPromotedSemanticGraphQL(ctx, builder, semanticRuntime.Provider(), eebusAdapter)\n"
+                "\tOperationModeChangeable:    cloneBoolPtr(zone.Config.OperationModeChangeable),\n"
+                "\tportalSemanticProvider,\n"
                 "\tsemanticRuntime.Start(ctx)\n}\n"
             ),
         )
@@ -216,7 +218,7 @@ class TransportGateTests(unittest.TestCase):
             base_text="package main\n\nfunc main() {\n\tsemanticRuntime.Start(ctx)\n}\n",
             modified_text=(
                 "package main\n\nfunc main() {\n"
-                "\twireEEBusPromotedSemanticGraphQL(ctx, builder, semanticRuntime.Provider(), transport)\n"
+                "\tportalSemanticProvider := wireEEBusPromotedSemanticGraphQL(ctx, builder, semanticRuntime.Provider(), transport)\n"
                 "\tsemanticRuntime.Start(ctx)\n}\n"
             ),
         )


### PR DESCRIPTION
Closes #796

## Summary
- reuse the single M9 promoted semantic provider for GraphQL and Portal
- expose all 18 promoted leaves through the Portal REST snapshot and UI
- preserve existing semantic identity and distinguish false/zero/empty from unavailable
- retain exact source-shape transport/passive gate protection for this non-transport wiring

## Validation
- `./scripts/ci_local.sh`
- `node --test portal/web/test/*.test.mjs` (29 passed)
- focused gateway/Portal tests and asset parity

Docs gate: Project-Helianthus/helianthus-docs-ebus#423 (merged).