### PR TITLE
FMV3-M4-01: compose owned Modbus TCP gateway endpoint

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -178,6 +178,23 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 		}()
 	}
 
+	modbusAdapter, err := startModbusRuntime(
+		ctx,
+		cfg.ModbusTCPConfig,
+		dialModbusEndpointFn,
+		newModbusEndpointFn,
+	)
+	if err != nil {
+		return fmt.Errorf("Modbus TCP sidecar: %w", err)
+	}
+	if modbusAdapter != nil {
+		defer func() {
+			if err := modbusAdapter.Close(); err != nil {
+				result = errors.Join(result, fmt.Errorf("shutdown Modbus TCP sidecar: %w", err))
+			}
+		}()
+	}
+
 	eebusAdapter, err := startEEBusRuntime(ctx, cfg.EEBusConfig, resolveEEBusInterfaceAddressesFn, newEEBusRuntimeFn)
 	if err != nil {
 		return fmt.Errorf("eeBUS sidecar: %w", err)

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -185,7 +185,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 		newModbusEndpointFn,
 	)
 	if err != nil {
-		return fmt.Errorf("Modbus TCP sidecar: %w", err)
+		return fmt.Errorf("modbus TCP sidecar: %w", err)
 	}
 	if modbusAdapter != nil {
 		defer func() {

--- a/cmd/gateway/modbus_runtime_adapter.go
+++ b/cmd/gateway/modbus_runtime_adapter.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/modbusadapter"
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+var (
+	newModbusEndpointFn modbusadapter.Factory = func(config modbus.TCPEndpointConfig) (modbusadapter.Endpoint, error) {
+		return modbus.NewTCPEndpoint(config)
+	}
+	dialModbusEndpointFn modbusadapter.Dialer = (&net.Dialer{}).DialContext
+)
+
+func startModbusRuntime(
+	ctx context.Context,
+	config ebusgateway.ModbusTCPConfig,
+	dial modbusadapter.Dialer,
+	factory modbusadapter.Factory,
+) (*modbusadapter.Adapter, error) {
+	runtimeConfig, err := mapModbusRuntimeConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("map Modbus TCP runtime configuration: %w", err)
+	}
+	adapter, err := modbusadapter.Start(ctx, runtimeConfig, dial, factory)
+	if err != nil {
+		return nil, fmt.Errorf("start Modbus TCP runtime: %w", err)
+	}
+	return adapter, nil
+}

--- a/cmd/gateway/modbus_runtime_adapter_test.go
+++ b/cmd/gateway/modbus_runtime_adapter_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/modbusadapter"
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+type modbusRunLifecycleEndpoint struct {
+	closeCalls int
+	closeErr   error
+}
+
+func (*modbusRunLifecycleEndpoint) OpenConnection(net.Conn) (modbus.TCPConnectionHandle, error) {
+	return modbus.TCPConnectionHandle{}, nil
+}
+
+func (*modbusRunLifecycleEndpoint) EnqueueRead(modbus.TCPReadPlan) (modbus.TCPRequestHandle, error) {
+	return modbus.TCPRequestHandle{}, nil
+}
+
+func (*modbusRunLifecycleEndpoint) Dispatch() (modbus.TCPDispatch, bool) {
+	return modbus.TCPDispatch{}, false
+}
+
+func (*modbusRunLifecycleEndpoint) Write(context.Context, modbus.TCPDispatch) (modbus.OwnerTransition, error) {
+	return modbus.OwnerTransition{}, nil
+}
+
+func (*modbusRunLifecycleEndpoint) Read(context.Context, modbus.TCPConnectionHandle) (modbus.TCPReadBatch, error) {
+	return modbus.TCPReadBatch{}, nil
+}
+
+func (*modbusRunLifecycleEndpoint) Cancel(modbus.TCPRequestHandle) error { return nil }
+
+func (*modbusRunLifecycleEndpoint) Snapshot() modbus.TCPEndpointSnapshot {
+	return modbus.TCPEndpointSnapshot{}
+}
+
+func (endpoint *modbusRunLifecycleEndpoint) Close() error {
+	endpoint.closeCalls++
+	return endpoint.closeErr
+}
+
+func TestRunClosesModbusSidecarOnceAndJoinsLaterEEBusFailure(t *testing.T) {
+	originalDial := dialModbusEndpointFn
+	originalFactory := newModbusEndpointFn
+	originalResolver := resolveEEBusInterfaceAddressesFn
+	t.Cleanup(func() {
+		dialModbusEndpointFn = originalDial
+		newModbusEndpointFn = originalFactory
+		resolveEEBusInterfaceAddressesFn = originalResolver
+	})
+
+	client, peer := net.Pipe()
+	t.Cleanup(func() { _ = peer.Close() })
+	endpoint := &modbusRunLifecycleEndpoint{closeErr: errors.New("modbus shutdown failed")}
+	dialModbusEndpointFn = func(context.Context, string, string) (net.Conn, error) {
+		return client, nil
+	}
+	newModbusEndpointFn = func(modbus.TCPEndpointConfig) (modbusadapter.Endpoint, error) {
+		return endpoint, nil
+	}
+	laterErr := errors.New("eebus interface resolution failed")
+	resolveEEBusInterfaceAddressesFn = func(string) ([]netip.Addr, error) {
+		return nil, laterErr
+	}
+
+	cfg := ebusgateway.DefaultConfig()
+	cfg.ModbusTCPConfig = ebusgateway.ModbusTCPConfig{
+		Enabled:     true,
+		Endpoint:    "tcp://127.0.0.1:1502",
+		DialTimeout: time.Second,
+	}
+	cfg.EEBusConfig = msp05bEnabledConfig()
+
+	err := run(context.Background(), cfg)
+	if !errors.Is(err, laterErr) || !errors.Is(err, endpoint.closeErr) {
+		t.Fatalf("run error = %v; want later eeBUS and Modbus shutdown causes", err)
+	}
+	if endpoint.closeCalls != 1 {
+		t.Fatalf("Modbus endpoint close calls = %d; want 1", endpoint.closeCalls)
+	}
+}

--- a/cmd/gateway/modbus_runtime_config.go
+++ b/cmd/gateway/modbus_runtime_config.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"errors"
+	"time"
+
+	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/modbusadapter"
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+type zeroModbusJitter struct{}
+
+func (zeroModbusJitter) Next(time.Duration) time.Duration { return 0 }
+
+func mapModbusRuntimeConfig(config ebusgateway.ModbusTCPConfig) (modbusadapter.Config, error) {
+	if !config.Enabled {
+		if config.Endpoint != "" || config.DialTimeout != 0 {
+			return modbusadapter.Config{}, errors.New("disabled Modbus TCP configuration contains active fields")
+		}
+		return modbusadapter.Config{}, nil
+	}
+	if config.Endpoint == "" || config.DialTimeout <= 0 {
+		return modbusadapter.Config{}, errors.New("enabled Modbus TCP configuration is incomplete")
+	}
+
+	clock := modbus.NewRealTCPMonotonicClock()
+	source, err := modbus.NewRuntimeAcquisitionSource(modbus.RuntimeAcquisitionConfig{
+		Limits: modbus.RuntimeAcquisitionLimits{
+			MaxLiveCapabilities:                        256,
+			MaxAttempts:                                64,
+			MaxMembersPerAttempt:                       32,
+			AttemptKeyMaxUTF8Bytes:                     256,
+			SourceEvidenceIDMaxUTF8Bytes:               512,
+			NormalizationRecordMaxEncodedBytes:         16 << 10,
+			NormalizationRequiredStringMaxUTF8Bytes:    512,
+			NormalizationExtensionCountMax:             32,
+			NormalizationExtensionKeyMaxUTF8Bytes:      256,
+			NormalizationExtensionValueMaxEncodedBytes: 4 << 10,
+			RetainedDiagnosticCountPerObjectMax:        32,
+			RetainedDiagnosticMaxUTF8Bytes:             512,
+			CapabilityTombstoneLimit:                   512,
+			CapabilityTombstoneMaxEncodedBytes:         256,
+		},
+		ClaimLifetime: time.Minute,
+		Clock:         clock,
+	})
+	if err != nil {
+		return modbusadapter.Config{}, err
+	}
+
+	return modbusadapter.Config{
+		Enabled:     true,
+		DialTimeout: config.DialTimeout,
+		Endpoint: modbus.TCPEndpointConfig{
+			Endpoint: config.Endpoint,
+			PoolLimits: modbus.EndpointPoolLimits{
+				MaxConnections: 1,
+				Connection: modbus.ConnectionLimits{
+					MaxInFlight:   4,
+					MaxTombstones: 32,
+				},
+			},
+			SchedulerLimits: modbus.SchedulerLimits{
+				MaxActiveAdmissionKeys:         16,
+				ProtectedSlotsPerKey:           1,
+				SharedBurstSlots:               16,
+				TotalQueued:                    32,
+				MaxQueuedPerKey:                8,
+				MaxQueuedPerAuthorizationScope: 16,
+				MaxCoalescedDependentsPerKey:   8,
+				MaxRetryAttempts:               2,
+				MaxInFlightRequests:            4,
+			},
+			Backoff: modbus.BackoffConfig{
+				Floor:             time.Second,
+				Ceiling:           30 * time.Second,
+				MaxAttempts:       5,
+				Jitter:            zeroModbusJitter{},
+				JitterAlgorithmID: "gateway-zero-jitter",
+				JitterVersion:     "v1",
+				JitterEvidence:    "deterministic-zero-schedule",
+			},
+			MaxBufferedBytes:         260,
+			MaxRequestDeadline:       30 * time.Second,
+			MaxResponseDeadline:      10 * time.Second,
+			Clock:                    clock,
+			RuntimeAcquisitionSource: source,
+		},
+	}, nil
+}

--- a/cmd/gateway/modbus_runtime_config_test.go
+++ b/cmd/gateway/modbus_runtime_config_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
+)
+
+func TestMapModbusRuntimeConfigDisabledIsInert(t *testing.T) {
+	config, err := mapModbusRuntimeConfig(ebusgateway.ModbusTCPConfig{})
+	if err != nil {
+		t.Fatalf("map disabled config: %v", err)
+	}
+	if config.Enabled {
+		t.Fatal("disabled config became enabled")
+	}
+}
+
+func TestMapModbusRuntimeConfigRejectsActiveFieldsWhileDisabled(t *testing.T) {
+	_, err := mapModbusRuntimeConfig(ebusgateway.ModbusTCPConfig{
+		Endpoint: "tcp://127.0.0.1:502",
+	})
+	if err == nil {
+		t.Fatal("disabled config with endpoint was accepted")
+	}
+}
+
+func TestMapModbusRuntimeConfigBuildsFiniteReadOnlyBounds(t *testing.T) {
+	config, err := mapModbusRuntimeConfig(ebusgateway.ModbusTCPConfig{
+		Enabled:     true,
+		Endpoint:    "tcp://192.0.2.10:502",
+		DialTimeout: 3 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("map enabled config: %v", err)
+	}
+	if !config.Enabled || config.Endpoint.Endpoint != "tcp://192.0.2.10:502" {
+		t.Fatalf("mapped config = %+v", config)
+	}
+	if config.Endpoint.SchedulerLimits.MaxActiveAdmissionKeys < 2 ||
+		config.Endpoint.SchedulerLimits.ProtectedSlotsPerKey < 1 ||
+		config.Endpoint.SchedulerLimits.TotalQueued < 2 ||
+		config.Endpoint.MaxRequestDeadline <= 0 ||
+		config.Endpoint.MaxResponseDeadline <= 0 ||
+		config.Endpoint.RuntimeAcquisitionSource == nil {
+		t.Fatalf("mapped bounds are incomplete: %+v", config.Endpoint)
+	}
+}
+
+func TestDefaultConfigLeavesModbusDisabled(t *testing.T) {
+	config := ebusgateway.DefaultConfig().ModbusTCPConfig
+	if config.Enabled || config.Endpoint != "" {
+		t.Fatalf("default Modbus config is active: %+v", config)
+	}
+}

--- a/config.go
+++ b/config.go
@@ -125,6 +125,7 @@ type Config struct {
 	ProxyListenAddr          string                 // TCP listen address for ENH proxy clients (empty disables)
 	TransportConfig          TransportConfig
 	EEBusConfig              EEBusConfig
+	ModbusTCPConfig          ModbusTCPConfig
 	EvidenceRecorderConfig   EvidenceRecorderConfig
 	EvidenceOneShotEnabled   bool
 	BusConfig                protocol.BusConfig

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260521144203-f9919f4b1007
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260510071332-e7b3e38e42d2
 	github.com/Project-Helianthus/helianthus-eebusreg v0.1.30
+	github.com/Project-Helianthus/helianthus-modbus v0.0.0-20260810083147-eab30aed9eb6
+	github.com/Project-Helianthus/helianthus-modbusreg v0.0.0-20260810220548-7b95df29e73f
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,10 @@ github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.15 h1:B13tnw
 github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.15/go.mod h1:l+1CGEnGgDCGjg59f6pAjCWKpRluLu1smboO9fVX8tw=
 github.com/Project-Helianthus/helianthus-eebusreg v0.1.30 h1:FGjBHg09A7AB18dtDZBTLnEq/GcfOf+J2Nuye3bMDHg=
 github.com/Project-Helianthus/helianthus-eebusreg v0.1.30/go.mod h1:Fe5/tUOucsDpFO400yj7EEQZ7NYSCPGEkPWGT9ZMlBA=
+github.com/Project-Helianthus/helianthus-modbus v0.0.0-20260810083147-eab30aed9eb6 h1:+l+s7VBz51iKqZYhm081RydM439iPM/Uf6bubzvA3/4=
+github.com/Project-Helianthus/helianthus-modbus v0.0.0-20260810083147-eab30aed9eb6/go.mod h1:Nr8SW7fE3SIjnp+rj8PCOtwk8JZ9wqafu1ZCgq3Zz+Q=
+github.com/Project-Helianthus/helianthus-modbusreg v0.0.0-20260810220548-7b95df29e73f h1:B7ckvY3M6wh22YylMScRL4BFFFpNMurcyDWJQ/DT6us=
+github.com/Project-Helianthus/helianthus-modbusreg v0.0.0-20260810220548-7b95df29e73f/go.mod h1:b1DlK4MkW72E+j+ejZqXHbMBiMUexU/+QWIT10zZVjU=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.13 h1:nUC9KzWElbeSAYwG6cToEBJhC7hfQP6G+YESA0eghh4=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.13/go.mod h1:qPqQTDqmPjyOJCr0JMNjhSC1XW1k3h5P/EZqRGy80Vs=
 github.com/Project-Helianthus/helianthus-spine-go v0.7.1-helianthus.9 h1:pV1GQmlPJyy22YGK/Amf5FMu1C3IzL3qxIxGmGUUTEo=

--- a/internal/modbusadapter/adapter.go
+++ b/internal/modbusadapter/adapter.go
@@ -1,0 +1,200 @@
+package modbusadapter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"sync"
+	"time"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+// Endpoint is the public Modbus TCP runtime surface used by the gateway.
+// The gateway adapter deliberately adds no scheduler or provenance model.
+type Endpoint interface {
+	OpenConnection(net.Conn) (modbus.TCPConnectionHandle, error)
+	EnqueueRead(modbus.TCPReadPlan) (modbus.TCPRequestHandle, error)
+	Dispatch() (modbus.TCPDispatch, bool)
+	Write(context.Context, modbus.TCPDispatch) (modbus.OwnerTransition, error)
+	Read(context.Context, modbus.TCPConnectionHandle) (modbus.TCPReadBatch, error)
+	Cancel(modbus.TCPRequestHandle) error
+	Snapshot() modbus.TCPEndpointSnapshot
+	Close() error
+}
+
+// Factory constructs the single endpoint owned by one adapter instance.
+type Factory func(modbus.TCPEndpointConfig) (Endpoint, error)
+
+// Dialer is injectable so integration tests can use an isolated fake peer.
+type Dialer func(context.Context, string, string) (net.Conn, error)
+
+// Config contains the already-validated bounded runtime configuration.
+type Config struct {
+	Enabled     bool
+	Endpoint    modbus.TCPEndpointConfig
+	DialTimeout time.Duration
+}
+
+// ReadPlan is a gateway-side request without socket ownership. The adapter
+// injects its current opaque connection handle and preserves every other field.
+type ReadPlan struct {
+	UnitID             byte
+	AuthorizationScope string
+	PollGeneration     uint64
+	DeadlineIdentity   uint64
+	Timeout            time.Duration
+	Reads              []modbus.TCPLogicalRead
+}
+
+// Adapter owns exactly one endpoint and its active connection generation.
+type Adapter struct {
+	endpoint   Endpoint
+	connection modbus.TCPConnectionHandle
+	source     *modbus.RuntimeAcquisitionSource
+
+	closeOnce sync.Once
+	closeErr  error
+}
+
+// Start constructs and connects one endpoint. Disabled configuration is inert.
+func Start(
+	ctx context.Context,
+	config Config,
+	dial Dialer,
+	factory Factory,
+) (*Adapter, error) {
+	if !config.Enabled {
+		return nil, nil
+	}
+	if ctx == nil || dial == nil || factory == nil || config.DialTimeout <= 0 {
+		return nil, errors.New("enabled Modbus TCP adapter configuration is incomplete")
+	}
+	address, err := dialAddress(config.Endpoint.Endpoint)
+	if err != nil {
+		return nil, err
+	}
+	endpoint, err := factory(config.Endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("construct Modbus TCP endpoint: %w", err)
+	}
+	if endpoint == nil {
+		return nil, errors.New("construct Modbus TCP endpoint: factory returned nil")
+	}
+
+	dialCtx, cancel := context.WithTimeout(ctx, config.DialTimeout)
+	defer cancel()
+	connection, err := dial(dialCtx, "tcp", address)
+	if err != nil {
+		return nil, errors.Join(
+			fmt.Errorf("dial Modbus TCP endpoint: %w", err),
+			endpoint.Close(),
+		)
+	}
+	handle, err := endpoint.OpenConnection(connection)
+	if err != nil {
+		return nil, errors.Join(
+			fmt.Errorf("open Modbus TCP endpoint: %w", err),
+			connection.Close(),
+			endpoint.Close(),
+		)
+	}
+	return &Adapter{
+		endpoint:   endpoint,
+		connection: handle,
+		source:     config.Endpoint.RuntimeAcquisitionSource,
+	}, nil
+}
+
+func dialAddress(endpoint string) (string, error) {
+	parsed, err := url.Parse(endpoint)
+	if err != nil || parsed.Scheme != "tcp" || parsed.Host == "" ||
+		parsed.User != nil || parsed.Path != "" || parsed.RawQuery != "" ||
+		parsed.Fragment != "" {
+		return "", errors.New("invalid Modbus TCP endpoint")
+	}
+	if _, _, err := net.SplitHostPort(parsed.Host); err != nil {
+		return "", errors.New("invalid Modbus TCP endpoint")
+	}
+	return parsed.Host, nil
+}
+
+// EnqueueRead admits a logical request without exposing connection ownership.
+func (adapter *Adapter) EnqueueRead(plan ReadPlan) (modbus.TCPRequestHandle, error) {
+	if adapter == nil || adapter.endpoint == nil {
+		return modbus.TCPRequestHandle{}, errors.New("Modbus TCP adapter unavailable")
+	}
+	return adapter.endpoint.EnqueueRead(modbus.TCPReadPlan{
+		Connection:         adapter.connection,
+		UnitID:             plan.UnitID,
+		AuthorizationScope: plan.AuthorizationScope,
+		PollGeneration:     plan.PollGeneration,
+		DeadlineIdentity:   plan.DeadlineIdentity,
+		Timeout:            plan.Timeout,
+		Reads:              append([]modbus.TCPLogicalRead(nil), plan.Reads...),
+	})
+}
+
+// Dispatch delegates deterministic fair service to helianthus-modbus.
+func (adapter *Adapter) Dispatch() (modbus.TCPDispatch, bool) {
+	if adapter == nil || adapter.endpoint == nil {
+		return modbus.TCPDispatch{}, false
+	}
+	return adapter.endpoint.Dispatch()
+}
+
+// Write crosses the public runtime's owned transport boundary.
+func (adapter *Adapter) Write(
+	ctx context.Context,
+	dispatch modbus.TCPDispatch,
+) (modbus.OwnerTransition, error) {
+	if adapter == nil || adapter.endpoint == nil {
+		return modbus.OwnerTransition{}, errors.New("Modbus TCP adapter unavailable")
+	}
+	return adapter.endpoint.Write(ctx, dispatch)
+}
+
+// Read returns the public runtime batch unchanged.
+func (adapter *Adapter) Read(ctx context.Context) (modbus.TCPReadBatch, error) {
+	if adapter == nil || adapter.endpoint == nil {
+		return modbus.TCPReadBatch{}, errors.New("Modbus TCP adapter unavailable")
+	}
+	return adapter.endpoint.Read(ctx, adapter.connection)
+}
+
+// Cancel delegates cancellation to the endpoint owner.
+func (adapter *Adapter) Cancel(handle modbus.TCPRequestHandle) error {
+	if adapter == nil || adapter.endpoint == nil {
+		return errors.New("Modbus TCP adapter unavailable")
+	}
+	return adapter.endpoint.Cancel(handle)
+}
+
+// Snapshot exposes only the public bounded endpoint health snapshot.
+func (adapter *Adapter) Snapshot() modbus.TCPEndpointSnapshot {
+	if adapter == nil || adapter.endpoint == nil {
+		return modbus.TCPEndpointSnapshot{}
+	}
+	return adapter.endpoint.Snapshot()
+}
+
+// RuntimeAcquisitionSource returns the source owner attached to endpoint views.
+func (adapter *Adapter) RuntimeAcquisitionSource() *modbus.RuntimeAcquisitionSource {
+	if adapter == nil {
+		return nil
+	}
+	return adapter.source
+}
+
+// Close retires all work and the socket exactly once.
+func (adapter *Adapter) Close() error {
+	if adapter == nil || adapter.endpoint == nil {
+		return nil
+	}
+	adapter.closeOnce.Do(func() {
+		adapter.closeErr = adapter.endpoint.Close()
+	})
+	return adapter.closeErr
+}

--- a/internal/modbusadapter/adapter.go
+++ b/internal/modbusadapter/adapter.go
@@ -124,7 +124,7 @@ func dialAddress(endpoint string) (string, error) {
 // EnqueueRead admits a logical request without exposing connection ownership.
 func (adapter *Adapter) EnqueueRead(plan ReadPlan) (modbus.TCPRequestHandle, error) {
 	if adapter == nil || adapter.endpoint == nil {
-		return modbus.TCPRequestHandle{}, errors.New("Modbus TCP adapter unavailable")
+		return modbus.TCPRequestHandle{}, errors.New("modbus TCP adapter unavailable")
 	}
 	return adapter.endpoint.EnqueueRead(modbus.TCPReadPlan{
 		Connection:         adapter.connection,
@@ -151,7 +151,7 @@ func (adapter *Adapter) Write(
 	dispatch modbus.TCPDispatch,
 ) (modbus.OwnerTransition, error) {
 	if adapter == nil || adapter.endpoint == nil {
-		return modbus.OwnerTransition{}, errors.New("Modbus TCP adapter unavailable")
+		return modbus.OwnerTransition{}, errors.New("modbus TCP adapter unavailable")
 	}
 	return adapter.endpoint.Write(ctx, dispatch)
 }
@@ -159,7 +159,7 @@ func (adapter *Adapter) Write(
 // Read returns the public runtime batch unchanged.
 func (adapter *Adapter) Read(ctx context.Context) (modbus.TCPReadBatch, error) {
 	if adapter == nil || adapter.endpoint == nil {
-		return modbus.TCPReadBatch{}, errors.New("Modbus TCP adapter unavailable")
+		return modbus.TCPReadBatch{}, errors.New("modbus TCP adapter unavailable")
 	}
 	return adapter.endpoint.Read(ctx, adapter.connection)
 }
@@ -167,7 +167,7 @@ func (adapter *Adapter) Read(ctx context.Context) (modbus.TCPReadBatch, error) {
 // Cancel delegates cancellation to the endpoint owner.
 func (adapter *Adapter) Cancel(handle modbus.TCPRequestHandle) error {
 	if adapter == nil || adapter.endpoint == nil {
-		return errors.New("Modbus TCP adapter unavailable")
+		return errors.New("modbus TCP adapter unavailable")
 	}
 	return adapter.endpoint.Cancel(handle)
 }

--- a/internal/modbusadapter/adapter_integration_test.go
+++ b/internal/modbusadapter/adapter_integration_test.go
@@ -1,0 +1,518 @@
+package modbusadapter
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"reflect"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+	modbusreg "github.com/Project-Helianthus/helianthus-modbusreg"
+)
+
+type integrationJitter struct{}
+
+func (integrationJitter) Next(time.Duration) time.Duration { return 0 }
+
+func integrationConfig(t *testing.T, endpoint string) Config {
+	t.Helper()
+	clock := modbus.NewRealTCPMonotonicClock()
+	source, err := modbus.NewRuntimeAcquisitionSource(modbus.RuntimeAcquisitionConfig{
+		Limits: modbus.RuntimeAcquisitionLimits{
+			MaxLiveCapabilities:                        16,
+			MaxAttempts:                                8,
+			MaxMembersPerAttempt:                       8,
+			AttemptKeyMaxUTF8Bytes:                     128,
+			SourceEvidenceIDMaxUTF8Bytes:               256,
+			NormalizationRecordMaxEncodedBytes:         4096,
+			NormalizationRequiredStringMaxUTF8Bytes:    256,
+			NormalizationExtensionCountMax:             8,
+			NormalizationExtensionKeyMaxUTF8Bytes:      128,
+			NormalizationExtensionValueMaxEncodedBytes: 1024,
+			RetainedDiagnosticCountPerObjectMax:        8,
+			RetainedDiagnosticMaxUTF8Bytes:             256,
+			CapabilityTombstoneLimit:                   32,
+			CapabilityTombstoneMaxEncodedBytes:         128,
+		},
+		ClaimLifetime: time.Minute,
+		Clock:         clock,
+	})
+	if err != nil {
+		t.Fatalf("NewRuntimeAcquisitionSource: %v", err)
+	}
+	return Config{
+		Enabled:     true,
+		DialTimeout: time.Second,
+		Endpoint: modbus.TCPEndpointConfig{
+			Endpoint: endpoint,
+			PoolLimits: modbus.EndpointPoolLimits{
+				MaxConnections: 1,
+				Connection: modbus.ConnectionLimits{
+					MaxInFlight:   4,
+					MaxTombstones: 8,
+				},
+			},
+			SchedulerLimits: modbus.SchedulerLimits{
+				MaxActiveAdmissionKeys:         4,
+				ProtectedSlotsPerKey:           1,
+				SharedBurstSlots:               4,
+				TotalQueued:                    8,
+				MaxQueuedPerKey:                4,
+				MaxQueuedPerAuthorizationScope: 8,
+				MaxCoalescedDependentsPerKey:   4,
+				MaxRetryAttempts:               1,
+				MaxInFlightRequests:            4,
+			},
+			Backoff: modbus.BackoffConfig{
+				Floor:             time.Millisecond,
+				Ceiling:           time.Millisecond,
+				MaxAttempts:       1,
+				Jitter:            integrationJitter{},
+				JitterAlgorithmID: "integration-zero",
+				JitterVersion:     "v1",
+				JitterEvidence:    "deterministic-test",
+			},
+			MaxBufferedBytes:         260,
+			MaxRequestDeadline:       time.Second,
+			MaxResponseDeadline:      time.Second,
+			Clock:                    clock,
+			RuntimeAcquisitionSource: source,
+		},
+	}
+}
+
+func realFactory(config modbus.TCPEndpointConfig) (Endpoint, error) {
+	return modbus.NewTCPEndpoint(config)
+}
+
+func realDialer(ctx context.Context, network, address string) (net.Conn, error) {
+	return (&net.Dialer{}).DialContext(ctx, network, address)
+}
+
+func serveResponse(listener net.Listener, words []uint16) <-chan error {
+	done := make(chan error, 1)
+	go func() {
+		connection, err := listener.Accept()
+		if err != nil {
+			done <- err
+			return
+		}
+		defer func() { _ = connection.Close() }()
+		header := make([]byte, 7)
+		if _, err := io.ReadFull(connection, header); err != nil {
+			done <- err
+			return
+		}
+		length := int(binary.BigEndian.Uint16(header[4:6]))
+		if length < 2 {
+			done <- fmt.Errorf("invalid request length %d", length)
+			return
+		}
+		body := make([]byte, length-1)
+		if _, err := io.ReadFull(connection, body); err != nil {
+			done <- err
+			return
+		}
+		response := []byte{
+			header[0], header[1], 0, 0,
+			0, byte(3 + len(words)*2), header[6],
+			body[0], byte(len(words) * 2),
+		}
+		for _, word := range words {
+			response = append(response, byte(word>>8), byte(word))
+		}
+		_, err = connection.Write(response)
+		done <- err
+	}()
+	return done
+}
+
+func TestAdapterDelegatesFairUnitScheduling(t *testing.T) {
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+	adapter, err := Start(
+		context.Background(),
+		integrationConfig(t, "tcp://"+listener.Addr().String()),
+		realDialer,
+		realFactory,
+	)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = adapter.Close() }()
+
+	request, err := modbus.NewReadRegistersRequest(modbus.FunctionReadInputRegisters, 100, 1)
+	if err != nil {
+		t.Fatalf("NewReadRegistersRequest: %v", err)
+	}
+	unitOneFirst, err := adapter.EnqueueRead(ReadPlan{
+		UnitID: 1, AuthorizationScope: "site", PollGeneration: 1,
+		DeadlineIdentity: 1, Timeout: time.Second,
+		Reads: []modbus.TCPLogicalRead{{LogicalViewID: 1, Request: request}},
+	})
+	if err != nil {
+		t.Fatalf("enqueue unit one first: %v", err)
+	}
+	unitOneSecond, err := adapter.EnqueueRead(ReadPlan{
+		UnitID: 1, AuthorizationScope: "site", PollGeneration: 1,
+		DeadlineIdentity: 2, Timeout: time.Second,
+		Reads: []modbus.TCPLogicalRead{{LogicalViewID: 2, Request: request}},
+	})
+	if err != nil {
+		t.Fatalf("enqueue unit one second: %v", err)
+	}
+	unitTwo, err := adapter.EnqueueRead(ReadPlan{
+		UnitID: 2, AuthorizationScope: "site", PollGeneration: 1,
+		DeadlineIdentity: 3, Timeout: time.Second,
+		Reads: []modbus.TCPLogicalRead{{LogicalViewID: 3, Request: request}},
+	})
+	if err != nil {
+		t.Fatalf("enqueue unit two: %v", err)
+	}
+
+	want := []uint64{unitOneFirst.RequestID(), unitTwo.RequestID(), unitOneSecond.RequestID()}
+	got := make([]uint64, 0, len(want))
+	for range want {
+		dispatch, ok := adapter.Dispatch()
+		if !ok {
+			t.Fatal("fair scheduler returned no dispatch")
+		}
+		got = append(got, dispatch.RequestID())
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("dispatch order = %v; want fair unit rotation %v", got, want)
+	}
+}
+
+func TestAdapterRejectsSecondOwnerForSameRemote(t *testing.T) {
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+	endpoint := "tcp://" + listener.Addr().String()
+	first, err := Start(context.Background(), integrationConfig(t, endpoint), realDialer, realFactory)
+	if err != nil {
+		t.Fatalf("Start(first): %v", err)
+	}
+	defer func() { _ = first.Close() }()
+	second, err := Start(context.Background(), integrationConfig(t, endpoint), realDialer, realFactory)
+	if err == nil || second != nil {
+		t.Fatalf("Start(second owner) = %#v, %v; want nil, error", second, err)
+	}
+}
+
+func TestAdapterRejectsQueuedWorkFromRetiredGenerationAndCancelsQueuedRead(t *testing.T) {
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+	config := integrationConfig(t, "tcp://"+listener.Addr().String())
+	adapter, err := Start(context.Background(), config, realDialer, realFactory)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = adapter.Close() }()
+	endpoint := adapter.endpoint.(*modbus.TCPEndpoint)
+
+	request, err := modbus.NewReadRegistersRequest(modbus.FunctionReadInputRegisters, 100, 1)
+	if err != nil {
+		t.Fatalf("NewReadRegistersRequest: %v", err)
+	}
+	oldRequest, err := adapter.EnqueueRead(ReadPlan{
+		UnitID: 1, AuthorizationScope: "site", PollGeneration: 1,
+		DeadlineIdentity: 1, Timeout: time.Second,
+		Reads: []modbus.TCPLogicalRead{{LogicalViewID: 1, Request: request}},
+	})
+	if err != nil {
+		t.Fatalf("enqueue old generation: %v", err)
+	}
+	oldConnection := adapter.connection
+	if err := endpoint.CloseConnection(oldConnection); err != nil {
+		t.Fatalf("CloseConnection(old): %v", err)
+	}
+	connection, err := realDialer(context.Background(), "tcp", listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial replacement: %v", err)
+	}
+	newConnection, err := endpoint.OpenConnection(connection)
+	if err != nil {
+		t.Fatalf("OpenConnection(replacement): %v", err)
+	}
+	if newConnection.Generation() == oldConnection.Generation() {
+		t.Fatalf("replacement reused transport generation %d", newConnection.Generation())
+	}
+	adapter.connection = newConnection
+	if dispatch, ok := adapter.Dispatch(); ok {
+		t.Fatalf("retired-generation request %d dispatched as %d", oldRequest.RequestID(), dispatch.RequestID())
+	}
+
+	newRequest, err := adapter.EnqueueRead(ReadPlan{
+		UnitID: 2, AuthorizationScope: "site", PollGeneration: 2,
+		DeadlineIdentity: 2, Timeout: time.Second,
+		Reads: []modbus.TCPLogicalRead{{LogicalViewID: 2, Request: request}},
+	})
+	if err != nil {
+		t.Fatalf("enqueue replacement generation: %v", err)
+	}
+	if err := adapter.Cancel(newRequest); err != nil {
+		t.Fatalf("Cancel(queued): %v", err)
+	}
+	if dispatch, ok := adapter.Dispatch(); ok {
+		t.Fatalf("cancelled request dispatched as %d", dispatch.RequestID())
+	}
+	snapshot := adapter.Snapshot()
+	if snapshot.Resources.QueuedRequests != 0 || snapshot.Resources.InFlightRequests != 0 {
+		t.Fatalf("cancelled/retired work remained scheduled: %+v", snapshot.Resources)
+	}
+}
+
+func TestAdapterPreservesCoalescedWireAndLogicalViewProvenance(t *testing.T) {
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+	done := serveResponse(listener, []uint16{0x1111, 0x2222, 0x3333})
+	config := integrationConfig(t, "tcp://"+listener.Addr().String())
+	adapter, err := Start(context.Background(), config, realDialer, realFactory)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = adapter.Close() }()
+
+	first, err := modbus.NewReadRegistersRequest(modbus.FunctionReadInputRegisters, 100, 2)
+	if err != nil {
+		t.Fatalf("first request: %v", err)
+	}
+	second, err := modbus.NewReadRegistersRequest(modbus.FunctionReadInputRegisters, 101, 2)
+	if err != nil {
+		t.Fatalf("second request: %v", err)
+	}
+	_, err = adapter.EnqueueRead(ReadPlan{
+		UnitID:             7,
+		AuthorizationScope: "readonly:site-a",
+		PollGeneration:     41,
+		DeadlineIdentity:   12,
+		Timeout:            time.Second,
+		Reads: []modbus.TCPLogicalRead{
+			{LogicalViewID: 1001, Request: first},
+			{LogicalViewID: 1002, Request: second},
+		},
+	})
+	if err != nil {
+		t.Fatalf("EnqueueRead: %v", err)
+	}
+	dispatch, ok := adapter.Dispatch()
+	if !ok {
+		t.Fatal("no dispatch")
+	}
+	if _, err := adapter.Write(context.Background(), dispatch); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	batch, err := adapter.Read(context.Background())
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("fake peer: %v", err)
+	}
+	if len(batch.Responses) != 1 || len(batch.Views) != 2 {
+		t.Fatalf("batch responses/views = %d/%d; want 1/2", len(batch.Responses), len(batch.Views))
+	}
+	sort.Slice(batch.Views, func(i, j int) bool {
+		return batch.Views[i].LogicalViewID() < batch.Views[j].LogicalViewID()
+	})
+	response := batch.Responses[0]
+	if response.WireResponseID() == 0 || response.Outcome() != modbus.WireSuccessfulData {
+		t.Fatalf("wire response identity/outcome = %d/%s", response.WireResponseID(), response.Outcome())
+	}
+	for _, view := range batch.Views {
+		provenance := view.Provenance()
+		if view.WireResponseID() != response.WireResponseID() ||
+			provenance.Wire.Endpoint != config.Endpoint.Endpoint ||
+			provenance.Wire.Transport != modbus.TransportTCP ||
+			provenance.Wire.TransportGeneration == 0 ||
+			provenance.Wire.UnitID != 7 ||
+			provenance.AuthorizationScope != "readonly:site-a" ||
+			provenance.PollGeneration != 41 ||
+			provenance.DeadlineIdentity != 12 {
+			t.Fatalf("logical provenance changed: %+v", provenance)
+		}
+	}
+	if got := batch.Views[0].Words(); !reflect.DeepEqual(got, []uint16{0x1111, 0x2222}) {
+		t.Fatalf("first view words = %x", got)
+	}
+	if got := batch.Views[1].Words(); !reflect.DeepEqual(got, []uint16{0x2222, 0x3333}) {
+		t.Fatalf("second view words = %x", got)
+	}
+}
+
+type observationCommitter struct {
+	mu      sync.Mutex
+	state   modbusreg.SampleLedgerState
+	restart modbusreg.LedgerRestartState
+}
+
+func (committer *observationCommitter) CommitPublication(
+	ctx context.Context,
+	request modbusreg.PublicationCommitRequest,
+) (modbusreg.PublicationCommitDecision, error) {
+	if err := ctx.Err(); err != nil {
+		return modbusreg.PublicationCommitCancelled, nil
+	}
+	committer.mu.Lock()
+	defer committer.mu.Unlock()
+	if committer.state != request.ExpectedState {
+		return "", errorsNew("sample state conflict")
+	}
+	committer.state = request.PublishedState
+	committer.restart = request.PublishedRestartState
+	return modbusreg.PublicationCommitCommitted, nil
+}
+
+func (committer *observationCommitter) CommitTerminalState(
+	ctx context.Context,
+	request modbusreg.TerminalStateCommitRequest,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	committer.mu.Lock()
+	defer committer.mu.Unlock()
+	committer.restart = request.TerminalRestartState
+	return nil
+}
+
+func errorsNew(message string) error { return fmt.Errorf("%s", message) }
+
+func TestAdapterViewsPublishWithoutChangingSampleFacts(t *testing.T) {
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+	done := serveResponse(listener, []uint16{0x5375})
+	config := integrationConfig(t, "tcp://"+listener.Addr().String())
+	adapter, err := Start(context.Background(), config, realDialer, realFactory)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = adapter.Close() }()
+
+	request, err := modbus.NewReadRegistersRequest(modbus.FunctionReadHoldingRegisters, 40000, 1)
+	if err != nil {
+		t.Fatalf("NewReadRegistersRequest: %v", err)
+	}
+	_, err = adapter.EnqueueRead(ReadPlan{
+		UnitID: 1, AuthorizationScope: "readonly:fronius", PollGeneration: 91,
+		DeadlineIdentity: 77, Timeout: time.Second,
+		Reads: []modbus.TCPLogicalRead{{LogicalViewID: 9001, Request: request}},
+	})
+	if err != nil {
+		t.Fatalf("EnqueueRead: %v", err)
+	}
+	dispatch, ok := adapter.Dispatch()
+	if !ok {
+		t.Fatal("no dispatch")
+	}
+	if _, err := adapter.Write(context.Background(), dispatch); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	batch, err := adapter.Read(context.Background())
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("fake peer: %v", err)
+	}
+	if len(batch.Views) != 1 {
+		t.Fatalf("views = %d; want 1", len(batch.Views))
+	}
+
+	profile, err := modbusreg.NewSunSpecPhaseOneProfile(modbusreg.SunSpecPhaseOneVersions{
+		Profile: modbusreg.CurrentSchemaVersion(),
+		Codec:   modbusreg.CurrentCodecContractVersion(),
+	})
+	if err != nil {
+		t.Fatalf("NewSunSpecPhaseOneProfile: %v", err)
+	}
+	initial, err := modbusreg.EmptySampleLedgerState("gateway-modbus", profile)
+	if err != nil {
+		t.Fatalf("EmptySampleLedgerState: %v", err)
+	}
+	ledger, err := modbusreg.NewSampleLedger(initial, 0)
+	if err != nil {
+		t.Fatalf("NewSampleLedger: %v", err)
+	}
+	committer := &observationCommitter{state: initial}
+	factory, err := modbusreg.NewObservationFactory(profile, ledger, committer)
+	if err != nil {
+		t.Fatalf("NewObservationFactory: %v", err)
+	}
+	sourceTime := time.Unix(1_800_000_000, 123).UTC()
+	receiptTime := sourceTime.Add(250 * time.Millisecond)
+	attempt, err := factory.BeginRuntimeAttempt(modbusreg.RuntimeAttemptRequest{
+		Source:     adapter.RuntimeAcquisitionSource(),
+		AttemptKey: "fronius-poll-91",
+		Identity:   modbusreg.AttemptIdentity{PollGenerationID: 91},
+		Observation: modbusreg.RuntimeObservationFacts{
+			SourceValidity:          modbusreg.SourceValid,
+			SourceTime:              modbusreg.SourceTimeObserved(sourceTime),
+			LocalReceiptTime:        receiptTime,
+			LocalReceiptTimePresent: true,
+		},
+		Dependencies: []modbusreg.RuntimeDependencyFacts{{
+			SourceTime: modbusreg.SourceTimeUnavailable(),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("BeginRuntimeAttempt: %v", err)
+	}
+	normalization, err := adapter.RuntimeAcquisitionSource().ParseNormalizationRecord([]byte(
+		`{"schema_version":1,"source_kind":"runtime","source_evidence_id":"urn:helianthus:evidence:sunspec-phase-one-v1","documentary_notation":"40001","documentary_address":40001,"documentary_address_base":"one_based_register","function_code":3,"logical_table":"holding_registers","normalized_zero_based_pdu_offset":40000,"word_count":1}`,
+	))
+	if err != nil {
+		t.Fatalf("ParseNormalizationRecord: %v", err)
+	}
+	if err := attempt.Issue(0, batch.Views[0], normalization); err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	if err := attempt.Admit(); err != nil {
+		t.Fatalf("Admit: %v", err)
+	}
+	if outcome, err := attempt.Claim(0); err != nil || outcome != modbusreg.ClaimSucceeded {
+		t.Fatalf("Claim = %q, %v", outcome, err)
+	}
+	if err := attempt.Seal(); err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	observation, err := attempt.Publish(context.Background())
+	if err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	spec := observation.Spec()
+	if spec.PollGenerationID != 91 || spec.SourceValidity != modbusreg.SourceValid ||
+		spec.SourceTime.State != modbusreg.SourceTimeObservedState ||
+		!spec.SourceTime.Time.Equal(sourceTime) || !spec.LocalReceiptTime.Equal(receiptTime) ||
+		spec.Endpoint != config.Endpoint.Endpoint || spec.UnitID != 1 || spec.SampleID == "" {
+		t.Fatalf("sample facts changed: %+v", spec)
+	}
+	replay := observation.Replay()
+	if len(replay) != 1 || replay[0].LogicalViewID() != 9001 ||
+		replay[0].WireResponseID() != batch.Views[0].WireResponseID() ||
+		replay[0].LogicalOffset() != 40000 ||
+		!reflect.DeepEqual(replay[0].RawWords(), []uint16{0x5375}) {
+		t.Fatalf("dependency provenance changed: %+v", replay)
+	}
+}

--- a/internal/modbusadapter/adapter_test.go
+++ b/internal/modbusadapter/adapter_test.go
@@ -1,0 +1,205 @@
+package modbusadapter
+
+import (
+	"context"
+	"errors"
+	"net"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+type fakeEndpoint struct {
+	mu sync.Mutex
+
+	openCalls    int
+	enqueueCalls int
+	cancelCalls  int
+	closeCalls   int
+	lastPlan     modbus.TCPReadPlan
+	openErr      error
+	closeErr     error
+}
+
+func (endpoint *fakeEndpoint) OpenConnection(net.Conn) (modbus.TCPConnectionHandle, error) {
+	endpoint.mu.Lock()
+	defer endpoint.mu.Unlock()
+	endpoint.openCalls++
+	return modbus.TCPConnectionHandle{}, endpoint.openErr
+}
+
+func (endpoint *fakeEndpoint) EnqueueRead(plan modbus.TCPReadPlan) (modbus.TCPRequestHandle, error) {
+	endpoint.mu.Lock()
+	defer endpoint.mu.Unlock()
+	endpoint.enqueueCalls++
+	endpoint.lastPlan = plan
+	return modbus.TCPRequestHandle{}, nil
+}
+
+func (*fakeEndpoint) Dispatch() (modbus.TCPDispatch, bool) {
+	return modbus.TCPDispatch{}, false
+}
+
+func (*fakeEndpoint) Write(context.Context, modbus.TCPDispatch) (modbus.OwnerTransition, error) {
+	return modbus.OwnerTransition{}, nil
+}
+
+func (*fakeEndpoint) Read(context.Context, modbus.TCPConnectionHandle) (modbus.TCPReadBatch, error) {
+	return modbus.TCPReadBatch{}, nil
+}
+
+func (endpoint *fakeEndpoint) Cancel(modbus.TCPRequestHandle) error {
+	endpoint.mu.Lock()
+	defer endpoint.mu.Unlock()
+	endpoint.cancelCalls++
+	return nil
+}
+
+func (*fakeEndpoint) Snapshot() modbus.TCPEndpointSnapshot {
+	return modbus.TCPEndpointSnapshot{Endpoint: "tcp://127.0.0.1:1502"}
+}
+
+func (endpoint *fakeEndpoint) Close() error {
+	endpoint.mu.Lock()
+	defer endpoint.mu.Unlock()
+	endpoint.closeCalls++
+	return endpoint.closeErr
+}
+
+func validConfig() Config {
+	return Config{
+		Enabled: true,
+		Endpoint: modbus.TCPEndpointConfig{
+			Endpoint: "tcp://127.0.0.1:1502",
+		},
+		DialTimeout: time.Second,
+	}
+}
+
+func TestStartDisabledIsInert(t *testing.T) {
+	factoryCalled := false
+	dialerCalled := false
+	adapter, err := Start(
+		context.Background(),
+		Config{},
+		func(context.Context, string, string) (net.Conn, error) {
+			dialerCalled = true
+			return nil, errors.New("unexpected dial")
+		},
+		func(modbus.TCPEndpointConfig) (Endpoint, error) {
+			factoryCalled = true
+			return nil, errors.New("unexpected factory")
+		},
+	)
+	if err != nil || adapter != nil {
+		t.Fatalf("Start(disabled) = %#v, %v; want nil, nil", adapter, err)
+	}
+	if factoryCalled || dialerCalled {
+		t.Fatalf("disabled adapter invoked factory=%v dialer=%v", factoryCalled, dialerCalled)
+	}
+}
+
+func TestStartOwnsExactlyOneEndpointAndForwardsReadIdentity(t *testing.T) {
+	endpoint := &fakeEndpoint{}
+	client, peer := net.Pipe()
+	defer func() { _ = peer.Close() }()
+
+	factoryCalls := 0
+	dialCalls := 0
+	adapter, err := Start(
+		context.Background(),
+		validConfig(),
+		func(_ context.Context, network, address string) (net.Conn, error) {
+			dialCalls++
+			if network != "tcp" || address != "127.0.0.1:1502" {
+				t.Fatalf("dial target = %s/%s", network, address)
+			}
+			return client, nil
+		},
+		func(config modbus.TCPEndpointConfig) (Endpoint, error) {
+			factoryCalls++
+			if config.Endpoint != "tcp://127.0.0.1:1502" {
+				t.Fatalf("factory endpoint = %q", config.Endpoint)
+			}
+			return endpoint, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if factoryCalls != 1 || dialCalls != 1 || endpoint.openCalls != 1 {
+		t.Fatalf("ownership calls factory/dial/open = %d/%d/%d; want 1/1/1", factoryCalls, dialCalls, endpoint.openCalls)
+	}
+
+	request, err := modbus.NewReadRegistersRequest(modbus.FunctionReadInputRegisters, 100, 2)
+	if err != nil {
+		t.Fatalf("NewReadRegistersRequest: %v", err)
+	}
+	plan := ReadPlan{
+		UnitID:             7,
+		AuthorizationScope: "readonly:site-a",
+		PollGeneration:     41,
+		DeadlineIdentity:   12,
+		Timeout:            900 * time.Millisecond,
+		Reads: []modbus.TCPLogicalRead{{
+			LogicalViewID: 1001,
+			Request:       request,
+		}},
+	}
+	if _, err := adapter.EnqueueRead(plan); err != nil {
+		t.Fatalf("EnqueueRead: %v", err)
+	}
+	got := endpoint.lastPlan
+	if got.UnitID != plan.UnitID ||
+		got.AuthorizationScope != plan.AuthorizationScope ||
+		got.PollGeneration != plan.PollGeneration ||
+		got.DeadlineIdentity != plan.DeadlineIdentity ||
+		got.Timeout != plan.Timeout ||
+		!reflect.DeepEqual(got.Reads, plan.Reads) {
+		t.Fatalf("forwarded plan changed identity: got=%+v want=%+v", got, plan)
+	}
+	if endpoint.enqueueCalls != 1 {
+		t.Fatalf("enqueue calls = %d; want 1", endpoint.enqueueCalls)
+	}
+
+	if err := adapter.Cancel(modbus.TCPRequestHandle{}); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if endpoint.cancelCalls != 1 {
+		t.Fatalf("cancel calls = %d; want 1", endpoint.cancelCalls)
+	}
+	if err := adapter.Close(); err != nil {
+		t.Fatalf("Close(first): %v", err)
+	}
+	if err := adapter.Close(); err != nil {
+		t.Fatalf("Close(second): %v", err)
+	}
+	if endpoint.closeCalls != 1 {
+		t.Fatalf("endpoint close calls = %d; want 1", endpoint.closeCalls)
+	}
+}
+
+func TestStartFailureClosesConstructedEndpointAndSocket(t *testing.T) {
+	endpoint := &fakeEndpoint{openErr: errors.New("open failed")}
+	client, peer := net.Pipe()
+	defer func() { _ = peer.Close() }()
+
+	adapter, err := Start(
+		context.Background(),
+		validConfig(),
+		func(context.Context, string, string) (net.Conn, error) { return client, nil },
+		func(modbus.TCPEndpointConfig) (Endpoint, error) { return endpoint, nil },
+	)
+	if err == nil || adapter != nil {
+		t.Fatalf("Start(open failure) = %#v, %v; want nil, error", adapter, err)
+	}
+	if endpoint.closeCalls != 1 {
+		t.Fatalf("endpoint close calls = %d; want 1", endpoint.closeCalls)
+	}
+	if err := client.SetDeadline(time.Now()); err == nil {
+		t.Fatal("dialed socket remained open after OpenConnection failure")
+	}
+}

--- a/modbus_config.go
+++ b/modbus_config.go
@@ -1,0 +1,11 @@
+package ebusgateway
+
+import "time"
+
+// ModbusTCPConfig is the disabled-by-default gateway composition boundary.
+// Add-on and CLI configuration are introduced separately in FMV3-M4-03.
+type ModbusTCPConfig struct {
+	Enabled     bool
+	Endpoint    string
+	DialTimeout time.Duration
+}


### PR DESCRIPTION
## Summary

- compose one disabled-by-default Modbus TCP endpoint behind the gateway adapter boundary
- preserve helianthus-modbus scheduling, coalescing, cancellation, generation, wire, logical-view, sample, poll, source-time, and validity provenance
- retain helianthus-modbusreg as the source-fact owner and add no canonical freshness, availability, or source-precedence policy
- close the sidecar exactly once and join its shutdown error when a later gateway startup stage fails

Closes #798.

## Dependencies

- docs contract: Project-Helianthus/helianthus-docs-ebus#372 at 7b0dd0abba8bc3420f1d8d2bae2db5bc229b75f3
- runtime: Project-Helianthus/helianthus-modbus#6; pinned main eab30aed9eb6f78a61c679c3bd9403d587025214
- registry/evidence: Project-Helianthus/helianthus-modbusreg#12 at 7b95df29e73f784db2e70b3446b1b034063c9bc8

## TDD

RED public head: 0fff3e65a2f638be249e3a5a9e197e5f2e62be46

The RED checkpoint contains tests only and fails because the adapter, gateway config boundary, and module pin are intentionally absent.

## Validation

Exact HEAD: 9df6dff05c121a6ac2c90041ede7348a7f2fa8b1

- [x] focused Modbus adapter and gateway lifecycle tests with race
- [x] local CI: terminology, gofmt/assets, vet, build, linux/386 build, full go test -race, schema coverage, 198 Python tests, golangci-lint
- [x] passive smoke gate: 6/6 canonical cases pass
- [x] transport gate owner override: M4-01 adds an independent disabled-by-default Modbus TCP sidecar and changes no eBUS transport/protocol path; focused fake-peer integration tests exercise the changed Modbus surface, while a live T01..T88 HA run would exercise unrelated eBUS paths
- [ ] fresh exact-HEAD NO_BLOCKING_FINDINGS

No live installation or device mutation is part of M4-01.