### PR TITLE
FMV3-M4-03: load Modbus endpoint from protected file

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -133,6 +133,9 @@ func main() {
 	defer stop()
 
 	if err := run(ctx, cfg); err != nil {
+		if inputs.modbusEndpointFile != "" {
+			err = redactFileSourcedModbusError(err, cfg.ModbusTCPConfig.Endpoint)
+		}
 		log.Fatalf("gateway: %v", err)
 	}
 }

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -122,8 +122,11 @@ func (observer *runtimeWatchObserver) Observe(key ebusgateway.WatchKey) ebusgate
 
 func main() {
 	cfg := ebusgateway.DefaultConfig()
-	bindFlags(flag.CommandLine, &cfg)
+	inputs := bindFlags(flag.CommandLine, &cfg)
 	flag.Parse()
+	if err := resolveModbusEndpointFile(&cfg.ModbusTCPConfig, inputs.modbusEndpointFile); err != nil {
+		log.Fatalf("gateway: %v", err)
+	}
 	applyTransportSourcePolicy(&cfg)
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -1312,9 +1315,10 @@ func gatewayMDNSText(cfg ebusgateway.Config) []string {
 	return text
 }
 
-func bindFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) {
+func bindFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) *gatewayFlagInputs {
+	inputs := &gatewayFlagInputs{}
 	if fs == nil || cfg == nil {
-		return
+		return inputs
 	}
 
 	fs.StringVar((*string)(&cfg.TransportConfig.Protocol), "transport", string(cfg.TransportConfig.Protocol), "transport protocol: enh, ens, udp-plain, tcp-plain, or ebusd-tcp")
@@ -1325,6 +1329,7 @@ func bindFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) {
 	fs.DurationVar(&cfg.TransportConfig.DialTimeout, "dial-timeout", cfg.TransportConfig.DialTimeout, "transport dial timeout")
 	fs.BoolVar(&cfg.ModbusTCPConfig.Enabled, "modbus-tcp-enabled", cfg.ModbusTCPConfig.Enabled, "enable the read-only Modbus TCP sidecar")
 	fs.StringVar(&cfg.ModbusTCPConfig.Endpoint, "modbus-tcp-endpoint", cfg.ModbusTCPConfig.Endpoint, "Modbus TCP endpoint URI (tcp://host:port)")
+	fs.StringVar(&inputs.modbusEndpointFile, "modbus-tcp-endpoint-file", "", "path to an owner-only file containing the Modbus TCP endpoint URI")
 	fs.DurationVar(&cfg.ModbusTCPConfig.DialTimeout, "modbus-tcp-dial-timeout", cfg.ModbusTCPConfig.DialTimeout, "Modbus TCP dial timeout")
 	bindEEBusFlags(fs, cfg)
 	fs.BoolVar(
@@ -1463,6 +1468,7 @@ func bindFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) {
 		return nil
 	})
 	fs.BoolVar(&cfg.StartupSource.Validate, "startup-source-override-validate", cfg.StartupSource.Validate, "run source-address selector in advisory-only mode alongside startup-source-override")
+	return inputs
 }
 
 // parseHexByteList parses a comma-separated list of hex byte literals

--- a/cmd/gateway/modbus_endpoint_file.go
+++ b/cmd/gateway/modbus_endpoint_file.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"io"
+	"net"
 	"net/url"
 	"os"
 	"sort"
@@ -77,6 +78,7 @@ func redactFileSourcedModbusError(err error, endpoint string) error {
 	if parsed, parseErr := url.Parse(endpoint); parseErr == nil {
 		values = append(values, parsed.Host, parsed.Hostname())
 	}
+	values = append(values, modbusErrorNetworkAddresses(err, 0)...)
 	sort.Slice(values, func(i, j int) bool { return len(values[i]) > len(values[j]) })
 	message := err.Error()
 	for _, value := range values {
@@ -85,4 +87,27 @@ func redactFileSourcedModbusError(err error, endpoint string) error {
 		}
 	}
 	return errors.New(message)
+}
+
+func modbusErrorNetworkAddresses(err error, depth int) []string {
+	if err == nil || depth > 32 {
+		return nil
+	}
+	values := make([]string, 0, 2)
+	if networkError, ok := err.(*net.OpError); ok && networkError.Addr != nil {
+		values = append(values, networkError.Addr.String())
+	}
+	if dnsError, ok := err.(*net.DNSError); ok && dnsError.Name != "" {
+		values = append(values, dnsError.Name)
+	}
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		for _, child := range joined.Unwrap() {
+			values = append(values, modbusErrorNetworkAddresses(child, depth+1)...)
+		}
+		return values
+	}
+	if wrapped, ok := err.(interface{ Unwrap() error }); ok {
+		values = append(values, modbusErrorNetworkAddresses(wrapped.Unwrap(), depth+1)...)
+	}
+	return values
 }

--- a/cmd/gateway/modbus_endpoint_file.go
+++ b/cmd/gateway/modbus_endpoint_file.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"net"
+	"net/url"
+	"os"
+	"syscall"
+
+	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
+)
+
+const maxModbusEndpointFileBytes = 512
+
+type gatewayFlagInputs struct {
+	modbusEndpointFile string
+}
+
+func resolveModbusEndpointFile(config *ebusgateway.ModbusTCPConfig, path string) error {
+	if config == nil {
+		return errors.New("invalid Modbus TCP endpoint file configuration")
+	}
+	if !config.Enabled {
+		*config = ebusgateway.ModbusTCPConfig{}
+		return nil
+	}
+	if path == "" {
+		return nil
+	}
+	if config.Endpoint != "" {
+		return errors.New("Modbus TCP endpoint inputs are mutually exclusive")
+	}
+
+	before, err := os.Lstat(path)
+	if err != nil || !before.Mode().IsRegular() {
+		return errors.New("invalid Modbus TCP endpoint file")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return errors.New("invalid Modbus TCP endpoint file")
+	}
+	defer func() { _ = file.Close() }()
+	after, err := file.Stat()
+	if err != nil || !after.Mode().IsRegular() || !os.SameFile(before, after) {
+		return errors.New("invalid Modbus TCP endpoint file")
+	}
+	if permissions := after.Mode().Perm(); permissions != 0o400 && permissions != 0o600 {
+		return errors.New("invalid Modbus TCP endpoint file")
+	}
+	stat, ok := after.Sys().(*syscall.Stat_t)
+	if !ok || stat.Uid != uint32(os.Geteuid()) {
+		return errors.New("invalid Modbus TCP endpoint file")
+	}
+	if after.Size() < 1 || after.Size() > maxModbusEndpointFileBytes {
+		return errors.New("invalid Modbus TCP endpoint file")
+	}
+	content, err := io.ReadAll(io.LimitReader(file, maxModbusEndpointFileBytes+1))
+	if err != nil || len(content) < 1 || len(content) > maxModbusEndpointFileBytes {
+		return errors.New("invalid Modbus TCP endpoint file")
+	}
+	endpoint := string(content)
+	if !validModbusTCPEndpoint(endpoint) {
+		return errors.New("invalid Modbus TCP endpoint file")
+	}
+	config.Endpoint = endpoint
+	return nil
+}
+
+func validModbusTCPEndpoint(endpoint string) bool {
+	parsed, err := url.Parse(endpoint)
+	if err != nil || parsed.Scheme != "tcp" || parsed.Host == "" ||
+		parsed.User != nil || parsed.Path != "" || parsed.RawQuery != "" ||
+		parsed.Fragment != "" {
+		return false
+	}
+	_, _, err = net.SplitHostPort(parsed.Host)
+	return err == nil
+}

--- a/cmd/gateway/modbus_endpoint_file.go
+++ b/cmd/gateway/modbus_endpoint_file.go
@@ -3,12 +3,14 @@ package main
 import (
 	"errors"
 	"io"
-	"net"
 	"net/url"
 	"os"
+	"sort"
+	"strings"
 	"syscall"
 
 	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/modbusadapter"
 )
 
 const maxModbusEndpointFileBytes = 512
@@ -60,20 +62,27 @@ func resolveModbusEndpointFile(config *ebusgateway.ModbusTCPConfig, path string)
 		return errors.New("invalid Modbus TCP endpoint file")
 	}
 	endpoint := string(content)
-	if !validModbusTCPEndpoint(endpoint) {
+	if err := modbusadapter.ValidateTCPEndpoint(endpoint); err != nil {
 		return errors.New("invalid Modbus TCP endpoint file")
 	}
 	config.Endpoint = endpoint
 	return nil
 }
 
-func validModbusTCPEndpoint(endpoint string) bool {
-	parsed, err := url.Parse(endpoint)
-	if err != nil || parsed.Scheme != "tcp" || parsed.Host == "" ||
-		parsed.User != nil || parsed.Path != "" || parsed.RawQuery != "" ||
-		parsed.Fragment != "" {
-		return false
+func redactFileSourcedModbusError(err error, endpoint string) error {
+	if err == nil || endpoint == "" {
+		return err
 	}
-	_, _, err = net.SplitHostPort(parsed.Host)
-	return err == nil
+	values := []string{endpoint}
+	if parsed, parseErr := url.Parse(endpoint); parseErr == nil {
+		values = append(values, parsed.Host, parsed.Hostname())
+	}
+	sort.Slice(values, func(i, j int) bool { return len(values[i]) > len(values[j]) })
+	message := err.Error()
+	for _, value := range values {
+		if value != "" {
+			message = strings.ReplaceAll(message, value, "[REDACTED_MODBUS_ENDPOINT]")
+		}
+	}
+	return errors.New(message)
 }

--- a/cmd/gateway/modbus_endpoint_file.go
+++ b/cmd/gateway/modbus_endpoint_file.go
@@ -29,7 +29,7 @@ func resolveModbusEndpointFile(config *ebusgateway.ModbusTCPConfig, path string)
 		return nil
 	}
 	if config.Endpoint != "" {
-		return errors.New("Modbus TCP endpoint inputs are mutually exclusive")
+		return errors.New("modbus TCP endpoint inputs are mutually exclusive")
 	}
 
 	before, err := os.Lstat(path)

--- a/cmd/gateway/modbus_endpoint_file_test.go
+++ b/cmd/gateway/modbus_endpoint_file_test.go
@@ -44,17 +44,21 @@ func TestBindFlagsKeepsModbusEndpointFileOutOfRuntimeConfig(t *testing.T) {
 }
 
 func TestResolveModbusEndpointFileLoadsProtectedBoundedValue(t *testing.T) {
-	path := writeProtectedEndpointFile(t, "tcp://192.0.2.40:502", 0o600)
-	cfg := ebusgateway.ModbusTCPConfig{Enabled: true, DialTimeout: 3 * time.Second}
+	for _, mode := range []os.FileMode{0o400, 0o600} {
+		t.Run(mode.String(), func(t *testing.T) {
+			path := writeProtectedEndpointFile(t, "tcp://192.0.2.40:502", mode)
+			cfg := ebusgateway.ModbusTCPConfig{Enabled: true, DialTimeout: 3 * time.Second}
 
-	if err := resolveModbusEndpointFile(&cfg, path); err != nil {
-		t.Fatalf("resolve endpoint file: %v", err)
-	}
-	if cfg.Endpoint != "tcp://192.0.2.40:502" {
-		t.Fatalf("endpoint = %q", cfg.Endpoint)
-	}
-	if _, err := mapModbusRuntimeConfig(cfg); err != nil {
-		t.Fatalf("map resolved config: %v", err)
+			if err := resolveModbusEndpointFile(&cfg, path); err != nil {
+				t.Fatalf("resolve endpoint file: %v", err)
+			}
+			if cfg.Endpoint != "tcp://192.0.2.40:502" {
+				t.Fatalf("endpoint = %q", cfg.Endpoint)
+			}
+			if _, err := mapModbusRuntimeConfig(cfg); err != nil {
+				t.Fatalf("map resolved config: %v", err)
+			}
+		})
 	}
 }
 
@@ -99,14 +103,17 @@ func TestResolveModbusEndpointFileRejectsUnsafeFilesAndBounds(t *testing.T) {
 	unsafeMode := writeProtectedEndpointFile(t, "tcp://192.0.2.40:502", 0o644)
 	empty := writeProtectedEndpointFile(t, "", 0o600)
 	oversized := writeProtectedEndpointFile(t, strings.Repeat("x", 513), 0o600)
+	invalid := writeProtectedEndpointFile(t, "tcp://sensitive.internal:502\n", 0o600)
 	directory := t.TempDir()
 
 	for name, path := range map[string]string{
-		"symlink":    symlink,
+		"symlink":     symlink,
 		"unsafe-mode": unsafeMode,
-		"empty":      empty,
-		"oversized":  oversized,
-		"directory":  directory,
+		"empty":       empty,
+		"oversized":   oversized,
+		"invalid":     invalid,
+		"directory":   directory,
+		"missing":     filepath.Join(t.TempDir(), "missing"),
 	} {
 		t.Run(name, func(t *testing.T) {
 			cfg := ebusgateway.ModbusTCPConfig{Enabled: true, DialTimeout: time.Second}
@@ -119,4 +126,3 @@ func TestResolveModbusEndpointFileRejectsUnsafeFilesAndBounds(t *testing.T) {
 		})
 	}
 }
-

--- a/cmd/gateway/modbus_endpoint_file_test.go
+++ b/cmd/gateway/modbus_endpoint_file_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"os"
 	"path/filepath"
@@ -124,5 +125,33 @@ func TestResolveModbusEndpointFileRejectsUnsafeFilesAndBounds(t *testing.T) {
 				t.Fatalf("unsafe endpoint file populated config: %q", cfg.Endpoint)
 			}
 		})
+	}
+}
+
+func TestRedactFileSourcedModbusErrorRemovesEndpointVariants(t *testing.T) {
+	endpoint := "tcp://sensitive.internal:502"
+	err := errors.New(
+		"dial tcp://sensitive.internal:502 via sensitive.internal:502: " +
+			"lookup sensitive.internal: no such host",
+	)
+
+	redacted := redactFileSourcedModbusError(err, endpoint)
+	if redacted == nil {
+		t.Fatal("redacted error is nil")
+	}
+	for _, secret := range []string{endpoint, "sensitive.internal:502", "sensitive.internal"} {
+		if strings.Contains(redacted.Error(), secret) {
+			t.Fatalf("redacted startup error contains %q: %v", secret, redacted)
+		}
+	}
+	if !strings.Contains(redacted.Error(), "[REDACTED_MODBUS_ENDPOINT]") {
+		t.Fatalf("redacted startup error has no marker: %v", redacted)
+	}
+}
+
+func TestRedactFileSourcedModbusErrorLeavesInlineErrorUnchanged(t *testing.T) {
+	original := errors.New("dial tcp://inline.internal:502 failed")
+	if got := redactFileSourcedModbusError(original, ""); got != original {
+		t.Fatalf("inline error identity changed: got %v want %v", got, original)
 	}
 }

--- a/cmd/gateway/modbus_endpoint_file_test.go
+++ b/cmd/gateway/modbus_endpoint_file_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"errors"
 	"flag"
+	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -153,5 +155,45 @@ func TestRedactFileSourcedModbusErrorLeavesInlineErrorUnchanged(t *testing.T) {
 	original := errors.New("dial tcp://inline.internal:502 failed")
 	if got := redactFileSourcedModbusError(original, ""); got != original {
 		t.Fatalf("inline error identity changed: got %v want %v", got, original)
+	}
+}
+
+func TestRedactFileSourcedModbusErrorRemovesResolvedNetworkAddresses(t *testing.T) {
+	endpoint := "tcp://modbus.internal:502"
+	for name, address := range map[string]*net.TCPAddr{
+		"ipv4": {IP: net.ParseIP("192.0.2.40"), Port: 502},
+		"ipv6": {IP: net.ParseIP("2001:db8::40"), Port: 502},
+	} {
+		t.Run(name, func(t *testing.T) {
+			dialError := &net.OpError{
+				Op:   "dial",
+				Net:  "tcp",
+				Addr: address,
+				Err:  errors.New("connection refused"),
+			}
+			wrapped := fmt.Errorf(
+				"modbus startup: %w",
+				errors.Join(errors.New("sidecar failed"), dialError),
+			)
+
+			redacted := redactFileSourcedModbusError(wrapped, endpoint)
+			if strings.Contains(redacted.Error(), address.String()) ||
+				strings.Contains(redacted.Error(), "modbus.internal") {
+				t.Fatalf("redacted error leaks remote address: %v", redacted)
+			}
+			if !strings.Contains(redacted.Error(), "[REDACTED_MODBUS_ENDPOINT]") {
+				t.Fatalf("redacted error has no marker: %v", redacted)
+			}
+		})
+	}
+}
+
+func TestRedactFileSourcedModbusErrorRemovesWrappedDNSName(t *testing.T) {
+	endpoint := "tcp://configured.invalid:502"
+	dnsError := &net.DNSError{Name: "canonical.internal", Err: "no such host"}
+	redacted := redactFileSourcedModbusError(fmt.Errorf("resolve: %w", dnsError), endpoint)
+	if strings.Contains(redacted.Error(), "configured.invalid") ||
+		strings.Contains(redacted.Error(), "canonical.internal") {
+		t.Fatalf("redacted error leaks DNS name: %v", redacted)
 	}
 }

--- a/cmd/gateway/modbus_endpoint_file_test.go
+++ b/cmd/gateway/modbus_endpoint_file_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
+)
+
+func writeProtectedEndpointFile(t *testing.T, content string, mode os.FileMode) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "modbus-endpoint")
+	if err := os.WriteFile(path, []byte(content), mode); err != nil {
+		t.Fatalf("write endpoint file: %v", err)
+	}
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatalf("chmod endpoint file: %v", err)
+	}
+	return path
+}
+
+func TestBindFlagsKeepsModbusEndpointFileOutOfRuntimeConfig(t *testing.T) {
+	cfg := ebusgateway.DefaultConfig()
+	fs := flag.NewFlagSet("modbus-endpoint-file", flag.ContinueOnError)
+	inputs := bindFlags(fs, &cfg)
+	path := "/run/helianthus/modbus-endpoint"
+	if err := fs.Parse([]string{
+		"-modbus-tcp-enabled=true",
+		"-modbus-tcp-endpoint-file", path,
+		"-modbus-tcp-dial-timeout", "3s",
+	}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	if inputs == nil || inputs.modbusEndpointFile != path {
+		t.Fatalf("endpoint-file input = %+v", inputs)
+	}
+	if cfg.ModbusTCPConfig.Endpoint != "" {
+		t.Fatalf("raw endpoint reached flag-populated runtime config: %q", cfg.ModbusTCPConfig.Endpoint)
+	}
+}
+
+func TestResolveModbusEndpointFileLoadsProtectedBoundedValue(t *testing.T) {
+	path := writeProtectedEndpointFile(t, "tcp://192.0.2.40:502", 0o600)
+	cfg := ebusgateway.ModbusTCPConfig{Enabled: true, DialTimeout: 3 * time.Second}
+
+	if err := resolveModbusEndpointFile(&cfg, path); err != nil {
+		t.Fatalf("resolve endpoint file: %v", err)
+	}
+	if cfg.Endpoint != "tcp://192.0.2.40:502" {
+		t.Fatalf("endpoint = %q", cfg.Endpoint)
+	}
+	if _, err := mapModbusRuntimeConfig(cfg); err != nil {
+		t.Fatalf("map resolved config: %v", err)
+	}
+}
+
+func TestResolveModbusEndpointFileRejectsInlineConflictWithoutEchoingEndpoint(t *testing.T) {
+	secretEndpoint := "tcp://sensitive.internal:502"
+	path := writeProtectedEndpointFile(t, secretEndpoint, 0o600)
+	cfg := ebusgateway.ModbusTCPConfig{
+		Enabled:     true,
+		Endpoint:    "tcp://other.internal:502",
+		DialTimeout: time.Second,
+	}
+
+	err := resolveModbusEndpointFile(&cfg, path)
+	if err == nil {
+		t.Fatal("inline/file conflict was accepted")
+	}
+	if strings.Contains(err.Error(), secretEndpoint) || strings.Contains(err.Error(), cfg.Endpoint) {
+		t.Fatalf("error leaked endpoint material: %v", err)
+	}
+}
+
+func TestResolveModbusEndpointFileDisabledIsInertForAnyRetainedInputs(t *testing.T) {
+	cfg := ebusgateway.ModbusTCPConfig{
+		Endpoint:    "tcp://retained.invalid:502",
+		DialTimeout: -time.Second,
+	}
+
+	if err := resolveModbusEndpointFile(&cfg, "/missing/retained-endpoint"); err != nil {
+		t.Fatalf("disabled config inspected retained inputs: %v", err)
+	}
+	if cfg != (ebusgateway.ModbusTCPConfig{}) {
+		t.Fatalf("disabled config is not inert: %+v", cfg)
+	}
+}
+
+func TestResolveModbusEndpointFileRejectsUnsafeFilesAndBounds(t *testing.T) {
+	valid := writeProtectedEndpointFile(t, "tcp://192.0.2.40:502", 0o600)
+	symlink := filepath.Join(t.TempDir(), "endpoint-link")
+	if err := os.Symlink(valid, symlink); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+	unsafeMode := writeProtectedEndpointFile(t, "tcp://192.0.2.40:502", 0o644)
+	empty := writeProtectedEndpointFile(t, "", 0o600)
+	oversized := writeProtectedEndpointFile(t, strings.Repeat("x", 513), 0o600)
+	directory := t.TempDir()
+
+	for name, path := range map[string]string{
+		"symlink":    symlink,
+		"unsafe-mode": unsafeMode,
+		"empty":      empty,
+		"oversized":  oversized,
+		"directory":  directory,
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg := ebusgateway.ModbusTCPConfig{Enabled: true, DialTimeout: time.Second}
+			if err := resolveModbusEndpointFile(&cfg, path); err == nil {
+				t.Fatalf("unsafe endpoint file %s was accepted", name)
+			}
+			if cfg.Endpoint != "" {
+				t.Fatalf("unsafe endpoint file populated config: %q", cfg.Endpoint)
+			}
+		})
+	}
+}
+

--- a/internal/modbusadapter/adapter.go
+++ b/internal/modbusadapter/adapter.go
@@ -123,6 +123,13 @@ func Start(
 	}, nil
 }
 
+// ValidateTCPEndpoint applies the endpoint grammar used by Start without
+// opening a connection.
+func ValidateTCPEndpoint(endpoint string) error {
+	_, err := dialAddress(endpoint)
+	return err
+}
+
 func dialAddress(endpoint string) (string, error) {
 	parsed, err := url.Parse(endpoint)
 	if err != nil || parsed.Scheme != "tcp" || parsed.Host == "" ||


### PR DESCRIPTION
## Summary

- add `-modbus-tcp-endpoint-file` as a nonsecret argv channel for the existing read-only Modbus endpoint
- require a current-UID regular file with mode 0400/0600 and a maximum of 512 bytes
- reject symlink/swap, inline/file conflicts, invalid endpoint content, and content-bearing errors
- use the adapter's canonical endpoint parser for both inline and file-backed inputs
- redact configured and resolved endpoint identities from file-sourced fatal errors, including wrapped/joined IPv4, IPv6, and DNS failures
- keep disabled Modbus inert and preserve the existing inline endpoint flag for non-add-on callers

## Evidence

- RED head: 30de4a485b369d3684517e8e5c845adbbc40acd9
- current exact head: 20a165e9d5722fc254dfc61b98f27f3104606e46
- `go test -race ./cmd/gateway ./internal/modbusadapter`
- `go vet ./cmd/gateway ./internal/modbusadapter`
- `golangci-lint run ./cmd/gateway/... ./internal/modbusadapter/...` (0 issues)
- full exact-head local and GitHub CI required before merge
- transport/passive owner override reason: protected configuration ingress and fatal-log redaction only; no transport, framing, protocol, passive-observation, or wire behavior changes. Live T01..T88 remains behind the M4-04 operator-confirmation hard stop.
- companion public docs gate is required before merge

## Scope

Configuration ingress and endpoint-error redaction only. No Modbus wire behavior, eeBUS, MCP, GraphQL, Portal, semantic, polling, or live-device changes.

Closes #803
