### PR TITLE
FMV3-M4-04: qualify Fronius read-only smoke and recovery

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -204,6 +204,11 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 				result = errors.Join(result, fmt.Errorf("shutdown Modbus TCP sidecar: %w", err))
 			}
 		}()
+		sunSpecWorker := newGatewaySunSpecLiveSmokeWorker(ctx, modbusAdapter, log.Printf)
+		if sunSpecWorker != nil {
+			sunSpecWorker.Start()
+			defer func() { _ = sunSpecWorker.Close() }()
+		}
 	}
 
 	eebusAdapter, err := startEEBusRuntime(ctx, cfg.EEBusConfig, resolveEEBusInterfaceAddressesFn, newEEBusRuntimeFn)

--- a/cmd/gateway/modbus_sunspec_runtime.go
+++ b/cmd/gateway/modbus_sunspec_runtime.go
@@ -1,0 +1,269 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/modbusadapter"
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+const (
+	sunSpecLiveSmokeUnitID             = byte(1)
+	sunSpecLiveSmokeAuthorizationScope = "smoke:fronius-readonly"
+	sunSpecLiveSmokeProfile            = "sunspec.phase1"
+	sunSpecLiveSmokeReadTimeout        = 2 * time.Second
+	sunSpecLiveSmokeAttemptTimeout     = 30 * time.Second
+)
+
+type sunSpecLiveSmokeDecision string
+
+const (
+	sunSpecLiveSmokeDecisionGO   sunSpecLiveSmokeDecision = "GO"
+	sunSpecLiveSmokeDecisionNoGo sunSpecLiveSmokeDecision = "NO_GO"
+	sunSpecLiveSmokeDecisionStop sunSpecLiveSmokeDecision = "STOP"
+)
+
+type sunSpecLiveSmokeAttempt struct {
+	PollID     uint64
+	DeadlineID uint64
+	Deadline   time.Duration
+}
+
+type sunSpecLiveSmokeSnapshot = modbus.TCPEndpointSnapshot
+
+type sunSpecLiveSmokePollResult struct {
+	Snapshot      sunSpecLiveSmokeSnapshot
+	Qualification modbusadapter.SunSpecQualificationResult
+	Err           error
+}
+
+type sunSpecLiveSmokeQualification struct {
+	Supported          bool
+	UnsupportedProfile bool
+	Incoherent         bool
+	Sample             string
+	Profile            string
+	Err                error
+}
+
+type sunSpecLiveSmokeResult struct {
+	Decision  sunSpecLiveSmokeDecision
+	Outcome   string
+	Category  string
+	Attempts  int
+	Recovered bool
+	Sample    string
+	Profile   string
+}
+
+type sunSpecLiveSmokeDriver interface {
+	Poll(context.Context, sunSpecLiveSmokeAttempt) (sunSpecLiveSmokePollResult, error)
+	Reconnect(context.Context) error
+}
+
+type sunSpecLiveSmokeQualifier interface {
+	Qualify(context.Context, sunSpecLiveSmokeAttempt, sunSpecLiveSmokePollResult) sunSpecLiveSmokeQualification
+}
+
+type modbusSunSpecLiveSmokeDriver struct {
+	adapter  *modbusadapter.Adapter
+	producer *modbusadapter.SunSpecProducer
+}
+
+func (driver *modbusSunSpecLiveSmokeDriver) Poll(ctx context.Context, attempt sunSpecLiveSmokeAttempt) (sunSpecLiveSmokePollResult, error) {
+	qualification, err := driver.producer.Qualify(ctx, modbusadapter.SunSpecPollIdentity{
+		PollGeneration: attempt.PollID, DeadlineIdentity: attempt.DeadlineID,
+	})
+	result := sunSpecLiveSmokePollResult{
+		Snapshot: driver.adapter.Snapshot(), Qualification: qualification, Err: err,
+	}
+	return result, err
+}
+
+func (driver *modbusSunSpecLiveSmokeDriver) Reconnect(ctx context.Context) error {
+	return driver.adapter.Reconnect(ctx)
+}
+
+type modbusSunSpecLiveSmokeQualifier struct{}
+
+func (modbusSunSpecLiveSmokeQualifier) Qualify(_ context.Context, _ sunSpecLiveSmokeAttempt, poll sunSpecLiveSmokePollResult) sunSpecLiveSmokeQualification {
+	if poll.Err != nil {
+		return sunSpecLiveSmokeQualification{Err: poll.Err}
+	}
+	switch poll.Qualification.Outcome {
+	case modbusadapter.SunSpecQualificationSupported:
+		return sunSpecLiveSmokeQualification{
+			Supported: true, Sample: poll.Qualification.SampleID, Profile: sunSpecLiveSmokeProfile,
+		}
+	case modbusadapter.SunSpecQualificationUnsupportedProfile:
+		return sunSpecLiveSmokeQualification{UnsupportedProfile: true}
+	case modbusadapter.SunSpecQualificationIncoherentCapture:
+		return sunSpecLiveSmokeQualification{Incoherent: true}
+	default:
+		return sunSpecLiveSmokeQualification{Err: errUnknownSunSpecQualificationOutcome}
+	}
+}
+
+type categoricalSunSpecLiveSmokeError string
+
+func (err categoricalSunSpecLiveSmokeError) Error() string { return string(err) }
+
+const errUnknownSunSpecQualificationOutcome categoricalSunSpecLiveSmokeError = "unknown SunSpec qualification outcome"
+
+var sunSpecLiveSmokeIdentity atomic.Uint64
+
+func nextSunSpecLiveSmokeIdentity() uint64 {
+	for {
+		if identity := sunSpecLiveSmokeIdentity.Add(1); identity != 0 {
+			return identity
+		}
+	}
+}
+
+func runSunSpecLiveSmoke(
+	ctx context.Context,
+	attemptTimeout time.Duration,
+	driver sunSpecLiveSmokeDriver,
+	qualifier sunSpecLiveSmokeQualifier,
+	logf func(string, ...any),
+) (result sunSpecLiveSmokeResult) {
+	result = sunSpecLiveSmokeResult{Decision: sunSpecLiveSmokeDecisionStop, Outcome: "error", Category: "invalid_runtime"}
+	if logf == nil {
+		logf = func(string, ...any) {}
+	}
+	defer func() {
+		logf(
+			"modbus sunspec live smoke decision=%s outcome=%s category=%s attempts=%d recovered=%t",
+			result.Decision, result.Outcome, result.Category, result.Attempts, result.Recovered,
+		)
+	}()
+	if ctx == nil || attemptTimeout <= 0 || driver == nil || qualifier == nil {
+		return result
+	}
+
+	for attemptIndex := 0; attemptIndex < 2; attemptIndex++ {
+		attempt := sunSpecLiveSmokeAttempt{
+			PollID: nextSunSpecLiveSmokeIdentity(), DeadlineID: nextSunSpecLiveSmokeIdentity(), Deadline: attemptTimeout,
+		}
+		attemptCtx, cancel := context.WithTimeout(ctx, attemptTimeout)
+		poll, err := driver.Poll(attemptCtx, attempt)
+		if err == nil {
+			err = poll.Err
+		}
+		result.Attempts++
+		if err == nil {
+			qualification := qualifier.Qualify(attemptCtx, attempt, poll)
+			cancel()
+			result.Recovered = attemptIndex == 1
+			return mapSunSpecLiveSmokeQualification(qualification, result)
+		}
+		cancel()
+
+		if attemptIndex != 0 || !poll.Snapshot.ReconnectRequired {
+			result.Category = "poll_error"
+			return result
+		}
+		reconnectCtx, reconnectCancel := context.WithTimeout(ctx, attemptTimeout)
+		reconnectErr := driver.Reconnect(reconnectCtx)
+		reconnectCancel()
+		if reconnectErr != nil {
+			result.Category = "reconnect_error"
+			return result
+		}
+	}
+	return result
+}
+
+func mapSunSpecLiveSmokeQualification(qualification sunSpecLiveSmokeQualification, base sunSpecLiveSmokeResult) sunSpecLiveSmokeResult {
+	base.Sample, base.Profile = "", ""
+	if qualification.Err != nil {
+		base.Decision, base.Outcome, base.Category = sunSpecLiveSmokeDecisionStop, "error", "qualification_error"
+		return base
+	}
+	states := 0
+	for _, set := range []bool{qualification.Supported, qualification.UnsupportedProfile, qualification.Incoherent} {
+		if set {
+			states++
+		}
+	}
+	if states != 1 {
+		base.Decision, base.Outcome, base.Category = sunSpecLiveSmokeDecisionStop, "incoherent", "invalid_qualification"
+		return base
+	}
+	if qualification.Supported {
+		base.Decision, base.Outcome, base.Category = sunSpecLiveSmokeDecisionGO, "supported", "qualified"
+		base.Sample, base.Profile = qualification.Sample, qualification.Profile
+		return base
+	}
+	if qualification.UnsupportedProfile {
+		base.Decision, base.Outcome, base.Category = sunSpecLiveSmokeDecisionNoGo, "unsupported_profile", "unsupported_profile"
+		return base
+	}
+	base.Decision, base.Outcome, base.Category = sunSpecLiveSmokeDecisionStop, "incoherent", "incoherent_capture"
+	return base
+}
+
+type sunSpecLiveSmokeWorker struct {
+	cancel context.CancelFunc
+	done   chan struct{}
+	run    func()
+
+	startOnce sync.Once
+	closeOnce sync.Once
+}
+
+func newSunSpecLiveSmokeWorker(
+	parent context.Context,
+	attemptTimeout time.Duration,
+	driver sunSpecLiveSmokeDriver,
+	qualifier sunSpecLiveSmokeQualifier,
+	logf func(string, ...any),
+) *sunSpecLiveSmokeWorker {
+	ctx, cancel := context.WithCancel(parent)
+	worker := &sunSpecLiveSmokeWorker{cancel: cancel, done: make(chan struct{})}
+	worker.run = func() {
+		defer close(worker.done)
+		_ = runSunSpecLiveSmoke(ctx, attemptTimeout, driver, qualifier, logf)
+	}
+	return worker
+}
+
+func (worker *sunSpecLiveSmokeWorker) Start() {
+	if worker == nil {
+		return
+	}
+	worker.startOnce.Do(func() { go worker.run() })
+}
+
+func (worker *sunSpecLiveSmokeWorker) Close() error {
+	if worker == nil {
+		return nil
+	}
+	worker.closeOnce.Do(func() {
+		worker.cancel()
+		worker.Start()
+		<-worker.done
+	})
+	return nil
+}
+
+func newGatewaySunSpecLiveSmokeWorker(
+	parent context.Context,
+	adapter *modbusadapter.Adapter,
+	logf func(string, ...any),
+) *sunSpecLiveSmokeWorker {
+	producer, err := modbusadapter.NewSunSpecProducer(adapter, modbusadapter.SunSpecProducerConfig{
+		UnitID:             sunSpecLiveSmokeUnitID,
+		AuthorizationScope: sunSpecLiveSmokeAuthorizationScope,
+		ReadTimeout:        sunSpecLiveSmokeReadTimeout,
+	})
+	if err != nil {
+		logf("modbus sunspec live smoke decision=STOP outcome=error category=configuration_error attempts=0 recovered=false")
+		return nil
+	}
+	driver := &modbusSunSpecLiveSmokeDriver{adapter: adapter, producer: producer}
+	return newSunSpecLiveSmokeWorker(parent, sunSpecLiveSmokeAttemptTimeout, driver, modbusSunSpecLiveSmokeQualifier{}, logf)
+}

--- a/cmd/gateway/modbus_sunspec_runtime_test.go
+++ b/cmd/gateway/modbus_sunspec_runtime_test.go
@@ -13,10 +13,14 @@ type sunSpecLiveSmokeFakeDriver struct {
 	polls          []sunSpecLiveSmokePollResult
 	pollCalls      []sunSpecLiveSmokeAttempt
 	reconnectCalls int
+	pollFn         func(context.Context, sunSpecLiveSmokeAttempt) (sunSpecLiveSmokePollResult, error)
 }
 
-func (driver *sunSpecLiveSmokeFakeDriver) Poll(_ context.Context, attempt sunSpecLiveSmokeAttempt) (sunSpecLiveSmokePollResult, error) {
+func (driver *sunSpecLiveSmokeFakeDriver) Poll(ctx context.Context, attempt sunSpecLiveSmokeAttempt) (sunSpecLiveSmokePollResult, error) {
 	driver.pollCalls = append(driver.pollCalls, attempt)
+	if driver.pollFn != nil {
+		return driver.pollFn(ctx, attempt)
+	}
 	if len(driver.polls) == 0 {
 		return sunSpecLiveSmokePollResult{}, errors.New("unexpected third poll")
 	}
@@ -91,6 +95,90 @@ func TestRunSunSpecLiveSmokeReconnectsOnceOnlyForReconnectRequiredError(t *testi
 	}
 	if qualifier.attempts[0].DeadlineID != final.DeadlineID || qualifier.attempts[0].Deadline <= 0 {
 		t.Fatalf("qualifier attempt = %#v; want final total deadline", qualifier.attempts[0])
+	}
+}
+
+func TestRunSunSpecLiveSmokeEnforcesTotalAttemptDeadlineOnPollContext(t *testing.T) {
+	const attemptTimeout = 25 * time.Millisecond
+	var sawDeadline bool
+	var pollErr error
+	driver := &sunSpecLiveSmokeFakeDriver{pollFn: func(ctx context.Context, _ sunSpecLiveSmokeAttempt) (sunSpecLiveSmokePollResult, error) {
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			return sunSpecLiveSmokePollResult{}, errors.New("poll context has no deadline")
+		}
+		sawDeadline = true
+		if remaining := time.Until(deadline); remaining <= 0 || remaining > attemptTimeout {
+			return sunSpecLiveSmokePollResult{}, fmt.Errorf("poll deadline remaining = %s; want within (0, %s]", remaining, attemptTimeout)
+		}
+		<-ctx.Done()
+		pollErr = ctx.Err()
+		return sunSpecLiveSmokePollResult{}, pollErr
+	}}
+
+	started := time.Now()
+	result := runSunSpecLiveSmoke(context.Background(), attemptTimeout, driver, &sunSpecLiveSmokeFakeQualifier{}, func(string, ...any) {})
+	elapsed := time.Since(started)
+
+	if result.Decision != sunSpecLiveSmokeDecisionStop {
+		t.Fatalf("decision = %q; want STOP", result.Decision)
+	}
+	if !sawDeadline || !errors.Is(pollErr, context.DeadlineExceeded) {
+		t.Fatalf("saw deadline=%v poll error=%v; want real expired poll context", sawDeadline, pollErr)
+	}
+	if elapsed < attemptTimeout || elapsed > 500*time.Millisecond {
+		t.Fatalf("elapsed = %s; want bounded by attempt timeout", elapsed)
+	}
+}
+
+func TestSunSpecLiveSmokeWorkerCloseCancelsAndJoinsPollBeforeReturning(t *testing.T) {
+	pollStarted := make(chan struct{})
+	cancelObserved := make(chan struct{})
+	allowPollExit := make(chan struct{})
+	pollExited := make(chan struct{})
+	driver := &sunSpecLiveSmokeFakeDriver{pollFn: func(ctx context.Context, _ sunSpecLiveSmokeAttempt) (sunSpecLiveSmokePollResult, error) {
+		close(pollStarted)
+		<-ctx.Done()
+		close(cancelObserved)
+		<-allowPollExit
+		defer close(pollExited)
+		return sunSpecLiveSmokePollResult{}, ctx.Err()
+	}}
+	worker := newSunSpecLiveSmokeWorker(context.Background(), time.Minute, driver, &sunSpecLiveSmokeFakeQualifier{}, func(string, ...any) {})
+	worker.Start()
+
+	select {
+	case <-pollStarted:
+	case <-time.After(time.Second):
+		t.Fatal("worker did not start Poll")
+	}
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- worker.Close() }()
+	select {
+	case <-cancelObserved:
+	case <-time.After(time.Second):
+		t.Fatal("Close did not cancel Poll context")
+	}
+	select {
+	case err := <-closeDone:
+		t.Fatalf("Close returned before Poll exited: %v", err)
+	default:
+	}
+
+	close(allowPollExit)
+	select {
+	case <-pollExited:
+	case <-time.After(time.Second):
+		t.Fatal("Poll did not exit after cancellation")
+	}
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("Close error = %v; want nil", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Close did not join exited Poll")
 	}
 }
 

--- a/cmd/gateway/modbus_sunspec_runtime_test.go
+++ b/cmd/gateway/modbus_sunspec_runtime_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+type sunSpecLiveSmokeFakeDriver struct {
+	polls          []sunSpecLiveSmokePollResult
+	pollCalls      []sunSpecLiveSmokeAttempt
+	reconnectCalls int
+}
+
+func (driver *sunSpecLiveSmokeFakeDriver) Poll(_ context.Context, attempt sunSpecLiveSmokeAttempt) (sunSpecLiveSmokePollResult, error) {
+	driver.pollCalls = append(driver.pollCalls, attempt)
+	if len(driver.polls) == 0 {
+		return sunSpecLiveSmokePollResult{}, errors.New("unexpected third poll")
+	}
+	result := driver.polls[0]
+	driver.polls = driver.polls[1:]
+	return result, result.Err
+}
+
+func (driver *sunSpecLiveSmokeFakeDriver) Reconnect(context.Context) error {
+	driver.reconnectCalls++
+	return nil
+}
+
+type sunSpecLiveSmokeFakeQualifier struct {
+	qualifications []sunSpecLiveSmokeQualification
+	attempts       []sunSpecLiveSmokeAttempt
+}
+
+func (qualifier *sunSpecLiveSmokeFakeQualifier) Qualify(_ context.Context, attempt sunSpecLiveSmokeAttempt, _ sunSpecLiveSmokePollResult) sunSpecLiveSmokeQualification {
+	qualifier.attempts = append(qualifier.attempts, attempt)
+	result := qualifier.qualifications[0]
+	qualifier.qualifications = qualifier.qualifications[1:]
+	return result
+}
+
+func TestRunSunSpecLiveSmokeMapsQualificationDecision(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		qualification sunSpecLiveSmokeQualification
+		want          sunSpecLiveSmokeDecision
+	}{
+		{name: "supported", qualification: sunSpecLiveSmokeQualification{Supported: true}, want: sunSpecLiveSmokeDecisionGO},
+		{name: "unsupported profile", qualification: sunSpecLiveSmokeQualification{UnsupportedProfile: true}, want: sunSpecLiveSmokeDecisionNoGo},
+		{name: "incoherent", qualification: sunSpecLiveSmokeQualification{Incoherent: true}, want: sunSpecLiveSmokeDecisionStop},
+		{name: "qualifier error", qualification: sunSpecLiveSmokeQualification{Err: errors.New("qualifier failure")}, want: sunSpecLiveSmokeDecisionStop},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			driver := &sunSpecLiveSmokeFakeDriver{polls: []sunSpecLiveSmokePollResult{{}}}
+			qualifier := &sunSpecLiveSmokeFakeQualifier{qualifications: []sunSpecLiveSmokeQualification{test.qualification}}
+
+			result := runSunSpecLiveSmoke(context.Background(), time.Second, driver, qualifier, func(string, ...any) {})
+			if result.Decision != test.want {
+				t.Fatalf("decision = %q; want %q", result.Decision, test.want)
+			}
+			if len(driver.pollCalls) != 1 || len(qualifier.attempts) != 1 || driver.reconnectCalls != 0 {
+				t.Fatalf("polls=%d qualifications=%d reconnects=%d; want 1, 1, 0", len(driver.pollCalls), len(qualifier.attempts), driver.reconnectCalls)
+			}
+		})
+	}
+}
+
+func TestRunSunSpecLiveSmokeReconnectsOnceOnlyForReconnectRequiredError(t *testing.T) {
+	driver := &sunSpecLiveSmokeFakeDriver{polls: []sunSpecLiveSmokePollResult{
+		{Snapshot: sunSpecLiveSmokeSnapshot{ReconnectRequired: true}, Err: errors.New("first transport failure")},
+		{},
+	}}
+	qualifier := &sunSpecLiveSmokeFakeQualifier{qualifications: []sunSpecLiveSmokeQualification{{Supported: true}}}
+
+	result := runSunSpecLiveSmoke(context.Background(), time.Second, driver, qualifier, func(string, ...any) {})
+	if result.Decision != sunSpecLiveSmokeDecisionGO {
+		t.Fatalf("decision = %q; want GO", result.Decision)
+	}
+	if driver.reconnectCalls != 1 || len(driver.pollCalls) != 2 || len(qualifier.attempts) != 1 {
+		t.Fatalf("reconnects=%d polls=%d qualifications=%d; want 1, 2, 1", driver.reconnectCalls, len(driver.pollCalls), len(qualifier.attempts))
+	}
+	first, final := driver.pollCalls[0], driver.pollCalls[1]
+	if first.PollID == 0 || first.DeadlineID == 0 || final.PollID == 0 || final.DeadlineID == 0 {
+		t.Fatalf("attempt IDs = %#v, %#v; want nonzero poll and deadline IDs", first, final)
+	}
+	if first.PollID == final.PollID || first.DeadlineID == final.DeadlineID {
+		t.Fatalf("attempt IDs reused across reconnect: %#v, %#v", first, final)
+	}
+	if qualifier.attempts[0].DeadlineID != final.DeadlineID || qualifier.attempts[0].Deadline <= 0 {
+		t.Fatalf("qualifier attempt = %#v; want final total deadline", qualifier.attempts[0])
+	}
+}
+
+func TestRunSunSpecLiveSmokeDoesNotReconnectOutsideRecoverableError(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		poll sunSpecLiveSmokePollResult
+		qual sunSpecLiveSmokeQualification
+	}{
+		{name: "successful unsupported profile", qual: sunSpecLiveSmokeQualification{UnsupportedProfile: true}},
+		{name: "successful incoherent", qual: sunSpecLiveSmokeQualification{Incoherent: true}},
+		{name: "error without reconnect required", poll: sunSpecLiveSmokePollResult{Err: errors.New("non-recoverable transport failure")}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			driver := &sunSpecLiveSmokeFakeDriver{polls: []sunSpecLiveSmokePollResult{test.poll}}
+			qualifier := &sunSpecLiveSmokeFakeQualifier{qualifications: []sunSpecLiveSmokeQualification{test.qual}}
+
+			result := runSunSpecLiveSmoke(context.Background(), time.Second, driver, qualifier, func(string, ...any) {})
+			if result.Decision == sunSpecLiveSmokeDecisionGO {
+				t.Fatalf("decision = GO; want NO_GO or STOP")
+			}
+			if driver.reconnectCalls != 0 || len(driver.pollCalls) != 1 {
+				t.Fatalf("reconnects=%d polls=%d; want 0, 1", driver.reconnectCalls, len(driver.pollCalls))
+			}
+		})
+	}
+}
+
+func TestRunSunSpecLiveSmokeSanitizesFailureAndNoGoEvidence(t *testing.T) {
+	const endpointSentinel = "tcp://endpoint-sentinel.invalid:502"
+	const errorSentinel = "raw-error-sentinel"
+
+	driver := &sunSpecLiveSmokeFakeDriver{polls: []sunSpecLiveSmokePollResult{{
+		Snapshot: sunSpecLiveSmokeSnapshot{Endpoint: endpointSentinel},
+		Err:      fmt.Errorf("dial %s: %s", endpointSentinel, errorSentinel),
+	}}}
+	var logs []string
+	result := runSunSpecLiveSmoke(context.Background(), time.Second, driver, &sunSpecLiveSmokeFakeQualifier{}, func(format string, args ...any) {
+		logs = append(logs, fmt.Sprintf(format, args...))
+	})
+	if result.Decision != sunSpecLiveSmokeDecisionStop {
+		t.Fatalf("error decision = %q; want STOP", result.Decision)
+	}
+	assertSunSpecLiveSmokeSanitized(t, endpointSentinel, errorSentinel, result, logs)
+
+	noGoDriver := &sunSpecLiveSmokeFakeDriver{polls: []sunSpecLiveSmokePollResult{{}}}
+	noGoQualifier := &sunSpecLiveSmokeFakeQualifier{qualifications: []sunSpecLiveSmokeQualification{{
+		UnsupportedProfile: true,
+		Sample:             "sample-must-not-be-published",
+		Profile:            "profile-must-not-be-published",
+	}}}
+	noGo := runSunSpecLiveSmoke(context.Background(), time.Second, noGoDriver, noGoQualifier, func(string, ...any) {})
+	if noGo.Decision != sunSpecLiveSmokeDecisionNoGo || noGo.Sample != "" || noGo.Profile != "" {
+		t.Fatalf("NO_GO result = %#v; want no sample or profile", noGo)
+	}
+}
+
+func assertSunSpecLiveSmokeSanitized(t *testing.T, endpointSentinel, errorSentinel string, result sunSpecLiveSmokeResult, logs []string) {
+	t.Helper()
+	visible := fmt.Sprintf("%#v %v", result, logs)
+	for _, sentinel := range []string{endpointSentinel, errorSentinel} {
+		if strings.Contains(visible, sentinel) {
+			t.Fatalf("sanitized result/log leaks %q: %s", sentinel, visible)
+		}
+	}
+}

--- a/internal/modbusadapter/adapter.go
+++ b/internal/modbusadapter/adapter.go
@@ -55,12 +55,17 @@ type Adapter struct {
 	endpoint   Endpoint
 	connection modbus.TCPConnectionHandle
 	source     *modbus.RuntimeAcquisitionSource
+	config     Config
+	dial       Dialer
 
-	closeOnce sync.Once
-	closeErr  error
-	executeMu sync.Mutex
-	profileMu sync.RWMutex
-	profiles  map[string]ProfileObservationRecord
+	closeOnce    sync.Once
+	closeErr     error
+	executeMu    sync.Mutex
+	connectionMu sync.RWMutex
+	closed       bool
+	lastRequest  modbus.TCPRequestHandle
+	profileMu    sync.RWMutex
+	profiles     map[string]ProfileObservationRecord
 }
 
 const maxRetainedProfileObservations = 32
@@ -119,6 +124,8 @@ func Start(
 		endpoint:   endpoint,
 		connection: handle,
 		source:     config.Endpoint.RuntimeAcquisitionSource,
+		config:     config,
+		dial:       dial,
 		profiles:   make(map[string]ProfileObservationRecord),
 	}, nil
 }
@@ -148,7 +155,12 @@ func (adapter *Adapter) EnqueueRead(plan ReadPlan) (modbus.TCPRequestHandle, err
 	if adapter == nil || adapter.endpoint == nil {
 		return modbus.TCPRequestHandle{}, errors.New("modbus TCP adapter unavailable")
 	}
-	return adapter.endpoint.EnqueueRead(modbus.TCPReadPlan{
+	adapter.connectionMu.Lock()
+	defer adapter.connectionMu.Unlock()
+	if adapter.closed {
+		return modbus.TCPRequestHandle{}, errors.New("modbus TCP adapter is closed")
+	}
+	handle, err := adapter.endpoint.EnqueueRead(modbus.TCPReadPlan{
 		Connection:         adapter.connection,
 		UnitID:             plan.UnitID,
 		AuthorizationScope: plan.AuthorizationScope,
@@ -157,6 +169,10 @@ func (adapter *Adapter) EnqueueRead(plan ReadPlan) (modbus.TCPRequestHandle, err
 		Timeout:            plan.Timeout,
 		Reads:              append([]modbus.TCPLogicalRead(nil), plan.Reads...),
 	})
+	if err == nil {
+		adapter.lastRequest = handle
+	}
+	return handle, err
 }
 
 // Dispatch delegates deterministic fair service to helianthus-modbus.
@@ -183,7 +199,81 @@ func (adapter *Adapter) Read(ctx context.Context) (modbus.TCPReadBatch, error) {
 	if adapter == nil || adapter.endpoint == nil {
 		return modbus.TCPReadBatch{}, errors.New("modbus TCP adapter unavailable")
 	}
+	adapter.connectionMu.RLock()
+	defer adapter.connectionMu.RUnlock()
+	if adapter.closed {
+		return modbus.TCPReadBatch{}, errors.New("modbus TCP adapter is closed")
+	}
 	return adapter.endpoint.Read(ctx, adapter.connection)
+}
+
+type reconnectEndpoint interface {
+	CloseConnection(modbus.TCPConnectionHandle) error
+	WaitReconnect(context.Context, modbus.TCPRequestHandle, modbus.DelayWaiter) error
+}
+
+type contextDelayWaiter struct{}
+
+func (contextDelayWaiter) Wait(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// Reconnect retires the old endpoint-owned generation before a fresh dial.
+// It never moves an admitted request across generations; endpoint-owned
+// backoff is consumed only as recovery authorization for the next poll.
+func (adapter *Adapter) Reconnect(ctx context.Context) error {
+	if adapter == nil || adapter.endpoint == nil || ctx == nil {
+		return errors.New("modbus TCP adapter unavailable")
+	}
+	reconnector, ok := adapter.endpoint.(reconnectEndpoint)
+	if !ok {
+		return errors.New("modbus TCP endpoint does not support reconnect")
+	}
+	adapter.executeMu.Lock()
+	defer adapter.executeMu.Unlock()
+	adapter.connectionMu.Lock()
+	defer adapter.connectionMu.Unlock()
+	if adapter.closed {
+		return errors.New("modbus TCP adapter is closed")
+	}
+	oldConnection, request := adapter.connection, adapter.lastRequest
+	if err := reconnector.CloseConnection(oldConnection); err != nil {
+		return fmt.Errorf("retire Modbus TCP connection: %w", err)
+	}
+	adapter.lastRequest = modbus.TCPRequestHandle{}
+	if request.RequestID() != 0 {
+		if err := reconnector.WaitReconnect(ctx, request, contextDelayWaiter{}); err != nil {
+			// Closing a queued, never-written request terminalizes it without
+			// granting retry/backoff. A real failed request may authorize the
+			// endpoint-owned wait; neither kind is ever retried on this handle.
+			if ctx.Err() != nil {
+				return fmt.Errorf("wait endpoint reconnect backoff: %w", err)
+			}
+		}
+	}
+	address, err := dialAddress(adapter.config.Endpoint.Endpoint)
+	if err != nil {
+		return err
+	}
+	dialCtx, cancel := context.WithTimeout(ctx, adapter.config.DialTimeout)
+	defer cancel()
+	connection, err := adapter.dial(dialCtx, "tcp", address)
+	if err != nil {
+		return fmt.Errorf("redial Modbus TCP endpoint: %w", err)
+	}
+	handle, err := adapter.endpoint.OpenConnection(connection)
+	if err != nil {
+		return errors.Join(fmt.Errorf("reopen Modbus TCP endpoint: %w", err), connection.Close())
+	}
+	adapter.connection = handle
+	return nil
 }
 
 // ExecuteRead serializes one bounded request through the endpoint owner. It
@@ -277,6 +367,9 @@ func (adapter *Adapter) Close() error {
 		return nil
 	}
 	adapter.closeOnce.Do(func() {
+		adapter.connectionMu.Lock()
+		adapter.closed = true
+		adapter.connectionMu.Unlock()
 		adapter.closeErr = adapter.endpoint.Close()
 	})
 	return adapter.closeErr

--- a/internal/modbusadapter/adapter.go
+++ b/internal/modbusadapter/adapter.go
@@ -244,18 +244,16 @@ func (adapter *Adapter) Reconnect(ctx context.Context) error {
 		return errors.New("modbus TCP adapter is closed")
 	}
 	oldConnection, request := adapter.connection, adapter.lastRequest
-	if err := reconnector.CloseConnection(oldConnection); err != nil {
+	beforeRetirement := adapter.endpoint.Snapshot()
+	if err := reconnector.CloseConnection(oldConnection); err != nil && !beforeRetirement.ReconnectRequired {
 		return fmt.Errorf("retire Modbus TCP connection: %w", err)
 	}
 	adapter.lastRequest = modbus.TCPRequestHandle{}
-	if request.RequestID() != 0 {
+	// A failed socket may already have retired its handle. Only the endpoint's
+	// public state authorizes consuming request-bound reconnect backoff.
+	if request.RequestID() != 0 && beforeRetirement.ReconnectRequired {
 		if err := reconnector.WaitReconnect(ctx, request, contextDelayWaiter{}); err != nil {
-			// Closing a queued, never-written request terminalizes it without
-			// granting retry/backoff. A real failed request may authorize the
-			// endpoint-owned wait; neither kind is ever retried on this handle.
-			if ctx.Err() != nil {
-				return fmt.Errorf("wait endpoint reconnect backoff: %w", err)
-			}
+			return fmt.Errorf("wait endpoint reconnect backoff: %w", err)
 		}
 	}
 	address, err := dialAddress(adapter.config.Endpoint.Endpoint)

--- a/internal/modbusadapter/adapter_reconnect_test.go
+++ b/internal/modbusadapter/adapter_reconnect_test.go
@@ -109,7 +109,18 @@ func TestAdapterReconnectAfterSocketLossRetiresFailedGenerationAndHonorsBackoff(
 	if err != nil {
 		t.Fatalf("NewReadRegistersRequest: %v", err)
 	}
-	if _, err := adapter.ExecuteRead(context.Background(), ReadPlan{UnitID: 1, AuthorizationScope: "smoke:fronius-readonly", PollGeneration: 62, DeadlineIdentity: 72, Timeout: time.Second, Reads: []modbus.TCPLogicalRead{{LogicalViewID: 82, Request: request}}}); err == nil {
+	stale, err := adapter.EnqueueRead(ReadPlan{UnitID: 1, AuthorizationScope: "smoke:fronius-readonly", PollGeneration: 62, DeadlineIdentity: 72, Timeout: time.Second, Reads: []modbus.TCPLogicalRead{{LogicalViewID: 82, Request: request}}})
+	if err != nil {
+		t.Fatalf("EnqueueRead: %v", err)
+	}
+	dispatch, ok := adapter.Dispatch()
+	if !ok || dispatch.RequestID() != stale.RequestID() {
+		t.Fatalf("Dispatch = %#v, %v; want failed request %d", dispatch, ok, stale.RequestID())
+	}
+	if _, err := adapter.Write(context.Background(), dispatch); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if _, err := adapter.Read(context.Background()); err == nil {
 		t.Fatal("ExecuteRead after peer socket loss unexpectedly succeeded")
 	}
 	if snapshot := adapter.Snapshot(); !snapshot.ReconnectRequired {
@@ -128,7 +139,7 @@ func TestAdapterReconnectAfterSocketLossRetiresFailedGenerationAndHonorsBackoff(
 	if adapter.connection.Generation() == old.Generation() {
 		t.Fatalf("reconnect reused failed transport generation %d", old.Generation())
 	}
-	if snapshot := adapter.Snapshot(); snapshot.Resources.QueuedRequests != 0 || snapshot.Resources.RetainedRetries != 0 {
-		t.Fatalf("failed generation retained stale request: %#v", snapshot.Resources)
+	if dispatch, ok := adapter.Dispatch(); ok && dispatch.RequestID() == stale.RequestID() {
+		t.Fatalf("stale failed request %d was retried on recovered generation", stale.RequestID())
 	}
 }

--- a/internal/modbusadapter/adapter_reconnect_test.go
+++ b/internal/modbusadapter/adapter_reconnect_test.go
@@ -2,6 +2,7 @@ package modbusadapter
 
 import (
 	"context"
+	"io"
 	"net"
 	"testing"
 	"time"
@@ -72,5 +73,62 @@ func TestAdapterReconnectRetiresOldGenerationBeforeFreshDialAndNeverRetriesStale
 	}
 	if snapshot := adapter.Snapshot(); snapshot.Resources.QueuedRequests != 0 {
 		t.Fatalf("stale queued work survived reconnect: %+v", snapshot.Resources)
+	}
+}
+
+func TestAdapterReconnectAfterSocketLossRetiresFailedGenerationAndHonorsBackoff(t *testing.T) {
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	accepted := make(chan struct{}, 2)
+	go func() {
+		for range 2 {
+			connection, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			accepted <- struct{}{}
+			go func() {
+				defer func() { _ = connection.Close() }()
+				// The first FC03 reaches a real peer, then loses its socket before
+				// any response. The endpoint must own recovery classification.
+				request := make([]byte, 12)
+				_, _ = io.ReadFull(connection, request)
+			}()
+		}
+	}()
+	adapter, err := Start(context.Background(), integrationConfig(t, "tcp://"+listener.Addr().String()), realDialer, realFactory)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+	old := adapter.connection
+	request, err := modbus.NewReadRegistersRequest(modbus.FunctionReadHoldingRegisters, 40000, 1)
+	if err != nil {
+		t.Fatalf("NewReadRegistersRequest: %v", err)
+	}
+	if _, err := adapter.ExecuteRead(context.Background(), ReadPlan{UnitID: 1, AuthorizationScope: "smoke:fronius-readonly", PollGeneration: 62, DeadlineIdentity: 72, Timeout: time.Second, Reads: []modbus.TCPLogicalRead{{LogicalViewID: 82, Request: request}}}); err == nil {
+		t.Fatal("ExecuteRead after peer socket loss unexpectedly succeeded")
+	}
+	if snapshot := adapter.Snapshot(); !snapshot.ReconnectRequired {
+		t.Fatalf("socket-loss endpoint state = %#v; want reconnect required", snapshot)
+	}
+	if err := adapter.Reconnect(context.Background()); err != nil {
+		t.Fatalf("Reconnect after socket loss: %v", err)
+	}
+	for range 2 {
+		select {
+		case <-accepted:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for original and recovered socket")
+		}
+	}
+	if adapter.connection.Generation() == old.Generation() {
+		t.Fatalf("reconnect reused failed transport generation %d", old.Generation())
+	}
+	if snapshot := adapter.Snapshot(); snapshot.Resources.QueuedRequests != 0 || snapshot.Resources.RetainedRetries != 0 {
+		t.Fatalf("failed generation retained stale request: %#v", snapshot.Resources)
 	}
 }

--- a/internal/modbusadapter/adapter_reconnect_test.go
+++ b/internal/modbusadapter/adapter_reconnect_test.go
@@ -3,7 +3,6 @@ package modbusadapter
 import (
 	"context"
 	"net"
-	"sync"
 	"testing"
 	"time"
 
@@ -17,15 +16,14 @@ func TestAdapterReconnectRetiresOldGenerationBeforeFreshDialAndNeverRetriesStale
 	}
 	t.Cleanup(func() { _ = listener.Close() })
 
-	var accepted sync.WaitGroup
-	accepted.Add(2)
+	accepted := make(chan struct{}, 2)
 	go func() {
 		for range 2 {
 			connection, err := listener.Accept()
 			if err != nil {
 				return
 			}
-			accepted.Done()
+			accepted <- struct{}{}
 			go func() {
 				defer func() { _ = connection.Close() }()
 				<-time.After(time.Second)
@@ -59,7 +57,13 @@ func TestAdapterReconnectRetiresOldGenerationBeforeFreshDialAndNeverRetriesStale
 	if err := adapter.Reconnect(context.Background()); err != nil {
 		t.Fatalf("Reconnect: %v", err)
 	}
-	accepted.Wait()
+	for range 2 {
+		select {
+		case <-accepted:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for reconnect accepts")
+		}
+	}
 	if adapter.connection.Generation() == oldConnection.Generation() {
 		t.Fatalf("reconnect reused transport generation %d", oldConnection.Generation())
 	}

--- a/internal/modbusadapter/adapter_reconnect_test.go
+++ b/internal/modbusadapter/adapter_reconnect_test.go
@@ -1,0 +1,72 @@
+package modbusadapter
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+func TestAdapterReconnectRetiresOldGenerationBeforeFreshDialAndNeverRetriesStaleRead(t *testing.T) {
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	var accepted sync.WaitGroup
+	accepted.Add(2)
+	go func() {
+		for range 2 {
+			connection, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			accepted.Done()
+			go func() {
+				defer func() { _ = connection.Close() }()
+				<-time.After(time.Second)
+			}()
+		}
+	}()
+
+	config := integrationConfig(t, "tcp://"+listener.Addr().String())
+	adapter, err := Start(context.Background(), config, realDialer, realFactory)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+	oldConnection := adapter.connection
+	request, err := modbus.NewReadRegistersRequest(modbus.FunctionReadHoldingRegisters, 40000, 1)
+	if err != nil {
+		t.Fatalf("NewReadRegistersRequest: %v", err)
+	}
+	stale, err := adapter.EnqueueRead(ReadPlan{
+		UnitID: 1, AuthorizationScope: "smoke:fronius-readonly", PollGeneration: 61,
+		DeadlineIdentity: 71, Timeout: time.Second,
+		Reads: []modbus.TCPLogicalRead{{LogicalViewID: 81, Request: request}},
+	})
+	if err != nil {
+		t.Fatalf("EnqueueRead(stale): %v", err)
+	}
+
+	// Reconnect is adapter orchestration only: the endpoint owns its configured
+	// backoff. The adapter must retire the old handle before dialing this same
+	// remote again, and must not carry an admitted old-generation read forward.
+	if err := adapter.Reconnect(context.Background()); err != nil {
+		t.Fatalf("Reconnect: %v", err)
+	}
+	accepted.Wait()
+	if adapter.connection.Generation() == oldConnection.Generation() {
+		t.Fatalf("reconnect reused transport generation %d", oldConnection.Generation())
+	}
+	if dispatch, ok := adapter.Dispatch(); ok && dispatch.RequestID() == stale.RequestID() {
+		t.Fatalf("stale request %d dispatched after reconnect", stale.RequestID())
+	}
+	if snapshot := adapter.Snapshot(); snapshot.Resources.QueuedRequests != 0 {
+		t.Fatalf("stale queued work survived reconnect: %+v", snapshot.Resources)
+	}
+}

--- a/internal/modbusadapter/sunspec_producer.go
+++ b/internal/modbusadapter/sunspec_producer.go
@@ -56,7 +56,7 @@ type sunSpecSourceView struct {
 }
 
 func NewSunSpecProducer(adapter *Adapter, config SunSpecProducerConfig) (*SunSpecProducer, error) {
-	if adapter == nil || adapter.RuntimeAcquisitionSource() == nil || config.UnitID == 0 ||
+	if adapter == nil || adapter.RuntimeAcquisitionSource() == nil || config.UnitID == 0 || config.UnitID > 247 ||
 		config.AuthorizationScope == "" || config.ReadTimeout <= 0 {
 		return nil, errors.New("SunSpec producer configuration is incomplete")
 	}
@@ -141,7 +141,9 @@ func (producer *SunSpecProducer) acquire(ctx context.Context, identity SunSpecPo
 		if modelID == 0xffff {
 			break
 		}
-		if length == 0 || len(words)+int(length) > modbusreg.MaxSunSpecPhaseOneChainWords {
+		// The dynamic budget includes the following header: otherwise a model
+		// payload can reach the bound and then over-read its terminator.
+		if length == 0 || len(words)+int(length)+2 > modbusreg.MaxSunSpecPhaseOneChainWords {
 			break
 		}
 		for remaining := length; remaining > 0; {
@@ -176,6 +178,9 @@ func (producer *SunSpecProducer) qualifyCapture(ctx context.Context, identity Su
 	if err != nil {
 		return SunSpecQualificationResult{Outcome: SunSpecQualificationIncoherentCapture}, nil
 	}
+	if !completeSunSpecChain(raw) {
+		return SunSpecQualificationResult{Outcome: SunSpecQualificationIncoherentCapture}, nil
+	}
 	if deferredSunSpecModelInRaw(raw) {
 		return SunSpecQualificationResult{Outcome: SunSpecQualificationUnsupportedProfile, UnsupportedProfile: sunSpecProfileID}, nil
 	}
@@ -184,28 +189,30 @@ func (producer *SunSpecProducer) qualifyCapture(ctx context.Context, identity Su
 		return SunSpecQualificationResult{Outcome: SunSpecQualificationIncoherentCapture}, nil
 	}
 	now := time.Now().UTC()
-	attempt, err := producer.factory.BeginRuntimeAttempt(modbusreg.RuntimeAttemptRequest{Source: producer.adapter.RuntimeAcquisitionSource(), AttemptKey: fmt.Sprintf("sunspec-%d", identity.PollGeneration), Identity: modbusreg.AttemptIdentity{PollGenerationID: identity.PollGeneration}, Observation: modbusreg.RuntimeObservationFacts{SourceValidity: modbusreg.SourceValid, SourceTime: modbusreg.SourceTimeObserved(now), LocalReceiptTime: now, LocalReceiptTimePresent: true}, Dependencies: []modbusreg.RuntimeDependencyFacts{{SourceTime: modbusreg.SourceTimeUnavailable()}}, Diagnostics: []string{"sunspec_detection:standard_chain"}})
+	attempt, err := producer.factory.BeginRuntimeAttempt(modbusreg.RuntimeAttemptRequest{Source: producer.adapter.RuntimeAcquisitionSource(), AttemptKey: fmt.Sprintf("sunspec-%d", identity.PollGeneration), Identity: modbusreg.AttemptIdentity{PollGenerationID: identity.PollGeneration}, Observation: modbusreg.RuntimeObservationFacts{SourceValidity: modbusreg.SourceValid, SourceTime: modbusreg.SourceTimeUnavailable(), LocalReceiptTime: now, LocalReceiptTimePresent: true}, Dependencies: []modbusreg.RuntimeDependencyFacts{{SourceTime: modbusreg.SourceTimeUnavailable()}}, Diagnostics: []string{"sunspec_detection:standard_chain"}})
 	if err != nil {
 		return SunSpecQualificationResult{}, fmt.Errorf("begin SunSpec observation: %w", err)
 	}
+	published := false
+	defer func() {
+		if !published {
+			_, _ = attempt.Cancel()
+		}
+	}()
 	normalization, err := producer.adapter.RuntimeAcquisitionSource().ParseNormalizationRecord([]byte(`{"schema_version":1,"source_kind":"runtime","source_evidence_id":"urn:helianthus:evidence:sunspec-phase-one-v1","documentary_notation":"40001","documentary_address":40001,"documentary_address_base":"one_based_register","function_code":3,"logical_table":"holding_registers","normalized_zero_based_pdu_offset":40000,"word_count":1}`))
 	if err != nil {
-		_, _ = attempt.Cancel()
 		return SunSpecQualificationResult{}, err
 	}
 	if err := attempt.Issue(0, views[0].view, normalization); err != nil {
-		_, _ = attempt.Cancel()
 		return SunSpecQualificationResult{}, err
 	}
 	if err := attempt.Admit(); err != nil {
 		return SunSpecQualificationResult{}, err
 	}
 	if outcome, err := attempt.Claim(0); err != nil || outcome != modbusreg.ClaimSucceeded {
-		_, _ = attempt.Cancel()
 		return SunSpecQualificationResult{}, fmt.Errorf("claim SunSpec observation: %w", err)
 	}
 	if err := attempt.Seal(); err != nil {
-		_, _ = attempt.Cancel()
 		return SunSpecQualificationResult{}, err
 	}
 	observation, err := attempt.Publish(ctx)
@@ -222,6 +229,7 @@ func (producer *SunSpecProducer) qualifyCapture(ctx context.Context, identity Su
 	if err := producer.adapter.RecordProfileObservation(ProfileObservationRecord{Observation: observation, DetectionEvidence: []string{"sunspec_detection:standard_chain"}, ActivationEvidence: []string{"sunspec_activation:coherent_chain"}}); err != nil {
 		return SunSpecQualificationResult{}, err
 	}
+	published = true
 	_ = activated
 	return SunSpecQualificationResult{Outcome: SunSpecQualificationSupported, ObservationCount: 1, SampleID: observation.Spec().SampleID, Chain: chain}, nil
 }
@@ -296,6 +304,23 @@ func deferredSunSpecModelInRaw(words []uint16) bool {
 			return true
 		}
 		if id == 0xffff || length == 0 || offset+2+int(length) > len(words) {
+			return false
+		}
+		offset += 2 + int(length)
+	}
+	return false
+}
+
+func completeSunSpecChain(words []uint16) bool {
+	if len(words) < 4 || words[0] != 0x5375 || words[1] != 0x6e53 {
+		return false
+	}
+	for offset := 2; offset+1 < len(words); {
+		id, length := words[offset], words[offset+1]
+		if id == 0xffff {
+			return length == 0 && offset+2 == len(words)
+		}
+		if length == 0 || offset+2+int(length) > len(words) {
 			return false
 		}
 		offset += 2 + int(length)

--- a/internal/modbusadapter/sunspec_producer.go
+++ b/internal/modbusadapter/sunspec_producer.go
@@ -1,0 +1,332 @@
+package modbusadapter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+	modbusreg "github.com/Project-Helianthus/helianthus-modbusreg"
+)
+
+const sunSpecProfileID = "sunspec.phase1"
+
+type SunSpecQualificationOutcome string
+
+const (
+	SunSpecQualificationSupported          SunSpecQualificationOutcome = "supported"
+	SunSpecQualificationUnsupportedProfile SunSpecQualificationOutcome = "unsupported_profile"
+	SunSpecQualificationIncoherentCapture  SunSpecQualificationOutcome = "incoherent_capture"
+)
+
+type SunSpecProducerConfig struct {
+	UnitID             byte
+	AuthorizationScope string
+	ReadTimeout        time.Duration
+}
+
+type SunSpecPollIdentity struct {
+	PollGeneration   uint64
+	DeadlineIdentity uint64
+}
+
+type SunSpecQualificationResult struct {
+	Outcome            SunSpecQualificationOutcome
+	UnsupportedProfile string
+	ObservationCount   int
+	SampleID           string
+	Chain              modbusreg.SunSpecPhaseOneChain
+}
+
+// SunSpecProducer composes the transport-owned adapter with the registry-owned
+// SunSpec phase-one contracts. It has no write or freshness policy surface.
+type SunSpecProducer struct {
+	adapter *Adapter
+	config  SunSpecProducerConfig
+	decoder modbusreg.SunSpecPhaseOneDecoder
+	factory *modbusreg.ObservationFactory
+	mu      sync.Mutex
+}
+
+type sunSpecSourceView struct {
+	view      modbus.LogicalReadView
+	wireBytes []byte
+}
+
+func NewSunSpecProducer(adapter *Adapter, config SunSpecProducerConfig) (*SunSpecProducer, error) {
+	if adapter == nil || adapter.RuntimeAcquisitionSource() == nil || config.UnitID == 0 ||
+		config.AuthorizationScope == "" || config.ReadTimeout <= 0 {
+		return nil, errors.New("SunSpec producer configuration is incomplete")
+	}
+	profile, err := modbusreg.NewSunSpecPhaseOneProfile(modbusreg.SunSpecPhaseOneVersions{
+		Profile: modbusreg.CurrentSchemaVersion(), Codec: modbusreg.CurrentCodecContractVersion(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create SunSpec phase-one profile: %w", err)
+	}
+	decoder, err := modbusreg.NewSunSpecPhaseOneDecoder(profile)
+	if err != nil {
+		return nil, fmt.Errorf("create SunSpec phase-one decoder: %w", err)
+	}
+	initial, err := modbusreg.EmptySampleLedgerState("gateway-modbus", profile)
+	if err != nil {
+		return nil, fmt.Errorf("create SunSpec sample ledger state: %w", err)
+	}
+	ledger, err := modbusreg.NewSampleLedger(initial, 0)
+	if err != nil {
+		return nil, fmt.Errorf("create SunSpec sample ledger: %w", err)
+	}
+	factory, err := modbusreg.NewObservationFactory(profile, ledger, &inMemoryPublicationCommitter{state: initial})
+	if err != nil {
+		return nil, fmt.Errorf("create SunSpec observation factory: %w", err)
+	}
+	return &SunSpecProducer{adapter: adapter, config: config, decoder: decoder, factory: factory}, nil
+}
+
+func (producer *SunSpecProducer) Qualify(ctx context.Context, identity SunSpecPollIdentity) (SunSpecQualificationResult, error) {
+	if producer == nil || ctx == nil || identity.PollGeneration == 0 || identity.DeadlineIdentity == 0 {
+		return SunSpecQualificationResult{}, errors.New("SunSpec qualification request is incomplete")
+	}
+	producer.mu.Lock()
+	defer producer.mu.Unlock()
+	views, err := producer.acquire(ctx, identity)
+	if err != nil {
+		return SunSpecQualificationResult{}, err
+	}
+	return producer.qualifyCapture(ctx, identity, views)
+}
+
+func (producer *SunSpecProducer) acquire(ctx context.Context, identity SunSpecPollIdentity) ([]sunSpecSourceView, error) {
+	read := func(offset, count uint16, logicalID uint64) (sunSpecSourceView, error) {
+		request, err := modbus.NewReadRegistersRequest(modbus.FunctionReadHoldingRegisters, offset, count)
+		if err != nil {
+			return sunSpecSourceView{}, err
+		}
+		batch, err := producer.adapter.ExecuteRead(ctx, ReadPlan{UnitID: producer.config.UnitID, AuthorizationScope: producer.config.AuthorizationScope, PollGeneration: identity.PollGeneration, DeadlineIdentity: identity.DeadlineIdentity, Timeout: producer.config.ReadTimeout, Reads: []modbus.TCPLogicalRead{{LogicalViewID: logicalID, Request: request}}})
+		if err != nil {
+			return sunSpecSourceView{}, err
+		}
+		if len(batch.Views) != 1 || len(batch.Views[0].Words()) != int(count) {
+			return sunSpecSourceView{}, errors.New("SunSpec read did not return its exact logical view")
+		}
+		for _, response := range batch.Responses {
+			if response.WireResponseID() == batch.Views[0].WireResponseID() {
+				return sunSpecSourceView{view: batch.Views[0], wireBytes: response.Bytes()}, nil
+			}
+		}
+		return sunSpecSourceView{}, errors.New("SunSpec read did not retain wire evidence")
+	}
+	first, err := read(40000, 1, 1)
+	if err != nil {
+		return nil, err
+	}
+	views := []sunSpecSourceView{first}
+	offset, nextID := uint16(40001), uint64(2)
+	// The remaining signature word and first header establish the dynamic walk.
+	head, err := read(offset, 3, nextID)
+	if err != nil {
+		return nil, err
+	}
+	views = append(views, head)
+	offset += 3
+	nextID++
+	words := append(append([]uint16(nil), first.view.Words()...), head.view.Words()...)
+	if len(words) < 4 || words[0] != 0x5375 || words[1] != 0x6e53 {
+		return views, nil
+	}
+	for {
+		modelID, length := words[len(words)-2], words[len(words)-1]
+		if modelID == 0xffff {
+			break
+		}
+		if length == 0 || len(words)+int(length) > modbusreg.MaxSunSpecPhaseOneChainWords {
+			break
+		}
+		for remaining := length; remaining > 0; {
+			count := remaining
+			if count > 125 {
+				count = 125
+			}
+			view, err := read(offset, count, nextID)
+			if err != nil {
+				return nil, err
+			}
+			views, words = append(views, view), append(words, view.view.Words()...)
+			offset += count
+			nextID++
+			remaining -= count
+		}
+		header, err := read(offset, 2, nextID)
+		if err != nil {
+			return nil, err
+		}
+		views, words = append(views, header), append(words, header.view.Words()...)
+		offset += 2
+		nextID++
+	}
+	return views, nil
+}
+
+// qualifyCapture is deliberately internal: tests can feed exact source views
+// without adding a production-only test hook to the public producer surface.
+func (producer *SunSpecProducer) qualifyCapture(ctx context.Context, identity SunSpecPollIdentity, views []sunSpecSourceView) (SunSpecQualificationResult, error) {
+	capture, raw, err := sunSpecCapture(views)
+	if err != nil {
+		return SunSpecQualificationResult{Outcome: SunSpecQualificationIncoherentCapture}, nil
+	}
+	if deferredSunSpecModelInRaw(raw) {
+		return SunSpecQualificationResult{Outcome: SunSpecQualificationUnsupportedProfile, UnsupportedProfile: sunSpecProfileID}, nil
+	}
+	chain, err := producer.decoder.Parse(raw)
+	if err != nil {
+		return SunSpecQualificationResult{Outcome: SunSpecQualificationIncoherentCapture}, nil
+	}
+	now := time.Now().UTC()
+	attempt, err := producer.factory.BeginRuntimeAttempt(modbusreg.RuntimeAttemptRequest{Source: producer.adapter.RuntimeAcquisitionSource(), AttemptKey: fmt.Sprintf("sunspec-%d", identity.PollGeneration), Identity: modbusreg.AttemptIdentity{PollGenerationID: identity.PollGeneration}, Observation: modbusreg.RuntimeObservationFacts{SourceValidity: modbusreg.SourceValid, SourceTime: modbusreg.SourceTimeObserved(now), LocalReceiptTime: now, LocalReceiptTimePresent: true}, Dependencies: []modbusreg.RuntimeDependencyFacts{{SourceTime: modbusreg.SourceTimeUnavailable()}}, Diagnostics: []string{"sunspec_detection:standard_chain"}})
+	if err != nil {
+		return SunSpecQualificationResult{}, fmt.Errorf("begin SunSpec observation: %w", err)
+	}
+	normalization, err := producer.adapter.RuntimeAcquisitionSource().ParseNormalizationRecord([]byte(`{"schema_version":1,"source_kind":"runtime","source_evidence_id":"urn:helianthus:evidence:sunspec-phase-one-v1","documentary_notation":"40001","documentary_address":40001,"documentary_address_base":"one_based_register","function_code":3,"logical_table":"holding_registers","normalized_zero_based_pdu_offset":40000,"word_count":1}`))
+	if err != nil {
+		_, _ = attempt.Cancel()
+		return SunSpecQualificationResult{}, err
+	}
+	if err := attempt.Issue(0, views[0].view, normalization); err != nil {
+		_, _ = attempt.Cancel()
+		return SunSpecQualificationResult{}, err
+	}
+	if err := attempt.Admit(); err != nil {
+		return SunSpecQualificationResult{}, err
+	}
+	if outcome, err := attempt.Claim(0); err != nil || outcome != modbusreg.ClaimSucceeded {
+		_, _ = attempt.Cancel()
+		return SunSpecQualificationResult{}, fmt.Errorf("claim SunSpec observation: %w", err)
+	}
+	if err := attempt.Seal(); err != nil {
+		_, _ = attempt.Cancel()
+		return SunSpecQualificationResult{}, err
+	}
+	observation, err := attempt.Publish(ctx)
+	if err != nil {
+		return SunSpecQualificationResult{}, fmt.Errorf("publish SunSpec observation: %w", err)
+	}
+	// The registry-owned runtime observation preserves the original base-view
+	// wire evidence. Reuse that exact snapshot for activation's dependency bind.
+	capture.SourceViews[0] = observation.Spec().Dependencies[0].View
+	activated, err := producer.decoder.Activate(modbusreg.SunSpecPhaseOneActivation{Chain: chain, RawWords: raw, Capture: capture, Observation: observation.Spec()})
+	if err != nil {
+		return SunSpecQualificationResult{}, fmt.Errorf("activate SunSpec capture: %w", err)
+	}
+	if err := producer.adapter.RecordProfileObservation(ProfileObservationRecord{Observation: observation, DetectionEvidence: []string{"sunspec_detection:standard_chain"}, ActivationEvidence: []string{"sunspec_activation:coherent_chain"}}); err != nil {
+		return SunSpecQualificationResult{}, err
+	}
+	_ = activated
+	return SunSpecQualificationResult{Outcome: SunSpecQualificationSupported, ObservationCount: 1, SampleID: observation.Spec().SampleID, Chain: chain}, nil
+}
+
+func sunSpecCapture(views []sunSpecSourceView) (modbusreg.SunSpecPhaseOneCapture, []uint16, error) {
+	if len(views) == 0 {
+		return modbusreg.SunSpecPhaseOneCapture{}, nil, errors.New("SunSpec capture is empty")
+	}
+	snapshots := make([]modbusreg.LogicalViewSnapshot, 0, len(views))
+	for _, sourceView := range views {
+		view, provenance := sourceView.view, sourceView.view.Provenance()
+		snapshot, err := modbusreg.NewLogicalViewSnapshot(modbusreg.LogicalViewRecord{
+			LogicalViewID: view.LogicalViewID(), WireResponseID: view.WireResponseID(),
+			PhysicalRequestID: provenance.PhysicalRequestID, Endpoint: provenance.Wire.Endpoint,
+			ConnectionID: provenance.Wire.ConnectionID, Transport: provenance.Wire.Transport,
+			TransportGeneration: provenance.Wire.TransportGeneration, UnitID: provenance.Wire.UnitID,
+			RequestedFunction: provenance.Wire.RequestedFunction, ReceivedFunction: provenance.Wire.ReceivedFunction,
+			Table: provenance.Wire.Table, PhysicalOffset: provenance.Wire.Offset,
+			PhysicalWordCount: provenance.Wire.Quantity, AuthorizationScope: provenance.AuthorizationScope,
+			PollGeneration: provenance.PollGeneration, DeadlineIdentity: provenance.DeadlineIdentity,
+			LogicalOffset: provenance.LogicalOffset, LogicalWordCount: provenance.LogicalWordCount,
+			SliceOffset: provenance.SliceOffset, SliceWordCount: provenance.SliceWordCount,
+			Words: view.Words(), WireResponseBytes: sourceView.wireBytes,
+		})
+		if err != nil {
+			return modbusreg.SunSpecPhaseOneCapture{}, nil, err
+		}
+		snapshots = append(snapshots, snapshot)
+	}
+	return sunSpecCaptureSnapshots(snapshots)
+}
+
+func sunSpecCaptureSnapshots(snapshots []modbusreg.LogicalViewSnapshot) (modbusreg.SunSpecPhaseOneCapture, []uint16, error) {
+	capture := modbusreg.SunSpecPhaseOneCapture{SourceViews: append([]modbusreg.LogicalViewSnapshot(nil), snapshots...)}
+	raw := make([]uint16, 0, modbusreg.MaxSunSpecPhaseOneChainWords)
+	for _, snapshot := range snapshots {
+		raw = append(raw, snapshot.Record().Words...)
+	}
+	// Activate repeats this validation at the profile boundary; running it here
+	// rejects detached generations before a factory attempt can be retained.
+	if _, err := producerCaptureValidator(capture, raw); err != nil {
+		return modbusreg.SunSpecPhaseOneCapture{}, nil, err
+	}
+	return capture, raw, nil
+}
+
+func producerCaptureValidator(capture modbusreg.SunSpecPhaseOneCapture, raw []uint16) ([]uint16, error) {
+	if len(capture.SourceViews) == 0 || len(raw) > modbusreg.MaxSunSpecPhaseOneChainWords {
+		return nil, errors.New("SunSpec capture exceeds bounds")
+	}
+	first := capture.SourceViews[0].Record()
+	offset := uint32(40000)
+	for _, snapshot := range capture.SourceViews {
+		record := snapshot.Record()
+		if uint32(record.LogicalOffset) != offset || record.Endpoint != first.Endpoint ||
+			record.UnitID != first.UnitID || record.PollGeneration != first.PollGeneration ||
+			record.Transport != first.Transport || record.TransportGeneration != first.TransportGeneration ||
+			record.ConnectionID != first.ConnectionID || record.AuthorizationScope != first.AuthorizationScope ||
+			record.RequestedFunction != modbusreg.FunctionReadHoldingRegisters ||
+			record.ReceivedFunction != modbusreg.FunctionReadHoldingRegisters {
+			return nil, errors.New("SunSpec source views are detached or incoherent")
+		}
+		offset += uint32(record.LogicalWordCount)
+	}
+	return raw, nil
+}
+
+func deferredSunSpecModelInRaw(words []uint16) bool {
+	for offset := 2; offset+1 < len(words); {
+		id, length := words[offset], words[offset+1]
+		if (id >= 111 && id <= 113) || (id >= 120 && id <= 124) || id == 160 || (id >= 200 && id <= 219) || (id >= 700 && id <= 799) {
+			return true
+		}
+		if id == 0xffff || length == 0 || offset+2+int(length) > len(words) {
+			return false
+		}
+		offset += 2 + int(length)
+	}
+	return false
+}
+
+type inMemoryPublicationCommitter struct {
+	mu      sync.Mutex
+	state   modbusreg.SampleLedgerState
+	restart modbusreg.LedgerRestartState
+}
+
+func (c *inMemoryPublicationCommitter) CommitPublication(ctx context.Context, request modbusreg.PublicationCommitRequest) (modbusreg.PublicationCommitDecision, error) {
+	if err := ctx.Err(); err != nil {
+		return modbusreg.PublicationCommitCancelled, nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.state != request.ExpectedState {
+		return "", errors.New("volatile publication state conflict")
+	}
+	c.state, c.restart = request.PublishedState, request.PublishedRestartState
+	return modbusreg.PublicationCommitCommitted, nil
+}
+func (c *inMemoryPublicationCommitter) CommitTerminalState(ctx context.Context, request modbusreg.TerminalStateCommitRequest) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.restart = request.TerminalRestartState
+	return nil
+}

--- a/internal/modbusadapter/sunspec_producer_test.go
+++ b/internal/modbusadapter/sunspec_producer_test.go
@@ -163,6 +163,9 @@ func TestSunSpecProducerFailsClosedForObservedFloatProfileWithoutRetention(t *te
 		result.ObservationCount != 0 || result.SampleID != "" {
 		t.Fatalf("float chain result = %#v; want typed fail-closed unsupported profile", result)
 	}
+	if _, ok := adapter.ProfileObservation("sunspec.phase1", "gateway-modbus:1"); ok {
+		t.Fatal("float chain profile observation was retained")
+	}
 }
 
 func TestSunSpecProducerRejectsMixedTransportGenerationWithoutPublishing(t *testing.T) {

--- a/internal/modbusadapter/sunspec_producer_test.go
+++ b/internal/modbusadapter/sunspec_producer_test.go
@@ -53,6 +53,9 @@ func TestSunSpecProducerDiscoversBoundedStandardChainAndPublishesExactObservatio
 		len(spec.Dependencies) != 1 {
 		t.Fatalf("retained observation identity changed: %#v", spec)
 	}
+	if spec.SourceTime.State != modbusreg.SourceTimeUnavailableState || spec.LocalReceiptTime.IsZero() {
+		t.Fatalf("retained observation time facts = source=%#v receipt=%v; want unavailable source time and local receipt", spec.SourceTime, spec.LocalReceiptTime)
+	}
 	view := spec.Dependencies[0].View.Record()
 	if view.LogicalOffset != 40000 || view.LogicalWordCount == 0 ||
 		view.PollGeneration != 41 || view.TransportGeneration == 0 ||
@@ -63,6 +66,48 @@ func TestSunSpecProducerDiscoversBoundedStandardChainAndPublishesExactObservatio
 		name := reflect.TypeOf(producer).Method(index).Name
 		if name == "Write" || name == "Set" || name == "Control" {
 			t.Fatalf("SunSpec producer exposes forbidden write operation %q", name)
+		}
+	}
+}
+
+func TestSunSpecProducerReservesTerminatorInsideReadBudget(t *testing.T) {
+	// The payload reaches the bound only when its following two-word header is
+	// incorrectly excluded from the dynamic acquisition budget.
+	words := sunSpecWords(1, 508, 0xffff, 0)
+	listener, requests := serveSunSpecChain(t, words)
+	adapter, err := Start(context.Background(), integrationConfig(t, "tcp://"+listener.Addr().String()), realDialer, realFactory)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+	producer, err := NewSunSpecProducer(adapter, SunSpecProducerConfig{UnitID: 1, AuthorizationScope: "smoke:fronius-readonly", ReadTimeout: time.Second})
+	if err != nil {
+		t.Fatalf("NewSunSpecProducer: %v", err)
+	}
+	if _, err := producer.Qualify(context.Background(), SunSpecPollIdentity{PollGeneration: 44, DeadlineIdentity: 94}); err != nil {
+		t.Fatalf("Qualify(boundary chain): %v", err)
+	}
+	assertBoundedFC03Discovery(t, requests(), 1)
+}
+
+func TestDeferredSunSpecModelRequiresCompleteTerminatedChain(t *testing.T) {
+	// A float-family header alone is not sufficient evidence of a structurally
+	// complete unsupported profile.
+	if deferredSunSpecModelInRaw([]uint16{0x5375, 0x6e53, 113, 1, 0}) {
+		t.Fatal("truncated deferred chain was classified as unsupported profile")
+	}
+}
+
+func TestSunSpecProducerRejectsInvalidModbusUnitID(t *testing.T) {
+	listener, _ := serveSunSpecChain(t, sunSpecWords(0xffff, 0))
+	adapter, err := Start(context.Background(), integrationConfig(t, "tcp://"+listener.Addr().String()), realDialer, realFactory)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+	for _, unitID := range []byte{0, 248} {
+		if producer, err := NewSunSpecProducer(adapter, SunSpecProducerConfig{UnitID: unitID, AuthorizationScope: "smoke:fronius-readonly", ReadTimeout: time.Second}); err == nil || producer != nil {
+			t.Fatalf("NewSunSpecProducer(unit %d) = %#v, %v; want rejection", unitID, producer, err)
 		}
 	}
 }

--- a/internal/modbusadapter/sunspec_producer_test.go
+++ b/internal/modbusadapter/sunspec_producer_test.go
@@ -109,14 +109,26 @@ func TestSunSpecProducerRejectsMixedTransportGenerationWithoutPublishing(t *test
 		t.Fatalf("NewSunSpecProducer: %v", err)
 	}
 
-	result, err := producer.QualifyMixedGenerationForTest(context.Background(), SunSpecPollIdentity{
-		PollGeneration: 43, DeadlineIdentity: 93,
-	})
+	views, err := producer.acquire(context.Background(), SunSpecPollIdentity{PollGeneration: 43, DeadlineIdentity: 93})
 	if err != nil {
-		t.Fatalf("QualifyMixedGenerationForTest: %v", err)
+		t.Fatalf("acquire: %v", err)
 	}
-	if result.Outcome != SunSpecQualificationIncoherentCapture || result.ObservationCount != 0 || result.SampleID != "" {
-		t.Fatalf("mixed generation result = %#v; want incoherent capture without publication", result)
+	capture, _, err := sunSpecCapture(views)
+	if err != nil {
+		t.Fatalf("sunSpecCapture(valid): %v", err)
+	}
+	mixed := capture.Views()
+	record := mixed[1].Record()
+	record.TransportGeneration++
+	mixed[1], err = modbusreg.NewLogicalViewSnapshot(record)
+	if err != nil {
+		t.Fatalf("NewLogicalViewSnapshot(mixed): %v", err)
+	}
+	if _, _, err := sunSpecCaptureSnapshots(mixed); err == nil {
+		t.Fatal("mixed connection/generation capture was accepted")
+	}
+	if _, ok := adapter.ProfileObservation("sunspec.phase1", "gateway-modbus:1"); ok {
+		t.Fatal("mixed capture was retained")
 	}
 }
 
@@ -188,13 +200,18 @@ func assertBoundedFC03Discovery(t *testing.T, requests []sunSpecReadRequest, uni
 	if len(requests) == 0 {
 		t.Fatal("producer did not issue discovery reads")
 	}
+	if requests[0].Offset != 40000 || requests[0].WordCount != 1 {
+		t.Fatalf("first discovery request = %+v; want exact base view 40000 x 1", requests[0])
+	}
 	var total uint16
+	nextOffset := uint16(40000)
 	for _, request := range requests {
 		if request.UnitID != unitID || request.Function != modbus.FunctionReadHoldingRegisters ||
-			request.Offset < 40000 || request.WordCount == 0 || request.WordCount > 125 {
+			request.Offset != nextOffset || request.WordCount == 0 || request.WordCount > 125 {
 			t.Fatalf("discovery request = %+v; want bounded unit-1 FC03 from PDU 40000", request)
 		}
 		total += request.WordCount
+		nextOffset += request.WordCount
 	}
 	if total > modbusreg.MaxSunSpecPhaseOneChainWords {
 		t.Fatalf("discovery read budget = %d; want <= %d words", total, modbusreg.MaxSunSpecPhaseOneChainWords)

--- a/internal/modbusadapter/sunspec_producer_test.go
+++ b/internal/modbusadapter/sunspec_producer_test.go
@@ -1,0 +1,221 @@
+package modbusadapter
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"net"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+	modbusreg "github.com/Project-Helianthus/helianthus-modbusreg"
+)
+
+func TestSunSpecProducerDiscoversBoundedStandardChainAndPublishesExactObservation(t *testing.T) {
+	words := sunSpecWords(1, 65, 101, 50, 102, 50, 103, 50, 0xffff, 0)
+	listener, requests := serveSunSpecChain(t, words)
+	adapter, err := Start(context.Background(), integrationConfig(t, "tcp://"+listener.Addr().String()), realDialer, realFactory)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	producer, err := NewSunSpecProducer(adapter, SunSpecProducerConfig{
+		UnitID: 1, AuthorizationScope: "smoke:fronius-readonly", ReadTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewSunSpecProducer: %v", err)
+	}
+	result, err := producer.Qualify(context.Background(), SunSpecPollIdentity{
+		PollGeneration: 41, DeadlineIdentity: 91,
+	})
+	if err != nil {
+		t.Fatalf("Qualify(standard chain): %v", err)
+	}
+	if result.Outcome != SunSpecQualificationSupported || result.ObservationCount != 1 {
+		t.Fatalf("qualification result = %#v; want one supported observation", result)
+	}
+	if got := result.Chain.Models(); !reflect.DeepEqual(sunSpecModelIDs(got), []uint16{1, 101, 102, 103}) {
+		t.Fatalf("published SunSpec models = %v; want [1 101 102 103]", sunSpecModelIDs(got))
+	}
+	assertBoundedFC03Discovery(t, requests(), 1)
+
+	record, ok := adapter.ProfileObservation("sunspec.phase1", result.SampleID)
+	if !ok {
+		t.Fatalf("registry-owned observation sunspec.phase1/%q was not retained", result.SampleID)
+	}
+	spec := record.Observation.Spec()
+	if spec.SampleID != result.SampleID || spec.PollGenerationID != 41 ||
+		spec.Endpoint != "tcp://"+listener.Addr().String() || spec.UnitID != 1 ||
+		len(spec.Dependencies) != 1 {
+		t.Fatalf("retained observation identity changed: %#v", spec)
+	}
+	view := spec.Dependencies[0].View.Record()
+	if view.LogicalOffset != 40000 || view.LogicalWordCount == 0 ||
+		view.PollGeneration != 41 || view.TransportGeneration == 0 ||
+		view.ConnectionID == 0 || view.WireResponseID == 0 {
+		t.Fatalf("retained source view lost exact sample identity: %#v", view)
+	}
+	for index := 0; index < reflect.TypeOf(producer).NumMethod(); index++ {
+		name := reflect.TypeOf(producer).Method(index).Name
+		if name == "Write" || name == "Set" || name == "Control" {
+			t.Fatalf("SunSpec producer exposes forbidden write operation %q", name)
+		}
+	}
+}
+
+func TestSunSpecProducerFailsClosedForObservedFloatProfileWithoutRetention(t *testing.T) {
+	// Exact live-observed Fronius chain: deferred float-family models must not
+	// become a partial or guessed phase-one observation.
+	listener, _ := serveSunSpecChain(t, sunSpecWords(
+		1, 65, 113, 60, 120, 26, 121, 30, 122, 44, 160, 88, 124, 24, 0xffff, 0,
+	))
+	adapter, err := Start(context.Background(), integrationConfig(t, "tcp://"+listener.Addr().String()), realDialer, realFactory)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+	producer, err := NewSunSpecProducer(adapter, SunSpecProducerConfig{
+		UnitID: 1, AuthorizationScope: "smoke:fronius-readonly", ReadTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewSunSpecProducer: %v", err)
+	}
+
+	result, err := producer.Qualify(context.Background(), SunSpecPollIdentity{PollGeneration: 42, DeadlineIdentity: 92})
+	if err != nil {
+		t.Fatalf("Qualify(live float chain): %v", err)
+	}
+	if result.Outcome != SunSpecQualificationUnsupportedProfile || result.UnsupportedProfile == "" ||
+		result.ObservationCount != 0 || result.SampleID != "" {
+		t.Fatalf("float chain result = %#v; want typed fail-closed unsupported profile", result)
+	}
+}
+
+func TestSunSpecProducerRejectsMixedTransportGenerationWithoutPublishing(t *testing.T) {
+	listener, _ := serveSunSpecChain(t, sunSpecWords(1, 65, 101, 50, 0xffff, 0))
+	adapter, err := Start(context.Background(), integrationConfig(t, "tcp://"+listener.Addr().String()), realDialer, realFactory)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+	producer, err := NewSunSpecProducer(adapter, SunSpecProducerConfig{
+		UnitID: 1, AuthorizationScope: "smoke:fronius-readonly", ReadTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewSunSpecProducer: %v", err)
+	}
+
+	result, err := producer.QualifyMixedGenerationForTest(context.Background(), SunSpecPollIdentity{
+		PollGeneration: 43, DeadlineIdentity: 93,
+	})
+	if err != nil {
+		t.Fatalf("QualifyMixedGenerationForTest: %v", err)
+	}
+	if result.Outcome != SunSpecQualificationIncoherentCapture || result.ObservationCount != 0 || result.SampleID != "" {
+		t.Fatalf("mixed generation result = %#v; want incoherent capture without publication", result)
+	}
+}
+
+type sunSpecReadRequest struct {
+	UnitID    byte
+	Function  modbus.FunctionCode
+	Offset    uint16
+	WordCount uint16
+}
+
+func serveSunSpecChain(t *testing.T, words []uint16) (net.Listener, func() []sunSpecReadRequest) {
+	t.Helper()
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	var mu sync.Mutex
+	var requests []sunSpecReadRequest
+	go func() {
+		connection, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = connection.Close() }()
+		for {
+			header := make([]byte, 7)
+			if _, err := io.ReadFull(connection, header); err != nil {
+				return
+			}
+			length := int(binary.BigEndian.Uint16(header[4:6]))
+			body := make([]byte, length-1)
+			if _, err := io.ReadFull(connection, body); err != nil || len(body) != 5 {
+				return
+			}
+			request := sunSpecReadRequest{
+				UnitID: header[6], Function: modbus.FunctionCode(body[0]),
+				Offset: binary.BigEndian.Uint16(body[1:3]), WordCount: binary.BigEndian.Uint16(body[3:5]),
+			}
+			mu.Lock()
+			requests = append(requests, request)
+			mu.Unlock()
+			start := int(request.Offset) - 40000
+			end := start + int(request.WordCount)
+			if start < 0 || end > len(words) {
+				return
+			}
+			response := make([]byte, 9+2*int(request.WordCount))
+			copy(response[:2], header[:2])
+			binary.BigEndian.PutUint16(response[4:6], uint16(3+2*int(request.WordCount)))
+			response[6], response[7], response[8] = request.UnitID, byte(request.Function), byte(2*request.WordCount)
+			for index, word := range words[start:end] {
+				binary.BigEndian.PutUint16(response[9+2*index:], word)
+			}
+			if _, err := connection.Write(response); err != nil {
+				return
+			}
+		}
+	}()
+	return listener, func() []sunSpecReadRequest {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]sunSpecReadRequest(nil), requests...)
+	}
+}
+
+func assertBoundedFC03Discovery(t *testing.T, requests []sunSpecReadRequest, unitID byte) {
+	t.Helper()
+	if len(requests) == 0 {
+		t.Fatal("producer did not issue discovery reads")
+	}
+	var total uint16
+	for _, request := range requests {
+		if request.UnitID != unitID || request.Function != modbus.FunctionReadHoldingRegisters ||
+			request.Offset < 40000 || request.WordCount == 0 || request.WordCount > 125 {
+			t.Fatalf("discovery request = %+v; want bounded unit-1 FC03 from PDU 40000", request)
+		}
+		total += request.WordCount
+	}
+	if total > modbusreg.MaxSunSpecPhaseOneChainWords {
+		t.Fatalf("discovery read budget = %d; want <= %d words", total, modbusreg.MaxSunSpecPhaseOneChainWords)
+	}
+}
+
+func sunSpecWords(headers ...uint16) []uint16 {
+	words := []uint16{0x5375, 0x6e53}
+	for index := 0; index < len(headers); index += 2 {
+		words = append(words, headers[index], headers[index+1])
+		if headers[index] != 0xffff {
+			words = append(words, make([]uint16, headers[index+1])...)
+		}
+	}
+	return words
+}
+
+func sunSpecModelIDs(models []modbusreg.SunSpecPhaseOneModel) []uint16 {
+	ids := make([]uint16, len(models))
+	for index, model := range models {
+		ids[index] = model.ID()
+	}
+	return ids
+}

--- a/internal/modbusadapter/sunspec_producer_test.go
+++ b/internal/modbusadapter/sunspec_producer_test.go
@@ -93,8 +93,33 @@ func TestSunSpecProducerReservesTerminatorInsideReadBudget(t *testing.T) {
 func TestDeferredSunSpecModelRequiresCompleteTerminatedChain(t *testing.T) {
 	// A float-family header alone is not sufficient evidence of a structurally
 	// complete unsupported profile.
-	if deferredSunSpecModelInRaw([]uint16{0x5375, 0x6e53, 113, 1, 0}) {
-		t.Fatal("truncated deferred chain was classified as unsupported profile")
+	if completeSunSpecChain([]uint16{0x5375, 0x6e53, 113, 1, 0}) {
+		t.Fatal("truncated deferred chain was accepted as structurally complete")
+	}
+}
+
+func TestSunSpecProducerClassifiesTruncatedDeferredChainAsIncoherentWithoutRetention(t *testing.T) {
+	listener, _ := serveSunSpecChain(t, sunSpecWords(113, 1, 0xffff, 0))
+	adapter, err := Start(context.Background(), integrationConfig(t, "tcp://"+listener.Addr().String()), realDialer, realFactory)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+	producer, err := NewSunSpecProducer(adapter, SunSpecProducerConfig{UnitID: 1, AuthorizationScope: "smoke:fronius-readonly", ReadTimeout: time.Second})
+	if err != nil {
+		t.Fatalf("NewSunSpecProducer: %v", err)
+	}
+	identity := SunSpecPollIdentity{PollGeneration: 45, DeadlineIdentity: 95}
+	views, err := producer.acquire(context.Background(), identity)
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	result, err := producer.qualifyCapture(context.Background(), identity, views[:len(views)-1])
+	if err != nil || result.Outcome != SunSpecQualificationIncoherentCapture {
+		t.Fatalf("truncated deferred chain = %#v, %v; want incoherent capture", result, err)
+	}
+	if _, ok := adapter.ProfileObservation("sunspec.phase1", "gateway-modbus:1"); ok {
+		t.Fatal("truncated deferred chain was retained")
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements FMV3-M4-04 as the explicitly authorized read-only Fronius/SunSpec live qualification and recovery gate.

## Current state

- RED public: `18648bd08815388211d5ee7ef2e2f8e47e0a72d2`
- live preflight is sanitized in issue #807
- current hardware is a Fronius Symo GEN24 10.0 / firmware 1.41.11-1 with float model 113, so the existing int+SF `sunspec.phase1` contract must fail closed rather than widen silently
- production implementation and final GO/NO_GO/STOP evidence are pending

## Scope

- bounded FC03 dynamic SunSpec chain discovery on the existing owned Modbus endpoint
- registry-owned profile observation publication only for the admitted int+SF phase-one chain
- typed unsupported-profile result for float/deferred chains
- disconnect/reconnect generation integrity without retrying stale reads
- reproducible read-only live smoke and rollback proof

## Exclusions

No writes, inverter configuration changes, Fronius overlay, canonical freshness/source precedence, GraphQL, Portal, HA entities, eeBUS/Matter binding, or MCP schema change.

## Gates

Strict RED-first, focused and full race CI, T01..T88 applicability, live read-only smoke/recovery, fresh exact-HEAD NO_BLOCKING_FINDINGS, squash merge.