### PR TITLE
FMV3-M4-04 R5: integrate registry-selected SunSpec qualification V3

### DIFF
--- a/cmd/gateway/modbus_sunspec_runtime.go
+++ b/cmd/gateway/modbus_sunspec_runtime.go
@@ -16,6 +16,7 @@ const (
 	sunSpecLiveSmokeAuthorizationScope = "smoke:fronius-readonly"
 	sunSpecLiveSmokeReadTimeout        = 2 * time.Second
 	sunSpecLiveSmokeAttemptTimeout     = 30 * time.Second
+	sunSpecLiveSmokeCurrentFlavor      = modbusreg.SunSpecFroniusObservedFlavorV11ID
 )
 
 type sunSpecLiveSmokeDecision string
@@ -179,7 +180,7 @@ func mapSunSpecLiveSmokeQualification(qualification sunSpecLiveSmokeQualificatio
 	case modbusadapter.SunSpecQualificationGO:
 		if qualification.Sample == "" ||
 			qualification.Capability != modbusreg.SunSpecThreePhaseMonitoringCapabilityID ||
-			qualification.Flavor != modbusreg.SunSpecFroniusObservedFlavorID ||
+			!isSupportedSunSpecLiveSmokeFlavor(qualification.Flavor) ||
 			qualification.CapabilityReason != modbusreg.SunSpecCapabilityReasonAdmitted ||
 			qualification.FlavorReason != modbusreg.SunSpecFroniusFlavorReasonMatched {
 			base.Decision, base.Outcome, base.Category = sunSpecLiveSmokeDecisionStop, "incoherent", "invalid_qualification"
@@ -198,6 +199,10 @@ func mapSunSpecLiveSmokeQualification(qualification sunSpecLiveSmokeQualificatio
 		base.Decision, base.Outcome, base.Category = sunSpecLiveSmokeDecisionStop, "incoherent", "invalid_qualification"
 		return base
 	}
+}
+
+func isSupportedSunSpecLiveSmokeFlavor(flavor string) bool {
+	return flavor == modbusreg.SunSpecFroniusObservedFlavorID || flavor == sunSpecLiveSmokeCurrentFlavor
 }
 
 type sunSpecLiveSmokeWorker struct {

--- a/cmd/gateway/modbus_sunspec_runtime_test.go
+++ b/cmd/gateway/modbus_sunspec_runtime_test.go
@@ -61,6 +61,13 @@ func TestRunSunSpecLiveSmokeMapsQualificationDecision(t *testing.T) {
 			Capability: modbusreg.SunSpecThreePhaseMonitoringCapabilityID,
 			Flavor:     modbusreg.SunSpecFroniusObservedFlavorID,
 		}, want: sunSpecLiveSmokeDecisionStop},
+		{name: "unselected flavor", qualification: sunSpecLiveSmokeQualification{
+			Outcome: modbusadapter.SunSpecQualificationGO, Sample: "sample-1",
+			Capability:       modbusreg.SunSpecThreePhaseMonitoringCapabilityID,
+			Flavor:           "sunspec.flavor.fronius.unselected@1.0.0",
+			CapabilityReason: modbusreg.SunSpecCapabilityReasonAdmitted,
+			FlavorReason:     modbusreg.SunSpecFroniusFlavorReasonMatched,
+		}, want: sunSpecLiveSmokeDecisionStop},
 		{name: "not qualified", qualification: sunSpecLiveSmokeQualification{Outcome: modbusadapter.SunSpecQualificationNoGo}, want: sunSpecLiveSmokeDecisionNoGo},
 		{name: "stop", qualification: sunSpecLiveSmokeQualification{Outcome: modbusadapter.SunSpecQualificationStop}, want: sunSpecLiveSmokeDecisionStop},
 		{name: "qualifier error", qualification: sunSpecLiveSmokeQualification{Err: errors.New("qualifier failure")}, want: sunSpecLiveSmokeDecisionStop},
@@ -86,14 +93,14 @@ func TestRunSunSpecLiveSmokeAcceptsRegistrySelectedV11Qualification(t *testing.T
 		Outcome:          modbusadapter.SunSpecQualificationGO,
 		Sample:           "sample-v1.1",
 		Capability:       modbusreg.SunSpecThreePhaseMonitoringCapabilityID,
-		Flavor:           "sunspec.flavor.fronius.gen24.float.observed@1.1.0",
+		Flavor:           sunSpecLiveSmokeCurrentFlavor,
 		CapabilityReason: modbusreg.SunSpecCapabilityReasonAdmitted,
 		FlavorReason:     modbusreg.SunSpecFroniusFlavorReasonMatched,
 	}}}
 
 	result := runSunSpecLiveSmoke(context.Background(), time.Second, driver, qualifier, func(string, ...any) {})
 	if result.Decision != sunSpecLiveSmokeDecisionGO ||
-		result.Flavor != "sunspec.flavor.fronius.gen24.float.observed@1.1.0" {
+		result.Flavor != sunSpecLiveSmokeCurrentFlavor {
 		t.Fatalf("V1.1 result = %#v; want registry-selected GO", result)
 	}
 }

--- a/cmd/gateway/modbus_sunspec_runtime_test.go
+++ b/cmd/gateway/modbus_sunspec_runtime_test.go
@@ -80,6 +80,24 @@ func TestRunSunSpecLiveSmokeMapsQualificationDecision(t *testing.T) {
 	}
 }
 
+func TestRunSunSpecLiveSmokeAcceptsRegistrySelectedV11Qualification(t *testing.T) {
+	driver := &sunSpecLiveSmokeFakeDriver{polls: []sunSpecLiveSmokePollResult{{}}}
+	qualifier := &sunSpecLiveSmokeFakeQualifier{qualifications: []sunSpecLiveSmokeQualification{{
+		Outcome:          modbusadapter.SunSpecQualificationGO,
+		Sample:           "sample-v1.1",
+		Capability:       modbusreg.SunSpecThreePhaseMonitoringCapabilityID,
+		Flavor:           "sunspec.flavor.fronius.gen24.float.observed@1.1.0",
+		CapabilityReason: modbusreg.SunSpecCapabilityReasonAdmitted,
+		FlavorReason:     modbusreg.SunSpecFroniusFlavorReasonMatched,
+	}}}
+
+	result := runSunSpecLiveSmoke(context.Background(), time.Second, driver, qualifier, func(string, ...any) {})
+	if result.Decision != sunSpecLiveSmokeDecisionGO ||
+		result.Flavor != "sunspec.flavor.fronius.gen24.float.observed@1.1.0" {
+		t.Fatalf("V1.1 result = %#v; want registry-selected GO", result)
+	}
+}
+
 func TestRunSunSpecLiveSmokeReconnectsOnceOnlyForReconnectRequiredError(t *testing.T) {
 	driver := &sunSpecLiveSmokeFakeDriver{polls: []sunSpecLiveSmokePollResult{
 		{Snapshot: sunSpecLiveSmokeSnapshot{ReconnectRequired: true}, Err: errors.New("first transport failure")},

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260813222631-92a35b3ec2eb
 	github.com/Project-Helianthus/helianthus-eebusreg v0.1.31
 	github.com/Project-Helianthus/helianthus-modbus v0.0.0-20260810083147-eab30aed9eb6
-	github.com/Project-Helianthus/helianthus-modbusreg v0.1.0
+	github.com/Project-Helianthus/helianthus-modbusreg v0.2.0
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/Project-Helianthus/helianthus-eebusreg v0.1.31 h1:N6S/XxqWbOOPGCteOXY
 github.com/Project-Helianthus/helianthus-eebusreg v0.1.31/go.mod h1:zicxGucHssiyjsA186nACwFfu3kUDEixIcY2b7DleEM=
 github.com/Project-Helianthus/helianthus-modbus v0.0.0-20260810083147-eab30aed9eb6 h1:+l+s7VBz51iKqZYhm081RydM439iPM/Uf6bubzvA3/4=
 github.com/Project-Helianthus/helianthus-modbus v0.0.0-20260810083147-eab30aed9eb6/go.mod h1:Nr8SW7fE3SIjnp+rj8PCOtwk8JZ9wqafu1ZCgq3Zz+Q=
-github.com/Project-Helianthus/helianthus-modbusreg v0.1.0 h1:I2Eu22HqrghDZVJfCBgprsmPZqI9iWO2GzPCCZcMyq0=
-github.com/Project-Helianthus/helianthus-modbusreg v0.1.0/go.mod h1:b1DlK4MkW72E+j+ejZqXHbMBiMUexU/+QWIT10zZVjU=
+github.com/Project-Helianthus/helianthus-modbusreg v0.2.0 h1:V8kWhn7dEzjpcaaQultjAble5wGlU5lloK9b6i7HOkc=
+github.com/Project-Helianthus/helianthus-modbusreg v0.2.0/go.mod h1:b1DlK4MkW72E+j+ejZqXHbMBiMUexU/+QWIT10zZVjU=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.15 h1:FhdTAcv/kckjVhao5ovAQmLRvTG0EEPZT8lmdwHuymY=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.15/go.mod h1:qPqQTDqmPjyOJCr0JMNjhSC1XW1k3h5P/EZqRGy80Vs=
 github.com/Project-Helianthus/helianthus-spine-go v0.7.1-helianthus.9 h1:pV1GQmlPJyy22YGK/Amf5FMu1C3IzL3qxIxGmGUUTEo=

--- a/internal/modbusadapter/sunspec_producer.go
+++ b/internal/modbusadapter/sunspec_producer.go
@@ -202,7 +202,6 @@ func (producer *SunSpecProducer) classify(identity SunSpecPollIdentity, snapshot
 	capability := producer.registry.EvaluateThreePhaseMonitoring(snapshot)
 	result := SunSpecQualificationResult{
 		CapabilityID: capability.ProfileID(), CapabilityReason: capability.Reason(),
-		Chain: snapshot,
 	}
 	if !capability.Admitted() {
 		if capability.Reason() == modbusreg.SunSpecCapabilityReasonInvalidChain {
@@ -225,6 +224,7 @@ func (producer *SunSpecProducer) classify(identity SunSpecPollIdentity, snapshot
 		result.Outcome = SunSpecQualificationGO
 		result.ObservationCount = 1
 		result.SampleID = fmt.Sprintf("sunspec-%d-%d", identity.PollGeneration, identity.DeadlineIdentity)
+		result.Chain = snapshot
 		return result
 	}
 	switch selection.Reason() {

--- a/internal/modbusadapter/sunspec_producer.go
+++ b/internal/modbusadapter/sunspec_producer.go
@@ -110,7 +110,6 @@ func (producer *SunSpecProducer) qualify(ctx context.Context, identity SunSpecPo
 			Outcome:          SunSpecQualificationStop,
 			CapabilityID:     modbusreg.SunSpecThreePhaseMonitoringCapabilityID,
 			CapabilityReason: modbusreg.SunSpecCapabilityReasonInvalidChain,
-			FlavorID:         modbusreg.SunSpecFroniusObservedFlavorID,
 		}, nil
 	}
 	return producer.classify(identity, snapshot), nil
@@ -203,7 +202,7 @@ func (producer *SunSpecProducer) classify(identity SunSpecPollIdentity, snapshot
 	capability := producer.registry.EvaluateThreePhaseMonitoring(snapshot)
 	result := SunSpecQualificationResult{
 		CapabilityID: capability.ProfileID(), CapabilityReason: capability.Reason(),
-		FlavorID: modbusreg.SunSpecFroniusObservedFlavorID, Chain: snapshot,
+		Chain: snapshot,
 	}
 	if !capability.Admitted() {
 		if capability.Reason() == modbusreg.SunSpecCapabilityReasonInvalidChain {
@@ -214,21 +213,39 @@ func (producer *SunSpecProducer) classify(identity SunSpecPollIdentity, snapshot
 		return result
 	}
 
-	flavor := producer.registry.EvaluateFroniusObservedFlavor(snapshot)
-	result.FlavorID, result.FlavorReason = flavor.FlavorID(), flavor.Reason()
-	if flavor.Matched() {
+	selection := producer.registry.SelectFroniusObservedFlavor(snapshot)
+	if selection.Matched() {
+		flavor, ok := selection.Decision()
+		if !ok || selection.Reason() != modbusreg.SunSpecFroniusFlavorSelectionReasonMatched ||
+			!flavor.Matched() || flavor.Reason() != modbusreg.SunSpecFroniusFlavorReasonMatched {
+			result.Outcome = SunSpecQualificationStop
+			return result
+		}
+		result.FlavorID, result.FlavorReason = flavor.FlavorID(), flavor.Reason()
 		result.Outcome = SunSpecQualificationGO
 		result.ObservationCount = 1
 		result.SampleID = fmt.Sprintf("sunspec-%d-%d", identity.PollGeneration, identity.DeadlineIdentity)
 		return result
 	}
-	switch flavor.Reason() {
-	case modbusreg.SunSpecFroniusFlavorReasonCommonIdentityMismatch,
-		modbusreg.SunSpecFroniusFlavorReasonFirmwareMismatch,
-		modbusreg.SunSpecFroniusFlavorReasonChainMismatch:
+	switch selection.Reason() {
+	case modbusreg.SunSpecFroniusFlavorSelectionReasonNoMatch:
 		result.Outcome = SunSpecQualificationNoGo
+		result.FlavorReason = commonRejectedFroniusFlavorReason(selection.Evaluations())
 	default:
 		result.Outcome = SunSpecQualificationStop
 	}
 	return result
+}
+
+func commonRejectedFroniusFlavorReason(evaluations []modbusreg.SunSpecFroniusFlavorDecision) modbusreg.SunSpecFroniusFlavorReason {
+	if len(evaluations) == 0 || evaluations[0].Matched() {
+		return ""
+	}
+	reason := evaluations[0].Reason()
+	for _, evaluation := range evaluations[1:] {
+		if evaluation.Matched() || evaluation.Reason() != reason {
+			return ""
+		}
+	}
+	return reason
 }

--- a/internal/modbusadapter/sunspec_producer_test.go
+++ b/internal/modbusadapter/sunspec_producer_test.go
@@ -74,6 +74,47 @@ func TestSunSpecProducerQualifiesExactObservedFroniusChainThroughRegistry(t *tes
 	}
 }
 
+func TestSunSpecProducerQualifiesExactObservedFroniusControlsChainThroughRegistry(t *testing.T) {
+	words := observedFroniusFloatControlsWords()
+	listener, requests := serveSunSpecChain(t, words)
+	adapter, err := Start(context.Background(), integrationConfig(t, "tcp://"+listener.Addr().String()), realDialer, realFactory)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	producer, err := NewSunSpecProducer(adapter, SunSpecProducerConfig{
+		UnitID: 1, AuthorizationScope: "smoke:fronius-readonly", ReadTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewSunSpecProducer: %v", err)
+	}
+	result, err := producer.Qualify(context.Background(), SunSpecPollIdentity{
+		PollGeneration: 44, DeadlineIdentity: 94,
+	})
+	if err != nil {
+		t.Fatalf("Qualify(controls chain): %v", err)
+	}
+	if result.Outcome != SunSpecQualificationGO || result.ObservationCount != 1 || result.SampleID == "" {
+		t.Fatalf("qualification result = %#v; want one GO observation", result)
+	}
+	if result.CapabilityID != modbusreg.SunSpecThreePhaseMonitoringCapabilityID ||
+		result.CapabilityReason != modbusreg.SunSpecCapabilityReasonAdmitted ||
+		result.FlavorID != "sunspec.flavor.fronius.gen24.float.observed@1.1.0" ||
+		result.FlavorReason != modbusreg.SunSpecFroniusFlavorReasonMatched {
+		t.Fatalf("registry decisions = %#v; want exact capability and V1.1 flavor match", result)
+	}
+	if got := sunSpecWireKeys(result.Chain.Occurrences()); !reflect.DeepEqual(got, []modbusreg.SunSpecWireKey{
+		{ModelID: 1, ModelLength: 65}, {ModelID: 113, ModelLength: 60},
+		{ModelID: 120, ModelLength: 26}, {ModelID: 121, ModelLength: 30},
+		{ModelID: 122, ModelLength: 44}, {ModelID: 123, ModelLength: 24},
+		{ModelID: 160, ModelLength: 88}, {ModelID: 124, ModelLength: 24},
+	}) {
+		t.Fatalf("published SunSpec chain = %v; want exact observed Fronius controls chain", got)
+	}
+	assertBoundedFC03Discovery(t, requests(), 1)
+}
+
 func TestSunSpecProducerReturnsNoGoForAdmittedCapabilityWithFlavorMismatch(t *testing.T) {
 	listener, _ := serveSunSpecChain(t, admittedFloatChainWords())
 	adapter, err := Start(context.Background(), integrationConfig(t, "tcp://"+listener.Addr().String()), realDialer, realFactory)
@@ -134,7 +175,7 @@ func TestSunSpecProducerSourceDelegatesSemanticSelectionToModbusreg(t *testing.T
 	for _, required := range []string{
 		"NewStandardSunSpecDecoderRegistry",
 		"EvaluateThreePhaseMonitoring",
-		"EvaluateFroniusObservedFlavor",
+		"SelectFroniusObservedFlavor",
 	} {
 		if !strings.Contains(text, required) {
 			t.Fatalf("producer does not delegate through %s", required)
@@ -143,6 +184,7 @@ func TestSunSpecProducerSourceDelegatesSemanticSelectionToModbusreg(t *testing.T
 	for _, forbidden := range []string{
 		"sunspec.phase1",
 		"deferredSunSpecModelInRaw",
+		"EvaluateFroniusObservedFlavor(snapshot)",
 		"id >= 111",
 		"id >= 120",
 		"id >= 200",
@@ -258,6 +300,19 @@ func observedFroniusFloatWords() []uint16 {
 		sunSpecFixtureModel{120, 26, make([]uint16, 26)},
 		sunSpecFixtureModel{121, 30, make([]uint16, 30)},
 		sunSpecFixtureModel{122, 44, make([]uint16, 44)},
+		sunSpecFixtureModel{160, 88, mpptPayload(4)},
+		sunSpecFixtureModel{124, 24, make([]uint16, 24)},
+	)
+}
+
+func observedFroniusFloatControlsWords() []uint16 {
+	return sunSpecFixtureWords(
+		sunSpecFixtureModel{1, 65, commonPayload("Fronius", "Symo GEN24 10.0", "1.41.11-1")},
+		sunSpecFixtureModel{113, 60, floatInverterPayload()},
+		sunSpecFixtureModel{120, 26, make([]uint16, 26)},
+		sunSpecFixtureModel{121, 30, make([]uint16, 30)},
+		sunSpecFixtureModel{122, 44, make([]uint16, 44)},
+		sunSpecFixtureModel{123, 24, make([]uint16, 24)},
 		sunSpecFixtureModel{160, 88, mpptPayload(4)},
 		sunSpecFixtureModel{124, 24, make([]uint16, 24)},
 	)

--- a/internal/modbusadapter/sunspec_producer_test.go
+++ b/internal/modbusadapter/sunspec_producer_test.go
@@ -100,7 +100,7 @@ func TestSunSpecProducerQualifiesExactObservedFroniusControlsChainThroughRegistr
 	}
 	if result.CapabilityID != modbusreg.SunSpecThreePhaseMonitoringCapabilityID ||
 		result.CapabilityReason != modbusreg.SunSpecCapabilityReasonAdmitted ||
-		result.FlavorID != "sunspec.flavor.fronius.gen24.float.observed@1.1.0" ||
+		result.FlavorID != modbusreg.SunSpecFroniusObservedFlavorV11ID ||
 		result.FlavorReason != modbusreg.SunSpecFroniusFlavorReasonMatched {
 		t.Fatalf("registry decisions = %#v; want exact capability and V1.1 flavor match", result)
 	}
@@ -111,6 +111,16 @@ func TestSunSpecProducerQualifiesExactObservedFroniusControlsChainThroughRegistr
 		{ModelID: 160, ModelLength: 88}, {ModelID: 124, ModelLength: 24},
 	}) {
 		t.Fatalf("published SunSpec chain = %v; want exact observed Fronius controls chain", got)
+	}
+	controls := result.Chain.ByModelID(123)
+	if len(controls) != 1 || controls[0].Disposition != modbusreg.SunSpecChainDispositionAdmitted {
+		t.Fatalf("Model 123 occurrences = %#v; want one admitted standard model", controls)
+	}
+	decoderKey, ok := controls[0].DecoderKey()
+	if !ok || decoderKey != (modbusreg.SunSpecDecoderKey{
+		ModelID: 123, ModelLength: 24, SchemaRevision: modbusreg.SunSpecModelsRevisionV1,
+	}) {
+		t.Fatalf("Model 123 decoder key = %#v, %v; want exact standard registry key", decoderKey, ok)
 	}
 	assertBoundedFC03Discovery(t, requests(), 1)
 }

--- a/internal/modbusadapter/sunspec_producer_test.go
+++ b/internal/modbusadapter/sunspec_producer_test.go
@@ -149,6 +149,7 @@ func TestSunSpecProducerReturnsNoGoForAdmittedCapabilityWithFlavorMismatch(t *te
 		result.ObservationCount != 0 || result.SampleID != "" {
 		t.Fatalf("flavor-mismatch result = %#v; want closed NO_GO without observation", result)
 	}
+	assertNoSunSpecQualificationChain(t, result)
 }
 
 func TestSunSpecProducerRejectsMixedTransportGenerationWithoutPublishing(t *testing.T) {
@@ -173,6 +174,14 @@ func TestSunSpecProducerRejectsMixedTransportGenerationWithoutPublishing(t *test
 	}
 	if result.Outcome != SunSpecQualificationStop || result.ObservationCount != 0 || result.SampleID != "" {
 		t.Fatalf("mixed generation result = %#v; want STOP without publication", result)
+	}
+	assertNoSunSpecQualificationChain(t, result)
+}
+
+func assertNoSunSpecQualificationChain(t *testing.T, result SunSpecQualificationResult) {
+	t.Helper()
+	if len(result.Chain.RawWords()) != 0 || len(result.Chain.Occurrences()) != 0 || len(result.Chain.SourceViews()) != 0 {
+		t.Fatalf("%s result retained qualification chain evidence", result.Outcome)
 	}
 }
 


### PR DESCRIPTION
Closes #813

## Dependencies
- docs gate: `helianthus-docs-ebus#445`, merge `b70063ff8f803f32768059290f2b02f84e1d542d`
- registry: `helianthus-modbusreg v0.2.0`, merge `1f32bf3018aba9671b36f699a8642b6b1a90a563`, tag object `da104813ef8ad94cd638c4795780faf25efb0bd0`
- gateway base: `81e18e67a1b7d1adff5273c8c43f08243a3e2a0a`

## Scope
- repin modbusreg v0.2.0
- registry-owned exact-one V1/V1.1 flavor selection
- current live target V1.1, while preserving V1 compatibility
- no gateway-owned Model 123 or chain policy
- preserve FC03-only acquisition, reconnect/generation provenance, redaction, and worker lifecycle

## TDD
- initial RED `700b20dcc34ccaf88f98a419f5a8fb0acc906902`: V1.1 NO_GO, direct V1 evaluator, runtime rejects V1.1
- initial GREEN `a2d5cf3a5ce22bb23b304acf220279ff1b58b0b3`
- review P2 RED `4ed12b26fc9e8f614c9f393d6acae727ac9a7f66`: NO_GO retained qualification chain
- final GREEN exact `1ec03d1c8bbe306349e7b23aea6d836f1c62ad69`: chain retained only on GO

## Validation
- focused real-socket FC03 and runtime race tests PASS
- full `GOWORK=off ./scripts/ci_local.sh` PASS
- Portal 42/42; full Go race; Python 168+6+9+7+6+2; lint 0
- GitHub terminology/build/test/lint all SUCCESS on exact HEAD
- first GitHub test run exposed one unrelated eeBUS MCP timeout; focused race 10/10 passed and clean exact-HEAD rerun succeeded
- fresh exact-HEAD `NO_BLOCKING_FINDINGS`; prior P2 closed; zero P3/P4
- T01..T88 and passive smoke not triggered: registry dispatch only, no framing/request/reconnect behavior change

## Safety
No Modbus writes, live access, MCP/GraphQL/Portal/HA publication, canonical PV publication, or support claim.
