### PR TITLE
Post-M9: restore FM5 structural retention

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -2410,22 +2410,16 @@ func portalFM5Interpretation(provider graphql.SemanticProvider) graphql.Fm5Inter
 	if provider == nil {
 		return graphql.Fm5Interpretation{}
 	}
-	if typed, ok := provider.(graphql.FM5InterpretationProvider); ok {
-		verdict := typed.FM5Interpretation()
-		if verdict == (graphql.Fm5Interpretation{}) {
-			return verdict
-		}
-		if verdict.Validate() == nil {
-			return verdict
-		}
+	typed, ok := provider.(graphql.FM5InterpretationProvider)
+	if !ok {
+		return graphql.Fm5Interpretation{}
 	}
-	mode := provider.FM5SemanticMode()
-	if mode == "" {
-		mode = graphql.Fm5SemanticModeAbsent
+	verdict := typed.FM5Interpretation()
+	if verdict == (graphql.Fm5Interpretation{}) {
+		return verdict
 	}
-	verdict := graphql.Fm5Interpretation{Mode: mode, EvidenceRevision: "legacy"}
-	if mode == graphql.Fm5SemanticModeGPIOOnly {
-		verdict.DegradedReason = graphql.Fm5SemanticDegradedReasonConfigurationNotInterpretable
+	if verdict.Validate() != nil {
+		return graphql.Fm5Interpretation{}
 	}
 	return verdict
 }

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -2408,10 +2408,13 @@ func startHTTPServer(
 
 func portalFM5Interpretation(provider graphql.SemanticProvider) graphql.Fm5Interpretation {
 	if provider == nil {
-		return graphql.Fm5Interpretation{Mode: graphql.Fm5SemanticModeAbsent, EvidenceRevision: "initial"}
+		return graphql.Fm5Interpretation{}
 	}
 	if typed, ok := provider.(graphql.FM5InterpretationProvider); ok {
 		verdict := typed.FM5Interpretation()
+		if verdict == (graphql.Fm5Interpretation{}) {
+			return verdict
+		}
 		if verdict.Validate() == nil {
 			return verdict
 		}
@@ -2422,7 +2425,7 @@ func portalFM5Interpretation(provider graphql.SemanticProvider) graphql.Fm5Inter
 	}
 	verdict := graphql.Fm5Interpretation{Mode: mode, EvidenceRevision: "legacy"}
 	if mode == graphql.Fm5SemanticModeGPIOOnly {
-		verdict.DegradedReason = graphql.Fm5SemanticDegradedReasonIncoherentAcquisition
+		verdict.DegradedReason = graphql.Fm5SemanticDegradedReasonConfigurationNotInterpretable
 	}
 	return verdict
 }

--- a/cmd/gateway/post_m9_defects_red_test.go
+++ b/cmd/gateway/post_m9_defects_red_test.go
@@ -657,6 +657,12 @@ func TestFM5StartupIdentityClassification_UsesCompleteFunctionalModuleIdentityTu
 			firmwarePayload: []byte{0xFF, 0xFF, 0xFF},
 			hardwarePayload: []byte{0xFF},
 		},
+		{
+			name:             "connected slot without identity",
+			connectedPayload: []byte{0x01},
+			firmwarePayload:  []byte{0xFF, 0xFF, 0xFF},
+			hardwarePayload:  []byte{0xFF, 0xFF},
+		},
 	}
 
 	for _, test := range tests {
@@ -783,17 +789,17 @@ func TestRefreshRadioDevices_IncompleteCurrentFM5IdentityTupleRetainsPriorClassi
 		provider.SetCylinders([]graphql.CylinderStatus{{Index: 0, TemperatureC: &temperature}})
 		return provider
 	}
-	assertRetained := func(t *testing.T, provider *graphql.LiveSemanticProvider) {
+	assertRetainedMode := func(t *testing.T, provider *graphql.LiveSemanticProvider, wantMode graphql.Fm5SemanticMode) {
 		t.Helper()
 		got := provider.FM5Interpretation()
-		if got.Mode != graphql.Fm5SemanticModeInterpreted || got.DegradedReason != graphql.Fm5SemanticDegradedReasonIncoherentAcquisition {
-			t.Errorf("incomplete current identity verdict = %#v; want retained INTERPRETED/INCOHERENT_ACQUISITION", got)
+		if got.Mode != wantMode || got.DegradedReason != graphql.Fm5SemanticDegradedReasonIncoherentAcquisition {
+			t.Errorf("incomplete current identity verdict = %#v; want retained %s/INCOHERENT_ACQUISITION", got, wantMode)
 		}
 		if got.EvidenceRevision == "" || got.EvidenceRevision == previous.EvidenceRevision {
 			t.Errorf("incomplete current identity revision = %q; want advancement from %q", got.EvidenceRevision, previous.EvidenceRevision)
 		}
-		if gotMode := provider.FM5SemanticMode(); gotMode != graphql.Fm5SemanticModeInterpreted {
-			t.Errorf("incomplete current identity legacy scalar = %s; want retained INTERPRETED", gotMode)
+		if gotMode := provider.FM5SemanticMode(); gotMode != wantMode {
+			t.Errorf("incomplete current identity legacy scalar = %s; want retained %s", gotMode, wantMode)
 		}
 		if solar := provider.Solar(); solar == nil || solar.CollectorTemperatureC == nil || *solar.CollectorTemperatureC != collector {
 			t.Errorf("incomplete current identity solar = %#v; want retained collector temperature", solar)
@@ -801,6 +807,10 @@ func TestRefreshRadioDevices_IncompleteCurrentFM5IdentityTupleRetainsPriorClassi
 		if cylinders := provider.Cylinders(); len(cylinders) != 1 || cylinders[0].TemperatureC == nil || *cylinders[0].TemperatureC != temperature {
 			t.Errorf("incomplete current identity cylinders = %#v; want retained temperature", cylinders)
 		}
+	}
+	assertRetained := func(t *testing.T, provider *graphql.LiveSemanticProvider) {
+		t.Helper()
+		assertRetainedMode(t, provider, graphql.Fm5SemanticModeInterpreted)
 	}
 
 	t.Run("same-call firmware identity then detail timeout", func(t *testing.T) {
@@ -877,6 +887,51 @@ func TestRefreshRadioDevices_IncompleteCurrentFM5IdentityTupleRetainsPriorClassi
 
 		poller.refreshRadioDevices(context.Background())
 		assertRetained(t, provider)
+	})
+
+	t.Run("full scan connected slot without identity", func(t *testing.T) {
+		for _, wantMode := range []graphql.Fm5SemanticMode{
+			graphql.Fm5SemanticModeInterpreted,
+			graphql.Fm5SemanticModeAbsent,
+		} {
+			t.Run(string(wantMode), func(t *testing.T) {
+				provider := newProvider()
+				poller := newPoller(provider)
+				prior := previous
+				prior.Mode = wantMode
+				provider.SetFM5Interpretation(prior)
+				poller.fm5Mode = wantMode
+				poller.fm5Interpretation = prior
+				poller.sendFrameFn = func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+					if len(frame.Data) != 6 {
+						return nil, errors.New("invalid B524 selector")
+					}
+					group := frame.Data[2]
+					instance := frame.Data[3]
+					addr := uint16(frame.Data[4]) | uint16(frame.Data[5])<<8
+					if group == remoteFunctionalModules.group {
+						switch addr {
+						case device_slot_connected:
+							value := byte(0x00)
+							if instance == 0x04 {
+								value = 0x01
+							}
+							return testB524ResponseForSelectorPayload(frame.Data, value), nil
+						case device_slot_class_address:
+							return testB524ResponseForSelectorPayload(frame.Data, 0xFF), nil
+						case device_slot_firmware:
+							return testB524ResponseForSelectorPayload(frame.Data, 0xFF, 0xFF, 0xFF), nil
+						case device_slot_hardware_identifier:
+							return testB524ResponseForSelectorPayload(frame.Data, 0xFF, 0xFF), nil
+						}
+					}
+					return testB524ResponseForSelectorPayload(frame.Data, 0x00, 0x00, 0x00, 0x00), nil
+				}
+
+				poller.refreshRadioDevices(context.Background())
+				assertRetainedMode(t, provider, wantMode)
+			})
+		}
 	})
 
 	t.Run("cached hardware identity then later detail timeout", func(t *testing.T) {

--- a/cmd/gateway/post_m9_defects_red_test.go
+++ b/cmd/gateway/post_m9_defects_red_test.go
@@ -621,11 +621,12 @@ func TestFM5StartupIdentityClassification_UsesCompleteFunctionalModuleIdentityTu
 	now := time.Date(2026, 8, 15, 16, 0, 0, 0, time.UTC)
 	config := uint16(2)
 	tests := []struct {
-		name            string
-		firmwarePayload []byte
-		hardwarePayload []byte
-		firmwareTimeout bool
-		wantMode        graphql.Fm5SemanticMode
+		name             string
+		connectedPayload []byte
+		firmwarePayload  []byte
+		hardwarePayload  []byte
+		firmwareTimeout  bool
+		wantMode         graphql.Fm5SemanticMode
 	}{
 		{
 			name:            "firmware-only identity",
@@ -644,6 +645,17 @@ func TestFM5StartupIdentityClassification_UsesCompleteFunctionalModuleIdentityTu
 			firmwarePayload: []byte{0xFF, 0xFF, 0xFF},
 			hardwarePayload: []byte{0xFF, 0xFF},
 			firmwareTimeout: true,
+		},
+		{
+			name:             "invalid connected sentinel",
+			connectedPayload: []byte{0xFF},
+			firmwarePayload:  []byte{0xFF, 0xFF, 0xFF},
+			hardwarePayload:  []byte{0xFF, 0xFF},
+		},
+		{
+			name:            "short hardware field",
+			firmwarePayload: []byte{0xFF, 0xFF, 0xFF},
+			hardwarePayload: []byte{0xFF},
 		},
 	}
 
@@ -674,7 +686,11 @@ func TestFM5StartupIdentityClassification_UsesCompleteFunctionalModuleIdentityTu
 				if group == remoteFunctionalModules.group {
 					switch addr {
 					case device_slot_connected:
-						return testB524ResponseForSelectorPayload(frame.Data, 0x00), nil
+						payload := []byte{0x00}
+						if instance == 0x04 && test.connectedPayload != nil {
+							payload = test.connectedPayload
+						}
+						return testB524ResponseForSelectorPayload(frame.Data, payload...), nil
 					case device_slot_class_address:
 						return testB524ResponseForSelectorPayload(frame.Data, 0xFF), nil
 					case device_slot_firmware:
@@ -830,6 +846,39 @@ func TestRefreshRadioDevices_IncompleteCurrentFM5IdentityTupleRetainsPriorClassi
 		assertRetained(t, provider)
 	})
 
+	t.Run("full scan invalid connected sentinel", func(t *testing.T) {
+		provider := newProvider()
+		poller := newPoller(provider)
+		poller.sendFrameFn = func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+			if len(frame.Data) != 6 {
+				return nil, errors.New("invalid B524 selector")
+			}
+			group := frame.Data[2]
+			instance := frame.Data[3]
+			addr := uint16(frame.Data[4]) | uint16(frame.Data[5])<<8
+			if group == remoteFunctionalModules.group {
+				switch addr {
+				case device_slot_connected:
+					value := byte(0x00)
+					if instance == 0x04 {
+						value = 0xFF
+					}
+					return testB524ResponseForSelectorPayload(frame.Data, value), nil
+				case device_slot_class_address:
+					return testB524ResponseForSelectorPayload(frame.Data, 0xFF), nil
+				case device_slot_firmware:
+					return testB524ResponseForSelectorPayload(frame.Data, 0xFF, 0xFF, 0xFF), nil
+				case device_slot_hardware_identifier:
+					return testB524ResponseForSelectorPayload(frame.Data, 0xFF, 0xFF), nil
+				}
+			}
+			return testB524ResponseForSelectorPayload(frame.Data, 0x00, 0x00, 0x00, 0x00), nil
+		}
+
+		poller.refreshRadioDevices(context.Background())
+		assertRetained(t, provider)
+	})
+
 	t.Run("cached hardware identity then later detail timeout", func(t *testing.T) {
 		provider := newProvider()
 		poller := newPoller(provider)
@@ -871,6 +920,47 @@ func TestRefreshRadioDevices_IncompleteCurrentFM5IdentityTupleRetainsPriorClassi
 		}
 
 		poller.refreshRadioDevices(ctx)
+		assertRetained(t, provider)
+	})
+
+	t.Run("cached identity then first connected read timeout", func(t *testing.T) {
+		provider := newProvider()
+		poller := newPoller(provider)
+		hardware := uint16(0x1234)
+		poller.radioDevices = map[radioDeviceKey]*vaillantRadioDeviceSnapshot{
+			{Group: remoteFunctionalModules.group, Instance: 0x04}: {
+				Group:              remoteFunctionalModules.group,
+				Instance:           0x04,
+				SlotMode:           "inventory",
+				HardwareIdentifier: &hardware,
+			},
+		}
+		poller.deviceSlotCache[deviceSlotKey{Group: remoteFunctionalModules.group, Instance: 0x04}] = true
+		poller.deviceSlotDiscoveryDone = true
+		poller.deviceSlotDiscoveryAt = now
+		poller.deviceSlotRediscoveryTTL = time.Hour
+		connectedReads := 0
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		poller.sendFrameFn = func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+			if len(frame.Data) != 6 {
+				return nil, errors.New("invalid B524 selector")
+			}
+			if frame.Data[2] == remoteFunctionalModules.group {
+				addr := uint16(frame.Data[4]) | uint16(frame.Data[5])<<8
+				if addr == device_slot_connected {
+					connectedReads++
+					cancel()
+					return nil, errors.New("current connected timeout")
+				}
+			}
+			return testB524ResponseForSelectorPayload(frame.Data, 0x00, 0x00, 0x00, 0x00), nil
+		}
+
+		poller.refreshRadioDevices(ctx)
+		if connectedReads == 0 {
+			t.Fatal("current device_connected read was not attempted")
+		}
 		assertRetained(t, provider)
 	})
 }

--- a/cmd/gateway/post_m9_defects_red_test.go
+++ b/cmd/gateway/post_m9_defects_red_test.go
@@ -26,7 +26,7 @@ func TestDeriveFM5Interpretation_CoherentClassificationsAndUnavailableBootstrap(
 		wantReason          graphql.Fm5SemanticDegradedReason
 	}{
 		{"incomplete bootstrap", false, nil, false, false, false, false, false, "", ""},
-		{"fresh coherent absence", true, &configInterpretable, false, false, false, false, false, graphql.Fm5SemanticModeAbsent, ""},
+		{"no completed negative identity acquisition", true, &configInterpretable, false, false, false, false, false, "", ""},
 		{"configuration deliberately unsupported", true, &configUnsupported, false, false, true, false, false, graphql.Fm5SemanticModeGPIOOnly, graphql.Fm5SemanticDegradedReasonConfigurationNotInterpretable},
 		{"coherent interpretation", true, &configInterpretable, true, true, true, false, false, graphql.Fm5SemanticModeInterpreted, ""},
 	}
@@ -312,6 +312,215 @@ func TestCommitFM5Acquisition_RegistryMutationAfterPostReadCaptureIsIncoherent(t
 	}
 	if verdict.EvidenceRevision == "fm5-g0-a0" {
 		t.Fatalf("registry interleaving revision = %q; want advanced revision", verdict.EvidenceRevision)
+	}
+}
+
+func TestRefreshDiscovery_TransientRootFailureRetainsFM5ClassificationAndValues(t *testing.T) {
+	config := uint16(2)
+	classAddress := uint8(circuitManagingDeviceVR71Address)
+	collector := 61.5
+	temperature := 47.25
+	provider := graphql.NewLiveSemanticProvider()
+	previous := graphql.Fm5Interpretation{
+		Mode:             graphql.Fm5SemanticModeInterpreted,
+		EvidenceRevision: "fm5-g7-a41",
+	}
+	provider.SetFM5Interpretation(previous)
+	provider.SetSolar(&graphql.SolarStatus{CollectorTemperatureC: &collector})
+	provider.SetCylinders([]graphql.CylinderStatus{{Index: 0, TemperatureC: &temperature}})
+
+	reg := registry.NewDeviceRegistry(nil)
+	reg.Register(registry.DeviceInfo{Address: 0x15, Manufacturer: "Vaillant", DeviceID: "BASV2"})
+	poller := &vaillantSemanticPoller{
+		reg:                   reg,
+		provider:              provider,
+		controller:            0x15,
+		system:                &vaillantSystemSnapshot{Controller: 0x15, ModuleConfigurationVR71: &config},
+		radioDevices:          map[radioDeviceKey]*vaillantRadioDeviceSnapshot{{Group: remoteFunctionalModules.group}: {DeviceClassAddress: &classAddress}},
+		zones:                 make(map[byte]*vaillantZoneSnapshot),
+		presence:              make(map[byte]*zonePresenceRecord),
+		circuits:              make(map[byte]*vaillantCircuitSnapshot),
+		fm5Mode:               graphql.Fm5SemanticModeInterpreted,
+		fm5Interpretation:     previous,
+		fm5EvidenceRevision:   41,
+		fm5EvidenceGeneration: 7,
+		fm5IdentityObservedAt: time.Now(),
+		solar:                 &vaillantSolarSnapshot{CollectorTemperatureC: &collector},
+		solarCylinders:        map[byte]*vaillantCylinderSnapshot{0: {Instance: 0, TemperatureC: &temperature}},
+		b524ProbeFn:           mockB524Probe(map[byte]bool{}, nil),
+		nowFn:                 time.Now,
+	}
+
+	poller.refreshDiscovery(context.Background())
+
+	verdict := provider.FM5Interpretation()
+	if verdict.Mode != graphql.Fm5SemanticModeInterpreted || verdict.DegradedReason != graphql.Fm5SemanticDegradedReasonControllerUnreachable {
+		t.Errorf("root-discovery failure verdict = %#v; want retained INTERPRETED/CONTROLLER_UNREACHABLE", verdict)
+	}
+	if verdict.EvidenceRevision == "" || verdict.EvidenceRevision == previous.EvidenceRevision {
+		t.Errorf("root-discovery failure revision = %q; want advancement from %q", verdict.EvidenceRevision, previous.EvidenceRevision)
+	}
+	if got := provider.FM5SemanticMode(); got != graphql.Fm5SemanticModeInterpreted {
+		t.Errorf("root-discovery failure legacy scalar = %s; want retained INTERPRETED", got)
+	}
+	if solar := provider.Solar(); solar == nil || solar.CollectorTemperatureC == nil || *solar.CollectorTemperatureC != collector {
+		t.Errorf("root-discovery failure solar = %#v; want retained collector temperature %.2f", solar, collector)
+	}
+	if cylinders := provider.Cylinders(); len(cylinders) != 1 || cylinders[0].TemperatureC == nil || *cylinders[0].TemperatureC != temperature {
+		t.Errorf("root-discovery failure cylinders = %#v; want retained temperature %.2f", cylinders, temperature)
+	}
+}
+
+func TestRefreshFM5Semantic_StaleIdentityOutranksUnsupportedConfiguration(t *testing.T) {
+	now := time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)
+	configUnsupported := uint16(3)
+	classAddress := uint8(circuitManagingDeviceVR71Address)
+	newPoller := func(provider *graphql.LiveSemanticProvider) *vaillantSemanticPoller {
+		return &vaillantSemanticPoller{
+			reg:                   registry.NewDeviceRegistry(nil),
+			provider:              provider,
+			controller:            0x15,
+			system:                &vaillantSystemSnapshot{Controller: 0x15, ModuleConfigurationVR71: &configUnsupported},
+			radioDevices:          map[radioDeviceKey]*vaillantRadioDeviceSnapshot{{Group: remoteFunctionalModules.group}: {DeviceClassAddress: &classAddress}},
+			solarCylinders:        make(map[byte]*vaillantCylinderSnapshot),
+			fm5EvidenceTTL:        5 * time.Minute,
+			fm5IdentityObservedAt: now.Add(-6 * time.Minute),
+			fm5EvidenceGeneration: 7,
+			fm5EvidenceRevision:   41,
+			nowFn:                 func() time.Time { return now },
+		}
+	}
+
+	t.Run("bootstrap remains unavailable", func(t *testing.T) {
+		provider := graphql.NewLiveSemanticProvider()
+		poller := newPoller(provider)
+		poller.refreshFM5Semantic(context.Background())
+		if got := provider.FM5Interpretation(); got.Mode != "" || got.DegradedReason != "" || got.EvidenceRevision != "" {
+			t.Fatalf("stale unsupported bootstrap verdict = %#v; want unavailable zero tuple", got)
+		}
+	})
+
+	t.Run("coherent family retains prior classification and values", func(t *testing.T) {
+		collector := 61.5
+		temperature := 47.25
+		provider := graphql.NewLiveSemanticProvider()
+		poller := newPoller(provider)
+		poller.fm5Mode = graphql.Fm5SemanticModeInterpreted
+		poller.fm5Interpretation = graphql.Fm5Interpretation{
+			Mode:             graphql.Fm5SemanticModeInterpreted,
+			EvidenceRevision: "fm5-g7-a41",
+		}
+		poller.solar = &vaillantSolarSnapshot{CollectorTemperatureC: &collector}
+		poller.solarCylinders[0] = &vaillantCylinderSnapshot{Instance: 0, TemperatureC: &temperature}
+
+		poller.refreshFM5Semantic(context.Background())
+		got := provider.FM5Interpretation()
+		if got.Mode != graphql.Fm5SemanticModeInterpreted || got.DegradedReason != graphql.Fm5SemanticDegradedReasonEvidenceStale {
+			t.Errorf("stale unsupported retained verdict = %#v; want INTERPRETED/EVIDENCE_STALE", got)
+		}
+		if got.EvidenceRevision == "" || got.EvidenceRevision == "fm5-g7-a41" {
+			t.Errorf("stale unsupported revision = %q; want advancement", got.EvidenceRevision)
+		}
+		if solar := provider.Solar(); solar == nil || solar.CollectorTemperatureC == nil || *solar.CollectorTemperatureC != collector {
+			t.Errorf("stale unsupported solar = %#v; want retained coherent value", solar)
+		}
+		if cylinders := provider.Cylinders(); len(cylinders) != 1 || cylinders[0].TemperatureC == nil || *cylinders[0].TemperatureC != temperature {
+			t.Errorf("stale unsupported cylinders = %#v; want retained coherent value", cylinders)
+		}
+	})
+}
+
+func TestRefreshFM5Semantic_AbsenceRequiresFreshCompletedNegativeIdentityAcquisition(t *testing.T) {
+	now := time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)
+	config := uint16(2)
+	newPoller := func(provider *graphql.LiveSemanticProvider) *vaillantSemanticPoller {
+		return &vaillantSemanticPoller{
+			reg:            registry.NewDeviceRegistry(nil),
+			provider:       provider,
+			controller:     0x15,
+			system:         &vaillantSystemSnapshot{Controller: 0x15, ModuleConfigurationVR71: &config},
+			radioDevices:   make(map[radioDeviceKey]*vaillantRadioDeviceSnapshot),
+			solarCylinders: make(map[byte]*vaillantCylinderSnapshot),
+			fm5EvidenceTTL: 5 * time.Minute,
+			nowFn:          func() time.Time { return now },
+		}
+	}
+
+	provider := graphql.NewLiveSemanticProvider()
+	poller := newPoller(provider)
+	poller.refreshFM5Semantic(context.Background())
+	if got := provider.FM5Interpretation(); got.Mode != "" || got.DegradedReason != "" || got.EvidenceRevision != "" {
+		t.Errorf("unobserved startup verdict = %#v; want unavailable zero tuple", got)
+	}
+
+	provider = graphql.NewLiveSemanticProvider()
+	poller = newPoller(provider)
+	poller.startupRadioDevicesProbed = true
+	poller.fm5IdentityObservedAt = now
+	poller.refreshFM5Semantic(context.Background())
+	if got := provider.FM5Interpretation(); got.Mode != graphql.Fm5SemanticModeAbsent || got.DegradedReason != "" || got.EvidenceRevision == "" {
+		t.Errorf("fresh completed negative verdict = %#v; want healthy ABSENT with revision", got)
+	}
+}
+
+func TestFM5Acquisition_EmptyEvidenceGenerationInterleavingRetainsPriorClassification(t *testing.T) {
+	configUnsupported := uint16(3)
+	collector := 61.5
+	temperature := 47.25
+	reg := registry.NewDeviceRegistry(nil)
+	poller := &vaillantSemanticPoller{
+		reg:          reg,
+		controller:   0x15,
+		system:       &vaillantSystemSnapshot{Controller: 0x15, ModuleConfigurationVR71: &configUnsupported},
+		radioDevices: make(map[radioDeviceKey]*vaillantRadioDeviceSnapshot),
+		fm5Mode:      graphql.Fm5SemanticModeInterpreted,
+		fm5Interpretation: graphql.Fm5Interpretation{
+			Mode:             graphql.Fm5SemanticModeInterpreted,
+			EvidenceRevision: "fm5-g7-a41",
+		},
+		fm5EvidenceGeneration: 7,
+		fm5EvidenceRevision:   41,
+		solar:                 &vaillantSolarSnapshot{CollectorTemperatureC: &collector},
+		solarCylinders:        map[byte]*vaillantCylinderSnapshot{0: {Instance: 0, TemperatureC: &temperature}},
+		nowFn:                 time.Now,
+	}
+
+	before := poller.captureFM5Evidence()
+	reg.Register(registry.DeviceInfo{Address: 0x08, Manufacturer: "Vaillant", DeviceID: "BAI00"})
+	after := poller.captureFM5Evidence()
+	if before.hasEvidence() || after.hasEvidence() {
+		t.Fatal("non-FM5 registry mutation unexpectedly fabricated FM5 identity evidence")
+	}
+	if before.sameGeneration(after) {
+		t.Fatal("registry observation-generation interleaving was not detected")
+	}
+
+	verdict := deriveFM5Interpretation(
+		before.controller != 0,
+		before.moduleConfig,
+		false,
+		false,
+		false,
+		false,
+		true,
+		poller.nextFM5EvidenceRevision(before.generation, after.generation),
+	)
+	verdict = poller.commitFM5Acquisition(after, verdict, nil, nil)
+
+	if verdict.Mode != graphql.Fm5SemanticModeInterpreted || verdict.DegradedReason != graphql.Fm5SemanticDegradedReasonIncoherentAcquisition {
+		t.Errorf("empty-evidence interleaving verdict = %#v; want retained INTERPRETED/INCOHERENT_ACQUISITION", verdict)
+	}
+	if verdict.EvidenceRevision == "" || verdict.EvidenceRevision == "fm5-g7-a41" {
+		t.Errorf("empty-evidence interleaving revision = %q; want advancement", verdict.EvidenceRevision)
+	}
+	if poller.fm5Mode != graphql.Fm5SemanticModeInterpreted {
+		t.Errorf("empty-evidence interleaving legacy scalar = %s; want retained INTERPRETED", poller.fm5Mode)
+	}
+	if poller.solar == nil || poller.solar.CollectorTemperatureC == nil || *poller.solar.CollectorTemperatureC != collector {
+		t.Errorf("empty-evidence interleaving solar = %#v; want retained coherent value", poller.solar)
+	}
+	if poller.solarCylinders[0] == nil || poller.solarCylinders[0].TemperatureC == nil || *poller.solarCylinders[0].TemperatureC != temperature {
+		t.Errorf("empty-evidence interleaving cylinders = %#v; want retained coherent value", poller.solarCylinders)
 	}
 }
 

--- a/cmd/gateway/post_m9_defects_red_test.go
+++ b/cmd/gateway/post_m9_defects_red_test.go
@@ -646,6 +646,20 @@ func TestRefreshRadioDevices_CompleteNegativeFM5ScanSupersedesRetainedRegistryId
 		if len(frame.Data) != 6 {
 			return nil, errors.New("invalid B524 selector")
 		}
+		group := frame.Data[2]
+		addr := uint16(frame.Data[4]) | uint16(frame.Data[5])<<8
+		if group == remoteFunctionalModules.group {
+			switch addr {
+			case device_slot_connected:
+				return testB524ResponseForSelectorPayload(frame.Data, 0x00), nil
+			case device_slot_class_address:
+				return testB524ResponseForSelectorPayload(frame.Data, 0xFF), nil
+			case device_slot_firmware:
+				return testB524ResponseForSelectorPayload(frame.Data, 0xFF, 0xFF, 0xFF), nil
+			case device_slot_hardware_identifier:
+				return testB524ResponseForSelectorPayload(frame.Data, 0xFF, 0xFF), nil
+			}
+		}
 		return testB524ResponseForSelectorPayload(frame.Data, 0x00, 0x00, 0x00, 0x00), nil
 	}
 

--- a/cmd/gateway/post_m9_defects_red_test.go
+++ b/cmd/gateway/post_m9_defects_red_test.go
@@ -1018,6 +1018,283 @@ func TestRefreshRadioDevices_IncompleteCurrentFM5IdentityTupleRetainsPriorClassi
 		}
 		assertRetained(t, provider)
 	})
+
+	t.Run("complete FM negative survives non-FM detail timeout", func(t *testing.T) {
+		provider := newProvider()
+		poller := newPoller(provider)
+		regulatorConnectedReads := 0
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		poller.sendFrameFn = func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+			if len(frame.Data) != 6 {
+				return nil, errors.New("invalid B524 selector")
+			}
+			group := frame.Data[2]
+			instance := frame.Data[3]
+			addr := uint16(frame.Data[4]) | uint16(frame.Data[5])<<8
+			if group == remoteFunctionalModules.group {
+				switch addr {
+				case device_slot_connected:
+					return testB524ResponseForSelectorPayload(frame.Data, 0x00), nil
+				case device_slot_class_address:
+					return testB524ResponseForSelectorPayload(frame.Data, 0xFF), nil
+				case device_slot_firmware:
+					return testB524ResponseForSelectorPayload(frame.Data, 0xFF, 0xFF, 0xFF), nil
+				case device_slot_hardware_identifier:
+					return testB524ResponseForSelectorPayload(frame.Data, 0xFF, 0xFF), nil
+				}
+			}
+			if group == remoteRegulators.group && instance == 0x01 && addr == device_slot_connected {
+				regulatorConnectedReads++
+				if regulatorConnectedReads > 1 {
+					cancel()
+					return nil, errors.New("current regulator detail timeout")
+				}
+				return testB524ResponseForSelectorPayload(frame.Data, 0x01), nil
+			}
+			return testB524ResponseForSelectorPayload(frame.Data, 0x00, 0x00, 0x00, 0x00), nil
+		}
+
+		poller.refreshRadioDevices(ctx)
+		if regulatorConnectedReads < 2 {
+			t.Fatalf("regulator connected reads = %d; want discovery success then detail timeout", regulatorConnectedReads)
+		}
+		got := provider.FM5Interpretation()
+		if got.Mode != graphql.Fm5SemanticModeAbsent || got.DegradedReason != "" {
+			t.Errorf("complete negative with non-FM detail timeout verdict = %#v; want healthy ABSENT", got)
+		}
+		if got.EvidenceRevision == "" || got.EvidenceRevision == previous.EvidenceRevision {
+			t.Errorf("complete negative with non-FM detail timeout revision = %q; want advancement", got.EvidenceRevision)
+		}
+		if solar := provider.Solar(); solar == nil || solar.CollectorTemperatureC != nil {
+			t.Errorf("complete negative with non-FM detail timeout solar = %#v; want cleared structural plane", solar)
+		}
+		if cylinders := provider.Cylinders(); len(cylinders) != 0 {
+			t.Errorf("complete negative with non-FM detail timeout cylinders = %#v; want cleared structural plane", cylinders)
+		}
+	})
+}
+
+func TestRefreshSystem_FM5ConfigurationRequiresCurrentAcquisition(t *testing.T) {
+	now := time.Date(2026, 8, 15, 18, 0, 0, 0, time.UTC)
+	configInterpretable := uint16(2)
+	configUnsupported := uint16(3)
+	classAddress := uint8(circuitManagingDeviceVR71Address)
+	collector := 61.5
+	temperature := 47.25
+	previous := graphql.Fm5Interpretation{
+		Mode:             graphql.Fm5SemanticModeInterpreted,
+		EvidenceRevision: "fm5-g7-a41",
+	}
+	newPoller := func(provider *graphql.LiveSemanticProvider, config *uint16) *vaillantSemanticPoller {
+		return &vaillantSemanticPoller{
+			scheduler:             ebusgateway.NewSemanticReadScheduler(),
+			reg:                   registry.NewDeviceRegistry(nil),
+			provider:              provider,
+			source:                0x7F,
+			controller:            0x15,
+			requestTimeout:        50 * time.Millisecond,
+			system:                &vaillantSystemSnapshot{Controller: 0x15, ModuleConfigurationVR71: config},
+			radioDevices:          map[radioDeviceKey]*vaillantRadioDeviceSnapshot{{Group: remoteFunctionalModules.group}: {DeviceClassAddress: &classAddress}},
+			fm5Mode:               previous.Mode,
+			fm5Interpretation:     previous,
+			fm5EvidenceRevision:   41,
+			fm5EvidenceGeneration: 7,
+			fm5IdentityObservedAt: now,
+			fm5EvidenceTTL:        5 * time.Minute,
+			solar:                 &vaillantSolarSnapshot{CollectorTemperatureC: &collector},
+			solarCylinders:        map[byte]*vaillantCylinderSnapshot{0: {Instance: 0, TemperatureC: &temperature}},
+			nowFn:                 func() time.Time { return now },
+		}
+	}
+	newProvider := func() *graphql.LiveSemanticProvider {
+		provider := graphql.NewLiveSemanticProvider()
+		provider.SetFM5Interpretation(previous)
+		provider.SetSolar(&graphql.SolarStatus{CollectorTemperatureC: &collector})
+		provider.SetCylinders([]graphql.CylinderStatus{{Index: 0, TemperatureC: &temperature}})
+		return provider
+	}
+	assertRetained := func(t *testing.T, provider *graphql.LiveSemanticProvider, familyReads int) {
+		t.Helper()
+		got := provider.FM5Interpretation()
+		if got.Mode != graphql.Fm5SemanticModeInterpreted || got.DegradedReason != graphql.Fm5SemanticDegradedReasonConfigurationUnavailable {
+			t.Errorf("configuration timeout verdict = %#v; want retained INTERPRETED/CONFIGURATION_UNAVAILABLE", got)
+		}
+		if got.EvidenceRevision == "" || got.EvidenceRevision == previous.EvidenceRevision {
+			t.Errorf("configuration timeout revision = %q; want advancement from %q", got.EvidenceRevision, previous.EvidenceRevision)
+		}
+		if familyReads != 0 {
+			t.Errorf("configuration timeout family reads = %d; want 0", familyReads)
+		}
+		if solar := provider.Solar(); solar == nil || solar.CollectorTemperatureC == nil || *solar.CollectorTemperatureC != collector {
+			t.Errorf("configuration timeout solar = %#v; want retained collector temperature", solar)
+		}
+		if cylinders := provider.Cylinders(); len(cylinders) != 1 || cylinders[0].TemperatureC == nil || *cylinders[0].TemperatureC != temperature {
+			t.Errorf("configuration timeout cylinders = %#v; want retained temperature", cylinders)
+		}
+	}
+
+	t.Run("all system fields fail", func(t *testing.T) {
+		provider := newProvider()
+		poller := newPoller(provider, &configInterpretable)
+		familyReads := 0
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		poller.sendFrameFn = func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+			if len(frame.Data) == 6 && (frame.Data[2] == localSolar.group || frame.Data[2] == localCylinders.group) {
+				familyReads++
+			}
+			cancel()
+			return nil, errors.New("system acquisition timeout")
+		}
+
+		poller.refreshSystem(ctx)
+		assertRetained(t, provider, familyReads)
+	})
+
+	t.Run("another system field succeeds", func(t *testing.T) {
+		provider := newProvider()
+		poller := newPoller(provider, &configInterpretable)
+		familyReads := 0
+		configReads := 0
+		poller.sendFrameFn = func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+			if len(frame.Data) != 6 {
+				return nil, errors.New("invalid B524 selector")
+			}
+			group := frame.Data[2]
+			addr := uint16(frame.Data[4]) | uint16(frame.Data[5])<<8
+			if group == localRegulator.group && addr == system_module_configuration_vr71 {
+				configReads++
+				return nil, errors.New("module configuration timeout")
+			}
+			if group == localSolar.group || group == localCylinders.group {
+				familyReads++
+			}
+			return testB524ResponseForSelectorPayload(frame.Data, 0x00, 0x00, 0x00, 0x00), nil
+		}
+
+		poller.refreshSystem(context.Background())
+		if configReads == 0 {
+			t.Fatal("module_configuration_vr71 read was not attempted")
+		}
+		assertRetained(t, provider, familyReads)
+	})
+
+	t.Run("stale unsupported config cannot classify bootstrap", func(t *testing.T) {
+		provider := graphql.NewLiveSemanticProvider()
+		poller := newPoller(provider, &configUnsupported)
+		poller.fm5Mode = ""
+		poller.fm5Interpretation = graphql.Fm5Interpretation{}
+		poller.solar = nil
+		poller.solarCylinders = make(map[byte]*vaillantCylinderSnapshot)
+		poller.sendFrameFn = func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+			if len(frame.Data) != 6 {
+				return nil, errors.New("invalid B524 selector")
+			}
+			group := frame.Data[2]
+			addr := uint16(frame.Data[4]) | uint16(frame.Data[5])<<8
+			if group == localRegulator.group && addr == system_module_configuration_vr71 {
+				return nil, errors.New("module configuration timeout")
+			}
+			return testB524ResponseForSelectorPayload(frame.Data, 0x00, 0x00, 0x00, 0x00), nil
+		}
+
+		poller.refreshSystem(context.Background())
+		if got := provider.FM5Interpretation(); got != (graphql.Fm5Interpretation{}) {
+			t.Errorf("stale unsupported config bootstrap verdict = %#v; want unavailable zero tuple", got)
+		}
+	})
+}
+
+func TestFM5PositiveIdentityDoesNotRequireNegativeNamespaceCompleteness(t *testing.T) {
+	now := time.Date(2026, 8, 15, 19, 0, 0, 0, time.UTC)
+	config := uint16(2)
+	newPoller := func(provider *graphql.LiveSemanticProvider, reg *registry.DeviceRegistry) *vaillantSemanticPoller {
+		return &vaillantSemanticPoller{
+			scheduler:       ebusgateway.NewSemanticReadScheduler(),
+			reg:             reg,
+			provider:        provider,
+			source:          0x7F,
+			controller:      0x15,
+			requestTimeout:  50 * time.Millisecond,
+			system:          &vaillantSystemSnapshot{Controller: 0x15, ModuleConfigurationVR71: &config},
+			radioDevices:    make(map[radioDeviceKey]*vaillantRadioDeviceSnapshot),
+			solarCylinders:  make(map[byte]*vaillantCylinderSnapshot),
+			fm5EvidenceTTL:  5 * time.Minute,
+			deviceSlotCache: make(map[deviceSlotKey]bool),
+			nowFn:           func() time.Time { return now },
+		}
+	}
+	assertInterpreted := func(t *testing.T, provider *graphql.LiveSemanticProvider) {
+		t.Helper()
+		got := provider.FM5Interpretation()
+		if got.Mode != graphql.Fm5SemanticModeInterpreted || got.DegradedReason != "" || got.EvidenceRevision == "" {
+			t.Fatalf("positive partial-namespace verdict = %#v; want healthy INTERPRETED with revision", got)
+		}
+	}
+	responder := func(positiveInstance byte, timeoutInstance *byte) func(context.Context, protocol.Frame) (*protocol.Frame, error) {
+		return func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+			if len(frame.Data) != 6 {
+				return nil, errors.New("invalid B524 selector")
+			}
+			group := frame.Data[2]
+			instance := frame.Data[3]
+			addr := uint16(frame.Data[4]) | uint16(frame.Data[5])<<8
+			if group == remoteFunctionalModules.group {
+				if timeoutInstance != nil && instance == *timeoutInstance && addr == device_slot_connected {
+					return nil, errors.New("unrelated functional-module slot timeout")
+				}
+				switch addr {
+				case device_slot_connected:
+					return testB524ResponseForSelectorPayload(frame.Data, 0x00), nil
+				case device_slot_class_address:
+					value := byte(0xFF)
+					if instance == positiveInstance {
+						value = circuitManagingDeviceVR71Address
+					}
+					return testB524ResponseForSelectorPayload(frame.Data, value), nil
+				case device_slot_firmware:
+					return testB524ResponseForSelectorPayload(frame.Data, 0xFF, 0xFF, 0xFF), nil
+				case device_slot_hardware_identifier:
+					return testB524ResponseForSelectorPayload(frame.Data, 0xFF, 0xFF), nil
+				}
+			}
+			return testB524ResponseForSelectorPayload(frame.Data, 0x00, 0x00, 0x00, 0x00), nil
+		}
+	}
+
+	t.Run("startup registry-seeded low-slot positive", func(t *testing.T) {
+		provider := graphql.NewLiveSemanticProvider()
+		reg := registry.NewDeviceRegistry(nil)
+		reg.Register(registry.DeviceInfo{Address: circuitManagingDeviceVR71Address, Manufacturer: "Vaillant", DeviceID: circuitManagingDeviceVR71ID})
+		poller := newPoller(provider, reg)
+		poller.sendFrameFn = responder(0x00, nil)
+
+		poller.refreshRadioDevicesStartup(context.Background())
+		poller.refreshFM5SemanticStartup(context.Background())
+		assertInterpreted(t, provider)
+	})
+
+	t.Run("startup positive with unrelated slot timeout", func(t *testing.T) {
+		provider := graphql.NewLiveSemanticProvider()
+		poller := newPoller(provider, registry.NewDeviceRegistry(nil))
+		timeoutInstance := byte(0x07)
+		poller.sendFrameFn = responder(0x04, &timeoutInstance)
+
+		poller.refreshRadioDevicesStartup(context.Background())
+		poller.refreshFM5SemanticStartup(context.Background())
+		assertInterpreted(t, provider)
+	})
+
+	t.Run("steady positive with unrelated slot timeout", func(t *testing.T) {
+		provider := graphql.NewLiveSemanticProvider()
+		poller := newPoller(provider, registry.NewDeviceRegistry(nil))
+		timeoutInstance := byte(0x07)
+		poller.sendFrameFn = responder(0x04, &timeoutInstance)
+
+		poller.refreshRadioDevices(context.Background())
+		assertInterpreted(t, provider)
+	})
 }
 
 func TestRefreshRadioDevices_CompleteNegativeFM5ScanSupersedesRetainedRegistryIdentity(t *testing.T) {

--- a/cmd/gateway/post_m9_defects_red_test.go
+++ b/cmd/gateway/post_m9_defects_red_test.go
@@ -603,6 +603,102 @@ func TestFM5IdentityClassification_RequiresCompleteFunctionalModuleNamespaceScan
 	})
 }
 
+func TestFM5StartupIdentityClassification_UsesCompleteFunctionalModuleIdentityTuple(t *testing.T) {
+	now := time.Date(2026, 8, 15, 16, 0, 0, 0, time.UTC)
+	config := uint16(2)
+	tests := []struct {
+		name            string
+		firmwarePayload []byte
+		hardwarePayload []byte
+		firmwareTimeout bool
+		wantMode        graphql.Fm5SemanticMode
+	}{
+		{
+			name:            "firmware-only identity",
+			firmwarePayload: []byte{0x00, 0x00, 0x00},
+			hardwarePayload: []byte{0xFF, 0xFF},
+			wantMode:        graphql.Fm5SemanticModeInterpreted,
+		},
+		{
+			name:            "hardware-only identity",
+			firmwarePayload: []byte{0xFF, 0xFF, 0xFF},
+			hardwarePayload: []byte{0x34, 0x12},
+			wantMode:        graphql.Fm5SemanticModeInterpreted,
+		},
+		{
+			name:            "missing firmware field",
+			firmwarePayload: []byte{0xFF, 0xFF, 0xFF},
+			hardwarePayload: []byte{0xFF, 0xFF},
+			firmwareTimeout: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			provider := graphql.NewLiveSemanticProvider()
+			poller := &vaillantSemanticPoller{
+				scheduler:       ebusgateway.NewSemanticReadScheduler(),
+				reg:             registry.NewDeviceRegistry(nil),
+				provider:        provider,
+				source:          0x7F,
+				controller:      0x15,
+				requestTimeout:  50 * time.Millisecond,
+				system:          &vaillantSystemSnapshot{Controller: 0x15, ModuleConfigurationVR71: &config},
+				radioDevices:    make(map[radioDeviceKey]*vaillantRadioDeviceSnapshot),
+				solarCylinders:  make(map[byte]*vaillantCylinderSnapshot),
+				fm5EvidenceTTL:  5 * time.Minute,
+				deviceSlotCache: make(map[deviceSlotKey]bool),
+				nowFn:           func() time.Time { return now },
+			}
+			poller.sendFrameFn = func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+				if len(frame.Data) != 6 {
+					return nil, errors.New("invalid B524 selector")
+				}
+				group := frame.Data[2]
+				instance := frame.Data[3]
+				addr := uint16(frame.Data[4]) | uint16(frame.Data[5])<<8
+				if group == remoteFunctionalModules.group {
+					switch addr {
+					case device_slot_connected:
+						return testB524ResponseForSelectorPayload(frame.Data, 0x00), nil
+					case device_slot_class_address:
+						return testB524ResponseForSelectorPayload(frame.Data, 0xFF), nil
+					case device_slot_firmware:
+						if instance == 0x04 && test.firmwareTimeout {
+							return nil, errors.New("firmware timeout")
+						}
+						payload := []byte{0xFF, 0xFF, 0xFF}
+						if instance == 0x04 {
+							payload = test.firmwarePayload
+						}
+						return testB524ResponseForSelectorPayload(frame.Data, payload...), nil
+					case device_slot_hardware_identifier:
+						payload := []byte{0xFF, 0xFF}
+						if instance == 0x04 {
+							payload = test.hardwarePayload
+						}
+						return testB524ResponseForSelectorPayload(frame.Data, payload...), nil
+					}
+				}
+				return testB524ResponseForSelectorPayload(frame.Data, 0x00, 0x00, 0x00, 0x00), nil
+			}
+
+			poller.refreshRadioDevicesStartup(context.Background())
+			poller.refreshFM5Semantic(context.Background())
+			got := provider.FM5Interpretation()
+			if test.wantMode == "" {
+				if got.Mode != "" || got.DegradedReason != "" || got.EvidenceRevision != "" {
+					t.Fatalf("incomplete startup identity tuple verdict = %#v; want unavailable zero tuple", got)
+				}
+				return
+			}
+			if got.Mode != test.wantMode || got.DegradedReason != "" || got.EvidenceRevision == "" {
+				t.Fatalf("startup identity tuple verdict = %#v; want healthy %s with revision", got, test.wantMode)
+			}
+		})
+	}
+}
+
 func TestRefreshRadioDevices_CompleteNegativeFM5ScanSupersedesRetainedRegistryIdentity(t *testing.T) {
 	now := time.Date(2026, 8, 15, 15, 0, 0, 0, time.UTC)
 	config := uint16(2)

--- a/cmd/gateway/post_m9_defects_red_test.go
+++ b/cmd/gateway/post_m9_defects_red_test.go
@@ -713,6 +713,168 @@ func TestFM5StartupIdentityClassification_UsesCompleteFunctionalModuleIdentityTu
 	}
 }
 
+func TestRefreshRadioDevices_IncompleteCurrentFM5IdentityTupleRetainsPriorClassification(t *testing.T) {
+	now := time.Date(2026, 8, 15, 17, 0, 0, 0, time.UTC)
+	config := uint16(2)
+	collector := 61.5
+	temperature := 47.25
+	previous := graphql.Fm5Interpretation{
+		Mode:             graphql.Fm5SemanticModeInterpreted,
+		EvidenceRevision: "fm5-g7-a41",
+	}
+	zeroFreshnessObserver := staticSemanticReadWatchObserver{
+		observation: ebusgateway.WatchObservation{
+			State:         ebusgateway.WatchObservationStateActive,
+			HasDescriptor: true,
+			Descriptor: ebusgateway.WatchDescriptor{
+				SemanticClass:     ebusgateway.WatchSemanticClassDebug,
+				FreshnessProfile:  ebusgateway.WatchFreshnessProfileDebug,
+				DecoderID:         "test.fm5.current.identity",
+				CorrelationPolicy: ebusgateway.WatchCorrelationPolicyRequestResponse,
+				DirectApplyPolicy: ebusgateway.WatchDirectApplyPolicyNever,
+			},
+			Sources: []ebusgateway.WatchActivationSource{ebusgateway.WatchActivationSourcePoller},
+		},
+	}
+
+	newPoller := func(provider *graphql.LiveSemanticProvider) *vaillantSemanticPoller {
+		return &vaillantSemanticPoller{
+			scheduler:               ebusgateway.NewSemanticReadScheduler(),
+			watchObserver:           zeroFreshnessObserver,
+			reg:                     registry.NewDeviceRegistry(nil),
+			provider:                provider,
+			source:                  0x7F,
+			controller:              0x15,
+			requestTimeout:          50 * time.Millisecond,
+			system:                  &vaillantSystemSnapshot{Controller: 0x15, ModuleConfigurationVR71: &config},
+			deviceSlotCache:         make(map[deviceSlotKey]bool),
+			fm5Mode:                 graphql.Fm5SemanticModeInterpreted,
+			fm5Interpretation:       previous,
+			fm5EvidenceRevision:     41,
+			fm5EvidenceGeneration:   7,
+			fm5IdentityScanComplete: true,
+			fm5IdentityObservedAt:   now,
+			fm5EvidenceTTL:          5 * time.Minute,
+			solar:                   &vaillantSolarSnapshot{CollectorTemperatureC: &collector},
+			solarCylinders:          map[byte]*vaillantCylinderSnapshot{0: {Instance: 0, TemperatureC: &temperature}},
+			nowFn:                   func() time.Time { return now },
+		}
+	}
+	newProvider := func() *graphql.LiveSemanticProvider {
+		provider := graphql.NewLiveSemanticProvider()
+		provider.SetFM5Interpretation(previous)
+		provider.SetSolar(&graphql.SolarStatus{CollectorTemperatureC: &collector})
+		provider.SetCylinders([]graphql.CylinderStatus{{Index: 0, TemperatureC: &temperature}})
+		return provider
+	}
+	assertRetained := func(t *testing.T, provider *graphql.LiveSemanticProvider) {
+		t.Helper()
+		got := provider.FM5Interpretation()
+		if got.Mode != graphql.Fm5SemanticModeInterpreted || got.DegradedReason != graphql.Fm5SemanticDegradedReasonIncoherentAcquisition {
+			t.Errorf("incomplete current identity verdict = %#v; want retained INTERPRETED/INCOHERENT_ACQUISITION", got)
+		}
+		if got.EvidenceRevision == "" || got.EvidenceRevision == previous.EvidenceRevision {
+			t.Errorf("incomplete current identity revision = %q; want advancement from %q", got.EvidenceRevision, previous.EvidenceRevision)
+		}
+		if gotMode := provider.FM5SemanticMode(); gotMode != graphql.Fm5SemanticModeInterpreted {
+			t.Errorf("incomplete current identity legacy scalar = %s; want retained INTERPRETED", gotMode)
+		}
+		if solar := provider.Solar(); solar == nil || solar.CollectorTemperatureC == nil || *solar.CollectorTemperatureC != collector {
+			t.Errorf("incomplete current identity solar = %#v; want retained collector temperature", solar)
+		}
+		if cylinders := provider.Cylinders(); len(cylinders) != 1 || cylinders[0].TemperatureC == nil || *cylinders[0].TemperatureC != temperature {
+			t.Errorf("incomplete current identity cylinders = %#v; want retained temperature", cylinders)
+		}
+	}
+
+	t.Run("same-call firmware identity then detail timeout", func(t *testing.T) {
+		provider := newProvider()
+		poller := newPoller(provider)
+		firmwareReads := 0
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		poller.sendFrameFn = func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+			if len(frame.Data) != 6 {
+				return nil, errors.New("invalid B524 selector")
+			}
+			group := frame.Data[2]
+			instance := frame.Data[3]
+			addr := uint16(frame.Data[4]) | uint16(frame.Data[5])<<8
+			if group == remoteFunctionalModules.group {
+				switch addr {
+				case device_slot_connected:
+					return testB524ResponseForSelectorPayload(frame.Data, 0x00), nil
+				case device_slot_class_address:
+					return testB524ResponseForSelectorPayload(frame.Data, 0xFF), nil
+				case device_slot_firmware:
+					if instance == 0x04 {
+						firmwareReads++
+						if firmwareReads > 1 {
+							cancel()
+							return nil, errors.New("current firmware detail timeout")
+						}
+						return testB524ResponseForSelectorPayload(frame.Data, 0x00, 0x00, 0x00), nil
+					}
+					return testB524ResponseForSelectorPayload(frame.Data, 0xFF, 0xFF, 0xFF), nil
+				case device_slot_hardware_identifier:
+					return testB524ResponseForSelectorPayload(frame.Data, 0xFF, 0xFF), nil
+				}
+			}
+			return testB524ResponseForSelectorPayload(frame.Data, 0x00, 0x00, 0x00, 0x00), nil
+		}
+
+		poller.refreshRadioDevices(ctx)
+		if firmwareReads < 2 {
+			t.Fatalf("firmware reads = %d; want discovery identity followed by current detail read", firmwareReads)
+		}
+		assertRetained(t, provider)
+	})
+
+	t.Run("cached hardware identity then later detail timeout", func(t *testing.T) {
+		provider := newProvider()
+		poller := newPoller(provider)
+		hardware := uint16(0x1234)
+		poller.radioDevices = map[radioDeviceKey]*vaillantRadioDeviceSnapshot{
+			{Group: remoteFunctionalModules.group, Instance: 0x04}: {
+				Group:              remoteFunctionalModules.group,
+				Instance:           0x04,
+				SlotMode:           "inventory",
+				HardwareIdentifier: &hardware,
+			},
+		}
+		poller.deviceSlotCache[deviceSlotKey{Group: remoteFunctionalModules.group, Instance: 0x04}] = true
+		poller.deviceSlotDiscoveryDone = true
+		poller.deviceSlotDiscoveryAt = now
+		poller.deviceSlotRediscoveryTTL = time.Hour
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		poller.sendFrameFn = func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+			if len(frame.Data) != 6 {
+				return nil, errors.New("invalid B524 selector")
+			}
+			group := frame.Data[2]
+			addr := uint16(frame.Data[4]) | uint16(frame.Data[5])<<8
+			if group == remoteFunctionalModules.group {
+				switch addr {
+				case device_slot_connected:
+					return testB524ResponseForSelectorPayload(frame.Data, 0x00), nil
+				case device_slot_class_address:
+					return testB524ResponseForSelectorPayload(frame.Data, 0xFF), nil
+				case device_slot_firmware:
+					return testB524ResponseForSelectorPayload(frame.Data, 0xFF, 0xFF, 0xFF), nil
+				case device_slot_hardware_identifier:
+					cancel()
+					return nil, errors.New("current hardware detail timeout")
+				}
+			}
+			return testB524ResponseForSelectorPayload(frame.Data, 0x00, 0x00, 0x00, 0x00), nil
+		}
+
+		poller.refreshRadioDevices(ctx)
+		assertRetained(t, provider)
+	})
+}
+
 func TestRefreshRadioDevices_CompleteNegativeFM5ScanSupersedesRetainedRegistryIdentity(t *testing.T) {
 	now := time.Date(2026, 8, 15, 15, 0, 0, 0, time.UTC)
 	config := uint16(2)

--- a/cmd/gateway/post_m9_defects_red_test.go
+++ b/cmd/gateway/post_m9_defects_red_test.go
@@ -494,16 +494,29 @@ func TestPortalFM5Interpretation_UnavailableBeforeFirstCoherentClassification(t 
 	}
 }
 
-func TestPortalFM5Interpretation_LegacyGPIOOnlyIsStructurallyExplained(t *testing.T) {
+func TestPortalFM5Interpretation_LegacyOnlyProviderIsUnavailable(t *testing.T) {
 	provider := graphql.NewLiveSemanticProvider()
 	provider.SetFM5SemanticMode(graphql.Fm5SemanticModeGPIOOnly)
 	legacy := legacyOnlySemanticProvider{SemanticProvider: provider}
 
-	verdict := portalFM5Interpretation(legacy)
-	if err := verdict.Validate(); err != nil {
-		t.Fatalf("Portal fallback verdict invalid: %v", err)
+	if got := legacy.FM5SemanticMode(); got != graphql.Fm5SemanticModeGPIOOnly {
+		t.Fatalf("legacy FM5 scalar = %s; want stable GPIO_ONLY", got)
 	}
-	if verdict.DegradedReason != graphql.Fm5SemanticDegradedReasonConfigurationNotInterpretable {
-		t.Fatalf("Portal fallback reason = %q; want %q", verdict.DegradedReason, graphql.Fm5SemanticDegradedReasonConfigurationNotInterpretable)
+	if got := portalFM5Interpretation(legacy); got != (graphql.Fm5Interpretation{}) {
+		t.Fatalf("Portal legacy-only interpretation = %#v; want unavailable zero tuple", got)
+	}
+}
+
+func TestMCPSemanticProviderAdapter_LegacyOnlyInterpretationIsUnavailable(t *testing.T) {
+	provider := graphql.NewLiveSemanticProvider()
+	provider.SetFM5SemanticMode(graphql.Fm5SemanticModeGPIOOnly)
+	legacy := legacyOnlySemanticProvider{SemanticProvider: provider}
+
+	if got := legacy.FM5SemanticMode(); got != graphql.Fm5SemanticModeGPIOOnly {
+		t.Fatalf("legacy FM5 scalar = %s; want stable GPIO_ONLY", got)
+	}
+	mcpVerdict := (mcpSemanticProviderAdapter{provider: legacy}).FM5Interpretation()
+	if mcpVerdict.Mode != "" || mcpVerdict.DegradedReason != nil || mcpVerdict.EvidenceRevision != "" {
+		t.Fatalf("MCP adapter legacy-only interpretation = %#v; want unavailable zero tuple", mcpVerdict)
 	}
 }

--- a/cmd/gateway/post_m9_defects_red_test.go
+++ b/cmd/gateway/post_m9_defects_red_test.go
@@ -1022,6 +1022,41 @@ func TestRefreshRadioDevices_IncompleteCurrentFM5IdentityTupleRetainsPriorClassi
 	t.Run("complete FM negative survives non-FM detail timeout", func(t *testing.T) {
 		provider := newProvider()
 		poller := newPoller(provider)
+		connected := true
+		classAddress := uint8(0x15)
+		roomTemperature := 21.375
+		roomHumidity := 48.0
+		roomMapping := uint16(1)
+		poller.radioDevices = map[radioDeviceKey]*vaillantRadioDeviceSnapshot{
+			{Group: remoteRegulators.group, Instance: 0x01}: {
+				Group:              remoteRegulators.group,
+				Instance:           0x01,
+				SlotMode:           "active",
+				DeviceConnected:    &connected,
+				DeviceClassAddress: &classAddress,
+				DeviceModel:        "retained regulator",
+				RoomTemperatureC:   &roomTemperature,
+				RoomHumidityPct:    &roomHumidity,
+			},
+		}
+		poller.zones = map[byte]*vaillantZoneSnapshot{
+			0x00: {
+				Instance: 0x00,
+				Present:  true,
+				Name:     "Living",
+				ConfigurationRoomTemperatureZoneMappingRaw: &roomMapping,
+			},
+		}
+		poller.publishRadioDevices(semanticSnapshotSourceLive)
+		poller.publishZones(semanticSnapshotSourceLive)
+		retainedRadioDevices := provider.RadioDevices()
+		if len(retainedRadioDevices) != 1 {
+			t.Fatalf("retained radio fixture = %#v; want one regulator", retainedRadioDevices)
+		}
+		retainedZones := provider.Zones()
+		if len(retainedZones) != 1 || retainedZones[0].State.CurrentTempC == nil || *retainedZones[0].State.CurrentTempC != roomTemperature || retainedZones[0].State.CurrentHumidityPct == nil || *retainedZones[0].State.CurrentHumidityPct != roomHumidity {
+			t.Fatalf("retained zone fixture = %#v; want regulator temperature/humidity fallback", retainedZones)
+		}
 		regulatorConnectedReads := 0
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -1071,6 +1106,15 @@ func TestRefreshRadioDevices_IncompleteCurrentFM5IdentityTupleRetainsPriorClassi
 		}
 		if cylinders := provider.Cylinders(); len(cylinders) != 0 {
 			t.Errorf("complete negative with non-FM detail timeout cylinders = %#v; want cleared structural plane", cylinders)
+		}
+
+		poller.publishZones(semanticSnapshotSourceLive)
+		if radioDevices := provider.RadioDevices(); !radioDevicesEqual(radioDevices, retainedRadioDevices) {
+			t.Errorf("complete negative with non-FM detail timeout radio devices = %#v; want retained %#v", radioDevices, retainedRadioDevices)
+		}
+		zones := provider.Zones()
+		if len(zones) != 1 || zones[0].State.CurrentTempC == nil || *zones[0].State.CurrentTempC != roomTemperature || zones[0].State.CurrentHumidityPct == nil || *zones[0].State.CurrentHumidityPct != roomHumidity {
+			t.Errorf("complete negative with non-FM detail timeout zone fallback = %#v; want retained regulator temperature/humidity", zones)
 		}
 	})
 }

--- a/cmd/gateway/post_m9_defects_red_test.go
+++ b/cmd/gateway/post_m9_defects_red_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
 )
 
-func TestDeriveFM5Interpretation_ClosedReasonsAndPrecedence(t *testing.T) {
+func TestDeriveFM5Interpretation_CoherentClassificationsAndUnavailableBootstrap(t *testing.T) {
 	configInterpretable := uint16(2)
 	configUnsupported := uint16(3)
 	tests := []struct {
@@ -25,14 +25,9 @@ func TestDeriveFM5Interpretation_ClosedReasonsAndPrecedence(t *testing.T) {
 		wantMode            graphql.Fm5SemanticMode
 		wantReason          graphql.Fm5SemanticDegradedReason
 	}{
-		{"absent without evidence", false, nil, false, false, false, false, false, graphql.Fm5SemanticModeAbsent, ""},
-		{"controller unavailable", false, nil, false, false, true, false, false, graphql.Fm5SemanticModeGPIOOnly, graphql.Fm5SemanticDegradedReasonControllerUnreachable},
-		{"configuration unavailable", true, nil, false, false, true, false, false, graphql.Fm5SemanticModeGPIOOnly, graphql.Fm5SemanticDegradedReasonConfigurationUnavailable},
+		{"incomplete bootstrap", false, nil, false, false, false, false, false, "", ""},
+		{"fresh coherent absence", true, &configInterpretable, false, false, false, false, false, graphql.Fm5SemanticModeAbsent, ""},
 		{"configuration deliberately unsupported", true, &configUnsupported, false, false, true, false, false, graphql.Fm5SemanticModeGPIOOnly, graphql.Fm5SemanticDegradedReasonConfigurationNotInterpretable},
-		{"stale identity before family reads", true, &configInterpretable, false, false, true, true, false, graphql.Fm5SemanticModeGPIOOnly, graphql.Fm5SemanticDegradedReasonEvidenceStale},
-		{"solar read failed before cylinder", true, &configInterpretable, false, false, true, false, false, graphql.Fm5SemanticModeGPIOOnly, graphql.Fm5SemanticDegradedReasonSolarAcquisitionFailed},
-		{"cylinder read failed", true, &configInterpretable, true, false, true, false, false, graphql.Fm5SemanticModeGPIOOnly, graphql.Fm5SemanticDegradedReasonCylinderAcquisitionFailed},
-		{"generation changed during acquisition", true, &configInterpretable, true, true, true, false, true, graphql.Fm5SemanticModeGPIOOnly, graphql.Fm5SemanticDegradedReasonIncoherentAcquisition},
 		{"coherent interpretation", true, &configInterpretable, true, true, true, false, false, graphql.Fm5SemanticModeInterpreted, ""},
 	}
 
@@ -51,8 +46,50 @@ func TestDeriveFM5Interpretation_ClosedReasonsAndPrecedence(t *testing.T) {
 			if got.Mode != test.wantMode || got.DegradedReason != test.wantReason {
 				t.Fatalf("deriveFM5Interpretation() = %#v; want mode=%s reason=%s", got, test.wantMode, test.wantReason)
 			}
-			if got.EvidenceRevision != "acq-42" {
+			if test.wantMode == "" && got.EvidenceRevision != "" {
+				t.Fatalf("unavailable bootstrap evidence revision = %q; want empty", got.EvidenceRevision)
+			}
+			if test.wantMode != "" && got.EvidenceRevision != "acq-42" {
 				t.Fatalf("evidence revision = %q; want acq-42", got.EvidenceRevision)
+			}
+		})
+	}
+}
+
+func TestDeriveFM5Interpretation_TransientReasonPrecedence(t *testing.T) {
+	configInterpretable := uint16(2)
+	tests := []struct {
+		name                string
+		controllerReachable bool
+		moduleConfig        *uint16
+		solarReadable       bool
+		cylindersReadable   bool
+		evidenceStale       bool
+		incoherent          bool
+		wantReason          graphql.Fm5SemanticDegradedReason
+	}{
+		{"controller unavailable", false, nil, false, false, false, false, graphql.Fm5SemanticDegradedReasonControllerUnreachable},
+		{"configuration unavailable", true, nil, false, false, false, false, graphql.Fm5SemanticDegradedReasonConfigurationUnavailable},
+		{"stale identity before family reads", true, &configInterpretable, false, false, true, false, graphql.Fm5SemanticDegradedReasonEvidenceStale},
+		{"solar read failed before cylinder", true, &configInterpretable, false, false, false, false, graphql.Fm5SemanticDegradedReasonSolarAcquisitionFailed},
+		{"cylinder read failed", true, &configInterpretable, true, false, false, false, graphql.Fm5SemanticDegradedReasonCylinderAcquisitionFailed},
+		{"generation changed during acquisition", true, &configInterpretable, true, true, false, true, graphql.Fm5SemanticDegradedReasonIncoherentAcquisition},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := deriveFM5Interpretation(
+				test.controllerReachable,
+				test.moduleConfig,
+				test.solarReadable,
+				test.cylindersReadable,
+				true,
+				test.evidenceStale,
+				test.incoherent,
+				"acq-42",
+			)
+			if got.DegradedReason != test.wantReason {
+				t.Fatalf("deriveFM5Interpretation() = %#v; want reason=%s", got, test.wantReason)
 			}
 		})
 	}
@@ -72,7 +109,7 @@ func TestApplyFM5Acquisition_RetainsTransientAndWithdrawsStructural(t *testing.T
 		nil,
 		nil,
 		graphql.Fm5Interpretation{
-			Mode:             graphql.Fm5SemanticModeGPIOOnly,
+			Mode:             graphql.Fm5SemanticModeInterpreted,
 			DegradedReason:   graphql.Fm5SemanticDegradedReasonSolarAcquisitionFailed,
 			EvidenceRevision: "acq-43",
 		},
@@ -97,6 +134,71 @@ func TestApplyFM5Acquisition_RetainsTransientAndWithdrawsStructural(t *testing.T
 	)
 	if withdrawnSolar != nil || len(withdrawnCylinders) != 0 {
 		t.Fatalf("structural withdrawal = solar %#v cylinders %#v; want empty", withdrawnSolar, withdrawnCylinders)
+	}
+}
+
+func TestCommitFM5Acquisition_RetainsCoherentModeAcrossTransientFailures(t *testing.T) {
+	config := uint16(2)
+	tests := []struct {
+		coherentMode graphql.Fm5SemanticMode
+		reason       graphql.Fm5SemanticDegradedReason
+	}{
+		{graphql.Fm5SemanticModeInterpreted, graphql.Fm5SemanticDegradedReasonControllerUnreachable},
+		{graphql.Fm5SemanticModeInterpreted, graphql.Fm5SemanticDegradedReasonConfigurationUnavailable},
+		{graphql.Fm5SemanticModeInterpreted, graphql.Fm5SemanticDegradedReasonSolarAcquisitionFailed},
+		{graphql.Fm5SemanticModeInterpreted, graphql.Fm5SemanticDegradedReasonCylinderAcquisitionFailed},
+		{graphql.Fm5SemanticModeInterpreted, graphql.Fm5SemanticDegradedReasonEvidenceStale},
+		{graphql.Fm5SemanticModeInterpreted, graphql.Fm5SemanticDegradedReasonIncoherentAcquisition},
+		{graphql.Fm5SemanticModeAbsent, graphql.Fm5SemanticDegradedReasonControllerUnreachable},
+	}
+
+	for _, test := range tests {
+		t.Run(string(test.coherentMode)+"/"+string(test.reason), func(t *testing.T) {
+			collector := 61.5
+			temperature := 47.25
+			poller := &vaillantSemanticPoller{
+				controller:            0x15,
+				system:                &vaillantSystemSnapshot{Controller: 0x15, ModuleConfigurationVR71: &config},
+				fm5Mode:               test.coherentMode,
+				fm5Interpretation:     graphql.Fm5Interpretation{Mode: test.coherentMode, EvidenceRevision: "fm5-g7-a41"},
+				fm5EvidenceGeneration: 7,
+				solarCylinders:        make(map[byte]*vaillantCylinderSnapshot),
+			}
+			if test.coherentMode == graphql.Fm5SemanticModeInterpreted {
+				poller.solar = &vaillantSolarSnapshot{CollectorTemperatureC: &collector}
+				poller.solarCylinders[0] = &vaillantCylinderSnapshot{Instance: 0, TemperatureC: &temperature}
+			}
+			captured := fm5EvidenceCapture{
+				controller:       0x15,
+				moduleConfig:     &config,
+				generation:       7,
+				registryCoherent: true,
+			}
+
+			got := poller.commitFM5Acquisition(captured, graphql.Fm5Interpretation{
+				Mode:             graphql.Fm5SemanticModeGPIOOnly,
+				DegradedReason:   test.reason,
+				EvidenceRevision: "fm5-g7-a42",
+			}, nil, nil)
+
+			if got.Mode != test.coherentMode || got.DegradedReason != test.reason {
+				t.Fatalf("transient commit verdict = %#v; want retained %s/%s", got, test.coherentMode, test.reason)
+			}
+			if got.EvidenceRevision != "fm5-g7-a42" || got.EvidenceRevision == "fm5-g7-a41" {
+				t.Fatalf("transient commit revision = %q; want advanced fm5-g7-a42", got.EvidenceRevision)
+			}
+			if poller.fm5Mode != test.coherentMode {
+				t.Fatalf("legacy FM5 scalar = %s; want retained %s", poller.fm5Mode, test.coherentMode)
+			}
+			if test.coherentMode == graphql.Fm5SemanticModeInterpreted {
+				if poller.solar == nil || poller.solar.CollectorTemperatureC == nil || *poller.solar.CollectorTemperatureC != collector {
+					t.Fatalf("retained solar = %#v; want prior coherent value", poller.solar)
+				}
+				if poller.solarCylinders[0] == nil || poller.solarCylinders[0].TemperatureC == nil || *poller.solarCylinders[0].TemperatureC != temperature {
+					t.Fatalf("retained cylinders = %#v; want prior coherent value", poller.solarCylinders)
+				}
+			}
+		})
 	}
 }
 
@@ -149,13 +251,22 @@ func TestRefreshFM5Semantic_StaleEvidenceSkipsReadsAndRetainsCoherentFamily(t *t
 		fm5EvidenceTTL:        5 * time.Minute,
 		fm5IdentityObservedAt: now.Add(-6 * time.Minute),
 		fm5EvidenceGeneration: 7,
-		nowFn:                 func() time.Time { return now },
+		fm5Mode:               graphql.Fm5SemanticModeInterpreted,
+		fm5Interpretation: graphql.Fm5Interpretation{
+			Mode:             graphql.Fm5SemanticModeInterpreted,
+			EvidenceRevision: "fm5-g7-a41",
+		},
+		fm5EvidenceRevision: 41,
+		nowFn:               func() time.Time { return now },
 	}
 
 	poller.refreshFM5Semantic(context.Background())
 	verdict := provider.FM5Interpretation()
-	if verdict.Mode != graphql.Fm5SemanticModeGPIOOnly || verdict.DegradedReason != graphql.Fm5SemanticDegradedReasonEvidenceStale {
-		t.Fatalf("stale refresh verdict = %#v; want GPIO_ONLY/EVIDENCE_STALE", verdict)
+	if verdict.Mode != graphql.Fm5SemanticModeInterpreted || verdict.DegradedReason != graphql.Fm5SemanticDegradedReasonEvidenceStale {
+		t.Fatalf("stale refresh verdict = %#v; want INTERPRETED/EVIDENCE_STALE", verdict)
+	}
+	if verdict.EvidenceRevision == "fm5-g7-a41" {
+		t.Fatalf("stale refresh evidence revision = %q; want advanced revision", verdict.EvidenceRevision)
 	}
 	if solar := provider.Solar(); solar == nil || solar.CollectorTemperatureC == nil || *solar.CollectorTemperatureC != collector {
 		t.Fatalf("stale refresh solar = %#v; want retained coherent snapshot", solar)
@@ -170,10 +281,15 @@ func TestCommitFM5Acquisition_RegistryMutationAfterPostReadCaptureIsIncoherent(t
 	config := uint16(2)
 	reg := registry.NewDeviceRegistry(nil)
 	poller := &vaillantSemanticPoller{
-		reg:            reg,
-		controller:     0x15,
-		system:         &vaillantSystemSnapshot{Controller: 0x15, ModuleConfigurationVR71: &config},
-		radioDevices:   map[radioDeviceKey]*vaillantRadioDeviceSnapshot{{Group: remoteFunctionalModules.group}: {DeviceClassAddress: &classAddress}},
+		reg:          reg,
+		controller:   0x15,
+		system:       &vaillantSystemSnapshot{Controller: 0x15, ModuleConfigurationVR71: &config},
+		radioDevices: map[radioDeviceKey]*vaillantRadioDeviceSnapshot{{Group: remoteFunctionalModules.group}: {DeviceClassAddress: &classAddress}},
+		fm5Mode:      graphql.Fm5SemanticModeInterpreted,
+		fm5Interpretation: graphql.Fm5Interpretation{
+			Mode:             graphql.Fm5SemanticModeInterpreted,
+			EvidenceRevision: "fm5-g0-a0",
+		},
 		solarCylinders: make(map[byte]*vaillantCylinderSnapshot),
 		nowFn:          time.Now,
 	}
@@ -191,8 +307,11 @@ func TestCommitFM5Acquisition_RegistryMutationAfterPostReadCaptureIsIncoherent(t
 		Mode:             graphql.Fm5SemanticModeInterpreted,
 		EvidenceRevision: "fm5-g0-a1",
 	}, &vaillantSolarSnapshot{}, map[byte]*vaillantCylinderSnapshot{})
-	if verdict.Mode != graphql.Fm5SemanticModeGPIOOnly || verdict.DegradedReason != graphql.Fm5SemanticDegradedReasonIncoherentAcquisition {
-		t.Fatalf("registry interleaving verdict = %#v; want GPIO_ONLY/INCOHERENT_ACQUISITION", verdict)
+	if verdict.Mode != graphql.Fm5SemanticModeInterpreted || verdict.DegradedReason != graphql.Fm5SemanticDegradedReasonIncoherentAcquisition {
+		t.Fatalf("registry interleaving verdict = %#v; want INTERPRETED/INCOHERENT_ACQUISITION", verdict)
+	}
+	if verdict.EvidenceRevision == "fm5-g0-a0" {
+		t.Fatalf("registry interleaving revision = %q; want advanced revision", verdict.EvidenceRevision)
 	}
 }
 
@@ -364,7 +483,18 @@ type legacyOnlySemanticProvider struct {
 	graphql.SemanticProvider
 }
 
-func TestPortalFM5Interpretation_LegacyGPIOOnlyIsExplained(t *testing.T) {
+func TestPortalFM5Interpretation_UnavailableBeforeFirstCoherentClassification(t *testing.T) {
+	provider := graphql.NewLiveSemanticProvider()
+
+	if got := portalFM5Interpretation(provider); got != (graphql.Fm5Interpretation{}) {
+		t.Fatalf("Portal FM5 interpretation = %#v; want unavailable zero tuple", got)
+	}
+	if got := provider.FM5SemanticMode(); got != graphql.Fm5SemanticModeAbsent {
+		t.Fatalf("legacy FM5 scalar = %s; want stable ABSENT", got)
+	}
+}
+
+func TestPortalFM5Interpretation_LegacyGPIOOnlyIsStructurallyExplained(t *testing.T) {
 	provider := graphql.NewLiveSemanticProvider()
 	provider.SetFM5SemanticMode(graphql.Fm5SemanticModeGPIOOnly)
 	legacy := legacyOnlySemanticProvider{SemanticProvider: provider}
@@ -373,7 +503,7 @@ func TestPortalFM5Interpretation_LegacyGPIOOnlyIsExplained(t *testing.T) {
 	if err := verdict.Validate(); err != nil {
 		t.Fatalf("Portal fallback verdict invalid: %v", err)
 	}
-	if verdict.DegradedReason != graphql.Fm5SemanticDegradedReasonIncoherentAcquisition {
-		t.Fatalf("Portal fallback reason = %q; want %q", verdict.DegradedReason, graphql.Fm5SemanticDegradedReasonIncoherentAcquisition)
+	if verdict.DegradedReason != graphql.Fm5SemanticDegradedReasonConfigurationNotInterpretable {
+		t.Fatalf("Portal fallback reason = %q; want %q", verdict.DegradedReason, graphql.Fm5SemanticDegradedReasonConfigurationNotInterpretable)
 	}
 }

--- a/cmd/gateway/post_m9_defects_red_test.go
+++ b/cmd/gateway/post_m9_defects_red_test.go
@@ -458,6 +458,7 @@ func TestRefreshFM5Semantic_AbsenceRequiresFreshCompletedNegativeIdentityAcquisi
 	provider = graphql.NewLiveSemanticProvider()
 	poller = newPoller(provider)
 	poller.startupRadioDevicesProbed = true
+	poller.fm5IdentityScanComplete = true
 	poller.fm5IdentityObservedAt = now
 	poller.refreshFM5Semantic(context.Background())
 	if got := provider.FM5Interpretation(); got.Mode != graphql.Fm5SemanticModeAbsent || got.DegradedReason != "" || got.EvidenceRevision == "" {

--- a/cmd/gateway/post_m9_defects_red_test.go
+++ b/cmd/gateway/post_m9_defects_red_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 	"time"
 
+	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/graphql"
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
 )
 
@@ -521,6 +523,149 @@ func TestFM5Acquisition_EmptyEvidenceGenerationInterleavingRetainsPriorClassific
 	}
 	if poller.solarCylinders[0] == nil || poller.solarCylinders[0].TemperatureC == nil || *poller.solarCylinders[0].TemperatureC != temperature {
 		t.Errorf("empty-evidence interleaving cylinders = %#v; want retained coherent value", poller.solarCylinders)
+	}
+}
+
+func TestFM5IdentityClassification_RequiresCompleteFunctionalModuleNamespaceScan(t *testing.T) {
+	now := time.Date(2026, 8, 15, 15, 0, 0, 0, time.UTC)
+	config := uint16(2)
+	newPoller := func(provider *graphql.LiveSemanticProvider) *vaillantSemanticPoller {
+		return &vaillantSemanticPoller{
+			scheduler:               ebusgateway.NewSemanticReadScheduler(),
+			reg:                     registry.NewDeviceRegistry(nil),
+			provider:                provider,
+			source:                  0x7F,
+			controller:              0x15,
+			requestTimeout:          50 * time.Millisecond,
+			system:                  &vaillantSystemSnapshot{Controller: 0x15, ModuleConfigurationVR71: &config},
+			radioDevices:            make(map[radioDeviceKey]*vaillantRadioDeviceSnapshot),
+			solarCylinders:          make(map[byte]*vaillantCylinderSnapshot),
+			fm5EvidenceTTL:          5 * time.Minute,
+			deviceSlotCache:         make(map[deviceSlotKey]bool),
+			deviceSlotDiscoveryDone: false,
+			nowFn:                   func() time.Time { return now },
+		}
+	}
+	assertUnavailable := func(t *testing.T, got graphql.Fm5Interpretation) {
+		t.Helper()
+		if got.Mode != "" || got.DegradedReason != "" || got.EvidenceRevision != "" {
+			t.Fatalf("partial FM5 namespace verdict = %#v; want unavailable zero tuple", got)
+		}
+	}
+	partialResponder := func(cancel context.CancelFunc) func(context.Context, protocol.Frame) (*protocol.Frame, error) {
+		return func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+			if len(frame.Data) != 6 {
+				return nil, errors.New("invalid B524 selector")
+			}
+			if frame.Data[2] == remoteFunctionalModules.group {
+				cancel()
+				return nil, errors.New("functional-module namespace timeout")
+			}
+			return testB524ResponseForSelectorPayload(frame.Data, 0x00, 0x00, 0x00, 0x00), nil
+		}
+	}
+
+	t.Run("startup non-FM5 success does not classify absence", func(t *testing.T) {
+		provider := graphql.NewLiveSemanticProvider()
+		poller := newPoller(provider)
+		ctx, cancel := context.WithCancel(context.Background())
+		poller.sendFrameFn = partialResponder(cancel)
+		poller.refreshRadioDevicesStartup(ctx)
+		poller.refreshFM5Semantic(context.Background())
+		assertUnavailable(t, provider.FM5Interpretation())
+	})
+
+	t.Run("steady non-FM5 success does not classify absence", func(t *testing.T) {
+		provider := graphql.NewLiveSemanticProvider()
+		poller := newPoller(provider)
+		ctx, cancel := context.WithCancel(context.Background())
+		poller.sendFrameFn = partialResponder(cancel)
+		poller.refreshRadioDevices(ctx)
+		assertUnavailable(t, provider.FM5Interpretation())
+	})
+
+	t.Run("complete negative functional-module scan permits absence", func(t *testing.T) {
+		provider := graphql.NewLiveSemanticProvider()
+		poller := newPoller(provider)
+		poller.sendFrameFn = func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+			if len(frame.Data) != 6 {
+				return nil, errors.New("invalid B524 selector")
+			}
+			return testB524ResponseForSelectorPayload(frame.Data, 0x00, 0x00, 0x00, 0x00), nil
+		}
+		poller.refreshRadioDevicesStartup(context.Background())
+		poller.refreshFM5Semantic(context.Background())
+		got := provider.FM5Interpretation()
+		if got.Mode != graphql.Fm5SemanticModeAbsent || got.DegradedReason != "" || got.EvidenceRevision == "" {
+			t.Fatalf("complete negative FM5 namespace verdict = %#v; want healthy ABSENT with revision", got)
+		}
+	})
+}
+
+func TestRefreshRadioDevices_CompleteNegativeFM5ScanSupersedesRetainedRegistryIdentity(t *testing.T) {
+	now := time.Date(2026, 8, 15, 15, 0, 0, 0, time.UTC)
+	config := uint16(2)
+	classAddress := uint8(circuitManagingDeviceVR71Address)
+	collector := 61.5
+	temperature := 47.25
+	previous := graphql.Fm5Interpretation{
+		Mode:             graphql.Fm5SemanticModeInterpreted,
+		EvidenceRevision: "fm5-g7-a41",
+	}
+	provider := graphql.NewLiveSemanticProvider()
+	provider.SetFM5Interpretation(previous)
+	provider.SetSolar(&graphql.SolarStatus{CollectorTemperatureC: &collector})
+	provider.SetCylinders([]graphql.CylinderStatus{{Index: 0, TemperatureC: &temperature}})
+	reg := registry.NewDeviceRegistry(nil)
+	reg.Register(registry.DeviceInfo{
+		Address:      circuitManagingDeviceVR71Address,
+		Manufacturer: "Vaillant",
+		DeviceID:     circuitManagingDeviceVR71ID,
+	})
+	poller := &vaillantSemanticPoller{
+		scheduler:             ebusgateway.NewSemanticReadScheduler(),
+		reg:                   reg,
+		provider:              provider,
+		source:                0x7F,
+		controller:            0x15,
+		requestTimeout:        50 * time.Millisecond,
+		system:                &vaillantSystemSnapshot{Controller: 0x15, ModuleConfigurationVR71: &config},
+		radioDevices:          map[radioDeviceKey]*vaillantRadioDeviceSnapshot{{Group: remoteFunctionalModules.group}: {DeviceClassAddress: &classAddress}},
+		deviceSlotCache:       make(map[deviceSlotKey]bool),
+		fm5Mode:               graphql.Fm5SemanticModeInterpreted,
+		fm5Interpretation:     previous,
+		fm5EvidenceRevision:   41,
+		fm5EvidenceGeneration: 7,
+		fm5IdentityObservedAt: now,
+		fm5EvidenceTTL:        5 * time.Minute,
+		solar:                 &vaillantSolarSnapshot{CollectorTemperatureC: &collector},
+		solarCylinders:        map[byte]*vaillantCylinderSnapshot{0: {Instance: 0, TemperatureC: &temperature}},
+		nowFn:                 func() time.Time { return now },
+	}
+	poller.sendFrameFn = func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+		if len(frame.Data) != 6 {
+			return nil, errors.New("invalid B524 selector")
+		}
+		return testB524ResponseForSelectorPayload(frame.Data, 0x00, 0x00, 0x00, 0x00), nil
+	}
+
+	poller.refreshRadioDevices(context.Background())
+
+	got := provider.FM5Interpretation()
+	if got.Mode != graphql.Fm5SemanticModeAbsent || got.DegradedReason != "" {
+		t.Errorf("complete negative scan verdict = %#v; want healthy ABSENT despite retained registry entry", got)
+	}
+	if got.EvidenceRevision == "" || got.EvidenceRevision == previous.EvidenceRevision {
+		t.Errorf("complete negative scan revision = %q; want advancement from %q", got.EvidenceRevision, previous.EvidenceRevision)
+	}
+	if gotMode := provider.FM5SemanticMode(); gotMode != graphql.Fm5SemanticModeAbsent {
+		t.Errorf("complete negative scan legacy scalar = %s; want ABSENT", gotMode)
+	}
+	if solar := provider.Solar(); solar == nil || solar.CollectorTemperatureC != nil {
+		t.Errorf("complete negative scan solar = %#v; want cleared structural plane", solar)
+	}
+	if cylinders := provider.Cylinders(); len(cylinders) != 0 {
+		t.Errorf("complete negative scan cylinders = %#v; want cleared structural plane", cylinders)
 	}
 }
 

--- a/cmd/gateway/post_m9_defects_red_test.go
+++ b/cmd/gateway/post_m9_defects_red_test.go
@@ -592,6 +592,20 @@ func TestFM5IdentityClassification_RequiresCompleteFunctionalModuleNamespaceScan
 			if len(frame.Data) != 6 {
 				return nil, errors.New("invalid B524 selector")
 			}
+			group := frame.Data[2]
+			addr := uint16(frame.Data[4]) | uint16(frame.Data[5])<<8
+			if group == remoteFunctionalModules.group {
+				switch addr {
+				case device_slot_connected:
+					return testB524ResponseForSelectorPayload(frame.Data, 0x00), nil
+				case device_slot_class_address:
+					return testB524ResponseForSelectorPayload(frame.Data, 0xFF), nil
+				case device_slot_firmware:
+					return testB524ResponseForSelectorPayload(frame.Data, 0xFF, 0xFF, 0xFF), nil
+				case device_slot_hardware_identifier:
+					return testB524ResponseForSelectorPayload(frame.Data, 0xFF, 0xFF), nil
+				}
+			}
 			return testB524ResponseForSelectorPayload(frame.Data, 0x00, 0x00, 0x00, 0x00), nil
 		}
 		poller.refreshRadioDevicesStartup(context.Background())

--- a/cmd/gateway/semantic_provider.go
+++ b/cmd/gateway/semantic_provider.go
@@ -206,13 +206,7 @@ func (adapter mcpSemanticProviderAdapter) FM5Interpretation() mcp.Fm5Interpretat
 	}
 	provider, ok := adapter.provider.(graphql.FM5InterpretationProvider)
 	if !ok {
-		mode := adapter.FM5SemanticMode()
-		out := mcp.Fm5Interpretation{Mode: mode, EvidenceRevision: "legacy"}
-		if mode == mcp.Fm5SemanticModeGPIOOnly {
-			reason := mcp.Fm5SemanticDegradedReason(graphql.Fm5SemanticDegradedReasonConfigurationNotInterpretable)
-			out.DegradedReason = &reason
-		}
-		return out
+		return mcp.Fm5Interpretation{}
 	}
 	verdict := provider.FM5Interpretation()
 	out := mcp.Fm5Interpretation{

--- a/cmd/gateway/semantic_provider.go
+++ b/cmd/gateway/semantic_provider.go
@@ -202,14 +202,14 @@ func (adapter mcpSemanticProviderAdapter) FM5SemanticMode() mcp.Fm5SemanticMode 
 
 func (adapter mcpSemanticProviderAdapter) FM5Interpretation() mcp.Fm5Interpretation {
 	if adapter.provider == nil {
-		return mcp.Fm5Interpretation{Mode: mcp.Fm5SemanticModeAbsent, EvidenceRevision: "initial"}
+		return mcp.Fm5Interpretation{}
 	}
 	provider, ok := adapter.provider.(graphql.FM5InterpretationProvider)
 	if !ok {
 		mode := adapter.FM5SemanticMode()
 		out := mcp.Fm5Interpretation{Mode: mode, EvidenceRevision: "legacy"}
 		if mode == mcp.Fm5SemanticModeGPIOOnly {
-			reason := mcp.Fm5SemanticDegradedReason(graphql.Fm5SemanticDegradedReasonIncoherentAcquisition)
+			reason := mcp.Fm5SemanticDegradedReason(graphql.Fm5SemanticDegradedReasonConfigurationNotInterpretable)
 			out.DegradedReason = &reason
 		}
 		return out

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -365,6 +365,7 @@ type vaillantSemanticPoller struct {
 	fm5EvidenceGeneration       uint64
 	fm5IdentityScanComplete     bool
 	fm5IdentityIncoherent       bool
+	fm5ConfigurationFailed      bool
 	fm5RegistryEvidenceIgnored  bool
 	fm5IdentityObservedAt       time.Time
 	solar                       *vaillantSolarSnapshot
@@ -1752,6 +1753,7 @@ func (p *vaillantSemanticPoller) refreshSystemStartup(ctx context.Context) {
 	p.mu.Unlock()
 	snapshot := &vaillantSystemSnapshot{Controller: controller}
 	readAny := false
+	configurationAcquired := false
 	if raw, ok := p.readB524Uint16Startup(ctx, localRegulator.opcode, localRegulator.group, regulatorInstance, system_scheme); ok && raw != nil {
 		snapshot.SystemScheme = cloneUint16Ptr(raw)
 		readAny = true
@@ -1759,6 +1761,7 @@ func (p *vaillantSemanticPoller) refreshSystemStartup(ctx context.Context) {
 	if raw, ok := p.readB524Uint16Startup(ctx, localRegulator.opcode, localRegulator.group, regulatorInstance, system_module_configuration_vr71); ok && raw != nil {
 		snapshot.ModuleConfigurationVR71 = cloneUint16Ptr(raw)
 		readAny = true
+		configurationAcquired = true
 	}
 	if raw, ok := p.readB524Startup(ctx, localRegulator.opcode, localRegulator.group, regulatorInstance, system_water_pressure); ok {
 		if value := decodeB524Float32FromRaw(raw); value != nil {
@@ -1769,6 +1772,7 @@ func (p *vaillantSemanticPoller) refreshSystemStartup(ctx context.Context) {
 
 	p.mu.Lock()
 	source := semanticSnapshotSourceCache
+	p.updateFM5ConfigurationAcquisitionLocked(configurationAcquired)
 	if readAny {
 		if snapshot.SystemFlowTemperature != nil {
 			snapshot.SystemFlowTemperatureLiveAt = p.now()
@@ -1873,7 +1877,7 @@ func (p *vaillantSemanticPoller) refreshRadioDevicesStartup(ctx context.Context)
 	p.mu.Lock()
 	p.startupRadioDevicesProbed = readAny
 	p.fm5IdentityScanComplete = fm5NamespaceComplete
-	p.fm5IdentityIncoherent = !fm5NamespaceComplete
+	p.fm5IdentityIncoherent = !fm5NamespaceComplete && !liveFM5Evidence
 	if fm5NamespaceComplete {
 		p.fm5RegistryEvidenceIgnored = !liveFM5Evidence
 	} else if liveFM5Evidence {
@@ -2001,7 +2005,11 @@ func (p *vaillantSemanticPoller) refreshFM5SemanticStartup(ctx context.Context) 
 	}
 
 	evidence := p.captureFM5Evidence()
-	fm5GateSatisfied := evidence.moduleConfig != nil && *evidence.moduleConfig <= 2
+	moduleConfig := evidence.moduleConfig
+	if evidence.configurationFailed {
+		moduleConfig = nil
+	}
+	fm5GateSatisfied := moduleConfig != nil && *moduleConfig <= 2
 	observedAt := p.now()
 	evidenceStale := evidence.staleAt(observedAt, p.fm5EvidenceTTL)
 	var incomingSolar *vaillantSolarSnapshot
@@ -2019,7 +2027,7 @@ func (p *vaillantSemanticPoller) refreshFM5SemanticStartup(ctx context.Context) 
 	freshNegativeIdentityObserved := evidence.hasFreshNegativeObservation(observedAt, p.fm5EvidenceTTL) &&
 		currentEvidence.hasFreshNegativeObservation(observedAt, p.fm5EvidenceTTL)
 	var verdict graphql.Fm5Interpretation
-	if freshNegativeIdentityObserved && !incoherent && evidence.controller != 0 && evidence.moduleConfig != nil {
+	if freshNegativeIdentityObserved && !incoherent && evidence.controller != 0 && moduleConfig != nil {
 		verdict = graphql.Fm5Interpretation{
 			Mode:             graphql.Fm5SemanticModeAbsent,
 			EvidenceRevision: evidenceRevision,
@@ -2027,7 +2035,7 @@ func (p *vaillantSemanticPoller) refreshFM5SemanticStartup(ctx context.Context) 
 	} else {
 		verdict = deriveFM5Interpretation(
 			evidence.controller != 0,
-			evidence.moduleConfig,
+			moduleConfig,
 			solarReadable,
 			cylindersReadable,
 			evidence.hasEvidence() || currentEvidence.hasEvidence() || negativeIdentityObserved,
@@ -5078,6 +5086,7 @@ func (p *vaillantSemanticPoller) refreshSystem(ctx context.Context) {
 
 	snapshot := &vaillantSystemSnapshot{Controller: controller}
 	updated := false
+	configurationAcquired := false
 
 	if raw, ok := p.readB524Uint16(ctx, localRegulator.opcode, localRegulator.group, regulatorInstance, system_off); ok && raw != nil {
 		value := *raw != 0
@@ -5196,15 +5205,19 @@ func (p *vaillantSemanticPoller) refreshSystem(ctx context.Context) {
 	if raw, ok := p.readB524Uint16(ctx, localRegulator.opcode, localRegulator.group, regulatorInstance, system_module_configuration_vr71); ok && raw != nil {
 		snapshot.ModuleConfigurationVR71 = cloneUint16Ptr(raw)
 		updated = true
-	}
-
-	if !updated {
-		return
+		configurationAcquired = true
 	}
 
 	p.mu.Lock()
-	p.updateSystemSnapshotLocked(mergeSystemSnapshotNonDestructive(p.system, snapshot))
+	p.updateFM5ConfigurationAcquisitionLocked(configurationAcquired)
+	if updated {
+		p.updateSystemSnapshotLocked(mergeSystemSnapshotNonDestructive(p.system, snapshot))
+	}
 	p.mu.Unlock()
+	if !updated {
+		p.refreshFM5Semantic(ctx)
+		return
+	}
 
 	p.publishSystem(semanticSnapshotSourceLive)
 	p.refreshFM5Semantic(ctx)
@@ -5505,7 +5518,8 @@ func (p *vaillantSemanticPoller) refreshRadioDevices(ctx context.Context) {
 		discovered[radioDeviceKey{Group: group, Instance: instance}] = device
 	}
 
-	if !readAny && len(phaseOneFM5Snapshots) == 0 && !fm5SlotReadAttempted {
+	completePhaseOneFM5Negative := needsDiscovery && discoveryObserved && fm5NamespaceComplete && len(phaseOneFM5Snapshots) == 0
+	if !readAny && len(phaseOneFM5Snapshots) == 0 && !fm5SlotReadAttempted && !completePhaseOneFM5Negative {
 		return
 	}
 
@@ -5520,7 +5534,7 @@ func (p *vaillantSemanticPoller) refreshRadioDevices(ctx context.Context) {
 	currentFM5Evidence := hasFM5EvidenceFromRadioMap(discovered)
 	authoritativeFM5Snapshot := needsDiscovery && discoveryObserved && fm5NamespaceComplete && !fm5DetailIncomplete
 	fm5IdentityIncoherent := fm5DetailIncomplete ||
-		(needsDiscovery && !authoritativeFM5Snapshot) ||
+		(needsDiscovery && !authoritativeFM5Snapshot && !currentFM5Evidence) ||
 		(!needsDiscovery && fm5SlotReadAttempted && !currentFM5Evidence)
 	p.mu.Lock()
 	if !authoritativeFM5Snapshot {
@@ -5728,7 +5742,11 @@ func (p *vaillantSemanticPoller) refreshFM5Semantic(ctx context.Context) {
 	}
 
 	evidence := p.captureFM5Evidence()
-	fm5GateSatisfied := evidence.moduleConfig != nil && *evidence.moduleConfig <= 2
+	moduleConfig := evidence.moduleConfig
+	if evidence.configurationFailed {
+		moduleConfig = nil
+	}
+	fm5GateSatisfied := moduleConfig != nil && *moduleConfig <= 2
 	observedAt := p.now()
 	evidenceStale := evidence.staleAt(observedAt, p.fm5EvidenceTTL)
 
@@ -5748,7 +5766,7 @@ func (p *vaillantSemanticPoller) refreshFM5Semantic(ctx context.Context) {
 	freshNegativeIdentityObserved := evidence.hasFreshNegativeObservation(observedAt, p.fm5EvidenceTTL) &&
 		currentEvidence.hasFreshNegativeObservation(observedAt, p.fm5EvidenceTTL)
 	var verdict graphql.Fm5Interpretation
-	if freshNegativeIdentityObserved && !incoherent && evidence.controller != 0 && evidence.moduleConfig != nil {
+	if freshNegativeIdentityObserved && !incoherent && evidence.controller != 0 && moduleConfig != nil {
 		verdict = graphql.Fm5Interpretation{
 			Mode:             graphql.Fm5SemanticModeAbsent,
 			EvidenceRevision: evidenceRevision,
@@ -5756,7 +5774,7 @@ func (p *vaillantSemanticPoller) refreshFM5Semantic(ctx context.Context) {
 	} else {
 		verdict = deriveFM5Interpretation(
 			evidence.controller != 0,
-			evidence.moduleConfig,
+			moduleConfig,
 			solarReadable,
 			cylindersReadable,
 			evidence.hasEvidence() || currentEvidence.hasEvidence() || negativeIdentityObserved,
@@ -5794,6 +5812,7 @@ type fm5EvidenceCapture struct {
 	registryEvidenceIgnored     bool
 	identityAcquisitionComplete bool
 	identityIncoherent          bool
+	configurationFailed         bool
 	identityObservedAt          time.Time
 	generation                  uint64
 }
@@ -5809,6 +5828,7 @@ func (p *vaillantSemanticPoller) captureFM5Evidence() fm5EvidenceCapture {
 		registryEvidenceIgnored:     p.fm5RegistryEvidenceIgnored,
 		identityAcquisitionComplete: p.fm5IdentityScanComplete,
 		identityIncoherent:          p.fm5IdentityIncoherent,
+		configurationFailed:         p.fm5ConfigurationFailed,
 		identityObservedAt:          p.fm5IdentityObservedAt,
 		generation:                  p.fm5EvidenceGeneration,
 		radioSnapshots:              make([]*vaillantRadioDeviceSnapshot, 0, len(p.radioDevices)),
@@ -5867,6 +5887,7 @@ func (capture fm5EvidenceCapture) sameGeneration(other fm5EvidenceCapture) bool 
 		capture.registryEvidenceIgnored == other.registryEvidenceIgnored &&
 		capture.identityAcquisitionComplete == other.identityAcquisitionComplete &&
 		capture.identityIncoherent == other.identityIncoherent &&
+		capture.configurationFailed == other.configurationFailed &&
 		capture.identityObservedAt.Equal(other.identityObservedAt) &&
 		capture.registryGeneration == other.registryGeneration &&
 		capture.registryEvidence == other.registryEvidence
@@ -5886,6 +5907,7 @@ func (capture fm5EvidenceCapture) matchesLockedPoller(p *vaillantSemanticPoller)
 		capture.registryEvidenceIgnored == p.fm5RegistryEvidenceIgnored &&
 		capture.identityAcquisitionComplete == p.fm5IdentityScanComplete &&
 		capture.identityIncoherent == p.fm5IdentityIncoherent &&
+		capture.configurationFailed == p.fm5ConfigurationFailed &&
 		capture.identityObservedAt.Equal(p.fm5IdentityObservedAt)
 }
 
@@ -5951,6 +5973,14 @@ func (p *vaillantSemanticPoller) updateSystemSnapshotLocked(snapshot *vaillantSy
 	}
 	p.system = snapshot
 	if !uint16PointersEqual(previousConfig, nextConfig) {
+		p.fm5EvidenceGeneration++
+	}
+}
+
+func (p *vaillantSemanticPoller) updateFM5ConfigurationAcquisitionLocked(acquired bool) {
+	failed := !acquired
+	if p.fm5ConfigurationFailed != failed {
+		p.fm5ConfigurationFailed = failed
 		p.fm5EvidenceGeneration++
 	}
 }

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -1802,13 +1802,34 @@ func (p *vaillantSemanticPoller) refreshRadioDevicesStartup(ctx context.Context)
 		}
 		readAny = true
 		connected := connectedRaw[0] == 1
-		classAddress := p.readB524U8Startup(ctx, grp.opcode, grp.group, instance, device_slot_class_address)
-		if grp.group == remoteFunctionalModules.group && classAddress == nil {
-			fm5NamespaceComplete = false
+		var classAddress *uint8
+		var firmware *string
+		var hardware *uint16
+		if grp.group == remoteFunctionalModules.group {
+			classRaw, classOK := p.readB524Startup(ctx, grp.opcode, grp.group, instance, device_slot_class_address)
+			firmwareRaw, firmwareOK := p.readB524Startup(ctx, grp.opcode, grp.group, instance, device_slot_firmware)
+			hardwareRaw, hardwareOK := p.readB524Startup(ctx, grp.opcode, grp.group, instance, device_slot_hardware_identifier)
+			if !classOK || len(classRaw) == 0 || !firmwareOK || len(firmwareRaw) < 3 || !hardwareOK || len(hardwareRaw) == 0 {
+				fm5NamespaceComplete = false
+			}
+			if len(classRaw) > 0 && classRaw[0] != 0xFF {
+				value := classRaw[0]
+				classAddress = &value
+			}
+			firmware = decodeB524FirmwareVersion(firmwareRaw)
+			if value, ok := decodeB524Uint16(hardwareRaw); ok && value != 0xFFFF {
+				hardware = &value
+			}
+		} else {
+			classAddress = p.readB524U8Startup(ctx, grp.opcode, grp.group, instance, device_slot_class_address)
 		}
 		key := radioDeviceKey{Group: grp.group, Instance: instance}
 		verified[key] = true
 		include, slotMode := startupRadioDeviceInclude(grp.group, connected, classAddress)
+		if grp.group == remoteFunctionalModules.group && !include && hasRemoteIdentityEvidence(classAddress, firmware, hardware) {
+			include = true
+			slotMode = "inventory"
+		}
 		if !include {
 			delete(discovered, key)
 			return
@@ -1820,6 +1841,8 @@ func (p *vaillantSemanticPoller) refreshRadioDevicesStartup(ctx context.Context)
 			DeviceConnected:    &connected,
 			DeviceClassAddress: cloneUint8Ptr(classAddress),
 			DeviceModel:        decodeRadioDeviceModel(classAddress),
+			FirmwareVersion:    cloneStringPtr(firmware),
+			HardwareIdentifier: cloneUint16Ptr(hardware),
 		}
 	}
 

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -5634,7 +5634,10 @@ func (p *vaillantSemanticPoller) commitFM5Acquisition(
 				EvidenceRevision: formatFM5EvidenceRevision(captured.generation, p.fm5EvidenceGeneration, p.fm5EvidenceRevision),
 			}
 		}
-		p.fm5Mode = verdict.Mode
+		verdict = retainFM5StructuralMode(p.fm5Interpretation, verdict)
+		if verdict.Mode != "" {
+			p.fm5Mode = verdict.Mode
+		}
 		p.fm5Interpretation = verdict
 		p.solar, p.solarCylinders = applyFM5Acquisition(
 			p.solar, p.solarCylinders, incomingSolar, incomingCylinders, verdict,
@@ -5704,11 +5707,16 @@ func deriveFM5Interpretation(
 	incoherent bool,
 	evidenceRevision string,
 ) graphql.Fm5Interpretation {
-	verdict := graphql.Fm5Interpretation{EvidenceRevision: evidenceRevision}
 	if !hasEvidence {
-		verdict.Mode = graphql.Fm5SemanticModeAbsent
-		return verdict
+		if !controllerReachable || moduleConfig == nil || evidenceStale || incoherent {
+			return graphql.Fm5Interpretation{}
+		}
+		return graphql.Fm5Interpretation{
+			Mode:             graphql.Fm5SemanticModeAbsent,
+			EvidenceRevision: evidenceRevision,
+		}
 	}
+	verdict := graphql.Fm5Interpretation{EvidenceRevision: evidenceRevision}
 	verdict.Mode = graphql.Fm5SemanticModeGPIOOnly
 	switch {
 	case incoherent:
@@ -5731,6 +5739,39 @@ func deriveFM5Interpretation(
 	return verdict
 }
 
+func retainFM5StructuralMode(previous, candidate graphql.Fm5Interpretation) graphql.Fm5Interpretation {
+	if !isFM5TransientAcquisitionReason(candidate.DegradedReason) {
+		return candidate
+	}
+	if previous.Validate() != nil {
+		return graphql.Fm5Interpretation{}
+	}
+	switch previous.Mode {
+	case graphql.Fm5SemanticModeInterpreted, graphql.Fm5SemanticModeAbsent:
+		candidate.Mode = previous.Mode
+		return candidate
+	case graphql.Fm5SemanticModeGPIOOnly:
+		previous.EvidenceRevision = candidate.EvidenceRevision
+		return previous
+	default:
+		return graphql.Fm5Interpretation{}
+	}
+}
+
+func isFM5TransientAcquisitionReason(reason graphql.Fm5SemanticDegradedReason) bool {
+	switch reason {
+	case graphql.Fm5SemanticDegradedReasonControllerUnreachable,
+		graphql.Fm5SemanticDegradedReasonConfigurationUnavailable,
+		graphql.Fm5SemanticDegradedReasonSolarAcquisitionFailed,
+		graphql.Fm5SemanticDegradedReasonCylinderAcquisitionFailed,
+		graphql.Fm5SemanticDegradedReasonEvidenceStale,
+		graphql.Fm5SemanticDegradedReasonIncoherentAcquisition:
+		return true
+	default:
+		return false
+	}
+}
+
 func applyFM5Acquisition(
 	previousSolar *vaillantSolarSnapshot,
 	previousCylinders map[byte]*vaillantCylinderSnapshot,
@@ -5739,6 +5780,8 @@ func applyFM5Acquisition(
 	verdict graphql.Fm5Interpretation,
 ) (*vaillantSolarSnapshot, map[byte]*vaillantCylinderSnapshot) {
 	switch {
+	case isFM5TransientAcquisitionReason(verdict.DegradedReason):
+		return cloneSolarSnapshot(previousSolar), cloneCylinderSnapshotsMap(previousCylinders)
 	case verdict.Mode == graphql.Fm5SemanticModeInterpreted:
 		return mergeSolarSnapshotNonDestructive(previousSolar, incomingSolar),
 			mergeCylinderSnapshotMapNonDestructive(previousCylinders, incomingCylinders)
@@ -5750,7 +5793,7 @@ func applyFM5Acquisition(
 }
 
 func isFM5StructuralWithdrawal(verdict graphql.Fm5Interpretation) bool {
-	return verdict.Mode == graphql.Fm5SemanticModeAbsent ||
+	return (verdict.Mode == graphql.Fm5SemanticModeAbsent && verdict.DegradedReason == "") ||
 		(verdict.Mode == graphql.Fm5SemanticModeGPIOOnly &&
 			verdict.DegradedReason == graphql.Fm5SemanticDegradedReasonConfigurationNotInterpretable)
 }
@@ -5775,14 +5818,7 @@ func (p *vaillantSemanticPoller) publishFM5Semantic(source semanticSnapshotSourc
 	}
 
 	p.mu.Lock()
-	mode := p.fm5Mode
-	if mode == "" {
-		mode = graphql.Fm5SemanticModeAbsent
-	}
 	verdict := p.fm5Interpretation
-	if verdict.Mode == "" {
-		verdict = graphql.Fm5Interpretation{Mode: mode, EvidenceRevision: "legacy"}
-	}
 	solarSnapshot := cloneSolarSnapshot(p.solar)
 	cylindersSnapshot := cloneCylinderSnapshotsMap(p.solarCylinders)
 	p.mu.Unlock()

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -1810,17 +1810,19 @@ func (p *vaillantSemanticPoller) refreshRadioDevicesStartup(ctx context.Context)
 			classRaw, classOK := p.readB524Startup(ctx, grp.opcode, grp.group, instance, device_slot_class_address)
 			firmwareRaw, firmwareOK := p.readB524Startup(ctx, grp.opcode, grp.group, instance, device_slot_firmware)
 			hardwareRaw, hardwareOK := p.readB524Startup(ctx, grp.opcode, grp.group, instance, device_slot_hardware_identifier)
-			if !classOK || len(classRaw) == 0 || !firmwareOK || len(firmwareRaw) < 3 || !hardwareOK || len(hardwareRaw) == 0 {
+			tuple := decodeFunctionalModuleIdentityTuple(
+				connectedRaw, true,
+				classRaw, classOK,
+				firmwareRaw, firmwareOK,
+				hardwareRaw, hardwareOK,
+			)
+			if !tuple.complete {
 				fm5NamespaceComplete = false
 			}
-			if len(classRaw) > 0 && classRaw[0] != 0xFF {
-				value := classRaw[0]
-				classAddress = &value
-			}
-			firmware = decodeB524FirmwareVersion(firmwareRaw)
-			if value, ok := decodeB524Uint16(hardwareRaw); ok && value != 0xFFFF {
-				hardware = &value
-			}
+			connected = tuple.connected
+			classAddress = tuple.classAddress
+			firmware = tuple.firmware
+			hardware = tuple.hardware
 		} else {
 			classAddress = p.readB524U8Startup(ctx, grp.opcode, grp.group, instance, device_slot_class_address)
 		}
@@ -1871,6 +1873,7 @@ func (p *vaillantSemanticPoller) refreshRadioDevicesStartup(ctx context.Context)
 	p.mu.Lock()
 	p.startupRadioDevicesProbed = readAny
 	p.fm5IdentityScanComplete = fm5NamespaceComplete
+	p.fm5IdentityIncoherent = !fm5NamespaceComplete
 	if fm5NamespaceComplete {
 		p.fm5RegistryEvidenceIgnored = !liveFM5Evidence
 	} else if liveFM5Evidence {
@@ -5261,41 +5264,87 @@ func (p *vaillantSemanticPoller) readFunctionalModuleIdentitySnapshot(ctx contex
 	if !connectedOK || len(connectedRaw) == 0 {
 		return nil, false, false
 	}
-	connected := connectedRaw[0] == 1
 	classRaw, classOK := p.readB524Value(ctx, vaillantB524OpcodeRead, remoteFunctionalModules.group, instance, device_slot_class_address)
 	firmwareRaw, firmwareOK := p.readB524Value(ctx, vaillantB524OpcodeRead, remoteFunctionalModules.group, instance, device_slot_firmware)
 	hardwareRaw, hardwareOK := p.readB524Value(ctx, vaillantB524OpcodeRead, remoteFunctionalModules.group, instance, device_slot_hardware_identifier)
-	complete := classOK && len(classRaw) > 0 &&
-		firmwareOK && len(firmwareRaw) >= 3 &&
-		hardwareOK && len(hardwareRaw) >= 2
-
-	var classAddress *uint8
-	if len(classRaw) > 0 && classRaw[0] != 0xFF {
-		value := classRaw[0]
-		classAddress = &value
-	}
-	firmware := decodeB524FirmwareVersion(firmwareRaw)
-	var hardware *uint16
-	if value, ok := decodeB524Uint16(hardwareRaw); ok && value != 0xFFFF {
-		hardware = &value
-	}
-	if !connected && !hasRemoteIdentityEvidence(classAddress, firmware, hardware) {
-		return nil, true, complete
+	tuple := decodeFunctionalModuleIdentityTuple(
+		connectedRaw, connectedOK,
+		classRaw, classOK,
+		firmwareRaw, firmwareOK,
+		hardwareRaw, hardwareOK,
+	)
+	if !tuple.connected && !hasRemoteIdentityEvidence(tuple.classAddress, tuple.firmware, tuple.hardware) {
+		return nil, true, tuple.complete
 	}
 	slotMode := "active"
-	if !connected {
+	if !tuple.connected {
 		slotMode = "inventory"
 	}
 	return &vaillantRadioDeviceSnapshot{
 		Group:              remoteFunctionalModules.group,
 		Instance:           instance,
 		SlotMode:           slotMode,
-		DeviceConnected:    cloneBoilerBoolPtr(&connected),
-		DeviceClassAddress: cloneUint8Ptr(classAddress),
-		DeviceModel:        decodeRadioDeviceModel(classAddress),
-		FirmwareVersion:    cloneStringPtr(firmware),
-		HardwareIdentifier: cloneUint16Ptr(hardware),
-	}, true, complete
+		DeviceConnected:    cloneBoilerBoolPtr(&tuple.connected),
+		DeviceClassAddress: cloneUint8Ptr(tuple.classAddress),
+		DeviceModel:        decodeRadioDeviceModel(tuple.classAddress),
+		FirmwareVersion:    cloneStringPtr(tuple.firmware),
+		HardwareIdentifier: cloneUint16Ptr(tuple.hardware),
+	}, true, tuple.complete
+}
+
+type functionalModuleIdentityTuple struct {
+	connected    bool
+	classAddress *uint8
+	firmware     *string
+	hardware     *uint16
+	complete     bool
+}
+
+func decodeFunctionalModuleIdentityTuple(
+	connectedRaw []byte,
+	connectedOK bool,
+	classRaw []byte,
+	classOK bool,
+	firmwareRaw []byte,
+	firmwareOK bool,
+	hardwareRaw []byte,
+	hardwareOK bool,
+) functionalModuleIdentityTuple {
+	connected, connectedValid := decodeExactB524Bool(connectedRaw)
+	tuple := functionalModuleIdentityTuple{
+		connected: connected,
+		complete: connectedOK && connectedValid &&
+			classOK && len(classRaw) >= 1 &&
+			firmwareOK && len(firmwareRaw) >= 3 &&
+			hardwareOK && len(hardwareRaw) >= 2,
+	}
+	if classOK && len(classRaw) >= 1 && classRaw[0] != 0xFF {
+		value := classRaw[0]
+		tuple.classAddress = &value
+	}
+	if firmwareOK && len(firmwareRaw) >= 3 {
+		tuple.firmware = decodeB524FirmwareVersion(firmwareRaw)
+	}
+	if hardwareOK && len(hardwareRaw) >= 2 {
+		if value, ok := decodeB524Uint16(hardwareRaw); ok && value != 0xFFFF {
+			tuple.hardware = &value
+		}
+	}
+	return tuple
+}
+
+func decodeExactB524Bool(raw []byte) (bool, bool) {
+	if len(raw) == 0 {
+		return false, false
+	}
+	switch raw[0] {
+	case 0:
+		return false, true
+	case 1:
+		return true, true
+	default:
+		return false, false
+	}
 }
 
 func (p *vaillantSemanticPoller) refreshRadioDevices(ctx context.Context) {
@@ -5453,7 +5502,7 @@ func (p *vaillantSemanticPoller) refreshRadioDevices(ctx context.Context) {
 		discovered[radioDeviceKey{Group: group, Instance: instance}] = device
 	}
 
-	if !readAny && len(phaseOneFM5Snapshots) == 0 {
+	if !readAny && len(phaseOneFM5Snapshots) == 0 && !fm5SlotReadAttempted {
 		return
 	}
 

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -5721,15 +5721,6 @@ func uint16PointersEqual(left, right *uint16) bool {
 	return *left == *right
 }
 
-func hasFM5EvidenceFromRadioMap(snapshots map[radioDeviceKey]*vaillantRadioDeviceSnapshot) bool {
-	for _, snapshot := range snapshots {
-		if hasFM5EvidenceFromRadioSnapshots([]*vaillantRadioDeviceSnapshot{snapshot}) {
-			return true
-		}
-	}
-	return false
-}
-
 func deriveFM5Interpretation(
 	controllerReachable bool,
 	moduleConfig *uint16,

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -363,6 +363,8 @@ type vaillantSemanticPoller struct {
 	fm5Interpretation           graphql.Fm5Interpretation
 	fm5EvidenceRevision         uint64
 	fm5EvidenceGeneration       uint64
+	fm5IdentityScanComplete     bool
+	fm5RegistryEvidenceIgnored  bool
 	fm5IdentityObservedAt       time.Time
 	solar                       *vaillantSolarSnapshot
 	solarCylinders              map[byte]*vaillantCylinderSnapshot
@@ -1533,8 +1535,10 @@ func (p *vaillantSemanticPoller) startupL1PrimingStatus() startupL1PrimingStatus
 		}
 	}
 	radioProbed := p.startupRadioDevicesProbed
+	fm5RegistryEvidenceIgnored := p.fm5RegistryEvidenceIgnored
 	p.mu.Unlock()
-	fm5Evidence := hasFM5EvidenceFromRadioSnapshots(radioSnapshots) || p.hasFM5RegistryEvidence()
+	liveFM5Evidence := hasFM5EvidenceFromRadioSnapshots(radioSnapshots)
+	fm5Evidence := liveFM5Evidence || (!fm5RegistryEvidenceIgnored && p.hasFM5RegistryEvidence())
 	fm5Required := fm5Evidence && moduleConfig != nil && *moduleConfig <= 2
 	zonesReady := p.provider.Zones() != nil
 	solarReady := p.provider.Solar() != nil
@@ -1785,16 +1789,23 @@ func (p *vaillantSemanticPoller) refreshRadioDevicesStartup(ctx context.Context)
 
 	discovered := p.registryRadioDeviceSeeds()
 	fullScanGroups := startupRadioFullScanGroups(discovered)
+	fm5NamespaceComplete := fullScanGroups[remoteFunctionalModules.group]
 	verified := make(map[radioDeviceKey]bool)
 	readAny := false
 	probeSlot := func(grp b524GroupDef, instance byte) {
 		connectedRaw, ok := p.readB524Startup(ctx, grp.opcode, grp.group, instance, device_slot_connected)
 		if !ok || len(connectedRaw) == 0 {
+			if grp.group == remoteFunctionalModules.group {
+				fm5NamespaceComplete = false
+			}
 			return
 		}
 		readAny = true
 		connected := connectedRaw[0] == 1
 		classAddress := p.readB524U8Startup(ctx, grp.opcode, grp.group, instance, device_slot_class_address)
+		if grp.group == remoteFunctionalModules.group && classAddress == nil {
+			fm5NamespaceComplete = false
+		}
 		key := radioDeviceKey{Group: grp.group, Instance: instance}
 		verified[key] = true
 		include, slotMode := startupRadioDeviceInclude(grp.group, connected, classAddress)
@@ -1832,13 +1843,22 @@ func (p *vaillantSemanticPoller) refreshRadioDevicesStartup(ctx context.Context)
 		}
 	}
 
+	liveFM5Evidence := hasFM5EvidenceFromRadioMap(discovered)
 	p.mu.Lock()
 	p.startupRadioDevicesProbed = readAny
+	p.fm5IdentityScanComplete = fm5NamespaceComplete
+	if fm5NamespaceComplete {
+		p.fm5RegistryEvidenceIgnored = !liveFM5Evidence
+	} else if liveFM5Evidence {
+		p.fm5RegistryEvidenceIgnored = false
+	}
 	if len(discovered) == 0 {
 		if readAny {
 			p.radioDevices = make(map[radioDeviceKey]*vaillantRadioDeviceSnapshot)
 			p.fm5EvidenceGeneration++
-			p.fm5IdentityObservedAt = p.now()
+			if fm5NamespaceComplete {
+				p.fm5IdentityObservedAt = p.now()
+			}
 		}
 		p.mu.Unlock()
 		if readAny {
@@ -1854,7 +1874,9 @@ func (p *vaillantSemanticPoller) refreshRadioDevicesStartup(ctx context.Context)
 	}
 	if readAny {
 		p.fm5EvidenceGeneration++
-		p.fm5IdentityObservedAt = p.now()
+		if fm5NamespaceComplete || liveFM5Evidence {
+			p.fm5IdentityObservedAt = p.now()
+		}
 	}
 	p.mu.Unlock()
 	source := semanticSnapshotSourceCache
@@ -5169,10 +5191,48 @@ func (p *vaillantSemanticPoller) refreshSystem(ctx context.Context) {
 // This runs at startup and every deviceSlotRediscoveryTTL to avoid
 // probing empty slots on every poll cycle (~30 timeouts eliminated).
 func (p *vaillantSemanticPoller) discoverDeviceSlots(ctx context.Context) (map[deviceSlotKey]bool, bool) {
+	active, observedAny, _ := p.discoverDeviceSlotsWithFM5Completeness(ctx)
+	return active, observedAny
+}
+
+func (p *vaillantSemanticPoller) discoverDeviceSlotsWithFM5Completeness(ctx context.Context) (map[deviceSlotKey]bool, bool, bool) {
 	active := make(map[deviceSlotKey]bool)
 	observedAny := false
+	fm5NamespaceComplete := true
 	for _, grp := range remoteDeviceGroups {
 		for instance := byte(0x00); instance <= 0x0A; instance++ {
+			if grp.group == remoteFunctionalModules.group {
+				connectedRaw, connectedOK := p.readB524Value(ctx, grp.opcode, grp.group, instance, device_slot_connected)
+				if !connectedOK || len(connectedRaw) == 0 {
+					fm5NamespaceComplete = false
+					continue
+				}
+				observedAny = true
+				connected := connectedRaw[0] == 1
+
+				classRaw, classOK := p.readB524Value(ctx, grp.opcode, grp.group, instance, device_slot_class_address)
+				firmwareRaw, firmwareOK := p.readB524Value(ctx, grp.opcode, grp.group, instance, device_slot_firmware)
+				hardwareRaw, hardwareOK := p.readB524Value(ctx, grp.opcode, grp.group, instance, device_slot_hardware_identifier)
+				if !classOK || len(classRaw) == 0 || !firmwareOK || len(firmwareRaw) < 3 || !hardwareOK || len(hardwareRaw) == 0 {
+					fm5NamespaceComplete = false
+				}
+
+				var classAddress *uint8
+				if len(classRaw) > 0 && classRaw[0] != 0xFF {
+					value := classRaw[0]
+					classAddress = &value
+				}
+				firmware := decodeB524FirmwareVersion(firmwareRaw)
+				var hardware *uint16
+				if value, ok := decodeB524Uint16(hardwareRaw); ok && value != 0xFFFF {
+					hardware = &value
+				}
+				if connected || hasRemoteIdentityEvidence(classAddress, firmware, hardware) {
+					active[deviceSlotKey{Group: grp.group, Instance: instance}] = true
+				}
+				continue
+			}
+
 			connectedRaw := p.readB524U8(ctx, grp.opcode, grp.group, instance, device_slot_connected)
 			if connectedRaw == nil {
 				continue
@@ -5180,20 +5240,10 @@ func (p *vaillantSemanticPoller) discoverDeviceSlots(ctx context.Context) (map[d
 			observedAny = true
 			if *connectedRaw == 1 {
 				active[deviceSlotKey{Group: grp.group, Instance: instance}] = true
-				continue
-			}
-			if grp.group != remoteFunctionalModules.group {
-				continue
-			}
-			classAddress := p.readB524U8(ctx, grp.opcode, grp.group, instance, device_slot_class_address)
-			firmware := p.readB524Firmware(ctx, grp.opcode, grp.group, instance, device_slot_firmware)
-			hardware := p.readB524U16(ctx, grp.opcode, grp.group, instance, device_slot_hardware_identifier)
-			if hasRemoteIdentityEvidence(classAddress, firmware, hardware) {
-				active[deviceSlotKey{Group: grp.group, Instance: instance}] = true
 			}
 		}
 	}
-	return active, observedAny
+	return active, observedAny, fm5NamespaceComplete
 }
 
 func (p *vaillantSemanticPoller) refreshRadioDevices(ctx context.Context) {
@@ -5205,6 +5255,7 @@ func (p *vaillantSemanticPoller) refreshRadioDevices(ctx context.Context) {
 	controller := p.controller
 	needsDiscovery := !p.deviceSlotDiscoveryDone ||
 		(p.deviceSlotRediscoveryTTL > 0 && p.now().Sub(p.deviceSlotDiscoveryAt) >= p.deviceSlotRediscoveryTTL)
+	fm5ScanComplete := p.fm5IdentityScanComplete
 	p.mu.Unlock()
 	if controller == 0 {
 		return
@@ -5214,14 +5265,16 @@ func (p *vaillantSemanticPoller) refreshRadioDevices(ctx context.Context) {
 	// Runs at startup and every deviceSlotRediscoveryTTL (30min default).
 	discoveryObserved := false
 	if needsDiscovery {
-		activeSlots, observedAny := p.discoverDeviceSlots(ctx)
+		activeSlots, observedAny, fm5NamespaceComplete := p.discoverDeviceSlotsWithFM5Completeness(ctx)
 		discoveryObserved = observedAny
 		if observedAny {
 			p.mu.Lock()
 			p.deviceSlotCache = activeSlots
 			p.deviceSlotDiscoveryDone = true
 			p.deviceSlotDiscoveryAt = p.now()
+			p.fm5IdentityScanComplete = fm5NamespaceComplete
 			p.mu.Unlock()
+			fm5ScanComplete = fm5NamespaceComplete
 		}
 	}
 
@@ -5232,12 +5285,25 @@ func (p *vaillantSemanticPoller) refreshRadioDevices(ctx context.Context) {
 	if len(slots) == 0 {
 		if discoveryObserved {
 			p.mu.Lock()
-			p.radioDevices = make(map[radioDeviceKey]*vaillantRadioDeviceSnapshot)
+			retained := make(map[radioDeviceKey]*vaillantRadioDeviceSnapshot)
+			if !fm5ScanComplete {
+				for key, snapshot := range p.radioDevices {
+					if key.Group == remoteFunctionalModules.group {
+						retained[key] = snapshot
+					}
+				}
+			}
+			p.radioDevices = retained
 			p.fm5EvidenceGeneration++
-			p.fm5IdentityObservedAt = p.now()
+			if fm5ScanComplete {
+				p.fm5RegistryEvidenceIgnored = true
+				p.fm5IdentityObservedAt = p.now()
+			}
 			p.mu.Unlock()
 			p.publishRadioDevices(semanticSnapshotSourceLive)
-			p.refreshFM5Semantic(ctx)
+			if fm5ScanComplete {
+				p.refreshFM5Semantic(ctx)
+			}
 		}
 		return
 	}
@@ -5311,10 +5377,25 @@ func (p *vaillantSemanticPoller) refreshRadioDevices(ctx context.Context) {
 		p.reg.Register(preserveExistingRegistryMetadata(p.reg, info))
 	}
 
+	liveFM5Evidence := hasFM5EvidenceFromRadioMap(discovered)
 	p.mu.Lock()
+	if !fm5ScanComplete && !liveFM5Evidence {
+		for key, snapshot := range p.radioDevices {
+			if key.Group == remoteFunctionalModules.group {
+				discovered[key] = snapshot
+			}
+		}
+	}
 	p.radioDevices = discovered
 	p.fm5EvidenceGeneration++
-	p.fm5IdentityObservedAt = p.now()
+	if fm5ScanComplete {
+		p.fm5RegistryEvidenceIgnored = !liveFM5Evidence
+	} else if liveFM5Evidence {
+		p.fm5RegistryEvidenceIgnored = false
+	}
+	if fm5ScanComplete || liveFM5Evidence {
+		p.fm5IdentityObservedAt = p.now()
+	}
 	p.mu.Unlock()
 
 	p.publishRadioDevices(semanticSnapshotSourceLive)
@@ -5561,6 +5642,7 @@ type fm5EvidenceCapture struct {
 	registryEvidence            string
 	registryGeneration          uint64
 	registryCoherent            bool
+	registryEvidenceIgnored     bool
 	identityAcquisitionComplete bool
 	identityObservedAt          time.Time
 	generation                  uint64
@@ -5574,7 +5656,8 @@ func (p *vaillantSemanticPoller) captureFM5Evidence() fm5EvidenceCapture {
 	capture := fm5EvidenceCapture{
 		controller:                  p.controller,
 		systemSnapshot:              cloneSystemSnapshot(p.system),
-		identityAcquisitionComplete: p.startupRadioDevicesProbed || p.deviceSlotDiscoveryDone,
+		registryEvidenceIgnored:     p.fm5RegistryEvidenceIgnored,
+		identityAcquisitionComplete: p.fm5IdentityScanComplete,
 		identityObservedAt:          p.fm5IdentityObservedAt,
 		generation:                  p.fm5EvidenceGeneration,
 		radioSnapshots:              make([]*vaillantRadioDeviceSnapshot, 0, len(p.radioDevices)),
@@ -5604,7 +5687,10 @@ func (p *vaillantSemanticPoller) captureFM5Evidence() fm5EvidenceCapture {
 }
 
 func (capture fm5EvidenceCapture) hasEvidence() bool {
-	return capture.registryEvidence != "" || hasFM5EvidenceFromRadioSnapshots(capture.radioSnapshots)
+	if hasFM5EvidenceFromRadioSnapshots(capture.radioSnapshots) {
+		return true
+	}
+	return !capture.registryEvidenceIgnored && capture.registryEvidence != ""
 }
 
 func (capture fm5EvidenceCapture) staleAt(now time.Time, ttl time.Duration) bool {
@@ -5627,6 +5713,7 @@ func (capture fm5EvidenceCapture) sameGeneration(other fm5EvidenceCapture) bool 
 		capture.generation == other.generation &&
 		capture.controller == other.controller &&
 		uint16PointersEqual(capture.moduleConfig, other.moduleConfig) &&
+		capture.registryEvidenceIgnored == other.registryEvidenceIgnored &&
 		capture.identityAcquisitionComplete == other.identityAcquisitionComplete &&
 		capture.identityObservedAt.Equal(other.identityObservedAt) &&
 		capture.registryGeneration == other.registryGeneration &&
@@ -5644,7 +5731,8 @@ func (capture fm5EvidenceCapture) matchesLockedPoller(p *vaillantSemanticPoller)
 	return capture.generation == p.fm5EvidenceGeneration &&
 		capture.controller == p.controller &&
 		uint16PointersEqual(capture.moduleConfig, moduleConfig) &&
-		capture.identityAcquisitionComplete == (p.startupRadioDevicesProbed || p.deviceSlotDiscoveryDone) &&
+		capture.registryEvidenceIgnored == p.fm5RegistryEvidenceIgnored &&
+		capture.identityAcquisitionComplete == p.fm5IdentityScanComplete &&
 		capture.identityObservedAt.Equal(p.fm5IdentityObservedAt)
 }
 
@@ -6005,6 +6093,15 @@ func hasFM5EvidenceFromRadioSnapshots(snapshots []*vaillantRadioDeviceSnapshot) 
 			return true
 		}
 		if strings.EqualFold(strings.TrimSpace(snapshot.DeviceModel), "VR71/FM5") {
+			return true
+		}
+	}
+	return false
+}
+
+func hasFM5EvidenceFromRadioMap(snapshots map[radioDeviceKey]*vaillantRadioDeviceSnapshot) bool {
+	for _, snapshot := range snapshots {
+		if hasFM5EvidenceFromRadioSnapshots([]*vaillantRadioDeviceSnapshot{snapshot}) {
 			return true
 		}
 	}

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -1838,6 +1838,7 @@ func (p *vaillantSemanticPoller) refreshRadioDevicesStartup(ctx context.Context)
 		if readAny {
 			p.radioDevices = make(map[radioDeviceKey]*vaillantRadioDeviceSnapshot)
 			p.fm5EvidenceGeneration++
+			p.fm5IdentityObservedAt = p.now()
 		}
 		p.mu.Unlock()
 		if readAny {
@@ -1853,9 +1854,7 @@ func (p *vaillantSemanticPoller) refreshRadioDevicesStartup(ctx context.Context)
 	}
 	if readAny {
 		p.fm5EvidenceGeneration++
-		if hasFM5EvidenceFromRadioMap(p.radioDevices) {
-			p.fm5IdentityObservedAt = p.now()
-		}
+		p.fm5IdentityObservedAt = p.now()
 	}
 	p.mu.Unlock()
 	source := semanticSnapshotSourceCache
@@ -1954,7 +1953,8 @@ func (p *vaillantSemanticPoller) refreshFM5SemanticStartup(ctx context.Context) 
 
 	evidence := p.captureFM5Evidence()
 	fm5GateSatisfied := evidence.moduleConfig != nil && *evidence.moduleConfig <= 2
-	evidenceStale := evidence.staleAt(p.now(), p.fm5EvidenceTTL)
+	observedAt := p.now()
+	evidenceStale := evidence.staleAt(observedAt, p.fm5EvidenceTTL)
 	var incomingSolar *vaillantSolarSnapshot
 	incomingCylinders := make(map[byte]*vaillantCylinderSnapshot)
 	solarReadable := false
@@ -1965,16 +1965,28 @@ func (p *vaillantSemanticPoller) refreshFM5SemanticStartup(ctx context.Context) 
 	}
 	currentEvidence := p.captureFM5Evidence()
 	incoherent := !evidence.sameGeneration(currentEvidence)
-	verdict := deriveFM5Interpretation(
-		evidence.controller != 0,
-		evidence.moduleConfig,
-		solarReadable,
-		cylindersReadable,
-		evidence.hasEvidence() || currentEvidence.hasEvidence(),
-		evidenceStale,
-		incoherent,
-		p.nextFM5EvidenceRevision(evidence.generation, currentEvidence.generation),
-	)
+	evidenceRevision := p.nextFM5EvidenceRevision(evidence.generation, currentEvidence.generation)
+	negativeIdentityObserved := evidence.hasNegativeObservation() && currentEvidence.hasNegativeObservation()
+	freshNegativeIdentityObserved := evidence.hasFreshNegativeObservation(observedAt, p.fm5EvidenceTTL) &&
+		currentEvidence.hasFreshNegativeObservation(observedAt, p.fm5EvidenceTTL)
+	var verdict graphql.Fm5Interpretation
+	if freshNegativeIdentityObserved && !incoherent && evidence.controller != 0 && evidence.moduleConfig != nil {
+		verdict = graphql.Fm5Interpretation{
+			Mode:             graphql.Fm5SemanticModeAbsent,
+			EvidenceRevision: evidenceRevision,
+		}
+	} else {
+		verdict = deriveFM5Interpretation(
+			evidence.controller != 0,
+			evidence.moduleConfig,
+			solarReadable,
+			cylindersReadable,
+			evidence.hasEvidence() || currentEvidence.hasEvidence() || negativeIdentityObserved,
+			evidenceStale,
+			incoherent,
+			evidenceRevision,
+		)
+	}
 	verdict = p.commitFM5Acquisition(currentEvidence, verdict, incomingSolar, incomingCylinders)
 	for _, info := range fm5InventoryRegistryInfos(evidence.systemSnapshot, verdict.Mode) {
 		p.reg.Register(preserveExistingRegistryMetadata(p.reg, info))
@@ -2473,13 +2485,8 @@ func (p *vaillantSemanticPoller) refreshDiscovery(ctx context.Context) {
 		p.zones = make(map[byte]*vaillantZoneSnapshot)
 		p.presence = make(map[byte]*zonePresenceRecord)
 		p.circuits = make(map[byte]*vaillantCircuitSnapshot)
-		p.radioDevices = make(map[radioDeviceKey]*vaillantRadioDeviceSnapshot)
-		p.fm5Mode = graphql.Fm5SemanticModeAbsent
 		p.fm5EvidenceGeneration++
-		p.solar = nil
-		p.solarCylinders = make(map[byte]*vaillantCylinderSnapshot)
 		p.startupSemanticPrimed = false
-		p.startupRadioDevicesProbed = false
 		semanticZoneCount.Set(0)
 		p.mu.Unlock()
 		if regCap != prev {
@@ -5227,6 +5234,7 @@ func (p *vaillantSemanticPoller) refreshRadioDevices(ctx context.Context) {
 			p.mu.Lock()
 			p.radioDevices = make(map[radioDeviceKey]*vaillantRadioDeviceSnapshot)
 			p.fm5EvidenceGeneration++
+			p.fm5IdentityObservedAt = p.now()
 			p.mu.Unlock()
 			p.publishRadioDevices(semanticSnapshotSourceLive)
 			p.refreshFM5Semantic(ctx)
@@ -5306,9 +5314,7 @@ func (p *vaillantSemanticPoller) refreshRadioDevices(ctx context.Context) {
 	p.mu.Lock()
 	p.radioDevices = discovered
 	p.fm5EvidenceGeneration++
-	if hasFM5EvidenceFromRadioMap(discovered) {
-		p.fm5IdentityObservedAt = p.now()
-	}
+	p.fm5IdentityObservedAt = p.now()
 	p.mu.Unlock()
 
 	p.publishRadioDevices(semanticSnapshotSourceLive)
@@ -5493,7 +5499,8 @@ func (p *vaillantSemanticPoller) refreshFM5Semantic(ctx context.Context) {
 
 	evidence := p.captureFM5Evidence()
 	fm5GateSatisfied := evidence.moduleConfig != nil && *evidence.moduleConfig <= 2
-	evidenceStale := evidence.staleAt(p.now(), p.fm5EvidenceTTL)
+	observedAt := p.now()
+	evidenceStale := evidence.staleAt(observedAt, p.fm5EvidenceTTL)
 
 	var incomingSolar *vaillantSolarSnapshot
 	incomingCylinders := make(map[byte]*vaillantCylinderSnapshot)
@@ -5506,16 +5513,28 @@ func (p *vaillantSemanticPoller) refreshFM5Semantic(ctx context.Context) {
 
 	currentEvidence := p.captureFM5Evidence()
 	incoherent := !evidence.sameGeneration(currentEvidence)
-	verdict := deriveFM5Interpretation(
-		evidence.controller != 0,
-		evidence.moduleConfig,
-		solarReadable,
-		cylindersReadable,
-		evidence.hasEvidence() || currentEvidence.hasEvidence(),
-		evidenceStale,
-		incoherent,
-		p.nextFM5EvidenceRevision(evidence.generation, currentEvidence.generation),
-	)
+	evidenceRevision := p.nextFM5EvidenceRevision(evidence.generation, currentEvidence.generation)
+	negativeIdentityObserved := evidence.hasNegativeObservation() && currentEvidence.hasNegativeObservation()
+	freshNegativeIdentityObserved := evidence.hasFreshNegativeObservation(observedAt, p.fm5EvidenceTTL) &&
+		currentEvidence.hasFreshNegativeObservation(observedAt, p.fm5EvidenceTTL)
+	var verdict graphql.Fm5Interpretation
+	if freshNegativeIdentityObserved && !incoherent && evidence.controller != 0 && evidence.moduleConfig != nil {
+		verdict = graphql.Fm5Interpretation{
+			Mode:             graphql.Fm5SemanticModeAbsent,
+			EvidenceRevision: evidenceRevision,
+		}
+	} else {
+		verdict = deriveFM5Interpretation(
+			evidence.controller != 0,
+			evidence.moduleConfig,
+			solarReadable,
+			cylindersReadable,
+			evidence.hasEvidence() || currentEvidence.hasEvidence() || negativeIdentityObserved,
+			evidenceStale,
+			incoherent,
+			evidenceRevision,
+		)
+	}
 	verdict = p.commitFM5Acquisition(currentEvidence, verdict, incomingSolar, incomingCylinders)
 	for _, info := range fm5InventoryRegistryInfos(evidence.systemSnapshot, verdict.Mode) {
 		p.reg.Register(preserveExistingRegistryMetadata(p.reg, info))
@@ -5535,15 +5554,16 @@ func deriveFM5SemanticMode(controllerReachable, fm5GateSatisfied, solarReadable,
 }
 
 type fm5EvidenceCapture struct {
-	controller         byte
-	moduleConfig       *uint16
-	systemSnapshot     *vaillantSystemSnapshot
-	radioSnapshots     []*vaillantRadioDeviceSnapshot
-	registryEvidence   string
-	registryGeneration uint64
-	registryCoherent   bool
-	identityObservedAt time.Time
-	generation         uint64
+	controller                  byte
+	moduleConfig                *uint16
+	systemSnapshot              *vaillantSystemSnapshot
+	radioSnapshots              []*vaillantRadioDeviceSnapshot
+	registryEvidence            string
+	registryGeneration          uint64
+	registryCoherent            bool
+	identityAcquisitionComplete bool
+	identityObservedAt          time.Time
+	generation                  uint64
 }
 
 func (p *vaillantSemanticPoller) captureFM5Evidence() fm5EvidenceCapture {
@@ -5552,11 +5572,12 @@ func (p *vaillantSemanticPoller) captureFM5Evidence() fm5EvidenceCapture {
 	}
 	p.mu.Lock()
 	capture := fm5EvidenceCapture{
-		controller:         p.controller,
-		systemSnapshot:     cloneSystemSnapshot(p.system),
-		identityObservedAt: p.fm5IdentityObservedAt,
-		generation:         p.fm5EvidenceGeneration,
-		radioSnapshots:     make([]*vaillantRadioDeviceSnapshot, 0, len(p.radioDevices)),
+		controller:                  p.controller,
+		systemSnapshot:              cloneSystemSnapshot(p.system),
+		identityAcquisitionComplete: p.startupRadioDevicesProbed || p.deviceSlotDiscoveryDone,
+		identityObservedAt:          p.fm5IdentityObservedAt,
+		generation:                  p.fm5EvidenceGeneration,
+		radioSnapshots:              make([]*vaillantRadioDeviceSnapshot, 0, len(p.radioDevices)),
 	}
 	if p.system != nil {
 		capture.moduleConfig = cloneUint16Ptr(p.system.ModuleConfigurationVR71)
@@ -5587,10 +5608,18 @@ func (capture fm5EvidenceCapture) hasEvidence() bool {
 }
 
 func (capture fm5EvidenceCapture) staleAt(now time.Time, ttl time.Duration) bool {
-	if !capture.hasEvidence() || capture.identityObservedAt.IsZero() || ttl <= 0 {
+	if (!capture.hasEvidence() && !capture.identityAcquisitionComplete) || capture.identityObservedAt.IsZero() || ttl <= 0 {
 		return false
 	}
 	return now.Sub(capture.identityObservedAt) > ttl
+}
+
+func (capture fm5EvidenceCapture) hasFreshNegativeObservation(now time.Time, ttl time.Duration) bool {
+	return capture.hasNegativeObservation() && !capture.staleAt(now, ttl)
+}
+
+func (capture fm5EvidenceCapture) hasNegativeObservation() bool {
+	return !capture.hasEvidence() && capture.identityAcquisitionComplete && !capture.identityObservedAt.IsZero()
 }
 
 func (capture fm5EvidenceCapture) sameGeneration(other fm5EvidenceCapture) bool {
@@ -5598,6 +5627,8 @@ func (capture fm5EvidenceCapture) sameGeneration(other fm5EvidenceCapture) bool 
 		capture.generation == other.generation &&
 		capture.controller == other.controller &&
 		uint16PointersEqual(capture.moduleConfig, other.moduleConfig) &&
+		capture.identityAcquisitionComplete == other.identityAcquisitionComplete &&
+		capture.identityObservedAt.Equal(other.identityObservedAt) &&
 		capture.registryGeneration == other.registryGeneration &&
 		capture.registryEvidence == other.registryEvidence
 }
@@ -5612,7 +5643,9 @@ func (capture fm5EvidenceCapture) matchesLockedPoller(p *vaillantSemanticPoller)
 	}
 	return capture.generation == p.fm5EvidenceGeneration &&
 		capture.controller == p.controller &&
-		uint16PointersEqual(capture.moduleConfig, moduleConfig)
+		uint16PointersEqual(capture.moduleConfig, moduleConfig) &&
+		capture.identityAcquisitionComplete == (p.startupRadioDevicesProbed || p.deviceSlotDiscoveryDone) &&
+		capture.identityObservedAt.Equal(p.fm5IdentityObservedAt)
 }
 
 func (p *vaillantSemanticPoller) commitFM5Acquisition(
@@ -5707,28 +5740,21 @@ func deriveFM5Interpretation(
 	incoherent bool,
 	evidenceRevision string,
 ) graphql.Fm5Interpretation {
-	if !hasEvidence {
-		if !controllerReachable || moduleConfig == nil || evidenceStale || incoherent {
-			return graphql.Fm5Interpretation{}
-		}
-		return graphql.Fm5Interpretation{
-			Mode:             graphql.Fm5SemanticModeAbsent,
-			EvidenceRevision: evidenceRevision,
-		}
-	}
 	verdict := graphql.Fm5Interpretation{EvidenceRevision: evidenceRevision}
 	verdict.Mode = graphql.Fm5SemanticModeGPIOOnly
 	switch {
 	case incoherent:
 		verdict.DegradedReason = graphql.Fm5SemanticDegradedReasonIncoherentAcquisition
+	case !hasEvidence:
+		return graphql.Fm5Interpretation{}
 	case !controllerReachable:
 		verdict.DegradedReason = graphql.Fm5SemanticDegradedReasonControllerUnreachable
 	case moduleConfig == nil:
 		verdict.DegradedReason = graphql.Fm5SemanticDegradedReasonConfigurationUnavailable
-	case *moduleConfig > 2:
-		verdict.DegradedReason = graphql.Fm5SemanticDegradedReasonConfigurationNotInterpretable
 	case evidenceStale:
 		verdict.DegradedReason = graphql.Fm5SemanticDegradedReasonEvidenceStale
+	case *moduleConfig > 2:
+		verdict.DegradedReason = graphql.Fm5SemanticDegradedReasonConfigurationNotInterpretable
 	case !solarReadable:
 		verdict.DegradedReason = graphql.Fm5SemanticDegradedReasonSolarAcquisitionFailed
 	case !cylindersReadable:

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -5381,11 +5381,13 @@ func (p *vaillantSemanticPoller) refreshRadioDevices(ctx context.Context) {
 	// Runs at startup and every deviceSlotRediscoveryTTL (30min default).
 	discoveryObserved := false
 	fm5NamespaceComplete := false
+	phaseOneActiveSlots := make(map[deviceSlotKey]bool)
 	phaseOneFM5Snapshots := make(map[radioDeviceKey]*vaillantRadioDeviceSnapshot)
 	if needsDiscovery {
 		activeSlots, observedAny, complete, snapshots := p.discoverDeviceSlotsWithFM5Completeness(ctx)
 		discoveryObserved = observedAny
 		fm5NamespaceComplete = complete
+		phaseOneActiveSlots = activeSlots
 		phaseOneFM5Snapshots = snapshots
 		if observedAny {
 			p.mu.Lock()
@@ -5476,6 +5478,14 @@ func (p *vaillantSemanticPoller) refreshRadioDevices(ctx context.Context) {
 
 		connectedRaw := p.readB524U8(ctx, opcode, group, instance, device_slot_connected)
 		if connectedRaw == nil {
+			if phaseOneActiveSlots[key] {
+				p.mu.Lock()
+				previous := cloneRadioSnapshot(p.radioDevices[radioDeviceKey{Group: group, Instance: instance}])
+				p.mu.Unlock()
+				if previous != nil {
+					discovered[radioDeviceKey{Group: group, Instance: instance}] = previous
+				}
+			}
 			continue
 		}
 		readAny = true

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -364,6 +364,7 @@ type vaillantSemanticPoller struct {
 	fm5EvidenceRevision         uint64
 	fm5EvidenceGeneration       uint64
 	fm5IdentityScanComplete     bool
+	fm5IdentityIncoherent       bool
 	fm5RegistryEvidenceIgnored  bool
 	fm5IdentityObservedAt       time.Time
 	solar                       *vaillantSolarSnapshot
@@ -2004,12 +2005,12 @@ func (p *vaillantSemanticPoller) refreshFM5SemanticStartup(ctx context.Context) 
 	incomingCylinders := make(map[byte]*vaillantCylinderSnapshot)
 	solarReadable := false
 	cylindersReadable := false
-	if evidence.controller != 0 && fm5GateSatisfied && !evidenceStale {
+	if evidence.controller != 0 && fm5GateSatisfied && !evidenceStale && !evidence.identityIncoherent {
 		incomingSolar, solarReadable = p.readSolarSnapshotStartup(ctx)
 		incomingCylinders, cylindersReadable = p.readCylinderSnapshotsStartup(ctx)
 	}
 	currentEvidence := p.captureFM5Evidence()
-	incoherent := !evidence.sameGeneration(currentEvidence)
+	incoherent := evidence.identityIncoherent || currentEvidence.identityIncoherent || !evidence.sameGeneration(currentEvidence)
 	evidenceRevision := p.nextFM5EvidenceRevision(evidence.generation, currentEvidence.generation)
 	negativeIdentityObserved := evidence.hasNegativeObservation() && currentEvidence.hasNegativeObservation()
 	freshNegativeIdentityObserved := evidence.hasFreshNegativeObservation(observedAt, p.fm5EvidenceTTL) &&
@@ -5214,44 +5215,30 @@ func (p *vaillantSemanticPoller) refreshSystem(ctx context.Context) {
 // This runs at startup and every deviceSlotRediscoveryTTL to avoid
 // probing empty slots on every poll cycle (~30 timeouts eliminated).
 func (p *vaillantSemanticPoller) discoverDeviceSlots(ctx context.Context) (map[deviceSlotKey]bool, bool) {
-	active, observedAny, _ := p.discoverDeviceSlotsWithFM5Completeness(ctx)
+	active, observedAny, _, _ := p.discoverDeviceSlotsWithFM5Completeness(ctx)
 	return active, observedAny
 }
 
-func (p *vaillantSemanticPoller) discoverDeviceSlotsWithFM5Completeness(ctx context.Context) (map[deviceSlotKey]bool, bool, bool) {
+func (p *vaillantSemanticPoller) discoverDeviceSlotsWithFM5Completeness(ctx context.Context) (map[deviceSlotKey]bool, bool, bool, map[radioDeviceKey]*vaillantRadioDeviceSnapshot) {
 	active := make(map[deviceSlotKey]bool)
 	observedAny := false
 	fm5NamespaceComplete := true
+	fm5Snapshots := make(map[radioDeviceKey]*vaillantRadioDeviceSnapshot)
 	for _, grp := range remoteDeviceGroups {
 		for instance := byte(0x00); instance <= 0x0A; instance++ {
 			if grp.group == remoteFunctionalModules.group {
-				connectedRaw, connectedOK := p.readB524Value(ctx, grp.opcode, grp.group, instance, device_slot_connected)
-				if !connectedOK || len(connectedRaw) == 0 {
+				snapshot, observed, complete := p.readFunctionalModuleIdentitySnapshot(ctx, instance)
+				if !observed {
 					fm5NamespaceComplete = false
 					continue
 				}
 				observedAny = true
-				connected := connectedRaw[0] == 1
-
-				classRaw, classOK := p.readB524Value(ctx, grp.opcode, grp.group, instance, device_slot_class_address)
-				firmwareRaw, firmwareOK := p.readB524Value(ctx, grp.opcode, grp.group, instance, device_slot_firmware)
-				hardwareRaw, hardwareOK := p.readB524Value(ctx, grp.opcode, grp.group, instance, device_slot_hardware_identifier)
-				if !classOK || len(classRaw) == 0 || !firmwareOK || len(firmwareRaw) < 3 || !hardwareOK || len(hardwareRaw) == 0 {
+				if !complete {
 					fm5NamespaceComplete = false
 				}
-
-				var classAddress *uint8
-				if len(classRaw) > 0 && classRaw[0] != 0xFF {
-					value := classRaw[0]
-					classAddress = &value
-				}
-				firmware := decodeB524FirmwareVersion(firmwareRaw)
-				var hardware *uint16
-				if value, ok := decodeB524Uint16(hardwareRaw); ok && value != 0xFFFF {
-					hardware = &value
-				}
-				if connected || hasRemoteIdentityEvidence(classAddress, firmware, hardware) {
+				if snapshot != nil {
 					active[deviceSlotKey{Group: grp.group, Instance: instance}] = true
+					fm5Snapshots[radioDeviceKey{Group: grp.group, Instance: instance}] = snapshot
 				}
 				continue
 			}
@@ -5266,7 +5253,49 @@ func (p *vaillantSemanticPoller) discoverDeviceSlotsWithFM5Completeness(ctx cont
 			}
 		}
 	}
-	return active, observedAny, fm5NamespaceComplete
+	return active, observedAny, fm5NamespaceComplete, fm5Snapshots
+}
+
+func (p *vaillantSemanticPoller) readFunctionalModuleIdentitySnapshot(ctx context.Context, instance byte) (*vaillantRadioDeviceSnapshot, bool, bool) {
+	connectedRaw, connectedOK := p.readB524Value(ctx, vaillantB524OpcodeRead, remoteFunctionalModules.group, instance, device_slot_connected)
+	if !connectedOK || len(connectedRaw) == 0 {
+		return nil, false, false
+	}
+	connected := connectedRaw[0] == 1
+	classRaw, classOK := p.readB524Value(ctx, vaillantB524OpcodeRead, remoteFunctionalModules.group, instance, device_slot_class_address)
+	firmwareRaw, firmwareOK := p.readB524Value(ctx, vaillantB524OpcodeRead, remoteFunctionalModules.group, instance, device_slot_firmware)
+	hardwareRaw, hardwareOK := p.readB524Value(ctx, vaillantB524OpcodeRead, remoteFunctionalModules.group, instance, device_slot_hardware_identifier)
+	complete := classOK && len(classRaw) > 0 &&
+		firmwareOK && len(firmwareRaw) >= 3 &&
+		hardwareOK && len(hardwareRaw) >= 2
+
+	var classAddress *uint8
+	if len(classRaw) > 0 && classRaw[0] != 0xFF {
+		value := classRaw[0]
+		classAddress = &value
+	}
+	firmware := decodeB524FirmwareVersion(firmwareRaw)
+	var hardware *uint16
+	if value, ok := decodeB524Uint16(hardwareRaw); ok && value != 0xFFFF {
+		hardware = &value
+	}
+	if !connected && !hasRemoteIdentityEvidence(classAddress, firmware, hardware) {
+		return nil, true, complete
+	}
+	slotMode := "active"
+	if !connected {
+		slotMode = "inventory"
+	}
+	return &vaillantRadioDeviceSnapshot{
+		Group:              remoteFunctionalModules.group,
+		Instance:           instance,
+		SlotMode:           slotMode,
+		DeviceConnected:    cloneBoilerBoolPtr(&connected),
+		DeviceClassAddress: cloneUint8Ptr(classAddress),
+		DeviceModel:        decodeRadioDeviceModel(classAddress),
+		FirmwareVersion:    cloneStringPtr(firmware),
+		HardwareIdentifier: cloneUint16Ptr(hardware),
+	}, true, complete
 }
 
 func (p *vaillantSemanticPoller) refreshRadioDevices(ctx context.Context) {
@@ -5278,7 +5307,6 @@ func (p *vaillantSemanticPoller) refreshRadioDevices(ctx context.Context) {
 	controller := p.controller
 	needsDiscovery := !p.deviceSlotDiscoveryDone ||
 		(p.deviceSlotRediscoveryTTL > 0 && p.now().Sub(p.deviceSlotDiscoveryAt) >= p.deviceSlotRediscoveryTTL)
-	fm5ScanComplete := p.fm5IdentityScanComplete
 	p.mu.Unlock()
 	if controller == 0 {
 		return
@@ -5287,17 +5315,19 @@ func (p *vaillantSemanticPoller) refreshRadioDevices(ctx context.Context) {
 	// Phase 1: Device slot discovery — full scan of all OP=0x06 groups.
 	// Runs at startup and every deviceSlotRediscoveryTTL (30min default).
 	discoveryObserved := false
+	fm5NamespaceComplete := false
+	phaseOneFM5Snapshots := make(map[radioDeviceKey]*vaillantRadioDeviceSnapshot)
 	if needsDiscovery {
-		activeSlots, observedAny, fm5NamespaceComplete := p.discoverDeviceSlotsWithFM5Completeness(ctx)
+		activeSlots, observedAny, complete, snapshots := p.discoverDeviceSlotsWithFM5Completeness(ctx)
 		discoveryObserved = observedAny
+		fm5NamespaceComplete = complete
+		phaseOneFM5Snapshots = snapshots
 		if observedAny {
 			p.mu.Lock()
 			p.deviceSlotCache = activeSlots
 			p.deviceSlotDiscoveryDone = true
 			p.deviceSlotDiscoveryAt = p.now()
-			p.fm5IdentityScanComplete = fm5NamespaceComplete
 			p.mu.Unlock()
-			fm5ScanComplete = fm5NamespaceComplete
 		}
 	}
 
@@ -5307,6 +5337,7 @@ func (p *vaillantSemanticPoller) refreshRadioDevices(ctx context.Context) {
 
 	if len(slots) == 0 {
 		if discoveryObserved {
+			fm5ScanComplete := fm5NamespaceComplete
 			p.mu.Lock()
 			retained := make(map[radioDeviceKey]*vaillantRadioDeviceSnapshot)
 			if !fm5ScanComplete {
@@ -5318,15 +5349,15 @@ func (p *vaillantSemanticPoller) refreshRadioDevices(ctx context.Context) {
 			}
 			p.radioDevices = retained
 			p.fm5EvidenceGeneration++
+			p.fm5IdentityScanComplete = fm5ScanComplete
+			p.fm5IdentityIncoherent = !fm5ScanComplete
 			if fm5ScanComplete {
 				p.fm5RegistryEvidenceIgnored = true
 				p.fm5IdentityObservedAt = p.now()
 			}
 			p.mu.Unlock()
 			p.publishRadioDevices(semanticSnapshotSourceLive)
-			if fm5ScanComplete {
-				p.refreshFM5Semantic(ctx)
-			}
+			p.refreshFM5Semantic(ctx)
 		}
 		return
 	}
@@ -5334,10 +5365,49 @@ func (p *vaillantSemanticPoller) refreshRadioDevices(ctx context.Context) {
 	// Phase 2: Read detail registers for cached active slots only.
 	discovered := make(map[radioDeviceKey]*vaillantRadioDeviceSnapshot)
 	readAny := false
+	fm5SlotReadAttempted := false
+	fm5DetailIncomplete := false
 	for key := range slots {
 		group := key.Group
 		instance := key.Instance
 		opcode := vaillantB524OpcodeRead
+		if group == remoteFunctionalModules.group {
+			fm5SlotReadAttempted = true
+			device, observed, complete := p.readFunctionalModuleIdentitySnapshot(ctx, instance)
+			if !observed {
+				fm5DetailIncomplete = true
+				continue
+			}
+			readAny = true
+			radioKey := radioDeviceKey{Group: group, Instance: instance}
+			if !complete {
+				fm5DetailIncomplete = true
+				if phaseOne := phaseOneFM5Snapshots[radioKey]; phaseOne != nil {
+					discovered[radioKey] = phaseOne
+				} else if device != nil {
+					discovered[radioKey] = device
+				}
+				continue
+			}
+			if phaseOne := phaseOneFM5Snapshots[radioKey]; phaseOne != nil && device == nil {
+				fm5DetailIncomplete = true
+				discovered[radioKey] = phaseOne
+				continue
+			}
+			if device == nil {
+				continue
+			}
+			if device.DeviceConnected != nil && *device.DeviceConnected {
+				device.RemoteControlAddress = p.readB524U8(ctx, opcode, group, instance, device_slot_remote_control_address)
+				device.DevicePaired = p.readB524Bool(ctx, opcode, group, instance, device_slot_paired)
+				device.ReceptionStrength = p.readB524U8(ctx, opcode, group, instance, device_slot_reception_strength)
+				device.ZoneAssignment = p.readB524U8(ctx, opcode, group, instance, device_slot_zone_assignment)
+				device.RoomTemperatureC = p.readB524F32(ctx, opcode, group, instance, device_slot_room_temperature)
+				device.RoomHumidityPct = p.readB524F32(ctx, opcode, group, instance, device_slot_room_humidity)
+			}
+			discovered[radioKey] = device
+			continue
+		}
 
 		connectedRaw := p.readB524U8(ctx, opcode, group, instance, device_slot_connected)
 		if connectedRaw == nil {
@@ -5355,11 +5425,6 @@ func (p *vaillantSemanticPoller) refreshRadioDevices(ctx context.Context) {
 		switch group {
 		case remoteRegulators.group, remoteThermostats.group:
 			include = connected
-		case remoteFunctionalModules.group:
-			include = connected || hasRemoteIdentityEvidence(classAddress, firmware, hardware)
-			if !connected {
-				slotMode = "inventory"
-			}
 		default:
 			include = connected
 		}
@@ -5388,7 +5453,7 @@ func (p *vaillantSemanticPoller) refreshRadioDevices(ctx context.Context) {
 		discovered[radioDeviceKey{Group: group, Instance: instance}] = device
 	}
 
-	if !readAny {
+	if !readAny && len(phaseOneFM5Snapshots) == 0 {
 		return
 	}
 
@@ -5400,24 +5465,33 @@ func (p *vaillantSemanticPoller) refreshRadioDevices(ctx context.Context) {
 		p.reg.Register(preserveExistingRegistryMetadata(p.reg, info))
 	}
 
-	liveFM5Evidence := hasFM5EvidenceFromRadioMap(discovered)
+	currentFM5Evidence := hasFM5EvidenceFromRadioMap(discovered)
+	authoritativeFM5Snapshot := needsDiscovery && discoveryObserved && fm5NamespaceComplete && !fm5DetailIncomplete
+	fm5IdentityIncoherent := fm5DetailIncomplete ||
+		(needsDiscovery && !authoritativeFM5Snapshot) ||
+		(!needsDiscovery && fm5SlotReadAttempted && !currentFM5Evidence)
 	p.mu.Lock()
-	if !fm5ScanComplete && !liveFM5Evidence {
+	if !authoritativeFM5Snapshot {
 		for key, snapshot := range p.radioDevices {
-			if key.Group == remoteFunctionalModules.group {
+			if key.Group == remoteFunctionalModules.group && discovered[key] == nil {
 				discovered[key] = snapshot
 			}
 		}
 	}
 	p.radioDevices = discovered
 	p.fm5EvidenceGeneration++
-	if fm5ScanComplete {
-		p.fm5RegistryEvidenceIgnored = !liveFM5Evidence
-	} else if liveFM5Evidence {
-		p.fm5RegistryEvidenceIgnored = false
-	}
-	if fm5ScanComplete || liveFM5Evidence {
-		p.fm5IdentityObservedAt = p.now()
+	if needsDiscovery || fm5SlotReadAttempted {
+		p.fm5IdentityScanComplete = authoritativeFM5Snapshot
+		p.fm5IdentityIncoherent = fm5IdentityIncoherent
+		if authoritativeFM5Snapshot {
+			p.fm5RegistryEvidenceIgnored = !currentFM5Evidence
+			p.fm5IdentityObservedAt = p.now()
+		} else if currentFM5Evidence {
+			p.fm5RegistryEvidenceIgnored = false
+			if !fm5IdentityIncoherent {
+				p.fm5IdentityObservedAt = p.now()
+			}
+		}
 	}
 	p.mu.Unlock()
 
@@ -5610,13 +5684,13 @@ func (p *vaillantSemanticPoller) refreshFM5Semantic(ctx context.Context) {
 	incomingCylinders := make(map[byte]*vaillantCylinderSnapshot)
 	solarReadable := false
 	cylindersReadable := false
-	if evidence.controller != 0 && fm5GateSatisfied && !evidenceStale {
+	if evidence.controller != 0 && fm5GateSatisfied && !evidenceStale && !evidence.identityIncoherent {
 		incomingSolar, solarReadable = p.readSolarSnapshot(ctx)
 		incomingCylinders, cylindersReadable = p.readCylinderSnapshots(ctx)
 	}
 
 	currentEvidence := p.captureFM5Evidence()
-	incoherent := !evidence.sameGeneration(currentEvidence)
+	incoherent := evidence.identityIncoherent || currentEvidence.identityIncoherent || !evidence.sameGeneration(currentEvidence)
 	evidenceRevision := p.nextFM5EvidenceRevision(evidence.generation, currentEvidence.generation)
 	negativeIdentityObserved := evidence.hasNegativeObservation() && currentEvidence.hasNegativeObservation()
 	freshNegativeIdentityObserved := evidence.hasFreshNegativeObservation(observedAt, p.fm5EvidenceTTL) &&
@@ -5667,6 +5741,7 @@ type fm5EvidenceCapture struct {
 	registryCoherent            bool
 	registryEvidenceIgnored     bool
 	identityAcquisitionComplete bool
+	identityIncoherent          bool
 	identityObservedAt          time.Time
 	generation                  uint64
 }
@@ -5681,6 +5756,7 @@ func (p *vaillantSemanticPoller) captureFM5Evidence() fm5EvidenceCapture {
 		systemSnapshot:              cloneSystemSnapshot(p.system),
 		registryEvidenceIgnored:     p.fm5RegistryEvidenceIgnored,
 		identityAcquisitionComplete: p.fm5IdentityScanComplete,
+		identityIncoherent:          p.fm5IdentityIncoherent,
 		identityObservedAt:          p.fm5IdentityObservedAt,
 		generation:                  p.fm5EvidenceGeneration,
 		radioSnapshots:              make([]*vaillantRadioDeviceSnapshot, 0, len(p.radioDevices)),
@@ -5738,6 +5814,7 @@ func (capture fm5EvidenceCapture) sameGeneration(other fm5EvidenceCapture) bool 
 		uint16PointersEqual(capture.moduleConfig, other.moduleConfig) &&
 		capture.registryEvidenceIgnored == other.registryEvidenceIgnored &&
 		capture.identityAcquisitionComplete == other.identityAcquisitionComplete &&
+		capture.identityIncoherent == other.identityIncoherent &&
 		capture.identityObservedAt.Equal(other.identityObservedAt) &&
 		capture.registryGeneration == other.registryGeneration &&
 		capture.registryEvidence == other.registryEvidence
@@ -5756,6 +5833,7 @@ func (capture fm5EvidenceCapture) matchesLockedPoller(p *vaillantSemanticPoller)
 		uint16PointersEqual(capture.moduleConfig, moduleConfig) &&
 		capture.registryEvidenceIgnored == p.fm5RegistryEvidenceIgnored &&
 		capture.identityAcquisitionComplete == p.fm5IdentityScanComplete &&
+		capture.identityIncoherent == p.fm5IdentityIncoherent &&
 		capture.identityObservedAt.Equal(p.fm5IdentityObservedAt)
 }
 

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -5330,6 +5330,9 @@ func decodeFunctionalModuleIdentityTuple(
 			tuple.hardware = &value
 		}
 	}
+	if tuple.connected && !hasRemoteIdentityEvidence(tuple.classAddress, tuple.firmware, tuple.hardware) {
+		tuple.complete = false
+	}
 	return tuple
 }
 

--- a/graphql/fm5_interpretation_red_test.go
+++ b/graphql/fm5_interpretation_red_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestLiveSemanticProvider_FM5InterpretationIsAtomic(t *testing.T) {
 	provider := NewLiveSemanticProvider()
 	want := Fm5Interpretation{
-		Mode:             Fm5SemanticModeGPIOOnly,
+		Mode:             Fm5SemanticModeInterpreted,
 		DegradedReason:   Fm5SemanticDegradedReasonControllerUnreachable,
 		EvidenceRevision: "acq-9",
 	}
@@ -19,17 +19,31 @@ func TestLiveSemanticProvider_FM5InterpretationIsAtomic(t *testing.T) {
 	}
 }
 
-func TestFM5InterpretationValidationRejectsUnexplainedGPIOOnly(t *testing.T) {
+func TestLiveSemanticProvider_FM5InterpretationUnavailableBeforeFirstCoherentClassification(t *testing.T) {
+	provider := NewLiveSemanticProvider()
+
+	if got := provider.FM5Interpretation(); got != (Fm5Interpretation{}) {
+		t.Fatalf("FM5Interpretation() = %#v; want unavailable zero tuple", got)
+	}
+	if got := provider.FM5SemanticMode(); got != Fm5SemanticModeAbsent {
+		t.Fatalf("legacy FM5SemanticMode() = %s; want stable ABSENT scalar", got)
+	}
+}
+
+func TestFM5InterpretationValidationSeparatesStructuralModeFromTransientHealth(t *testing.T) {
 	tests := []struct {
 		name  string
 		value Fm5Interpretation
 		valid bool
 	}{
-		{"interpreted", Fm5Interpretation{Mode: Fm5SemanticModeInterpreted, EvidenceRevision: "acq-1"}, true},
-		{"absent", Fm5Interpretation{Mode: Fm5SemanticModeAbsent, EvidenceRevision: "acq-2"}, true},
-		{"explained gpio", Fm5Interpretation{Mode: Fm5SemanticModeGPIOOnly, DegradedReason: Fm5SemanticDegradedReasonEvidenceStale, EvidenceRevision: "acq-3"}, true},
-		{"unexplained gpio", Fm5Interpretation{Mode: Fm5SemanticModeGPIOOnly, EvidenceRevision: "acq-4"}, false},
-		{"reason on interpreted", Fm5Interpretation{Mode: Fm5SemanticModeInterpreted, DegradedReason: Fm5SemanticDegradedReasonSolarAcquisitionFailed, EvidenceRevision: "acq-5"}, false},
+		{"healthy interpreted", Fm5Interpretation{Mode: Fm5SemanticModeInterpreted, EvidenceRevision: "acq-1"}, true},
+		{"transient on interpreted", Fm5Interpretation{Mode: Fm5SemanticModeInterpreted, DegradedReason: Fm5SemanticDegradedReasonSolarAcquisitionFailed, EvidenceRevision: "acq-2"}, true},
+		{"healthy absent", Fm5Interpretation{Mode: Fm5SemanticModeAbsent, EvidenceRevision: "acq-3"}, true},
+		{"transient on absent", Fm5Interpretation{Mode: Fm5SemanticModeAbsent, DegradedReason: Fm5SemanticDegradedReasonControllerUnreachable, EvidenceRevision: "acq-4"}, true},
+		{"coherent unsupported configuration", Fm5Interpretation{Mode: Fm5SemanticModeGPIOOnly, DegradedReason: Fm5SemanticDegradedReasonConfigurationNotInterpretable, EvidenceRevision: "acq-5"}, true},
+		{"transient cannot create gpio", Fm5Interpretation{Mode: Fm5SemanticModeGPIOOnly, DegradedReason: Fm5SemanticDegradedReasonEvidenceStale, EvidenceRevision: "acq-6"}, false},
+		{"unexplained gpio", Fm5Interpretation{Mode: Fm5SemanticModeGPIOOnly, EvidenceRevision: "acq-7"}, false},
+		{"structural reason cannot accompany interpreted", Fm5Interpretation{Mode: Fm5SemanticModeInterpreted, DegradedReason: Fm5SemanticDegradedReasonConfigurationNotInterpretable, EvidenceRevision: "acq-8"}, false},
 		{"missing revision", Fm5Interpretation{Mode: Fm5SemanticModeAbsent}, false},
 	}
 	for _, test := range tests {
@@ -41,7 +55,7 @@ func TestFM5InterpretationValidationRejectsUnexplainedGPIOOnly(t *testing.T) {
 	}
 }
 
-func TestLiveSemanticProvider_LegacyGPIOOnlyCannotBecomeUnexplained(t *testing.T) {
+func TestLiveSemanticProvider_LegacyGPIOOnlyRemainsStableAndStructurallyExplained(t *testing.T) {
 	provider := NewLiveSemanticProvider()
 	provider.SetFM5SemanticMode(Fm5SemanticModeGPIOOnly)
 
@@ -49,7 +63,10 @@ func TestLiveSemanticProvider_LegacyGPIOOnlyCannotBecomeUnexplained(t *testing.T
 	if err := verdict.Validate(); err != nil {
 		t.Fatalf("legacy GPIO_ONLY verdict is invalid: %v", err)
 	}
-	if verdict.DegradedReason != Fm5SemanticDegradedReasonIncoherentAcquisition {
-		t.Fatalf("legacy GPIO_ONLY reason = %q; want %q", verdict.DegradedReason, Fm5SemanticDegradedReasonIncoherentAcquisition)
+	if verdict.DegradedReason != Fm5SemanticDegradedReasonConfigurationNotInterpretable {
+		t.Fatalf("legacy GPIO_ONLY reason = %q; want %q", verdict.DegradedReason, Fm5SemanticDegradedReasonConfigurationNotInterpretable)
+	}
+	if got := provider.FM5SemanticMode(); got != Fm5SemanticModeGPIOOnly {
+		t.Fatalf("legacy FM5SemanticMode() = %s; want stable GPIO_ONLY scalar", got)
 	}
 }

--- a/graphql/promoted_semantic.go
+++ b/graphql/promoted_semantic.go
@@ -132,7 +132,7 @@ func (p promotedSemanticProvider) FM5Interpretation() Fm5Interpretation {
 	if provider, ok := p.base.(FM5InterpretationProvider); ok {
 		return provider.FM5Interpretation()
 	}
-	return legacyFM5Interpretation(p.base.FM5SemanticMode())
+	return Fm5Interpretation{}
 }
 func (p promotedSemanticProvider) Solar() *SolarStatus         { return p.base.Solar() }
 func (p promotedSemanticProvider) Cylinders() []CylinderStatus { return p.base.Cylinders() }

--- a/graphql/promoted_semantic_test.go
+++ b/graphql/promoted_semantic_test.go
@@ -6,6 +6,15 @@ import (
 	graphqlgo "github.com/graphql-go/graphql"
 )
 
+type promotedLegacyFM5Provider struct {
+	SemanticProvider
+	mode Fm5SemanticMode
+}
+
+func (provider promotedLegacyFM5Provider) FM5SemanticMode() Fm5SemanticMode {
+	return provider.mode
+}
+
 func TestPromotedSemanticGraphQL_AllEighteenValuesFillOnlyMissing(t *testing.T) {
 	base := NewLiveSemanticProvider()
 	ebusTemp := 19.5
@@ -61,6 +70,27 @@ func TestPromotedSemanticOverlayDoesNotCreateZonesOrSurviveClear(t *testing.T) {
 	o = PromotedSemanticOverlay{}
 	if zones := provider.Zones(); zones[0].Config.SourceLabel != nil {
 		t.Fatalf("cleared overlay retained value: %#v", zones[0])
+	}
+}
+
+func TestPromotedSemanticProvider_LegacyOnlyFM5InterpretationIsUnavailable(t *testing.T) {
+	base := promotedLegacyFM5Provider{
+		SemanticProvider: NewLiveSemanticProvider(),
+		mode:             Fm5SemanticModeGPIOOnly,
+	}
+	provider := NewPromotedSemanticProvider(base, func() PromotedSemanticOverlay {
+		return PromotedSemanticOverlay{}
+	})
+
+	if got := provider.FM5SemanticMode(); got != Fm5SemanticModeGPIOOnly {
+		t.Fatalf("legacy FM5 scalar = %s; want stable GPIO_ONLY", got)
+	}
+	interpretationProvider, ok := provider.(FM5InterpretationProvider)
+	if !ok {
+		t.Fatal("promoted provider does not expose FM5InterpretationProvider")
+	}
+	if got := interpretationProvider.FM5Interpretation(); got != (Fm5Interpretation{}) {
+		t.Fatalf("legacy-only promoted FM5 interpretation = %#v; want unavailable zero tuple", got)
 	}
 }
 

--- a/graphql/queries.go
+++ b/graphql/queries.go
@@ -5125,7 +5125,7 @@ func buildQueryType(builder *Builder, types graphqlSchemaTypes) *graphqlgo.Objec
 						}
 						return verdict, nil
 					}
-					return legacyFM5Interpretation(provider.FM5SemanticMode()), nil
+					return nil, nil
 				},
 			},
 			"fm5_semantic_mode": &graphqlgo.Field{

--- a/graphql/queries.go
+++ b/graphql/queries.go
@@ -5112,11 +5112,14 @@ func buildQueryType(builder *Builder, types graphqlSchemaTypes) *graphqlgo.Objec
 				},
 			},
 			"fm5Interpretation": &graphqlgo.Field{
-				Type: graphqlgo.NewNonNull(types.fm5Interpretation),
+				Type: types.fm5Interpretation,
 				Resolve: func(params graphqlgo.ResolveParams) (any, error) {
 					provider := builder.semanticProvider()
 					if typed, ok := provider.(FM5InterpretationProvider); ok {
 						verdict := typed.FM5Interpretation()
+						if verdict == (Fm5Interpretation{}) {
+							return nil, nil
+						}
 						if err := verdict.Validate(); err != nil {
 							return nil, err
 						}

--- a/graphql/queries_test.go
+++ b/graphql/queries_test.go
@@ -54,6 +54,15 @@ func (provider testGatewayIdentityProvider) GatewayIdentity() GatewayIdentity {
 	return provider.identity
 }
 
+type legacyFM5ScalarOnlyProvider struct {
+	SemanticProvider
+	mode Fm5SemanticMode
+}
+
+func (provider legacyFM5ScalarOnlyProvider) FM5SemanticMode() Fm5SemanticMode {
+	return provider.mode
+}
+
 type driftingBusObservabilityProvider struct {
 	mu    sync.Mutex
 	calls int
@@ -2228,5 +2237,42 @@ func TestQueryResolvers_FM5InterpretationNullBeforeFirstCoherentClassification(t
 	}
 	if got, ok := response.Data["fm5Interpretation"]; !ok || got != nil {
 		t.Fatalf("fm5Interpretation = %#v present=%t; want explicit null", got, ok)
+	}
+}
+
+func TestQueryResolvers_FM5InterpretationNullForLegacyScalarOnlyProvider(t *testing.T) {
+	builder := NewBuilder(registry.NewDeviceRegistry(nil), nil)
+	builder.SetSemanticProvider(legacyFM5ScalarOnlyProvider{
+		SemanticProvider: NewLiveSemanticProvider(),
+		mode:             Fm5SemanticModeGPIOOnly,
+	})
+	handler, err := NewHandler(builder)
+	if err != nil {
+		t.Fatalf("NewHandler error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/graphql", strings.NewReader(`{"query":"{ fm5SemanticMode fm5Interpretation { mode degradedReason evidenceRevision } }"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var response struct {
+		Data   map[string]any `json:"data"`
+		Errors []any          `json:"errors"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("json.Unmarshal response: %v body=%s", err, rec.Body.String())
+	}
+	if len(response.Errors) != 0 {
+		t.Fatalf("errors = %#v; want none", response.Errors)
+	}
+	if got := response.Data["fm5SemanticMode"]; got != string(Fm5SemanticModeGPIOOnly) {
+		t.Fatalf("legacy fm5SemanticMode = %#v; want stable GPIO_ONLY", got)
+	}
+	if got, ok := response.Data["fm5Interpretation"]; !ok || got != nil {
+		t.Fatalf("legacy-only fm5Interpretation = %#v present=%t; want explicit null", got, ok)
 	}
 }

--- a/graphql/queries_test.go
+++ b/graphql/queries_test.go
@@ -1210,7 +1210,7 @@ func TestQueryResolvers_Integration(t *testing.T) {
 		associatedCircuit := 1
 		roomTemperatureZoneMapping := 2
 		semantic.SetFM5Interpretation(Fm5Interpretation{
-			Mode:             Fm5SemanticModeGPIOOnly,
+			Mode:             Fm5SemanticModeInterpreted,
 			DegradedReason:   Fm5SemanticDegradedReasonEvidenceStale,
 			EvidenceRevision: "fm5-g7-a3",
 		})
@@ -1545,11 +1545,11 @@ func TestQueryResolvers_Integration(t *testing.T) {
 		if len(response.RadioDevices) != 0 {
 			t.Fatalf("radioDevices = %d; want 0", len(response.RadioDevices))
 		}
-		if response.FM5SemanticMode != "GPIO_ONLY" {
-			t.Fatalf("fm5SemanticMode = %q; want GPIO_ONLY", response.FM5SemanticMode)
+		if response.FM5SemanticMode != "INTERPRETED" {
+			t.Fatalf("fm5SemanticMode = %q; want INTERPRETED", response.FM5SemanticMode)
 		}
-		if response.FM5Interpretation.Mode != "GPIO_ONLY" || response.FM5Interpretation.DegradedReason == nil || *response.FM5Interpretation.DegradedReason != "EVIDENCE_STALE" || response.FM5Interpretation.EvidenceRevision != "fm5-g7-a3" {
-			t.Fatalf("fm5Interpretation = %#v; want GPIO_ONLY/EVIDENCE_STALE/fm5-g7-a3", response.FM5Interpretation)
+		if response.FM5Interpretation.Mode != "INTERPRETED" || response.FM5Interpretation.DegradedReason == nil || *response.FM5Interpretation.DegradedReason != "EVIDENCE_STALE" || response.FM5Interpretation.EvidenceRevision != "fm5-g7-a3" {
+			t.Fatalf("fm5Interpretation = %#v; want INTERPRETED/EVIDENCE_STALE/fm5-g7-a3", response.FM5Interpretation)
 		}
 		if response.Solar != nil {
 			t.Fatalf("solar expected nil with static provider")
@@ -2194,5 +2194,39 @@ func TestQueryResolvers_DevicesReflectLateRegistryPopulation(t *testing.T) {
 	}
 	if response.Devices[0].Address != 21 || response.Devices[0].DeviceID != "BASV2" {
 		t.Fatalf("device payload = %+v; want address=21 deviceId=BASV2", response.Devices[0])
+	}
+}
+
+func TestQueryResolvers_FM5InterpretationNullBeforeFirstCoherentClassification(t *testing.T) {
+	builder := NewBuilder(registry.NewDeviceRegistry(nil), nil)
+	builder.SetSemanticProvider(NewLiveSemanticProvider())
+	handler, err := NewHandler(builder)
+	if err != nil {
+		t.Fatalf("NewHandler error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/graphql", strings.NewReader(`{"query":"{ fm5SemanticMode fm5Interpretation { mode degradedReason evidenceRevision } }"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var response struct {
+		Data   map[string]any `json:"data"`
+		Errors []any          `json:"errors"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("json.Unmarshal response: %v body=%s", err, rec.Body.String())
+	}
+	if len(response.Errors) != 0 {
+		t.Fatalf("errors = %#v; want none", response.Errors)
+	}
+	if got := response.Data["fm5SemanticMode"]; got != string(Fm5SemanticModeAbsent) {
+		t.Fatalf("legacy fm5SemanticMode = %#v; want stable ABSENT", got)
+	}
+	if got, ok := response.Data["fm5Interpretation"]; !ok || got != nil {
+		t.Fatalf("fm5Interpretation = %#v present=%t; want explicit null", got, ok)
 	}
 }

--- a/graphql/semantic.go
+++ b/graphql/semantic.go
@@ -160,12 +160,12 @@ func (value Fm5Interpretation) Validate() error {
 	}
 	switch value.Mode {
 	case Fm5SemanticModeInterpreted, Fm5SemanticModeAbsent:
-		if value.DegradedReason != "" {
-			return errors.New("fm5 degraded reason is forbidden outside GPIO_ONLY")
+		if value.DegradedReason != "" && !validFm5TransientDegradedReason(value.DegradedReason) {
+			return errors.New("fm5 retained structural mode requires a transient degraded reason")
 		}
 	case Fm5SemanticModeGPIOOnly:
-		if !validFm5SemanticDegradedReason(value.DegradedReason) {
-			return errors.New("fm5 GPIO_ONLY requires one closed degraded reason")
+		if value.DegradedReason != Fm5SemanticDegradedReasonConfigurationNotInterpretable {
+			return errors.New("fm5 GPIO_ONLY requires CONFIGURATION_NOT_INTERPRETABLE")
 		}
 	default:
 		return errors.New("invalid fm5 semantic mode")
@@ -188,13 +188,18 @@ func validFm5SemanticDegradedReason(reason Fm5SemanticDegradedReason) bool {
 	}
 }
 
+func validFm5TransientDegradedReason(reason Fm5SemanticDegradedReason) bool {
+	return validFm5SemanticDegradedReason(reason) &&
+		reason != Fm5SemanticDegradedReasonConfigurationNotInterpretable
+}
+
 func legacyFM5Interpretation(mode Fm5SemanticMode) Fm5Interpretation {
 	if mode == "" {
 		mode = Fm5SemanticModeAbsent
 	}
 	verdict := Fm5Interpretation{Mode: mode, EvidenceRevision: "legacy"}
 	if mode == Fm5SemanticModeGPIOOnly {
-		verdict.DegradedReason = Fm5SemanticDegradedReasonIncoherentAcquisition
+		verdict.DegradedReason = Fm5SemanticDegradedReasonConfigurationNotInterpretable
 	}
 	return verdict
 }

--- a/graphql/semantic_live.go
+++ b/graphql/semantic_live.go
@@ -101,7 +101,6 @@ func NewLiveSemanticProvider() *LiveSemanticProvider {
 		phase:            SemanticStartupPhaseBootInit,
 		startupUpdatedAt: time.Now().UTC(),
 		fm5Mode:          Fm5SemanticModeAbsent,
-		fm5Verdict:       Fm5Interpretation{Mode: Fm5SemanticModeAbsent, EvidenceRevision: "initial"},
 		energyMerge:      newEnergyMergeStore(),
 	}
 }
@@ -259,18 +258,11 @@ func (provider *LiveSemanticProvider) FM5SemanticMode() Fm5SemanticMode {
 
 func (provider *LiveSemanticProvider) FM5Interpretation() Fm5Interpretation {
 	if provider == nil {
-		return Fm5Interpretation{Mode: Fm5SemanticModeAbsent, EvidenceRevision: "initial"}
+		return Fm5Interpretation{}
 	}
 	provider.mu.RLock()
 	defer provider.mu.RUnlock()
-	verdict := provider.fm5Verdict
-	if verdict.Mode == "" {
-		verdict.Mode = Fm5SemanticModeAbsent
-	}
-	if strings.TrimSpace(verdict.EvidenceRevision) == "" {
-		verdict.EvidenceRevision = "legacy"
-	}
-	return verdict
+	return provider.fm5Verdict
 }
 
 func (provider *LiveSemanticProvider) Solar() *SolarStatus {

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -326,29 +326,28 @@ func (value Fm5Interpretation) validate() error {
 		return errors.New("fm5 evidence revision is required")
 	}
 	if value.Mode == Fm5SemanticModeGPIOOnly {
-		if value.DegradedReason == nil || strings.TrimSpace(string(*value.DegradedReason)) == "" {
-			return errors.New("fm5 GPIO_ONLY requires a degraded reason")
-		}
-		switch *value.DegradedReason {
-		case "CONTROLLER_UNREACHABLE",
-			"CONFIGURATION_UNAVAILABLE",
-			"CONFIGURATION_NOT_INTERPRETABLE",
-			"SOLAR_ACQUISITION_FAILED",
-			"CYLINDER_ACQUISITION_FAILED",
-			"EVIDENCE_STALE",
-			"INCOHERENT_ACQUISITION":
-		default:
-			return errors.New("fm5 degraded reason is outside the closed set")
+		if value.DegradedReason == nil || *value.DegradedReason != "CONFIGURATION_NOT_INTERPRETABLE" {
+			return errors.New("fm5 GPIO_ONLY requires CONFIGURATION_NOT_INTERPRETABLE")
 		}
 		return nil
 	}
 	if value.Mode != Fm5SemanticModeInterpreted && value.Mode != Fm5SemanticModeAbsent {
 		return errors.New("invalid fm5 semantic mode")
 	}
-	if value.DegradedReason != nil {
-		return errors.New("fm5 degraded reason is forbidden outside GPIO_ONLY")
+	if value.DegradedReason == nil {
+		return nil
 	}
-	return nil
+	switch *value.DegradedReason {
+	case "CONTROLLER_UNREACHABLE",
+		"CONFIGURATION_UNAVAILABLE",
+		"SOLAR_ACQUISITION_FAILED",
+		"CYLINDER_ACQUISITION_FAILED",
+		"EVIDENCE_STALE",
+		"INCOHERENT_ACQUISITION":
+		return nil
+	default:
+		return errors.New("fm5 retained structural mode requires a transient degraded reason")
+	}
 }
 
 func legacyFM5Interpretation(mode Fm5SemanticMode) Fm5Interpretation {
@@ -357,7 +356,7 @@ func legacyFM5Interpretation(mode Fm5SemanticMode) Fm5Interpretation {
 	}
 	verdict := Fm5Interpretation{Mode: mode, EvidenceRevision: "legacy"}
 	if mode == Fm5SemanticModeGPIOOnly {
-		reason := Fm5SemanticDegradedReason("INCOHERENT_ACQUISITION")
+		reason := Fm5SemanticDegradedReason("CONFIGURATION_NOT_INTERPRETABLE")
 		verdict.DegradedReason = &reason
 	}
 	return verdict
@@ -1607,6 +1606,9 @@ func (s *Server) handleToolsCall(ctx context.Context, params json.RawMessage) (a
 			return callToolResultText(mustJSON(newToolEnvelope(nil, err)), true), nil
 		}
 		verdict := s.snapshotFM5Interpretation(snapshot)
+		if verdict == (Fm5Interpretation{}) {
+			return callToolResultText(mustJSON(newToolEnvelopeWithConsistency(nil, nil, consistency)), false), nil
+		}
 		if err := verdict.validate(); err != nil {
 			return callToolResultText(mustJSON(newToolEnvelope(nil, err)), true), nil
 		}
@@ -3065,12 +3067,7 @@ func (s *Server) snapshotFM5Mode(snapshot *snapshotState) Fm5SemanticMode {
 
 func (s *Server) snapshotFM5Interpretation(snapshot *snapshotState) Fm5Interpretation {
 	if snapshot != nil {
-		verdict := snapshot.fm5Verdict
-		if verdict.Mode == "" {
-			verdict.Mode = s.snapshotFM5Mode(snapshot)
-			verdict = legacyFM5Interpretation(s.snapshotFM5Mode(snapshot))
-		}
-		return verdict
+		return snapshot.fm5Verdict
 	}
 	if s != nil && s.semantic != nil {
 		if provider, ok := s.semantic.(FM5InterpretationProvider); ok {

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -350,18 +350,6 @@ func (value Fm5Interpretation) validate() error {
 	}
 }
 
-func legacyFM5Interpretation(mode Fm5SemanticMode) Fm5Interpretation {
-	if mode == "" {
-		mode = Fm5SemanticModeAbsent
-	}
-	verdict := Fm5Interpretation{Mode: mode, EvidenceRevision: "legacy"}
-	if mode == Fm5SemanticModeGPIOOnly {
-		reason := Fm5SemanticDegradedReason("CONFIGURATION_NOT_INTERPRETABLE")
-		verdict.DegradedReason = &reason
-	}
-	return verdict
-}
-
 type FM5InterpretationProvider interface {
 	FM5Interpretation() Fm5Interpretation
 }
@@ -3074,7 +3062,7 @@ func (s *Server) snapshotFM5Interpretation(snapshot *snapshotState) Fm5Interpret
 			return provider.FM5Interpretation()
 		}
 	}
-	return legacyFM5Interpretation(s.snapshotFM5Mode(nil))
+	return Fm5Interpretation{}
 }
 
 func (s *Server) snapshotSolar(snapshot *snapshotState) *SolarStatus {

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -1386,17 +1386,25 @@ func TestServer_ToolsCallSemanticSnapshots(t *testing.T) {
 	})
 
 	t.Run("fm5 interpretation payload is atomic", func(t *testing.T) {
-		for index, reason := range []Fm5SemanticDegradedReason{"EVIDENCE_STALE", "INCOHERENT_ACQUISITION"} {
-			t.Run(string(reason), func(t *testing.T) {
+		tests := []struct {
+			mode   Fm5SemanticMode
+			reason Fm5SemanticDegradedReason
+		}{
+			{Fm5SemanticModeInterpreted, "EVIDENCE_STALE"},
+			{Fm5SemanticModeAbsent, "INCOHERENT_ACQUISITION"},
+			{Fm5SemanticModeGPIOOnly, "CONFIGURATION_NOT_INTERPRETABLE"},
+		}
+		for index, test := range tests {
+			t.Run(string(test.mode)+"/"+string(test.reason), func(t *testing.T) {
 				verdictServer, err := NewServer(reg, &testInvoker{})
 				if err != nil {
 					t.Fatalf("NewServer error = %v", err)
 				}
 				verdictServer.SetSemanticProvider(testFM5InterpretationProvider{
-					testSemanticProvider: testSemanticProvider{fm5Mode: Fm5SemanticModeGPIOOnly},
+					testSemanticProvider: testSemanticProvider{fm5Mode: test.mode},
 					verdict: Fm5Interpretation{
-						Mode:             Fm5SemanticModeGPIOOnly,
-						DegradedReason:   &reason,
+						Mode:             test.mode,
+						DegradedReason:   &test.reason,
 						EvidenceRevision: "fm5-g7-a17",
 					},
 				})
@@ -1412,11 +1420,11 @@ func TestServer_ToolsCallSemanticSnapshots(t *testing.T) {
 				if !ok {
 					t.Fatalf("fm5 interpretation data type = %T; want map", envelope["data"])
 				}
-				if got := data["mode"]; got != string(Fm5SemanticModeGPIOOnly) {
-					t.Fatalf("fm5 interpretation mode = %v; want %s", got, Fm5SemanticModeGPIOOnly)
+				if got := data["mode"]; got != string(test.mode) {
+					t.Fatalf("fm5 interpretation mode = %v; want %s", got, test.mode)
 				}
-				if got := data["degraded_reason"]; got != string(reason) {
-					t.Fatalf("fm5 interpretation degraded_reason = %v; want %s", got, reason)
+				if got := data["degraded_reason"]; got != string(test.reason) {
+					t.Fatalf("fm5 interpretation degraded_reason = %v; want %s", got, test.reason)
 				}
 				if got := data["evidence_revision"]; got != "fm5-g7-a17" {
 					t.Fatalf("fm5 interpretation evidence_revision = %v; want fm5-g7-a17", got)
@@ -1425,22 +1433,45 @@ func TestServer_ToolsCallSemanticSnapshots(t *testing.T) {
 		}
 	})
 
-	t.Run("fm5 interpretation rejects unexplained GPIO only", func(t *testing.T) {
+	t.Run("fm5 interpretation is null before first coherent classification", func(t *testing.T) {
+		unavailableServer, err := NewServer(reg, &testInvoker{})
+		if err != nil {
+			t.Fatalf("NewServer error = %v", err)
+		}
+		unavailableServer.SetSemanticProvider(testFM5InterpretationProvider{
+			testSemanticProvider: testSemanticProvider{fm5Mode: Fm5SemanticModeAbsent},
+		})
+
+		res := doRPC(t, unavailableServer.Handler(), rpcRequest{
+			JSONRPC: "2.0",
+			ID:      24,
+			Method:  "tools/call",
+			Params:  json.RawMessage(`{"name":"ebus.v1.semantic.fm5_interpretation.get","arguments":{}}`),
+		})
+		envelope := envelopeFromResult(t, res)
+		if envelope["data"] != nil || envelope["error"] != nil {
+			t.Fatalf("unavailable FM5 envelope = %#v; want data=null error=null", envelope)
+		}
+	})
+
+	t.Run("fm5 interpretation rejects transient GPIO only", func(t *testing.T) {
 		invalidServer, err := NewServer(reg, &testInvoker{})
 		if err != nil {
 			t.Fatalf("NewServer error = %v", err)
 		}
+		reason := Fm5SemanticDegradedReason("EVIDENCE_STALE")
 		invalidServer.SetSemanticProvider(testFM5InterpretationProvider{
 			testSemanticProvider: testSemanticProvider{fm5Mode: Fm5SemanticModeGPIOOnly},
 			verdict: Fm5Interpretation{
 				Mode:             Fm5SemanticModeGPIOOnly,
+				DegradedReason:   &reason,
 				EvidenceRevision: "fm5-acq-invalid",
 			},
 		})
 
 		res := doRPC(t, invalidServer.Handler(), rpcRequest{
 			JSONRPC: "2.0",
-			ID:      24,
+			ID:      25,
 			Method:  "tools/call",
 			Params:  json.RawMessage(`{"name":"ebus.v1.semantic.fm5_interpretation.get","arguments":{}}`),
 		})

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -1454,6 +1454,34 @@ func TestServer_ToolsCallSemanticSnapshots(t *testing.T) {
 		}
 	})
 
+	t.Run("fm5 interpretation is null for legacy scalar only provider", func(t *testing.T) {
+		legacyServer, err := NewServer(reg, &testInvoker{})
+		if err != nil {
+			t.Fatalf("NewServer error = %v", err)
+		}
+		legacyServer.SetSemanticProvider(testSemanticProvider{fm5Mode: Fm5SemanticModeGPIOOnly})
+
+		modeEnvelope := envelopeFromResult(t, doRPC(t, legacyServer.Handler(), rpcRequest{
+			JSONRPC: "2.0",
+			ID:      25,
+			Method:  "tools/call",
+			Params:  json.RawMessage(`{"name":"ebus.v1.semantic.fm5_mode.get","arguments":{}}`),
+		}))
+		if got := modeEnvelope["data"]; got != string(Fm5SemanticModeGPIOOnly) {
+			t.Fatalf("legacy fm5 mode = %#v; want stable GPIO_ONLY", got)
+		}
+
+		interpretationEnvelope := envelopeFromResult(t, doRPC(t, legacyServer.Handler(), rpcRequest{
+			JSONRPC: "2.0",
+			ID:      26,
+			Method:  "tools/call",
+			Params:  json.RawMessage(`{"name":"ebus.v1.semantic.fm5_interpretation.get","arguments":{}}`),
+		}))
+		if interpretationEnvelope["data"] != nil || interpretationEnvelope["error"] != nil {
+			t.Fatalf("legacy-only FM5 envelope = %#v; want data=null error=null", interpretationEnvelope)
+		}
+	})
+
 	t.Run("fm5 interpretation rejects transient GPIO only", func(t *testing.T) {
 		invalidServer, err := NewServer(reg, &testInvoker{})
 		if err != nil {
@@ -1471,7 +1499,7 @@ func TestServer_ToolsCallSemanticSnapshots(t *testing.T) {
 
 		res := doRPC(t, invalidServer.Handler(), rpcRequest{
 			JSONRPC: "2.0",
-			ID:      25,
+			ID:      27,
 			Method:  "tools/call",
 			Params:  json.RawMessage(`{"name":"ebus.v1.semantic.fm5_interpretation.get","arguments":{}}`),
 		})

--- a/portal/handler.go
+++ b/portal/handler.go
@@ -113,6 +113,28 @@ type SemanticSnapshot struct {
 	CapturedUTC         string                `json:"captured_utc"`
 }
 
+func (snapshot SemanticSnapshot) MarshalJSON() ([]byte, error) {
+	type semanticSnapshotJSON SemanticSnapshot
+	if snapshot.FM5Mode == "" {
+		unavailable := snapshot
+		unavailable.FM5DegradedReason = nil
+		unavailable.FM5EvidenceRevision = ""
+		return json.Marshal(semanticSnapshotJSON(unavailable))
+	}
+	reason := snapshot.FM5DegradedReason
+	return json.Marshal(struct {
+		semanticSnapshotJSON
+		FM5Mode             string   `json:"fm5_semantic_mode"`
+		FM5DegradedReason   **string `json:"fm5_semantic_degraded_reason"`
+		FM5EvidenceRevision string   `json:"fm5_semantic_evidence_revision"`
+	}{
+		semanticSnapshotJSON: semanticSnapshotJSON(snapshot),
+		FM5Mode:              snapshot.FM5Mode,
+		FM5DegradedReason:    &reason,
+		FM5EvidenceRevision:  snapshot.FM5EvidenceRevision,
+	})
+}
+
 type SemanticAdapterInfo struct {
 	FirmwareVersion    string   `json:"firmware_version"`
 	FirmwareChecksum   string   `json:"firmware_checksum,omitempty"`

--- a/portal/handler.go
+++ b/portal/handler.go
@@ -105,7 +105,7 @@ type SemanticSnapshot struct {
 	Circuits            []SemanticCircuit     `json:"circuits,omitempty"`
 	RadioDevices        []SemanticRadioDevice `json:"radio_devices,omitempty"`
 	FM5Mode             string                `json:"fm5_semantic_mode,omitempty"`
-	FM5DegradedReason   *string               `json:"fm5_semantic_degraded_reason"`
+	FM5DegradedReason   *string               `json:"fm5_semantic_degraded_reason,omitempty"`
 	FM5EvidenceRevision string                `json:"fm5_semantic_evidence_revision,omitempty"`
 	Solar               *SemanticSolarStatus  `json:"solar,omitempty"`
 	Cylinders           []SemanticCylinder    `json:"cylinders,omitempty"`

--- a/portal/handler_test.go
+++ b/portal/handler_test.go
@@ -706,8 +706,10 @@ func TestSemanticSnapshotEndpoint_PromotedFieldsArePublicAndNilSafe(t *testing.T
 	}
 }
 
-func TestSemanticSnapshotEndpoint_DefaultWhenMissingProvider(t *testing.T) {
-	h := NewHandler(Options{})
+func TestSemanticSnapshotEndpoint_UnavailableFM5FieldsAreOmitted(t *testing.T) {
+	h := NewHandler(Options{
+		ListSemantic: func() SemanticSnapshot { return SemanticSnapshot{} },
+	})
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/semantic/snapshot", nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
@@ -721,6 +723,15 @@ func TestSemanticSnapshotEndpoint_DefaultWhenMissingProvider(t *testing.T) {
 	zones := payload["zones"].([]any)
 	if len(zones) != 0 {
 		t.Fatalf("zones=%d; want 0", len(zones))
+	}
+	for _, field := range []string{
+		"fm5_semantic_mode",
+		"fm5_semantic_degraded_reason",
+		"fm5_semantic_evidence_revision",
+	} {
+		if value, ok := payload[field]; ok {
+			t.Fatalf("unavailable FM5 field %q published as %#v; want omitted", field, value)
+		}
 	}
 }
 

--- a/portal/handler_test.go
+++ b/portal/handler_test.go
@@ -817,8 +817,12 @@ func TestSemanticSnapshotEndpoint_ExtensionFamilies(t *testing.T) {
 	if payload["fm5_semantic_mode"] != "INTERPRETED" {
 		t.Fatalf("fm5_semantic_mode=%v; want INTERPRETED", payload["fm5_semantic_mode"])
 	}
-	if payload["fm5_semantic_degraded_reason"] != nil {
-		t.Fatalf("fm5_semantic_degraded_reason=%v; want null", payload["fm5_semantic_degraded_reason"])
+	reason, reasonPresent := payload["fm5_semantic_degraded_reason"]
+	if !reasonPresent {
+		t.Fatal("fm5_semantic_degraded_reason omitted for available healthy verdict; want explicit null")
+	}
+	if reason != nil {
+		t.Fatalf("fm5_semantic_degraded_reason=%v; want null", reason)
 	}
 	if payload["fm5_semantic_evidence_revision"] != "fm5-acq-7" {
 		t.Fatalf("fm5_semantic_evidence_revision=%v; want fm5-acq-7", payload["fm5_semantic_evidence_revision"])


### PR DESCRIPTION
Closes #815.

Implements the post-M9 FM5 defect node from execution-plans #92 after canonical docs gates:
- docs-eebus `6f8154011c36f4811db473fea03db8544ab488bc`
- docs-ebus `5b536c68d06abe366410565672b5e1d9bb22469a`

Scope is limited to structural-mode retention, bootstrap null/unpublished behavior, and one provider-owned tuple through MCP/GraphQL/Portal. No eeBUS auth/SHIP/SPINE, Modbus, add-on, HA, transport, or live work.

Public RED: `c1ec8b2124f82af4c1c30bc43f425c56d0a736d5`.

T01..T88: N/A; no transport/protocol framing or request-path change. Full gateway regression CI remains mandatory before merge.
