### PR TITLE
Post-M9: consume eebusreg retry-ready recovery release

### DIFF
--- a/cmd/gateway/eebus_operator_boundary_red_test.go
+++ b/cmd/gateway/eebus_operator_boundary_red_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 )
 
-func TestIssue809ReleasedDependencyClosurePinsEEBusregV0131(t *testing.T) {
+func TestIssue819ReleasedDependencyClosurePinsEEBusregV0132(t *testing.T) {
 	goMod, err := os.Open("../../go.mod")
 	if err != nil {
 		t.Fatal(err)
@@ -33,8 +33,8 @@ func TestIssue809ReleasedDependencyClosurePinsEEBusregV0131(t *testing.T) {
 	if err := scanner.Err(); err != nil {
 		t.Fatal(err)
 	}
-	if len(versions) != 1 || versions[0] != "v0.1.31" {
-		t.Fatalf("%s versions = %v, want exactly [v0.1.31]", module, versions)
+	if len(versions) != 1 || versions[0] != "v0.1.32" {
+		t.Fatalf("%s versions = %v, want exactly [v0.1.32]", module, versions)
 	}
 }
 

--- a/eebusreg_v0114_contract_test.go
+++ b/eebusreg_v0114_contract_test.go
@@ -25,7 +25,7 @@ const (
 // This source-level contract is retained because it proves the declared and
 // selected transitive release graph; runtime behavior cannot detect an
 // accidental downgrade or a local replace directive.
-func TestIssue809ReleasedEEBusDependencyClosure(t *testing.T) {
+func TestIssue819ReleasedEEBusDependencyClosure(t *testing.T) {
 	contents, err := os.ReadFile("go.mod")
 	if err != nil {
 		t.Fatalf("read go.mod: %v", err)
@@ -39,7 +39,7 @@ func TestIssue809ReleasedEEBusDependencyClosure(t *testing.T) {
 	}
 
 	want := map[string]string{
-		eebusregModule: "v0.1.31",
+		eebusregModule: "v0.1.32",
 		eebusgoModule:  "v0.7.1-helianthus.17",
 		shipgoModule:   "v0.6.1-helianthus.15",
 		spinegoModule:  "v0.7.1-helianthus.9",

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260521144203-f9919f4b1007
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260813222631-92a35b3ec2eb
-	github.com/Project-Helianthus/helianthus-eebusreg v0.1.31
+	github.com/Project-Helianthus/helianthus-eebusreg v0.1.32
 	github.com/Project-Helianthus/helianthus-modbus v0.0.0-20260810083147-eab30aed9eb6
 	github.com/Project-Helianthus/helianthus-modbusreg v0.2.0
 	github.com/grandcat/zeroconf v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.17 h1:JI+MbI
 github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.17/go.mod h1:a2alpEsrFkG70XPP7Ab+fpe1oA5MBmfZUSarcMuJtMQ=
 github.com/Project-Helianthus/helianthus-eebusreg v0.1.31 h1:N6S/XxqWbOOPGCteOXYNvTfIeUtpQenvDlzayFmzQy4=
 github.com/Project-Helianthus/helianthus-eebusreg v0.1.31/go.mod h1:zicxGucHssiyjsA186nACwFfu3kUDEixIcY2b7DleEM=
+github.com/Project-Helianthus/helianthus-eebusreg v0.1.32 h1:HPDEHF+YjR+Z+S63YfNeTYAPFGbZJWrEUUC4fWfMhNo=
+github.com/Project-Helianthus/helianthus-eebusreg v0.1.32/go.mod h1:zicxGucHssiyjsA186nACwFfu3kUDEixIcY2b7DleEM=
 github.com/Project-Helianthus/helianthus-modbus v0.0.0-20260810083147-eab30aed9eb6 h1:+l+s7VBz51iKqZYhm081RydM439iPM/Uf6bubzvA3/4=
 github.com/Project-Helianthus/helianthus-modbus v0.0.0-20260810083147-eab30aed9eb6/go.mod h1:Nr8SW7fE3SIjnp+rj8PCOtwk8JZ9wqafu1ZCgq3Zz+Q=
 github.com/Project-Helianthus/helianthus-modbusreg v0.2.0 h1:V8kWhn7dEzjpcaaQultjAble5wGlU5lloK9b6i7HOkc=


### PR DESCRIPTION
Closes #819.

Pins helianthus-eebusreg v0.1.32, whose release contains the exact identity-bound AdminV1 RETRY_READY recovery admission. This PR changes only dependency closure and its exact-version regression; no gateway runtime, transport, Portal, HA, add-on, Modbus, or live behavior is changed.

Docs gate: helianthus-docs-eebus merge 6b0cc60b72cf7428793030a4099c58151cb374ec.

RED: 5c1a7fb4bfb041494c849bb1070d62274669b566.

T01..T88: N/A, dependency-only adoption with no wire/transport source change.