### PR TITLE
Fronius R6B: retain canonical SunSpec qualification before GO

### DIFF
--- a/cmd/gateway/modbus_mcp_provider.go
+++ b/cmd/gateway/modbus_mcp_provider.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/modbusadapter"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
 	modbus "github.com/Project-Helianthus/helianthus-modbus"
+	modbusreg "github.com/Project-Helianthus/helianthus-modbusreg"
 )
 
 type gatewayModbusMCPProvider struct {
@@ -30,6 +31,7 @@ type gatewayModbusMCPProvider struct {
 type modbusMCPAdapter interface {
 	ExecuteRead(context.Context, modbusadapter.ReadPlan) (modbus.TCPReadBatch, error)
 	ProfileObservation(string, string) (modbusadapter.ProfileObservationRecord, bool)
+	SunSpecQualificationObservation(string, string) (modbusreg.SunSpecQualificationObservation, []byte, bool)
 }
 
 func newGatewayModbusMCPProvider(adapter *modbusadapter.Adapter) mcp.ModbusV1Provider {
@@ -114,9 +116,17 @@ func (provider *gatewayModbusMCPProvider) admitRawRead() bool {
 
 func (provider *gatewayModbusMCPProvider) ProfileObservation(_ context.Context, profileID, sampleID string) (mcp.ModbusProfileObservationResult, error) {
 	record, ok := provider.adapter.ProfileObservation(profileID, sampleID)
+	if ok {
+		return profileObservationResult(record)
+	}
+	qualification, encoded, ok := provider.adapter.SunSpecQualificationObservation(profileID, sampleID)
 	if !ok {
 		return mcp.ModbusProfileObservationResult{}, errors.New("profile observation not found")
 	}
+	return sunSpecQualificationObservationResult(qualification, encoded)
+}
+
+func profileObservationResult(record modbusadapter.ProfileObservationRecord) (mcp.ModbusProfileObservationResult, error) {
 	spec := record.Observation.Spec()
 	encoded, err := json.Marshal(record.Observation)
 	if err != nil {
@@ -157,6 +167,42 @@ func (provider *gatewayModbusMCPProvider) ProfileObservation(_ context.Context, 
 		DetectionEvidence:  append([]string{}, record.DetectionEvidence...),
 		ActivationEvidence: append([]string{}, record.ActivationEvidence...),
 		ObservationJSONB64: base64.StdEncoding.EncodeToString(sanitizedObservation),
+		Replay:             views,
+	}, nil
+}
+
+func sunSpecQualificationObservationResult(observation modbusreg.SunSpecQualificationObservation, encoded []byte) (mcp.ModbusProfileObservationResult, error) {
+	if len(encoded) == 0 {
+		return mcp.ModbusProfileObservationResult{}, errors.New("SunSpec qualification observation is not serializable")
+	}
+	var envelope any
+	if err := json.Unmarshal(encoded, &envelope); err != nil {
+		return mcp.ModbusProfileObservationResult{}, fmt.Errorf("decode SunSpec qualification observation envelope: %w", err)
+	}
+	redactModbusEndpoints(envelope)
+	sanitized, err := json.Marshal(envelope)
+	if err != nil {
+		return mcp.ModbusProfileObservationResult{}, fmt.Errorf("encode sanitized SunSpec qualification observation: %w", err)
+	}
+	replay, err := observation.Replay()
+	if err != nil {
+		return mcp.ModbusProfileObservationResult{}, fmt.Errorf("replay SunSpec qualification observation: %w", err)
+	}
+	views := make([]mcp.ModbusReplayView, 0, len(replay.SourceViews()))
+	for _, source := range replay.SourceViews() {
+		view := source.Record()
+		views = append(views, mcp.ModbusReplayView{
+			LogicalViewID: view.LogicalViewID, WireResponseID: view.WireResponseID,
+			Offset: view.LogicalOffset, Words: append([]uint16(nil), view.Words...),
+		})
+	}
+	identity := observation.SampleIdentity()
+	return mcp.ModbusProfileObservationResult{
+		ProfileID:          observation.Capability().ProfileID(),
+		SampleID:           observation.SampleID(),
+		PollGenerationID:   identity.PollGeneration(),
+		SourceValidity:     "terminal_verified",
+		ObservationJSONB64: base64.StdEncoding.EncodeToString(sanitized),
 		Replay:             views,
 	}, nil
 }

--- a/cmd/gateway/modbus_mcp_provider_test.go
+++ b/cmd/gateway/modbus_mcp_provider_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/modbusadapter"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
 	modbus "github.com/Project-Helianthus/helianthus-modbus"
+	modbusreg "github.com/Project-Helianthus/helianthus-modbusreg"
 )
 
 type countingModbusMCPAdapter struct{ reads int }
@@ -21,6 +22,10 @@ func (adapter *countingModbusMCPAdapter) ExecuteRead(context.Context, modbusadap
 
 func (*countingModbusMCPAdapter) ProfileObservation(string, string) (modbusadapter.ProfileObservationRecord, bool) {
 	return modbusadapter.ProfileObservationRecord{}, false
+}
+
+func (*countingModbusMCPAdapter) SunSpecQualificationObservation(string, string) (modbusreg.SunSpecQualificationObservation, []byte, bool) {
+	return modbusreg.SunSpecQualificationObservation{}, nil, false
 }
 
 func TestNewGatewayModbusMCPProviderDisabledIsInert(t *testing.T) {

--- a/cmd/gateway/modbus_mcp_provider_test.go
+++ b/cmd/gateway/modbus_mcp_provider_test.go
@@ -86,3 +86,11 @@ func TestGatewayModbusMCPProviderRejectsBurstBeforeWireIO(t *testing.T) {
 		t.Fatalf("wire reads after refill = %d", adapter.reads)
 	}
 }
+
+func TestGatewayModbusMCPProviderReportsUnavailableForUnretainedQualificationSample(t *testing.T) {
+	provider := &gatewayModbusMCPProvider{adapter: &countingModbusMCPAdapter{}}
+	_, err := provider.ProfileObservation(context.Background(), "sunspec.inverter.three_phase.monitoring@1.0.0", "sunspec-44-94")
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("unretained qualification MCP error = %v; want unavailable", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260813222631-92a35b3ec2eb
 	github.com/Project-Helianthus/helianthus-eebusreg v0.1.32
 	github.com/Project-Helianthus/helianthus-modbus v0.0.0-20260810083147-eab30aed9eb6
-	github.com/Project-Helianthus/helianthus-modbusreg v0.2.0
+	github.com/Project-Helianthus/helianthus-modbusreg v0.2.1
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/Project-Helianthus/helianthus-modbus v0.0.0-20260810083147-eab30aed9e
 github.com/Project-Helianthus/helianthus-modbus v0.0.0-20260810083147-eab30aed9eb6/go.mod h1:Nr8SW7fE3SIjnp+rj8PCOtwk8JZ9wqafu1ZCgq3Zz+Q=
 github.com/Project-Helianthus/helianthus-modbusreg v0.2.0 h1:V8kWhn7dEzjpcaaQultjAble5wGlU5lloK9b6i7HOkc=
 github.com/Project-Helianthus/helianthus-modbusreg v0.2.0/go.mod h1:b1DlK4MkW72E+j+ejZqXHbMBiMUexU/+QWIT10zZVjU=
+github.com/Project-Helianthus/helianthus-modbusreg v0.2.1 h1:IuWNO1FpYwTC/3b/Gf6G8DTlUwVb20kjjWlGQ7eFTDc=
+github.com/Project-Helianthus/helianthus-modbusreg v0.2.1/go.mod h1:b1DlK4MkW72E+j+ejZqXHbMBiMUexU/+QWIT10zZVjU=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.15 h1:FhdTAcv/kckjVhao5ovAQmLRvTG0EEPZT8lmdwHuymY=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.15/go.mod h1:qPqQTDqmPjyOJCr0JMNjhSC1XW1k3h5P/EZqRGy80Vs=
 github.com/Project-Helianthus/helianthus-spine-go v0.7.1-helianthus.9 h1:pV1GQmlPJyy22YGK/Amf5FMu1C3IzL3qxIxGmGUUTEo=

--- a/internal/modbusadapter/adapter.go
+++ b/internal/modbusadapter/adapter.go
@@ -2,6 +2,7 @@ package modbusadapter
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -58,14 +59,15 @@ type Adapter struct {
 	config     Config
 	dial       Dialer
 
-	closeOnce    sync.Once
-	closeErr     error
-	executeMu    sync.Mutex
-	connectionMu sync.RWMutex
-	closed       bool
-	lastRequest  modbus.TCPRequestHandle
-	profileMu    sync.RWMutex
-	profiles     map[string]ProfileObservationRecord
+	closeOnce      sync.Once
+	closeErr       error
+	executeMu      sync.Mutex
+	connectionMu   sync.RWMutex
+	closed         bool
+	lastRequest    modbus.TCPRequestHandle
+	profileMu      sync.RWMutex
+	profiles       map[string]ProfileObservationRecord
+	qualifications map[string]sunSpecQualificationRecord
 }
 
 const maxRetainedProfileObservations = 32
@@ -76,6 +78,11 @@ type ProfileObservationRecord struct {
 	Observation        modbusreg.Observation
 	DetectionEvidence  []string
 	ActivationEvidence []string
+}
+
+type sunSpecQualificationRecord struct {
+	observation modbusreg.SunSpecQualificationObservation
+	encoded     []byte
 }
 
 // Start constructs and connects one endpoint. Disabled configuration is inert.
@@ -121,12 +128,13 @@ func Start(
 		)
 	}
 	return &Adapter{
-		endpoint:   endpoint,
-		connection: handle,
-		source:     config.Endpoint.RuntimeAcquisitionSource,
-		config:     config,
-		dial:       dial,
-		profiles:   make(map[string]ProfileObservationRecord),
+		endpoint:       endpoint,
+		connection:     handle,
+		source:         config.Endpoint.RuntimeAcquisitionSource,
+		config:         config,
+		dial:           dial,
+		profiles:       make(map[string]ProfileObservationRecord),
+		qualifications: make(map[string]sunSpecQualificationRecord),
 	}, nil
 }
 
@@ -310,12 +318,37 @@ func (adapter *Adapter) RecordProfileObservation(record ProfileObservationRecord
 	key := spec.ProfileID + "\x00" + spec.SampleID
 	adapter.profileMu.Lock()
 	defer adapter.profileMu.Unlock()
-	if _, exists := adapter.profiles[key]; !exists && len(adapter.profiles) >= maxRetainedProfileObservations {
+	if _, exists := adapter.profiles[key]; !exists && len(adapter.profiles)+len(adapter.qualifications) >= maxRetainedProfileObservations {
 		return errors.New("profile observation retention limit reached")
 	}
 	record.DetectionEvidence = append([]string(nil), record.DetectionEvidence...)
 	record.ActivationEvidence = append([]string(nil), record.ActivationEvidence...)
 	adapter.profiles[key] = record
+	return nil
+}
+
+// RecordSunSpecQualificationObservation first proves deterministic
+// serialization, then retains one immutable terminal registry observation.
+// The shared bound covers legacy profile observations as well.
+func (adapter *Adapter) RecordSunSpecQualificationObservation(observation modbusreg.SunSpecQualificationObservation) error {
+	if adapter == nil {
+		return errors.New("modbus TCP adapter unavailable")
+	}
+	encoded, err := json.Marshal(observation)
+	if err != nil {
+		return fmt.Errorf("serialize SunSpec qualification observation: %w", err)
+	}
+	capability, sampleID := observation.Capability().ProfileID(), observation.SampleID()
+	if capability == "" || sampleID == "" {
+		return errors.New("SunSpec qualification observation identity is incomplete")
+	}
+	key := capability + "\x00" + sampleID
+	adapter.profileMu.Lock()
+	defer adapter.profileMu.Unlock()
+	if _, exists := adapter.qualifications[key]; !exists && len(adapter.profiles)+len(adapter.qualifications) >= maxRetainedProfileObservations {
+		return errors.New("profile observation retention limit reached")
+	}
+	adapter.qualifications[key] = sunSpecQualificationRecord{observation: observation, encoded: append([]byte(nil), encoded...)}
 	return nil
 }
 
@@ -333,6 +366,21 @@ func (adapter *Adapter) ProfileObservation(profileID, sampleID string) (ProfileO
 	record.DetectionEvidence = append([]string(nil), record.DetectionEvidence...)
 	record.ActivationEvidence = append([]string(nil), record.ActivationEvidence...)
 	return record, true
+}
+
+// SunSpecQualificationObservation returns a detached immutable terminal
+// qualification and the serialization proven before it was retained.
+func (adapter *Adapter) SunSpecQualificationObservation(profileID, sampleID string) (modbusreg.SunSpecQualificationObservation, []byte, bool) {
+	if adapter == nil {
+		return modbusreg.SunSpecQualificationObservation{}, nil, false
+	}
+	adapter.profileMu.RLock()
+	defer adapter.profileMu.RUnlock()
+	record, ok := adapter.qualifications[profileID+"\x00"+sampleID]
+	if !ok {
+		return modbusreg.SunSpecQualificationObservation{}, nil, false
+	}
+	return record.observation, append([]byte(nil), record.encoded...), true
 }
 
 // Cancel delegates cancellation to the endpoint owner.

--- a/internal/modbusadapter/sunspec_producer.go
+++ b/internal/modbusadapter/sunspec_producer.go
@@ -220,10 +220,19 @@ func (producer *SunSpecProducer) classify(identity SunSpecPollIdentity, snapshot
 			result.Outcome = SunSpecQualificationStop
 			return result
 		}
+		observation, err := modbusreg.NewSunSpecQualificationObservation(producer.registry, snapshot)
+		if err != nil {
+			result.Outcome = SunSpecQualificationStop
+			return result
+		}
+		if err := producer.adapter.RecordSunSpecQualificationObservation(observation); err != nil {
+			result.Outcome = SunSpecQualificationStop
+			return result
+		}
 		result.FlavorID, result.FlavorReason = flavor.FlavorID(), flavor.Reason()
 		result.Outcome = SunSpecQualificationGO
 		result.ObservationCount = 1
-		result.SampleID = fmt.Sprintf("sunspec-%d-%d", identity.PollGeneration, identity.DeadlineIdentity)
+		result.SampleID = observation.SampleID()
 		result.Chain = snapshot
 		return result
 	}

--- a/internal/modbusadapter/sunspec_producer_test.go
+++ b/internal/modbusadapter/sunspec_producer_test.go
@@ -127,12 +127,23 @@ func TestSunSpecProducerQualifiesExactObservedFroniusControlsChainThroughRegistr
 
 	// A terminal GO is not publishable until its registry-owned capture is
 	// retained under the exact capability/sample identity.
-	retained, ok := adapter.ProfileObservation(result.CapabilityID, result.SampleID)
+	retained, encoded, ok := adapter.SunSpecQualificationObservation(result.CapabilityID, result.SampleID)
 	if !ok {
 		t.Fatalf("GO sample %q is unavailable from retained profile observations", result.SampleID)
 	}
-	if retained.Observation.SampleID() != result.SampleID {
-		t.Fatalf("retained sample = %q; want %q", retained.Observation.SampleID(), result.SampleID)
+	if retained.SampleID() != result.SampleID || len(encoded) == 0 {
+		t.Fatalf("retained sample = %q encoded=%d; want %q with deterministic evidence", retained.SampleID(), len(encoded), result.SampleID)
+	}
+	replay, err := retained.Replay()
+	if err != nil {
+		t.Fatalf("retained Replay: %v", err)
+	}
+	if views := replay.SourceViews(); len(views) == 0 || views[0].Record().PollGeneration != 44 || views[0].Record().DeadlineIdentity != 94 {
+		t.Fatalf("retained replay lost exact ordered poll identity: %#v", views)
+	}
+	occurrences := replay.Occurrences()
+	if len(occurrences) != 8 || occurrences[5].WireKey != (modbusreg.SunSpecWireKey{ModelID: 123, ModelLength: 24}) {
+		t.Fatalf("retained replay lost Model 123 chain evidence: %#v", occurrences)
 	}
 }
 
@@ -163,6 +174,22 @@ func TestSunSpecProducerStopsWhenQualificationRetentionCapacityIsExhausted(t *te
 	}
 	if result.Outcome != SunSpecQualificationStop || result.SampleID != "" || len(result.Chain.RawWords()) != 0 {
 		t.Fatalf("capacity-exhausted qualification outcome=%q sample=%q raw_words=%d; want terminal STOP without partial evidence", result.Outcome, result.SampleID, len(result.Chain.RawWords()))
+	}
+}
+
+func TestSunSpecQualificationRetentionRejectsUnserializableObservationWithoutStoringIt(t *testing.T) {
+	listener, _ := serveSunSpecChain(t, observedFroniusFloatControlsWords())
+	adapter, err := Start(context.Background(), integrationConfig(t, "tcp://"+listener.Addr().String()), realDialer, realFactory)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	if err := adapter.RecordSunSpecQualificationObservation(modbusreg.SunSpecQualificationObservation{}); err == nil {
+		t.Fatal("unserializable qualification observation was retained")
+	}
+	if _, _, ok := adapter.SunSpecQualificationObservation("sunspec.inverter.three_phase.monitoring@1.0.0", "sunspec-45-95"); ok {
+		t.Fatal("failed qualification serialization left a partial retained record")
 	}
 }
 

--- a/internal/modbusadapter/sunspec_producer_test.go
+++ b/internal/modbusadapter/sunspec_producer_test.go
@@ -3,6 +3,7 @@ package modbusadapter
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
 	"io"
 	"net"
 	"os"
@@ -123,6 +124,46 @@ func TestSunSpecProducerQualifiesExactObservedFroniusControlsChainThroughRegistr
 		t.Fatalf("Model 123 decoder key = %#v, %v; want exact standard registry key", decoderKey, ok)
 	}
 	assertBoundedFC03Discovery(t, requests(), 1)
+
+	// A terminal GO is not publishable until its registry-owned capture is
+	// retained under the exact capability/sample identity.
+	retained, ok := adapter.ProfileObservation(result.CapabilityID, result.SampleID)
+	if !ok {
+		t.Fatalf("GO sample %q is unavailable from retained profile observations", result.SampleID)
+	}
+	if retained.Observation.SampleID() != result.SampleID {
+		t.Fatalf("retained sample = %q; want %q", retained.Observation.SampleID(), result.SampleID)
+	}
+}
+
+func TestSunSpecProducerStopsWhenQualificationRetentionCapacityIsExhausted(t *testing.T) {
+	listener, _ := serveSunSpecChain(t, observedFroniusFloatControlsWords())
+	adapter, err := Start(context.Background(), integrationConfig(t, "tcp://"+listener.Addr().String()), realDialer, realFactory)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	// The bounded retention owner must fail closed before GO when it cannot
+	// reserve one more exact qualification record.
+	for index := 0; index < maxRetainedProfileObservations; index++ {
+		adapter.profiles[fmt.Sprintf("occupied-%d", index)] = ProfileObservationRecord{}
+	}
+	producer, err := NewSunSpecProducer(adapter, SunSpecProducerConfig{
+		UnitID: 1, AuthorizationScope: "smoke:fronius-readonly", ReadTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewSunSpecProducer: %v", err)
+	}
+	result, err := producer.Qualify(context.Background(), SunSpecPollIdentity{
+		PollGeneration: 45, DeadlineIdentity: 95,
+	})
+	if err != nil {
+		t.Fatalf("Qualify: %v", err)
+	}
+	if result.Outcome != SunSpecQualificationStop || result.SampleID != "" || len(result.Chain.RawWords()) != 0 {
+		t.Fatalf("capacity-exhausted qualification outcome=%q sample=%q raw_words=%d; want terminal STOP without partial evidence", result.Outcome, result.SampleID, len(result.Chain.RawWords()))
+	}
 }
 
 func TestSunSpecProducerReturnsNoGoForAdmittedCapabilityWithFlavorMismatch(t *testing.T) {


### PR DESCRIPTION
Closes #821.

Pins helianthus-modbusreg v0.2.1 and retains its immutable SunSpecQualificationObservation atomically before reporting GO. Build, deterministic serialization, retention capacity, or store failure returns STOP without partial sample/chain. Existing MCP profile observation lookup supports both legacy observations and canonical qualification observations with sanitized deterministic JSON and ordered replay.

RED: 2b9ae92b716c53288ac26819fb04b43b557159f2.
GREEN: 6b903f319438f784d6dad093bbaa8c0485b47a2f.

No transport acquisition, writes, eeBUS/eBUS semantic, Portal, HA, add-on or live-device change.