### PR TITLE
Stabilize eeBUS MCP live harness timeout

### DIFF
--- a/mcp/eebus_v1_contract_test.go
+++ b/mcp/eebus_v1_contract_test.go
@@ -120,7 +120,7 @@ func msp06TestServer(t *testing.T, provider EEBusV1Provider) (*Server, *msp06Clo
 	err = server.registerEEBusV1Provider(provider, eebusV1RegistrationOptions{
 		now: clock.Now, entropy: &msp06EntropyReader{},
 		pseudonymKey: bytes.Repeat([]byte{0x5a}, sha256.Size),
-		liveTimeout:  100 * time.Millisecond,
+		liveTimeout:  5 * time.Second,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -393,6 +393,7 @@ func TestMSP06ProviderTimeoutIsNormalized(t *testing.T) {
 		return msp06Snapshot(t, "late"), nil
 	})
 	server, _ := msp06TestServer(t, blocking)
+	server.eebusV1.liveTimeout = 100 * time.Millisecond
 	result := msp06Call(t, server.Handler(), msp06TopologyGetTool, map[string]any{})
 	msp06AssertError(t, result, msp06TopologyGetTool, "topology", "timeout")
 }


### PR DESCRIPTION
Closes #823.

Test-only stabilization: normal eeBUS MCP success fixtures use a bounded 5-second timeout under the full race suite; the dedicated timeout-normalization test retains an explicit 100 ms deadline. No production/runtime/protocol behavior changes.

Observed failure proof: main CI run 31869781315 attempt 1 timed out in Issue743 success/determinism paths.

Focused validation: `go test -race ./mcp -run '^(TestMSP06ProviderTimeoutIsNormalized|TestIssue743EveryLiveToolUsesOneFreshSnapshotAndClosedDTOs|TestIssue743EveryCollectionPermutationIsByteAndHashDeterministic)$' -count=20`.