### PR TITLE
deps(eebus): repin eebusreg v0.1.33

### DIFF
--- a/cmd/gateway/eebus_operator_boundary_red_test.go
+++ b/cmd/gateway/eebus_operator_boundary_red_test.go
@@ -33,8 +33,8 @@ func TestIssue819ReleasedDependencyClosurePinsEEBusregV0132(t *testing.T) {
 	if err := scanner.Err(); err != nil {
 		t.Fatal(err)
 	}
-	if len(versions) != 1 || versions[0] != "v0.1.32" {
-		t.Fatalf("%s versions = %v, want exactly [v0.1.32]", module, versions)
+	if len(versions) != 1 || versions[0] != "v0.1.33" {
+		t.Fatalf("%s versions = %v, want exactly [v0.1.33]", module, versions)
 	}
 }
 

--- a/eebusreg_v0114_contract_test.go
+++ b/eebusreg_v0114_contract_test.go
@@ -39,7 +39,7 @@ func TestIssue819ReleasedEEBusDependencyClosure(t *testing.T) {
 	}
 
 	want := map[string]string{
-		eebusregModule: "v0.1.32",
+		eebusregModule: "v0.1.33",
 		eebusgoModule:  "v0.7.1-helianthus.17",
 		shipgoModule:   "v0.6.1-helianthus.15",
 		spinegoModule:  "v0.7.1-helianthus.9",

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260521144203-f9919f4b1007
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260813222631-92a35b3ec2eb
-	github.com/Project-Helianthus/helianthus-eebusreg v0.1.32
+	github.com/Project-Helianthus/helianthus-eebusreg v0.1.33
 	github.com/Project-Helianthus/helianthus-modbus v0.0.0-20260810083147-eab30aed9eb6
 	github.com/Project-Helianthus/helianthus-modbusreg v0.2.1
 	github.com/grandcat/zeroconf v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -4,14 +4,10 @@ github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260813222631-92a35b3ec
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260813222631-92a35b3ec2eb/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
 github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.17 h1:JI+MbIug6iRBnh7IoqHvLnJnLf+NhnXyktjWYRE+RvA=
 github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.17/go.mod h1:a2alpEsrFkG70XPP7Ab+fpe1oA5MBmfZUSarcMuJtMQ=
-github.com/Project-Helianthus/helianthus-eebusreg v0.1.31 h1:N6S/XxqWbOOPGCteOXYNvTfIeUtpQenvDlzayFmzQy4=
-github.com/Project-Helianthus/helianthus-eebusreg v0.1.31/go.mod h1:zicxGucHssiyjsA186nACwFfu3kUDEixIcY2b7DleEM=
-github.com/Project-Helianthus/helianthus-eebusreg v0.1.32 h1:HPDEHF+YjR+Z+S63YfNeTYAPFGbZJWrEUUC4fWfMhNo=
-github.com/Project-Helianthus/helianthus-eebusreg v0.1.32/go.mod h1:zicxGucHssiyjsA186nACwFfu3kUDEixIcY2b7DleEM=
+github.com/Project-Helianthus/helianthus-eebusreg v0.1.33 h1:E9GwFD5a1qclli8qwfYJfoULgpY5eJhAsfrK5BbDZgw=
+github.com/Project-Helianthus/helianthus-eebusreg v0.1.33/go.mod h1:zicxGucHssiyjsA186nACwFfu3kUDEixIcY2b7DleEM=
 github.com/Project-Helianthus/helianthus-modbus v0.0.0-20260810083147-eab30aed9eb6 h1:+l+s7VBz51iKqZYhm081RydM439iPM/Uf6bubzvA3/4=
 github.com/Project-Helianthus/helianthus-modbus v0.0.0-20260810083147-eab30aed9eb6/go.mod h1:Nr8SW7fE3SIjnp+rj8PCOtwk8JZ9wqafu1ZCgq3Zz+Q=
-github.com/Project-Helianthus/helianthus-modbusreg v0.2.0 h1:V8kWhn7dEzjpcaaQultjAble5wGlU5lloK9b6i7HOkc=
-github.com/Project-Helianthus/helianthus-modbusreg v0.2.0/go.mod h1:b1DlK4MkW72E+j+ejZqXHbMBiMUexU/+QWIT10zZVjU=
 github.com/Project-Helianthus/helianthus-modbusreg v0.2.1 h1:IuWNO1FpYwTC/3b/Gf6G8DTlUwVb20kjjWlGQ7eFTDc=
 github.com/Project-Helianthus/helianthus-modbusreg v0.2.1/go.mod h1:b1DlK4MkW72E+j+ejZqXHbMBiMUexU/+QWIT10zZVjU=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.15 h1:FhdTAcv/kckjVhao5ovAQmLRvTG0EEPZT8lmdwHuymY=


### PR DESCRIPTION
## What changed

Repins `github.com/Project-Helianthus/helianthus-eebusreg` from `v0.1.32` to released `v0.1.33`. The verified tag object is `05798b63f5ecd036afffc5519ed868fdcbffc68e`, dereferencing to release commit `7e88b1326230cf723f6f6780374de25661a96670`.

## Why

Deploy the exact retry-ready recovery release specified by #825. No gateway runtime, transport, semantic, GraphQL, MCP, Portal, or auth behavior changes are included.

## TDD and validation

- RED-first commit `507dc7734a572d50850ac5291377e79f892aa2cd`: both dependency-closure contracts fail while `go.mod` remains at `v0.1.32`.
- GREEN commit `1d18423b1f98fa77cab9ed8e689a2422d2a25c94`: focused root and `cmd/gateway` contract tests pass normally and with `-race`.
- `go vet ./...`
- `go build ./...`
- `git diff --check`

## Documentation gates

- `c9fb935e1a8bf3a2a7109dab1e93eab7c77d6c67`
- clarification `41ee68034f8c82e9be5f9fb10bee264dcaddebce`

Closes #825