### PR TITLE
Fix FM5 startup budget and late identity convergence

### DIFF
--- a/cmd/gateway/post_m9_defects_red_test.go
+++ b/cmd/gateway/post_m9_defects_red_test.go
@@ -1797,7 +1797,8 @@ func TestEnqueueAddressIdentityProbe_LateFM5RecoveryReadsTargetedGateBeforeNoncr
 			}
 			return fm5InstanceOneSemanticTestResponse(frame)
 		}
-		if group == localRegulator.group && !radioRecorded {
+		targetedSystemRead := addr == system_scheme || addr == system_water_pressure
+		if group == localRegulator.group && !targetedSystemRead && !radioRecorded {
 			blockedNoncriticalSystem = true
 			cancelTask()
 			return nil, context.DeadlineExceeded

--- a/cmd/gateway/post_m9_defects_red_test.go
+++ b/cmd/gateway/post_m9_defects_red_test.go
@@ -1756,7 +1756,7 @@ func TestEnqueueAddressIdentityProbe_SaturatedQueueCoalescesGuaranteedOrderedFM5
 	}
 }
 
-func TestEnqueueAddressIdentityProbe_LateFM5RecoveryReadsTargetedGateBeforeNoncriticalSystem(t *testing.T) {
+func TestEnqueueAddressIdentityProbe_LateFM5RecoveryReadsStartupSubsetBeforeOtherSystem(t *testing.T) {
 	originalScanDirected := registryScanDirectedFn
 	t.Cleanup(func() { registryScanDirectedFn = originalScanDirected })
 
@@ -1779,7 +1779,7 @@ func TestEnqueueAddressIdentityProbe_LateFM5RecoveryReadsTargetedGateBeforeNoncr
 	taskCtx, cancelTask := context.WithCancel(context.Background())
 	defer cancelTask()
 	readOrder := make([]string, 0, 2)
-	blockedNoncriticalSystem := false
+	blockedOutsideStartupSubset := false
 	gateRecorded := false
 	radioRecorded := false
 	poller.sendFrameFn = func(ctx context.Context, frame protocol.Frame) (*protocol.Frame, error) {
@@ -1798,9 +1798,9 @@ func TestEnqueueAddressIdentityProbe_LateFM5RecoveryReadsTargetedGateBeforeNoncr
 			}
 			return fm5InstanceOneSemanticTestResponse(frame)
 		}
-		targetedSystemRead := addr == system_scheme || addr == system_water_pressure
-		if group == localRegulator.group && !targetedSystemRead && !radioRecorded {
-			blockedNoncriticalSystem = true
+		startupSubsetRead := addr == system_scheme || addr == system_water_pressure
+		if group == localRegulator.group && !startupSubsetRead && !radioRecorded {
+			blockedOutsideStartupSubset = true
 			cancelTask()
 			return nil, context.DeadlineExceeded
 		}
@@ -1824,9 +1824,9 @@ func TestEnqueueAddressIdentityProbe_LateFM5RecoveryReadsTargetedGateBeforeNoncr
 
 	verdict := provider.FM5Interpretation()
 	ordered := len(readOrder) == 2 && readOrder[0] == "gate" && readOrder[1] == "radio"
-	if !scanSeamCalled || blockedNoncriticalSystem || !ordered ||
+	if !scanSeamCalled || blockedOutsideStartupSubset || !ordered ||
 		verdict.Mode != graphql.Fm5SemanticModeInterpreted || verdict.DegradedReason != "" || verdict.EvidenceRevision == "" {
-		t.Fatalf("deadline-aware late recovery seam_called=%t blocked_noncritical=%t read_order=%v verdict=%#v; want targeted gate then radio and healthy INTERPRETED without ordinary ticker", scanSeamCalled, blockedNoncriticalSystem, readOrder, verdict)
+		t.Fatalf("deadline-aware late recovery seam_called=%t blocked_outside_startup_subset=%t read_order=%v verdict=%#v; want startup subset gate path then radio and healthy INTERPRETED without ordinary ticker", scanSeamCalled, blockedOutsideStartupSubset, readOrder, verdict)
 	}
 }
 
@@ -2200,6 +2200,68 @@ func TestEnqueueAddressIdentityProbe_MaxSlotVR71ConvergesWithinBoundedRecoveryBu
 		retainedRegulator == nil || !publishedRegulator || verdict.Mode != graphql.Fm5SemanticModeInterpreted ||
 		verdict.DegradedReason != "" || verdict.EvidenceRevision == "" {
 		t.Fatalf("max-slot late recovery seam=%t reads=%d exhausted=%t cached=%t fm5=%#v retained_non_fm=%#v published_non_fm=%t verdict=%#v; want one bounded directed recovery to publish slot 0x0A INTERPRETED without losing non-FM state", scanSeamCalled, selectorReads, budgetExhausted, fm5Cached, fm5Snapshot, retainedRegulator, publishedRegulator, verdict)
+	}
+}
+
+func TestEnqueueAddressIdentityProbe_MaxSlotVR71RecoveryReadsOnlyConfigurationGate(t *testing.T) {
+	originalScanDirected := registryScanDirectedFn
+	t.Cleanup(func() { registryScanDirectedFn = originalScanDirected })
+
+	taskScheduler := newSemanticTaskScheduler()
+	poller, provider := newFM5DeadlineRecoveryTestPoller(taskScheduler)
+	scanSeamCalled := false
+	registryScanDirectedFn = func(_ context.Context, _ registry.ScanBus, reg *registry.DeviceRegistry, _ byte, _ []byte) ([]registry.DeviceEntry, error) {
+		scanSeamCalled = true
+		entry := reg.Register(registry.DeviceInfo{
+			Address:      circuitManagingDeviceVR71Address,
+			Manufacturer: "Vaillant",
+			DeviceID:     circuitManagingDeviceVR71ID,
+		})
+		return []registry.DeviceEntry{entry}, nil
+	}
+
+	recoveryCtx, cancelRecovery := context.WithCancel(context.Background())
+	defer cancelRecovery()
+	systemSelectors := make([]uint16, 0, 1)
+	selectorReads := 0
+	budgetExhausted := false
+	poller.sendFrameFn = func(ctx context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+		if len(frame.Data) != 6 {
+			return nil, errors.New("invalid B524 selector")
+		}
+		group := frame.Data[2]
+		addr := uint16(frame.Data[4]) | uint16(frame.Data[5])<<8
+		if group == localRegulator.group {
+			systemSelectors = append(systemSelectors, addr)
+			if addr != system_module_configuration_vr71 {
+				cancelRecovery()
+				return nil, errors.New("late FM5 recovery attempted non-gate system selector")
+			}
+		}
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return fm5HighSlotBudgetedResponse(ctx, frame, &selectorReads, &budgetExhausted, cancelRecovery)
+	}
+
+	poller.EnqueueAddressIdentityProbe(circuitManagingDeviceVR71Address)
+	probeTask := taskScheduler.nextTask(context.Background())
+	if probeTask == nil {
+		t.Fatal("late identity probe task was not scheduled")
+	}
+	probeTask.run(recoveryCtx)
+	taskScheduler.taskDone(probeTask)
+
+	fm5Key := radioDeviceKey{Group: remoteFunctionalModules.group, Instance: semanticStartupSlotFullMaxInstance}
+	poller.mu.Lock()
+	fm5Snapshot := cloneRadioSnapshot(poller.radioDevices[fm5Key])
+	poller.mu.Unlock()
+	verdict := provider.FM5Interpretation()
+	onlyGateRead := len(systemSelectors) == 1 && systemSelectors[0] == system_module_configuration_vr71
+	if !scanSeamCalled || !onlyGateRead || budgetExhausted || selectorReads > fm5HighSlotSelectorBudget ||
+		fm5Snapshot == nil || fm5Snapshot.DeviceClassAddress == nil || *fm5Snapshot.DeviceClassAddress != circuitManagingDeviceVR71Address ||
+		verdict.Mode != graphql.Fm5SemanticModeInterpreted || verdict.DegradedReason != "" || verdict.EvidenceRevision == "" {
+		t.Fatalf("gate-only max-slot recovery seam=%t system_selectors=%#v reads=%d exhausted=%t fm5=%#v verdict=%#v; want only module_configuration_vr71 before bounded slot 0x0A INTERPRETED recovery", scanSeamCalled, systemSelectors, selectorReads, budgetExhausted, fm5Snapshot, verdict)
 	}
 }
 

--- a/cmd/gateway/post_m9_defects_red_test.go
+++ b/cmd/gateway/post_m9_defects_red_test.go
@@ -1755,6 +1755,79 @@ func TestEnqueueAddressIdentityProbe_SaturatedQueueCoalescesGuaranteedOrderedFM5
 	}
 }
 
+func TestEnqueueAddressIdentityProbe_LateFM5RecoveryReadsTargetedGateBeforeNoncriticalSystem(t *testing.T) {
+	originalScanDirected := registryScanDirectedFn
+	t.Cleanup(func() { registryScanDirectedFn = originalScanDirected })
+
+	taskScheduler := newSemanticTaskScheduler()
+	poller, provider := newFM5DeadlineRecoveryTestPoller(taskScheduler)
+	scanSeamCalled := false
+	registryScanDirectedFn = func(_ context.Context, _ registry.ScanBus, reg *registry.DeviceRegistry, _ byte, targets []byte) ([]registry.DeviceEntry, error) {
+		scanSeamCalled = true
+		if len(targets) != 1 || targets[0] != circuitManagingDeviceVR71Address {
+			return nil, errors.New("unexpected directed identity target")
+		}
+		entry := reg.Register(registry.DeviceInfo{
+			Address:      circuitManagingDeviceVR71Address,
+			Manufacturer: "Vaillant",
+			DeviceID:     circuitManagingDeviceVR71ID,
+		})
+		return []registry.DeviceEntry{entry}, nil
+	}
+
+	taskCtx, cancelTask := context.WithCancel(context.Background())
+	defer cancelTask()
+	readOrder := make([]string, 0, 2)
+	blockedNoncriticalSystem := false
+	gateRecorded := false
+	radioRecorded := false
+	poller.sendFrameFn = func(ctx context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+		if len(frame.Data) != 6 {
+			return nil, errors.New("invalid B524 selector")
+		}
+		group := frame.Data[2]
+		addr := uint16(frame.Data[4]) | uint16(frame.Data[5])<<8
+		if group == localRegulator.group && addr == system_module_configuration_vr71 {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			if !gateRecorded {
+				readOrder = append(readOrder, "gate")
+				gateRecorded = true
+			}
+			return fm5InstanceOneSemanticTestResponse(frame)
+		}
+		if group == localRegulator.group && !radioRecorded {
+			blockedNoncriticalSystem = true
+			cancelTask()
+			return nil, context.DeadlineExceeded
+		}
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if (group == remoteRegulators.group || group == remoteThermostats.group || group == remoteFunctionalModules.group) && !radioRecorded {
+			readOrder = append(readOrder, "radio")
+			radioRecorded = true
+		}
+		return fm5InstanceOneSemanticTestResponse(frame)
+	}
+
+	poller.EnqueueAddressIdentityProbe(circuitManagingDeviceVR71Address)
+	probeTask := taskScheduler.nextTask(context.Background())
+	if probeTask == nil {
+		t.Fatal("late identity probe task was not scheduled")
+	}
+	probeTask.run(taskCtx)
+	taskScheduler.taskDone(probeTask)
+
+	verdict := provider.FM5Interpretation()
+	ordered := len(readOrder) == 2 && readOrder[0] == "gate" && readOrder[1] == "radio"
+	if !scanSeamCalled || blockedNoncriticalSystem || !ordered ||
+		verdict.Mode != graphql.Fm5SemanticModeInterpreted || verdict.DegradedReason != "" || verdict.EvidenceRevision == "" {
+		t.Fatalf("deadline-aware late recovery seam_called=%t blocked_noncritical=%t read_order=%v verdict=%#v; want targeted gate then radio and healthy INTERPRETED without ordinary ticker", scanSeamCalled, blockedNoncriticalSystem, readOrder, verdict)
+	}
+}
+
 func TestRefreshRadioDevices_CompleteNegativeFM5ScanSupersedesRetainedRegistryIdentity(t *testing.T) {
 	now := time.Date(2026, 8, 15, 15, 0, 0, 0, time.UTC)
 	config := uint16(2)

--- a/cmd/gateway/post_m9_defects_red_test.go
+++ b/cmd/gateway/post_m9_defects_red_test.go
@@ -1829,6 +1829,78 @@ func TestEnqueueAddressIdentityProbe_LateFM5RecoveryReadsTargetedGateBeforeNoncr
 	}
 }
 
+func TestEnqueueAddressIdentityProbe_FreshEmptySlotCacheForcesBoundedFM5Discovery(t *testing.T) {
+	originalScanDirected := registryScanDirectedFn
+	t.Cleanup(func() { registryScanDirectedFn = originalScanDirected })
+
+	taskScheduler := newSemanticTaskScheduler()
+	poller, provider := newFM5DeadlineRecoveryTestPoller(taskScheduler)
+	freshDiscoveryAt := time.Date(2026, 8, 15, 20, 59, 0, 0, time.UTC)
+	poller.deviceSlotDiscoveryDone = true
+	poller.deviceSlotDiscoveryAt = freshDiscoveryAt
+	poller.deviceSlotCache = make(map[deviceSlotKey]bool)
+
+	scanSeamCalled := false
+	registryScanDirectedFn = func(_ context.Context, _ registry.ScanBus, reg *registry.DeviceRegistry, _ byte, targets []byte) ([]registry.DeviceEntry, error) {
+		scanSeamCalled = true
+		if len(targets) != 1 || targets[0] != circuitManagingDeviceVR71Address {
+			return nil, errors.New("unexpected directed identity target")
+		}
+		entry := reg.Register(registry.DeviceInfo{
+			Address:      circuitManagingDeviceVR71Address,
+			Manufacturer: "Vaillant",
+			DeviceID:     circuitManagingDeviceVR71ID,
+		})
+		return []registry.DeviceEntry{entry}, nil
+	}
+
+	gateReads := 0
+	fm5SlotReads := 0
+	nonFMRadioReads := 0
+	poller.sendFrameFn = func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+		if len(frame.Data) != 6 {
+			return nil, errors.New("invalid B524 selector")
+		}
+		group := frame.Data[2]
+		addr := uint16(frame.Data[4]) | uint16(frame.Data[5])<<8
+		if group == localRegulator.group && addr == system_module_configuration_vr71 {
+			gateReads++
+		}
+		switch group {
+		case remoteFunctionalModules.group:
+			fm5SlotReads++
+		case remoteRegulators.group, remoteThermostats.group:
+			nonFMRadioReads++
+		}
+		return fm5InstanceOneSemanticTestResponse(frame)
+	}
+
+	poller.EnqueueAddressIdentityProbe(circuitManagingDeviceVR71Address)
+	probeTask := taskScheduler.nextTask(context.Background())
+	if probeTask == nil {
+		t.Fatal("late identity probe task was not scheduled")
+	}
+	probeTask.run(context.Background())
+	taskScheduler.taskDone(probeTask)
+
+	poller.mu.Lock()
+	globalDiscoveryDone := poller.deviceSlotDiscoveryDone
+	globalDiscoveryAt := poller.deviceSlotDiscoveryAt
+	nonFMCacheEntries := 0
+	for key := range poller.deviceSlotCache {
+		if key.Group != remoteFunctionalModules.group {
+			nonFMCacheEntries++
+		}
+	}
+	poller.mu.Unlock()
+	verdict := provider.FM5Interpretation()
+	if !scanSeamCalled || gateReads == 0 || fm5SlotReads == 0 || nonFMRadioReads != 0 ||
+		!globalDiscoveryDone || !globalDiscoveryAt.Equal(freshDiscoveryAt) || nonFMCacheEntries != 0 ||
+		verdict.Mode != graphql.Fm5SemanticModeInterpreted || verdict.DegradedReason != "" || verdict.EvidenceRevision == "" {
+		t.Fatalf("fresh-cache late recovery seam_called=%t gate_reads=%d fm5_reads=%d non_fm_reads=%d discovery_done=%t discovery_at=%s non_fm_cache=%d verdict=%#v; want bounded forced FM5-only discovery and healthy INTERPRETED without ticker/TTL mutation", scanSeamCalled, gateReads, fm5SlotReads, nonFMRadioReads, globalDiscoveryDone, globalDiscoveryAt.Format(time.RFC3339), nonFMCacheEntries, verdict)
+	}
+}
+
 func TestRefreshRadioDevices_CompleteNegativeFM5ScanSupersedesRetainedRegistryIdentity(t *testing.T) {
 	now := time.Date(2026, 8, 15, 15, 0, 0, 0, time.UTC)
 	config := uint16(2)

--- a/cmd/gateway/post_m9_defects_red_test.go
+++ b/cmd/gateway/post_m9_defects_red_test.go
@@ -1442,6 +1442,128 @@ func TestFM5Startup_UnseededLowSlotPositiveDoesNotLosePrimingBudget(t *testing.T
 	}
 }
 
+func TestEnqueueAddressIdentityProbe_LateFM5SuccessTriggersBoundedSemanticReacquisition(t *testing.T) {
+	originalScanDirected := registryScanDirectedFn
+	t.Cleanup(func() { registryScanDirectedFn = originalScanDirected })
+
+	now := time.Date(2026, 8, 15, 20, 30, 0, 0, time.UTC)
+	provider := graphql.NewLiveSemanticProvider()
+	taskScheduler := newSemanticTaskScheduler()
+	poller := &vaillantSemanticPoller{
+		scheduler:                ebusgateway.NewSemanticReadScheduler(),
+		tasks:                    taskScheduler,
+		reg:                      registry.NewDeviceRegistry(nil),
+		bus:                      &protocol.Bus{},
+		provider:                 provider,
+		source:                   0x7F,
+		controller:               0x15,
+		requestTimeout:           50 * time.Millisecond,
+		system:                   &vaillantSystemSnapshot{Controller: 0x15},
+		radioDevices:             make(map[radioDeviceKey]*vaillantRadioDeviceSnapshot),
+		solarCylinders:           make(map[byte]*vaillantCylinderSnapshot),
+		fm5EvidenceTTL:           5 * time.Minute,
+		deviceSlotRediscoveryTTL: 30 * time.Minute,
+		deviceSlotCache:          make(map[deviceSlotKey]bool),
+		nowFn:                    func() time.Time { return now },
+	}
+
+	scanSeamCalled := false
+	registryScanDirectedFn = func(_ context.Context, _ registry.ScanBus, reg *registry.DeviceRegistry, source byte, targets []byte) ([]registry.DeviceEntry, error) {
+		scanSeamCalled = true
+		if source != poller.source || len(targets) != 1 || targets[0] != circuitManagingDeviceVR71Address {
+			return nil, errors.New("unexpected directed identity target")
+		}
+		entry := reg.Register(registry.DeviceInfo{
+			Address:      circuitManagingDeviceVR71Address,
+			Manufacturer: "Vaillant",
+			DeviceID:     circuitManagingDeviceVR71ID,
+		})
+		return []registry.DeviceEntry{entry}, nil
+	}
+
+	poller.sendFrameFn = func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+		if len(frame.Data) != 6 {
+			return nil, errors.New("invalid B524 selector")
+		}
+		group := frame.Data[2]
+		instance := frame.Data[3]
+		addr := uint16(frame.Data[4]) | uint16(frame.Data[5])<<8
+		if group == localRegulator.group && addr == system_module_configuration_vr71 {
+			return testB524ResponseForSelectorPayload(frame.Data, 0x02, 0x00), nil
+		}
+		if group == remoteFunctionalModules.group {
+			switch addr {
+			case device_slot_connected:
+				connected := byte(0x00)
+				if instance == 0x01 {
+					connected = 0x01
+				}
+				return testB524ResponseForSelectorPayload(frame.Data, connected), nil
+			case device_slot_class_address:
+				classAddress := byte(0xFF)
+				if instance == 0x01 {
+					classAddress = circuitManagingDeviceVR71Address
+				}
+				return testB524ResponseForSelectorPayload(frame.Data, classAddress), nil
+			case device_slot_firmware:
+				firmware := []byte{0xFF, 0xFF, 0xFF}
+				if instance == 0x01 {
+					firmware = []byte{0x01, 0x00, 0x00}
+				}
+				return testB524ResponseForSelectorPayload(frame.Data, firmware...), nil
+			case device_slot_hardware_identifier:
+				hardware := []byte{0xFF, 0xFF}
+				if instance == 0x01 {
+					hardware = []byte{0x71, 0x00}
+				}
+				return testB524ResponseForSelectorPayload(frame.Data, hardware...), nil
+			}
+		}
+		if group == localSolar.group {
+			switch addr {
+			case solar_collector_temp:
+				return testB524ResponseForSelectorPayload(frame.Data, testB524Float32Payload(61.5)...), nil
+			case solar_enabled, solar_pump_active:
+				return testB524ResponseForSelectorPayload(frame.Data, 0x01), nil
+			}
+		}
+		if group == localCylinders.group && addr == cylinder_temperature {
+			return testB524ResponseForSelectorPayload(frame.Data, testB524Float32Payload(47.25)...), nil
+		}
+		return testB524ResponseForSelectorPayload(frame.Data, 0x00, 0x00, 0x00, 0x00), nil
+	}
+
+	poller.EnqueueAddressIdentityProbe(circuitManagingDeviceVR71Address)
+	probeTask := taskScheduler.nextTask(context.Background())
+	if probeTask == nil {
+		t.Fatal("late identity probe was not scheduled")
+	}
+	canceledProbeCtx, cancelProbe := context.WithCancel(context.Background())
+	cancelProbe()
+	probeTask.run(canceledProbeCtx)
+	taskScheduler.taskDone(probeTask)
+
+	scheduled := make([]semanticTaskKey, 0, 2)
+	for len(scheduled) < 2 {
+		taskScheduler.mu.Lock()
+		pending := len(taskScheduler.queue)
+		taskScheduler.mu.Unlock()
+		if pending == 0 {
+			break
+		}
+		task := taskScheduler.nextTask(context.Background())
+		scheduled = append(scheduled, task.key)
+		task.run(context.Background())
+		taskScheduler.taskDone(task)
+	}
+	verdict := provider.FM5Interpretation()
+	if !scanSeamCalled || len(scheduled) != 2 ||
+		scheduled[0] != semanticTaskRefreshSystem || scheduled[1] != semanticTaskRefreshRadioDevices ||
+		verdict.Mode != graphql.Fm5SemanticModeInterpreted || verdict.DegradedReason != "" || verdict.EvidenceRevision == "" {
+		t.Fatalf("late FM5 recovery seam_called=%t scheduled=%v verdict=%#v; want directed success then [refresh_system refresh_radio_devices] and healthy INTERPRETED without ticker", scanSeamCalled, scheduled, verdict)
+	}
+}
+
 func TestRefreshRadioDevices_CompleteNegativeFM5ScanSupersedesRetainedRegistryIdentity(t *testing.T) {
 	now := time.Date(2026, 8, 15, 15, 0, 0, 0, time.UTC)
 	config := uint16(2)

--- a/cmd/gateway/post_m9_defects_red_test.go
+++ b/cmd/gateway/post_m9_defects_red_test.go
@@ -1557,10 +1557,9 @@ func TestEnqueueAddressIdentityProbe_LateFM5SuccessTriggersBoundedSemanticReacqu
 		taskScheduler.taskDone(task)
 	}
 	verdict := provider.FM5Interpretation()
-	if !scanSeamCalled || len(scheduled) != 2 ||
-		scheduled[0] != semanticTaskRefreshSystem || scheduled[1] != semanticTaskRefreshRadioDevices ||
+	if !scanSeamCalled || len(scheduled) != 0 ||
 		verdict.Mode != graphql.Fm5SemanticModeInterpreted || verdict.DegradedReason != "" || verdict.EvidenceRevision == "" {
-		t.Fatalf("late FM5 recovery seam_called=%t scheduled=%v verdict=%#v; want directed success then [refresh_system refresh_radio_devices] and healthy INTERPRETED without ticker", scanSeamCalled, scheduled, verdict)
+		t.Fatalf("late FM5 recovery seam_called=%t scheduled=%v verdict=%#v; want directed success with inline bounded recovery, no extra queued tasks, and healthy INTERPRETED without ticker", scanSeamCalled, scheduled, verdict)
 	}
 }
 

--- a/cmd/gateway/post_m9_defects_red_test.go
+++ b/cmd/gateway/post_m9_defects_red_test.go
@@ -1946,6 +1946,28 @@ func fm5SemanticTestResponseForClasses(frame protocol.Frame, classes map[byte]by
 	return testB524ResponseForSelectorPayload(frame.Data, 0x00, 0x00, 0x00, 0x00), nil
 }
 
+const fm5HighSlotSelectorBudget = 28
+
+func fm5HighSlotBudgetedResponse(
+	ctx context.Context,
+	frame protocol.Frame,
+	selectorReads *int,
+	budgetExhausted *bool,
+	cancel context.CancelFunc,
+) (*protocol.Frame, error) {
+	if len(frame.Data) == 6 && frame.Data[2] == remoteFunctionalModules.group {
+		*selectorReads = *selectorReads + 1
+		if *selectorReads > fm5HighSlotSelectorBudget {
+			*budgetExhausted = true
+			cancel()
+			return nil, ctx.Err()
+		}
+	}
+	return fm5SemanticTestResponseForClasses(frame, map[byte]byte{
+		semanticStartupSlotFullMaxInstance: circuitManagingDeviceVR71Address,
+	})
+}
+
 func TestFM5Startup_HighSlotPositivePreemptsUnrelatedRadioTails(t *testing.T) {
 	poller, provider := newFM5DeadlineRecoveryTestPoller(nil)
 	config := uint16(2)
@@ -2028,6 +2050,48 @@ func TestFM5Startup_FastPositiveRetainsDeferredHighSlotRegistrySeed(t *testing.T
 	}
 }
 
+func TestFM5Startup_MaxSlotVR71ConvergesWithinBoundedIdentityBudget(t *testing.T) {
+	poller, provider := newFM5DeadlineRecoveryTestPoller(nil)
+	config := uint16(2)
+	poller.system.ModuleConfigurationVR71 = &config
+	seedAddresses := []byte{0x15, 0x16, 0x17, 0x18}
+	for instance, address := range seedAddresses {
+		poller.reg.Register(registry.DeviceInfo{
+			Address:      address,
+			Manufacturer: "Vaillant",
+			DeviceID:     fmt.Sprintf("BASV%d", instance),
+		})
+	}
+	highRegulatorKey := radioDeviceKey{Group: remoteRegulators.group, Instance: 0x03}
+	if seed := poller.registryRadioDeviceSeeds()[highRegulatorKey]; seed == nil {
+		t.Fatal("high-slot regulator registry seed fixture is missing")
+	}
+
+	recoveryCtx, cancelRecovery := context.WithCancel(context.Background())
+	defer cancelRecovery()
+	selectorReads := 0
+	budgetExhausted := false
+	poller.sendFrameFn = func(ctx context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+		return fm5HighSlotBudgetedResponse(ctx, frame, &selectorReads, &budgetExhausted, cancelRecovery)
+	}
+
+	poller.refreshRadioDevicesStartup(recoveryCtx)
+	poller.refreshFM5SemanticStartup(recoveryCtx)
+
+	fm5Key := radioDeviceKey{Group: remoteFunctionalModules.group, Instance: semanticStartupSlotFullMaxInstance}
+	poller.mu.Lock()
+	fm5Snapshot := cloneRadioSnapshot(poller.radioDevices[fm5Key])
+	retainedRegulator := cloneRadioSnapshot(poller.radioDevices[highRegulatorKey])
+	poller.mu.Unlock()
+	verdict := provider.FM5Interpretation()
+	if budgetExhausted || selectorReads > fm5HighSlotSelectorBudget || fm5Snapshot == nil ||
+		fm5Snapshot.DeviceClassAddress == nil || *fm5Snapshot.DeviceClassAddress != circuitManagingDeviceVR71Address ||
+		retainedRegulator == nil || retainedRegulator.SlotMode != "registry" ||
+		verdict.Mode != graphql.Fm5SemanticModeInterpreted || verdict.DegradedReason != "" || verdict.EvidenceRevision == "" {
+		t.Fatalf("max-slot startup reads=%d exhausted=%t fm5=%#v retained_non_fm=%#v verdict=%#v; want slot 0x0A INTERPRETED within one bounded path with deferred non-FM seed retained", selectorReads, budgetExhausted, fm5Snapshot, retainedRegulator, verdict)
+	}
+}
+
 func TestEnqueueAddressIdentityProbe_GenericFunctionalModuleDoesNotPreemptLaterVR71(t *testing.T) {
 	originalScanDirected := registryScanDirectedFn
 	t.Cleanup(func() { registryScanDirectedFn = originalScanDirected })
@@ -2070,6 +2134,72 @@ func TestEnqueueAddressIdentityProbe_GenericFunctionalModuleDoesNotPreemptLaterV
 	if genericCached || genericSnapshot != nil || !realCached || realSnapshot == nil || realSnapshot.DeviceClassAddress == nil || *realSnapshot.DeviceClassAddress != circuitManagingDeviceVR71Address ||
 		verdict.Mode != graphql.Fm5SemanticModeInterpreted || verdict.DegradedReason != "" || verdict.EvidenceRevision == "" {
 		t.Fatalf("generic-before-VR71 generic_cached=%t generic_snapshot=%#v real_cached=%t real_snapshot=%#v verdict=%#v; want generic ignored, later slot 4 VR71 merged, and healthy INTERPRETED", genericCached, genericSnapshot, realCached, realSnapshot, verdict)
+	}
+}
+
+func TestEnqueueAddressIdentityProbe_MaxSlotVR71ConvergesWithinBoundedRecoveryBudget(t *testing.T) {
+	originalScanDirected := registryScanDirectedFn
+	t.Cleanup(func() { registryScanDirectedFn = originalScanDirected })
+
+	taskScheduler := newSemanticTaskScheduler()
+	poller, provider := newFM5DeadlineRecoveryTestPoller(taskScheduler)
+	connected := true
+	nonFMClass := uint8(0x18)
+	highRegulatorKey := radioDeviceKey{Group: remoteRegulators.group, Instance: 0x03}
+	poller.radioDevices[highRegulatorKey] = &vaillantRadioDeviceSnapshot{
+		Group:              highRegulatorKey.Group,
+		Instance:           highRegulatorKey.Instance,
+		SlotMode:           "registry",
+		DeviceConnected:    &connected,
+		DeviceClassAddress: &nonFMClass,
+	}
+
+	scanSeamCalled := false
+	registryScanDirectedFn = func(_ context.Context, _ registry.ScanBus, reg *registry.DeviceRegistry, _ byte, _ []byte) ([]registry.DeviceEntry, error) {
+		scanSeamCalled = true
+		entry := reg.Register(registry.DeviceInfo{
+			Address:      circuitManagingDeviceVR71Address,
+			Manufacturer: "Vaillant",
+			DeviceID:     circuitManagingDeviceVR71ID,
+		})
+		return []registry.DeviceEntry{entry}, nil
+	}
+
+	recoveryCtx, cancelRecovery := context.WithCancel(context.Background())
+	defer cancelRecovery()
+	selectorReads := 0
+	budgetExhausted := false
+	poller.sendFrameFn = func(ctx context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+		return fm5HighSlotBudgetedResponse(ctx, frame, &selectorReads, &budgetExhausted, cancelRecovery)
+	}
+
+	poller.EnqueueAddressIdentityProbe(circuitManagingDeviceVR71Address)
+	probeTask := taskScheduler.nextTask(context.Background())
+	if probeTask == nil {
+		t.Fatal("late identity probe task was not scheduled")
+	}
+	probeTask.run(recoveryCtx)
+	taskScheduler.taskDone(probeTask)
+
+	fm5DeviceKey := deviceSlotKey{Group: remoteFunctionalModules.group, Instance: semanticStartupSlotFullMaxInstance}
+	poller.mu.Lock()
+	fm5Cached := poller.deviceSlotCache[fm5DeviceKey]
+	fm5Snapshot := cloneRadioSnapshot(poller.radioDevices[radioDeviceKey(fm5DeviceKey)])
+	retainedRegulator := cloneRadioSnapshot(poller.radioDevices[highRegulatorKey])
+	poller.mu.Unlock()
+	publishedRegulator := false
+	for _, device := range provider.RadioDevices() {
+		if device.Group == int(highRegulatorKey.Group) && device.Instance == int(highRegulatorKey.Instance) {
+			publishedRegulator = true
+			break
+		}
+	}
+	verdict := provider.FM5Interpretation()
+	if !scanSeamCalled || budgetExhausted || selectorReads > fm5HighSlotSelectorBudget || !fm5Cached || fm5Snapshot == nil ||
+		fm5Snapshot.DeviceClassAddress == nil || *fm5Snapshot.DeviceClassAddress != circuitManagingDeviceVR71Address ||
+		retainedRegulator == nil || !publishedRegulator || verdict.Mode != graphql.Fm5SemanticModeInterpreted ||
+		verdict.DegradedReason != "" || verdict.EvidenceRevision == "" {
+		t.Fatalf("max-slot late recovery seam=%t reads=%d exhausted=%t cached=%t fm5=%#v retained_non_fm=%#v published_non_fm=%t verdict=%#v; want one bounded directed recovery to publish slot 0x0A INTERPRETED without losing non-FM state", scanSeamCalled, selectorReads, budgetExhausted, fm5Cached, fm5Snapshot, retainedRegulator, publishedRegulator, verdict)
 	}
 }
 

--- a/cmd/gateway/post_m9_defects_red_test.go
+++ b/cmd/gateway/post_m9_defects_red_test.go
@@ -1341,6 +1341,107 @@ func TestFM5PositiveIdentityDoesNotRequireNegativeNamespaceCompleteness(t *testi
 	})
 }
 
+func TestFM5Startup_UnseededLowSlotPositiveDoesNotLosePrimingBudget(t *testing.T) {
+	now := time.Date(2026, 8, 15, 20, 0, 0, 0, time.UTC)
+	config := uint16(2)
+	const (
+		collectorTemperature = 61.5
+		cylinderTemperature  = 47.25
+	)
+	provider := graphql.NewLiveSemanticProvider()
+	poller := &vaillantSemanticPoller{
+		scheduler:       ebusgateway.NewSemanticReadScheduler(),
+		reg:             registry.NewDeviceRegistry(nil),
+		provider:        provider,
+		source:          0x7F,
+		controller:      0x15,
+		requestTimeout:  50 * time.Millisecond,
+		system:          &vaillantSystemSnapshot{Controller: 0x15, ModuleConfigurationVR71: &config},
+		radioDevices:    make(map[radioDeviceKey]*vaillantRadioDeviceSnapshot),
+		solarCylinders:  make(map[byte]*vaillantCylinderSnapshot),
+		fm5EvidenceTTL:  5 * time.Minute,
+		deviceSlotCache: make(map[deviceSlotKey]bool),
+		nowFn:           func() time.Time { return now },
+	}
+
+	startupCtx, cancelStartup := context.WithCancel(context.Background())
+	defer cancelStartup()
+	tailEntered := false
+	blockedFamilyReads := 0
+	poller.sendFrameFn = func(ctx context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+		if len(frame.Data) != 6 {
+			return nil, errors.New("invalid B524 selector")
+		}
+		group := frame.Data[2]
+		instance := frame.Data[3]
+		addr := uint16(frame.Data[4]) | uint16(frame.Data[5])<<8
+
+		if group == remoteFunctionalModules.group && instance >= semanticStartupSlotFastMaxInstance+1 {
+			tailEntered = true
+			cancelStartup()
+		}
+		if (group == localSolar.group || group == localCylinders.group) && ctx.Err() != nil {
+			blockedFamilyReads++
+			return nil, ctx.Err()
+		}
+
+		if group == remoteFunctionalModules.group {
+			switch addr {
+			case device_slot_connected:
+				connected := byte(0x00)
+				if instance == 0x01 {
+					connected = 0x01
+				}
+				return testB524ResponseForSelectorPayload(frame.Data, connected), nil
+			case device_slot_class_address:
+				classAddress := byte(0xFF)
+				if instance == 0x01 {
+					classAddress = circuitManagingDeviceVR71Address
+				}
+				return testB524ResponseForSelectorPayload(frame.Data, classAddress), nil
+			case device_slot_firmware:
+				firmware := []byte{0xFF, 0xFF, 0xFF}
+				if instance == 0x01 {
+					firmware = []byte{0x01, 0x00, 0x00}
+				}
+				return testB524ResponseForSelectorPayload(frame.Data, firmware...), nil
+			case device_slot_hardware_identifier:
+				hardware := []byte{0xFF, 0xFF}
+				if instance == 0x01 {
+					hardware = []byte{0x71, 0x00}
+				}
+				return testB524ResponseForSelectorPayload(frame.Data, hardware...), nil
+			}
+		}
+		if group == localSolar.group {
+			switch addr {
+			case solar_collector_temp:
+				return testB524ResponseForSelectorPayload(frame.Data, testB524Float32Payload(collectorTemperature)...), nil
+			case solar_enabled, solar_pump_active:
+				return testB524ResponseForSelectorPayload(frame.Data, 0x01), nil
+			}
+		}
+		if group == localCylinders.group && addr == cylinder_temperature {
+			return testB524ResponseForSelectorPayload(frame.Data, testB524Float32Payload(cylinderTemperature)...), nil
+		}
+		return testB524ResponseForSelectorPayload(frame.Data, 0x00, 0x00, 0x00, 0x00), nil
+	}
+
+	poller.refreshRadioDevicesStartup(startupCtx)
+	poller.refreshFM5SemanticStartup(startupCtx)
+
+	got := provider.FM5Interpretation()
+	if got.Mode != graphql.Fm5SemanticModeInterpreted || got.DegradedReason != "" || got.EvidenceRevision == "" {
+		t.Fatalf("unseeded low-slot startup verdict = %#v; want healthy INTERPRETED with revision (tail_entered=%t blocked_family_reads=%d)", got, tailEntered, blockedFamilyReads)
+	}
+	if solar := provider.Solar(); solar == nil || solar.CollectorTemperatureC == nil || *solar.CollectorTemperatureC != collectorTemperature {
+		t.Fatalf("unseeded low-slot startup solar = %#v; want collector temperature %v", solar, collectorTemperature)
+	}
+	if cylinders := provider.Cylinders(); len(cylinders) == 0 || cylinders[0].TemperatureC == nil || *cylinders[0].TemperatureC != cylinderTemperature {
+		t.Fatalf("unseeded low-slot startup cylinders = %#v; want temperature %v", cylinders, cylinderTemperature)
+	}
+}
+
 func TestRefreshRadioDevices_CompleteNegativeFM5ScanSupersedesRetainedRegistryIdentity(t *testing.T) {
 	now := time.Date(2026, 8, 15, 15, 0, 0, 0, time.UTC)
 	config := uint16(2)

--- a/cmd/gateway/post_m9_defects_red_test.go
+++ b/cmd/gateway/post_m9_defects_red_test.go
@@ -1564,6 +1564,198 @@ func TestEnqueueAddressIdentityProbe_LateFM5SuccessTriggersBoundedSemanticReacqu
 	}
 }
 
+func newFM5DeadlineRecoveryTestPoller(tasks *semanticTaskScheduler) (*vaillantSemanticPoller, *graphql.LiveSemanticProvider) {
+	now := time.Date(2026, 8, 15, 21, 0, 0, 0, time.UTC)
+	provider := graphql.NewLiveSemanticProvider()
+	return &vaillantSemanticPoller{
+		scheduler:                ebusgateway.NewSemanticReadScheduler(),
+		tasks:                    tasks,
+		reg:                      registry.NewDeviceRegistry(nil),
+		bus:                      &protocol.Bus{},
+		provider:                 provider,
+		source:                   0x7F,
+		controller:               0x15,
+		requestTimeout:           50 * time.Millisecond,
+		system:                   &vaillantSystemSnapshot{Controller: 0x15},
+		radioDevices:             make(map[radioDeviceKey]*vaillantRadioDeviceSnapshot),
+		solarCylinders:           make(map[byte]*vaillantCylinderSnapshot),
+		fm5EvidenceTTL:           5 * time.Minute,
+		deviceSlotRediscoveryTTL: 30 * time.Minute,
+		deviceSlotCache:          make(map[deviceSlotKey]bool),
+		nowFn:                    func() time.Time { return now },
+	}, provider
+}
+
+func fm5InstanceOneSemanticTestResponse(frame protocol.Frame) (*protocol.Frame, error) {
+	if len(frame.Data) != 6 {
+		return nil, errors.New("invalid B524 selector")
+	}
+	group := frame.Data[2]
+	instance := frame.Data[3]
+	addr := uint16(frame.Data[4]) | uint16(frame.Data[5])<<8
+	if group == localRegulator.group && addr == system_module_configuration_vr71 {
+		return testB524ResponseForSelectorPayload(frame.Data, 0x02, 0x00), nil
+	}
+	if group == remoteFunctionalModules.group {
+		switch addr {
+		case device_slot_connected:
+			if instance == 0x01 {
+				return testB524ResponseForSelectorPayload(frame.Data, 0x01), nil
+			}
+			return testB524ResponseForSelectorPayload(frame.Data, 0x00), nil
+		case device_slot_class_address:
+			if instance == 0x01 {
+				return testB524ResponseForSelectorPayload(frame.Data, circuitManagingDeviceVR71Address), nil
+			}
+			return testB524ResponseForSelectorPayload(frame.Data, 0xFF), nil
+		case device_slot_firmware:
+			if instance == 0x01 {
+				return testB524ResponseForSelectorPayload(frame.Data, 0x01, 0x00, 0x00), nil
+			}
+			return testB524ResponseForSelectorPayload(frame.Data, 0xFF, 0xFF, 0xFF), nil
+		case device_slot_hardware_identifier:
+			if instance == 0x01 {
+				return testB524ResponseForSelectorPayload(frame.Data, 0x71, 0x00), nil
+			}
+			return testB524ResponseForSelectorPayload(frame.Data, 0xFF, 0xFF), nil
+		}
+	}
+	if group == localSolar.group && (addr == solar_enabled || addr == solar_pump_active) {
+		return testB524ResponseForSelectorPayload(frame.Data, 0x01), nil
+	}
+	if group == localSolar.group || group == localCylinders.group {
+		return testB524ResponseForSelectorPayload(frame.Data, testB524Float32Payload(47.25)...), nil
+	}
+	return testB524ResponseForSelectorPayload(frame.Data, 0x00, 0x00, 0x00, 0x00), nil
+}
+
+func TestFM5Startup_PositiveFastSlotClassifiesBeforeUnrelatedRadioTailDeadline(t *testing.T) {
+	poller, provider := newFM5DeadlineRecoveryTestPoller(nil)
+	config := uint16(2)
+	poller.system.ModuleConfigurationVR71 = &config
+	startupCtx, cancelStartup := context.WithCancel(context.Background())
+	defer cancelStartup()
+	tailEntered := false
+	poller.sendFrameFn = func(ctx context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+		if len(frame.Data) == 6 &&
+			(frame.Data[2] == remoteRegulators.group || frame.Data[2] == remoteThermostats.group) &&
+			frame.Data[3] > semanticStartupSlotFastMaxInstance {
+			tailEntered = true
+			cancelStartup()
+		}
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return fm5InstanceOneSemanticTestResponse(frame)
+	}
+
+	poller.refreshRadioDevicesStartup(startupCtx)
+	poller.refreshFM5SemanticStartup(startupCtx)
+
+	verdict := provider.FM5Interpretation()
+	if verdict.Mode != graphql.Fm5SemanticModeInterpreted || verdict.DegradedReason != "" || verdict.EvidenceRevision == "" {
+		t.Fatalf("deadline-aware startup verdict=%#v tail_entered=%t; want healthy INTERPRETED before unrelated regulator/thermostat tail", verdict, tailEntered)
+	}
+}
+
+func TestEnqueueAddressIdentityProbe_SaturatedQueueCoalescesGuaranteedOrderedFM5Recovery(t *testing.T) {
+	originalScanDirected := registryScanDirectedFn
+	t.Cleanup(func() { registryScanDirectedFn = originalScanDirected })
+
+	taskScheduler := newSemanticTaskScheduler()
+	taskScheduler.maxDepth = 4
+	poller, provider := newFM5DeadlineRecoveryTestPoller(taskScheduler)
+	scanSeamCalled := false
+	registryScanDirectedFn = func(_ context.Context, _ registry.ScanBus, reg *registry.DeviceRegistry, _ byte, targets []byte) ([]registry.DeviceEntry, error) {
+		scanSeamCalled = true
+		if len(targets) != 1 || targets[0] != circuitManagingDeviceVR71Address {
+			return nil, errors.New("unexpected directed identity target")
+		}
+		entry := reg.Register(registry.DeviceInfo{
+			Address:      circuitManagingDeviceVR71Address,
+			Manufacturer: "Vaillant",
+			DeviceID:     circuitManagingDeviceVR71ID,
+		})
+		return []registry.DeviceEntry{entry}, nil
+	}
+
+	readOrder := make([]string, 0, 2)
+	systemRecorded := false
+	radioRecorded := false
+	poller.sendFrameFn = func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+		if len(frame.Data) == 6 {
+			group := frame.Data[2]
+			addr := uint16(frame.Data[4]) | uint16(frame.Data[5])<<8
+			if group == localRegulator.group && addr == system_module_configuration_vr71 && !systemRecorded {
+				readOrder = append(readOrder, "system")
+				systemRecorded = true
+			} else if (group == remoteRegulators.group || group == remoteThermostats.group || group == remoteFunctionalModules.group) && !radioRecorded {
+				readOrder = append(readOrder, "radio")
+				radioRecorded = true
+			}
+		}
+		return fm5InstanceOneSemanticTestResponse(frame)
+	}
+
+	if err := taskScheduler.submitCoalesced(semanticTaskRefreshRadioDevices, semanticTaskPriorityLow, func(ctx context.Context) {
+		poller.refreshRadioDevices(ctx)
+	}); err != nil {
+		t.Fatalf("queue older radio task: %v", err)
+	}
+	poller.EnqueueAddressIdentityProbe(circuitManagingDeviceVR71Address)
+	for _, key := range []semanticTaskKey{"fm5-p2-fill-1", "fm5-p2-fill-2"} {
+		if err := taskScheduler.submitCoalesced(key, semanticTaskPriorityLow, func(context.Context) {}); err != nil {
+			t.Fatalf("fill queue before probe: %v", err)
+		}
+	}
+
+	var probeTask *semanticTask
+	taskScheduler.mu.Lock()
+	for i, task := range taskScheduler.queue {
+		if task.key == "" {
+			probeTask = task
+			taskScheduler.queue = append(taskScheduler.queue[:i], taskScheduler.queue[i+1:]...)
+			break
+		}
+	}
+	taskScheduler.mu.Unlock()
+	if probeTask == nil {
+		t.Fatal("late identity probe task missing from saturated queue fixture")
+	}
+	if err := taskScheduler.submitCoalesced("fm5-p2-fill-3", semanticTaskPriorityLow, func(context.Context) {}); err != nil {
+		t.Fatalf("refill queue while identity probe runs: %v", err)
+	}
+	probeTask.run(context.Background())
+	taskScheduler.taskDone(probeTask)
+
+	recoveryTasks := 0
+	taskScheduler.mu.Lock()
+	for _, task := range taskScheduler.queue {
+		if task.key == semanticTaskRefreshSystem || task.key == semanticTaskRefreshRadioDevices {
+			recoveryTasks++
+		}
+	}
+	taskScheduler.mu.Unlock()
+	for {
+		taskScheduler.mu.Lock()
+		pending := len(taskScheduler.queue)
+		taskScheduler.mu.Unlock()
+		if pending == 0 {
+			break
+		}
+		task := taskScheduler.nextTask(context.Background())
+		task.run(context.Background())
+		taskScheduler.taskDone(task)
+	}
+
+	verdict := provider.FM5Interpretation()
+	ordered := len(readOrder) >= 2 && readOrder[0] == "system" && readOrder[1] == "radio"
+	if !scanSeamCalled || recoveryTasks != 1 || !ordered ||
+		verdict.Mode != graphql.Fm5SemanticModeInterpreted || verdict.DegradedReason != "" || verdict.EvidenceRevision == "" {
+		t.Fatalf("saturated late recovery seam_called=%t recovery_tasks=%d read_order=%v verdict=%#v; want one guaranteed coalesced system-then-radio recovery and healthy INTERPRETED", scanSeamCalled, recoveryTasks, readOrder, verdict)
+	}
+}
+
 func TestRefreshRadioDevices_CompleteNegativeFM5ScanSupersedesRetainedRegistryIdentity(t *testing.T) {
 	now := time.Date(2026, 8, 15, 15, 0, 0, 0, time.UTC)
 	config := uint16(2)

--- a/cmd/gateway/post_m9_defects_red_test.go
+++ b/cmd/gateway/post_m9_defects_red_test.go
@@ -1901,6 +1901,128 @@ func TestEnqueueAddressIdentityProbe_FreshEmptySlotCacheForcesBoundedFM5Discover
 	}
 }
 
+func fm5SemanticTestResponseForClasses(frame protocol.Frame, classes map[byte]byte) (*protocol.Frame, error) {
+	if len(frame.Data) != 6 {
+		return nil, errors.New("invalid B524 selector")
+	}
+	group := frame.Data[2]
+	instance := frame.Data[3]
+	addr := uint16(frame.Data[4]) | uint16(frame.Data[5])<<8
+	if group == localRegulator.group && addr == system_module_configuration_vr71 {
+		return testB524ResponseForSelectorPayload(frame.Data, 0x02, 0x00), nil
+	}
+	if group == remoteFunctionalModules.group {
+		classAddress, populated := classes[instance]
+		switch addr {
+		case device_slot_connected:
+			if populated {
+				return testB524ResponseForSelectorPayload(frame.Data, 0x01), nil
+			}
+			return testB524ResponseForSelectorPayload(frame.Data, 0x00), nil
+		case device_slot_class_address:
+			if populated {
+				return testB524ResponseForSelectorPayload(frame.Data, classAddress), nil
+			}
+			return testB524ResponseForSelectorPayload(frame.Data, 0xFF), nil
+		case device_slot_firmware:
+			if populated {
+				return testB524ResponseForSelectorPayload(frame.Data, 0x01, 0x00, 0x00), nil
+			}
+			return testB524ResponseForSelectorPayload(frame.Data, 0xFF, 0xFF, 0xFF), nil
+		case device_slot_hardware_identifier:
+			if populated {
+				return testB524ResponseForSelectorPayload(frame.Data, 0x71, 0x00), nil
+			}
+			return testB524ResponseForSelectorPayload(frame.Data, 0xFF, 0xFF), nil
+		}
+	}
+	if group == localSolar.group && (addr == solar_enabled || addr == solar_pump_active) {
+		return testB524ResponseForSelectorPayload(frame.Data, 0x01), nil
+	}
+	if group == localSolar.group || group == localCylinders.group {
+		return testB524ResponseForSelectorPayload(frame.Data, testB524Float32Payload(47.25)...), nil
+	}
+	return testB524ResponseForSelectorPayload(frame.Data, 0x00, 0x00, 0x00, 0x00), nil
+}
+
+func TestFM5Startup_HighSlotPositivePreemptsUnrelatedRadioTails(t *testing.T) {
+	poller, provider := newFM5DeadlineRecoveryTestPoller(nil)
+	config := uint16(2)
+	poller.system.ModuleConfigurationVR71 = &config
+	classes := map[byte]byte{0x03: circuitManagingDeviceVR71Address}
+	startupCtx, cancelStartup := context.WithCancel(context.Background())
+	defer cancelStartup()
+	unrelatedTailEntered := false
+	poller.sendFrameFn = func(ctx context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+		if len(frame.Data) == 6 && frame.Data[3] > semanticStartupSlotFastMaxInstance &&
+			(frame.Data[2] == remoteRegulators.group || frame.Data[2] == remoteThermostats.group) {
+			unrelatedTailEntered = true
+			cancelStartup()
+		}
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return fm5SemanticTestResponseForClasses(frame, classes)
+	}
+
+	poller.refreshRadioDevicesStartup(startupCtx)
+	poller.refreshFM5SemanticStartup(startupCtx)
+
+	poller.mu.Lock()
+	realSnapshot := poller.radioDevices[radioDeviceKey{Group: remoteFunctionalModules.group, Instance: 0x03}]
+	poller.mu.Unlock()
+	verdict := provider.FM5Interpretation()
+	if unrelatedTailEntered || realSnapshot == nil || realSnapshot.DeviceClassAddress == nil || *realSnapshot.DeviceClassAddress != circuitManagingDeviceVR71Address ||
+		verdict.Mode != graphql.Fm5SemanticModeInterpreted || verdict.DegradedReason != "" || verdict.EvidenceRevision == "" {
+		t.Fatalf("high-slot startup unrelated_tail=%t snapshot=%#v verdict=%#v; want FM tail first, real slot 3 VR71, and healthy INTERPRETED", unrelatedTailEntered, realSnapshot, verdict)
+	}
+}
+
+func TestEnqueueAddressIdentityProbe_GenericFunctionalModuleDoesNotPreemptLaterVR71(t *testing.T) {
+	originalScanDirected := registryScanDirectedFn
+	t.Cleanup(func() { registryScanDirectedFn = originalScanDirected })
+
+	taskScheduler := newSemanticTaskScheduler()
+	poller, provider := newFM5DeadlineRecoveryTestPoller(taskScheduler)
+	classes := map[byte]byte{
+		0x00: 0x2A,
+		0x04: circuitManagingDeviceVR71Address,
+	}
+	registryScanDirectedFn = func(_ context.Context, _ registry.ScanBus, reg *registry.DeviceRegistry, _ byte, _ []byte) ([]registry.DeviceEntry, error) {
+		entry := reg.Register(registry.DeviceInfo{
+			Address:      circuitManagingDeviceVR71Address,
+			Manufacturer: "Vaillant",
+			DeviceID:     circuitManagingDeviceVR71ID,
+		})
+		return []registry.DeviceEntry{entry}, nil
+	}
+	poller.sendFrameFn = func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+		return fm5SemanticTestResponseForClasses(frame, classes)
+	}
+
+	poller.EnqueueAddressIdentityProbe(circuitManagingDeviceVR71Address)
+	probeTask := taskScheduler.nextTask(context.Background())
+	if probeTask == nil {
+		t.Fatal("late identity probe task was not scheduled")
+	}
+	probeTask.run(context.Background())
+	taskScheduler.taskDone(probeTask)
+
+	genericKey := deviceSlotKey{Group: remoteFunctionalModules.group, Instance: 0x00}
+	realKey := deviceSlotKey{Group: remoteFunctionalModules.group, Instance: 0x04}
+	poller.mu.Lock()
+	genericCached := poller.deviceSlotCache[genericKey]
+	realCached := poller.deviceSlotCache[realKey]
+	genericSnapshot := poller.radioDevices[radioDeviceKey(genericKey)]
+	realSnapshot := poller.radioDevices[radioDeviceKey(realKey)]
+	poller.mu.Unlock()
+	verdict := provider.FM5Interpretation()
+	if genericCached || genericSnapshot != nil || !realCached || realSnapshot == nil || realSnapshot.DeviceClassAddress == nil || *realSnapshot.DeviceClassAddress != circuitManagingDeviceVR71Address ||
+		verdict.Mode != graphql.Fm5SemanticModeInterpreted || verdict.DegradedReason != "" || verdict.EvidenceRevision == "" {
+		t.Fatalf("generic-before-VR71 generic_cached=%t generic_snapshot=%#v real_cached=%t real_snapshot=%#v verdict=%#v; want generic ignored, later slot 4 VR71 merged, and healthy INTERPRETED", genericCached, genericSnapshot, realCached, realSnapshot, verdict)
+	}
+}
+
 func TestRefreshRadioDevices_CompleteNegativeFM5ScanSupersedesRetainedRegistryIdentity(t *testing.T) {
 	now := time.Date(2026, 8, 15, 15, 0, 0, 0, time.UTC)
 	config := uint16(2)

--- a/cmd/gateway/post_m9_defects_red_test.go
+++ b/cmd/gateway/post_m9_defects_red_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -1975,6 +1976,55 @@ func TestFM5Startup_HighSlotPositivePreemptsUnrelatedRadioTails(t *testing.T) {
 	if unrelatedTailEntered || realSnapshot == nil || realSnapshot.DeviceClassAddress == nil || *realSnapshot.DeviceClassAddress != circuitManagingDeviceVR71Address ||
 		verdict.Mode != graphql.Fm5SemanticModeInterpreted || verdict.DegradedReason != "" || verdict.EvidenceRevision == "" {
 		t.Fatalf("high-slot startup unrelated_tail=%t snapshot=%#v verdict=%#v; want FM tail first, real slot 3 VR71, and healthy INTERPRETED", unrelatedTailEntered, realSnapshot, verdict)
+	}
+}
+
+func TestFM5Startup_FastPositiveRetainsDeferredHighSlotRegistrySeed(t *testing.T) {
+	poller, provider := newFM5DeadlineRecoveryTestPoller(nil)
+	config := uint16(2)
+	poller.system.ModuleConfigurationVR71 = &config
+	seedAddresses := []byte{0x15, 0x16, 0x17, 0x18}
+	for instance, address := range seedAddresses {
+		poller.reg.Register(registry.DeviceInfo{
+			Address:      address,
+			Manufacturer: "Vaillant",
+			DeviceID:     fmt.Sprintf("BASV%d", instance),
+		})
+	}
+	highKey := radioDeviceKey{Group: remoteRegulators.group, Instance: 0x03}
+	seededHigh := poller.registryRadioDeviceSeeds()[highKey]
+	if seededHigh == nil || seededHigh.DeviceClassAddress == nil || *seededHigh.DeviceClassAddress != seedAddresses[3] {
+		t.Fatalf("high-slot registry seed fixture = %#v; want regulator instance 3 at 0x%02X", seededHigh, seedAddresses[3])
+	}
+
+	unrelatedTailEntered := false
+	poller.sendFrameFn = func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+		if len(frame.Data) == 6 && frame.Data[3] > semanticStartupSlotFastMaxInstance &&
+			(frame.Data[2] == remoteRegulators.group || frame.Data[2] == remoteThermostats.group) {
+			unrelatedTailEntered = true
+		}
+		return fm5SemanticTestResponseForClasses(frame, map[byte]byte{0x01: circuitManagingDeviceVR71Address})
+	}
+
+	poller.refreshRadioDevicesStartup(context.Background())
+	poller.refreshFM5SemanticStartup(context.Background())
+
+	poller.mu.Lock()
+	highSnapshot := cloneRadioSnapshot(poller.radioDevices[highKey])
+	poller.mu.Unlock()
+	publishedHighSeed := false
+	for _, device := range provider.RadioDevices() {
+		if device.Group == int(highKey.Group) && device.Instance == int(highKey.Instance) &&
+			device.DeviceClassAddress != nil && *device.DeviceClassAddress == int(seedAddresses[3]) {
+			publishedHighSeed = true
+			break
+		}
+	}
+	verdict := provider.FM5Interpretation()
+	if unrelatedTailEntered || highSnapshot == nil || highSnapshot.SlotMode != "registry" ||
+		highSnapshot.DeviceClassAddress == nil || *highSnapshot.DeviceClassAddress != seedAddresses[3] || !publishedHighSeed ||
+		verdict.Mode != graphql.Fm5SemanticModeInterpreted {
+		t.Fatalf("fast-positive deferred seed tail_entered=%t snapshot=%#v published=%t verdict=%#v; want no non-FM tail I/O and retained high-slot registry seed until deferred scan", unrelatedTailEntered, highSnapshot, publishedHighSeed, verdict)
 	}
 }
 

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -190,6 +190,7 @@ const (
 	semanticStartupSlotFastMaxInstance = byte(0x02)
 	semanticStartupSlotFullMaxInstance = byte(0x0A)
 	semanticStartupCriticalDHWAttempts = 3
+	semanticIdentityRecoveryTimeout    = 35 * time.Second
 	semanticCircuitFullScanInterval    = 30 * time.Minute
 	semanticCircuitPartialScanInterval = 5 * time.Minute
 )
@@ -1864,19 +1865,20 @@ func (p *vaillantSemanticPoller) refreshRadioDevicesStartup(ctx context.Context)
 			}
 		}
 	}
-	for _, grp := range remoteDeviceGroups {
-		if fullScanGroups[grp.group] {
-			if grp.group == remoteFunctionalModules.group && fm5PositiveObserved {
-				fm5NamespaceComplete = false
+	if fm5PositiveObserved {
+		fm5NamespaceComplete = false
+	} else {
+	tailScan:
+		for _, grp := range remoteDeviceGroups {
+			if !fullScanGroups[grp.group] {
 				continue
 			}
 			for instance := semanticStartupSlotFastMaxInstance + 1; instance <= semanticStartupSlotFullMaxInstance; instance++ {
 				if probeSlot(grp, instance) && grp.group == remoteFunctionalModules.group {
-					fm5PositiveObserved = true
 					if instance < semanticStartupSlotFullMaxInstance {
 						fm5NamespaceComplete = false
 					}
-					break
+					break tailScan
 				}
 			}
 		}
@@ -9158,8 +9160,10 @@ func (p *vaillantSemanticPoller) EnqueueAddressIdentityProbe(addr byte) {
 		}
 		log.Printf("semantic_address_identity_probe address=0x%02X status=ok", probeAddr)
 		if probeAddr == circuitManagingDeviceVR71Address {
-			p.enqueueTask(semanticTaskRefreshSystem, semanticTaskPriorityMedium, p.refreshSystem)
-			p.enqueueTask(semanticTaskRefreshRadioDevices, semanticTaskPriorityMedium, p.refreshRadioDevices)
+			recoveryCtx, recoveryCancel := context.WithTimeout(ctx, semanticIdentityRecoveryTimeout)
+			defer recoveryCancel()
+			p.refreshSystem(recoveryCtx)
+			p.refreshRadioDevices(recoveryCtx)
 		}
 	}
 	if scheduler == nil {

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -1795,21 +1795,23 @@ func (p *vaillantSemanticPoller) refreshRadioDevicesStartup(ctx context.Context)
 	discovered := p.registryRadioDeviceSeeds()
 	fullScanGroups := startupRadioFullScanGroups(discovered)
 	fm5NamespaceComplete := fullScanGroups[remoteFunctionalModules.group]
+	fm5PositiveObserved := false
 	verified := make(map[radioDeviceKey]bool)
 	readAny := false
-	probeSlot := func(grp b524GroupDef, instance byte) {
+	probeSlot := func(grp b524GroupDef, instance byte) bool {
 		connectedRaw, ok := p.readB524Startup(ctx, grp.opcode, grp.group, instance, device_slot_connected)
 		if !ok || len(connectedRaw) == 0 {
 			if grp.group == remoteFunctionalModules.group {
 				fm5NamespaceComplete = false
 			}
-			return
+			return false
 		}
 		readAny = true
 		connected := connectedRaw[0] == 1
 		var classAddress *uint8
 		var firmware *string
 		var hardware *uint16
+		completePositiveFM5 := false
 		if grp.group == remoteFunctionalModules.group {
 			classRaw, classOK := p.readB524Startup(ctx, grp.opcode, grp.group, instance, device_slot_class_address)
 			firmwareRaw, firmwareOK := p.readB524Startup(ctx, grp.opcode, grp.group, instance, device_slot_firmware)
@@ -1827,6 +1829,7 @@ func (p *vaillantSemanticPoller) refreshRadioDevicesStartup(ctx context.Context)
 			classAddress = tuple.classAddress
 			firmware = tuple.firmware
 			hardware = tuple.hardware
+			completePositiveFM5 = tuple.complete && hasRemoteIdentityEvidence(classAddress, firmware, hardware)
 		} else {
 			classAddress = p.readB524U8Startup(ctx, grp.opcode, grp.group, instance, device_slot_class_address)
 		}
@@ -1839,7 +1842,7 @@ func (p *vaillantSemanticPoller) refreshRadioDevicesStartup(ctx context.Context)
 		}
 		if !include {
 			delete(discovered, key)
-			return
+			return false
 		}
 		discovered[key] = &vaillantRadioDeviceSnapshot{
 			Group:              grp.group,
@@ -1851,17 +1854,30 @@ func (p *vaillantSemanticPoller) refreshRadioDevicesStartup(ctx context.Context)
 			FirmwareVersion:    cloneStringPtr(firmware),
 			HardwareIdentifier: cloneUint16Ptr(hardware),
 		}
+		return completePositiveFM5
 	}
 
 	for _, grp := range remoteDeviceGroups {
 		for instance := byte(0x00); instance <= semanticStartupSlotFastMaxInstance; instance++ {
-			probeSlot(grp, instance)
+			if probeSlot(grp, instance) {
+				fm5PositiveObserved = true
+			}
 		}
 	}
 	for _, grp := range remoteDeviceGroups {
 		if fullScanGroups[grp.group] {
+			if grp.group == remoteFunctionalModules.group && fm5PositiveObserved {
+				fm5NamespaceComplete = false
+				continue
+			}
 			for instance := semanticStartupSlotFastMaxInstance + 1; instance <= semanticStartupSlotFullMaxInstance; instance++ {
-				probeSlot(grp, instance)
+				if probeSlot(grp, instance) && grp.group == remoteFunctionalModules.group {
+					fm5PositiveObserved = true
+					if instance < semanticStartupSlotFullMaxInstance {
+						fm5NamespaceComplete = false
+					}
+					break
+				}
 			}
 		}
 	}

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -9151,12 +9151,16 @@ func (p *vaillantSemanticPoller) EnqueueAddressIdentityProbe(addr byte) {
 	probeFn := func(ctx context.Context) {
 		probeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
-		_, err := registry.ScanDirected(probeCtx, p.bus, p.reg, p.source, []byte{probeAddr})
+		_, err := registryScanDirectedFn(probeCtx, p.bus, p.reg, p.source, []byte{probeAddr})
 		if err != nil {
 			log.Printf("semantic_address_identity_probe address=0x%02X status=fail err=%v", probeAddr, err)
 			return
 		}
 		log.Printf("semantic_address_identity_probe address=0x%02X status=ok", probeAddr)
+		if probeAddr == circuitManagingDeviceVR71Address {
+			p.enqueueTask(semanticTaskRefreshSystem, semanticTaskPriorityMedium, p.refreshSystem)
+			p.enqueueTask(semanticTaskRefreshRadioDevices, semanticTaskPriorityMedium, p.refreshRadioDevices)
+		}
 	}
 	if scheduler == nil {
 		// No scheduler wired (unit tests, etc.) — run inline.

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -9162,7 +9162,7 @@ func (p *vaillantSemanticPoller) EnqueueAddressIdentityProbe(addr byte) {
 		if probeAddr == circuitManagingDeviceVR71Address {
 			recoveryCtx, recoveryCancel := context.WithTimeout(ctx, semanticIdentityRecoveryTimeout)
 			defer recoveryCancel()
-			p.refreshSystem(recoveryCtx)
+			p.refreshSystemStartup(recoveryCtx)
 			p.refreshRadioDevices(recoveryCtx)
 		}
 	}

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -1898,6 +1898,9 @@ func (p *vaillantSemanticPoller) refreshRadioDevicesStartup(ctx context.Context)
 	if readAny {
 		for key, snapshot := range discovered {
 			if snapshot != nil && snapshot.SlotMode == "registry" && !verified[key] {
+				if fm5PositiveObserved && key.Group != remoteFunctionalModules.group {
+					continue
+				}
 				delete(discovered, key)
 			}
 		}

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -1795,60 +1795,23 @@ func (p *vaillantSemanticPoller) refreshRadioDevicesStartup(ctx context.Context)
 
 	discovered := p.registryRadioDeviceSeeds()
 	fullScanGroups := startupRadioFullScanGroups(discovered)
-	fm5NamespaceComplete := fullScanGroups[remoteFunctionalModules.group]
 	fm5PositiveObserved := false
 	verified := make(map[radioDeviceKey]bool)
 	readAny := false
-	probeSlot := func(grp b524GroupDef, instance byte) bool {
+	probeSlot := func(grp b524GroupDef, instance byte) {
 		connectedRaw, ok := p.readB524Startup(ctx, grp.opcode, grp.group, instance, device_slot_connected)
 		if !ok || len(connectedRaw) == 0 {
-			if grp.group == remoteFunctionalModules.group {
-				fm5NamespaceComplete = false
-			}
-			return false
+			return
 		}
 		readAny = true
 		connected := connectedRaw[0] == 1
-		var classAddress *uint8
-		var firmware *string
-		var hardware *uint16
-		completePositiveFM5 := false
-		if grp.group == remoteFunctionalModules.group {
-			classRaw, classOK := p.readB524Startup(ctx, grp.opcode, grp.group, instance, device_slot_class_address)
-			firmwareRaw, firmwareOK := p.readB524Startup(ctx, grp.opcode, grp.group, instance, device_slot_firmware)
-			hardwareRaw, hardwareOK := p.readB524Startup(ctx, grp.opcode, grp.group, instance, device_slot_hardware_identifier)
-			tuple := decodeFunctionalModuleIdentityTuple(
-				connectedRaw, true,
-				classRaw, classOK,
-				firmwareRaw, firmwareOK,
-				hardwareRaw, hardwareOK,
-			)
-			if !tuple.complete {
-				fm5NamespaceComplete = false
-			}
-			connected = tuple.connected
-			classAddress = tuple.classAddress
-			firmware = tuple.firmware
-			hardware = tuple.hardware
-			completePositiveFM5 = completeVR71IdentityTuple(tuple)
-		} else {
-			classAddress = p.readB524U8Startup(ctx, grp.opcode, grp.group, instance, device_slot_class_address)
-		}
+		classAddress := p.readB524U8Startup(ctx, grp.opcode, grp.group, instance, device_slot_class_address)
 		key := radioDeviceKey{Group: grp.group, Instance: instance}
 		verified[key] = true
 		include, slotMode := startupRadioDeviceInclude(grp.group, connected, classAddress)
-		if grp.group == remoteFunctionalModules.group && classAddress != nil && *classAddress != circuitManagingDeviceVR71Address {
-			include = false
-		}
-		if grp.group == remoteFunctionalModules.group && !include && hasRemoteIdentityEvidence(classAddress, firmware, hardware) {
-			if classAddress == nil || *classAddress == circuitManagingDeviceVR71Address {
-				include = true
-				slotMode = "inventory"
-			}
-		}
 		if !include {
 			delete(discovered, key)
-			return false
+			return
 		}
 		discovered[key] = &vaillantRadioDeviceSnapshot{
 			Group:              grp.group,
@@ -1857,34 +1820,36 @@ func (p *vaillantSemanticPoller) refreshRadioDevicesStartup(ctx context.Context)
 			DeviceConnected:    &connected,
 			DeviceClassAddress: cloneUint8Ptr(classAddress),
 			DeviceModel:        decodeRadioDeviceModel(classAddress),
-			FirmwareVersion:    cloneStringPtr(firmware),
-			HardwareIdentifier: cloneUint16Ptr(hardware),
 		}
-		return completePositiveFM5
 	}
 
 	for _, grp := range remoteDeviceGroups {
+		if grp.group == remoteFunctionalModules.group {
+			continue
+		}
 		for instance := byte(0x00); instance <= semanticStartupSlotFastMaxInstance; instance++ {
-			if probeSlot(grp, instance) {
-				fm5PositiveObserved = true
-			}
+			probeSlot(grp, instance)
 		}
 	}
-	if fm5PositiveObserved {
-		fm5NamespaceComplete = false
-	} else {
-		if fullScanGroups[remoteFunctionalModules.group] {
-			for instance := semanticStartupSlotFastMaxInstance + 1; instance <= semanticStartupSlotFullMaxInstance; instance++ {
-				if probeSlot(remoteFunctionalModules, instance) {
-					fm5PositiveObserved = true
-					if instance < semanticStartupSlotFullMaxInstance {
-						fm5NamespaceComplete = false
-					}
-					break
-				}
-			}
+	fm5LastInstance := semanticStartupSlotFastMaxInstance
+	if fullScanGroups[remoteFunctionalModules.group] {
+		fm5LastInstance = semanticStartupSlotFullMaxInstance
+	}
+	fm5Scan := p.scanFunctionalModuleIdentityBudgetAwareWith(ctx, 0x00, fm5LastInstance, p.readB524Startup)
+	if fm5Scan.observedAny {
+		readAny = true
+	}
+	for instance := byte(0x00); instance <= fm5LastInstance; instance++ {
+		key := radioDeviceKey{Group: remoteFunctionalModules.group, Instance: instance}
+		verified[key] = true
+		if snapshot := fm5Scan.snapshots[instance]; snapshot != nil {
+			discovered[key] = snapshot
+		} else {
+			delete(discovered, key)
 		}
 	}
+	fm5PositiveObserved = fm5Scan.positiveSnapshot != nil
+	fm5NamespaceComplete := fullScanGroups[remoteFunctionalModules.group] && fm5Scan.namespaceComplete
 	if !fm5PositiveObserved {
 		for _, grp := range remoteDeviceGroups {
 			if grp.group == remoteFunctionalModules.group || !fullScanGroups[grp.group] {
@@ -5309,14 +5274,121 @@ func (p *vaillantSemanticPoller) readFunctionalModuleIdentitySnapshot(ctx contex
 	return p.readFunctionalModuleIdentitySnapshotWith(ctx, instance, p.readB524Value)
 }
 
-func (p *vaillantSemanticPoller) readFunctionalModuleIdentitySnapshotStartup(ctx context.Context, instance byte) (*vaillantRadioDeviceSnapshot, bool, bool) {
-	return p.readFunctionalModuleIdentitySnapshotWith(ctx, instance, p.readB524Startup)
+type functionalModuleIdentityReadFunc func(context.Context, byte, byte, byte, uint16) ([]byte, bool)
+
+type functionalModuleIdentityProbe struct {
+	instance     byte
+	connectedRaw []byte
+	connectedOK  bool
+	classRaw     []byte
+	classOK      bool
+	completed    bool
+}
+
+type functionalModuleIdentityScanResult struct {
+	snapshots         map[byte]*vaillantRadioDeviceSnapshot
+	observedAny       bool
+	namespaceComplete bool
+	positiveInstance  byte
+	positiveSnapshot  *vaillantRadioDeviceSnapshot
+}
+
+func (p *vaillantSemanticPoller) scanFunctionalModuleIdentityBudgetAwareWith(
+	ctx context.Context,
+	firstInstance byte,
+	lastInstance byte,
+	read functionalModuleIdentityReadFunc,
+) functionalModuleIdentityScanResult {
+	result := functionalModuleIdentityScanResult{
+		snapshots:         make(map[byte]*vaillantRadioDeviceSnapshot),
+		namespaceComplete: true,
+	}
+	if lastInstance < firstInstance {
+		result.namespaceComplete = false
+		return result
+	}
+	probes := make([]functionalModuleIdentityProbe, 0, int(lastInstance-firstInstance)+1)
+	preflight := func(first byte, last byte) {
+		for instance := first; instance <= last; instance++ {
+			connectedRaw, connectedOK := read(ctx, vaillantB524OpcodeRead, remoteFunctionalModules.group, instance, device_slot_connected)
+			classRaw, classOK := read(ctx, vaillantB524OpcodeRead, remoteFunctionalModules.group, instance, device_slot_class_address)
+			if connectedOK && len(connectedRaw) > 0 {
+				result.observedAny = true
+			}
+			probes = append(probes, functionalModuleIdentityProbe{
+				instance:     instance,
+				connectedRaw: connectedRaw,
+				connectedOK:  connectedOK,
+				classRaw:     classRaw,
+				classOK:      classOK,
+			})
+		}
+	}
+
+	completeProbe := func(probe *functionalModuleIdentityProbe) functionalModuleIdentityTuple {
+		firmwareRaw, firmwareOK := read(ctx, vaillantB524OpcodeRead, remoteFunctionalModules.group, probe.instance, device_slot_firmware)
+		hardwareRaw, hardwareOK := read(ctx, vaillantB524OpcodeRead, remoteFunctionalModules.group, probe.instance, device_slot_hardware_identifier)
+		probe.completed = true
+		tuple := decodeFunctionalModuleIdentityTuple(
+			probe.connectedRaw, probe.connectedOK,
+			probe.classRaw, probe.classOK,
+			firmwareRaw, firmwareOK,
+			hardwareRaw, hardwareOK,
+		)
+		if !tuple.complete {
+			result.namespaceComplete = false
+		}
+		if snapshot := functionalModuleIdentitySnapshot(probe.instance, tuple); snapshot != nil {
+			result.snapshots[probe.instance] = snapshot
+		}
+		return tuple
+	}
+
+	completeCandidates := func(firstProbe int) bool {
+		for i := firstProbe; i < len(probes); i++ {
+			probe := &probes[i]
+			if !probe.classOK || len(probe.classRaw) == 0 || probe.classRaw[0] != circuitManagingDeviceVR71Address {
+				continue
+			}
+			tuple := completeProbe(probe)
+			if completeVR71IdentityTuple(tuple) {
+				result.namespaceComplete = false
+				result.positiveInstance = probe.instance
+				result.positiveSnapshot = result.snapshots[probe.instance]
+				return true
+			}
+		}
+		return false
+	}
+
+	fastLast := lastInstance
+	if fastLast > semanticStartupSlotFastMaxInstance {
+		fastLast = semanticStartupSlotFastMaxInstance
+	}
+	preflight(firstInstance, fastLast)
+	if completeCandidates(0) {
+		return result
+	}
+	if fastLast < lastInstance {
+		firstTailProbe := len(probes)
+		preflight(fastLast+1, lastInstance)
+		if completeCandidates(firstTailProbe) {
+			return result
+		}
+	}
+
+	for i := range probes {
+		if !probes[i].completed {
+			completeProbe(&probes[i])
+		}
+	}
+	return result
 }
 
 func (p *vaillantSemanticPoller) readFunctionalModuleIdentitySnapshotWith(
 	ctx context.Context,
 	instance byte,
-	read func(context.Context, byte, byte, byte, uint16) ([]byte, bool),
+	read functionalModuleIdentityReadFunc,
 ) (*vaillantRadioDeviceSnapshot, bool, bool) {
 	connectedRaw, connectedOK := read(ctx, vaillantB524OpcodeRead, remoteFunctionalModules.group, instance, device_slot_connected)
 	if !connectedOK || len(connectedRaw) == 0 {
@@ -5331,11 +5403,15 @@ func (p *vaillantSemanticPoller) readFunctionalModuleIdentitySnapshotWith(
 		firmwareRaw, firmwareOK,
 		hardwareRaw, hardwareOK,
 	)
+	return functionalModuleIdentitySnapshot(instance, tuple), true, tuple.complete
+}
+
+func functionalModuleIdentitySnapshot(instance byte, tuple functionalModuleIdentityTuple) *vaillantRadioDeviceSnapshot {
 	if tuple.classAddress != nil && *tuple.classAddress != circuitManagingDeviceVR71Address {
-		return nil, true, tuple.complete
+		return nil
 	}
 	if !tuple.connected && !hasRemoteIdentityEvidence(tuple.classAddress, tuple.firmware, tuple.hardware) {
-		return nil, true, tuple.complete
+		return nil
 	}
 	slotMode := "active"
 	if !tuple.connected {
@@ -5350,41 +5426,19 @@ func (p *vaillantSemanticPoller) readFunctionalModuleIdentitySnapshotWith(
 		DeviceModel:        decodeRadioDeviceModel(tuple.classAddress),
 		FirmwareVersion:    cloneStringPtr(tuple.firmware),
 		HardwareIdentifier: cloneUint16Ptr(tuple.hardware),
-	}, true, tuple.complete
+	}
 }
 
 func (p *vaillantSemanticPoller) refreshFM5AfterLateIdentity(ctx context.Context) {
 	if p == nil {
 		return
 	}
-	probe := func(instance byte) (*vaillantRadioDeviceSnapshot, bool) {
-		snapshot, observed, complete := p.readFunctionalModuleIdentitySnapshotStartup(ctx, instance)
-		if !observed || !complete || snapshot == nil || snapshot.DeviceClassAddress == nil || *snapshot.DeviceClassAddress != circuitManagingDeviceVR71Address {
-			return nil, false
-		}
-		return snapshot, true
-	}
-
-	var (
-		instance byte
-		snapshot *vaillantRadioDeviceSnapshot
-		found    bool
-	)
-	for instance = 0; instance <= semanticStartupSlotFastMaxInstance; instance++ {
-		if snapshot, found = probe(instance); found {
-			break
-		}
-	}
-	if !found {
-		for instance = semanticStartupSlotFastMaxInstance + 1; instance <= semanticStartupSlotFullMaxInstance; instance++ {
-			if snapshot, found = probe(instance); found {
-				break
-			}
-		}
-	}
-	if !found {
+	scan := p.scanFunctionalModuleIdentityBudgetAwareWith(ctx, 0x00, semanticStartupSlotFullMaxInstance, p.readB524Startup)
+	if scan.positiveSnapshot == nil {
 		return
 	}
+	instance := scan.positiveInstance
+	snapshot := scan.positiveSnapshot
 
 	deviceKey := deviceSlotKey{Group: remoteFunctionalModules.group, Instance: instance}
 	radioKey := radioDeviceKey{Group: remoteFunctionalModules.group, Instance: instance}

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -1788,6 +1788,35 @@ func (p *vaillantSemanticPoller) refreshSystemStartup(ctx context.Context) {
 	}
 }
 
+func (p *vaillantSemanticPoller) refreshFM5ConfigurationForLateIdentity(ctx context.Context) {
+	if p == nil {
+		return
+	}
+
+	p.mu.Lock()
+	controller := p.controller
+	p.mu.Unlock()
+	snapshot := &vaillantSystemSnapshot{Controller: controller}
+	configurationAcquired := false
+	if raw, ok := p.readB524Uint16Startup(ctx, localRegulator.opcode, localRegulator.group, regulatorInstance, system_module_configuration_vr71); ok && raw != nil {
+		snapshot.ModuleConfigurationVR71 = cloneUint16Ptr(raw)
+		configurationAcquired = true
+	}
+
+	p.mu.Lock()
+	source := semanticSnapshotSourceCache
+	p.updateFM5ConfigurationAcquisitionLocked(configurationAcquired)
+	if configurationAcquired {
+		p.updateSystemSnapshotLocked(mergeSystemSnapshotNonDestructive(p.system, snapshot))
+		source = semanticSnapshotSourceLive
+	}
+	hasSnapshot := p.system != nil
+	p.mu.Unlock()
+	if hasSnapshot {
+		p.publishSystem(source)
+	}
+}
+
 func (p *vaillantSemanticPoller) refreshRadioDevicesStartup(ctx context.Context) {
 	if p == nil {
 		return
@@ -9305,7 +9334,7 @@ func (p *vaillantSemanticPoller) EnqueueAddressIdentityProbe(addr byte) {
 		if probeAddr == circuitManagingDeviceVR71Address {
 			recoveryCtx, recoveryCancel := context.WithTimeout(ctx, semanticIdentityRecoveryTimeout)
 			defer recoveryCancel()
-			p.refreshSystemStartup(recoveryCtx)
+			p.refreshFM5ConfigurationForLateIdentity(recoveryCtx)
 			p.refreshFM5AfterLateIdentity(recoveryCtx)
 		}
 	}

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -1830,16 +1830,21 @@ func (p *vaillantSemanticPoller) refreshRadioDevicesStartup(ctx context.Context)
 			classAddress = tuple.classAddress
 			firmware = tuple.firmware
 			hardware = tuple.hardware
-			completePositiveFM5 = tuple.complete && hasRemoteIdentityEvidence(classAddress, firmware, hardware)
+			completePositiveFM5 = completeVR71IdentityTuple(tuple)
 		} else {
 			classAddress = p.readB524U8Startup(ctx, grp.opcode, grp.group, instance, device_slot_class_address)
 		}
 		key := radioDeviceKey{Group: grp.group, Instance: instance}
 		verified[key] = true
 		include, slotMode := startupRadioDeviceInclude(grp.group, connected, classAddress)
+		if grp.group == remoteFunctionalModules.group && classAddress != nil && *classAddress != circuitManagingDeviceVR71Address {
+			include = false
+		}
 		if grp.group == remoteFunctionalModules.group && !include && hasRemoteIdentityEvidence(classAddress, firmware, hardware) {
-			include = true
-			slotMode = "inventory"
+			if classAddress == nil || *classAddress == circuitManagingDeviceVR71Address {
+				include = true
+				slotMode = "inventory"
+			}
 		}
 		if !include {
 			delete(discovered, key)
@@ -1868,18 +1873,25 @@ func (p *vaillantSemanticPoller) refreshRadioDevicesStartup(ctx context.Context)
 	if fm5PositiveObserved {
 		fm5NamespaceComplete = false
 	} else {
-	tailScan:
-		for _, grp := range remoteDeviceGroups {
-			if !fullScanGroups[grp.group] {
-				continue
-			}
+		if fullScanGroups[remoteFunctionalModules.group] {
 			for instance := semanticStartupSlotFastMaxInstance + 1; instance <= semanticStartupSlotFullMaxInstance; instance++ {
-				if probeSlot(grp, instance) && grp.group == remoteFunctionalModules.group {
+				if probeSlot(remoteFunctionalModules, instance) {
+					fm5PositiveObserved = true
 					if instance < semanticStartupSlotFullMaxInstance {
 						fm5NamespaceComplete = false
 					}
-					break tailScan
+					break
 				}
+			}
+		}
+	}
+	if !fm5PositiveObserved {
+		for _, grp := range remoteDeviceGroups {
+			if grp.group == remoteFunctionalModules.group || !fullScanGroups[grp.group] {
+				continue
+			}
+			for instance := semanticStartupSlotFastMaxInstance + 1; instance <= semanticStartupSlotFullMaxInstance; instance++ {
+				probeSlot(grp, instance)
 			}
 		}
 	}
@@ -5316,6 +5328,9 @@ func (p *vaillantSemanticPoller) readFunctionalModuleIdentitySnapshotWith(
 		firmwareRaw, firmwareOK,
 		hardwareRaw, hardwareOK,
 	)
+	if tuple.classAddress != nil && *tuple.classAddress != circuitManagingDeviceVR71Address {
+		return nil, true, tuple.complete
+	}
 	if !tuple.connected && !hasRemoteIdentityEvidence(tuple.classAddress, tuple.firmware, tuple.hardware) {
 		return nil, true, tuple.complete
 	}
@@ -5341,7 +5356,7 @@ func (p *vaillantSemanticPoller) refreshFM5AfterLateIdentity(ctx context.Context
 	}
 	probe := func(instance byte) (*vaillantRadioDeviceSnapshot, bool) {
 		snapshot, observed, complete := p.readFunctionalModuleIdentitySnapshotStartup(ctx, instance)
-		if !observed || !complete || snapshot == nil || !hasFM5EvidenceFromRadioSnapshots([]*vaillantRadioDeviceSnapshot{snapshot}) {
+		if !observed || !complete || snapshot == nil || snapshot.DeviceClassAddress == nil || *snapshot.DeviceClassAddress != circuitManagingDeviceVR71Address {
 			return nil, false
 		}
 		return snapshot, true
@@ -5396,6 +5411,10 @@ type functionalModuleIdentityTuple struct {
 	firmware     *string
 	hardware     *uint16
 	complete     bool
+}
+
+func completeVR71IdentityTuple(tuple functionalModuleIdentityTuple) bool {
+	return tuple.complete && tuple.classAddress != nil && *tuple.classAddress == circuitManagingDeviceVR71Address
 }
 
 func decodeFunctionalModuleIdentityTuple(

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -5291,13 +5291,25 @@ func (p *vaillantSemanticPoller) discoverDeviceSlotsWithFM5Completeness(ctx cont
 }
 
 func (p *vaillantSemanticPoller) readFunctionalModuleIdentitySnapshot(ctx context.Context, instance byte) (*vaillantRadioDeviceSnapshot, bool, bool) {
-	connectedRaw, connectedOK := p.readB524Value(ctx, vaillantB524OpcodeRead, remoteFunctionalModules.group, instance, device_slot_connected)
+	return p.readFunctionalModuleIdentitySnapshotWith(ctx, instance, p.readB524Value)
+}
+
+func (p *vaillantSemanticPoller) readFunctionalModuleIdentitySnapshotStartup(ctx context.Context, instance byte) (*vaillantRadioDeviceSnapshot, bool, bool) {
+	return p.readFunctionalModuleIdentitySnapshotWith(ctx, instance, p.readB524Startup)
+}
+
+func (p *vaillantSemanticPoller) readFunctionalModuleIdentitySnapshotWith(
+	ctx context.Context,
+	instance byte,
+	read func(context.Context, byte, byte, byte, uint16) ([]byte, bool),
+) (*vaillantRadioDeviceSnapshot, bool, bool) {
+	connectedRaw, connectedOK := read(ctx, vaillantB524OpcodeRead, remoteFunctionalModules.group, instance, device_slot_connected)
 	if !connectedOK || len(connectedRaw) == 0 {
 		return nil, false, false
 	}
-	classRaw, classOK := p.readB524Value(ctx, vaillantB524OpcodeRead, remoteFunctionalModules.group, instance, device_slot_class_address)
-	firmwareRaw, firmwareOK := p.readB524Value(ctx, vaillantB524OpcodeRead, remoteFunctionalModules.group, instance, device_slot_firmware)
-	hardwareRaw, hardwareOK := p.readB524Value(ctx, vaillantB524OpcodeRead, remoteFunctionalModules.group, instance, device_slot_hardware_identifier)
+	classRaw, classOK := read(ctx, vaillantB524OpcodeRead, remoteFunctionalModules.group, instance, device_slot_class_address)
+	firmwareRaw, firmwareOK := read(ctx, vaillantB524OpcodeRead, remoteFunctionalModules.group, instance, device_slot_firmware)
+	hardwareRaw, hardwareOK := read(ctx, vaillantB524OpcodeRead, remoteFunctionalModules.group, instance, device_slot_hardware_identifier)
 	tuple := decodeFunctionalModuleIdentityTuple(
 		connectedRaw, connectedOK,
 		classRaw, classOK,
@@ -5321,6 +5333,61 @@ func (p *vaillantSemanticPoller) readFunctionalModuleIdentitySnapshot(ctx contex
 		FirmwareVersion:    cloneStringPtr(tuple.firmware),
 		HardwareIdentifier: cloneUint16Ptr(tuple.hardware),
 	}, true, tuple.complete
+}
+
+func (p *vaillantSemanticPoller) refreshFM5AfterLateIdentity(ctx context.Context) {
+	if p == nil {
+		return
+	}
+	probe := func(instance byte) (*vaillantRadioDeviceSnapshot, bool) {
+		snapshot, observed, complete := p.readFunctionalModuleIdentitySnapshotStartup(ctx, instance)
+		if !observed || !complete || snapshot == nil || !hasFM5EvidenceFromRadioSnapshots([]*vaillantRadioDeviceSnapshot{snapshot}) {
+			return nil, false
+		}
+		return snapshot, true
+	}
+
+	var (
+		instance byte
+		snapshot *vaillantRadioDeviceSnapshot
+		found    bool
+	)
+	for instance = 0; instance <= semanticStartupSlotFastMaxInstance; instance++ {
+		if snapshot, found = probe(instance); found {
+			break
+		}
+	}
+	if !found {
+		for instance = semanticStartupSlotFastMaxInstance + 1; instance <= semanticStartupSlotFullMaxInstance; instance++ {
+			if snapshot, found = probe(instance); found {
+				break
+			}
+		}
+	}
+	if !found {
+		return
+	}
+
+	deviceKey := deviceSlotKey{Group: remoteFunctionalModules.group, Instance: instance}
+	radioKey := radioDeviceKey{Group: remoteFunctionalModules.group, Instance: instance}
+	p.mu.Lock()
+	if p.deviceSlotCache == nil {
+		p.deviceSlotCache = make(map[deviceSlotKey]bool)
+	}
+	if p.radioDevices == nil {
+		p.radioDevices = make(map[radioDeviceKey]*vaillantRadioDeviceSnapshot)
+	}
+	p.deviceSlotCache[deviceKey] = true
+	p.radioDevices[radioKey] = snapshot
+	p.fm5EvidenceGeneration++
+	p.fm5IdentityScanComplete = false
+	p.fm5IdentityIncoherent = false
+	p.fm5RegistryEvidenceIgnored = false
+	p.fm5IdentityObservedAt = p.now()
+	p.mu.Unlock()
+
+	p.publishRadioDevices(semanticSnapshotSourceLive)
+	p.refreshFM5Semantic(ctx)
 }
 
 type functionalModuleIdentityTuple struct {
@@ -9163,7 +9230,7 @@ func (p *vaillantSemanticPoller) EnqueueAddressIdentityProbe(addr byte) {
 			recoveryCtx, recoveryCancel := context.WithTimeout(ctx, semanticIdentityRecoveryTimeout)
 			defer recoveryCancel()
 			p.refreshSystemStartup(recoveryCtx)
-			p.refreshRadioDevices(recoveryCtx)
+			p.refreshFM5AfterLateIdentity(recoveryCtx)
 		}
 	}
 	if scheduler == nil {


### PR DESCRIPTION
## Summary

Fix the live FM5 regression where a connected VR71/FM5 was visible in the radio inventory while the semantic tuple remained unavailable and the legacy scalar reported ABSENT.

- stop/defer the unseeded negative FM tail after the first complete positive FM5 identity tuple during startup;
- retain the full conclusive-negative scan when no positive FM5 evidence exists;
- route late identity probes through the existing directed-scan seam;
- after a successful 0x26 identity recovery, coalesce refresh_system then refresh_radio_devices so classification converges without the ordinary ticker.

## Scope

Only:
- cmd/gateway/semantic_vaillant.go
- cmd/gateway/post_m9_defects_red_test.go

No Modbus/Fronius, eeBUS admin, Portal, GraphQL, MCP, configuration, add-on, HA, or live changes.

## TDD evidence

RED 1: 4079d57a81f9f1f9befee6dffd4ab5509794bf67
- unseeded instance-1 FM5 enters the negative tail, blocks five family reads, and returns the zero tuple.

GREEN 1: ce022568456028ddc1eae939c4272f1184d42292
- positive complete FM5 evidence defers the negative tail; conclusive-negative behavior remains unchanged.

RED 2: 79ee14ff7fdc0120fd424b6b5f0101bd49bc1ec8
- late identity success bypasses the scan seam, schedules no semantic recovery, and leaves a zero tuple.

GREEN 2: af53a8832739d8e6f164bd9f5d84bf6188d22570
- directed-scan seam plus ordered coalesced system/radio recovery.

## Validation

- focused regressions normal and race: PASS
- all FM5 tests normal: PASS
- all FM5 tests race: PASS
- full go test ./cmd/gateway -count=1: PASS, exit 0
- go vet ./cmd/gateway: PASS
- golangci-lint run ./cmd/gateway: PASS, 0 issues
- git diff --check: PASS

Docs gate is already satisfied by the merged FM5 contract. Transport gate is not applicable because no transport/protocol path is changed.

Closes #827.