### PR TITLE
M4-04: preserve endpoint ownership in startup redaction

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -196,7 +196,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 		newModbusEndpointFn,
 	)
 	if err != nil {
-		return fmt.Errorf("modbus TCP sidecar: %w", err)
+		return withEndpointOwner(endpointOwnerModbus, fmt.Errorf("modbus TCP sidecar: %w", err))
 	}
 	if modbusAdapter != nil {
 		defer func() {
@@ -271,7 +271,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 	// and passive transports before gateway construction.
 	adapterMuxCloser, adapterClassifier, err := wireAdapterDirect(ctx, &cfg)
 	if err != nil {
-		return fmt.Errorf("adapter-direct: %w", err)
+		return withEndpointOwner(endpointOwnerAdapterDirect, fmt.Errorf("adapter-direct: %w", err))
 	}
 	if adapterMuxCloser != nil {
 		defer func() {

--- a/cmd/gateway/modbus_endpoint_file.go
+++ b/cmd/gateway/modbus_endpoint_file.go
@@ -16,6 +16,43 @@ import (
 
 const maxModbusEndpointFileBytes = 512
 
+const (
+	redactedModbusEndpoint        = "[REDACTED_MODBUS_ENDPOINT]"
+	redactedAdapterDirectEndpoint = "[REDACTED_ADAPTER_DIRECT_ENDPOINT]"
+	redactedNetworkEndpoint       = "[REDACTED_NETWORK_ENDPOINT]"
+)
+
+type endpointOwner uint8
+
+const (
+	endpointOwnerUnknown endpointOwner = iota
+	endpointOwnerModbus
+	endpointOwnerAdapterDirect
+)
+
+type endpointOwnedError struct {
+	owner endpointOwner
+	err   error
+}
+
+func (err *endpointOwnedError) Error() string { return err.err.Error() }
+func (err *endpointOwnedError) Unwrap() error { return err.err }
+
+func withEndpointOwner(owner endpointOwner, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &endpointOwnedError{owner: owner, err: err}
+}
+
+func endpointOwnerOf(err error) endpointOwner {
+	var owned *endpointOwnedError
+	if errors.As(err, &owned) {
+		return owned.owner
+	}
+	return endpointOwnerUnknown
+}
+
 type gatewayFlagInputs struct {
 	modbusEndpointFile string
 }
@@ -74,40 +111,67 @@ func redactFileSourcedModbusError(err error, endpoint string) error {
 	if err == nil || endpoint == "" {
 		return err
 	}
-	values := []string{endpoint}
+	values := make(map[string]string)
+	addEndpointRedaction(values, endpoint, redactedModbusEndpoint)
 	if parsed, parseErr := url.Parse(endpoint); parseErr == nil {
-		values = append(values, parsed.Host, parsed.Hostname())
+		addEndpointRedaction(values, parsed.Host, redactedModbusEndpoint)
+		addEndpointRedaction(values, parsed.Hostname(), redactedModbusEndpoint)
 	}
-	values = append(values, modbusErrorNetworkAddresses(err, 0)...)
-	sort.Slice(values, func(i, j int) bool { return len(values[i]) > len(values[j]) })
+	collectEndpointRedactions(err, endpointOwnerUnknown, values, 0)
+	ordered := make([]string, 0, len(values))
+	for value := range values {
+		ordered = append(ordered, value)
+	}
+	sort.Slice(ordered, func(i, j int) bool { return len(ordered[i]) > len(ordered[j]) })
 	message := err.Error()
-	for _, value := range values {
-		if value != "" {
-			message = strings.ReplaceAll(message, value, "[REDACTED_MODBUS_ENDPOINT]")
-		}
+	for _, value := range ordered {
+		message = strings.ReplaceAll(message, value, values[value])
 	}
 	return errors.New(message)
 }
 
-func modbusErrorNetworkAddresses(err error, depth int) []string {
-	if err == nil || depth > 32 {
-		return nil
+func addEndpointRedaction(values map[string]string, value, marker string) {
+	if value == "" {
+		return
 	}
-	values := make([]string, 0, 2)
+	if current, exists := values[value]; exists && current != marker {
+		values[value] = redactedNetworkEndpoint
+		return
+	}
+	values[value] = marker
+}
+
+func markerForEndpointOwner(owner endpointOwner) string {
+	switch owner {
+	case endpointOwnerModbus:
+		return redactedModbusEndpoint
+	case endpointOwnerAdapterDirect:
+		return redactedAdapterDirectEndpoint
+	default:
+		return redactedNetworkEndpoint
+	}
+}
+
+func collectEndpointRedactions(err error, owner endpointOwner, values map[string]string, depth int) {
+	if err == nil || depth > 32 {
+		return
+	}
+	if owned, ok := err.(*endpointOwnedError); ok {
+		owner = owned.owner
+	}
 	if networkError, ok := err.(*net.OpError); ok && networkError.Addr != nil {
-		values = append(values, networkError.Addr.String())
+		addEndpointRedaction(values, networkError.Addr.String(), markerForEndpointOwner(owner))
 	}
 	if dnsError, ok := err.(*net.DNSError); ok && dnsError.Name != "" {
-		values = append(values, dnsError.Name)
+		addEndpointRedaction(values, dnsError.Name, markerForEndpointOwner(owner))
 	}
 	if joined, ok := err.(interface{ Unwrap() []error }); ok {
 		for _, child := range joined.Unwrap() {
-			values = append(values, modbusErrorNetworkAddresses(child, depth+1)...)
+			collectEndpointRedactions(child, owner, values, depth+1)
 		}
-		return values
+		return
 	}
 	if wrapped, ok := err.(interface{ Unwrap() error }); ok {
-		values = append(values, modbusErrorNetworkAddresses(wrapped.Unwrap(), depth+1)...)
+		collectEndpointRedactions(wrapped.Unwrap(), owner, values, depth+1)
 	}
-	return values
 }

--- a/cmd/gateway/modbus_endpoint_file_test.go
+++ b/cmd/gateway/modbus_endpoint_file_test.go
@@ -197,3 +197,56 @@ func TestRedactFileSourcedModbusErrorRemovesWrappedDNSName(t *testing.T) {
 		t.Fatalf("redacted error leaks DNS name: %v", redacted)
 	}
 }
+
+func TestRedactFileSourcedModbusErrorPreservesEndpointOwnership(t *testing.T) {
+	modbusEndpoint := "tcp://modbus.internal:502"
+	modbusAddress := &net.TCPAddr{IP: net.ParseIP("192.0.2.40"), Port: 502}
+	adapterAddress := &net.TCPAddr{IP: net.ParseIP("192.0.2.41"), Port: 9999}
+	err := errors.Join(
+		withEndpointOwner(endpointOwnerModbus, fmt.Errorf("modbus TCP sidecar: %w", &net.OpError{
+			Op: "dial", Net: "tcp", Addr: modbusAddress, Err: errors.New("connection refused"),
+		})),
+		withEndpointOwner(endpointOwnerAdapterDirect, fmt.Errorf("adapter-direct: %w", &net.OpError{
+			Op: "dial", Net: "tcp", Addr: adapterAddress, Err: errors.New("no route to host"),
+		})),
+	)
+
+	redacted := redactFileSourcedModbusError(err, modbusEndpoint)
+	if redacted == nil {
+		t.Fatal("redacted error is nil")
+	}
+	for _, secret := range []string{
+		modbusEndpoint,
+		"modbus.internal",
+		modbusAddress.String(),
+		adapterAddress.String(),
+	} {
+		if strings.Contains(redacted.Error(), secret) {
+			t.Fatalf("redacted startup error contains %q: %v", secret, redacted)
+		}
+	}
+	if !strings.Contains(redacted.Error(), "[REDACTED_MODBUS_ENDPOINT]") {
+		t.Fatalf("redacted startup error has no Modbus marker: %v", redacted)
+	}
+	if !strings.Contains(redacted.Error(), "[REDACTED_ADAPTER_DIRECT_ENDPOINT]") {
+		t.Fatalf("redacted startup error has no adapter-direct marker: %v", redacted)
+	}
+}
+
+func TestRedactFileSourcedModbusErrorUsesNeutralMarkerForUnownedNetworkError(t *testing.T) {
+	address := &net.TCPAddr{IP: net.ParseIP("192.0.2.42"), Port: 4712}
+	err := fmt.Errorf("unclassified sidecar: %w", &net.OpError{
+		Op: "dial", Net: "tcp", Addr: address, Err: errors.New("connection refused"),
+	})
+
+	redacted := redactFileSourcedModbusError(err, "tcp://modbus.internal:502")
+	if strings.Contains(redacted.Error(), address.String()) {
+		t.Fatalf("redacted startup error leaks network address: %v", redacted)
+	}
+	if !strings.Contains(redacted.Error(), "[REDACTED_NETWORK_ENDPOINT]") {
+		t.Fatalf("redacted startup error has no neutral marker: %v", redacted)
+	}
+	if strings.Contains(redacted.Error(), "[REDACTED_MODBUS_ENDPOINT]") {
+		t.Fatalf("unowned network error was mislabeled as Modbus: %v", redacted)
+	}
+}

--- a/cmd/gateway/modbus_endpoint_file_test.go
+++ b/cmd/gateway/modbus_endpoint_file_test.go
@@ -171,10 +171,10 @@ func TestRedactFileSourcedModbusErrorRemovesResolvedNetworkAddresses(t *testing.
 				Addr: address,
 				Err:  errors.New("connection refused"),
 			}
-			wrapped := fmt.Errorf(
+			wrapped := withEndpointOwner(endpointOwnerModbus, fmt.Errorf(
 				"modbus startup: %w",
 				errors.Join(errors.New("sidecar failed"), dialError),
-			)
+			))
 
 			redacted := redactFileSourcedModbusError(wrapped, endpoint)
 			if strings.Contains(redacted.Error(), address.String()) ||
@@ -191,7 +191,10 @@ func TestRedactFileSourcedModbusErrorRemovesResolvedNetworkAddresses(t *testing.
 func TestRedactFileSourcedModbusErrorRemovesWrappedDNSName(t *testing.T) {
 	endpoint := "tcp://configured.invalid:502"
 	dnsError := &net.DNSError{Name: "canonical.internal", Err: "no such host"}
-	redacted := redactFileSourcedModbusError(fmt.Errorf("resolve: %w", dnsError), endpoint)
+	redacted := redactFileSourcedModbusError(
+		withEndpointOwner(endpointOwnerModbus, fmt.Errorf("resolve: %w", dnsError)),
+		endpoint,
+	)
 	if strings.Contains(redacted.Error(), "configured.invalid") ||
 		strings.Contains(redacted.Error(), "canonical.internal") {
 		t.Fatalf("redacted error leaks DNS name: %v", redacted)

--- a/cmd/gateway/modbus_runtime_adapter_test.go
+++ b/cmd/gateway/modbus_runtime_adapter_test.go
@@ -89,3 +89,40 @@ func TestRunClosesModbusSidecarOnceAndJoinsLaterEEBusFailure(t *testing.T) {
 		t.Fatalf("Modbus endpoint close calls = %d; want 1", endpoint.closeCalls)
 	}
 }
+
+func TestRunMarksAdapterDirectStartupFailureForOwnedRedaction(t *testing.T) {
+	originalDial := dialModbusEndpointFn
+	originalFactory := newModbusEndpointFn
+	t.Cleanup(func() {
+		dialModbusEndpointFn = originalDial
+		newModbusEndpointFn = originalFactory
+	})
+
+	client, peer := net.Pipe()
+	t.Cleanup(func() { _ = peer.Close() })
+	endpoint := &modbusRunLifecycleEndpoint{}
+	dialModbusEndpointFn = func(context.Context, string, string) (net.Conn, error) {
+		return client, nil
+	}
+	newModbusEndpointFn = func(modbus.TCPEndpointConfig) (modbusadapter.Endpoint, error) {
+		return endpoint, nil
+	}
+
+	cfg := ebusgateway.DefaultConfig()
+	cfg.ModbusTCPConfig = ebusgateway.ModbusTCPConfig{
+		Enabled:     true,
+		Endpoint:    "tcp://127.0.0.1:1502",
+		DialTimeout: time.Second,
+	}
+	cfg.TransportConfig.Protocol = ebusgateway.TransportAdapterDirect
+	cfg.TransportConfig.Network = "tcp"
+	cfg.TransportConfig.Address = ""
+
+	err := run(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("run accepted adapter-direct without an address")
+	}
+	if got := endpointOwnerOf(err); got != endpointOwnerAdapterDirect {
+		t.Fatalf("startup error owner = %v; want adapter-direct; error=%v", got, err)
+	}
+}


### PR DESCRIPTION
Closes #829.

## Scope

Preserve endpoint ownership while fully redacting wrapped and joined startup network errors:

- Modbus-owned errors use `[REDACTED_MODBUS_ENDPOINT]`;
- adapter-direct-owned errors use `[REDACTED_ADAPTER_DIRECT_ENDPOINT]`;
- unowned network errors use `[REDACTED_NETWORK_ENDPOINT]`.

No FM5, Modbus transport/runtime, SunSpec, dependency, add-on, or live changes.

## TDD

Mode: strict RED-first because this is a security-relevant observable error-classification defect.

- Public RED: `214326b`
- GREEN exact HEAD: `07cb309e6ed16080f4754039348f5ca80d6530b9`

Focused tests and full `go test -race ./cmd/gateway` pass.

## Gates

- Doc gate: existing FMV3-M4-05 publication, docs-ebus merge `a1e26e351cfb19f89eb903c8ae798ab69b2a8671`.
- Full local `./scripts/ci_local.sh`: PASS.
- Transport owner override: error ownership metadata and log redaction only; no framing, wire, request, scheduler, dial, or transport behavior change.
- Passive-smoke owner override: startup error classification only; no passive transport, observer, or semantic behavior change.
- GitHub CI: terminology/build/test/lint 4/4 SUCCESS.
- Fresh exact-HEAD review: `NO_BLOCKING_FINDINGS`; zero P3/P4.
