### PR TITLE
Keep Modbus startup failure protocol-local

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -196,7 +196,8 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 		newModbusEndpointFn,
 	)
 	if err != nil {
-		return withEndpointOwner(endpointOwnerModbus, fmt.Errorf("modbus TCP sidecar: %w", err))
+		log.Printf("Modbus TCP unavailable; continuing without Modbus")
+		modbusAdapter = nil
 	}
 	if modbusAdapter != nil {
 		defer func() {

--- a/cmd/gateway/modbus_runtime_adapter_test.go
+++ b/cmd/gateway/modbus_runtime_adapter_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log"
 	"net"
 	"net/netip"
+	"strings"
 	"testing"
 	"time"
 
@@ -87,6 +90,53 @@ func TestRunClosesModbusSidecarOnceAndJoinsLaterEEBusFailure(t *testing.T) {
 	}
 	if endpoint.closeCalls != 1 {
 		t.Fatalf("Modbus endpoint close calls = %d; want 1", endpoint.closeCalls)
+	}
+}
+
+func TestRunKeepsModbusStartupFailureProtocolLocal(t *testing.T) {
+	originalDial := dialModbusEndpointFn
+	originalResolver := resolveEEBusInterfaceAddressesFn
+	originalLogWriter := log.Writer()
+	originalLogFlags := log.Flags()
+	t.Cleanup(func() {
+		dialModbusEndpointFn = originalDial
+		resolveEEBusInterfaceAddressesFn = originalResolver
+		log.SetOutput(originalLogWriter)
+		log.SetFlags(originalLogFlags)
+	})
+
+	endpoint := "tcp://192.0.2.44:1502"
+	dialErr := errors.New("dial " + endpoint + ": unavailable")
+	dialModbusEndpointFn = func(context.Context, string, string) (net.Conn, error) {
+		return nil, dialErr
+	}
+	laterErr := errors.New("eebus interface resolution failed")
+	resolveEEBusInterfaceAddressesFn = func(string) ([]netip.Addr, error) {
+		return nil, laterErr
+	}
+	var logs bytes.Buffer
+	log.SetOutput(&logs)
+	log.SetFlags(0)
+
+	cfg := ebusgateway.DefaultConfig()
+	cfg.ModbusTCPConfig = ebusgateway.ModbusTCPConfig{
+		Enabled:     true,
+		Endpoint:    endpoint,
+		DialTimeout: time.Second,
+	}
+	cfg.EEBusConfig = msp05bEnabledConfig()
+
+	err := run(context.Background(), cfg)
+	if !errors.Is(err, laterErr) {
+		t.Fatalf("run error = %v; want later eeBUS error", err)
+	}
+	if errors.Is(err, dialErr) {
+		t.Fatalf("run error retained protocol-local Modbus startup failure: %v", err)
+	}
+	if got := logs.String(); !strings.Contains(got, "Modbus TCP unavailable; continuing without Modbus") {
+		t.Fatalf("gateway log = %q; want protocol-local unavailability diagnostic", got)
+	} else if strings.Contains(got, endpoint) || strings.Contains(got, "192.0.2.44") {
+		t.Fatalf("gateway log disclosed Modbus endpoint: %q", got)
 	}
 }
 


### PR DESCRIPTION
Closes #831.

Makes Modbus TCP startup failure protocol-local: the shared gateway continues without a Modbus adapter/provider and emits only a static, endpoint-free diagnostic. Successful Modbus lifecycle is unchanged.

RED: 9cf208a456626a50defe88e25ab15ded743cb6e7
GREEN: 0700fc8732f99ef88ac8f6f2fd64ef30ef95d8bd
Docs gate: Project-Helianthus/helianthus-docs-ebus#455

Validation: focused race green; full local CI green with owner overrides limited to composition-only startup isolation (no transport/framing/wire or passive-path change); GitHub terminology/build/test/lint green; fresh exact-HEAD NO_BLOCKING_FINDINGS.