### PR TITLE
MODBUS-M4-04: recover raw MCP after one transport reset

### DIFF
--- a/cmd/gateway/modbus_mcp_provider.go
+++ b/cmd/gateway/modbus_mcp_provider.go
@@ -29,9 +29,7 @@ type gatewayModbusMCPProvider struct {
 }
 
 type modbusMCPAdapter interface {
-	ExecuteRead(context.Context, modbusadapter.ReadPlan) (modbus.TCPReadBatch, error)
-	Snapshot() modbus.TCPEndpointSnapshot
-	Reconnect(context.Context) error
+	ExecuteReadWithReconnect(context.Context, modbusadapter.ReadPlan) (modbus.TCPReadBatch, error)
 	ProfileObservation(string, string) (modbusadapter.ProfileObservationRecord, bool)
 	SunSpecQualificationObservation(string, string) (modbusreg.SunSpecQualificationObservation, []byte, bool)
 }
@@ -69,13 +67,7 @@ func (provider *gatewayModbusMCPProvider) RawRead(ctx context.Context, request m
 	}
 	operationCtx, cancel := context.WithTimeout(ctx, plan.Timeout)
 	defer cancel()
-	batch, err := provider.adapter.ExecuteRead(operationCtx, plan)
-	if err != nil && provider.adapter.Snapshot().ReconnectRequired {
-		if reconnectErr := provider.adapter.Reconnect(operationCtx); reconnectErr != nil {
-			return mcp.ModbusRawReadResult{}, reconnectErr
-		}
-		batch, err = provider.adapter.ExecuteRead(operationCtx, plan)
-	}
+	batch, err := provider.adapter.ExecuteReadWithReconnect(operationCtx, plan)
 	if err != nil {
 		return mcp.ModbusRawReadResult{}, err
 	}

--- a/cmd/gateway/modbus_mcp_provider.go
+++ b/cmd/gateway/modbus_mcp_provider.go
@@ -30,6 +30,8 @@ type gatewayModbusMCPProvider struct {
 
 type modbusMCPAdapter interface {
 	ExecuteRead(context.Context, modbusadapter.ReadPlan) (modbus.TCPReadBatch, error)
+	Snapshot() modbus.TCPEndpointSnapshot
+	Reconnect(context.Context) error
 	ProfileObservation(string, string) (modbusadapter.ProfileObservationRecord, bool)
 	SunSpecQualificationObservation(string, string) (modbusreg.SunSpecQualificationObservation, []byte, bool)
 }
@@ -54,7 +56,7 @@ func (provider *gatewayModbusMCPProvider) RawRead(ctx context.Context, request m
 		return mcp.ModbusRawReadResult{}, err
 	}
 	id := provider.nextID.Add(1)
-	batch, err := provider.adapter.ExecuteRead(ctx, modbusadapter.ReadPlan{
+	plan := modbusadapter.ReadPlan{
 		UnitID:             request.UnitID,
 		AuthorizationScope: "mcp:modbus.raw.read",
 		PollGeneration:     id,
@@ -64,7 +66,16 @@ func (provider *gatewayModbusMCPProvider) RawRead(ctx context.Context, request m
 			LogicalViewID: id,
 			Request:       read,
 		}},
-	})
+	}
+	operationCtx, cancel := context.WithTimeout(ctx, plan.Timeout)
+	defer cancel()
+	batch, err := provider.adapter.ExecuteRead(operationCtx, plan)
+	if err != nil && provider.adapter.Snapshot().ReconnectRequired {
+		if reconnectErr := provider.adapter.Reconnect(operationCtx); reconnectErr != nil {
+			return mcp.ModbusRawReadResult{}, reconnectErr
+		}
+		batch, err = provider.adapter.ExecuteRead(operationCtx, plan)
+	}
 	if err != nil {
 		return mcp.ModbusRawReadResult{}, err
 	}

--- a/cmd/gateway/modbus_mcp_provider_test.go
+++ b/cmd/gateway/modbus_mcp_provider_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -13,11 +14,31 @@ import (
 	modbusreg "github.com/Project-Helianthus/helianthus-modbusreg"
 )
 
-type countingModbusMCPAdapter struct{ reads int }
+type countingModbusMCPAdapter struct {
+	reads             int
+	reconnects        int
+	reconnectRequired bool
+	reconnectErr      error
+	readErrors        []error
+	plans             []modbusadapter.ReadPlan
+}
 
-func (adapter *countingModbusMCPAdapter) ExecuteRead(context.Context, modbusadapter.ReadPlan) (modbus.TCPReadBatch, error) {
+func (adapter *countingModbusMCPAdapter) ExecuteRead(_ context.Context, plan modbusadapter.ReadPlan) (modbus.TCPReadBatch, error) {
 	adapter.reads++
+	adapter.plans = append(adapter.plans, plan)
+	if len(adapter.readErrors) >= adapter.reads {
+		return modbus.TCPReadBatch{}, adapter.readErrors[adapter.reads-1]
+	}
 	return modbus.TCPReadBatch{}, errors.New("fixture transport unavailable")
+}
+
+func (adapter *countingModbusMCPAdapter) Snapshot() modbus.TCPEndpointSnapshot {
+	return modbus.TCPEndpointSnapshot{ReconnectRequired: adapter.reconnectRequired}
+}
+
+func (adapter *countingModbusMCPAdapter) Reconnect(context.Context) error {
+	adapter.reconnects++
+	return adapter.reconnectErr
 }
 
 func (*countingModbusMCPAdapter) ProfileObservation(string, string) (modbusadapter.ProfileObservationRecord, bool) {
@@ -89,6 +110,44 @@ func TestGatewayModbusMCPProviderRejectsBurstBeforeWireIO(t *testing.T) {
 	_, _ = provider.RawRead(context.Background(), request)
 	if adapter.reads != mcp.ModbusV1MaxRawReadsPerWindow+1 {
 		t.Fatalf("wire reads after refill = %d", adapter.reads)
+	}
+}
+
+func TestGatewayModbusMCPProviderReconnectsAndRetriesOnceInsideOneQuotaAdmission(t *testing.T) {
+	firstErr := errors.New("fixture retryable transport failure")
+	secondErr := errors.New("fixture retry remained unavailable")
+	adapter := &countingModbusMCPAdapter{
+		reconnectRequired: true,
+		readErrors:        []error{firstErr, secondErr},
+	}
+	provider := &gatewayModbusMCPProvider{adapter: adapter, now: time.Now}
+	request := mcp.ModbusRawReadRequest{UnitID: 7, Function: 3, Offset: 40000, Quantity: 2}
+
+	_, err := provider.RawRead(context.Background(), request)
+	if !errors.Is(err, secondErr) {
+		t.Fatalf("RawRead error = %v; want retry error", err)
+	}
+	if adapter.reads != 2 || adapter.reconnects != 1 {
+		t.Fatalf("physical attempts/reconnects = %d/%d; want 2/1", adapter.reads, adapter.reconnects)
+	}
+	if provider.rateN != 1 {
+		t.Fatalf("quota admissions = %d; want 1", provider.rateN)
+	}
+	if len(adapter.plans) != 2 || !reflect.DeepEqual(adapter.plans[0], adapter.plans[1]) {
+		t.Fatalf("retry changed immutable admitted plan: %#v", adapter.plans)
+	}
+}
+
+func TestGatewayModbusMCPProviderDoesNotReconnectWithoutOwnerAuthorization(t *testing.T) {
+	adapter := &countingModbusMCPAdapter{
+		readErrors: []error{errors.New("permanent provider failure")},
+	}
+	provider := &gatewayModbusMCPProvider{adapter: adapter, now: time.Now}
+	request := mcp.ModbusRawReadRequest{UnitID: 7, Function: 3, Offset: 40000, Quantity: 1}
+
+	_, _ = provider.RawRead(context.Background(), request)
+	if adapter.reads != 1 || adapter.reconnects != 0 {
+		t.Fatalf("physical attempts/reconnects = %d/%d; want 1/0", adapter.reads, adapter.reconnects)
 	}
 }
 

--- a/cmd/gateway/modbus_mcp_provider_test.go
+++ b/cmd/gateway/modbus_mcp_provider_test.go
@@ -37,6 +37,18 @@ func (adapter *countingModbusMCPAdapter) ExecuteRead(_ context.Context, plan mod
 	return modbus.TCPReadBatch{}, errors.New("fixture transport unavailable")
 }
 
+func (adapter *countingModbusMCPAdapter) ExecuteReadWithReconnect(ctx context.Context, plan modbusadapter.ReadPlan) (modbus.TCPReadBatch, error) {
+	batch, err := adapter.ExecuteRead(ctx, plan)
+	if err == nil || !adapter.reconnectRequired {
+		return batch, err
+	}
+	if reconnectErr := adapter.Reconnect(ctx); reconnectErr != nil {
+		return modbus.TCPReadBatch{}, reconnectErr
+	}
+	adapter.reconnectRequired = false
+	return adapter.ExecuteRead(ctx, plan)
+}
+
 func (adapter *countingModbusMCPAdapter) Snapshot() modbus.TCPEndpointSnapshot {
 	return modbus.TCPEndpointSnapshot{ReconnectRequired: adapter.reconnectRequired}
 }

--- a/cmd/gateway/modbus_mcp_provider_test.go
+++ b/cmd/gateway/modbus_mcp_provider_test.go
@@ -2,12 +2,16 @@ package main
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
+	"io"
+	"net"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
 
+	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/modbusadapter"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
 	modbus "github.com/Project-Helianthus/helianthus-modbus"
@@ -19,6 +23,7 @@ type countingModbusMCPAdapter struct {
 	reconnects        int
 	reconnectRequired bool
 	reconnectErr      error
+	reconnectWait     bool
 	readErrors        []error
 	plans             []modbusadapter.ReadPlan
 }
@@ -36,8 +41,12 @@ func (adapter *countingModbusMCPAdapter) Snapshot() modbus.TCPEndpointSnapshot {
 	return modbus.TCPEndpointSnapshot{ReconnectRequired: adapter.reconnectRequired}
 }
 
-func (adapter *countingModbusMCPAdapter) Reconnect(context.Context) error {
+func (adapter *countingModbusMCPAdapter) Reconnect(ctx context.Context) error {
 	adapter.reconnects++
+	if adapter.reconnectWait {
+		<-ctx.Done()
+		return ctx.Err()
+	}
 	return adapter.reconnectErr
 }
 
@@ -148,6 +157,131 @@ func TestGatewayModbusMCPProviderDoesNotReconnectWithoutOwnerAuthorization(t *te
 	_, _ = provider.RawRead(context.Background(), request)
 	if adapter.reads != 1 || adapter.reconnects != 0 {
 		t.Fatalf("physical attempts/reconnects = %d/%d; want 1/0", adapter.reads, adapter.reconnects)
+	}
+}
+
+func TestGatewayModbusMCPProviderStopsWhenReconnectFails(t *testing.T) {
+	firstErr := errors.New("fixture retryable transport failure")
+	reconnectErr := errors.New("fixture reconnect failure")
+	adapter := &countingModbusMCPAdapter{
+		reconnectRequired: true,
+		reconnectErr:      reconnectErr,
+		readErrors:        []error{firstErr},
+	}
+	provider := &gatewayModbusMCPProvider{adapter: adapter, now: time.Now}
+	request := mcp.ModbusRawReadRequest{UnitID: 7, Function: 3, Offset: 40000, Quantity: 1}
+
+	_, err := provider.RawRead(context.Background(), request)
+	if !errors.Is(err, reconnectErr) {
+		t.Fatalf("RawRead error = %v; want reconnect error", err)
+	}
+	if adapter.reads != 1 || adapter.reconnects != 1 {
+		t.Fatalf("physical attempts/reconnects = %d/%d; want 1/1", adapter.reads, adapter.reconnects)
+	}
+}
+
+func TestGatewayModbusMCPProviderReconnectHonorsShorterCallerDeadline(t *testing.T) {
+	adapter := &countingModbusMCPAdapter{
+		reconnectRequired: true,
+		reconnectWait:     true,
+		readErrors:        []error{errors.New("fixture retryable transport failure")},
+	}
+	provider := &gatewayModbusMCPProvider{adapter: adapter, now: time.Now}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	_, err := provider.RawRead(ctx, mcp.ModbusRawReadRequest{
+		UnitID: 7, Function: 3, Offset: 40000, Quantity: 1,
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("RawRead error = %v; want caller deadline", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("bounded reconnect took %s", elapsed)
+	}
+	if adapter.reads != 1 || adapter.reconnects != 1 {
+		t.Fatalf("physical attempts/reconnects = %d/%d; want 1/1", adapter.reads, adapter.reconnects)
+	}
+}
+
+func TestGatewayModbusMCPProviderReturnsOnlyRecoveredConnectionData(t *testing.T) {
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	peerDone := make(chan error, 1)
+	requests := make(chan [12]byte, 2)
+	go func() {
+		for attempt := 0; attempt < 2; attempt++ {
+			connection, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				peerDone <- acceptErr
+				return
+			}
+			var request [12]byte
+			_, readErr := io.ReadFull(connection, request[:])
+			if readErr != nil {
+				_ = connection.Close()
+				peerDone <- readErr
+				return
+			}
+			requests <- request
+			if attempt == 0 {
+				_ = connection.Close()
+				continue
+			}
+			response := make([]byte, 11)
+			copy(response[0:4], request[0:4])
+			binary.BigEndian.PutUint16(response[4:6], 5)
+			response[6], response[7], response[8] = request[6], request[7], 2
+			binary.BigEndian.PutUint16(response[9:11], 0x1234)
+			_, writeErr := connection.Write(response)
+			_ = connection.Close()
+			peerDone <- writeErr
+			return
+		}
+	}()
+
+	config, err := mapModbusRuntimeConfig(ebusgateway.ModbusTCPConfig{
+		Enabled: true, Endpoint: "tcp://" + listener.Addr().String(), DialTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("map Modbus config: %v", err)
+	}
+	config.Endpoint.Backoff.Floor = time.Millisecond
+	config.Endpoint.Backoff.Ceiling = time.Millisecond
+	config.Endpoint.Backoff.MaxAttempts = 1
+	adapter, err := modbusadapter.Start(
+		context.Background(), config,
+		(&net.Dialer{}).DialContext,
+		func(config modbus.TCPEndpointConfig) (modbusadapter.Endpoint, error) {
+			return modbus.NewTCPEndpoint(config)
+		},
+	)
+	if err != nil {
+		t.Fatalf("start Modbus adapter: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+	provider := newGatewayModbusMCPProvider(adapter).(*gatewayModbusMCPProvider)
+	result, err := provider.RawRead(context.Background(), mcp.ModbusRawReadRequest{
+		UnitID: 1, Function: 3, Offset: 40000, Quantity: 1,
+	})
+	if err != nil {
+		t.Fatalf("RawRead after recoverable socket loss: %v", err)
+	}
+	if !reflect.DeepEqual(result.Words, []uint16{0x1234}) || result.TransportGeneration < 2 || result.ConnectionID < 2 {
+		t.Fatalf("recovered result = %#v", result)
+	}
+	if provider.rateN != 1 {
+		t.Fatalf("quota admissions = %d; want 1", provider.rateN)
+	}
+	first, second := <-requests, <-requests
+	if !reflect.DeepEqual(first[6:], second[6:]) {
+		t.Fatalf("retry changed immutable Modbus PDU: first=%x second=%x", first[6:], second[6:])
+	}
+	if err := <-peerDone; err != nil {
+		t.Fatalf("fake peer: %v", err)
 	}
 }
 

--- a/internal/modbusadapter/adapter.go
+++ b/internal/modbusadapter/adapter.go
@@ -240,46 +240,57 @@ func (adapter *Adapter) Reconnect(ctx context.Context) error {
 	if adapter == nil || adapter.endpoint == nil || ctx == nil {
 		return errors.New("modbus TCP adapter unavailable")
 	}
-	reconnector, ok := adapter.endpoint.(reconnectEndpoint)
-	if !ok {
-		return errors.New("modbus TCP endpoint does not support reconnect")
-	}
 	adapter.executeMu.Lock()
 	defer adapter.executeMu.Unlock()
+	_, err := adapter.reconnectLocked(ctx, false)
+	return err
+}
+
+// reconnectLocked checks owner recovery state and replaces the connection while
+// executeMu is held. requireOwnerAuthorization makes the check and replacement
+// one atomic adapter operation for caller-triggered recovery.
+func (adapter *Adapter) reconnectLocked(ctx context.Context, requireOwnerAuthorization bool) (bool, error) {
+	reconnector, ok := adapter.endpoint.(reconnectEndpoint)
+	if !ok {
+		return false, errors.New("modbus TCP endpoint does not support reconnect")
+	}
 	adapter.connectionMu.Lock()
 	defer adapter.connectionMu.Unlock()
 	if adapter.closed {
-		return errors.New("modbus TCP adapter is closed")
+		return false, errors.New("modbus TCP adapter is closed")
 	}
 	oldConnection, request := adapter.connection, adapter.lastRequest
 	beforeRetirement := adapter.endpoint.Snapshot()
+	if requireOwnerAuthorization && !beforeRetirement.ReconnectRequired {
+		return false, nil
+	}
 	if err := reconnector.CloseConnection(oldConnection); err != nil && !beforeRetirement.ReconnectRequired {
-		return fmt.Errorf("retire Modbus TCP connection: %w", err)
+		return false, fmt.Errorf("retire Modbus TCP connection: %w", err)
 	}
 	adapter.lastRequest = modbus.TCPRequestHandle{}
 	// A failed socket may already have retired its handle. Only the endpoint's
 	// public state authorizes consuming request-bound reconnect backoff.
 	if request.RequestID() != 0 && beforeRetirement.ReconnectRequired {
 		if err := reconnector.WaitReconnect(ctx, request, contextDelayWaiter{}); err != nil {
-			return fmt.Errorf("wait endpoint reconnect backoff: %w", err)
+			return false, fmt.Errorf("wait endpoint reconnect backoff: %w", err)
 		}
 	}
 	address, err := dialAddress(adapter.config.Endpoint.Endpoint)
 	if err != nil {
-		return err
+		return false, err
 	}
 	dialCtx, cancel := context.WithTimeout(ctx, adapter.config.DialTimeout)
 	defer cancel()
 	connection, err := adapter.dial(dialCtx, "tcp", address)
 	if err != nil {
-		return fmt.Errorf("redial Modbus TCP endpoint: %w", err)
+		return false, fmt.Errorf("redial Modbus TCP endpoint: %w", err)
 	}
 	handle, err := adapter.endpoint.OpenConnection(connection)
 	if err != nil {
-		return errors.Join(fmt.Errorf("reopen Modbus TCP endpoint: %w", err), connection.Close())
+		return false, errors.Join(fmt.Errorf("reopen Modbus TCP endpoint: %w", err), connection.Close())
 	}
 	adapter.connection = handle
-	return nil
+	return true, nil
 }
 
 // ExecuteRead serializes one bounded request through the endpoint owner. It
@@ -290,6 +301,33 @@ func (adapter *Adapter) ExecuteRead(ctx context.Context, plan ReadPlan) (modbus.
 	}
 	adapter.executeMu.Lock()
 	defer adapter.executeMu.Unlock()
+	return adapter.executeReadLocked(ctx, plan)
+}
+
+// ExecuteReadWithReconnect owns one bounded read operation across a retryable
+// transport failure. The owner check, connection replacement, and single retry
+// remain serialized with every other adapter execution.
+func (adapter *Adapter) ExecuteReadWithReconnect(ctx context.Context, plan ReadPlan) (modbus.TCPReadBatch, error) {
+	if adapter == nil || adapter.endpoint == nil {
+		return modbus.TCPReadBatch{}, errors.New("modbus TCP adapter unavailable")
+	}
+	adapter.executeMu.Lock()
+	defer adapter.executeMu.Unlock()
+	batch, err := adapter.executeReadLocked(ctx, plan)
+	if err == nil {
+		return batch, nil
+	}
+	reconnected, reconnectErr := adapter.reconnectLocked(ctx, true)
+	if reconnectErr != nil {
+		return modbus.TCPReadBatch{}, reconnectErr
+	}
+	if !reconnected {
+		return modbus.TCPReadBatch{}, err
+	}
+	return adapter.executeReadLocked(ctx, plan)
+}
+
+func (adapter *Adapter) executeReadLocked(ctx context.Context, plan ReadPlan) (modbus.TCPReadBatch, error) {
 	handle, err := adapter.EnqueueRead(plan)
 	if err != nil {
 		return modbus.TCPReadBatch{}, err

--- a/internal/modbusadapter/adapter_reconnect_test.go
+++ b/internal/modbusadapter/adapter_reconnect_test.go
@@ -2,8 +2,10 @@ package modbusadapter
 
 import (
 	"context"
+	"encoding/binary"
 	"io"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -140,5 +142,104 @@ func TestAdapterReconnectAfterSocketLossRetiresFailedGenerationAndHonorsBackoff(
 	}
 	if dispatch, ok := adapter.Dispatch(); ok && dispatch.RequestID() == stale.RequestID() {
 		t.Fatalf("stale failed request %d was retried on recovered generation", stale.RequestID())
+	}
+}
+
+func TestAdapterExecuteReadWithReconnectSerializesConcurrentRecovery(t *testing.T) {
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	peerDone := make(chan error, 1)
+	go func() {
+		first, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			peerDone <- acceptErr
+			return
+		}
+		request := make([]byte, 12)
+		_, readErr := io.ReadFull(first, request)
+		_ = first.Close()
+		if readErr != nil {
+			peerDone <- readErr
+			return
+		}
+		second, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			peerDone <- acceptErr
+			return
+		}
+		defer func() { _ = second.Close() }()
+		for index := 0; index < 2; index++ {
+			if _, readErr = io.ReadFull(second, request); readErr != nil {
+				peerDone <- readErr
+				return
+			}
+			response := make([]byte, 11)
+			copy(response[0:4], request[0:4])
+			binary.BigEndian.PutUint16(response[4:6], 5)
+			response[6], response[7], response[8] = request[6], request[7], 2
+			binary.BigEndian.PutUint16(response[9:11], uint16(0x1200+index))
+			if _, writeErr := second.Write(response); writeErr != nil {
+				peerDone <- writeErr
+				return
+			}
+		}
+		peerDone <- nil
+	}()
+
+	adapter, err := Start(
+		context.Background(), integrationConfig(t, "tcp://"+listener.Addr().String()),
+		realDialer, realFactory,
+	)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+	request, err := modbus.NewReadRegistersRequest(modbus.FunctionReadHoldingRegisters, 40000, 1)
+	if err != nil {
+		t.Fatalf("NewReadRegistersRequest: %v", err)
+	}
+	type result struct {
+		batch modbus.TCPReadBatch
+		err   error
+	}
+	results := make(chan result, 2)
+	start := make(chan struct{})
+	var callers sync.WaitGroup
+	for caller := range 2 {
+		callers.Add(1)
+		go func(caller int) {
+			defer callers.Done()
+			<-start
+			batch, callErr := adapter.ExecuteReadWithReconnect(context.Background(), ReadPlan{
+				UnitID: 1, AuthorizationScope: "mcp:modbus.raw.read",
+				PollGeneration: uint64(caller + 1), DeadlineIdentity: uint64(caller + 1),
+				Timeout: time.Second,
+				Reads:   []modbus.TCPLogicalRead{{LogicalViewID: uint64(caller + 1), Request: request}},
+			})
+			results <- result{batch: batch, err: callErr}
+		}(caller)
+	}
+	close(start)
+	callers.Wait()
+	close(results)
+	for result := range results {
+		if result.err != nil {
+			t.Fatalf("ExecuteReadWithReconnect: %v", result.err)
+		}
+		if len(result.batch.Views) != 1 || result.batch.Views[0].Provenance().Wire.TransportGeneration < 2 {
+			t.Fatalf("recovered batch = %#v", result.batch)
+		}
+	}
+	if err := <-peerDone; err != nil {
+		t.Fatalf("peer: %v", err)
+	}
+	if generation := adapter.connection.Generation(); generation != 2 {
+		t.Fatalf("connection generation = %d; want exactly one reconnect to generation 2", generation)
+	}
+	if snapshot := adapter.Snapshot(); snapshot.ReconnectRequired || !snapshot.Healthy {
+		t.Fatalf("post-recovery snapshot = %#v", snapshot)
 	}
 }

--- a/mcp/modbus_v1.go
+++ b/mcp/modbus_v1.go
@@ -234,17 +234,20 @@ func newModbusV1Envelope(
 	var envelopeError any
 	if err != nil {
 		code := "INVALID_ARGUMENT"
+		message := err.Error()
 		retriable := false
 		if providerCalled {
 			code = "UNAVAILABLE"
+			message = "modbus provider unavailable"
 			retriable = true
 		}
 		if errors.Is(err, ErrModbusV1ResourceExhausted) {
 			code = "RESOURCE_EXHAUSTED"
+			message = "modbus raw read quota exhausted"
 		}
 		envelopeError = map[string]any{
 			"code":         code,
-			"message":      err.Error(),
+			"message":      message,
 			"retriable":    retriable,
 			"source_layer": "modbus",
 		}

--- a/mcp/modbus_v1_test.go
+++ b/mcp/modbus_v1_test.go
@@ -58,10 +58,13 @@ func TestModbusV1ProviderErrorIsStaticAndEndpointFree(t *testing.T) {
 		envelopeError["message"] != "modbus provider unavailable" {
 		t.Fatalf("provider error envelope = %#v", envelopeError)
 	}
-	encoded := result.raw
+	message, ok := envelopeError["message"].(string)
+	if !ok {
+		t.Fatalf("provider error message = %#v", envelopeError["message"])
+	}
 	for _, forbidden := range []string{leaked, "192.0.2.10", "192.0.2.20", "49152", "502"} {
-		if strings.Contains(encoded, forbidden) {
-			t.Fatalf("provider error leaked %q: %s", forbidden, encoded)
+		if strings.Contains(message, forbidden) {
+			t.Fatalf("provider error leaked %q: %s", forbidden, message)
 		}
 	}
 }

--- a/mcp/modbus_v1_test.go
+++ b/mcp/modbus_v1_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -13,10 +14,14 @@ import (
 
 type modbusV1FixtureProvider struct {
 	rawRequest ModbusRawReadRequest
+	rawErr     error
 }
 
 func (provider *modbusV1FixtureProvider) RawRead(_ context.Context, request ModbusRawReadRequest) (ModbusRawReadResult, error) {
 	provider.rawRequest = request
+	if provider.rawErr != nil {
+		return ModbusRawReadResult{}, provider.rawErr
+	}
 	return ModbusRawReadResult{
 		EndpointRef:         "sha256:endpoint",
 		UnitID:              request.UnitID,
@@ -32,6 +37,33 @@ func (provider *modbusV1FixtureProvider) RawRead(_ context.Context, request Modb
 		PollGenerationID:    96,
 		DeadlineIdentity:    97,
 	}, nil
+}
+
+func TestModbusV1ProviderErrorIsStaticAndEndpointFree(t *testing.T) {
+	server, err := NewServer(&testRegistry{entries: make(map[byte]registry.DeviceEntry)}, &testInvoker{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaked := "read tcp 192.0.2.10:49152->192.0.2.20:502: connection reset"
+	RegisterModbusV1Tools(server, &modbusV1FixtureProvider{rawErr: errors.New(leaked)})
+
+	result := msp06Call(t, server.Handler(), ModbusV1RawReadTool, map[string]any{
+		"unit_id": 1, "function": 3, "offset": 40000, "quantity": 1,
+	})
+	if !result.isError {
+		t.Fatal("provider failure returned success")
+	}
+	envelopeError := msp06Map(t, result.envelope["error"], "error")
+	if envelopeError["code"] != "UNAVAILABLE" || envelopeError["retriable"] != true ||
+		envelopeError["message"] != "modbus provider unavailable" {
+		t.Fatalf("provider error envelope = %#v", envelopeError)
+	}
+	encoded := result.raw
+	for _, forbidden := range []string{leaked, "192.0.2.10", "192.0.2.20", "49152", "502"} {
+		if strings.Contains(encoded, forbidden) {
+			t.Fatalf("provider error leaked %q: %s", forbidden, encoded)
+		}
+	}
 }
 
 func (*modbusV1FixtureProvider) ProfileObservation(_ context.Context, profileID, sampleID string) (ModbusProfileObservationResult, error) {


### PR DESCRIPTION
Closes #833.

Docs gate: Project-Helianthus/helianthus-docs-ebus#461, merge `1ca1438813ec80b12a9c4e9565086cecd6160e19`.

## TDD
- live-blocker RED: `77885ddac7021804b523c7a6b93adf3163aaa816`
- first GREEN: `d5cd63caaf508c9927af32a7662dca33883be2fa`
- concurrent-recovery P2 RED: `822fa53588f74853ac5e4ea3a50cd2646e88cb5f`
- current GREEN: `dc5778cad8bffbd872df606d515cab9ebc567225`

## Implementation
- one raw quota admission per caller operation
- adapter-owner atomic first read, ReconnectRequired gate, one reconnect, one retry
- executeMu covers owner check and recovery so concurrent calls cannot tear down the recovered generation
- original/3s maximum context and immutable request across retry
- result exclusively from the recovered connection generation
- static endpoint-free provider error envelope
- retained profile reader remains wire-free

## Validation
- real TCP reset/reconnect test
- deterministic two-caller recovery test proving exactly one generation transition
- full `./scripts/ci_local.sh`
- repository transport/passive gates not triggered by scoped files
- fresh exact-HEAD review required before merge

No Modbus writes, semantic widening, eBUS/eeBUS, adaptermux, add-on, or live mutation.