### PR TITLE
FMV3-M5-05: implement PUBLIC_GRAPHQL_M2M_V1 parity

### DIFF
--- a/cmd/gateway/m2m_graphql_config.go
+++ b/cmd/gateway/m2m_graphql_config.go
@@ -29,6 +29,11 @@ func bindM2MGraphQLFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) {
 		sort.Strings(cfg.M2MGraphQL.AllowedAssets)
 		return nil
 	})
+	fs.Func("m2m-graphql-known-assets", "comma-separated assets known independently of retained snapshots", func(value string) error {
+		cfg.M2MGraphQL.KnownAssets = normalizeEEBusList(value, false)
+		sort.Strings(cfg.M2MGraphQL.KnownAssets)
+		return nil
+	})
 	fs.Func("m2m-graphql-denied-principals", "comma-separated SHA-256 client certificate fingerprints", func(value string) error {
 		cfg.M2MGraphQL.DeniedPrincipalFingerprints = normalizeEEBusList(value, true)
 		sort.Strings(cfg.M2MGraphQL.DeniedPrincipalFingerprints)

--- a/cmd/gateway/m2m_graphql_config.go
+++ b/cmd/gateway/m2m_graphql_config.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"errors"
+	"flag"
+	"sort"
 
 	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
 )
@@ -11,4 +13,25 @@ func validateM2MGraphQLConfig(config ebusgateway.M2MGraphQLConfig) error {
 		return errors.New("M2M GraphQL configuration is invalid")
 	}
 	return nil
+}
+
+func bindM2MGraphQLFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) {
+	if fs == nil || cfg == nil {
+		return
+	}
+	fs.StringVar(&cfg.M2MGraphQL.ListenAddr, "m2m-graphql-listen", cfg.M2MGraphQL.ListenAddr, "dedicated M2M GraphQL TLS listen address")
+	fs.StringVar(&cfg.M2MGraphQL.ServerName, "m2m-graphql-server-name", cfg.M2MGraphQL.ServerName, "dedicated M2M GraphQL server certificate identity")
+	fs.StringVar(&cfg.M2MGraphQL.ClientCAFile, "m2m-graphql-client-ca", cfg.M2MGraphQL.ClientCAFile, "client CA file for the dedicated M2M GraphQL listener")
+	fs.StringVar(&cfg.M2MGraphQL.ServerCertFile, "m2m-graphql-server-cert", cfg.M2MGraphQL.ServerCertFile, "server certificate file for the dedicated M2M GraphQL listener")
+	fs.StringVar(&cfg.M2MGraphQL.ServerKeyFile, "m2m-graphql-server-key", cfg.M2MGraphQL.ServerKeyFile, "server private-key file for the dedicated M2M GraphQL listener")
+	fs.Func("m2m-graphql-allowed-assets", "comma-separated opaque asset allowlist", func(value string) error {
+		cfg.M2MGraphQL.AllowedAssets = normalizeEEBusList(value, false)
+		sort.Strings(cfg.M2MGraphQL.AllowedAssets)
+		return nil
+	})
+	fs.Func("m2m-graphql-denied-principals", "comma-separated SHA-256 client certificate fingerprints", func(value string) error {
+		cfg.M2MGraphQL.DeniedPrincipalFingerprints = normalizeEEBusList(value, true)
+		sort.Strings(cfg.M2MGraphQL.DeniedPrincipalFingerprints)
+		return nil
+	})
 }

--- a/cmd/gateway/m2m_graphql_config.go
+++ b/cmd/gateway/m2m_graphql_config.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"errors"
+
+	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
+)
+
+func validateM2MGraphQLConfig(config ebusgateway.M2MGraphQLConfig) error {
+	if err := config.Validate(); err != nil {
+		return errors.New("M2M GraphQL configuration is invalid")
+	}
+	return nil
+}

--- a/cmd/gateway/m2m_graphql_runtime.go
+++ b/cmd/gateway/m2m_graphql_runtime.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
@@ -25,9 +26,46 @@ type m2mGraphQLRuntime struct {
 }
 
 const (
-	m2mHTTPHeaderTimeout = 5 * time.Second
-	m2mHTTPBodyTimeout   = 10 * time.Second
+	m2mHTTPHeaderTimeout    = 5 * time.Second
+	m2mHTTPBodyTimeout      = 10 * time.Second
+	m2mMaxPreTLSConnections = 16
 )
+
+type boundedM2MListener struct {
+	net.Listener
+	slots chan struct{}
+}
+
+type boundedM2MConnection struct {
+	net.Conn
+	release func()
+	once    sync.Once
+}
+
+func newBoundedM2MListener(listener net.Listener, capacity int) *boundedM2MListener {
+	return &boundedM2MListener{Listener: listener, slots: make(chan struct{}, capacity)}
+}
+
+func (listener *boundedM2MListener) Accept() (net.Conn, error) {
+	for {
+		connection, err := listener.Listener.Accept()
+		if err != nil {
+			return nil, err
+		}
+		select {
+		case listener.slots <- struct{}{}:
+			return &boundedM2MConnection{Conn: connection, release: func() { <-listener.slots }}, nil
+		default:
+			_ = connection.Close()
+		}
+	}
+}
+
+func (connection *boundedM2MConnection) Close() error {
+	err := connection.Conn.Close()
+	connection.once.Do(connection.release)
+	return err
+}
 
 func newM2MGraphQLRuntime(config ebusgateway.Config, adapter *modbusadapter.Adapter) (*m2mGraphQLRuntime, error) {
 	if config.M2MGraphQL.Disabled() {
@@ -44,9 +82,16 @@ func newM2MGraphQLRuntime(config ebusgateway.Config, adapter *modbusadapter.Adap
 	for _, asset := range config.M2MGraphQL.AllowedAssets {
 		allowed[asset] = struct{}{}
 	}
+	known := make(map[string]struct{}, len(config.M2MGraphQL.KnownAssets))
+	for _, asset := range config.M2MGraphQL.KnownAssets {
+		known[asset] = struct{}{}
+	}
 	handler, err := m2mgraphql.NewHandler(m2mgraphql.Config{
 		AllowedAssets: allowed,
 		AssetExists: func(asset string) bool {
+			if _, ok := known[asset]; ok {
+				return true
+			}
 			if adapter == nil {
 				return false
 			}
@@ -63,10 +108,11 @@ func newM2MGraphQLRuntime(config ebusgateway.Config, adapter *modbusadapter.Adap
 	if err != nil {
 		return nil, errors.New("M2M GraphQL handler configuration is invalid")
 	}
-	listener, err := net.Listen("tcp", config.M2MGraphQL.ListenAddr)
+	rawListener, err := net.Listen("tcp", config.M2MGraphQL.ListenAddr)
 	if err != nil {
 		return nil, errors.New("M2M GraphQL listener could not start")
 	}
+	listener := newBoundedM2MListener(rawListener, m2mMaxPreTLSConnections)
 	runtime := &m2mGraphQLRuntime{listener: listener}
 	runtime.server = &http.Server{TLSConfig: tlsConfig, ReadHeaderTimeout: m2mHTTPHeaderTimeout, ReadTimeout: m2mHTTPBodyTimeout, WriteTimeout: m2mHTTPBodyTimeout, IdleTimeout: m2mHTTPBodyTimeout, Handler: http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		if request.TLS == nil || len(request.TLS.VerifiedChains) == 0 || len(request.TLS.PeerCertificates) == 0 {

--- a/cmd/gateway/m2m_graphql_runtime.go
+++ b/cmd/gateway/m2m_graphql_runtime.go
@@ -7,6 +7,8 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"errors"
+	"io"
+	"log"
 	"net"
 	"net/http"
 	"os"
@@ -114,7 +116,7 @@ func newM2MGraphQLRuntime(config ebusgateway.Config, adapter *modbusadapter.Adap
 	}
 	listener := newBoundedM2MListener(rawListener, m2mMaxPreTLSConnections)
 	runtime := &m2mGraphQLRuntime{listener: listener}
-	runtime.server = &http.Server{TLSConfig: tlsConfig, ReadHeaderTimeout: m2mHTTPHeaderTimeout, ReadTimeout: m2mHTTPBodyTimeout, WriteTimeout: m2mHTTPBodyTimeout, IdleTimeout: m2mHTTPBodyTimeout, Handler: http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+	runtime.server = &http.Server{TLSConfig: tlsConfig, ErrorLog: log.New(io.Discard, "", 0), ReadHeaderTimeout: m2mHTTPHeaderTimeout, ReadTimeout: m2mHTTPBodyTimeout, WriteTimeout: m2mHTTPBodyTimeout, IdleTimeout: m2mHTTPBodyTimeout, Handler: http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		if request.TLS == nil || len(request.TLS.VerifiedChains) == 0 || len(request.TLS.PeerCertificates) == 0 {
 			response.WriteHeader(http.StatusUnauthorized)
 			return

--- a/cmd/gateway/m2m_graphql_runtime.go
+++ b/cmd/gateway/m2m_graphql_runtime.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"errors"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/modbusadapter"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/m2mgraphql"
+	pv "github.com/Project-Helianthus/helianthus-ebusreg/pv"
+)
+
+type m2mGraphQLRuntime struct {
+	listener net.Listener
+	server   *http.Server
+}
+
+func newM2MGraphQLRuntime(config ebusgateway.Config, adapter *modbusadapter.Adapter) (*m2mGraphQLRuntime, error) {
+	if config.M2MGraphQL.Disabled() {
+		return nil, nil
+	}
+	if err := validateM2MGraphQLConfig(config.M2MGraphQL); err != nil {
+		return nil, err
+	}
+	tlsConfig, err := newM2MTLSConfig(config.M2MGraphQL)
+	if err != nil {
+		return nil, errors.New("M2M GraphQL TLS configuration is invalid")
+	}
+	allowed := make(map[string]struct{}, len(config.M2MGraphQL.AllowedAssets))
+	for _, asset := range config.M2MGraphQL.AllowedAssets {
+		allowed[asset] = struct{}{}
+	}
+	handler, err := m2mgraphql.NewHandler(m2mgraphql.Config{
+		AllowedAssets: allowed,
+		AssetExists: func(asset string) bool {
+			if adapter == nil {
+				return false
+			}
+			_, _, ok := adapter.CanonicalPVSnapshotByAsset(asset)
+			return ok
+		},
+		SnapshotByAssetAt: func(_ context.Context, asset string) (pv.Snapshot, time.Time, bool) {
+			if adapter == nil {
+				return pv.Snapshot{}, time.Time{}, false
+			}
+			return adapter.CanonicalPVSnapshotByAsset(asset)
+		},
+	})
+	if err != nil {
+		return nil, errors.New("M2M GraphQL handler configuration is invalid")
+	}
+	listener, err := net.Listen("tcp", config.M2MGraphQL.ListenAddr)
+	if err != nil {
+		return nil, errors.New("M2M GraphQL listener could not start")
+	}
+	runtime := &m2mGraphQLRuntime{listener: listener}
+	runtime.server = &http.Server{Handler: http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.TLS == nil || len(request.TLS.VerifiedChains) == 0 || len(request.TLS.PeerCertificates) == 0 {
+			response.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		handler.ServeHTTP(response, request.WithContext(m2mgraphql.WithMTLSPrincipal(request.Context(), m2mFingerprint(request.TLS.PeerCertificates[0].Raw))))
+	})}
+	go func() { _ = runtime.server.Serve(m2mTLSListener{Listener: listener, config: tlsConfig}) }()
+	return runtime, nil
+}
+
+// m2mTLSListener completes the handshake before handing a connection to the
+// HTTP server. Besides avoiding unauthenticated work in net/http, this makes a
+// missing or denied client certificate fail at TLS dial time.
+type m2mTLSListener struct {
+	net.Listener
+	config *tls.Config
+}
+
+func (listener m2mTLSListener) Accept() (net.Conn, error) {
+	for {
+		connection, err := listener.Listener.Accept()
+		if err != nil {
+			return nil, err
+		}
+		tlsConnection := tls.Server(connection, listener.config)
+		if err := tlsConnection.Handshake(); err != nil {
+			_ = connection.Close()
+			continue
+		}
+		return tlsConnection, nil
+	}
+}
+
+func newM2MTLSConfig(config ebusgateway.M2MGraphQLConfig) (*tls.Config, error) {
+	certificate, err := tls.LoadX509KeyPair(config.ServerCertFile, config.ServerKeyFile)
+	if err != nil {
+		return nil, err
+	}
+	caPEM, err := os.ReadFile(config.ClientCAFile)
+	if err != nil {
+		return nil, err
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caPEM) {
+		return nil, errors.New("invalid client CA")
+	}
+	denied := make(map[string]struct{}, len(config.DeniedPrincipalFingerprints))
+	for _, fingerprint := range config.DeniedPrincipalFingerprints {
+		denied[strings.ToLower(fingerprint)] = struct{}{}
+	}
+	return &tls.Config{MinVersion: tls.VersionTLS13, Certificates: []tls.Certificate{certificate}, ClientAuth: tls.RequireAndVerifyClientCert, ClientCAs: pool, VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+		if len(verifiedChains) == 0 || len(rawCerts) == 0 {
+			return errors.New("unverified client certificate")
+		}
+		if _, blocked := denied[m2mFingerprint(rawCerts[0])]; blocked {
+			return errors.New("denied client certificate")
+		}
+		return nil
+	}, SessionTicketsDisabled: true}, nil
+}
+
+func m2mFingerprint(der []byte) string { sum := sha256.Sum256(der); return hex.EncodeToString(sum[:]) }
+func (runtime *m2mGraphQLRuntime) Addr() string {
+	if runtime == nil || runtime.listener == nil {
+		return ""
+	}
+	return runtime.listener.Addr().String()
+}
+func (runtime *m2mGraphQLRuntime) RequiresVerifiedClientCertificate() bool {
+	return runtime != nil && runtime.server != nil
+}
+func (runtime *m2mGraphQLRuntime) Close() error {
+	if runtime == nil || runtime.server == nil {
+		return nil
+	}
+	return runtime.server.Close()
+}

--- a/cmd/gateway/m2m_graphql_runtime.go
+++ b/cmd/gateway/m2m_graphql_runtime.go
@@ -24,6 +24,11 @@ type m2mGraphQLRuntime struct {
 	server   *http.Server
 }
 
+const (
+	m2mHTTPHeaderTimeout = 5 * time.Second
+	m2mHTTPBodyTimeout   = 10 * time.Second
+)
+
 func newM2MGraphQLRuntime(config ebusgateway.Config, adapter *modbusadapter.Adapter) (*m2mGraphQLRuntime, error) {
 	if config.M2MGraphQL.Disabled() {
 		return nil, nil
@@ -63,38 +68,15 @@ func newM2MGraphQLRuntime(config ebusgateway.Config, adapter *modbusadapter.Adap
 		return nil, errors.New("M2M GraphQL listener could not start")
 	}
 	runtime := &m2mGraphQLRuntime{listener: listener}
-	runtime.server = &http.Server{Handler: http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+	runtime.server = &http.Server{TLSConfig: tlsConfig, ReadHeaderTimeout: m2mHTTPHeaderTimeout, ReadTimeout: m2mHTTPBodyTimeout, WriteTimeout: m2mHTTPBodyTimeout, IdleTimeout: m2mHTTPBodyTimeout, Handler: http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		if request.TLS == nil || len(request.TLS.VerifiedChains) == 0 || len(request.TLS.PeerCertificates) == 0 {
 			response.WriteHeader(http.StatusUnauthorized)
 			return
 		}
 		handler.ServeHTTP(response, request.WithContext(m2mgraphql.WithMTLSPrincipal(request.Context(), m2mFingerprint(request.TLS.PeerCertificates[0].Raw))))
 	})}
-	go func() { _ = runtime.server.Serve(m2mTLSListener{Listener: listener, config: tlsConfig}) }()
+	go func() { _ = runtime.server.Serve(tls.NewListener(listener, tlsConfig)) }()
 	return runtime, nil
-}
-
-// m2mTLSListener completes the handshake before handing a connection to the
-// HTTP server. Besides avoiding unauthenticated work in net/http, this makes a
-// missing or denied client certificate fail at TLS dial time.
-type m2mTLSListener struct {
-	net.Listener
-	config *tls.Config
-}
-
-func (listener m2mTLSListener) Accept() (net.Conn, error) {
-	for {
-		connection, err := listener.Listener.Accept()
-		if err != nil {
-			return nil, err
-		}
-		tlsConnection := tls.Server(connection, listener.config)
-		if err := tlsConnection.Handshake(); err != nil {
-			_ = connection.Close()
-			continue
-		}
-		return tlsConnection, nil
-	}
 }
 
 func newM2MTLSConfig(config ebusgateway.M2MGraphQLConfig) (*tls.Config, error) {
@@ -102,6 +84,11 @@ func newM2MTLSConfig(config ebusgateway.M2MGraphQLConfig) (*tls.Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	leaf, err := x509.ParseCertificate(certificate.Certificate[0])
+	if err != nil || leaf.VerifyHostname(config.ServerName) != nil {
+		return nil, errors.New("server certificate identity mismatch")
+	}
+	certificate.Leaf = leaf
 	caPEM, err := os.ReadFile(config.ClientCAFile)
 	if err != nil {
 		return nil, err

--- a/cmd/gateway/m2m_graphql_runtime_red_test.go
+++ b/cmd/gateway/m2m_graphql_runtime_red_test.go
@@ -10,10 +10,12 @@ import (
 	"crypto/x509/pkix"
 	"encoding/hex"
 	"encoding/pem"
+	"flag"
 	"math/big"
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -64,6 +66,43 @@ func TestM2MGraphQLRuntime_IncompleteEnabledConfigFailsClosed(t *testing.T) {
 	_, err := newM2MGraphQLRuntime(ebusgateway.Config{M2MGraphQL: ebusgateway.M2MGraphQLConfig{ListenAddr: "127.0.0.1:0", AllowedAssets: []string{"pv-asset-fixture"}}}, nil)
 	if err == nil {
 		t.Fatal("incomplete enabled M2M configuration started a listener")
+	}
+}
+
+func TestM2MGraphQLRuntime_RejectsServerCertificateForDifferentConfiguredIdentity(t *testing.T) {
+	certs := newM2MTLSCertificates(t)
+	_, err := newM2MGraphQLRuntime(ebusgateway.Config{M2MGraphQL: ebusgateway.M2MGraphQLConfig{
+		ListenAddr: "127.0.0.1:0", ServerName: "other.gateway.test",
+		ClientCAFile: certs.caFile, ServerCertFile: certs.serverCertFile, ServerKeyFile: certs.serverKeyFile,
+		AllowedAssets: []string{"pv-asset-fixture"},
+	}}, nil)
+	if err == nil {
+		t.Fatal("server certificate identity mismatch was accepted")
+	}
+}
+
+func TestM2MGraphQLFlags_WireDedicatedListenerConfiguration(t *testing.T) {
+	cfg := ebusgateway.DefaultConfig()
+	fs := flag.NewFlagSet("m2m-graphql", flag.ContinueOnError)
+	bindFlags(fs, &cfg)
+	err := fs.Parse([]string{
+		"-m2m-graphql-listen=127.0.0.1:8443",
+		"-m2m-graphql-server-name=m2m.gateway.test",
+		"-m2m-graphql-client-ca=/run/secrets/client-ca.pem",
+		"-m2m-graphql-server-cert=/run/secrets/server.pem",
+		"-m2m-graphql-server-key=/run/secrets/server-key.pem",
+		"-m2m-graphql-allowed-assets=pv-b,pv-a",
+		"-m2m-graphql-denied-principals=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+	})
+	if err != nil {
+		t.Fatalf("parse M2M GraphQL flags: %v", err)
+	}
+	got := cfg.M2MGraphQL
+	if got.ListenAddr != "127.0.0.1:8443" || got.ServerName != "m2m.gateway.test" ||
+		got.ClientCAFile != "/run/secrets/client-ca.pem" || got.ServerCertFile != "/run/secrets/server.pem" ||
+		got.ServerKeyFile != "/run/secrets/server-key.pem" || len(got.AllowedAssets) != 2 || got.AllowedAssets[0] != "pv-a" ||
+		len(got.DeniedPrincipalFingerprints) != 1 || got.DeniedPrincipalFingerprints[0] != strings.Repeat("a", 64) {
+		t.Fatalf("M2M GraphQL flag config=%+v", got)
 	}
 }
 

--- a/cmd/gateway/m2m_graphql_runtime_red_test.go
+++ b/cmd/gateway/m2m_graphql_runtime_red_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
@@ -9,10 +10,12 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/hex"
+	"encoding/json"
 	"encoding/pem"
 	"flag"
 	"math/big"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -116,6 +119,7 @@ func TestM2MGraphQLFlags_WireDedicatedListenerConfiguration(t *testing.T) {
 		"-m2m-graphql-server-cert=/run/secrets/server.pem",
 		"-m2m-graphql-server-key=/run/secrets/server-key.pem",
 		"-m2m-graphql-allowed-assets=pv-b,pv-a",
+		"-m2m-graphql-known-assets=pv-a",
 		"-m2m-graphql-denied-principals=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
 	})
 	if err != nil {
@@ -124,10 +128,101 @@ func TestM2MGraphQLFlags_WireDedicatedListenerConfiguration(t *testing.T) {
 	got := cfg.M2MGraphQL
 	if got.ListenAddr != "127.0.0.1:8443" || got.ServerName != "m2m.gateway.test" ||
 		got.ClientCAFile != "/run/secrets/client-ca.pem" || got.ServerCertFile != "/run/secrets/server.pem" ||
-		got.ServerKeyFile != "/run/secrets/server-key.pem" || len(got.AllowedAssets) != 2 || got.AllowedAssets[0] != "pv-a" ||
+		got.ServerKeyFile != "/run/secrets/server-key.pem" || len(got.AllowedAssets) != 2 || got.AllowedAssets[0] != "pv-a" || len(got.KnownAssets) != 1 || got.KnownAssets[0] != "pv-a" ||
 		len(got.DeniedPrincipalFingerprints) != 1 || got.DeniedPrincipalFingerprints[0] != strings.Repeat("a", 64) {
 		t.Fatalf("M2M GraphQL flag config=%+v", got)
 	}
+}
+
+func TestM2MGraphQLRuntime_KnownAssetWithoutSnapshotReturnsSourceUnavailable(t *testing.T) {
+	certs := newM2MTLSCertificates(t)
+	cfg := ebusgateway.Config{M2MGraphQL: ebusgateway.M2MGraphQLConfig{
+		ListenAddr: "127.0.0.1:0", ServerName: "m2m.gateway.test",
+		ClientCAFile: certs.caFile, ServerCertFile: certs.serverCertFile, ServerKeyFile: certs.serverKeyFile,
+		AllowedAssets: []string{"pv-asset-known"}, KnownAssets: []string{"pv-asset-known"},
+	}}
+	runtime, err := newM2MGraphQLRuntime(cfg, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = runtime.Close() })
+	query, err := os.ReadFile("../../m2mgraphql/testdata/public-graphql-m2m-v1.query.graphql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := json.Marshal(map[string]any{
+		"operationName": "M2MCurrentSnapshot", "query": string(query),
+		"variables": map[string]any{"request": map[string]string{"contractId": "PUBLIC_GRAPHQL_M2M_V1", "assetRef": "pv-asset-known"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{
+		RootCAs: certs.pool, ServerName: "m2m.gateway.test", MinVersion: tls.VersionTLS13, Certificates: []tls.Certificate{certs.goodClient},
+	}}}
+	response, err := client.Post("https://"+runtime.Addr()+"/graphql/m2m/v1", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	var envelope struct {
+		Errors []struct {
+			Extensions struct {
+				Code string `json:"code"`
+			} `json:"extensions"`
+		} `json:"errors"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&envelope); err != nil {
+		t.Fatal(err)
+	}
+	if len(envelope.Errors) != 1 || envelope.Errors[0].Extensions.Code != "SOURCE_UNAVAILABLE" {
+		t.Fatalf("known asset without snapshot response=%+v", envelope)
+	}
+}
+
+func TestM2MGraphQLRuntime_BoundsPreMTLSConnectionsAndReleasesSlots(t *testing.T) {
+	certs := newM2MTLSCertificates(t)
+	cfg := ebusgateway.Config{M2MGraphQL: ebusgateway.M2MGraphQLConfig{
+		ListenAddr: "127.0.0.1:0", ServerName: "m2m.gateway.test",
+		ClientCAFile: certs.caFile, ServerCertFile: certs.serverCertFile, ServerKeyFile: certs.serverKeyFile,
+		AllowedAssets: []string{"pv-asset-fixture"},
+	}}
+	runtime, err := newM2MGraphQLRuntime(cfg, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = runtime.Close() })
+	stalled := make([]net.Conn, 0, m2mMaxPreTLSConnections-1)
+	for range m2mMaxPreTLSConnections - 1 {
+		connection, err := net.Dial("tcp", runtime.Addr())
+		if err != nil {
+			t.Fatal(err)
+		}
+		stalled = append(stalled, connection)
+	}
+	t.Cleanup(func() {
+		for _, connection := range stalled {
+			_ = connection.Close()
+		}
+	})
+	time.Sleep(50 * time.Millisecond)
+	valid, err := tls.DialWithDialer(&net.Dialer{Timeout: time.Second}, "tcp", runtime.Addr(), &tls.Config{
+		RootCAs: certs.pool, ServerName: "m2m.gateway.test", MinVersion: tls.VersionTLS13, Certificates: []tls.Certificate{certs.goodClient},
+	})
+	if err != nil {
+		t.Fatalf("admitted client failed while bounded slots remained: %v", err)
+	}
+	excess, err := net.Dial("tcp", runtime.Addr())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = excess.SetReadDeadline(time.Now().Add(time.Second))
+	if _, err := excess.Read(make([]byte, 1)); err == nil {
+		t.Fatal("connection beyond pre-mTLS capacity was not rejected")
+	}
+	_ = excess.Close()
+	_ = valid.Close()
+	assertM2MTLSDial(t, runtime.Addr(), certs.pool, "m2m.gateway.test", certs.goodClient, true)
 }
 
 type m2mTLSCertificates struct {

--- a/cmd/gateway/m2m_graphql_runtime_red_test.go
+++ b/cmd/gateway/m2m_graphql_runtime_red_test.go
@@ -47,6 +47,9 @@ func TestM2MGraphQLRuntime_RequiresMutualTLSAndClosesListener(t *testing.T) {
 	if runtime == nil || !runtime.RequiresVerifiedClientCertificate() {
 		t.Fatalf("runtime=%#v; want dedicated verified-mTLS listener", runtime)
 	}
+	if runtime.server.ReadHeaderTimeout <= 0 || runtime.server.ReadTimeout <= 0 || runtime.server.WriteTimeout <= 0 || runtime.server.IdleTimeout <= 0 || m2mTLSHandshakeTimeout <= 0 {
+		t.Fatalf("M2M listener has unbounded network deadlines: %#v", runtime.server)
+	}
 	t.Cleanup(func() { _ = runtime.Close() })
 
 	assertM2MTLSDial(t, runtime.Addr(), certs.pool, "m2m.gateway.test", certs.goodClient, true)

--- a/cmd/gateway/m2m_graphql_runtime_red_test.go
+++ b/cmd/gateway/m2m_graphql_runtime_red_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"testing"
+
+	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
+)
+
+func TestM2MGraphQLRuntime_IsDisabledByDefaultAndSeparateFromGenericHTTP(t *testing.T) {
+	cfg := ebusgateway.DefaultConfig()
+	runtime, err := newM2MGraphQLRuntime(cfg, nil)
+	if err != nil {
+		t.Fatalf("newM2MGraphQLRuntime: %v", err)
+	}
+	if runtime != nil {
+		t.Fatalf("default config exposed M2M runtime: %#v", runtime)
+	}
+}
+
+func TestM2MGraphQLRuntime_RequiresMutualTLSAndClosesListener(t *testing.T) {
+	runtime, err := newM2MGraphQLRuntime(ebusgateway.Config{M2MGraphQL: ebusgateway.M2MGraphQLConfig{ListenAddr: "127.0.0.1:0", ClientCAFile: "testdata/client-ca.pem", ServerCertFile: "testdata/server.pem", ServerKeyFile: "testdata/server-key.pem", AllowedAssets: []string{"pv-asset-fixture"}}}, nil)
+	if err != nil {
+		t.Fatalf("newM2MGraphQLRuntime: %v", err)
+	}
+	if runtime == nil || !runtime.RequiresVerifiedClientCertificate() {
+		t.Fatalf("runtime=%#v; want dedicated verified-mTLS listener", runtime)
+	}
+	if err := runtime.Close(); err != nil {
+		t.Fatalf("close dedicated M2M listener: %v", err)
+	}
+}

--- a/cmd/gateway/m2m_graphql_runtime_red_test.go
+++ b/cmd/gateway/m2m_graphql_runtime_red_test.go
@@ -144,6 +144,13 @@ func assertM2MTLSDial(t *testing.T, addr string, roots *x509.CertPool, name stri
 		config.Certificates = []tls.Certificate{certificate}
 	}
 	connection, err := tls.Dial("tcp", addr, config)
+	// TLS 1.3 allows the client to finish locally before it observes the
+	// server's fatal client-certificate alert. Force one application read so
+	// this assertion observes the peer's final authentication outcome.
+	if err == nil && !want {
+		_ = connection.SetDeadline(time.Now().Add(250 * time.Millisecond))
+		_, err = connection.Read(make([]byte, 1))
+	}
 	if connection != nil {
 		_ = connection.Close()
 	}

--- a/cmd/gateway/m2m_graphql_runtime_red_test.go
+++ b/cmd/gateway/m2m_graphql_runtime_red_test.go
@@ -47,7 +47,7 @@ func TestM2MGraphQLRuntime_RequiresMutualTLSAndClosesListener(t *testing.T) {
 	if runtime == nil || !runtime.RequiresVerifiedClientCertificate() {
 		t.Fatalf("runtime=%#v; want dedicated verified-mTLS listener", runtime)
 	}
-	if runtime.server.ReadHeaderTimeout <= 0 || runtime.server.ReadTimeout <= 0 || runtime.server.WriteTimeout <= 0 || runtime.server.IdleTimeout <= 0 || m2mTLSHandshakeTimeout <= 0 {
+	if runtime.server.ReadHeaderTimeout <= 0 || runtime.server.ReadTimeout <= 0 || runtime.server.WriteTimeout <= 0 || runtime.server.IdleTimeout <= 0 {
 		t.Fatalf("M2M listener has unbounded network deadlines: %#v", runtime.server)
 	}
 	t.Cleanup(func() { _ = runtime.Close() })

--- a/cmd/gateway/m2m_graphql_runtime_red_test.go
+++ b/cmd/gateway/m2m_graphql_runtime_red_test.go
@@ -72,6 +72,27 @@ func TestM2MGraphQLRuntime_IncompleteEnabledConfigFailsClosed(t *testing.T) {
 	}
 }
 
+func TestM2MGraphQLRuntime_StalledHandshakeDoesNotBlockOtherPrincipals(t *testing.T) {
+	certs := newM2MTLSCertificates(t)
+	cfg := ebusgateway.Config{M2MGraphQL: ebusgateway.M2MGraphQLConfig{
+		ListenAddr: "127.0.0.1:0", ServerName: "m2m.gateway.test",
+		ClientCAFile: certs.caFile, ServerCertFile: certs.serverCertFile, ServerKeyFile: certs.serverKeyFile,
+		AllowedAssets: []string{"pv-asset-fixture"},
+	}}
+	runtime, err := newM2MGraphQLRuntime(cfg, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = runtime.Close() })
+	stalled, err := net.Dial("tcp", runtime.Addr())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = stalled.Close() })
+	time.Sleep(50 * time.Millisecond)
+	assertM2MTLSDial(t, runtime.Addr(), certs.pool, "m2m.gateway.test", certs.goodClient, true)
+}
+
 func TestM2MGraphQLRuntime_RejectsServerCertificateForDifferentConfiguredIdentity(t *testing.T) {
 	certs := newM2MTLSCertificates(t)
 	_, err := newM2MGraphQLRuntime(ebusgateway.Config{M2MGraphQL: ebusgateway.M2MGraphQLConfig{
@@ -185,7 +206,8 @@ func assertM2MTLSDial(t *testing.T, addr string, roots *x509.CertPool, name stri
 	if len(certificate.Certificate) != 0 {
 		config.Certificates = []tls.Certificate{certificate}
 	}
-	connection, err := tls.Dial("tcp", addr, config)
+	dialer := &net.Dialer{Timeout: time.Second}
+	connection, err := tls.DialWithDialer(dialer, "tcp", addr, config)
 	// TLS 1.3 allows the client to finish locally before it observes the
 	// server's fatal client-certificate alert. Force one application read so
 	// this assertion observes the peer's final authentication outcome.

--- a/cmd/gateway/m2m_graphql_runtime_red_test.go
+++ b/cmd/gateway/m2m_graphql_runtime_red_test.go
@@ -164,7 +164,11 @@ func TestM2MGraphQLRuntime_KnownAssetWithoutSnapshotReturnsSourceUnavailable(t *
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer response.Body.Close()
+	t.Cleanup(func() {
+		if err := response.Body.Close(); err != nil {
+			t.Errorf("close response body: %v", err)
+		}
+	})
 	var envelope struct {
 		Errors []struct {
 			Extensions struct {

--- a/cmd/gateway/m2m_graphql_runtime_red_test.go
+++ b/cmd/gateway/m2m_graphql_runtime_red_test.go
@@ -222,7 +222,19 @@ func TestM2MGraphQLRuntime_BoundsPreMTLSConnectionsAndReleasesSlots(t *testing.T
 	}
 	_ = excess.Close()
 	_ = valid.Close()
-	assertM2MTLSDial(t, runtime.Addr(), certs.pool, "m2m.gateway.test", certs.goodClient, true)
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		config := &tls.Config{RootCAs: certs.pool, ServerName: "m2m.gateway.test", MinVersion: tls.VersionTLS13, Certificates: []tls.Certificate{certs.goodClient}}
+		connection, err := tls.DialWithDialer(&net.Dialer{Timeout: 250 * time.Millisecond}, "tcp", runtime.Addr(), config)
+		if err == nil {
+			_ = connection.Close()
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("released pre-mTLS slot did not become reusable: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 
 type m2mTLSCertificates struct {

--- a/cmd/gateway/m2m_graphql_runtime_red_test.go
+++ b/cmd/gateway/m2m_graphql_runtime_red_test.go
@@ -1,7 +1,21 @@
 package main
 
 import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
 )
@@ -18,14 +32,122 @@ func TestM2MGraphQLRuntime_IsDisabledByDefaultAndSeparateFromGenericHTTP(t *test
 }
 
 func TestM2MGraphQLRuntime_RequiresMutualTLSAndClosesListener(t *testing.T) {
-	runtime, err := newM2MGraphQLRuntime(ebusgateway.Config{M2MGraphQL: ebusgateway.M2MGraphQLConfig{ListenAddr: "127.0.0.1:0", ClientCAFile: "testdata/client-ca.pem", ServerCertFile: "testdata/server.pem", ServerKeyFile: "testdata/server-key.pem", AllowedAssets: []string{"pv-asset-fixture"}}}, nil)
+	certs := newM2MTLSCertificates(t)
+	cfg := ebusgateway.Config{M2MGraphQL: ebusgateway.M2MGraphQLConfig{
+		ListenAddr: "127.0.0.1:0", ServerName: "m2m.gateway.test",
+		ClientCAFile: certs.caFile, ServerCertFile: certs.serverCertFile, ServerKeyFile: certs.serverKeyFile,
+		AllowedAssets: []string{"pv-asset-fixture"}, DeniedPrincipalFingerprints: []string{certs.deniedFingerprint},
+	}}
+	runtime, err := newM2MGraphQLRuntime(cfg, nil)
 	if err != nil {
 		t.Fatalf("newM2MGraphQLRuntime: %v", err)
 	}
 	if runtime == nil || !runtime.RequiresVerifiedClientCertificate() {
 		t.Fatalf("runtime=%#v; want dedicated verified-mTLS listener", runtime)
 	}
+	t.Cleanup(func() { _ = runtime.Close() })
+
+	assertM2MTLSDial(t, runtime.Addr(), certs.pool, "m2m.gateway.test", certs.goodClient, true)
+	assertM2MTLSDial(t, runtime.Addr(), certs.pool, "wrong.m2m.gateway.test", certs.goodClient, false)
+	assertM2MTLSDial(t, runtime.Addr(), certs.pool, "m2m.gateway.test", tls.Certificate{}, false)
+	assertM2MTLSDial(t, runtime.Addr(), certs.pool, "m2m.gateway.test", certs.untrustedClient, false)
+	assertM2MTLSDial(t, runtime.Addr(), certs.pool, "m2m.gateway.test", certs.deniedClient, false)
 	if err := runtime.Close(); err != nil {
 		t.Fatalf("close dedicated M2M listener: %v", err)
+	}
+	if _, err := net.DialTimeout("tcp", runtime.Addr(), 100*time.Millisecond); err == nil {
+		t.Fatal("closed dedicated M2M listener still accepts TCP")
+	}
+}
+
+func TestM2MGraphQLRuntime_IncompleteEnabledConfigFailsClosed(t *testing.T) {
+	_, err := newM2MGraphQLRuntime(ebusgateway.Config{M2MGraphQL: ebusgateway.M2MGraphQLConfig{ListenAddr: "127.0.0.1:0", AllowedAssets: []string{"pv-asset-fixture"}}}, nil)
+	if err == nil {
+		t.Fatal("incomplete enabled M2M configuration started a listener")
+	}
+}
+
+type m2mTLSCertificates struct {
+	pool                                      *x509.CertPool
+	caFile, serverCertFile, serverKeyFile     string
+	goodClient, untrustedClient, deniedClient tls.Certificate
+	deniedFingerprint                         string
+}
+
+func newM2MTLSCertificates(t *testing.T) m2mTLSCertificates {
+	t.Helper()
+	dir := t.TempDir()
+	caKey, ca := newM2MCertificateAuthority(t)
+	server := newM2MLeafCertificate(t, ca, caKey, "m2m.gateway.test", false)
+	good := newM2MLeafCertificate(t, ca, caKey, "principal-good", true)
+	denied := newM2MLeafCertificate(t, ca, caKey, "principal-denied", true)
+	otherKey, otherCA := newM2MCertificateAuthority(t)
+	untrusted := newM2MLeafCertificate(t, otherCA, otherKey, "principal-untrusted", true)
+	pool := x509.NewCertPool()
+	pool.AddCert(ca)
+	return m2mTLSCertificates{pool: pool, caFile: writeM2MPEM(t, dir, "client-ca.pem", "CERTIFICATE", ca.Raw), serverCertFile: writeM2MPEM(t, dir, "server.pem", "CERTIFICATE", server.Certificate[0]), serverKeyFile: writeM2MPEM(t, dir, "server-key.pem", "RSA PRIVATE KEY", x509.MarshalPKCS1PrivateKey(server.PrivateKey.(*rsa.PrivateKey))), goodClient: good, untrustedClient: untrusted, deniedClient: denied, deniedFingerprint: m2mCertificateFingerprint(denied.Certificate[0])}
+}
+
+func newM2MCertificateAuthority(t *testing.T) (*rsa.PrivateKey, *x509.Certificate) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{SerialNumber: big.NewInt(1), Subject: pkix.Name{CommonName: "m2m test CA"}, NotBefore: time.Now().Add(-time.Hour), NotAfter: time.Now().Add(time.Hour), IsCA: true, BasicConstraintsValid: true, KeyUsage: x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return key, cert
+}
+
+func newM2MLeafCertificate(t *testing.T, ca *x509.Certificate, caKey crypto.Signer, name string, client bool) tls.Certificate {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{SerialNumber: big.NewInt(time.Now().UnixNano()), Subject: pkix.Name{CommonName: name}, DNSNames: []string{name}, NotBefore: time.Now().Add(-time.Hour), NotAfter: time.Now().Add(time.Hour), KeyUsage: x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment}
+	if client {
+		tmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+	} else {
+		tmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca, &key.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
+}
+
+func writeM2MPEM(t *testing.T, dir, name, kind string, der []byte) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: kind, Bytes: der}), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+func m2mCertificateFingerprint(der []byte) string {
+	sum := sha256.Sum256(der)
+	return hex.EncodeToString(sum[:])
+}
+func assertM2MTLSDial(t *testing.T, addr string, roots *x509.CertPool, name string, certificate tls.Certificate, want bool) {
+	t.Helper()
+	config := &tls.Config{RootCAs: roots, ServerName: name, MinVersion: tls.VersionTLS13}
+	if len(certificate.Certificate) != 0 {
+		config.Certificates = []tls.Certificate{certificate}
+	}
+	connection, err := tls.Dial("tcp", addr, config)
+	if connection != nil {
+		_ = connection.Close()
+	}
+	if (err == nil) != want {
+		t.Fatalf("TLS dial serverName=%q certificate=%t err=%v want success=%t", name, len(certificate.Certificate) != 0, err, want)
 	}
 }

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -1370,6 +1370,7 @@ func bindFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) *gatewayFlagInputs {
 	fs.StringVar(&inputs.modbusEndpointFile, "modbus-tcp-endpoint-file", "", "path to an owner-only file containing the Modbus TCP endpoint URI")
 	fs.DurationVar(&cfg.ModbusTCPConfig.DialTimeout, "modbus-tcp-dial-timeout", cfg.ModbusTCPConfig.DialTimeout, "Modbus TCP dial timeout")
 	bindEEBusFlags(fs, cfg)
+	bindM2MGraphQLFlags(fs, cfg)
 	fs.BoolVar(
 		&cfg.EvidenceOneShotEnabled,
 		"synchronized-evidence-one-shot-enabled",

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -211,6 +211,17 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 			defer func() { _ = sunSpecWorker.Close() }()
 		}
 	}
+	m2mRuntime, err := newM2MGraphQLRuntime(cfg, modbusAdapter)
+	if err != nil {
+		return fmt.Errorf("M2M GraphQL sidecar: %w", err)
+	}
+	if m2mRuntime != nil {
+		defer func() {
+			if err := m2mRuntime.Close(); err != nil {
+				result = errors.Join(result, fmt.Errorf("shutdown M2M GraphQL sidecar: %w", err))
+			}
+		}()
+	}
 
 	eebusAdapter, eebusAdmin, eebusAdminAvailable, err := startEEBusAdminAwareRuntime(ctx, cfg)
 	if err != nil {

--- a/config.go
+++ b/config.go
@@ -2,6 +2,8 @@ package ebusgateway
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net"
@@ -117,13 +119,19 @@ func (config M2MGraphQLConfig) Validate() error {
 		strings.TrimSpace(config.ServerKeyFile) == "" || len(config.AllowedAssets) == 0 {
 		return errors.New("M2M GraphQL configuration is incomplete")
 	}
+	assets := make(map[string]struct{}, len(config.AllowedAssets))
 	for _, asset := range config.AllowedAssets {
 		if strings.TrimSpace(asset) == "" {
 			return errors.New("M2M GraphQL configuration contains an empty allowed asset")
 		}
+		if _, duplicate := assets[asset]; duplicate {
+			return errors.New("M2M GraphQL configuration contains a duplicate allowed asset")
+		}
+		assets[asset] = struct{}{}
 	}
 	for _, fingerprint := range config.DeniedPrincipalFingerprints {
-		if len(fingerprint) != 64 {
+		decoded, err := hex.DecodeString(fingerprint)
+		if err != nil || len(decoded) != sha256.Size {
 			return errors.New("M2M GraphQL configuration contains an invalid denied principal fingerprint")
 		}
 	}

--- a/config.go
+++ b/config.go
@@ -101,13 +101,14 @@ type M2MGraphQLConfig struct {
 	ServerCertFile              string
 	ServerKeyFile               string
 	AllowedAssets               []string
+	KnownAssets                 []string
 	DeniedPrincipalFingerprints []string
 }
 
 func (config M2MGraphQLConfig) Disabled() bool {
 	return config.ListenAddr == "" && config.ServerName == "" && config.ClientCAFile == "" &&
 		config.ServerCertFile == "" && config.ServerKeyFile == "" && len(config.AllowedAssets) == 0 &&
-		len(config.DeniedPrincipalFingerprints) == 0
+		len(config.KnownAssets) == 0 && len(config.DeniedPrincipalFingerprints) == 0
 }
 
 func (config M2MGraphQLConfig) Validate() error {
@@ -128,6 +129,16 @@ func (config M2MGraphQLConfig) Validate() error {
 			return errors.New("M2M GraphQL configuration contains a duplicate allowed asset")
 		}
 		assets[asset] = struct{}{}
+	}
+	known := make(map[string]struct{}, len(config.KnownAssets))
+	for _, asset := range config.KnownAssets {
+		if _, allowed := assets[asset]; !allowed {
+			return errors.New("M2M GraphQL configuration contains a known asset outside the allowlist")
+		}
+		if _, duplicate := known[asset]; duplicate {
+			return errors.New("M2M GraphQL configuration contains a duplicate known asset")
+		}
+		known[asset] = struct{}{}
 	}
 	for _, fingerprint := range config.DeniedPrincipalFingerprints {
 		decoded, err := hex.DecodeString(fingerprint)

--- a/config.go
+++ b/config.go
@@ -89,6 +89,47 @@ type EEBusConfig struct {
 	PairingWindowMode  EEBusPairingWindowMode
 }
 
+// M2MGraphQLConfig configures the dedicated public canonical-PV listener.
+// An all-zero value is disabled. Any partially populated value is rejected by
+// the command runtime rather than being silently enabled.
+type M2MGraphQLConfig struct {
+	ListenAddr                  string
+	ServerName                  string
+	ClientCAFile                string
+	ServerCertFile              string
+	ServerKeyFile               string
+	AllowedAssets               []string
+	DeniedPrincipalFingerprints []string
+}
+
+func (config M2MGraphQLConfig) Disabled() bool {
+	return config.ListenAddr == "" && config.ServerName == "" && config.ClientCAFile == "" &&
+		config.ServerCertFile == "" && config.ServerKeyFile == "" && len(config.AllowedAssets) == 0 &&
+		len(config.DeniedPrincipalFingerprints) == 0
+}
+
+func (config M2MGraphQLConfig) Validate() error {
+	if config.Disabled() {
+		return nil
+	}
+	if strings.TrimSpace(config.ListenAddr) == "" || strings.TrimSpace(config.ServerName) == "" ||
+		strings.TrimSpace(config.ClientCAFile) == "" || strings.TrimSpace(config.ServerCertFile) == "" ||
+		strings.TrimSpace(config.ServerKeyFile) == "" || len(config.AllowedAssets) == 0 {
+		return errors.New("M2M GraphQL configuration is incomplete")
+	}
+	for _, asset := range config.AllowedAssets {
+		if strings.TrimSpace(asset) == "" {
+			return errors.New("M2M GraphQL configuration contains an empty allowed asset")
+		}
+	}
+	for _, fingerprint := range config.DeniedPrincipalFingerprints {
+		if len(fingerprint) != 64 {
+			return errors.New("M2M GraphQL configuration contains an invalid denied principal fingerprint")
+		}
+	}
+	return nil
+}
+
 func DefaultEEBusConfig() EEBusConfig {
 	return EEBusConfig{
 		Interfaces:         []string{},
@@ -125,6 +166,7 @@ type Config struct {
 	ProxyListenAddr          string                 // TCP listen address for ENH proxy clients (empty disables)
 	TransportConfig          TransportConfig
 	EEBusConfig              EEBusConfig
+	M2MGraphQL               M2MGraphQLConfig
 	ModbusTCPConfig          ModbusTCPConfig
 	EvidenceRecorderConfig   EvidenceRecorderConfig
 	EvidenceOneShotEnabled   bool

--- a/config_test.go
+++ b/config_test.go
@@ -248,7 +248,7 @@ func TestM2MGraphQLConfig_RejectsIncompleteActiveConfiguration(t *testing.T) {
 func TestM2MGraphQLConfig_RejectsMalformedOrDuplicateAuthority(t *testing.T) {
 	base := M2MGraphQLConfig{
 		ListenAddr: "127.0.0.1:8443", ServerName: "m2m.gateway.test", ClientCAFile: "ca.pem",
-		ServerCertFile: "server.pem", ServerKeyFile: "server-key.pem", AllowedAssets: []string{"pv-one"},
+		ServerCertFile: "server.pem", ServerKeyFile: "server-key.pem", AllowedAssets: []string{"pv-one"}, KnownAssets: []string{"pv-one"},
 	}
 	malformed := base
 	malformed.DeniedPrincipalFingerprints = []string{strings.Repeat("z", 64)}
@@ -258,5 +258,15 @@ func TestM2MGraphQLConfig_RejectsMalformedOrDuplicateAuthority(t *testing.T) {
 		if err := config.Validate(); err == nil {
 			t.Fatalf("invalid M2M GraphQL authority accepted: %+v", config)
 		}
+	}
+}
+
+func TestM2MGraphQLConfig_RejectsKnownAssetOutsideAllowlist(t *testing.T) {
+	config := M2MGraphQLConfig{
+		ListenAddr: "127.0.0.1:8443", ServerName: "m2m.gateway.test", ClientCAFile: "ca.pem",
+		ServerCertFile: "server.pem", ServerKeyFile: "server-key.pem", AllowedAssets: []string{"pv-one"}, KnownAssets: []string{"pv-two"},
+	}
+	if err := config.Validate(); err == nil {
+		t.Fatal("known asset outside authorization allowlist was accepted")
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -230,3 +230,17 @@ func TestApplyDefaults_SetsPortalPath(t *testing.T) {
 		t.Fatalf("expected PortalPath=/portal after defaults, got %q", cfg.PortalPath)
 	}
 }
+
+func TestDefaultConfig_DisablesM2MGraphQL(t *testing.T) {
+	config := DefaultConfig().M2MGraphQL
+	if !config.Disabled() || config.Validate() != nil {
+		t.Fatalf("default M2M GraphQL config is not inert: %+v", config)
+	}
+}
+
+func TestM2MGraphQLConfig_RejectsIncompleteActiveConfiguration(t *testing.T) {
+	config := M2MGraphQLConfig{ListenAddr: "127.0.0.1:8443", AllowedAssets: []string{"pv-one"}}
+	if err := config.Validate(); err == nil {
+		t.Fatal("incomplete M2M GraphQL config was accepted")
+	}
+}

--- a/config_test.go
+++ b/config_test.go
@@ -244,3 +244,19 @@ func TestM2MGraphQLConfig_RejectsIncompleteActiveConfiguration(t *testing.T) {
 		t.Fatal("incomplete M2M GraphQL config was accepted")
 	}
 }
+
+func TestM2MGraphQLConfig_RejectsMalformedOrDuplicateAuthority(t *testing.T) {
+	base := M2MGraphQLConfig{
+		ListenAddr: "127.0.0.1:8443", ServerName: "m2m.gateway.test", ClientCAFile: "ca.pem",
+		ServerCertFile: "server.pem", ServerKeyFile: "server-key.pem", AllowedAssets: []string{"pv-one"},
+	}
+	malformed := base
+	malformed.DeniedPrincipalFingerprints = []string{strings.Repeat("z", 64)}
+	duplicate := base
+	duplicate.AllowedAssets = []string{"pv-one", "pv-one"}
+	for _, config := range []M2MGraphQLConfig{malformed, duplicate} {
+		if err := config.Validate(); err == nil {
+			t.Fatalf("invalid M2M GraphQL authority accepted: %+v", config)
+		}
+	}
+}

--- a/internal/modbusadapter/adapter.go
+++ b/internal/modbusadapter/adapter.go
@@ -431,6 +431,23 @@ func (adapter *Adapter) CanonicalPVSnapshot(profileID, sampleID string) (pv.Snap
 	return cloneCanonicalPVSnapshot(record.canonical), record.producedAt, true
 }
 
+// CanonicalPVSnapshotByAsset returns the retained canonical snapshot selected
+// by its public asset reference. It deliberately exposes no source transport
+// or qualification identity and always returns a detached value.
+func (adapter *Adapter) CanonicalPVSnapshotByAsset(assetRef string) (pv.Snapshot, time.Time, bool) {
+	if adapter == nil || assetRef == "" {
+		return pv.Snapshot{}, time.Time{}, false
+	}
+	adapter.profileMu.RLock()
+	defer adapter.profileMu.RUnlock()
+	for _, record := range adapter.qualifications {
+		if record.canonical.AssetRef == assetRef {
+			return cloneCanonicalPVSnapshot(record.canonical), record.producedAt, true
+		}
+	}
+	return pv.Snapshot{}, time.Time{}, false
+}
+
 func cloneCanonicalPVSnapshot(source pv.Snapshot) pv.Snapshot {
 	clone := source
 	clone.Facts = make(map[pv.FactKey]pv.Fact, len(source.Facts))

--- a/internal/modbusadapter/adapter.go
+++ b/internal/modbusadapter/adapter.go
@@ -440,10 +440,18 @@ func (adapter *Adapter) CanonicalPVSnapshotByAsset(assetRef string) (pv.Snapshot
 	}
 	adapter.profileMu.RLock()
 	defer adapter.profileMu.RUnlock()
+	var match *sunSpecQualificationRecord
 	for _, record := range adapter.qualifications {
 		if record.canonical.AssetRef == assetRef {
-			return cloneCanonicalPVSnapshot(record.canonical), record.producedAt, true
+			if match != nil {
+				return pv.Snapshot{}, time.Time{}, false
+			}
+			copy := record
+			match = &copy
 		}
+	}
+	if match != nil {
+		return cloneCanonicalPVSnapshot(match.canonical), match.producedAt, true
 	}
 	return pv.Snapshot{}, time.Time{}, false
 }

--- a/internal/modbusadapter/adapter.go
+++ b/internal/modbusadapter/adapter.go
@@ -451,7 +451,18 @@ func (adapter *Adapter) CanonicalPVSnapshotByAsset(assetRef string) (pv.Snapshot
 		}
 	}
 	if match != nil {
-		return cloneCanonicalPVSnapshot(match.canonical), match.producedAt, true
+		if adapter.canonicalPV == nil {
+			return cloneCanonicalPVSnapshot(match.canonical), match.producedAt, true
+		}
+		evaluated := time.Since(adapter.started)
+		if evaluated < 0 {
+			return pv.Snapshot{}, time.Time{}, false
+		}
+		current, err := adapter.canonicalPV.Snapshot(match.canonical.AssetRef, pv.MonotonicNanos(evaluated.Nanoseconds()))
+		if err != nil {
+			return pv.Snapshot{}, time.Time{}, false
+		}
+		return cloneCanonicalPVSnapshot(current), match.producedAt, true
 	}
 	return pv.Snapshot{}, time.Time{}, false
 }

--- a/internal/modbusadapter/canonical_pv.go
+++ b/internal/modbusadapter/canonical_pv.go
@@ -89,6 +89,13 @@ func (mapper *CanonicalPVMapper) Map(
 	return mapper.registry.Apply(update)
 }
 
+func (mapper *CanonicalPVMapper) Snapshot(assetRef string, evaluated pv.MonotonicNanos) (pv.Snapshot, error) {
+	if mapper == nil || mapper.registry == nil || assetRef == "" || evaluated < 0 {
+		return pv.Snapshot{}, errors.New("canonical PV snapshot input is incomplete")
+	}
+	return mapper.registry.Snapshot(assetRef, evaluated)
+}
+
 func (mapper *CanonicalPVMapper) assetRef(observation modbusreg.SunSpecQualificationObservation) (string, error) {
 	var identity []string
 	for _, occurrence := range observation.Occurrences() {

--- a/internal/modbusadapter/canonical_pv_asset_lookup_red_test.go
+++ b/internal/modbusadapter/canonical_pv_asset_lookup_red_test.go
@@ -1,10 +1,39 @@
 package modbusadapter
 
-import "testing"
+import (
+	"testing"
+	"time"
+
+	pv "github.com/Project-Helianthus/helianthus-ebusreg/pv"
+)
 
 func TestCanonicalPVSnapshotByAsset_IsReadOnlyAndReturnsDetachedRetainedSnapshot(t *testing.T) {
-	adapter := &Adapter{}
+	one := m2mAssetSnapshot("pv-asset-one", "11")
+	two := m2mAssetSnapshot("pv-asset-two", "22")
+	adapter := &Adapter{qualifications: map[string]sunSpecQualificationRecord{
+		"first":  {canonical: one, producedAt: time.Unix(100, 0).UTC()},
+		"second": {canonical: two, producedAt: time.Unix(200, 0).UTC()},
+	}}
 	if _, _, ok := adapter.CanonicalPVSnapshotByAsset("pv-asset-unknown"); ok {
 		t.Fatal("unknown asset returned a canonical snapshot")
 	}
+	got, producedAt, ok := adapter.CanonicalPVSnapshotByAsset("pv-asset-two")
+	if !ok || got.AssetRef != "pv-asset-two" || got.Generation != 22 || !producedAt.Equal(time.Unix(200, 0).UTC()) {
+		t.Fatalf("asset lookup = %#v, %s, %v", got, producedAt, ok)
+	}
+	key := pv.NewFactKey(pv.FactACActivePower, pv.Dimensions{Scope: pv.ScopeTotal})
+	mutated := got.Facts[key]
+	mutated.Value.Decimal.Coefficient = "999"
+	got.Facts[key] = mutated
+	again, _, ok := adapter.CanonicalPVSnapshotByAsset("pv-asset-two")
+	if !ok || again.Facts[pv.NewFactKey(pv.FactACActivePower, pv.Dimensions{Scope: pv.ScopeTotal})].Value.Decimal.Coefficient != "22" {
+		t.Fatal("asset lookup returned an attached retained snapshot")
+	}
+}
+
+func m2mAssetSnapshot(asset string, coefficient string) pv.Snapshot {
+	d := pv.MustDecimal(coefficient, 0)
+	dimensions := pv.Dimensions{Scope: pv.ScopeTotal}
+	key := pv.NewFactKey(pv.FactACActivePower, dimensions)
+	return pv.Snapshot{AssetRef: asset, Generation: uint64(len(coefficient)) * 11, Facts: map[pv.FactKey]pv.Fact{key: {ID: pv.FactACActivePower, Dimensions: dimensions, Value: pv.DecimalFactValue(d)}}}
 }

--- a/internal/modbusadapter/canonical_pv_asset_lookup_red_test.go
+++ b/internal/modbusadapter/canonical_pv_asset_lookup_red_test.go
@@ -1,0 +1,10 @@
+package modbusadapter
+
+import "testing"
+
+func TestCanonicalPVSnapshotByAsset_IsReadOnlyAndReturnsDetachedRetainedSnapshot(t *testing.T) {
+	adapter := &Adapter{}
+	if _, _, ok := adapter.CanonicalPVSnapshotByAsset("pv-asset-unknown"); ok {
+		t.Fatal("unknown asset returned a canonical snapshot")
+	}
+}

--- a/internal/modbusadapter/canonical_pv_asset_lookup_red_test.go
+++ b/internal/modbusadapter/canonical_pv_asset_lookup_red_test.go
@@ -31,6 +31,18 @@ func TestCanonicalPVSnapshotByAsset_IsReadOnlyAndReturnsDetachedRetainedSnapshot
 	}
 }
 
+func TestCanonicalPVSnapshotByAsset_FailsClosedWhenAssetIdentityIsAmbiguous(t *testing.T) {
+	one := m2mAssetSnapshot("pv-asset-duplicate", "11")
+	two := m2mAssetSnapshot("pv-asset-duplicate", "22")
+	adapter := &Adapter{qualifications: map[string]sunSpecQualificationRecord{
+		"first":  {canonical: one, producedAt: time.Unix(100, 0).UTC()},
+		"second": {canonical: two, producedAt: time.Unix(200, 0).UTC()},
+	}}
+	if snapshot, _, ok := adapter.CanonicalPVSnapshotByAsset("pv-asset-duplicate"); ok {
+		t.Fatalf("ambiguous asset returned nondeterministic snapshot: %#v", snapshot)
+	}
+}
+
 func m2mAssetSnapshot(asset string, coefficient string) pv.Snapshot {
 	d := pv.MustDecimal(coefficient, 0)
 	dimensions := pv.Dimensions{Scope: pv.ScopeTotal}

--- a/internal/modbusadapter/canonical_pv_red_test.go
+++ b/internal/modbusadapter/canonical_pv_red_test.go
@@ -78,3 +78,52 @@ func TestCanonicalPVMapperProjectsQualifiedFroniusObservation(t *testing.T) {
 		}
 	}
 }
+
+func TestCanonicalPVSnapshotByAssetReevaluatesLifecycleAtRequestTime(t *testing.T) {
+	listener, _ := serveSunSpecChain(t, observedFroniusFloatControlsWords())
+	adapter, err := Start(context.Background(), integrationConfig(t, "tcp://"+listener.Addr().String()), realDialer, realFactory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+	producer, err := NewSunSpecProducer(adapter, SunSpecProducerConfig{UnitID: 1, AuthorizationScope: "test:canonical-pv-lifecycle", ReadTimeout: time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	qualified, err := producer.Qualify(context.Background(), SunSpecPollIdentity{PollGeneration: 72, DeadlineIdentity: 82})
+	if err != nil || qualified.Outcome != SunSpecQualificationGO {
+		t.Fatalf("qualification=%#v err=%v", qualified, err)
+	}
+	initial, producedAt, ok := adapter.CanonicalPVSnapshot(qualified.CapabilityID, qualified.SampleID)
+	if !ok {
+		t.Fatal("canonical PV snapshot was not retained")
+	}
+	key := pv.NewFactKey(pv.FactACActivePower, pv.Dimensions{Scope: pv.ScopeTotal})
+	if fact := initial.Facts[key]; fact.Freshness != pv.FreshnessFresh || fact.Availability != pv.AvailabilityAvailable {
+		t.Fatalf("initial active power lifecycle=%s/%s", fact.Freshness, fact.Availability)
+	}
+
+	adapter.started = adapter.started.Add(-30 * time.Second)
+	stale, staleProducedAt, ok := adapter.CanonicalPVSnapshotByAsset(initial.AssetRef)
+	if !ok || !staleProducedAt.Equal(producedAt) {
+		t.Fatal("stale lifecycle lookup lost the retained observation")
+	}
+	if fact := stale.Facts[key]; fact.Freshness != pv.FreshnessStale || fact.Availability != pv.AvailabilityAvailable {
+		t.Fatalf("stale active power lifecycle=%s/%s", fact.Freshness, fact.Availability)
+	}
+	if stale.Source != initial.Source || len(stale.ProjectionReport) != len(initial.ProjectionReport) || len(stale.RequestedOutputs) != len(initial.RequestedOutputs) {
+		t.Fatal("stale lifecycle evaluation changed provenance or projection accounting")
+	}
+
+	adapter.started = adapter.started.Add(-270 * time.Second)
+	expired, expiredProducedAt, ok := adapter.CanonicalPVSnapshotByAsset(initial.AssetRef)
+	if !ok || !expiredProducedAt.Equal(producedAt) {
+		t.Fatal("expired lifecycle lookup lost the retained observation")
+	}
+	if fact := expired.Facts[key]; fact.Freshness != pv.FreshnessExpired || fact.Availability != pv.AvailabilityUnavailable {
+		t.Fatalf("expired active power lifecycle=%s/%s", fact.Freshness, fact.Availability)
+	}
+	if expired.Source != initial.Source || len(expired.ProjectionReport) != len(initial.ProjectionReport) || len(expired.RequestedOutputs) != len(initial.RequestedOutputs) {
+		t.Fatal("expired lifecycle evaluation changed provenance or projection accounting")
+	}
+}

--- a/m2mgraphql/admission_red_test.go
+++ b/m2mgraphql/admission_red_test.go
@@ -3,8 +3,10 @@ package m2mgraphql
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -43,6 +45,8 @@ func TestM2MAdmission_EnforcesPrecedenceAndWireBounds(t *testing.T) {
 		{"json-depth", strings.Repeat("[", 65) + "0" + strings.Repeat("]", 65), "REQUEST_INVALID"},
 		{"duplicate-json-key", `{"operationName":"M2MCurrentSnapshot","operationName":"M2MCurrentSnapshot"}`, "REQUEST_INVALID"},
 		{"alias", `{"operationName":"M2MCurrentSnapshot","query":"query M2MCurrentSnapshot($request: M2MCurrentSnapshotRequest!) { alias: m2mCurrentSnapshot(request: $request) { assetRef } }","variables":{"request":{"contractId":"PUBLIC_GRAPHQL_M2M_V1","assetRef":"pv-asset-fixture"}}}`, "QUERY_REJECTED"},
+		{"query-depth-before-shape", m2mRequestWithQuery(strings.Repeat("{", 9) + "m2mCurrentSnapshot" + strings.Repeat("}", 9)), "REQUEST_LIMIT_EXCEEDED"},
+		{"selected-fields-before-shape", m2mRequestWithQuery("query M2MCurrentSnapshot($request: M2MCurrentSnapshotRequest!) { m2mCurrentSnapshot(request: $request) { " + strings.Repeat("assetRef ", 257) + "} }"), "REQUEST_LIMIT_EXCEEDED"},
 		{"raw-body-limit", strings.Repeat("x", 16*1024+1), "REQUEST_LIMIT_EXCEEDED"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -68,6 +72,40 @@ func TestM2MAdmission_ReturnsSourceUnavailableOnlyAfterAssetExistence(t *testing
 	assertM2MErrorForRequest(t, handler, "principal-a", m2mRequest("PUBLIC_GRAPHQL_M2M_V1", "pv-asset-fixture"), "SOURCE_UNAVAILABLE")
 }
 
+func TestM2MAdmission_RejectsMissingOrEmptyMTLSPrincipalBeforeSnapshotLookup(t *testing.T) {
+	lookups := 0
+	handler, err := NewHandler(Config{
+		SnapshotByAsset: func(context.Context, string) (pv.Snapshot, bool) { lookups++; return m2mFixtureSnapshot(), true },
+		AssetExists:     func(string) bool { return true }, AllowedAssets: map[string]struct{}{"pv-asset-fixture": {}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, principal := range []string{"", "\t"} {
+		req := httptest.NewRequest(http.MethodPost, "/graphql/m2m/v1", strings.NewReader(m2mRequest("PUBLIC_GRAPHQL_M2M_V1", "pv-asset-fixture")))
+		if principal != "" {
+			req = req.WithContext(WithMTLSPrincipal(req.Context(), principal))
+		}
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, req)
+		assertM2MError(t, response, "REQUEST_INVALID")
+	}
+	if lookups != 0 {
+		t.Fatalf("unauthenticated requests invoked SnapshotByAsset %d times", lookups)
+	}
+}
+
+func TestM2MAdmission_RejectsResponsesOverOneMiBBeforeWritingPartialData(t *testing.T) {
+	handler, err := NewHandler(Config{
+		SnapshotByAsset: func(context.Context, string) (pv.Snapshot, bool) { return m2mOversizedSnapshot(), true },
+		AssetExists:     func(string) bool { return true }, AllowedAssets: map[string]struct{}{"pv-asset-fixture": {}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertM2MErrorForRequest(t, handler, "principal-response-limit", m2mRequest("PUBLIC_GRAPHQL_M2M_V1", "pv-asset-fixture"), "REQUEST_LIMIT_EXCEEDED")
+}
+
 func TestM2MAdmission_IsolatedByMTLSPrincipalAndDoesNotConsumeRejectedRateTokens(t *testing.T) {
 	clock := int64(10_000)
 	handler, err := NewHandler(Config{SnapshotByAsset: func(context.Context, string) (pv.Snapshot, bool) { return m2mFixtureSnapshot(), true }, AssetExists: func(string) bool { return true }, AllowedAssets: map[string]struct{}{"pv-asset-fixture": {}}, MonotonicMilliseconds: func() int64 { return clock }})
@@ -87,6 +125,23 @@ func TestM2MAdmission_IsolatedByMTLSPrincipalAndDoesNotConsumeRejectedRateTokens
 
 func m2mRequest(contractID, assetRef string) string {
 	return `{"operationName":"M2MCurrentSnapshot","query":"query M2MCurrentSnapshot($request: M2MCurrentSnapshotRequest!) { m2mCurrentSnapshot(request: $request) { assetRef } }","variables":{"request":{"contractId":"` + contractID + `","assetRef":"` + assetRef + `"}}}`
+}
+
+func m2mRequestWithQuery(query string) string {
+	return `{"operationName":"M2MCurrentSnapshot","query":` + strconv.Quote(query) + `,"variables":{"request":{"contractId":"PUBLIC_GRAPHQL_M2M_V1","assetRef":"pv-asset-fixture"}}}`
+}
+
+func m2mOversizedSnapshot() pv.Snapshot {
+	snapshot := m2mFixtureSnapshot()
+	snapshot.Origins = make(map[pv.Digest]pv.Provenance, 256)
+	for index := 0; index < 256; index++ {
+		ref := pv.Digest("sha256:" + fmt.Sprintf("%064x", index+1))
+		provenance := snapshot.Source
+		provenance.SourceObservationRef = ref
+		provenance.ProfileID = strings.Repeat("p", 5_000)
+		snapshot.Origins[ref] = provenance
+	}
+	return snapshot
 }
 
 func assertM2MSuccess(t *testing.T, handler http.Handler, principal string) {

--- a/m2mgraphql/admission_red_test.go
+++ b/m2mgraphql/admission_red_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	pv "github.com/Project-Helianthus/helianthus-ebusreg/pv"
 )
@@ -152,6 +153,22 @@ func TestM2MAdmission_IsolatedByMTLSPrincipalAndDoesNotConsumeRejectedRateTokens
 	assertM2MSuccess(t, handler, "principal-a")
 }
 
+func TestM2MAdmission_TokenBucketPreservesPartialRefillIntervals(t *testing.T) {
+	clock := int64(0)
+	handler, err := NewHandler(Config{SnapshotByAssetAt: func(context.Context, string) (pv.Snapshot, time.Time, bool) {
+		return m2mFixtureSnapshot(), time.Unix(100, 0).UTC(), true
+	}, AssetExists: func(string) bool { return true }, AllowedAssets: map[string]struct{}{"pv-asset-fixture": {}}, MonotonicMilliseconds: func() int64 { return clock }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertM2MSuccess(t, handler, "principal-partial-refill")
+	assertM2MSuccess(t, handler, "principal-partial-refill")
+	clock = 1_500
+	assertM2MSuccess(t, handler, "principal-partial-refill")
+	clock = 2_000
+	assertM2MSuccess(t, handler, "principal-partial-refill")
+}
+
 func m2mRequest(contractID, assetRef string) string {
 	request := m2mCanonicalRequest(canonicalM2MQuery, assetRef)
 	if contractID == "PUBLIC_GRAPHQL_M2M_V1" {
@@ -176,7 +193,8 @@ func m2mRequestWithQuery(query string) string {
 func m2mOversizedSnapshot() pv.Snapshot {
 	snapshot := m2mFixtureSnapshot()
 	snapshot.Origins = make(map[pv.Digest]pv.Provenance, 256)
-	for index := 0; index < 256; index++ {
+	snapshot.Origins[snapshot.Source.SourceObservationRef] = snapshot.Source
+	for index := 0; index < 255; index++ {
 		ref := pv.Digest("sha256:" + fmt.Sprintf("%064x", index+1))
 		provenance := snapshot.Source
 		provenance.SourceObservationRef = ref

--- a/m2mgraphql/admission_red_test.go
+++ b/m2mgraphql/admission_red_test.go
@@ -101,6 +101,29 @@ func TestM2MAdmission_RejectsMissingOrEmptyMTLSPrincipalBeforeSnapshotLookup(t *
 	}
 }
 
+func TestM2MAdmission_RejectsOpenJSONEnvelopesBeforeSemanticAdmission(t *testing.T) {
+	lookups := 0
+	handler, err := NewHandler(Config{
+		SnapshotByAsset: func(context.Context, string) (pv.Snapshot, bool) { lookups++; return m2mFixtureSnapshot(), true },
+		AssetExists:     func(string) bool { lookups++; return true },
+		AllowedAssets:   map[string]struct{}{"pv-asset-fixture": {}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := m2mRequest("OTHER", "pv-asset-fixture")
+	for _, body := range []string{
+		strings.Replace(base, `"operationName":`, `"extra":true,"operationName":`, 1),
+		strings.Replace(base, `"request":{`, `"extra":true,"request":{`, 1),
+		strings.Replace(base, `"assetRef":`, `"extra":true,"assetRef":`, 1),
+	} {
+		assertM2MErrorForRequest(t, handler, "principal-closed-envelope", body, "REQUEST_INVALID")
+	}
+	if lookups != 0 {
+		t.Fatalf("invalid request envelopes reached semantic admission %d times", lookups)
+	}
+}
+
 func TestM2MAdmission_RejectsResponsesOverOneMiBBeforeWritingPartialData(t *testing.T) {
 	handler, err := NewHandler(Config{
 		SnapshotByAsset: func(context.Context, string) (pv.Snapshot, bool) { return m2mOversizedSnapshot(), true },

--- a/m2mgraphql/admission_red_test.go
+++ b/m2mgraphql/admission_red_test.go
@@ -1,0 +1,110 @@
+package m2mgraphql
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	pv "github.com/Project-Helianthus/helianthus-ebusreg/pv"
+)
+
+func TestM2MAdmission_EnforcesPrecedenceAndWireBounds(t *testing.T) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	handler, err := NewHandler(Config{
+		SnapshotByAsset: func(context.Context, string) (pv.Snapshot, bool) {
+			select {
+			case entered <- struct{}{}:
+			default:
+			}
+			<-release
+			return m2mFixtureSnapshot(), true
+		},
+		AssetExists:           func(assetRef string) bool { return assetRef != "pv-asset-missing" },
+		AllowedAssets:         map[string]struct{}{"pv-asset-fixture": {}},
+		MonotonicMilliseconds: func() int64 { return 1_000 },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blocked := httptest.NewRequest(http.MethodPost, "/graphql/m2m/v1", bytes.NewBufferString(m2mRequest("PUBLIC_GRAPHQL_M2M_V1", "pv-asset-fixture")))
+	blocked = blocked.WithContext(WithMTLSPrincipal(blocked.Context(), "principal-a"))
+	go handler.ServeHTTP(httptest.NewRecorder(), blocked)
+	<-entered
+	for _, test := range []struct{ name, body, code string }{
+		{"same-principal-overlap", m2mRequest("PUBLIC_GRAPHQL_M2M_V1", "pv-asset-fixture"), "REQUEST_LIMIT_EXCEEDED"},
+		{"contract-before-asset", m2mRequest("OTHER", "not-allowed"), "CONTRACT_INCOMPATIBLE"},
+		{"allowlist-before-existence", m2mRequest("PUBLIC_GRAPHQL_M2M_V1", "not-allowed"), "ASSET_FORBIDDEN"},
+		{"unknown-allowed-asset", m2mRequest("PUBLIC_GRAPHQL_M2M_V1", "pv-asset-missing"), "ASSET_NOT_FOUND"},
+		{"json-depth", strings.Repeat("[", 65) + "0" + strings.Repeat("]", 65), "REQUEST_INVALID"},
+		{"duplicate-json-key", `{"operationName":"M2MCurrentSnapshot","operationName":"M2MCurrentSnapshot"}`, "REQUEST_INVALID"},
+		{"alias", `{"operationName":"M2MCurrentSnapshot","query":"query M2MCurrentSnapshot($request: M2MCurrentSnapshotRequest!) { alias: m2mCurrentSnapshot(request: $request) { assetRef } }","variables":{"request":{"contractId":"PUBLIC_GRAPHQL_M2M_V1","assetRef":"pv-asset-fixture"}}}`, "QUERY_REJECTED"},
+		{"raw-body-limit", strings.Repeat("x", 16*1024+1), "REQUEST_LIMIT_EXCEEDED"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/graphql/m2m/v1", strings.NewReader(test.body))
+			req = req.WithContext(WithMTLSPrincipal(req.Context(), "principal-a"))
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, req)
+			assertM2MError(t, response, test.code)
+		})
+	}
+	close(release)
+}
+
+func TestM2MAdmission_ReturnsSourceUnavailableOnlyAfterAssetExistence(t *testing.T) {
+	handler, err := NewHandler(Config{
+		SnapshotByAsset: func(context.Context, string) (pv.Snapshot, bool) { return pv.Snapshot{}, false },
+		AssetExists:     func(string) bool { return true },
+		AllowedAssets:   map[string]struct{}{"pv-asset-fixture": {}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertM2MErrorForRequest(t, handler, "principal-a", m2mRequest("PUBLIC_GRAPHQL_M2M_V1", "pv-asset-fixture"), "SOURCE_UNAVAILABLE")
+}
+
+func TestM2MAdmission_IsolatedByMTLSPrincipalAndDoesNotConsumeRejectedRateTokens(t *testing.T) {
+	clock := int64(10_000)
+	handler, err := NewHandler(Config{SnapshotByAsset: func(context.Context, string) (pv.Snapshot, bool) { return m2mFixtureSnapshot(), true }, AssetExists: func(string) bool { return true }, AllowedAssets: map[string]struct{}{"pv-asset-fixture": {}}, MonotonicMilliseconds: func() int64 { return clock }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, principal := range []string{"principal-a", "principal-b"} {
+		for range 2 {
+			assertM2MSuccess(t, handler, principal)
+		}
+	}
+	assertM2MErrorForRequest(t, handler, "principal-a", m2mRequest("PUBLIC_GRAPHQL_M2M_V1", "pv-asset-fixture"), "REQUEST_LIMIT_EXCEEDED")
+	assertM2MErrorForRequest(t, handler, "principal-a", m2mRequest("OTHER", "pv-asset-fixture"), "CONTRACT_INCOMPATIBLE")
+	clock += 1_000
+	assertM2MSuccess(t, handler, "principal-a")
+}
+
+func m2mRequest(contractID, assetRef string) string {
+	return `{"operationName":"M2MCurrentSnapshot","query":"query M2MCurrentSnapshot($request: M2MCurrentSnapshotRequest!) { m2mCurrentSnapshot(request: $request) { assetRef } }","variables":{"request":{"contractId":"` + contractID + `","assetRef":"` + assetRef + `"}}}`
+}
+
+func assertM2MSuccess(t *testing.T, handler http.Handler, principal string) {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodPost, "/graphql/m2m/v1", strings.NewReader(m2mRequest("PUBLIC_GRAPHQL_M2M_V1", "pv-asset-fixture")))
+	request = request.WithContext(WithMTLSPrincipal(request.Context(), principal))
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusOK || strings.Contains(response.Body.String(), `"errors"`) {
+		t.Fatalf("principal=%s body=%s", principal, response.Body.String())
+	}
+}
+
+func assertM2MErrorForRequest(t *testing.T, handler http.Handler, principal, body, code string) {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodPost, "/graphql/m2m/v1", strings.NewReader(body))
+	request = request.WithContext(WithMTLSPrincipal(request.Context(), principal))
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	assertM2MError(t, response, code)
+}

--- a/m2mgraphql/admission_red_test.go
+++ b/m2mgraphql/admission_red_test.go
@@ -26,7 +26,7 @@ func TestM2MAdmission_EnforcesPrecedenceAndWireBounds(t *testing.T) {
 			return m2mFixtureSnapshot(), true
 		},
 		AssetExists:           func(assetRef string) bool { return assetRef != "pv-asset-missing" },
-		AllowedAssets:         map[string]struct{}{"pv-asset-fixture": {}},
+		AllowedAssets:         map[string]struct{}{"pv-asset-fixture": {}, "pv-asset-missing": {}},
 		MonotonicMilliseconds: func() int64 { return 1_000 },
 	})
 	if err != nil {

--- a/m2mgraphql/admission_red_test.go
+++ b/m2mgraphql/admission_red_test.go
@@ -35,17 +35,24 @@ func TestM2MAdmission_EnforcesPrecedenceAndWireBounds(t *testing.T) {
 
 	blocked := httptest.NewRequest(http.MethodPost, "/graphql/m2m/v1", bytes.NewBufferString(m2mRequest("PUBLIC_GRAPHQL_M2M_V1", "pv-asset-fixture")))
 	blocked = blocked.WithContext(WithMTLSPrincipal(blocked.Context(), "principal-a"))
-	go handler.ServeHTTP(httptest.NewRecorder(), blocked)
+	blockedDone := make(chan struct{})
+	go func() {
+		defer close(blockedDone)
+		handler.ServeHTTP(httptest.NewRecorder(), blocked)
+	}()
 	<-entered
+	assertM2MErrorForRequest(t, handler, "principal-a", m2mRequest("PUBLIC_GRAPHQL_M2M_V1", "pv-asset-fixture"), "REQUEST_LIMIT_EXCEEDED")
+	close(release)
+	<-blockedDone
+
 	for _, test := range []struct{ name, body, code string }{
-		{"same-principal-overlap", m2mRequest("PUBLIC_GRAPHQL_M2M_V1", "pv-asset-fixture"), "REQUEST_LIMIT_EXCEEDED"},
 		{"contract-before-asset", m2mRequest("OTHER", "not-allowed"), "CONTRACT_INCOMPATIBLE"},
 		{"allowlist-before-existence", m2mRequest("PUBLIC_GRAPHQL_M2M_V1", "not-allowed"), "ASSET_FORBIDDEN"},
 		{"unknown-allowed-asset", m2mRequest("PUBLIC_GRAPHQL_M2M_V1", "pv-asset-missing"), "ASSET_NOT_FOUND"},
 		{"json-depth", strings.Repeat("[", 65) + "0" + strings.Repeat("]", 65), "REQUEST_INVALID"},
 		{"duplicate-json-key", `{"operationName":"M2MCurrentSnapshot","operationName":"M2MCurrentSnapshot"}`, "REQUEST_INVALID"},
 		{"alias", `{"operationName":"M2MCurrentSnapshot","query":"query M2MCurrentSnapshot($request: M2MCurrentSnapshotRequest!) { alias: m2mCurrentSnapshot(request: $request) { assetRef } }","variables":{"request":{"contractId":"PUBLIC_GRAPHQL_M2M_V1","assetRef":"pv-asset-fixture"}}}`, "QUERY_REJECTED"},
-		{"query-depth-before-shape", m2mRequestWithQuery(strings.Repeat("{", 9) + "m2mCurrentSnapshot" + strings.Repeat("}", 9)), "REQUEST_LIMIT_EXCEEDED"},
+		{"query-depth-before-shape", m2mRequestWithQuery(m2mSchemaValidDepthQuery()), "REQUEST_LIMIT_EXCEEDED"},
 		{"selected-fields-before-shape", m2mRequestWithQuery("query M2MCurrentSnapshot($request: M2MCurrentSnapshotRequest!) { m2mCurrentSnapshot(request: $request) { " + strings.Repeat("assetRef ", 257) + "} }"), "REQUEST_LIMIT_EXCEEDED"},
 		{"raw-body-limit", strings.Repeat("x", 16*1024+1), "REQUEST_LIMIT_EXCEEDED"},
 	} {
@@ -57,7 +64,6 @@ func TestM2MAdmission_EnforcesPrecedenceAndWireBounds(t *testing.T) {
 			assertM2MError(t, response, test.code)
 		})
 	}
-	close(release)
 }
 
 func TestM2MAdmission_ReturnsSourceUnavailableOnlyAfterAssetExistence(t *testing.T) {
@@ -124,7 +130,20 @@ func TestM2MAdmission_IsolatedByMTLSPrincipalAndDoesNotConsumeRejectedRateTokens
 }
 
 func m2mRequest(contractID, assetRef string) string {
-	return `{"operationName":"M2MCurrentSnapshot","query":"query M2MCurrentSnapshot($request: M2MCurrentSnapshotRequest!) { m2mCurrentSnapshot(request: $request) { assetRef } }","variables":{"request":{"contractId":"` + contractID + `","assetRef":"` + assetRef + `"}}}`
+	request := m2mCanonicalRequest(canonicalM2MQuery, assetRef)
+	if contractID == "PUBLIC_GRAPHQL_M2M_V1" {
+		return request
+	}
+	return strings.Replace(request, `"contractId":"PUBLIC_GRAPHQL_M2M_V1"`, `"contractId":"`+contractID+`"`, 1)
+}
+
+func m2mSchemaValidDepthQuery() string {
+	nested := "coefficient"
+	for range 9 {
+		nested = "... on M2MDecimalValue { " + nested + " }"
+	}
+	return "query M2MCurrentSnapshot($request: M2MCurrentSnapshotRequest!) { " +
+		"m2mCurrentSnapshot(request: $request) { facts { value { " + nested + " } } } }"
 }
 
 func m2mRequestWithQuery(query string) string {

--- a/m2mgraphql/admission_red_test.go
+++ b/m2mgraphql/admission_red_test.go
@@ -18,14 +18,14 @@ func TestM2MAdmission_EnforcesPrecedenceAndWireBounds(t *testing.T) {
 	entered := make(chan struct{})
 	release := make(chan struct{})
 	handler, err := NewHandler(Config{
-		SnapshotByAsset: func(context.Context, string) (pv.Snapshot, bool) {
+		SnapshotByAssetAt: m2mSnapshotAt(func(context.Context, string) (pv.Snapshot, bool) {
 			select {
 			case entered <- struct{}{}:
 			default:
 			}
 			<-release
 			return m2mFixtureSnapshot(), true
-		},
+		}),
 		AssetExists:           func(assetRef string) bool { return assetRef != "pv-asset-missing" },
 		AllowedAssets:         map[string]struct{}{"pv-asset-fixture": {}, "pv-asset-missing": {}},
 		MonotonicMilliseconds: func() int64 { return 1_000 },
@@ -69,9 +69,9 @@ func TestM2MAdmission_EnforcesPrecedenceAndWireBounds(t *testing.T) {
 
 func TestM2MAdmission_ReturnsSourceUnavailableOnlyAfterAssetExistence(t *testing.T) {
 	handler, err := NewHandler(Config{
-		SnapshotByAsset: func(context.Context, string) (pv.Snapshot, bool) { return pv.Snapshot{}, false },
-		AssetExists:     func(string) bool { return true },
-		AllowedAssets:   map[string]struct{}{"pv-asset-fixture": {}},
+		SnapshotByAssetAt: m2mSnapshotAt(func(context.Context, string) (pv.Snapshot, bool) { return pv.Snapshot{}, false }),
+		AssetExists:       func(string) bool { return true },
+		AllowedAssets:     map[string]struct{}{"pv-asset-fixture": {}},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -82,8 +82,8 @@ func TestM2MAdmission_ReturnsSourceUnavailableOnlyAfterAssetExistence(t *testing
 func TestM2MAdmission_RejectsMissingOrEmptyMTLSPrincipalBeforeSnapshotLookup(t *testing.T) {
 	lookups := 0
 	handler, err := NewHandler(Config{
-		SnapshotByAsset: func(context.Context, string) (pv.Snapshot, bool) { lookups++; return m2mFixtureSnapshot(), true },
-		AssetExists:     func(string) bool { return true }, AllowedAssets: map[string]struct{}{"pv-asset-fixture": {}},
+		SnapshotByAssetAt: m2mSnapshotAt(func(context.Context, string) (pv.Snapshot, bool) { lookups++; return m2mFixtureSnapshot(), true }),
+		AssetExists:       func(string) bool { return true }, AllowedAssets: map[string]struct{}{"pv-asset-fixture": {}},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -105,9 +105,9 @@ func TestM2MAdmission_RejectsMissingOrEmptyMTLSPrincipalBeforeSnapshotLookup(t *
 func TestM2MAdmission_RejectsOpenJSONEnvelopesBeforeSemanticAdmission(t *testing.T) {
 	lookups := 0
 	handler, err := NewHandler(Config{
-		SnapshotByAsset: func(context.Context, string) (pv.Snapshot, bool) { lookups++; return m2mFixtureSnapshot(), true },
-		AssetExists:     func(string) bool { lookups++; return true },
-		AllowedAssets:   map[string]struct{}{"pv-asset-fixture": {}},
+		SnapshotByAssetAt: m2mSnapshotAt(func(context.Context, string) (pv.Snapshot, bool) { lookups++; return m2mFixtureSnapshot(), true }),
+		AssetExists:       func(string) bool { lookups++; return true },
+		AllowedAssets:     map[string]struct{}{"pv-asset-fixture": {}},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -127,8 +127,8 @@ func TestM2MAdmission_RejectsOpenJSONEnvelopesBeforeSemanticAdmission(t *testing
 
 func TestM2MAdmission_RejectsResponsesOverOneMiBBeforeWritingPartialData(t *testing.T) {
 	handler, err := NewHandler(Config{
-		SnapshotByAsset: func(context.Context, string) (pv.Snapshot, bool) { return m2mOversizedSnapshot(), true },
-		AssetExists:     func(string) bool { return true }, AllowedAssets: map[string]struct{}{"pv-asset-fixture": {}},
+		SnapshotByAssetAt: m2mSnapshotAt(func(context.Context, string) (pv.Snapshot, bool) { return m2mOversizedSnapshot(), true }),
+		AssetExists:       func(string) bool { return true }, AllowedAssets: map[string]struct{}{"pv-asset-fixture": {}},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -138,7 +138,7 @@ func TestM2MAdmission_RejectsResponsesOverOneMiBBeforeWritingPartialData(t *test
 
 func TestM2MAdmission_IsolatedByMTLSPrincipalAndDoesNotConsumeRejectedRateTokens(t *testing.T) {
 	clock := int64(10_000)
-	handler, err := NewHandler(Config{SnapshotByAsset: func(context.Context, string) (pv.Snapshot, bool) { return m2mFixtureSnapshot(), true }, AssetExists: func(string) bool { return true }, AllowedAssets: map[string]struct{}{"pv-asset-fixture": {}}, MonotonicMilliseconds: func() int64 { return clock }})
+	handler, err := NewHandler(Config{SnapshotByAssetAt: m2mSnapshotAt(func(context.Context, string) (pv.Snapshot, bool) { return m2mFixtureSnapshot(), true }), AssetExists: func(string) bool { return true }, AllowedAssets: map[string]struct{}{"pv-asset-fixture": {}}, MonotonicMilliseconds: func() int64 { return clock }})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/m2mgraphql/contract_hardening_red_test.go
+++ b/m2mgraphql/contract_hardening_red_test.go
@@ -1,0 +1,208 @@
+package m2mgraphql
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	pv "github.com/Project-Helianthus/helianthus-ebusreg/pv"
+)
+
+//go:embed testdata/public-graphql-m2m-v1.query.graphql
+var canonicalM2MQuery string
+
+func TestM2MCurrentSnapshot_RequiresTheOneCanonicalQueryForEveryValidRequest(t *testing.T) {
+	handler, err := NewHandler(Config{
+		SnapshotByAsset: func(context.Context, string) (pv.Snapshot, bool) { return m2mGoldenSnapshot(), true },
+		AssetExists:     func(string) bool { return true }, AllowedAssets: map[string]struct{}{"pv-asset-golden": {}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct{ name, query, code string }{
+		{"canonical", canonicalM2MQuery, ""},
+		{"reduced", strings.Replace(canonicalM2MQuery, " contractId canonicalContractId assetRef generation producedAt", " contractId", 1), "QUERY_REJECTED"},
+		{"modified", strings.Replace(canonicalM2MQuery, "M2MCurrentSnapshot", "M2MCurrentSnapshotModified", 1), "QUERY_REJECTED"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodPost, "/graphql/m2m/v1", strings.NewReader(m2mCanonicalRequest(test.query, "pv-asset-golden")))
+			request = request.WithContext(WithMTLSPrincipal(request.Context(), "principal-canonical"))
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, request)
+			if test.code != "" {
+				assertM2MError(t, response, test.code)
+				return
+			}
+			if response.Code != http.StatusOK || strings.Contains(response.Body.String(), `"errors"`) {
+				t.Fatalf("body=%s", response.Body.String())
+			}
+		})
+	}
+}
+
+func TestM2MCurrentSnapshot_FullWireGoldenAndMCPParity(t *testing.T) {
+	snapshot := m2mGoldenSnapshot()
+	handler, err := NewHandler(Config{
+		SnapshotByAsset: func(context.Context, string) (pv.Snapshot, bool) { return snapshot, true },
+		AssetExists:     func(string) bool { return true }, AllowedAssets: map[string]struct{}{snapshot.AssetRef: {}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodPost, "/graphql/m2m/v1", bytes.NewBufferString(m2mCanonicalRequest(canonicalM2MQuery, snapshot.AssetRef)))
+	request = request.WithContext(WithMTLSPrincipal(request.Context(), "principal-golden"))
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+
+	var envelope struct {
+		Data struct {
+			Snapshot map[string]any `json:"m2mCurrentSnapshot"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	got := envelope.Data.Snapshot
+	assertM2MGoldenWire(t, got)
+
+	// Both ingress projections must be lossless views of the same immutable snapshot.
+	mcp, err := MCPCurrentSnapshot(snapshot)
+	if err != nil {
+		t.Fatalf("MCPCurrentSnapshot: %v", err)
+	}
+	graphqlWire, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mcpWire, err := json.Marshal(mcp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(graphqlWire, mcpWire) {
+		t.Fatalf("MCP/GraphQL parity mismatch\ngraphql=%s\nmcp=%s", graphqlWire, mcpWire)
+	}
+}
+
+func m2mCanonicalRequest(query, assetRef string) string {
+	b, err := json.Marshal(map[string]any{"operationName": "M2MCurrentSnapshot", "query": query, "variables": map[string]any{"request": map[string]string{"contractId": "PUBLIC_GRAPHQL_M2M_V1", "assetRef": assetRef}}})
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}
+
+func assertM2MGoldenWire(t *testing.T, got map[string]any) {
+	t.Helper()
+	for key, want := range map[string]any{
+		"contractId": "PUBLIC_GRAPHQL_M2M_V1", "canonicalContractId": "helianthus.canonical-pv/v1", "assetRef": "pv-asset-golden",
+		"generation": "71", "evaluatedMonotonicNs": "990", "sourceTimeState": "UNAVAILABLE",
+	} {
+		if got[key] != want {
+			t.Fatalf("%s=%#v want %#v", key, got[key], want)
+		}
+	}
+	if producedAt, ok := got["producedAt"].(string); !ok || producedAt == "" {
+		t.Fatalf("producedAt=%#v; want preserved publication time", got["producedAt"])
+	}
+	if _, leaked := got["sourceShadowRef"]; leaked {
+		t.Fatal("public sourceShadowRef leaked")
+	}
+	for _, key := range []string{"facts", "capabilities", "provenance", "requestedOutputs", "projectionReport"} {
+		if _, ok := got[key]; !ok {
+			t.Fatalf("missing %s", key)
+		}
+	}
+	facts, ok := got["facts"].([]any)
+	if !ok || len(facts) != 5 {
+		t.Fatalf("facts=%#v", got["facts"])
+	}
+	var dimensions, values, continuities = map[string]bool{}, map[string]bool{}, map[string]bool{}
+	for _, raw := range facts {
+		fact := raw.(map[string]any)
+		for k := range fact["dimension"].(map[string]any) {
+			dimensions[k] = true
+		}
+		value := fact["value"].(map[string]any)
+		if _, ok := value["coefficient"]; ok {
+			values["decimal"] = true
+		}
+		if _, ok := value["symbol"]; ok {
+			values["enum"] = true
+		}
+		if _, ok := value["symbols"]; ok {
+			values["bitfield"] = true
+		}
+		if c, ok := fact["continuity"].(map[string]any); ok {
+			continuities[c["__typename"].(string)] = true
+		}
+	}
+	for _, key := range []string{"scope", "phase", "phasePair", "inputId", "sensorId"} {
+		if !dimensions[key] {
+			t.Fatalf("dimension union missing %s: %#v", key, dimensions)
+		}
+	}
+	for _, key := range []string{"decimal", "enum", "bitfield"} {
+		if !values[key] {
+			t.Fatalf("value union missing %s: %#v", key, values)
+		}
+	}
+	for _, key := range []string{"M2MBaselineContinuity", "M2MContiguousContinuity", "M2MRolloverContinuity", "M2MResetContinuity", "M2MDiscontinuityContinuity"} {
+		if !continuities[key] {
+			t.Fatalf("continuity union missing %s: %#v", key, continuities)
+		}
+	}
+	provenance := got["provenance"].([]any)
+	if len(provenance) != 2 {
+		t.Fatalf("provenance=%#v", provenance)
+	}
+	for _, raw := range provenance {
+		row := raw.(map[string]any)
+		for _, key := range []string{"originRef", "sourceProtocol", "sourceProfileId", "sourceProfileVersion", "sourceValidity", "sourceRegistryRef", "sourceObservationRef", "evidenceRef"} {
+			if _, ok := row[key]; !ok {
+				t.Fatalf("provenance missing %s: %#v", key, row)
+			}
+		}
+		if _, leaked := row["sourceShadowRef"]; leaked {
+			t.Fatal("provenance leaked sourceShadowRef")
+		}
+	}
+	reports := got["projectionReport"].([]any)
+	kinds := map[string]bool{}
+	for _, raw := range reports {
+		kinds[raw.(map[string]any)["__typename"].(string)] = true
+	}
+	for _, key := range []string{"M2MMappedProjectionReportEntry", "M2MWithheldProjectionReportEntry", "M2MUnrepresentableProjectionReportEntry"} {
+		if !kinds[key] {
+			t.Fatalf("projection outcome missing %s", key)
+		}
+	}
+}
+
+func m2mGoldenSnapshot() pv.Snapshot {
+	originA := pv.Digest("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	originB := pv.Digest("sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+	provenance := func(ref pv.Digest) pv.Provenance {
+		return pv.Provenance{SourceIdentity: pv.SourceIdentity{Protocol: "sunspec_modbus", ProfileID: "sunspec.inverter.three_phase.monitoring@1.0.0", ProfileVersion: "1.0.0", Validity: pv.SourceTerminalVerified}, SourceRegistryRef: pv.Digest("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"), SourceObservationRef: ref, SourceShadowRef: pv.Digest("sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"), EvidenceRef: pv.Digest("sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")}
+	}
+	d := func(coefficient string) *pv.Decimal { value := pv.MustDecimal(coefficient, 0); return &value }
+	fact := func(id pv.FactID, dimensions pv.Dimensions, value pv.FactValue, continuity *pv.Continuity) pv.Fact {
+		return pv.Fact{ID: id, Dimensions: dimensions, Value: value, Unit: pv.UnitOne, Quality: pv.QualityGood, Availability: pv.AvailabilityAvailable, Freshness: pv.FreshnessFresh, Temporal: pv.Temporal{Receipt: 100, FreshUntil: 200, RetainUntil: 300, Policy: pv.PolicyTelemetryFastV1}, OriginRef: originA, Continuity: continuity}
+	}
+	facts := map[pv.FactKey]pv.Fact{}
+	add := func(f pv.Fact) { facts[pv.NewFactKey(f.ID, f.Dimensions)] = f }
+	add(fact(pv.FactACActivePower, pv.Dimensions{Scope: pv.ScopeTotal}, pv.DecimalFactValue(*d("7310")), &pv.Continuity{State: pv.ContinuityBaseline}))
+	add(fact(pv.FactACCurrent, pv.Dimensions{Phase: pv.PhaseL1}, pv.EnumFactValue("OPERATING"), &pv.Continuity{State: pv.ContinuityContiguous, Delta: d("1")}))
+	add(fact(pv.FactACVoltageLineToLine, pv.Dimensions{PhasePair: pv.PhasePairL1L2}, pv.BitfieldFactValue("A", "B"), &pv.Continuity{State: pv.ContinuityRollover, Delta: d("2"), Modulus: d("10"), EvidenceRef: originA}))
+	add(fact(pv.FactDCVoltage, pv.Dimensions{InputID: "input-1"}, pv.DecimalFactValue(*d("3")), &pv.Continuity{State: pv.ContinuityReset, EvidenceRef: originA}))
+	add(fact(pv.FactTemperature, pv.Dimensions{SensorID: "cabinet"}, pv.DecimalFactValue(*d("4")), &pv.Continuity{State: pv.ContinuityDiscontinuity, EvidenceRef: originB}))
+	return pv.Snapshot{ContractID: pv.ContractV1, AssetRef: "pv-asset-golden", Generation: 71, Evaluated: 990, SourceTimeState: pv.SourceTimeUnavailable, Source: provenance(originA), Origins: map[pv.Digest]pv.Provenance{originA: provenance(originA), originB: provenance(originB)}, Capability: pv.Capability{ID: pv.CapabilityThreePhaseTelemetryV1, Outcome: pv.CapabilitySatisfied}, Facts: facts, RequestedOutputs: []pv.RequestedOutput{{SourceRef: originA, RequestedOutputRef: originA}, {SourceRef: originB, RequestedOutputRef: originB}, {SourceRef: originA, RequestedOutputRef: originB}}, ProjectionReport: []pv.Projection{{SourceRef: originA, RequestedOutputRef: originA, FactID: pv.FactACActivePower, Dimensions: &pv.Dimensions{Scope: pv.ScopeTotal}, Outcome: pv.ProjectionMapped}, {SourceRef: originA, RequestedOutputRef: originB, Outcome: pv.ProjectionWithheld}, {SourceRef: originB, RequestedOutputRef: originA, Outcome: pv.ProjectionUnrepresentable}}}
+}

--- a/m2mgraphql/contract_hardening_red_test.go
+++ b/m2mgraphql/contract_hardening_red_test.go
@@ -47,6 +47,24 @@ func TestM2MCurrentSnapshot_RequiresTheOneCanonicalQueryForEveryValidRequest(t *
 	}
 }
 
+func TestM2MCurrentSnapshot_AcceptsCanonicalASTIndependentOfFormatting(t *testing.T) {
+	handler, err := NewHandler(Config{
+		SnapshotByAsset: func(context.Context, string) (pv.Snapshot, bool) { return m2mGoldenSnapshot(), true },
+		AssetExists:     func(string) bool { return true }, AllowedAssets: map[string]struct{}{"pv-asset-golden": {}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request := httptest.NewRequest(http.MethodPost, "/graphql/m2m/v1", strings.NewReader(m2mCanonicalRequest(strings.Join(strings.Fields(canonicalM2MQuery), " "), "pv-asset-golden")))
+	request = request.WithContext(WithMTLSPrincipal(request.Context(), "principal-canonical-ast"))
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusOK || strings.Contains(response.Body.String(), `"errors"`) {
+		t.Fatalf("canonical AST with alternate whitespace was rejected: %s", response.Body.String())
+	}
+}
+
 func TestM2MCurrentSnapshot_FullWireGoldenAndMCPParity(t *testing.T) {
 	snapshot := m2mGoldenSnapshot()
 	handler, err := NewHandler(Config{
@@ -142,6 +160,56 @@ func TestM2MCurrentSnapshot_ProjectsEachCanonicalContinuityVariant(t *testing.T)
 				}
 			}
 		})
+	}
+}
+
+func TestM2MCurrentSnapshot_EmitsExactClosedWireShapes(t *testing.T) {
+	handler, err := NewHandler(Config{
+		SnapshotByAsset: func(context.Context, string) (pv.Snapshot, bool) { return m2mGoldenSnapshot(), true },
+		AssetExists:     func(string) bool { return true }, AllowedAssets: map[string]struct{}{"pv-asset-golden": {}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodPost, "/graphql/m2m/v1", strings.NewReader(m2mCanonicalRequest(canonicalM2MQuery, "pv-asset-golden")))
+	request = request.WithContext(WithMTLSPrincipal(request.Context(), "principal-wire-shape"))
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	var envelope struct {
+		Data struct {
+			Snapshot struct {
+				Facts []map[string]any `json:"facts"`
+			} `json:"m2mCurrentSnapshot"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	for _, fact := range envelope.Data.Snapshot.Facts {
+		dimension := fact["dimension"].(map[string]any)
+		value := fact["value"].(map[string]any)
+		if _, exists := dimension["__typename"]; exists {
+			t.Fatalf("dimension exposed unselected __typename: %#v", dimension)
+		}
+		if _, exists := value["__typename"]; exists {
+			t.Fatalf("value exposed unselected __typename: %#v", value)
+		}
+		if scale, exists := value["scale"]; exists {
+			if _, ok := scale.(float64); !ok {
+				t.Fatalf("decimal scale is not a GraphQL Int: %#v", scale)
+			}
+		}
+		continuity, exists := fact["continuity"]
+		if !exists {
+			t.Fatalf("selected continuity field was omitted: %#v", fact)
+		}
+		if fact["factId"] == string(pv.FactEnergyActiveExportTotal) {
+			row := continuity.(map[string]any)
+			if row["baseline"] != "BASELINE" {
+				t.Fatalf("baseline marker=%#v want BASELINE", row["baseline"])
+			}
+		}
 	}
 }
 

--- a/m2mgraphql/contract_hardening_red_test.go
+++ b/m2mgraphql/contract_hardening_red_test.go
@@ -164,8 +164,22 @@ func TestM2MCurrentSnapshot_ProjectsEachCanonicalContinuityVariant(t *testing.T)
 }
 
 func TestM2MCurrentSnapshot_EmitsExactClosedWireShapes(t *testing.T) {
+	snapshot := m2mGoldenSnapshot()
+	currentOrigin := m2mDigest(2)
+	snapshot.Source = snapshot.Origins[currentOrigin]
+	for index := range snapshot.ProjectionReport {
+		if snapshot.ProjectionReport[index].Outcome == pv.ProjectionMapped {
+			continue
+		}
+		snapshot.ProjectionReport[index].SourceRef = currentOrigin
+		for requestedIndex := range snapshot.RequestedOutputs {
+			if snapshot.RequestedOutputs[requestedIndex].RequestedOutputRef == snapshot.ProjectionReport[index].RequestedOutputRef {
+				snapshot.RequestedOutputs[requestedIndex].SourceRef = currentOrigin
+			}
+		}
+	}
 	handler, err := NewHandler(Config{
-		SnapshotByAsset: func(context.Context, string) (pv.Snapshot, bool) { return m2mGoldenSnapshot(), true },
+		SnapshotByAsset: func(context.Context, string) (pv.Snapshot, bool) { return snapshot, true },
 		AssetExists:     func(string) bool { return true }, AllowedAssets: map[string]struct{}{"pv-asset-golden": {}},
 	})
 	if err != nil {

--- a/m2mgraphql/contract_hardening_red_test.go
+++ b/m2mgraphql/contract_hardening_red_test.go
@@ -19,8 +19,8 @@ var canonicalM2MQuery string
 
 func TestM2MCurrentSnapshot_RequiresTheOneCanonicalQueryForEveryValidRequest(t *testing.T) {
 	handler, err := NewHandler(Config{
-		SnapshotByAsset: func(context.Context, string) (pv.Snapshot, bool) { return m2mGoldenSnapshot(), true },
-		AssetExists:     func(string) bool { return true }, AllowedAssets: map[string]struct{}{"pv-asset-golden": {}},
+		SnapshotByAssetAt: m2mSnapshotAt(func(context.Context, string) (pv.Snapshot, bool) { return m2mGoldenSnapshot(), true }),
+		AssetExists:       func(string) bool { return true }, AllowedAssets: map[string]struct{}{"pv-asset-golden": {}},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -49,8 +49,8 @@ func TestM2MCurrentSnapshot_RequiresTheOneCanonicalQueryForEveryValidRequest(t *
 
 func TestM2MCurrentSnapshot_AcceptsCanonicalASTIndependentOfFormatting(t *testing.T) {
 	handler, err := NewHandler(Config{
-		SnapshotByAsset: func(context.Context, string) (pv.Snapshot, bool) { return m2mGoldenSnapshot(), true },
-		AssetExists:     func(string) bool { return true }, AllowedAssets: map[string]struct{}{"pv-asset-golden": {}},
+		SnapshotByAssetAt: m2mSnapshotAt(func(context.Context, string) (pv.Snapshot, bool) { return m2mGoldenSnapshot(), true }),
+		AssetExists:       func(string) bool { return true }, AllowedAssets: map[string]struct{}{"pv-asset-golden": {}},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -68,8 +68,8 @@ func TestM2MCurrentSnapshot_AcceptsCanonicalASTIndependentOfFormatting(t *testin
 func TestM2MCurrentSnapshot_FullWireGoldenAndMCPParity(t *testing.T) {
 	snapshot := m2mGoldenSnapshot()
 	handler, err := NewHandler(Config{
-		SnapshotByAsset: func(context.Context, string) (pv.Snapshot, bool) { return snapshot, true },
-		AssetExists:     func(string) bool { return true }, AllowedAssets: map[string]struct{}{snapshot.AssetRef: {}},
+		SnapshotByAssetAt: m2mSnapshotAt(func(context.Context, string) (pv.Snapshot, bool) { return snapshot, true }),
+		AssetExists:       func(string) bool { return true }, AllowedAssets: map[string]struct{}{snapshot.AssetRef: {}},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -94,7 +94,7 @@ func TestM2MCurrentSnapshot_FullWireGoldenAndMCPParity(t *testing.T) {
 	assertM2MGoldenWire(t, got)
 
 	// Both ingress projections must be lossless views of the same immutable snapshot.
-	mcp, err := MCPCurrentSnapshot(snapshot)
+	mcp, err := MCPCurrentSnapshot(snapshot, m2mTestProducedAt)
 	if err != nil {
 		t.Fatalf("MCPCurrentSnapshot: %v", err)
 	}
@@ -131,8 +131,8 @@ func TestM2MCurrentSnapshot_ProjectsEachCanonicalContinuityVariant(t *testing.T)
 			fact.Continuity = &continuity
 			snapshot.Facts[key] = fact
 			handler, err := NewHandler(Config{
-				SnapshotByAsset: func(context.Context, string) (pv.Snapshot, bool) { return snapshot, true },
-				AssetExists:     func(string) bool { return true }, AllowedAssets: map[string]struct{}{snapshot.AssetRef: {}},
+				SnapshotByAssetAt: m2mSnapshotAt(func(context.Context, string) (pv.Snapshot, bool) { return snapshot, true }),
+				AssetExists:       func(string) bool { return true }, AllowedAssets: map[string]struct{}{snapshot.AssetRef: {}},
 			})
 			if err != nil {
 				t.Fatal(err)
@@ -179,8 +179,8 @@ func TestM2MCurrentSnapshot_EmitsExactClosedWireShapes(t *testing.T) {
 		}
 	}
 	handler, err := NewHandler(Config{
-		SnapshotByAsset: func(context.Context, string) (pv.Snapshot, bool) { return snapshot, true },
-		AssetExists:     func(string) bool { return true }, AllowedAssets: map[string]struct{}{"pv-asset-golden": {}},
+		SnapshotByAssetAt: m2mSnapshotAt(func(context.Context, string) (pv.Snapshot, bool) { return snapshot, true }),
+		AssetExists:       func(string) bool { return true }, AllowedAssets: map[string]struct{}{"pv-asset-golden": {}},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -239,8 +239,8 @@ func TestM2MCurrentSnapshot_FailsClosedOnInvalidCanonicalSnapshot(t *testing.T) 
 	invalid.ID = pv.FactACActivePower
 	snapshot.Facts[key] = invalid
 	handler, err := NewHandler(Config{
-		SnapshotByAsset: func(context.Context, string) (pv.Snapshot, bool) { return snapshot, true },
-		AssetExists:     func(string) bool { return true }, AllowedAssets: map[string]struct{}{snapshot.AssetRef: {}},
+		SnapshotByAssetAt: m2mSnapshotAt(func(context.Context, string) (pv.Snapshot, bool) { return snapshot, true }),
+		AssetExists:       func(string) bool { return true }, AllowedAssets: map[string]struct{}{snapshot.AssetRef: {}},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/m2mgraphql/contract_hardening_red_test.go
+++ b/m2mgraphql/contract_hardening_red_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -92,6 +93,58 @@ func TestM2MCurrentSnapshot_FullWireGoldenAndMCPParity(t *testing.T) {
 	}
 }
 
+func TestM2MCurrentSnapshot_ProjectsEachCanonicalContinuityVariant(t *testing.T) {
+	variants := []struct {
+		continuity pv.Continuity
+		typename   string
+	}{
+		{pv.Continuity{State: pv.ContinuityBaseline}, "M2MBaselineContinuity"},
+		{pv.Continuity{State: pv.ContinuityContiguous, Delta: m2mDecimal("1")}, "M2MContiguousContinuity"},
+		{pv.Continuity{State: pv.ContinuityRollover, Delta: m2mDecimal("2"), Modulus: m2mDecimal("100"), EvidenceRef: m2mDigest(30)}, "M2MRolloverContinuity"},
+		{pv.Continuity{State: pv.ContinuityReset, EvidenceRef: m2mDigest(31)}, "M2MResetContinuity"},
+		{pv.Continuity{State: pv.ContinuityDiscontinuity}, "M2MDiscontinuityContinuity"},
+	}
+	for _, variant := range variants {
+		t.Run(variant.typename, func(t *testing.T) {
+			snapshot := m2mGoldenSnapshot()
+			key := pv.NewFactKey(pv.FactEnergyActiveExportTotal, pv.Dimensions{Scope: pv.ScopeTotal})
+			fact := snapshot.Facts[key]
+			continuity := variant.continuity
+			fact.Continuity = &continuity
+			snapshot.Facts[key] = fact
+			handler, err := NewHandler(Config{
+				SnapshotByAsset: func(context.Context, string) (pv.Snapshot, bool) { return snapshot, true },
+				AssetExists:     func(string) bool { return true }, AllowedAssets: map[string]struct{}{snapshot.AssetRef: {}},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			request := httptest.NewRequest(http.MethodPost, "/graphql/m2m/v1", strings.NewReader(m2mCanonicalRequest(canonicalM2MQuery, snapshot.AssetRef)))
+			request = request.WithContext(WithMTLSPrincipal(request.Context(), "principal-continuity"))
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, request)
+			var envelope struct {
+				Data struct {
+					Snapshot struct {
+						Facts []struct {
+							FactID     string         `json:"factId"`
+							Continuity map[string]any `json:"continuity"`
+						} `json:"facts"`
+					} `json:"m2mCurrentSnapshot"`
+				} `json:"data"`
+			}
+			if err := json.Unmarshal(response.Body.Bytes(), &envelope); err != nil {
+				t.Fatal(err)
+			}
+			for _, item := range envelope.Data.Snapshot.Facts {
+				if item.FactID == string(pv.FactEnergyActiveExportTotal) && item.Continuity["__typename"] != variant.typename {
+					t.Fatalf("continuity=%#v want %s", item.Continuity, variant.typename)
+				}
+			}
+		})
+	}
+}
+
 func m2mCanonicalRequest(query, assetRef string) string {
 	b, err := json.Marshal(map[string]any{"operationName": "M2MCurrentSnapshot", "query": query, "variables": map[string]any{"request": map[string]string{"contractId": "PUBLIC_GRAPHQL_M2M_V1", "assetRef": assetRef}}})
 	if err != nil {
@@ -122,7 +175,7 @@ func assertM2MGoldenWire(t *testing.T, got map[string]any) {
 		}
 	}
 	facts, ok := got["facts"].([]any)
-	if !ok || len(facts) != 5 {
+	if !ok || len(facts) != 7 {
 		t.Fatalf("facts=%#v", got["facts"])
 	}
 	var dimensions, values, continuities = map[string]bool{}, map[string]bool{}, map[string]bool{}
@@ -155,10 +208,8 @@ func assertM2MGoldenWire(t *testing.T, got map[string]any) {
 			t.Fatalf("value union missing %s: %#v", key, values)
 		}
 	}
-	for _, key := range []string{"M2MBaselineContinuity", "M2MContiguousContinuity", "M2MRolloverContinuity", "M2MResetContinuity", "M2MDiscontinuityContinuity"} {
-		if !continuities[key] {
-			t.Fatalf("continuity union missing %s: %#v", key, continuities)
-		}
+	if !continuities["M2MBaselineContinuity"] || len(continuities) != 1 {
+		t.Fatalf("golden continuity=%#v; want canonical baseline only", continuities)
 	}
 	provenance := got["provenance"].([]any)
 	if len(provenance) != 2 {
@@ -188,21 +239,49 @@ func assertM2MGoldenWire(t *testing.T, got map[string]any) {
 }
 
 func m2mGoldenSnapshot() pv.Snapshot {
-	originA := pv.Digest("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-	originB := pv.Digest("sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+	originA := m2mDigest(1)
+	originB := m2mDigest(2)
 	provenance := func(ref pv.Digest) pv.Provenance {
-		return pv.Provenance{SourceIdentity: pv.SourceIdentity{Protocol: "sunspec_modbus", ProfileID: "sunspec.inverter.three_phase.monitoring@1.0.0", ProfileVersion: "1.0.0", Validity: pv.SourceTerminalVerified}, SourceRegistryRef: pv.Digest("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"), SourceObservationRef: ref, SourceShadowRef: pv.Digest("sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"), EvidenceRef: pv.Digest("sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")}
+		return pv.Provenance{SourceIdentity: pv.SourceIdentity{Protocol: "sunspec_modbus", ProfileID: "sunspec.inverter.three_phase.monitoring@1.0.0", ProfileVersion: "1.0.0", Validity: pv.SourceTerminalVerified}, SourceRegistryRef: m2mDigest(3), SourceObservationRef: ref, SourceShadowRef: m2mDigest(4), EvidenceRef: m2mDigest(5)}
 	}
-	d := func(coefficient string) *pv.Decimal { value := pv.MustDecimal(coefficient, 0); return &value }
-	fact := func(id pv.FactID, dimensions pv.Dimensions, value pv.FactValue, continuity *pv.Continuity) pv.Fact {
-		return pv.Fact{ID: id, Dimensions: dimensions, Value: value, Unit: pv.UnitOne, Quality: pv.QualityGood, Availability: pv.AvailabilityAvailable, Freshness: pv.FreshnessFresh, Temporal: pv.Temporal{Receipt: 100, FreshUntil: 200, RetainUntil: 300, Policy: pv.PolicyTelemetryFastV1}, OriginRef: originA, Continuity: continuity}
+	fact := func(id pv.FactID, dimensions pv.Dimensions, value pv.FactValue, unit pv.Unit, policy pv.PolicyID, continuity *pv.Continuity) pv.Fact {
+		return pv.Fact{ID: id, Dimensions: dimensions, Value: value, Unit: unit, Quality: pv.QualityGood, Availability: pv.AvailabilityAvailable, Freshness: pv.FreshnessFresh, Temporal: pv.Temporal{Receipt: 100, FreshUntil: 200, RetainUntil: 300, Policy: policy}, OriginRef: originA, Continuity: continuity}
 	}
 	facts := map[pv.FactKey]pv.Fact{}
 	add := func(f pv.Fact) { facts[pv.NewFactKey(f.ID, f.Dimensions)] = f }
-	add(fact(pv.FactACActivePower, pv.Dimensions{Scope: pv.ScopeTotal}, pv.DecimalFactValue(*d("7310")), &pv.Continuity{State: pv.ContinuityBaseline}))
-	add(fact(pv.FactACCurrent, pv.Dimensions{Phase: pv.PhaseL1}, pv.EnumFactValue("OPERATING"), &pv.Continuity{State: pv.ContinuityContiguous, Delta: d("1")}))
-	add(fact(pv.FactACVoltageLineToLine, pv.Dimensions{PhasePair: pv.PhasePairL1L2}, pv.BitfieldFactValue("A", "B"), &pv.Continuity{State: pv.ContinuityRollover, Delta: d("2"), Modulus: d("10"), EvidenceRef: originA}))
-	add(fact(pv.FactDCVoltage, pv.Dimensions{InputID: "input-1"}, pv.DecimalFactValue(*d("3")), &pv.Continuity{State: pv.ContinuityReset, EvidenceRef: originA}))
-	add(fact(pv.FactTemperature, pv.Dimensions{SensorID: "cabinet"}, pv.DecimalFactValue(*d("4")), &pv.Continuity{State: pv.ContinuityDiscontinuity, EvidenceRef: originB}))
-	return pv.Snapshot{ContractID: pv.ContractV1, AssetRef: "pv-asset-golden", Generation: 71, Evaluated: 990, SourceTimeState: pv.SourceTimeUnavailable, Source: provenance(originA), Origins: map[pv.Digest]pv.Provenance{originA: provenance(originA), originB: provenance(originB)}, Capability: pv.Capability{ID: pv.CapabilityThreePhaseTelemetryV1, Outcome: pv.CapabilitySatisfied}, Facts: facts, RequestedOutputs: []pv.RequestedOutput{{SourceRef: originA, RequestedOutputRef: originA}, {SourceRef: originB, RequestedOutputRef: originB}, {SourceRef: originA, RequestedOutputRef: originB}}, ProjectionReport: []pv.Projection{{SourceRef: originA, RequestedOutputRef: originA, FactID: pv.FactACActivePower, Dimensions: &pv.Dimensions{Scope: pv.ScopeTotal}, Outcome: pv.ProjectionMapped}, {SourceRef: originA, RequestedOutputRef: originB, Outcome: pv.ProjectionWithheld}, {SourceRef: originB, RequestedOutputRef: originA, Outcome: pv.ProjectionUnrepresentable}}}
+	baseline := pv.Continuity{State: pv.ContinuityBaseline}
+	add(fact(pv.FactEnergyActiveExportTotal, pv.Dimensions{Scope: pv.ScopeTotal}, pv.DecimalFactValue(*m2mDecimal("7310")), pv.UnitWattHour, pv.PolicyAccumulatorV1, &baseline))
+	add(fact(pv.FactACCurrent, pv.Dimensions{Phase: pv.PhaseL1}, pv.DecimalFactValue(*m2mDecimal("11")), pv.UnitAmpere, pv.PolicyTelemetryFastV1, nil))
+	add(fact(pv.FactACVoltageLineToLine, pv.Dimensions{PhasePair: pv.PhasePairL1L2}, pv.DecimalFactValue(*m2mDecimal("400")), pv.UnitVolt, pv.PolicyTelemetryFastV1, nil))
+	add(fact(pv.FactDCVoltage, pv.Dimensions{InputID: "input-1"}, pv.DecimalFactValue(*m2mDecimal("600")), pv.UnitVolt, pv.PolicyTelemetryFastV1, nil))
+	add(fact(pv.FactTemperature, pv.Dimensions{SensorID: "cabinet"}, pv.DecimalFactValue(*m2mDecimal("42")), pv.UnitCelsius, pv.PolicyTelemetryFastV1, nil))
+	add(fact(pv.FactOperatingState, pv.Dimensions{Scope: pv.ScopeTotal}, pv.EnumFactValue(pv.OperatingStateOperating), pv.UnitOne, pv.PolicyStatusV1, nil))
+	add(fact(pv.FactEventFlags, pv.Dimensions{Scope: pv.ScopeTotal}, pv.BitfieldFactValue("COMMUNICATION_FAULT"), pv.UnitOne, pv.PolicyStatusV1, nil))
+
+	requested := make([]pv.RequestedOutput, 0, len(facts)+2)
+	report := make([]pv.Projection, 0, len(facts)+2)
+	index := 10
+	for _, value := range facts {
+		ref := m2mDigest(index)
+		index++
+		requested = append(requested, pv.RequestedOutput{SourceRef: originA, RequestedOutputRef: ref})
+		dimensions := value.Dimensions
+		report = append(report, pv.Projection{SourceRef: originA, RequestedOutputRef: ref, FactID: value.ID, Dimensions: &dimensions, Outcome: pv.ProjectionMapped})
+	}
+	for _, outcome := range []pv.ProjectionOutcome{pv.ProjectionWithheld, pv.ProjectionUnrepresentable} {
+		ref := m2mDigest(index)
+		index++
+		requested = append(requested, pv.RequestedOutput{SourceRef: originA, RequestedOutputRef: ref})
+		report = append(report, pv.Projection{SourceRef: originA, RequestedOutputRef: ref, Outcome: outcome})
+	}
+	return pv.Snapshot{ContractID: pv.ContractV1, AssetRef: "pv-asset-golden", Generation: 71, Evaluated: 990, SourceTimeState: pv.SourceTimeUnavailable, Source: provenance(originA), Origins: map[pv.Digest]pv.Provenance{originA: provenance(originA), originB: provenance(originB)}, Capability: pv.Capability{ID: pv.CapabilityThreePhaseTelemetryV1, Outcome: pv.CapabilityNotSatisfied}, Facts: facts, RequestedOutputs: requested, ProjectionReport: report}
+}
+
+func m2mDecimal(coefficient string) *pv.Decimal {
+	value := pv.MustDecimal(coefficient, 0)
+	return &value
+}
+
+func m2mDigest(index int) pv.Digest {
+	return pv.Digest(fmt.Sprintf("sha256:%064x", index))
 }

--- a/m2mgraphql/contract_hardening_red_test.go
+++ b/m2mgraphql/contract_hardening_red_test.go
@@ -179,7 +179,9 @@ func TestM2MCurrentSnapshot_EmitsExactClosedWireShapes(t *testing.T) {
 	var envelope struct {
 		Data struct {
 			Snapshot struct {
-				Facts []map[string]any `json:"facts"`
+				CurrentSourceOriginRef string           `json:"currentSourceOriginRef"`
+				Facts                  []map[string]any `json:"facts"`
+				Provenance             []map[string]any `json:"provenance"`
 			} `json:"m2mCurrentSnapshot"`
 		} `json:"data"`
 	}
@@ -211,6 +213,25 @@ func TestM2MCurrentSnapshot_EmitsExactClosedWireShapes(t *testing.T) {
 			}
 		}
 	}
+	if len(envelope.Data.Snapshot.Provenance) == 0 || envelope.Data.Snapshot.Provenance[0]["originRef"] != envelope.Data.Snapshot.CurrentSourceOriginRef {
+		t.Fatalf("current provenance is not first: current=%s provenance=%#v", envelope.Data.Snapshot.CurrentSourceOriginRef, envelope.Data.Snapshot.Provenance)
+	}
+}
+
+func TestM2MCurrentSnapshot_FailsClosedOnInvalidCanonicalSnapshot(t *testing.T) {
+	snapshot := m2mGoldenSnapshot()
+	key := pv.NewFactKey(pv.FactACActivePower, pv.Dimensions{Phase: pv.PhaseL1})
+	invalid := snapshot.Facts[pv.NewFactKey(pv.FactACCurrent, pv.Dimensions{Phase: pv.PhaseL1})]
+	invalid.ID = pv.FactACActivePower
+	snapshot.Facts[key] = invalid
+	handler, err := NewHandler(Config{
+		SnapshotByAsset: func(context.Context, string) (pv.Snapshot, bool) { return snapshot, true },
+		AssetExists:     func(string) bool { return true }, AllowedAssets: map[string]struct{}{snapshot.AssetRef: {}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertM2MErrorForRequest(t, handler, "principal-invalid-snapshot", m2mCanonicalRequest(canonicalM2MQuery, snapshot.AssetRef), "SOURCE_UNAVAILABLE")
 }
 
 func m2mCanonicalRequest(query, assetRef string) string {

--- a/m2mgraphql/contract_red_test.go
+++ b/m2mgraphql/contract_red_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	pv "github.com/Project-Helianthus/helianthus-ebusreg/pv"
 )
@@ -22,6 +23,15 @@ type contractFixtureShape struct {
 	OperationName       string `json:"operationName"`
 }
 
+var m2mTestProducedAt = time.Date(2026, 8, 17, 13, 46, 0, 0, time.UTC)
+
+func m2mSnapshotAt(provider func(context.Context, string) (pv.Snapshot, bool)) func(context.Context, string) (pv.Snapshot, time.Time, bool) {
+	return func(ctx context.Context, asset string) (pv.Snapshot, time.Time, bool) {
+		snapshot, ok := provider(ctx, asset)
+		return snapshot, m2mTestProducedAt, ok
+	}
+}
+
 func TestM2MCurrentSnapshot_OnlyAcceptsTheDedicatedFixedContract(t *testing.T) {
 	var contract contractFixtureShape
 	if err := json.Unmarshal(contractFixture, &contract); err != nil {
@@ -29,9 +39,9 @@ func TestM2MCurrentSnapshot_OnlyAcceptsTheDedicatedFixedContract(t *testing.T) {
 	}
 
 	handler, err := NewHandler(Config{
-		SnapshotByAsset: func(context.Context, string) (pv.Snapshot, bool) {
+		SnapshotByAssetAt: m2mSnapshotAt(func(context.Context, string) (pv.Snapshot, bool) {
 			return m2mFixtureSnapshot(), true
-		},
+		}),
 		AssetExists:   func(string) bool { return true },
 		AllowedAssets: map[string]struct{}{"pv-asset-fixture": {}},
 	})
@@ -73,7 +83,10 @@ func TestM2MCurrentSnapshot_OnlyAcceptsTheDedicatedFixedContract(t *testing.T) {
 }
 
 func TestM2MCurrentSnapshot_HasNoGenericFallbackRawOrSubscriptionSurface(t *testing.T) {
-	handler, err := NewHandler(Config{AllowedAssets: map[string]struct{}{}})
+	handler, err := NewHandler(Config{
+		SnapshotByAssetAt: m2mSnapshotAt(func(context.Context, string) (pv.Snapshot, bool) { return pv.Snapshot{}, false }),
+		AssetExists:       func(string) bool { return false }, AllowedAssets: map[string]struct{}{},
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,8 +107,7 @@ func TestM2MCurrentSnapshot_HasNoGenericFallbackRawOrSubscriptionSurface(t *test
 
 func TestM2MCurrentSnapshot_RequiresAuthoritativePublicationTimeProvider(t *testing.T) {
 	_, err := NewHandler(Config{
-		SnapshotByAsset: func(context.Context, string) (pv.Snapshot, bool) { return m2mFixtureSnapshot(), true },
-		AssetExists:     func(string) bool { return true }, AllowedAssets: map[string]struct{}{"pv-asset-fixture": {}},
+		AssetExists: func(string) bool { return true }, AllowedAssets: map[string]struct{}{"pv-asset-fixture": {}},
 	})
 	if err == nil {
 		t.Fatal("handler accepted snapshot provider without authoritative publication time")

--- a/m2mgraphql/contract_red_test.go
+++ b/m2mgraphql/contract_red_test.go
@@ -77,19 +77,18 @@ func TestM2MCurrentSnapshot_HasNoGenericFallbackRawOrSubscriptionSurface(t *test
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, request := range []*http.Request{
-		httptest.NewRequest(http.MethodGet, "/graphql/m2m/v1", nil),
-		httptest.NewRequest(http.MethodPost, "/graphql", bytes.NewBufferString(`{"query":"{ m2mCurrentSnapshot { assetRef } }"}`)),
-		httptest.NewRequest(http.MethodPost, "/graphql/m2m/v1", bytes.NewBufferString(`{"query":"subscription M2MCurrentSnapshot { m2mCurrentSnapshot { assetRef } }"}`)),
+	for _, test := range []struct {
+		request *http.Request
+		code    string
+	}{
+		{httptest.NewRequest(http.MethodGet, "/graphql/m2m/v1", nil), "REQUEST_INVALID"},
+		{httptest.NewRequest(http.MethodPost, "/graphql", bytes.NewBufferString(`{"query":"{ m2mCurrentSnapshot { assetRef } }"}`)), "QUERY_REJECTED"},
+		{httptest.NewRequest(http.MethodPost, "/graphql/m2m/v1", bytes.NewBufferString(`{"query":"subscription M2MCurrentSnapshot { m2mCurrentSnapshot { assetRef } }"}`)), "REQUEST_INVALID"},
 	} {
-		request = request.WithContext(WithMTLSPrincipal(request.Context(), "fixture-principal"))
+		request := test.request.WithContext(WithMTLSPrincipal(test.request.Context(), "fixture-principal"))
 		response := httptest.NewRecorder()
 		handler.ServeHTTP(response, request)
-		code := "QUERY_REJECTED"
-		if request.Method == http.MethodGet {
-			code = "REQUEST_INVALID"
-		}
-		assertM2MError(t, response, code)
+		assertM2MError(t, response, test.code)
 	}
 }
 

--- a/m2mgraphql/contract_red_test.go
+++ b/m2mgraphql/contract_red_test.go
@@ -1,0 +1,125 @@
+package m2mgraphql
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	pv "github.com/Project-Helianthus/helianthus-ebusreg/pv"
+)
+
+//go:embed testdata/contract.json
+var contractFixture []byte
+
+type contractFixtureShape struct {
+	ContractID          string `json:"contractId"`
+	CanonicalContractID string `json:"canonicalContractId"`
+	Route               string `json:"route"`
+	OperationName       string `json:"operationName"`
+}
+
+func TestM2MCurrentSnapshot_OnlyAcceptsTheDedicatedFixedContract(t *testing.T) {
+	var contract contractFixtureShape
+	if err := json.Unmarshal(contractFixture, &contract); err != nil {
+		t.Fatalf("decode contract fixture: %v", err)
+	}
+
+	handler, err := NewHandler(Config{
+		SnapshotByAsset: func(context.Context, string) (pv.Snapshot, bool) {
+			return m2mFixtureSnapshot(), true
+		},
+		AssetExists:   func(string) bool { return true },
+		AllowedAssets: map[string]struct{}{"pv-asset-fixture": {}},
+	})
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+
+	request := httptest.NewRequest(http.MethodPost, contract.Route, bytes.NewBufferString(`{"operationName":"M2MCurrentSnapshot","query":"query M2MCurrentSnapshot($request: M2MCurrentSnapshotRequest!) { m2mCurrentSnapshot(request: $request) { contractId canonicalContractId assetRef facts { factId value { ... on M2MDecimalValue { coefficient scale } } } } }","variables":{"request":{"contractId":"PUBLIC_GRAPHQL_M2M_V1","assetRef":"pv-asset-fixture"}}}`))
+	request.Header.Set("Content-Type", "application/json")
+	request = request.WithContext(WithMTLSPrincipal(request.Context(), "fixture-principal"))
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	var body struct {
+		Data struct {
+			M2MCurrentSnapshot struct {
+				ContractID          string `json:"contractId"`
+				CanonicalContractID string `json:"canonicalContractId"`
+				AssetRef            string `json:"assetRef"`
+				Facts               []struct {
+					Value map[string]any `json:"value"`
+				} `json:"facts"`
+			} `json:"m2mCurrentSnapshot"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Data.M2MCurrentSnapshot.ContractID != contract.ContractID ||
+		body.Data.M2MCurrentSnapshot.CanonicalContractID != contract.CanonicalContractID ||
+		body.Data.M2MCurrentSnapshot.AssetRef != "pv-asset-fixture" {
+		t.Fatalf("contract projection=%+v", body.Data.M2MCurrentSnapshot)
+	}
+	if len(body.Data.M2MCurrentSnapshot.Facts) != 1 || body.Data.M2MCurrentSnapshot.Facts[0].Value["coefficient"] != "7310" {
+		t.Fatalf("decimal projection=%#v; decimals must remain integer strings", body.Data.M2MCurrentSnapshot.Facts)
+	}
+}
+
+func TestM2MCurrentSnapshot_HasNoGenericFallbackRawOrSubscriptionSurface(t *testing.T) {
+	handler, err := NewHandler(Config{AllowedAssets: map[string]struct{}{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, request := range []*http.Request{
+		httptest.NewRequest(http.MethodGet, "/graphql/m2m/v1", nil),
+		httptest.NewRequest(http.MethodPost, "/graphql", bytes.NewBufferString(`{"query":"{ m2mCurrentSnapshot { assetRef } }"}`)),
+		httptest.NewRequest(http.MethodPost, "/graphql/m2m/v1", bytes.NewBufferString(`{"query":"subscription M2MCurrentSnapshot { m2mCurrentSnapshot { assetRef } }"}`)),
+	} {
+		request = request.WithContext(WithMTLSPrincipal(request.Context(), "fixture-principal"))
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, request)
+		code := "QUERY_REJECTED"
+		if request.Method == http.MethodGet {
+			code = "REQUEST_INVALID"
+		}
+		assertM2MError(t, response, code)
+	}
+}
+
+func m2mFixtureSnapshot() pv.Snapshot {
+	dimensions := pv.Dimensions{Scope: pv.ScopeTotal}
+	origin := pv.Digest("sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+	provenance := pv.Provenance{SourceIdentity: pv.SourceIdentity{Protocol: "sunspec_modbus", ProfileID: "sunspec.inverter.three_phase.monitoring@1.0.0", ProfileVersion: "1.0.0", Validity: pv.SourceTerminalVerified}, SourceRegistryRef: pv.Digest("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), SourceObservationRef: origin, SourceShadowRef: pv.Digest("sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"), EvidenceRef: pv.Digest("sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")}
+	key := pv.NewFactKey(pv.FactACActivePower, dimensions)
+	return pv.Snapshot{ContractID: pv.ContractV1, AssetRef: "pv-asset-fixture", Generation: 1, Evaluated: 100, SourceTimeState: pv.SourceTimeUnavailable, Source: provenance, Origins: map[pv.Digest]pv.Provenance{origin: provenance}, Capability: pv.Capability{ID: pv.CapabilityThreePhaseTelemetryV1, Outcome: pv.CapabilitySatisfied}, Facts: map[pv.FactKey]pv.Fact{key: {ID: pv.FactACActivePower, Dimensions: dimensions, Value: pv.DecimalFactValue(pv.MustDecimal("7310", 0)), Unit: pv.UnitWatt, Quality: pv.QualityGood, Availability: pv.AvailabilityAvailable, Freshness: pv.FreshnessFresh, Temporal: pv.Temporal{Receipt: 100, FreshUntil: 200, RetainUntil: 300, Policy: pv.PolicyTelemetryFastV1}, OriginRef: origin}}}
+}
+
+func assertM2MError(t *testing.T, response *httptest.ResponseRecorder, code string) {
+	t.Helper()
+	if response.Code != http.StatusOK {
+		t.Fatalf("status=%d; want 200 body=%s", response.Code, response.Body.String())
+	}
+	var envelope struct {
+		Data   any `json:"data"`
+		Errors []struct {
+			Message    string   `json:"message"`
+			Path       []string `json:"path"`
+			Extensions struct {
+				Code string `json:"code"`
+			} `json:"extensions"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode error envelope: %v", err)
+	}
+	if envelope.Data != nil || len(envelope.Errors) != 1 || envelope.Errors[0].Message != "M2M request failed" || len(envelope.Errors[0].Path) != 1 || envelope.Errors[0].Path[0] != "m2mCurrentSnapshot" || envelope.Errors[0].Extensions.Code != code {
+		t.Fatalf("error envelope=%s", response.Body.String())
+	}
+}

--- a/m2mgraphql/contract_red_test.go
+++ b/m2mgraphql/contract_red_test.go
@@ -39,7 +39,7 @@ func TestM2MCurrentSnapshot_OnlyAcceptsTheDedicatedFixedContract(t *testing.T) {
 		t.Fatalf("NewHandler: %v", err)
 	}
 
-	request := httptest.NewRequest(http.MethodPost, contract.Route, bytes.NewBufferString(`{"operationName":"M2MCurrentSnapshot","query":"query M2MCurrentSnapshot($request: M2MCurrentSnapshotRequest!) { m2mCurrentSnapshot(request: $request) { contractId canonicalContractId assetRef facts { factId value { ... on M2MDecimalValue { coefficient scale } } } } }","variables":{"request":{"contractId":"PUBLIC_GRAPHQL_M2M_V1","assetRef":"pv-asset-fixture"}}}`))
+	request := httptest.NewRequest(http.MethodPost, contract.Route, bytes.NewBufferString(m2mCanonicalRequest(canonicalM2MQuery, "pv-asset-fixture")))
 	request.Header.Set("Content-Type", "application/json")
 	request = request.WithContext(WithMTLSPrincipal(request.Context(), "fixture-principal"))
 	response := httptest.NewRecorder()
@@ -96,9 +96,10 @@ func TestM2MCurrentSnapshot_HasNoGenericFallbackRawOrSubscriptionSurface(t *test
 func m2mFixtureSnapshot() pv.Snapshot {
 	dimensions := pv.Dimensions{Scope: pv.ScopeTotal}
 	origin := pv.Digest("sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+	requestedRef := pv.Digest("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")
 	provenance := pv.Provenance{SourceIdentity: pv.SourceIdentity{Protocol: "sunspec_modbus", ProfileID: "sunspec.inverter.three_phase.monitoring@1.0.0", ProfileVersion: "1.0.0", Validity: pv.SourceTerminalVerified}, SourceRegistryRef: pv.Digest("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), SourceObservationRef: origin, SourceShadowRef: pv.Digest("sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"), EvidenceRef: pv.Digest("sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")}
 	key := pv.NewFactKey(pv.FactACActivePower, dimensions)
-	return pv.Snapshot{ContractID: pv.ContractV1, AssetRef: "pv-asset-fixture", Generation: 1, Evaluated: 100, SourceTimeState: pv.SourceTimeUnavailable, Source: provenance, Origins: map[pv.Digest]pv.Provenance{origin: provenance}, Capability: pv.Capability{ID: pv.CapabilityThreePhaseTelemetryV1, Outcome: pv.CapabilitySatisfied}, Facts: map[pv.FactKey]pv.Fact{key: {ID: pv.FactACActivePower, Dimensions: dimensions, Value: pv.DecimalFactValue(pv.MustDecimal("7310", 0)), Unit: pv.UnitWatt, Quality: pv.QualityGood, Availability: pv.AvailabilityAvailable, Freshness: pv.FreshnessFresh, Temporal: pv.Temporal{Receipt: 100, FreshUntil: 200, RetainUntil: 300, Policy: pv.PolicyTelemetryFastV1}, OriginRef: origin}}}
+	return pv.Snapshot{ContractID: pv.ContractV1, AssetRef: "pv-asset-fixture", Generation: 1, Evaluated: 100, SourceTimeState: pv.SourceTimeUnavailable, Source: provenance, Origins: map[pv.Digest]pv.Provenance{origin: provenance}, Capability: pv.Capability{ID: pv.CapabilityThreePhaseTelemetryV1, Outcome: pv.CapabilityNotSatisfied}, Facts: map[pv.FactKey]pv.Fact{key: {ID: pv.FactACActivePower, Dimensions: dimensions, Value: pv.DecimalFactValue(pv.MustDecimal("7310", 0)), Unit: pv.UnitWatt, Quality: pv.QualityGood, Availability: pv.AvailabilityAvailable, Freshness: pv.FreshnessFresh, Temporal: pv.Temporal{Receipt: 100, FreshUntil: 200, RetainUntil: 300, Policy: pv.PolicyTelemetryFastV1}, OriginRef: origin}}, RequestedOutputs: []pv.RequestedOutput{{SourceRef: origin, RequestedOutputRef: requestedRef}}, ProjectionReport: []pv.Projection{{SourceRef: origin, RequestedOutputRef: requestedRef, FactID: pv.FactACActivePower, Dimensions: &dimensions, Outcome: pv.ProjectionMapped}}}
 }
 
 func assertM2MError(t *testing.T, response *httptest.ResponseRecorder, code string) {

--- a/m2mgraphql/contract_red_test.go
+++ b/m2mgraphql/contract_red_test.go
@@ -92,6 +92,16 @@ func TestM2MCurrentSnapshot_HasNoGenericFallbackRawOrSubscriptionSurface(t *test
 	}
 }
 
+func TestM2MCurrentSnapshot_RequiresAuthoritativePublicationTimeProvider(t *testing.T) {
+	_, err := NewHandler(Config{
+		SnapshotByAsset: func(context.Context, string) (pv.Snapshot, bool) { return m2mFixtureSnapshot(), true },
+		AssetExists:     func(string) bool { return true }, AllowedAssets: map[string]struct{}{"pv-asset-fixture": {}},
+	})
+	if err == nil {
+		t.Fatal("handler accepted snapshot provider without authoritative publication time")
+	}
+}
+
 func m2mFixtureSnapshot() pv.Snapshot {
 	dimensions := pv.Dimensions{Scope: pv.ScopeTotal}
 	origin := pv.Digest("sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")

--- a/m2mgraphql/handler.go
+++ b/m2mgraphql/handler.go
@@ -1,0 +1,478 @@
+// Package m2mgraphql exposes the single, versioned machine-to-machine
+// canonical-PV query. It intentionally is not a general GraphQL engine.
+package m2mgraphql
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	pv "github.com/Project-Helianthus/helianthus-ebusreg/pv"
+)
+
+const (
+	route             = "/graphql/m2m/v1"
+	contractID        = "PUBLIC_GRAPHQL_M2M_V1"
+	maxRequestBytes   = 16 << 10
+	maxResponseBytes  = 1 << 20
+	maxJSONDepth      = 64
+	maxQueryDepth     = 8
+	maxSelectedFields = 256
+	maxFacts          = 256
+	maxProjectionRows = 512
+)
+
+const fixedQuery = `query M2MCurrentSnapshot($request: M2MCurrentSnapshotRequest!) {
+  m2mCurrentSnapshot(request: $request) {
+    contractId canonicalContractId assetRef generation producedAt
+    evaluatedMonotonicNs sourceTimeState currentSourceOriginRef
+    facts {
+      factId
+      dimension {
+        ... on M2MScopeDimension { scope }
+        ... on M2MPhaseDimension { phase }
+        ... on M2MPhasePairDimension { phasePair }
+        ... on M2MInputDimension { inputId }
+        ... on M2MSensorDimension { sensorId }
+      }
+      value {
+        ... on M2MDecimalValue { coefficient scale }
+        ... on M2MEnumValue { symbol }
+        ... on M2MBitfieldValue { symbols }
+      }
+      unit quality availability freshness receiptMonotonicNs
+      freshUntilMonotonicNs retainUntilMonotonicNs freshnessPolicy originRef
+      continuity {
+        __typename
+        ... on M2MBaselineContinuity { baseline }
+        ... on M2MContiguousContinuity { delta { coefficient scale } }
+        ... on M2MRolloverContinuity {
+          delta { coefficient scale } modulus { coefficient scale }
+          rolloverEvidenceRef
+        }
+        ... on M2MResetContinuity { resetEvidenceRef }
+        ... on M2MDiscontinuityContinuity { discontinuityEvidenceRef }
+      }
+    }
+    capabilities { id outcome }
+    provenance {
+      originRef sourceProtocol sourceProfileId sourceProfileVersion sourceValidity
+      sourceRegistryRef sourceObservationRef evidenceRef
+    }
+    requestedOutputs { sourceRef requestedOutputRef }
+    projectionReport {
+      __typename
+      ... on M2MMappedProjectionReportEntry {
+        sourceRef requestedOutputRef factId
+        dimension {
+          ... on M2MScopeDimension { scope }
+          ... on M2MPhaseDimension { phase }
+          ... on M2MPhasePairDimension { phasePair }
+          ... on M2MInputDimension { inputId }
+          ... on M2MSensorDimension { sensorId }
+        }
+      }
+      ... on M2MWithheldProjectionReportEntry { sourceRef requestedOutputRef }
+      ... on M2MUnrepresentableProjectionReportEntry { sourceRef requestedOutputRef }
+    }
+  }
+}
+`
+
+type Config struct {
+	SnapshotByAsset       func(context.Context, string) (pv.Snapshot, bool)
+	SnapshotByAssetAt     func(context.Context, string) (pv.Snapshot, time.Time, bool)
+	AssetExists           func(string) bool
+	AllowedAssets         map[string]struct{}
+	MonotonicMilliseconds func() int64
+}
+
+type handler struct {
+	cfg        Config
+	mu         sync.Mutex
+	principals map[string]*principalLimit
+}
+type principalLimit struct {
+	inFlight bool
+	tokens   int
+	at       int64
+}
+type principalKey struct{}
+
+func WithMTLSPrincipal(ctx context.Context, fingerprint string) context.Context {
+	return context.WithValue(ctx, principalKey{}, fingerprint)
+}
+
+func NewHandler(cfg Config) (http.Handler, error) {
+	if cfg.AllowedAssets == nil {
+		cfg.AllowedAssets = map[string]struct{}{}
+	}
+	if cfg.MonotonicMilliseconds == nil {
+		cfg.MonotonicMilliseconds = func() int64 { return time.Now().UnixMilli() }
+	}
+	return &handler{cfg: cfg, principals: make(map[string]*principalLimit)}, nil
+}
+
+func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, "REQUEST_INVALID")
+		return
+	}
+	if r.URL.Path != route {
+		writeError(w, "QUERY_REJECTED")
+		return
+	}
+	principal, _ := r.Context().Value(principalKey{}).(string)
+	if strings.TrimSpace(principal) == "" {
+		writeError(w, "REQUEST_INVALID")
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxRequestBytes+1))
+	if err != nil {
+		writeError(w, "REQUEST_INVALID")
+		return
+	}
+	if len(body) > maxRequestBytes {
+		writeError(w, "REQUEST_LIMIT_EXCEEDED")
+		return
+	}
+	if err := validateJSON(body); err != nil {
+		writeError(w, "REQUEST_INVALID")
+		return
+	}
+	var request struct {
+		OperationName string `json:"operationName"`
+		Query         string `json:"query"`
+		Variables     struct {
+			Request struct {
+				ContractID string `json:"contractId"`
+				AssetRef   string `json:"assetRef"`
+			} `json:"request"`
+		} `json:"variables"`
+	}
+	if json.Unmarshal(body, &request) != nil {
+		writeError(w, "REQUEST_INVALID")
+		return
+	}
+	if strings.HasPrefix(strings.TrimSpace(request.Query), "subscription") || strings.HasPrefix(strings.TrimSpace(request.Query), "mutation") {
+		writeError(w, "QUERY_REJECTED")
+		return
+	}
+	if request.Variables.Request.ContractID != contractID {
+		writeError(w, "CONTRACT_INCOMPATIBLE")
+		return
+	}
+	asset := request.Variables.Request.AssetRef
+	if _, ok := h.cfg.AllowedAssets[asset]; !ok {
+		writeError(w, "ASSET_FORBIDDEN")
+		return
+	}
+	if h.cfg.AssetExists != nil && !h.cfg.AssetExists(asset) {
+		writeError(w, "ASSET_NOT_FOUND")
+		return
+	}
+	if queryDepth(request.Query) > maxQueryDepth || selectedFields(request.Query) > maxSelectedFields {
+		writeError(w, "REQUEST_LIMIT_EXCEEDED")
+		return
+	}
+	if request.OperationName != "M2MCurrentSnapshot" || request.Query != fixedQuery {
+		writeError(w, "QUERY_REJECTED")
+		return
+	}
+	if !h.admit(principal) {
+		writeError(w, "REQUEST_LIMIT_EXCEEDED")
+		return
+	}
+	defer h.release(principal)
+	if h.cfg.SnapshotByAsset == nil && h.cfg.SnapshotByAssetAt == nil {
+		writeError(w, "SOURCE_UNAVAILABLE")
+		return
+	}
+	var snapshot pv.Snapshot
+	var producedAt time.Time
+	var ok bool
+	if h.cfg.SnapshotByAssetAt != nil {
+		snapshot, producedAt, ok = h.cfg.SnapshotByAssetAt(r.Context(), asset)
+	} else {
+		snapshot, ok = h.cfg.SnapshotByAsset(r.Context(), asset)
+	}
+	if !ok {
+		writeError(w, "SOURCE_UNAVAILABLE")
+		return
+	}
+	if len(snapshot.Facts) > maxFacts || len(snapshot.ProjectionReport) > maxProjectionRows {
+		writeError(w, "REQUEST_LIMIT_EXCEEDED")
+		return
+	}
+	wire, err := mcpCurrentSnapshotAt(snapshot, producedAt)
+	if err != nil {
+		writeError(w, "SOURCE_UNAVAILABLE")
+		return
+	}
+	encoded, err := json.Marshal(map[string]any{"data": map[string]any{"m2mCurrentSnapshot": wire}})
+	if err != nil || len(encoded) > maxResponseBytes {
+		writeError(w, "REQUEST_LIMIT_EXCEEDED")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(encoded)
+}
+
+func (h *handler) admit(principal string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	now := h.cfg.MonotonicMilliseconds()
+	limit := h.principals[principal]
+	if limit == nil {
+		limit = &principalLimit{tokens: 2, at: now}
+		h.principals[principal] = limit
+	}
+	if now > limit.at {
+		limit.tokens = min(2, limit.tokens+int((now-limit.at)/1000))
+		limit.at = now
+	}
+	if limit.inFlight || limit.tokens == 0 {
+		return false
+	}
+	limit.inFlight = true
+	limit.tokens--
+	return true
+}
+func (h *handler) release(principal string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if limit := h.principals[principal]; limit != nil {
+		limit.inFlight = false
+	}
+}
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func writeError(w http.ResponseWriter, code string) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"data": nil, "errors": []any{map[string]any{"message": "M2M request failed", "path": []string{"m2mCurrentSnapshot"}, "extensions": map[string]string{"code": code}}}})
+}
+
+func validateJSON(data []byte) error {
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	if err := walkJSON(decoder, 0); err != nil {
+		return err
+	}
+	if decoder.More() {
+		return errors.New("extra JSON value")
+	}
+	_, err := decoder.Token()
+	if err != io.EOF {
+		return errors.New("extra JSON value")
+	}
+	return nil
+}
+func walkJSON(decoder *json.Decoder, depth int) error {
+	if depth > maxJSONDepth {
+		return errors.New("JSON depth")
+	}
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	switch token := token.(type) {
+	case json.Delim:
+		switch token {
+		case '{':
+			seen := map[string]struct{}{}
+			for decoder.More() {
+				key, err := decoder.Token()
+				if err != nil {
+					return err
+				}
+				name, ok := key.(string)
+				if !ok {
+					return errors.New("object key")
+				}
+				if _, duplicate := seen[name]; duplicate {
+					return errors.New("duplicate key")
+				}
+				seen[name] = struct{}{}
+				if err := walkJSON(decoder, depth+1); err != nil {
+					return err
+				}
+			}
+		case '[':
+			for decoder.More() {
+				if err := walkJSON(decoder, depth+1); err != nil {
+					return err
+				}
+			}
+		default:
+			return errors.New("unexpected delimiter")
+		}
+		_, err = decoder.Token()
+		return err
+	default:
+		return nil
+	}
+}
+func queryDepth(query string) int {
+	depth, maximum := 0, 0
+	for _, char := range query {
+		if char == '{' {
+			depth++
+			if depth > maximum {
+				maximum = depth
+			}
+		}
+		if char == '}' {
+			depth--
+		}
+	}
+	return maximum
+}
+func selectedFields(query string) int {
+	return len(strings.Fields(query))
+}
+
+// MCPCurrentSnapshot is the one lossless public wire projection shared by the
+// dedicated GraphQL endpoint and the MCP-first semantic surface.
+func MCPCurrentSnapshot(snapshot pv.Snapshot) (map[string]any, error) {
+	return mcpCurrentSnapshotAt(snapshot, time.Unix(0, int64(snapshot.Evaluated)).UTC())
+}
+
+func mcpCurrentSnapshotAt(snapshot pv.Snapshot, producedAt time.Time) (map[string]any, error) {
+	if snapshot.ContractID != "" && snapshot.ContractID != pv.ContractV1 {
+		return nil, errors.New("unexpected canonical contract")
+	}
+	if producedAt.IsZero() {
+		producedAt = time.Unix(0, int64(snapshot.Evaluated)).UTC()
+	}
+	result := map[string]any{"contractId": contractID, "canonicalContractId": pv.ContractV1, "assetRef": snapshot.AssetRef, "generation": u64(snapshot.Generation), "producedAt": producedAt.UTC().Format(time.RFC3339Nano), "evaluatedMonotonicNs": i64(snapshot.Evaluated), "sourceTimeState": string(snapshot.SourceTimeState), "currentSourceOriginRef": string(snapshot.Source.SourceObservationRef), "capabilities": []any{map[string]any{"id": snapshot.Capability.ID, "outcome": string(snapshot.Capability.Outcome)}}}
+	facts := make([]pv.Fact, 0, len(snapshot.Facts))
+	for _, fact := range snapshot.Facts {
+		facts = append(facts, fact)
+	}
+	sort.Slice(facts, func(i, j int) bool {
+		return string(pv.NewFactKey(facts[i].ID, facts[i].Dimensions)) < string(pv.NewFactKey(facts[j].ID, facts[j].Dimensions))
+	})
+	result["facts"] = projectFacts(facts)
+	origins := make([]pv.Digest, 0, len(snapshot.Origins))
+	for ref := range snapshot.Origins {
+		origins = append(origins, ref)
+	}
+	if len(origins) == 0 && snapshot.Source.SourceObservationRef != "" {
+		origins = append(origins, snapshot.Source.SourceObservationRef)
+		snapshot.Origins = map[pv.Digest]pv.Provenance{snapshot.Source.SourceObservationRef: snapshot.Source}
+	}
+	sort.Slice(origins, func(i, j int) bool { return origins[i] < origins[j] })
+	provenance := make([]any, 0, len(origins))
+	for _, ref := range origins {
+		provenance = append(provenance, projectProvenance(ref, snapshot.Origins[ref]))
+	}
+	result["provenance"] = provenance
+	requested := append([]pv.RequestedOutput(nil), snapshot.RequestedOutputs...)
+	sort.Slice(requested, func(i, j int) bool {
+		return string(requested[i].SourceRef)+string(requested[i].RequestedOutputRef) < string(requested[j].SourceRef)+string(requested[j].RequestedOutputRef)
+	})
+	rows := make([]any, 0, len(requested))
+	for _, item := range requested {
+		rows = append(rows, map[string]any{"sourceRef": string(item.SourceRef), "requestedOutputRef": string(item.RequestedOutputRef)})
+	}
+	result["requestedOutputs"] = rows
+	report := append([]pv.Projection(nil), snapshot.ProjectionReport...)
+	sort.Slice(report, func(i, j int) bool {
+		return string(report[i].SourceRef)+string(report[i].RequestedOutputRef) < string(report[j].SourceRef)+string(report[j].RequestedOutputRef)
+	})
+	reports := make([]any, 0, len(report))
+	for _, item := range report {
+		row := map[string]any{"sourceRef": string(item.SourceRef), "requestedOutputRef": string(item.RequestedOutputRef)}
+		switch item.Outcome {
+		case pv.ProjectionMapped:
+			row["__typename"] = "M2MMappedProjectionReportEntry"
+			row["factId"] = string(item.FactID)
+			if item.Dimensions != nil {
+				row["dimension"] = projectDimension(*item.Dimensions)
+			}
+		case pv.ProjectionWithheld:
+			row["__typename"] = "M2MWithheldProjectionReportEntry"
+		default:
+			row["__typename"] = "M2MUnrepresentableProjectionReportEntry"
+		}
+		reports = append(reports, row)
+	}
+	result["projectionReport"] = reports
+	return result, nil
+}
+func projectFacts(facts []pv.Fact) []any {
+	out := make([]any, 0, len(facts))
+	for _, fact := range facts {
+		row := map[string]any{"factId": string(fact.ID), "dimension": projectDimension(fact.Dimensions), "value": projectValue(fact.Value), "unit": string(fact.Unit), "quality": string(fact.Quality), "availability": string(fact.Availability), "freshness": string(fact.Freshness), "receiptMonotonicNs": i64(fact.Temporal.Receipt), "freshUntilMonotonicNs": i64(fact.Temporal.FreshUntil), "retainUntilMonotonicNs": i64(fact.Temporal.RetainUntil), "freshnessPolicy": string(fact.Temporal.Policy), "originRef": string(fact.OriginRef)}
+		if fact.Continuity != nil {
+			row["continuity"] = projectContinuity(*fact.Continuity)
+		}
+		out = append(out, row)
+	}
+	return out
+}
+func projectDimension(d pv.Dimensions) map[string]any {
+	switch {
+	case d.Scope != "":
+		return map[string]any{"__typename": "M2MScopeDimension", "scope": string(d.Scope)}
+	case d.Phase != "":
+		return map[string]any{"__typename": "M2MPhaseDimension", "phase": string(d.Phase)}
+	case d.PhasePair != "":
+		return map[string]any{"__typename": "M2MPhasePairDimension", "phasePair": string(d.PhasePair)}
+	case d.InputID != "":
+		return map[string]any{"__typename": "M2MInputDimension", "inputId": d.InputID}
+	default:
+		return map[string]any{"__typename": "M2MSensorDimension", "sensorId": d.SensorID}
+	}
+}
+func projectValue(v pv.FactValue) map[string]any {
+	switch v.Kind {
+	case pv.ValueKindDecimal:
+		if v.Decimal != nil {
+			return map[string]any{"__typename": "M2MDecimalValue", "coefficient": v.Decimal.Coefficient, "scale": stringify(v.Decimal.Scale)}
+		}
+	case pv.ValueKindEnum:
+		return map[string]any{"__typename": "M2MEnumValue", "symbol": v.Symbol}
+	case pv.ValueKindBitfield:
+		symbols := append([]string(nil), v.Symbols...)
+		sort.Strings(symbols)
+		return map[string]any{"__typename": "M2MBitfieldValue", "symbols": symbols}
+	}
+	return map[string]any{}
+}
+func projectContinuity(c pv.Continuity) map[string]any {
+	switch c.State {
+	case pv.ContinuityBaseline:
+		return map[string]any{"__typename": "M2MBaselineContinuity", "baseline": true}
+	case pv.ContinuityContiguous:
+		return map[string]any{"__typename": "M2MContiguousContinuity", "delta": projectDecimal(c.Delta)}
+	case pv.ContinuityRollover:
+		return map[string]any{"__typename": "M2MRolloverContinuity", "delta": projectDecimal(c.Delta), "modulus": projectDecimal(c.Modulus), "rolloverEvidenceRef": string(c.EvidenceRef)}
+	case pv.ContinuityReset:
+		return map[string]any{"__typename": "M2MResetContinuity", "resetEvidenceRef": string(c.EvidenceRef)}
+	default:
+		return map[string]any{"__typename": "M2MDiscontinuityContinuity", "discontinuityEvidenceRef": string(c.EvidenceRef)}
+	}
+}
+func projectDecimal(d *pv.Decimal) any {
+	if d == nil {
+		return nil
+	}
+	return map[string]any{"coefficient": d.Coefficient, "scale": stringify(d.Scale)}
+}
+func projectProvenance(ref pv.Digest, p pv.Provenance) map[string]any {
+	return map[string]any{"originRef": string(ref), "sourceProtocol": p.Protocol, "sourceProfileId": p.ProfileID, "sourceProfileVersion": p.ProfileVersion, "sourceValidity": p.Validity, "sourceRegistryRef": string(p.SourceRegistryRef), "sourceObservationRef": string(p.SourceObservationRef), "evidenceRef": string(p.EvidenceRef)}
+}
+func u64(value uint64) string            { return json.Number(stringify(value)).String() }
+func i64(value pv.MonotonicNanos) string { return stringify(int64(value)) }
+func stringify(value any) string         { encoded, _ := json.Marshal(value); return string(encoded) }

--- a/m2mgraphql/handler.go
+++ b/m2mgraphql/handler.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"sort"
@@ -14,6 +15,9 @@ import (
 	"time"
 
 	pv "github.com/Project-Helianthus/helianthus-ebusreg/pv"
+	"github.com/graphql-go/graphql/language/ast"
+	"github.com/graphql-go/graphql/language/parser"
+	"github.com/graphql-go/graphql/language/printer"
 )
 
 const (
@@ -86,7 +90,6 @@ const fixedQuery = `query M2MCurrentSnapshot($request: M2MCurrentSnapshotRequest
 `
 
 type Config struct {
-	SnapshotByAsset       func(context.Context, string) (pv.Snapshot, bool)
 	SnapshotByAssetAt     func(context.Context, string) (pv.Snapshot, time.Time, bool)
 	AssetExists           func(string) bool
 	AllowedAssets         map[string]struct{}
@@ -94,9 +97,10 @@ type Config struct {
 }
 
 type handler struct {
-	cfg        Config
-	mu         sync.Mutex
-	principals map[string]*principalLimit
+	cfg                 Config
+	canonicalQueryShape string
+	mu                  sync.Mutex
+	principals          map[string]*principalLimit
 }
 type principalLimit struct {
 	inFlight bool
@@ -110,13 +114,21 @@ func WithMTLSPrincipal(ctx context.Context, fingerprint string) context.Context 
 }
 
 func NewHandler(cfg Config) (http.Handler, error) {
+	if cfg.SnapshotByAssetAt == nil || cfg.AssetExists == nil {
+		return nil, errors.New("authoritative asset and snapshot providers are required")
+	}
 	if cfg.AllowedAssets == nil {
 		cfg.AllowedAssets = map[string]struct{}{}
 	}
 	if cfg.MonotonicMilliseconds == nil {
-		cfg.MonotonicMilliseconds = func() int64 { return time.Now().UnixMilli() }
+		started := time.Now()
+		cfg.MonotonicMilliseconds = func() int64 { return time.Since(started).Milliseconds() }
 	}
-	return &handler{cfg: cfg, principals: make(map[string]*principalLimit)}, nil
+	canonicalShape, _, _, err := queryDocumentShape(fixedQuery)
+	if err != nil {
+		return nil, errors.New("invalid embedded canonical query")
+	}
+	return &handler{cfg: cfg, canonicalQueryShape: canonicalShape, principals: make(map[string]*principalLimit)}, nil
 }
 
 func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -124,7 +136,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		writeError(w, "REQUEST_INVALID")
 		return
 	}
-	if r.URL.Path != route {
+	if r.URL.Path != route || r.URL.RawQuery != "" {
 		writeError(w, "QUERY_REJECTED")
 		return
 	}
@@ -146,21 +158,17 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		writeError(w, "REQUEST_INVALID")
 		return
 	}
-	var request struct {
-		OperationName string `json:"operationName"`
-		Query         string `json:"query"`
-		Variables     struct {
-			Request struct {
-				ContractID string `json:"contractId"`
-				AssetRef   string `json:"assetRef"`
-			} `json:"request"`
-		} `json:"variables"`
-	}
-	if json.Unmarshal(body, &request) != nil {
+	request, err := decodeClosedRequest(body)
+	if err != nil {
 		writeError(w, "REQUEST_INVALID")
 		return
 	}
-	if strings.HasPrefix(strings.TrimSpace(request.Query), "subscription") || strings.HasPrefix(strings.TrimSpace(request.Query), "mutation") {
+	queryShape, queryDepth, queryFields, err := queryDocumentShape(request.Query)
+	if queryDepth > maxQueryDepth || queryFields > maxSelectedFields {
+		writeError(w, "REQUEST_LIMIT_EXCEEDED")
+		return
+	}
+	if err != nil || request.OperationName != "M2MCurrentSnapshot" || queryShape != h.canonicalQueryShape {
 		writeError(w, "QUERY_REJECTED")
 		return
 	}
@@ -177,37 +185,26 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		writeError(w, "ASSET_NOT_FOUND")
 		return
 	}
-	if queryDepth(request.Query) > maxQueryDepth || selectedFields(request.Query) > maxSelectedFields {
-		writeError(w, "REQUEST_LIMIT_EXCEEDED")
-		return
-	}
-	if request.OperationName != "M2MCurrentSnapshot" || request.Query != fixedQuery {
-		writeError(w, "QUERY_REJECTED")
-		return
-	}
 	if !h.admit(principal) {
 		writeError(w, "REQUEST_LIMIT_EXCEEDED")
 		return
 	}
 	defer h.release(principal)
-	if h.cfg.SnapshotByAsset == nil && h.cfg.SnapshotByAssetAt == nil {
-		writeError(w, "SOURCE_UNAVAILABLE")
-		return
-	}
-	var snapshot pv.Snapshot
-	var producedAt time.Time
-	var ok bool
-	if h.cfg.SnapshotByAssetAt != nil {
-		snapshot, producedAt, ok = h.cfg.SnapshotByAssetAt(r.Context(), asset)
-	} else {
-		snapshot, ok = h.cfg.SnapshotByAsset(r.Context(), asset)
-	}
+	snapshot, producedAt, ok := h.cfg.SnapshotByAssetAt(r.Context(), asset)
 	if !ok {
 		writeError(w, "SOURCE_UNAVAILABLE")
 		return
 	}
-	if len(snapshot.Facts) > maxFacts || len(snapshot.ProjectionReport) > maxProjectionRows {
+	if snapshot.AssetRef != asset {
+		writeError(w, "SOURCE_UNAVAILABLE")
+		return
+	}
+	if len(snapshot.Facts) > maxFacts || len(snapshot.Origins) > maxFacts || len(snapshot.RequestedOutputs) > maxProjectionRows || len(snapshot.ProjectionReport) > maxProjectionRows {
 		writeError(w, "REQUEST_LIMIT_EXCEEDED")
+		return
+	}
+	if err := validatePublicSnapshot(snapshot); err != nil {
+		writeError(w, "SOURCE_UNAVAILABLE")
 		return
 	}
 	wire, err := mcpCurrentSnapshotAt(snapshot, producedAt)
@@ -234,8 +231,9 @@ func (h *handler) admit(principal string) bool {
 		h.principals[principal] = limit
 	}
 	if now > limit.at {
-		limit.tokens = min(2, limit.tokens+int((now-limit.at)/1000))
-		limit.at = now
+		elapsedIntervals := (now - limit.at) / 1000
+		limit.tokens = min(2, limit.tokens+int(elapsedIntervals))
+		limit.at += elapsedIntervals * 1000
 	}
 	if limit.inFlight || limit.tokens == 0 {
 		return false
@@ -276,6 +274,58 @@ func validateJSON(data []byte) error {
 		return errors.New("extra JSON value")
 	}
 	return nil
+}
+
+type closedRequest struct {
+	OperationName string
+	Query         string
+	Variables     struct {
+		Request struct {
+			ContractID string
+			AssetRef   string
+		}
+	}
+}
+
+func decodeClosedRequest(data []byte) (closedRequest, error) {
+	var request closedRequest
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(data, &root); err != nil || !hasExactKeys(root, "operationName", "query", "variables") {
+		return request, errors.New("invalid request envelope")
+	}
+	if err := json.Unmarshal(root["operationName"], &request.OperationName); err != nil || request.OperationName == "" {
+		return request, errors.New("invalid operation name")
+	}
+	if err := json.Unmarshal(root["query"], &request.Query); err != nil || request.Query == "" {
+		return request, errors.New("invalid query")
+	}
+	var variables map[string]json.RawMessage
+	if err := json.Unmarshal(root["variables"], &variables); err != nil || !hasExactKeys(variables, "request") {
+		return request, errors.New("invalid variables")
+	}
+	var input map[string]json.RawMessage
+	if err := json.Unmarshal(variables["request"], &input); err != nil || !hasExactKeys(input, "contractId", "assetRef") {
+		return request, errors.New("invalid request input")
+	}
+	if err := json.Unmarshal(input["contractId"], &request.Variables.Request.ContractID); err != nil {
+		return request, errors.New("invalid contract ID")
+	}
+	if err := json.Unmarshal(input["assetRef"], &request.Variables.Request.AssetRef); err != nil {
+		return request, errors.New("invalid asset reference")
+	}
+	return request, nil
+}
+
+func hasExactKeys(values map[string]json.RawMessage, expected ...string) bool {
+	if len(values) != len(expected) {
+		return false
+	}
+	for _, key := range expected {
+		if _, ok := values[key]; !ok {
+			return false
+		}
+	}
+	return true
 }
 func walkJSON(decoder *json.Decoder, depth int) error {
 	if depth > maxJSONDepth {
@@ -322,37 +372,54 @@ func walkJSON(decoder *json.Decoder, depth int) error {
 		return nil
 	}
 }
-func queryDepth(query string) int {
-	depth, maximum := 0, 0
-	for _, char := range query {
-		if char == '{' {
-			depth++
-			if depth > maximum {
-				maximum = depth
-			}
+func queryDocumentShape(query string) (string, int, int, error) {
+	document, err := parser.Parse(parser.ParseParams{Source: query, Options: parser.ParseOptions{NoLocation: true, NoSource: true}})
+	if err != nil {
+		return "", 0, 0, err
+	}
+	maximumDepth, selectedFields := 0, 0
+	var walk func(*ast.SelectionSet, int)
+	walk = func(selectionSet *ast.SelectionSet, parentDepth int) {
+		if selectionSet == nil {
+			return
 		}
-		if char == '}' {
-			depth--
+		for _, selection := range selectionSet.Selections {
+			depth := parentDepth + 1
+			if depth > maximumDepth {
+				maximumDepth = depth
+			}
+			if _, ok := selection.(*ast.Field); ok {
+				selectedFields++
+			}
+			walk(selection.GetSelectionSet(), depth)
 		}
 	}
-	return maximum
-}
-func selectedFields(query string) int {
-	return len(strings.Fields(query))
+	for _, node := range document.Definitions {
+		definition, ok := node.(ast.Definition)
+		if !ok {
+			continue
+		}
+		walk(definition.GetSelectionSet(), 0)
+	}
+	printed, ok := printer.Print(document).(string)
+	if !ok {
+		return "", maximumDepth, selectedFields, fmt.Errorf("unexpected printed query type")
+	}
+	return printed, maximumDepth, selectedFields, nil
 }
 
 // MCPCurrentSnapshot is the one lossless public wire projection shared by the
 // dedicated GraphQL endpoint and the MCP-first semantic surface.
-func MCPCurrentSnapshot(snapshot pv.Snapshot) (map[string]any, error) {
-	return mcpCurrentSnapshotAt(snapshot, time.Unix(0, int64(snapshot.Evaluated)).UTC())
+func MCPCurrentSnapshot(snapshot pv.Snapshot, producedAt time.Time) (map[string]any, error) {
+	return mcpCurrentSnapshotAt(snapshot, producedAt)
 }
 
 func mcpCurrentSnapshotAt(snapshot pv.Snapshot, producedAt time.Time) (map[string]any, error) {
-	if snapshot.ContractID != "" && snapshot.ContractID != pv.ContractV1 {
-		return nil, errors.New("unexpected canonical contract")
+	if err := validatePublicSnapshot(snapshot); err != nil {
+		return nil, err
 	}
 	if producedAt.IsZero() {
-		producedAt = time.Unix(0, int64(snapshot.Evaluated)).UTC()
+		return nil, errors.New("publication time is unavailable")
 	}
 	result := map[string]any{"contractId": contractID, "canonicalContractId": pv.ContractV1, "assetRef": snapshot.AssetRef, "generation": u64(snapshot.Generation), "producedAt": producedAt.UTC().Format(time.RFC3339Nano), "evaluatedMonotonicNs": i64(snapshot.Evaluated), "sourceTimeState": string(snapshot.SourceTimeState), "currentSourceOriginRef": string(snapshot.Source.SourceObservationRef), "capabilities": []any{map[string]any{"id": snapshot.Capability.ID, "outcome": string(snapshot.Capability.Outcome)}}}
 	facts := make([]pv.Fact, 0, len(snapshot.Facts))
@@ -364,14 +431,19 @@ func mcpCurrentSnapshotAt(snapshot pv.Snapshot, producedAt time.Time) (map[strin
 	})
 	result["facts"] = projectFacts(facts)
 	origins := make([]pv.Digest, 0, len(snapshot.Origins))
+	currentOrigin := snapshot.Source.SourceObservationRef
 	for ref := range snapshot.Origins {
-		origins = append(origins, ref)
+		if ref != currentOrigin {
+			origins = append(origins, ref)
+		}
 	}
 	if len(origins) == 0 && snapshot.Source.SourceObservationRef != "" {
-		origins = append(origins, snapshot.Source.SourceObservationRef)
 		snapshot.Origins = map[pv.Digest]pv.Provenance{snapshot.Source.SourceObservationRef: snapshot.Source}
 	}
 	sort.Slice(origins, func(i, j int) bool { return origins[i] < origins[j] })
+	if currentOrigin != "" {
+		origins = append([]pv.Digest{currentOrigin}, origins...)
+	}
 	provenance := make([]any, 0, len(origins))
 	for _, ref := range origins {
 		provenance = append(provenance, projectProvenance(ref, snapshot.Origins[ref]))
@@ -410,10 +482,141 @@ func mcpCurrentSnapshotAt(snapshot pv.Snapshot, producedAt time.Time) (map[strin
 	result["projectionReport"] = reports
 	return result, nil
 }
+
+func validatePublicSnapshot(snapshot pv.Snapshot) error {
+	if snapshot.ContractID != "" && snapshot.ContractID != pv.ContractV1 {
+		return errors.New("unexpected canonical contract")
+	}
+	if snapshot.AssetRef == "" || snapshot.SourceTimeState != pv.SourceTimeUnavailable && snapshot.SourceTimeState != pv.SourceTimeValid && snapshot.SourceTimeState != pv.SourceTimeInvalid {
+		return errors.New("invalid snapshot identity")
+	}
+	if snapshot.Capability.ID != pv.CapabilityThreePhaseTelemetryV1 || snapshot.Capability.Outcome != pv.CapabilitySatisfied && snapshot.Capability.Outcome != pv.CapabilityNotSatisfied {
+		return errors.New("invalid capability")
+	}
+	current := snapshot.Source.SourceObservationRef
+	if current.Validate() != nil {
+		return errors.New("invalid current source")
+	}
+	if len(snapshot.Origins) == 0 {
+		snapshot.Origins = map[pv.Digest]pv.Provenance{current: snapshot.Source}
+	}
+	for ref, provenance := range snapshot.Origins {
+		if ref.Validate() != nil || provenance.SourceObservationRef != ref || provenance.SourceRegistryRef.Validate() != nil || provenance.SourceShadowRef.Validate() != nil || provenance.EvidenceRef.Validate() != nil || provenance.Validity != pv.SourceTerminalVerified || provenance.Protocol == "" || provenance.ProfileID == "" || provenance.ProfileVersion == "" {
+			return errors.New("invalid provenance")
+		}
+	}
+	if provenance, ok := snapshot.Origins[current]; !ok || provenance != snapshot.Source {
+		return errors.New("current source is not in provenance")
+	}
+	catalog := pv.CatalogV1()
+	for key, fact := range snapshot.Facts {
+		definition, known := catalog.Facts[fact.ID]
+		if !known || key != pv.NewFactKey(fact.ID, fact.Dimensions) || catalog.ValidateCandidate(pv.FactCandidate{ID: fact.ID, Dimensions: fact.Dimensions, Value: fact.Value, Unit: fact.Unit}) != nil || definition.Policy != fact.Temporal.Policy {
+			return errors.New("invalid fact")
+		}
+		if _, ok := snapshot.Origins[fact.OriginRef]; !ok {
+			return errors.New("fact origin unavailable")
+		}
+		if fact.Quality != pv.QualityGood && fact.Quality != pv.QualitySuspect && fact.Quality != pv.QualityBad {
+			return errors.New("invalid fact quality")
+		}
+		if fact.Availability != pv.AvailabilityAvailable && fact.Availability != pv.AvailabilityUnavailable && fact.Availability != pv.AvailabilityUnsupported {
+			return errors.New("invalid fact availability")
+		}
+		if fact.Freshness != pv.FreshnessFresh && fact.Freshness != pv.FreshnessStale && fact.Freshness != pv.FreshnessExpired {
+			return errors.New("invalid fact freshness")
+		}
+		if err := validateContinuity(definition.Accumulator, fact.Continuity); err != nil {
+			return err
+		}
+	}
+	return validateProjectionAccounting(snapshot)
+}
+
+func validateContinuity(accumulator bool, continuity *pv.Continuity) error {
+	if continuity == nil {
+		return nil
+	}
+	if !accumulator {
+		return errors.New("non-accumulator fact carries continuity")
+	}
+	validDecimal := func(value *pv.Decimal) bool { return value != nil && value.Validate() == nil }
+	switch continuity.State {
+	case pv.ContinuityBaseline:
+		if continuity.Delta != nil || continuity.Modulus != nil || continuity.EvidenceRef != "" {
+			return errors.New("invalid baseline continuity")
+		}
+	case pv.ContinuityContiguous:
+		if !validDecimal(continuity.Delta) || continuity.Modulus != nil || continuity.EvidenceRef != "" {
+			return errors.New("invalid contiguous continuity")
+		}
+	case pv.ContinuityRollover:
+		if !validDecimal(continuity.Delta) || !validDecimal(continuity.Modulus) || continuity.EvidenceRef.Validate() != nil {
+			return errors.New("invalid rollover continuity")
+		}
+	case pv.ContinuityReset:
+		if continuity.Delta != nil || continuity.Modulus != nil || continuity.EvidenceRef.Validate() != nil {
+			return errors.New("invalid reset continuity")
+		}
+	case pv.ContinuityDiscontinuity:
+		if continuity.Delta != nil || continuity.Modulus != nil || continuity.EvidenceRef != "" && continuity.EvidenceRef.Validate() != nil {
+			return errors.New("invalid discontinuity continuity")
+		}
+	default:
+		return errors.New("invalid continuity state")
+	}
+	return nil
+}
+
+func validateProjectionAccounting(snapshot pv.Snapshot) error {
+	type projectionKey struct{ source, output pv.Digest }
+	requested := make(map[projectionKey]struct{}, len(snapshot.RequestedOutputs))
+	for _, item := range snapshot.RequestedOutputs {
+		key := projectionKey{item.SourceRef, item.RequestedOutputRef}
+		if item.SourceRef.Validate() != nil || item.RequestedOutputRef.Validate() != nil {
+			return errors.New("invalid requested output")
+		}
+		if _, duplicate := requested[key]; duplicate {
+			return errors.New("duplicate requested output")
+		}
+		requested[key] = struct{}{}
+	}
+	reported := make(map[projectionKey]struct{}, len(snapshot.ProjectionReport))
+	for _, item := range snapshot.ProjectionReport {
+		key := projectionKey{item.SourceRef, item.RequestedOutputRef}
+		if _, ok := requested[key]; !ok {
+			return errors.New("unrequested projection")
+		}
+		if _, duplicate := reported[key]; duplicate {
+			return errors.New("duplicate projection")
+		}
+		reported[key] = struct{}{}
+		switch item.Outcome {
+		case pv.ProjectionMapped:
+			if item.Dimensions == nil {
+				return errors.New("mapped projection without dimensions")
+			}
+			fact, ok := snapshot.Facts[pv.NewFactKey(item.FactID, *item.Dimensions)]
+			if !ok || fact.OriginRef != item.SourceRef {
+				return errors.New("mapped projection does not resolve")
+			}
+		case pv.ProjectionWithheld, pv.ProjectionUnrepresentable:
+			if item.FactID != "" || item.Dimensions != nil || item.SourceRef != snapshot.Source.SourceObservationRef {
+				return errors.New("non-mapped projection carries mapped fields")
+			}
+		default:
+			return errors.New("invalid projection outcome")
+		}
+	}
+	if len(reported) != len(requested) {
+		return errors.New("incomplete projection accounting")
+	}
+	return nil
+}
 func projectFacts(facts []pv.Fact) []any {
 	out := make([]any, 0, len(facts))
 	for _, fact := range facts {
-		row := map[string]any{"factId": string(fact.ID), "dimension": projectDimension(fact.Dimensions), "value": projectValue(fact.Value), "unit": string(fact.Unit), "quality": string(fact.Quality), "availability": string(fact.Availability), "freshness": string(fact.Freshness), "receiptMonotonicNs": i64(fact.Temporal.Receipt), "freshUntilMonotonicNs": i64(fact.Temporal.FreshUntil), "retainUntilMonotonicNs": i64(fact.Temporal.RetainUntil), "freshnessPolicy": string(fact.Temporal.Policy), "originRef": string(fact.OriginRef)}
+		row := map[string]any{"factId": string(fact.ID), "dimension": projectDimension(fact.Dimensions), "value": projectValue(fact.Value), "unit": string(fact.Unit), "quality": string(fact.Quality), "availability": string(fact.Availability), "freshness": string(fact.Freshness), "receiptMonotonicNs": i64(fact.Temporal.Receipt), "freshUntilMonotonicNs": i64(fact.Temporal.FreshUntil), "retainUntilMonotonicNs": i64(fact.Temporal.RetainUntil), "freshnessPolicy": string(fact.Temporal.Policy), "originRef": string(fact.OriginRef), "continuity": nil}
 		if fact.Continuity != nil {
 			row["continuity"] = projectContinuity(*fact.Continuity)
 		}
@@ -424,36 +627,36 @@ func projectFacts(facts []pv.Fact) []any {
 func projectDimension(d pv.Dimensions) map[string]any {
 	switch {
 	case d.Scope != "":
-		return map[string]any{"__typename": "M2MScopeDimension", "scope": string(d.Scope)}
+		return map[string]any{"scope": string(d.Scope)}
 	case d.Phase != "":
-		return map[string]any{"__typename": "M2MPhaseDimension", "phase": string(d.Phase)}
+		return map[string]any{"phase": string(d.Phase)}
 	case d.PhasePair != "":
-		return map[string]any{"__typename": "M2MPhasePairDimension", "phasePair": string(d.PhasePair)}
+		return map[string]any{"phasePair": string(d.PhasePair)}
 	case d.InputID != "":
-		return map[string]any{"__typename": "M2MInputDimension", "inputId": d.InputID}
+		return map[string]any{"inputId": d.InputID}
 	default:
-		return map[string]any{"__typename": "M2MSensorDimension", "sensorId": d.SensorID}
+		return map[string]any{"sensorId": d.SensorID}
 	}
 }
 func projectValue(v pv.FactValue) map[string]any {
 	switch v.Kind {
 	case pv.ValueKindDecimal:
 		if v.Decimal != nil {
-			return map[string]any{"__typename": "M2MDecimalValue", "coefficient": v.Decimal.Coefficient, "scale": stringify(v.Decimal.Scale)}
+			return map[string]any{"coefficient": v.Decimal.Coefficient, "scale": v.Decimal.Scale}
 		}
 	case pv.ValueKindEnum:
-		return map[string]any{"__typename": "M2MEnumValue", "symbol": v.Symbol}
+		return map[string]any{"symbol": v.Symbol}
 	case pv.ValueKindBitfield:
 		symbols := append([]string(nil), v.Symbols...)
 		sort.Strings(symbols)
-		return map[string]any{"__typename": "M2MBitfieldValue", "symbols": symbols}
+		return map[string]any{"symbols": symbols}
 	}
 	return map[string]any{}
 }
 func projectContinuity(c pv.Continuity) map[string]any {
 	switch c.State {
 	case pv.ContinuityBaseline:
-		return map[string]any{"__typename": "M2MBaselineContinuity", "baseline": true}
+		return map[string]any{"__typename": "M2MBaselineContinuity", "baseline": "BASELINE"}
 	case pv.ContinuityContiguous:
 		return map[string]any{"__typename": "M2MContiguousContinuity", "delta": projectDecimal(c.Delta)}
 	case pv.ContinuityRollover:
@@ -468,7 +671,7 @@ func projectDecimal(d *pv.Decimal) any {
 	if d == nil {
 		return nil
 	}
-	return map[string]any{"coefficient": d.Coefficient, "scale": stringify(d.Scale)}
+	return map[string]any{"coefficient": d.Coefficient, "scale": d.Scale}
 }
 func projectProvenance(ref pv.Digest, p pv.Provenance) map[string]any {
 	return map[string]any{"originRef": string(ref), "sourceProtocol": p.Protocol, "sourceProfileId": p.ProfileID, "sourceProfileVersion": p.ProfileVersion, "sourceValidity": p.Validity, "sourceRegistryRef": string(p.SourceRegistryRef), "sourceObservationRef": string(p.SourceObservationRef), "evidenceRef": string(p.EvidenceRef)}

--- a/m2mgraphql/testdata/contract.json
+++ b/m2mgraphql/testdata/contract.json
@@ -1,0 +1,27 @@
+{
+  "contractId": "PUBLIC_GRAPHQL_M2M_V1",
+  "canonicalContractId": "helianthus.canonical-pv/v1",
+  "route": "/graphql/m2m/v1",
+  "operationName": "M2MCurrentSnapshot",
+  "limits": {
+    "requestBytes": 16384,
+    "responseBytes": 1048576,
+    "jsonDepth": 64,
+    "queryDepth": 8,
+    "selectedFields": 256,
+    "facts": 256,
+    "projectionRows": 512,
+    "concurrencyPerPrincipal": 1,
+    "ratePerSecond": 1,
+    "rateBurst": 2
+  },
+  "errorCodes": [
+    "CONTRACT_INCOMPATIBLE",
+    "ASSET_FORBIDDEN",
+    "ASSET_NOT_FOUND",
+    "SOURCE_UNAVAILABLE",
+    "REQUEST_INVALID",
+    "QUERY_REJECTED",
+    "REQUEST_LIMIT_EXCEEDED"
+  ]
+}

--- a/m2mgraphql/testdata/public-graphql-m2m-v1.query.graphql
+++ b/m2mgraphql/testdata/public-graphql-m2m-v1.query.graphql
@@ -1,0 +1,55 @@
+query M2MCurrentSnapshot($request: M2MCurrentSnapshotRequest!) {
+  m2mCurrentSnapshot(request: $request) {
+    contractId canonicalContractId assetRef generation producedAt
+    evaluatedMonotonicNs sourceTimeState currentSourceOriginRef
+    facts {
+      factId
+      dimension {
+        ... on M2MScopeDimension { scope }
+        ... on M2MPhaseDimension { phase }
+        ... on M2MPhasePairDimension { phasePair }
+        ... on M2MInputDimension { inputId }
+        ... on M2MSensorDimension { sensorId }
+      }
+      value {
+        ... on M2MDecimalValue { coefficient scale }
+        ... on M2MEnumValue { symbol }
+        ... on M2MBitfieldValue { symbols }
+      }
+      unit quality availability freshness receiptMonotonicNs
+      freshUntilMonotonicNs retainUntilMonotonicNs freshnessPolicy originRef
+      continuity {
+        __typename
+        ... on M2MBaselineContinuity { baseline }
+        ... on M2MContiguousContinuity { delta { coefficient scale } }
+        ... on M2MRolloverContinuity {
+          delta { coefficient scale } modulus { coefficient scale }
+          rolloverEvidenceRef
+        }
+        ... on M2MResetContinuity { resetEvidenceRef }
+        ... on M2MDiscontinuityContinuity { discontinuityEvidenceRef }
+      }
+    }
+    capabilities { id outcome }
+    provenance {
+      originRef sourceProtocol sourceProfileId sourceProfileVersion sourceValidity
+      sourceRegistryRef sourceObservationRef evidenceRef
+    }
+    requestedOutputs { sourceRef requestedOutputRef }
+    projectionReport {
+      __typename
+      ... on M2MMappedProjectionReportEntry {
+        sourceRef requestedOutputRef factId
+        dimension {
+          ... on M2MScopeDimension { scope }
+          ... on M2MPhaseDimension { phase }
+          ... on M2MPhasePairDimension { phasePair }
+          ... on M2MInputDimension { inputId }
+          ... on M2MSensorDimension { sensorId }
+        }
+      }
+      ... on M2MWithheldProjectionReportEntry { sourceRef requestedOutputRef }
+      ... on M2MUnrepresentableProjectionReportEntry { sourceRef requestedOutputRef }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated, disabled-by-default `PUBLIC_GRAPHQL_M2M_V1` endpoint
- admit one canonical GraphQL operation by parsed AST and return a closed JSON envelope
- project retained canonical PV snapshots with current canonical lifecycle, provenance, and projection-loss accounting
- require TLS 1.3, verified server identity, mandatory client certificates, and denied-client fingerprints
- enforce per-principal concurrency/rate limits plus a global bound on pre-mTLS connections
- distinguish configured known assets from allowed assets and from retained source availability

## Dependencies
- docs contract: `helianthus-docs-ebus` merge `65bdcead65c9deb49ce0593f210d38e27b6da84e`
- gateway base: `d8bdb0f66b30a30c09690935d18a887ff5c84f64`

## TDD evidence
Initial RED chain: `c1b120ff`, `ccffa0a`, `490907d`.

Corrective REDs:
- `f76d9b4`: closed envelope, AST equivalence, exact wire shape, ambiguous asset lookup
- `7e0aeb6`: deployment flags, server identity, invalid canonical snapshot
- `2d7931b`: token-bucket remainder and authoritative publication time
- `c0a8312`: concurrent TLS admission under a stalled peer
- `3a056ba`: known-source absence and global pre-mTLS bounds
- `555d6d7`: request-time canonical lifecycle boundaries

Final exact HEAD: `eac34de082ffb01aea87a73e01bcea9717c8d08d`.

## Validation
- focused repeated race: pre-mTLS bound/source-absence/stalled-handshake tests, 20 iterations, PASS
- canonical lifecycle: FRESH to STALE at 30s and EXPIRED/UNAVAILABLE at 300s, with stable provenance/projection accounting, PASS
- full local `GOWORK=off ./scripts/ci_local.sh`, PASS
- Portal 43/43; full Go race; Python 168+6+9+7+6+2; golangci-lint 0
- GitHub terminology/build/test/lint: 4/4 SUCCESS on exact HEAD
- T01..T88 owner disposition: `NOT_APPLICABLE`, independently validated `BY_DESIGN_VALID`; dedicated HTTP/mTLS listener and CLI composition only, with no eBUS/Modbus transport, framing, adaptermux, scheduler, passive acquisition, or FC03 path changed
- fresh independent exact-HEAD verdict: `NO_BLOCKING_FINDINGS`; no P3/P4

## Scope
No raw registers, writes, subscriptions, history, generic GraphQL fallback, transport changes, deployment, or live mutation.
