### PR TITLE
FMV3-M5-06: add Portal PV and bounded raw Modbus views

### DIFF
--- a/cmd/gateway/m2m_graphql_config.go
+++ b/cmd/gateway/m2m_graphql_config.go
@@ -39,4 +39,12 @@ func bindM2MGraphQLFlags(fs *flag.FlagSet, cfg *ebusgateway.Config) {
 		sort.Strings(cfg.M2MGraphQL.DeniedPrincipalFingerprints)
 		return nil
 	})
+	fs.BoolVar(&cfg.PortalPV.SemanticEnabled, "portal-pv-semantic-enabled", cfg.PortalPV.SemanticEnabled, "enable Portal PV semantic BFF")
+	fs.BoolVar(&cfg.PortalPV.RawReadEnabled, "portal-modbus-raw-read-enabled", cfg.PortalPV.RawReadEnabled, "enable Portal raw Modbus diagnostics")
+	fs.StringVar(&cfg.PortalPV.M2MURL, "portal-pv-m2m-url", cfg.PortalPV.M2MURL, "dedicated M2M GraphQL URL for Portal PV")
+	fs.StringVar(&cfg.PortalPV.M2MServerName, "portal-pv-m2m-server-name", cfg.PortalPV.M2MServerName, "dedicated M2M GraphQL certificate identity for Portal PV")
+	fs.StringVar(&cfg.PortalPV.M2MCAFile, "portal-pv-m2m-ca", cfg.PortalPV.M2MCAFile, "M2M GraphQL CA file for Portal PV")
+	fs.StringVar(&cfg.PortalPV.M2MClientCert, "portal-pv-m2m-client-cert", cfg.PortalPV.M2MClientCert, "M2M GraphQL client certificate for Portal PV")
+	fs.StringVar(&cfg.PortalPV.M2MClientKey, "portal-pv-m2m-client-key", cfg.PortalPV.M2MClientKey, "M2M GraphQL client private key for Portal PV")
+	fs.StringVar(&cfg.PortalPV.AssetRef, "portal-pv-asset-ref", cfg.PortalPV.AssetRef, "fixed canonical PV asset reference for Portal PV")
 }

--- a/cmd/gateway/m2m_graphql_runtime_red_test.go
+++ b/cmd/gateway/m2m_graphql_runtime_red_test.go
@@ -36,6 +36,19 @@ func TestM2MGraphQLRuntime_IsDisabledByDefaultAndSeparateFromGenericHTTP(t *test
 	}
 }
 
+func TestPortalRawModbusMainAuditLogListsOnlySanitizedFields(t *testing.T) {
+	source, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(source)
+	for _, required := range []string{"request_id=%s", "surface=%s", "tool=%s", "unit_id=%", "function=%", "offset=%", "quantity=%", "outcome=%s", "error_code=%s", "duration_ms=%", "endpoint_ref=%s"} {
+		if !strings.Contains(text, required) {
+			t.Fatalf("main audit log lacks %q", required)
+		}
+	}
+}
+
 func TestM2MGraphQLRuntime_RequiresMutualTLSAndClosesListener(t *testing.T) {
 	certs := newM2MTLSCertificates(t)
 	cfg := ebusgateway.Config{M2MGraphQL: ebusgateway.M2MGraphQLConfig{

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -1993,6 +1993,10 @@ func startHTTPServer(
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	portalPVClient, err := newPortalPVClient(cfg.PortalPV)
+	if err != nil {
+		return nil, nil, fmt.Errorf("portal PV configuration: %w", err)
+	}
 
 	queryHandler, err := graphql.NewInvokeHandler(builder, gateway.Registry, gateway.Router)
 	if err != nil {
@@ -2195,8 +2199,15 @@ func startHTTPServer(
 				}
 				return ""
 			}(),
-			GatewayVersion: buildInfo.ReleaseVersion,
-			BuildID:        buildInfo.BuildID,
+			GatewayVersion:    buildInfo.ReleaseVersion,
+			BuildID:           buildInfo.BuildID,
+			SemanticPVEnabled: cfg.PortalPV.SemanticEnabled,
+			RawModbusEnabled:  cfg.PortalPV.RawReadEnabled,
+			SemanticPV:        portalPVClient,
+			ModbusProvider:    modbusProvider,
+			RawModbusAudit: func(event portal.RawModbusAuditEvent) {
+				log.Printf("portal_modbus_raw_audit outcome=%s timestamp=%s", event.Outcome, event.At.Format(time.RFC3339Nano))
+			},
 			ListRegistry: func() []portal.RegistryDevice {
 				schemaSnapshot := builder.FreshSchema()
 				schemaByAddr := make(map[byte]graphql.Device, len(schemaSnapshot.Devices))

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -170,6 +170,9 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 	}
 
 	applyTransportSourcePolicy(&cfg)
+	if err := cfg.ValidatePortalPV(); err != nil {
+		return fmt.Errorf("validate Portal PV configuration: %w", err)
+	}
 	if err := ebusgateway.ValidateSynchronizedEvidenceConfig(cfg); err != nil {
 		return fmt.Errorf("validate synchronized evidence config: %w", err)
 	}
@@ -1993,6 +1996,9 @@ func startHTTPServer(
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	if err := cfg.ValidatePortalPV(); err != nil {
+		return nil, nil, fmt.Errorf("validate Portal PV configuration: %w", err)
+	}
 	portalPVClient, err := newPortalPVClient(cfg.PortalPV)
 	if err != nil {
 		return nil, nil, fmt.Errorf("portal PV configuration: %w", err)
@@ -2206,7 +2212,10 @@ func startHTTPServer(
 			SemanticPV:        portalPVClient,
 			ModbusProvider:    modbusProvider,
 			RawModbusAudit: func(event portal.RawModbusAuditEvent) {
-				log.Printf("portal_modbus_raw_audit outcome=%s timestamp=%s", event.Outcome, event.At.Format(time.RFC3339Nano))
+				log.Printf("portal_modbus_raw_audit request_id=%s surface=%s tool=%s unit_id=%s function=%s offset=%s quantity=%s outcome=%s error_code=%s duration_ms=%d endpoint_ref=%s timestamp=%s",
+					event.RequestID, event.Surface, event.Tool, auditNumber(event.UnitID), auditNumber(event.Function),
+					auditNumber(event.Offset), auditNumber(event.Quantity), event.Outcome, event.ErrorCode,
+					event.DurationMS, event.EndpointRef, event.At.Format(time.RFC3339Nano))
 			},
 			ListRegistry: func() []portal.RegistryDevice {
 				schemaSnapshot := builder.FreshSchema()
@@ -2426,6 +2435,13 @@ func startHTTPServer(
 	}()
 
 	return server, advertiser, nil
+}
+
+func auditNumber(value *uint64) string {
+	if value == nil {
+		return "-"
+	}
+	return strconv.FormatUint(*value, 10)
 }
 
 func portalFM5Interpretation(provider graphql.SemanticProvider) graphql.Fm5Interpretation {

--- a/cmd/gateway/portal_pv_client.go
+++ b/cmd/gateway/portal_pv_client.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"errors"
+
+	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/m2mgraphql"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/portal"
+)
+
+func newPortalPVClient(config ebusgateway.PortalPVConfig) (func(context.Context) (portal.ForwardedResponse, error), error) {
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+	if !config.SemanticEnabled {
+		return nil, nil
+	}
+	client, err := m2mgraphql.NewClient(m2mgraphql.ClientConfig{
+		URL: config.M2MURL, ServerName: config.M2MServerName, CAFile: config.M2MCAFile,
+		ClientCertFile: config.M2MClientCert, ClientKeyFile: config.M2MClientKey, AssetRef: config.AssetRef,
+	})
+	if err != nil {
+		return nil, errors.New("portal PV M2M client is invalid")
+	}
+	return func(ctx context.Context) (portal.ForwardedResponse, error) {
+		response, err := client.Current(ctx)
+		if err != nil {
+			return portal.ForwardedResponse{}, err
+		}
+		return portal.ForwardedResponse{Status: response.Status, ContentType: response.ContentType, Body: response.Body}, nil
+	}, nil
+}

--- a/config.go
+++ b/config.go
@@ -136,6 +136,32 @@ func (config PortalPVConfig) Validate() error {
 	return nil
 }
 
+// ValidatePortalPV enforces that the Portal semantic BFF can only target the
+// configured dedicated M2M listener and one of its admitted assets.
+func (cfg Config) ValidatePortalPV() error {
+	if err := cfg.PortalPV.Validate(); err != nil {
+		return err
+	}
+	if !cfg.PortalPV.SemanticEnabled {
+		return nil
+	}
+	if cfg.M2MGraphQL.Disabled() {
+		return errors.New("portal PV semantic BFF requires the dedicated M2M listener")
+	}
+	if err := cfg.M2MGraphQL.Validate(); err != nil {
+		return errors.New("portal PV semantic BFF requires a valid dedicated M2M listener")
+	}
+	if cfg.PortalPV.M2MServerName != cfg.M2MGraphQL.ServerName {
+		return errors.New("portal PV semantic BFF server identity does not match the dedicated M2M listener")
+	}
+	for _, asset := range cfg.M2MGraphQL.AllowedAssets {
+		if asset == cfg.PortalPV.AssetRef {
+			return nil
+		}
+	}
+	return errors.New("portal PV semantic BFF asset is not admitted by the dedicated M2M listener")
+}
+
 func (config M2MGraphQLConfig) Disabled() bool {
 	return config.ListenAddr == "" && config.ServerName == "" && config.ClientCAFile == "" &&
 		config.ServerCertFile == "" && config.ServerKeyFile == "" && len(config.AllowedAssets) == 0 &&

--- a/config.go
+++ b/config.go
@@ -105,6 +105,37 @@ type M2MGraphQLConfig struct {
 	DeniedPrincipalFingerprints []string
 }
 
+// PortalPVConfig independently enables the Portal PV BFF and raw Modbus
+// diagnostics. Both capabilities are disabled by default.
+type PortalPVConfig struct {
+	SemanticEnabled bool
+	RawReadEnabled  bool
+	M2MURL          string
+	M2MServerName   string
+	M2MCAFile       string
+	M2MClientCert   string
+	M2MClientKey    string
+	AssetRef        string
+}
+
+func (config PortalPVConfig) Validate() error {
+	fields := []string{config.M2MURL, config.M2MServerName, config.M2MCAFile, config.M2MClientCert, config.M2MClientKey, config.AssetRef}
+	if !config.SemanticEnabled {
+		for _, field := range fields {
+			if strings.TrimSpace(field) != "" {
+				return errors.New("disabled Portal PV semantic configuration contains active fields")
+			}
+		}
+		return nil
+	}
+	for _, field := range fields {
+		if strings.TrimSpace(field) == "" {
+			return errors.New("enabled Portal PV semantic configuration is incomplete")
+		}
+	}
+	return nil
+}
+
 func (config M2MGraphQLConfig) Disabled() bool {
 	return config.ListenAddr == "" && config.ServerName == "" && config.ClientCAFile == "" &&
 		config.ServerCertFile == "" && config.ServerKeyFile == "" && len(config.AllowedAssets) == 0 &&
@@ -186,6 +217,7 @@ type Config struct {
 	TransportConfig          TransportConfig
 	EEBusConfig              EEBusConfig
 	M2MGraphQL               M2MGraphQLConfig
+	PortalPV                 PortalPVConfig
 	ModbusTCPConfig          ModbusTCPConfig
 	EvidenceRecorderConfig   EvidenceRecorderConfig
 	EvidenceOneShotEnabled   bool

--- a/config.go
+++ b/config.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/url"
 	"strings"
 	"time"
 
@@ -153,6 +154,24 @@ func (cfg Config) ValidatePortalPV() error {
 	}
 	if cfg.PortalPV.M2MServerName != cfg.M2MGraphQL.ServerName {
 		return errors.New("portal PV semantic BFF server identity does not match the dedicated M2M listener")
+	}
+	parsedURL, err := url.Parse(cfg.PortalPV.M2MURL)
+	if err != nil || !parsedURL.IsAbs() || parsedURL.Scheme != "https" || parsedURL.Host == "" ||
+		parsedURL.User != nil || parsedURL.RawQuery != "" || parsedURL.Fragment != "" || parsedURL.Opaque != "" ||
+		parsedURL.ForceQuery || parsedURL.Path != "/graphql/m2m/v1" || parsedURL.RawPath != "" {
+		return errors.New("portal PV semantic BFF URL is invalid")
+	}
+	hostname := parsedURL.Hostname()
+	loopback := strings.EqualFold(hostname, "localhost")
+	if address := net.ParseIP(hostname); address != nil {
+		loopback = address.IsLoopback()
+	}
+	if !loopback {
+		return errors.New("portal PV semantic BFF URL must use a loopback host")
+	}
+	_, listenerPort, err := net.SplitHostPort(cfg.M2MGraphQL.ListenAddr)
+	if err != nil || listenerPort == "" || parsedURL.Port() == "" || parsedURL.Port() != listenerPort {
+		return errors.New("portal PV semantic BFF URL port does not match the dedicated M2M listener")
 	}
 	for _, asset := range cfg.M2MGraphQL.AllowedAssets {
 		if asset == cfg.PortalPV.AssetRef {

--- a/config_test.go
+++ b/config_test.go
@@ -22,6 +22,35 @@ func TestConfigDeclaresIndependentDisabledPortalPVCapabilities(t *testing.T) {
 	}
 }
 
+func TestConfigCrossValidatesPortalPVAgainstDedicatedM2MListener(t *testing.T) {
+	type portalPVValidator interface{ ValidatePortalPV() error }
+	validM2M := M2MGraphQLConfig{
+		ListenAddr: "127.0.0.1:8443", ServerName: "m2m.gateway.test", ClientCAFile: "ca.pem",
+		ServerCertFile: "server.pem", ServerKeyFile: "server-key.pem", AllowedAssets: []string{"pv-allowed"},
+	}
+	portal := PortalPVConfig{
+		SemanticEnabled: true, M2MURL: "https://127.0.0.1:8443/graphql/m2m/v1", M2MServerName: "m2m.gateway.test",
+		M2MCAFile: "ca.pem", M2MClientCert: "client.pem", M2MClientKey: "client-key.pem", AssetRef: "pv-allowed",
+	}
+	for _, cfg := range []*Config{
+		{PortalPV: portal},
+		{M2MGraphQL: validM2M, PortalPV: func() PortalPVConfig { value := portal; value.AssetRef = "pv-forbidden"; return value }()},
+	} {
+		validator, ok := any(cfg).(portalPVValidator)
+		if !ok {
+			t.Fatal("Config does not provide cross-configuration Portal PV validation")
+		}
+		if err := validator.ValidatePortalPV(); err == nil {
+			t.Fatalf("cross-configuration mismatch accepted: %+v", cfg)
+		}
+	}
+	valid := &Config{M2MGraphQL: validM2M, PortalPV: portal}
+	validator, ok := any(valid).(portalPVValidator)
+	if !ok || validator.ValidatePortalPV() != nil {
+		t.Fatalf("valid cross-configuration rejected: %+v", valid)
+	}
+}
+
 func TestDefaultConfig_DisablesDumpUploadPath(t *testing.T) {
 	cfg := DefaultConfig()
 	if cfg.DumpUploadPath != "" {

--- a/config_test.go
+++ b/config_test.go
@@ -51,6 +51,38 @@ func TestConfigCrossValidatesPortalPVAgainstDedicatedM2MListener(t *testing.T) {
 	}
 }
 
+func TestConfigPinsPortalPVURLToLoopbackDedicatedListenerPort(t *testing.T) {
+	base := Config{
+		M2MGraphQL: M2MGraphQLConfig{
+			ListenAddr: "0.0.0.0:8443", ServerName: "m2m.gateway.test", ClientCAFile: "ca.pem",
+			ServerCertFile: "server.pem", ServerKeyFile: "server-key.pem", AllowedAssets: []string{"pv-allowed"},
+		},
+		PortalPV: PortalPVConfig{
+			SemanticEnabled: true, M2MURL: "https://127.0.0.1:8443/graphql/m2m/v1", M2MServerName: "m2m.gateway.test",
+			M2MCAFile: "ca.pem", M2MClientCert: "client.pem", M2MClientKey: "client-key.pem", AssetRef: "pv-allowed",
+		},
+	}
+	if err := base.ValidatePortalPV(); err != nil {
+		t.Fatalf("loopback URL for wildcard listener rejected: %v", err)
+	}
+	ipv6 := base
+	ipv6.M2MGraphQL.ListenAddr = "[::]:8443"
+	ipv6.PortalPV.M2MURL = "https://[::1]:8443/graphql/m2m/v1"
+	if err := ipv6.ValidatePortalPV(); err != nil {
+		t.Fatalf("IPv6 loopback URL for wildcard listener rejected: %v", err)
+	}
+	for _, mutate := range []func(*Config){
+		func(cfg *Config) { cfg.PortalPV.M2MURL = "https://192.0.2.10:8443/graphql/m2m/v1" },
+		func(cfg *Config) { cfg.PortalPV.M2MURL = "https://127.0.0.1:9443/graphql/m2m/v1" },
+	} {
+		candidate := base
+		mutate(&candidate)
+		if err := candidate.ValidatePortalPV(); err == nil {
+			t.Fatalf("unpinned Portal PV URL accepted: %s", candidate.PortalPV.M2MURL)
+		}
+	}
+}
+
 func TestDefaultConfig_DisablesDumpUploadPath(t *testing.T) {
 	cfg := DefaultConfig()
 	if cfg.DumpUploadPath != "" {

--- a/config_test.go
+++ b/config_test.go
@@ -2,10 +2,25 @@ package ebusgateway
 
 import (
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 )
+
+func TestConfigDeclaresIndependentDisabledPortalPVCapabilities(t *testing.T) {
+	field, ok := reflect.TypeOf(Config{}).FieldByName("PortalPV")
+	if !ok {
+		t.Fatal("Config has no PortalPV capability configuration")
+	}
+	value := reflect.New(field.Type).Elem()
+	for _, name := range []string{"SemanticEnabled", "RawReadEnabled"} {
+		capability := value.FieldByName(name)
+		if !capability.IsValid() || capability.Kind() != reflect.Bool || capability.Bool() {
+			t.Fatalf("PortalPV.%s must exist and default disabled", name)
+		}
+	}
+}
 
 func TestDefaultConfig_DisablesDumpUploadPath(t *testing.T) {
 	cfg := DefaultConfig()

--- a/m2mgraphql/client.go
+++ b/m2mgraphql/client.go
@@ -8,7 +8,9 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"mime"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -42,6 +44,12 @@ func NewClient(config ClientConfig) (*Client, error) {
 		if strings.TrimSpace(value) == "" {
 			return nil, errors.New("M2M GraphQL client configuration is incomplete")
 		}
+	}
+	parsedURL, err := url.Parse(config.URL)
+	if err != nil || !parsedURL.IsAbs() || parsedURL.Scheme != "https" || parsedURL.Host == "" ||
+		parsedURL.User != nil || parsedURL.RawQuery != "" || parsedURL.Fragment != "" || parsedURL.Opaque != "" ||
+		parsedURL.ForceQuery || parsedURL.Path != route || parsedURL.RawPath != "" {
+		return nil, errors.New("M2M GraphQL client URL is invalid")
 	}
 	certificate, err := tls.LoadX509KeyPair(config.ClientCertFile, config.ClientKeyFile)
 	if err != nil {
@@ -80,8 +88,12 @@ func (client *Client) Current(ctx context.Context) (Response, error) {
 		return Response{}, errors.New("M2M GraphQL request failed")
 	}
 	defer func() { _ = response.Body.Close() }()
+	mediaType, _, contentTypeErr := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if response.StatusCode != http.StatusOK || contentTypeErr != nil || mediaType != "application/json" {
+		return Response{}, errors.New("M2M GraphQL response is invalid")
+	}
 	encoded, err := io.ReadAll(io.LimitReader(response.Body, maxResponseBytes+1))
-	if err != nil || len(encoded) > maxResponseBytes {
+	if err != nil || len(encoded) > maxResponseBytes || !json.Valid(encoded) {
 		return Response{}, errors.New("M2M GraphQL response is invalid")
 	}
 	return Response{Status: response.StatusCode, ContentType: response.Header.Get("Content-Type"), Body: encoded}, nil

--- a/m2mgraphql/client.go
+++ b/m2mgraphql/client.go
@@ -1,0 +1,88 @@
+package m2mgraphql
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const clientTimeout = 5 * time.Second
+
+type ClientConfig struct {
+	URL            string
+	ServerName     string
+	CAFile         string
+	ClientCertFile string
+	ClientKeyFile  string
+	AssetRef       string
+}
+
+type Client struct {
+	url   string
+	asset string
+	http  *http.Client
+}
+
+type Response struct {
+	Status      int
+	ContentType string
+	Body        []byte
+}
+
+func NewClient(config ClientConfig) (*Client, error) {
+	for _, value := range []string{config.URL, config.ServerName, config.CAFile, config.ClientCertFile, config.ClientKeyFile, config.AssetRef} {
+		if strings.TrimSpace(value) == "" {
+			return nil, errors.New("M2M GraphQL client configuration is incomplete")
+		}
+	}
+	certificate, err := tls.LoadX509KeyPair(config.ClientCertFile, config.ClientKeyFile)
+	if err != nil {
+		return nil, errors.New("M2M GraphQL client certificate is invalid")
+	}
+	caPEM, err := os.ReadFile(config.CAFile)
+	if err != nil {
+		return nil, errors.New("M2M GraphQL client CA is unavailable")
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caPEM) {
+		return nil, errors.New("M2M GraphQL client CA is invalid")
+	}
+	transport := &http.Transport{TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS13, RootCAs: pool, ServerName: config.ServerName, Certificates: []tls.Certificate{certificate}}, ResponseHeaderTimeout: clientTimeout}
+	return &Client{url: config.URL, asset: config.AssetRef, http: &http.Client{Transport: transport, Timeout: clientTimeout}}, nil
+}
+
+func (client *Client) Current(ctx context.Context) (Response, error) {
+	if client == nil || client.http == nil {
+		return Response{}, errors.New("M2M GraphQL client unavailable")
+	}
+	body, err := json.Marshal(map[string]any{
+		"operationName": "M2MCurrentSnapshot", "query": fixedQuery,
+		"variables": map[string]any{"request": map[string]string{"contractId": contractID, "assetRef": client.asset}},
+	})
+	if err != nil {
+		return Response{}, err
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, client.url, bytes.NewReader(body))
+	if err != nil {
+		return Response{}, errors.New("M2M GraphQL request is invalid")
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response, err := client.http.Do(request)
+	if err != nil {
+		return Response{}, errors.New("M2M GraphQL request failed")
+	}
+	defer func() { _ = response.Body.Close() }()
+	encoded, err := io.ReadAll(io.LimitReader(response.Body, maxResponseBytes+1))
+	if err != nil || len(encoded) > maxResponseBytes {
+		return Response{}, errors.New("M2M GraphQL response is invalid")
+	}
+	return Response{Status: response.StatusCode, ContentType: response.Header.Get("Content-Type"), Body: encoded}, nil
+}

--- a/m2mgraphql/client_red_test.go
+++ b/m2mgraphql/client_red_test.go
@@ -1,6 +1,16 @@
 package m2mgraphql
 
-import "testing"
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestPortalClientUsesTheEmbeddedClosedCanonicalQuery(t *testing.T) {
 	if _, ok := any(fixedQuery).(string); !ok {
@@ -8,5 +18,90 @@ func TestPortalClientUsesTheEmbeddedClosedCanonicalQuery(t *testing.T) {
 	}
 	if len(fixedQuery) == 0 {
 		t.Fatal("fixed canonical query is empty")
+	}
+}
+
+func TestPortalClientRejectsNonCanonicalUpstreamURLs(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer server.Close()
+	config := portalClientTestConfig(t, server)
+	for _, rawURL := range []string{
+		"http://example.test/graphql/m2m/v1",
+		"https://user:secret@example.test/graphql/m2m/v1",
+		"https://example.test/graphql",
+		"https://example.test/graphql/m2m/v1?query=1",
+		"https://example.test/graphql/m2m/v1#fragment",
+		"/graphql/m2m/v1",
+	} {
+		t.Run(rawURL, func(t *testing.T) {
+			candidate := config
+			candidate.URL = rawURL
+			if _, err := NewClient(candidate); err == nil {
+				t.Fatalf("NewClient accepted non-canonical URL %q", rawURL)
+			}
+		})
+	}
+}
+
+func TestPortalClientRejectsNonContractHTTPResponses(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		status      int
+		contentType string
+		body        string
+	}{
+		{name: "wrong_status", status: http.StatusBadGateway, contentType: "application/json", body: `{}`},
+		{name: "wrong_content_type", status: http.StatusOK, contentType: "text/plain", body: `{}`},
+		{name: "oversized", status: http.StatusOK, contentType: "application/json", body: strings.Repeat("x", maxResponseBytes+1)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", test.contentType)
+				w.WriteHeader(test.status)
+				_, _ = w.Write([]byte(test.body))
+			}))
+			defer server.Close()
+			client, err := NewClient(portalClientTestConfig(t, server))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := client.Current(context.Background()); err == nil {
+				t.Fatalf("Current accepted status=%d content-type=%q body-bytes=%d", test.status, test.contentType, len(test.body))
+			}
+		})
+	}
+}
+
+func portalClientTestConfig(t *testing.T, server *httptest.Server) ClientConfig {
+	t.Helper()
+	dir := t.TempDir()
+	certificate := server.TLS.Certificates[0]
+	leaf, err := x509.ParseCertificate(certificate.Certificate[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := x509.MarshalPKCS8PrivateKey(certificate.PrivateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certFile := filepath.Join(dir, "client.pem")
+	keyFile := filepath.Join(dir, "client-key.pem")
+	caFile := filepath.Join(dir, "ca.pem")
+	if err := os.WriteFile(certFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certificate.Certificate[0]}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyFile, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: key}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(caFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leaf.Raw}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	serverName := "example.com"
+	if len(leaf.DNSNames) > 0 {
+		serverName = leaf.DNSNames[0]
+	}
+	return ClientConfig{
+		URL: server.URL + "/graphql/m2m/v1", ServerName: serverName, CAFile: caFile,
+		ClientCertFile: certFile, ClientKeyFile: keyFile, AssetRef: "pv-asset-fixture",
 	}
 }

--- a/m2mgraphql/client_red_test.go
+++ b/m2mgraphql/client_red_test.go
@@ -1,0 +1,12 @@
+package m2mgraphql
+
+import "testing"
+
+func TestPortalClientUsesTheEmbeddedClosedCanonicalQuery(t *testing.T) {
+	if _, ok := any(fixedQuery).(string); !ok {
+		t.Fatal("fixed query is not available to the Portal client")
+	}
+	if len(fixedQuery) == 0 {
+		t.Fatal("fixed canonical query is empty")
+	}
+}

--- a/mcp/modbus_v1.go
+++ b/mcp/modbus_v1.go
@@ -150,16 +150,13 @@ func (server *Server) handleModbusV1Call(ctx context.Context, name string, args 
 	var data any
 	var err error
 	providerCalled := false
-	consistencyMode := "LIVE"
+	var consistencyMode string
 	dataTimestamp := time.Now().UTC().Format(time.RFC3339Nano)
 	switch name {
 	case ModbusV1RawReadTool:
-		var request ModbusRawReadRequest
-		request, err = parseModbusRawReadRequest(args)
-		if err == nil {
-			providerCalled = true
-			data, err = provider.RawRead(ctx, request)
-		}
+		envelope := modbusV1RawReadCall(ctx, provider, args)
+		_, failed := envelope["error"].(map[string]any)
+		return callToolResultText(mustJSON(envelope), failed), true
 	case ModbusV1ProfileObservationGetTool:
 		consistencyMode = "RETAINED_SOURCE_OBSERVATION"
 		var profileID, sampleID string
@@ -193,6 +190,31 @@ func (server *Server) handleModbusV1Call(ctx context.Context, name string, args 
 	return callToolResultText(mustJSON(newModbusV1Envelope(
 		data, err, providerCalled, consistencyMode, dataTimestamp,
 	)), err != nil), true
+}
+
+// InvokeModbusV1RawRead is the single closed raw-read invocation core used by
+// both the MCP tool and the Portal BFF. It owns parsing, provider invocation,
+// quota propagation, and the stable MCP envelope.
+func InvokeModbusV1RawRead(ctx context.Context, provider ModbusV1Provider, args map[string]any) map[string]any {
+	return modbusV1RawReadCall(ctx, provider, args)
+}
+
+func modbusV1RawReadCall(ctx context.Context, provider ModbusV1Provider, args map[string]any) map[string]any {
+	dataTimestamp := time.Now().UTC().Format(time.RFC3339Nano)
+	request, err := parseModbusRawReadRequest(args)
+	providerCalled := false
+	var data any
+	if err == nil && provider != nil {
+		providerCalled = true
+		data, err = provider.RawRead(ctx, request)
+	}
+	if provider == nil {
+		err = errors.New("modbus provider unavailable")
+	}
+	if err != nil {
+		data = nil
+	}
+	return newModbusV1Envelope(data, err, providerCalled, "LIVE", dataTimestamp)
 }
 
 func canonicalPVData(snapshot pv.Snapshot, producedAt string) map[string]any {

--- a/portal/handler.go
+++ b/portal/handler.go
@@ -1,22 +1,26 @@
 package portal
 
 import (
+	"bytes"
 	"cmp"
 	"context"
 	"embed"
 	"encoding/json"
+	"errors"
 	"expvar"
 	"fmt"
 	"html/template"
 	"io"
 	"io/fs"
 	"log"
+	"mime"
 	"net/http"
 	"path"
 	"slices"
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
@@ -85,17 +89,28 @@ type ForwardedResponse struct {
 }
 
 type RawModbusAuditEvent struct {
-	Outcome string
-	At      time.Time
+	RequestID   string    `json:"request_id"`
+	Surface     string    `json:"surface"`
+	Tool        string    `json:"tool"`
+	UnitID      *uint64   `json:"unit_id,omitempty"`
+	Function    *uint64   `json:"function,omitempty"`
+	Offset      *uint64   `json:"offset,omitempty"`
+	Quantity    *uint64   `json:"quantity,omitempty"`
+	Outcome     string    `json:"outcome"`
+	ErrorCode   string    `json:"error_code"`
+	DurationMS  int64     `json:"duration_ms"`
+	EndpointRef string    `json:"endpoint_ref,omitempty"`
+	At          time.Time `json:"at"`
 }
 
 type handler struct {
-	opts      Options
-	files     http.Handler
-	timeline  *timelineBuffer
-	snapshots *snapshotStore
-	sessions  *sessionStore
-	explorer  *explorerStore
+	opts          Options
+	files         http.Handler
+	timeline      *timelineBuffer
+	snapshots     *snapshotStore
+	sessions      *sessionStore
+	explorer      *explorerStore
+	rawRequestSeq atomic.Uint64
 }
 
 type RegistryDevice struct {
@@ -1090,44 +1105,111 @@ func (h *handler) handleRawModbusRead(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
+	started := time.Now()
+	event := RawModbusAuditEvent{
+		RequestID: fmt.Sprintf("raw-%016x", h.rawRequestSeq.Add(1)), Surface: "portal",
+		Tool: mcp.ModbusV1RawReadTool, Outcome: "rejected", ErrorCode: "INVALID_ARGUMENT", At: started.UTC(),
+	}
+	defer func() {
+		event.DurationMS = time.Since(started).Milliseconds()
+		h.auditRawModbus(event)
+	}()
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", http.MethodPost)
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	body, err := io.ReadAll(io.LimitReader(r.Body, (4<<10)+1))
-	if err != nil || len(body) > 4<<10 {
-		h.auditRawModbus("rejected")
-		http.Error(w, "invalid request", http.StatusBadRequest)
+	mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil || mediaType != "application/json" {
+		writeJSON(w, http.StatusUnsupportedMediaType, mcp.InvokeModbusV1RawRead(r.Context(), h.opts.ModbusProvider, nil))
 		return
 	}
-	var args map[string]any
-	decoder := json.NewDecoder(strings.NewReader(string(body)))
-	if err := decoder.Decode(&args); err != nil || decoder.Decode(&struct{}{}) != io.EOF {
-		h.auditRawModbus("rejected")
-		http.Error(w, "invalid request", http.StatusBadRequest)
+	body, err := io.ReadAll(io.LimitReader(r.Body, (4<<10)+1))
+	if err != nil || len(body) > 4<<10 {
+		writeJSON(w, http.StatusBadRequest, mcp.InvokeModbusV1RawRead(r.Context(), h.opts.ModbusProvider, nil))
+		return
+	}
+	args, err := decodeClosedRawModbusJSON(body)
+	event.UnitID = auditInteger(args, "unit_id")
+	event.Function = auditInteger(args, "function")
+	event.Offset = auditInteger(args, "offset")
+	event.Quantity = auditInteger(args, "quantity")
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, mcp.InvokeModbusV1RawRead(r.Context(), h.opts.ModbusProvider, nil))
 		return
 	}
 	envelope := mcp.InvokeModbusV1RawRead(r.Context(), h.opts.ModbusProvider, args)
-	outcome := "admitted"
+	event.Outcome = "admitted"
+	event.ErrorCode = ""
 	status := http.StatusOK
 	if errorValue, ok := envelope["error"].(map[string]any); ok {
 		switch errorValue["code"] {
 		case "INVALID_ARGUMENT":
-			outcome, status = "rejected", http.StatusBadRequest
+			event.Outcome, event.ErrorCode, status = "rejected", "INVALID_ARGUMENT", http.StatusBadRequest
 		case "RESOURCE_EXHAUSTED":
-			outcome, status = "exhausted", http.StatusTooManyRequests
+			event.Outcome, event.ErrorCode, status = "exhausted", "RESOURCE_EXHAUSTED", http.StatusTooManyRequests
 		default:
-			outcome, status = "failed", http.StatusBadGateway
+			event.Outcome, event.ErrorCode, status = "failed", "PROVIDER_FAILURE", http.StatusBadGateway
 		}
+	} else if data, ok := envelope["data"].(mcp.ModbusRawReadResult); ok && safeEndpointRef(data.EndpointRef) {
+		event.EndpointRef = data.EndpointRef
 	}
-	h.auditRawModbus(outcome)
 	writeJSON(w, status, envelope)
 }
 
-func (h *handler) auditRawModbus(outcome string) {
+func decodeClosedRawModbusJSON(body []byte) (map[string]any, error) {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	token, err := decoder.Token()
+	if err != nil || token != json.Delim('{') {
+		return nil, errors.New("raw Modbus request must be a JSON object")
+	}
+	args := make(map[string]any, 4)
+	for decoder.More() {
+		keyToken, err := decoder.Token()
+		if err != nil {
+			return args, errors.New("raw Modbus request is invalid")
+		}
+		key, ok := keyToken.(string)
+		if !ok {
+			return args, errors.New("raw Modbus request has an invalid key")
+		}
+		if _, duplicate := args[key]; duplicate {
+			return args, errors.New("raw Modbus request contains a duplicate key")
+		}
+		var value any
+		if err := decoder.Decode(&value); err != nil {
+			return args, errors.New("raw Modbus request has an invalid value")
+		}
+		args[key] = value
+	}
+	if token, err := decoder.Token(); err != nil || token != json.Delim('}') {
+		return args, errors.New("raw Modbus request object is incomplete")
+	}
+	if _, err := decoder.Token(); err != io.EOF {
+		return args, errors.New("raw Modbus request contains trailing data")
+	}
+	return args, nil
+}
+
+func auditInteger(args map[string]any, key string) *uint64 {
+	number, ok := args[key].(float64)
+	if !ok || number < 0 || number > 65535 || number != float64(uint64(number)) {
+		return nil
+	}
+	value := uint64(number)
+	return &value
+}
+
+func safeEndpointRef(value string) bool {
+	if !strings.HasPrefix(value, "sha256:") || len(value) > 128 || len(value) == len("sha256:") {
+		return false
+	}
+	return !strings.ContainsAny(value, " \t\r\n/\\@")
+}
+
+func (h *handler) auditRawModbus(event RawModbusAuditEvent) {
 	if h.opts.RawModbusAudit != nil {
-		h.opts.RawModbusAudit(RawModbusAuditEvent{Outcome: outcome, At: time.Now().UTC()})
+		h.opts.RawModbusAudit(event)
 	}
 }
 

--- a/portal/handler.go
+++ b/portal/handler.go
@@ -16,6 +16,7 @@ import (
 	"mime"
 	"net/http"
 	"path"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -53,6 +54,7 @@ var (
 	portalAssetETagByTarget = loadAssetETags()
 	portalStreamEventsTotal = expvar.NewMap("portal_stream_events_total")
 	portalStreamDropped     = expvar.NewMap("portal_stream_dropped_total")
+	endpointRefPattern      = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
 )
 
 type Options struct {
@@ -1201,10 +1203,7 @@ func auditInteger(args map[string]any, key string) *uint64 {
 }
 
 func safeEndpointRef(value string) bool {
-	if !strings.HasPrefix(value, "sha256:") || len(value) > 128 || len(value) == len("sha256:") {
-		return false
-	}
-	return !strings.ContainsAny(value, " \t\r\n/\\@")
+	return endpointRefPattern.MatchString(value)
 }
 
 func (h *handler) auditRawModbus(event RawModbusAuditEvent) {

--- a/portal/handler.go
+++ b/portal/handler.go
@@ -2,11 +2,13 @@ package portal
 
 import (
 	"cmp"
+	"context"
 	"embed"
 	"encoding/json"
 	"expvar"
 	"fmt"
 	"html/template"
+	"io"
 	"io/fs"
 	"log"
 	"net/http"
@@ -16,6 +18,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
 )
 
 //go:embed static/*
@@ -67,6 +71,22 @@ type Options struct {
 	// /api/v1/ebus-standard/* routes (they return 404) and hides the
 	// capability in /api/v1/bootstrap.
 	EbusStandardServer PortalEbusStandardServer
+	SemanticPVEnabled  bool
+	RawModbusEnabled   bool
+	SemanticPV         func(context.Context) (ForwardedResponse, error)
+	ModbusProvider     mcp.ModbusV1Provider
+	RawModbusAudit     func(RawModbusAuditEvent)
+}
+
+type ForwardedResponse struct {
+	Status      int
+	ContentType string
+	Body        []byte
+}
+
+type RawModbusAuditEvent struct {
+	Outcome string
+	At      time.Time
 }
 
 type handler struct {
@@ -893,6 +913,14 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 
 	// Explorer routes support POST/DELETE, must be checked before the GET-only guard.
 	trimmed := strings.Trim(path, "/")
+	if trimmed == "semantic/pv/current" {
+		h.handleSemanticPV(w, r)
+		return
+	}
+	if trimmed == "explorer/modbus/raw-read" {
+		h.handleRawModbusRead(w, r)
+		return
+	}
 	if h.explorer != nil && h.routeExplorer(w, r, trimmed) {
 		return
 	}
@@ -944,8 +972,10 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 				// must then disable the nav button and skip auto-activation
 				// of section-l7-catalog, otherwise the bootstrap fetch
 				// surfaces a broken section. Codex P2 on PR #507.
-				"ebus_standard": h.opts.EbusStandardServer != nil,
-				"eebus_admin":   h.opts.EEBusAdminPath != "",
+				"ebus_standard":   h.opts.EbusStandardServer != nil,
+				"eebus_admin":     h.opts.EEBusAdminPath != "",
+				"semantic_pv":     h.opts.SemanticPVEnabled && h.opts.SemanticPV != nil,
+				"modbus_raw_read": h.opts.RawModbusEnabled && h.opts.ModbusProvider != nil,
 			},
 			"endpoints": map[string]string{
 				"graphql":               h.opts.GraphQLPath,
@@ -975,6 +1005,8 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 				"explorer_read_b524":    "/portal/api/v1/explorer/read/b524",
 				"explorer_read_b509":    "/portal/api/v1/explorer/read/b509",
 				"explorer_read_scanid":  "/portal/api/v1/explorer/read/scanid",
+				"semantic_pv_current":   "/portal/api/v1/semantic/pv/current",
+				"modbus_raw_read":       "/portal/api/v1/explorer/modbus/raw-read",
 			},
 			"limits": map[string]any{
 				"max_events_per_second": 200,
@@ -1025,6 +1057,80 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 	}
 }
 
+func (h *handler) handleSemanticPV(w http.ResponseWriter, r *http.Request) {
+	if !h.opts.SemanticPVEnabled || h.opts.SemanticPV == nil {
+		http.NotFound(w, r)
+		return
+	}
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if r.URL.RawQuery != "" {
+		http.NotFound(w, r)
+		return
+	}
+	response, err := h.opts.SemanticPV(r.Context())
+	if err != nil {
+		http.Error(w, "semantic PV unavailable", http.StatusBadGateway)
+		return
+	}
+	if response.ContentType != "" {
+		w.Header().Set("Content-Type", response.ContentType)
+	} else {
+		w.Header().Set("Content-Type", "application/json")
+	}
+	w.WriteHeader(response.Status)
+	_, _ = w.Write(response.Body)
+}
+
+func (h *handler) handleRawModbusRead(w http.ResponseWriter, r *http.Request) {
+	if !h.opts.RawModbusEnabled || h.opts.ModbusProvider == nil {
+		http.NotFound(w, r)
+		return
+	}
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, (4<<10)+1))
+	if err != nil || len(body) > 4<<10 {
+		h.auditRawModbus("rejected")
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	var args map[string]any
+	decoder := json.NewDecoder(strings.NewReader(string(body)))
+	if err := decoder.Decode(&args); err != nil || decoder.Decode(&struct{}{}) != io.EOF {
+		h.auditRawModbus("rejected")
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	envelope := mcp.InvokeModbusV1RawRead(r.Context(), h.opts.ModbusProvider, args)
+	outcome := "admitted"
+	status := http.StatusOK
+	if errorValue, ok := envelope["error"].(map[string]any); ok {
+		switch errorValue["code"] {
+		case "INVALID_ARGUMENT":
+			outcome, status = "rejected", http.StatusBadRequest
+		case "RESOURCE_EXHAUSTED":
+			outcome, status = "exhausted", http.StatusTooManyRequests
+		default:
+			outcome, status = "failed", http.StatusBadGateway
+		}
+	}
+	h.auditRawModbus(outcome)
+	writeJSON(w, status, envelope)
+}
+
+func (h *handler) auditRawModbus(outcome string) {
+	if h.opts.RawModbusAudit != nil {
+		h.opts.RawModbusAudit(RawModbusAuditEvent{Outcome: outcome, At: time.Now().UTC()})
+	}
+}
+
 func writeJSON(w http.ResponseWriter, statusCode int, payload any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
@@ -1064,6 +1170,10 @@ func classifyRoute(path string) string {
 		return "api.registry.devices"
 	case strings.HasPrefix(path, "/api/v1/semantic/snapshot"):
 		return "api.semantic.snapshot"
+	case strings.HasPrefix(path, "/api/v1/semantic/pv/current"):
+		return "api.semantic.pv.current"
+	case strings.HasPrefix(path, "/api/v1/explorer/modbus/raw-read"):
+		return "api.explorer.modbus.raw_read"
 	case strings.HasPrefix(path, "/api/v1/bus/observability"):
 		return "api.bus.observability"
 	case strings.HasPrefix(path, "/api/v1/projection/devices"):

--- a/portal/pv_modbus_red_test.go
+++ b/portal/pv_modbus_red_test.go
@@ -1,0 +1,30 @@
+package portal
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestPortalPVAndRawModbusRoutesAreClosedAndDisabledByDefault(t *testing.T) {
+	handler := NewHandler(Options{})
+	for _, request := range []*http.Request{
+		httptest.NewRequest(http.MethodGet, "/api/v1/semantic/pv/current", nil),
+		httptest.NewRequest(http.MethodPost, "/api/v1/explorer/modbus/raw-read", strings.NewReader(`{"unit_id":1,"function":3,"offset":0,"quantity":1}`)),
+	} {
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, request)
+		if recorder.Code != http.StatusNotFound {
+			t.Fatalf("%s %s status=%d; want disabled 404", request.Method, request.URL.Path, recorder.Code)
+		}
+	}
+}
+
+func TestPortalBootstrapPublishesIndependentPVAndRawCapabilities(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	NewHandler(Options{}).ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/api/v1/bootstrap", nil))
+	if !strings.Contains(recorder.Body.String(), `"semantic_pv":false`) || !strings.Contains(recorder.Body.String(), `"modbus_raw_read":false`) {
+		t.Fatalf("bootstrap lacks independent disabled capabilities: %s", recorder.Body.String())
+	}
+}

--- a/portal/pv_modbus_red_test.go
+++ b/portal/pv_modbus_red_test.go
@@ -2,7 +2,9 @@ package portal
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -14,12 +16,20 @@ import (
 
 type portalRawReadProvider struct {
 	requests int
+	rawErr   error
+	result   mcp.ModbusRawReadResult
 }
 
 func (provider *portalRawReadProvider) RawRead(_ context.Context, request mcp.ModbusRawReadRequest) (mcp.ModbusRawReadResult, error) {
 	provider.requests++
+	if provider.rawErr != nil {
+		return mcp.ModbusRawReadResult{}, provider.rawErr
+	}
 	if provider.requests > mcp.ModbusV1MaxRawReadsPerWindow {
 		return mcp.ModbusRawReadResult{}, mcp.ErrModbusV1ResourceExhausted
+	}
+	if provider.result.EndpointRef != "" {
+		return provider.result, nil
 	}
 	return mcp.ModbusRawReadResult{UnitID: request.UnitID, Function: request.Function, Offset: request.Offset, Quantity: request.Quantity, Words: []uint16{42}}, nil
 }
@@ -67,12 +77,88 @@ func TestPortalPVForwardsClosedM2MEnvelopeAndRawReadUsesMCPEnvelope(t *testing.T
 	}
 
 	rawResponse := httptest.NewRecorder()
-	handler.ServeHTTP(rawResponse, httptest.NewRequest(http.MethodPost, "/api/v1/explorer/modbus/raw-read", strings.NewReader(`{"unit_id":1,"function":3,"offset":0,"quantity":1}`)))
+	rawRequest := httptest.NewRequest(http.MethodPost, "/api/v1/explorer/modbus/raw-read", strings.NewReader(`{"unit_id":1,"function":3,"offset":0,"quantity":1}`))
+	rawRequest.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(rawResponse, rawRequest)
 	if rawResponse.Code != http.StatusOK || !strings.Contains(rawResponse.Body.String(), `"name":"helianthus-modbus-mcp"`) || provider.requests != 1 {
 		t.Fatalf("raw response=%d %s requests=%d", rawResponse.Code, rawResponse.Body.String(), provider.requests)
 	}
 	if len(audit) != 1 || audit[0] != "admitted" {
 		t.Fatalf("raw audit=%v", audit)
+	}
+}
+
+func TestPortalRawModbusAdmissionRejectsNonClosedJSON(t *testing.T) {
+	for _, test := range []struct {
+		name, contentType, body string
+		wantStatus              int
+	}{
+		{name: "wrong_content_type", contentType: "text/plain", body: `{"unit_id":1,"function":3,"offset":0,"quantity":1}`, wantStatus: http.StatusUnsupportedMediaType},
+		{name: "duplicate_key", contentType: "application/json", body: `{"unit_id":1,"unit_id":2,"function":3,"offset":0,"quantity":1}`, wantStatus: http.StatusBadRequest},
+		{name: "null", contentType: "application/json", body: `null`, wantStatus: http.StatusBadRequest},
+		{name: "array", contentType: "application/json", body: `[]`, wantStatus: http.StatusBadRequest},
+		{name: "trailing", contentType: "application/json", body: `{"unit_id":1,"function":3,"offset":0,"quantity":1} {}`, wantStatus: http.StatusBadRequest},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			provider := &portalRawReadProvider{}
+			events := make([]RawModbusAuditEvent, 0, 1)
+			handler := NewHandler(Options{RawModbusEnabled: true, ModbusProvider: provider, RawModbusAudit: func(event RawModbusAuditEvent) { events = append(events, event) }})
+			request := httptest.NewRequest(http.MethodPost, "/api/v1/explorer/modbus/raw-read", strings.NewReader(test.body))
+			request.Header.Set("Content-Type", test.contentType)
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, request)
+			if response.Code != test.wantStatus || provider.requests != 0 || len(events) != 1 {
+				t.Fatalf("status=%d provider_requests=%d audit_events=%d", response.Code, provider.requests, len(events))
+			}
+		})
+	}
+}
+
+func TestPortalRawModbusAuditIsCompleteAndSanitizedForEveryOutcome(t *testing.T) {
+	for _, test := range []struct {
+		name, body, outcome, errorCode string
+		provider                       *portalRawReadProvider
+	}{
+		{name: "success", body: `{"unit_id":7,"function":4,"offset":12,"quantity":2}`, outcome: "admitted", provider: &portalRawReadProvider{result: mcp.ModbusRawReadResult{EndpointRef: "sha256:safe"}}},
+		{name: "rejected", body: `{"unit_id":7,"function":6,"offset":12,"quantity":2}`, outcome: "rejected", errorCode: "INVALID_ARGUMENT", provider: &portalRawReadProvider{}},
+		{name: "exhausted", body: `{"unit_id":7,"function":4,"offset":12,"quantity":2}`, outcome: "exhausted", errorCode: "RESOURCE_EXHAUSTED", provider: &portalRawReadProvider{rawErr: mcp.ErrModbusV1ResourceExhausted}},
+		{name: "failed", body: `{"unit_id":7,"function":4,"offset":12,"quantity":2}`, outcome: "failed", errorCode: "PROVIDER_FAILURE", provider: &portalRawReadProvider{rawErr: errors.New("tcp://operator:secret@example.test:502 private/path client.pem 1234")}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var events []RawModbusAuditEvent
+			handler := NewHandler(Options{RawModbusEnabled: true, ModbusProvider: test.provider, RawModbusAudit: func(event RawModbusAuditEvent) { events = append(events, event) }})
+			request := httptest.NewRequest(http.MethodPost, "/api/v1/explorer/modbus/raw-read", strings.NewReader(test.body))
+			request.Header.Set("Content-Type", "application/json")
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, request)
+			if len(events) != 1 {
+				t.Fatalf("audit events=%d", len(events))
+			}
+			encoded, err := json.Marshal(events[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+			var payload map[string]any
+			if err := json.Unmarshal(encoded, &payload); err != nil {
+				t.Fatal(err)
+			}
+			for key, want := range map[string]any{"surface": "portal", "tool": mcp.ModbusV1RawReadTool, "outcome": test.outcome, "error_code": test.errorCode} {
+				if payload[key] != want {
+					t.Fatalf("audit %s=%v; want %v; payload=%s", key, payload[key], want, encoded)
+				}
+			}
+			if requestID, _ := payload["request_id"].(string); requestID == "" || len(requestID) > 64 {
+				t.Fatalf("request_id is absent or unbounded: %q", requestID)
+			}
+			for _, forbidden := range []string{"words", "wire", "tcp://", "secret", "private/path", "client.pem", "1234"} {
+				if strings.Contains(strings.ToLower(string(encoded)), strings.ToLower(forbidden)) {
+					t.Fatalf("audit leaked %q: %s", forbidden, encoded)
+				}
+			}
+			if test.name == "success" && fmt.Sprint(payload["endpoint_ref"]) != "sha256:safe" {
+				t.Fatalf("safe endpoint_ref missing: %s", encoded)
+			}
+		})
 	}
 }
 

--- a/portal/pv_modbus_red_test.go
+++ b/portal/pv_modbus_red_test.go
@@ -1,11 +1,35 @@
 package portal
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
+	pv "github.com/Project-Helianthus/helianthus-ebusreg/pv"
 )
+
+type portalRawReadProvider struct {
+	requests int
+}
+
+func (provider *portalRawReadProvider) RawRead(_ context.Context, request mcp.ModbusRawReadRequest) (mcp.ModbusRawReadResult, error) {
+	provider.requests++
+	if provider.requests > mcp.ModbusV1MaxRawReadsPerWindow {
+		return mcp.ModbusRawReadResult{}, mcp.ErrModbusV1ResourceExhausted
+	}
+	return mcp.ModbusRawReadResult{UnitID: request.UnitID, Function: request.Function, Offset: request.Offset, Quantity: request.Quantity, Words: []uint16{42}}, nil
+}
+
+func (*portalRawReadProvider) ProfileObservation(context.Context, string, string) (mcp.ModbusProfileObservationResult, error) {
+	return mcp.ModbusProfileObservationResult{}, errors.New("not used")
+}
+func (*portalRawReadProvider) CanonicalPV(context.Context, string, string) (mcp.ModbusCanonicalPVResult, error) {
+	return mcp.ModbusCanonicalPVResult{Snapshot: pv.Snapshot{}}, errors.New("not used")
+}
 
 func TestPortalPVAndRawModbusRoutesAreClosedAndDisabledByDefault(t *testing.T) {
 	handler := NewHandler(Options{})
@@ -18,6 +42,37 @@ func TestPortalPVAndRawModbusRoutesAreClosedAndDisabledByDefault(t *testing.T) {
 		if recorder.Code != http.StatusNotFound {
 			t.Fatalf("%s %s status=%d; want disabled 404", request.Method, request.URL.Path, recorder.Code)
 		}
+	}
+}
+
+func TestPortalPVForwardsClosedM2MEnvelopeAndRawReadUsesMCPEnvelope(t *testing.T) {
+	provider := &portalRawReadProvider{}
+	audit := make([]string, 0, 2)
+	handler := NewHandler(Options{
+		SemanticPVEnabled: true,
+		SemanticPV: func(context.Context) (ForwardedResponse, error) {
+			return ForwardedResponse{Status: http.StatusOK, ContentType: "application/json", Body: []byte(`{"data":{"m2mCurrentSnapshot":{"contractId":"PUBLIC_GRAPHQL_M2M_V1"}}}`)}, nil
+		},
+		RawModbusEnabled: true,
+		ModbusProvider:   provider,
+		RawModbusAudit: func(event RawModbusAuditEvent) {
+			audit = append(audit, event.Outcome)
+		},
+	})
+
+	pvResponse := httptest.NewRecorder()
+	handler.ServeHTTP(pvResponse, httptest.NewRequest(http.MethodGet, "/api/v1/semantic/pv/current", nil))
+	if pvResponse.Code != http.StatusOK || pvResponse.Body.String() != `{"data":{"m2mCurrentSnapshot":{"contractId":"PUBLIC_GRAPHQL_M2M_V1"}}}` {
+		t.Fatalf("semantic PV response=%d %s", pvResponse.Code, pvResponse.Body.String())
+	}
+
+	rawResponse := httptest.NewRecorder()
+	handler.ServeHTTP(rawResponse, httptest.NewRequest(http.MethodPost, "/api/v1/explorer/modbus/raw-read", strings.NewReader(`{"unit_id":1,"function":3,"offset":0,"quantity":1}`)))
+	if rawResponse.Code != http.StatusOK || !strings.Contains(rawResponse.Body.String(), `"name":"helianthus-modbus-mcp"`) || provider.requests != 1 {
+		t.Fatalf("raw response=%d %s requests=%d", rawResponse.Code, rawResponse.Body.String(), provider.requests)
+	}
+	if len(audit) != 1 || audit[0] != "admitted" {
+		t.Fatalf("raw audit=%v", audit)
 	}
 }
 

--- a/portal/pv_modbus_red_test.go
+++ b/portal/pv_modbus_red_test.go
@@ -119,7 +119,7 @@ func TestPortalRawModbusAuditIsCompleteAndSanitizedForEveryOutcome(t *testing.T)
 		name, body, outcome, errorCode string
 		provider                       *portalRawReadProvider
 	}{
-		{name: "success", body: `{"unit_id":7,"function":4,"offset":12,"quantity":2}`, outcome: "admitted", provider: &portalRawReadProvider{result: mcp.ModbusRawReadResult{EndpointRef: "sha256:safe"}}},
+		{name: "success", body: `{"unit_id":7,"function":4,"offset":12,"quantity":2}`, outcome: "admitted", provider: &portalRawReadProvider{result: mcp.ModbusRawReadResult{EndpointRef: "sha256:" + strings.Repeat("a", 64)}}},
 		{name: "rejected", body: `{"unit_id":7,"function":6,"offset":12,"quantity":2}`, outcome: "rejected", errorCode: "INVALID_ARGUMENT", provider: &portalRawReadProvider{}},
 		{name: "exhausted", body: `{"unit_id":7,"function":4,"offset":12,"quantity":2}`, outcome: "exhausted", errorCode: "RESOURCE_EXHAUSTED", provider: &portalRawReadProvider{rawErr: mcp.ErrModbusV1ResourceExhausted}},
 		{name: "failed", body: `{"unit_id":7,"function":4,"offset":12,"quantity":2}`, outcome: "failed", errorCode: "PROVIDER_FAILURE", provider: &portalRawReadProvider{rawErr: errors.New("tcp://operator:secret@example.test:502 private/path client.pem 1234")}},
@@ -155,10 +155,29 @@ func TestPortalRawModbusAuditIsCompleteAndSanitizedForEveryOutcome(t *testing.T)
 					t.Fatalf("audit leaked %q: %s", forbidden, encoded)
 				}
 			}
-			if test.name == "success" && fmt.Sprint(payload["endpoint_ref"]) != "sha256:safe" {
+			if test.name == "success" && fmt.Sprint(payload["endpoint_ref"]) != "sha256:"+strings.Repeat("a", 64) {
 				t.Fatalf("safe endpoint_ref missing: %s", encoded)
 			}
 		})
+	}
+}
+
+func TestSafeEndpointRefRequiresExactLowercaseSHA256Contract(t *testing.T) {
+	valid := "sha256:" + strings.Repeat("a", 64)
+	if !safeEndpointRef(valid) {
+		t.Fatalf("valid endpoint ref rejected: %q", valid)
+	}
+	for _, value := range []string{
+		"sha256:safe",
+		"sha256:" + strings.Repeat("A", 64),
+		"sha256:" + strings.Repeat("a", 63),
+		"sha256:" + strings.Repeat("a", 65),
+		"sha256:" + strings.Repeat("a", 63) + "/",
+		"sha256:" + strings.Repeat("a", 64) + "@evil",
+	} {
+		if safeEndpointRef(value) {
+			t.Fatalf("unsafe endpoint ref accepted: %q", value)
+		}
 	}
 }
 

--- a/portal/static/assets/app.css
+++ b/portal/static/assets/app.css
@@ -455,6 +455,17 @@ body {
   color: var(--warn);
 }
 
+.pv-output {
+  max-height: 22rem;
+  overflow: auto;
+  padding: 0.65rem;
+  border: 1px solid var(--border);
+  background: var(--panel);
+  font-family: "IBM Plex Mono", "Fira Code", monospace;
+  font-size: 0.78rem;
+  white-space: pre-wrap;
+}
+
 @media (max-width: 900px) {
   .topbar {
     grid-template-columns: 1fr;

--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -400,9 +400,25 @@ class PortalShell extends HTMLElement {
       });
     });
     this.bindExplorerEvents();
+    const rawRead = this.querySelector('[data-role="modbus-raw-read"]');
+    if (rawRead) rawRead.addEventListener("click", () => this.readRawModbus());
     this.bindL7CatalogEvents();
     this.bindVaillantB503Events();
 	this.bindEEBusAdminEvents();
+  }
+
+  async readRawModbus() {
+    const output = this.querySelector('[data-role="modbus-raw-output"]');
+    const unit = Number(this.querySelector('[data-role="modbus-unit"]')?.value);
+    const func = Number(this.querySelector('[data-role="modbus-function"]')?.value);
+    const offset = Number(this.querySelector('[data-role="modbus-offset"]')?.value);
+    const quantity = Number(this.querySelector('[data-role="modbus-quantity"]')?.value);
+    if (!output || !this._capabilityRawModbus || !Number.isInteger(unit) || unit < 1 || unit > 247 || ![3, 4].includes(func) || !Number.isInteger(offset) || offset < 0 || offset > 65535 || !Number.isInteger(quantity) || quantity < 1 || quantity > 125) {
+      if (output) output.textContent = "Invalid raw read bounds";
+      return;
+    }
+    const response = await fetch("api/v1/explorer/modbus/raw-read", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ unit_id: unit, function: func, offset, quantity }) });
+    output.textContent = JSON.stringify(await response.json(), null, 2);
   }
 
   // bindL7CatalogEvents wires the L7 Standard Catalog section (M5_PORTAL)
@@ -640,6 +656,7 @@ class PortalShell extends HTMLElement {
 	    ? bootstrap.endpoints.eebus_admin.replace(/\/$/, "")
 	    : "";
       this.applyCapabilityState(capabilities);
+      this._capabilityRawModbus = Boolean(capabilities.modbus_raw_read);
       const firstEnabled = this.querySelector("[data-nav-target]:not([disabled])");
       if (firstEnabled) {
         this.activateSection(firstEnabled.getAttribute("data-nav-target"));
@@ -2775,6 +2792,15 @@ class PortalShell extends HTMLElement {
                   <span class="muted-inline" data-role="explorer-quick-result"></span>
                 </div>
               </div>
+              <h3>Raw Modbus</h3>
+              <div class="explorer-row">
+                <label class="explorer-label">Unit <input class="search explorer-input" data-role="modbus-unit" value="1" inputmode="numeric" /></label>
+                <label class="explorer-label">Function <select class="select" data-role="modbus-function"><option value="3">FC03</option><option value="4">FC04</option></select></label>
+                <label class="explorer-label">Offset <input class="search explorer-input" data-role="modbus-offset" value="0" inputmode="numeric" /></label>
+                <label class="explorer-label">Quantity <input class="search explorer-input" data-role="modbus-quantity" value="1" inputmode="numeric" /></label>
+                <button class="button" data-role="modbus-raw-read" type="button">Read</button>
+              </div>
+              <pre class="pv-output" data-role="modbus-raw-output">Raw diagnostics unavailable</pre>
             </section>
             <section id="section-adapter" class="registry-preview">
               <h2>Adapter Hardware Info</h2>

--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -417,12 +417,17 @@ class PortalShell extends HTMLElement {
     const func = Number(this.querySelector('[data-role="modbus-function"]')?.value);
     const offset = Number(this.querySelector('[data-role="modbus-offset"]')?.value);
     const quantity = Number(this.querySelector('[data-role="modbus-quantity"]')?.value);
-    if (!output || !this._capabilityRawModbus || !Number.isInteger(unit) || unit < 1 || unit > 247 || ![3, 4].includes(func) || !Number.isInteger(offset) || offset < 0 || offset > 65535 || !Number.isInteger(quantity) || quantity < 1 || quantity > 125) {
+    if (!output || !this._capabilityRawModbus || !Number.isInteger(unit) || unit < 1 || unit > 247 || ![3, 4].includes(func) || !Number.isInteger(offset) || offset < 0 || offset > 65535 || !Number.isInteger(quantity) || quantity < 1 || quantity > 125 || offset + quantity > 65536) {
       if (output) output.textContent = "Invalid raw read bounds";
       return;
     }
-    const response = await fetch("api/v1/explorer/modbus/raw-read", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ unit_id: unit, function: func, offset, quantity }) });
-    output.textContent = JSON.stringify(await response.json(), null, 2);
+    try {
+      const response = await fetch("api/v1/explorer/modbus/raw-read", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ unit_id: unit, function: func, offset, quantity }) });
+      if (!response.ok) throw new Error("raw read failed");
+      output.textContent = JSON.stringify(await response.json(), null, 2);
+    } catch {
+      output.textContent = "Raw read unavailable";
+    }
   }
 
   async refreshPV() {
@@ -433,6 +438,20 @@ class PortalShell extends HTMLElement {
       output.textContent = response.ok ? JSON.stringify(await response.json(), null, 2) : `PV unavailable (${response.status})`;
     } catch {
       output.textContent = "PV unavailable";
+    }
+  }
+
+  applyPVModbusCapabilityState(capabilities) {
+    const cap = capabilities || {};
+    this._capabilitySemanticPV = Boolean(cap.semantic_pv);
+    this._capabilityRawModbus = Boolean(cap.modbus_raw_read);
+    const pvPanel = this.querySelector('[data-role="pv-panel"]');
+    const rawPanel = this.querySelector('[data-role="modbus-raw-panel"]');
+    if (pvPanel) pvPanel.hidden = !this._capabilitySemanticPV;
+    if (rawPanel) rawPanel.hidden = !this._capabilityRawModbus;
+    if (!this._capabilitySemanticPV && this.pvInterval) {
+      clearInterval(this.pvInterval);
+      this.pvInterval = undefined;
     }
   }
 
@@ -671,8 +690,7 @@ class PortalShell extends HTMLElement {
 	    ? bootstrap.endpoints.eebus_admin.replace(/\/$/, "")
 	    : "";
       this.applyCapabilityState(capabilities);
-      this._capabilityRawModbus = Boolean(capabilities.modbus_raw_read);
-      this._capabilitySemanticPV = Boolean(capabilities.semantic_pv);
+	  this.applyPVModbusCapabilityState(capabilities);
       if (this._capabilitySemanticPV) {
         await this.refreshPV();
         if (this.pvInterval) clearInterval(this.pvInterval);
@@ -845,10 +863,10 @@ class PortalShell extends HTMLElement {
   applyCapabilityState(capabilities) {
     const cap = capabilities || {};
     this.setNavState("registry", cap.registry);
-    this.setNavState("semantic", cap.semantic);
+    this.setNavState("semantic", cap.semantic || cap.semantic_pv);
     this.setNavState("bus", cap.bus_observability);
     this.setNavState("projection", cap.projection);
-    this.setNavState("explorer", cap.explorer);
+    this.setNavState("explorer", cap.explorer || cap.modbus_raw_read);
     this.setNavState("adapter", cap.semantic);
     this.setNavState("timeline", cap.timeline || cap.provenance);
     this.setNavState("snapshots", cap.snapshots || cap.snapshot_diff);
@@ -2713,8 +2731,10 @@ class PortalShell extends HTMLElement {
               <ul data-role="semantic-list">
                 <li>Loading semantic snapshot...</li>
               </ul>
-              <h3>PV Current</h3>
-              <pre class="pv-output" data-role="pv-current">PV unavailable</pre>
+              <div data-role="pv-panel" hidden>
+                <h3>PV Current</h3>
+                <pre class="pv-output" data-role="pv-current">PV unavailable</pre>
+              </div>
             </section>
             <section id="section-bus" class="registry-preview">
               <h2>Bus Observability</h2>
@@ -2815,15 +2835,17 @@ class PortalShell extends HTMLElement {
                   <span class="muted-inline" data-role="explorer-quick-result"></span>
                 </div>
               </div>
-              <h3>Raw Modbus</h3>
-              <div class="explorer-row">
-                <label class="explorer-label">Unit <input class="search explorer-input" data-role="modbus-unit" value="1" inputmode="numeric" /></label>
-                <label class="explorer-label">Function <select class="select" data-role="modbus-function"><option value="3">FC03</option><option value="4">FC04</option></select></label>
-                <label class="explorer-label">Offset <input class="search explorer-input" data-role="modbus-offset" value="0" inputmode="numeric" /></label>
-                <label class="explorer-label">Quantity <input class="search explorer-input" data-role="modbus-quantity" value="1" inputmode="numeric" /></label>
-                <button class="button" data-role="modbus-raw-read" type="button">Read</button>
+              <div data-role="modbus-raw-panel" hidden>
+                <h3>Raw Modbus</h3>
+                <div class="explorer-row">
+                  <label class="explorer-label">Unit <input class="search explorer-input" data-role="modbus-unit" value="1" inputmode="numeric" /></label>
+                  <label class="explorer-label">Function <select class="select" data-role="modbus-function"><option value="3">FC03</option><option value="4">FC04</option></select></label>
+                  <label class="explorer-label">Offset <input class="search explorer-input" data-role="modbus-offset" value="0" inputmode="numeric" /></label>
+                  <label class="explorer-label">Quantity <input class="search explorer-input" data-role="modbus-quantity" value="1" inputmode="numeric" /></label>
+                  <button class="button" data-role="modbus-raw-read" type="button">Read</button>
+                </div>
+                <pre class="pv-output" data-role="modbus-raw-output">Raw diagnostics unavailable</pre>
               </div>
-              <pre class="pv-output" data-role="modbus-raw-output">Raw diagnostics unavailable</pre>
             </section>
             <section id="section-adapter" class="registry-preview">
               <h2>Adapter Hardware Info</h2>

--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -257,6 +257,10 @@ class PortalShell extends HTMLElement {
       clearInterval(this.busObservabilityInterval);
       this.busObservabilityInterval = undefined;
     }
+    if (this.pvInterval) {
+      clearInterval(this.pvInterval);
+      this.pvInterval = undefined;
+    }
     if (this._explorerPollTimer) {
       clearInterval(this._explorerPollTimer);
       this._explorerPollTimer = undefined;
@@ -419,6 +423,17 @@ class PortalShell extends HTMLElement {
     }
     const response = await fetch("api/v1/explorer/modbus/raw-read", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ unit_id: unit, function: func, offset, quantity }) });
     output.textContent = JSON.stringify(await response.json(), null, 2);
+  }
+
+  async refreshPV() {
+    const output = this.querySelector('[data-role="pv-current"]');
+    if (!output || !this._capabilitySemanticPV) return;
+    try {
+      const response = await fetch("api/v1/semantic/pv/current");
+      output.textContent = response.ok ? JSON.stringify(await response.json(), null, 2) : `PV unavailable (${response.status})`;
+    } catch {
+      output.textContent = "PV unavailable";
+    }
   }
 
   // bindL7CatalogEvents wires the L7 Standard Catalog section (M5_PORTAL)
@@ -657,6 +672,12 @@ class PortalShell extends HTMLElement {
 	    : "";
       this.applyCapabilityState(capabilities);
       this._capabilityRawModbus = Boolean(capabilities.modbus_raw_read);
+      this._capabilitySemanticPV = Boolean(capabilities.semantic_pv);
+      if (this._capabilitySemanticPV) {
+        await this.refreshPV();
+        if (this.pvInterval) clearInterval(this.pvInterval);
+        this.pvInterval = setInterval(() => this.refreshPV(), 5000);
+      }
       const firstEnabled = this.querySelector("[data-nav-target]:not([disabled])");
       if (firstEnabled) {
         this.activateSection(firstEnabled.getAttribute("data-nav-target"));
@@ -2692,6 +2713,8 @@ class PortalShell extends HTMLElement {
               <ul data-role="semantic-list">
                 <li>Loading semantic snapshot...</li>
               </ul>
+              <h3>PV Current</h3>
+              <pre class="pv-output" data-role="pv-current">PV unavailable</pre>
             </section>
             <section id="section-bus" class="registry-preview">
               <h2>Bus Observability</h2>

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,12 +2,12 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 159917,
-      "sha256": "706fb363040498bc7e81effa151eea4a5cd8c32ea2a36be43ac00d0e2e61fa53"
+      "bytes": 162163,
+      "sha256": "df8d5675f79c7a513c15356e7a5e5a50bb2c0246c6c559297ac0acfd3bbb3670"
     },
     "app.css": {
-      "bytes": 8606,
-      "sha256": "2b457027a4aee7a8c588dbf82e5a33fd93b800a388239df3e23e77879ad2e156"
+      "bytes": 8847,
+      "sha256": "809e1df96ad0d7b5ce115c1ead5ac3c51a0348cdbc2b07a577d906af3ad6889e"
     }
   }
 }

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,8 +2,8 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 163084,
-      "sha256": "41a3286644d7fc2f7281a48eaacad99fad3cb3d8afb3dc908e089651909eca9e"
+      "bytes": 163991,
+      "sha256": "50b5e108892a959f4aff2e3cc2c814848c0994800bb142d84051781475906d1d"
     },
     "app.css": {
       "bytes": 8847,

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,8 +2,8 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 162163,
-      "sha256": "df8d5675f79c7a513c15356e7a5e5a50bb2c0246c6c559297ac0acfd3bbb3670"
+      "bytes": 163084,
+      "sha256": "41a3286644d7fc2f7281a48eaacad99fad3cb3d8afb3dc908e089651909eca9e"
     },
     "app.css": {
       "bytes": 8847,

--- a/portal/web/src/app.css
+++ b/portal/web/src/app.css
@@ -454,6 +454,17 @@ body {
   color: var(--warn);
 }
 
+.pv-output {
+  max-height: 22rem;
+  overflow: auto;
+  padding: 0.65rem;
+  border: 1px solid var(--border);
+  background: var(--panel);
+  font-family: "IBM Plex Mono", "Fira Code", monospace;
+  font-size: 0.78rem;
+  white-space: pre-wrap;
+}
+
 @media (max-width: 900px) {
   .topbar {
     grid-template-columns: 1fr;

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -416,12 +416,17 @@ class PortalShell extends HTMLElement {
     const func = Number(this.querySelector('[data-role="modbus-function"]')?.value);
     const offset = Number(this.querySelector('[data-role="modbus-offset"]')?.value);
     const quantity = Number(this.querySelector('[data-role="modbus-quantity"]')?.value);
-    if (!output || !this._capabilityRawModbus || !Number.isInteger(unit) || unit < 1 || unit > 247 || ![3, 4].includes(func) || !Number.isInteger(offset) || offset < 0 || offset > 65535 || !Number.isInteger(quantity) || quantity < 1 || quantity > 125) {
+    if (!output || !this._capabilityRawModbus || !Number.isInteger(unit) || unit < 1 || unit > 247 || ![3, 4].includes(func) || !Number.isInteger(offset) || offset < 0 || offset > 65535 || !Number.isInteger(quantity) || quantity < 1 || quantity > 125 || offset + quantity > 65536) {
       if (output) output.textContent = "Invalid raw read bounds";
       return;
     }
-    const response = await fetch("api/v1/explorer/modbus/raw-read", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ unit_id: unit, function: func, offset, quantity }) });
-    output.textContent = JSON.stringify(await response.json(), null, 2);
+    try {
+      const response = await fetch("api/v1/explorer/modbus/raw-read", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ unit_id: unit, function: func, offset, quantity }) });
+      if (!response.ok) throw new Error("raw read failed");
+      output.textContent = JSON.stringify(await response.json(), null, 2);
+    } catch {
+      output.textContent = "Raw read unavailable";
+    }
   }
 
   async refreshPV() {
@@ -432,6 +437,20 @@ class PortalShell extends HTMLElement {
       output.textContent = response.ok ? JSON.stringify(await response.json(), null, 2) : `PV unavailable (${response.status})`;
     } catch {
       output.textContent = "PV unavailable";
+    }
+  }
+
+  applyPVModbusCapabilityState(capabilities) {
+    const cap = capabilities || {};
+    this._capabilitySemanticPV = Boolean(cap.semantic_pv);
+    this._capabilityRawModbus = Boolean(cap.modbus_raw_read);
+    const pvPanel = this.querySelector('[data-role="pv-panel"]');
+    const rawPanel = this.querySelector('[data-role="modbus-raw-panel"]');
+    if (pvPanel) pvPanel.hidden = !this._capabilitySemanticPV;
+    if (rawPanel) rawPanel.hidden = !this._capabilityRawModbus;
+    if (!this._capabilitySemanticPV && this.pvInterval) {
+      clearInterval(this.pvInterval);
+      this.pvInterval = undefined;
     }
   }
 
@@ -670,8 +689,7 @@ class PortalShell extends HTMLElement {
 	    ? bootstrap.endpoints.eebus_admin.replace(/\/$/, "")
 	    : "";
       this.applyCapabilityState(capabilities);
-      this._capabilityRawModbus = Boolean(capabilities.modbus_raw_read);
-      this._capabilitySemanticPV = Boolean(capabilities.semantic_pv);
+	  this.applyPVModbusCapabilityState(capabilities);
       if (this._capabilitySemanticPV) {
         await this.refreshPV();
         if (this.pvInterval) clearInterval(this.pvInterval);
@@ -844,10 +862,10 @@ class PortalShell extends HTMLElement {
   applyCapabilityState(capabilities) {
     const cap = capabilities || {};
     this.setNavState("registry", cap.registry);
-    this.setNavState("semantic", cap.semantic);
+    this.setNavState("semantic", cap.semantic || cap.semantic_pv);
     this.setNavState("bus", cap.bus_observability);
     this.setNavState("projection", cap.projection);
-    this.setNavState("explorer", cap.explorer);
+    this.setNavState("explorer", cap.explorer || cap.modbus_raw_read);
     this.setNavState("adapter", cap.semantic);
     this.setNavState("timeline", cap.timeline || cap.provenance);
     this.setNavState("snapshots", cap.snapshots || cap.snapshot_diff);
@@ -2712,8 +2730,10 @@ class PortalShell extends HTMLElement {
               <ul data-role="semantic-list">
                 <li>Loading semantic snapshot...</li>
               </ul>
-              <h3>PV Current</h3>
-              <pre class="pv-output" data-role="pv-current">PV unavailable</pre>
+              <div data-role="pv-panel" hidden>
+                <h3>PV Current</h3>
+                <pre class="pv-output" data-role="pv-current">PV unavailable</pre>
+              </div>
             </section>
             <section id="section-bus" class="registry-preview">
               <h2>Bus Observability</h2>
@@ -2814,15 +2834,17 @@ class PortalShell extends HTMLElement {
                   <span class="muted-inline" data-role="explorer-quick-result"></span>
                 </div>
               </div>
-              <h3>Raw Modbus</h3>
-              <div class="explorer-row">
-                <label class="explorer-label">Unit <input class="search explorer-input" data-role="modbus-unit" value="1" inputmode="numeric" /></label>
-                <label class="explorer-label">Function <select class="select" data-role="modbus-function"><option value="3">FC03</option><option value="4">FC04</option></select></label>
-                <label class="explorer-label">Offset <input class="search explorer-input" data-role="modbus-offset" value="0" inputmode="numeric" /></label>
-                <label class="explorer-label">Quantity <input class="search explorer-input" data-role="modbus-quantity" value="1" inputmode="numeric" /></label>
-                <button class="button" data-role="modbus-raw-read" type="button">Read</button>
+              <div data-role="modbus-raw-panel" hidden>
+                <h3>Raw Modbus</h3>
+                <div class="explorer-row">
+                  <label class="explorer-label">Unit <input class="search explorer-input" data-role="modbus-unit" value="1" inputmode="numeric" /></label>
+                  <label class="explorer-label">Function <select class="select" data-role="modbus-function"><option value="3">FC03</option><option value="4">FC04</option></select></label>
+                  <label class="explorer-label">Offset <input class="search explorer-input" data-role="modbus-offset" value="0" inputmode="numeric" /></label>
+                  <label class="explorer-label">Quantity <input class="search explorer-input" data-role="modbus-quantity" value="1" inputmode="numeric" /></label>
+                  <button class="button" data-role="modbus-raw-read" type="button">Read</button>
+                </div>
+                <pre class="pv-output" data-role="modbus-raw-output">Raw diagnostics unavailable</pre>
               </div>
-              <pre class="pv-output" data-role="modbus-raw-output">Raw diagnostics unavailable</pre>
             </section>
             <section id="section-adapter" class="registry-preview">
               <h2>Adapter Hardware Info</h2>

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -256,6 +256,10 @@ class PortalShell extends HTMLElement {
       clearInterval(this.busObservabilityInterval);
       this.busObservabilityInterval = undefined;
     }
+    if (this.pvInterval) {
+      clearInterval(this.pvInterval);
+      this.pvInterval = undefined;
+    }
     if (this._explorerPollTimer) {
       clearInterval(this._explorerPollTimer);
       this._explorerPollTimer = undefined;
@@ -418,6 +422,17 @@ class PortalShell extends HTMLElement {
     }
     const response = await fetch("api/v1/explorer/modbus/raw-read", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ unit_id: unit, function: func, offset, quantity }) });
     output.textContent = JSON.stringify(await response.json(), null, 2);
+  }
+
+  async refreshPV() {
+    const output = this.querySelector('[data-role="pv-current"]');
+    if (!output || !this._capabilitySemanticPV) return;
+    try {
+      const response = await fetch("api/v1/semantic/pv/current");
+      output.textContent = response.ok ? JSON.stringify(await response.json(), null, 2) : `PV unavailable (${response.status})`;
+    } catch {
+      output.textContent = "PV unavailable";
+    }
   }
 
   // bindL7CatalogEvents wires the L7 Standard Catalog section (M5_PORTAL)
@@ -656,6 +671,12 @@ class PortalShell extends HTMLElement {
 	    : "";
       this.applyCapabilityState(capabilities);
       this._capabilityRawModbus = Boolean(capabilities.modbus_raw_read);
+      this._capabilitySemanticPV = Boolean(capabilities.semantic_pv);
+      if (this._capabilitySemanticPV) {
+        await this.refreshPV();
+        if (this.pvInterval) clearInterval(this.pvInterval);
+        this.pvInterval = setInterval(() => this.refreshPV(), 5000);
+      }
       const firstEnabled = this.querySelector("[data-nav-target]:not([disabled])");
       if (firstEnabled) {
         this.activateSection(firstEnabled.getAttribute("data-nav-target"));
@@ -2691,6 +2712,8 @@ class PortalShell extends HTMLElement {
               <ul data-role="semantic-list">
                 <li>Loading semantic snapshot...</li>
               </ul>
+              <h3>PV Current</h3>
+              <pre class="pv-output" data-role="pv-current">PV unavailable</pre>
             </section>
             <section id="section-bus" class="registry-preview">
               <h2>Bus Observability</h2>

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -399,9 +399,25 @@ class PortalShell extends HTMLElement {
       });
     });
     this.bindExplorerEvents();
+    const rawRead = this.querySelector('[data-role="modbus-raw-read"]');
+    if (rawRead) rawRead.addEventListener("click", () => this.readRawModbus());
     this.bindL7CatalogEvents();
     this.bindVaillantB503Events();
 	this.bindEEBusAdminEvents();
+  }
+
+  async readRawModbus() {
+    const output = this.querySelector('[data-role="modbus-raw-output"]');
+    const unit = Number(this.querySelector('[data-role="modbus-unit"]')?.value);
+    const func = Number(this.querySelector('[data-role="modbus-function"]')?.value);
+    const offset = Number(this.querySelector('[data-role="modbus-offset"]')?.value);
+    const quantity = Number(this.querySelector('[data-role="modbus-quantity"]')?.value);
+    if (!output || !this._capabilityRawModbus || !Number.isInteger(unit) || unit < 1 || unit > 247 || ![3, 4].includes(func) || !Number.isInteger(offset) || offset < 0 || offset > 65535 || !Number.isInteger(quantity) || quantity < 1 || quantity > 125) {
+      if (output) output.textContent = "Invalid raw read bounds";
+      return;
+    }
+    const response = await fetch("api/v1/explorer/modbus/raw-read", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ unit_id: unit, function: func, offset, quantity }) });
+    output.textContent = JSON.stringify(await response.json(), null, 2);
   }
 
   // bindL7CatalogEvents wires the L7 Standard Catalog section (M5_PORTAL)
@@ -639,6 +655,7 @@ class PortalShell extends HTMLElement {
 	    ? bootstrap.endpoints.eebus_admin.replace(/\/$/, "")
 	    : "";
       this.applyCapabilityState(capabilities);
+      this._capabilityRawModbus = Boolean(capabilities.modbus_raw_read);
       const firstEnabled = this.querySelector("[data-nav-target]:not([disabled])");
       if (firstEnabled) {
         this.activateSection(firstEnabled.getAttribute("data-nav-target"));
@@ -2774,6 +2791,15 @@ class PortalShell extends HTMLElement {
                   <span class="muted-inline" data-role="explorer-quick-result"></span>
                 </div>
               </div>
+              <h3>Raw Modbus</h3>
+              <div class="explorer-row">
+                <label class="explorer-label">Unit <input class="search explorer-input" data-role="modbus-unit" value="1" inputmode="numeric" /></label>
+                <label class="explorer-label">Function <select class="select" data-role="modbus-function"><option value="3">FC03</option><option value="4">FC04</option></select></label>
+                <label class="explorer-label">Offset <input class="search explorer-input" data-role="modbus-offset" value="0" inputmode="numeric" /></label>
+                <label class="explorer-label">Quantity <input class="search explorer-input" data-role="modbus-quantity" value="1" inputmode="numeric" /></label>
+                <button class="button" data-role="modbus-raw-read" type="button">Read</button>
+              </div>
+              <pre class="pv-output" data-role="modbus-raw-output">Raw diagnostics unavailable</pre>
             </section>
             <section id="section-adapter" class="registry-preview">
               <h2>Adapter Hardware Info</h2>

--- a/portal/web/test/pv-modbus.test.mjs
+++ b/portal/web/test/pv-modbus.test.mjs
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
+import vm from "node:vm";
 
 test("raw Modbus browser call uses the fixed Portal route", async () => {
   const here = path.dirname(fileURLToPath(import.meta.url));
@@ -11,4 +12,98 @@ test("raw Modbus browser call uses the fixed Portal route", async () => {
   assert.match(source, /api\/v1\/semantic\/pv\/current/);
   assert.match(source, /setInterval\(\(\) => this\.refreshPV\(\), 5000\)/);
   assert.doesNotMatch(source, /portal-pv-m2m-url|m2m-graphql-listen/);
+});
+
+async function loadPortalShell() {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const sourcePath = path.resolve(here, "../src/app.js");
+  const source = await readFile(sourcePath, "utf8");
+  const cleared = [];
+  const sandbox = {
+    console: { error() {}, log() {}, warn() {} },
+    document: { documentElement: { setAttribute() {} }, removeEventListener() {} },
+    customElements: { define() {} },
+    HTMLElement: class {},
+    localStorage: { getItem() { return null; }, setItem() {} },
+    clearInterval(value) { cleared.push(value); },
+    clearTimeout() {},
+    setInterval() { return {}; },
+    setTimeout,
+    AbortController,
+    URLSearchParams,
+    TextDecoder,
+  };
+  sandbox.globalThis = sandbox;
+  vm.createContext(sandbox);
+  vm.runInContext(`${source}\n;globalThis.__PortalShell = PortalShell;`, sandbox, { filename: sourcePath });
+  return { PortalShell: sandbox.__PortalShell, sandbox, cleared, source };
+}
+
+test("PV and raw panels follow all independent capability combinations", async () => {
+  const { PortalShell } = await loadPortalShell();
+  for (const semanticPV of [false, true]) {
+    for (const rawModbus of [false, true]) {
+      const pvPanel = { hidden: false };
+      const rawPanel = { hidden: false };
+      const shell = new PortalShell();
+      shell.querySelector = (selector) => selector === '[data-role="pv-panel"]' ? pvPanel : selector === '[data-role="modbus-raw-panel"]' ? rawPanel : null;
+      shell.applyPVModbusCapabilityState({ semantic_pv: semanticPV, modbus_raw_read: rawModbus });
+      assert.equal(pvPanel.hidden, !semanticPV, `semantic_pv=${semanticPV} raw=${rawModbus}`);
+      assert.equal(rawPanel.hidden, !rawModbus, `semantic_pv=${semanticPV} raw=${rawModbus}`);
+    }
+  }
+});
+
+test("PV polling interval is cleared during teardown", async () => {
+  const { PortalShell, cleared, source } = await loadPortalShell();
+  assert.match(source, /if \(this\.pvInterval\)[\s\S]*clearInterval\(this\.pvInterval\)[\s\S]*this\.pvInterval = undefined/);
+  const shell = new PortalShell();
+  const interval = {};
+  shell.pvInterval = interval;
+  shell.endBootstrapLifecycle = () => {};
+  shell.clearEEBusVisibilityAuthority = () => {};
+  shell.clearEEBusSPINETree = () => {};
+  shell.clearEEBusPendingMutation = () => {};
+  shell.disconnectedCallback();
+  assert.ok(cleared.includes(interval));
+  assert.equal(shell.pvInterval, undefined);
+});
+
+test("raw Modbus renders bounded unavailable text for network and non-JSON failures", async () => {
+  for (const failure of ["network", "non_json"]) {
+    const { PortalShell, sandbox } = await loadPortalShell();
+    const output = { textContent: "" };
+    const values = { unit: "1", function: "3", offset: "0", quantity: "1" };
+    const shell = new PortalShell();
+    shell._capabilityRawModbus = true;
+    shell.querySelector = (selector) => {
+      if (selector === '[data-role="modbus-raw-output"]') return output;
+      const match = selector.match(/data-role="modbus-([^"]+)"/);
+      return match && values[match[1]] !== undefined ? { value: values[match[1]] } : null;
+    };
+    sandbox.fetch = failure === "network"
+      ? async () => { throw new Error("private upstream detail"); }
+      : async () => ({ json: async () => { throw new Error("private non-JSON body"); } });
+    await shell.readRawModbus();
+    assert.equal(output.textContent, "Raw read unavailable");
+    assert.ok(output.textContent.length <= 64);
+  }
+});
+
+test("raw Modbus rejects a range crossing 65536 before fetch", async () => {
+  const { PortalShell, sandbox } = await loadPortalShell();
+  const output = { textContent: "" };
+  let fetches = 0;
+  sandbox.fetch = async () => { fetches += 1; return { json: async () => ({}) }; };
+  const values = { unit: "1", function: "3", offset: "65535", quantity: "2" };
+  const shell = new PortalShell();
+  shell._capabilityRawModbus = true;
+  shell.querySelector = (selector) => {
+    if (selector === '[data-role="modbus-raw-output"]') return output;
+    const match = selector.match(/data-role="modbus-([^"]+)"/);
+    return match && values[match[1]] !== undefined ? { value: values[match[1]] } : null;
+  };
+  await shell.readRawModbus();
+  assert.equal(fetches, 0);
+  assert.equal(output.textContent, "Invalid raw read bounds");
 });

--- a/portal/web/test/pv-modbus.test.mjs
+++ b/portal/web/test/pv-modbus.test.mjs
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+test("raw Modbus browser call uses the fixed Portal route", async () => {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const source = await readFile(path.resolve(here, "../src/app.js"), "utf8");
+  assert.match(source, /api\/v1\/explorer\/modbus\/raw-read/);
+  assert.doesNotMatch(source, /portal-pv-m2m-url|m2m-graphql-listen/);
+});

--- a/portal/web/test/pv-modbus.test.mjs
+++ b/portal/web/test/pv-modbus.test.mjs
@@ -8,5 +8,7 @@ test("raw Modbus browser call uses the fixed Portal route", async () => {
   const here = path.dirname(fileURLToPath(import.meta.url));
   const source = await readFile(path.resolve(here, "../src/app.js"), "utf8");
   assert.match(source, /api\/v1\/explorer\/modbus\/raw-read/);
+  assert.match(source, /api\/v1\/semantic\/pv\/current/);
+  assert.match(source, /setInterval\(\(\) => this\.refreshPV\(\), 5000\)/);
   assert.doesNotMatch(source, /portal-pv-m2m-url|m2m-graphql-listen/);
 });


### PR DESCRIPTION
## Summary
- add disabled-by-default Portal semantic PV BFF over the exact `PUBLIC_GRAPHQL_M2M_V1` mTLS listener
- add a separate closed raw Modbus Portal route that reuses the MCP raw-read core and shared quota
- add independent bootstrap/UI capabilities, bounded polling, strict request parsing, sanitized audit, and deterministic assets
- pin the BFF to the configured local listener and keep all M2M credential material server-side

## Dependencies
- Portal docs gate: `92f2847cc09f0989765357b9942b158fa691c444`
- gateway M5-05 base: `b9ce5a907c2439763dfdd58b08174df748254964`

## TDD evidence
- initial RED: `aa533e7f55e704ffc1404b1d420fd310993ed069`
- corrective REDs: `bc0a7beae3d1ecf3577a40e6be79e1019297c63b`, `693937d3340323e11ebfdcc748a2096400005741`
- final GREEN: `e27408845483c57d69490644d100162c899ba423`

## Validation
- Portal Node 48/48; generated asset parity PASS
- full Go race; Python 168+6+9+7+6+2; golangci-lint 0
- full local `GOWORK=off ./scripts/ci_local.sh` PASS with strict owner overrides
- T01..T88 N/A: HTTP/BFF composition reuses existing M2M/MCP providers; no transport, framing, adaptermux, scheduler, reconnect, FC03/FC04 implementation, or wire path changes
- passive smoke N/A: no passive acquisition, classifier, source selection, or semantic poller changes
- no deployment or live mutation

Closes #839
