### PR TITLE
FMV3-M5-08: continuously refresh canonical SunSpec PV

### DIFF
--- a/cmd/gateway/modbus_sunspec_runtime.go
+++ b/cmd/gateway/modbus_sunspec_runtime.go
@@ -15,7 +15,8 @@ const (
 	sunSpecLiveSmokeUnitID             = byte(1)
 	sunSpecLiveSmokeAuthorizationScope = "smoke:fronius-readonly"
 	sunSpecLiveSmokeReadTimeout        = 2 * time.Second
-	sunSpecLiveSmokeAttemptTimeout     = 30 * time.Second
+	sunSpecLiveSmokeAttemptTimeout     = 10 * time.Second
+	sunSpecLiveSmokeCycleInterval      = 15 * time.Second
 	sunSpecLiveSmokeCurrentFlavor      = modbusreg.SunSpecFroniusObservedFlavorV11ID
 )
 
@@ -72,14 +73,31 @@ type sunSpecLiveSmokeQualifier interface {
 }
 
 type modbusSunSpecLiveSmokeDriver struct {
-	adapter  *modbusadapter.Adapter
-	producer *modbusadapter.SunSpecProducer
+	adapter   *modbusadapter.Adapter
+	producer  *modbusadapter.SunSpecProducer
+	mu        sync.Mutex
+	qualified bool
 }
 
 func (driver *modbusSunSpecLiveSmokeDriver) Poll(ctx context.Context, attempt sunSpecLiveSmokeAttempt) (sunSpecLiveSmokePollResult, error) {
-	qualification, err := driver.producer.Qualify(ctx, modbusadapter.SunSpecPollIdentity{
+	driver.mu.Lock()
+	initial := !driver.qualified
+	driver.mu.Unlock()
+	identity := modbusadapter.SunSpecPollIdentity{
 		PollGeneration: attempt.PollID, DeadlineIdentity: attempt.DeadlineID,
-	})
+	}
+	var qualification modbusadapter.SunSpecQualificationResult
+	var err error
+	if initial {
+		qualification, err = driver.producer.Qualify(ctx, identity)
+		if err == nil && qualification.Outcome == modbusadapter.SunSpecQualificationGO {
+			driver.mu.Lock()
+			driver.qualified = true
+			driver.mu.Unlock()
+		}
+	} else {
+		qualification, err = driver.producer.Refresh(ctx, identity)
+	}
 	result := sunSpecLiveSmokePollResult{
 		Snapshot: driver.adapter.Snapshot(), Qualification: qualification, Err: err,
 	}
@@ -137,37 +155,41 @@ func runSunSpecLiveSmoke(
 		return result
 	}
 
+	cycleCtx, cancel := context.WithTimeout(ctx, attemptTimeout)
+	defer cancel()
 	for attemptIndex := 0; attemptIndex < 2; attemptIndex++ {
 		attempt := sunSpecLiveSmokeAttempt{
-			PollID: nextSunSpecLiveSmokeIdentity(), DeadlineID: nextSunSpecLiveSmokeIdentity(), Deadline: attemptTimeout,
+			PollID: nextSunSpecLiveSmokeIdentity(), DeadlineID: nextSunSpecLiveSmokeIdentity(), Deadline: time.Until(deadlineOrNow(cycleCtx)),
 		}
-		attemptCtx, cancel := context.WithTimeout(ctx, attemptTimeout)
-		poll, err := driver.Poll(attemptCtx, attempt)
+		poll, err := driver.Poll(cycleCtx, attempt)
 		if err == nil {
 			err = poll.Err
 		}
 		result.Attempts++
 		if err == nil {
-			qualification := qualifier.Qualify(attemptCtx, attempt, poll)
-			cancel()
+			qualification := qualifier.Qualify(cycleCtx, attempt, poll)
 			result.Recovered = attemptIndex == 1
 			return mapSunSpecLiveSmokeQualification(qualification, result)
 		}
-		cancel()
-
 		if attemptIndex != 0 || !poll.Snapshot.ReconnectRequired {
 			result.Category = "poll_error"
 			return result
 		}
-		reconnectCtx, reconnectCancel := context.WithTimeout(ctx, attemptTimeout)
-		reconnectErr := driver.Reconnect(reconnectCtx)
-		reconnectCancel()
+		reconnectErr := driver.Reconnect(cycleCtx)
 		if reconnectErr != nil {
 			result.Category = "reconnect_error"
 			return result
 		}
 	}
 	return result
+}
+
+func deadlineOrNow(ctx context.Context) time.Time {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return time.Now()
+	}
+	return deadline
 }
 
 func mapSunSpecLiveSmokeQualification(qualification sunSpecLiveSmokeQualification, base sunSpecLiveSmokeResult) sunSpecLiveSmokeResult {
@@ -214,6 +236,8 @@ type sunSpecLiveSmokeWorker struct {
 	closeOnce sync.Once
 }
 
+type sunSpecLiveSmokeWait func(context.Context, time.Duration) error
+
 func newSunSpecLiveSmokeWorker(
 	parent context.Context,
 	attemptTimeout time.Duration,
@@ -221,13 +245,40 @@ func newSunSpecLiveSmokeWorker(
 	qualifier sunSpecLiveSmokeQualifier,
 	logf func(string, ...any),
 ) *sunSpecLiveSmokeWorker {
+	return newSunSpecLiveSmokeWorkerWithWait(parent, attemptTimeout, sunSpecLiveSmokeCycleInterval, driver, qualifier, logf, waitSunSpecLiveSmokeCycle)
+}
+
+func newSunSpecLiveSmokeWorkerWithWait(
+	parent context.Context,
+	attemptTimeout, cycleInterval time.Duration,
+	driver sunSpecLiveSmokeDriver,
+	qualifier sunSpecLiveSmokeQualifier,
+	logf func(string, ...any),
+	wait sunSpecLiveSmokeWait,
+) *sunSpecLiveSmokeWorker {
 	ctx, cancel := context.WithCancel(parent)
 	worker := &sunSpecLiveSmokeWorker{cancel: cancel, done: make(chan struct{})}
 	worker.run = func() {
 		defer close(worker.done)
-		_ = runSunSpecLiveSmoke(ctx, attemptTimeout, driver, qualifier, logf)
+		for {
+			_ = runSunSpecLiveSmoke(ctx, attemptTimeout, driver, qualifier, logf)
+			if wait(ctx, cycleInterval) != nil {
+				return
+			}
+		}
 	}
 	return worker
+}
+
+func waitSunSpecLiveSmokeCycle(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func (worker *sunSpecLiveSmokeWorker) Start() {

--- a/cmd/gateway/modbus_sunspec_runtime_test.go
+++ b/cmd/gateway/modbus_sunspec_runtime_test.go
@@ -17,6 +17,7 @@ type sunSpecLiveSmokeFakeDriver struct {
 	pollCalls      []sunSpecLiveSmokeAttempt
 	reconnectCalls int
 	pollFn         func(context.Context, sunSpecLiveSmokeAttempt) (sunSpecLiveSmokePollResult, error)
+	reconnectFn    func(context.Context) error
 }
 
 func (driver *sunSpecLiveSmokeFakeDriver) Poll(ctx context.Context, attempt sunSpecLiveSmokeAttempt) (sunSpecLiveSmokePollResult, error) {
@@ -32,8 +33,11 @@ func (driver *sunSpecLiveSmokeFakeDriver) Poll(ctx context.Context, attempt sunS
 	return result, result.Err
 }
 
-func (driver *sunSpecLiveSmokeFakeDriver) Reconnect(context.Context) error {
+func (driver *sunSpecLiveSmokeFakeDriver) Reconnect(ctx context.Context) error {
 	driver.reconnectCalls++
+	if driver.reconnectFn != nil {
+		return driver.reconnectFn(ctx)
+	}
 	return nil
 }
 
@@ -212,6 +216,99 @@ func TestSunSpecLiveSmokeWorkerCloseCancelsAndJoinsPollBeforeReturning(t *testin
 		}
 	case <-time.After(time.Second):
 		t.Fatal("Close did not join exited Poll")
+	}
+}
+
+func TestSunSpecLiveSmokeWorkerRunsSerialCyclesAfterCompletionAndContinuesAfterError(t *testing.T) {
+	firstPollStarted := make(chan struct{})
+	allowFirstPoll := make(chan struct{})
+	secondPollStarted := make(chan struct{})
+	delayStarted := make(chan time.Duration, 2)
+	allowNextCycle := make(chan struct{})
+	driver := &sunSpecLiveSmokeFakeDriver{}
+	driver.pollFn = func(_ context.Context, _ sunSpecLiveSmokeAttempt) (sunSpecLiveSmokePollResult, error) {
+		switch len(driver.pollCalls) {
+		case 1:
+			close(firstPollStarted)
+			<-allowFirstPoll
+			return sunSpecLiveSmokePollResult{Err: errors.New("first cycle failed")}, errors.New("first cycle failed")
+		case 2:
+			close(secondPollStarted)
+			return sunSpecLiveSmokePollResult{}, nil
+		default:
+			return sunSpecLiveSmokePollResult{}, errors.New("unexpected extra cycle")
+		}
+	}
+	qualifier := &sunSpecLiveSmokeFakeQualifier{qualifications: []sunSpecLiveSmokeQualification{goSunSpecQualification()}}
+	worker := newSunSpecLiveSmokeWorkerWithWait(context.Background(), time.Second, 15*time.Second, driver, qualifier, func(string, ...any) {}, func(ctx context.Context, delay time.Duration) error {
+		delayStarted <- delay
+		select {
+		case <-allowNextCycle:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	})
+	worker.Start()
+	select {
+	case <-firstPollStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first immediate cycle did not start")
+	}
+	select {
+	case <-delayStarted:
+		t.Fatal("worker scheduled another cycle before the first finished")
+	default:
+	}
+	close(allowFirstPoll)
+	select {
+	case delay := <-delayStarted:
+		if delay != 15*time.Second {
+			t.Fatalf("post-cycle delay = %s; want 15s", delay)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("worker did not schedule next cycle after failed cycle completed")
+	}
+	// Allow the first post-cycle waiter to return once so the second cycle may begin.
+	close(allowNextCycle)
+	select {
+	case <-secondPollStarted:
+	case <-time.After(time.Second):
+		t.Fatal("worker did not continue after failed cycle")
+	}
+	if err := worker.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestRunSunSpecLiveSmokeSharesOneDeadlineAcrossReconnectAndRetry(t *testing.T) {
+	const cycleTimeout = 40 * time.Millisecond
+	var retryRemaining time.Duration
+	driver := &sunSpecLiveSmokeFakeDriver{
+		polls: []sunSpecLiveSmokePollResult{{Snapshot: sunSpecLiveSmokeSnapshot{ReconnectRequired: true}, Err: errors.New("reconnect")}},
+		reconnectFn: func(ctx context.Context) error {
+			select {
+			case <-time.After(25 * time.Millisecond):
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		},
+	}
+	driver.pollFn = func(ctx context.Context, _ sunSpecLiveSmokeAttempt) (sunSpecLiveSmokePollResult, error) {
+		if len(driver.pollCalls) == 1 {
+			return driver.polls[0], driver.polls[0].Err
+		}
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			return sunSpecLiveSmokePollResult{}, errors.New("retry lacks shared deadline")
+		}
+		retryRemaining = time.Until(deadline)
+		return sunSpecLiveSmokePollResult{}, nil
+	}
+	result := runSunSpecLiveSmoke(context.Background(), cycleTimeout, driver, &sunSpecLiveSmokeFakeQualifier{qualifications: []sunSpecLiveSmokeQualification{goSunSpecQualification()}}, func(string, ...any) {})
+	if result.Decision != sunSpecLiveSmokeDecisionGO || retryRemaining <= 0 || retryRemaining >= cycleTimeout-10*time.Millisecond {
+		t.Fatalf("result=%#v retry remaining=%s; want retry inside original deadline", result, retryRemaining)
 	}
 }
 

--- a/cmd/gateway/modbus_sunspec_runtime_test.go
+++ b/cmd/gateway/modbus_sunspec_runtime_test.go
@@ -225,6 +225,7 @@ func TestSunSpecLiveSmokeWorkerRunsSerialCyclesAfterCompletionAndContinuesAfterE
 	secondPollStarted := make(chan struct{})
 	delayStarted := make(chan time.Duration, 2)
 	allowNextCycle := make(chan struct{})
+	waitCalls := 0
 	driver := &sunSpecLiveSmokeFakeDriver{}
 	driver.pollFn = func(_ context.Context, _ sunSpecLiveSmokeAttempt) (sunSpecLiveSmokePollResult, error) {
 		switch len(driver.pollCalls) {
@@ -241,7 +242,12 @@ func TestSunSpecLiveSmokeWorkerRunsSerialCyclesAfterCompletionAndContinuesAfterE
 	}
 	qualifier := &sunSpecLiveSmokeFakeQualifier{qualifications: []sunSpecLiveSmokeQualification{goSunSpecQualification()}}
 	worker := newSunSpecLiveSmokeWorkerWithWait(context.Background(), time.Second, 15*time.Second, driver, qualifier, func(string, ...any) {}, func(ctx context.Context, delay time.Duration) error {
+		waitCalls++
 		delayStarted <- delay
+		if waitCalls > 1 {
+			<-ctx.Done()
+			return ctx.Err()
+		}
 		select {
 		case <-allowNextCycle:
 			return nil
@@ -275,6 +281,10 @@ func TestSunSpecLiveSmokeWorkerRunsSerialCyclesAfterCompletionAndContinuesAfterE
 	case <-secondPollStarted:
 	case <-time.After(time.Second):
 		t.Fatal("worker did not continue after failed cycle")
+	}
+	if len(driver.pollCalls) < 2 || driver.pollCalls[0].PollID == 0 || driver.pollCalls[0].DeadlineID == 0 ||
+		driver.pollCalls[0].PollID == driver.pollCalls[1].PollID || driver.pollCalls[0].DeadlineID == driver.pollCalls[1].DeadlineID {
+		t.Fatalf("successive cycle identities = %#v", driver.pollCalls)
 	}
 	if err := worker.Close(); err != nil {
 		t.Fatalf("Close: %v", err)

--- a/internal/modbusadapter/adapter.go
+++ b/internal/modbusadapter/adapter.go
@@ -441,6 +441,8 @@ func (adapter *Adapter) PublishSunSpecCurrent(observation modbusreg.SunSpecQuali
 	if err != nil {
 		return fmt.Errorf("serialize current SunSpec observation: %w", err)
 	}
+	adapter.profileMu.Lock()
+	defer adapter.profileMu.Unlock()
 	evaluated := time.Since(adapter.started)
 	if evaluated < 0 || adapter.canonicalPV == nil {
 		return errors.New("canonical PV mapper unavailable")
@@ -449,8 +451,6 @@ func (adapter *Adapter) PublishSunSpecCurrent(observation modbusreg.SunSpecQuali
 	if err != nil {
 		return fmt.Errorf("map current canonical PV observation: %w", err)
 	}
-	adapter.profileMu.Lock()
-	defer adapter.profileMu.Unlock()
 	if adapter.currentPV == nil {
 		adapter.currentPV = make(map[string]canonicalPVCurrentRecord)
 	}

--- a/internal/modbusadapter/adapter.go
+++ b/internal/modbusadapter/adapter.go
@@ -70,6 +70,7 @@ type Adapter struct {
 	profileMu      sync.RWMutex
 	profiles       map[string]ProfileObservationRecord
 	qualifications map[string]sunSpecQualificationRecord
+	currentPV      map[string]canonicalPVCurrentRecord
 	canonicalPV    *CanonicalPVMapper
 	started        time.Time
 }
@@ -89,6 +90,13 @@ type sunSpecQualificationRecord struct {
 	encoded     []byte
 	canonical   pv.Snapshot
 	producedAt  time.Time
+}
+
+// canonicalPVCurrentRecord is the replaceable semantic publication for one
+// asset. It is deliberately independent from retained qualification evidence.
+type canonicalPVCurrentRecord struct {
+	canonical  pv.Snapshot
+	producedAt time.Time
 }
 
 // Start constructs and connects one endpoint. Disabled configuration is inert.
@@ -145,6 +153,7 @@ func Start(
 		dial:           dial,
 		profiles:       make(map[string]ProfileObservationRecord),
 		qualifications: make(map[string]sunSpecQualificationRecord),
+		currentPV:      make(map[string]canonicalPVCurrentRecord),
 		canonicalPV:    canonicalMapper,
 		started:        time.Now(),
 	}, nil
@@ -412,8 +421,41 @@ func (adapter *Adapter) RecordSunSpecQualificationObservation(observation modbus
 	if err != nil {
 		return fmt.Errorf("map canonical PV observation: %w", err)
 	}
+	producedAt := time.Now().UTC()
 	adapter.qualifications[key] = sunSpecQualificationRecord{
-		observation: observation, encoded: append([]byte(nil), encoded...), canonical: cloneCanonicalPVSnapshot(canonical), producedAt: time.Now().UTC(),
+		observation: observation, encoded: append([]byte(nil), encoded...), canonical: cloneCanonicalPVSnapshot(canonical), producedAt: producedAt,
+	}
+	adapter.currentPV[canonical.AssetRef] = canonicalPVCurrentRecord{
+		canonical: cloneCanonicalPVSnapshot(canonical), producedAt: producedAt,
+	}
+	return nil
+}
+
+// PublishSunSpecCurrent replaces only the semantic current slot for an asset.
+// It neither retains nor mutates terminal qualification evidence.
+func (adapter *Adapter) PublishSunSpecCurrent(observation modbusreg.SunSpecQualificationObservation) error {
+	if adapter == nil {
+		return errors.New("modbus TCP adapter unavailable")
+	}
+	encoded, err := json.Marshal(observation)
+	if err != nil {
+		return fmt.Errorf("serialize current SunSpec observation: %w", err)
+	}
+	evaluated := time.Since(adapter.started)
+	if evaluated < 0 || adapter.canonicalPV == nil {
+		return errors.New("canonical PV mapper unavailable")
+	}
+	canonical, err := adapter.canonicalPV.Map(observation, encoded, pv.MonotonicNanos(evaluated.Nanoseconds()))
+	if err != nil {
+		return fmt.Errorf("map current canonical PV observation: %w", err)
+	}
+	adapter.profileMu.Lock()
+	defer adapter.profileMu.Unlock()
+	if adapter.currentPV == nil {
+		adapter.currentPV = make(map[string]canonicalPVCurrentRecord)
+	}
+	adapter.currentPV[canonical.AssetRef] = canonicalPVCurrentRecord{
+		canonical: cloneCanonicalPVSnapshot(canonical), producedAt: time.Now().UTC(),
 	}
 	return nil
 }
@@ -451,18 +493,22 @@ func (adapter *Adapter) CanonicalPVSnapshotByAsset(assetRef string) (pv.Snapshot
 		}
 	}
 	if match != nil {
-		if adapter.canonicalPV == nil {
+		current, currentOK := adapter.currentPV[assetRef]
+		if !currentOK {
 			return cloneCanonicalPVSnapshot(match.canonical), match.producedAt, true
+		}
+		if adapter.canonicalPV == nil {
+			return cloneCanonicalPVSnapshot(current.canonical), current.producedAt, true
 		}
 		evaluated := time.Since(adapter.started)
 		if evaluated < 0 {
 			return pv.Snapshot{}, time.Time{}, false
 		}
-		current, err := adapter.canonicalPV.Snapshot(match.canonical.AssetRef, pv.MonotonicNanos(evaluated.Nanoseconds()))
+		snapshot, err := adapter.canonicalPV.Snapshot(assetRef, pv.MonotonicNanos(evaluated.Nanoseconds()))
 		if err != nil {
 			return pv.Snapshot{}, time.Time{}, false
 		}
-		return cloneCanonicalPVSnapshot(current), match.producedAt, true
+		return cloneCanonicalPVSnapshot(snapshot), current.producedAt, true
 	}
 	return pv.Snapshot{}, time.Time{}, false
 }

--- a/internal/modbusadapter/sunspec_producer.go
+++ b/internal/modbusadapter/sunspec_producer.go
@@ -87,14 +87,20 @@ func NewSunSpecProducer(adapter *Adapter, config SunSpecProducerConfig) (*SunSpe
 }
 
 func (producer *SunSpecProducer) Qualify(ctx context.Context, identity SunSpecPollIdentity) (SunSpecQualificationResult, error) {
-	return producer.qualify(ctx, identity, false)
+	return producer.qualify(ctx, identity, false, true)
+}
+
+// Refresh acquires and publishes a newer canonical state without consuming the
+// immutable qualification-observation retention budget.
+func (producer *SunSpecProducer) Refresh(ctx context.Context, identity SunSpecPollIdentity) (SunSpecQualificationResult, error) {
+	return producer.qualify(ctx, identity, false, false)
 }
 
 func (producer *SunSpecProducer) qualifyMixedGenerationForTest(ctx context.Context, identity SunSpecPollIdentity) (SunSpecQualificationResult, error) {
-	return producer.qualify(ctx, identity, true)
+	return producer.qualify(ctx, identity, true, true)
 }
 
-func (producer *SunSpecProducer) qualify(ctx context.Context, identity SunSpecPollIdentity, mixGeneration bool) (SunSpecQualificationResult, error) {
+func (producer *SunSpecProducer) qualify(ctx context.Context, identity SunSpecPollIdentity, mixGeneration, retainEvidence bool) (SunSpecQualificationResult, error) {
 	if producer == nil || ctx == nil || identity.PollGeneration == 0 || identity.DeadlineIdentity == 0 {
 		return SunSpecQualificationResult{}, errors.New("SunSpec qualification request is incomplete")
 	}
@@ -112,7 +118,7 @@ func (producer *SunSpecProducer) qualify(ctx context.Context, identity SunSpecPo
 			CapabilityReason: modbusreg.SunSpecCapabilityReasonInvalidChain,
 		}, nil
 	}
-	return producer.classify(identity, snapshot), nil
+	return producer.classify(identity, snapshot, retainEvidence), nil
 }
 
 func (producer *SunSpecProducer) acquire(ctx context.Context, identity SunSpecPollIdentity, mixGeneration bool) (modbusreg.SunSpecChainSnapshot, bool, error) {
@@ -198,7 +204,7 @@ func (source sunSpecSourceView) snapshot() (modbusreg.LogicalViewSnapshot, error
 	})
 }
 
-func (producer *SunSpecProducer) classify(identity SunSpecPollIdentity, snapshot modbusreg.SunSpecChainSnapshot) SunSpecQualificationResult {
+func (producer *SunSpecProducer) classify(identity SunSpecPollIdentity, snapshot modbusreg.SunSpecChainSnapshot, retainEvidence bool) SunSpecQualificationResult {
 	capability := producer.registry.EvaluateThreePhaseMonitoring(snapshot)
 	result := SunSpecQualificationResult{
 		CapabilityID: capability.ProfileID(), CapabilityReason: capability.Reason(),
@@ -225,14 +231,21 @@ func (producer *SunSpecProducer) classify(identity SunSpecPollIdentity, snapshot
 			result.Outcome = SunSpecQualificationStop
 			return result
 		}
-		if err := producer.adapter.RecordSunSpecQualificationObservation(observation); err != nil {
+		if retainEvidence {
+			if err := producer.adapter.RecordSunSpecQualificationObservation(observation); err != nil {
+				result.Outcome = SunSpecQualificationStop
+				return result
+			}
+		} else if err := producer.adapter.PublishSunSpecCurrent(observation); err != nil {
 			result.Outcome = SunSpecQualificationStop
 			return result
 		}
 		result.FlavorID, result.FlavorReason = flavor.FlavorID(), flavor.Reason()
 		result.Outcome = SunSpecQualificationGO
-		result.ObservationCount = 1
-		result.SampleID = observation.SampleID()
+		if retainEvidence {
+			result.ObservationCount = 1
+			result.SampleID = observation.SampleID()
+		}
 		result.Chain = snapshot
 		return result
 	}

--- a/internal/modbusadapter/sunspec_producer.go
+++ b/internal/modbusadapter/sunspec_producer.go
@@ -242,9 +242,9 @@ func (producer *SunSpecProducer) classify(identity SunSpecPollIdentity, snapshot
 		}
 		result.FlavorID, result.FlavorReason = flavor.FlavorID(), flavor.Reason()
 		result.Outcome = SunSpecQualificationGO
+		result.SampleID = observation.SampleID()
 		if retainEvidence {
 			result.ObservationCount = 1
-			result.SampleID = observation.SampleID()
 		}
 		result.Chain = snapshot
 		return result

--- a/internal/modbusadapter/sunspec_producer_test.go
+++ b/internal/modbusadapter/sunspec_producer_test.go
@@ -264,6 +264,34 @@ func TestSunSpecProducerRefreshFailurePreservesPriorCurrentAndNaturalFreshnessAg
 	}
 }
 
+func TestSunSpecProducerRefreshPublicationFailurePreservesPriorCurrentSlot(t *testing.T) {
+	listener, _ := serveSunSpecChain(t, observedFroniusFloatControlsWords())
+	adapter, err := Start(context.Background(), integrationConfig(t, "tcp://"+listener.Addr().String()), realDialer, realFactory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+	producer, err := NewSunSpecProducer(adapter, SunSpecProducerConfig{UnitID: 1, AuthorizationScope: "test:publication-preservation", ReadTimeout: time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	initial, err := producer.Qualify(context.Background(), SunSpecPollIdentity{PollGeneration: 1001, DeadlineIdentity: 1002})
+	if err != nil || initial.Outcome != SunSpecQualificationGO {
+		t.Fatalf("initial qualification=%#v err=%v", initial, err)
+	}
+	assetRef := mustCanonicalPVAsset(t, adapter, initial)
+	before := adapter.currentPV[assetRef]
+	adapter.canonicalPV = nil
+	result, err := producer.Refresh(context.Background(), SunSpecPollIdentity{PollGeneration: 1003, DeadlineIdentity: 1004})
+	if err != nil || result.Outcome != SunSpecQualificationStop {
+		t.Fatalf("publication failure result=%#v err=%v; want STOP without transport failure", result, err)
+	}
+	after := adapter.currentPV[assetRef]
+	if after.producedAt != before.producedAt || after.canonical.Generation != before.canonical.Generation {
+		t.Fatalf("publication failure changed current slot: before=%#v after=%#v", before, after)
+	}
+}
+
 func mustCanonicalPVAsset(t *testing.T, adapter *Adapter, result SunSpecQualificationResult) string {
 	t.Helper()
 	snapshot, _, ok := adapter.CanonicalPVSnapshot(result.CapabilityID, result.SampleID)

--- a/internal/modbusadapter/sunspec_producer_test.go
+++ b/internal/modbusadapter/sunspec_producer_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	pv "github.com/Project-Helianthus/helianthus-ebusreg/pv"
 	modbus "github.com/Project-Helianthus/helianthus-modbus"
 	modbusreg "github.com/Project-Helianthus/helianthus-modbusreg"
 )
@@ -175,6 +176,101 @@ func TestSunSpecProducerStopsWhenQualificationRetentionCapacityIsExhausted(t *te
 	if result.Outcome != SunSpecQualificationStop || result.SampleID != "" || len(result.Chain.RawWords()) != 0 {
 		t.Fatalf("capacity-exhausted qualification outcome=%q sample=%q raw_words=%d; want terminal STOP without partial evidence", result.Outcome, result.SampleID, len(result.Chain.RawWords()))
 	}
+}
+
+func TestSunSpecProducerRefreshPublishesCurrentWithoutConsumingQualificationRetention(t *testing.T) {
+	listener, _ := serveSunSpecChain(t, observedFroniusFloatControlsWords())
+	adapter, err := Start(context.Background(), integrationConfig(t, "tcp://"+listener.Addr().String()), realDialer, realFactory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+	producer, err := NewSunSpecProducer(adapter, SunSpecProducerConfig{UnitID: 1, AuthorizationScope: "test:continuous", ReadTimeout: time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	initial, err := producer.Qualify(context.Background(), SunSpecPollIdentity{PollGeneration: 501, DeadlineIdentity: 601})
+	if err != nil || initial.Outcome != SunSpecQualificationGO {
+		t.Fatalf("initial qualification=%#v err=%v", initial, err)
+	}
+	evidence, encoded, ok := adapter.SunSpecQualificationObservation(initial.CapabilityID, initial.SampleID)
+	if !ok {
+		t.Fatal("initial immutable qualification was not retained")
+	}
+	before, beforeAt, ok := adapter.CanonicalPVSnapshotByAsset(mustCanonicalPVAsset(t, adapter, initial))
+	if !ok {
+		t.Fatal("initial current canonical slot was not published")
+	}
+	for index := uint64(0); index < maxRetainedProfileObservations+1; index++ {
+		result, err := producer.Refresh(context.Background(), SunSpecPollIdentity{PollGeneration: 700 + index, DeadlineIdentity: 800 + index})
+		if err != nil || result.Outcome != SunSpecQualificationGO || result.ObservationCount != 0 || result.SampleID != "" {
+			t.Fatalf("refresh %d=%#v err=%v; want GO without retained sample", index, result, err)
+		}
+	}
+	if len(adapter.qualifications) != 1 || len(adapter.profiles) != 0 {
+		t.Fatalf("retained evidence qualifications=%d profiles=%d; want initial qualification only", len(adapter.qualifications), len(adapter.profiles))
+	}
+	after, afterAt, ok := adapter.CanonicalPVSnapshotByAsset(before.AssetRef)
+	if !ok || after.Generation <= before.Generation || !afterAt.After(beforeAt) {
+		t.Fatalf("current snapshot generation/time = %d/%s; want later than %d/%s", after.Generation, afterAt, before.Generation, beforeAt)
+	}
+	mutated := after.Facts[pv.NewFactKey(pv.FactACActivePower, pv.Dimensions{Scope: pv.ScopeTotal})]
+	mutated.Value.Decimal.Coefficient = "999"
+	after.Facts[pv.NewFactKey(pv.FactACActivePower, pv.Dimensions{Scope: pv.ScopeTotal})] = mutated
+	detached, _, ok := adapter.CanonicalPVSnapshotByAsset(before.AssetRef)
+	if !ok || detached.Facts[pv.NewFactKey(pv.FactACActivePower, pv.Dimensions{Scope: pv.ScopeTotal})].Value.Decimal.Coefficient == "999" {
+		t.Fatal("current canonical slot was not detached")
+	}
+	retained, retainedEncoded, ok := adapter.SunSpecQualificationObservation(initial.CapabilityID, initial.SampleID)
+	if !ok || retained.SampleID() != evidence.SampleID() || !reflect.DeepEqual(retainedEncoded, encoded) {
+		t.Fatal("refresh rewrote immutable qualification evidence")
+	}
+}
+
+func TestSunSpecProducerRefreshFailurePreservesPriorCurrentAndNaturalFreshnessAging(t *testing.T) {
+	listener, _ := serveSunSpecChain(t, observedFroniusFloatControlsWords())
+	adapter, err := Start(context.Background(), integrationConfig(t, "tcp://"+listener.Addr().String()), realDialer, realFactory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+	producer, err := NewSunSpecProducer(adapter, SunSpecProducerConfig{UnitID: 1, AuthorizationScope: "test:failure-preservation", ReadTimeout: time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	initial, err := producer.Qualify(context.Background(), SunSpecPollIdentity{PollGeneration: 901, DeadlineIdentity: 902})
+	if err != nil || initial.Outcome != SunSpecQualificationGO {
+		t.Fatalf("initial qualification=%#v err=%v", initial, err)
+	}
+	assetRef := mustCanonicalPVAsset(t, adapter, initial)
+	before, beforeAt, ok := adapter.CanonicalPVSnapshotByAsset(assetRef)
+	if !ok {
+		t.Fatal("initial current canonical slot was not published")
+	}
+	if err := adapter.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := producer.Refresh(context.Background(), SunSpecPollIdentity{PollGeneration: 903, DeadlineIdentity: 904}); err == nil {
+		t.Fatal("refresh through closed adapter succeeded")
+	}
+	adapter.started = adapter.started.Add(-31 * time.Second)
+	after, afterAt, ok := adapter.CanonicalPVSnapshotByAsset(assetRef)
+	if !ok || !afterAt.Equal(beforeAt) || after.Generation != before.Generation {
+		t.Fatalf("failed refresh changed current publication: %#v %s", after, afterAt)
+	}
+	key := pv.NewFactKey(pv.FactACActivePower, pv.Dimensions{Scope: pv.ScopeTotal})
+	if fact := after.Facts[key]; fact.Freshness != pv.FreshnessStale || fact.Availability != pv.AvailabilityAvailable {
+		t.Fatalf("failed refresh did not age naturally: %s/%s", fact.Freshness, fact.Availability)
+	}
+}
+
+func mustCanonicalPVAsset(t *testing.T, adapter *Adapter, result SunSpecQualificationResult) string {
+	t.Helper()
+	snapshot, _, ok := adapter.CanonicalPVSnapshot(result.CapabilityID, result.SampleID)
+	if !ok || snapshot.AssetRef == "" {
+		t.Fatalf("missing exact canonical qualification snapshot: %#v", result)
+	}
+	return snapshot.AssetRef
 }
 
 func TestSunSpecQualificationRetentionRejectsUnserializableObservationWithoutStoringIt(t *testing.T) {

--- a/internal/modbusadapter/sunspec_producer_test.go
+++ b/internal/modbusadapter/sunspec_producer_test.go
@@ -203,8 +203,11 @@ func TestSunSpecProducerRefreshPublishesCurrentWithoutConsumingQualificationRete
 	}
 	for index := uint64(0); index < maxRetainedProfileObservations+1; index++ {
 		result, err := producer.Refresh(context.Background(), SunSpecPollIdentity{PollGeneration: 700 + index, DeadlineIdentity: 800 + index})
-		if err != nil || result.Outcome != SunSpecQualificationGO || result.ObservationCount != 0 || result.SampleID != "" {
-			t.Fatalf("refresh %d=%#v err=%v; want GO without retained sample", index, result, err)
+		if err != nil || result.Outcome != SunSpecQualificationGO || result.ObservationCount != 0 || result.SampleID == "" {
+			t.Fatalf("refresh %d=%#v err=%v; want GO with unretained current-sample identity", index, result, err)
+		}
+		if _, _, retained := adapter.SunSpecQualificationObservation(result.CapabilityID, result.SampleID); retained {
+			t.Fatalf("refresh %d sample %q consumed immutable evidence retention", index, result.SampleID)
 		}
 	}
 	if len(adapter.qualifications) != 1 || len(adapter.profiles) != 0 {


### PR DESCRIPTION
Closes #841

Docs gate: Project-Helianthus/helianthus-docs-ebus#471, merge `0db56ebc6c5eac649c1312240563b2f7133a98e6`.

## Summary
- replace startup-only SunSpec qualification with immediate and periodic serialized acquisition
- apply one shared 10-second deadline across poll, one reconnect, and retry, followed by a 15-second post-cycle delay
- preserve immutable exact qualification evidence while later samples replace only the per-asset current semantic slot
- keep failed cycles non-destructive and join the worker before adapter shutdown

## TDD
- RED `cd7f00f44d19accb5d9a7979d0416acaaac371e7`
- GREEN `3c4dbbe6143fe5c2f25f58a8704372fab25bbc8a`
- atomic publication correction `4257224`

## Validation
- `GOWORK=off go test -race ./internal/modbusadapter -count=1`
- `GOWORK=off go test -race ./cmd/gateway -run 'Test(RunSunSpecLiveSmoke|SunSpecLiveSmokeWorker)' -count=1 -timeout=60s`\n- `GOWORK=off go vet ./internal/modbusadapter ./cmd/gateway`\n- gofmt and `git diff --check`\n\n## Safety\nCurrent Fronius acquisition remains registry/profile-owned FC03-only. No Modbus writes, configuration mutation, eeBUS/FM5, GraphQL schema, Portal UI, HA, add-on release, deployment, or live mutation.