### PR TITLE
feat: separate eeBUS Pairing SHIP and SPINE workspaces

### DIFF
--- a/internal/eebusadmin/server.go
+++ b/internal/eebusadmin/server.go
@@ -54,6 +54,7 @@ const (
 
 type capabilityRecord struct {
 	kind        capabilityKind
+	view        eebusruntime.AdminViewV1
 	scopeID     string
 	revision    uint64
 	expiresAt   time.Time
@@ -379,7 +380,7 @@ func (server *server) projectPartners(view eebusruntime.AdminViewV1, snapshot ee
 	case eebusruntime.AdminViewV1Trusted:
 		for _, partner := range snapshot.Trusted {
 			row := partnerRow{View: string(view), RemoteSKI: partner.SKI, RemoteSHIPID: partner.SHIPID, TrustState: partner.TrustState, LastSeen: partner.LastSeen}
-			id, err := server.issueCapability(capabilityRecord{kind: capabilityPartner, revision: snapshot.StateRevision, ski: partner.SKI, partner: partner.Partner, trustAction: true}, "partner|"+partner.SKI)
+			id, err := server.issueCapability(capabilityRecord{kind: capabilityPartner, view: view, revision: snapshot.StateRevision, ski: partner.SKI, partner: partner.Partner, trustAction: true}, "partner|"+partner.SKI)
 			if err != nil {
 				return nil, err
 			}
@@ -389,7 +390,7 @@ func (server *server) projectPartners(view eebusruntime.AdminViewV1, snapshot ee
 	case eebusruntime.AdminViewV1Connected:
 		for _, partner := range snapshot.Connected {
 			row := partnerRow{View: string(view), RemoteSKI: partner.SKI, RemoteSHIPID: partner.SHIPID, Endpoint: partner.Endpoint, TrustState: partner.TrustState, ConnectionState: partner.ConnectionState, LastSeen: partner.LastSeen}
-			id, err := server.issueCapability(capabilityRecord{kind: capabilityPartner, revision: snapshot.StateRevision, ski: partner.SKI}, "connected|"+partner.SKI)
+			id, err := server.issueCapability(capabilityRecord{kind: capabilityPartner, view: view, revision: snapshot.StateRevision, ski: partner.SKI}, "connected|"+partner.SKI)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/eebusadmin/spine.go
+++ b/internal/eebusadmin/spine.go
@@ -22,6 +22,8 @@ type RawSnapshotProvider interface {
 	Snapshot() (eebusruntime.SnapshotV1, error)
 }
 
+var errSpineTopologyUnavailable = errors.New("partner has no raw device inventory")
+
 type spineSnapshot struct {
 	id        string
 	hash      string
@@ -122,6 +124,10 @@ func (server *server) spineRoot(w http.ResponseWriter, partnerID string) {
 		server.writeError(w, http.StatusConflict, "snapshot_expired")
 		return
 	}
+	if partner.view != eebusruntime.AdminViewV1Connected {
+		server.writeError(w, http.StatusConflict, "disconnected")
+		return
+	}
 	if server.raw == nil {
 		server.writeError(w, http.StatusServiceUnavailable, "admin_boundary_unavailable")
 		return
@@ -133,6 +139,10 @@ func (server *server) spineRoot(w http.ResponseWriter, partnerID string) {
 	}
 	snapshot, err := server.buildSpineSnapshot(raw.Clone(), partnerID, partner.ski, partner.revision)
 	if err != nil {
+		if errors.Is(err, errSpineTopologyUnavailable) {
+			server.writeError(w, http.StatusServiceUnavailable, "spine_topology_unavailable")
+			return
+		}
 		server.writeError(w, http.StatusServiceUnavailable, "admin_boundary_unavailable")
 		return
 	}
@@ -209,7 +219,7 @@ func (server *server) buildSpineSnapshot(raw eebusruntime.SnapshotV1, partnerID,
 		deviceIDs[device.Address] = node.ID
 	}
 	if len(deviceIDs) == 0 {
-		return nil, errors.New("partner has no raw device inventory")
+		return nil, errSpineTopologyUnavailable
 	}
 	for _, entity := range raw.Entities {
 		parentID, exists := deviceIDs[entity.DeviceAddress]

--- a/internal/eebusadmin/spine_test.go
+++ b/internal/eebusadmin/spine_test.go
@@ -188,10 +188,6 @@ func TestIssue844ConnectedWithoutTopologyHasScopedAvailabilityError(t *testing.T
 	}
 }
 
-func issue817TrustedPartnerID(t *testing.T, handler http.Handler) string {
-	return issue844PartnerID(t, handler, "trusted")
-}
-
 func issue844PartnerID(t *testing.T, handler http.Handler, view string) string {
 	t.Helper()
 	request := httptest.NewRequest(http.MethodGet, "/admin/eebus/v1/partners?view="+view, nil)

--- a/internal/eebusadmin/spine_test.go
+++ b/internal/eebusadmin/spine_test.go
@@ -40,10 +40,10 @@ func TestIssue817LazySPINETreePreservesVR940CanonicalInventory(t *testing.T) {
 	ski := raw.snapshot.Devices[0].SKI
 	adminSnapshot := testAdminSnapshot()
 	adminSnapshot.StateRevision = 41
-	adminSnapshot.Trusted = []eebusruntime.TrustedPartnerV1{{SKI: ski, TrustState: "durably_trusted"}}
-	admin := &adminV1Stub{snapshot: adminSnapshot, snapshots: map[eebusruntime.AdminViewV1]eebusruntime.AdminSnapshotV1{eebusruntime.AdminViewV1Trusted: adminSnapshot}}
+	adminSnapshot.Connected = []eebusruntime.ConnectedPartnerV1{{SKI: ski, ConnectionState: "connected"}}
+	admin := &adminV1Stub{snapshot: adminSnapshot, snapshots: map[eebusruntime.AdminViewV1]eebusruntime.AdminSnapshotV1{eebusruntime.AdminViewV1Connected: adminSnapshot}}
 	handler := newIssue817Server(t, admin, raw, nil)
-	partnerID := issue817TrustedPartnerID(t, handler)
+	partnerID := issue844PartnerID(t, handler, "connected")
 
 	root := issue817GetSpinePage(t, handler, "/admin/eebus/v1/partners/"+partnerID+"/spine?request=root")
 	if root.SnapshotID == "" || root.SnapshotHash != raw.snapshot.Meta.DataHash || root.ParentNodeID != nil || len(root.Nodes) != 1 || root.Nodes[0].Kind != "device" {
@@ -98,10 +98,10 @@ func TestIssue817LazySPINETreePreservesVR940CanonicalInventory(t *testing.T) {
 func TestIssue817SPINEUsesTheSameOperatorScopeAndRejectsUnknownQueryBeforeRawCapture(t *testing.T) {
 	raw := &issue809RawSnapshotStub{snapshot: issue809VR940Snapshot(t)}
 	adminSnapshot := testAdminSnapshot()
-	adminSnapshot.Trusted = []eebusruntime.TrustedPartnerV1{{SKI: raw.snapshot.Devices[0].SKI, TrustState: "durably_trusted"}}
-	admin := &adminV1Stub{snapshot: adminSnapshot, snapshots: map[eebusruntime.AdminViewV1]eebusruntime.AdminSnapshotV1{eebusruntime.AdminViewV1Trusted: adminSnapshot}}
+	adminSnapshot.Connected = []eebusruntime.ConnectedPartnerV1{{SKI: raw.snapshot.Devices[0].SKI, ConnectionState: "connected"}}
+	admin := &adminV1Stub{snapshot: adminSnapshot, snapshots: map[eebusruntime.AdminViewV1]eebusruntime.AdminSnapshotV1{eebusruntime.AdminViewV1Connected: adminSnapshot}}
 	handler := newIssue817Server(t, admin, raw, nil)
-	partnerID := issue817TrustedPartnerID(t, handler)
+	partnerID := issue844PartnerID(t, handler, "connected")
 	bad := httptest.NewRequest(http.MethodGet, "/admin/eebus/v1/partners/"+partnerID+"/spine?request=root&cursor=extra", nil)
 	issue817AddIrrelevantAuthMaterial(bad)
 	badResponse := httptest.NewRecorder()
@@ -129,10 +129,10 @@ func TestIssue817SPINEFailsClosedOnUnattributedTopLevelOpaqueForMultiplePartners
 	}
 	raw := &issue809RawSnapshotStub{snapshot: snapshot}
 	adminSnapshot := testAdminSnapshot()
-	adminSnapshot.Trusted = []eebusruntime.TrustedPartnerV1{{SKI: snapshot.Devices[0].SKI, TrustState: "durably_trusted"}}
-	admin := &adminV1Stub{snapshot: adminSnapshot, snapshots: map[eebusruntime.AdminViewV1]eebusruntime.AdminSnapshotV1{eebusruntime.AdminViewV1Trusted: adminSnapshot}}
+	adminSnapshot.Connected = []eebusruntime.ConnectedPartnerV1{{SKI: snapshot.Devices[0].SKI, ConnectionState: "connected"}}
+	admin := &adminV1Stub{snapshot: adminSnapshot, snapshots: map[eebusruntime.AdminViewV1]eebusruntime.AdminSnapshotV1{eebusruntime.AdminViewV1Connected: adminSnapshot}}
 	handler := newIssue817Server(t, admin, raw, nil)
-	partnerID := issue817TrustedPartnerID(t, handler)
+	partnerID := issue844PartnerID(t, handler, "connected")
 	request := httptest.NewRequest(http.MethodGet, "/admin/eebus/v1/partners/"+partnerID+"/spine?request=root", nil)
 	response := httptest.NewRecorder()
 	handler.ServeHTTP(response, request)
@@ -141,9 +141,60 @@ func TestIssue817SPINEFailsClosedOnUnattributedTopLevelOpaqueForMultiplePartners
 	}
 }
 
+func TestIssue844TrustedOfflineSPINEIsDisconnectedBeforeRawCapture(t *testing.T) {
+	raw := &issue809RawSnapshotStub{snapshot: issue809VR940Snapshot(t)}
+	adminSnapshot := testAdminSnapshot()
+	adminSnapshot.Trusted = []eebusruntime.TrustedPartnerV1{{SKI: raw.snapshot.Devices[0].SKI, TrustState: "durably_trusted"}}
+	admin := &adminV1Stub{snapshot: adminSnapshot, snapshots: map[eebusruntime.AdminViewV1]eebusruntime.AdminSnapshotV1{eebusruntime.AdminViewV1Trusted: adminSnapshot}}
+	handler := newIssue817Server(t, admin, raw, nil)
+	partnerID := issue844PartnerID(t, handler, "trusted")
+
+	request := httptest.NewRequest(http.MethodGet, "/admin/eebus/v1/partners/"+partnerID+"/spine?request=root", nil)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	assertIssue817ErrorEnvelope(t, response.Body.String(), "disconnected")
+	if response.Code != http.StatusConflict || raw.calls != 0 {
+		t.Fatalf("trusted-offline status/raw=%d/%d body=%s", response.Code, raw.calls, response.Body.String())
+	}
+}
+
+func TestIssue844ConnectedWithoutTopologyHasScopedAvailabilityError(t *testing.T) {
+	snapshot := issue809VR940Snapshot(t)
+	ski := snapshot.Devices[0].SKI
+	snapshot.Devices = nil
+	snapshot.Entities = nil
+	snapshot.Features = nil
+	snapshot.UseCases = nil
+	snapshot.Opaque = nil
+	snapshot.Meta.DataHash = ""
+	var err error
+	snapshot, err = eebusruntime.NewSnapshotV1(snapshot)
+	if err != nil {
+		t.Fatalf("build empty raw snapshot: %v", err)
+	}
+	raw := &issue809RawSnapshotStub{snapshot: snapshot}
+	adminSnapshot := testAdminSnapshot()
+	adminSnapshot.Connected = []eebusruntime.ConnectedPartnerV1{{SKI: ski, ConnectionState: "connected"}}
+	admin := &adminV1Stub{snapshot: adminSnapshot, snapshots: map[eebusruntime.AdminViewV1]eebusruntime.AdminSnapshotV1{eebusruntime.AdminViewV1Connected: adminSnapshot}}
+	handler := newIssue817Server(t, admin, raw, nil)
+	partnerID := issue844PartnerID(t, handler, "connected")
+
+	request := httptest.NewRequest(http.MethodGet, "/admin/eebus/v1/partners/"+partnerID+"/spine?request=root", nil)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	assertIssue817ErrorEnvelope(t, response.Body.String(), "spine_topology_unavailable")
+	if response.Code != http.StatusServiceUnavailable || raw.calls != 1 {
+		t.Fatalf("connected-empty status/raw=%d/%d body=%s", response.Code, raw.calls, response.Body.String())
+	}
+}
+
 func issue817TrustedPartnerID(t *testing.T, handler http.Handler) string {
+	return issue844PartnerID(t, handler, "trusted")
+}
+
+func issue844PartnerID(t *testing.T, handler http.Handler, view string) string {
 	t.Helper()
-	request := httptest.NewRequest(http.MethodGet, "/admin/eebus/v1/partners?view=trusted", nil)
+	request := httptest.NewRequest(http.MethodGet, "/admin/eebus/v1/partners?view="+view, nil)
 	response := httptest.NewRecorder()
 	handler.ServeHTTP(response, request)
 	var envelope struct {
@@ -154,7 +205,7 @@ func issue817TrustedPartnerID(t *testing.T, handler http.Handler) string {
 		} `json:"data"`
 	}
 	if response.Code != http.StatusOK || json.Unmarshal(response.Body.Bytes(), &envelope) != nil || len(envelope.Data.Partners) != 1 || envelope.Data.Partners[0].PartnerID == "" {
-		t.Fatalf("trusted status=%d body=%s", response.Code, response.Body.String())
+		t.Fatalf("%s status=%d body=%s", view, response.Code, response.Body.String())
 	}
 	return envelope.Data.Partners[0].PartnerID
 }

--- a/portal/static/assets/app.css
+++ b/portal/static/assets/app.css
@@ -428,6 +428,102 @@ body {
   align-items: center;
 }
 
+.eebus-heading-row,
+.eebus-workspace-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.eebus-heading-row h2,
+.eebus-workspace-heading h3,
+.eebus-workspace h4 {
+  margin-top: 0;
+}
+
+.eebus-health-strip {
+  margin: 0.85rem 0;
+  min-height: 2.75rem;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.eebus-workspace-nav {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.65rem;
+  margin: 1rem 0;
+}
+
+.eebus-workspace-nav .button {
+  min-height: 4rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 0.15rem;
+  text-align: left;
+}
+
+.eebus-workspace-nav .button span {
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.eebus-workspace-nav .button[aria-current="page"] {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 14%, var(--panel));
+}
+
+.eebus-workspace {
+  padding: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 0.65rem;
+  background: color-mix(in srgb, var(--panel) 86%, transparent);
+}
+
+.eebus-workspace[hidden] {
+  display: none;
+}
+
+.eebus-workspace-status {
+  min-height: 2.75rem;
+  display: flex;
+  align-items: center;
+  padding: 0.55rem 0.7rem;
+  margin: 0.65rem 0;
+  border-left: 3px solid var(--border);
+}
+
+.eebus-field {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.8rem;
+  color: var(--text);
+  font-weight: 600;
+}
+
+.eebus-field span {
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 400;
+}
+
+.eebus-ski-input {
+  width: 100%;
+  min-height: 2.75rem;
+  margin-top: 0.35rem;
+  font-family: "IBM Plex Mono", "Fira Code", monospace;
+}
+
+.eebus-partner-state {
+  margin-top: 0;
+  color: var(--muted);
+  font-weight: 600;
+}
+
 .eebus-partner,
 .eebus-spine-node,
 .eebus-candidate-panel {
@@ -473,6 +569,24 @@ body {
 
   .content {
     grid-template-columns: 1fr;
+  }
+
+  .eebus-heading-row,
+  .eebus-workspace-heading {
+    flex-direction: column;
+  }
+
+  .eebus-workspace-nav {
+    grid-template-columns: 1fr;
+  }
+
+  .eebus-workspace .snapshot-controls {
+    align-items: stretch;
+  }
+
+  .eebus-workspace .snapshot-controls > * {
+    width: 100%;
+    min-height: 2.75rem;
   }
 
 }

--- a/portal/static/assets/app.js
+++ b/portal/static/assets/app.js
@@ -2313,10 +2313,13 @@ class PortalShell extends HTMLElement {
     };
     onClick("eebus-refresh-status", () => void this.refreshEEBusStatus().catch((error) => this.showEEBusError(error)));
 	 onClick("eebus-retry-pending", () => void this.refreshAndRetryPendingEEBusMutation().catch((error) => this.showEEBusError(error)));
-    onClick("eebus-refresh-partners", () => {
-      const view = this.querySelector('[data-role="eebus-partner-view"]')?.value || "trusted";
-      void this.refreshEEBusPartners(view).catch((error) => this.showEEBusError(error));
+    onClick("eebus-refresh-discovered", () => void this.refreshEEBusPartners("discovered").catch((error) => this.showEEBusError(error, "pairing")));
+    onClick("eebus-refresh-candidate", () => void this.refreshEEBusPartners("candidate").catch((error) => this.showEEBusError(error, "pairing")));
+    onClick("eebus-refresh-ship", () => {
+      const view = this.querySelector('[data-role="eebus-ship-view"]')?.value || "trusted";
+      void this.refreshEEBusPartners(view).catch((error) => this.showEEBusError(error, "ship"));
     });
+    onClick("eebus-refresh-spine-peers", () => void this.refreshEEBusSPINEPeers().catch((error) => this.showEEBusError(error, "spine")));
     onClick("eebus-window-open", () => void this.openEEBusPairingWindow().catch((error) => this.showEEBusError(error)));
     onClick("eebus-window-close", () => void this.closeEEBusPairingWindow().catch((error) => this.showEEBusError(error)));
     onClick("eebus-candidate-cancel", () => void this.cancelEEBusCandidate().catch((error) => this.showEEBusError(error)));
@@ -2324,8 +2327,15 @@ class PortalShell extends HTMLElement {
       const value = this.querySelector('[data-role="eebus-confirm-ski"]')?.value || "";
       void this.confirmEEBusCandidate(value).catch((error) => this.showEEBusError(error));
     });
-    const partners = this.querySelector('[data-role="eebus-partners"]');
-    if (partners) {
+    this.querySelectorAll("[data-eebus-workspace-target]").forEach((button) => {
+      button.addEventListener("click", () => {
+        const workspace = button.getAttribute("data-eebus-workspace-target") || "";
+        this.switchEEBusWorkspace(workspace);
+        if (workspace === "ship") void this.refreshEEBusPartners("trusted").catch((error) => this.showEEBusError(error, "ship"));
+        if (workspace === "spine") void this.refreshEEBusSPINEPeers().catch((error) => this.showEEBusError(error, "spine"));
+      });
+    });
+    for (const partners of this.querySelectorAll('[data-role="eebus-pairing-partners"], [data-role="eebus-ship-partners"], [data-role="eebus-spine-peers"]')) {
       partners.addEventListener("click", (event) => {
         const button = event.target?.closest?.("[data-eebus-action]");
         if (!button) return;
@@ -2337,7 +2347,10 @@ class PortalShell extends HTMLElement {
           retry: () => this.retryEEBusPartner(id),
 		  "arm-untrust": () => this.armEEBusUntrust(id),
 		  untrust: () => this.untrustEEBusPartner(id),
-          spine: () => this.loadEEBusSPINERoot(id),
+          spine: async () => {
+            this.switchEEBusWorkspace("spine");
+            return this.loadEEBusSPINERoot(id);
+          },
         };
         if (operations[action]) void operations[action]().catch((error) => this.showEEBusError(error));
       });
@@ -2361,6 +2374,30 @@ class PortalShell extends HTMLElement {
     if (typeof document.addEventListener === "function") {
       document.addEventListener("visibilitychange", this._eebusVisibilityHandler);
     }
+    this.switchEEBusWorkspace("pairing");
+  }
+
+  switchEEBusWorkspace(workspace) {
+    if (!new Set(["pairing", "ship", "spine"]).has(workspace)) return;
+    const previous = this._eebusWorkspace || "pairing";
+    if (previous !== workspace) {
+      if (previous === "pairing") {
+        this.clearEEBusCandidate();
+        this._eebusSelection = undefined;
+      } else if (previous === "ship") {
+        this._eebusUntrustArmedID = undefined;
+      } else if (previous === "spine") {
+        this.clearEEBusSPINETree();
+      }
+      if (this._eebusPendingMutation?.workspace === previous) this.clearEEBusPendingMutation();
+    }
+    this._eebusWorkspace = workspace;
+    this.querySelectorAll("[data-eebus-workspace]").forEach((panel) => {
+      panel.hidden = panel.dataset?.eebusWorkspace !== workspace;
+    });
+    this.querySelectorAll("[data-eebus-workspace-target]").forEach((button) => {
+      button.setAttribute("aria-current", button.dataset?.eebusWorkspaceTarget === workspace ? "page" : "false");
+    });
   }
 
   async eebusAdminFetch(path, options = {}) {
@@ -2426,12 +2463,25 @@ class PortalShell extends HTMLElement {
 		this._eebusCandidateTimer = setTimeout(() => this.clearEEBusCandidate(), delay);
 	  }
     }
-    this.renderEEBusPartners(rows, view);
+	this.renderEEBusPartners(rows, view);
+	return payload;
+  }
+
+  async refreshEEBusSPINEPeers() {
+    this.clearEEBusSPINETree();
+    const payload = await this.eebusAdminFetch("/partners?view=connected");
+    const rows = Array.isArray(payload?.data?.partners) ? payload.data.partners : [];
+    this.renderEEBusSPINEPeers(rows);
     return payload;
   }
 
+  eebusPartnerContainer(view) {
+    const role = view === "trusted" || view === "connected" ? "eebus-ship-partners" : "eebus-pairing-partners";
+    return this.querySelector(`[data-role="${role}"]`) || this.querySelector('[data-role="eebus-partners"]');
+  }
+
   renderEEBusPartners(rows, view) {
-    const container = this.querySelector('[data-role="eebus-partners"]');
+	const container = this.eebusPartnerContainer(view);
     if (!container) return;
     const rendered = rows.map((row) => {
       const safe = escapeHtml(JSON.stringify(row, null, 2));
@@ -2444,13 +2494,25 @@ class PortalShell extends HTMLElement {
 		  ? `<button class="button" data-eebus-action="untrust" data-eebus-id="${id}">Confirm untrust</button>`
 		  : `<button class="button" data-eebus-action="arm-untrust" data-eebus-id="${id}">Arm untrust</button>`;
 	  }
-      if ((view === "trusted" || view === "connected") && row.partner_id) actions += `<button class="button" data-eebus-action="spine" data-eebus-id="${id}">Browse SPINE</button>`;
-      return `<article class="eebus-partner"><pre>${safe}</pre><div class="snapshot-controls">${actions}</div></article>`;
+      if (view === "connected" && row.partner_id) actions += `<button class="button" data-eebus-action="spine" data-eebus-id="${id}">Open in SPINE</button>`;
+      const state = view === "trusted" ? '<p class="eebus-partner-state">Disconnected — Reconnect required</p>' : "";
+      return `<article class="eebus-partner">${state}<pre>${safe}</pre><div class="snapshot-controls">${actions}</div></article>`;
     }).join("");
     const connect = this._eebusSelection
       ? `<button class="button" data-eebus-action="connect">Connect selected partner</button>`
       : "";
     container.innerHTML = `${connect}${rendered || '<div class="muted-inline">No partners in this view.</div>'}`;
+  }
+
+  renderEEBusSPINEPeers(rows) {
+    const container = this.querySelector('[data-role="eebus-spine-peers"]');
+    if (!container) return;
+    const rendered = rows.map((row) => {
+      const safe = escapeHtml(JSON.stringify(row, null, 2));
+      const id = escapeHtml(row.partner_id || "");
+      return `<article class="eebus-partner"><p class="eebus-partner-state">Live SHIP session</p><pre>${safe}</pre><button class="button" data-eebus-action="spine" data-eebus-id="${id}">Load SPINE snapshot</button></article>`;
+    }).join("");
+    container.innerHTML = rendered || '<div class="muted-inline">No live SHIP session. Open SHIP to reconnect.</div>';
   }
 
   async eebusMutation(path, body, method = "POST") {
@@ -2465,6 +2527,7 @@ class PortalShell extends HTMLElement {
 		method,
 		path,
 		body: serializedBody,
+		workspace: this._eebusWorkspace || "pairing",
 		idempotencyKey: crypto.randomUUID(),
 		expiresAt: Date.now() + 2 * 60 * 1000,
 	  };
@@ -2615,7 +2678,7 @@ class PortalShell extends HTMLElement {
 	const input = this.querySelector?.('[data-role="eebus-confirm-ski"]');
 	if (input) input.value = "";
 	if (this._eebusPartnerView === "candidate") {
-	  const partners = this.querySelector?.('[data-role="eebus-partners"]');
+	  const partners = this.eebusPartnerContainer?.("candidate");
 	  if (partners) partners.innerHTML = '<div class="muted-inline">Candidate view cleared.</div>';
 	}
   }
@@ -2640,9 +2703,16 @@ class PortalShell extends HTMLElement {
 	if (retry) retry.disabled = !this._eebusPendingMutation;
   }
 
-  showEEBusError(error) {
-    const status = this.querySelector('[data-role="eebus-status"]');
-    if (status) status.textContent = `eeBUS: ${error?.message || "unknown error"}`;
+  showEEBusError(error, workspace = this._eebusWorkspace || "pairing") {
+    const code = error?.message || "unknown error";
+    const messages = {
+      disconnected: "No live SHIP session. Open SHIP and use Retry to reconnect.",
+      spine_topology_unavailable: "The live SHIP session has no SPINE topology yet. Reload the connected sessions.",
+      snapshot_expired: "The SPINE snapshot expired. Load a new snapshot.",
+    };
+    const role = code === "admin_boundary_unavailable" ? "eebus-status" : `eebus-${workspace}-status`;
+    const status = this.querySelector(`[data-role="${role}"]`) || this.querySelector('[data-role="eebus-status"]');
+    if (status) status.textContent = messages[code] || `eeBUS: ${code}`;
   }
 
   async loadEEBusSPINERoot(partnerID) {
@@ -2984,35 +3054,75 @@ class PortalShell extends HTMLElement {
                 <div class="muted-inline">Loading Vaillant B503 capability...</div>
               </div>
             </section>
-			<section id="section-eebus" class="registry-preview">
-			  <h2>eeBUS SHIP / SPINE</h2>
-			  <p class="muted-inline">Host operator workbench. Candidate identity stays only in this active view.</p>
-			  <div class="snapshot-controls">
-			    <button class="button" data-role="eebus-refresh-status" type="button">Refresh status</button>
+			<section id="section-eebus" class="registry-preview eebus-workbench">
+			  <div class="eebus-heading-row">
+			    <div>
+			      <h2>eeBUS</h2>
+			      <p class="muted-inline">Host operator workbench. Pairing authority and raw protocol data stay only in this active view.</p>
+			    </div>
+			    <button class="button" data-role="eebus-refresh-status" type="button">Refresh health</button>
 			  </div>
-			  <div class="bus-banner bus-state-unavailable" data-role="eebus-status">Loading eeBUS operator status.</div>
-			  <div class="snapshot-controls">
-			    <button class="button" data-role="eebus-window-open" type="button">Open pairing window</button>
-			    <button class="button" data-role="eebus-window-close" type="button">Close pairing window</button>
-			    <button class="button" data-role="eebus-candidate-cancel" type="button">Cancel candidate</button>
-			    <button class="button" data-role="eebus-retry-pending" type="button" disabled>Retry pending action</button>
-			  </div>
-			  <div class="snapshot-controls">
-			    <select class="select" data-role="eebus-partner-view" aria-label="eeBUS partner view">
-			      <option value="trusted">Trusted</option><option value="connected">Connected</option><option value="discovered">Discovered</option><option value="candidate">Candidate</option>
-			    </select>
-			    <button class="button" data-role="eebus-refresh-partners" type="button">Refresh partners</button>
-			  </div>
-			  <input class="search timeline-filter" data-role="eebus-select-ski" autocomplete="off" placeholder="Enter the independent OOB 40-character SKI before Select" />
-			  <div data-role="eebus-partners"><div class="muted-inline">No partner view loaded.</div></div>
-			  <div class="eebus-candidate-panel">
-			    <h3>OOB candidate</h3>
-			    <pre data-role="eebus-candidate"></pre>
-			    <input class="search timeline-filter" data-role="eebus-confirm-ski" autocomplete="off" placeholder="Retype the complete 40-character SKI" />
-			    <button class="button" data-role="eebus-candidate-confirm" type="button">Confirm exact SKI</button>
-			  </div>
-			  <h3>Lazy SPINE tree</h3>
-			  <div data-role="eebus-spine-tree" class="eebus-spine-tree"><div class="muted-inline">Choose Browse SPINE on a trusted or connected partner.</div></div>
+			  <div class="bus-banner bus-state-unavailable eebus-health-strip" data-role="eebus-status" role="status" aria-live="polite" aria-atomic="true">Loading eeBUS operator health.</div>
+			  <nav class="eebus-workspace-nav" data-role="eebus-workspace-nav" aria-label="eeBUS workspaces">
+			    <button class="button" data-eebus-workspace-target="pairing" type="button" aria-current="page"><strong>Pairing</strong><span>Discover and establish trust</span></button>
+			    <button class="button" data-eebus-workspace-target="ship" type="button" aria-current="false"><strong>SHIP</strong><span>Trust and live sessions</span></button>
+			    <button class="button" data-eebus-workspace-target="spine" type="button" aria-current="false"><strong>SPINE</strong><span>Read-only topology</span></button>
+			  </nav>
+
+			  <section class="eebus-workspace" data-eebus-workspace="pairing" aria-labelledby="eebus-pairing-heading">
+			    <div class="eebus-workspace-heading">
+			      <div><h3 id="eebus-pairing-heading">Pair a device</h3><p class="muted-inline">Open discovery, verify the independent OOB SKI, connect, then confirm the TLS-bound candidate.</p></div>
+			      <div class="snapshot-controls">
+			        <button class="button" data-role="eebus-window-open" type="button">Open pairing window</button>
+			        <button class="button" data-role="eebus-window-close" type="button">Close pairing window</button>
+			      </div>
+			    </div>
+			    <div class="eebus-workspace-status muted-inline" data-role="eebus-pairing-status" role="status" aria-live="polite" aria-atomic="true">Pairing controls are ready.</div>
+			    <div class="snapshot-controls">
+			      <button class="button" data-role="eebus-refresh-discovered" type="button">Refresh discovered services</button>
+			      <button class="button" data-role="eebus-refresh-candidate" type="button">Refresh candidate</button>
+			      <button class="button" data-role="eebus-retry-pending" type="button" disabled>Retry pending action</button>
+			    </div>
+			    <label class="eebus-field" for="eebus-select-ski">Independent OOB SKI <span>40 lowercase hexadecimal characters</span></label>
+			    <input id="eebus-select-ski" class="search timeline-filter eebus-ski-input" data-role="eebus-select-ski" autocomplete="off" inputmode="text" spellcheck="false" maxlength="40" placeholder="Enter the SKI before Select" />
+			    <div data-role="eebus-pairing-partners"><div class="muted-inline">No discovered service loaded.</div></div>
+			    <div class="eebus-candidate-panel">
+			      <h4>TLS-bound candidate</h4>
+			      <pre data-role="eebus-candidate"></pre>
+			      <label class="eebus-field" for="eebus-confirm-ski">Confirm complete candidate SKI <span>Must exactly match the independent value</span></label>
+			      <input id="eebus-confirm-ski" class="search timeline-filter eebus-ski-input" data-role="eebus-confirm-ski" autocomplete="off" inputmode="text" spellcheck="false" maxlength="40" placeholder="Retype the complete SKI" />
+			      <div class="snapshot-controls">
+			        <button class="button" data-role="eebus-candidate-confirm" type="button">Confirm exact SKI</button>
+			        <button class="button" data-role="eebus-candidate-cancel" type="button">Cancel candidate</button>
+			      </div>
+			    </div>
+			  </section>
+
+			  <section class="eebus-workspace" data-eebus-workspace="ship" aria-labelledby="eebus-ship-heading" hidden>
+			    <div class="eebus-workspace-heading">
+			      <div><h3 id="eebus-ship-heading">SHIP associations and sessions</h3><p class="muted-inline">Trusted associations persist independently from live sessions. Retry is always an explicit operator action.</p></div>
+			      <div class="snapshot-controls">
+			        <select class="select" data-role="eebus-ship-view" aria-label="SHIP partner view">
+			          <option value="trusted">Trusted associations</option>
+			          <option value="connected">Live sessions</option>
+			        </select>
+			        <button class="button" data-role="eebus-refresh-ship" type="button">Refresh SHIP</button>
+			      </div>
+			    </div>
+			    <div class="eebus-workspace-status muted-inline" data-role="eebus-ship-status" role="status" aria-live="polite" aria-atomic="true">Choose Trusted associations or Live sessions.</div>
+			    <div data-role="eebus-ship-partners"><div class="muted-inline">No SHIP view loaded.</div></div>
+			  </section>
+
+			  <section class="eebus-workspace" data-eebus-workspace="spine" aria-labelledby="eebus-spine-heading" hidden>
+			    <div class="eebus-workspace-heading">
+			      <div><h3 id="eebus-spine-heading">SPINE topology browser</h3><p class="muted-inline">Read-only snapshots from a current connected SHIP session. Browsing never reconnects or mutates trust.</p></div>
+			      <button class="button" data-role="eebus-refresh-spine-peers" type="button">Refresh connected sessions</button>
+			    </div>
+			    <div class="eebus-workspace-status muted-inline" data-role="eebus-spine-status" role="status" aria-live="polite" aria-atomic="true">No live SHIP session selected.</div>
+			    <div data-role="eebus-spine-peers"><div class="muted-inline">No live SHIP session. Open SHIP to reconnect.</div></div>
+			    <h4>Lazy topology snapshot</h4>
+			    <div data-role="eebus-spine-tree" class="eebus-spine-tree"><div class="muted-inline">Select a connected peer to load a read-only SPINE snapshot.</div></div>
+			  </section>
 			</section>
             <div class="meta" data-role="stream-status">Stream idle</div>
             <div class="meta" data-role="meta">Waiting for bootstrap...</div>

--- a/portal/static/assets/manifest.json
+++ b/portal/static/assets/manifest.json
@@ -2,12 +2,12 @@
   "generatedBy": "portal/web/scripts/build.mjs",
   "assets": {
     "app.js": {
-      "bytes": 163991,
-      "sha256": "50b5e108892a959f4aff2e3cc2c814848c0994800bb142d84051781475906d1d"
+      "bytes": 171612,
+      "sha256": "8eaaf9aeceae10c4f737835ae12d2cc548bb280671816c72f6261e940b2be60f"
     },
     "app.css": {
-      "bytes": 8847,
-      "sha256": "809e1df96ad0d7b5ce115c1ead5ac3c51a0348cdbc2b07a577d906af3ad6889e"
+      "bytes": 10903,
+      "sha256": "62955b2dd57cda99273002f7b96ac6e45eb394ed4de683759cb9b59b92d62fc2"
     }
   }
 }

--- a/portal/web/src/app.css
+++ b/portal/web/src/app.css
@@ -427,6 +427,102 @@ body {
   align-items: center;
 }
 
+.eebus-heading-row,
+.eebus-workspace-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.eebus-heading-row h2,
+.eebus-workspace-heading h3,
+.eebus-workspace h4 {
+  margin-top: 0;
+}
+
+.eebus-health-strip {
+  margin: 0.85rem 0;
+  min-height: 2.75rem;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.eebus-workspace-nav {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.65rem;
+  margin: 1rem 0;
+}
+
+.eebus-workspace-nav .button {
+  min-height: 4rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 0.15rem;
+  text-align: left;
+}
+
+.eebus-workspace-nav .button span {
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.eebus-workspace-nav .button[aria-current="page"] {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 14%, var(--panel));
+}
+
+.eebus-workspace {
+  padding: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 0.65rem;
+  background: color-mix(in srgb, var(--panel) 86%, transparent);
+}
+
+.eebus-workspace[hidden] {
+  display: none;
+}
+
+.eebus-workspace-status {
+  min-height: 2.75rem;
+  display: flex;
+  align-items: center;
+  padding: 0.55rem 0.7rem;
+  margin: 0.65rem 0;
+  border-left: 3px solid var(--border);
+}
+
+.eebus-field {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.8rem;
+  color: var(--text);
+  font-weight: 600;
+}
+
+.eebus-field span {
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 400;
+}
+
+.eebus-ski-input {
+  width: 100%;
+  min-height: 2.75rem;
+  margin-top: 0.35rem;
+  font-family: "IBM Plex Mono", "Fira Code", monospace;
+}
+
+.eebus-partner-state {
+  margin-top: 0;
+  color: var(--muted);
+  font-weight: 600;
+}
+
 .eebus-partner,
 .eebus-spine-node,
 .eebus-candidate-panel {
@@ -472,6 +568,24 @@ body {
 
   .content {
     grid-template-columns: 1fr;
+  }
+
+  .eebus-heading-row,
+  .eebus-workspace-heading {
+    flex-direction: column;
+  }
+
+  .eebus-workspace-nav {
+    grid-template-columns: 1fr;
+  }
+
+  .eebus-workspace .snapshot-controls {
+    align-items: stretch;
+  }
+
+  .eebus-workspace .snapshot-controls > * {
+    width: 100%;
+    min-height: 2.75rem;
   }
 
 }

--- a/portal/web/src/app.js
+++ b/portal/web/src/app.js
@@ -2312,10 +2312,13 @@ class PortalShell extends HTMLElement {
     };
     onClick("eebus-refresh-status", () => void this.refreshEEBusStatus().catch((error) => this.showEEBusError(error)));
 	 onClick("eebus-retry-pending", () => void this.refreshAndRetryPendingEEBusMutation().catch((error) => this.showEEBusError(error)));
-    onClick("eebus-refresh-partners", () => {
-      const view = this.querySelector('[data-role="eebus-partner-view"]')?.value || "trusted";
-      void this.refreshEEBusPartners(view).catch((error) => this.showEEBusError(error));
+    onClick("eebus-refresh-discovered", () => void this.refreshEEBusPartners("discovered").catch((error) => this.showEEBusError(error, "pairing")));
+    onClick("eebus-refresh-candidate", () => void this.refreshEEBusPartners("candidate").catch((error) => this.showEEBusError(error, "pairing")));
+    onClick("eebus-refresh-ship", () => {
+      const view = this.querySelector('[data-role="eebus-ship-view"]')?.value || "trusted";
+      void this.refreshEEBusPartners(view).catch((error) => this.showEEBusError(error, "ship"));
     });
+    onClick("eebus-refresh-spine-peers", () => void this.refreshEEBusSPINEPeers().catch((error) => this.showEEBusError(error, "spine")));
     onClick("eebus-window-open", () => void this.openEEBusPairingWindow().catch((error) => this.showEEBusError(error)));
     onClick("eebus-window-close", () => void this.closeEEBusPairingWindow().catch((error) => this.showEEBusError(error)));
     onClick("eebus-candidate-cancel", () => void this.cancelEEBusCandidate().catch((error) => this.showEEBusError(error)));
@@ -2323,8 +2326,15 @@ class PortalShell extends HTMLElement {
       const value = this.querySelector('[data-role="eebus-confirm-ski"]')?.value || "";
       void this.confirmEEBusCandidate(value).catch((error) => this.showEEBusError(error));
     });
-    const partners = this.querySelector('[data-role="eebus-partners"]');
-    if (partners) {
+    this.querySelectorAll("[data-eebus-workspace-target]").forEach((button) => {
+      button.addEventListener("click", () => {
+        const workspace = button.getAttribute("data-eebus-workspace-target") || "";
+        this.switchEEBusWorkspace(workspace);
+        if (workspace === "ship") void this.refreshEEBusPartners("trusted").catch((error) => this.showEEBusError(error, "ship"));
+        if (workspace === "spine") void this.refreshEEBusSPINEPeers().catch((error) => this.showEEBusError(error, "spine"));
+      });
+    });
+    for (const partners of this.querySelectorAll('[data-role="eebus-pairing-partners"], [data-role="eebus-ship-partners"], [data-role="eebus-spine-peers"]')) {
       partners.addEventListener("click", (event) => {
         const button = event.target?.closest?.("[data-eebus-action]");
         if (!button) return;
@@ -2336,7 +2346,10 @@ class PortalShell extends HTMLElement {
           retry: () => this.retryEEBusPartner(id),
 		  "arm-untrust": () => this.armEEBusUntrust(id),
 		  untrust: () => this.untrustEEBusPartner(id),
-          spine: () => this.loadEEBusSPINERoot(id),
+          spine: async () => {
+            this.switchEEBusWorkspace("spine");
+            return this.loadEEBusSPINERoot(id);
+          },
         };
         if (operations[action]) void operations[action]().catch((error) => this.showEEBusError(error));
       });
@@ -2360,6 +2373,30 @@ class PortalShell extends HTMLElement {
     if (typeof document.addEventListener === "function") {
       document.addEventListener("visibilitychange", this._eebusVisibilityHandler);
     }
+    this.switchEEBusWorkspace("pairing");
+  }
+
+  switchEEBusWorkspace(workspace) {
+    if (!new Set(["pairing", "ship", "spine"]).has(workspace)) return;
+    const previous = this._eebusWorkspace || "pairing";
+    if (previous !== workspace) {
+      if (previous === "pairing") {
+        this.clearEEBusCandidate();
+        this._eebusSelection = undefined;
+      } else if (previous === "ship") {
+        this._eebusUntrustArmedID = undefined;
+      } else if (previous === "spine") {
+        this.clearEEBusSPINETree();
+      }
+      if (this._eebusPendingMutation?.workspace === previous) this.clearEEBusPendingMutation();
+    }
+    this._eebusWorkspace = workspace;
+    this.querySelectorAll("[data-eebus-workspace]").forEach((panel) => {
+      panel.hidden = panel.dataset?.eebusWorkspace !== workspace;
+    });
+    this.querySelectorAll("[data-eebus-workspace-target]").forEach((button) => {
+      button.setAttribute("aria-current", button.dataset?.eebusWorkspaceTarget === workspace ? "page" : "false");
+    });
   }
 
   async eebusAdminFetch(path, options = {}) {
@@ -2425,12 +2462,25 @@ class PortalShell extends HTMLElement {
 		this._eebusCandidateTimer = setTimeout(() => this.clearEEBusCandidate(), delay);
 	  }
     }
-    this.renderEEBusPartners(rows, view);
+	this.renderEEBusPartners(rows, view);
+	return payload;
+  }
+
+  async refreshEEBusSPINEPeers() {
+    this.clearEEBusSPINETree();
+    const payload = await this.eebusAdminFetch("/partners?view=connected");
+    const rows = Array.isArray(payload?.data?.partners) ? payload.data.partners : [];
+    this.renderEEBusSPINEPeers(rows);
     return payload;
   }
 
+  eebusPartnerContainer(view) {
+    const role = view === "trusted" || view === "connected" ? "eebus-ship-partners" : "eebus-pairing-partners";
+    return this.querySelector(`[data-role="${role}"]`) || this.querySelector('[data-role="eebus-partners"]');
+  }
+
   renderEEBusPartners(rows, view) {
-    const container = this.querySelector('[data-role="eebus-partners"]');
+	const container = this.eebusPartnerContainer(view);
     if (!container) return;
     const rendered = rows.map((row) => {
       const safe = escapeHtml(JSON.stringify(row, null, 2));
@@ -2443,13 +2493,25 @@ class PortalShell extends HTMLElement {
 		  ? `<button class="button" data-eebus-action="untrust" data-eebus-id="${id}">Confirm untrust</button>`
 		  : `<button class="button" data-eebus-action="arm-untrust" data-eebus-id="${id}">Arm untrust</button>`;
 	  }
-      if ((view === "trusted" || view === "connected") && row.partner_id) actions += `<button class="button" data-eebus-action="spine" data-eebus-id="${id}">Browse SPINE</button>`;
-      return `<article class="eebus-partner"><pre>${safe}</pre><div class="snapshot-controls">${actions}</div></article>`;
+      if (view === "connected" && row.partner_id) actions += `<button class="button" data-eebus-action="spine" data-eebus-id="${id}">Open in SPINE</button>`;
+      const state = view === "trusted" ? '<p class="eebus-partner-state">Disconnected — Reconnect required</p>' : "";
+      return `<article class="eebus-partner">${state}<pre>${safe}</pre><div class="snapshot-controls">${actions}</div></article>`;
     }).join("");
     const connect = this._eebusSelection
       ? `<button class="button" data-eebus-action="connect">Connect selected partner</button>`
       : "";
     container.innerHTML = `${connect}${rendered || '<div class="muted-inline">No partners in this view.</div>'}`;
+  }
+
+  renderEEBusSPINEPeers(rows) {
+    const container = this.querySelector('[data-role="eebus-spine-peers"]');
+    if (!container) return;
+    const rendered = rows.map((row) => {
+      const safe = escapeHtml(JSON.stringify(row, null, 2));
+      const id = escapeHtml(row.partner_id || "");
+      return `<article class="eebus-partner"><p class="eebus-partner-state">Live SHIP session</p><pre>${safe}</pre><button class="button" data-eebus-action="spine" data-eebus-id="${id}">Load SPINE snapshot</button></article>`;
+    }).join("");
+    container.innerHTML = rendered || '<div class="muted-inline">No live SHIP session. Open SHIP to reconnect.</div>';
   }
 
   async eebusMutation(path, body, method = "POST") {
@@ -2464,6 +2526,7 @@ class PortalShell extends HTMLElement {
 		method,
 		path,
 		body: serializedBody,
+		workspace: this._eebusWorkspace || "pairing",
 		idempotencyKey: crypto.randomUUID(),
 		expiresAt: Date.now() + 2 * 60 * 1000,
 	  };
@@ -2614,7 +2677,7 @@ class PortalShell extends HTMLElement {
 	const input = this.querySelector?.('[data-role="eebus-confirm-ski"]');
 	if (input) input.value = "";
 	if (this._eebusPartnerView === "candidate") {
-	  const partners = this.querySelector?.('[data-role="eebus-partners"]');
+	  const partners = this.eebusPartnerContainer?.("candidate");
 	  if (partners) partners.innerHTML = '<div class="muted-inline">Candidate view cleared.</div>';
 	}
   }
@@ -2639,9 +2702,16 @@ class PortalShell extends HTMLElement {
 	if (retry) retry.disabled = !this._eebusPendingMutation;
   }
 
-  showEEBusError(error) {
-    const status = this.querySelector('[data-role="eebus-status"]');
-    if (status) status.textContent = `eeBUS: ${error?.message || "unknown error"}`;
+  showEEBusError(error, workspace = this._eebusWorkspace || "pairing") {
+    const code = error?.message || "unknown error";
+    const messages = {
+      disconnected: "No live SHIP session. Open SHIP and use Retry to reconnect.",
+      spine_topology_unavailable: "The live SHIP session has no SPINE topology yet. Reload the connected sessions.",
+      snapshot_expired: "The SPINE snapshot expired. Load a new snapshot.",
+    };
+    const role = code === "admin_boundary_unavailable" ? "eebus-status" : `eebus-${workspace}-status`;
+    const status = this.querySelector(`[data-role="${role}"]`) || this.querySelector('[data-role="eebus-status"]');
+    if (status) status.textContent = messages[code] || `eeBUS: ${code}`;
   }
 
   async loadEEBusSPINERoot(partnerID) {
@@ -2983,35 +3053,75 @@ class PortalShell extends HTMLElement {
                 <div class="muted-inline">Loading Vaillant B503 capability...</div>
               </div>
             </section>
-			<section id="section-eebus" class="registry-preview">
-			  <h2>eeBUS SHIP / SPINE</h2>
-			  <p class="muted-inline">Host operator workbench. Candidate identity stays only in this active view.</p>
-			  <div class="snapshot-controls">
-			    <button class="button" data-role="eebus-refresh-status" type="button">Refresh status</button>
+			<section id="section-eebus" class="registry-preview eebus-workbench">
+			  <div class="eebus-heading-row">
+			    <div>
+			      <h2>eeBUS</h2>
+			      <p class="muted-inline">Host operator workbench. Pairing authority and raw protocol data stay only in this active view.</p>
+			    </div>
+			    <button class="button" data-role="eebus-refresh-status" type="button">Refresh health</button>
 			  </div>
-			  <div class="bus-banner bus-state-unavailable" data-role="eebus-status">Loading eeBUS operator status.</div>
-			  <div class="snapshot-controls">
-			    <button class="button" data-role="eebus-window-open" type="button">Open pairing window</button>
-			    <button class="button" data-role="eebus-window-close" type="button">Close pairing window</button>
-			    <button class="button" data-role="eebus-candidate-cancel" type="button">Cancel candidate</button>
-			    <button class="button" data-role="eebus-retry-pending" type="button" disabled>Retry pending action</button>
-			  </div>
-			  <div class="snapshot-controls">
-			    <select class="select" data-role="eebus-partner-view" aria-label="eeBUS partner view">
-			      <option value="trusted">Trusted</option><option value="connected">Connected</option><option value="discovered">Discovered</option><option value="candidate">Candidate</option>
-			    </select>
-			    <button class="button" data-role="eebus-refresh-partners" type="button">Refresh partners</button>
-			  </div>
-			  <input class="search timeline-filter" data-role="eebus-select-ski" autocomplete="off" placeholder="Enter the independent OOB 40-character SKI before Select" />
-			  <div data-role="eebus-partners"><div class="muted-inline">No partner view loaded.</div></div>
-			  <div class="eebus-candidate-panel">
-			    <h3>OOB candidate</h3>
-			    <pre data-role="eebus-candidate"></pre>
-			    <input class="search timeline-filter" data-role="eebus-confirm-ski" autocomplete="off" placeholder="Retype the complete 40-character SKI" />
-			    <button class="button" data-role="eebus-candidate-confirm" type="button">Confirm exact SKI</button>
-			  </div>
-			  <h3>Lazy SPINE tree</h3>
-			  <div data-role="eebus-spine-tree" class="eebus-spine-tree"><div class="muted-inline">Choose Browse SPINE on a trusted or connected partner.</div></div>
+			  <div class="bus-banner bus-state-unavailable eebus-health-strip" data-role="eebus-status" role="status" aria-live="polite" aria-atomic="true">Loading eeBUS operator health.</div>
+			  <nav class="eebus-workspace-nav" data-role="eebus-workspace-nav" aria-label="eeBUS workspaces">
+			    <button class="button" data-eebus-workspace-target="pairing" type="button" aria-current="page"><strong>Pairing</strong><span>Discover and establish trust</span></button>
+			    <button class="button" data-eebus-workspace-target="ship" type="button" aria-current="false"><strong>SHIP</strong><span>Trust and live sessions</span></button>
+			    <button class="button" data-eebus-workspace-target="spine" type="button" aria-current="false"><strong>SPINE</strong><span>Read-only topology</span></button>
+			  </nav>
+
+			  <section class="eebus-workspace" data-eebus-workspace="pairing" aria-labelledby="eebus-pairing-heading">
+			    <div class="eebus-workspace-heading">
+			      <div><h3 id="eebus-pairing-heading">Pair a device</h3><p class="muted-inline">Open discovery, verify the independent OOB SKI, connect, then confirm the TLS-bound candidate.</p></div>
+			      <div class="snapshot-controls">
+			        <button class="button" data-role="eebus-window-open" type="button">Open pairing window</button>
+			        <button class="button" data-role="eebus-window-close" type="button">Close pairing window</button>
+			      </div>
+			    </div>
+			    <div class="eebus-workspace-status muted-inline" data-role="eebus-pairing-status" role="status" aria-live="polite" aria-atomic="true">Pairing controls are ready.</div>
+			    <div class="snapshot-controls">
+			      <button class="button" data-role="eebus-refresh-discovered" type="button">Refresh discovered services</button>
+			      <button class="button" data-role="eebus-refresh-candidate" type="button">Refresh candidate</button>
+			      <button class="button" data-role="eebus-retry-pending" type="button" disabled>Retry pending action</button>
+			    </div>
+			    <label class="eebus-field" for="eebus-select-ski">Independent OOB SKI <span>40 lowercase hexadecimal characters</span></label>
+			    <input id="eebus-select-ski" class="search timeline-filter eebus-ski-input" data-role="eebus-select-ski" autocomplete="off" inputmode="text" spellcheck="false" maxlength="40" placeholder="Enter the SKI before Select" />
+			    <div data-role="eebus-pairing-partners"><div class="muted-inline">No discovered service loaded.</div></div>
+			    <div class="eebus-candidate-panel">
+			      <h4>TLS-bound candidate</h4>
+			      <pre data-role="eebus-candidate"></pre>
+			      <label class="eebus-field" for="eebus-confirm-ski">Confirm complete candidate SKI <span>Must exactly match the independent value</span></label>
+			      <input id="eebus-confirm-ski" class="search timeline-filter eebus-ski-input" data-role="eebus-confirm-ski" autocomplete="off" inputmode="text" spellcheck="false" maxlength="40" placeholder="Retype the complete SKI" />
+			      <div class="snapshot-controls">
+			        <button class="button" data-role="eebus-candidate-confirm" type="button">Confirm exact SKI</button>
+			        <button class="button" data-role="eebus-candidate-cancel" type="button">Cancel candidate</button>
+			      </div>
+			    </div>
+			  </section>
+
+			  <section class="eebus-workspace" data-eebus-workspace="ship" aria-labelledby="eebus-ship-heading" hidden>
+			    <div class="eebus-workspace-heading">
+			      <div><h3 id="eebus-ship-heading">SHIP associations and sessions</h3><p class="muted-inline">Trusted associations persist independently from live sessions. Retry is always an explicit operator action.</p></div>
+			      <div class="snapshot-controls">
+			        <select class="select" data-role="eebus-ship-view" aria-label="SHIP partner view">
+			          <option value="trusted">Trusted associations</option>
+			          <option value="connected">Live sessions</option>
+			        </select>
+			        <button class="button" data-role="eebus-refresh-ship" type="button">Refresh SHIP</button>
+			      </div>
+			    </div>
+			    <div class="eebus-workspace-status muted-inline" data-role="eebus-ship-status" role="status" aria-live="polite" aria-atomic="true">Choose Trusted associations or Live sessions.</div>
+			    <div data-role="eebus-ship-partners"><div class="muted-inline">No SHIP view loaded.</div></div>
+			  </section>
+
+			  <section class="eebus-workspace" data-eebus-workspace="spine" aria-labelledby="eebus-spine-heading" hidden>
+			    <div class="eebus-workspace-heading">
+			      <div><h3 id="eebus-spine-heading">SPINE topology browser</h3><p class="muted-inline">Read-only snapshots from a current connected SHIP session. Browsing never reconnects or mutates trust.</p></div>
+			      <button class="button" data-role="eebus-refresh-spine-peers" type="button">Refresh connected sessions</button>
+			    </div>
+			    <div class="eebus-workspace-status muted-inline" data-role="eebus-spine-status" role="status" aria-live="polite" aria-atomic="true">No live SHIP session selected.</div>
+			    <div data-role="eebus-spine-peers"><div class="muted-inline">No live SHIP session. Open SHIP to reconnect.</div></div>
+			    <h4>Lazy topology snapshot</h4>
+			    <div data-role="eebus-spine-tree" class="eebus-spine-tree"><div class="muted-inline">Select a connected peer to load a read-only SPINE snapshot.</div></div>
+			  </section>
 			</section>
             <div class="meta" data-role="stream-status">Stream idle</div>
             <div class="meta" data-role="meta">Waiting for bootstrap...</div>

--- a/portal/web/test/post-m9-eebus.test.mjs
+++ b/portal/web/test/post-m9-eebus.test.mjs
@@ -219,3 +219,71 @@ test("candidate and raw SPINE remain active-memory only and clear on visibility 
   assert.equal(input.value, "");
   assert.doesNotMatch(tree.innerHTML, /EnergyManagementSystem/);
 });
+
+test("eeBUS renders three separate Pairing SHIP and SPINE workspaces", async () => {
+  const { source } = await issue817Shell(async () => response({ state_revision: 1, data: {} }));
+  assert.match(source, /data-role="eebus-workspace-nav"/);
+  for (const workspace of ["pairing", "ship", "spine"]) {
+    assert.match(source, new RegExp(`data-eebus-workspace="${workspace}"`));
+    assert.match(source, new RegExp(`data-eebus-workspace-target="${workspace}"`));
+  }
+  const spinePanel = source.match(/data-eebus-workspace="spine"[\s\S]*?<\/section>/)?.[0] || "";
+  for (const forbidden of ["eebus-window-open", "eebus-candidate-confirm", "data-eebus-action=\\\"retry\\\"", "data-eebus-action=\\\"untrust\\\""]) {
+    assert.equal(spinePanel.includes(forbidden), false, `SPINE retains mutation control ${forbidden}`);
+  }
+});
+
+test("trusted offline rows show reconnect required and never expose Browse SPINE", async () => {
+  const shipPartners = { innerHTML: "" };
+  const { shell } = await issue817Shell(async () => response({ state_revision: 4, data: {}, error: null }), new Map([
+    ['[data-role="eebus-ship-partners"]', shipPartners],
+  ]));
+  shell.renderEEBusPartners([{ partner_id: "trusted-1", view: "trusted", trust_state: "trusted" }], "trusted");
+  assert.match(shipPartners.innerHTML, /Reconnect required/);
+  assert.match(shipPartners.innerHTML, /data-eebus-action="retry"/);
+  assert.doesNotMatch(shipPartners.innerHTML, /data-eebus-action="spine"/);
+});
+
+test("SPINE peer refresh requests only the connected view and Browse stays GET-only", async () => {
+  const calls = [];
+  const spinePeers = { innerHTML: "" };
+  const tree = { innerHTML: "" };
+  const { shell } = await issue817Shell(async (url, init = {}) => {
+    calls.push({ url: String(url), init });
+    if (String(url).includes("partners?view=connected")) {
+      return response({ state_revision: 5, data: { partners: [{ partner_id: "live-1", view: "connected", connection_state: "connected" }] }, error: null });
+    }
+    return response({ state_revision: 5, data: { snapshot_id: "snapshot-1", snapshot_hash: `sha256:${"a".repeat(64)}`, parent_node_id: null, nodes: [] }, error: null });
+  }, new Map([
+    ['[data-role="eebus-spine-peers"]', spinePeers],
+    ['[data-role="eebus-spine-tree"]', tree],
+  ]));
+
+  await shell.refreshEEBusSPINEPeers();
+  assert.match(spinePeers.innerHTML, /data-eebus-action="spine"/);
+  await shell.loadEEBusSPINERoot("live-1");
+  assert.equal(calls.length, 2);
+  assert.match(calls[0].url, /partners\?view=connected$/);
+  assert.equal(calls[0].init.method, "GET");
+  assert.equal(calls[1].init.method, "GET");
+  assert.match(calls[1].url, /\/partners\/live-1\/spine\?request=root$/);
+});
+
+test("workspace navigation clears only the departing workspace volatile authority", async () => {
+  const panels = ["pairing", "ship", "spine"].map((name) => ({ dataset: { eebusWorkspace: name }, hidden: false }));
+  const buttons = ["pairing", "ship", "spine"].map((name) => ({ dataset: { eebusWorkspaceTarget: name }, setAttribute() {} }));
+  const { shell } = await issue817Shell(async () => response({ state_revision: 1, data: {}, error: null }));
+  shell.querySelectorAll = (selector) => selector.includes("workspace-target") ? buttons : panels;
+  shell.clearEEBusCandidate = () => { shell._candidateCleared = true; };
+  shell.clearEEBusSPINETree = () => { shell._spineCleared = true; };
+  shell._eebusWorkspace = "pairing";
+  shell._eebusSelection = { id: "selection-1" };
+  shell._eebusUntrustArmedID = "partner-1";
+  shell.switchEEBusWorkspace("ship");
+  assert.equal(shell._candidateCleared, true);
+  assert.equal(shell._eebusSelection, undefined);
+  shell.switchEEBusWorkspace("spine");
+  assert.equal(shell._eebusUntrustArmedID, undefined);
+  shell.switchEEBusWorkspace("pairing");
+  assert.equal(shell._spineCleared, true);
+});


### PR DESCRIPTION
Closes #844

Docs gate: Project-Helianthus/helianthus-docs-eebus#129

RED: dbb59309bd8f296974ec7be01d0735dcbf737b71
GREEN: cc3cc4f4eb7c78d49f876e472ab538837082cf6e

- reject trusted-only SPINE browsing as disconnected without reading raw topology
- distinguish valid-but-empty topology from AdminV1 boundary failure
- separate Pairing, SHIP, and read-only SPINE Portal workspaces
- preserve active-memory-only authority and explicit retry/trust mutations