### PR TITLE
fix: isolate eeBUS startup and unify runtime identity

### DIFF
--- a/cmd/gateway/eebus_admin_config.go
+++ b/cmd/gateway/eebus_admin_config.go
@@ -59,7 +59,13 @@ type eebusStartupFailure struct {
 }
 
 func (failure *eebusStartupFailure) Error() string { return failure.err.Error() }
-func (failure *eebusStartupFailure) Unwrap() error { return failure.err }
+
+// Unwrap replaces, rather than extends, the gateway's existing public error
+// layer. That keeps previously sanitized cause-chain depth stable.
+func (failure *eebusStartupFailure) Unwrap() error { return errors.Unwrap(failure.err) }
+func (failure *eebusStartupFailure) Is(target error) bool {
+	return errors.Is(failure.err, target)
+}
 
 func markEEBusStartupFailure(reason eebusadmin.EEBusDegradedReason, err error) error {
 	if err == nil {

--- a/cmd/gateway/eebus_admin_config.go
+++ b/cmd/gateway/eebus_admin_config.go
@@ -2,27 +2,409 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log"
+	"net/http"
+	"sync"
+	"time"
 
 	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/eebusadmin"
 	eebusruntime "github.com/Project-Helianthus/helianthus-eebusreg"
 )
 
-// startEEBusAdminAwareRuntime always attempts the typed operator-capable
-// runtime when eeBUS is enabled. If that private capability cannot be built,
-// the public read-only runtime remains available and only the HTTP operator
-// boundary degrades.
-func startEEBusAdminAwareRuntime(ctx context.Context, config ebusgateway.Config) (*eebusRuntimeAdapter, eebusruntime.AdminV1, bool, error) {
+const (
+	eebusStartupMaxAttempts = 3
+	eebusStartupBackoff     = 5 * time.Second
+)
+
+type eebusLifecycleState string
+
+const (
+	eebusLifecycleDisabled eebusLifecycleState = "disabled"
+	eebusLifecycleStarting eebusLifecycleState = "starting"
+	eebusLifecycleRunning  eebusLifecycleState = "running"
+	eebusLifecycleBackoff  eebusLifecycleState = "backoff"
+	eebusLifecycleDegraded eebusLifecycleState = "degraded"
+	eebusLifecycleStopped  eebusLifecycleState = "stopped"
+)
+
+type eebusRestartPolicy struct {
+	MaxAttempts int
+	Backoff     time.Duration
+}
+
+type eebusRuntimeStarter func(context.Context) (*eebusRuntimeAdapter, eebusruntime.AdminV1, bool, error)
+type eebusRestartWait func(context.Context, time.Duration) bool
+
+type eebusRuntimeLifecycleOptions struct {
+	policy eebusRestartPolicy
+	start  eebusRuntimeStarter
+	wait   eebusRestartWait
+}
+
+type eebusRuntimeLifecycleSnapshot struct {
+	State            eebusLifecycleState
+	Attempts         int
+	Revision         uint64
+	AdminAvailable   bool
+	TimerOutstanding bool
+}
+
+// eebusRuntimeLifecycle owns only startup reconstruction and capability
+// replacement. It deliberately exposes no operator start/stop/restart API;
+// that broader surface belongs to the later generic DriverManager.
+type eebusRuntimeLifecycle struct {
+	mu sync.RWMutex
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	start  eebusRuntimeStarter
+	wait   eebusRestartWait
+	policy eebusRestartPolicy
+
+	slot    *eebusRuntimeSlot
+	adapter *eebusRuntimeAdapter
+	handler http.Handler
+	admin   eebusruntime.AdminV1
+
+	state            eebusLifecycleState
+	attempts         int
+	revision         uint64
+	adminAvailable   bool
+	timerOutstanding bool
+
+	recovery sync.WaitGroup
+	stopOnce sync.Once
+	stopErr  error
+}
+
+// startEEBusAdminAwareRuntime always returns the stable lifecycle seam when
+// eeBUS is configured, including when the first construction attempt fails.
+// The initial error remains available to the caller for a sanitized log, while
+// the lifecycle owns the bounded reconstruction window.
+func startEEBusAdminAwareRuntime(ctx context.Context, config ebusgateway.Config) (*eebusRuntimeAdapter, eebusruntime.AdminV1, *eebusRuntimeLifecycle, bool, error) {
+	resolver := resolveEEBusInterfaceAddressesFn
+	operatorFactory := newEEBusOperatorRuntimeFn
+	runtimeFactory := newEEBusRuntimeFn
+	lifecycle, initialErr := newEEBusRuntimeLifecycle(ctx, config.EEBusConfig.Enabled, eebusRuntimeLifecycleOptions{
+		policy: eebusRestartPolicy{MaxAttempts: eebusStartupMaxAttempts, Backoff: eebusStartupBackoff},
+		wait:   waitEEBusRestart,
+		start: func(attemptCtx context.Context) (*eebusRuntimeAdapter, eebusruntime.AdminV1, bool, error) {
+			return startEEBusAdminAwareRuntimeOnce(attemptCtx, config, resolver, operatorFactory, runtimeFactory)
+		},
+	})
+	return lifecycle.Adapter(), lifecycle.Admin(), lifecycle, lifecycle.AdminAvailable(), initialErr
+}
+
+// startEEBusAdminAwareRuntimeOnce attempts the typed operator-capable runtime
+// first. If that private capability cannot be built, the public read-only
+// runtime remains available and only the HTTP operator boundary degrades.
+func startEEBusAdminAwareRuntimeOnce(
+	ctx context.Context,
+	config ebusgateway.Config,
+	resolver eebusInterfaceAddressResolver,
+	operatorFactory eebusOperatorRuntimeFactory,
+	runtimeFactory eebusRuntimeFactory,
+) (*eebusRuntimeAdapter, eebusruntime.AdminV1, bool, error) {
 	if config.EEBusConfig.Enabled {
-		adapter, admin, runtimeErr := startEEBusOperatorRuntime(ctx, config.EEBusConfig, resolveEEBusInterfaceAddressesFn, newEEBusOperatorRuntimeFn)
+		adapter, admin, runtimeErr := startEEBusOperatorRuntime(ctx, config.EEBusConfig, resolver, operatorFactory)
 		if runtimeErr == nil {
 			return adapter, admin, true, nil
 		}
 		log.Printf("eeBUS operator boundary unavailable reason=operator_runtime")
 	}
-	adapter, err := startEEBusRuntime(ctx, config.EEBusConfig, resolveEEBusInterfaceAddressesFn, newEEBusRuntimeFn)
+	adapter, err := startEEBusRuntime(ctx, config.EEBusConfig, resolver, runtimeFactory)
 	if err != nil {
 		return nil, nil, false, err
 	}
 	return adapter, nil, false, nil
+}
+
+func newEEBusRuntimeLifecycle(
+	parent context.Context,
+	enabled bool,
+	options eebusRuntimeLifecycleOptions,
+) (*eebusRuntimeLifecycle, error) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithCancel(parent)
+	lifecycle := &eebusRuntimeLifecycle{
+		ctx: ctx, cancel: cancel,
+		start: options.start, wait: options.wait, policy: options.policy,
+		handler: eebusadmin.NewUnavailableHandler(),
+		state:   eebusLifecycleDisabled, revision: 1,
+	}
+	if !enabled {
+		return lifecycle, nil
+	}
+	if lifecycle.start == nil {
+		cancel()
+		return nil, errors.New("enabled eeBUS lifecycle requires a starter")
+	}
+	if lifecycle.wait == nil {
+		lifecycle.wait = waitEEBusRestart
+	}
+	if lifecycle.policy.MaxAttempts <= 0 {
+		lifecycle.policy.MaxAttempts = eebusStartupMaxAttempts
+	}
+	if lifecycle.policy.Backoff <= 0 {
+		lifecycle.policy.Backoff = eebusStartupBackoff
+	}
+	lifecycle.slot = newEEBusRuntimeSlot(nil)
+	lifecycle.slot.setCancel(cancel)
+	lifecycle.adapter = &eebusRuntimeAdapter{runtime: lifecycle.slot}
+
+	initialErr, complete := lifecycle.attempt(false)
+	if !complete {
+		lifecycle.scheduleRecovery()
+	}
+	return lifecycle, initialErr
+}
+
+func (lifecycle *eebusRuntimeLifecycle) attempt(retire bool) (error, bool) {
+	if lifecycle == nil {
+		return errors.New("eeBUS lifecycle unavailable"), false
+	}
+	if retire {
+		lifecycle.publishUnavailable(eebusLifecycleStarting)
+		lifecycle.slot.Retire()
+	} else {
+		lifecycle.setState(eebusLifecycleStarting, false)
+	}
+
+	lifecycle.mu.Lock()
+	lifecycle.attempts++
+	lifecycle.revision++
+	lifecycle.mu.Unlock()
+
+	adapter, admin, adminAvailable, err := lifecycle.start(lifecycle.ctx)
+	if err != nil {
+		if adapter != nil {
+			_ = adapter.Shutdown()
+		}
+		lifecycle.publishUnavailable(eebusLifecycleDegraded)
+		return err, false
+	}
+	if adapter == nil || adapter.runtime == nil {
+		lifecycle.publishUnavailable(eebusLifecycleDegraded)
+		return errors.New("eeBUS starter returned no runtime"), false
+	}
+	if adminAvailable && admin == nil {
+		_ = adapter.Shutdown()
+		lifecycle.publishUnavailable(eebusLifecycleDegraded)
+		return errors.New("eeBUS starter returned incomplete admin capability"), false
+	}
+
+	handler := eebusadmin.NewUnavailableHandler()
+	if adminAvailable {
+		var handlerErr error
+		handler, handlerErr = newEEBusAdminHandler(adapter, admin)
+		if handlerErr != nil {
+			admin = nil
+			adminAvailable = false
+			err = errors.Join(err, handlerErr)
+		}
+	}
+	if !lifecycle.slot.Replace(adapter.runtime) {
+		lifecycle.publishUnavailable(eebusLifecycleStopped)
+		return context.Canceled, false
+	}
+
+	lifecycle.mu.Lock()
+	lifecycle.handler = handler
+	lifecycle.admin = admin
+	lifecycle.adminAvailable = adminAvailable
+	lifecycle.timerOutstanding = false
+	if adminAvailable {
+		lifecycle.state = eebusLifecycleRunning
+	} else {
+		lifecycle.state = eebusLifecycleDegraded
+	}
+	lifecycle.revision++
+	lifecycle.mu.Unlock()
+	return err, adminAvailable
+}
+
+func (lifecycle *eebusRuntimeLifecycle) scheduleRecovery() {
+	if lifecycle == nil {
+		return
+	}
+	lifecycle.mu.Lock()
+	if lifecycle.state == eebusLifecycleDisabled || lifecycle.state == eebusLifecycleStopped || lifecycle.attempts >= lifecycle.policy.MaxAttempts {
+		lifecycle.state = eebusLifecycleDegraded
+		lifecycle.timerOutstanding = false
+		lifecycle.revision++
+		lifecycle.mu.Unlock()
+		return
+	}
+	lifecycle.state = eebusLifecycleBackoff
+	lifecycle.timerOutstanding = true
+	lifecycle.revision++
+	lifecycle.mu.Unlock()
+
+	lifecycle.recovery.Add(1)
+	go lifecycle.recover()
+}
+
+func (lifecycle *eebusRuntimeLifecycle) recover() {
+	defer lifecycle.recovery.Done()
+	for {
+		if !lifecycle.wait(lifecycle.ctx, lifecycle.policy.Backoff) {
+			lifecycle.markStoppedIfCancelled()
+			return
+		}
+		lifecycle.mu.Lock()
+		lifecycle.timerOutstanding = false
+		lifecycle.revision++
+		lifecycle.mu.Unlock()
+
+		_, complete := lifecycle.attempt(true)
+		if complete {
+			return
+		}
+
+		lifecycle.mu.Lock()
+		if lifecycle.ctx.Err() != nil {
+			lifecycle.state = eebusLifecycleStopped
+			lifecycle.timerOutstanding = false
+			lifecycle.revision++
+			lifecycle.mu.Unlock()
+			return
+		}
+		if lifecycle.attempts >= lifecycle.policy.MaxAttempts {
+			lifecycle.state = eebusLifecycleDegraded
+			lifecycle.timerOutstanding = false
+			lifecycle.revision++
+			lifecycle.mu.Unlock()
+			return
+		}
+		lifecycle.state = eebusLifecycleBackoff
+		lifecycle.timerOutstanding = true
+		lifecycle.revision++
+		lifecycle.mu.Unlock()
+	}
+}
+
+func (lifecycle *eebusRuntimeLifecycle) publishUnavailable(state eebusLifecycleState) {
+	if lifecycle == nil {
+		return
+	}
+	lifecycle.mu.Lock()
+	lifecycle.handler = eebusadmin.NewUnavailableHandler()
+	lifecycle.admin = nil
+	lifecycle.adminAvailable = false
+	lifecycle.state = state
+	lifecycle.timerOutstanding = false
+	lifecycle.revision++
+	lifecycle.mu.Unlock()
+}
+
+func (lifecycle *eebusRuntimeLifecycle) setState(state eebusLifecycleState, timerOutstanding bool) {
+	if lifecycle == nil {
+		return
+	}
+	lifecycle.mu.Lock()
+	lifecycle.state = state
+	lifecycle.timerOutstanding = timerOutstanding
+	lifecycle.revision++
+	lifecycle.mu.Unlock()
+}
+
+func (lifecycle *eebusRuntimeLifecycle) markStoppedIfCancelled() {
+	if lifecycle == nil || lifecycle.ctx.Err() == nil {
+		return
+	}
+	lifecycle.publishUnavailable(eebusLifecycleStopped)
+}
+
+func (lifecycle *eebusRuntimeLifecycle) Adapter() *eebusRuntimeAdapter {
+	if lifecycle == nil {
+		return nil
+	}
+	return lifecycle.adapter
+}
+
+func (lifecycle *eebusRuntimeLifecycle) Admin() eebusruntime.AdminV1 {
+	if lifecycle == nil {
+		return nil
+	}
+	lifecycle.mu.RLock()
+	defer lifecycle.mu.RUnlock()
+	return lifecycle.admin
+}
+
+func (lifecycle *eebusRuntimeLifecycle) AdminAvailable() bool {
+	if lifecycle == nil {
+		return false
+	}
+	lifecycle.mu.RLock()
+	defer lifecycle.mu.RUnlock()
+	return lifecycle.adminAvailable
+}
+
+func (lifecycle *eebusRuntimeLifecycle) Configured() bool {
+	return lifecycle != nil && lifecycle.adapter != nil
+}
+
+func (lifecycle *eebusRuntimeLifecycle) LifecycleSnapshot() eebusRuntimeLifecycleSnapshot {
+	if lifecycle == nil {
+		return eebusRuntimeLifecycleSnapshot{State: eebusLifecycleDisabled}
+	}
+	lifecycle.mu.RLock()
+	defer lifecycle.mu.RUnlock()
+	return eebusRuntimeLifecycleSnapshot{
+		State: lifecycle.state, Attempts: lifecycle.attempts, Revision: lifecycle.revision,
+		AdminAvailable: lifecycle.adminAvailable, TimerOutstanding: lifecycle.timerOutstanding,
+	}
+}
+
+func (lifecycle *eebusRuntimeLifecycle) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	if lifecycle == nil {
+		eebusadmin.NewUnavailableHandler().ServeHTTP(writer, request)
+		return
+	}
+	lifecycle.mu.RLock()
+	defer lifecycle.mu.RUnlock()
+	lifecycle.handler.ServeHTTP(writer, request)
+}
+
+func (lifecycle *eebusRuntimeLifecycle) Shutdown() error {
+	if lifecycle == nil {
+		return nil
+	}
+	lifecycle.stopOnce.Do(func() {
+		lifecycle.cancel()
+		lifecycle.recovery.Wait()
+		lifecycle.publishUnavailable(eebusLifecycleStopped)
+		if lifecycle.adapter != nil {
+			lifecycle.stopErr = lifecycle.adapter.Shutdown()
+		}
+	})
+	return lifecycle.stopErr
+}
+
+func waitEEBusRestart(ctx context.Context, delay time.Duration) bool {
+	if delay <= 0 {
+		return false
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+func newEEBusAdminHandler(eebusAdapter *eebusRuntimeAdapter, eebusAdmin eebusruntime.AdminV1) (http.Handler, error) {
+	config := eebusadmin.Config{Admin: eebusAdmin, Raw: eebusAdapter}
+	config.Audit = func(event eebusadmin.AuditEvent) {
+		log.Printf("eebus_admin_audit action=%s scope=host_operator request_id=%s idempotency=%s prior=%s resulting=%s reason=%s timestamp=%s",
+			event.Action, event.RequestID, event.IdempotencyOutcome, event.PriorStateClass,
+			event.ResultingStateClass, event.Reason, event.Timestamp.UTC().Format(time.RFC3339Nano))
+	}
+	return eebusadmin.NewServer(config)
 }

--- a/cmd/gateway/eebus_admin_config.go
+++ b/cmd/gateway/eebus_admin_config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -49,6 +50,55 @@ type eebusRuntimeLifecycleSnapshot struct {
 	Revision         uint64
 	AdminAvailable   bool
 	TimerOutstanding bool
+	DegradedReason   eebusadmin.EEBusDegradedReason
+}
+
+type eebusStartupFailure struct {
+	reason eebusadmin.EEBusDegradedReason
+	err    error
+}
+
+func (failure *eebusStartupFailure) Error() string { return failure.err.Error() }
+func (failure *eebusStartupFailure) Unwrap() error { return failure.err }
+
+func markEEBusStartupFailure(reason eebusadmin.EEBusDegradedReason, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &eebusStartupFailure{reason: reason, err: err}
+}
+
+func eebusStartupFailureReason(err error) eebusadmin.EEBusDegradedReason {
+	var failure *eebusStartupFailure
+	if errors.As(err, &failure) && failure.reason != "" {
+		return failure.reason
+	}
+	return eebusadmin.EEBusDegradedReasonUnknownStartupFailure
+}
+
+func classifyEEBusConfigFailure(err error) eebusadmin.EEBusDegradedReason {
+	message := strings.ToLower(err.Error())
+	if strings.Contains(message, "resolve eebus interface") ||
+		strings.Contains(message, "interface resolved") ||
+		strings.Contains(message, "interface address selection") {
+		return eebusadmin.EEBusDegradedReasonListenerUnavailable
+	}
+	return eebusadmin.EEBusDegradedReasonConfigurationInvalid
+}
+
+func classifyEEBusFactoryFailure(err error) eebusadmin.EEBusDegradedReason {
+	message := strings.ToLower(err.Error())
+	for _, marker := range []string{"local identity", "certificate", "private key", " ski", "ski "} {
+		if strings.Contains(message, marker) {
+			return eebusadmin.EEBusDegradedReasonLocalIdentityUnavailable
+		}
+	}
+	for _, marker := range []string{"listener", "listen ", "bind ", "address already in use"} {
+		if strings.Contains(message, marker) {
+			return eebusadmin.EEBusDegradedReasonListenerUnavailable
+		}
+	}
+	return eebusadmin.EEBusDegradedReasonRuntimeFactoryUnavailable
 }
 
 // eebusRuntimeLifecycle owns only startup reconstruction and capability
@@ -73,6 +123,7 @@ type eebusRuntimeLifecycle struct {
 	revision         uint64
 	adminAvailable   bool
 	timerOutstanding bool
+	degradedReason   eebusadmin.EEBusDegradedReason
 
 	recovery sync.WaitGroup
 	stopOnce sync.Once
@@ -107,16 +158,21 @@ func startEEBusAdminAwareRuntimeOnce(
 	operatorFactory eebusOperatorRuntimeFactory,
 	runtimeFactory eebusRuntimeFactory,
 ) (*eebusRuntimeAdapter, eebusruntime.AdminV1, bool, error) {
+	var operatorErr error
 	if config.EEBusConfig.Enabled {
 		adapter, admin, runtimeErr := startEEBusOperatorRuntime(ctx, config.EEBusConfig, resolver, operatorFactory)
 		if runtimeErr == nil {
 			return adapter, admin, true, nil
 		}
+		operatorErr = runtimeErr
 		log.Printf("eeBUS operator boundary unavailable reason=operator_runtime")
 	}
 	adapter, err := startEEBusRuntime(ctx, config.EEBusConfig, resolver, runtimeFactory)
 	if err != nil {
-		return nil, nil, false, err
+		return nil, nil, false, errors.Join(operatorErr, err)
+	}
+	if adapter != nil && operatorErr != nil {
+		adapter.startupDegradedReason = eebusStartupFailureReason(operatorErr)
 	}
 	return adapter, nil, false, nil
 }
@@ -133,8 +189,11 @@ func newEEBusRuntimeLifecycle(
 	lifecycle := &eebusRuntimeLifecycle{
 		ctx: ctx, cancel: cancel,
 		start: options.start, wait: options.wait, policy: options.policy,
-		handler: eebusadmin.NewUnavailableHandler(),
-		state:   eebusLifecycleDisabled, revision: 1,
+		handler: unavailableEEBusAdminHandler(eebusadmin.ReadinessV1{
+			ProcessReadiness: eebusadmin.ProcessReadinessReady,
+			EEBusReadiness:   eebusadmin.EEBusReadinessDisabled,
+		}),
+		state: eebusLifecycleDisabled, revision: 1,
 	}
 	if !enabled {
 		return lifecycle, nil
@@ -168,7 +227,7 @@ func (lifecycle *eebusRuntimeLifecycle) attempt(retire bool) (error, bool) {
 		return errors.New("eeBUS lifecycle unavailable"), false
 	}
 	if retire {
-		lifecycle.publishUnavailable(eebusLifecycleStarting)
+		lifecycle.publishUnavailable(eebusLifecycleStarting, "")
 		lifecycle.slot.Retire()
 	} else {
 		lifecycle.setState(eebusLifecycleStarting, false)
@@ -180,35 +239,52 @@ func (lifecycle *eebusRuntimeLifecycle) attempt(retire bool) (error, bool) {
 	lifecycle.mu.Unlock()
 
 	adapter, admin, adminAvailable, err := lifecycle.start(lifecycle.ctx)
-	if err != nil {
-		if adapter != nil {
-			_ = adapter.Shutdown()
-		}
-		lifecycle.publishUnavailable(eebusLifecycleDegraded)
+	reason := eebusStartupFailureReason(err)
+	if err == nil && adapter != nil && adapter.startupDegradedReason != "" {
+		reason = adapter.startupDegradedReason
+	}
+	if err != nil && adapter == nil {
+		lifecycle.publishUnavailable(eebusLifecycleDegraded, reason)
 		return err, false
 	}
 	if adapter == nil || adapter.runtime == nil {
-		lifecycle.publishUnavailable(eebusLifecycleDegraded)
+		lifecycle.publishUnavailable(eebusLifecycleDegraded, eebusadmin.EEBusDegradedReasonRuntimeFactoryUnavailable)
 		return errors.New("eeBUS starter returned no runtime"), false
 	}
 	if adminAvailable && admin == nil {
 		_ = adapter.Shutdown()
-		lifecycle.publishUnavailable(eebusLifecycleDegraded)
+		lifecycle.publishUnavailable(eebusLifecycleDegraded, eebusadmin.EEBusDegradedReasonAdminBoundaryUnavailable)
 		return errors.New("eeBUS starter returned incomplete admin capability"), false
 	}
 
-	handler := eebusadmin.NewUnavailableHandler()
+	if !adminAvailable && err == nil && reason == eebusadmin.EEBusDegradedReasonUnknownStartupFailure {
+		reason = eebusadmin.EEBusDegradedReasonAdminBoundaryUnavailable
+	}
+	handler := unavailableEEBusAdminHandler(eebusadmin.ReadinessV1{
+		ProcessReadiness:    eebusadmin.ProcessReadinessReady,
+		EEBusReadiness:      eebusadmin.EEBusReadinessDegraded,
+		EEBusDegradedReason: reason,
+	})
 	if adminAvailable {
 		var handlerErr error
-		handler, handlerErr = newEEBusAdminHandler(adapter, admin)
+		handler, handlerErr = newEEBusAdminHandler(adapter, admin, eebusadmin.ReadinessV1{
+			ProcessReadiness: eebusadmin.ProcessReadinessReady,
+			EEBusReadiness:   eebusadmin.EEBusReadinessReady,
+		})
 		if handlerErr != nil {
 			admin = nil
 			adminAvailable = false
 			err = errors.Join(err, handlerErr)
+			reason = eebusadmin.EEBusDegradedReasonAdminBoundaryUnavailable
+			handler = unavailableEEBusAdminHandler(eebusadmin.ReadinessV1{
+				ProcessReadiness:    eebusadmin.ProcessReadinessReady,
+				EEBusReadiness:      eebusadmin.EEBusReadinessDegraded,
+				EEBusDegradedReason: reason,
+			})
 		}
 	}
 	if !lifecycle.slot.Replace(adapter.runtime) {
-		lifecycle.publishUnavailable(eebusLifecycleStopped)
+		lifecycle.publishUnavailable(eebusLifecycleStopped, eebusadmin.EEBusDegradedReasonUnknownStartupFailure)
 		return context.Canceled, false
 	}
 
@@ -219,8 +295,10 @@ func (lifecycle *eebusRuntimeLifecycle) attempt(retire bool) (error, bool) {
 	lifecycle.timerOutstanding = false
 	if adminAvailable {
 		lifecycle.state = eebusLifecycleRunning
+		lifecycle.degradedReason = ""
 	} else {
 		lifecycle.state = eebusLifecycleDegraded
+		lifecycle.degradedReason = reason
 	}
 	lifecycle.revision++
 	lifecycle.mu.Unlock()
@@ -287,15 +365,17 @@ func (lifecycle *eebusRuntimeLifecycle) recover() {
 	}
 }
 
-func (lifecycle *eebusRuntimeLifecycle) publishUnavailable(state eebusLifecycleState) {
+func (lifecycle *eebusRuntimeLifecycle) publishUnavailable(state eebusLifecycleState, reason eebusadmin.EEBusDegradedReason) {
 	if lifecycle == nil {
 		return
 	}
 	lifecycle.mu.Lock()
-	lifecycle.handler = eebusadmin.NewUnavailableHandler()
+	readiness := eebusReadinessForLifecycle(eebusRuntimeLifecycleSnapshot{State: state, DegradedReason: reason})
+	lifecycle.handler = unavailableEEBusAdminHandler(readiness)
 	lifecycle.admin = nil
 	lifecycle.adminAvailable = false
 	lifecycle.state = state
+	lifecycle.degradedReason = readiness.EEBusDegradedReason
 	lifecycle.timerOutstanding = false
 	lifecycle.revision++
 	lifecycle.mu.Unlock()
@@ -308,6 +388,11 @@ func (lifecycle *eebusRuntimeLifecycle) setState(state eebusLifecycleState, time
 	lifecycle.mu.Lock()
 	lifecycle.state = state
 	lifecycle.timerOutstanding = timerOutstanding
+	readiness := eebusReadinessForLifecycle(eebusRuntimeLifecycleSnapshot{State: state, DegradedReason: lifecycle.degradedReason})
+	if state != eebusLifecycleRunning {
+		lifecycle.handler = unavailableEEBusAdminHandler(readiness)
+	}
+	lifecycle.degradedReason = readiness.EEBusDegradedReason
 	lifecycle.revision++
 	lifecycle.mu.Unlock()
 }
@@ -316,7 +401,7 @@ func (lifecycle *eebusRuntimeLifecycle) markStoppedIfCancelled() {
 	if lifecycle == nil || lifecycle.ctx.Err() == nil {
 		return
 	}
-	lifecycle.publishUnavailable(eebusLifecycleStopped)
+	lifecycle.publishUnavailable(eebusLifecycleStopped, lifecycle.LifecycleSnapshot().DegradedReason)
 }
 
 func (lifecycle *eebusRuntimeLifecycle) Adapter() *eebusRuntimeAdapter {
@@ -357,12 +442,13 @@ func (lifecycle *eebusRuntimeLifecycle) LifecycleSnapshot() eebusRuntimeLifecycl
 	return eebusRuntimeLifecycleSnapshot{
 		State: lifecycle.state, Attempts: lifecycle.attempts, Revision: lifecycle.revision,
 		AdminAvailable: lifecycle.adminAvailable, TimerOutstanding: lifecycle.timerOutstanding,
+		DegradedReason: lifecycle.degradedReason,
 	}
 }
 
 func (lifecycle *eebusRuntimeLifecycle) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 	if lifecycle == nil {
-		eebusadmin.NewUnavailableHandler().ServeHTTP(writer, request)
+		unavailableEEBusAdminHandler(eebusReadinessForLifecycle(eebusRuntimeLifecycleSnapshot{State: eebusLifecycleDisabled})).ServeHTTP(writer, request)
 		return
 	}
 	lifecycle.mu.RLock()
@@ -377,7 +463,7 @@ func (lifecycle *eebusRuntimeLifecycle) Shutdown() error {
 	lifecycle.stopOnce.Do(func() {
 		lifecycle.cancel()
 		lifecycle.recovery.Wait()
-		lifecycle.publishUnavailable(eebusLifecycleStopped)
+		lifecycle.publishUnavailable(eebusLifecycleStopped, lifecycle.LifecycleSnapshot().DegradedReason)
 		if lifecycle.adapter != nil {
 			lifecycle.stopErr = lifecycle.adapter.Shutdown()
 		}
@@ -399,12 +485,35 @@ func waitEEBusRestart(ctx context.Context, delay time.Duration) bool {
 	}
 }
 
-func newEEBusAdminHandler(eebusAdapter *eebusRuntimeAdapter, eebusAdmin eebusruntime.AdminV1) (http.Handler, error) {
-	config := eebusadmin.Config{Admin: eebusAdmin, Raw: eebusAdapter}
+func newEEBusAdminHandler(eebusAdapter *eebusRuntimeAdapter, eebusAdmin eebusruntime.AdminV1, readiness eebusadmin.ReadinessV1) (http.Handler, error) {
+	config := eebusadmin.Config{Admin: eebusAdmin, Raw: eebusAdapter, Readiness: func() eebusadmin.ReadinessV1 { return readiness }}
 	config.Audit = func(event eebusadmin.AuditEvent) {
 		log.Printf("eebus_admin_audit action=%s scope=host_operator request_id=%s idempotency=%s prior=%s resulting=%s reason=%s timestamp=%s",
 			event.Action, event.RequestID, event.IdempotencyOutcome, event.PriorStateClass,
 			event.ResultingStateClass, event.Reason, event.Timestamp.UTC().Format(time.RFC3339Nano))
 	}
 	return eebusadmin.NewServer(config)
+}
+
+func unavailableEEBusAdminHandler(readiness eebusadmin.ReadinessV1) http.Handler {
+	return eebusadmin.NewUnavailableHandlerWithReadiness(func() eebusadmin.ReadinessV1 { return readiness })
+}
+
+func eebusReadinessForLifecycle(snapshot eebusRuntimeLifecycleSnapshot) eebusadmin.ReadinessV1 {
+	readiness := eebusadmin.ReadinessV1{ProcessReadiness: eebusadmin.ProcessReadinessReady}
+	switch snapshot.State {
+	case eebusLifecycleDisabled:
+		readiness.EEBusReadiness = eebusadmin.EEBusReadinessDisabled
+	case eebusLifecycleStarting:
+		readiness.EEBusReadiness = eebusadmin.EEBusReadinessStarting
+	case eebusLifecycleRunning:
+		readiness.EEBusReadiness = eebusadmin.EEBusReadinessReady
+	default:
+		readiness.EEBusReadiness = eebusadmin.EEBusReadinessDegraded
+		readiness.EEBusDegradedReason = snapshot.DegradedReason
+		if readiness.EEBusDegradedReason == "" {
+			readiness.EEBusDegradedReason = eebusadmin.EEBusDegradedReasonUnknownStartupFailure
+		}
+	}
+	return readiness
 }

--- a/cmd/gateway/eebus_admin_wiring_test.go
+++ b/cmd/gateway/eebus_admin_wiring_test.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/eebusadmin"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/portal"
 	eebusruntime "github.com/Project-Helianthus/helianthus-eebusreg"
 )
 
@@ -317,4 +319,36 @@ func issue846WaitForLifecycleState(t *testing.T, lifecycle *eebusRuntimeLifecycl
 		time.Sleep(time.Millisecond)
 	}
 	t.Fatalf("lifecycle state = %s; want %s", lifecycle.LifecycleSnapshot().State, want)
+}
+
+func TestIssue846GatewayReadinessProjectsLifecycleAndConditionalProxy(t *testing.T) {
+	tests := []struct {
+		name        string
+		proxyListen string
+		lifecycle   eebusRuntimeLifecycleSnapshot
+		wantProxy   string
+		wantEEBus   string
+		wantReason  eebusadmin.EEBusDegradedReason
+	}{
+		{name: "disabled", lifecycle: eebusRuntimeLifecycleSnapshot{State: eebusLifecycleDisabled}, wantProxy: "DISABLED", wantEEBus: "DISABLED"},
+		{name: "starting with conditional proxy", proxyListen: ":19001", lifecycle: eebusRuntimeLifecycleSnapshot{State: eebusLifecycleStarting}, wantProxy: "READY", wantEEBus: "STARTING"},
+		{name: "initial failure backoff", lifecycle: eebusRuntimeLifecycleSnapshot{State: eebusLifecycleBackoff, DegradedReason: eebusadmin.EEBusDegradedReasonListenerUnavailable}, wantProxy: "DISABLED", wantEEBus: "DEGRADED", wantReason: eebusadmin.EEBusDegradedReasonListenerUnavailable},
+		{name: "recovered", proxyListen: ":19001", lifecycle: eebusRuntimeLifecycleSnapshot{State: eebusLifecycleRunning}, wantProxy: "READY", wantEEBus: "READY"},
+		{name: "unknown failure", lifecycle: eebusRuntimeLifecycleSnapshot{State: eebusLifecycleDegraded, DegradedReason: eebusadmin.EEBusDegradedReasonUnknownStartupFailure}, wantProxy: "DISABLED", wantEEBus: "DEGRADED", wantReason: eebusadmin.EEBusDegradedReasonUnknownStartupFailure},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := ebusgateway.DefaultConfig()
+			cfg.ProxyListenAddr = test.proxyListen
+			got := projectGatewayReadiness(cfg, test.lifecycle)
+			if got.ProcessReadiness != "READY" || got.HTTPReadiness != "READY" || got.ProxyReadiness != test.wantProxy || got.EEBusReadiness != test.wantEEBus || got.EEBusDegradedReason != string(test.wantReason) {
+				t.Fatalf("readiness=%#v; want process/http READY proxy=%s eeBUS=%s reason=%s", got, test.wantProxy, test.wantEEBus, test.wantReason)
+			}
+			if test.wantEEBus != "DEGRADED" && got.EEBusDegradedReason != "" {
+				t.Fatalf("non-degraded readiness leaked reason: %#v", got)
+			}
+			var _ portal.RuntimeReadiness = got
+		})
+	}
 }

--- a/cmd/gateway/eebus_admin_wiring_test.go
+++ b/cmd/gateway/eebus_admin_wiring_test.go
@@ -352,3 +352,26 @@ func TestIssue846GatewayReadinessProjectsLifecycleAndConditionalProxy(t *testing
 		})
 	}
 }
+
+func TestIssue846StartupFailureReasonsUseClosedCanonicalMapping(t *testing.T) {
+	tests := []struct {
+		name string
+		got  eebusadmin.EEBusDegradedReason
+		want eebusadmin.EEBusDegradedReason
+	}{
+		{name: "configuration", got: classifyEEBusConfigFailure(errors.New("enabled eeBUS configuration requires a state root")), want: eebusadmin.EEBusDegradedReasonConfigurationInvalid},
+		{name: "interface resolution", got: classifyEEBusConfigFailure(errors.New("resolve eeBUS interface addresses: unavailable")), want: eebusadmin.EEBusDegradedReasonListenerUnavailable},
+		{name: "local identity", got: classifyEEBusFactoryFailure(errors.New("load local identity certificate")), want: eebusadmin.EEBusDegradedReasonLocalIdentityUnavailable},
+		{name: "listener", got: classifyEEBusFactoryFailure(errors.New("listener bind failed")), want: eebusadmin.EEBusDegradedReasonListenerUnavailable},
+		{name: "runtime factory", got: classifyEEBusFactoryFailure(errors.New("backend construction failed")), want: eebusadmin.EEBusDegradedReasonRuntimeFactoryUnavailable},
+		{name: "admin boundary", got: eebusStartupFailureReason(markEEBusStartupFailure(eebusadmin.EEBusDegradedReasonAdminBoundaryUnavailable, errors.New("incomplete capability pair"))), want: eebusadmin.EEBusDegradedReasonAdminBoundaryUnavailable},
+		{name: "unknown", got: eebusStartupFailureReason(errors.New("future startup failure")), want: eebusadmin.EEBusDegradedReasonUnknownStartupFailure},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.got != test.want {
+				t.Fatalf("reason=%s; want %s", test.got, test.want)
+			}
+		})
+	}
+}

--- a/cmd/gateway/eebus_admin_wiring_test.go
+++ b/cmd/gateway/eebus_admin_wiring_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"net/netip"
 	"os"
 	"reflect"
@@ -90,7 +92,11 @@ func TestIssue817GatewayMountsOneCredentialFreeTypedOperatorBoundary(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
-	source := string(content)
+	configContent, err := os.ReadFile("eebus_admin_config.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := string(content) + "\n" + string(configContent)
 	for _, required := range []string{
 		`mux.Handle("/admin/eebus/v1/", eebusAdminHandler)`,
 		`eebusAdminHandler := eebusadmin.NewUnavailableHandler()`,
@@ -213,6 +219,11 @@ func TestIssue846LifecycleUsesBoundedBackoffAndRecoversOneRuntimeAdminPair(t *te
 		t.Fatalf("initial lifecycle = %#v; want one degraded attempt in backoff", initial)
 	}
 	initialRevision := initial.Revision
+	unavailableResponse := httptest.NewRecorder()
+	lifecycle.ServeHTTP(unavailableResponse, httptest.NewRequest(http.MethodGet, "/admin/eebus/v1/unknown", nil))
+	if unavailableResponse.Code != http.StatusServiceUnavailable {
+		t.Fatalf("initial Admin handler status = %d; want closed unavailable", unavailableResponse.Code)
+	}
 	if delay := <-waiter.durations; delay <= 0 {
 		t.Fatalf("first restart delay = %s; want nonzero backoff", delay)
 	}
@@ -232,6 +243,11 @@ func TestIssue846LifecycleUsesBoundedBackoffAndRecoversOneRuntimeAdminPair(t *te
 	}
 	if waiter.maxActive.Load() != 1 {
 		t.Fatalf("maximum concurrent restart waits = %d; want one outstanding timer", waiter.maxActive.Load())
+	}
+	availableResponse := httptest.NewRecorder()
+	lifecycle.ServeHTTP(availableResponse, httptest.NewRequest(http.MethodGet, "/admin/eebus/v1/unknown", nil))
+	if availableResponse.Code != http.StatusNotFound {
+		t.Fatalf("recovered Admin handler status = %d; want live typed handler", availableResponse.Code)
 	}
 }
 

--- a/cmd/gateway/eebus_admin_wiring_test.go
+++ b/cmd/gateway/eebus_admin_wiring_test.go
@@ -7,7 +7,9 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
 	eebusruntime "github.com/Project-Helianthus/helianthus-eebusreg"
@@ -147,4 +149,156 @@ func issue817StartAdminAwareRuntime(t *testing.T, ctx context.Context, cfg ebusg
 		err = results[errorIndex].Interface().(error)
 	}
 	return adapter, admin, results[availableIndex].Bool(), err
+}
+
+type issue846RestartWaiter struct {
+	durations chan time.Duration
+	releases  chan struct{}
+	active    atomic.Int32
+	maxActive atomic.Int32
+}
+
+func newIssue846RestartWaiter() *issue846RestartWaiter {
+	return &issue846RestartWaiter{
+		durations: make(chan time.Duration, 8),
+		releases:  make(chan struct{}, 8),
+	}
+}
+
+func (waiter *issue846RestartWaiter) Wait(ctx context.Context, delay time.Duration) bool {
+	active := waiter.active.Add(1)
+	defer waiter.active.Add(-1)
+	for {
+		maximum := waiter.maxActive.Load()
+		if active <= maximum || waiter.maxActive.CompareAndSwap(maximum, active) {
+			break
+		}
+	}
+	waiter.durations <- delay
+	select {
+	case <-ctx.Done():
+		return false
+	case <-waiter.releases:
+		return true
+	}
+}
+
+func TestIssue846LifecycleUsesBoundedBackoffAndRecoversOneRuntimeAdminPair(t *testing.T) {
+	waiter := newIssue846RestartWaiter()
+	firstRuntime := &msp05bRuntime{}
+	recoveredRuntime := &msp05bRuntime{}
+	var attempts atomic.Int32
+
+	lifecycle, initialErr := newEEBusRuntimeLifecycle(context.Background(), true, eebusRuntimeLifecycleOptions{
+		policy: eebusRestartPolicy{MaxAttempts: 3, Backoff: time.Minute},
+		wait:   waiter.Wait,
+		start: func(context.Context) (*eebusRuntimeAdapter, eebusruntime.AdminV1, bool, error) {
+			switch attempts.Add(1) {
+			case 1:
+				return &eebusRuntimeAdapter{runtime: firstRuntime}, nil, false, nil
+			case 2:
+				return nil, nil, false, errors.New("listener still unavailable")
+			default:
+				return &eebusRuntimeAdapter{runtime: recoveredRuntime}, issue809AdminStub{}, true, nil
+			}
+		},
+	})
+	if initialErr != nil {
+		t.Fatalf("partial initial runtime = %v; want contained degraded result", initialErr)
+	}
+	t.Cleanup(func() { _ = lifecycle.Shutdown() })
+
+	initial := lifecycle.LifecycleSnapshot()
+	if initial.State != eebusLifecycleBackoff || initial.Attempts != 1 || initial.AdminAvailable || initial.Revision == 0 {
+		t.Fatalf("initial lifecycle = %#v; want one degraded attempt in backoff", initial)
+	}
+	initialRevision := initial.Revision
+	if delay := <-waiter.durations; delay <= 0 {
+		t.Fatalf("first restart delay = %s; want nonzero backoff", delay)
+	}
+	waiter.releases <- struct{}{}
+	if delay := <-waiter.durations; delay <= 0 {
+		t.Fatalf("second restart delay = %s; want nonzero backoff", delay)
+	}
+	waiter.releases <- struct{}{}
+
+	issue846WaitForLifecycleState(t, lifecycle, eebusLifecycleRunning)
+	recovered := lifecycle.LifecycleSnapshot()
+	if recovered.Attempts != 3 || !recovered.AdminAvailable || recovered.Revision <= initialRevision || recovered.TimerOutstanding {
+		t.Fatalf("recovered lifecycle = %#v; want one available replacement after three attempts", recovered)
+	}
+	if firstRuntime.stopCalls != 1 {
+		t.Fatalf("replaced partial runtime shutdown calls = %d; want one", firstRuntime.stopCalls)
+	}
+	if waiter.maxActive.Load() != 1 {
+		t.Fatalf("maximum concurrent restart waits = %d; want one outstanding timer", waiter.maxActive.Load())
+	}
+}
+
+func TestIssue846LifecycleStopsAfterFiniteAttempts(t *testing.T) {
+	waiter := newIssue846RestartWaiter()
+	var attempts atomic.Int32
+	lifecycle, _ := newEEBusRuntimeLifecycle(context.Background(), true, eebusRuntimeLifecycleOptions{
+		policy: eebusRestartPolicy{MaxAttempts: 3, Backoff: time.Second},
+		wait:   waiter.Wait,
+		start: func(context.Context) (*eebusRuntimeAdapter, eebusruntime.AdminV1, bool, error) {
+			attempts.Add(1)
+			return nil, nil, false, errors.New("startup unavailable")
+		},
+	})
+	t.Cleanup(func() { _ = lifecycle.Shutdown() })
+
+	for range 2 {
+		if delay := <-waiter.durations; delay <= 0 {
+			t.Fatalf("restart delay = %s; want nonzero", delay)
+		}
+		waiter.releases <- struct{}{}
+	}
+	issue846WaitForLifecycleState(t, lifecycle, eebusLifecycleDegraded)
+	snapshot := lifecycle.LifecycleSnapshot()
+	if snapshot.Attempts != 3 || snapshot.TimerOutstanding || attempts.Load() != 3 {
+		t.Fatalf("exhausted lifecycle = %#v calls=%d; want finite three-attempt window", snapshot, attempts.Load())
+	}
+	select {
+	case delay := <-waiter.durations:
+		t.Fatalf("unexpected fourth restart timer with delay %s", delay)
+	default:
+	}
+}
+
+func TestIssue846LifecycleCancellationStopsOutstandingTimerAndRuntime(t *testing.T) {
+	waiter := newIssue846RestartWaiter()
+	runtime := &msp05bRuntime{}
+	var attempts atomic.Int32
+	lifecycle, _ := newEEBusRuntimeLifecycle(context.Background(), true, eebusRuntimeLifecycleOptions{
+		policy: eebusRestartPolicy{MaxAttempts: 3, Backoff: time.Second},
+		wait:   waiter.Wait,
+		start: func(context.Context) (*eebusRuntimeAdapter, eebusruntime.AdminV1, bool, error) {
+			attempts.Add(1)
+			return &eebusRuntimeAdapter{runtime: runtime}, nil, false, nil
+		},
+	})
+	<-waiter.durations
+	if err := lifecycle.Shutdown(); err != nil {
+		t.Fatalf("lifecycle shutdown: %v", err)
+	}
+	snapshot := lifecycle.LifecycleSnapshot()
+	if snapshot.State != eebusLifecycleStopped || snapshot.TimerOutstanding || attempts.Load() != 1 {
+		t.Fatalf("cancelled lifecycle = %#v calls=%d; want stopped before retry", snapshot, attempts.Load())
+	}
+	if runtime.stopCalls != 1 {
+		t.Fatalf("active runtime shutdown calls = %d; want one", runtime.stopCalls)
+	}
+}
+
+func issue846WaitForLifecycleState(t *testing.T, lifecycle *eebusRuntimeLifecycle, want eebusLifecycleState) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if lifecycle.LifecycleSnapshot().State == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("lifecycle state = %s; want %s", lifecycle.LifecycleSnapshot().State, want)
 }

--- a/cmd/gateway/eebus_admin_wiring_test.go
+++ b/cmd/gateway/eebus_admin_wiring_test.go
@@ -15,7 +15,6 @@ import (
 
 	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/eebusadmin"
-	"github.com/Project-Helianthus/helianthus-ebusgateway/portal"
 	eebusruntime "github.com/Project-Helianthus/helianthus-eebusreg"
 )
 
@@ -348,7 +347,6 @@ func TestIssue846GatewayReadinessProjectsLifecycleAndConditionalProxy(t *testing
 			if test.wantEEBus != "DEGRADED" && got.EEBusDegradedReason != "" {
 				t.Fatalf("non-degraded readiness leaked reason: %#v", got)
 			}
-			var _ portal.RuntimeReadiness = got
 		})
 	}
 }

--- a/cmd/gateway/eebus_runtime_adapter.go
+++ b/cmd/gateway/eebus_runtime_adapter.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/eebusadmin"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/eebuscommand"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
 	eebusruntime "github.com/Project-Helianthus/helianthus-eebusreg"
@@ -23,8 +24,9 @@ var (
 )
 
 type eebusRuntimeAdapter struct {
-	runtime   eebusruntime.Runtime
-	promotion mcp.LeafPromotionCapture
+	runtime               eebusruntime.Runtime
+	promotion             mcp.LeafPromotionCapture
+	startupDegradedReason eebusadmin.EEBusDegradedReason
 
 	shutdownOnce sync.Once
 	shutdownErr  error
@@ -291,17 +293,17 @@ func startEEBusOperatorRuntime(
 ) (*eebusRuntimeAdapter, eebusruntime.AdminV1, error) {
 	runtimeConfig, err := mapEEBusRuntimeConfig(config, resolve)
 	if err != nil {
-		return nil, nil, fmt.Errorf("map eeBUS runtime configuration: %w", err)
+		return nil, nil, markEEBusStartupFailure(classifyEEBusConfigFailure(err), fmt.Errorf("map eeBUS runtime configuration: %w", err))
 	}
 	if !config.Enabled {
 		return nil, nil, nil
 	}
 	if factory == nil {
-		return nil, nil, errors.New("enabled eeBUS admin configuration requires an operator runtime factory")
+		return nil, nil, markEEBusStartupFailure(eebusadmin.EEBusDegradedReasonRuntimeFactoryUnavailable, errors.New("enabled eeBUS admin configuration requires an operator runtime factory"))
 	}
 	profile, err := loadEEBusMutationLabProfile(runtimeConfig.StateRoot)
 	if err != nil {
-		return nil, nil, fmt.Errorf("load eeBUS mutation lab profile: %w", err)
+		return nil, nil, markEEBusStartupFailure(eebusadmin.EEBusDegradedReasonConfigurationInvalid, fmt.Errorf("load eeBUS mutation lab profile: %w", err))
 	}
 	if profile != nil {
 		runtimeConfig.MutationLabProfiles = []eebusraw.MutationLabProfileV1{profile.Clone()}
@@ -312,16 +314,16 @@ func startEEBusOperatorRuntime(
 			factoryErr = errors.Join(factoryErr, runtime.Shutdown())
 		}
 		if factoryErr != nil {
-			return nil, nil, fmt.Errorf("construct eeBUS operator runtime: %w", factoryErr)
+			return nil, nil, markEEBusStartupFailure(classifyEEBusFactoryFailure(factoryErr), fmt.Errorf("construct eeBUS operator runtime: %w", factoryErr))
 		}
-		return nil, nil, errors.New("construct eeBUS operator runtime: factory returned incomplete capability pair")
+		return nil, nil, markEEBusStartupFailure(eebusadmin.EEBusDegradedReasonAdminBoundaryUnavailable, errors.New("construct eeBUS operator runtime: factory returned incomplete capability pair"))
 	}
 	adapter := &eebusRuntimeAdapter{runtime: runtime}
 	if factoryErr != nil {
-		return nil, nil, fmt.Errorf("construct eeBUS operator runtime: %w", errors.Join(factoryErr, adapter.Shutdown()))
+		return nil, nil, markEEBusStartupFailure(classifyEEBusFactoryFailure(factoryErr), fmt.Errorf("construct eeBUS operator runtime: %w", errors.Join(factoryErr, adapter.Shutdown())))
 	}
 	if err := runtime.Start(ctx); err != nil {
-		return nil, nil, fmt.Errorf("start eeBUS operator runtime: %w", errors.Join(err, adapter.Shutdown()))
+		return nil, nil, markEEBusStartupFailure(eebusadmin.EEBusDegradedReasonListenerUnavailable, fmt.Errorf("start eeBUS operator runtime: %w", errors.Join(err, adapter.Shutdown())))
 	}
 	return adapter, admin, nil
 }
@@ -361,17 +363,17 @@ func startEEBusRuntime(
 ) (*eebusRuntimeAdapter, error) {
 	runtimeConfig, err := mapEEBusRuntimeConfig(config, resolve)
 	if err != nil {
-		return nil, fmt.Errorf("map eeBUS runtime configuration: %w", err)
+		return nil, markEEBusStartupFailure(classifyEEBusConfigFailure(err), fmt.Errorf("map eeBUS runtime configuration: %w", err))
 	}
 	if !config.Enabled {
 		return nil, nil
 	}
 	if factory == nil {
-		return nil, errors.New("enabled eeBUS configuration requires a runtime factory")
+		return nil, markEEBusStartupFailure(eebusadmin.EEBusDegradedReasonRuntimeFactoryUnavailable, errors.New("enabled eeBUS configuration requires a runtime factory"))
 	}
 	profile, err := loadEEBusMutationLabProfile(runtimeConfig.StateRoot)
 	if err != nil {
-		return nil, fmt.Errorf("load eeBUS mutation lab profile: %w", err)
+		return nil, markEEBusStartupFailure(eebusadmin.EEBusDegradedReasonConfigurationInvalid, fmt.Errorf("load eeBUS mutation lab profile: %w", err))
 	}
 	if profile != nil {
 		runtimeConfig.MutationLabProfiles = []eebusraw.MutationLabProfileV1{
@@ -382,16 +384,16 @@ func startEEBusRuntime(
 	runtime, factoryErr := factory(runtimeConfig)
 	if runtime == nil {
 		if factoryErr != nil {
-			return nil, fmt.Errorf("construct eeBUS runtime: %w", factoryErr)
+			return nil, markEEBusStartupFailure(classifyEEBusFactoryFailure(factoryErr), fmt.Errorf("construct eeBUS runtime: %w", factoryErr))
 		}
-		return nil, errors.New("construct eeBUS runtime: factory returned nil")
+		return nil, markEEBusStartupFailure(eebusadmin.EEBusDegradedReasonRuntimeFactoryUnavailable, errors.New("construct eeBUS runtime: factory returned nil"))
 	}
 	adapter := &eebusRuntimeAdapter{runtime: runtime}
 	if factoryErr != nil {
-		return nil, fmt.Errorf("construct eeBUS runtime: %w", errors.Join(factoryErr, adapter.Shutdown()))
+		return nil, markEEBusStartupFailure(classifyEEBusFactoryFailure(factoryErr), fmt.Errorf("construct eeBUS runtime: %w", errors.Join(factoryErr, adapter.Shutdown())))
 	}
 	if err := runtime.Start(ctx); err != nil {
-		return nil, fmt.Errorf("start eeBUS runtime: %w", errors.Join(err, adapter.Shutdown()))
+		return nil, markEEBusStartupFailure(eebusadmin.EEBusDegradedReasonListenerUnavailable, fmt.Errorf("start eeBUS runtime: %w", errors.Join(err, adapter.Shutdown())))
 	}
 	return adapter, nil
 }

--- a/cmd/gateway/eebus_runtime_adapter.go
+++ b/cmd/gateway/eebus_runtime_adapter.go
@@ -30,6 +30,259 @@ type eebusRuntimeAdapter struct {
 	shutdownErr  error
 }
 
+// eebusRuntimeSlot is the gateway-owned indirection used by the startup
+// lifecycle. Readers retain the read lock through the delegated call, so a
+// replacement cannot retire the old runtime while a request is still using
+// it. The seam is intentionally eeBUS-local; a later DriverManager can own the
+// same start/replace/stop shape without changing the runtime package.
+type eebusRuntimeSlot struct {
+	mu      sync.RWMutex
+	runtime eebusruntime.Runtime
+	closed  bool
+	cancel  context.CancelFunc
+
+	operationMu  sync.Mutex
+	retiredErr   error
+	shutdownOnce sync.Once
+	shutdownErr  error
+}
+
+func newEEBusRuntimeSlot(runtime eebusruntime.Runtime) *eebusRuntimeSlot {
+	return &eebusRuntimeSlot{runtime: runtime}
+}
+
+func (slot *eebusRuntimeSlot) setCancel(cancel context.CancelFunc) {
+	if slot == nil {
+		return
+	}
+	slot.operationMu.Lock()
+	slot.cancel = cancel
+	slot.operationMu.Unlock()
+}
+
+// Replace publishes exactly one new runtime and retires the old runtime only
+// after every in-flight reader has released it. A replacement arriving after
+// shutdown is rejected and shut down immediately.
+func (slot *eebusRuntimeSlot) Replace(runtime eebusruntime.Runtime) bool {
+	if slot == nil || runtime == nil {
+		return false
+	}
+	slot.operationMu.Lock()
+	defer slot.operationMu.Unlock()
+
+	slot.mu.Lock()
+	if slot.closed {
+		slot.mu.Unlock()
+		if err := runtime.Shutdown(); err != nil {
+			slot.retiredErr = errors.Join(slot.retiredErr, err)
+		}
+		return false
+	}
+	previous := slot.runtime
+	slot.runtime = runtime
+	slot.mu.Unlock()
+
+	if previous != nil {
+		if err := previous.Shutdown(); err != nil {
+			slot.retiredErr = errors.Join(slot.retiredErr, err)
+		}
+	}
+	return true
+}
+
+// Retire makes the slot unavailable before a reconstruction attempt. It is
+// separate from Shutdown so a successful attempt may publish a replacement.
+func (slot *eebusRuntimeSlot) Retire() {
+	if slot == nil {
+		return
+	}
+	slot.operationMu.Lock()
+	defer slot.operationMu.Unlock()
+
+	slot.mu.Lock()
+	if slot.closed {
+		slot.mu.Unlock()
+		return
+	}
+	previous := slot.runtime
+	slot.runtime = nil
+	slot.mu.Unlock()
+	if previous != nil {
+		if err := previous.Shutdown(); err != nil {
+			slot.retiredErr = errors.Join(slot.retiredErr, err)
+		}
+	}
+}
+
+func (slot *eebusRuntimeSlot) Start(ctx context.Context) error {
+	if slot == nil {
+		return errors.New("eeBUS runtime unavailable")
+	}
+	slot.mu.RLock()
+	defer slot.mu.RUnlock()
+	if slot.runtime == nil {
+		return errors.New("eeBUS runtime unavailable")
+	}
+	return slot.runtime.Start(ctx)
+}
+
+func (slot *eebusRuntimeSlot) Shutdown() error {
+	if slot == nil {
+		return nil
+	}
+	slot.shutdownOnce.Do(func() {
+		slot.operationMu.Lock()
+		defer slot.operationMu.Unlock()
+		if slot.cancel != nil {
+			slot.cancel()
+		}
+		slot.mu.Lock()
+		slot.closed = true
+		previous := slot.runtime
+		slot.runtime = nil
+		slot.mu.Unlock()
+		if previous != nil {
+			slot.shutdownErr = previous.Shutdown()
+		}
+		slot.shutdownErr = errors.Join(slot.retiredErr, slot.shutdownErr)
+	})
+	return slot.shutdownErr
+}
+
+func (slot *eebusRuntimeSlot) Snapshot() (eebusruntime.SnapshotV1, error) {
+	if slot == nil {
+		return eebusruntime.SnapshotV1{}, errors.New("eeBUS runtime unavailable")
+	}
+	slot.mu.RLock()
+	defer slot.mu.RUnlock()
+	if slot.runtime == nil {
+		return eebusruntime.SnapshotV1{}, errors.New("eeBUS runtime unavailable")
+	}
+	return slot.runtime.Snapshot()
+}
+
+func (slot *eebusRuntimeSlot) PairingState() ([]eebusruntime.PairingObservationV1, error) {
+	if slot == nil {
+		return nil, errors.New("eeBUS runtime unavailable")
+	}
+	slot.mu.RLock()
+	defer slot.mu.RUnlock()
+	if slot.runtime == nil {
+		return nil, errors.New("eeBUS runtime unavailable")
+	}
+	return slot.runtime.PairingState()
+}
+
+func (slot *eebusRuntimeSlot) FeaturesGet(
+	ctx context.Context,
+	authorization eebusraw.ReadAuthorizationV1,
+	request eebusraw.FeaturesGetRequestV1,
+) (eebusraw.FeaturesGetDataV1, *eebusraw.ErrorV1) {
+	if slot == nil {
+		return eebusraw.FeaturesGetDataV1{}, eebusRuntimeUnavailableError()
+	}
+	slot.mu.RLock()
+	defer slot.mu.RUnlock()
+	if slot.runtime == nil {
+		return eebusraw.FeaturesGetDataV1{}, eebusRuntimeUnavailableError()
+	}
+	return slot.runtime.FeaturesGet(ctx, authorization, request)
+}
+
+func (slot *eebusRuntimeSlot) FeaturesDataGet(
+	ctx context.Context,
+	authorization eebusraw.ReadAuthorizationV1,
+	request eebusraw.FeatureDataGetRequestV1,
+) (eebusraw.FeatureDataGetDataV1, *eebusraw.ErrorV1) {
+	if slot == nil {
+		return eebusraw.FeatureDataGetDataV1{}, eebusRuntimeUnavailableError()
+	}
+	slot.mu.RLock()
+	defer slot.mu.RUnlock()
+	if slot.runtime == nil {
+		return eebusraw.FeatureDataGetDataV1{}, eebusRuntimeUnavailableError()
+	}
+	return slot.runtime.FeaturesDataGet(ctx, authorization, request)
+}
+
+func (slot *eebusRuntimeSlot) FeaturesDataSet(
+	ctx context.Context,
+	authorization eebusraw.WriteAuthorizationV1,
+	request eebusraw.FeatureDataSetRequestV1,
+) (eebusruntime.RawMutationOutcomeV1, *eebusraw.ErrorV1) {
+	if slot == nil {
+		return eebusruntime.RawMutationOutcomeV1{}, eebusRuntimeUnavailableError()
+	}
+	slot.mu.RLock()
+	defer slot.mu.RUnlock()
+	if slot.runtime == nil {
+		return eebusruntime.RawMutationOutcomeV1{}, eebusRuntimeUnavailableError()
+	}
+	runtime, ok := slot.runtime.(eebusruntime.RawMutationRuntimeV1)
+	if !ok || runtime == nil {
+		return eebusruntime.RawMutationOutcomeV1{}, eebusMutationUnavailableError()
+	}
+	return runtime.FeaturesDataSet(ctx, authorization, request)
+}
+
+func (slot *eebusRuntimeSlot) MutationsGet(
+	ctx context.Context,
+	authorization eebusraw.ReadAuthorizationV1,
+	request eebusraw.MutationGetRequestV1,
+) (eebusruntime.RawMutationOutcomeV1, *eebusraw.ErrorV1) {
+	if slot == nil {
+		return eebusruntime.RawMutationOutcomeV1{}, eebusRuntimeUnavailableError()
+	}
+	slot.mu.RLock()
+	defer slot.mu.RUnlock()
+	if slot.runtime == nil {
+		return eebusruntime.RawMutationOutcomeV1{}, eebusRuntimeUnavailableError()
+	}
+	runtime, ok := slot.runtime.(eebusruntime.RawMutationRuntimeV1)
+	if !ok || runtime == nil {
+		return eebusruntime.RawMutationOutcomeV1{}, eebusMutationUnavailableError()
+	}
+	return runtime.MutationsGet(ctx, authorization, request)
+}
+
+func (slot *eebusRuntimeSlot) MutationsRollback(
+	ctx context.Context,
+	authorization eebusraw.WriteAuthorizationV1,
+	request eebusraw.MutationRollbackRequestV1,
+) (eebusruntime.RawMutationOutcomeV1, *eebusraw.ErrorV1) {
+	if slot == nil {
+		return eebusruntime.RawMutationOutcomeV1{}, eebusRuntimeUnavailableError()
+	}
+	slot.mu.RLock()
+	defer slot.mu.RUnlock()
+	if slot.runtime == nil {
+		return eebusruntime.RawMutationOutcomeV1{}, eebusRuntimeUnavailableError()
+	}
+	runtime, ok := slot.runtime.(eebusruntime.RawMutationRuntimeV1)
+	if !ok || runtime == nil {
+		return eebusruntime.RawMutationOutcomeV1{}, eebusMutationUnavailableError()
+	}
+	return runtime.MutationsRollback(ctx, authorization, request)
+}
+
+func eebusRuntimeUnavailableError() *eebusraw.ErrorV1 {
+	return eebusraw.NewErrorV1(
+		eebusraw.ErrorCodeV1Disconnected,
+		"raw eeBUS runtime is unavailable",
+		true,
+		eebusraw.SourceLayerV1Runtime,
+	)
+}
+
+func eebusMutationUnavailableError() *eebusraw.ErrorV1 {
+	return eebusraw.NewErrorV1(
+		eebusraw.ErrorCodeV1UnsupportedOperation,
+		"raw eeBUS mutation capability is unavailable",
+		false,
+		eebusraw.SourceLayerV1Runtime,
+	)
+}
+
 func startEEBusOperatorRuntime(
 	ctx context.Context,
 	config ebusgateway.EEBusConfig,

--- a/cmd/gateway/eebus_runtime_adapter_test.go
+++ b/cmd/gateway/eebus_runtime_adapter_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/netip"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
@@ -413,6 +414,66 @@ func TestIssue846RunKeepsGatewayAvailableWhenEEBusStartupFails(t *testing.T) {
 	}
 	if !httpStarted {
 		t.Fatal("HTTP gateway did not start after isolated eeBUS failure")
+	}
+}
+
+type issue846BlockingRuntime struct {
+	msp05bRuntime
+	snapshotEntered chan struct{}
+	snapshotRelease chan struct{}
+	shutdownCalled  chan struct{}
+	enterOnce       sync.Once
+	shutdownOnce    sync.Once
+}
+
+func (runtime *issue846BlockingRuntime) Snapshot() (eebusruntime.SnapshotV1, error) {
+	runtime.enterOnce.Do(func() { close(runtime.snapshotEntered) })
+	<-runtime.snapshotRelease
+	return eebusruntime.SnapshotV1{}, nil
+}
+
+func (runtime *issue846BlockingRuntime) Shutdown() error {
+	runtime.shutdownOnce.Do(func() { close(runtime.shutdownCalled) })
+	return runtime.msp05bRuntime.Shutdown()
+}
+
+func TestIssue846RuntimeSlotWaitsForInFlightReadersBeforeSwapAndShutdown(t *testing.T) {
+	oldRuntime := &issue846BlockingRuntime{
+		snapshotEntered: make(chan struct{}),
+		snapshotRelease: make(chan struct{}),
+		shutdownCalled:  make(chan struct{}),
+	}
+	nextRuntime := &msp05bRuntime{}
+	slot := newEEBusRuntimeSlot(oldRuntime)
+	adapter := &eebusRuntimeAdapter{runtime: slot}
+
+	readDone := make(chan struct{})
+	go func() {
+		defer close(readDone)
+		_, _ = adapter.Snapshot()
+	}()
+	<-oldRuntime.snapshotEntered
+
+	swapDone := make(chan bool, 1)
+	go func() { swapDone <- slot.Replace(nextRuntime) }()
+	select {
+	case <-oldRuntime.shutdownCalled:
+		t.Fatal("old runtime shut down while a snapshot read was still in flight")
+	default:
+	}
+
+	close(oldRuntime.snapshotRelease)
+	<-readDone
+	if replaced := <-swapDone; !replaced {
+		t.Fatal("runtime slot rejected a live replacement")
+	}
+	select {
+	case <-oldRuntime.shutdownCalled:
+	default:
+		t.Fatal("old runtime was not shut down after the safe swap")
+	}
+	if oldRuntime.stopCalls != 1 {
+		t.Fatalf("old runtime shutdown calls = %d; want one", oldRuntime.stopCalls)
 	}
 }
 

--- a/cmd/gateway/eebus_runtime_adapter_test.go
+++ b/cmd/gateway/eebus_runtime_adapter_test.go
@@ -373,6 +373,49 @@ func TestMSP05BRunCleanCancellationReturnsSidecarShutdownError(t *testing.T) {
 	}
 }
 
+func TestIssue846RunKeepsGatewayAvailableWhenEEBusStartupFails(t *testing.T) {
+	originalResolver := resolveEEBusInterfaceAddressesFn
+	originalOperatorFactory := newEEBusOperatorRuntimeFn
+	originalRuntimeFactory := newEEBusRuntimeFn
+	originalWire := wireObserveFirstObserversFn
+	originalDiscovery := startDiscoveryScanLoopFn
+	originalSemantic := startVaillantSemanticPollingFn
+	originalHTTP := startHTTPServerFn
+	t.Cleanup(func() {
+		resolveEEBusInterfaceAddressesFn = originalResolver
+		newEEBusOperatorRuntimeFn = originalOperatorFactory
+		newEEBusRuntimeFn = originalRuntimeFactory
+		wireObserveFirstObserversFn = originalWire
+		startDiscoveryScanLoopFn = originalDiscovery
+		startVaillantSemanticPollingFn = originalSemantic
+		startHTTPServerFn = originalHTTP
+	})
+
+	installMSP05BRunDependencies(&msp05bRuntime{})
+	newEEBusOperatorRuntimeFn = func(eebusruntime.Config) (eebusruntime.Runtime, eebusruntime.AdminV1, error) {
+		return nil, nil, errors.New("operator listener unavailable")
+	}
+	newEEBusRuntimeFn = func(eebusruntime.Config) (eebusruntime.Runtime, error) {
+		return nil, errors.New("public listener unavailable")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	httpStarted := false
+	startHTTPServerFn = func(context.Context, ebusgateway.Config, *ebusgateway.Gateway, *graphql.Builder, *graphql.BroadcastHub, graphql.SemanticProvider, mcp.ScheduleWriter, mcp.ConfigWriter, *ebusgateway.BusObservabilityStore, *ebusgateway.ShadowCache) (*http.Server, mdns.Advertiser, error) {
+		httpStarted = true
+		cancel()
+		return nil, nil, nil
+	}
+
+	err := run(ctx, msp05bGatewayRunConfig(t))
+	if err != nil {
+		t.Fatalf("run returned fatal eeBUS startup error: %v", err)
+	}
+	if !httpStarted {
+		t.Fatal("HTTP gateway did not start after isolated eeBUS failure")
+	}
+}
+
 func installMSP05BRunDependencies(runtime eebusruntime.Runtime) {
 	resolveEEBusInterfaceAddressesFn = func(string) ([]netip.Addr, error) {
 		return []netip.Addr{netip.MustParseAddr("192.0.2.42")}, nil

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -228,7 +228,10 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 
 	eebusAdapter, eebusAdmin, eebusAdminAvailable, err := startEEBusAdminAwareRuntime(ctx, cfg)
 	if err != nil {
-		return fmt.Errorf("eeBUS sidecar: %w", err)
+		log.Printf("eeBUS runtime unavailable; continuing without eeBUS reason=startup")
+		eebusAdapter = nil
+		eebusAdmin = nil
+		eebusAdminAvailable = false
 	}
 	if eebusAdapter != nil {
 		defer func() {

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -238,10 +238,8 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 		}()
 	}
 	eebusAdminHandler := eebusadmin.NewUnavailableHandler()
-	eebusAdminAvailable := false
-	if eebusLifecycle != nil && eebusLifecycle.Configured() {
+	if eebusLifecycle != nil {
 		eebusAdminHandler = eebusLifecycle
-		eebusAdminAvailable = true
 	}
 	if evidenceRuntime != nil {
 		var captureEEBus eebusEvidenceCapture
@@ -1127,7 +1125,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 		}
 		return startHTTPServer(
 			ctx, cfg, gateway, builder, hub, semanticProvider, eebusProvider, eebusCommandRouter,
-			modbusProvider, scheduleWriter, configWriter, busObservability, shadowCache, eebusAdminHandler, eebusAdminAvailable, resolvedBuildInfo,
+			modbusProvider, scheduleWriter, configWriter, busObservability, shadowCache, eebusAdminHandler, eebusLifecycle, resolvedBuildInfo,
 		)
 	}
 	server, advertiser, err := startHTTPServerFn(
@@ -1967,7 +1965,7 @@ func startHTTPServer(
 	busObservability *ebusgateway.BusObservabilityStore,
 	shadowCache *ebusgateway.ShadowCache,
 	eebusAdminHandler http.Handler,
-	eebusAdminAvailable bool,
+	eebusLifecycle *eebusRuntimeLifecycle,
 	buildInfo gatewayBuildInfo,
 ) (*http.Server, mdns.Advertiser, error) {
 	if cfg.HTTPAddr == "" {
@@ -2191,12 +2189,10 @@ func startHTTPServer(
 			SnapshotPath:     cfg.SnapshotPath,
 			SubscriptionPath: cfg.SubscriptionPath,
 			MCPPath:          cfg.MCPPath,
-			EEBusAdminPath: func() string {
-				if eebusAdminAvailable {
-					return "/admin/eebus/v1"
-				}
-				return ""
-			}(),
+			EEBusAdminPath:   "/admin/eebus/v1",
+			Readiness: func() portal.RuntimeReadiness {
+				return projectGatewayReadiness(cfg, eebusLifecycle.LifecycleSnapshot())
+			},
 			GatewayVersion:    buildInfo.ReleaseVersion,
 			BuildID:           buildInfo.BuildID,
 			SemanticPVEnabled: cfg.PortalPV.SemanticEnabled,
@@ -3054,6 +3050,8 @@ func initRuntimeStateManager(ctx context.Context, cfg ebusgateway.Config, buildI
 		if perr := mgr.EagerPersistInstanceGUID(ctx, cfg.InstanceGUID, source); perr != nil {
 			log.Printf("runtime_state: eager-persist instance_guid failed (continuing): %v", perr)
 		}
+	} else if perr := mgr.Flush(ctx); perr != nil {
+		log.Printf("runtime_state: startup metadata persist failed (continuing): %v", perr)
 	}
 
 	if serr := mgr.Start(ctx); serr != nil {
@@ -3061,6 +3059,21 @@ func initRuntimeStateManager(ctx context.Context, cfg ebusgateway.Config, buildI
 	}
 
 	return mgr, state
+}
+
+func projectGatewayReadiness(cfg ebusgateway.Config, snapshot eebusRuntimeLifecycleSnapshot) portal.RuntimeReadiness {
+	eebusReadiness := eebusReadinessForLifecycle(snapshot)
+	proxyReadiness := "DISABLED"
+	if cfg.ProxyListenAddr != "" {
+		proxyReadiness = "READY"
+	}
+	return portal.RuntimeReadiness{
+		ProcessReadiness:    string(eebusReadiness.ProcessReadiness),
+		HTTPReadiness:       "READY",
+		ProxyReadiness:      proxyReadiness,
+		EEBusReadiness:      string(eebusReadiness.EEBusReadiness),
+		EEBusDegradedReason: string(eebusReadiness.EEBusDegradedReason),
+	}
 }
 
 // identitySourceFromCfg maps the CLI -instance-guid-source flag value to the

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -2023,6 +2023,9 @@ func startHTTPServer(
 	if err != nil {
 		return nil, nil, err
 	}
+	if err := mcpServer.SetServerVersion(buildInfo.ReleaseVersion); err != nil {
+		return nil, nil, fmt.Errorf("configure MCP build identity: %w", err)
+	}
 	if eebusProvider != nil {
 		if err := mcpServer.RegisterEEBusV1Provider(eebusProvider); err != nil {
 			return nil, nil, fmt.Errorf("register eeBUS MCP provider: %w", err)
@@ -3048,7 +3051,7 @@ func initRuntimeStateManager(ctx context.Context, cfg ebusgateway.Config, buildI
 	mgr := runtimestate.New(runtimestate.Options{
 		Path:         cfg.RuntimeStatePath,
 		GatewayBuild: gatewayBuildString(buildInfo),
-		AddonVersion: "", // populated by add-on via future flag if needed
+		AddonVersion: buildInfo.ReleaseVersion,
 	})
 	state, err := mgr.Load(ctx)
 	if err != nil {

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -226,36 +226,22 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 		}()
 	}
 
-	eebusAdapter, eebusAdmin, eebusAdminAvailable, err := startEEBusAdminAwareRuntime(ctx, cfg)
+	eebusAdapter, _, eebusLifecycle, _, err := startEEBusAdminAwareRuntime(ctx, cfg)
 	if err != nil {
 		log.Printf("eeBUS runtime unavailable; continuing without eeBUS reason=startup")
-		eebusAdapter = nil
-		eebusAdmin = nil
-		eebusAdminAvailable = false
 	}
-	if eebusAdapter != nil {
+	if eebusLifecycle != nil {
 		defer func() {
-			if err := eebusAdapter.Shutdown(); err != nil {
+			if err := eebusLifecycle.Shutdown(); err != nil {
 				result = errors.Join(result, fmt.Errorf("shutdown eeBUS sidecar: %w", err))
 			}
 		}()
 	}
 	eebusAdminHandler := eebusadmin.NewUnavailableHandler()
-	if eebusAdminAvailable {
-		availableHandler, boundaryErr := eebusadmin.NewServer(eebusadmin.Config{
-			Admin: eebusAdmin, Raw: eebusAdapter,
-			Audit: func(event eebusadmin.AuditEvent) {
-				log.Printf("eebus_admin_audit action=%s scope=host_operator request_id=%s idempotency=%s prior=%s resulting=%s reason=%s timestamp=%s",
-					event.Action, event.RequestID, event.IdempotencyOutcome, event.PriorStateClass,
-					event.ResultingStateClass, event.Reason, event.Timestamp.UTC().Format(time.RFC3339Nano))
-			},
-		})
-		if boundaryErr != nil {
-			log.Printf("eeBUS admin boundary unavailable reason=http_boundary")
-			eebusAdminAvailable = false
-		} else {
-			eebusAdminHandler = availableHandler
-		}
+	eebusAdminAvailable := false
+	if eebusLifecycle != nil && eebusLifecycle.Configured() {
+		eebusAdminHandler = eebusLifecycle
+		eebusAdminAvailable = true
 	}
 	if evidenceRuntime != nil {
 		var captureEEBus eebusEvidenceCapture

--- a/cmd/gateway/modbus_runtime_adapter_test.go
+++ b/cmd/gateway/modbus_runtime_adapter_test.go
@@ -52,14 +52,16 @@ func (endpoint *modbusRunLifecycleEndpoint) Close() error {
 	return endpoint.closeErr
 }
 
-func TestRunClosesModbusSidecarOnceAndJoinsLaterEEBusFailure(t *testing.T) {
+func TestRunKeepsEEBusFailureNonfatalAndClosesModbusSidecarOnce(t *testing.T) {
 	originalDial := dialModbusEndpointFn
 	originalFactory := newModbusEndpointFn
 	originalResolver := resolveEEBusInterfaceAddressesFn
+	originalWire := wireObserveFirstObserversFn
 	t.Cleanup(func() {
 		dialModbusEndpointFn = originalDial
 		newModbusEndpointFn = originalFactory
 		resolveEEBusInterfaceAddressesFn = originalResolver
+		wireObserveFirstObserversFn = originalWire
 	})
 
 	client, peer := net.Pipe()
@@ -71,22 +73,25 @@ func TestRunClosesModbusSidecarOnceAndJoinsLaterEEBusFailure(t *testing.T) {
 	newModbusEndpointFn = func(modbus.TCPEndpointConfig) (modbusadapter.Endpoint, error) {
 		return endpoint, nil
 	}
-	laterErr := errors.New("eebus interface resolution failed")
+	eebusErr := errors.New("eebus interface resolution failed")
 	resolveEEBusInterfaceAddressesFn = func(string) ([]netip.Addr, error) {
-		return nil, laterErr
+		return nil, eebusErr
+	}
+	laterErr := errors.New("later gateway startup failed")
+	wireObserveFirstObserversFn = func(*ebusgateway.Config) (*ebusgateway.BusObservabilityStore, *ebusgateway.ActivePassiveDeduplicator, error) {
+		return nil, nil, laterErr
 	}
 
-	cfg := ebusgateway.DefaultConfig()
+	cfg := msp05bGatewayRunConfig(t)
 	cfg.ModbusTCPConfig = ebusgateway.ModbusTCPConfig{
 		Enabled:     true,
 		Endpoint:    "tcp://127.0.0.1:1502",
 		DialTimeout: time.Second,
 	}
-	cfg.EEBusConfig = msp05bEnabledConfig()
 
 	err := run(context.Background(), cfg)
-	if !errors.Is(err, laterErr) || !errors.Is(err, endpoint.closeErr) {
-		t.Fatalf("run error = %v; want later eeBUS and Modbus shutdown causes", err)
+	if !errors.Is(err, laterErr) || !errors.Is(err, endpoint.closeErr) || errors.Is(err, eebusErr) {
+		t.Fatalf("run error = %v; want later gateway and Modbus shutdown causes without fatal eeBUS startup", err)
 	}
 	if endpoint.closeCalls != 1 {
 		t.Fatalf("Modbus endpoint close calls = %d; want 1", endpoint.closeCalls)
@@ -96,11 +101,13 @@ func TestRunClosesModbusSidecarOnceAndJoinsLaterEEBusFailure(t *testing.T) {
 func TestRunKeepsModbusStartupFailureProtocolLocal(t *testing.T) {
 	originalDial := dialModbusEndpointFn
 	originalResolver := resolveEEBusInterfaceAddressesFn
+	originalWire := wireObserveFirstObserversFn
 	originalLogWriter := log.Writer()
 	originalLogFlags := log.Flags()
 	t.Cleanup(func() {
 		dialModbusEndpointFn = originalDial
 		resolveEEBusInterfaceAddressesFn = originalResolver
+		wireObserveFirstObserversFn = originalWire
 		log.SetOutput(originalLogWriter)
 		log.SetFlags(originalLogFlags)
 	})
@@ -110,28 +117,31 @@ func TestRunKeepsModbusStartupFailureProtocolLocal(t *testing.T) {
 	dialModbusEndpointFn = func(context.Context, string, string) (net.Conn, error) {
 		return nil, dialErr
 	}
-	laterErr := errors.New("eebus interface resolution failed")
+	eebusErr := errors.New("eebus interface resolution failed")
 	resolveEEBusInterfaceAddressesFn = func(string) ([]netip.Addr, error) {
-		return nil, laterErr
+		return nil, eebusErr
+	}
+	laterErr := errors.New("later gateway startup failed")
+	wireObserveFirstObserversFn = func(*ebusgateway.Config) (*ebusgateway.BusObservabilityStore, *ebusgateway.ActivePassiveDeduplicator, error) {
+		return nil, nil, laterErr
 	}
 	var logs bytes.Buffer
 	log.SetOutput(&logs)
 	log.SetFlags(0)
 
-	cfg := ebusgateway.DefaultConfig()
+	cfg := msp05bGatewayRunConfig(t)
 	cfg.ModbusTCPConfig = ebusgateway.ModbusTCPConfig{
 		Enabled:     true,
 		Endpoint:    endpoint,
 		DialTimeout: time.Second,
 	}
-	cfg.EEBusConfig = msp05bEnabledConfig()
 
 	err := run(context.Background(), cfg)
 	if !errors.Is(err, laterErr) {
-		t.Fatalf("run error = %v; want later eeBUS error", err)
+		t.Fatalf("run error = %v; want later gateway error after isolated protocol failures", err)
 	}
-	if errors.Is(err, dialErr) {
-		t.Fatalf("run error retained protocol-local Modbus startup failure: %v", err)
+	if errors.Is(err, dialErr) || errors.Is(err, eebusErr) {
+		t.Fatalf("run error retained protocol-local startup failure: %v", err)
 	}
 	if got := logs.String(); !strings.Contains(got, "Modbus TCP unavailable; continuing without Modbus") {
 		t.Fatalf("gateway log = %q; want protocol-local unavailability diagnostic", got)

--- a/cmd/gateway/post_m9_defects_red_test.go
+++ b/cmd/gateway/post_m9_defects_red_test.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -2528,6 +2530,23 @@ func TestIssue846RuntimeStateUsesTheProcessReleaseAuthority(t *testing.T) {
 	}
 	if state.Meta.AddonVersion != info.ReleaseVersion {
 		t.Fatalf("add-on version = %q; want process release %q", state.Meta.AddonVersion, info.ReleaseVersion)
+	}
+	content, err := os.ReadFile(cfg.RuntimeStatePath)
+	if err != nil {
+		t.Fatalf("startup metadata is not durable before init returns: %v", err)
+	}
+	var persisted struct {
+		Meta struct {
+			InstanceGUID string `json:"instance_guid"`
+			GatewayBuild string `json:"gateway_build"`
+			AddonVersion string `json:"addon_version"`
+		} `json:"meta"`
+	}
+	if err := json.Unmarshal(content, &persisted); err != nil {
+		t.Fatalf("decode persisted runtime state: %v", err)
+	}
+	if persisted.Meta.InstanceGUID != "" || persisted.Meta.GatewayBuild != gatewayBuildString(info) || persisted.Meta.AddonVersion != info.ReleaseVersion {
+		t.Fatalf("persisted startup metadata = %#v; want empty identity and exact process build", persisted.Meta)
 	}
 }
 

--- a/cmd/gateway/post_m9_defects_red_test.go
+++ b/cmd/gateway/post_m9_defects_red_test.go
@@ -2510,6 +2510,27 @@ func TestGatewayBuildInfo_ExplicitNonRevisionBuildIDHasClosedEvidenceForm(t *tes
 	}
 }
 
+func TestIssue846RuntimeStateUsesTheProcessReleaseAuthority(t *testing.T) {
+	cfg := ebusgateway.DefaultConfig()
+	cfg.RuntimeStatePath = t.TempDir() + "/runtime-state.json"
+	info, err := newGatewayBuildInfo("0.6.56", "0123456789abcdef0123456789abcdef01234567")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mgr, state := initRuntimeStateManager(context.Background(), cfg, info)
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = mgr.Stop(stopCtx)
+	})
+	if state.Meta.GatewayBuild != gatewayBuildString(info) {
+		t.Fatalf("gateway build = %q; want %q", state.Meta.GatewayBuild, gatewayBuildString(info))
+	}
+	if state.Meta.AddonVersion != info.ReleaseVersion {
+		t.Fatalf("add-on version = %q; want process release %q", state.Meta.AddonVersion, info.ReleaseVersion)
+	}
+}
+
 type legacyOnlySemanticProvider struct {
 	graphql.SemanticProvider
 }

--- a/internal/eebusadmin/server.go
+++ b/internal/eebusadmin/server.go
@@ -23,12 +23,13 @@ const maxRequestBodyBytes = 4096
 const maxHTTPMutationReplays = 128
 
 type server struct {
-	admin   eebusruntime.AdminV1
-	raw     RawSnapshotProvider
-	audit   func(AuditEvent)
-	now     func() time.Time
-	random  io.Reader
-	scopeID string
+	admin     eebusruntime.AdminV1
+	raw       RawSnapshotProvider
+	audit     func(AuditEvent)
+	now       func() time.Time
+	random    io.Reader
+	readiness ReadinessProvider
+	scopeID   string
 
 	capabilityMu       sync.Mutex
 	capabilityRevision uint64
@@ -110,13 +111,18 @@ func NewServer(config Config) (http.Handler, error) {
 	if config.Random == nil {
 		config.Random = rand.Reader
 	}
+	if config.Readiness == nil {
+		config.Readiness = func() ReadinessV1 {
+			return ReadinessV1{ProcessReadiness: ProcessReadinessReady, EEBusReadiness: EEBusReadinessReady}
+		}
+	}
 	scopeID, err := randomToken(config.Random)
 	if err != nil {
 		return nil, errors.New("operator scope unavailable")
 	}
 	return &server{
 		admin: config.Admin, raw: config.Raw, audit: config.Audit,
-		now: config.Now, random: config.Random, scopeID: scopeID,
+		now: config.Now, random: config.Random, readiness: config.Readiness, scopeID: scopeID,
 		capabilities: make(map[string]capabilityRecord), capabilityByTarget: make(map[string]string),
 		spineSnapshots:  make(map[string]*spineSnapshot),
 		mutationReplays: make(map[string]httpMutationReplay),
@@ -718,7 +724,8 @@ func (server *server) status(w http.ResponseWriter, request *http.Request) {
 		return
 	}
 	data := ownerStatus{
-		Status: snapshot.Status, Window: snapshot.Window, WindowDeadline: snapshot.WindowDeadline,
+		Readiness: normalizeReadiness(server.readiness()),
+		Status:    snapshot.Status, Window: snapshot.Window, WindowDeadline: snapshot.WindowDeadline,
 		Register: snapshot.Register, Listener: snapshot.Listener, Discovery: snapshot.Discovery,
 		TrustedCount: snapshot.TrustedCount, ConnectedCount: snapshot.ConnectedCount,
 		DiscoveredCount: snapshot.DiscoveredCount, CandidateCount: snapshot.CandidateCount,
@@ -727,6 +734,33 @@ func (server *server) status(w http.ResponseWriter, request *http.Request) {
 	server.writeJSON(w, http.StatusOK, ownerEnvelope{
 		Contract: ContractV1, RequestID: server.requestID(), StateRevision: snapshot.StateRevision, Data: data,
 	})
+}
+
+func normalizeReadiness(value ReadinessV1) ReadinessV1 {
+	switch value.ProcessReadiness {
+	case ProcessReadinessReady, ProcessReadinessNotReady:
+	default:
+		value.ProcessReadiness = ProcessReadinessNotReady
+	}
+	switch value.EEBusReadiness {
+	case EEBusReadinessDisabled, EEBusReadinessStarting, EEBusReadinessReady:
+		value.EEBusDegradedReason = ""
+	case EEBusReadinessDegraded:
+		switch value.EEBusDegradedReason {
+		case EEBusDegradedReasonConfigurationInvalid,
+			EEBusDegradedReasonLocalIdentityUnavailable,
+			EEBusDegradedReasonListenerUnavailable,
+			EEBusDegradedReasonRuntimeFactoryUnavailable,
+			EEBusDegradedReasonAdminBoundaryUnavailable,
+			EEBusDegradedReasonUnknownStartupFailure:
+		default:
+			value.EEBusDegradedReason = EEBusDegradedReasonUnknownStartupFailure
+		}
+	default:
+		value.EEBusReadiness = EEBusReadinessDegraded
+		value.EEBusDegradedReason = EEBusDegradedReasonUnknownStartupFailure
+	}
+	return value
 }
 
 type openPairingWindowBody struct {

--- a/internal/eebusadmin/server_test.go
+++ b/internal/eebusadmin/server_test.go
@@ -116,6 +116,48 @@ func TestIssue817UnavailableBoundaryStaysMountedAndSanitized(t *testing.T) {
 	}
 }
 
+func TestIssue846StatusExposesCanonicalReadinessWhenAvailableOrUnavailable(t *testing.T) {
+	degraded := ReadinessV1{
+		ProcessReadiness:    ProcessReadinessReady,
+		EEBusReadiness:      EEBusReadinessDegraded,
+		EEBusDegradedReason: EEBusDegradedReasonAdminBoundaryUnavailable,
+	}
+
+	unavailable := NewUnavailableHandlerWithReadiness(func() ReadinessV1 { return degraded })
+	unavailableResponse := httptest.NewRecorder()
+	unavailable.ServeHTTP(unavailableResponse, httptest.NewRequest(http.MethodGet, "/admin/eebus/v1/status", nil))
+	assertIssue846Readiness(t, unavailableResponse, http.StatusServiceUnavailable, degraded)
+
+	ready := ReadinessV1{ProcessReadiness: ProcessReadinessReady, EEBusReadiness: EEBusReadinessReady}
+	snapshot := testAdminSnapshot()
+	snapshot.StateRevision = 31
+	available, err := NewServer(Config{
+		Admin:     &adminV1Stub{snapshot: snapshot},
+		Readiness: func() ReadinessV1 { return ready },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	availableResponse := httptest.NewRecorder()
+	available.ServeHTTP(availableResponse, httptest.NewRequest(http.MethodGet, "/admin/eebus/v1/status", nil))
+	assertIssue846Readiness(t, availableResponse, http.StatusOK, ready)
+}
+
+func assertIssue846Readiness(t *testing.T, response *httptest.ResponseRecorder, wantStatus int, want ReadinessV1) {
+	t.Helper()
+	var envelope struct {
+		Data struct {
+			Readiness ReadinessV1 `json:"readiness"`
+		} `json:"data"`
+	}
+	if response.Code != wantStatus || json.Unmarshal(response.Body.Bytes(), &envelope) != nil {
+		t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+	}
+	if envelope.Data.Readiness != want {
+		t.Fatalf("readiness=%#v; want %#v; body=%s", envelope.Data.Readiness, want, response.Body.String())
+	}
+}
+
 func TestIssue817CredentialFreeReadsUseOneStateRevisionEnvelope(t *testing.T) {
 	const ski = "0123456789abcdef0123456789abcdef01234567"
 	snapshot := testAdminSnapshot()

--- a/internal/eebusadmin/types.go
+++ b/internal/eebusadmin/types.go
@@ -13,12 +13,48 @@ type Principal string
 
 const PrincipalHostOperator Principal = "host_operator"
 
+type ProcessReadiness string
+
+const (
+	ProcessReadinessReady    ProcessReadiness = "READY"
+	ProcessReadinessNotReady ProcessReadiness = "NOT_READY"
+)
+
+type EEBusReadiness string
+
+const (
+	EEBusReadinessDisabled EEBusReadiness = "DISABLED"
+	EEBusReadinessStarting EEBusReadiness = "STARTING"
+	EEBusReadinessReady    EEBusReadiness = "READY"
+	EEBusReadinessDegraded EEBusReadiness = "DEGRADED"
+)
+
+type EEBusDegradedReason string
+
+const (
+	EEBusDegradedReasonConfigurationInvalid      EEBusDegradedReason = "CONFIGURATION_INVALID"
+	EEBusDegradedReasonLocalIdentityUnavailable  EEBusDegradedReason = "LOCAL_IDENTITY_UNAVAILABLE"
+	EEBusDegradedReasonListenerUnavailable       EEBusDegradedReason = "LISTENER_UNAVAILABLE"
+	EEBusDegradedReasonRuntimeFactoryUnavailable EEBusDegradedReason = "RUNTIME_FACTORY_UNAVAILABLE"
+	EEBusDegradedReasonAdminBoundaryUnavailable  EEBusDegradedReason = "ADMIN_BOUNDARY_UNAVAILABLE"
+	EEBusDegradedReasonUnknownStartupFailure     EEBusDegradedReason = "UNKNOWN_STARTUP_FAILURE"
+)
+
+type ReadinessV1 struct {
+	ProcessReadiness    ProcessReadiness    `json:"process_readiness"`
+	EEBusReadiness      EEBusReadiness      `json:"eebus_readiness"`
+	EEBusDegradedReason EEBusDegradedReason `json:"eebus_degraded_reason,omitempty"`
+}
+
+type ReadinessProvider func() ReadinessV1
+
 type Config struct {
-	Admin  eebusruntime.AdminV1
-	Raw    RawSnapshotProvider
-	Audit  func(AuditEvent)
-	Now    func() time.Time
-	Random io.Reader
+	Admin     eebusruntime.AdminV1
+	Raw       RawSnapshotProvider
+	Audit     func(AuditEvent)
+	Now       func() time.Time
+	Random    io.Reader
+	Readiness ReadinessProvider
 }
 
 // AuditEvent deliberately has no representation for operational identities,
@@ -47,17 +83,18 @@ type ownerEnvelope struct {
 }
 
 type ownerStatus struct {
-	Status          string    `json:"status"`
-	Window          string    `json:"pairing_window"`
-	WindowDeadline  time.Time `json:"pairing_window_deadline,omitempty"`
-	Register        string    `json:"register"`
-	Listener        string    `json:"listener"`
-	Discovery       string    `json:"discovery"`
-	TrustedCount    uint16    `json:"trusted_count"`
-	ConnectedCount  uint16    `json:"connected_count"`
-	DiscoveredCount uint16    `json:"discovered_count"`
-	CandidateCount  uint16    `json:"candidate_count"`
-	DegradedCode    string    `json:"degraded_code,omitempty"`
+	Readiness       ReadinessV1 `json:"readiness"`
+	Status          string      `json:"status"`
+	Window          string      `json:"pairing_window"`
+	WindowDeadline  time.Time   `json:"pairing_window_deadline,omitempty"`
+	Register        string      `json:"register"`
+	Listener        string      `json:"listener"`
+	Discovery       string      `json:"discovery"`
+	TrustedCount    uint16      `json:"trusted_count"`
+	ConnectedCount  uint16      `json:"connected_count"`
+	DiscoveredCount uint16      `json:"discovered_count"`
+	CandidateCount  uint16      `json:"candidate_count"`
+	DegradedCode    string      `json:"degraded_code,omitempty"`
 }
 
 type partnersData struct {

--- a/internal/eebusadmin/unavailable.go
+++ b/internal/eebusadmin/unavailable.go
@@ -9,6 +9,19 @@ import (
 // NewUnavailableHandler keeps the operator namespace deterministic while the
 // private runtime capability is unavailable.
 func NewUnavailableHandler() http.Handler {
+	return NewUnavailableHandlerWithReadiness(func() ReadinessV1 {
+		return ReadinessV1{
+			ProcessReadiness:    ProcessReadinessReady,
+			EEBusReadiness:      EEBusReadinessDegraded,
+			EEBusDegradedReason: EEBusDegradedReasonAdminBoundaryUnavailable,
+		}
+	})
+}
+
+func NewUnavailableHandlerWithReadiness(readiness ReadinessProvider) http.Handler {
+	if readiness == nil {
+		return NewUnavailableHandler()
+	}
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Cache-Control", "private, no-store")
@@ -23,6 +36,7 @@ func NewUnavailableHandler() http.Handler {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		_ = json.NewEncoder(w).Encode(ownerEnvelope{
 			Contract: ContractV1, RequestID: requestID, StateRevision: 0,
+			Data:  ownerStatus{Readiness: normalizeReadiness(readiness())},
 			Error: &errorData{Code: "admin_boundary_unavailable"},
 		})
 	})

--- a/internal/runtimestate/runtimestate.go
+++ b/internal/runtimestate/runtimestate.go
@@ -485,8 +485,17 @@ func (m *Manager) EvictKnownBusMember(addr byte) {
 func (m *Manager) replaceState(s *State) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if s == nil {
+		s = &State{SchemaVersion: SchemaVersion}
+	}
+	metadataChanged := s.Meta.GatewayBuild != m.opts.GatewayBuild || s.Meta.AddonVersion != m.opts.AddonVersion
+	s.Meta.GatewayBuild = m.opts.GatewayBuild
+	s.Meta.AddonVersion = m.opts.AddonVersion
 	m.state = s
-	m.dirty = false
+	m.dirty = metadataChanged
+	if metadataChanged {
+		m.writeGen++
+	}
 }
 
 func cloneState(s *State) *State {

--- a/internal/runtimestate/runtimestate.go
+++ b/internal/runtimestate/runtimestate.go
@@ -347,6 +347,26 @@ func (m *Manager) State() *State {
 	return cloneState(m.state)
 }
 
+// Flush makes one bounded synchronous persistence attempt when state is dirty.
+// It does not retry and returns before the periodic persister is started by the
+// caller, closing the crash window for startup metadata changes.
+func (m *Manager) Flush(ctx context.Context) error {
+	if ctx != nil {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+	}
+	m.mu.Lock()
+	dirty := m.dirty && m.state != nil
+	m.mu.Unlock()
+	if !dirty {
+		return nil
+	}
+	return m.persistFlush()
+}
+
 // UpdateSelf replaces ebus.self with the given Self and marks state dirty.
 // Used after a successful SourceAddressSelection per AD14.
 //

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -506,6 +506,7 @@ type Server struct {
 	eebusV1CommandRouter        EEBusV1CommandRouter
 	synchronizedEvidenceCapture SynchronizedEvidenceCapture
 	leafPromotionCapture        LeafPromotionCapture
+	serverVersion               string
 
 	tools []Tool
 
@@ -789,6 +790,7 @@ func NewServer(reg Registry, invoker Invoker) (*Server, error) {
 		semantic:       staticSemanticProvider{},
 		idempotency:    make(map[string]idempotencyEntry),
 		snapshots:      make(map[string]snapshotState),
+		serverVersion:  "0.0.0",
 	}
 	server.tools = []Tool{
 		{
@@ -1246,6 +1248,20 @@ func (s *Server) SetStatusProvider(provider StatusProvider) {
 	s.statusProvider = provider
 }
 
+// SetServerVersion binds the immutable process release authority exposed by
+// MCP initialize. Callers configure it once during server construction.
+func (s *Server) SetServerVersion(version string) error {
+	if s == nil {
+		return errors.New("mcp server is nil")
+	}
+	version = strings.TrimSpace(version)
+	if version == "" || len(version) > 64 || strings.ContainsAny(version, "\r\n\x00") {
+		return errors.New("mcp server version is invalid")
+	}
+	s.serverVersion = version
+	return nil
+}
+
 func (s *Server) SetBusObservabilityProvider(provider BusObservabilityProvider) {
 	if s == nil || provider == nil {
 		return
@@ -1397,7 +1413,7 @@ func (s *Server) handleInitialize(params json.RawMessage) (any, *rpcError) {
 		},
 		"serverInfo": map[string]any{
 			"name":    "helianthus-ebusgateway",
-			"version": "0.0.0",
+			"version": s.serverVersion,
 		},
 		"sessionId": sessionID,
 	}, nil

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -381,6 +381,9 @@ func TestServer_InitializeAndTools(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewServer error = %v", err)
 	}
+	if err := server.SetServerVersion("0.6.56"); err != nil {
+		t.Fatalf("SetServerVersion error = %v", err)
+	}
 
 	res := doRPC(t, server.Handler(), rpcRequest{JSONRPC: "2.0", ID: 1, Method: "initialize", Params: json.RawMessage(`{}`)})
 	if res.Error != nil {
@@ -395,6 +398,10 @@ func TestServer_InitializeAndTools(t *testing.T) {
 	}
 	if resultMap["sessionId"] == "" {
 		t.Fatalf("missing sessionId in initialize result")
+	}
+	serverInfo, ok := resultMap["serverInfo"].(map[string]any)
+	if !ok || serverInfo["version"] != "0.6.56" {
+		t.Fatalf("serverInfo = %#v; want process release version", resultMap["serverInfo"])
 	}
 
 	res = doRPC(t, server.Handler(), rpcRequest{JSONRPC: "2.0", ID: 2, Method: "tools/list", Params: nil})

--- a/portal/handler.go
+++ b/portal/handler.go
@@ -82,6 +82,15 @@ type Options struct {
 	SemanticPV         func(context.Context) (ForwardedResponse, error)
 	ModbusProvider     mcp.ModbusV1Provider
 	RawModbusAudit     func(RawModbusAuditEvent)
+	Readiness          func() RuntimeReadiness
+}
+
+type RuntimeReadiness struct {
+	ProcessReadiness    string `json:"process_readiness"`
+	HTTPReadiness       string `json:"http_readiness"`
+	ProxyReadiness      string `json:"proxy_readiness"`
+	EEBusReadiness      string `json:"eebus_readiness"`
+	EEBusDegradedReason string `json:"eebus_degraded_reason,omitempty"`
 }
 
 type ForwardedResponse struct {
@@ -578,6 +587,18 @@ func NewHandler(opts Options) http.Handler {
 	if opts.BuildID == "" {
 		opts.BuildID = "unknown"
 	}
+	if opts.Readiness == nil {
+		eebusReadiness := "DISABLED"
+		if opts.EEBusAdminPath != "" {
+			eebusReadiness = "READY"
+		}
+		opts.Readiness = func() RuntimeReadiness {
+			return RuntimeReadiness{
+				ProcessReadiness: "READY", HTTPReadiness: "READY", ProxyReadiness: "DISABLED",
+				EEBusReadiness: eebusReadiness,
+			}
+		}
+	}
 	h := &handler{
 		opts:      opts,
 		files:     http.FileServer(http.FS(staticFS)),
@@ -963,9 +984,15 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 			"gateway_version": h.opts.GatewayVersion,
 			"build_id":        h.opts.BuildID,
 			"time_utc":        time.Now().UTC().Format(time.RFC3339),
+			"readiness":       h.opts.Readiness(),
 		})
 	case "bootstrap":
 		streamEnabled := h.opts.ListRegistry != nil || h.opts.ListSemantic != nil || h.opts.ListProjections != nil
+		eebusAdminAvailable := h.opts.Readiness().EEBusReadiness == "READY"
+		eebusAdminPath := ""
+		if eebusAdminAvailable {
+			eebusAdminPath = h.opts.EEBusAdminPath
+		}
 		writeJSON(w, http.StatusOK, map[string]any{
 			"capabilities": map[string]bool{
 				"registry":          h.opts.ListRegistry != nil,
@@ -990,7 +1017,7 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 				// of section-l7-catalog, otherwise the bootstrap fetch
 				// surfaces a broken section. Codex P2 on PR #507.
 				"ebus_standard":   h.opts.EbusStandardServer != nil,
-				"eebus_admin":     h.opts.EEBusAdminPath != "",
+				"eebus_admin":     eebusAdminAvailable,
 				"semantic_pv":     h.opts.SemanticPVEnabled && h.opts.SemanticPV != nil,
 				"modbus_raw_read": h.opts.RawModbusEnabled && h.opts.ModbusProvider != nil,
 			},
@@ -999,7 +1026,7 @@ func (h *handler) handleAPI(w http.ResponseWriter, r *http.Request, path string)
 				"snapshot":              h.opts.SnapshotPath,
 				"subscriptions":         h.opts.SubscriptionPath,
 				"mcp":                   h.opts.MCPPath,
-				"eebus_admin":           h.opts.EEBusAdminPath,
+				"eebus_admin":           eebusAdminPath,
 				"bus_observability":     "/portal/api/v1/bus/observability",
 				"search":                "/portal/api/v1/search",
 				"stream":                "/portal/api/v1/stream",

--- a/portal/handler_test.go
+++ b/portal/handler_test.go
@@ -143,6 +143,54 @@ func TestHealthEndpoint(t *testing.T) {
 	}
 }
 
+func TestIssue846HealthReadinessAndBootstrapTrackCurrentEEBusAvailability(t *testing.T) {
+	readiness := RuntimeReadiness{
+		ProcessReadiness:    "READY",
+		HTTPReadiness:       "READY",
+		ProxyReadiness:      "DISABLED",
+		EEBusReadiness:      "DEGRADED",
+		EEBusDegradedReason: "ADMIN_BOUNDARY_UNAVAILABLE",
+	}
+	handler := NewHandler(Options{
+		EEBusAdminPath: "/admin/eebus/v1",
+		Readiness:      func() RuntimeReadiness { return readiness },
+	})
+
+	health := httptest.NewRecorder()
+	handler.ServeHTTP(health, httptest.NewRequest(http.MethodGet, "/api/v1/health", nil))
+	var healthPayload struct {
+		Status    string           `json:"status"`
+		Readiness RuntimeReadiness `json:"readiness"`
+	}
+	if health.Code != http.StatusOK || json.Unmarshal(health.Body.Bytes(), &healthPayload) != nil {
+		t.Fatalf("health status=%d body=%s", health.Code, health.Body.String())
+	}
+	if healthPayload.Status != "ok" || healthPayload.Readiness != readiness {
+		t.Fatalf("health readiness=%#v status=%q; want independent degraded eeBUS", healthPayload.Readiness, healthPayload.Status)
+	}
+
+	assertBootstrap := func(wantAvailable bool, wantPath string) {
+		t.Helper()
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/api/v1/bootstrap", nil))
+		var payload struct {
+			Capabilities map[string]bool   `json:"capabilities"`
+			Endpoints    map[string]string `json:"endpoints"`
+		}
+		if response.Code != http.StatusOK || json.Unmarshal(response.Body.Bytes(), &payload) != nil {
+			t.Fatalf("bootstrap status=%d body=%s", response.Code, response.Body.String())
+		}
+		if payload.Capabilities["eebus_admin"] != wantAvailable || payload.Endpoints["eebus_admin"] != wantPath {
+			t.Fatalf("bootstrap eeBUS capability/path=%v/%q; want %v/%q", payload.Capabilities["eebus_admin"], payload.Endpoints["eebus_admin"], wantAvailable, wantPath)
+		}
+	}
+
+	assertBootstrap(false, "")
+	readiness.EEBusReadiness = "READY"
+	readiness.EEBusDegradedReason = ""
+	assertBootstrap(true, "/admin/eebus/v1")
+}
+
 func TestBootstrapEndpoint(t *testing.T) {
 	h := NewHandler(Options{
 		GraphQLPath:      "/graphql",

--- a/portal/pv_modbus_red_test.go
+++ b/portal/pv_modbus_red_test.go
@@ -150,9 +150,19 @@ func TestPortalRawModbusAuditIsCompleteAndSanitizedForEveryOutcome(t *testing.T)
 			if requestID, _ := payload["request_id"].(string); requestID == "" || len(requestID) > 64 {
 				t.Fatalf("request_id is absent or unbounded: %q", requestID)
 			}
+			auditedFields := make(map[string]any, len(payload)-2)
+			for key, value := range payload {
+				if key != "at" && key != "request_id" {
+					auditedFields[key] = value
+				}
+			}
+			encodedFields, err := json.Marshal(auditedFields)
+			if err != nil {
+				t.Fatal(err)
+			}
 			for _, forbidden := range []string{"words", "wire", "tcp://", "secret", "private/path", "client.pem", "1234"} {
-				if strings.Contains(strings.ToLower(string(encoded)), strings.ToLower(forbidden)) {
-					t.Fatalf("audit leaked %q: %s", forbidden, encoded)
+				if strings.Contains(strings.ToLower(string(encodedFields)), strings.ToLower(forbidden)) {
+					t.Fatalf("audit fields leaked %q: %s", forbidden, encodedFields)
 				}
 			}
 			if test.name == "success" && fmt.Sprint(payload["endpoint_ref"]) != "sha256:"+strings.Repeat("a", 64) {


### PR DESCRIPTION
## Summary

- isolate eeBUS map, factory, Start, and Admin construction failures from gateway process availability
- preserve a closed unavailable AdminV1 boundary and stable raw-provider seam while eeBUS is degraded
- add a gateway-owned three-attempt startup window with five-second nonzero backoff, one serialized timer, shutdown cancellation, safe in-flight-reader drain, and unavailable-to-available runtime/Admin replacement
- keep eBUS, Modbus, gateway APIs, Portal, MCP, GraphQL and other drivers running while eeBUS reconstruction is unavailable
- unify process build identity across Portal health, MCP initialize and runtime-state metadata
- correct two stale Modbus lifecycle tests and a timestamp-sensitive Portal audit anti-leak assertion without changing Modbus or Portal production code

## Strict RED / GREEN evidence

- startup isolation RED: 46e871524aa24c69f82707c42bb9282488450f72
- startup isolation GREEN: 13b78bd
- runtime identity RED: 4fd22ea
- runtime identity GREEN: 8c9df65dd5cb8565d861ced5b7443ed16858a231
- bounded lifecycle RED: 7323b6960c6c6db9110e8b5a4334ba5109175aed
- exact GREEN HEAD: 5131ae3e5e75f762823b0cf60a053e0b2e682019

The bounded lifecycle RED failed credibly at compile on the absent runtime-slot and lifecycle seams before implementation.

## Validation at exact GREEN HEAD

- focused normal tests: cmd/gateway and portal PASS
- focused race tests: cmd/gateway and portal PASS
- full local CI: PASS, including terminology, 52 Portal node tests, asset parity, gofmt, vet, build, linux 386/armv7/armv6 builds, full race suite, source-selection schema coverage, 198 Python gate tests, golangci-lint with 0 issues, transport gate, and passive smoke gate
- transport gate: PASS using the newest available complete 88-case evidence; 46 pass, 7 expected fail, 2 inherited positive xpass T65/T66, 33 blocked infrastructure, 88 total. This PR changes no eBUS transport/protocol path.
- passive smoke gate: PASS, 6 of 6 cases
- GitHub CI: terminology, build, test and lint all green at exact HEAD

## Dependencies and boundary

- Closes #846
- Docs gate: Project-Helianthus/helianthus-docs-eebus#131 at 47ab1bfed50513205432e9dde1413fcebfa4dce8, all checks green
- Coordinated main.go ownership with task 019f47bb-70ff-72d1-9b7f-4a1bacbd5451
- No generic operator start/stop/restart API, Modbus/SunSpec/PV production change, semantic_vaillant change, HA/add-on/live mutation, or transport mutation

Draft; fresh exact-HEAD review and merge gates remain pending.