### PR TITLE
Gateway DriverManager: always-up shell and managed eBUS lifecycle

### DIFF
--- a/cmd/gateway/driver_manager_process_red_test.go
+++ b/cmd/gateway/driver_manager_process_red_test.go
@@ -93,3 +93,76 @@ func TestIssue851RunKeepsHTTPShellAliveWhenEBusConstructionFails(t *testing.T) {
 		t.Fatal("test did not exercise eBUS construction")
 	}
 }
+
+func TestIssue851HTTPShellStartsWhileEBusConstructionIsBlocked(t *testing.T) {
+	originalWire := wireObserveFirstObserversFn
+	originalDiscovery := startDiscoveryScanLoopFn
+	originalSemantic := startVaillantSemanticPollingFn
+	originalHTTP := startHTTPServerFn
+	t.Cleanup(func() {
+		wireObserveFirstObserversFn = originalWire
+		startDiscoveryScanLoopFn = originalDiscovery
+		startVaillantSemanticPollingFn = originalSemantic
+		startHTTPServerFn = originalHTTP
+	})
+	wireObserveFirstObserversFn = func(*ebusgateway.Config) (*ebusgateway.BusObservabilityStore, *ebusgateway.ActivePassiveDeduplicator, error) {
+		return nil, nil, nil
+	}
+	startDiscoveryScanLoopFn = func(context.Context, ebusgateway.Config, *ebusgateway.Gateway, *graphql.Builder, activeTxnClassifier) startupScanSignals {
+		return startupScanSignals{}
+	}
+	startVaillantSemanticPollingFn = func(context.Context, ebusgateway.Config, *ebusgateway.Gateway, *graphql.LiveSemanticProvider, *graphql.BroadcastHub, <-chan struct{}) *vaillantSemanticPoller {
+		return nil
+	}
+
+	dialStarted := make(chan struct{}, 1)
+	dialRelease := make(chan struct{})
+	httpStarted := make(chan struct{}, 1)
+	startHTTPServerFn = func(context.Context, ebusgateway.Config, *ebusgateway.Gateway, *graphql.Builder, *graphql.BroadcastHub, graphql.SemanticProvider, mcp.ScheduleWriter, mcp.ConfigWriter, *ebusgateway.BusObservabilityStore, *ebusgateway.ShadowCache) (*http.Server, mdns.Advertiser, error) {
+		httpStarted <- struct{}{}
+		return nil, nil, nil
+	}
+
+	cfg := ebusgateway.DefaultConfig()
+	cfg.Transport = nil
+	cfg.TransportConfig.Protocol = ebusgateway.TransportTCPPlain
+	cfg.TransportConfig.Network = "tcp"
+	cfg.TransportConfig.Address = "blocked.invalid:9999"
+	cfg.TransportConfig.Dial = func(context.Context, string, string, time.Duration) (net.Conn, error) {
+		select {
+		case dialStarted <- struct{}{}:
+		default:
+		}
+		<-dialRelease // deliberately ignores context
+		return nil, errors.New("offline")
+	}
+	cfg.BroadcastListen = false
+	cfg.ScanOnStart = false
+	cfg.RuntimeStatePath = filepath.Join(t.TempDir(), "runtime-state.json")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- run(ctx, cfg) }()
+	select {
+	case <-dialStarted:
+	case <-time.After(time.Second):
+		t.Fatal("eBUS construction did not start")
+	}
+	select {
+	case <-httpStarted:
+	case err := <-done:
+		t.Fatalf("run exited while eBUS construction was blocked: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("HTTP shell waited for blocked eBUS construction")
+	}
+	close(dialRelease)
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("run() error = %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("run did not shut down after blocked construction was released")
+	}
+}

--- a/cmd/gateway/driver_manager_process_red_test.go
+++ b/cmd/gateway/driver_manager_process_red_test.go
@@ -167,6 +167,92 @@ func TestIssue851HTTPShellStartsWhileEBusConstructionIsBlocked(t *testing.T) {
 	}
 }
 
+func TestIssue851HTTPShellStartsBeforeENHSourceSelectionWarmup(t *testing.T) {
+	originalWire := wireObserveFirstObserversFn
+	originalDiscovery := startDiscoveryScanLoopFn
+	originalSemantic := startVaillantSemanticPollingFn
+	originalHTTP := startHTTPServerFn
+	t.Cleanup(func() {
+		wireObserveFirstObserversFn = originalWire
+		startDiscoveryScanLoopFn = originalDiscovery
+		startVaillantSemanticPollingFn = originalSemantic
+		startHTTPServerFn = originalHTTP
+	})
+	wireObserveFirstObserversFn = func(*ebusgateway.Config) (*ebusgateway.BusObservabilityStore, *ebusgateway.ActivePassiveDeduplicator, error) {
+		return nil, nil, nil
+	}
+	startDiscoveryScanLoopFn = func(context.Context, ebusgateway.Config, *ebusgateway.Gateway, *graphql.Builder, activeTxnClassifier) startupScanSignals {
+		return startupScanSignals{}
+	}
+	startVaillantSemanticPollingFn = func(context.Context, ebusgateway.Config, *ebusgateway.Gateway, *graphql.LiveSemanticProvider, *graphql.BroadcastHub, <-chan struct{}) *vaillantSemanticPoller {
+		return nil
+	}
+
+	dialStarted := make(chan struct{}, 1)
+	dialRelease := make(chan struct{})
+	httpStarted := make(chan struct{}, 1)
+	var surfaceErr error
+	startHTTPServerFn = func(_ context.Context, _ ebusgateway.Config, gateway *ebusgateway.Gateway, builder *graphql.Builder, _ *graphql.BroadcastHub, _ graphql.SemanticProvider, schedule mcp.ScheduleWriter, config mcp.ConfigWriter, _ *ebusgateway.BusObservabilityStore, _ *ebusgateway.ShadowCache) (*http.Server, mdns.Advertiser, error) {
+		if gateway == nil || gateway.Transport == nil || builder == nil || schedule == nil || config == nil {
+			surfaceErr = errors.New("early HTTP shell received nil runtime binding")
+		} else if _, admitted := builder.AdmittedMutationSource(); admitted {
+			surfaceErr = errors.New("early HTTP shell exposed an admitted write source")
+		} else if result, err := schedule.SetZoneTimeProgram(context.Background(), 0, 0, nil); err != nil || result.Success || result.Error != semanticWriterSourceNotAdmittedError {
+			surfaceErr = errors.New("early HTTP schedule binding did not fail closed")
+		} else if result := config.SetSystemConfig(context.Background(), "field", "value"); result.Success || result.Error != semanticWriterSourceNotAdmittedError {
+			surfaceErr = errors.New("early HTTP config binding did not fail closed")
+		}
+		httpStarted <- struct{}{}
+		return nil, nil, nil
+	}
+
+	cfg := ebusgateway.DefaultConfig()
+	cfg.Transport = nil
+	cfg.TransportConfig.Protocol = ebusgateway.TransportENH
+	cfg.TransportConfig.Network = "tcp"
+	cfg.TransportConfig.Address = "blocked.invalid:8888"
+	cfg.TransportConfig.Dial = func(context.Context, string, string, time.Duration) (net.Conn, error) {
+		select {
+		case dialStarted <- struct{}{}:
+		default:
+		}
+		<-dialRelease // deliberately ignores context
+		return nil, errors.New("offline")
+	}
+	cfg.BroadcastListen = true
+	cfg.ScanOnStart = false
+	cfg.RuntimeStatePath = filepath.Join(t.TempDir(), "runtime-state.json")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- run(ctx, cfg) }()
+	select {
+	case <-dialStarted:
+	case <-time.After(time.Second):
+		t.Fatal("eBUS ENH construction did not start")
+	}
+	select {
+	case <-httpStarted:
+	case err := <-done:
+		t.Fatalf("run exited before early HTTP shell: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("HTTP shell waited for ENH passive source-selection warmup")
+	}
+	if surfaceErr != nil {
+		t.Fatal(surfaceErr)
+	}
+	close(dialRelease)
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("run() error = %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("run did not shut down after early HTTP test cancellation")
+	}
+}
+
 func TestIssue851RunCanonicalizesURIOverrideForAllRuntimePolicies(t *testing.T) {
 	originalWire := wireObserveFirstObserversFn
 	originalDiscovery := startDiscoveryScanLoopFn
@@ -191,6 +277,8 @@ func TestIssue851RunCanonicalizesURIOverrideForAllRuntimePolicies(t *testing.T) 
 		{name: "ebusd", uri: "ebusd://127.0.0.1:8888", wantProtocol: ebusgateway.TransportEbusdTCP, wantNetwork: "tcp", wantAddress: "127.0.0.1:8888", wantAdmission: true, wantSource: ebusgateway.DefaultConfig().ScanSource},
 		{name: "tcp plain", uri: "tcp-plain://127.0.0.1:9999", wantProtocol: ebusgateway.TransportTCPPlain, wantNetwork: "tcp", wantAddress: "127.0.0.1:9999"},
 		{name: "udp plain", uri: "udp-plain://127.0.0.1:9999", wantProtocol: ebusgateway.TransportUDPPlain, wantNetwork: "udp", wantAddress: "127.0.0.1:9999"},
+		{name: "adapter direct enh", uri: "adapter-direct://127.0.0.1:1", wantProtocol: ebusgateway.TransportAdapterDirect, wantNetwork: "tcp", wantAddress: "127.0.0.1:1"},
+		{name: "adapter direct ens", uri: "adapter-direct-ens://127.0.0.1:1", wantProtocol: adapterDirectENSProtocol, wantNetwork: "tcp", wantAddress: "127.0.0.1:1"},
 	}
 
 	for _, test := range tests {
@@ -201,27 +289,28 @@ func TestIssue851RunCanonicalizesURIOverrideForAllRuntimePolicies(t *testing.T) 
 				source   byte
 			}
 			wireObserved := make(chan ebusgateway.Config, 1)
-			discoveryObserved := make(chan ebusgateway.Config, 1)
+			discoveryObserved := make(chan runtimeObservation, 1)
 			httpObserved := make(chan runtimeObservation, 1)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
 			wireObserveFirstObserversFn = func(cfg *ebusgateway.Config) (*ebusgateway.BusObservabilityStore, *ebusgateway.ActivePassiveDeduplicator, error) {
 				wireObserved <- *cfg
 				return nil, nil, nil
 			}
-			startDiscoveryScanLoopFn = func(_ context.Context, cfg ebusgateway.Config, _ *ebusgateway.Gateway, _ *graphql.Builder, _ activeTxnClassifier) startupScanSignals {
-				discoveryObserved <- cfg
+			startDiscoveryScanLoopFn = func(_ context.Context, cfg ebusgateway.Config, _ *ebusgateway.Gateway, builder *graphql.Builder, _ activeTxnClassifier) startupScanSignals {
+				source, admitted := builder.AdmittedMutationSource()
+				discoveryObserved <- runtimeObservation{cfg: cfg, admitted: admitted, source: source}
+				cancel()
 				return startupScanSignals{}
 			}
 			startVaillantSemanticPollingFn = func(context.Context, ebusgateway.Config, *ebusgateway.Gateway, *graphql.LiveSemanticProvider, *graphql.BroadcastHub, <-chan struct{}) *vaillantSemanticPoller {
 				return nil
 			}
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
 			startHTTPServerFn = func(_ context.Context, cfg ebusgateway.Config, _ *ebusgateway.Gateway, builder *graphql.Builder, _ *graphql.BroadcastHub, _ graphql.SemanticProvider, _ mcp.ScheduleWriter, _ mcp.ConfigWriter, _ *ebusgateway.BusObservabilityStore, _ *ebusgateway.ShadowCache) (*http.Server, mdns.Advertiser, error) {
 				source, admitted := builder.AdmittedMutationSource()
 				httpObserved <- runtimeObservation{cfg: cfg, admitted: admitted, source: source}
-				cancel()
 				return nil, nil, nil
 			}
 
@@ -250,15 +339,6 @@ func TestIssue851RunCanonicalizesURIOverrideForAllRuntimePolicies(t *testing.T) 
 			case <-time.After(2 * time.Second):
 				t.Fatal("HTTP runtime did not start")
 			}
-			select {
-			case err := <-done:
-				if err != nil {
-					t.Fatalf("run() error = %v", err)
-				}
-			case <-time.After(2 * time.Second):
-				t.Fatal("run() did not stop after HTTP observation")
-			}
-
 			assertCanonical := func(label string, observed ebusgateway.Config) {
 				t.Helper()
 				if observed.TransportConfig.Protocol != test.wantProtocol || observed.TransportConfig.Network != test.wantNetwork || observed.TransportConfig.Address != test.wantAddress {
@@ -273,13 +353,24 @@ func TestIssue851RunCanonicalizesURIOverrideForAllRuntimePolicies(t *testing.T) 
 				t.Fatal("observer wiring did not receive runtime config")
 			}
 			select {
-			case observed := <-discoveryObserved:
-				assertCanonical("discovery", observed)
-			default:
+			case discoveryResult := <-discoveryObserved:
+				assertCanonical("discovery", discoveryResult.cfg)
+				if discoveryResult.admitted != test.wantAdmission || discoveryResult.source != test.wantSource {
+					t.Fatalf("discovery admitted source = 0x%02X admitted=%v, want 0x%02X/%v", discoveryResult.source, discoveryResult.admitted, test.wantSource, test.wantAdmission)
+				}
+			case <-time.After(2 * time.Second):
 				t.Fatal("discovery did not receive runtime config")
 			}
-			if httpResult.admitted != test.wantAdmission || httpResult.source != test.wantSource {
-				t.Fatalf("HTTP admitted source = 0x%02X admitted=%v, want 0x%02X/%v", httpResult.source, httpResult.admitted, test.wantSource, test.wantAdmission)
+			if httpResult.admitted || httpResult.source != 0 {
+				t.Fatalf("early HTTP admitted source = 0x%02X admitted=%v, want fail-closed 0x00/false", httpResult.source, httpResult.admitted)
+			}
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Fatalf("run() error = %v", err)
+				}
+			case <-time.After(3 * time.Second):
+				t.Fatal("run() did not stop after discovery observation")
 			}
 		})
 	}

--- a/cmd/gateway/driver_manager_process_red_test.go
+++ b/cmd/gateway/driver_manager_process_red_test.go
@@ -167,6 +167,114 @@ func TestIssue851HTTPShellStartsWhileEBusConstructionIsBlocked(t *testing.T) {
 	}
 }
 
+func TestIssue851DelayedHealthyDriverWakesOneImmediateStartupScan(t *testing.T) {
+	originalWire := wireObserveFirstObserversFn
+	originalDiscovery := startDiscoveryScanLoopFn
+	originalSemantic := startVaillantSemanticPollingFn
+	originalHTTP := startHTTPServerFn
+	t.Cleanup(func() {
+		wireObserveFirstObserversFn = originalWire
+		startDiscoveryScanLoopFn = originalDiscovery
+		startVaillantSemanticPollingFn = originalSemantic
+		startHTTPServerFn = originalHTTP
+	})
+	wireObserveFirstObserversFn = func(*ebusgateway.Config) (*ebusgateway.BusObservabilityStore, *ebusgateway.ActivePassiveDeduplicator, error) {
+		return nil, nil, nil
+	}
+	startVaillantSemanticPollingFn = func(context.Context, ebusgateway.Config, *ebusgateway.Gateway, *graphql.LiveSemanticProvider, *graphql.BroadcastHub, <-chan struct{}) *vaillantSemanticPoller {
+		return nil
+	}
+
+	dialStarted := make(chan struct{}, 1)
+	dialRelease := make(chan struct{})
+	defer func() {
+		select {
+		case <-dialRelease:
+		default:
+			close(dialRelease)
+		}
+	}()
+	httpStarted := make(chan struct{}, 1)
+	scanStarted := make(chan struct{}, 1)
+	var scanCalls atomic.Int32
+	startHTTPServerFn = func(context.Context, ebusgateway.Config, *ebusgateway.Gateway, *graphql.Builder, *graphql.BroadcastHub, graphql.SemanticProvider, mcp.ScheduleWriter, mcp.ConfigWriter, *ebusgateway.BusObservabilityStore, *ebusgateway.ShadowCache) (*http.Server, mdns.Advertiser, error) {
+		httpStarted <- struct{}{}
+		return nil, nil, nil
+	}
+	startDiscoveryScanLoopFn = func(context.Context, ebusgateway.Config, *ebusgateway.Gateway, *graphql.Builder, activeTxnClassifier) startupScanSignals {
+		scanCalls.Add(1)
+		select {
+		case scanStarted <- struct{}{}:
+		default:
+		}
+		return startupScanSignals{}
+	}
+
+	client, peer := net.Pipe()
+	t.Cleanup(func() { _ = peer.Close() })
+	cfg := ebusgateway.DefaultConfig()
+	cfg.Transport = nil
+	cfg.TransportConfig.Protocol = ebusgateway.TransportTCPPlain
+	cfg.TransportConfig.Network = "tcp"
+	cfg.TransportConfig.Address = "delayed.invalid:9999"
+	cfg.TransportConfig.Dial = func(context.Context, string, string, time.Duration) (net.Conn, error) {
+		select {
+		case dialStarted <- struct{}{}:
+		default:
+		}
+		<-dialRelease
+		return client, nil
+	}
+	cfg.BroadcastListen = false
+	cfg.ScanOnStart = true
+	cfg.ScanInterval = time.Minute
+	cfg.RuntimeStatePath = filepath.Join(t.TempDir(), "runtime-state.json")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- run(ctx, cfg) }()
+	select {
+	case <-dialStarted:
+	case <-time.After(time.Second):
+		t.Fatal("delayed eBUS construction did not start")
+	}
+	select {
+	case <-httpStarted:
+	case err := <-done:
+		t.Fatalf("run() exited before HTTP shell startup: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("HTTP shell waited for delayed healthy eBUS construction")
+	}
+	select {
+	case <-scanStarted:
+		t.Fatal("startup scan ran before the first correlated RUNNING generation")
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	close(dialRelease)
+	select {
+	case <-scanStarted:
+	case err := <-done:
+		t.Fatalf("run() exited before delayed healthy startup scan: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("RUNNING notification did not wake the initial scan immediately")
+	}
+	time.Sleep(25 * time.Millisecond)
+	if got := scanCalls.Load(); got != 1 {
+		t.Fatalf("startup scan calls = %d, want exactly one", got)
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("run() error = %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("run() did not shut down after delayed healthy scan")
+	}
+}
+
 func TestIssue851HTTPShellStartsBeforeENHSourceSelectionWarmup(t *testing.T) {
 	originalWire := wireObserveFirstObserversFn
 	originalDiscovery := startDiscoveryScanLoopFn

--- a/cmd/gateway/driver_manager_process_red_test.go
+++ b/cmd/gateway/driver_manager_process_red_test.go
@@ -166,3 +166,121 @@ func TestIssue851HTTPShellStartsWhileEBusConstructionIsBlocked(t *testing.T) {
 		t.Fatal("run did not shut down after blocked construction was released")
 	}
 }
+
+func TestIssue851RunCanonicalizesURIOverrideForAllRuntimePolicies(t *testing.T) {
+	originalWire := wireObserveFirstObserversFn
+	originalDiscovery := startDiscoveryScanLoopFn
+	originalSemantic := startVaillantSemanticPollingFn
+	originalHTTP := startHTTPServerFn
+	t.Cleanup(func() {
+		wireObserveFirstObserversFn = originalWire
+		startDiscoveryScanLoopFn = originalDiscovery
+		startVaillantSemanticPollingFn = originalSemantic
+		startHTTPServerFn = originalHTTP
+	})
+
+	tests := []struct {
+		name          string
+		uri           string
+		wantProtocol  ebusgateway.TransportProtocol
+		wantNetwork   string
+		wantAddress   string
+		wantAdmission bool
+		wantSource    byte
+	}{
+		{name: "ebusd", uri: "ebusd://127.0.0.1:8888", wantProtocol: ebusgateway.TransportEbusdTCP, wantNetwork: "tcp", wantAddress: "127.0.0.1:8888", wantAdmission: true, wantSource: ebusgateway.DefaultConfig().ScanSource},
+		{name: "tcp plain", uri: "tcp-plain://127.0.0.1:9999", wantProtocol: ebusgateway.TransportTCPPlain, wantNetwork: "tcp", wantAddress: "127.0.0.1:9999"},
+		{name: "udp plain", uri: "udp-plain://127.0.0.1:9999", wantProtocol: ebusgateway.TransportUDPPlain, wantNetwork: "udp", wantAddress: "127.0.0.1:9999"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			type runtimeObservation struct {
+				cfg      ebusgateway.Config
+				admitted bool
+				source   byte
+			}
+			wireObserved := make(chan ebusgateway.Config, 1)
+			discoveryObserved := make(chan ebusgateway.Config, 1)
+			httpObserved := make(chan runtimeObservation, 1)
+
+			wireObserveFirstObserversFn = func(cfg *ebusgateway.Config) (*ebusgateway.BusObservabilityStore, *ebusgateway.ActivePassiveDeduplicator, error) {
+				wireObserved <- *cfg
+				return nil, nil, nil
+			}
+			startDiscoveryScanLoopFn = func(_ context.Context, cfg ebusgateway.Config, _ *ebusgateway.Gateway, _ *graphql.Builder, _ activeTxnClassifier) startupScanSignals {
+				discoveryObserved <- cfg
+				return startupScanSignals{}
+			}
+			startVaillantSemanticPollingFn = func(context.Context, ebusgateway.Config, *ebusgateway.Gateway, *graphql.LiveSemanticProvider, *graphql.BroadcastHub, <-chan struct{}) *vaillantSemanticPoller {
+				return nil
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			startHTTPServerFn = func(_ context.Context, cfg ebusgateway.Config, _ *ebusgateway.Gateway, builder *graphql.Builder, _ *graphql.BroadcastHub, _ graphql.SemanticProvider, _ mcp.ScheduleWriter, _ mcp.ConfigWriter, _ *ebusgateway.BusObservabilityStore, _ *ebusgateway.ShadowCache) (*http.Server, mdns.Advertiser, error) {
+				source, admitted := builder.AdmittedMutationSource()
+				httpObserved <- runtimeObservation{cfg: cfg, admitted: admitted, source: source}
+				cancel()
+				return nil, nil, nil
+			}
+
+			cfg := ebusgateway.DefaultConfig()
+			cfg.Transport = nil
+			cfg.TransportConfig.Protocol = ebusgateway.TransportENH
+			cfg.TransportConfig.Network = "unix"
+			cfg.TransportConfig.Address = test.uri
+			cfg.TransportConfig.DialTimeout = time.Millisecond
+			cfg.TransportConfig.Dial = func(context.Context, string, string, time.Duration) (net.Conn, error) {
+				return nil, errors.New("test transport unavailable")
+			}
+			cfg.BroadcastListen = false
+			cfg.ScanOnStart = false
+			cfg.ScanSource = 0
+			cfg.ScanSourceAuto = true
+			cfg.RuntimeStatePath = filepath.Join(t.TempDir(), "runtime-state.json")
+
+			done := make(chan error, 1)
+			go func() { done <- run(ctx, cfg) }()
+			var httpResult runtimeObservation
+			select {
+			case httpResult = <-httpObserved:
+			case err := <-done:
+				t.Fatalf("run() exited before HTTP observation: %v", err)
+			case <-time.After(2 * time.Second):
+				t.Fatal("HTTP runtime did not start")
+			}
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Fatalf("run() error = %v", err)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("run() did not stop after HTTP observation")
+			}
+
+			assertCanonical := func(label string, observed ebusgateway.Config) {
+				t.Helper()
+				if observed.TransportConfig.Protocol != test.wantProtocol || observed.TransportConfig.Network != test.wantNetwork || observed.TransportConfig.Address != test.wantAddress {
+					t.Fatalf("%s transport = protocol:%q network:%q address:%q, want %q/%q/%q", label, observed.TransportConfig.Protocol, observed.TransportConfig.Network, observed.TransportConfig.Address, test.wantProtocol, test.wantNetwork, test.wantAddress)
+				}
+			}
+			assertCanonical("HTTP", httpResult.cfg)
+			select {
+			case observed := <-wireObserved:
+				assertCanonical("observer wiring", observed)
+			default:
+				t.Fatal("observer wiring did not receive runtime config")
+			}
+			select {
+			case observed := <-discoveryObserved:
+				assertCanonical("discovery", observed)
+			default:
+				t.Fatal("discovery did not receive runtime config")
+			}
+			if httpResult.admitted != test.wantAdmission || httpResult.source != test.wantSource {
+				t.Fatalf("HTTP admitted source = 0x%02X admitted=%v, want 0x%02X/%v", httpResult.source, httpResult.admitted, test.wantSource, test.wantAdmission)
+			}
+		})
+	}
+}

--- a/cmd/gateway/driver_manager_process_red_test.go
+++ b/cmd/gateway/driver_manager_process_red_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/graphql"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/mdns"
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+func TestIssue851RunKeepsHTTPShellAliveWhenEBusConstructionFails(t *testing.T) {
+	originalWire := wireObserveFirstObserversFn
+	originalDiscovery := startDiscoveryScanLoopFn
+	originalSemantic := startVaillantSemanticPollingFn
+	originalHTTP := startHTTPServerFn
+	t.Cleanup(func() {
+		wireObserveFirstObserversFn = originalWire
+		startDiscoveryScanLoopFn = originalDiscovery
+		startVaillantSemanticPollingFn = originalSemantic
+		startHTTPServerFn = originalHTTP
+	})
+
+	wireObserveFirstObserversFn = func(*ebusgateway.Config) (*ebusgateway.BusObservabilityStore, *ebusgateway.ActivePassiveDeduplicator, error) {
+		return nil, nil, nil
+	}
+	startDiscoveryScanLoopFn = func(context.Context, ebusgateway.Config, *ebusgateway.Gateway, *graphql.Builder, activeTxnClassifier) startupScanSignals {
+		return startupScanSignals{}
+	}
+	startVaillantSemanticPollingFn = func(context.Context, ebusgateway.Config, *ebusgateway.Gateway, *graphql.LiveSemanticProvider, *graphql.BroadcastHub, <-chan struct{}) *vaillantSemanticPoller {
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	httpStarted := make(chan struct{}, 1)
+	var surfaceErr error
+	startHTTPServerFn = func(_ context.Context, _ ebusgateway.Config, gateway *ebusgateway.Gateway, _ *graphql.Builder, _ *graphql.BroadcastHub, _ graphql.SemanticProvider, _ mcp.ScheduleWriter, _ mcp.ConfigWriter, _ *ebusgateway.BusObservabilityStore, _ *ebusgateway.ShadowCache) (*http.Server, mdns.Advertiser, error) {
+		if gateway == nil || gateway.Registry == nil || gateway.Router == nil || gateway.Transport == nil {
+			surfaceErr = errors.New("HTTP shell received an incomplete stable gateway")
+		} else if _, err := gateway.Transport.ReadByte(); !errors.Is(err, transport.ErrDriverUnavailable) {
+			surfaceErr = errors.New("stable eBUS provider did not return typed unavailable state")
+		}
+		httpStarted <- struct{}{}
+		cancel()
+		return nil, nil, nil
+	}
+
+	var dialCalls atomic.Int32
+	cfg := ebusgateway.DefaultConfig()
+	cfg.Transport = nil
+	cfg.TransportConfig.Protocol = ebusgateway.TransportTCPPlain
+	cfg.TransportConfig.Network = "tcp"
+	cfg.TransportConfig.Address = "secret-user:secret-password@example.invalid:9999"
+	cfg.TransportConfig.DialTimeout = 5 * time.Millisecond
+	cfg.TransportConfig.Dial = func(context.Context, string, string, time.Duration) (net.Conn, error) {
+		dialCalls.Add(1)
+		return nil, errors.New("secret endpoint unavailable")
+	}
+	cfg.BroadcastListen = false
+	cfg.ScanOnStart = false
+	cfg.RuntimeStatePath = filepath.Join(t.TempDir(), "runtime-state.json")
+
+	done := make(chan error, 1)
+	go func() { done <- run(ctx, cfg) }()
+	select {
+	case <-httpStarted:
+	case err := <-done:
+		t.Fatalf("run exited before HTTP shell startup: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("HTTP shell did not start after eBUS construction failure")
+	}
+	if surfaceErr != nil {
+		t.Fatal(surfaceErr)
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("run returned fatal eBUS construction/shutdown error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("run did not exit after context cancellation")
+	}
+	if dialCalls.Load() == 0 {
+		t.Fatal("test did not exercise eBUS construction")
+	}
+}

--- a/cmd/gateway/ebus_driver_runtime.go
+++ b/cmd/gateway/ebus_driver_runtime.go
@@ -72,6 +72,7 @@ func newEBusDriverController(cfg ebusgateway.Config) (*ebusDriverController, err
 		controller.passive = newEBusStablePassiveTransport(
 			managedEBusSlotInvoker{manager: manager, id: primaryEBusDriverID},
 			protocol,
+			reporter,
 		)
 	}
 	if protocol == ebusgateway.TransportAdapterDirect {
@@ -94,13 +95,17 @@ func configuredEBusDriverProtocol(cfg ebusgateway.Config) ebusgateway.TransportP
 	if strings.HasPrefix(address, "adapter-direct://") || strings.HasPrefix(address, "adapter-direct-ens://") {
 		return ebusgateway.TransportAdapterDirect
 	}
-	return ebusgateway.CanonicalTransportProtocol(cfg.TransportConfig.Protocol)
+	return ebusgateway.EBusDriverTransportProtocol(cfg.TransportConfig)
 }
 
 func newEBusDriverFactory(cfg ebusgateway.Config, protocol ebusgateway.TransportProtocol, needsPassive bool) transport.DriverRuntimeFactory {
+	var injectedUsed atomic.Bool
 	return func(ctx context.Context) (*transport.ManagedRawTransport, error) {
-		if protocol == ebusgateway.TransportAdapterDirect {
+		if protocol == ebusgateway.TransportAdapterDirect && cfg.Transport == nil {
 			return buildManagedAdapterDirectGeneration(ctx, cfg)
+		}
+		if cfg.Transport != nil && !injectedUsed.CompareAndSwap(false, true) {
+			return nil, transport.ErrDriverUnavailable
 		}
 		active, activeClose, err := ebusgateway.OpenEBusDriverTransport(ctx, cfg)
 		if err != nil {
@@ -111,7 +116,11 @@ func newEBusDriverFactory(cfg ebusgateway.Config, protocol ebusgateway.Transport
 		}
 		var passive transport.RawTransport
 		if needsPassive {
-			passive, err = ebusgateway.OpenEBusDriverPassiveTransport(ctx, cfg)
+			if cfg.PassiveTransport != nil {
+				passive = cfg.PassiveTransport
+			} else {
+				passive, err = ebusgateway.OpenEBusDriverPassiveTransport(ctx, cfg)
+			}
 			if err != nil {
 				// Return the partially constructed generation with its error so
 				// DriverRuntime retires it through the same CloseRequest/Closed
@@ -174,7 +183,7 @@ func (controller *ebusDriverController) Start(ctx context.Context) error {
 	if controller == nil || controller.manager == nil {
 		return drivermanager.ErrUnavailable
 	}
-	return controller.manager.Start(ctx, primaryEBusDriverID)
+	return controller.manager.StartAsync(ctx, primaryEBusDriverID)
 }
 
 func (controller *ebusDriverController) Shutdown(ctx context.Context) error {
@@ -547,15 +556,20 @@ func (slot *ebusStableAdapterDirectTransport) Write(payload []byte) (written int
 }
 
 type ebusStablePassiveTransport struct {
-	invoker ebusSlotInvoker
+	invoker  ebusSlotInvoker
+	reporter ebusFailureReporter
+
+	readMu  sync.Mutex
+	readSeq uint64
+	reads   map[uint64]context.CancelFunc
 }
 
 type ebusStableEnhancedPassiveTransport struct {
 	*ebusStablePassiveTransport
 }
 
-func newEBusStablePassiveTransport(invoker ebusSlotInvoker, protocol ebusgateway.TransportProtocol) transport.RawTransport {
-	base := &ebusStablePassiveTransport{invoker: invoker}
+func newEBusStablePassiveTransport(invoker ebusSlotInvoker, protocol ebusgateway.TransportProtocol, reporter ebusFailureReporter) transport.RawTransport {
+	base := &ebusStablePassiveTransport{invoker: invoker, reporter: reporter}
 	switch ebusgateway.CanonicalTransportProtocol(protocol) {
 	case ebusgateway.TransportENH, ebusgateway.TransportENS, ebusgateway.TransportAdapterDirect:
 		return &ebusStableEnhancedPassiveTransport{ebusStablePassiveTransport: base}
@@ -564,11 +578,13 @@ func newEBusStablePassiveTransport(invoker ebusSlotInvoker, protocol ebusgateway
 	}
 }
 
-func (slot *ebusStablePassiveTransport) withPassive(callback func(transport.RawTransport) error) error {
+func (slot *ebusStablePassiveTransport) withPassive(callback func(context.Context, transport.RawTransport) error) error {
 	if slot == nil || slot.invoker == nil {
 		return transport.ErrDriverUnavailable
 	}
-	_, err := slot.invoker.Invoke(context.Background(), drivermanager.CapabilityRead, func(raw transport.RawTransport) error {
+	readCtx, finishRead := slot.beginRead()
+	defer finishRead()
+	correlation, err := slot.invoker.Invoke(readCtx, drivermanager.CapabilityRead, func(raw transport.RawTransport) error {
 		provider, ok := raw.(interface{ PassiveTransport() transport.RawTransport })
 		if !ok {
 			return transport.ErrDriverUnavailable
@@ -577,29 +593,67 @@ func (slot *ebusStablePassiveTransport) withPassive(callback func(transport.RawT
 		if passive == nil {
 			return transport.ErrDriverUnavailable
 		}
-		return callback(passive)
+		return callback(readCtx, passive)
 	})
 	if errors.Is(err, drivermanager.ErrUnavailable) {
-		return errors.Join(transport.ErrDriverUnavailable, err)
+		err = errors.Join(transport.ErrDriverUnavailable, err)
+	}
+	if readCtx.Err() == nil && shouldReportPassiveFailure(err) && slot.reporter != nil {
+		slot.reporter(correlation, err)
 	}
 	return err
 }
 
+func (slot *ebusStablePassiveTransport) beginRead() (context.Context, func()) {
+	ctx, cancel := context.WithCancel(context.Background())
+	slot.readMu.Lock()
+	slot.readSeq++
+	id := slot.readSeq
+	if slot.reads == nil {
+		slot.reads = make(map[uint64]context.CancelFunc)
+	}
+	slot.reads[id] = cancel
+	slot.readMu.Unlock()
+	return ctx, func() {
+		cancel()
+		slot.readMu.Lock()
+		delete(slot.reads, id)
+		slot.readMu.Unlock()
+	}
+}
+
+func shouldReportPassiveFailure(err error) bool {
+	return err != nil &&
+		!errors.Is(err, context.Canceled) &&
+		!errors.Is(err, context.DeadlineExceeded) &&
+		!errors.Is(err, ebuserrors.ErrTimeout) &&
+		!errors.Is(err, transport.ErrDriverUnavailable) &&
+		!errors.Is(err, transport.ErrStaleDriverGeneration)
+}
+
 func (slot *ebusStablePassiveTransport) ReadByte() (value byte, err error) {
-	err = slot.withPassive(func(passive transport.RawTransport) error {
-		value, err = passive.ReadByte()
+	err = slot.withPassive(func(ctx context.Context, passive transport.RawTransport) error {
+		reader, ok := passive.(interface {
+			ReadByteContext(context.Context) (byte, error)
+		})
+		if !ok {
+			return transport.ErrDriverUnavailable
+		}
+		value, err = reader.ReadByteContext(ctx)
 		return err
 	})
 	return value, err
 }
 
 func (slot *ebusStableEnhancedPassiveTransport) ReadEvent() (event transport.StreamEvent, err error) {
-	err = slot.withPassive(func(passive transport.RawTransport) error {
-		reader, ok := passive.(transport.StreamEventReader)
+	err = slot.withPassive(func(ctx context.Context, passive transport.RawTransport) error {
+		reader, ok := passive.(interface {
+			ReadEventContext(context.Context) (transport.StreamEvent, error)
+		})
 		if !ok {
 			return transport.ErrDriverUnavailable
 		}
-		event, err = reader.ReadEvent()
+		event, err = reader.ReadEventContext(ctx)
 		return err
 	})
 	return event, err
@@ -609,7 +663,21 @@ func (*ebusStablePassiveTransport) Write([]byte) (int, error) {
 	return 0, transport.ErrDriverUnavailable
 }
 
-func (*ebusStablePassiveTransport) Close() error { return nil }
+func (slot *ebusStablePassiveTransport) Close() error {
+	if slot == nil {
+		return nil
+	}
+	slot.readMu.Lock()
+	cancels := make([]context.CancelFunc, 0, len(slot.reads))
+	for _, cancel := range slot.reads {
+		cancels = append(cancels, cancel)
+	}
+	slot.readMu.Unlock()
+	for _, cancel := range cancels {
+		cancel()
+	}
+	return nil
+}
 
 func (*ebusStableEnhancedPassiveTransport) BytesAreUnescaped() bool { return true }
 
@@ -661,12 +729,13 @@ func (classifier *ebusStableClassifier) ActiveTxnSnapshot() (snapshot adaptermux
 
 func (classifier *ebusStableClassifier) V8Classifier() (result *v8classifier.Classifier) {
 	classifier.withClassifier(func(current activeTxnClassifier) {
-		mux, ok := current.(*adaptermux.Mux)
+		provider, ok := current.(interface {
+			V8Classifier() *v8classifier.Classifier
+		})
 		if ok {
-			result = mux.V8Classifier()
+			result = provider.V8Classifier()
 		}
 	})
-	v8AdminEventsCurrentClassifier.Store(result)
 	return result
 }
 
@@ -675,11 +744,15 @@ type managedEBusReadResult struct {
 	err   error
 }
 
+type managedEBusReadRequest struct {
+	ctx    context.Context
+	result chan managedEBusReadResult
+}
+
 type managedEBusEndpoint struct {
 	ctx      context.Context
 	raw      transport.RawTransport
-	demand   chan struct{}
-	results  chan managedEBusReadResult
+	requests chan managedEBusReadRequest
 	pumpDone chan struct{}
 	closing  *atomic.Bool
 }
@@ -731,8 +804,7 @@ func newManagedEBusEndpoint(ctx context.Context, raw transport.RawTransport, clo
 	endpoint := &managedEBusEndpoint{
 		ctx:      ctx,
 		raw:      raw,
-		demand:   make(chan struct{}),
-		results:  make(chan managedEBusReadResult),
+		requests: make(chan managedEBusReadRequest),
 		pumpDone: make(chan struct{}),
 		closing:  closing,
 	}
@@ -753,19 +825,20 @@ func (endpoint *managedEBusEndpoint) pump() {
 		select {
 		case <-endpoint.ctx.Done():
 			return
-		case <-endpoint.demand:
-		}
-		if endpoint.ctx.Err() != nil {
-			return
-		}
-		event, err := readManagedEBusEvent(endpoint.raw)
-		select {
-		case endpoint.results <- managedEBusReadResult{event: event, err: err}:
-		case <-endpoint.ctx.Done():
-			return
-		}
-		if err != nil && endpoint.closing.Load() {
-			return
+		case request := <-endpoint.requests:
+			if request.ctx.Err() != nil {
+				continue
+			}
+			event, err := readManagedEBusEvent(endpoint.raw)
+			select {
+			case request.result <- managedEBusReadResult{event: event, err: err}:
+			case <-request.ctx.Done():
+			case <-endpoint.ctx.Done():
+				return
+			}
+			if err != nil && endpoint.closing.Load() {
+				return
+			}
 		}
 	}
 }
@@ -798,23 +871,20 @@ func readManagedEBusEvent(raw transport.RawTransport) (transport.StreamEvent, er
 }
 
 func (endpoint *managedEBusEndpoint) nextByte() (byte, bool, error) {
+	return endpoint.nextByteContext(context.Background())
+}
+
+func (endpoint *managedEBusEndpoint) nextByteContext(ctx context.Context) (byte, bool, error) {
 	for {
-		if err := endpoint.requestRead(); err != nil {
-			return 0, false, err
+		result := endpoint.readContext(ctx)
+		if result.err != nil {
+			return 0, false, result.err
 		}
-		select {
-		case <-endpoint.ctx.Done():
-			return 0, false, ebuserrors.ErrTransportClosed
-		case result := <-endpoint.results:
-			if result.err != nil {
-				return 0, false, result.err
-			}
-			switch result.event.Kind {
-			case transport.StreamEventByte:
-				return result.event.Byte, result.event.WasEscaped, nil
-			case transport.StreamEventReset:
-				return 0, false, ebuserrors.ErrAdapterReset
-			}
+		switch result.event.Kind {
+		case transport.StreamEventByte:
+			return result.event.Byte, result.event.WasEscaped, nil
+		case transport.StreamEventReset:
+			return 0, false, ebuserrors.ErrAdapterReset
 		}
 	}
 }
@@ -833,26 +903,36 @@ func (generation *managedEBusGeneration) ReadEvent() (transport.StreamEvent, err
 }
 
 func (endpoint *managedEBusEndpoint) readEvent() (transport.StreamEvent, error) {
-	if err := endpoint.requestRead(); err != nil {
-		return transport.StreamEvent{}, err
-	}
-	select {
-	case <-endpoint.ctx.Done():
-		return transport.StreamEvent{}, ebuserrors.ErrTransportClosed
-	case result := <-endpoint.results:
-		return result.event, result.err
-	}
+	return endpoint.readEventContext(context.Background())
 }
 
-func (endpoint *managedEBusEndpoint) requestRead() error {
+func (endpoint *managedEBusEndpoint) readEventContext(ctx context.Context) (transport.StreamEvent, error) {
+	result := endpoint.readContext(ctx)
+	return result.event, result.err
+}
+
+func (endpoint *managedEBusEndpoint) readContext(ctx context.Context) managedEBusReadResult {
 	if endpoint == nil || endpoint.raw == nil {
-		return transport.ErrDriverUnavailable
+		return managedEBusReadResult{err: transport.ErrDriverUnavailable}
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	request := managedEBusReadRequest{ctx: ctx, result: make(chan managedEBusReadResult)}
+	select {
+	case <-endpoint.ctx.Done():
+		return managedEBusReadResult{err: ebuserrors.ErrTransportClosed}
+	case <-ctx.Done():
+		return managedEBusReadResult{err: ctx.Err()}
+	case endpoint.requests <- request:
 	}
 	select {
 	case <-endpoint.ctx.Done():
-		return ebuserrors.ErrTransportClosed
-	case endpoint.demand <- struct{}{}:
-		return nil
+		return managedEBusReadResult{err: ebuserrors.ErrTransportClosed}
+	case <-ctx.Done():
+		return managedEBusReadResult{err: ctx.Err()}
+	case result := <-request.result:
+		return result
 	}
 }
 
@@ -945,8 +1025,17 @@ func (passive *managedEBusPassiveTransport) ReadByte() (byte, error) {
 	return value, err
 }
 
+func (passive *managedEBusPassiveTransport) ReadByteContext(ctx context.Context) (byte, error) {
+	value, _, err := passive.endpoint.nextByteContext(ctx)
+	return value, err
+}
+
 func (passive *managedEBusPassiveTransport) ReadEvent() (transport.StreamEvent, error) {
 	return passive.endpoint.readEvent()
+}
+
+func (passive *managedEBusPassiveTransport) ReadEventContext(ctx context.Context) (transport.StreamEvent, error) {
+	return passive.endpoint.readEventContext(ctx)
 }
 
 func (*managedEBusPassiveTransport) Write([]byte) (int, error) {

--- a/cmd/gateway/ebus_driver_runtime.go
+++ b/cmd/gateway/ebus_driver_runtime.go
@@ -147,18 +147,19 @@ func newEBusDriverFactory(cfg ebusgateway.Config, protocol ebusgateway.Transport
 }
 
 func buildManagedAdapterDirectGeneration(factoryCtx context.Context, cfg ebusgateway.Config, v8Counter *ebusV8CumulativeCounter) (*transport.ManagedRawTransport, error) {
-	adapterCtx, adapterCancel := context.WithCancel(context.Background())
-	stopForward := context.AfterFunc(factoryCtx, adapterCancel)
+	// DriverRuntime owns factoryCtx for the admitted generation and cancels it
+	// at the withdrawal boundary. Deriving the adapter context preserves that
+	// fence for the proxy listener and mux; close proof still belongs to the
+	// adapter-owned lifecycle worker below.
+	adapterCtx, adapterCancel := context.WithCancel(factoryCtx)
 	generationCfg := cfg
 	health := &ebusGenerationHealth{}
 	closer, classifier, err := wireAdapterDirectWithConnectionLost(adapterCtx, &generationCfg, health.connectionLost)
 	if err != nil {
-		stopForward()
 		adapterCancel()
 		return nil, err
 	}
 	if generationCfg.Transport == nil || closer == nil {
-		stopForward()
 		adapterCancel()
 		return nil, errors.New("adapter-direct provider unavailable")
 	}
@@ -171,16 +172,17 @@ func buildManagedAdapterDirectGeneration(factoryCtx context.Context, cfg ebusgat
 	managed := newManagedEBusGenerationParts(factoryCtx, generationCfg.Transport, generationCfg.PassiveTransport, classifier, closeFn)
 	if generation, ok := managed.Transport.(*managedEBusGeneration); ok {
 		generation.health = health
+		generation.adapterCancel = adapterCancel
+		if lifecycle, ok := classifier.(managedEBusProxyLifecycle); ok {
+			generation.proxyLifecycle = lifecycle
+		}
 		// The adapter-direct constructor returns successfully only after the
 		// configured proxy listener has bound. Keep that fact generation-local;
 		// readiness still has to acquire this generation through DriverManager.
 		generation.proxyListenerBound = generationCfg.ProxyListenAddr != ""
 	}
-	if !stopForward() || factoryCtx.Err() != nil {
-		if err := factoryCtx.Err(); err != nil {
-			return managed, err
-		}
-		return managed, context.Canceled
+	if err := factoryCtx.Err(); err != nil {
+		return managed, err
 	}
 	return managed, nil
 }
@@ -241,7 +243,7 @@ func (controller *ebusDriverController) ProxyReadiness() string {
 		drivermanager.CapabilityRead,
 		func(provider any) error {
 			generation, ok := provider.(*managedEBusGeneration)
-			if !ok || generation == nil || !generation.proxyListenerBound {
+			if !ok || generation == nil || !generation.proxyReady() {
 				return drivermanager.ErrUnavailable
 			}
 			return nil
@@ -281,6 +283,7 @@ type ebusDriverRuntime struct {
 	runtime  *transport.DriverRuntime
 	reporter ebusFailureReporter
 	running  chan<- drivermanager.Correlation
+	current  atomic.Pointer[managedEBusGeneration]
 }
 
 func (runtime *ebusDriverRuntime) Start(ctx context.Context) (uint64, error) {
@@ -288,6 +291,9 @@ func (runtime *ebusDriverRuntime) Start(ctx context.Context) (uint64, error) {
 		return 0, drivermanager.ErrUnavailable
 	}
 	generation, err := runtime.runtime.Start(ctx)
+	if err == nil {
+		runtime.captureGeneration(generation)
+	}
 	return generation, mapEBusLifecycleError(err)
 }
 
@@ -295,7 +301,12 @@ func (runtime *ebusDriverRuntime) Replace(ctx context.Context) (uint64, error) {
 	if runtime == nil || runtime.runtime == nil {
 		return 0, drivermanager.ErrUnavailable
 	}
+	runtime.FenceWithdrawal()
+	runtime.current.Store(nil)
 	generation, err := runtime.runtime.Replace(ctx)
+	if err == nil {
+		runtime.captureGeneration(generation)
+	}
 	return generation, mapEBusLifecycleError(err)
 }
 
@@ -303,7 +314,42 @@ func (runtime *ebusDriverRuntime) Stop(ctx context.Context) error {
 	if runtime == nil || runtime.runtime == nil {
 		return nil
 	}
+	runtime.FenceWithdrawal()
+	runtime.current.Store(nil)
 	return mapEBusLifecycleError(runtime.runtime.Stop(ctx))
+}
+
+// FenceWithdrawal implements drivermanager's private non-blocking withdrawal
+// hook. It must remain lock-free and manager-non-reentrant because the manager
+// invokes it under the same state lock that publishes STOPPING.
+func (runtime *ebusDriverRuntime) FenceWithdrawal() {
+	if runtime == nil {
+		return
+	}
+	if generation := runtime.current.Load(); generation != nil {
+		generation.fenceProxy()
+	}
+}
+
+func (runtime *ebusDriverRuntime) captureGeneration(generation uint64) {
+	if runtime == nil || runtime.runtime == nil || generation == 0 {
+		return
+	}
+	lease, err := runtime.runtime.Admit(context.Background())
+	if err != nil {
+		return
+	}
+	defer func() { _ = lease.Release() }()
+	if lease.Generation() != generation {
+		return
+	}
+	_ = lease.Invoke(func(raw transport.RawTransport) error {
+		managed, ok := raw.(*managedEBusGeneration)
+		if ok {
+			runtime.current.Store(managed)
+		}
+		return nil
+	})
 }
 
 func (runtime *ebusDriverRuntime) Generation() uint64 {
@@ -342,8 +388,11 @@ func (runtime *ebusDriverRuntime) BindCorrelation(correlation drivermanager.Corr
 	}
 	err = lease.Invoke(func(raw transport.RawTransport) error {
 		generation, ok := raw.(*managedEBusGeneration)
-		if ok && runtime.reporter != nil {
-			generation.bindFailureReporter(correlation, runtime.reporter)
+		if ok {
+			runtime.current.Store(generation)
+			if runtime.reporter != nil {
+				generation.bindFailureReporter(correlation, runtime.reporter)
+			}
 		}
 		return nil
 	})
@@ -954,6 +1003,11 @@ type ebusGenerationHealth struct {
 	reporter    ebusFailureReporter
 }
 
+type managedEBusProxyLifecycle interface {
+	FenceManagedConnection()
+	ManagedConnectionReady() bool
+}
+
 func (health *ebusGenerationHealth) connectionLost() {
 	health.mu.Lock()
 	health.lost = true
@@ -996,11 +1050,29 @@ type managedEBusGeneration struct {
 	closeFn            func() error
 	health             *ebusGenerationHealth
 	proxyListenerBound bool
+	proxyLifecycle     managedEBusProxyLifecycle
+	adapterCancel      context.CancelFunc
 
 	closeRequest chan struct{}
 	closed       chan struct{}
 	closing      atomic.Bool
 	closeOnce    sync.Once
+}
+
+func (generation *managedEBusGeneration) fenceProxy() {
+	if generation == nil {
+		return
+	}
+	if generation.proxyLifecycle != nil {
+		generation.proxyLifecycle.FenceManagedConnection()
+	}
+	if generation.adapterCancel != nil {
+		generation.adapterCancel()
+	}
+}
+
+func (generation *managedEBusGeneration) proxyReady() bool {
+	return generation != nil && generation.proxyListenerBound && generation.proxyLifecycle != nil && generation.proxyLifecycle.ManagedConnectionReady()
 }
 
 func (generation *managedEBusGeneration) bindFailureReporter(correlation drivermanager.Correlation, reporter ebusFailureReporter) {

--- a/cmd/gateway/ebus_driver_runtime.go
+++ b/cmd/gateway/ebus_driver_runtime.go
@@ -500,10 +500,24 @@ func (runtime *ebusDriverRuntime) SafetyQuarantined() bool {
 	return runtime != nil && runtime.runtime != nil && runtime.runtime.SafetyQuarantined()
 }
 
-// BindCorrelation attaches asynchronous generation health only after
-// DriverManager has published RUNNING with a stable operation-zero
-// correlation. If loss raced construction, the generation health object
-// replays it exactly once here.
+// ActivateCorrelation publishes the process-local generation lifecycle before
+// DriverManager exposes RUNNING capabilities. It is bounded and never calls
+// back into DriverManager; asynchronous health binding remains a separate
+// post-publication operation below.
+func (runtime *ebusDriverRuntime) ActivateCorrelation(correlation drivermanager.Correlation) {
+	if runtime == nil || runtime.runtime == nil || correlation.Generation == 0 {
+		return
+	}
+	if runtime.runtime.Generation() != correlation.Generation {
+		return
+	}
+	runtime.activateLifecycle(correlation)
+}
+
+// BindCorrelation attaches asynchronous generation health after DriverManager
+// has published RUNNING with a stable operation-zero correlation. If loss
+// raced construction, the generation health object replays it exactly once
+// here and may therefore re-enter DriverManager.
 func (runtime *ebusDriverRuntime) BindCorrelation(correlation drivermanager.Correlation) {
 	if runtime == nil || runtime.runtime == nil || correlation.Generation == 0 {
 		return
@@ -520,10 +534,6 @@ func (runtime *ebusDriverRuntime) BindCorrelation(correlation drivermanager.Corr
 		generation, ok := raw.(*managedEBusGeneration)
 		if ok {
 			runtime.current.Store(generation)
-			// Activation must precede asynchronous health binding: bind may
-			// synchronously replay an already-observed connection loss, whose
-			// DriverManager failure path then withdraws this exact correlation.
-			runtime.activateLifecycle(correlation)
 			if runtime.reporter != nil {
 				generation.bindFailureReporter(correlation, runtime.reporter)
 			}

--- a/cmd/gateway/ebus_driver_runtime.go
+++ b/cmd/gateway/ebus_driver_runtime.go
@@ -170,9 +170,18 @@ func buildManagedAdapterDirectGeneration(factoryCtx context.Context, cfg ebusgat
 		adapterCancel()
 		return nil, errors.New("adapter-direct provider unavailable")
 	}
+	passiveBridge := generationCfg.PassiveTransport
 	closeFn := func() error {
 		adapterCancel()
-		err := closer()
+		// The passive bridge is generation-owned but is not closed by Mux.Close:
+		// the mux only retains its delivery callback. Close it before waiting on
+		// the adapter-owned passive pump, otherwise a demanded ReadEvent can stay
+		// parked forever after both Stop and loss-driven Replace.
+		var passiveErr error
+		if passiveBridge != nil {
+			passiveErr = passiveBridge.Close()
+		}
+		err := errors.Join(passiveErr, closer())
 		v8Counter.retire(classifier)
 		return err
 	}

--- a/cmd/gateway/ebus_driver_runtime.go
+++ b/cmd/gateway/ebus_driver_runtime.go
@@ -23,6 +23,7 @@ const (
 	defaultEBusRetryBudget        = 5
 	defaultEBusRetryInitialDelay  = time.Second
 	defaultEBusRetryMaxDelay      = 30 * time.Second
+	defaultEBusRetryJitterRatio   = 0.2
 )
 
 type ebusDriverController struct {
@@ -56,6 +57,7 @@ func newEBusDriverController(cfg ebusgateway.Config) (*ebusDriverController, err
 			Budget:       defaultEBusRetryBudget,
 			InitialDelay: defaultEBusRetryInitialDelay,
 			MaxDelay:     defaultEBusRetryMaxDelay,
+			JitterRatio:  defaultEBusRetryJitterRatio,
 		},
 	}}})
 	if err != nil {

--- a/cmd/gateway/ebus_driver_runtime.go
+++ b/cmd/gateway/ebus_driver_runtime.go
@@ -755,16 +755,20 @@ func (classifier *ebusStableClassifier) ActiveTxnSnapshot() (snapshot adaptermux
 	return snapshot
 }
 
-func (classifier *ebusStableClassifier) V8Classifier() (result *v8classifier.Classifier) {
+func (classifier *ebusStableClassifier) WithV8Classifier(callback func(*v8classifier.Classifier)) {
+	if callback == nil {
+		return
+	}
 	classifier.withClassifier(func(current activeTxnClassifier) {
 		provider, ok := current.(interface {
 			V8Classifier() *v8classifier.Classifier
 		})
 		if ok {
-			result = provider.V8Classifier()
+			if v8 := provider.V8Classifier(); v8 != nil {
+				callback(v8)
+			}
 		}
 	})
-	return result
 }
 
 type managedEBusReadResult struct {
@@ -909,6 +913,15 @@ func (endpoint *managedEBusEndpoint) pump() {
 				continue
 			}
 			event, err := readManagedEBusEvent(endpoint.raw)
+			// Generation withdrawal dominates a final raw result. These explicit
+			// checks avoid relying on select ordering when cancellation and the
+			// old connection's last byte become ready together.
+			if endpoint.ctx.Err() != nil {
+				return
+			}
+			if request.ctx.Err() != nil {
+				continue
+			}
 			select {
 			case request.result <- managedEBusReadResult{event: event, err: err}:
 			case <-request.ctx.Done():
@@ -1005,14 +1018,30 @@ func (endpoint *managedEBusEndpoint) readContext(ctx context.Context) managedEBu
 		return managedEBusReadResult{err: ctx.Err()}
 	case endpoint.requests <- request:
 	}
+	if canceled, ok := endpoint.cancellationResult(ctx); ok {
+		return canceled
+	}
 	select {
 	case <-endpoint.ctx.Done():
 		return managedEBusReadResult{err: ebuserrors.ErrTransportClosed}
 	case <-ctx.Done():
 		return managedEBusReadResult{err: ctx.Err()}
 	case result := <-request.result:
+		if canceled, ok := endpoint.cancellationResult(ctx); ok {
+			return canceled
+		}
 		return result
 	}
+}
+
+func (endpoint *managedEBusEndpoint) cancellationResult(ctx context.Context) (managedEBusReadResult, bool) {
+	if endpoint.ctx.Err() != nil {
+		return managedEBusReadResult{err: ebuserrors.ErrTransportClosed}, true
+	}
+	if ctx.Err() != nil {
+		return managedEBusReadResult{err: ctx.Err()}, true
+	}
+	return managedEBusReadResult{}, false
 }
 
 func (generation *managedEBusGeneration) Write(payload []byte) (int, error) {

--- a/cmd/gateway/ebus_driver_runtime.go
+++ b/cmd/gateway/ebus_driver_runtime.go
@@ -30,16 +30,19 @@ type ebusDriverController struct {
 	active     transport.RawTransport
 	passive    transport.RawTransport
 	classifier activeTxnClassifier
+	running    <-chan drivermanager.Correlation
 }
 
 func newEBusDriverController(cfg ebusgateway.Config) (*ebusDriverController, error) {
 	protocol := configuredEBusDriverProtocol(cfg)
 	needsPassive := cfg.BroadcastListen && (protocol == ebusgateway.TransportAdapterDirect || shouldStartPassiveObserveFirst(cfg))
+	running := make(chan drivermanager.Correlation, 1)
+	v8Counter := &ebusV8CumulativeCounter{}
 	runtimeSeam := transport.NewDriverRuntime(
-		newEBusDriverFactory(cfg, protocol, needsPassive),
+		newEBusDriverFactory(cfg, protocol, needsPassive, v8Counter),
 		transport.DriverRuntimeConfig{DrainTimeout: defaultEBusDriverDrainTimeout},
 	)
-	runtime := &ebusDriverRuntime{runtime: runtimeSeam}
+	runtime := &ebusDriverRuntime{runtime: runtimeSeam, running: running}
 	manager, err := drivermanager.New(drivermanager.Config{Drivers: []drivermanager.DriverConfig{{
 		ID:      primaryEBusDriverID,
 		Enabled: true,
@@ -69,6 +72,7 @@ func newEBusDriverController(cfg ebusgateway.Config) (*ebusDriverController, err
 	controller := &ebusDriverController{
 		manager: manager,
 		active:  newManagedEBusStableTransport(manager, protocol, reporter),
+		running: running,
 	}
 	if needsPassive {
 		controller.passive = newEBusStablePassiveTransport(
@@ -78,7 +82,10 @@ func newEBusDriverController(cfg ebusgateway.Config) (*ebusDriverController, err
 		)
 	}
 	if protocol == ebusgateway.TransportAdapterDirect {
-		controller.classifier = &ebusStableClassifier{invoker: managedEBusSlotInvoker{manager: manager, id: primaryEBusDriverID}}
+		controller.classifier = &ebusStableClassifier{
+			invoker: managedEBusSlotInvoker{manager: manager, id: primaryEBusDriverID},
+			counter: v8Counter,
+		}
 	}
 	return controller, nil
 }
@@ -96,11 +103,11 @@ func configuredEBusDriverProtocol(cfg ebusgateway.Config) ebusgateway.TransportP
 	return ebusgateway.EBusDriverTransportProtocol(cfg.TransportConfig)
 }
 
-func newEBusDriverFactory(cfg ebusgateway.Config, protocol ebusgateway.TransportProtocol, needsPassive bool) transport.DriverRuntimeFactory {
+func newEBusDriverFactory(cfg ebusgateway.Config, protocol ebusgateway.TransportProtocol, needsPassive bool, v8Counter *ebusV8CumulativeCounter) transport.DriverRuntimeFactory {
 	var injectedUsed atomic.Bool
 	return func(ctx context.Context) (*transport.ManagedRawTransport, error) {
 		if protocol == ebusgateway.TransportAdapterDirect && cfg.Transport == nil {
-			return buildManagedAdapterDirectGeneration(ctx, cfg)
+			return buildManagedAdapterDirectGeneration(ctx, cfg, v8Counter)
 		}
 		if cfg.Transport != nil && !injectedUsed.CompareAndSwap(false, true) {
 			return nil, transport.ErrDriverUnavailable
@@ -137,7 +144,7 @@ func newEBusDriverFactory(cfg ebusgateway.Config, protocol ebusgateway.Transport
 	}
 }
 
-func buildManagedAdapterDirectGeneration(factoryCtx context.Context, cfg ebusgateway.Config) (*transport.ManagedRawTransport, error) {
+func buildManagedAdapterDirectGeneration(factoryCtx context.Context, cfg ebusgateway.Config, v8Counter *ebusV8CumulativeCounter) (*transport.ManagedRawTransport, error) {
 	adapterCtx, adapterCancel := context.WithCancel(context.Background())
 	stopForward := context.AfterFunc(factoryCtx, adapterCancel)
 	generationCfg := cfg
@@ -155,7 +162,9 @@ func buildManagedAdapterDirectGeneration(factoryCtx context.Context, cfg ebusgat
 	}
 	closeFn := func() error {
 		adapterCancel()
-		return closer()
+		err := closer()
+		v8Counter.retire(classifier)
+		return err
 	}
 	managed := newManagedEBusGenerationParts(factoryCtx, generationCfg.Transport, generationCfg.PassiveTransport, classifier, closeFn)
 	if generation, ok := managed.Transport.(*managedEBusGeneration); ok {
@@ -203,9 +212,34 @@ func (controller *ebusDriverController) Snapshot() drivermanager.Snapshot {
 	return snapshot
 }
 
+// WaitRunning blocks eBUS-only startup work until a correlated generation is
+// actually admitted. The process-owned HTTP/API shell is started before this
+// wait, so a slow provider cannot delay control-plane availability.
+func (controller *ebusDriverController) WaitRunning(ctx context.Context) bool {
+	if controller == nil || controller.manager == nil {
+		return false
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	for {
+		if controller.Snapshot().ObservedState == drivermanager.ObservedRunning {
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-controller.running:
+			// Loss can race the RUNNING notification, so always recheck the
+			// manager's correlated state before admitting startup work.
+		}
+	}
+}
+
 type ebusDriverRuntime struct {
 	runtime  *transport.DriverRuntime
 	reporter ebusFailureReporter
+	running  chan<- drivermanager.Correlation
 }
 
 func (runtime *ebusDriverRuntime) Start(ctx context.Context) (uint64, error) {
@@ -254,7 +288,7 @@ func (runtime *ebusDriverRuntime) SafetyQuarantined() bool {
 // correlation. If loss raced construction, the generation health object
 // replays it exactly once here.
 func (runtime *ebusDriverRuntime) BindCorrelation(correlation drivermanager.Correlation) {
-	if runtime == nil || runtime.runtime == nil || runtime.reporter == nil || correlation.Generation == 0 {
+	if runtime == nil || runtime.runtime == nil || correlation.Generation == 0 {
 		return
 	}
 	lease, err := runtime.runtime.Admit(context.Background())
@@ -265,13 +299,22 @@ func (runtime *ebusDriverRuntime) BindCorrelation(correlation drivermanager.Corr
 	if lease.Generation() != correlation.Generation {
 		return
 	}
-	_ = lease.Invoke(func(raw transport.RawTransport) error {
+	err = lease.Invoke(func(raw transport.RawTransport) error {
 		generation, ok := raw.(*managedEBusGeneration)
-		if ok {
+		if ok && runtime.reporter != nil {
 			generation.bindFailureReporter(correlation, runtime.reporter)
 		}
 		return nil
 	})
+	if err != nil || runtime.running == nil {
+		return
+	}
+	select {
+	case runtime.running <- correlation:
+	default:
+		// One buffered wakeup is enough because WaitRunning rechecks the
+		// authoritative manager snapshot after every notification.
+	}
 }
 
 func (runtime *ebusDriverRuntime) Admit(ctx context.Context) (*drivermanager.Admission, error) {
@@ -711,6 +754,56 @@ func (*ebusStableEnhancedPassiveTransport) BytesAreUnescaped() bool { return tru
 
 type ebusStableClassifier struct {
 	invoker ebusSlotInvoker
+	counter *ebusV8CumulativeCounter
+}
+
+// ebusV8CumulativeCounter keeps the process-level Prometheus/expvar total
+// monotonic while adapter-direct classifiers remain generation-owned. The
+// live classifier is read only inside stable driver admission; retirement
+// captures increments that happened between scrapes before it is discarded.
+type ebusV8CumulativeCounter struct {
+	mu      sync.Mutex
+	retired uint64
+	floor   uint64
+}
+
+func (counter *ebusV8CumulativeCounter) retire(classifier activeTxnClassifier) {
+	if counter == nil {
+		return
+	}
+	current := v8ClassifierFor(classifier).ShadowWouldHaveDroppedTotal()
+	counter.mu.Lock()
+	counter.retired += current
+	if counter.retired > counter.floor {
+		counter.floor = counter.retired
+	}
+	counter.mu.Unlock()
+}
+
+func (counter *ebusV8CumulativeCounter) total(current *v8classifier.Classifier) uint64 {
+	if counter == nil {
+		return current.ShadowWouldHaveDroppedTotal()
+	}
+	currentTotal := current.ShadowWouldHaveDroppedTotal()
+	counter.mu.Lock()
+	total := counter.retired + currentTotal
+	if total > counter.floor {
+		counter.floor = total
+	} else {
+		total = counter.floor
+	}
+	counter.mu.Unlock()
+	return total
+}
+
+func v8ClassifierFor(classifier activeTxnClassifier) *v8classifier.Classifier {
+	provider, ok := classifier.(interface {
+		V8Classifier() *v8classifier.Classifier
+	})
+	if !ok {
+		return nil
+	}
+	return provider.V8Classifier()
 }
 
 func (classifier *ebusStableClassifier) withClassifier(callback func(activeTxnClassifier)) {
@@ -769,6 +862,25 @@ func (classifier *ebusStableClassifier) WithV8Classifier(callback func(*v8classi
 			}
 		}
 	})
+}
+
+// V8ShadowWouldHaveDroppedTotal resolves the live generation under admission
+// and folds it into a process-owned cumulative offset. During replacement,
+// when no generation is admitted, the last monotonic floor is returned.
+func (classifier *ebusStableClassifier) V8ShadowWouldHaveDroppedTotal() uint64 {
+	if classifier == nil {
+		return 0
+	}
+	var total uint64
+	resolved := false
+	classifier.withClassifier(func(current activeTxnClassifier) {
+		resolved = true
+		total = classifier.counter.total(v8ClassifierFor(current))
+	})
+	if !resolved {
+		return classifier.counter.total(nil)
+	}
+	return total
 }
 
 type managedEBusReadResult struct {

--- a/cmd/gateway/ebus_driver_runtime.go
+++ b/cmd/gateway/ebus_driver_runtime.go
@@ -64,6 +64,7 @@ func newEBusDriverController(cfg ebusgateway.Config) (*ebusDriverController, err
 	reporter := func(correlation drivermanager.Correlation, rawErr error) {
 		manager.ReportFailure(primaryEBusDriverID, correlation, classifyEBusDriverError(rawErr))
 	}
+	runtime.reporter = reporter
 	controller := &ebusDriverController{
 		manager: manager,
 		active:  newManagedEBusStableTransport(manager, protocol, reporter),
@@ -143,7 +144,8 @@ func buildManagedAdapterDirectGeneration(factoryCtx context.Context, cfg ebusgat
 	adapterCtx, adapterCancel := context.WithCancel(context.Background())
 	stopForward := context.AfterFunc(factoryCtx, adapterCancel)
 	generationCfg := cfg
-	closer, classifier, err := wireAdapterDirect(adapterCtx, &generationCfg)
+	health := &ebusGenerationHealth{}
+	closer, classifier, err := wireAdapterDirectWithConnectionLost(adapterCtx, &generationCfg, health.connectionLost)
 	if err != nil {
 		stopForward()
 		adapterCancel()
@@ -159,6 +161,9 @@ func buildManagedAdapterDirectGeneration(factoryCtx context.Context, cfg ebusgat
 		return closer()
 	}
 	managed := newManagedEBusGenerationParts(factoryCtx, generationCfg.Transport, generationCfg.PassiveTransport, classifier, closeFn)
+	if generation, ok := managed.Transport.(*managedEBusGeneration); ok {
+		generation.health = health
+	}
 	if !stopForward() || factoryCtx.Err() != nil {
 		if err := factoryCtx.Err(); err != nil {
 			return managed, err
@@ -202,7 +207,8 @@ func (controller *ebusDriverController) Snapshot() drivermanager.Snapshot {
 }
 
 type ebusDriverRuntime struct {
-	runtime *transport.DriverRuntime
+	runtime  *transport.DriverRuntime
+	reporter ebusFailureReporter
 }
 
 func (runtime *ebusDriverRuntime) Start(ctx context.Context) (uint64, error) {
@@ -244,6 +250,31 @@ func (runtime *ebusDriverRuntime) Revision() uint64 {
 
 func (runtime *ebusDriverRuntime) SafetyQuarantined() bool {
 	return runtime != nil && runtime.runtime != nil && runtime.runtime.SafetyQuarantined()
+}
+
+// BindCorrelation attaches asynchronous generation health only after
+// DriverManager has published RUNNING with a stable operation-zero
+// correlation. If loss raced construction, the generation health object
+// replays it exactly once here.
+func (runtime *ebusDriverRuntime) BindCorrelation(correlation drivermanager.Correlation) {
+	if runtime == nil || runtime.runtime == nil || runtime.reporter == nil || correlation.Generation == 0 {
+		return
+	}
+	lease, err := runtime.runtime.Admit(context.Background())
+	if err != nil {
+		return
+	}
+	defer func() { _ = lease.Release() }()
+	if lease.Generation() != correlation.Generation {
+		return
+	}
+	_ = lease.Invoke(func(raw transport.RawTransport) error {
+		generation, ok := raw.(*managedEBusGeneration)
+		if ok {
+			generation.bindFailureReporter(correlation, runtime.reporter)
+		}
+		return nil
+	})
 }
 
 func (runtime *ebusDriverRuntime) Admit(ctx context.Context) (*drivermanager.Admission, error) {
@@ -757,6 +788,50 @@ type managedEBusEndpoint struct {
 	closing  *atomic.Bool
 }
 
+// ebusGenerationHealth bridges adapter-owned asynchronous connection loss to
+// the manager's exact stable generation. Loss may race construction, so it is
+// retained until RUNNING correlation is bound. Each generation reports at most
+// once; ordinary read timeouts never call connectionLost.
+type ebusGenerationHealth struct {
+	mu          sync.Mutex
+	lost        bool
+	reported    bool
+	correlation drivermanager.Correlation
+	reporter    ebusFailureReporter
+}
+
+func (health *ebusGenerationHealth) connectionLost() {
+	health.mu.Lock()
+	health.lost = true
+	reporter, correlation := health.pendingReportLocked()
+	health.mu.Unlock()
+	if reporter != nil {
+		reporter(correlation, ebuserrors.ErrAdapterReset)
+	}
+}
+
+func (health *ebusGenerationHealth) bind(correlation drivermanager.Correlation, reporter ebusFailureReporter) {
+	if health == nil || reporter == nil || correlation.Generation == 0 {
+		return
+	}
+	health.mu.Lock()
+	health.correlation = correlation
+	health.reporter = reporter
+	report, reportCorrelation := health.pendingReportLocked()
+	health.mu.Unlock()
+	if report != nil {
+		report(reportCorrelation, ebuserrors.ErrAdapterReset)
+	}
+}
+
+func (health *ebusGenerationHealth) pendingReportLocked() (ebusFailureReporter, drivermanager.Correlation) {
+	if !health.lost || health.reported || health.reporter == nil || health.correlation.Generation == 0 {
+		return nil, drivermanager.Correlation{}
+	}
+	health.reported = true
+	return health.reporter, health.correlation
+}
+
 // managedEBusGeneration keeps the blocking raw reader adapter-owned. Stable
 // provider callbacks block only on results and return as soon as generation
 // context is canceled, allowing DriverRuntime to drain before CloseRequest.
@@ -765,11 +840,18 @@ type managedEBusGeneration struct {
 	passive    *managedEBusEndpoint
 	classifier activeTxnClassifier
 	closeFn    func() error
+	health     *ebusGenerationHealth
 
 	closeRequest chan struct{}
 	closed       chan struct{}
 	closing      atomic.Bool
 	closeOnce    sync.Once
+}
+
+func (generation *managedEBusGeneration) bindFailureReporter(correlation drivermanager.Correlation, reporter ebusFailureReporter) {
+	if generation != nil && generation.health != nil {
+		generation.health.bind(correlation, reporter)
+	}
 }
 
 func newManagedEBusGeneration(ctx context.Context, raw transport.RawTransport, closeFn func() error) *transport.ManagedRawTransport {

--- a/cmd/gateway/ebus_driver_runtime.go
+++ b/cmd/gateway/ebus_driver_runtime.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"errors"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -93,10 +92,6 @@ func configuredEBusDriverProtocol(cfg ebusgateway.Config) ebusgateway.TransportP
 			return ebusgateway.TransportAdapterDirect
 		}
 		return ebusgateway.TransportENH
-	}
-	address := strings.ToLower(strings.TrimSpace(cfg.TransportConfig.Address))
-	if strings.HasPrefix(address, "adapter-direct://") || strings.HasPrefix(address, "adapter-direct-ens://") {
-		return ebusgateway.TransportAdapterDirect
 	}
 	return ebusgateway.EBusDriverTransportProtocol(cfg.TransportConfig)
 }

--- a/cmd/gateway/ebus_driver_runtime.go
+++ b/cmd/gateway/ebus_driver_runtime.go
@@ -26,11 +26,12 @@ const (
 )
 
 type ebusDriverController struct {
-	manager    *drivermanager.Manager
-	active     transport.RawTransport
-	passive    transport.RawTransport
-	classifier activeTxnClassifier
-	running    <-chan drivermanager.Correlation
+	manager         *drivermanager.Manager
+	active          transport.RawTransport
+	passive         transport.RawTransport
+	classifier      activeTxnClassifier
+	running         <-chan drivermanager.Correlation
+	proxyConfigured bool
 }
 
 func newEBusDriverController(cfg ebusgateway.Config) (*ebusDriverController, error) {
@@ -70,9 +71,10 @@ func newEBusDriverController(cfg ebusgateway.Config) (*ebusDriverController, err
 	}
 	runtime.reporter = reporter
 	controller := &ebusDriverController{
-		manager: manager,
-		active:  newManagedEBusStableTransport(manager, protocol, reporter),
-		running: running,
+		manager:         manager,
+		active:          newManagedEBusStableTransport(manager, protocol, reporter),
+		running:         running,
+		proxyConfigured: cfg.ProxyListenAddr != "",
 	}
 	if needsPassive {
 		controller.passive = newEBusStablePassiveTransport(
@@ -169,6 +171,10 @@ func buildManagedAdapterDirectGeneration(factoryCtx context.Context, cfg ebusgat
 	managed := newManagedEBusGenerationParts(factoryCtx, generationCfg.Transport, generationCfg.PassiveTransport, classifier, closeFn)
 	if generation, ok := managed.Transport.(*managedEBusGeneration); ok {
 		generation.health = health
+		// The adapter-direct constructor returns successfully only after the
+		// configured proxy listener has bound. Keep that fact generation-local;
+		// readiness still has to acquire this generation through DriverManager.
+		generation.proxyListenerBound = generationCfg.ProxyListenAddr != ""
 	}
 	if !stopForward() || factoryCtx.Err() != nil {
 		if err := factoryCtx.Err(); err != nil {
@@ -210,6 +216,41 @@ func (controller *ebusDriverController) Snapshot() drivermanager.Snapshot {
 	}
 	snapshot, _ := controller.manager.Snapshot(primaryEBusDriverID)
 	return snapshot
+}
+
+const (
+	ebusProxyReadinessDisabled = "DISABLED"
+	ebusProxyReadinessDegraded = "DEGRADED"
+	ebusProxyReadinessReady    = "READY"
+)
+
+// ProxyReadiness resolves the listener through the current admitted driver
+// generation. A configured address alone is never readiness authority: dial
+// and bind failures have no admitted generation, and lifecycle withdrawal
+// closes admission before the listener is torn down.
+func (controller *ebusDriverController) ProxyReadiness() string {
+	if controller == nil || !controller.proxyConfigured {
+		return ebusProxyReadinessDisabled
+	}
+	if controller.manager == nil {
+		return ebusProxyReadinessDegraded
+	}
+	_, err := controller.manager.Invoke(
+		context.Background(),
+		primaryEBusDriverID,
+		drivermanager.CapabilityRead,
+		func(provider any) error {
+			generation, ok := provider.(*managedEBusGeneration)
+			if !ok || generation == nil || !generation.proxyListenerBound {
+				return drivermanager.ErrUnavailable
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return ebusProxyReadinessDegraded
+	}
+	return ebusProxyReadinessReady
 }
 
 // WaitRunning blocks eBUS-only startup work until a correlated generation is
@@ -949,11 +990,12 @@ func (health *ebusGenerationHealth) pendingReportLocked() (ebusFailureReporter, 
 // provider callbacks block only on results and return as soon as generation
 // context is canceled, allowing DriverRuntime to drain before CloseRequest.
 type managedEBusGeneration struct {
-	active     *managedEBusEndpoint
-	passive    *managedEBusEndpoint
-	classifier activeTxnClassifier
-	closeFn    func() error
-	health     *ebusGenerationHealth
+	active             *managedEBusEndpoint
+	passive            *managedEBusEndpoint
+	classifier         activeTxnClassifier
+	closeFn            func() error
+	health             *ebusGenerationHealth
+	proxyListenerBound bool
 
 	closeRequest chan struct{}
 	closed       chan struct{}

--- a/cmd/gateway/ebus_driver_runtime.go
+++ b/cmd/gateway/ebus_driver_runtime.go
@@ -1,0 +1,957 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/adaptermux"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/adaptermux/v8classifier"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/drivermanager"
+	ebuserrors "github.com/Project-Helianthus/helianthus-ebusgo/errors"
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+const primaryEBusDriverID = "ebus.primary"
+
+const (
+	defaultEBusDriverDrainTimeout = 2 * time.Second
+	defaultEBusRetryBudget        = 5
+	defaultEBusRetryInitialDelay  = time.Second
+	defaultEBusRetryMaxDelay      = 30 * time.Second
+)
+
+type ebusDriverController struct {
+	manager    *drivermanager.Manager
+	active     transport.RawTransport
+	passive    transport.RawTransport
+	classifier activeTxnClassifier
+}
+
+func newEBusDriverController(cfg ebusgateway.Config) (*ebusDriverController, error) {
+	protocol := configuredEBusDriverProtocol(cfg)
+	needsPassive := cfg.BroadcastListen && (protocol == ebusgateway.TransportAdapterDirect || shouldStartPassiveObserveFirst(cfg))
+	runtimeSeam := transport.NewDriverRuntime(
+		newEBusDriverFactory(cfg, protocol, needsPassive),
+		transport.DriverRuntimeConfig{DrainTimeout: defaultEBusDriverDrainTimeout},
+	)
+	runtime := &ebusDriverRuntime{runtime: runtimeSeam}
+	manager, err := drivermanager.New(drivermanager.Config{Drivers: []drivermanager.DriverConfig{{
+		ID:      primaryEBusDriverID,
+		Enabled: true,
+		Runtime: runtime,
+		Capabilities: []drivermanager.Capability{
+			drivermanager.CapabilityDiscovery,
+			drivermanager.CapabilityRawEvidence,
+			drivermanager.CapabilityRead,
+			drivermanager.CapabilitySemanticProjection,
+			drivermanager.CapabilityWrite,
+		},
+		ClassifyError: classifyEBusDriverError,
+		Retry: drivermanager.RetryPolicy{
+			Budget:       defaultEBusRetryBudget,
+			InitialDelay: defaultEBusRetryInitialDelay,
+			MaxDelay:     defaultEBusRetryMaxDelay,
+		},
+	}}})
+	if err != nil {
+		return nil, err
+	}
+	reporter := func(correlation drivermanager.Correlation, rawErr error) {
+		manager.ReportFailure(primaryEBusDriverID, correlation, classifyEBusDriverError(rawErr))
+	}
+	controller := &ebusDriverController{
+		manager: manager,
+		active:  newManagedEBusStableTransport(manager, protocol, reporter),
+	}
+	if needsPassive {
+		controller.passive = newEBusStablePassiveTransport(
+			managedEBusSlotInvoker{manager: manager, id: primaryEBusDriverID},
+			protocol,
+		)
+	}
+	if protocol == ebusgateway.TransportAdapterDirect {
+		controller.classifier = &ebusStableClassifier{invoker: managedEBusSlotInvoker{manager: manager, id: primaryEBusDriverID}}
+	}
+	return controller, nil
+}
+
+func configuredEBusDriverProtocol(cfg ebusgateway.Config) ebusgateway.TransportProtocol {
+	if cfg.Transport != nil {
+		if _, ok := cfg.Transport.(transport.EscapeAware); !ok {
+			return ebusgateway.TransportTCPPlain
+		}
+		if _, ok := cfg.Transport.(transport.StructuralWriteSignaler); ok {
+			return ebusgateway.TransportAdapterDirect
+		}
+		return ebusgateway.TransportENH
+	}
+	address := strings.ToLower(strings.TrimSpace(cfg.TransportConfig.Address))
+	if strings.HasPrefix(address, "adapter-direct://") || strings.HasPrefix(address, "adapter-direct-ens://") {
+		return ebusgateway.TransportAdapterDirect
+	}
+	return ebusgateway.CanonicalTransportProtocol(cfg.TransportConfig.Protocol)
+}
+
+func newEBusDriverFactory(cfg ebusgateway.Config, protocol ebusgateway.TransportProtocol, needsPassive bool) transport.DriverRuntimeFactory {
+	return func(ctx context.Context) (*transport.ManagedRawTransport, error) {
+		if protocol == ebusgateway.TransportAdapterDirect {
+			return buildManagedAdapterDirectGeneration(ctx, cfg)
+		}
+		active, activeClose, err := ebusgateway.OpenEBusDriverTransport(ctx, cfg)
+		if err != nil {
+			return nil, err
+		}
+		if active == nil {
+			return nil, errors.New("eBUS provider unavailable")
+		}
+		var passive transport.RawTransport
+		if needsPassive {
+			passive, err = ebusgateway.OpenEBusDriverPassiveTransport(ctx, cfg)
+			if err != nil {
+				// Return the partially constructed generation with its error so
+				// DriverRuntime retires it through the same CloseRequest/Closed
+				// proof path; the factory never closes beneath lifecycle code.
+				return newManagedEBusGenerationParts(ctx, active, nil, nil, activeClose), err
+			}
+		}
+		closeFn := func() error {
+			var passiveErr error
+			if passive != nil {
+				passiveErr = passive.Close()
+			}
+			return errors.Join(activeClose(), passiveErr)
+		}
+		return newManagedEBusGenerationParts(ctx, active, passive, nil, closeFn), nil
+	}
+}
+
+func buildManagedAdapterDirectGeneration(factoryCtx context.Context, cfg ebusgateway.Config) (*transport.ManagedRawTransport, error) {
+	adapterCtx, adapterCancel := context.WithCancel(context.Background())
+	stopForward := context.AfterFunc(factoryCtx, adapterCancel)
+	generationCfg := cfg
+	closer, classifier, err := wireAdapterDirect(adapterCtx, &generationCfg)
+	if err != nil {
+		stopForward()
+		adapterCancel()
+		return nil, err
+	}
+	if generationCfg.Transport == nil || closer == nil {
+		stopForward()
+		adapterCancel()
+		return nil, errors.New("adapter-direct provider unavailable")
+	}
+	closeFn := func() error {
+		adapterCancel()
+		return closer()
+	}
+	managed := newManagedEBusGenerationParts(factoryCtx, generationCfg.Transport, generationCfg.PassiveTransport, classifier, closeFn)
+	if !stopForward() || factoryCtx.Err() != nil {
+		if err := factoryCtx.Err(); err != nil {
+			return managed, err
+		}
+		return managed, context.Canceled
+	}
+	return managed, nil
+}
+
+func classifyEBusDriverError(err error) drivermanager.Failure {
+	switch {
+	case errors.Is(err, drivermanager.ErrUnavailable), errors.Is(err, transport.ErrDriverUnavailable):
+		return drivermanager.Failure{Reason: drivermanager.Reason{Code: drivermanager.ReasonProviderUnavailable}}
+	case errors.Is(err, ebuserrors.ErrInvalidPayload):
+		return drivermanager.Failure{Reason: drivermanager.Reason{Code: drivermanager.ReasonConfigInvalid}}
+	default:
+		return drivermanager.Failure{Reason: drivermanager.Reason{Code: drivermanager.ReasonDependencyUnavailable, Retryable: true}}
+	}
+}
+
+func (controller *ebusDriverController) Start(ctx context.Context) error {
+	if controller == nil || controller.manager == nil {
+		return drivermanager.ErrUnavailable
+	}
+	return controller.manager.Start(ctx, primaryEBusDriverID)
+}
+
+func (controller *ebusDriverController) Shutdown(ctx context.Context) error {
+	if controller == nil || controller.manager == nil {
+		return nil
+	}
+	return controller.manager.Shutdown(ctx)
+}
+
+func (controller *ebusDriverController) Snapshot() drivermanager.Snapshot {
+	if controller == nil || controller.manager == nil {
+		return drivermanager.Snapshot{DriverID: primaryEBusDriverID, ObservedState: drivermanager.ObservedFailed, Reason: drivermanager.Reason{Code: drivermanager.ReasonProviderUnavailable}}
+	}
+	snapshot, _ := controller.manager.Snapshot(primaryEBusDriverID)
+	return snapshot
+}
+
+type ebusDriverRuntime struct {
+	runtime *transport.DriverRuntime
+}
+
+func (runtime *ebusDriverRuntime) Start(ctx context.Context) (uint64, error) {
+	if runtime == nil || runtime.runtime == nil {
+		return 0, drivermanager.ErrUnavailable
+	}
+	generation, err := runtime.runtime.Start(ctx)
+	return generation, mapEBusLifecycleError(err)
+}
+
+func (runtime *ebusDriverRuntime) Replace(ctx context.Context) (uint64, error) {
+	if runtime == nil || runtime.runtime == nil {
+		return 0, drivermanager.ErrUnavailable
+	}
+	generation, err := runtime.runtime.Replace(ctx)
+	return generation, mapEBusLifecycleError(err)
+}
+
+func (runtime *ebusDriverRuntime) Stop(ctx context.Context) error {
+	if runtime == nil || runtime.runtime == nil {
+		return nil
+	}
+	return mapEBusLifecycleError(runtime.runtime.Stop(ctx))
+}
+
+func (runtime *ebusDriverRuntime) Generation() uint64 {
+	if runtime == nil || runtime.runtime == nil {
+		return 0
+	}
+	return runtime.runtime.Generation()
+}
+
+func (runtime *ebusDriverRuntime) Revision() uint64 {
+	if runtime == nil || runtime.runtime == nil {
+		return 0
+	}
+	return runtime.runtime.Revision()
+}
+
+func (runtime *ebusDriverRuntime) SafetyQuarantined() bool {
+	return runtime != nil && runtime.runtime != nil && runtime.runtime.SafetyQuarantined()
+}
+
+func (runtime *ebusDriverRuntime) Admit(ctx context.Context) (*drivermanager.Admission, error) {
+	if runtime == nil || runtime.runtime == nil {
+		return nil, drivermanager.ErrUnavailable
+	}
+	lease, err := runtime.runtime.Admit(ctx)
+	if err != nil {
+		return nil, mapEBusLifecycleError(err)
+	}
+	return &drivermanager.Admission{
+		Correlation: drivermanager.Correlation{Generation: lease.Generation()},
+		Invoke: func(callback func(any) error) error {
+			return mapEBusLifecycleError(lease.Invoke(func(raw transport.RawTransport) error {
+				if callback == nil {
+					return transport.ErrDriverUnavailable
+				}
+				return callback(raw)
+			}))
+		},
+		Release: lease.Release,
+	}, nil
+}
+
+func mapEBusLifecycleError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, transport.ErrDriverSafetyQuarantined):
+		return errors.Join(drivermanager.ErrSafetyQuarantined, err)
+	case errors.Is(err, transport.ErrDriverStopTimeout):
+		return errors.Join(drivermanager.ErrStopTimeout, err)
+	case errors.Is(err, transport.ErrDriverUnavailable):
+		return errors.Join(drivermanager.ErrUnavailable, err)
+	default:
+		return err
+	}
+}
+
+type ebusSlotInvoker interface {
+	Invoke(context.Context, drivermanager.Capability, func(transport.RawTransport) error) (drivermanager.Correlation, error)
+}
+
+type directEBusSlotInvoker struct {
+	runtime *transport.DriverRuntime
+}
+
+func (invoker directEBusSlotInvoker) Invoke(ctx context.Context, _ drivermanager.Capability, callback func(transport.RawTransport) error) (drivermanager.Correlation, error) {
+	if invoker.runtime == nil {
+		return drivermanager.Correlation{}, transport.ErrDriverUnavailable
+	}
+	lease, err := invoker.runtime.Admit(ctx)
+	if err != nil {
+		return drivermanager.Correlation{Generation: invoker.runtime.Generation()}, err
+	}
+	defer func() { _ = lease.Release() }()
+	correlation := drivermanager.Correlation{Generation: lease.Generation()}
+	return correlation, lease.Invoke(callback)
+}
+
+type managedEBusSlotInvoker struct {
+	manager *drivermanager.Manager
+	id      string
+}
+
+func (invoker managedEBusSlotInvoker) Invoke(ctx context.Context, capability drivermanager.Capability, callback func(transport.RawTransport) error) (drivermanager.Correlation, error) {
+	if invoker.manager == nil {
+		return drivermanager.Correlation{}, transport.ErrDriverUnavailable
+	}
+	return invoker.manager.Invoke(ctx, invoker.id, capability, func(provider any) error {
+		raw, ok := provider.(transport.RawTransport)
+		if !ok || raw == nil {
+			return transport.ErrDriverUnavailable
+		}
+		return callback(raw)
+	})
+}
+
+type ebusFailureReporter func(drivermanager.Correlation, error)
+
+type ebusStableTransport struct {
+	invoker  ebusSlotInvoker
+	reporter ebusFailureReporter
+}
+
+func newEBusStableTransport(runtime *transport.DriverRuntime, protocol ebusgateway.TransportProtocol, onFailure func(uint64, error)) transport.RawTransport {
+	var reporter ebusFailureReporter
+	if onFailure != nil {
+		reporter = func(correlation drivermanager.Correlation, err error) {
+			onFailure(correlation.Generation, err)
+		}
+	}
+	return newEBusStableTransportWithInvoker(directEBusSlotInvoker{runtime: runtime}, protocol, reporter)
+}
+
+func newManagedEBusStableTransport(manager *drivermanager.Manager, protocol ebusgateway.TransportProtocol, reporter ebusFailureReporter) transport.RawTransport {
+	return newEBusStableTransportWithInvoker(managedEBusSlotInvoker{manager: manager, id: primaryEBusDriverID}, protocol, reporter)
+}
+
+func newEBusStableTransportWithInvoker(invoker ebusSlotInvoker, protocol ebusgateway.TransportProtocol, reporter ebusFailureReporter) transport.RawTransport {
+	base := &ebusStableTransport{invoker: invoker, reporter: reporter}
+	switch ebusgateway.CanonicalTransportProtocol(protocol) {
+	case ebusgateway.TransportENH, ebusgateway.TransportENS:
+		return &ebusStableEnhancedTransport{ebusStableTransport: base}
+	case ebusgateway.TransportAdapterDirect:
+		return &ebusStableAdapterDirectTransport{ebusStableTransport: base}
+	default:
+		return base
+	}
+}
+
+func (slot *ebusStableTransport) ReadByte() (value byte, err error) {
+	err = slot.invoke(drivermanager.CapabilityRead, func(raw transport.RawTransport) error {
+		value, err = raw.ReadByte()
+		return err
+	})
+	return value, err
+}
+
+func (slot *ebusStableTransport) Write(payload []byte) (written int, err error) {
+	err = slot.invoke(drivermanager.CapabilityWrite, func(raw transport.RawTransport) error {
+		written, err = raw.Write(payload)
+		return err
+	})
+	return written, err
+}
+
+// Close is deliberately a no-op. DriverManager is the sole sender of the
+// generation CloseRequest and therefore the sole lifecycle owner.
+func (*ebusStableTransport) Close() error { return nil }
+
+func (slot *ebusStableTransport) invoke(capability drivermanager.Capability, callback func(transport.RawTransport) error) error {
+	if slot == nil || slot.invoker == nil {
+		return transport.ErrDriverUnavailable
+	}
+	correlation, err := slot.invoker.Invoke(context.Background(), capability, callback)
+	if errors.Is(err, drivermanager.ErrUnavailable) {
+		err = errors.Join(transport.ErrDriverUnavailable, err)
+	}
+	if errors.Is(err, transport.ErrStaleDriverGeneration) || (correlation.Generation > 0 && errors.Is(err, transport.ErrDriverUnavailable)) {
+		err = errors.Join(ebuserrors.ErrTransportClosed, err)
+	}
+	if err != nil && slot.reporter != nil && errors.Is(err, ebuserrors.ErrTransportClosed) {
+		slot.reporter(correlation, err)
+	}
+	return err
+}
+
+type ebusStableEnhancedTransport struct {
+	*ebusStableTransport
+}
+
+func (*ebusStableEnhancedTransport) BytesAreUnescaped() bool      { return true }
+func (*ebusStableEnhancedTransport) ArbitrationSendsSource() bool { return true }
+
+func (slot *ebusStableEnhancedTransport) ReadByteWithEscape() (value byte, escaped bool, err error) {
+	err = slot.invoke(drivermanager.CapabilityRead, func(raw transport.RawTransport) error {
+		reader, ok := raw.(transport.EscapeFlaggedReader)
+		if !ok {
+			return transport.ErrDriverUnavailable
+		}
+		value, escaped, err = reader.ReadByteWithEscape()
+		return err
+	})
+	return value, escaped, err
+}
+
+func (slot *ebusStableEnhancedTransport) ReadEvent() (event transport.StreamEvent, err error) {
+	err = slot.invoke(drivermanager.CapabilityRead, func(raw transport.RawTransport) error {
+		reader, ok := raw.(transport.StreamEventReader)
+		if !ok {
+			return transport.ErrDriverUnavailable
+		}
+		event, err = reader.ReadEvent()
+		return err
+	})
+	return event, err
+}
+
+func (slot *ebusStableEnhancedTransport) StartArbitration(initiator byte) error {
+	return slot.invoke(drivermanager.CapabilityWrite, func(raw transport.RawTransport) error {
+		starter, ok := raw.(interface{ StartArbitration(byte) error })
+		if !ok {
+			return transport.ErrDriverUnavailable
+		}
+		return starter.StartArbitration(initiator)
+	})
+}
+
+func (slot *ebusStableEnhancedTransport) RequestInfo(id transport.AdapterInfoID) (data []byte, err error) {
+	err = slot.invoke(drivermanager.CapabilityRead, func(raw transport.RawTransport) error {
+		requester, ok := raw.(transport.InfoRequester)
+		if !ok {
+			return transport.ErrDriverUnavailable
+		}
+		data, err = requester.RequestInfo(id)
+		return err
+	})
+	return data, err
+}
+
+func (slot *ebusStableEnhancedTransport) Reconnect() error {
+	return slot.invoke(drivermanager.CapabilityRead, func(raw transport.RawTransport) error {
+		reconnectable, ok := raw.(transport.Reconnectable)
+		if !ok {
+			return transport.ErrDriverUnavailable
+		}
+		return reconnectable.Reconnect()
+	})
+}
+
+func (slot *ebusStableEnhancedTransport) SendResponderBytes(payload []byte) (written int, err error) {
+	err = slot.invoke(drivermanager.CapabilityWrite, func(raw transport.RawTransport) error {
+		responder, ok := raw.(transport.ResponderTransport)
+		if !ok {
+			return transport.ErrDriverUnavailable
+		}
+		written, err = responder.SendResponderBytes(payload)
+		return err
+	})
+	return written, err
+}
+
+func (slot *ebusStableEnhancedTransport) PostGrantWindowExpiredCount() (count uint64) {
+	_ = slot.invoke(drivermanager.CapabilityRead, func(raw transport.RawTransport) error {
+		reporter, ok := raw.(transport.PostGrantWindowExpiredReporter)
+		if !ok {
+			return transport.ErrDriverUnavailable
+		}
+		count = reporter.PostGrantWindowExpiredCount()
+		return nil
+	})
+	return count
+}
+
+type ebusStableAdapterDirectTransport struct {
+	*ebusStableTransport
+	pendingStructuralSyn atomic.Bool
+}
+
+func (*ebusStableAdapterDirectTransport) BytesAreUnescaped() bool      { return true }
+func (*ebusStableAdapterDirectTransport) ArbitrationSendsSource() bool { return true }
+
+func (slot *ebusStableAdapterDirectTransport) ReadByteWithEscape() (value byte, escaped bool, err error) {
+	err = slot.invoke(drivermanager.CapabilityRead, func(raw transport.RawTransport) error {
+		reader, ok := raw.(transport.EscapeFlaggedReader)
+		if !ok {
+			return transport.ErrDriverUnavailable
+		}
+		value, escaped, err = reader.ReadByteWithEscape()
+		return err
+	})
+	return value, escaped, err
+}
+
+func (slot *ebusStableAdapterDirectTransport) ReadEvent() (event transport.StreamEvent, err error) {
+	err = slot.invoke(drivermanager.CapabilityRead, func(raw transport.RawTransport) error {
+		reader, ok := raw.(transport.StreamEventReader)
+		if !ok {
+			return transport.ErrDriverUnavailable
+		}
+		event, err = reader.ReadEvent()
+		return err
+	})
+	return event, err
+}
+
+func (slot *ebusStableAdapterDirectTransport) StartArbitration(initiator byte) error {
+	return slot.invoke(drivermanager.CapabilityWrite, func(raw transport.RawTransport) error {
+		starter, ok := raw.(interface{ StartArbitration(byte) error })
+		if !ok {
+			return transport.ErrDriverUnavailable
+		}
+		return starter.StartArbitration(initiator)
+	})
+}
+
+func (slot *ebusStableAdapterDirectTransport) RequestInfo(id transport.AdapterInfoID) (data []byte, err error) {
+	err = slot.invoke(drivermanager.CapabilityRead, func(raw transport.RawTransport) error {
+		requester, ok := raw.(transport.InfoRequester)
+		if !ok {
+			return transport.ErrDriverUnavailable
+		}
+		data, err = requester.RequestInfo(id)
+		return err
+	})
+	return data, err
+}
+
+// SignalNextWriteIsStructuralSyn is paired with the next Write inside one
+// generation admission, so replacement cannot split the signal from its write.
+func (slot *ebusStableAdapterDirectTransport) SignalNextWriteIsStructuralSyn() {
+	slot.pendingStructuralSyn.Store(true)
+}
+
+func (slot *ebusStableAdapterDirectTransport) Write(payload []byte) (written int, err error) {
+	structural := slot.pendingStructuralSyn.Swap(false)
+	err = slot.invoke(drivermanager.CapabilityWrite, func(raw transport.RawTransport) error {
+		if structural {
+			signaler, ok := raw.(transport.StructuralWriteSignaler)
+			if !ok {
+				return transport.ErrDriverUnavailable
+			}
+			signaler.SignalNextWriteIsStructuralSyn()
+		}
+		written, err = raw.Write(payload)
+		return err
+	})
+	return written, err
+}
+
+type ebusStablePassiveTransport struct {
+	invoker ebusSlotInvoker
+}
+
+type ebusStableEnhancedPassiveTransport struct {
+	*ebusStablePassiveTransport
+}
+
+func newEBusStablePassiveTransport(invoker ebusSlotInvoker, protocol ebusgateway.TransportProtocol) transport.RawTransport {
+	base := &ebusStablePassiveTransport{invoker: invoker}
+	switch ebusgateway.CanonicalTransportProtocol(protocol) {
+	case ebusgateway.TransportENH, ebusgateway.TransportENS, ebusgateway.TransportAdapterDirect:
+		return &ebusStableEnhancedPassiveTransport{ebusStablePassiveTransport: base}
+	default:
+		return base
+	}
+}
+
+func (slot *ebusStablePassiveTransport) withPassive(callback func(transport.RawTransport) error) error {
+	if slot == nil || slot.invoker == nil {
+		return transport.ErrDriverUnavailable
+	}
+	_, err := slot.invoker.Invoke(context.Background(), drivermanager.CapabilityRead, func(raw transport.RawTransport) error {
+		provider, ok := raw.(interface{ PassiveTransport() transport.RawTransport })
+		if !ok {
+			return transport.ErrDriverUnavailable
+		}
+		passive := provider.PassiveTransport()
+		if passive == nil {
+			return transport.ErrDriverUnavailable
+		}
+		return callback(passive)
+	})
+	if errors.Is(err, drivermanager.ErrUnavailable) {
+		return errors.Join(transport.ErrDriverUnavailable, err)
+	}
+	return err
+}
+
+func (slot *ebusStablePassiveTransport) ReadByte() (value byte, err error) {
+	err = slot.withPassive(func(passive transport.RawTransport) error {
+		value, err = passive.ReadByte()
+		return err
+	})
+	return value, err
+}
+
+func (slot *ebusStableEnhancedPassiveTransport) ReadEvent() (event transport.StreamEvent, err error) {
+	err = slot.withPassive(func(passive transport.RawTransport) error {
+		reader, ok := passive.(transport.StreamEventReader)
+		if !ok {
+			return transport.ErrDriverUnavailable
+		}
+		event, err = reader.ReadEvent()
+		return err
+	})
+	return event, err
+}
+
+func (*ebusStablePassiveTransport) Write([]byte) (int, error) {
+	return 0, transport.ErrDriverUnavailable
+}
+
+func (*ebusStablePassiveTransport) Close() error { return nil }
+
+func (*ebusStableEnhancedPassiveTransport) BytesAreUnescaped() bool { return true }
+
+type ebusStableClassifier struct {
+	invoker ebusSlotInvoker
+}
+
+func (classifier *ebusStableClassifier) withClassifier(callback func(activeTxnClassifier)) {
+	if classifier == nil || classifier.invoker == nil {
+		return
+	}
+	_, _ = classifier.invoker.Invoke(context.Background(), drivermanager.CapabilityRead, func(raw transport.RawTransport) error {
+		provider, ok := raw.(interface{ Classifier() activeTxnClassifier })
+		if !ok {
+			return nil
+		}
+		current := provider.Classifier()
+		if current != nil {
+			callback(current)
+		}
+		return nil
+	})
+}
+
+func (classifier *ebusStableClassifier) LastTxnClass() (class string) {
+	classifier.withClassifier(func(current activeTxnClassifier) { class = current.LastTxnClass() })
+	return class
+}
+
+func (classifier *ebusStableClassifier) ActiveTxnSnapshotForScan() (id uint64, writePrefix, readPrefix []byte, class string) {
+	classifier.withClassifier(func(current activeTxnClassifier) {
+		snapshotter, ok := current.(activeTxnSnapshotter)
+		if ok {
+			id, writePrefix, readPrefix, class = snapshotter.ActiveTxnSnapshotForScan()
+		}
+	})
+	return id, writePrefix, readPrefix, class
+}
+
+func (classifier *ebusStableClassifier) ActiveTxnSnapshot() (snapshot adaptermux.ActiveTxnSnapshot) {
+	classifier.withClassifier(func(current activeTxnClassifier) {
+		snapshotter, ok := current.(adaptermuxDiagSnapshotter)
+		if ok {
+			snapshot = snapshotter.ActiveTxnSnapshot()
+		}
+	})
+	return snapshot
+}
+
+func (classifier *ebusStableClassifier) V8Classifier() (result *v8classifier.Classifier) {
+	classifier.withClassifier(func(current activeTxnClassifier) {
+		mux, ok := current.(*adaptermux.Mux)
+		if ok {
+			result = mux.V8Classifier()
+		}
+	})
+	v8AdminEventsCurrentClassifier.Store(result)
+	return result
+}
+
+type managedEBusReadResult struct {
+	event transport.StreamEvent
+	err   error
+}
+
+type managedEBusEndpoint struct {
+	ctx      context.Context
+	raw      transport.RawTransport
+	demand   chan struct{}
+	results  chan managedEBusReadResult
+	pumpDone chan struct{}
+	closing  *atomic.Bool
+}
+
+// managedEBusGeneration keeps the blocking raw reader adapter-owned. Stable
+// provider callbacks block only on results and return as soon as generation
+// context is canceled, allowing DriverRuntime to drain before CloseRequest.
+type managedEBusGeneration struct {
+	active     *managedEBusEndpoint
+	passive    *managedEBusEndpoint
+	classifier activeTxnClassifier
+	closeFn    func() error
+
+	closeRequest chan struct{}
+	closed       chan struct{}
+	closing      atomic.Bool
+	closeOnce    sync.Once
+}
+
+func newManagedEBusGeneration(ctx context.Context, raw transport.RawTransport, closeFn func() error) *transport.ManagedRawTransport {
+	return newManagedEBusGenerationParts(ctx, raw, nil, nil, closeFn)
+}
+
+func newManagedEBusGenerationParts(ctx context.Context, active, passive transport.RawTransport, classifier activeTxnClassifier, closeFn func() error) *transport.ManagedRawTransport {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	generation := &managedEBusGeneration{
+		classifier:   classifier,
+		closeFn:      closeFn,
+		closeRequest: make(chan struct{}),
+		closed:       make(chan struct{}),
+	}
+	generation.active = newManagedEBusEndpoint(ctx, active, &generation.closing)
+	if passive != nil {
+		generation.passive = newManagedEBusEndpoint(ctx, passive, &generation.closing)
+	}
+	go generation.closeWorker()
+	return &transport.ManagedRawTransport{
+		Transport: generation,
+		Lifecycle: transport.DriverLifecycleHandle{
+			CloseRequest: generation.closeRequest,
+			Closed:       generation.closed,
+		},
+	}
+}
+
+func newManagedEBusEndpoint(ctx context.Context, raw transport.RawTransport, closing *atomic.Bool) *managedEBusEndpoint {
+	endpoint := &managedEBusEndpoint{
+		ctx:      ctx,
+		raw:      raw,
+		demand:   make(chan struct{}),
+		results:  make(chan managedEBusReadResult),
+		pumpDone: make(chan struct{}),
+		closing:  closing,
+	}
+	go endpoint.pump()
+	return endpoint
+}
+
+func (endpoint *managedEBusEndpoint) pump() {
+	defer close(endpoint.pumpDone)
+	if endpoint.raw == nil {
+		return
+	}
+	for {
+		// Never prefetch from a live transport. ENH/ENS arbitration and INFO
+		// exchanges consume control responses under their own read lock; an idle
+		// pump must not race them and steal those bytes. The protocol-facing
+		// ReadByte/ReadEvent call creates exactly one unit of demand instead.
+		select {
+		case <-endpoint.ctx.Done():
+			return
+		case <-endpoint.demand:
+		}
+		if endpoint.ctx.Err() != nil {
+			return
+		}
+		event, err := readManagedEBusEvent(endpoint.raw)
+		select {
+		case endpoint.results <- managedEBusReadResult{event: event, err: err}:
+		case <-endpoint.ctx.Done():
+			return
+		}
+		if err != nil && endpoint.closing.Load() {
+			return
+		}
+	}
+}
+
+func (generation *managedEBusGeneration) closeWorker() {
+	<-generation.closeRequest
+	generation.closing.Store(true)
+	generation.closeOnce.Do(func() {
+		if generation.closeFn != nil {
+			_ = generation.closeFn()
+		} else if generation.active != nil && generation.active.raw != nil {
+			_ = generation.active.raw.Close()
+		}
+	})
+	if generation.active != nil {
+		<-generation.active.pumpDone
+	}
+	if generation.passive != nil {
+		<-generation.passive.pumpDone
+	}
+	close(generation.closed)
+}
+
+func readManagedEBusEvent(raw transport.RawTransport) (transport.StreamEvent, error) {
+	if reader, ok := raw.(transport.StreamEventReader); ok {
+		return reader.ReadEvent()
+	}
+	value, err := raw.ReadByte()
+	return transport.StreamEvent{Kind: transport.StreamEventByte, Byte: value}, err
+}
+
+func (endpoint *managedEBusEndpoint) nextByte() (byte, bool, error) {
+	for {
+		if err := endpoint.requestRead(); err != nil {
+			return 0, false, err
+		}
+		select {
+		case <-endpoint.ctx.Done():
+			return 0, false, ebuserrors.ErrTransportClosed
+		case result := <-endpoint.results:
+			if result.err != nil {
+				return 0, false, result.err
+			}
+			switch result.event.Kind {
+			case transport.StreamEventByte:
+				return result.event.Byte, result.event.WasEscaped, nil
+			case transport.StreamEventReset:
+				return 0, false, ebuserrors.ErrAdapterReset
+			}
+		}
+	}
+}
+
+func (generation *managedEBusGeneration) ReadByte() (byte, error) {
+	value, _, err := generation.active.nextByte()
+	return value, err
+}
+
+func (generation *managedEBusGeneration) ReadByteWithEscape() (byte, bool, error) {
+	return generation.active.nextByte()
+}
+
+func (generation *managedEBusGeneration) ReadEvent() (transport.StreamEvent, error) {
+	return generation.active.readEvent()
+}
+
+func (endpoint *managedEBusEndpoint) readEvent() (transport.StreamEvent, error) {
+	if err := endpoint.requestRead(); err != nil {
+		return transport.StreamEvent{}, err
+	}
+	select {
+	case <-endpoint.ctx.Done():
+		return transport.StreamEvent{}, ebuserrors.ErrTransportClosed
+	case result := <-endpoint.results:
+		return result.event, result.err
+	}
+}
+
+func (endpoint *managedEBusEndpoint) requestRead() error {
+	if endpoint == nil || endpoint.raw == nil {
+		return transport.ErrDriverUnavailable
+	}
+	select {
+	case <-endpoint.ctx.Done():
+		return ebuserrors.ErrTransportClosed
+	case endpoint.demand <- struct{}{}:
+		return nil
+	}
+}
+
+func (generation *managedEBusGeneration) Write(payload []byte) (int, error) {
+	if generation.active == nil || generation.active.raw == nil {
+		return 0, transport.ErrDriverUnavailable
+	}
+	return generation.active.raw.Write(payload)
+}
+
+// Close never owns teardown; DriverRuntime's CloseRequest does.
+func (*managedEBusGeneration) Close() error { return nil }
+
+func (generation *managedEBusGeneration) BytesAreUnescaped() bool {
+	escapeAware, ok := generation.active.raw.(transport.EscapeAware)
+	return ok && escapeAware.BytesAreUnescaped()
+}
+
+func (generation *managedEBusGeneration) StartArbitration(initiator byte) error {
+	starter, ok := generation.active.raw.(interface{ StartArbitration(byte) error })
+	if !ok {
+		return transport.ErrDriverUnavailable
+	}
+	return starter.StartArbitration(initiator)
+}
+
+func (generation *managedEBusGeneration) ArbitrationSendsSource() bool {
+	behavior, ok := generation.active.raw.(interface{ ArbitrationSendsSource() bool })
+	return ok && behavior.ArbitrationSendsSource()
+}
+
+func (generation *managedEBusGeneration) RequestInfo(id transport.AdapterInfoID) ([]byte, error) {
+	requester, ok := generation.active.raw.(transport.InfoRequester)
+	if !ok {
+		return nil, transport.ErrDriverUnavailable
+	}
+	return requester.RequestInfo(id)
+}
+
+func (generation *managedEBusGeneration) Reconnect() error {
+	reconnectable, ok := generation.active.raw.(transport.Reconnectable)
+	if !ok {
+		return transport.ErrDriverUnavailable
+	}
+	return reconnectable.Reconnect()
+}
+
+func (generation *managedEBusGeneration) SendResponderBytes(payload []byte) (int, error) {
+	responder, ok := generation.active.raw.(transport.ResponderTransport)
+	if !ok {
+		return 0, transport.ErrDriverUnavailable
+	}
+	return responder.SendResponderBytes(payload)
+}
+
+func (generation *managedEBusGeneration) PostGrantWindowExpiredCount() uint64 {
+	reporter, ok := generation.active.raw.(transport.PostGrantWindowExpiredReporter)
+	if !ok {
+		return 0
+	}
+	return reporter.PostGrantWindowExpiredCount()
+}
+
+func (generation *managedEBusGeneration) SignalNextWriteIsStructuralSyn() {
+	if signaler, ok := generation.active.raw.(transport.StructuralWriteSignaler); ok {
+		signaler.SignalNextWriteIsStructuralSyn()
+	}
+}
+
+func (generation *managedEBusGeneration) PassiveTransport() transport.RawTransport {
+	if generation == nil || generation.passive == nil {
+		return nil
+	}
+	return &managedEBusPassiveTransport{endpoint: generation.passive}
+}
+
+func (generation *managedEBusGeneration) Classifier() activeTxnClassifier {
+	if generation == nil {
+		return nil
+	}
+	return generation.classifier
+}
+
+type managedEBusPassiveTransport struct {
+	endpoint *managedEBusEndpoint
+}
+
+func (passive *managedEBusPassiveTransport) ReadByte() (byte, error) {
+	value, _, err := passive.endpoint.nextByte()
+	return value, err
+}
+
+func (passive *managedEBusPassiveTransport) ReadEvent() (transport.StreamEvent, error) {
+	return passive.endpoint.readEvent()
+}
+
+func (*managedEBusPassiveTransport) Write([]byte) (int, error) {
+	return 0, transport.ErrDriverUnavailable
+}
+
+func (*managedEBusPassiveTransport) Close() error            { return nil }
+func (*managedEBusPassiveTransport) BytesAreUnescaped() bool { return true }

--- a/cmd/gateway/ebus_driver_runtime.go
+++ b/cmd/gateway/ebus_driver_runtime.go
@@ -107,6 +107,7 @@ func configuredEBusDriverProtocol(cfg ebusgateway.Config) ebusgateway.TransportP
 
 func newEBusDriverFactory(cfg ebusgateway.Config, protocol ebusgateway.TransportProtocol, needsPassive bool, v8Counter *ebusV8CumulativeCounter) transport.DriverRuntimeFactory {
 	var injectedUsed atomic.Bool
+	var injectedPassiveUsed atomic.Bool
 	return func(ctx context.Context) (*transport.ManagedRawTransport, error) {
 		if protocol == ebusgateway.TransportAdapterDirect && cfg.Transport == nil {
 			return buildManagedAdapterDirectGeneration(ctx, cfg, v8Counter)
@@ -124,6 +125,12 @@ func newEBusDriverFactory(cfg ebusgateway.Config, protocol ebusgateway.Transport
 		var passive transport.RawTransport
 		if needsPassive {
 			if cfg.PassiveTransport != nil {
+				// An injected passive transport is the same concrete resource
+				// across config copies. Retirement closes it, so a replacement
+				// must never publish the closed pointer as a fresh generation.
+				if !injectedPassiveUsed.CompareAndSwap(false, true) {
+					return newManagedEBusGenerationParts(ctx, active, nil, nil, activeClose), transport.ErrDriverUnavailable
+				}
 				passive = cfg.PassiveTransport
 			} else {
 				passive, err = ebusgateway.OpenEBusDriverPassiveTransport(ctx, cfg)

--- a/cmd/gateway/ebus_driver_runtime.go
+++ b/cmd/gateway/ebus_driver_runtime.go
@@ -236,6 +236,41 @@ func (controller *ebusDriverController) Snapshot() drivermanager.Snapshot {
 	return snapshot
 }
 
+// newManagedEBusSourceProvider intersects the builder-selected source with
+// current DriverManager write admission. A configured or previously selected
+// source is not operational authority while the driver is STARTING, BACKOFF,
+// FAILED, withdrawn, or degraded without WRITE capability.
+func newManagedEBusSourceProvider(controller *ebusDriverController, selectedSource func() (byte, bool)) func() (byte, bool) {
+	return func() (byte, bool) {
+		if controller == nil || controller.manager == nil || selectedSource == nil {
+			return 0, false
+		}
+		source, selected := selectedSource()
+		if !selected || source == 0 {
+			return 0, false
+		}
+		_, err := controller.manager.Invoke(
+			context.Background(),
+			primaryEBusDriverID,
+			drivermanager.CapabilityWrite,
+			func(provider any) error {
+				if provider == nil {
+					return drivermanager.ErrUnavailable
+				}
+				return nil
+			},
+		)
+		if err != nil {
+			return 0, false
+		}
+		currentSource, stillSelected := selectedSource()
+		if !stillSelected || currentSource == 0 || currentSource != source {
+			return 0, false
+		}
+		return currentSource, true
+	}
+}
+
 const (
 	ebusProxyReadinessDisabled = "DISABLED"
 	ebusProxyReadinessDegraded = "DEGRADED"
@@ -755,11 +790,14 @@ func newEBusStablePassiveTransport(invoker ebusSlotInvoker, protocol ebusgateway
 	}
 }
 
-func (slot *ebusStablePassiveTransport) withPassive(callback func(context.Context, transport.RawTransport) error) error {
+func (slot *ebusStablePassiveTransport) withPassive(parent context.Context, callback func(context.Context, transport.RawTransport) error) error {
 	if slot == nil || slot.invoker == nil {
 		return transport.ErrDriverUnavailable
 	}
-	readCtx, finishRead := slot.beginRead()
+	if parent == nil {
+		parent = context.Background()
+	}
+	readCtx, finishRead := slot.beginRead(parent)
 	defer finishRead()
 	correlation, err := slot.invoker.Invoke(readCtx, drivermanager.CapabilityRead, func(raw transport.RawTransport) error {
 		provider, ok := raw.(interface{ PassiveTransport() transport.RawTransport })
@@ -781,8 +819,8 @@ func (slot *ebusStablePassiveTransport) withPassive(callback func(context.Contex
 	return err
 }
 
-func (slot *ebusStablePassiveTransport) beginRead() (context.Context, func()) {
-	ctx, cancel := context.WithCancel(context.Background())
+func (slot *ebusStablePassiveTransport) beginRead(parent context.Context) (context.Context, func()) {
+	ctx, cancel := context.WithCancel(parent)
 	slot.readMu.Lock()
 	slot.readSeq++
 	id := slot.readSeq
@@ -809,7 +847,11 @@ func shouldReportPassiveFailure(err error) bool {
 }
 
 func (slot *ebusStablePassiveTransport) ReadByte() (value byte, err error) {
-	err = slot.withPassive(func(ctx context.Context, passive transport.RawTransport) error {
+	return slot.ReadByteContext(context.Background())
+}
+
+func (slot *ebusStablePassiveTransport) ReadByteContext(parent context.Context) (value byte, err error) {
+	err = slot.withPassive(parent, func(ctx context.Context, passive transport.RawTransport) error {
 		reader, ok := passive.(interface {
 			ReadByteContext(context.Context) (byte, error)
 		})
@@ -823,7 +865,11 @@ func (slot *ebusStablePassiveTransport) ReadByte() (value byte, err error) {
 }
 
 func (slot *ebusStableEnhancedPassiveTransport) ReadEvent() (event transport.StreamEvent, err error) {
-	err = slot.withPassive(func(ctx context.Context, passive transport.RawTransport) error {
+	return slot.ReadEventContext(context.Background())
+}
+
+func (slot *ebusStableEnhancedPassiveTransport) ReadEventContext(parent context.Context) (event transport.StreamEvent, err error) {
+	err = slot.withPassive(parent, func(ctx context.Context, passive transport.RawTransport) error {
 		reader, ok := passive.(interface {
 			ReadEventContext(context.Context) (transport.StreamEvent, error)
 		})

--- a/cmd/gateway/ebus_driver_runtime.go
+++ b/cmd/gateway/ebus_driver_runtime.go
@@ -27,6 +27,7 @@ const (
 
 type ebusDriverController struct {
 	manager         *drivermanager.Manager
+	runtime         *ebusDriverRuntime
 	active          transport.RawTransport
 	passive         transport.RawTransport
 	classifier      activeTxnClassifier
@@ -72,6 +73,7 @@ func newEBusDriverController(cfg ebusgateway.Config) (*ebusDriverController, err
 	runtime.reporter = reporter
 	controller := &ebusDriverController{
 		manager:         manager,
+		runtime:         runtime,
 		active:          newManagedEBusStableTransport(manager, protocol, reporter),
 		running:         running,
 		proxyConfigured: cfg.ProxyListenAddr != "",
@@ -236,6 +238,16 @@ func (controller *ebusDriverController) Snapshot() drivermanager.Snapshot {
 	return snapshot
 }
 
+// SetLifecycleObserver binds the one process-owned consumer of exact eBUS
+// driver activation and withdrawal events. The observer stays private to the
+// gateway process; DriverManager remains the sole lifecycle authority.
+func (controller *ebusDriverController) SetLifecycleObserver(observer ebusDriverLifecycleObserver) {
+	if controller == nil || controller.runtime == nil {
+		return
+	}
+	controller.runtime.setLifecycleObserver(observer)
+}
+
 // newManagedEBusSourceProvider intersects the builder-selected source with
 // current DriverManager write admission. A configured or previously selected
 // source is not operational authority while the driver is STARTING, BACKOFF,
@@ -335,6 +347,72 @@ type ebusDriverRuntime struct {
 	reporter ebusFailureReporter
 	running  chan<- drivermanager.Correlation
 	current  atomic.Pointer[managedEBusGeneration]
+
+	// lifecycleMu orders activation and withdrawal for the private B503
+	// observer. Observer callbacks are bounded local FSM mutations: they must
+	// perform no I/O and must never re-enter DriverManager. Keeping the callback
+	// under this mutex prevents a late activation from overtaking withdrawal.
+	lifecycleMu            sync.Mutex
+	lifecycleObserver      ebusDriverLifecycleObserver
+	lifecycleCorrelation   drivermanager.Correlation
+	lifecycleLastWithdrawn uint64
+}
+
+// ebusDriverLifecycleObserver is intentionally private. It projects the exact
+// DriverManager generation boundary into process-local consumers without
+// creating a public drivers API or a second lifecycle authority.
+type ebusDriverLifecycleObserver interface {
+	EBusDriverActivated(drivermanager.Correlation)
+	EBusDriverWithdrawn(drivermanager.Correlation)
+}
+
+func (runtime *ebusDriverRuntime) setLifecycleObserver(observer ebusDriverLifecycleObserver) {
+	if runtime == nil || observer == nil {
+		return
+	}
+	runtime.lifecycleMu.Lock()
+	defer runtime.lifecycleMu.Unlock()
+	// The B503 runtime is process-owned and installed once. Refuse replacement
+	// so a late registration cannot replay an activation to multiple owners.
+	if runtime.lifecycleObserver != nil {
+		return
+	}
+	runtime.lifecycleObserver = observer
+	if runtime.lifecycleCorrelation.Generation != 0 {
+		observer.EBusDriverActivated(runtime.lifecycleCorrelation)
+	}
+}
+
+func (runtime *ebusDriverRuntime) activateLifecycle(correlation drivermanager.Correlation) {
+	if runtime == nil || correlation.Generation == 0 {
+		return
+	}
+	runtime.lifecycleMu.Lock()
+	defer runtime.lifecycleMu.Unlock()
+	if correlation.Generation <= runtime.lifecycleLastWithdrawn || runtime.lifecycleCorrelation == correlation {
+		return
+	}
+	runtime.lifecycleCorrelation = correlation
+	if runtime.lifecycleObserver != nil {
+		runtime.lifecycleObserver.EBusDriverActivated(correlation)
+	}
+}
+
+func (runtime *ebusDriverRuntime) withdrawLifecycle() {
+	if runtime == nil {
+		return
+	}
+	runtime.lifecycleMu.Lock()
+	defer runtime.lifecycleMu.Unlock()
+	correlation := runtime.lifecycleCorrelation
+	if correlation.Generation == 0 || correlation.Generation <= runtime.lifecycleLastWithdrawn {
+		return
+	}
+	runtime.lifecycleCorrelation = drivermanager.Correlation{}
+	runtime.lifecycleLastWithdrawn = correlation.Generation
+	if runtime.lifecycleObserver != nil {
+		runtime.lifecycleObserver.EBusDriverWithdrawn(correlation)
+	}
 }
 
 func (runtime *ebusDriverRuntime) Start(ctx context.Context) (uint64, error) {
@@ -370,13 +448,14 @@ func (runtime *ebusDriverRuntime) Stop(ctx context.Context) error {
 	return mapEBusLifecycleError(runtime.runtime.Stop(ctx))
 }
 
-// FenceWithdrawal implements drivermanager's private non-blocking withdrawal
-// hook. It must remain lock-free and manager-non-reentrant because the manager
-// invokes it under the same state lock that publishes STOPPING.
+// FenceWithdrawal implements drivermanager's private bounded withdrawal hook.
+// It performs only process-local, manager-non-reentrant FSM mutations because
+// DriverManager invokes it under the state lock before publishing withdrawal.
 func (runtime *ebusDriverRuntime) FenceWithdrawal() {
 	if runtime == nil {
 		return
 	}
+	runtime.withdrawLifecycle()
 	if generation := runtime.current.Load(); generation != nil {
 		generation.fenceProxy()
 	}
@@ -441,6 +520,10 @@ func (runtime *ebusDriverRuntime) BindCorrelation(correlation drivermanager.Corr
 		generation, ok := raw.(*managedEBusGeneration)
 		if ok {
 			runtime.current.Store(generation)
+			// Activation must precede asynchronous health binding: bind may
+			// synchronously replay an already-observed connection loss, whose
+			// DriverManager failure path then withdraws this exact correlation.
+			runtime.activateLifecycle(correlation)
 			if runtime.reporter != nil {
 				generation.bindFailureReporter(correlation, runtime.reporter)
 			}

--- a/cmd/gateway/ebus_driver_runtime_test.go
+++ b/cmd/gateway/ebus_driver_runtime_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/adaptermux"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/adaptermux/v8classifier"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/drivermanager"
 	ebuserrors "github.com/Project-Helianthus/helianthus-ebusgo/errors"
@@ -1128,6 +1129,70 @@ func TestIssue851ProxyReadinessDropsAtMuxFenceBeforeManagerFailure(t *testing.T)
 	}
 	if got := controller.ProxyReadiness(); got != ebusProxyReadinessDegraded {
 		t.Fatalf("loss-fenced readiness = %q, want DEGRADED", got)
+	}
+}
+
+func TestIssue851FatalProxyAcceptRecoversOnceAndRejectsStaleGeneration(t *testing.T) {
+	adapterAddress := newIssue851AdapterServer(t)
+	cfg := ebusgateway.DefaultConfig()
+	cfg.BroadcastListen = false
+	cfg.TransportConfig.Protocol = ebusgateway.TransportAdapterDirect
+	cfg.TransportConfig.Network = "tcp"
+	cfg.TransportConfig.Address = adapterAddress
+	cfg.TransportConfig.DialTimeout = time.Second
+	cfg.ProxyListenAddr = "127.0.0.1:0"
+	controller, err := newEBusDriverController(cfg)
+	if err != nil {
+		t.Fatalf("newEBusDriverController() error = %v", err)
+	}
+	defer func() { _ = controller.Shutdown(context.Background()) }()
+	if err := controller.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	firstSnapshot := requireEBusDriverObservedState(t, controller.manager, drivermanager.ObservedRunning, 2*time.Second)
+	var firstGeneration *managedEBusGeneration
+	if _, err := controller.manager.Invoke(context.Background(), primaryEBusDriverID, drivermanager.CapabilityRead, func(provider any) error {
+		firstGeneration, _ = provider.(*managedEBusGeneration)
+		return nil
+	}); err != nil || firstGeneration == nil {
+		t.Fatalf("capture first generation = (%T, %v)", firstGeneration, err)
+	}
+	firstMux, ok := firstGeneration.proxyLifecycle.(*adaptermux.Mux)
+	if !ok || firstGeneration.health == nil {
+		t.Fatalf("first generation listener lifecycle = %T health=%v", firstGeneration.proxyLifecycle, firstGeneration.health != nil)
+	}
+	onFatal := adapterDirectProxyFatalCallback(firstMux, firstGeneration.health.connectionLost)
+	if onFatal == nil {
+		t.Fatal("managed proxy fatal callback is nil")
+	}
+	onFatal(net.ErrClosed)
+	backoff := requireEBusDriverObservedState(t, controller.manager, drivermanager.ObservedBackoff, time.Second)
+	if got := controller.ProxyReadiness(); got != ebusProxyReadinessDegraded {
+		t.Fatalf("fatal-Accept readiness = %q, want DEGRADED", got)
+	}
+	// The same listener/mux can surface follow-on errors while teardown drains.
+	// Generation health and the wire-level owner are one-shot, so this cannot
+	// schedule a second replacement or consume another retry.
+	onFatal(errors.New("stale accept-loop completion"))
+	afterDuplicate, _ := controller.manager.Snapshot(primaryEBusDriverID)
+	if afterDuplicate.Revision != backoff.Revision || afterDuplicate.Attempt != backoff.Attempt {
+		t.Fatalf("duplicate fatal Accept changed recovery: before=%#v after=%#v", backoff, afterDuplicate)
+	}
+
+	if err := controller.Start(context.Background()); err != nil {
+		t.Fatalf("expedite recovery Start() error = %v", err)
+	}
+	second := requireEBusDriverObservedState(t, controller.manager, drivermanager.ObservedRunning, 2*time.Second)
+	if second.Generation != firstSnapshot.Generation+1 || controller.ProxyReadiness() != ebusProxyReadinessReady {
+		t.Fatalf("fatal-Accept recovery snapshot=%#v readiness=%q", second, controller.ProxyReadiness())
+	}
+	// A late callback from the retired listener is generation-correlated and
+	// must not fence or replace the healthy successor.
+	onFatal(errors.New("late retired-listener error"))
+	time.Sleep(25 * time.Millisecond)
+	afterStale, _ := controller.manager.Snapshot(primaryEBusDriverID)
+	if afterStale.ObservedState != drivermanager.ObservedRunning || afterStale.Generation != second.Generation || afterStale.Revision != second.Revision {
+		t.Fatalf("stale listener callback changed successor: before=%#v after=%#v", second, afterStale)
 	}
 }
 

--- a/cmd/gateway/ebus_driver_runtime_test.go
+++ b/cmd/gateway/ebus_driver_runtime_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"net"
 	"sync"
 	"testing"
 	"time"
@@ -39,6 +40,17 @@ type issue851TerminalPassiveRaw struct {
 	err       error
 	closed    chan struct{}
 	closeOnce sync.Once
+}
+
+type issue851ReadSignalingRaw struct {
+	transport.RawTransport
+	readStarted chan struct{}
+	readOnce    sync.Once
+}
+
+func (raw *issue851ReadSignalingRaw) ReadByte() (byte, error) {
+	raw.readOnce.Do(func() { close(raw.readStarted) })
+	return raw.RawTransport.ReadByte()
 }
 
 func newIssue851TerminalPassiveRaw(err error) *issue851TerminalPassiveRaw {
@@ -222,6 +234,91 @@ func TestIssue851ManagedReadLoopDrainsBeforeCloseAndReplaceFencesOldGeneration(t
 	}
 	if err := runtime.Stop(context.Background()); err != nil {
 		t.Fatalf("Stop generation 2: %v", err)
+	}
+}
+
+func TestIssue851EbusdActiveReadRetiresWithTransportLevelClose(t *testing.T) {
+	for _, action := range []string{"stop", "replace"} {
+		t.Run(action, func(t *testing.T) {
+			cfg := ebusgateway.DefaultConfig()
+			cfg.BroadcastListen = false
+			cfg.TransportConfig.Protocol = ebusgateway.TransportEbusdTCP
+			cfg.TransportConfig.Network = "tcp"
+			cfg.TransportConfig.Address = "127.0.0.1:8888"
+			var mu sync.Mutex
+			var servers []net.Conn
+			var raws []*issue851ReadSignalingRaw
+			cfg.TransportConfig.Dial = func(context.Context, string, string, time.Duration) (net.Conn, error) {
+				client, server := net.Pipe()
+				mu.Lock()
+				servers = append(servers, server)
+				mu.Unlock()
+				return client, nil
+			}
+			t.Cleanup(func() {
+				mu.Lock()
+				defer mu.Unlock()
+				for _, server := range servers {
+					_ = server.Close()
+				}
+			})
+			factory := func(ctx context.Context) (*transport.ManagedRawTransport, error) {
+				active, activeClose, err := ebusgateway.OpenEBusDriverTransport(ctx, cfg)
+				if err != nil {
+					return nil, err
+				}
+				raw := &issue851ReadSignalingRaw{RawTransport: active, readStarted: make(chan struct{})}
+				mu.Lock()
+				raws = append(raws, raw)
+				mu.Unlock()
+				return newManagedEBusGeneration(ctx, raw, activeClose), nil
+			}
+			runtime := transport.NewDriverRuntime(factory, transport.DriverRuntimeConfig{DrainTimeout: 100 * time.Millisecond})
+			stable := newEBusStableTransport(runtime, ebusgateway.TransportEbusdTCP, nil)
+			if _, err := runtime.Start(context.Background()); err != nil {
+				t.Fatalf("Start() error = %v", err)
+			}
+			mu.Lock()
+			first := raws[0]
+			mu.Unlock()
+			readDone := make(chan error, 1)
+			go func() {
+				_, err := stable.ReadByte()
+				readDone <- err
+			}()
+			select {
+			case <-first.readStarted:
+			case <-time.After(time.Second):
+				t.Fatal("ebusd-tcp read did not enter the transport-local wait")
+			}
+
+			switch action {
+			case "stop":
+				if err := runtime.Stop(context.Background()); err != nil {
+					t.Fatalf("Stop() error = %v", err)
+				}
+			case "replace":
+				if generation, err := runtime.Replace(context.Background()); err != nil {
+					t.Fatalf("Replace() error = %v", err)
+				} else if generation != 2 {
+					t.Fatalf("Replace() generation = %d, want 2", generation)
+				}
+				if err := runtime.Stop(context.Background()); err != nil {
+					t.Fatalf("Stop replacement error = %v", err)
+				}
+			}
+			if runtime.SafetyQuarantined() {
+				t.Fatal("ordinary ebusd-tcp retirement entered safety quarantine")
+			}
+			select {
+			case err := <-readDone:
+				if !errors.Is(err, ebuserrors.ErrTransportClosed) && !errors.Is(err, context.Canceled) {
+					t.Fatalf("retired ebusd-tcp read error = %v", err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("transport-level close did not wake ebusd-tcp reader")
+			}
+		})
 	}
 }
 
@@ -563,6 +660,99 @@ func TestIssue851PassiveDisconnectReportsFailureAndReplacesGeneration(t *testing
 	}
 }
 
+func TestIssue851AdapterDirectConnectionLossWithdrawsCapabilitiesAndRecoversOnce(t *testing.T) {
+	var mu sync.Mutex
+	var healthByGeneration []*ebusGenerationHealth
+	var rawByGeneration []*issue851TerminalPassiveRaw
+	factoryCalls := 0
+	runtimeSeam := transport.NewDriverRuntime(func(ctx context.Context) (*transport.ManagedRawTransport, error) {
+		health := &ebusGenerationHealth{}
+		raw := newIssue851TerminalPassiveRaw(ebuserrors.ErrTimeout)
+		managed := newManagedEBusGeneration(ctx, raw, raw.Close)
+		managed.Transport.(*managedEBusGeneration).health = health
+		mu.Lock()
+		factoryCalls++
+		healthByGeneration = append(healthByGeneration, health)
+		rawByGeneration = append(rawByGeneration, raw)
+		mu.Unlock()
+		return managed, nil
+	}, transport.DriverRuntimeConfig{DrainTimeout: 100 * time.Millisecond})
+	runtime := &ebusDriverRuntime{runtime: runtimeSeam}
+	manager, err := drivermanager.New(drivermanager.Config{Drivers: []drivermanager.DriverConfig{{
+		ID:           primaryEBusDriverID,
+		Enabled:      true,
+		Runtime:      runtime,
+		Capabilities: []drivermanager.Capability{drivermanager.CapabilityRead, drivermanager.CapabilityWrite},
+		ClassifyError: func(error) drivermanager.Failure {
+			return drivermanager.Failure{Reason: drivermanager.Reason{Code: drivermanager.ReasonDependencyUnavailable, Retryable: true}}
+		},
+		Retry: drivermanager.RetryPolicy{Budget: 1, InitialDelay: 25 * time.Millisecond, MaxDelay: 25 * time.Millisecond},
+	}}})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer func() { _ = manager.Shutdown(context.Background()) }()
+	runtime.reporter = func(correlation drivermanager.Correlation, rawErr error) {
+		manager.ReportFailure(primaryEBusDriverID, correlation, classifyEBusDriverError(rawErr))
+	}
+	stable := newManagedEBusStableTransport(manager, ebusgateway.TransportAdapterDirect, runtime.reporter)
+	if err := manager.Start(context.Background(), primaryEBusDriverID); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	first := requireEBusDriverObservedState(t, manager, drivermanager.ObservedRunning, time.Second)
+	if first.Generation != 1 {
+		t.Fatalf("first generation = %d, want 1", first.Generation)
+	}
+
+	// A normal idle timeout is an operation outcome, not a connection-health
+	// transition. It must not withdraw capabilities or churn the generation.
+	if _, err := stable.ReadByte(); !errors.Is(err, ebuserrors.ErrTimeout) {
+		t.Fatalf("ReadByte() error = %v, want ErrTimeout", err)
+	}
+	afterTimeout, _ := manager.Snapshot(primaryEBusDriverID)
+	if afterTimeout.ObservedState != drivermanager.ObservedRunning || afterTimeout.Generation != first.Generation || afterTimeout.Revision != first.Revision {
+		t.Fatalf("idle timeout changed lifecycle snapshot: before=%#v after=%#v", first, afterTimeout)
+	}
+
+	mu.Lock()
+	firstHealth := healthByGeneration[0]
+	firstRaw := rawByGeneration[0]
+	mu.Unlock()
+	firstHealth.connectionLost()
+	backoff := requireEBusDriverObservedState(t, manager, drivermanager.ObservedBackoff, time.Second)
+	if backoff.Generation != first.Generation || len(backoff.EffectiveCapabilities) != 0 || backoff.Reason.Code != drivermanager.ReasonRetryScheduled {
+		t.Fatalf("connection-loss BACKOFF snapshot = %#v", backoff)
+	}
+
+	second := requireEBusDriverObservedState(t, manager, drivermanager.ObservedRunning, time.Second)
+	if second.Generation != first.Generation+1 || len(second.EffectiveCapabilities) != len(second.Capabilities) {
+		t.Fatalf("recovered snapshot = %#v, want generation %d with full capabilities", second, first.Generation+1)
+	}
+	mu.Lock()
+	calls := factoryCalls
+	mu.Unlock()
+	if calls != 2 {
+		t.Fatalf("factory calls = %d, want exactly 2", calls)
+	}
+	select {
+	case <-firstRaw.closed:
+	case <-time.After(time.Second):
+		t.Fatal("lost generation was not proven closed during replacement")
+	}
+
+	// The old mux may observe another terminal edge while it is retiring.
+	// Its generation health is one-shot and cannot start generation 3.
+	firstHealth.connectionLost()
+	time.Sleep(50 * time.Millisecond)
+	afterStale, _ := manager.Snapshot(primaryEBusDriverID)
+	mu.Lock()
+	calls = factoryCalls
+	mu.Unlock()
+	if afterStale.ObservedState != drivermanager.ObservedRunning || afterStale.Generation != second.Generation || calls != 2 {
+		t.Fatalf("stale old connection signal changed recovered generation: snapshot=%#v calls=%d", afterStale, calls)
+	}
+}
+
 func TestIssue851InjectedTransportIsNotReadmittedAfterReplacement(t *testing.T) {
 	raw := newIssue851BlockingRawTransport()
 	cfg := ebusgateway.DefaultConfig()
@@ -595,6 +785,29 @@ func TestIssue851InjectedTransportIsNotReadmittedAfterReplacement(t *testing.T) 
 	case <-raw.closed:
 	case <-time.After(time.Second):
 		t.Fatal("one-shot injected transport was not closed")
+	}
+}
+
+func TestIssue851InvalidTransportURIIsImmediateConfigFailure(t *testing.T) {
+	cfg := ebusgateway.DefaultConfig()
+	cfg.BroadcastListen = false
+	cfg.TransportConfig.Address = "unsupported://adapter.invalid:9999"
+	controller, err := newEBusDriverController(cfg)
+	if err != nil {
+		t.Fatalf("newEBusDriverController() error = %v", err)
+	}
+	defer func() { _ = controller.Shutdown(context.Background()) }()
+	if err := controller.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	failed := requireEBusDriverObservedState(t, controller.manager, drivermanager.ObservedFailed, time.Second)
+	if failed.Reason.Code != drivermanager.ReasonConfigInvalid || failed.Reason.Retryable || failed.Retry != nil || failed.Generation != 0 || failed.Attempt != 1 {
+		t.Fatalf("invalid URI snapshot = %#v", failed)
+	}
+	time.Sleep(25 * time.Millisecond)
+	after, _ := controller.manager.Snapshot(primaryEBusDriverID)
+	if after.Revision != failed.Revision || after.Attempt != 1 || after.ObservedState != drivermanager.ObservedFailed {
+		t.Fatalf("invalid URI unexpectedly retried: before=%#v after=%#v", failed, after)
 	}
 }
 
@@ -633,4 +846,18 @@ func TestIssue851AdminClassifierResolvesCurrentGenerationWithoutMetricsScrape(t 
 	if err := runtime.Stop(context.Background()); err != nil {
 		t.Fatalf("Stop() error = %v", err)
 	}
+}
+
+func requireEBusDriverObservedState(t *testing.T, manager *drivermanager.Manager, want drivermanager.ObservedState, timeout time.Duration) drivermanager.Snapshot {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if snapshot, ok := manager.Snapshot(primaryEBusDriverID); ok && snapshot.ObservedState == want {
+			return snapshot
+		}
+		time.Sleep(time.Millisecond)
+	}
+	snapshot, _ := manager.Snapshot(primaryEBusDriverID)
+	t.Fatalf("eBUS driver state = %s, want %s; snapshot=%#v", snapshot.ObservedState, want, snapshot)
+	return drivermanager.Snapshot{}
 }

--- a/cmd/gateway/ebus_driver_runtime_test.go
+++ b/cmd/gateway/ebus_driver_runtime_test.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
+	ebuserrors "github.com/Project-Helianthus/helianthus-ebusgo/errors"
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+type issue851BlockingRawTransport struct {
+	readStarted chan struct{}
+	readResult  chan issue851ReadResult
+	closed      chan struct{}
+	closeOnce   sync.Once
+}
+
+type issue851ReadResult struct {
+	value byte
+	err   error
+}
+
+func newIssue851BlockingRawTransport() *issue851BlockingRawTransport {
+	return &issue851BlockingRawTransport{
+		readStarted: make(chan struct{}, 1),
+		readResult:  make(chan issue851ReadResult),
+		closed:      make(chan struct{}),
+	}
+}
+
+func (raw *issue851BlockingRawTransport) ReadByte() (byte, error) {
+	select {
+	case raw.readStarted <- struct{}{}:
+	default:
+	}
+	select {
+	case result := <-raw.readResult:
+		return result.value, result.err
+	case <-raw.closed:
+		return 0, ebuserrors.ErrTransportClosed
+	}
+}
+
+func (*issue851BlockingRawTransport) Write(data []byte) (int, error) { return len(data), nil }
+
+func (raw *issue851BlockingRawTransport) Close() error {
+	raw.closeOnce.Do(func() { close(raw.closed) })
+	return nil
+}
+
+func TestIssue851ManagedReadLoopDrainsBeforeCloseAndReplaceFencesOldGeneration(t *testing.T) {
+	var mu sync.Mutex
+	var generations []*issue851BlockingRawTransport
+	factory := func(ctx context.Context) (*transport.ManagedRawTransport, error) {
+		raw := newIssue851BlockingRawTransport()
+		mu.Lock()
+		generations = append(generations, raw)
+		mu.Unlock()
+		return newManagedEBusGeneration(ctx, raw, raw.Close), nil
+	}
+	runtime := transport.NewDriverRuntime(factory, transport.DriverRuntimeConfig{DrainTimeout: 100 * time.Millisecond})
+	slot := newEBusStableTransport(runtime, ebusgateway.TransportTCPPlain, nil)
+
+	if _, err := runtime.Start(context.Background()); err != nil {
+		t.Fatalf("Start generation 1: %v", err)
+	}
+	mu.Lock()
+	first := generations[0]
+	mu.Unlock()
+	readDone := make(chan error, 1)
+	go func() {
+		_, err := slot.ReadByte()
+		readDone <- err
+	}()
+	select {
+	case <-first.readStarted:
+	case <-time.After(time.Second):
+		t.Fatal("generation 1 adapter-owned read pump did not start")
+	}
+
+	if generation, err := runtime.Replace(context.Background()); err != nil {
+		t.Fatalf("Replace() error = %v", err)
+	} else if generation != 2 {
+		t.Fatalf("Replace() generation = %d, want 2", generation)
+	}
+	if runtime.SafetyQuarantined() {
+		t.Fatal("normal blocking read loop caused CLOSE_UNCONFIRMED quarantine")
+	}
+	select {
+	case err := <-readDone:
+		if !errors.Is(err, ebuserrors.ErrTransportClosed) && !errors.Is(err, context.Canceled) {
+			t.Fatalf("old generation ReadByte error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("old generation stable-slot reader was not fenced")
+	}
+	select {
+	case <-first.closed:
+	case <-time.After(time.Second):
+		t.Fatal("old raw transport did not close after admitted reader drained")
+	}
+
+	mu.Lock()
+	second := generations[1]
+	mu.Unlock()
+	second.readResult <- issue851ReadResult{value: 0x5a}
+	if value, err := slot.ReadByte(); err != nil || value != 0x5a {
+		t.Fatalf("new generation ReadByte = (0x%02X, %v), want (0x5A, nil)", value, err)
+	}
+	if err := runtime.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop generation 2: %v", err)
+	}
+}
+
+func TestIssue851StableTransportShapeMatchesConfiguredFamily(t *testing.T) {
+	runtime := transport.NewDriverRuntime(nil, transport.DriverRuntimeConfig{})
+
+	for _, protocol := range []ebusgateway.TransportProtocol{ebusgateway.TransportENH, ebusgateway.TransportENS} {
+		slot := newEBusStableTransport(runtime, protocol, nil)
+		if _, ok := slot.(transport.EscapeAware); !ok {
+			t.Errorf("%s slot does not preserve EscapeAware", protocol)
+		}
+		if _, ok := slot.(transport.EscapeFlaggedReader); !ok {
+			t.Errorf("%s slot does not preserve EscapeFlaggedReader", protocol)
+		}
+		if _, ok := slot.(interface{ StartArbitration(byte) error }); !ok {
+			t.Errorf("%s slot does not preserve enhanced arbitration", protocol)
+		}
+	}
+
+	for _, protocol := range []ebusgateway.TransportProtocol{ebusgateway.TransportTCPPlain, ebusgateway.TransportUDPPlain, ebusgateway.TransportEbusdTCP} {
+		slot := newEBusStableTransport(runtime, protocol, nil)
+		if _, ok := slot.(transport.EscapeAware); ok {
+			t.Errorf("%s slot unexpectedly advertises EscapeAware", protocol)
+		}
+		if _, ok := slot.(transport.EscapeFlaggedReader); ok {
+			t.Errorf("%s slot unexpectedly advertises EscapeFlaggedReader", protocol)
+		}
+		if _, ok := slot.(interface{ StartArbitration(byte) error }); ok {
+			t.Errorf("%s slot unexpectedly advertises enhanced arbitration", protocol)
+		}
+	}
+}
+
+func TestIssue851ActiveCallbackTimeoutQuarantinesWithoutClosingRawTransport(t *testing.T) {
+	raw := newIssue851BlockingRawTransport()
+	runtime := transport.NewDriverRuntime(func(ctx context.Context) (*transport.ManagedRawTransport, error) {
+		return newManagedEBusGeneration(ctx, raw, raw.Close), nil
+	}, transport.DriverRuntimeConfig{DrainTimeout: 20 * time.Millisecond})
+	if _, err := runtime.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	callbackEntered := make(chan struct{})
+	callbackRelease := make(chan struct{})
+	invokeDone := make(chan error, 1)
+	go func() {
+		invokeDone <- runtime.Invoke(context.Background(), func(transport.RawTransport) error {
+			close(callbackEntered)
+			<-callbackRelease
+			return nil
+		})
+	}()
+	<-callbackEntered
+
+	if err := runtime.Stop(context.Background()); !errors.Is(err, transport.ErrDriverSafetyQuarantined) {
+		t.Fatalf("Stop() error = %v, want ErrDriverSafetyQuarantined", err)
+	}
+	select {
+	case <-raw.closed:
+		t.Fatal("raw transport closed beneath an active admitted callback")
+	default:
+	}
+	close(callbackRelease)
+	if err := <-invokeDone; err != nil {
+		t.Fatalf("admitted callback error = %v", err)
+	}
+}

--- a/cmd/gateway/ebus_driver_runtime_test.go
+++ b/cmd/gateway/ebus_driver_runtime_test.go
@@ -55,6 +55,26 @@ type issue851CancelBeforeByteRaw struct {
 	value  byte
 }
 
+type issue851ProxyLifecycle struct {
+	ready  atomic.Bool
+	fences atomic.Int32
+}
+
+func newIssue851ProxyLifecycle() *issue851ProxyLifecycle {
+	lifecycle := &issue851ProxyLifecycle{}
+	lifecycle.ready.Store(true)
+	return lifecycle
+}
+
+func (lifecycle *issue851ProxyLifecycle) FenceManagedConnection() {
+	lifecycle.fences.Add(1)
+	lifecycle.ready.Store(false)
+}
+
+func (lifecycle *issue851ProxyLifecycle) ManagedConnectionReady() bool {
+	return lifecycle != nil && lifecycle.ready.Load()
+}
+
 func newIssue851AdapterServer(t *testing.T) string {
 	t.Helper()
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
@@ -984,6 +1004,104 @@ func TestIssue851ProxyReadinessWithdrawsAndRecoversWithAdmittedListener(t *testi
 	}
 	if got := controller.ProxyReadiness(); got != ebusProxyReadinessReady {
 		t.Fatalf("recovered proxy readiness = %q, want READY", got)
+	}
+}
+
+func TestIssue851ManagerWithdrawalFencesCurrentProxyGeneration(t *testing.T) {
+	for _, action := range []string{"stop", "replace"} {
+		t.Run(action, func(t *testing.T) {
+			var mu sync.Mutex
+			var lifecycles []*issue851ProxyLifecycle
+			runtimeSeam := transport.NewDriverRuntime(func(ctx context.Context) (*transport.ManagedRawTransport, error) {
+				raw := newIssue851BlockingRawTransport()
+				lifecycle := newIssue851ProxyLifecycle()
+				managed := newManagedEBusGeneration(ctx, raw, raw.Close)
+				generation := managed.Transport.(*managedEBusGeneration)
+				generation.proxyListenerBound = true
+				generation.proxyLifecycle = lifecycle
+				mu.Lock()
+				lifecycles = append(lifecycles, lifecycle)
+				mu.Unlock()
+				return managed, nil
+			}, transport.DriverRuntimeConfig{DrainTimeout: 100 * time.Millisecond})
+			runtime := &ebusDriverRuntime{runtime: runtimeSeam}
+			manager, err := drivermanager.New(drivermanager.Config{Drivers: []drivermanager.DriverConfig{{
+				ID: primaryEBusDriverID, Enabled: true, Runtime: runtime,
+				Capabilities: []drivermanager.Capability{drivermanager.CapabilityRead, drivermanager.CapabilityWrite},
+			}}})
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+			controller := &ebusDriverController{manager: manager, proxyConfigured: true}
+			defer func() { _ = manager.Shutdown(context.Background()) }()
+			if err := manager.Start(context.Background(), primaryEBusDriverID); err != nil {
+				t.Fatalf("Start() error = %v", err)
+			}
+			if got := controller.ProxyReadiness(); got != ebusProxyReadinessReady {
+				t.Fatalf("pre-withdrawal readiness = %q, want READY", got)
+			}
+			mu.Lock()
+			first := lifecycles[0]
+			mu.Unlock()
+
+			switch action {
+			case "stop":
+				if err := manager.Stop(context.Background(), primaryEBusDriverID); err != nil {
+					t.Fatalf("Stop() error = %v", err)
+				}
+				if got := controller.ProxyReadiness(); got != ebusProxyReadinessDegraded {
+					t.Fatalf("post-stop readiness = %q, want DEGRADED", got)
+				}
+			case "replace":
+				if err := manager.Replace(context.Background(), primaryEBusDriverID); err != nil {
+					t.Fatalf("Replace() error = %v", err)
+				}
+				if got := controller.ProxyReadiness(); got != ebusProxyReadinessReady {
+					t.Fatalf("replacement readiness = %q, want READY", got)
+				}
+			}
+			if first.ready.Load() || first.fences.Load() == 0 {
+				t.Fatalf("old proxy generation was not fenced before %s: ready=%v fences=%d", action, first.ready.Load(), first.fences.Load())
+			}
+		})
+	}
+}
+
+func TestIssue851ProxyReadinessDropsAtMuxFenceBeforeManagerFailure(t *testing.T) {
+	raw := newIssue851BlockingRawTransport()
+	lifecycle := newIssue851ProxyLifecycle()
+	runtimeSeam := transport.NewDriverRuntime(func(ctx context.Context) (*transport.ManagedRawTransport, error) {
+		managed := newManagedEBusGeneration(ctx, raw, raw.Close)
+		generation := managed.Transport.(*managedEBusGeneration)
+		generation.proxyListenerBound = true
+		generation.proxyLifecycle = lifecycle
+		return managed, nil
+	}, transport.DriverRuntimeConfig{DrainTimeout: 100 * time.Millisecond})
+	runtime := &ebusDriverRuntime{runtime: runtimeSeam}
+	manager, err := drivermanager.New(drivermanager.Config{Drivers: []drivermanager.DriverConfig{{
+		ID: primaryEBusDriverID, Enabled: true, Runtime: runtime,
+		Capabilities: []drivermanager.Capability{drivermanager.CapabilityRead},
+	}}})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer func() { _ = manager.Shutdown(context.Background()) }()
+	controller := &ebusDriverController{manager: manager, proxyConfigured: true}
+	if err := manager.Start(context.Background(), primaryEBusDriverID); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if got := controller.ProxyReadiness(); got != ebusProxyReadinessReady {
+		t.Fatalf("healthy readiness = %q, want READY", got)
+	}
+
+	// This is the reachable interval after adaptermux fenced physical loss but
+	// before its owner callback publishes DriverManager BACKOFF.
+	lifecycle.FenceManagedConnection()
+	if snapshot := controller.Snapshot(); snapshot.ObservedState != drivermanager.ObservedRunning {
+		t.Fatalf("manager state changed before failure callback: %#v", snapshot)
+	}
+	if got := controller.ProxyReadiness(); got != ebusProxyReadinessDegraded {
+		t.Fatalf("loss-fenced readiness = %q, want DEGRADED", got)
 	}
 }
 

--- a/cmd/gateway/ebus_driver_runtime_test.go
+++ b/cmd/gateway/ebus_driver_runtime_test.go
@@ -60,6 +60,32 @@ type issue851ProxyLifecycle struct {
 	fences atomic.Int32
 }
 
+type issue851OneShotPassiveRaw struct {
+	closed          atomic.Bool
+	closeCalls      atomic.Int32
+	reads           atomic.Int32
+	readsAfterClose atomic.Int32
+}
+
+func (raw *issue851OneShotPassiveRaw) ReadByte() (byte, error) {
+	raw.reads.Add(1)
+	if raw.closed.Load() {
+		raw.readsAfterClose.Add(1)
+		return 0, ebuserrors.ErrTransportClosed
+	}
+	return 0x55, nil
+}
+
+func (*issue851OneShotPassiveRaw) Write([]byte) (int, error) {
+	return 0, transport.ErrDriverUnavailable
+}
+
+func (raw *issue851OneShotPassiveRaw) Close() error {
+	raw.closeCalls.Add(1)
+	raw.closed.Store(true)
+	return nil
+}
+
 func newIssue851ProxyLifecycle() *issue851ProxyLifecycle {
 	lifecycle := &issue851ProxyLifecycle{}
 	lifecycle.ready.Store(true)
@@ -1137,6 +1163,73 @@ func TestIssue851InjectedTransportIsNotReadmittedAfterReplacement(t *testing.T) 
 	case <-raw.closed:
 	case <-time.After(time.Second):
 		t.Fatal("one-shot injected transport was not closed")
+	}
+}
+
+func TestIssue851InjectedPassiveTransportIsNotReadmittedAfterReplacement(t *testing.T) {
+	passive := &issue851OneShotPassiveRaw{}
+	var serversMu sync.Mutex
+	var servers []net.Conn
+	cfg := ebusgateway.DefaultConfig()
+	cfg.BroadcastListen = true
+	cfg.PassiveTransport = passive
+	cfg.TransportConfig.Protocol = ebusgateway.TransportTCPPlain
+	cfg.TransportConfig.Network = "tcp"
+	cfg.TransportConfig.Address = "fresh-active.invalid:9999"
+	cfg.TransportConfig.Dial = func(context.Context, string, string, time.Duration) (net.Conn, error) {
+		client, server := net.Pipe()
+		serversMu.Lock()
+		servers = append(servers, server)
+		serversMu.Unlock()
+		return client, nil
+	}
+	defer func() {
+		serversMu.Lock()
+		defer serversMu.Unlock()
+		for _, server := range servers {
+			_ = server.Close()
+		}
+	}()
+
+	runtimeSeam := transport.NewDriverRuntime(
+		newEBusDriverFactory(cfg, ebusgateway.TransportTCPPlain, true, &ebusV8CumulativeCounter{}),
+		transport.DriverRuntimeConfig{DrainTimeout: 100 * time.Millisecond},
+	)
+	runtime := &ebusDriverRuntime{runtime: runtimeSeam}
+	manager, err := drivermanager.New(drivermanager.Config{Drivers: []drivermanager.DriverConfig{{
+		ID: primaryEBusDriverID, Enabled: true, Runtime: runtime,
+		Capabilities: []drivermanager.Capability{drivermanager.CapabilityRead},
+	}}})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer func() { _ = manager.Shutdown(context.Background()) }()
+	passiveSlot := newEBusStablePassiveTransport(
+		managedEBusSlotInvoker{manager: manager, id: primaryEBusDriverID},
+		ebusgateway.TransportTCPPlain,
+		nil,
+	)
+	if err := manager.Start(context.Background(), primaryEBusDriverID); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if err := manager.Replace(context.Background(), primaryEBusDriverID); err != nil {
+		t.Fatalf("Replace() manager error = %v", err)
+	}
+	// Exercise the stable passive slot after replacement intent. A reused
+	// generation would call ReadByte on the already-closed injected pointer;
+	// the one-shot factory must instead leave the manager unavailable.
+	if _, err := passiveSlot.ReadByte(); err == nil {
+		t.Fatal("passive slot unexpectedly reached a replacement provider")
+	}
+	snapshot, _ := manager.Snapshot(primaryEBusDriverID)
+	if snapshot.ObservedState != drivermanager.ObservedFailed || snapshot.Reason.Code != drivermanager.ReasonProviderUnavailable || snapshot.Generation != 1 {
+		t.Fatalf("passive replacement snapshot = %#v, want generation-1 PROVIDER_UNAVAILABLE", snapshot)
+	}
+	if got := passive.closeCalls.Load(); got != 1 {
+		t.Fatalf("injected passive Close calls = %d, want exactly 1", got)
+	}
+	if got := passive.reads.Load(); got != 0 {
+		t.Fatalf("retired injected passive was accessed after replacement: reads=%d after_close=%d", got, passive.readsAfterClose.Load())
 	}
 }
 

--- a/cmd/gateway/ebus_driver_runtime_test.go
+++ b/cmd/gateway/ebus_driver_runtime_test.go
@@ -24,11 +24,30 @@ type issue851ReadResult struct {
 	err   error
 }
 
+type issue851EnhancedArbitrationRaw struct {
+	readStarted        chan struct{}
+	readResult         chan transport.StreamEvent
+	arbitrationEntered chan struct{}
+	arbitrationRelease chan struct{}
+	closed             chan struct{}
+	closeOnce          sync.Once
+}
+
 func newIssue851BlockingRawTransport() *issue851BlockingRawTransport {
 	return &issue851BlockingRawTransport{
 		readStarted: make(chan struct{}, 1),
 		readResult:  make(chan issue851ReadResult),
 		closed:      make(chan struct{}),
+	}
+}
+
+func newIssue851EnhancedArbitrationRaw() *issue851EnhancedArbitrationRaw {
+	return &issue851EnhancedArbitrationRaw{
+		readStarted:        make(chan struct{}, 1),
+		readResult:         make(chan transport.StreamEvent),
+		arbitrationEntered: make(chan struct{}),
+		arbitrationRelease: make(chan struct{}),
+		closed:             make(chan struct{}),
 	}
 }
 
@@ -48,6 +67,41 @@ func (raw *issue851BlockingRawTransport) ReadByte() (byte, error) {
 func (*issue851BlockingRawTransport) Write(data []byte) (int, error) { return len(data), nil }
 
 func (raw *issue851BlockingRawTransport) Close() error {
+	raw.closeOnce.Do(func() { close(raw.closed) })
+	return nil
+}
+
+func (raw *issue851EnhancedArbitrationRaw) ReadEvent() (transport.StreamEvent, error) {
+	select {
+	case raw.readStarted <- struct{}{}:
+	default:
+	}
+	select {
+	case event := <-raw.readResult:
+		return event, nil
+	case <-raw.closed:
+		return transport.StreamEvent{}, ebuserrors.ErrTransportClosed
+	}
+}
+
+func (raw *issue851EnhancedArbitrationRaw) ReadByte() (byte, error) {
+	event, err := raw.ReadEvent()
+	return event.Byte, err
+}
+
+func (*issue851EnhancedArbitrationRaw) Write(data []byte) (int, error) { return len(data), nil }
+
+func (raw *issue851EnhancedArbitrationRaw) StartArbitration(byte) error {
+	close(raw.arbitrationEntered)
+	select {
+	case <-raw.arbitrationRelease:
+		return nil
+	case <-raw.closed:
+		return ebuserrors.ErrTransportClosed
+	}
+}
+
+func (raw *issue851EnhancedArbitrationRaw) Close() error {
 	raw.closeOnce.Do(func() { close(raw.closed) })
 	return nil
 }
@@ -107,12 +161,88 @@ func TestIssue851ManagedReadLoopDrainsBeforeCloseAndReplaceFencesOldGeneration(t
 	mu.Lock()
 	second := generations[1]
 	mu.Unlock()
+	newReadDone := make(chan issue851ReadResult, 1)
+	go func() {
+		value, err := slot.ReadByte()
+		newReadDone <- issue851ReadResult{value: value, err: err}
+	}()
+	select {
+	case <-second.readStarted:
+	case <-time.After(time.Second):
+		t.Fatal("generation 2 read demand did not reach raw transport")
+	}
 	second.readResult <- issue851ReadResult{value: 0x5a}
-	if value, err := slot.ReadByte(); err != nil || value != 0x5a {
+	if result := <-newReadDone; result.err != nil || result.value != 0x5a {
+		value, err := result.value, result.err
 		t.Fatalf("new generation ReadByte = (0x%02X, %v), want (0x5A, nil)", value, err)
 	}
 	if err := runtime.Stop(context.Background()); err != nil {
 		t.Fatalf("Stop generation 2: %v", err)
+	}
+}
+
+func TestIssue851EnhancedReadPumpWaitsForDemandAndDoesNotStealArbitration(t *testing.T) {
+	raw := newIssue851EnhancedArbitrationRaw()
+	runtime := transport.NewDriverRuntime(func(ctx context.Context) (*transport.ManagedRawTransport, error) {
+		return newManagedEBusGeneration(ctx, raw, raw.Close), nil
+	}, transport.DriverRuntimeConfig{DrainTimeout: 100 * time.Millisecond})
+	slot := newEBusStableTransport(runtime, ebusgateway.TransportENH, nil)
+	if _, err := runtime.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	// Stable-slot Close belongs to the process shell, not a driver generation.
+	if err := slot.Close(); err != nil {
+		t.Fatalf("stable slot Close() error = %v", err)
+	}
+	select {
+	case <-raw.closed:
+		t.Fatal("stable-slot Close retired the active generation")
+	default:
+	}
+
+	// The adapter-owned pump exists, but it must not prefetch. In particular,
+	// it must not hold the ENH/ENS read path while START arbitration consumes
+	// its own control response.
+	select {
+	case <-raw.readStarted:
+		t.Fatal("read pump touched raw transport without protocol demand")
+	case <-time.After(25 * time.Millisecond):
+	}
+	starter := slot.(interface{ StartArbitration(byte) error })
+	arbitrationDone := make(chan error, 1)
+	go func() { arbitrationDone <- starter.StartArbitration(0x31) }()
+	select {
+	case <-raw.arbitrationEntered:
+	case <-time.After(time.Second):
+		t.Fatal("StartArbitration did not reach enhanced transport")
+	}
+	select {
+	case <-raw.readStarted:
+		t.Fatal("read pump raced an active START arbitration")
+	case <-time.After(25 * time.Millisecond):
+	}
+	close(raw.arbitrationRelease)
+	if err := <-arbitrationDone; err != nil {
+		t.Fatalf("StartArbitration() error = %v", err)
+	}
+
+	readDone := make(chan issue851ReadResult, 1)
+	go func() {
+		value, err := slot.ReadByte()
+		readDone <- issue851ReadResult{value: value, err: err}
+	}()
+	select {
+	case <-raw.readStarted:
+	case <-time.After(time.Second):
+		t.Fatal("explicit ReadByte demand did not reach enhanced transport")
+	}
+	raw.readResult <- transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0x5a}
+	if result := <-readDone; result.err != nil || result.value != 0x5a {
+		t.Fatalf("ReadByte() = (0x%02X, %v), want (0x5A, nil)", result.value, result.err)
+	}
+	if err := runtime.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop() error = %v", err)
 	}
 }
 
@@ -121,6 +251,7 @@ func TestIssue851StableTransportShapeMatchesConfiguredFamily(t *testing.T) {
 
 	for _, protocol := range []ebusgateway.TransportProtocol{ebusgateway.TransportENH, ebusgateway.TransportENS} {
 		slot := newEBusStableTransport(runtime, protocol, nil)
+		passive := newEBusStablePassiveTransport(directEBusSlotInvoker{runtime: runtime}, protocol)
 		if _, ok := slot.(transport.EscapeAware); !ok {
 			t.Errorf("%s slot does not preserve EscapeAware", protocol)
 		}
@@ -130,10 +261,17 @@ func TestIssue851StableTransportShapeMatchesConfiguredFamily(t *testing.T) {
 		if _, ok := slot.(interface{ StartArbitration(byte) error }); !ok {
 			t.Errorf("%s slot does not preserve enhanced arbitration", protocol)
 		}
+		if _, ok := passive.(transport.EscapeAware); !ok {
+			t.Errorf("%s passive slot does not preserve EscapeAware", protocol)
+		}
+		if _, ok := passive.(transport.StreamEventReader); !ok {
+			t.Errorf("%s passive slot does not preserve StreamEventReader", protocol)
+		}
 	}
 
 	for _, protocol := range []ebusgateway.TransportProtocol{ebusgateway.TransportTCPPlain, ebusgateway.TransportUDPPlain, ebusgateway.TransportEbusdTCP} {
 		slot := newEBusStableTransport(runtime, protocol, nil)
+		passive := newEBusStablePassiveTransport(directEBusSlotInvoker{runtime: runtime}, protocol)
 		if _, ok := slot.(transport.EscapeAware); ok {
 			t.Errorf("%s slot unexpectedly advertises EscapeAware", protocol)
 		}
@@ -142,6 +280,12 @@ func TestIssue851StableTransportShapeMatchesConfiguredFamily(t *testing.T) {
 		}
 		if _, ok := slot.(interface{ StartArbitration(byte) error }); ok {
 			t.Errorf("%s slot unexpectedly advertises enhanced arbitration", protocol)
+		}
+		if _, ok := passive.(transport.EscapeAware); ok {
+			t.Errorf("%s passive slot unexpectedly advertises EscapeAware", protocol)
+		}
+		if _, ok := passive.(transport.StreamEventReader); ok {
+			t.Errorf("%s passive slot unexpectedly advertises StreamEventReader", protocol)
 		}
 	}
 }
@@ -179,4 +323,5 @@ func TestIssue851ActiveCallbackTimeoutQuarantinesWithoutClosingRawTransport(t *t
 	if err := <-invokeDone; err != nil {
 		t.Fatalf("admitted callback error = %v", err)
 	}
+	_ = raw.Close()
 }

--- a/cmd/gateway/ebus_driver_runtime_test.go
+++ b/cmd/gateway/ebus_driver_runtime_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/adaptermux"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/adaptermux/v8classifier"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/drivermanager"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/vaillant/b503session"
 	ebuserrors "github.com/Project-Helianthus/helianthus-ebusgo/errors"
 	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
 )
@@ -1347,6 +1348,122 @@ func TestIssue851ProxyReadinessWithdrawsAndRecoversWithAdmittedListener(t *testi
 	}
 	if got := controller.ProxyReadiness(); got != ebusProxyReadinessReady {
 		t.Fatalf("recovered proxy readiness = %q, want READY", got)
+	}
+}
+
+func TestIssue851B503SessionTracksDriverWithdrawalAndRecoveryWithoutRequests(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		retryBudget    int
+		withdrawnState drivermanager.ObservedState
+	}{
+		{name: "backoff", retryBudget: 1, withdrawnState: drivermanager.ObservedBackoff},
+		{name: "failed", retryBudget: 0, withdrawnState: drivermanager.ObservedFailed},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var rawsMu sync.Mutex
+			var raws []*issue851BlockingRawTransport
+			runtimeSeam := transport.NewDriverRuntime(func(ctx context.Context) (*transport.ManagedRawTransport, error) {
+				raw := newIssue851BlockingRawTransport()
+				rawsMu.Lock()
+				raws = append(raws, raw)
+				rawsMu.Unlock()
+				return newManagedEBusGeneration(ctx, raw, raw.Close), nil
+			}, transport.DriverRuntimeConfig{DrainTimeout: 100 * time.Millisecond})
+			runtime := &ebusDriverRuntime{runtime: runtimeSeam}
+			manager, err := drivermanager.New(drivermanager.Config{Drivers: []drivermanager.DriverConfig{{
+				ID:           primaryEBusDriverID,
+				Enabled:      true,
+				Runtime:      runtime,
+				Capabilities: []drivermanager.Capability{drivermanager.CapabilityRead, drivermanager.CapabilityWrite},
+				ClassifyError: func(error) drivermanager.Failure {
+					return drivermanager.Failure{Reason: drivermanager.Reason{Code: drivermanager.ReasonDependencyUnavailable, Retryable: true}}
+				},
+				Retry: drivermanager.RetryPolicy{
+					Budget:       tc.retryBudget,
+					InitialDelay: time.Hour,
+					MaxDelay:     time.Hour,
+					JitterRatio:  -1,
+				},
+			}}})
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+			controller := &ebusDriverController{manager: manager, runtime: runtime}
+			b503rt := &b503Runtime{manager: b503session.New(
+				b503session.TransportKey{AdapterInstanceID: "gateway"},
+				30*time.Second,
+				b503StubRefresh,
+			)}
+			controller.SetLifecycleObserver(b503rt)
+			t.Cleanup(func() { _ = controller.Shutdown(context.Background()) })
+
+			if err := manager.Start(context.Background(), primaryEBusDriverID); err != nil {
+				t.Fatalf("Start() error = %v", err)
+			}
+			first := requireEBusDriverObservedState(t, manager, drivermanager.ObservedRunning, time.Second)
+			if got := b503rt.manager.TransportKey().TransportEpoch; got != first.Generation {
+				t.Fatalf("B503 epoch after activation = %d, want generation %d", got, first.Generation)
+			}
+			oldIssuer, err := b503rt.manager.Enable(context.Background())
+			if err != nil {
+				t.Fatalf("B503 Enable() error = %v", err)
+			}
+			// A duplicate correlation bind must not re-run epoch activation and
+			// expire the live owner.
+			runtime.BindCorrelation(drivermanager.Correlation{Generation: first.Generation})
+			if !b503rt.manager.IsOwned() {
+				t.Fatal("duplicate activation disconnected the current B503 issuer")
+			}
+
+			if accepted := manager.ReportFailure(
+				primaryEBusDriverID,
+				drivermanager.Correlation{Generation: first.Generation},
+				drivermanager.Failure{Reason: drivermanager.Reason{Code: drivermanager.ReasonDependencyUnavailable, Retryable: true}},
+			); !accepted {
+				t.Fatal("current-generation failure was rejected")
+			}
+			requireEBusDriverObservedState(t, manager, tc.withdrawnState, time.Second)
+			if b503rt.manager.IsOwned() {
+				t.Fatal("DriverManager withdrawal retained the old B503 issuer without an outage request")
+			}
+			if got := b503rt.manager.TransportKey().TransportEpoch; got != first.Generation {
+				t.Fatalf("B503 withdrawal manufactured epoch %d, want %d", got, first.Generation)
+			}
+			// A repeated fence for the same generation is a no-op.
+			runtime.FenceWithdrawal()
+			if got := b503rt.manager.TransportKey().TransportEpoch; got != first.Generation {
+				t.Fatalf("duplicate withdrawal manufactured epoch %d, want %d", got, first.Generation)
+			}
+
+			if err := manager.Start(context.Background(), primaryEBusDriverID); err != nil {
+				t.Fatalf("recovery Start() error = %v", err)
+			}
+			second := requireEBusDriverObservedState(t, manager, drivermanager.ObservedRunning, time.Second)
+			if second.Generation != first.Generation+1 {
+				t.Fatalf("recovered generation = %d, want %d", second.Generation, first.Generation+1)
+			}
+			if got := b503rt.manager.TransportKey().TransportEpoch; got != second.Generation {
+				t.Fatalf("B503 recovery epoch = %d, want generation %d", got, second.Generation)
+			}
+			if err := b503rt.manager.Read(oldIssuer.Transport); !errors.Is(err, b503session.ErrNotActive) {
+				t.Fatalf("old generation issuer Read() error = %v, want ErrNotActive", err)
+			}
+			newIssuer, err := b503rt.manager.Enable(context.Background())
+			if err != nil {
+				t.Fatalf("new generation Enable() error = %v", err)
+			}
+			if newIssuer.Transport.TransportEpoch != second.Generation {
+				t.Fatalf("new issuer epoch = %d, want %d", newIssuer.Transport.TransportEpoch, second.Generation)
+			}
+
+			rawsMu.Lock()
+			constructed := len(raws)
+			rawsMu.Unlock()
+			if constructed != 2 {
+				t.Fatalf("constructed generations = %d, want exactly 2", constructed)
+			}
+		})
 	}
 }
 

--- a/cmd/gateway/ebus_driver_runtime_test.go
+++ b/cmd/gateway/ebus_driver_runtime_test.go
@@ -62,6 +62,19 @@ type issue851ProxyLifecycle struct {
 	fences atomic.Int32
 }
 
+type issue851BindBarrierRuntime struct {
+	*ebusDriverRuntime
+	bindOnce    sync.Once
+	bindEntered chan struct{}
+	bindRelease <-chan struct{}
+}
+
+func (runtime *issue851BindBarrierRuntime) BindCorrelation(correlation drivermanager.Correlation) {
+	runtime.bindOnce.Do(func() { close(runtime.bindEntered) })
+	<-runtime.bindRelease
+	runtime.ebusDriverRuntime.BindCorrelation(correlation)
+}
+
 type issue851OneShotPassiveRaw struct {
 	closed          atomic.Bool
 	closeCalls      atomic.Int32
@@ -1464,6 +1477,90 @@ func TestIssue851B503SessionTracksDriverWithdrawalAndRecoveryWithoutRequests(t *
 				t.Fatalf("constructed generations = %d, want exactly 2", constructed)
 			}
 		})
+	}
+}
+
+func TestIssue851B503ActivationPrecedesRunningAdmission(t *testing.T) {
+	raw := newIssue851BlockingRawTransport()
+	runtimeSeam := transport.NewDriverRuntime(func(ctx context.Context) (*transport.ManagedRawTransport, error) {
+		return newManagedEBusGeneration(ctx, raw, raw.Close), nil
+	}, transport.DriverRuntimeConfig{DrainTimeout: 100 * time.Millisecond})
+	ebusRuntime := &ebusDriverRuntime{runtime: runtimeSeam}
+	bindEntered := make(chan struct{})
+	bindRelease := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseBind := func() { releaseOnce.Do(func() { close(bindRelease) }) }
+	defer releaseBind()
+	barrierRuntime := &issue851BindBarrierRuntime{
+		ebusDriverRuntime: ebusRuntime,
+		bindEntered:       bindEntered,
+		bindRelease:       bindRelease,
+	}
+	manager, err := drivermanager.New(drivermanager.Config{Drivers: []drivermanager.DriverConfig{{
+		ID:           primaryEBusDriverID,
+		Enabled:      true,
+		Runtime:      barrierRuntime,
+		Capabilities: []drivermanager.Capability{drivermanager.CapabilityRead, drivermanager.CapabilityWrite},
+	}}})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	controller := &ebusDriverController{manager: manager, runtime: ebusRuntime}
+	b503rt := &b503Runtime{manager: b503session.New(
+		b503session.TransportKey{AdapterInstanceID: "gateway"},
+		30*time.Second,
+		b503StubRefresh,
+	)}
+	controller.SetLifecycleObserver(b503rt)
+	t.Cleanup(func() {
+		releaseBind()
+		_ = controller.Shutdown(context.Background())
+	})
+
+	startDone := make(chan error, 1)
+	go func() { startDone <- manager.Start(context.Background(), primaryEBusDriverID) }()
+	select {
+	case <-bindEntered:
+		// RUNNING is already published on the buggy path, but post-publication
+		// BindCorrelation has not yet activated the B503 epoch.
+	case <-time.After(time.Second):
+		t.Fatal("driver did not reach the post-publication BindCorrelation barrier")
+	}
+	snapshot, ok := manager.Snapshot(primaryEBusDriverID)
+	if !ok || snapshot.ObservedState != drivermanager.ObservedRunning {
+		t.Fatalf("snapshot at bind barrier = %#v, want RUNNING", snapshot)
+	}
+
+	issuer, enableErr := b503rt.manager.Enable(context.Background())
+	bus := newB503DispatcherMockBus()
+	bus.setResp([2]byte{0x00, 0x01}, []byte{0x01})
+	sourceProvider := newManagedEBusSourceProvider(controller, func() (byte, bool) { return 0x77, true })
+	dispatcher := newRawFrameDispatcherWithSourceProvider(bus, sourceProvider, nil, b503rt.manager, time.Second)
+	dispatcher.disconnectIfCurrent = b503rt.disconnectIfCurrent
+	_, invokeErr := dispatcher.Invoke(context.Background(), 0x08, []byte{0x00, 0x01})
+	requestEpoch := issuer.Transport.TransportEpoch
+	busCalls := bus.callCount()
+
+	releaseBind()
+	select {
+	case err := <-startDone:
+		if err != nil {
+			t.Fatalf("Start() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Start() did not finish after releasing BindCorrelation")
+	}
+	if enableErr != nil {
+		t.Fatalf("B503 Enable() error = %v", enableErr)
+	}
+	if invokeErr != nil {
+		t.Fatalf("B503 Invoke() error = %v", invokeErr)
+	}
+	if requestEpoch != snapshot.Generation {
+		t.Fatalf("B503 request sent %d time(s) via driver generation %d with stale issuer epoch %d", busCalls, snapshot.Generation, requestEpoch)
+	}
+	if !b503rt.manager.IsOwned() {
+		t.Fatal("post-bind activation immediately retired the issuer that was admitted during RUNNING")
 	}
 }
 

--- a/cmd/gateway/ebus_driver_runtime_test.go
+++ b/cmd/gateway/ebus_driver_runtime_test.go
@@ -68,6 +68,59 @@ type issue851OneShotPassiveRaw struct {
 	readsAfterClose atomic.Int32
 }
 
+type issue851LatePassiveRead struct {
+	inner         transport.RawTransport
+	readEntered   chan struct{}
+	releaseRead   chan struct{}
+	closeReturned chan struct{}
+	readOnce      sync.Once
+	closeOnce     sync.Once
+}
+
+type issue851PassiveTapConsumer struct{}
+
+func (issue851PassiveTapConsumer) OnPassiveTapEvent(ebusgateway.PassiveTapEvent) {}
+
+func (raw *issue851LatePassiveRead) ReadEvent() (transport.StreamEvent, error) {
+	return raw.ReadEventContext(context.Background())
+}
+
+func (raw *issue851LatePassiveRead) ReadEventContext(ctx context.Context) (transport.StreamEvent, error) {
+	raw.readOnce.Do(func() { close(raw.readEntered) })
+	<-raw.releaseRead
+	if reader, ok := raw.inner.(interface {
+		ReadEventContext(context.Context) (transport.StreamEvent, error)
+	}); ok {
+		return reader.ReadEventContext(ctx)
+	}
+	reader, ok := raw.inner.(transport.StreamEventReader)
+	if !ok {
+		return transport.StreamEvent{}, transport.ErrDriverUnavailable
+	}
+	return reader.ReadEvent()
+}
+
+func (raw *issue851LatePassiveRead) ReadByte() (byte, error) {
+	return raw.ReadByteContext(context.Background())
+}
+
+func (raw *issue851LatePassiveRead) ReadByteContext(ctx context.Context) (byte, error) {
+	event, err := raw.ReadEventContext(ctx)
+	return event.Byte, err
+}
+
+func (*issue851LatePassiveRead) Write([]byte) (int, error) {
+	return 0, transport.ErrDriverUnavailable
+}
+
+func (raw *issue851LatePassiveRead) Close() error {
+	err := raw.inner.Close()
+	raw.closeOnce.Do(func() { close(raw.closeReturned) })
+	return err
+}
+
+func (*issue851LatePassiveRead) BytesAreUnescaped() bool { return true }
+
 func (raw *issue851OneShotPassiveRaw) ReadByte() (byte, error) {
 	raw.reads.Add(1)
 	if raw.closed.Load() {
@@ -747,6 +800,175 @@ func TestIssue851PassiveCloseInterruptsReadWithoutOwningGeneration(t *testing.T)
 	}
 	if err := runtime.Stop(context.Background()); err != nil {
 		t.Fatalf("runtime Stop() error = %v", err)
+	}
+}
+
+func TestIssue851PassiveTapCloseFencesReadThatStartsAfterCloseSnapshot(t *testing.T) {
+	active := newIssue851BlockingRawTransport()
+	passive := newIssue851BlockingRawTransport()
+	runtime := transport.NewDriverRuntime(func(ctx context.Context) (*transport.ManagedRawTransport, error) {
+		return newManagedEBusGenerationParts(ctx, active, passive, nil, func() error {
+			return errors.Join(active.Close(), passive.Close())
+		}), nil
+	}, transport.DriverRuntimeConfig{DrainTimeout: 100 * time.Millisecond})
+	if _, err := runtime.Start(context.Background()); err != nil {
+		t.Fatalf("runtime Start() error = %v", err)
+	}
+	stable := newEBusStablePassiveTransport(directEBusSlotInvoker{runtime: runtime}, ebusgateway.TransportENH, nil)
+	late := &issue851LatePassiveRead{
+		inner:         stable,
+		readEntered:   make(chan struct{}),
+		releaseRead:   make(chan struct{}),
+		closeReturned: make(chan struct{}),
+	}
+	cfg := ebusgateway.DefaultConfig()
+	cfg.BroadcastListen = true
+	cfg.PassiveTransport = stable
+	tap, err := ebusgateway.StartPassiveBusTapWithTransport(
+		context.Background(),
+		cfg,
+		issue851PassiveTapConsumer{},
+		func(transport.RawTransport) transport.RawTransport { return late },
+	)
+	if err != nil {
+		_ = runtime.Stop(context.Background())
+		t.Fatalf("StartPassiveBusTapWithTransport() error = %v", err)
+	}
+	select {
+	case <-late.readEntered:
+	case <-time.After(time.Second):
+		_ = runtime.Stop(context.Background())
+		t.Fatal("passive tap did not pass its context check and enter delayed read")
+	}
+
+	tapCloseDone := make(chan error, 1)
+	go func() { tapCloseDone <- tap.Close() }()
+	select {
+	case <-late.closeReturned:
+	case <-time.After(time.Second):
+		_ = runtime.Stop(context.Background())
+		t.Fatal("passive tap Close did not close the stable slot")
+	}
+	// Delegate only after stable Close has taken its read snapshot and
+	// returned. A post-Close read must be rejected before it reaches the raw
+	// generation; otherwise PassiveBusTap.Close waits forever on its run loop.
+	close(late.releaseRead)
+	select {
+	case err := <-tapCloseDone:
+		if err != nil {
+			t.Fatalf("PassiveBusTap.Close() error = %v", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		_ = runtime.Stop(context.Background())
+		<-tapCloseDone
+		t.Fatal("PassiveBusTap.Close blocked on read admitted after stable Close")
+	}
+	select {
+	case <-passive.readStarted:
+		_ = runtime.Stop(context.Background())
+		t.Fatal("post-Close passive read reached retired raw generation")
+	default:
+	}
+	if err := runtime.Stop(context.Background()); err != nil {
+		t.Fatalf("runtime Stop() error = %v", err)
+	}
+}
+
+func TestIssue851PassiveTapReconnectsStableSlotAfterManagedRecovery(t *testing.T) {
+	var mu sync.Mutex
+	var recoveredPassive *issue851BlockingRawTransport
+	factoryCalls := 0
+	runtimeSeam := transport.NewDriverRuntime(func(ctx context.Context) (*transport.ManagedRawTransport, error) {
+		mu.Lock()
+		factoryCalls++
+		call := factoryCalls
+		mu.Unlock()
+		active := newIssue851BlockingRawTransport()
+		var passive transport.RawTransport = newIssue851TerminalPassiveRaw(errors.New("passive provider disconnected"))
+		if call > 1 {
+			blocking := newIssue851BlockingRawTransport()
+			passive = blocking
+			mu.Lock()
+			recoveredPassive = blocking
+			mu.Unlock()
+		}
+		return newManagedEBusGenerationParts(ctx, active, passive, nil, func() error {
+			return errors.Join(active.Close(), passive.Close())
+		}), nil
+	}, transport.DriverRuntimeConfig{DrainTimeout: 100 * time.Millisecond})
+	runtime := &ebusDriverRuntime{runtime: runtimeSeam}
+	manager, err := drivermanager.New(drivermanager.Config{Drivers: []drivermanager.DriverConfig{{
+		ID:           primaryEBusDriverID,
+		Enabled:      true,
+		Runtime:      runtime,
+		Capabilities: []drivermanager.Capability{drivermanager.CapabilityRead, drivermanager.CapabilityWrite},
+		ClassifyError: func(error) drivermanager.Failure {
+			return drivermanager.Failure{Reason: drivermanager.Reason{Code: drivermanager.ReasonDependencyUnavailable, Retryable: true}}
+		},
+		Retry: drivermanager.RetryPolicy{Budget: 1, InitialDelay: 5 * time.Millisecond, MaxDelay: 5 * time.Millisecond},
+	}}})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	reporter := func(correlation drivermanager.Correlation, rawErr error) {
+		manager.ReportFailure(primaryEBusDriverID, correlation, drivermanager.Failure{Reason: drivermanager.Reason{Code: drivermanager.ReasonDependencyUnavailable, Retryable: true}})
+	}
+	stable := newEBusStablePassiveTransport(
+		managedEBusSlotInvoker{manager: manager, id: primaryEBusDriverID},
+		ebusgateway.TransportENH,
+		reporter,
+	)
+	if err := manager.Start(context.Background(), primaryEBusDriverID); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	cfg := ebusgateway.DefaultConfig()
+	cfg.BroadcastListen = true
+	cfg.PassiveTransport = stable
+	cfg.PassiveReconnectInitialDelay = time.Millisecond
+	cfg.PassiveReconnectMaxDelay = time.Millisecond
+	tap, err := ebusgateway.StartPassiveBusTap(context.Background(), cfg, issue851PassiveTapConsumer{})
+	if err != nil {
+		_ = manager.Shutdown(context.Background())
+		t.Fatalf("StartPassiveBusTap() error = %v", err)
+	}
+	defer func() {
+		_ = tap.Close()
+		_ = manager.Shutdown(context.Background())
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	var recovered drivermanager.Snapshot
+	for {
+		recovered, _ = manager.Snapshot(primaryEBusDriverID)
+		if recovered.ObservedState == drivermanager.ObservedRunning && recovered.Generation == 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("managed recovery snapshot = %#v, want RUNNING generation 2", recovered)
+		}
+		time.Sleep(time.Millisecond)
+	}
+	mu.Lock()
+	passive := recoveredPassive
+	mu.Unlock()
+	if passive == nil {
+		t.Fatal("recovered passive generation was not constructed")
+	}
+	select {
+	case <-passive.readStarted:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("PassiveBusTap did not reopen the stable slot after managed recovery")
+	}
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- tap.Close() }()
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("PassiveBusTap.Close() error = %v", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("PassiveBusTap.Close() blocked after recovered read")
 	}
 }
 

--- a/cmd/gateway/ebus_driver_runtime_test.go
+++ b/cmd/gateway/ebus_driver_runtime_test.go
@@ -1512,6 +1512,63 @@ func TestIssue851FatalProxyAcceptRecoversOnceAndRejectsStaleGeneration(t *testin
 	}
 }
 
+func TestIssue851FatalProxyAcceptClosesExistingSessionBeforeOwnerPublication(t *testing.T) {
+	adapterAddress := newIssue851AdapterServer(t)
+	cfg := ebusgateway.DefaultConfig()
+	cfg.BroadcastListen = false
+	cfg.TransportConfig.Protocol = ebusgateway.TransportAdapterDirect
+	cfg.TransportConfig.Network = "tcp"
+	cfg.TransportConfig.Address = adapterAddress
+	cfg.TransportConfig.DialTimeout = time.Second
+	cfg.ProxyListenAddr = "127.0.0.1:0"
+	controller, err := newEBusDriverController(cfg)
+	if err != nil {
+		t.Fatalf("newEBusDriverController() error = %v", err)
+	}
+	defer func() { _ = controller.Shutdown(context.Background()) }()
+	if err := controller.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	requireEBusDriverObservedState(t, controller.manager, drivermanager.ObservedRunning, 2*time.Second)
+	var generation *managedEBusGeneration
+	if _, err := controller.manager.Invoke(context.Background(), primaryEBusDriverID, drivermanager.CapabilityRead, func(provider any) error {
+		generation, _ = provider.(*managedEBusGeneration)
+		return nil
+	}); err != nil || generation == nil {
+		t.Fatalf("capture generation = (%T, %v)", generation, err)
+	}
+	mux, ok := generation.proxyLifecycle.(*adaptermux.Mux)
+	if !ok {
+		t.Fatalf("proxy lifecycle = %T, want *adaptermux.Mux", generation.proxyLifecycle)
+	}
+	server, client := net.Pipe()
+	defer func() { _ = client.Close() }()
+	if id := mux.AddSession(server); id == 0 {
+		t.Fatal("pre-failure proxy session was rejected")
+	}
+
+	ownerCalled := make(chan struct{})
+	var ownerSawOpen atomic.Bool
+	onFatal := adapterDirectProxyFatalCallback(mux, func() {
+		if err := client.SetWriteDeadline(time.Now().Add(100 * time.Millisecond)); err == nil {
+			initRequest := transport.EncodeENH(transport.ENHReqInit, 0x03)
+			if _, writeErr := client.Write(initRequest[:]); writeErr == nil {
+				ownerSawOpen.Store(true)
+			}
+		}
+		close(ownerCalled)
+	})
+	onFatal(net.ErrClosed)
+	select {
+	case <-ownerCalled:
+	case <-time.After(time.Second):
+		t.Fatal("fatal listener owner was not called")
+	}
+	if ownerSawOpen.Load() {
+		t.Fatal("failure owner published while existing proxy session still accepted cached INIT")
+	}
+}
+
 func TestIssue851InjectedTransportIsNotReadmittedAfterReplacement(t *testing.T) {
 	raw := newIssue851BlockingRawTransport()
 	cfg := ebusgateway.DefaultConfig()

--- a/cmd/gateway/ebus_driver_runtime_test.go
+++ b/cmd/gateway/ebus_driver_runtime_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"io"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -52,6 +53,73 @@ type issue851ReadSignalingRaw struct {
 type issue851CancelBeforeByteRaw struct {
 	cancel context.CancelFunc
 	value  byte
+}
+
+func newIssue851AdapterServer(t *testing.T) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen fake adapter: %v", err)
+	}
+	var connectionMu sync.Mutex
+	connections := make(map[net.Conn]struct{})
+	var connectionWG sync.WaitGroup
+	acceptDone := make(chan struct{})
+	go func() {
+		defer close(acceptDone)
+		for {
+			connection, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				return
+			}
+			connectionMu.Lock()
+			connections[connection] = struct{}{}
+			connectionMu.Unlock()
+			connectionWG.Add(1)
+			go func() {
+				defer connectionWG.Done()
+				defer func() {
+					connectionMu.Lock()
+					delete(connections, connection)
+					connectionMu.Unlock()
+					_ = connection.Close()
+				}()
+				request := make([]byte, 2)
+				if _, readErr := io.ReadFull(connection, request); readErr != nil {
+					return
+				}
+				response := transport.EncodeENH(transport.ENHResResetted, 0x01)
+				if _, writeErr := connection.Write(response[:]); writeErr != nil {
+					return
+				}
+				// adaptermux always probes INFO version once during startup. A
+				// one-byte payload is deliberately non-parseable, which proves the
+				// request path without triggering the optional paced INFO sweep.
+				infoRequest := make([]byte, 2)
+				if _, readErr := io.ReadFull(connection, infoRequest); readErr != nil {
+					return
+				}
+				infoLength := transport.EncodeENH(transport.ENHResInfo, 0x01)
+				infoValue := transport.EncodeENH(transport.ENHResInfo, 0x00)
+				infoResponse := append(infoLength[:], infoValue[:]...)
+				if _, writeErr := connection.Write(infoResponse); writeErr != nil {
+					return
+				}
+				_, _ = io.Copy(io.Discard, connection)
+			}()
+		}
+	}()
+	t.Cleanup(func() {
+		_ = listener.Close()
+		<-acceptDone
+		connectionMu.Lock()
+		for connection := range connections {
+			_ = connection.Close()
+		}
+		connectionMu.Unlock()
+		connectionWG.Wait()
+	})
+	return listener.Addr().String()
 }
 
 func (raw issue851CancelBeforeByteRaw) ReadByte() (byte, error) {
@@ -801,6 +869,121 @@ func TestIssue851AdapterDirectConnectionLossWithdrawsCapabilitiesAndRecoversOnce
 	mu.Unlock()
 	if afterStale.ObservedState != drivermanager.ObservedRunning || afterStale.Generation != second.Generation || calls != 2 {
 		t.Fatalf("stale old connection signal changed recovered generation: snapshot=%#v calls=%d", afterStale, calls)
+	}
+}
+
+func TestIssue851ProxyReadinessStaysDegradedOnAdapterDialFailure(t *testing.T) {
+	unused, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve unused adapter address: %v", err)
+	}
+	adapterAddress := unused.Addr().String()
+	if err := unused.Close(); err != nil {
+		t.Fatalf("release unused adapter address: %v", err)
+	}
+
+	cfg := ebusgateway.DefaultConfig()
+	cfg.BroadcastListen = false
+	cfg.TransportConfig.Protocol = ebusgateway.TransportAdapterDirect
+	cfg.TransportConfig.Network = "tcp"
+	cfg.TransportConfig.Address = adapterAddress
+	cfg.TransportConfig.DialTimeout = 100 * time.Millisecond
+	cfg.ProxyListenAddr = "127.0.0.1:0"
+	controller, err := newEBusDriverController(cfg)
+	if err != nil {
+		t.Fatalf("newEBusDriverController() error = %v", err)
+	}
+	defer func() { _ = controller.Shutdown(context.Background()) }()
+
+	if got := controller.ProxyReadiness(); got != ebusProxyReadinessDegraded {
+		t.Fatalf("pre-construction proxy readiness = %q, want DEGRADED", got)
+	}
+	if err := controller.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	requireEBusDriverObservedState(t, controller.manager, drivermanager.ObservedBackoff, time.Second)
+	if got := controller.ProxyReadiness(); got != ebusProxyReadinessDegraded {
+		t.Fatalf("dial-failure proxy readiness = %q, want DEGRADED", got)
+	}
+}
+
+func TestIssue851ProxyReadinessStaysDegradedOnListenerBindFailure(t *testing.T) {
+	adapterAddress := newIssue851AdapterServer(t)
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("occupy proxy address: %v", err)
+	}
+	defer func() { _ = occupied.Close() }()
+
+	cfg := ebusgateway.DefaultConfig()
+	cfg.BroadcastListen = false
+	cfg.TransportConfig.Protocol = ebusgateway.TransportAdapterDirect
+	cfg.TransportConfig.Network = "tcp"
+	cfg.TransportConfig.Address = adapterAddress
+	cfg.TransportConfig.DialTimeout = time.Second
+	cfg.ProxyListenAddr = occupied.Addr().String()
+	controller, err := newEBusDriverController(cfg)
+	if err != nil {
+		t.Fatalf("newEBusDriverController() error = %v", err)
+	}
+	defer func() { _ = controller.Shutdown(context.Background()) }()
+
+	if err := controller.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	requireEBusDriverObservedState(t, controller.manager, drivermanager.ObservedBackoff, time.Second)
+	if got := controller.ProxyReadiness(); got != ebusProxyReadinessDegraded {
+		t.Fatalf("bind-failure proxy readiness = %q, want DEGRADED", got)
+	}
+}
+
+func TestIssue851ProxyReadinessWithdrawsAndRecoversWithAdmittedListener(t *testing.T) {
+	adapterAddress := newIssue851AdapterServer(t)
+	cfg := ebusgateway.DefaultConfig()
+	cfg.BroadcastListen = false
+	cfg.TransportConfig.Protocol = ebusgateway.TransportAdapterDirect
+	cfg.TransportConfig.Network = "tcp"
+	cfg.TransportConfig.Address = adapterAddress
+	cfg.TransportConfig.DialTimeout = time.Second
+	cfg.ProxyListenAddr = "127.0.0.1:0"
+	controller, err := newEBusDriverController(cfg)
+	if err != nil {
+		t.Fatalf("newEBusDriverController() error = %v", err)
+	}
+	defer func() { _ = controller.Shutdown(context.Background()) }()
+
+	if err := controller.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	first := requireEBusDriverObservedState(t, controller.manager, drivermanager.ObservedRunning, 2*time.Second)
+	if got := controller.ProxyReadiness(); got != ebusProxyReadinessReady {
+		t.Fatalf("bound generation proxy readiness = %q, want READY", got)
+	}
+
+	if accepted := controller.manager.ReportFailure(
+		primaryEBusDriverID,
+		drivermanager.Correlation{Generation: first.Generation},
+		drivermanager.Failure{Reason: drivermanager.Reason{Code: drivermanager.ReasonDependencyUnavailable, Retryable: true}},
+	); !accepted {
+		t.Fatal("current-generation proxy withdrawal was rejected")
+	}
+	requireEBusDriverObservedState(t, controller.manager, drivermanager.ObservedBackoff, time.Second)
+	if got := controller.ProxyReadiness(); got != ebusProxyReadinessDegraded {
+		t.Fatalf("withdrawn generation proxy readiness = %q, want DEGRADED", got)
+	}
+
+	// Explicit repeated RUNNING intent expedites the already-scheduled
+	// replacement. The next generation cannot publish READY until its own
+	// listener has bound and DriverManager admits that exact generation.
+	if err := controller.Start(context.Background()); err != nil {
+		t.Fatalf("recovery Start() error = %v", err)
+	}
+	second := requireEBusDriverObservedState(t, controller.manager, drivermanager.ObservedRunning, 2*time.Second)
+	if second.Generation != first.Generation+1 {
+		t.Fatalf("recovered generation = %d, want %d", second.Generation, first.Generation+1)
+	}
+	if got := controller.ProxyReadiness(); got != ebusProxyReadinessReady {
+		t.Fatalf("recovered proxy readiness = %q, want READY", got)
 	}
 }
 

--- a/cmd/gateway/ebus_driver_runtime_test.go
+++ b/cmd/gateway/ebus_driver_runtime_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -47,6 +48,22 @@ type issue851ReadSignalingRaw struct {
 	readStarted chan struct{}
 	readOnce    sync.Once
 }
+
+type issue851CancelBeforeByteRaw struct {
+	cancel context.CancelFunc
+	value  byte
+}
+
+func (raw issue851CancelBeforeByteRaw) ReadByte() (byte, error) {
+	// Make generation withdrawal and the old byte ready in the same pump
+	// turn. A select-only fence can leak the byte; post-receive cancellation
+	// dominance must discard it deterministically.
+	raw.cancel()
+	return raw.value, nil
+}
+
+func (issue851CancelBeforeByteRaw) Write(data []byte) (int, error) { return len(data), nil }
+func (issue851CancelBeforeByteRaw) Close() error                   { return nil }
 
 func (raw *issue851ReadSignalingRaw) ReadByte() (byte, error) {
 	raw.readOnce.Do(func() { close(raw.readStarted) })
@@ -319,6 +336,40 @@ func TestIssue851EbusdActiveReadRetiresWithTransportLevelClose(t *testing.T) {
 				t.Fatal("transport-level close did not wake ebusd-tcp reader")
 			}
 		})
+	}
+}
+
+func TestIssue851CanceledGenerationDominatesConcurrentlyReadyOldByte(t *testing.T) {
+	for iteration := 0; iteration < 200; iteration++ {
+		generationCtx, cancelGeneration := context.WithCancel(context.Background())
+		closing := &atomic.Bool{}
+		endpoint := newManagedEBusEndpoint(
+			generationCtx,
+			issue851CancelBeforeByteRaw{cancel: cancelGeneration, value: 0x5a},
+			closing,
+		)
+		resultCh := make(chan issue851ReadResult, 1)
+		go func() {
+			value, _, err := endpoint.nextByte()
+			resultCh <- issue851ReadResult{value: value, err: err}
+		}()
+
+		select {
+		case result := <-resultCh:
+			if result.err == nil || result.value == 0x5a {
+				t.Fatalf("iteration %d returned retired-generation byte: %#v", iteration, result)
+			}
+			if !errors.Is(result.err, ebuserrors.ErrTransportClosed) {
+				t.Fatalf("iteration %d error = %v, want transport closed", iteration, result.err)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("iteration %d canceled read did not return", iteration)
+		}
+		select {
+		case <-endpoint.pumpDone:
+		case <-time.After(time.Second):
+			t.Fatalf("iteration %d read pump did not retire", iteration)
+		}
 	}
 }
 
@@ -830,21 +881,29 @@ func TestIssue851AdminClassifierResolvesCurrentGenerationWithoutMetricsScrape(t 
 	}, transport.DriverRuntimeConfig{DrainTimeout: 100 * time.Millisecond})
 	stable := &ebusStableClassifier{invoker: directEBusSlotInvoker{runtime: runtime}}
 	v8AdminEventsCurrentClassifier.Store(nil)
-	v8AdminEventsCurrentProvider.Store(&v8AdminClassifierProvider{classifierFn: stable.V8Classifier})
+	v8AdminEventsCurrentProvider.Store(&v8AdminClassifierProvider{withClassifier: stable.WithV8Classifier})
+	currentClassifier := func() *v8classifier.Classifier {
+		var current *v8classifier.Classifier
+		withCurrentV8AdminClassifier(func(classifier *v8classifier.Classifier) { current = classifier })
+		return current
+	}
 	if _, err := runtime.Start(context.Background()); err != nil {
 		t.Fatalf("Start() error = %v", err)
 	}
-	if got := currentV8AdminClassifier(); got != first {
+	if got := currentClassifier(); got != first {
 		t.Fatalf("generation 1 admin classifier = %p, want %p", got, first)
 	}
 	if _, err := runtime.Replace(context.Background()); err != nil {
 		t.Fatalf("Replace() error = %v", err)
 	}
-	if got := currentV8AdminClassifier(); got != second {
+	if got := currentClassifier(); got != second {
 		t.Fatalf("generation 2 admin classifier = %p, want %p", got, second)
 	}
 	if err := runtime.Stop(context.Background()); err != nil {
 		t.Fatalf("Stop() error = %v", err)
+	}
+	if got := currentClassifier(); got != nil {
+		t.Fatalf("stopped admin classifier = %p, want nil", got)
 	}
 }
 

--- a/cmd/gateway/ebus_driver_runtime_test.go
+++ b/cmd/gateway/ebus_driver_runtime_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/adaptermux/v8classifier"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/drivermanager"
 	ebuserrors "github.com/Project-Helianthus/helianthus-ebusgo/errors"
 	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
 )
@@ -31,6 +33,48 @@ type issue851EnhancedArbitrationRaw struct {
 	arbitrationRelease chan struct{}
 	closed             chan struct{}
 	closeOnce          sync.Once
+}
+
+type issue851TerminalPassiveRaw struct {
+	err       error
+	closed    chan struct{}
+	closeOnce sync.Once
+}
+
+func newIssue851TerminalPassiveRaw(err error) *issue851TerminalPassiveRaw {
+	return &issue851TerminalPassiveRaw{err: err, closed: make(chan struct{})}
+}
+
+func (raw *issue851TerminalPassiveRaw) ReadByte() (byte, error) {
+	select {
+	case <-raw.closed:
+		return 0, ebuserrors.ErrTransportClosed
+	default:
+		return 0, raw.err
+	}
+}
+
+func (raw *issue851TerminalPassiveRaw) ReadEvent() (transport.StreamEvent, error) {
+	_, err := raw.ReadByte()
+	return transport.StreamEvent{}, err
+}
+
+func (*issue851TerminalPassiveRaw) Write([]byte) (int, error) {
+	return 0, transport.ErrDriverUnavailable
+}
+
+func (raw *issue851TerminalPassiveRaw) Close() error {
+	raw.closeOnce.Do(func() { close(raw.closed) })
+	return nil
+}
+
+type issue851Classifier struct {
+	v8 *v8classifier.Classifier
+}
+
+func (*issue851Classifier) LastTxnClass() string { return "" }
+func (classifier *issue851Classifier) V8Classifier() *v8classifier.Classifier {
+	return classifier.v8
 }
 
 func newIssue851BlockingRawTransport() *issue851BlockingRawTransport {
@@ -251,7 +295,7 @@ func TestIssue851StableTransportShapeMatchesConfiguredFamily(t *testing.T) {
 
 	for _, protocol := range []ebusgateway.TransportProtocol{ebusgateway.TransportENH, ebusgateway.TransportENS} {
 		slot := newEBusStableTransport(runtime, protocol, nil)
-		passive := newEBusStablePassiveTransport(directEBusSlotInvoker{runtime: runtime}, protocol)
+		passive := newEBusStablePassiveTransport(directEBusSlotInvoker{runtime: runtime}, protocol, nil)
 		if _, ok := slot.(transport.EscapeAware); !ok {
 			t.Errorf("%s slot does not preserve EscapeAware", protocol)
 		}
@@ -271,7 +315,7 @@ func TestIssue851StableTransportShapeMatchesConfiguredFamily(t *testing.T) {
 
 	for _, protocol := range []ebusgateway.TransportProtocol{ebusgateway.TransportTCPPlain, ebusgateway.TransportUDPPlain, ebusgateway.TransportEbusdTCP} {
 		slot := newEBusStableTransport(runtime, protocol, nil)
-		passive := newEBusStablePassiveTransport(directEBusSlotInvoker{runtime: runtime}, protocol)
+		passive := newEBusStablePassiveTransport(directEBusSlotInvoker{runtime: runtime}, protocol, nil)
 		if _, ok := slot.(transport.EscapeAware); ok {
 			t.Errorf("%s slot unexpectedly advertises EscapeAware", protocol)
 		}
@@ -286,6 +330,26 @@ func TestIssue851StableTransportShapeMatchesConfiguredFamily(t *testing.T) {
 		}
 		if _, ok := passive.(transport.StreamEventReader); ok {
 			t.Errorf("%s passive slot unexpectedly advertises StreamEventReader", protocol)
+		}
+	}
+}
+
+func TestIssue851TransportURIOverrideSelectsPlainStableShape(t *testing.T) {
+	for _, endpoint := range []string{
+		"tcp-plain://127.0.0.1:9999",
+		"udp-plain://127.0.0.1:9999",
+		"ebusd://127.0.0.1:8888",
+	} {
+		cfg := ebusgateway.DefaultConfig()
+		cfg.TransportConfig.Protocol = ebusgateway.TransportENH
+		cfg.TransportConfig.Address = endpoint
+		protocol := configuredEBusDriverProtocol(cfg)
+		slot := newEBusStableTransport(transport.NewDriverRuntime(nil, transport.DriverRuntimeConfig{}), protocol, nil)
+		if _, ok := slot.(transport.EscapeAware); ok {
+			t.Errorf("endpoint %q resolved protocol %q with enhanced EscapeAware shape", endpoint, protocol)
+		}
+		if _, ok := slot.(interface{ StartArbitration(byte) error }); ok {
+			t.Errorf("endpoint %q resolved protocol %q with enhanced arbitration shape", endpoint, protocol)
 		}
 	}
 }
@@ -324,4 +388,249 @@ func TestIssue851ActiveCallbackTimeoutQuarantinesWithoutClosingRawTransport(t *t
 		t.Fatalf("admitted callback error = %v", err)
 	}
 	_ = raw.Close()
+}
+
+func TestIssue851ManagerStopReachesRuntimeWithIgnoringContextFactory(t *testing.T) {
+	factoryStarted := make(chan struct{})
+	factoryRelease := make(chan struct{})
+	raw := newIssue851BlockingRawTransport()
+	runtimeSeam := transport.NewDriverRuntime(func(ctx context.Context) (*transport.ManagedRawTransport, error) {
+		close(factoryStarted)
+		<-factoryRelease // deliberately ignores ctx
+		return newManagedEBusGeneration(ctx, raw, raw.Close), nil
+	}, transport.DriverRuntimeConfig{DrainTimeout: 20 * time.Millisecond})
+	manager, err := drivermanager.New(drivermanager.Config{Drivers: []drivermanager.DriverConfig{{
+		ID:           primaryEBusDriverID,
+		Enabled:      true,
+		Runtime:      &ebusDriverRuntime{runtime: runtimeSeam},
+		Capabilities: []drivermanager.Capability{drivermanager.CapabilityRead},
+	}}})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	startDone := make(chan error, 1)
+	go func() { startDone <- manager.Start(context.Background(), primaryEBusDriverID) }()
+	select {
+	case <-factoryStarted:
+	case <-time.After(time.Second):
+		t.Fatal("factory did not start")
+	}
+
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- manager.Stop(context.Background(), primaryEBusDriverID) }()
+	select {
+	case err := <-stopDone:
+		if err != nil {
+			t.Fatalf("Stop() error = %v", err)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Stop could not reach DriverRuntime bounded cancellation")
+	}
+	snapshot, _ := manager.Snapshot(primaryEBusDriverID)
+	if !snapshot.SafetyQuarantined || snapshot.Reason.Code != drivermanager.ReasonCloseUnconfirmed {
+		t.Fatalf("snapshot after uncooperative factory = %#v", snapshot)
+	}
+	close(factoryRelease)
+	select {
+	case err := <-startDone:
+		if err != nil {
+			t.Fatalf("Start() returned manager error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Start did not retire canceled construction after release")
+	}
+}
+
+func TestIssue851PassiveCloseInterruptsReadWithoutOwningGeneration(t *testing.T) {
+	active := newIssue851BlockingRawTransport()
+	passive := newIssue851BlockingRawTransport()
+	runtime := transport.NewDriverRuntime(func(ctx context.Context) (*transport.ManagedRawTransport, error) {
+		return newManagedEBusGenerationParts(ctx, active, passive, nil, func() error {
+			return errors.Join(active.Close(), passive.Close())
+		}), nil
+	}, transport.DriverRuntimeConfig{DrainTimeout: 100 * time.Millisecond})
+	if _, err := runtime.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	slot := newEBusStablePassiveTransport(directEBusSlotInvoker{runtime: runtime}, ebusgateway.TransportENH, nil)
+	readDone := make(chan error, 1)
+	go func() {
+		_, err := slot.(transport.StreamEventReader).ReadEvent()
+		readDone <- err
+	}()
+	select {
+	case <-passive.readStarted:
+	case <-time.After(time.Second):
+		t.Fatal("passive read did not reach adapter-owned pump")
+	}
+	if err := slot.Close(); err != nil {
+		t.Fatalf("stable passive Close() error = %v", err)
+	}
+	select {
+	case err := <-readDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("interrupted ReadEvent() error = %v, want context.Canceled", err)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("stable passive Close did not interrupt current read")
+	}
+	select {
+	case <-passive.closed:
+		t.Fatal("stable passive Close retired the driver generation")
+	default:
+	}
+	if runtime.SafetyQuarantined() {
+		t.Fatal("interrupting the passive consumer quarantined the generation")
+	}
+	if err := runtime.Stop(context.Background()); err != nil {
+		t.Fatalf("runtime Stop() error = %v", err)
+	}
+}
+
+func TestIssue851PassiveDisconnectReportsFailureAndReplacesGeneration(t *testing.T) {
+	var mu sync.Mutex
+	var activeGenerations []*issue851BlockingRawTransport
+	factoryCalls := 0
+	runtimeSeam := transport.NewDriverRuntime(func(ctx context.Context) (*transport.ManagedRawTransport, error) {
+		mu.Lock()
+		factoryCalls++
+		call := factoryCalls
+		active := newIssue851BlockingRawTransport()
+		activeGenerations = append(activeGenerations, active)
+		mu.Unlock()
+		var passive transport.RawTransport = newIssue851BlockingRawTransport()
+		if call == 1 {
+			passive = newIssue851TerminalPassiveRaw(errors.New("passive provider disconnected"))
+		}
+		return newManagedEBusGenerationParts(ctx, active, passive, nil, func() error {
+			return errors.Join(active.Close(), passive.Close())
+		}), nil
+	}, transport.DriverRuntimeConfig{DrainTimeout: 100 * time.Millisecond})
+	runtime := &ebusDriverRuntime{runtime: runtimeSeam}
+	manager, err := drivermanager.New(drivermanager.Config{Drivers: []drivermanager.DriverConfig{{
+		ID:           primaryEBusDriverID,
+		Enabled:      true,
+		Runtime:      runtime,
+		Capabilities: []drivermanager.Capability{drivermanager.CapabilityRead, drivermanager.CapabilityWrite},
+		ClassifyError: func(error) drivermanager.Failure {
+			return drivermanager.Failure{Reason: drivermanager.Reason{Code: drivermanager.ReasonDependencyUnavailable, Retryable: true}}
+		},
+		Retry: drivermanager.RetryPolicy{Budget: 1, InitialDelay: 5 * time.Millisecond, MaxDelay: 5 * time.Millisecond},
+	}}})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer func() { _ = manager.Shutdown(context.Background()) }()
+	reporter := func(correlation drivermanager.Correlation, rawErr error) {
+		manager.ReportFailure(primaryEBusDriverID, correlation, drivermanager.Failure{Reason: drivermanager.Reason{Code: drivermanager.ReasonDependencyUnavailable, Retryable: true}})
+	}
+	activeSlot := newManagedEBusStableTransport(manager, ebusgateway.TransportTCPPlain, reporter)
+	passiveSlot := newEBusStablePassiveTransport(managedEBusSlotInvoker{manager: manager, id: primaryEBusDriverID}, ebusgateway.TransportENH, reporter)
+	if err := manager.Start(context.Background(), primaryEBusDriverID); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if written, err := activeSlot.Write([]byte{0x01}); err != nil || written != 1 {
+		t.Fatalf("active Write before passive failure = (%d, %v)", written, err)
+	}
+	if _, err := passiveSlot.(transport.StreamEventReader).ReadEvent(); err == nil {
+		t.Fatal("passive disconnect did not surface an error")
+	}
+	deadline := time.Now().Add(time.Second)
+	for {
+		snapshot, _ := manager.Snapshot(primaryEBusDriverID)
+		if snapshot.ObservedState == drivermanager.ObservedRunning && snapshot.Generation == 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("passive failure did not replace generation: %#v", snapshot)
+		}
+		time.Sleep(time.Millisecond)
+	}
+	mu.Lock()
+	first := activeGenerations[0]
+	calls := factoryCalls
+	mu.Unlock()
+	if calls != 2 {
+		t.Fatalf("factory calls = %d, want 2", calls)
+	}
+	select {
+	case <-first.closed:
+	case <-time.After(time.Second):
+		t.Fatal("old generation did not close after passive disconnect")
+	}
+	if written, err := activeSlot.Write([]byte{0x02}); err != nil || written != 1 {
+		t.Fatalf("active Write after passive replacement = (%d, %v)", written, err)
+	}
+}
+
+func TestIssue851InjectedTransportIsNotReadmittedAfterReplacement(t *testing.T) {
+	raw := newIssue851BlockingRawTransport()
+	cfg := ebusgateway.DefaultConfig()
+	cfg.Transport = raw
+	cfg.TransportConfig.Protocol = ebusgateway.TransportTCPPlain
+	cfg.BroadcastListen = false
+	controller, err := newEBusDriverController(cfg)
+	if err != nil {
+		t.Fatalf("newEBusDriverController() error = %v", err)
+	}
+	defer func() { _ = controller.Shutdown(context.Background()) }()
+	if err := controller.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	deadline := time.Now().Add(time.Second)
+	for controller.Snapshot().ObservedState != drivermanager.ObservedRunning {
+		if time.Now().After(deadline) {
+			t.Fatalf("injected generation did not start: %#v", controller.Snapshot())
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if err := controller.manager.Replace(context.Background(), primaryEBusDriverID); err != nil {
+		t.Fatalf("Replace() manager error = %v", err)
+	}
+	snapshot := controller.Snapshot()
+	if snapshot.ObservedState != drivermanager.ObservedFailed || snapshot.Reason.Code != drivermanager.ReasonProviderUnavailable || snapshot.Generation != 1 {
+		t.Fatalf("replacement reused injected transport: %#v", snapshot)
+	}
+	select {
+	case <-raw.closed:
+	case <-time.After(time.Second):
+		t.Fatal("one-shot injected transport was not closed")
+	}
+}
+
+func TestIssue851AdminClassifierResolvesCurrentGenerationWithoutMetricsScrape(t *testing.T) {
+	originalStatic := v8AdminEventsCurrentClassifier.Load()
+	originalProvider := v8AdminEventsCurrentProvider.Load()
+	t.Cleanup(func() {
+		v8AdminEventsCurrentClassifier.Store(originalStatic)
+		v8AdminEventsCurrentProvider.Store(originalProvider)
+	})
+	first := v8classifier.New(v8classifier.ModeShadow)
+	second := v8classifier.New(v8classifier.ModeShadow)
+	classifiers := []*v8classifier.Classifier{first, second}
+	index := 0
+	runtime := transport.NewDriverRuntime(func(ctx context.Context) (*transport.ManagedRawTransport, error) {
+		raw := newIssue851BlockingRawTransport()
+		classifier := &issue851Classifier{v8: classifiers[index]}
+		index++
+		return newManagedEBusGenerationParts(ctx, raw, nil, classifier, raw.Close), nil
+	}, transport.DriverRuntimeConfig{DrainTimeout: 100 * time.Millisecond})
+	stable := &ebusStableClassifier{invoker: directEBusSlotInvoker{runtime: runtime}}
+	v8AdminEventsCurrentClassifier.Store(nil)
+	v8AdminEventsCurrentProvider.Store(&v8AdminClassifierProvider{classifierFn: stable.V8Classifier})
+	if _, err := runtime.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if got := currentV8AdminClassifier(); got != first {
+		t.Fatalf("generation 1 admin classifier = %p, want %p", got, first)
+	}
+	if _, err := runtime.Replace(context.Background()); err != nil {
+		t.Fatalf("Replace() error = %v", err)
+	}
+	if got := currentV8AdminClassifier(); got != second {
+		t.Fatalf("generation 2 admin classifier = %p, want %p", got, second)
+	}
+	if err := runtime.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
 }

--- a/cmd/gateway/ebus_driver_runtime_test.go
+++ b/cmd/gateway/ebus_driver_runtime_test.go
@@ -907,6 +907,62 @@ func TestIssue851AdminClassifierResolvesCurrentGenerationWithoutMetricsScrape(t 
 	}
 }
 
+func TestIssue851V8ShadowTotalIsProcessMonotonicAcrossReplacement(t *testing.T) {
+	first := v8classifier.New(v8classifier.ModeShadow)
+	second := v8classifier.New(v8classifier.ModeShadow)
+	classifiers := []*v8classifier.Classifier{first, second}
+	counter := &ebusV8CumulativeCounter{}
+	index := 0
+	runtime := transport.NewDriverRuntime(func(ctx context.Context) (*transport.ManagedRawTransport, error) {
+		if index >= len(classifiers) {
+			return nil, errors.New("unexpected extra generation")
+		}
+		classifier := &issue851Classifier{v8: classifiers[index]}
+		index++
+		raw := newIssue851BlockingRawTransport()
+		closeFn := func() error {
+			err := raw.Close()
+			counter.retire(classifier)
+			return err
+		}
+		return newManagedEBusGenerationParts(ctx, raw, nil, classifier, closeFn), nil
+	}, transport.DriverRuntimeConfig{DrainTimeout: 100 * time.Millisecond})
+	defer func() { _ = runtime.Stop(context.Background()) }()
+	stable := &ebusStableClassifier{
+		invoker: directEBusSlotInvoker{runtime: runtime},
+		counter: counter,
+	}
+	observeShadowDrop := func(classifier *v8classifier.Classifier) {
+		now := time.Unix(0, 0)
+		classifier.Observe(transport.StreamEvent{Kind: transport.StreamEventStarted, Data: 0x71}, now)
+		classifier.Observe(transport.StreamEvent{Kind: transport.StreamEventByte, Byte: 0xAA}, now)
+	}
+
+	if _, err := runtime.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	observeShadowDrop(first)
+	if got := stable.V8ShadowWouldHaveDroppedTotal(); got != 1 {
+		t.Fatalf("generation 1 process total = %d, want 1", got)
+	}
+	if _, err := runtime.Replace(context.Background()); err != nil {
+		t.Fatalf("Replace() error = %v", err)
+	}
+	if got := stable.V8ShadowWouldHaveDroppedTotal(); got != 1 {
+		t.Fatalf("post-replacement process total = %d, want retained 1", got)
+	}
+
+	// Do not scrape generation 2 before retirement. Its final increment must
+	// still be folded into the process total by the close-proof path.
+	observeShadowDrop(second)
+	if err := runtime.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+	if got := stable.V8ShadowWouldHaveDroppedTotal(); got != 2 {
+		t.Fatalf("post-stop process total = %d, want unscraped generation 2 increment retained", got)
+	}
+}
+
 func requireEBusDriverObservedState(t *testing.T, manager *drivermanager.Manager, want drivermanager.ObservedState, timeout time.Duration) drivermanager.Snapshot {
 	t.Helper()
 	deadline := time.Now().Add(timeout)

--- a/cmd/gateway/ebus_driver_runtime_test.go
+++ b/cmd/gateway/ebus_driver_runtime_test.go
@@ -919,6 +919,100 @@ func TestIssue851AdapterDirectConnectionLossWithdrawsCapabilitiesAndRecoversOnce
 	}
 }
 
+func TestIssue851AdapterDirectBroadcastPassiveBridgeRetiresWithGeneration(t *testing.T) {
+	for _, action := range []string{"stop", "loss_replace"} {
+		t.Run(action, func(t *testing.T) {
+			cfg := ebusgateway.DefaultConfig()
+			cfg.BroadcastListen = true
+			cfg.TransportConfig.Protocol = ebusgateway.TransportAdapterDirect
+			cfg.TransportConfig.Network = "tcp"
+			cfg.TransportConfig.Address = newIssue851AdapterServer(t)
+			cfg.TransportConfig.DialTimeout = time.Second
+
+			controller, err := newEBusDriverController(cfg)
+			if err != nil {
+				t.Fatalf("newEBusDriverController() error = %v", err)
+			}
+			defer func() { _ = controller.Shutdown(context.Background()) }()
+			if err := controller.Start(context.Background()); err != nil {
+				t.Fatalf("Start() error = %v", err)
+			}
+			firstSnapshot := requireEBusDriverObservedState(t, controller.manager, drivermanager.ObservedRunning, 2*time.Second)
+			var first *managedEBusGeneration
+			if _, err := controller.manager.Invoke(context.Background(), primaryEBusDriverID, drivermanager.CapabilityRead, func(provider any) error {
+				first, _ = provider.(*managedEBusGeneration)
+				return nil
+			}); err != nil || first == nil || first.passive == nil || first.health == nil {
+				t.Fatalf("capture broadcast generation = (%T, %v), passive=%v health=%v", first, err, first != nil && first.passive != nil, first != nil && first.health != nil)
+			}
+
+			// Mux.Start publishes one connected/reset boundary before the factory
+			// returns. Drain it, then hand one demand directly to the generation's
+			// adapter-owned pump. The send completes only after the pump accepts the
+			// request; with no further fake-adapter traffic it is then blocked in the
+			// generation-owned passive bridge.
+			reader, ok := first.passive.raw.(transport.StreamEventReader)
+			if !ok {
+				t.Fatalf("passive bridge = %T, want StreamEventReader", first.passive.raw)
+			}
+			if _, err := reader.ReadEvent(); err != nil {
+				t.Fatalf("drain passive connected boundary: %v", err)
+			}
+			requestCtx, cancelRequest := context.WithCancel(context.Background())
+			defer cancelRequest()
+			staleResult := make(chan managedEBusReadResult, 1)
+			select {
+			case first.passive.requests <- managedEBusReadRequest{ctx: requestCtx, result: staleResult}:
+			case <-time.After(time.Second):
+				t.Fatal("passive generation pump did not accept blocking demand")
+			}
+
+			switch action {
+			case "stop":
+				stopCtx, cancelStop := context.WithTimeout(context.Background(), 3*time.Second)
+				defer cancelStop()
+				if err := controller.manager.Stop(stopCtx, primaryEBusDriverID); err != nil {
+					t.Fatalf("Stop() error = %v", err)
+				}
+				stopped := requireEBusDriverObservedState(t, controller.manager, drivermanager.ObservedStopped, time.Second)
+				if stopped.SafetyQuarantined || stopped.Generation != firstSnapshot.Generation {
+					t.Fatalf("broadcast Stop snapshot = %#v", stopped)
+				}
+			case "loss_replace":
+				// Physical mux loss fences adapter work before its correlated owner
+				// callback publishes BACKOFF.
+				first.fenceProxy()
+				first.health.connectionLost()
+				requireEBusDriverObservedState(t, controller.manager, drivermanager.ObservedBackoff, time.Second)
+				if err := controller.Start(context.Background()); err != nil {
+					t.Fatalf("expedite recovery Start() error = %v", err)
+				}
+				second := requireEBusDriverObservedState(t, controller.manager, drivermanager.ObservedRunning, 3*time.Second)
+				if second.SafetyQuarantined || second.Generation != firstSnapshot.Generation+1 {
+					t.Fatalf("broadcast loss recovery snapshot = %#v", second)
+				}
+				first.health.connectionLost()
+				time.Sleep(25 * time.Millisecond)
+				afterStale, _ := controller.manager.Snapshot(primaryEBusDriverID)
+				if afterStale.ObservedState != drivermanager.ObservedRunning || afterStale.Generation != second.Generation || afterStale.Revision != second.Revision {
+					t.Fatalf("stale broadcast generation changed successor: before=%#v after=%#v", second, afterStale)
+				}
+			}
+
+			select {
+			case <-first.passive.pumpDone:
+			case <-time.After(time.Second):
+				t.Fatal("retired broadcast passive pump did not close")
+			}
+			select {
+			case result := <-staleResult:
+				t.Fatalf("retired broadcast generation published stale result: %#v", result)
+			default:
+			}
+		})
+	}
+}
+
 func TestIssue851ProxyReadinessStaysDegradedOnAdapterDialFailure(t *testing.T) {
 	unused, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -1318,6 +1412,37 @@ func TestIssue851InvalidTransportURIIsImmediateConfigFailure(t *testing.T) {
 	after, _ := controller.manager.Snapshot(primaryEBusDriverID)
 	if after.Revision != failed.Revision || after.Attempt != 1 || after.ObservedState != drivermanager.ObservedFailed {
 		t.Fatalf("invalid URI unexpectedly retried: before=%#v after=%#v", failed, after)
+	}
+}
+
+func TestIssue851TCPFamilyURIWithoutPortFailsConfigBeforeDialOrRetry(t *testing.T) {
+	var dials atomic.Int32
+	cfg := ebusgateway.DefaultConfig()
+	cfg.BroadcastListen = false
+	cfg.TransportConfig.Address = "tcp-plain://adapter.invalid"
+	cfg.TransportConfig.Dial = func(context.Context, string, string, time.Duration) (net.Conn, error) {
+		dials.Add(1)
+		return nil, errors.New("dial must not be reached")
+	}
+	controller, err := newEBusDriverController(cfg)
+	if err != nil {
+		t.Fatalf("newEBusDriverController() error = %v", err)
+	}
+	defer func() { _ = controller.Shutdown(context.Background()) }()
+	if err := controller.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	failed := requireEBusDriverObservedState(t, controller.manager, drivermanager.ObservedFailed, 250*time.Millisecond)
+	if failed.Reason.Code != drivermanager.ReasonConfigInvalid || failed.Reason.Retryable || failed.Retry != nil || failed.Generation != 0 || failed.Attempt != 1 {
+		t.Fatalf("invalid host:port snapshot = %#v", failed)
+	}
+	if got := dials.Load(); got != 0 {
+		t.Fatalf("invalid host:port dial calls = %d, want 0", got)
+	}
+	time.Sleep(25 * time.Millisecond)
+	after, _ := controller.manager.Snapshot(primaryEBusDriverID)
+	if after.Revision != failed.Revision || after.Attempt != 1 || after.ObservedState != drivermanager.ObservedFailed {
+		t.Fatalf("invalid host:port unexpectedly retried: before=%#v after=%#v", failed, after)
 	}
 }
 

--- a/cmd/gateway/ebus_http_bindings.go
+++ b/cmd/gateway/ebus_http_bindings.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/Project-Helianthus/helianthus-ebusgateway/graphql"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/m8sourcestate"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
+)
+
+// These bindings keep the HTTP/MCP surface stable while eBUS startup and
+// source selection continue behind it. Before binding, mutations fail closed;
+// after binding, calls delegate to the same admitted writers used previously.
+type lateEBusScheduleWriter struct {
+	mu       sync.RWMutex
+	delegate mcp.ScheduleWriter
+}
+
+func (writer *lateEBusScheduleWriter) Bind(delegate mcp.ScheduleWriter) {
+	writer.mu.Lock()
+	writer.delegate = delegate
+	writer.mu.Unlock()
+}
+
+func (writer *lateEBusScheduleWriter) current() mcp.ScheduleWriter {
+	writer.mu.RLock()
+	delegate := writer.delegate
+	writer.mu.RUnlock()
+	return delegate
+}
+
+func (writer *lateEBusScheduleWriter) SetZoneTimeProgram(ctx context.Context, zone, weekday int, slots []mcp.TimeProgramSlot) (*mcp.TimeProgramWriteResult, error) {
+	delegate := writer.current()
+	if delegate == nil {
+		return &mcp.TimeProgramWriteResult{Success: false, Error: semanticWriterSourceNotAdmittedError}, nil
+	}
+	return delegate.SetZoneTimeProgram(ctx, zone, weekday, slots)
+}
+
+func (writer *lateEBusScheduleWriter) SetDhwTimeProgram(ctx context.Context, weekday int, slots []mcp.TimeProgramSlot) (*mcp.TimeProgramWriteResult, error) {
+	delegate := writer.current()
+	if delegate == nil {
+		return &mcp.TimeProgramWriteResult{Success: false, Error: semanticWriterSourceNotAdmittedError}, nil
+	}
+	return delegate.SetDhwTimeProgram(ctx, weekday, slots)
+}
+
+func (writer *lateEBusScheduleWriter) M8CommandRoutingState() (m8sourcestate.CommandRoutingFragment, error) {
+	delegate := writer.current()
+	owner, ok := delegate.(m8CommandRoutingSnapshotter)
+	if !ok {
+		return m8sourcestate.CommandRoutingFragment{}, fmt.Errorf("schedule writer unavailable")
+	}
+	return owner.M8CommandRoutingState()
+}
+
+type lateEBusConfigWriter struct {
+	mu       sync.RWMutex
+	delegate mcp.ConfigWriter
+}
+
+func (writer *lateEBusConfigWriter) Bind(delegate mcp.ConfigWriter) {
+	writer.mu.Lock()
+	writer.delegate = delegate
+	writer.mu.Unlock()
+}
+
+func (writer *lateEBusConfigWriter) current() mcp.ConfigWriter {
+	writer.mu.RLock()
+	delegate := writer.delegate
+	writer.mu.RUnlock()
+	return delegate
+}
+
+func (writer *lateEBusConfigWriter) SetSystemConfig(ctx context.Context, field, value string) mcp.ConfigSetResult {
+	delegate := writer.current()
+	if delegate == nil {
+		return mcp.ConfigSetResult{Success: false, Error: semanticWriterSourceNotAdmittedError}
+	}
+	return delegate.SetSystemConfig(ctx, field, value)
+}
+
+func (writer *lateEBusConfigWriter) SetBoilerConfig(ctx context.Context, field, value string) mcp.ConfigSetResult {
+	delegate := writer.current()
+	if delegate == nil {
+		return mcp.ConfigSetResult{Success: false, Error: semanticWriterSourceNotAdmittedError}
+	}
+	return delegate.SetBoilerConfig(ctx, field, value)
+}
+
+func (writer *lateEBusConfigWriter) M8CommandRoutingState() (m8sourcestate.CommandRoutingFragment, error) {
+	delegate := writer.current()
+	owner, ok := delegate.(m8CommandRoutingSnapshotter)
+	if !ok {
+		return m8sourcestate.CommandRoutingFragment{}, fmt.Errorf("config writer unavailable")
+	}
+	return owner.M8CommandRoutingState()
+}
+
+type lateEBusWatchSummaryProvider struct {
+	mu       sync.RWMutex
+	delegate mcp.WatchSummaryProvider
+}
+
+type graphQLSemanticWriter interface {
+	graphql.BoilerConfigWriter
+	graphql.SystemConfigWriter
+	graphql.ScheduleWriter
+}
+
+// lateEBusGraphQLWriter is installed before the GraphQL schema is built. The
+// schema therefore keeps the same mutation fields for the lifetime of the
+// process; calls fail closed until the semantic poller is bound and admitted.
+type lateEBusGraphQLWriter struct {
+	mu       sync.RWMutex
+	delegate graphQLSemanticWriter
+}
+
+func (writer *lateEBusGraphQLWriter) Bind(delegate graphQLSemanticWriter) {
+	writer.mu.Lock()
+	writer.delegate = delegate
+	writer.mu.Unlock()
+}
+
+func (writer *lateEBusGraphQLWriter) current() graphQLSemanticWriter {
+	writer.mu.RLock()
+	delegate := writer.delegate
+	writer.mu.RUnlock()
+	return delegate
+}
+
+func (writer *lateEBusGraphQLWriter) SetBoilerConfig(ctx context.Context, fieldName, rawValue string) graphql.BoilerConfigMutationResult {
+	delegate := writer.current()
+	if delegate == nil {
+		return graphql.BoilerConfigMutationResult{Success: false, Error: semanticWriterSourceNotAdmittedError}
+	}
+	return delegate.SetBoilerConfig(ctx, fieldName, rawValue)
+}
+
+func (writer *lateEBusGraphQLWriter) SetSystemConfig(ctx context.Context, fieldName, rawValue string) graphql.ConfigMutationResult {
+	delegate := writer.current()
+	if delegate == nil {
+		return graphql.ConfigMutationResult{Success: false, Error: semanticWriterSourceNotAdmittedError}
+	}
+	return delegate.SetSystemConfig(ctx, fieldName, rawValue)
+}
+
+func (writer *lateEBusGraphQLWriter) SetZoneTimeProgram(ctx context.Context, zone, weekday int, slots []mcp.TimeProgramSlot) (*mcp.TimeProgramWriteResult, error) {
+	delegate := writer.current()
+	if delegate == nil {
+		return &mcp.TimeProgramWriteResult{Success: false, Error: semanticWriterSourceNotAdmittedError}, nil
+	}
+	return delegate.SetZoneTimeProgram(ctx, zone, weekday, slots)
+}
+
+func (writer *lateEBusGraphQLWriter) SetDhwTimeProgram(ctx context.Context, weekday int, slots []mcp.TimeProgramSlot) (*mcp.TimeProgramWriteResult, error) {
+	delegate := writer.current()
+	if delegate == nil {
+		return &mcp.TimeProgramWriteResult{Success: false, Error: semanticWriterSourceNotAdmittedError}, nil
+	}
+	return delegate.SetDhwTimeProgram(ctx, weekday, slots)
+}
+
+type lateEBusGraphQLWatchSummaryProvider struct {
+	mu       sync.RWMutex
+	delegate graphql.WatchSummaryProvider
+}
+
+func (provider *lateEBusGraphQLWatchSummaryProvider) Bind(delegate graphql.WatchSummaryProvider) {
+	provider.mu.Lock()
+	provider.delegate = delegate
+	provider.mu.Unlock()
+}
+
+func (provider *lateEBusGraphQLWatchSummaryProvider) Snapshot() graphql.WatchSummary {
+	provider.mu.RLock()
+	delegate := provider.delegate
+	provider.mu.RUnlock()
+	if delegate == nil {
+		return graphql.WatchSummary{Degraded: graphql.WatchSummaryDegraded{
+			Active:  true,
+			Reasons: []string{"driver_unavailable"},
+		}}
+	}
+	return delegate.Snapshot()
+}
+
+func (provider *lateEBusWatchSummaryProvider) Bind(delegate mcp.WatchSummaryProvider) {
+	provider.mu.Lock()
+	provider.delegate = delegate
+	provider.mu.Unlock()
+}
+
+func (provider *lateEBusWatchSummaryProvider) Snapshot() mcp.WatchSummary {
+	provider.mu.RLock()
+	delegate := provider.delegate
+	provider.mu.RUnlock()
+	if delegate == nil {
+		return mcp.WatchSummary{Degraded: mcp.WatchSummaryDegraded{
+			Active:  true,
+			Reasons: []string{"driver_unavailable"},
+		}}
+	}
+	return delegate.Snapshot()
+}

--- a/cmd/gateway/ebus_http_bindings_test.go
+++ b/cmd/gateway/ebus_http_bindings_test.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	gatewaygraphql "github.com/Project-Helianthus/helianthus-ebusgateway/graphql"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
+	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+	"github.com/Project-Helianthus/helianthus-ebusreg/router"
+	graphqlgo "github.com/graphql-go/graphql"
+)
+
+type recordingLateScheduleWriter struct{ calls int }
+
+func (writer *recordingLateScheduleWriter) SetZoneTimeProgram(context.Context, int, int, []mcp.TimeProgramSlot) (*mcp.TimeProgramWriteResult, error) {
+	writer.calls++
+	return &mcp.TimeProgramWriteResult{Success: true}, nil
+}
+
+func (writer *recordingLateScheduleWriter) SetDhwTimeProgram(context.Context, int, []mcp.TimeProgramSlot) (*mcp.TimeProgramWriteResult, error) {
+	writer.calls++
+	return &mcp.TimeProgramWriteResult{Success: true}, nil
+}
+
+type recordingLateConfigWriter struct{ calls int }
+
+func (writer *recordingLateConfigWriter) SetSystemConfig(context.Context, string, string) mcp.ConfigSetResult {
+	writer.calls++
+	return mcp.ConfigSetResult{Success: true}
+}
+
+func (writer *recordingLateConfigWriter) SetBoilerConfig(context.Context, string, string) mcp.ConfigSetResult {
+	writer.calls++
+	return mcp.ConfigSetResult{Success: true}
+}
+
+type staticLateWatchProvider struct{ snapshot mcp.WatchSummary }
+
+func (provider staticLateWatchProvider) Snapshot() mcp.WatchSummary { return provider.snapshot }
+
+type recordingLateGraphQLWriter struct{ calls int }
+
+func (writer *recordingLateGraphQLWriter) SetBoilerConfig(context.Context, string, string) gatewaygraphql.BoilerConfigMutationResult {
+	writer.calls++
+	return gatewaygraphql.BoilerConfigMutationResult{Success: true}
+}
+
+func (writer *recordingLateGraphQLWriter) SetSystemConfig(context.Context, string, string) gatewaygraphql.ConfigMutationResult {
+	writer.calls++
+	return gatewaygraphql.ConfigMutationResult{Success: true}
+}
+
+func (writer *recordingLateGraphQLWriter) SetZoneTimeProgram(context.Context, int, int, []mcp.TimeProgramSlot) (*mcp.TimeProgramWriteResult, error) {
+	writer.calls++
+	return &mcp.TimeProgramWriteResult{Success: true}, nil
+}
+
+func (writer *recordingLateGraphQLWriter) SetDhwTimeProgram(context.Context, int, []mcp.TimeProgramSlot) (*mcp.TimeProgramWriteResult, error) {
+	writer.calls++
+	return &mcp.TimeProgramWriteResult{Success: true}, nil
+}
+
+type staticLateGraphQLWatchProvider struct{ snapshot gatewaygraphql.WatchSummary }
+
+func (provider staticLateGraphQLWatchProvider) Snapshot() gatewaygraphql.WatchSummary {
+	return provider.snapshot
+}
+
+type emptyLateInvokeRegistry struct{}
+
+func (emptyLateInvokeRegistry) Lookup(byte) (registry.DeviceEntry, bool) {
+	return nil, false
+}
+
+type emptyLateInvoker struct{}
+
+func (emptyLateInvoker) Invoke(context.Context, router.Plane, string, map[string]any) (any, error) {
+	return nil, nil
+}
+
+func TestIssue851EarlyHTTPBindingsFailClosedThenDelegate(t *testing.T) {
+	schedule := &lateEBusScheduleWriter{}
+	config := &lateEBusConfigWriter{}
+	watch := &lateEBusWatchSummaryProvider{}
+	graphQLWriter := &lateEBusGraphQLWriter{}
+	graphQLWatch := &lateEBusGraphQLWatchSummaryProvider{}
+
+	if result, err := schedule.SetZoneTimeProgram(context.Background(), 0, 0, nil); err != nil || result.Success || result.Error != semanticWriterSourceNotAdmittedError {
+		t.Fatalf("unbound schedule result = %#v, %v", result, err)
+	}
+	if result := config.SetSystemConfig(context.Background(), "field", "value"); result.Success || result.Error != semanticWriterSourceNotAdmittedError {
+		t.Fatalf("unbound config result = %#v", result)
+	}
+	if snapshot := watch.Snapshot(); !snapshot.Degraded.Active || len(snapshot.Degraded.Reasons) != 1 || snapshot.Degraded.Reasons[0] != "driver_unavailable" {
+		t.Fatalf("unbound watch snapshot = %#v", snapshot)
+	}
+	if result := graphQLWriter.SetSystemConfig(context.Background(), "field", "value"); result.Success || result.Error != semanticWriterSourceNotAdmittedError {
+		t.Fatalf("unbound GraphQL config result = %#v", result)
+	}
+	if snapshot := graphQLWatch.Snapshot(); !snapshot.Degraded.Active || len(snapshot.Degraded.Reasons) != 1 || snapshot.Degraded.Reasons[0] != "driver_unavailable" {
+		t.Fatalf("unbound GraphQL watch snapshot = %#v", snapshot)
+	}
+
+	recordingSchedule := &recordingLateScheduleWriter{}
+	recordingConfig := &recordingLateConfigWriter{}
+	recordingGraphQL := &recordingLateGraphQLWriter{}
+	wantWatch := mcp.WatchSummary{Inventory: mcp.WatchSummaryInventory{TotalEntries: 3}}
+	wantGraphQLWatch := gatewaygraphql.WatchSummary{Inventory: gatewaygraphql.WatchSummaryInventory{TotalEntries: 4}}
+	schedule.Bind(recordingSchedule)
+	config.Bind(recordingConfig)
+	watch.Bind(staticLateWatchProvider{snapshot: wantWatch})
+	graphQLWriter.Bind(recordingGraphQL)
+	graphQLWatch.Bind(staticLateGraphQLWatchProvider{snapshot: wantGraphQLWatch})
+
+	if result, err := schedule.SetDhwTimeProgram(context.Background(), 0, nil); err != nil || !result.Success || recordingSchedule.calls != 1 {
+		t.Fatalf("bound schedule result = %#v, %v calls=%d", result, err, recordingSchedule.calls)
+	}
+	if result := config.SetBoilerConfig(context.Background(), "field", "value"); !result.Success || recordingConfig.calls != 1 {
+		t.Fatalf("bound config result = %#v calls=%d", result, recordingConfig.calls)
+	}
+	if got := watch.Snapshot(); got.Inventory.TotalEntries != wantWatch.Inventory.TotalEntries {
+		t.Fatalf("bound watch snapshot = %#v", got)
+	}
+	if result := graphQLWriter.SetSystemConfig(context.Background(), "field", "value"); !result.Success || recordingGraphQL.calls != 1 {
+		t.Fatalf("bound GraphQL config result = %#v calls=%d", result, recordingGraphQL.calls)
+	}
+	if got := graphQLWatch.Snapshot(); got.Inventory.TotalEntries != wantGraphQLWatch.Inventory.TotalEntries {
+		t.Fatalf("bound GraphQL watch snapshot = %#v", got)
+	}
+}
+
+func TestIssue851EarlyGraphQLMutationSurfaceRemainsStableAcrossBinding(t *testing.T) {
+	writer := &lateEBusGraphQLWriter{}
+	builder := gatewaygraphql.NewBuilder(nil, nil)
+	builder.SetBoilerConfigWriter(writer)
+	builder.SetSystemConfigWriter(writer)
+	builder.SetScheduleWriter(writer)
+	schema, err := gatewaygraphql.NewSchema(builder, emptyLateInvokeRegistry{}, emptyLateInvoker{}, nil)
+	if err != nil {
+		t.Fatalf("NewSchema() error = %v", err)
+	}
+
+	execute := func() map[string]any {
+		t.Helper()
+		result := graphqlgo.Do(graphqlgo.Params{
+			Schema:        schema,
+			RequestString: `mutation { setSystemConfig(field: "field", value: "value") { success error } }`,
+		})
+		if len(result.Errors) != 0 {
+			t.Fatalf("GraphQL mutation errors = %v", result.Errors)
+		}
+		root, ok := result.Data.(map[string]any)
+		if !ok {
+			t.Fatalf("GraphQL data = %#v", result.Data)
+		}
+		mutation, ok := root["setSystemConfig"].(map[string]any)
+		if !ok {
+			t.Fatalf("GraphQL mutation result = %#v", root["setSystemConfig"])
+		}
+		return mutation
+	}
+
+	unbound := execute()
+	if unbound["success"] != false || unbound["error"] != semanticWriterSourceNotAdmittedError {
+		t.Fatalf("unbound mutation = %#v", unbound)
+	}
+	recording := &recordingLateGraphQLWriter{}
+	writer.Bind(recording)
+	bound := execute()
+	if bound["success"] != true || bound["error"] != nil || recording.calls != 1 {
+		t.Fatalf("bound mutation = %#v calls=%d", bound, recording.calls)
+	}
+}

--- a/cmd/gateway/eebus_admin_wiring_test.go
+++ b/cmd/gateway/eebus_admin_wiring_test.go
@@ -322,25 +322,27 @@ func issue846WaitForLifecycleState(t *testing.T, lifecycle *eebusRuntimeLifecycl
 
 func TestIssue846GatewayReadinessProjectsLifecycleAndConditionalProxy(t *testing.T) {
 	tests := []struct {
-		name        string
-		proxyListen string
-		lifecycle   eebusRuntimeLifecycleSnapshot
-		wantProxy   string
-		wantEEBus   string
-		wantReason  eebusadmin.EEBusDegradedReason
+		name           string
+		proxyReadiness string
+		lifecycle      eebusRuntimeLifecycleSnapshot
+		wantProxy      string
+		wantEEBus      string
+		wantReason     eebusadmin.EEBusDegradedReason
 	}{
 		{name: "disabled", lifecycle: eebusRuntimeLifecycleSnapshot{State: eebusLifecycleDisabled}, wantProxy: "DISABLED", wantEEBus: "DISABLED"},
-		{name: "starting with conditional proxy", proxyListen: ":19001", lifecycle: eebusRuntimeLifecycleSnapshot{State: eebusLifecycleStarting}, wantProxy: "READY", wantEEBus: "STARTING"},
+		{name: "starting with unavailable proxy", proxyReadiness: "DEGRADED", lifecycle: eebusRuntimeLifecycleSnapshot{State: eebusLifecycleStarting}, wantProxy: "DEGRADED", wantEEBus: "STARTING"},
 		{name: "initial failure backoff", lifecycle: eebusRuntimeLifecycleSnapshot{State: eebusLifecycleBackoff, DegradedReason: eebusadmin.EEBusDegradedReasonListenerUnavailable}, wantProxy: "DISABLED", wantEEBus: "DEGRADED", wantReason: eebusadmin.EEBusDegradedReasonListenerUnavailable},
-		{name: "recovered", proxyListen: ":19001", lifecycle: eebusRuntimeLifecycleSnapshot{State: eebusLifecycleRunning}, wantProxy: "READY", wantEEBus: "READY"},
+		{name: "recovered", proxyReadiness: "READY", lifecycle: eebusRuntimeLifecycleSnapshot{State: eebusLifecycleRunning}, wantProxy: "READY", wantEEBus: "READY"},
 		{name: "unknown failure", lifecycle: eebusRuntimeLifecycleSnapshot{State: eebusLifecycleDegraded, DegradedReason: eebusadmin.EEBusDegradedReasonUnknownStartupFailure}, wantProxy: "DISABLED", wantEEBus: "DEGRADED", wantReason: eebusadmin.EEBusDegradedReasonUnknownStartupFailure},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cfg := ebusgateway.DefaultConfig()
-			cfg.ProxyListenAddr = test.proxyListen
-			got := projectGatewayReadiness(cfg, test.lifecycle)
+			var proxyReadiness func() string
+			if test.proxyReadiness != "" {
+				proxyReadiness = func() string { return test.proxyReadiness }
+			}
+			got := projectGatewayReadiness(proxyReadiness, test.lifecycle)
 			if got.ProcessReadiness != "READY" || got.HTTPReadiness != "READY" || got.ProxyReadiness != test.wantProxy || got.EEBusReadiness != test.wantEEBus || got.EEBusDegradedReason != string(test.wantReason) {
 				t.Fatalf("readiness=%#v; want process/http READY proxy=%s eeBUS=%s reason=%s", got, test.wantProxy, test.wantEEBus, test.wantReason)
 			}

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -2093,7 +2093,7 @@ func startHTTPServer(
 		}
 	}
 	mcpServer.SetAdmittedRPCSourceProvider(builder.AdmittedMutationSource)
-	mcpServer.SetStatusProvider(newMCPRuntimeStatusProvider(cfg, semanticProvider))
+	mcpServer.SetStatusProvider(newMCPRuntimeStatusProvider(semanticProvider, builder.AdmittedMutationSource))
 	if busObservability != nil {
 		mcpServer.SetBusObservabilityProvider(newMCPBusObservabilityProvider(busObservability))
 	}
@@ -2393,8 +2393,8 @@ func startHTTPServer(
 				}
 				return portal.ProjectionGraph{}, false
 			},
-			ExplorerBus:    gateway.Bus,
-			ExplorerSource: cfg.ScanSource,
+			ExplorerBus:            gateway.Bus,
+			ExplorerSourceProvider: builder.AdmittedMutationSource,
 			// Wire the in-process L7 catalog sub-server (M5_PORTAL).
 			// mcpServer.EbusStandardServer() returns the same instance
 			// RegisterEbusStandardTools installed inside mcp.NewServer;

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -1631,6 +1631,10 @@ func parseStartupProbeTargets(value string) ([]byte, error) {
 // at the call site in run() — never captured in a package-level closure —
 // so classifier state is strictly instance-local (Codex PR #502 P2).
 func wireAdapterDirect(ctx context.Context, cfg *ebusgateway.Config) (func() error, activeTxnClassifier, error) {
+	return wireAdapterDirectWithConnectionLost(ctx, cfg, nil)
+}
+
+func wireAdapterDirectWithConnectionLost(ctx context.Context, cfg *ebusgateway.Config, onConnectionLost func()) (func() error, activeTxnClassifier, error) {
 	network := cfg.TransportConfig.Network
 	address := cfg.TransportConfig.Address
 
@@ -1782,6 +1786,7 @@ func wireAdapterDirect(ctx context.Context, cfg *ebusgateway.Config) (func() err
 	}
 
 	mux := adaptermux.New(muxCfg)
+	mux.SetConnectionLostCallback(onConnectionLost)
 	// Codex PR #502 P2: the instance-scoped classifier is returned to
 	// run() and threaded explicitly as the 5th argument to
 	// startDiscoveryScanLoopFn. No package-level closure captures this

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -701,7 +701,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 		}
 		return startHTTPServer(
 			ctx, cfg, gateway, builder, hub, semanticProvider, eebusProvider, eebusCommandRouter,
-			modbusProvider, scheduleWriter, configWriter, busObservability, lateWatchProvider, eebusAdminHandler, eebusLifecycle, ebusDriver.ProxyReadiness, liveAdmittedEBusSource, resolvedBuildInfo,
+			modbusProvider, scheduleWriter, configWriter, busObservability, lateWatchProvider, eebusAdminHandler, eebusLifecycle, ebusDriver.ProxyReadiness, liveAdmittedEBusSource, resolvedBuildInfo, ebusDriver,
 		)
 	}
 	server, advertiser, err := startHTTPServerFn(
@@ -2042,6 +2042,7 @@ func startHTTPServer(
 	ebusProxyReadiness func() string,
 	ebusSourceProvider func() (byte, bool),
 	buildInfo gatewayBuildInfo,
+	ebusDriver *ebusDriverController,
 ) (*http.Server, mdns.Advertiser, error) {
 	if cfg.HTTPAddr == "" {
 		return nil, nil, nil
@@ -2149,6 +2150,9 @@ func startHTTPServer(
 	// epochs, and owner-conditional release are all exercised — only the
 	// raw bus dispatch is stubbed.
 	b503rt := installVaillantB503(mcpServer, gateway, &cfg, ebusSourceProvider)
+	if b503rt != nil && ebusDriver != nil {
+		ebusDriver.SetLifecycleObserver(b503rt)
+	}
 	// M2b_GATEWAY_GRAPHQL (execution-plans#19): wire the GraphQL B503
 	// provider to the same Manager + Dispatcher the MCP surface uses. A
 	// single Manager across both surfaces is mandatory — GraphQL

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -699,7 +699,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 		}
 		return startHTTPServer(
 			ctx, cfg, gateway, builder, hub, semanticProvider, eebusProvider, eebusCommandRouter,
-			modbusProvider, scheduleWriter, configWriter, busObservability, lateWatchProvider, eebusAdminHandler, eebusLifecycle, resolvedBuildInfo,
+			modbusProvider, scheduleWriter, configWriter, busObservability, lateWatchProvider, eebusAdminHandler, eebusLifecycle, ebusDriver.ProxyReadiness, resolvedBuildInfo,
 		)
 	}
 	server, advertiser, err := startHTTPServerFn(
@@ -2016,6 +2016,7 @@ func startHTTPServer(
 	watchSummaryProvider mcp.WatchSummaryProvider,
 	eebusAdminHandler http.Handler,
 	eebusLifecycle *eebusRuntimeLifecycle,
+	ebusProxyReadiness func() string,
 	buildInfo gatewayBuildInfo,
 ) (*http.Server, mdns.Advertiser, error) {
 	if cfg.HTTPAddr == "" {
@@ -2241,7 +2242,7 @@ func startHTTPServer(
 			MCPPath:          cfg.MCPPath,
 			EEBusAdminPath:   "/admin/eebus/v1",
 			Readiness: func() portal.RuntimeReadiness {
-				return projectGatewayReadiness(cfg, eebusLifecycle.LifecycleSnapshot())
+				return projectGatewayReadiness(ebusProxyReadiness, eebusLifecycle.LifecycleSnapshot())
 			},
 			GatewayVersion:    buildInfo.ReleaseVersion,
 			BuildID:           buildInfo.BuildID,
@@ -3111,11 +3112,11 @@ func initRuntimeStateManager(ctx context.Context, cfg ebusgateway.Config, buildI
 	return mgr, state
 }
 
-func projectGatewayReadiness(cfg ebusgateway.Config, snapshot eebusRuntimeLifecycleSnapshot) portal.RuntimeReadiness {
+func projectGatewayReadiness(ebusProxyReadiness func() string, snapshot eebusRuntimeLifecycleSnapshot) portal.RuntimeReadiness {
 	eebusReadiness := eebusReadinessForLifecycle(snapshot)
-	proxyReadiness := "DISABLED"
-	if cfg.ProxyListenAddr != "" {
-		proxyReadiness = "READY"
+	proxyReadiness := ebusProxyReadinessDisabled
+	if ebusProxyReadiness != nil {
+		proxyReadiness = ebusProxyReadiness()
 	}
 	return portal.RuntimeReadiness{
 		ProcessReadiness:    string(eebusReadiness.ProcessReadiness),

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -451,6 +451,11 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 			})
 			return total
 		}
+		if provider, ok := adapterClassifier.(interface {
+			V8ShadowWouldHaveDroppedTotal() uint64
+		}); ok {
+			shadowDropCountFn = provider.V8ShadowWouldHaveDroppedTotal
+		}
 		busObservability.SetV8RolloutProvider(func() ebusgateway.V8RolloutSnapshot {
 			return ebusgateway.V8RolloutSnapshot{
 				Round9AbsorbEntered:            bus.Round9AbsorbEntered(),
@@ -749,6 +754,15 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 			}
 		}
 	}()
+
+	// The control plane is already serving through stable fail-closed
+	// bindings. For startup-scan deployments, wait for the first correlated
+	// RUNNING generation before source admission and the one initial scan pass.
+	// This turns a slow healthy constructor into one immediate scan instead of
+	// an unavailable pass followed by the default 30-second retry interval.
+	if cfg.ScanOnStart && !ebusDriver.WaitRunning(ctx) {
+		return nil
+	}
 
 	var sourceSelection *protocol.SourceAddressSelection
 	if admissionPath == ebusgateway.TransportAdmissionSourceSelectionCapable && !overrideSet && cfg.ScanSourceAuto && cfg.ScanSource == 0x00 && !shouldStartPassiveObserveFirst(cfg) {

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -550,6 +550,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 
 	builder := graphql.NewBuilder(gateway.Registry, nil)
 	liveAdmittedEBusSource := newManagedEBusSourceProvider(ebusDriver, builder.AdmittedMutationSource)
+	builder.SetAdmittedMutationSourceProvider(liveAdmittedEBusSource)
 
 	// Phase A.5 runtime wire-up: AddressTable + AddressTableInserter consume
 	// the PassiveTransactionReconstructor's classified events to insert
@@ -1009,7 +1010,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 			boiler:   semanticPoller,
 			system:   semanticPoller,
 			schedule: semanticPoller,
-			admitted: builder.AdmittedMutationSource,
+			admitted: liveAdmittedEBusSource,
 		}
 		lateGraphQLWriter.Bind(gatedGraphQLWriter)
 		lateGraphQLWatchProvider.Bind(newGraphQLWatchSummaryProvider(semanticPoller.shadow))
@@ -1019,7 +1020,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 			semanticPoller,
 			eebusAdapter,
 			eebusMCPCommandRouter(eebusAdapter),
-			builder.AdmittedMutationSource,
+			liveAdmittedEBusSource,
 		)
 		captureRuntime, captureErr := newLeafPromotionCaptureRuntime(cfg.EEBusConfig.StateRoot, captureSource)
 		if captureErr != nil {
@@ -1241,11 +1242,11 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 	if semanticPoller != nil {
 		lateScheduleWriter.Bind(admittedMCPScheduleWriter{
 			writer:   semanticPoller,
-			admitted: builder.AdmittedMutationSource,
+			admitted: liveAdmittedEBusSource,
 		})
 		lateConfigWriter.Bind(admittedMCPConfigWriter{
 			writer:   &mcpConfigWriterAdapter{poller: semanticPoller},
-			admitted: builder.AdmittedMutationSource,
+			admitted: liveAdmittedEBusSource,
 		})
 		lateWatchProvider.Bind(newMCPWatchSummaryProvider(semanticPoller.shadow))
 	}
@@ -1853,9 +1854,10 @@ func adapterDirectProxyFatalCallback(mux *adaptermux.Mux, owner func()) func(err
 	}
 	return func(err error) {
 		// Fatal listener loss is a generation boundary just like upstream loss.
-		// Fence all proxy work before publishing failure; wireAdapterDirect's
-		// shared one-shot owner prevents duplicate recovery with a mux loss.
-		mux.FenceManagedConnection()
+		// Fence and synchronously retire every existing proxy session before
+		// publishing failure; wireAdapterDirect's shared one-shot owner prevents
+		// duplicate recovery with a concurrent upstream loss.
+		mux.RetireManagedProxySessions()
 		log.Printf("adapter-direct: proxy listener failed: %v", err)
 		owner()
 	}
@@ -2038,7 +2040,7 @@ func startHTTPServer(
 	eebusAdminHandler http.Handler,
 	eebusLifecycle *eebusRuntimeLifecycle,
 	ebusProxyReadiness func() string,
-	explorerSourceProvider func() (byte, bool),
+	ebusSourceProvider func() (byte, bool),
 	buildInfo gatewayBuildInfo,
 ) (*http.Server, mdns.Advertiser, error) {
 	if cfg.HTTPAddr == "" {
@@ -2115,8 +2117,8 @@ func startHTTPServer(
 			return nil, nil, fmt.Errorf("register synchronized evidence capture: %w", err)
 		}
 	}
-	mcpServer.SetAdmittedRPCSourceProvider(builder.AdmittedMutationSource)
-	mcpServer.SetStatusProvider(newMCPRuntimeStatusProvider(semanticProvider, builder.AdmittedMutationSource))
+	mcpServer.SetAdmittedRPCSourceProvider(ebusSourceProvider)
+	mcpServer.SetStatusProvider(newMCPRuntimeStatusProvider(semanticProvider, ebusSourceProvider))
 	if busObservability != nil {
 		mcpServer.SetBusObservabilityProvider(newMCPBusObservabilityProvider(busObservability))
 	}
@@ -2146,7 +2148,7 @@ func startHTTPServer(
 	// paths use the real session FSM so EXPIRED normalization, session
 	// epochs, and owner-conditional release are all exercised — only the
 	// raw bus dispatch is stubbed.
-	b503rt := installVaillantB503(mcpServer, gateway, &cfg, builder.AdmittedMutationSource)
+	b503rt := installVaillantB503(mcpServer, gateway, &cfg, ebusSourceProvider)
 	// M2b_GATEWAY_GRAPHQL (execution-plans#19): wire the GraphQL B503
 	// provider to the same Manager + Dispatcher the MCP surface uses. A
 	// single Manager across both surfaces is mandatory — GraphQL
@@ -2417,7 +2419,7 @@ func startHTTPServer(
 				return portal.ProjectionGraph{}, false
 			},
 			ExplorerBus:            gateway.Bus,
-			ExplorerSourceProvider: explorerSourceProvider,
+			ExplorerSourceProvider: ebusSourceProvider,
 			// Wire the in-process L7 catalog sub-server (M5_PORTAL).
 			// mcpServer.EbusStandardServer() returns the same instance
 			// RegisterEbusStandardTools installed inside mcp.NewServer;

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -1313,6 +1313,13 @@ func applyTransportSourcePolicy(cfg *ebusgateway.Config) {
 	if cfg == nil {
 		return
 	}
+	// Resolve a valid URI override once at the process integration boundary so
+	// every downstream admission/source/evidence decision sees the same
+	// canonical transport tuple as the driver factory. Invalid descriptors stay
+	// untouched and are classified driver-locally by DriverManager.
+	if normalized, err := ebusgateway.NormalizeEBusDriverTransportConfig(cfg.TransportConfig); err == nil {
+		cfg.TransportConfig = normalized
+	}
 
 	protocol := strings.TrimSpace(strings.ToLower(string(cfg.TransportConfig.Protocol)))
 	switch protocol {

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mdns"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/portal"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/ui"
+	ebuserrors "github.com/Project-Helianthus/helianthus-ebusgo/errors"
 	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
 	ebusgoTransport "github.com/Project-Helianthus/helianthus-ebusgo/transport"
 	vaillantproviders "github.com/Project-Helianthus/helianthus-ebusreg/providers/vaillant"
@@ -96,8 +97,8 @@ var (
 // non-nil after a successful ebusgateway.New(), and the wiring site
 // guards on it.
 type v8RolloutExpvarSource struct {
-	bus        *protocol.Bus
-	classifier *v8classifier.Classifier
+	bus          *protocol.Bus
+	classifierFn func() *v8classifier.Classifier
 }
 
 type runtimeWatchObserver struct {
@@ -269,18 +270,37 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 		}
 	}()
 
-	// Wire adapter-direct mode: create multiplexer, configure active
-	// and passive transports before gateway construction.
-	adapterMuxCloser, adapterClassifier, err := wireAdapterDirect(ctx, &cfg)
+	// Construct the protocol-neutral manager and stable eBUS provider before
+	// opening any eBUS resource. Driver-local construction failure is retained
+	// as categorical state and never promoted to process failure.
+	ebusDriver, err := newEBusDriverController(cfg)
 	if err != nil {
-		return withEndpointOwner(endpointOwnerAdapterDirect, fmt.Errorf("adapter-direct: %w", err))
+		return fmt.Errorf("construct eBUS DriverManager: %w", err)
 	}
-	if adapterMuxCloser != nil {
-		defer func() {
-			if err := adapterMuxCloser(); err != nil {
-				log.Printf("adapter-direct close: %v", err)
-			}
-		}()
+	defer func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 2*defaultEBusDriverDrainTimeout+time.Second)
+		defer cancel()
+		if err := ebusDriver.Shutdown(stopCtx); err != nil {
+			result = errors.Join(result, fmt.Errorf("shutdown eBUS driver: %w", err))
+		}
+	}()
+	cfg.Transport = ebusDriver.active
+	if ebusDriver.passive != nil {
+		cfg.PassiveTransport = ebusDriver.passive
+		if configuredEBusDriverProtocol(cfg) == ebusgateway.TransportAdapterDirect {
+			cfg.ObserveFirstWarmupCompletedTransactions = 0
+			cfg.ObserveFirstWarmupConnectedWindow = 0
+			cfg.ObserveFirstWarmupPostResetTransactions = 0
+			cfg.ObserveFirstWarmupPostResetWindow = 0
+		}
+	}
+	adapterClassifier := ebusDriver.classifier
+	if err := ebusDriver.Start(ctx); err != nil {
+		return fmt.Errorf("start eBUS DriverManager: %w", err)
+	}
+	ebusDriverSnapshot := ebusDriver.Snapshot()
+	if ebusDriverSnapshot.ObservedState != "RUNNING" {
+		log.Printf("eBUS driver unavailable; continuing state=%s reason=%s", ebusDriverSnapshot.ObservedState, ebusDriverSnapshot.Reason.Code)
 	}
 
 	// Warn if --proxy-listen is set but adapter-direct transport was not
@@ -396,11 +416,14 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 	// internal/adaptermux/v8classifier/classifier.go:848).
 	if busObservability != nil && gateway.Bus != nil {
 		bus := gateway.Bus
-		var classifier *v8classifier.Classifier
-		if m, ok := adapterClassifier.(*adaptermux.Mux); ok {
-			classifier = m.V8Classifier()
+		classifierFn := func() *v8classifier.Classifier { return nil }
+		if provider, ok := adapterClassifier.(interface {
+			V8Classifier() *v8classifier.Classifier
+		}); ok {
+			classifierFn = provider.V8Classifier
 		}
 		busObservability.SetV8RolloutProvider(func() ebusgateway.V8RolloutSnapshot {
+			classifier := classifierFn()
 			return ebusgateway.V8RolloutSnapshot{
 				Round9AbsorbEntered:            bus.Round9AbsorbEntered(),
 				PayloadAaAutoSynAbsorbed:       bus.PayloadAaAutoSynAbsorbed(),
@@ -427,8 +450,8 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 		// immediately starts reading the new bus — no surface
 		// inconsistency between /metrics and /debug/vars.
 		v8RolloutExpvarCurrent.Store(&v8RolloutExpvarSource{
-			bus:        bus,
-			classifier: classifier,
+			bus:          bus,
+			classifierFn: classifierFn,
 		})
 		// F-NEW-26: pin the current classifier for the
 		// /debug/v8/admin-events HTTP handler too. Same atomic-
@@ -439,7 +462,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 		// handler's nil-check returns an empty event list in
 		// that case so the surface stays available across
 		// transports for tooling that probes it unconditionally.
-		v8AdminEventsCurrentClassifier.Store(classifier)
+		v8AdminEventsCurrentClassifier.Store(classifierFn())
 		v8RolloutExpvarPublishOnce.Do(func() {
 			expvar.Publish("helianthus_round9_absorb_entered_total",
 				expvar.Func(func() any {
@@ -475,7 +498,11 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 						// classifier may be nil on non-adapter-direct
 						// transports — the method has nil-receiver
 						// handling and returns 0.
-						return src.classifier.ShadowWouldHaveDroppedTotal()
+						classifier := src.classifierFn
+						if classifier == nil {
+							return uint64(0)
+						}
+						return classifier().ShadowWouldHaveDroppedTotal()
 					}
 					return uint64(0)
 				}))
@@ -1625,7 +1652,7 @@ func wireAdapterDirect(ctx context.Context, cfg *ebusgateway.Config) (func() err
 		network = "tcp"
 	}
 	if address == "" {
-		return nil, nil, fmt.Errorf("adapter-direct requires an address (e.g. adapter-direct://boiler.local:9999)")
+		return nil, nil, fmt.Errorf("adapter-direct requires an address (e.g. adapter-direct://boiler.local:9999): %w", ebuserrors.ErrInvalidPayload)
 	}
 
 	// Determine ENH vs ENS sub-protocol. ENH is the default.

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -549,6 +549,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 	}
 
 	builder := graphql.NewBuilder(gateway.Registry, nil)
+	liveAdmittedEBusSource := newManagedEBusSourceProvider(ebusDriver, builder.AdmittedMutationSource)
 
 	// Phase A.5 runtime wire-up: AddressTable + AddressTableInserter consume
 	// the PassiveTransactionReconstructor's classified events to insert
@@ -632,7 +633,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 
 	semanticRuntime := graphql.WireSemantic(builder, gateway.Router, hub)
 	portalSemanticProvider := wireEEBusPromotedSemanticGraphQL(ctx, builder, semanticRuntime.Provider(), eebusAdapter)
-	builder.SetStatusProvider(newRuntimeStatusProvider(semanticRuntime.Provider(), builder.AdmittedMutationSource))
+	builder.SetStatusProvider(newRuntimeStatusProvider(semanticRuntime.Provider(), liveAdmittedEBusSource))
 	semanticRuntime.SetBootLiveTimeout(cfg.BootLiveTimeout)
 	semanticRuntime.Start(ctx)
 	if busObservability != nil && semanticRuntime.Provider() != nil {
@@ -699,7 +700,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 		}
 		return startHTTPServer(
 			ctx, cfg, gateway, builder, hub, semanticProvider, eebusProvider, eebusCommandRouter,
-			modbusProvider, scheduleWriter, configWriter, busObservability, lateWatchProvider, eebusAdminHandler, eebusLifecycle, ebusDriver.ProxyReadiness, resolvedBuildInfo,
+			modbusProvider, scheduleWriter, configWriter, busObservability, lateWatchProvider, eebusAdminHandler, eebusLifecycle, ebusDriver.ProxyReadiness, liveAdmittedEBusSource, resolvedBuildInfo,
 		)
 	}
 	server, advertiser, err := startHTTPServerFn(
@@ -972,7 +973,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 		cfg.ScanSource = overrideSource
 		cfg.ScanSourceAuto = false
 	}
-	builder.SetStatusProvider(newRuntimeStatusProvider(semanticRuntime.Provider(), builder.AdmittedMutationSource))
+	builder.SetStatusProvider(newRuntimeStatusProvider(semanticRuntime.Provider(), liveAdmittedEBusSource))
 	syncStaticAdmittedSource, syncStaticAdmitted := admittedMutationSourceForGateway(cfg, admissionPath, overrideSet)
 	if syncStaticAdmitted {
 		builder.SetAdmittedMutationSource(syncStaticAdmittedSource)
@@ -2037,6 +2038,7 @@ func startHTTPServer(
 	eebusAdminHandler http.Handler,
 	eebusLifecycle *eebusRuntimeLifecycle,
 	ebusProxyReadiness func() string,
+	explorerSourceProvider func() (byte, bool),
 	buildInfo gatewayBuildInfo,
 ) (*http.Server, mdns.Advertiser, error) {
 	if cfg.HTTPAddr == "" {
@@ -2415,7 +2417,7 @@ func startHTTPServer(
 				return portal.ProjectionGraph{}, false
 			},
 			ExplorerBus:            gateway.Bus,
-			ExplorerSourceProvider: builder.AdmittedMutationSource,
+			ExplorerSourceProvider: explorerSourceProvider,
 			// Wire the in-process L7 catalog sub-server (M5_PORTAL).
 			// mcpServer.EbusStandardServer() returns the same instance
 			// RegisterEbusStandardTools installed inside mcp.NewServer;

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -98,25 +98,29 @@ var (
 // non-nil after a successful ebusgateway.New(), and the wiring site
 // guards on it.
 type v8RolloutExpvarSource struct {
-	bus          *protocol.Bus
-	classifierFn func() *v8classifier.Classifier
+	bus               *protocol.Bus
+	shadowDropCountFn func() uint64
 }
 
 type v8AdminClassifierProvider struct {
-	classifierFn func() *v8classifier.Classifier
+	withClassifier func(func(*v8classifier.Classifier))
 }
 
-func currentV8AdminClassifier() *v8classifier.Classifier {
+func withCurrentV8AdminClassifier(callback func(*v8classifier.Classifier)) {
+	if callback == nil {
+		return
+	}
 	// Direct pointer is retained as a test/backward-compatible injection seam.
 	// Production clears it and installs the generation-aware provider below.
 	if classifier := v8AdminEventsCurrentClassifier.Load(); classifier != nil {
-		return classifier
+		callback(classifier)
+		return
 	}
 	provider := v8AdminEventsCurrentProvider.Load()
-	if provider == nil || provider.classifierFn == nil {
-		return nil
+	if provider == nil || provider.withClassifier == nil {
+		return
 	}
-	return provider.classifierFn()
+	provider.withClassifier(callback)
 }
 
 type runtimeWatchObserver struct {
@@ -323,7 +327,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 
 	// Warn if --proxy-listen is set but adapter-direct transport was not
 	// activated (the proxy endpoint requires the adapter multiplexer).
-	if cfg.ProxyListenAddr != "" && cfg.Transport == nil {
+	if cfg.ProxyListenAddr != "" && !adapterDirectProxyEnabled(cfg.TransportConfig) {
 		log.Printf("warning: --proxy-listen requires adapter-direct transport; proxy endpoint not started")
 	}
 
@@ -434,20 +438,26 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 	// internal/adaptermux/v8classifier/classifier.go:848).
 	if busObservability != nil && gateway.Bus != nil {
 		bus := gateway.Bus
-		classifierFn := func() *v8classifier.Classifier { return nil }
+		withClassifier := func(func(*v8classifier.Classifier)) {}
 		if provider, ok := adapterClassifier.(interface {
-			V8Classifier() *v8classifier.Classifier
+			WithV8Classifier(func(*v8classifier.Classifier))
 		}); ok {
-			classifierFn = provider.V8Classifier
+			withClassifier = provider.WithV8Classifier
+		}
+		shadowDropCountFn := func() uint64 {
+			var total uint64
+			withClassifier(func(classifier *v8classifier.Classifier) {
+				total = classifier.ShadowWouldHaveDroppedTotal()
+			})
+			return total
 		}
 		busObservability.SetV8RolloutProvider(func() ebusgateway.V8RolloutSnapshot {
-			classifier := classifierFn()
 			return ebusgateway.V8RolloutSnapshot{
 				Round9AbsorbEntered:            bus.Round9AbsorbEntered(),
 				PayloadAaAutoSynAbsorbed:       bus.PayloadAaAutoSynAbsorbed(),
 				PayloadAaAutoSynRecovered:      bus.PayloadAaAutoSynRecovered(),
 				PayloadAaAutoSynDrainExhausted: bus.PayloadAaAutoSynDrainExhausted(),
-				V8ShadowWouldHaveDroppedTotal:  classifier.ShadowWouldHaveDroppedTotal(),
+				V8ShadowWouldHaveDroppedTotal:  shadowDropCountFn(),
 			}
 		})
 
@@ -468,20 +478,16 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 		// immediately starts reading the new bus — no surface
 		// inconsistency between /metrics and /debug/vars.
 		v8RolloutExpvarCurrent.Store(&v8RolloutExpvarSource{
-			bus:          bus,
-			classifierFn: classifierFn,
+			bus:               bus,
+			shadowDropCountFn: shadowDropCountFn,
 		})
-		// F-NEW-26: pin the current classifier for the
-		// /debug/v8/admin-events HTTP handler too. Same atomic-
-		// pointer pattern as v8RolloutExpvarCurrent — handler
-		// registered ONCE per process at startHTTPServer,
-		// dereferences this pointer at request time. classifier
-		// may be nil (non-adapter-direct transports); the
-		// handler's nil-check returns an empty event list in
-		// that case so the surface stays available across
-		// transports for tooling that probes it unconditionally.
+		// F-NEW-26: install the current-generation classifier callback for
+		// /debug/v8/admin-events. Production operations execute inside stable
+		// driver admission, so a classifier pointer cannot escape across
+		// replacement. A missing classifier (non-adapter-direct transport)
+		// leaves the response empty while preserving the HTTP contract.
 		v8AdminEventsCurrentClassifier.Store(nil)
-		v8AdminEventsCurrentProvider.Store(&v8AdminClassifierProvider{classifierFn: classifierFn})
+		v8AdminEventsCurrentProvider.Store(&v8AdminClassifierProvider{withClassifier: withClassifier})
 		v8RolloutExpvarPublishOnce.Do(func() {
 			expvar.Publish("helianthus_round9_absorb_entered_total",
 				expvar.Func(func() any {
@@ -514,14 +520,11 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 			expvar.Publish("helianthus_v8_shadow_would_have_dropped_total",
 				expvar.Func(func() any {
 					if src := v8RolloutExpvarCurrent.Load(); src != nil {
-						// classifier may be nil on non-adapter-direct
-						// transports — the method has nil-receiver
-						// handling and returns 0.
-						classifier := src.classifierFn
-						if classifier == nil {
+						// Non-adapter-direct transports install no counter callback.
+						if src.shadowDropCountFn == nil {
 							return uint64(0)
 						}
-						return classifier().ShadowWouldHaveDroppedTotal()
+						return src.shadowDropCountFn()
 					}
 					return uint64(0)
 				}))
@@ -1830,6 +1833,10 @@ func adapterDirectMuxProtocol(protocol ebusgateway.TransportProtocol) string {
 	return "enh"
 }
 
+func adapterDirectProxyEnabled(config ebusgateway.TransportConfig) bool {
+	return ebusgateway.EBusDriverTransportProtocol(config) == ebusgateway.TransportAdapterDirect
+}
+
 // v8AdminEventsResponse is the JSON envelope returned by
 // /debug/v8/admin-events. Stable wire format — operator tooling
 // (dashboards, classifier-tuning workflows) parse this.
@@ -1928,8 +1935,7 @@ func handleV8AdminEvents(w http.ResponseWriter, r *http.Request) {
 		Events: []v8AdminEventJSON{},
 	}
 
-	classifier := currentV8AdminClassifier()
-	if classifier != nil {
+	withCurrentV8AdminClassifier(func(classifier *v8classifier.Classifier) {
 		var events []v8classifier.ClassifierAdminEvent
 		var dropped uint64
 		if peekOnly {
@@ -1955,7 +1961,7 @@ func handleV8AdminEvents(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		}
-	}
+	})
 
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	if peekOnly {

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -1775,7 +1775,12 @@ func wireAdapterDirectWithConnectionLost(ctx context.Context, cfg *ebusgateway.C
 	}
 
 	mux := adaptermux.New(muxCfg)
-	mux.SetConnectionLostCallback(onConnectionLost)
+	connectionLostOwner := onConnectionLost
+	if onConnectionLost != nil {
+		var connectionLostOnce sync.Once
+		connectionLostOwner = func() { connectionLostOnce.Do(onConnectionLost) }
+	}
+	mux.SetConnectionLostCallback(connectionLostOwner)
 	// Codex PR #502 P2: the instance-scoped classifier is returned to
 	// run() and threaded explicitly as the 5th argument to
 	// startDiscoveryScanLoopFn. No package-level closure captures this
@@ -1809,7 +1814,8 @@ func wireAdapterDirectWithConnectionLost(ctx context.Context, cfg *ebusgateway.C
 	// external clients like ebusd).
 	var proxyListener *adaptermux.ProxyListener
 	if cfg.ProxyListenAddr != "" {
-		pl, err := adaptermux.NewProxyListener(ctx, mux, cfg.ProxyListenAddr, log.Default())
+		onProxyFatal := adapterDirectProxyFatalCallback(mux, connectionLostOwner)
+		pl, err := adaptermux.NewProxyListenerWithFatalCallback(ctx, mux, cfg.ProxyListenAddr, log.Default(), onProxyFatal)
 		if err != nil {
 			if cerr := mux.Close(); cerr != nil {
 				log.Printf("adapter-direct: mux.Close after proxy-listener error: %v", cerr)
@@ -1838,6 +1844,20 @@ func wireAdapterDirectWithConnectionLost(ctx context.Context, cfg *ebusgateway.C
 		return mux.Close()
 	}
 	return closer, activeTxnClassifier(mux), nil
+}
+
+func adapterDirectProxyFatalCallback(mux *adaptermux.Mux, owner func()) func(error) {
+	if mux == nil || owner == nil {
+		return nil
+	}
+	return func(err error) {
+		// Fatal listener loss is a generation boundary just like upstream loss.
+		// Fence all proxy work before publishing failure; wireAdapterDirect's
+		// shared one-shot owner prevents duplicate recovery with a mux loss.
+		mux.FenceManagedConnection()
+		log.Printf("adapter-direct: proxy listener failed: %v", err)
+		owner()
+	}
 }
 
 func adapterDirectMuxProtocol(protocol ebusgateway.TransportProtocol) string {

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -646,6 +646,106 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 			semanticRuntime.Provider().RefreshEnergyFreshnessMetrics(now, passiveState)
 		})
 	}
+	// The control plane is process-owned, not eBUS-owned. Start it before
+	// passive source-selection warmup so a slow or unavailable provider cannot
+	// delay the stable HTTP/API shell. Mutable eBUS surfaces use late bindings:
+	// they fail closed before source admission and delegate without rebuilding
+	// the server once the healthy semantic poller is ready.
+	lateScheduleWriter := &lateEBusScheduleWriter{}
+	lateConfigWriter := &lateEBusConfigWriter{}
+	lateWatchProvider := &lateEBusWatchSummaryProvider{}
+	lateGraphQLWriter := &lateEBusGraphQLWriter{}
+	lateGraphQLWatchProvider := &lateEBusGraphQLWatchSummaryProvider{}
+	builder.SetBoilerConfigWriter(lateGraphQLWriter)
+	builder.SetSystemConfigWriter(lateGraphQLWriter)
+	builder.SetScheduleWriter(lateGraphQLWriter)
+	builder.SetWatchSummaryProvider(lateGraphQLWatchProvider)
+	if err := builder.Start(ctx); err != nil {
+		return err
+	}
+	var (
+		listener      *ebusgateway.BroadcastListener
+		reconstructor *ebusgateway.PassiveTransactionReconstructor
+	)
+	startHTTPServerOverride := startHTTPServerFn
+	startHTTPServerFn := func(
+		ctx context.Context,
+		cfg ebusgateway.Config,
+		gateway *ebusgateway.Gateway,
+		builder *graphql.Builder,
+		hub *graphql.BroadcastHub,
+		semanticProvider graphql.SemanticProvider,
+		eebusProvider mcp.EEBusV1Provider,
+		eebusCommandRouter mcp.EEBusV1CommandRouter,
+		modbusProvider mcp.ModbusV1Provider,
+		scheduleWriter mcp.ScheduleWriter,
+		configWriter mcp.ConfigWriter,
+		busObservability *ebusgateway.BusObservabilityStore,
+		shadowCache *ebusgateway.ShadowCache,
+	) (*http.Server, mdns.Advertiser, error) {
+		if startHTTPServerOverride != nil {
+			return startHTTPServerOverride(
+				ctx, cfg, gateway, builder, hub, semanticProvider, scheduleWriter,
+				configWriter, busObservability, shadowCache,
+			)
+		}
+		return startHTTPServer(
+			ctx, cfg, gateway, builder, hub, semanticProvider, eebusProvider, eebusCommandRouter,
+			modbusProvider, scheduleWriter, configWriter, busObservability, lateWatchProvider, eebusAdminHandler, eebusLifecycle, resolvedBuildInfo,
+		)
+	}
+	server, advertiser, err := startHTTPServerFn(
+		ctx,
+		cfg,
+		gateway,
+		builder,
+		hub,
+		portalSemanticProvider,
+		eebusMCPProvider(eebusAdapter),
+		eebusMCPCommandRouter(eebusAdapter),
+		newGatewayModbusMCPProvider(modbusAdapter),
+		lateScheduleWriter,
+		lateConfigWriter,
+		busObservability,
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		// Preserve the historical teardown order: stop eBUS consumers before
+		// closing observability, then retire mDNS and HTTP before Gateway/driver.
+		if listener != nil {
+			if err := listener.Close(); err != nil {
+				log.Printf("broadcast listener close: %v", err)
+			}
+		}
+		if deduplicator != nil {
+			if err := deduplicator.Close(); err != nil {
+				log.Printf("deduplicator close: %v", err)
+			}
+		}
+		if reconstructor != nil {
+			if err := reconstructor.Close(); err != nil {
+				log.Printf("reconstructor close: %v", err)
+			}
+		}
+		if busObservability != nil {
+			if err := busObservability.Close(); err != nil {
+				log.Printf("bus observability close: %v", err)
+			}
+		}
+		if advertiser != nil {
+			if err := advertiser.Close(); err != nil {
+				log.Printf("mdns close: %v", err)
+			}
+		}
+		if server != nil {
+			if err := server.Close(); err != nil {
+				log.Printf("http server close: %v", err)
+			}
+		}
+	}()
 
 	var sourceSelection *protocol.SourceAddressSelection
 	if admissionPath == ebusgateway.TransportAdmissionSourceSelectionCapable && !overrideSet && cfg.ScanSourceAuto && cfg.ScanSource == 0x00 && !shouldStartPassiveObserveFirst(cfg) {
@@ -688,8 +788,6 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 	}
 
 	var (
-		listener            *ebusgateway.BroadcastListener
-		reconstructor       *ebusgateway.PassiveTransactionReconstructor
 		insertSubscribeOnce sync.Once
 		insertSubscribed    atomic.Bool
 	)
@@ -895,10 +993,8 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 			schedule: semanticPoller,
 			admitted: builder.AdmittedMutationSource,
 		}
-		builder.SetSystemConfigWriter(gatedGraphQLWriter)
-		builder.SetBoilerConfigWriter(gatedGraphQLWriter)
-		builder.SetScheduleWriter(gatedGraphQLWriter)
-		builder.SetWatchSummaryProvider(newGraphQLWatchSummaryProvider(semanticPoller.shadow))
+		lateGraphQLWriter.Bind(gatedGraphQLWriter)
+		lateGraphQLWatchProvider.Bind(newGraphQLWatchSummaryProvider(semanticPoller.shadow))
 	}
 	if semanticPoller != nil && eebusAdapter != nil {
 		captureSource := newLeafPromotionLiveSource(
@@ -934,10 +1030,6 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 		if err := attachPassiveShadowProducerFn(semanticPoller, ctx, deduplicator); err != nil {
 			return err
 		}
-	}
-
-	if err := builder.Start(ctx); err != nil {
-		return err
 	}
 
 	startupCfg := resolveStartupScanSourceConfig(cfg)
@@ -1128,69 +1220,16 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 		}
 	}
 
-	var scheduleWriter mcp.ScheduleWriter
 	if semanticPoller != nil {
-		scheduleWriter = admittedMCPScheduleWriter{
+		lateScheduleWriter.Bind(admittedMCPScheduleWriter{
 			writer:   semanticPoller,
 			admitted: builder.AdmittedMutationSource,
-		}
-	}
-	var configWriter mcp.ConfigWriter
-	if semanticPoller != nil {
-		configWriter = admittedMCPConfigWriter{
+		})
+		lateConfigWriter.Bind(admittedMCPConfigWriter{
 			writer:   &mcpConfigWriterAdapter{poller: semanticPoller},
 			admitted: builder.AdmittedMutationSource,
-		}
-	}
-	var shadowCache *ebusgateway.ShadowCache
-	if semanticPoller != nil {
-		shadowCache = semanticPoller.shadow
-	}
-
-	startHTTPServerOverride := startHTTPServerFn
-	startHTTPServerFn := func(
-		ctx context.Context,
-		cfg ebusgateway.Config,
-		gateway *ebusgateway.Gateway,
-		builder *graphql.Builder,
-		hub *graphql.BroadcastHub,
-		semanticProvider graphql.SemanticProvider,
-		eebusProvider mcp.EEBusV1Provider,
-		eebusCommandRouter mcp.EEBusV1CommandRouter,
-		modbusProvider mcp.ModbusV1Provider,
-		scheduleWriter mcp.ScheduleWriter,
-		configWriter mcp.ConfigWriter,
-		busObservability *ebusgateway.BusObservabilityStore,
-		shadowCache *ebusgateway.ShadowCache,
-	) (*http.Server, mdns.Advertiser, error) {
-		if startHTTPServerOverride != nil {
-			return startHTTPServerOverride(
-				ctx, cfg, gateway, builder, hub, semanticProvider, scheduleWriter,
-				configWriter, busObservability, shadowCache,
-			)
-		}
-		return startHTTPServer(
-			ctx, cfg, gateway, builder, hub, semanticProvider, eebusProvider, eebusCommandRouter,
-			modbusProvider, scheduleWriter, configWriter, busObservability, shadowCache, eebusAdminHandler, eebusLifecycle, resolvedBuildInfo,
-		)
-	}
-	server, advertiser, err := startHTTPServerFn(
-		ctx,
-		cfg,
-		gateway,
-		builder,
-		hub,
-		portalSemanticProvider,
-		eebusMCPProvider(eebusAdapter),
-		eebusMCPCommandRouter(eebusAdapter),
-		newGatewayModbusMCPProvider(modbusAdapter),
-		scheduleWriter,
-		configWriter,
-		busObservability,
-		shadowCache,
-	)
-	if err != nil {
-		return err
+		})
+		lateWatchProvider.Bind(newMCPWatchSummaryProvider(semanticPoller.shadow))
 	}
 	if shouldStartPassiveObserveFirst(cfg) {
 		if reconstructor == nil {
@@ -1198,62 +1237,17 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 
 			reconstructor, err = startPassiveTransactionReconstructor(ctx, cfg)
 			if err != nil {
-				if advertiser != nil {
-					_ = advertiser.Close()
-				}
-				if server != nil {
-					_ = server.Close()
-				}
 				return err
 			}
 		}
 		if err := attachPassiveObserveFirst(); err != nil {
 			_ = reconstructor.Close()
-			if advertiser != nil {
-				_ = advertiser.Close()
-			}
-			if server != nil {
-				_ = server.Close()
-			}
 			return err
 		}
 	}
 	if cfg.BroadcastListen && !shouldStartPassiveObserveFirst(cfg) {
 		log.Printf("passive observe-first unavailable on transport=%s; continuing degraded", cfg.TransportConfig.Protocol)
 	}
-	defer func() {
-		if listener != nil {
-			if err := listener.Close(); err != nil {
-				log.Printf("broadcast listener close: %v", err)
-			}
-		}
-		if deduplicator != nil {
-			if err := deduplicator.Close(); err != nil {
-				log.Printf("deduplicator close: %v", err)
-			}
-		}
-		if reconstructor != nil {
-			if err := reconstructor.Close(); err != nil {
-				log.Printf("reconstructor close: %v", err)
-			}
-		}
-		if busObservability != nil {
-			if err := busObservability.Close(); err != nil {
-				log.Printf("bus observability close: %v", err)
-			}
-		}
-		if advertiser != nil {
-			if err := advertiser.Close(); err != nil {
-				log.Printf("mdns close: %v", err)
-			}
-		}
-		if server != nil {
-			if err := server.Close(); err != nil {
-				log.Printf("http server close: %v", err)
-			}
-		}
-	}()
-
 	<-ctx.Done()
 	return nil
 }
@@ -1641,56 +1635,27 @@ func wireAdapterDirect(ctx context.Context, cfg *ebusgateway.Config) (func() err
 	return wireAdapterDirectWithConnectionLost(ctx, cfg, nil)
 }
 
+const adapterDirectENSProtocol ebusgateway.TransportProtocol = "adapter-direct-ens"
+
 func wireAdapterDirectWithConnectionLost(ctx context.Context, cfg *ebusgateway.Config, onConnectionLost func()) (func() error, activeTxnClassifier, error) {
-	network := cfg.TransportConfig.Network
-	address := cfg.TransportConfig.Address
-
-	// Detect adapter-direct:// or adapter-direct-ens:// URI scheme in
-	// the address field. When the user passes
-	// --address=adapter-direct://host:port the protocol flag is still
-	// the default ("enh") because parseTransportEndpoint runs later
-	// inside ebusgateway.New.
-	const (
-		schemePrefix    = "adapter-direct://"
-		schemePrefixENS = "adapter-direct-ens://"
-	)
-	addrLower := strings.ToLower(address)
-	uriIsENS := strings.HasPrefix(addrLower, schemePrefixENS)
-	uriIsStd := strings.HasPrefix(addrLower, schemePrefix)
-	if !strings.EqualFold(string(cfg.TransportConfig.Protocol), string(ebusgateway.TransportAdapterDirect)) {
-		if !uriIsStd && !uriIsENS {
-			return nil, nil, nil
-		}
+	normalized, err := ebusgateway.NormalizeEBusDriverTransportConfig(cfg.TransportConfig)
+	if err != nil {
+		return nil, nil, err
 	}
-
-	// Always strip the scheme prefix if present, regardless of which
-	// detection branch was taken. Without this, net.Dial receives
-	// "adapter-direct://host:port" as the address and fails.
-	if uriIsENS {
-		address = address[len(schemePrefixENS):]
-		network = "tcp"
-	} else if uriIsStd {
-		address = address[len(schemePrefix):]
-		// The URI form implies TCP — force it unconditionally since
-		// the default TransportConfig.Network is "unix" and would
-		// cause net.Dial("unix", "host:port") to fail.
-		network = "tcp"
-	} else if network == "" || (network == "unix" && strings.Contains(address, ":")) {
-		// Explicit --transport adapter-direct path: if network is
-		// still the default "unix" but address looks like host:port,
-		// force TCP to avoid net.Dial("unix", "host:port") failures.
-		network = "tcp"
+	if normalized.Protocol != ebusgateway.TransportAdapterDirect && normalized.Protocol != adapterDirectENSProtocol {
+		return nil, nil, nil
 	}
+	cfg.TransportConfig = normalized
+	network := normalized.Network
+	address := normalized.Address
 	if address == "" {
 		return nil, nil, fmt.Errorf("adapter-direct requires an address (e.g. adapter-direct://boiler.local:9999): %w", ebuserrors.ErrInvalidPayload)
 	}
 
 	// Determine ENH vs ENS sub-protocol. ENH is the default.
-	// The adapter-direct-ens:// URI scheme selects ENS explicitly.
-	adapterProtocol := "enh"
-	if uriIsENS {
-		adapterProtocol = "ens"
-	}
+	// The shared normalizer preserves adapter-direct-ens as a private
+	// canonical literal after stripping the URI.
+	adapterProtocol := adapterDirectMuxProtocol(normalized.Protocol)
 
 	muxCfg := adaptermux.Config{
 		Protocol:     adapterProtocol,
@@ -1858,6 +1823,13 @@ func wireAdapterDirectWithConnectionLost(ctx context.Context, cfg *ebusgateway.C
 	return closer, activeTxnClassifier(mux), nil
 }
 
+func adapterDirectMuxProtocol(protocol ebusgateway.TransportProtocol) string {
+	if protocol == adapterDirectENSProtocol {
+		return "ens"
+	}
+	return "enh"
+}
+
 // v8AdminEventsResponse is the JSON envelope returned by
 // /debug/v8/admin-events. Stable wire format — operator tooling
 // (dashboards, classifier-tuning workflows) parse this.
@@ -2021,7 +1993,7 @@ func startHTTPServer(
 	scheduleWriter mcp.ScheduleWriter,
 	configWriter mcp.ConfigWriter,
 	busObservability *ebusgateway.BusObservabilityStore,
-	shadowCache *ebusgateway.ShadowCache,
+	watchSummaryProvider mcp.WatchSummaryProvider,
 	eebusAdminHandler http.Handler,
 	eebusLifecycle *eebusRuntimeLifecycle,
 	buildInfo gatewayBuildInfo,
@@ -2105,8 +2077,8 @@ func startHTTPServer(
 	if busObservability != nil {
 		mcpServer.SetBusObservabilityProvider(newMCPBusObservabilityProvider(busObservability))
 	}
-	if shadowCache != nil {
-		mcpServer.SetWatchSummaryProvider(newMCPWatchSummaryProvider(shadowCache))
+	if watchSummaryProvider != nil {
+		mcpServer.SetWatchSummaryProvider(watchSummaryProvider)
 	}
 	mcpServer.SetSemanticProvider(newMCPSemanticProvider(semanticProvider))
 

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -632,7 +632,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 
 	semanticRuntime := graphql.WireSemantic(builder, gateway.Router, hub)
 	portalSemanticProvider := wireEEBusPromotedSemanticGraphQL(ctx, builder, semanticRuntime.Provider(), eebusAdapter)
-	builder.SetStatusProvider(newRuntimeStatusProvider(cfg, semanticRuntime.Provider()))
+	builder.SetStatusProvider(newRuntimeStatusProvider(semanticRuntime.Provider(), builder.AdmittedMutationSource))
 	semanticRuntime.SetBootLiveTimeout(cfg.BootLiveTimeout)
 	semanticRuntime.Start(ctx)
 	if busObservability != nil && semanticRuntime.Provider() != nil {
@@ -972,7 +972,7 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 		cfg.ScanSource = overrideSource
 		cfg.ScanSourceAuto = false
 	}
-	builder.SetStatusProvider(newRuntimeStatusProvider(cfg, semanticRuntime.Provider()))
+	builder.SetStatusProvider(newRuntimeStatusProvider(semanticRuntime.Provider(), builder.AdmittedMutationSource))
 	syncStaticAdmittedSource, syncStaticAdmitted := admittedMutationSourceForGateway(cfg, admissionPath, overrideSet)
 	if syncStaticAdmitted {
 		builder.SetAdmittedMutationSource(syncStaticAdmittedSource)

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -87,6 +87,7 @@ var (
 	// empty events array + dropped=0 in that case so the contract
 	// degrades cleanly without 404-ing.
 	v8AdminEventsCurrentClassifier atomic.Pointer[v8classifier.Classifier]
+	v8AdminEventsCurrentProvider   atomic.Pointer[v8AdminClassifierProvider]
 )
 
 // v8RolloutExpvarSource is the indirection layer for the five
@@ -99,6 +100,23 @@ var (
 type v8RolloutExpvarSource struct {
 	bus          *protocol.Bus
 	classifierFn func() *v8classifier.Classifier
+}
+
+type v8AdminClassifierProvider struct {
+	classifierFn func() *v8classifier.Classifier
+}
+
+func currentV8AdminClassifier() *v8classifier.Classifier {
+	// Direct pointer is retained as a test/backward-compatible injection seam.
+	// Production clears it and installs the generation-aware provider below.
+	if classifier := v8AdminEventsCurrentClassifier.Load(); classifier != nil {
+		return classifier
+	}
+	provider := v8AdminEventsCurrentProvider.Load()
+	if provider == nil || provider.classifierFn == nil {
+		return nil
+	}
+	return provider.classifierFn()
 }
 
 type runtimeWatchObserver struct {
@@ -462,7 +480,8 @@ func run(ctx context.Context, cfg ebusgateway.Config) (result error) {
 		// handler's nil-check returns an empty event list in
 		// that case so the surface stays available across
 		// transports for tooling that probes it unconditionally.
-		v8AdminEventsCurrentClassifier.Store(classifierFn())
+		v8AdminEventsCurrentClassifier.Store(nil)
+		v8AdminEventsCurrentProvider.Store(&v8AdminClassifierProvider{classifierFn: classifierFn})
 		v8RolloutExpvarPublishOnce.Do(func() {
 			expvar.Publish("helianthus_round9_absorb_entered_total",
 				expvar.Func(func() any {
@@ -1925,7 +1944,7 @@ func handleV8AdminEvents(w http.ResponseWriter, r *http.Request) {
 		Events: []v8AdminEventJSON{},
 	}
 
-	classifier := v8AdminEventsCurrentClassifier.Load()
+	classifier := currentV8AdminClassifier()
 	if classifier != nil {
 		var events []v8classifier.ClassifierAdminEvent
 		var dropped uint64

--- a/cmd/gateway/main_address_table_wireup_test.go
+++ b/cmd/gateway/main_address_table_wireup_test.go
@@ -39,7 +39,9 @@ func TestRun_AddressTableInserterWiresThroughPassiveReconstructor(t *testing.T) 
 	// goroutine inside run() fires SetAdmittedMutationSource — which the
 	// inserter now gates its subscription on (Phase A.5 round 3 fix).
 	activeProbePassed := make(chan struct{})
+	discoveryStarted := make(chan struct{})
 	startDiscoveryScanLoopFn = func(context.Context, ebusgateway.Config, *ebusgateway.Gateway, *graphql.Builder, activeTxnClassifier) startupScanSignals {
+		close(discoveryStarted)
 		return startupScanSignals{
 			activeProbePassed: activeProbePassed,
 		}
@@ -47,7 +49,9 @@ func TestRun_AddressTableInserterWiresThroughPassiveReconstructor(t *testing.T) 
 	startVaillantSemanticPollingFn = func(context.Context, ebusgateway.Config, *ebusgateway.Gateway, *graphql.LiveSemanticProvider, *graphql.BroadcastHub, <-chan struct{}) *vaillantSemanticPoller {
 		return nil
 	}
+	passiveAttached := make(chan struct{})
 	startBroadcastListenerWithReconstructorFn = func(context.Context, *router.BusEventRouter, *ebusgateway.PassiveTransactionReconstructor) (*ebusgateway.BroadcastListener, error) {
+		close(passiveAttached)
 		return nil, nil
 	}
 
@@ -108,12 +112,25 @@ func TestRun_AddressTableInserterWiresThroughPassiveReconstructor(t *testing.T) 
 		t.Fatal("gateway runtime did not reach HTTP startup")
 	}
 
+	// HTTP now starts before source-selection warmup. Wait until the startup
+	// scan is actually installed before signaling its probe result.
+	select {
+	case <-discoveryStarted:
+	case <-time.After(8 * time.Second):
+		t.Fatal("gateway runtime did not finish source-selection warmup")
+	}
+
 	// Signal active-probe success so the async goroutine in run() calls
 	// builder.SetAdmittedMutationSource(sourceSelection.Source). The
 	// AddressTableInserter subscription is gated on AdmittedMutationSource
 	// returning ok=true (Phase A.5 round 3 — Codex bot P2). Without this
 	// signal the inserter never binds.
 	close(activeProbePassed)
+	select {
+	case <-passiveAttached:
+	case <-time.After(2 * time.Second):
+		t.Fatal("passive AddressTable path did not attach after admission")
+	}
 
 	feedCtx, stopFeed := context.WithCancel(ctx)
 	feedDone := make(chan struct{})

--- a/cmd/gateway/main_test.go
+++ b/cmd/gateway/main_test.go
@@ -1422,6 +1422,12 @@ func TestWireAdapterDirect_URIScheme_ForcesTCP(t *testing.T) {
 	if !strings.Contains(err.Error(), "192.0.2.1:9999") {
 		t.Fatalf("expected stripped address in error, got: %v", err)
 	}
+	if cfg.TransportConfig.Protocol != ebusgateway.TransportAdapterDirect || cfg.TransportConfig.Network != "tcp" || cfg.TransportConfig.Address != "192.0.2.1:9999" {
+		t.Fatalf("canonical adapter-direct tuple = %q/%q/%q", cfg.TransportConfig.Protocol, cfg.TransportConfig.Network, cfg.TransportConfig.Address)
+	}
+	if got := adapterDirectMuxProtocol(cfg.TransportConfig.Protocol); got != "enh" {
+		t.Fatalf("adapterDirectMuxProtocol() = %q, want enh", got)
+	}
 }
 
 func TestWireAdapterDirect_ExplicitProtocol_ForcesTCPForHostPort(t *testing.T) {
@@ -1478,9 +1484,12 @@ func TestWireAdapterDirect_ENSScheme_SelectsENS(t *testing.T) {
 	if !strings.Contains(err.Error(), "tcp") {
 		t.Fatalf("expected TCP network, got: %v", err)
 	}
-	// Note: ENS protocol selection is verified implicitly — if the
-	// scheme were not recognized, wireAdapterDirect would return (nil,
-	// nil) and we would not get a dial error.
+	if cfg.TransportConfig.Protocol != adapterDirectENSProtocol || cfg.TransportConfig.Network != "tcp" || cfg.TransportConfig.Address != "192.0.2.1:9999" {
+		t.Fatalf("canonical adapter-direct ENS tuple = %q/%q/%q", cfg.TransportConfig.Protocol, cfg.TransportConfig.Network, cfg.TransportConfig.Address)
+	}
+	if got := adapterDirectMuxProtocol(cfg.TransportConfig.Protocol); got != "ens" {
+		t.Fatalf("adapterDirectMuxProtocol() = %q, want ens", got)
+	}
 }
 
 func TestWireAdapterDirect_ProxyListener_ReturnedAsCloser(t *testing.T) {

--- a/cmd/gateway/main_test.go
+++ b/cmd/gateway/main_test.go
@@ -1492,6 +1492,27 @@ func TestWireAdapterDirect_ENSScheme_SelectsENS(t *testing.T) {
 	}
 }
 
+func TestAdapterDirectProxyAvailabilityUsesCanonicalEndpointProtocol(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  ebusgateway.TransportConfig
+		enabled bool
+	}{
+		{name: "explicit adapter direct", config: ebusgateway.TransportConfig{Protocol: ebusgateway.TransportAdapterDirect, Address: "adapter.local:9999"}, enabled: true},
+		{name: "adapter direct URI", config: ebusgateway.TransportConfig{Protocol: ebusgateway.TransportENH, Address: "adapter-direct://adapter.local:9999"}, enabled: true},
+		{name: "adapter direct ENS URI", config: ebusgateway.TransportConfig{Protocol: ebusgateway.TransportENH, Address: "adapter-direct-ens://adapter.local:9999"}, enabled: true},
+		{name: "ordinary ENH", config: ebusgateway.TransportConfig{Protocol: ebusgateway.TransportENH, Address: "adapter.local:9999"}},
+		{name: "TCP plain", config: ebusgateway.TransportConfig{Protocol: ebusgateway.TransportTCPPlain, Address: "adapter.local:9999"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := adapterDirectProxyEnabled(test.config); got != test.enabled {
+				t.Fatalf("adapterDirectProxyEnabled(%#v) = %v, want %v", test.config, got, test.enabled)
+			}
+		})
+	}
+}
+
 func TestWireAdapterDirect_ProxyListener_ReturnedAsCloser(t *testing.T) {
 	// Issue 3: when ProxyListenAddr is set, the returned closer should
 	// be non-nil (the proxy listener's Close). We cannot fully test

--- a/cmd/gateway/main_test.go
+++ b/cmd/gateway/main_test.go
@@ -882,6 +882,9 @@ func TestRun_DefersSemanticBootstrapUntilStartupConfirmationReadyOnPassiveObserv
 
 	cfg := ebusgateway.DefaultConfig()
 	cfg.Transport = transport.NewLoopback()
+	// DriverManager owns both active and passive generations when broadcast
+	// observe-first is enabled; keep this injected runtime fully in-memory.
+	cfg.PassiveTransport = transport.NewLoopback()
 	cfg.BroadcastListen = true
 	cfg.ScanOnStart = true
 
@@ -1129,6 +1132,9 @@ func TestRun_WaitsForStartupScanFirstPassBeforePassiveObserveFirst(t *testing.T)
 
 	cfg := ebusgateway.DefaultConfig()
 	cfg.Transport = transport.NewLoopback()
+	// DriverManager owns both active and passive generations when broadcast
+	// observe-first is enabled; keep this injected runtime fully in-memory.
+	cfg.PassiveTransport = transport.NewLoopback()
 	cfg.BroadcastListen = true
 	cfg.ScanOnStart = true
 

--- a/cmd/gateway/modbus_endpoint_file.go
+++ b/cmd/gateway/modbus_endpoint_file.go
@@ -45,14 +45,6 @@ func withEndpointOwner(owner endpointOwner, err error) error {
 	return &endpointOwnedError{owner: owner, err: err}
 }
 
-func endpointOwnerOf(err error) endpointOwner {
-	var owned *endpointOwnedError
-	if errors.As(err, &owned) {
-		return owned.owner
-	}
-	return endpointOwnerUnknown
-}
-
 type gatewayFlagInputs struct {
 	modbusEndpointFile string
 }

--- a/cmd/gateway/modbus_runtime_adapter_test.go
+++ b/cmd/gateway/modbus_runtime_adapter_test.go
@@ -6,13 +6,18 @@ import (
 	"errors"
 	"log"
 	"net"
+	"net/http"
 	"net/netip"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/graphql"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/modbusadapter"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/mdns"
 	modbus "github.com/Project-Helianthus/helianthus-modbus"
 )
 
@@ -150,12 +155,20 @@ func TestRunKeepsModbusStartupFailureProtocolLocal(t *testing.T) {
 	}
 }
 
-func TestRunMarksAdapterDirectStartupFailureForOwnedRedaction(t *testing.T) {
+func TestRunKeepsAdapterDirectConfigFailureDriverLocal(t *testing.T) {
 	originalDial := dialModbusEndpointFn
 	originalFactory := newModbusEndpointFn
+	originalWire := wireObserveFirstObserversFn
+	originalDiscovery := startDiscoveryScanLoopFn
+	originalSemantic := startVaillantSemanticPollingFn
+	originalHTTP := startHTTPServerFn
 	t.Cleanup(func() {
 		dialModbusEndpointFn = originalDial
 		newModbusEndpointFn = originalFactory
+		wireObserveFirstObserversFn = originalWire
+		startDiscoveryScanLoopFn = originalDiscovery
+		startVaillantSemanticPollingFn = originalSemantic
+		startHTTPServerFn = originalHTTP
 	})
 
 	client, peer := net.Pipe()
@@ -177,12 +190,31 @@ func TestRunMarksAdapterDirectStartupFailureForOwnedRedaction(t *testing.T) {
 	cfg.TransportConfig.Protocol = ebusgateway.TransportAdapterDirect
 	cfg.TransportConfig.Network = "tcp"
 	cfg.TransportConfig.Address = ""
+	cfg.BroadcastListen = false
+	cfg.ScanOnStart = false
+	cfg.RuntimeStatePath = filepath.Join(t.TempDir(), "runtime-state.json")
 
-	err := run(context.Background(), cfg)
-	if err == nil {
-		t.Fatal("run accepted adapter-direct without an address")
+	wireObserveFirstObserversFn = func(*ebusgateway.Config) (*ebusgateway.BusObservabilityStore, *ebusgateway.ActivePassiveDeduplicator, error) {
+		return nil, nil, nil
 	}
-	if got := endpointOwnerOf(err); got != endpointOwnerAdapterDirect {
-		t.Fatalf("startup error owner = %v; want adapter-direct; error=%v", got, err)
+	startDiscoveryScanLoopFn = func(context.Context, ebusgateway.Config, *ebusgateway.Gateway, *graphql.Builder, activeTxnClassifier) startupScanSignals {
+		return startupScanSignals{}
+	}
+	startVaillantSemanticPollingFn = func(context.Context, ebusgateway.Config, *ebusgateway.Gateway, *graphql.LiveSemanticProvider, *graphql.BroadcastHub, <-chan struct{}) *vaillantSemanticPoller {
+		return nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	httpStarted := false
+	startHTTPServerFn = func(context.Context, ebusgateway.Config, *ebusgateway.Gateway, *graphql.Builder, *graphql.BroadcastHub, graphql.SemanticProvider, mcp.ScheduleWriter, mcp.ConfigWriter, *ebusgateway.BusObservabilityStore, *ebusgateway.ShadowCache) (*http.Server, mdns.Advertiser, error) {
+		httpStarted = true
+		cancel()
+		return nil, nil, nil
+	}
+
+	if err := run(ctx, cfg); err != nil {
+		t.Fatalf("run promoted adapter-direct config failure to process failure: %v", err)
+	}
+	if !httpStarted {
+		t.Fatal("HTTP shell did not start after adapter-direct config failure")
 	}
 }

--- a/cmd/gateway/status_provider.go
+++ b/cmd/gateway/status_provider.go
@@ -9,8 +9,9 @@ import (
 )
 
 type runtimeStatusProvider struct {
-	daemon   graphql.ServiceStatus
-	semantic graphql.SemanticProvider
+	daemon         graphql.ServiceStatus
+	semantic       graphql.SemanticProvider
+	admittedSource func() (byte, bool)
 }
 
 type runtimeGatewayIdentityProvider struct {
@@ -18,7 +19,14 @@ type runtimeGatewayIdentityProvider struct {
 }
 
 func (p runtimeStatusProvider) DaemonStatus() graphql.ServiceStatus {
-	return p.daemon
+	status := p.daemon
+	status.InitiatorAddress = ""
+	if p.admittedSource != nil {
+		if source, ok := p.admittedSource(); ok && source != 0 {
+			status.InitiatorAddress = formatConfiguredInitiator(source, false)
+		}
+	}
+	return status
 }
 
 func (p runtimeStatusProvider) AdapterStatus() graphql.ServiceStatus {
@@ -29,15 +37,15 @@ func (p runtimeGatewayIdentityProvider) GatewayIdentity() graphql.GatewayIdentit
 	return graphql.GatewayIdentity{InstanceGUID: p.instanceGUID}
 }
 
-func newRuntimeStatusProvider(cfg ebusgateway.Config, semantic graphql.SemanticProvider) graphql.StatusProvider {
+func newRuntimeStatusProvider(semantic graphql.SemanticProvider, admittedSource func() (byte, bool)) graphql.StatusProvider {
 	return runtimeStatusProvider{
 		daemon: graphql.ServiceStatus{
 			Status:           "running",
 			FirmwareVersion:  "",
 			UpdatesAvailable: false,
-			InitiatorAddress: formatConfiguredInitiator(cfg.ScanSource, cfg.ScanSourceAuto),
 		},
-		semantic: semantic,
+		semantic:       semantic,
+		admittedSource: admittedSource,
 	}
 }
 

--- a/cmd/gateway/status_provider.go
+++ b/cmd/gateway/status_provider.go
@@ -46,12 +46,20 @@ func newRuntimeGatewayIdentityProvider(cfg ebusgateway.Config) graphql.GatewayId
 }
 
 type runtimeMCPStatusProvider struct {
-	daemon   mcp.ServiceStatus
-	semantic graphql.SemanticProvider
+	daemon         mcp.ServiceStatus
+	semantic       graphql.SemanticProvider
+	admittedSource func() (byte, bool)
 }
 
 func (p runtimeMCPStatusProvider) DaemonStatus() mcp.ServiceStatus {
-	return p.daemon
+	status := p.daemon
+	status.InitiatorAddress = "auto"
+	if p.admittedSource != nil {
+		if source, ok := p.admittedSource(); ok && source != 0 {
+			status.InitiatorAddress = formatConfiguredInitiator(source, false)
+		}
+	}
+	return status
 }
 
 func (p runtimeMCPStatusProvider) AdapterStatus() mcp.ServiceStatus {
@@ -64,15 +72,15 @@ func (p runtimeMCPStatusProvider) AdapterStatus() mcp.ServiceStatus {
 	}
 }
 
-func newMCPRuntimeStatusProvider(cfg ebusgateway.Config, semantic graphql.SemanticProvider) mcp.StatusProvider {
+func newMCPRuntimeStatusProvider(semantic graphql.SemanticProvider, admittedSource func() (byte, bool)) mcp.StatusProvider {
 	return runtimeMCPStatusProvider{
 		daemon: mcp.ServiceStatus{
 			Status:           "running",
 			FirmwareVersion:  "",
 			UpdatesAvailable: false,
-			InitiatorAddress: formatConfiguredInitiator(cfg.ScanSource, cfg.ScanSourceAuto),
 		},
-		semantic: semantic,
+		semantic:       semantic,
+		admittedSource: admittedSource,
 	}
 }
 

--- a/cmd/gateway/status_provider_test.go
+++ b/cmd/gateway/status_provider_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -14,6 +16,7 @@ import (
 	"github.com/Project-Helianthus/helianthus-ebusgateway/graphql"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/drivermanager"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/runtimestate"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/vaillant/b503session"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/portal"
 	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
@@ -148,7 +151,16 @@ func TestIssue851GraphQLAndExplorerRequireCurrentDriverWriteAdmission(t *testing
 	builder.SetAdmittedMutationSource(selected)
 	liveSource := newManagedEBusSourceProvider(controller, builder.AdmittedMutationSource)
 	status := newRuntimeStatusProvider(nil, liveSource)
+	mcpStatus := newMCPRuntimeStatusProvider(nil, liveSource)
 	explorerBus := &issue851LiveSourceExplorerBus{}
+	underlyingWriter := &recordingSemanticWriter{}
+	graphWriter := admittedGraphQLSemanticWriter{
+		boiler: underlyingWriter, system: underlyingWriter, schedule: underlyingWriter, admitted: liveSource,
+	}
+	mcpConfig := admittedMCPConfigWriter{writer: admittedMCPConfigAdapter{writer: underlyingWriter}, admitted: liveSource}
+	mcpSchedule := admittedMCPScheduleWriter{writer: underlyingWriter, admitted: liveSource}
+	b503Manager := b503session.New(b503session.TransportKey{}, 30*time.Second, nil)
+	b503Dispatcher := newRawFrameDispatcherWithSourceProvider(explorerBus, liveSource, &sync.Mutex{}, b503Manager, 100*time.Millisecond)
 	explorer := portal.NewHandler(portal.Options{
 		GatewayVersion:         "test",
 		BuildID:                "test",
@@ -161,7 +173,29 @@ func TestIssue851GraphQLAndExplorerRequireCurrentDriverWriteAdmission(t *testing
 		if got := status.DaemonStatus().InitiatorAddress; got != "" {
 			t.Fatalf("%s GraphQL source = %q, want unavailable", label, got)
 		}
+		if got := mcpStatus.DaemonStatus().InitiatorAddress; got == formatConfiguredInitiator(selected, false) {
+			t.Fatalf("%s MCP source retained selected authority = %q", label, got)
+		}
+		writerCalls := underlyingWriter.calls
+		if result := graphWriter.SetSystemConfig(context.Background(), "field", "value"); result.Success {
+			t.Fatalf("%s GraphQL writer delegated while unavailable: %#v", label, result)
+		}
+		if result := mcpConfig.SetBoilerConfig(context.Background(), "field", "value"); result.Success {
+			t.Fatalf("%s MCP config writer delegated while unavailable: %#v", label, result)
+		}
+		if result, err := mcpSchedule.SetZoneTimeProgram(context.Background(), 0, 0, nil); err != nil || result.Success {
+			t.Fatalf("%s MCP schedule writer = %#v/%v, want unavailable", label, result, err)
+		}
+		if underlyingWriter.calls != writerCalls {
+			t.Fatalf("%s writer delegates = %d->%d, want unchanged", label, writerCalls, underlyingWriter.calls)
+		}
 		before := len(explorerBus.snapshotSources())
+		if _, err := b503Dispatcher.Invoke(context.Background(), 0x15, []byte{0x01}); !errors.Is(err, b503session.ErrTransportDown) {
+			t.Fatalf("%s B503 error = %v, want transport unavailable", label, err)
+		}
+		if after := len(explorerBus.snapshotSources()); after != before {
+			t.Fatalf("%s B503 Bus.Send calls = %d->%d", label, before, after)
+		}
 		recorder := httptest.NewRecorder()
 		explorer.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/api/v1/explorer/read/b509?target=15&addr=0028", nil))
 		if recorder.Code != http.StatusServiceUnavailable {
@@ -175,6 +209,30 @@ func TestIssue851GraphQLAndExplorerRequireCurrentDriverWriteAdmission(t *testing
 		t.Helper()
 		if got, want := status.DaemonStatus().InitiatorAddress, formatConfiguredInitiator(selected, false); got != want {
 			t.Fatalf("%s GraphQL source = %q, want %q", label, got, want)
+		}
+		if got, want := mcpStatus.DaemonStatus().InitiatorAddress, formatConfiguredInitiator(selected, false); got != want {
+			t.Fatalf("%s MCP source = %q, want %q", label, got, want)
+		}
+		writerCalls := underlyingWriter.calls
+		if result := graphWriter.SetSystemConfig(context.Background(), "field", "value"); !result.Success {
+			t.Fatalf("%s GraphQL writer = %#v, want success", label, result)
+		}
+		if result := mcpConfig.SetBoilerConfig(context.Background(), "field", "value"); !result.Success {
+			t.Fatalf("%s MCP config writer = %#v, want success", label, result)
+		}
+		if result, err := mcpSchedule.SetZoneTimeProgram(context.Background(), 0, 0, nil); err != nil || !result.Success {
+			t.Fatalf("%s MCP schedule writer = %#v/%v, want success", label, result, err)
+		}
+		if underlyingWriter.calls != writerCalls+3 {
+			t.Fatalf("%s writer delegates = %d->%d, want +3", label, writerCalls, underlyingWriter.calls)
+		}
+		beforeB503 := len(explorerBus.snapshotSources())
+		if _, err := b503Dispatcher.Invoke(context.Background(), 0x15, []byte{0x01}); err != nil {
+			t.Fatalf("%s B503 Invoke() error = %v", label, err)
+		}
+		b503Sources := explorerBus.snapshotSources()
+		if len(b503Sources) != beforeB503+1 || b503Sources[len(b503Sources)-1] != selected {
+			t.Fatalf("%s B503 sources = %v, want one exact 0x%02X", label, b503Sources, selected)
 		}
 		recorder := httptest.NewRecorder()
 		explorer.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/api/v1/explorer/read/b509?target=15&addr=0028", nil))
@@ -238,6 +296,25 @@ func TestIssue851GraphQLAndExplorerRequireCurrentDriverWriteAdmission(t *testing
 	}
 	requireEBusDriverObservedState(t, manager, drivermanager.ObservedStopped, time.Second)
 	assertUnavailable("withdrawn STOPPED")
+}
+
+func TestIssue851MainWiresOneManagedSourceAuthorityToEveryEBusSurface(t *testing.T) {
+	source, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	text := string(source)
+	staleWiring := []string{
+		"admitted: builder.AdmittedMutationSource",
+		"SetAdmittedRPCSourceProvider(builder.AdmittedMutationSource)",
+		"newMCPRuntimeStatusProvider(semanticProvider, builder.AdmittedMutationSource)",
+		"installVaillantB503(mcpServer, gateway, &cfg, builder.AdmittedMutationSource)",
+	}
+	for _, stale := range staleWiring {
+		if strings.Contains(text, stale) {
+			t.Errorf("source-dependent surface bypasses live DriverManager authority: %s", stale)
+		}
+	}
 }
 
 func TestRuntimeStatusProviderReflectsAdapterFirmwareVersion(t *testing.T) {

--- a/cmd/gateway/status_provider_test.go
+++ b/cmd/gateway/status_provider_test.go
@@ -1,14 +1,48 @@
 package main
 
 import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/Project-Helianthus/helianthus-ebusgateway"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/graphql"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/drivermanager"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/runtimestate"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/portal"
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
 )
+
+type issue851LiveSourceExplorerBus struct {
+	mu      sync.Mutex
+	sources []byte
+}
+
+func (bus *issue851LiveSourceExplorerBus) Send(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+	bus.mu.Lock()
+	bus.sources = append(bus.sources, frame.Source)
+	bus.mu.Unlock()
+	return &protocol.Frame{
+		Source:    frame.Target,
+		Target:    frame.Source,
+		Primary:   frame.Primary,
+		Secondary: frame.Secondary,
+		Data:      []byte{0x01, 0x02, 0x03, 0x04},
+	}, nil
+}
+
+func (bus *issue851LiveSourceExplorerBus) snapshotSources() []byte {
+	bus.mu.Lock()
+	defer bus.mu.Unlock()
+	return append([]byte(nil), bus.sources...)
+}
 
 func TestFormatConfiguredInitiator(t *testing.T) {
 	tests := []struct {
@@ -57,6 +91,153 @@ func TestRuntimeStatusProviderRequiresLiveGraphQLAdmission(t *testing.T) {
 	if got := provider.DaemonStatus().InitiatorAddress; got != "" {
 		t.Fatalf("withdrawn daemon initiatorAddress = %q, want unavailable", got)
 	}
+}
+
+func TestIssue851GraphQLAndExplorerRequireCurrentDriverWriteAdmission(t *testing.T) {
+	startEntered := make(chan struct{})
+	startRelease := make(chan struct{})
+	var factoryCalls atomic.Int32
+	runtimeSeam := transport.NewDriverRuntime(func(ctx context.Context) (*transport.ManagedRawTransport, error) {
+		call := factoryCalls.Add(1)
+		if call == 1 {
+			close(startEntered)
+			select {
+			case <-startRelease:
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+		if call == 2 {
+			return nil, errors.New("retry construction unavailable")
+		}
+		raw := newIssue851BlockingRawTransport()
+		return newManagedEBusGeneration(ctx, raw, raw.Close), nil
+	}, transport.DriverRuntimeConfig{DrainTimeout: 100 * time.Millisecond})
+	runtime := &ebusDriverRuntime{runtime: runtimeSeam}
+	manager, err := drivermanager.New(drivermanager.Config{
+		RetryJitter: func(time.Duration) time.Duration { return 0 },
+		Drivers: []drivermanager.DriverConfig{{
+			ID:           primaryEBusDriverID,
+			Enabled:      true,
+			Runtime:      runtime,
+			Capabilities: []drivermanager.Capability{drivermanager.CapabilityRead, drivermanager.CapabilityWrite},
+			ClassifyError: func(error) drivermanager.Failure {
+				return drivermanager.Failure{Reason: drivermanager.Reason{Code: drivermanager.ReasonDependencyUnavailable, Retryable: true}}
+			},
+			Retry: drivermanager.RetryPolicy{Budget: 1, InitialDelay: 25 * time.Millisecond, MaxDelay: 25 * time.Millisecond},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("drivermanager.New() error = %v", err)
+	}
+	defer func() { _ = manager.Shutdown(context.Background()) }()
+	controller := &ebusDriverController{manager: manager}
+
+	// ScanOnStart=false still lets the static ebusd policy select a builder
+	// source synchronously. That selection is not runtime admission authority.
+	staticCfg := ebusgateway.DefaultConfig()
+	staticCfg.ScanOnStart = false
+	staticCfg.TransportConfig.Protocol = ebusgateway.TransportEbusdTCP
+	staticCfg.ScanSource = 0
+	staticCfg.ScanSourceAuto = true
+	selected, selectedOK := admittedMutationSourceForGateway(staticCfg, ebusgateway.TransportAdmissionStaticFallback, false)
+	if !selectedOK || selected == 0 {
+		t.Fatalf("static source fixture = 0x%02X/%v", selected, selectedOK)
+	}
+	builder := graphql.NewBuilder(nil, nil)
+	builder.SetAdmittedMutationSource(selected)
+	liveSource := newManagedEBusSourceProvider(controller, builder.AdmittedMutationSource)
+	status := newRuntimeStatusProvider(nil, liveSource)
+	explorerBus := &issue851LiveSourceExplorerBus{}
+	explorer := portal.NewHandler(portal.Options{
+		GatewayVersion:         "test",
+		BuildID:                "test",
+		ExplorerBus:            explorerBus,
+		ExplorerSourceProvider: liveSource,
+	})
+
+	assertUnavailable := func(label string) {
+		t.Helper()
+		if got := status.DaemonStatus().InitiatorAddress; got != "" {
+			t.Fatalf("%s GraphQL source = %q, want unavailable", label, got)
+		}
+		before := len(explorerBus.snapshotSources())
+		recorder := httptest.NewRecorder()
+		explorer.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/api/v1/explorer/read/b509?target=15&addr=0028", nil))
+		if recorder.Code != http.StatusServiceUnavailable {
+			t.Fatalf("%s Explorer status = %d, want %d", label, recorder.Code, http.StatusServiceUnavailable)
+		}
+		if after := len(explorerBus.snapshotSources()); after != before {
+			t.Fatalf("%s Explorer Bus.Send calls = %d->%d", label, before, after)
+		}
+	}
+	assertAvailable := func(label string) {
+		t.Helper()
+		if got, want := status.DaemonStatus().InitiatorAddress, formatConfiguredInitiator(selected, false); got != want {
+			t.Fatalf("%s GraphQL source = %q, want %q", label, got, want)
+		}
+		recorder := httptest.NewRecorder()
+		explorer.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/api/v1/explorer/read/b509?target=15&addr=0028", nil))
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("%s Explorer status = %d, want %d body=%s", label, recorder.Code, http.StatusOK, recorder.Body.String())
+		}
+		sources := explorerBus.snapshotSources()
+		if len(sources) == 0 || sources[len(sources)-1] != selected {
+			t.Fatalf("%s Explorer sources = %v, want last 0x%02X", label, sources, selected)
+		}
+	}
+
+	assertUnavailable("pending static source")
+	if err := manager.StartAsync(context.Background(), primaryEBusDriverID); err != nil {
+		t.Fatalf("StartAsync() error = %v", err)
+	}
+	select {
+	case <-startEntered:
+	case <-time.After(time.Second):
+		t.Fatal("initial construction did not enter")
+	}
+	requireEBusDriverObservedState(t, manager, drivermanager.ObservedStarting, time.Second)
+	assertUnavailable("STARTING")
+	close(startRelease)
+	first := requireEBusDriverObservedState(t, manager, drivermanager.ObservedRunning, time.Second)
+	selectionReads := 0
+	changingSelection := newManagedEBusSourceProvider(controller, func() (byte, bool) {
+		selectionReads++
+		if selectionReads == 1 {
+			return selected, true
+		}
+		return 0, false
+	})
+	if source, admitted := changingSelection(); admitted || source != 0 {
+		t.Fatalf("selection withdrawn during driver admission = 0x%02X/%v, want unavailable", source, admitted)
+	}
+	assertAvailable("RUNNING generation 1")
+
+	if accepted := manager.ReportFailure(
+		primaryEBusDriverID,
+		drivermanager.Correlation{Generation: first.Generation},
+		drivermanager.Failure{Reason: drivermanager.Reason{Code: drivermanager.ReasonDependencyUnavailable, Retryable: true}},
+	); !accepted {
+		t.Fatal("ReportFailure() rejected current generation")
+	}
+	requireEBusDriverObservedState(t, manager, drivermanager.ObservedBackoff, time.Second)
+	assertUnavailable("BACKOFF")
+	requireEBusDriverObservedState(t, manager, drivermanager.ObservedFailed, time.Second)
+	assertUnavailable("FAILED")
+
+	if err := manager.Start(context.Background(), primaryEBusDriverID); err != nil {
+		t.Fatalf("recovery Start() error = %v", err)
+	}
+	second := requireEBusDriverObservedState(t, manager, drivermanager.ObservedRunning, time.Second)
+	if second.Generation != first.Generation+1 {
+		t.Fatalf("recovery generation = %d, want %d", second.Generation, first.Generation+1)
+	}
+	assertAvailable("RUNNING recovery")
+	if err := manager.Stop(context.Background(), primaryEBusDriverID); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+	requireEBusDriverObservedState(t, manager, drivermanager.ObservedStopped, time.Second)
+	assertUnavailable("withdrawn STOPPED")
 }
 
 func TestRuntimeStatusProviderReflectsAdapterFirmwareVersion(t *testing.T) {

--- a/cmd/gateway/status_provider_test.go
+++ b/cmd/gateway/status_provider_test.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"sync/atomic"
 	"testing"
 
 	"github.com/Project-Helianthus/helianthus-ebusgateway"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/graphql"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/runtimestate"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
 )
 
 func TestFormatConfiguredInitiator(t *testing.T) {
@@ -130,7 +132,7 @@ func TestAD24_DaemonInitiatorAddressDoesNotLeakCachedHint(t *testing.T) {
 	// the package-level coupling enforces AD24 by construction (Codex
 	// reviewers should flag any change that introduces a runtimestate
 	// import here without an explicit hint-only audit).
-	mcpProvider := newMCPRuntimeStatusProvider(cfg, nil)
+	mcpProvider := newMCPRuntimeStatusProvider(nil, func() (byte, bool) { return 0, false })
 	mcpDaemon := mcpProvider.DaemonStatus()
 	if mcpDaemon.InitiatorAddress != "auto" {
 		t.Errorf("AD24 violation: MCP daemon InitiatorAddress = %q; want \"auto\"",
@@ -165,6 +167,41 @@ func TestAD24_DaemonInitiatorAddressReflectsValidatedSourcePostSelection(t *test
 	if daemon.InitiatorAddress != "0x77" {
 		t.Errorf("post-selection daemon InitiatorAddress = %q; want \"0x77\"",
 			daemon.InitiatorAddress)
+	}
+}
+
+func TestMCPRuntimeStatusProviderReadsLiveAdmissionThroughEarlyHTTPHandler(t *testing.T) {
+	var admitted atomic.Uint32
+	provider := newMCPRuntimeStatusProvider(nil, func() (byte, bool) {
+		source := admitted.Load()
+		return byte(source), source != 0
+	})
+	server, err := mcp.NewServer(emptyMCPRegistry{}, nil)
+	if err != nil {
+		t.Fatalf("mcp.NewServer() error = %v", err)
+	}
+	server.SetStatusProvider(provider)
+
+	initiatorAddress := func() string {
+		envelope := mcpCallToolEnvelope(t, server.Handler(), "ebus.v1.runtime.status.get", `{}`)
+		data, ok := envelope["data"].(map[string]any)
+		if !ok {
+			t.Fatalf("runtime status data = %T, want object", envelope["data"])
+		}
+		daemon, ok := data["daemon_status"].(map[string]any)
+		if !ok {
+			t.Fatalf("daemon_status = %T, want object", data["daemon_status"])
+		}
+		value, _ := daemon["initiator_address"].(string)
+		return value
+	}
+
+	if got := initiatorAddress(); got != "auto" {
+		t.Fatalf("pre-admission MCP initiator_address = %q, want auto", got)
+	}
+	admitted.Store(0x77)
+	if got := initiatorAddress(); got != "0x77" {
+		t.Fatalf("post-admission MCP initiator_address = %q, want 0x77", got)
 	}
 }
 

--- a/cmd/gateway/status_provider_test.go
+++ b/cmd/gateway/status_provider_test.go
@@ -32,11 +32,7 @@ func TestFormatConfiguredInitiator(t *testing.T) {
 }
 
 func TestRuntimeStatusProviderIncludesInitiatorAddress(t *testing.T) {
-	cfg := ebusgateway.DefaultConfig()
-	cfg.ScanSource = 0xF7
-	cfg.ScanSourceAuto = false
-
-	provider := newRuntimeStatusProvider(cfg, nil)
+	provider := newRuntimeStatusProvider(nil, func() (byte, bool) { return 0xF7, true })
 	daemon := provider.DaemonStatus()
 	adapter := provider.AdapterStatus()
 	if daemon.InitiatorAddress != "0xF7" {
@@ -47,8 +43,23 @@ func TestRuntimeStatusProviderIncludesInitiatorAddress(t *testing.T) {
 	}
 }
 
+func TestRuntimeStatusProviderRequiresLiveGraphQLAdmission(t *testing.T) {
+	builder := graphql.NewBuilder(nil, nil)
+	provider := newRuntimeStatusProvider(nil, builder.AdmittedMutationSource)
+	if got := provider.DaemonStatus().InitiatorAddress; got != "" {
+		t.Fatalf("pre-admission daemon initiatorAddress = %q, want unavailable", got)
+	}
+	builder.SetAdmittedMutationSource(0x77)
+	if got := provider.DaemonStatus().InitiatorAddress; got != "0x77" {
+		t.Fatalf("admitted daemon initiatorAddress = %q, want 0x77", got)
+	}
+	builder.ClearAdmittedMutationSource()
+	if got := provider.DaemonStatus().InitiatorAddress; got != "" {
+		t.Fatalf("withdrawn daemon initiatorAddress = %q, want unavailable", got)
+	}
+}
+
 func TestRuntimeStatusProviderReflectsAdapterFirmwareVersion(t *testing.T) {
-	cfg := ebusgateway.DefaultConfig()
 	semantic := graphql.NewLiveSemanticProvider()
 	semantic.SetAdapterHardwareInfo(&graphql.AdapterHardwareInfo{
 		FirmwareVersion:    "0x31",
@@ -56,7 +67,7 @@ func TestRuntimeStatusProviderReflectsAdapterFirmwareVersion(t *testing.T) {
 		VersionResponseLen: 5,
 	})
 
-	provider := newRuntimeStatusProvider(cfg, semantic)
+	provider := newRuntimeStatusProvider(semantic, nil)
 	adapter := provider.AdapterStatus()
 	if adapter.Status != "running" {
 		t.Fatalf("adapter status = %q; want running", adapter.Status)
@@ -89,9 +100,9 @@ func TestRuntimeGatewayIdentityProviderExposesConfiguredGUID(t *testing.T) {
 //
 // These tests pin the gateway-side surface contract: even when a
 // runtime-state cache holds ebus.self.last_admitted_source = X, BEFORE the
-// selector validates a candidate the surfaces (daemon InitiatorAddress,
-// gatewayIdentity, MCP runtime status) MUST report the configured/auto
-// state — never the cached X.
+// selector validates a candidate, GraphQL daemon status MUST keep the source
+// unavailable, MCP may report its documented "auto" state, and neither may
+// expose the cached X.
 // -----------------------------------------------------------------------------
 
 func TestAD24_DaemonInitiatorAddressDoesNotLeakCachedHint(t *testing.T) {
@@ -117,10 +128,10 @@ func TestAD24_DaemonInitiatorAddressDoesNotLeakCachedHint(t *testing.T) {
 	cfg.ScanSource = 0x00     // pre-selection auto
 	cfg.ScanSourceAuto = true // pre-selection auto
 
-	provider := newRuntimeStatusProvider(cfg, nil)
+	provider := newRuntimeStatusProvider(nil, nil)
 	daemon := provider.DaemonStatus()
-	if daemon.InitiatorAddress != "auto" {
-		t.Errorf("AD24 violation: daemon InitiatorAddress = %q; want \"auto\" "+
+	if daemon.InitiatorAddress != "" {
+		t.Errorf("AD24 violation: daemon InitiatorAddress = %q; want unavailable "+
 			"(cached hint 0x%02x must NOT leak into the daemon-status surface "+
 			"before SourceAddressSelector validation completes)",
 			daemon.InitiatorAddress, cachedHint)
@@ -152,17 +163,12 @@ func TestAD24_DaemonInitiatorAddressDoesNotLeakCachedHint(t *testing.T) {
 }
 
 func TestAD24_DaemonInitiatorAddressReflectsValidatedSourcePostSelection(t *testing.T) {
-	// After SourceAddressSelector validation succeeds (or operator pinned
-	// an explicit source), cfg.ScanSource is mutated to the validated
-	// byte and cfg.ScanSourceAuto is cleared. The daemon-status surface
-	// then reports the validated source — but the runtime-state cache
-	// is irrelevant to this transition: the surface reads from cfg, not
-	// from any State / Manager.
-	cfg := ebusgateway.DefaultConfig()
-	cfg.ScanSource = 0x77
-	cfg.ScanSourceAuto = false
-
-	provider := newRuntimeStatusProvider(cfg, nil)
+	// After validation succeeds (or an explicit source is admitted), GraphQL
+	// reports only the live builder authority. Runtime-state and copied config
+	// remain irrelevant to the transition.
+	builder := graphql.NewBuilder(nil, nil)
+	builder.SetAdmittedMutationSource(0x77)
+	provider := newRuntimeStatusProvider(nil, builder.AdmittedMutationSource)
 	daemon := provider.DaemonStatus()
 	if daemon.InitiatorAddress != "0x77" {
 		t.Errorf("post-selection daemon InitiatorAddress = %q; want \"0x77\"",
@@ -206,11 +212,10 @@ func TestMCPRuntimeStatusProviderReadsLiveAdmissionThroughEarlyHTTPHandler(t *te
 }
 
 func TestRuntimeStatusProviderKeepsUnknownWithoutAdapterIdentity(t *testing.T) {
-	cfg := ebusgateway.DefaultConfig()
 	semantic := graphql.NewLiveSemanticProvider()
 	semantic.SetAdapterHardwareInfo(&graphql.AdapterHardwareInfo{})
 
-	provider := newRuntimeStatusProvider(cfg, semantic)
+	provider := newRuntimeStatusProvider(semantic, nil)
 	adapter := provider.AdapterStatus()
 	if adapter.Status != "unknown" {
 		t.Fatalf("adapter status = %q; want unknown", adapter.Status)

--- a/cmd/gateway/v8_admin_events_handler_test.go
+++ b/cmd/gateway/v8_admin_events_handler_test.go
@@ -14,6 +14,13 @@ import (
 // v8_admin_events_handler_test.go pins the HTTP contract for the
 // /debug/v8/admin-events endpoint added by F-NEW-26 (2026-05-21).
 
+func isolateV8AdminProvider(t *testing.T) {
+	t.Helper()
+	original := v8AdminEventsCurrentProvider.Load()
+	v8AdminEventsCurrentProvider.Store(nil)
+	t.Cleanup(func() { v8AdminEventsCurrentProvider.Store(original) })
+}
+
 // TestHandleV8AdminEvents_NilClassifier_ReturnsEmptyResponse pins
 // the nil-safe degradation contract: when no classifier is
 // registered in v8AdminEventsCurrentClassifier (non-adapter-direct
@@ -21,6 +28,7 @@ import (
 // `{"events": [], "dropped": 0}` with HTTP 200. Tooling that
 // probes this endpoint unconditionally must NOT see a 404.
 func TestHandleV8AdminEvents_NilClassifier_ReturnsEmptyResponse(t *testing.T) {
+	isolateV8AdminProvider(t)
 	// Restore the original pointer after the test so subsequent
 	// tests that depend on a registered classifier (none today,
 	// but defensively) are not affected.
@@ -63,6 +71,7 @@ func TestHandleV8AdminEvents_NilClassifier_ReturnsEmptyResponse(t *testing.T) {
 // admin events returns those events JSON-encoded, drains the
 // buffer, and a subsequent GET returns the empty envelope.
 func TestHandleV8AdminEvents_DrainsClassifierEvents(t *testing.T) {
+	isolateV8AdminProvider(t)
 	orig := v8AdminEventsCurrentClassifier.Load()
 	t.Cleanup(func() { v8AdminEventsCurrentClassifier.Store(orig) })
 
@@ -137,6 +146,7 @@ func TestHandleV8AdminEvents_DrainsClassifierEvents(t *testing.T) {
 // respond 405 — the drain is state-mutating; only GET is the
 // documented action.
 func TestHandleV8AdminEvents_OnlyGetAllowed(t *testing.T) {
+	isolateV8AdminProvider(t)
 	orig := v8AdminEventsCurrentClassifier.Load()
 	t.Cleanup(func() { v8AdminEventsCurrentClassifier.Store(orig) })
 
@@ -169,6 +179,7 @@ func TestHandleV8AdminEvents_OnlyGetAllowed(t *testing.T) {
 // `max-age=1` (peek) so caching proxies treat the two modes
 // correctly.
 func TestHandleV8AdminEvents_PeekDoesNotDrain(t *testing.T) {
+	isolateV8AdminProvider(t)
 	orig := v8AdminEventsCurrentClassifier.Load()
 	t.Cleanup(func() { v8AdminEventsCurrentClassifier.Store(orig) })
 
@@ -257,6 +268,7 @@ func TestHandleV8AdminEvents_PeekDoesNotDrain(t *testing.T) {
 // affecting the registered handler. Mirrors the contract added
 // for v8RolloutExpvarCurrent in PR #655.
 func TestV8AdminEventsCurrentClassifier_AtomicSwap(t *testing.T) {
+	isolateV8AdminProvider(t)
 	orig := v8AdminEventsCurrentClassifier.Load()
 	t.Cleanup(func() { v8AdminEventsCurrentClassifier.Store(orig) })
 

--- a/cmd/gateway/vaillant_b503_dispatcher.go
+++ b/cmd/gateway/vaillant_b503_dispatcher.go
@@ -129,13 +129,22 @@ func newRawFrameDispatcher(bus b503Bus, source byte, readMu sync.Locker, mgr *b5
 }
 
 func newRawFrameDispatcherWithSourceProvider(bus b503Bus, sourceProvider func() (byte, bool), readMu sync.Locker, mgr *b503session.Manager, requestTimeout time.Duration) *rawFrameDispatcher {
-	return &rawFrameDispatcher{
+	dispatcher := &rawFrameDispatcher{
 		bus:            bus,
 		sourceProvider: sourceProvider,
 		readMu:         readMu,
 		mgr:            mgr,
 		requestTimeout: requestTimeout,
 	}
+	if mgr != nil {
+		// Standalone/test dispatchers still require the same serialized,
+		// generation-correlated disconnect boundary as production wiring.
+		// installVaillantB503 replaces this private gate with the process-owned
+		// b503Runtime shared by DriverManager lifecycle notifications.
+		lifecycle := &b503Runtime{manager: mgr}
+		dispatcher.disconnectIfCurrent = lifecycle.disconnectIfCurrent
+	}
+	return dispatcher
 }
 
 // Invoke implements mcp.RPCDispatcher.
@@ -184,11 +193,6 @@ func (d *rawFrameDispatcher) Invoke(ctx context.Context, target byte, payload []
 		// B503 transport epoch.
 		if d.disconnectIfCurrent != nil {
 			d.disconnectIfCurrent(transportAtIssue)
-		} else if d.mgr.TransportKey() == transportAtIssue {
-			// Direct constructor users have no lifecycle gate. Keep the legacy
-			// fail-closed behavior; production install always supplies the
-			// generation-correlated callback above.
-			d.mgr.OnTransportDisconnect()
 		}
 		return nil, fmt.Errorf("%w: %w", errRawFrameSourceNotAdmitted, b503session.ErrTransportDown)
 	}
@@ -199,7 +203,7 @@ func (d *rawFrameDispatcher) Invoke(ctx context.Context, target byte, payload []
 	// reply from epoch N arriving after a rollover to N+1 must be
 	// rejected without the Manager being consulted at completion-time
 	// in a way that could "rescue" the stale frame.
-	startEpoch := d.mgr.TransportKey().TransportEpoch
+	startEpoch := transportAtIssue.TransportEpoch
 
 	// Optional internal timeout. The caller's ctx still bounds the call
 	// regardless — whichever fires first wins.
@@ -248,7 +252,7 @@ func (d *rawFrameDispatcher) Invoke(ctx context.Context, target byte, payload []
 	}
 
 	if sendErr != nil {
-		return nil, d.classifySendErr(ctx, bsCtx, sendErr)
+		return nil, d.classifySendErr(ctx, bsCtx, transportAtIssue, sendErr)
 	}
 	if resp == nil {
 		// Defensive: bus.Send returned (nil, nil). Treat as protocol
@@ -271,8 +275,8 @@ func (d *rawFrameDispatcher) admittedSource() (byte, bool) {
 // classifySendErr maps bus.Send errors to dispatcher sentinels per
 // §12.4. The mapping is conservative:
 //
-//   - transport-closed / queue-full → TRANSPORT_DOWN AND fire
-//     OnTransportDisconnect so AD04 quiesce-release runs. The returned
+//   - transport-closed / queue-full → TRANSPORT_DOWN AND run the
+//     generation-correlated disconnect so AD04 quiesce-release runs. The returned
 //     error chain matches errors.Is(_, b503session.ErrTransportDown)
 //     so the existing capability probe classifies it correctly. This
 //     check runs FIRST (R1 P1 fix) — a sendErr that signals transport
@@ -288,15 +292,17 @@ func (d *rawFrameDispatcher) admittedSource() (byte, bool) {
 // explicitly the transport is closed; ambiguous bus errors remain
 // UPSTREAM_RPC_FAILED so legitimate B503 protocol failures are not
 // collapsed into transport errors (§12.4 discriminator rules).
-func (d *rawFrameDispatcher) classifySendErr(callerCtx, bsCtx context.Context, sendErr error) error {
+func (d *rawFrameDispatcher) classifySendErr(callerCtx, bsCtx context.Context, transportAtIssue b503session.TransportKey, sendErr error) error {
 	// Transport-down signal in sendErr takes precedence over ctx-cancel
 	// classification. A timed-out call whose underlying transport was
 	// dropped MUST trigger AD04 quiesce-release; otherwise the
 	// live-monitor session gate would stay held and surface SESSION_BUSY
-	// instead of TRANSPORT_DOWN to the next caller (R1 P1 fix).
+	// instead of TRANSPORT_DOWN to the next caller (R1 P1 fix). Correlation
+	// to transportAtIssue prevents a stale generation-N completion from
+	// disconnecting the issuer admitted on generation N+1.
 	if isTransportDownErr(sendErr) {
-		if d.mgr != nil {
-			d.mgr.OnTransportDisconnect()
+		if d.disconnectIfCurrent != nil {
+			d.disconnectIfCurrent(transportAtIssue)
 		}
 		// errors.Join lets the resulting error chain match BOTH
 		// errRawFrameTransportDown (M6 sentinel) AND

--- a/cmd/gateway/vaillant_b503_dispatcher.go
+++ b/cmd/gateway/vaillant_b503_dispatcher.go
@@ -96,12 +96,13 @@ var (
 // (R1 P2 fix). Production callers pass a `*sync.Mutex`, which satisfies
 // `sync.Locker` natively — no production behaviour change.
 type rawFrameDispatcher struct {
-	bus            b503Bus
-	source         byte
-	sourceProvider func() (byte, bool)
-	readMu         sync.Locker
-	mgr            *b503session.Manager
-	requestTimeout time.Duration
+	bus                 b503Bus
+	source              byte
+	sourceProvider      func() (byte, bool)
+	readMu              sync.Locker
+	mgr                 *b503session.Manager
+	requestTimeout      time.Duration
+	disconnectIfCurrent func(b503session.TransportKey)
 }
 
 // newRawFrameDispatcher constructs a production dispatcher.
@@ -172,8 +173,23 @@ func (d *rawFrameDispatcher) Invoke(ctx context.Context, target byte, payload []
 	if len(payload) >= 2 && payload[0] == b503PrimaryByte && payload[1] == b503SecondaryByte {
 		return nil, errRawFrameMalformedPayload
 	}
+	transportAtIssue := d.mgr.TransportKey()
 	source, admitted := d.admittedSource()
 	if !admitted || source == 0 {
+		// Source admission is intersected with DriverManager capability. A
+		// source disappearing therefore means the issuer's generation has
+		// withdrawn even when no transport error reached bus.Send. Release the
+		// owner here as an idempotent fallback; the correlated lifecycle event
+		// may already have performed the same disconnect and never advances the
+		// B503 transport epoch.
+		if d.disconnectIfCurrent != nil {
+			d.disconnectIfCurrent(transportAtIssue)
+		} else if d.mgr.TransportKey() == transportAtIssue {
+			// Direct constructor users have no lifecycle gate. Keep the legacy
+			// fail-closed behavior; production install always supplies the
+			// generation-correlated callback above.
+			d.mgr.OnTransportDisconnect()
+		}
 		return nil, fmt.Errorf("%w: %w", errRawFrameSourceNotAdmitted, b503session.ErrTransportDown)
 	}
 

--- a/cmd/gateway/vaillant_b503_dispatcher_test.go
+++ b/cmd/gateway/vaillant_b503_dispatcher_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/Project-Helianthus/helianthus-ebusgateway"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/drivermanager"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/vaillant/b503session"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
 	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
@@ -369,18 +370,82 @@ func TestM6Dispatcher_NilManager_ReturnsMisconfigured(t *testing.T) {
 	}
 }
 
-func TestM6Dispatcher_SourceNotAdmitted_FailsClosedBeforeBusSend(t *testing.T) {
+func TestIssue851B503SourceNotAdmittedDisconnectsOwnerWithoutAdvancingEpoch(t *testing.T) {
 	bus := newB503DispatcherMockBus()
-	mgr := b503session.New(b503session.TransportKey{}, 30*time.Second, nil)
+	mgr := b503session.New(
+		b503session.TransportKey{AdapterInstanceID: "gateway", TransportEpoch: 7},
+		30*time.Second,
+		nil,
+	)
+	if _, err := mgr.Enable(context.Background()); err != nil {
+		t.Fatalf("Enable() error = %v", err)
+	}
 	disp := newRawFrameDispatcherWithSourceProvider(bus, func() (byte, bool) {
 		return 0, false
 	}, nil, mgr, 0)
+	disp.disconnectIfCurrent = (&b503Runtime{manager: mgr}).disconnectIfCurrent
 	_, err := disp.Invoke(context.Background(), 0x08, []byte{0x00, 0x01})
 	if err == nil || !errors.Is(err, errRawFrameSourceNotAdmitted) {
 		t.Fatalf("Invoke before admission = %v; want errRawFrameSourceNotAdmitted", err)
 	}
 	if bus.callCount() != 0 {
 		t.Fatalf("bus.Send calls = %d; want 0 before source admission", bus.callCount())
+	}
+	if mgr.IsOwned() {
+		t.Fatal("source-unavailable read retained the old B503 issuer")
+	}
+	if got := mgr.TransportKey().TransportEpoch; got != 7 {
+		t.Fatalf("transport epoch after source-unavailable read = %d, want 7", got)
+	}
+	// A later lifecycle withdrawal for the same generation is intentionally
+	// idempotent: disconnect releases ownership but never manufactures an epoch.
+	mgr.OnTransportDisconnect()
+	if got := mgr.TransportKey().TransportEpoch; got != 7 {
+		t.Fatalf("transport epoch after duplicate disconnect = %d, want 7", got)
+	}
+}
+
+func TestIssue851B503StaleSourceFallbackCannotDisconnectRecoveredIssuer(t *testing.T) {
+	bus := newB503DispatcherMockBus()
+	mgr := b503session.New(
+		b503session.TransportKey{AdapterInstanceID: "gateway", TransportEpoch: 7},
+		30*time.Second,
+		nil,
+	)
+	if _, err := mgr.Enable(context.Background()); err != nil {
+		t.Fatalf("old generation Enable() error = %v", err)
+	}
+	runtime := &b503Runtime{manager: mgr}
+	var recovered b503session.SessionKey
+	disp := newRawFrameDispatcherWithSourceProvider(bus, func() (byte, bool) {
+		// Invoke already captured epoch 7. Complete the exact lifecycle
+		// withdrawal/recovery before returning the stale unavailable result.
+		runtime.EBusDriverWithdrawn(drivermanager.Correlation{Generation: 7})
+		runtime.EBusDriverActivated(drivermanager.Correlation{Generation: 8})
+		var err error
+		recovered, err = mgr.Enable(context.Background())
+		if err != nil {
+			t.Fatalf("recovered generation Enable() error = %v", err)
+		}
+		return 0, false
+	}, nil, mgr, 0)
+	disp.disconnectIfCurrent = runtime.disconnectIfCurrent
+
+	_, err := disp.Invoke(context.Background(), 0x08, []byte{0x00, 0x01})
+	if err == nil || !errors.Is(err, errRawFrameSourceNotAdmitted) {
+		t.Fatalf("Invoke with stale unavailable result = %v, want errRawFrameSourceNotAdmitted", err)
+	}
+	if !mgr.IsOwned() {
+		t.Fatal("epoch-7 source fallback disconnected the recovered epoch-8 issuer")
+	}
+	if got := mgr.TransportKey().TransportEpoch; got != 8 {
+		t.Fatalf("recovered transport epoch = %d, want 8", got)
+	}
+	if recovered.Transport.TransportEpoch != 8 {
+		t.Fatalf("recovered issuer epoch = %d, want 8", recovered.Transport.TransportEpoch)
+	}
+	if bus.callCount() != 0 {
+		t.Fatalf("bus.Send calls = %d, want 0 for unavailable source", bus.callCount())
 	}
 }
 

--- a/cmd/gateway/vaillant_b503_dispatcher_test.go
+++ b/cmd/gateway/vaillant_b503_dispatcher_test.go
@@ -62,6 +62,23 @@ type b503DispatcherMockBus struct {
 	blockUntil <-chan struct{}
 }
 
+// issue851ClassifyBarrierError blocks the first Error call. bus.Send returns
+// the value without formatting it, so reaching this barrier proves Invoke has
+// already completed its post-Send epoch check and entered error classification.
+type issue851ClassifyBarrierError struct {
+	once             sync.Once
+	classification   chan struct{}
+	continueClassify <-chan struct{}
+}
+
+func (err *issue851ClassifyBarrierError) Error() string {
+	err.once.Do(func() {
+		close(err.classification)
+		<-err.continueClassify
+	})
+	return "ebus: transport closed"
+}
+
 func newB503DispatcherMockBus() *b503DispatcherMockBus {
 	return &b503DispatcherMockBus{
 		respByPrefix: make(map[string]*protocol.Frame),
@@ -298,6 +315,67 @@ func TestM6Dispatcher_TransportDown_FiresOnTransportDisconnect(t *testing.T) {
 	}
 	if mgr.IsOwned() {
 		t.Fatalf("Manager.IsOwned() = true after transport-down; want false (OnTransportDisconnect should fire)")
+	}
+}
+
+func TestIssue851B503StaleSendErrorCannotDisconnectRecoveredIssuer(t *testing.T) {
+	disp, bus, mgr := newTestDispatcher(t)
+	runtime := &b503Runtime{manager: mgr}
+	disp.disconnectIfCurrent = runtime.disconnectIfCurrent
+	if _, err := mgr.Enable(context.Background()); err != nil {
+		t.Fatalf("old generation Enable() error = %v", err)
+	}
+
+	classification := make(chan struct{})
+	continueClassify := make(chan struct{})
+	defer func() {
+		select {
+		case <-continueClassify:
+		default:
+			close(continueClassify)
+		}
+	}()
+	bus.setErr([2]byte{0x00, 0x01}, &issue851ClassifyBarrierError{
+		classification:   classification,
+		continueClassify: continueClassify,
+	})
+	invokeDone := make(chan error, 1)
+	go func() {
+		_, err := disp.Invoke(context.Background(), 0x08, []byte{0x00, 0x01})
+		invokeDone <- err
+	}()
+
+	select {
+	case <-classification:
+		// The request from generation 1 passed its end-epoch check. Retire it
+		// and install a new issuer before the stale send error is classified.
+	case <-time.After(time.Second):
+		t.Fatal("Invoke did not reach the post-epoch-check classification barrier")
+	}
+	runtime.EBusDriverWithdrawn(drivermanager.Correlation{Generation: 1})
+	runtime.EBusDriverActivated(drivermanager.Correlation{Generation: 2})
+	recovered, err := mgr.Enable(context.Background())
+	if err != nil {
+		t.Fatalf("recovered generation Enable() error = %v", err)
+	}
+	close(continueClassify)
+
+	select {
+	case err := <-invokeDone:
+		if err == nil || !errors.Is(err, errRawFrameTransportDown) {
+			t.Fatalf("stale Invoke error = %v, want errRawFrameTransportDown", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("stale Invoke did not finish classification")
+	}
+	if !mgr.IsOwned() {
+		t.Fatal("generation-1 send error disconnected the recovered generation-2 issuer")
+	}
+	if got := mgr.TransportKey().TransportEpoch; got != 2 {
+		t.Fatalf("recovered transport epoch = %d, want 2", got)
+	}
+	if recovered.Transport.TransportEpoch != 2 {
+		t.Fatalf("recovered issuer epoch = %d, want 2", recovered.Transport.TransportEpoch)
 	}
 }
 

--- a/cmd/gateway/vaillant_b503_wiring.go
+++ b/cmd/gateway/vaillant_b503_wiring.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/Project-Helianthus/helianthus-ebusgateway"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/drivermanager"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/internal/vaillant/b503session"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
 )
@@ -61,9 +62,53 @@ func b503StubRefresh(ctx context.Context) (b503session.TransportKey, error) {
 // on a different Manager than MCP would trivially break the single-owner
 // invariant.
 type b503Runtime struct {
-	mcpServer  *mcp.Server
-	manager    *b503session.Manager
-	dispatcher mcp.RPCDispatcher
+	lifecycleMu sync.Mutex
+	mcpServer   *mcp.Server
+	manager     *b503session.Manager
+	dispatcher  mcp.RPCDispatcher
+}
+
+// EBusDriverActivated advances the B503 transport epoch to the exact admitted
+// DriverManager generation. Duplicate or stale notifications are no-ops. This
+// callback performs no I/O and never calls back into DriverManager.
+func (runtime *b503Runtime) EBusDriverActivated(correlation drivermanager.Correlation) {
+	if runtime == nil || runtime.manager == nil || correlation.Generation == 0 {
+		return
+	}
+	runtime.lifecycleMu.Lock()
+	defer runtime.lifecycleMu.Unlock()
+	if correlation.Generation <= runtime.manager.TransportKey().TransportEpoch {
+		return
+	}
+	runtime.manager.OnEpochAdvance(context.Background(), correlation.Generation)
+}
+
+// EBusDriverWithdrawn releases only the issuer owned by the withdrawn
+// generation. OnTransportDisconnect is idempotent and deliberately does not
+// advance the transport epoch; activation of generation N+1 owns that step.
+func (runtime *b503Runtime) EBusDriverWithdrawn(correlation drivermanager.Correlation) {
+	if runtime == nil || runtime.manager == nil || correlation.Generation == 0 {
+		return
+	}
+	runtime.disconnectIfCurrent(b503session.TransportKey{
+		AdapterInstanceID: runtime.manager.TransportKey().AdapterInstanceID,
+		TransportEpoch:    correlation.Generation,
+	})
+}
+
+// disconnectIfCurrent serializes the request-side source-unavailable fallback
+// with DriverManager activation/withdrawal. An invocation that observed epoch
+// N cannot disconnect a newly enabled issuer after epoch N+1 becomes active.
+func (runtime *b503Runtime) disconnectIfCurrent(expected b503session.TransportKey) {
+	if runtime == nil || runtime.manager == nil {
+		return
+	}
+	runtime.lifecycleMu.Lock()
+	defer runtime.lifecycleMu.Unlock()
+	if runtime.manager.TransportKey() != expected {
+		return
+	}
+	runtime.manager.OnTransportDisconnect()
 }
 
 // installVaillantB503 installs the Vaillant B503 MCP tool surface and
@@ -89,6 +134,7 @@ func installVaillantB503(s *mcp.Server, gw *ebusgateway.Gateway, cfg *ebusgatewa
 		TransportEpoch:    0,
 	}
 	mgr := b503session.New(initialTK, 30*time.Second, b503StubRefresh)
+	runtime := &b503Runtime{mcpServer: s, manager: mgr}
 
 	var disp mcp.RPCDispatcher
 	if gw != nil && gw.Bus != nil {
@@ -112,7 +158,9 @@ func installVaillantB503(s *mcp.Server, gw *ebusgateway.Gateway, cfg *ebusgatewa
 			// concurrency is governed at the bus.Send level (the bus
 			// arbitrates per-frame serially regardless).
 			readMu := &sync.Mutex{}
-			disp = newRawFrameDispatcherWithSourceProvider(gw.Bus, sourceProvider, readMu, mgr, b503DispatcherRequestTimeout)
+			rawDispatcher := newRawFrameDispatcherWithSourceProvider(gw.Bus, sourceProvider, readMu, mgr, b503DispatcherRequestTimeout)
+			rawDispatcher.disconnectIfCurrent = runtime.disconnectIfCurrent
+			disp = rawDispatcher
 		}
 	} else {
 		disp = b503StubDispatcher{}
@@ -124,9 +172,6 @@ func installVaillantB503(s *mcp.Server, gw *ebusgateway.Gateway, cfg *ebusgatewa
 		DefaultTarget:  defaultVaillantTarget,
 	})
 
-	return &b503Runtime{
-		mcpServer:  s,
-		manager:    mgr,
-		dispatcher: disp,
-	}
+	runtime.dispatcher = disp
+	return runtime
 }

--- a/config.go
+++ b/config.go
@@ -26,6 +26,10 @@ const (
 	TransportTCPPlain      TransportProtocol = "tcp-plain"
 	TransportEbusdTCP      TransportProtocol = "ebusd-tcp"
 	TransportAdapterDirect TransportProtocol = "adapter-direct"
+	// transportAdapterDirectENS is the private canonical form of the
+	// documented adapter-direct-ens:// URI. It preserves mux wire-family
+	// selection after URI stripping without widening the public enum surface.
+	transportAdapterDirectENS TransportProtocol = "adapter-direct-ens"
 
 	DefaultSemanticZonePresenceMissThreshold = 3
 	DefaultSemanticZonePresenceHitThreshold  = 2

--- a/driver_transport.go
+++ b/driver_transport.go
@@ -27,9 +27,16 @@ func OpenEBusDriverPassiveTransport(ctx context.Context, cfg Config) (transport.
 func EBusDriverTransportProtocol(config TransportConfig) TransportProtocol {
 	normalized, err := NormalizeEBusDriverTransportConfig(config)
 	if err == nil {
+		if isAdapterDirectTransportProtocol(normalized.Protocol) {
+			return TransportAdapterDirect
+		}
 		return normalized.Protocol
 	}
-	return canonicalTransportProtocol(config.Protocol)
+	protocol := canonicalTransportProtocol(config.Protocol)
+	if isAdapterDirectTransportProtocol(protocol) {
+		return TransportAdapterDirect
+	}
+	return protocol
 }
 
 // NormalizeEBusDriverTransportConfig resolves a valid endpoint URI into the

--- a/driver_transport.go
+++ b/driver_transport.go
@@ -1,0 +1,22 @@
+package ebusgateway
+
+import (
+	"context"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+// OpenEBusDriverTransport constructs one fresh eBUS transport generation.
+// Lifecycle ownership remains with the caller; the returned close function is
+// invoked only by the adapter-owned DriverRuntime close worker.
+func OpenEBusDriverTransport(ctx context.Context, cfg Config) (transport.RawTransport, func() error, error) {
+	cfg = applyDefaults(cfg)
+	return resolveTransport(ctx, cfg)
+}
+
+// OpenEBusDriverPassiveTransport constructs the generation-coupled passive
+// observer connection used by proxy-like ENH/ENS configurations.
+func OpenEBusDriverPassiveTransport(ctx context.Context, cfg Config) (transport.RawTransport, error) {
+	cfg = applyDefaults(cfg)
+	return resolvePassiveTransport(ctx, cfg)
+}

--- a/driver_transport.go
+++ b/driver_transport.go
@@ -20,3 +20,14 @@ func OpenEBusDriverPassiveTransport(ctx context.Context, cfg Config) (transport.
 	cfg = applyDefaults(cfg)
 	return resolvePassiveTransport(ctx, cfg)
 }
+
+// EBusDriverTransportProtocol resolves URI scheme overrides through the same
+// normalization used by transport construction. Invalid endpoints retain the
+// canonical configured fallback so their error remains driver-local.
+func EBusDriverTransportProtocol(config TransportConfig) TransportProtocol {
+	normalized, err := normalizeTransportConfig(config)
+	if err == nil {
+		return normalized.Protocol
+	}
+	return canonicalTransportProtocol(config.Protocol)
+}

--- a/driver_transport.go
+++ b/driver_transport.go
@@ -25,9 +25,17 @@ func OpenEBusDriverPassiveTransport(ctx context.Context, cfg Config) (transport.
 // normalization used by transport construction. Invalid endpoints retain the
 // canonical configured fallback so their error remains driver-local.
 func EBusDriverTransportProtocol(config TransportConfig) TransportProtocol {
-	normalized, err := normalizeTransportConfig(config)
+	normalized, err := NormalizeEBusDriverTransportConfig(config)
 	if err == nil {
 		return normalized.Protocol
 	}
 	return canonicalTransportProtocol(config.Protocol)
+}
+
+// NormalizeEBusDriverTransportConfig resolves a valid endpoint URI into the
+// canonical protocol/network/address tuple used by both the process shell and
+// transport construction. Callers must retain an invalid descriptor unchanged
+// so its failure remains isolated to the eBUS driver lifecycle.
+func NormalizeEBusDriverTransportConfig(config TransportConfig) (TransportConfig, error) {
+	return normalizeTransportConfig(config)
 }

--- a/gateway.go
+++ b/gateway.go
@@ -2,10 +2,12 @@ package ebusgateway
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -358,11 +360,31 @@ func parseTransportEndpoint(endpoint string, fallbackProtocol TransportProtocol)
 	if scheme == "unix" && network != "unix" {
 		return "", "", "", fmt.Errorf("gateway transport endpoint %q missing unix path", endpoint)
 	}
+	if network == "tcp" || network == "udp" {
+		if err := validateNetworkTransportHostPort(address); err != nil {
+			return "", "", "", fmt.Errorf("gateway transport endpoint %q invalid %s host:port: %w", endpoint, network, err)
+		}
+	}
 	if protocol == "" {
 		protocol = TransportENH
 	}
 
 	return protocol, network, address, nil
+}
+
+func validateNetworkTransportHostPort(address string) error {
+	host, portText, err := net.SplitHostPort(strings.TrimSpace(address))
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(host) == "" {
+		return errors.New("host is empty")
+	}
+	port, err := strconv.ParseUint(strings.TrimSpace(portText), 10, 16)
+	if err != nil || port == 0 {
+		return fmt.Errorf("port %q is not in numeric range 1..65535", portText)
+	}
+	return nil
 }
 
 func transportFromConn(protocolName TransportProtocol, conn net.Conn, readTimeout, writeTimeout time.Duration) (transport.RawTransport, error) {

--- a/gateway.go
+++ b/gateway.go
@@ -188,6 +188,10 @@ func normalizeTransportConfig(config TransportConfig) (TransportConfig, error) {
 		if config.Protocol == "" {
 			config.Protocol = TransportENH
 		}
+		if isAdapterDirectTransportProtocol(config.Protocol) &&
+			(config.Network == "" || (config.Network == "unix" && strings.Contains(config.Address, ":"))) {
+			config.Network = "tcp"
+		}
 		return config, nil
 	}
 
@@ -199,6 +203,11 @@ func normalizeTransportConfig(config TransportConfig) (TransportConfig, error) {
 	config.Network = network
 	config.Address = address
 	return config, nil
+}
+
+func isAdapterDirectTransportProtocol(protocol TransportProtocol) bool {
+	protocol = canonicalTransportProtocol(protocol)
+	return protocol == TransportAdapterDirect || protocol == transportAdapterDirectENS
 }
 
 func canonicalTransportProtocol(protocol TransportProtocol) TransportProtocol {
@@ -314,7 +323,9 @@ func parseTransportEndpoint(endpoint string, fallbackProtocol TransportProtocol)
 		}
 	case "unix":
 	case "adapter-direct":
-		return "", "", "", fmt.Errorf("gateway transport endpoint scheme %q requires preconfigured adapter-direct transport (use wireAdapterDirect)", scheme)
+		protocol = TransportAdapterDirect
+	case "adapter-direct-ens":
+		protocol = transportAdapterDirectENS
 	default:
 		return "", "", "", fmt.Errorf("gateway transport endpoint unsupported scheme %q", scheme)
 	}

--- a/gateway.go
+++ b/gateway.go
@@ -146,7 +146,10 @@ func resolveTransport(ctx context.Context, cfg Config) (transport.RawTransport, 
 		return nil, nil, err
 	}
 
-	return transportLayer, conn.Close, nil
+	// Close through the protocol transport, not just its underlying socket.
+	// Stateful transports such as ebusd-tcp have local waiters that are woken
+	// only when their Close method marks the transport closed and broadcasts.
+	return transportLayer, transportLayer.Close, nil
 }
 
 func clampEbusdTCPTimeouts(config TransportConfig, scanRequestTimeout time.Duration) TransportConfig {
@@ -190,7 +193,7 @@ func normalizeTransportConfig(config TransportConfig) (TransportConfig, error) {
 
 	protocol, network, address, err := parseTransportEndpoint(config.Address, config.Protocol)
 	if err != nil {
-		return TransportConfig{}, err
+		return TransportConfig{}, fmt.Errorf("invalid gateway transport endpoint: %w: %w", ebuserrors.ErrInvalidPayload, err)
 	}
 	config.Protocol = protocol
 	config.Network = network

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	ebuserrors "github.com/Project-Helianthus/helianthus-ebusgo/errors"
 	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
 	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
@@ -305,6 +306,30 @@ func TestNormalizeTransportConfigRejectsUnsupportedEndpointScheme(t *testing.T) 
 	})
 	if err == nil {
 		t.Fatalf("expected error for unsupported endpoint scheme")
+	}
+}
+
+func TestNormalizeTransportConfigRejectsNetworkURIWithoutHostPort(t *testing.T) {
+	for _, endpoint := range []string{
+		"enh://adapter.invalid",
+		"ens://adapter.invalid",
+		"tcp://adapter.invalid",
+		"tcp-plain://adapter.invalid",
+		"udp-plain://adapter.invalid",
+		"ebusd://adapter.invalid",
+		"ebusd-tcp://adapter.invalid",
+		"adapter-direct://adapter.invalid",
+		"adapter-direct-ens://adapter.invalid",
+		"tcp-plain://:9999",
+		"tcp-plain://adapter.invalid:",
+		"tcp-plain://adapter.invalid:notaport",
+	} {
+		t.Run(endpoint, func(t *testing.T) {
+			_, err := normalizeTransportConfig(TransportConfig{Address: endpoint})
+			if !errors.Is(err, ebuserrors.ErrInvalidPayload) {
+				t.Fatalf("normalizeTransportConfig(%q) error = %v, want ErrInvalidPayload", endpoint, err)
+			}
+		})
 	}
 }
 

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -362,6 +362,38 @@ func TestNormalizeTransportConfigTCPPlainEndpoint(t *testing.T) {
 	}
 }
 
+func TestNormalizeTransportConfigAdapterDirectEndpoints(t *testing.T) {
+	tests := []struct {
+		name         string
+		endpoint     string
+		wantProtocol TransportProtocol
+	}{
+		{name: "enh family", endpoint: "adapter-direct://adapter.local:9999", wantProtocol: TransportAdapterDirect},
+		{name: "ens family", endpoint: "adapter-direct-ens://adapter.local:9999", wantProtocol: transportAdapterDirectENS},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg, err := normalizeTransportConfig(TransportConfig{
+				Protocol: TransportENH,
+				Network:  "unix",
+				Address:  test.endpoint,
+			})
+			if err != nil {
+				t.Fatalf("normalizeTransportConfig() error = %v", err)
+			}
+			if cfg.Protocol != test.wantProtocol || cfg.Network != "tcp" || cfg.Address != "adapter.local:9999" {
+				t.Fatalf("normalized tuple = %q/%q/%q, want %q/tcp/adapter.local:9999", cfg.Protocol, cfg.Network, cfg.Address, test.wantProtocol)
+			}
+			if got := EBusDriverTransportProtocol(TransportConfig{Protocol: TransportENH, Network: "unix", Address: test.endpoint}); got != TransportAdapterDirect {
+				t.Fatalf("EBusDriverTransportProtocol() = %q, want stable adapter-direct shape", got)
+			}
+			if path, special := ResolveAdmissionPath(cfg.Protocol); path != TransportAdmissionSourceSelectionCapable || !special {
+				t.Fatalf("ResolveAdmissionPath(%q) = %q/%v, want source-selection-capable/true", cfg.Protocol, path, special)
+			}
+		})
+	}
+}
+
 func TestNormalizeTransportConfigCanonicalizesEbusdAlias(t *testing.T) {
 	cfg, err := normalizeTransportConfig(TransportConfig{
 		Protocol: TransportProtocol("ebusd"),

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Project-Helianthus/helianthus-ebusgateway
 go 1.22.0
 
 require (
-	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260521144203-f9919f4b1007
+	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260821185245-872b442444f2
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260817174811-f8b7082b3fa4
 	github.com/Project-Helianthus/helianthus-eebusreg v0.1.35
 	github.com/Project-Helianthus/helianthus-modbus v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260521144203-f9919f4b1007 h1:jDZeSPLUo+pShLNg6j4TnLORPJq6ow1f6XZ/FsbG7vk=
-github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260521144203-f9919f4b1007/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
+github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260821185245-872b442444f2 h1:+1wvyKlMgz93dRwmeVSkgkFqenp4CwyajdU4u7bwXbI=
+github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260821185245-872b442444f2/go.mod h1:thVkNAfYJ0Qv4jvdpr6xeCFokeUQAeuAbq510DXYXMU=
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260817174811-f8b7082b3fa4 h1:ge2WrXGf7GFhFG1WgrigexSslw9G5rorl1VLcGq4yic=
 github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260817174811-f8b7082b3fa4/go.mod h1:MhgS/S+s+EJ4+8c9KXom+pAXLTRYcjLI8qVSVCvsQu4=
 github.com/Project-Helianthus/helianthus-eebus-go v0.7.1-helianthus.20 h1:dI+WdUfRsAtW86x3LwKdSZ3NRLf0xyOc7N/m61NeNbg=

--- a/graphql/builder.go
+++ b/graphql/builder.go
@@ -19,6 +19,7 @@ type Builder struct {
 	vaillantB503           VaillantB503Provider
 	mutationSource         byte
 	mutationSourceAdmitted bool
+	mutationSourceProvider func() (byte, bool)
 
 	mu       sync.RWMutex
 	schema   Schema
@@ -280,6 +281,18 @@ func (b *Builder) ClearAdmittedMutationSource() {
 	b.mu.Unlock()
 }
 
+// SetAdmittedMutationSourceProvider installs the live request-time authority
+// used by GraphQL mutations. The builder's selected source remains separate so
+// source-selection state can survive a temporary driver withdrawal.
+func (b *Builder) SetAdmittedMutationSourceProvider(provider func() (byte, bool)) {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	b.mutationSourceProvider = provider
+	b.mu.Unlock()
+}
+
 func (b *Builder) admittedMutationSource() (byte, bool) {
 	if b == nil {
 		return 0, false
@@ -292,6 +305,19 @@ func (b *Builder) admittedMutationSource() (byte, bool) {
 }
 
 func (b *Builder) AdmittedMutationSource() (byte, bool) {
+	return b.admittedMutationSource()
+}
+
+func (b *Builder) mutationSourceForRequest() (byte, bool) {
+	if b == nil {
+		return 0, false
+	}
+	b.mu.RLock()
+	provider := b.mutationSourceProvider
+	b.mu.RUnlock()
+	if provider != nil {
+		return provider()
+	}
 	return b.admittedMutationSource()
 }
 

--- a/graphql/builder_test.go
+++ b/graphql/builder_test.go
@@ -181,6 +181,23 @@ func TestBuildSchema_ReflectsRegistry(t *testing.T) {
 	}
 }
 
+func TestIssue851MutationSourceProviderOverridesSelectedSourceSnapshot(t *testing.T) {
+	builder := NewBuilder(nil, nil)
+	builder.SetAdmittedMutationSource(0x77)
+	builder.SetAdmittedMutationSourceProvider(func() (byte, bool) {
+		return 0, false
+	})
+
+	// The selected source remains available to process-owned selection state,
+	// while GraphQL mutations use the live driver-intersected authority.
+	if selected, ok := builder.AdmittedMutationSource(); !ok || selected != 0x77 {
+		t.Fatalf("selected source = 0x%02X/%v, want 0x77/true", selected, ok)
+	}
+	if source, ok := builder.mutationSourceForRequest(); ok || source != 0 {
+		t.Fatalf("mutation source = 0x%02X/%v, want unavailable", source, ok)
+	}
+}
+
 func TestBuildSchema_ProjectionCanonicalIDs(t *testing.T) {
 	canonicalRoot := registry.ProjectionPath{
 		Plane: registry.ServicePlane,

--- a/graphql/mutations.go
+++ b/graphql/mutations.go
@@ -179,7 +179,7 @@ func NewSchema(builder *Builder, registry InvokeRegistry, invoker Invoker, hub *
 
 	var mutationType *graphqlgo.Object
 	if registry != nil && invoker != nil {
-		mutationType = buildMutationType(registry, invoker, builder.boilerConfigWriter(), builder.systemConfigWriter(), builder.scheduleWriter(), builder.admittedMutationSource)
+		mutationType = buildMutationType(registry, invoker, builder.boilerConfigWriter(), builder.systemConfigWriter(), builder.scheduleWriter(), builder.mutationSourceForRequest)
 	}
 
 	var subscriptionType *graphqlgo.Object

--- a/graphql/mutations_unit_test.go
+++ b/graphql/mutations_unit_test.go
@@ -402,6 +402,40 @@ func TestSetCircuitConfigMutation_FailsClosedBeforeSourceAdmission(t *testing.T)
 	}
 }
 
+func TestIssue851BuilderMutationProviderFencesDirectGraphQLInvoker(t *testing.T) {
+	registry := mutationTestRegistry{
+		entries: map[byte]registry.DeviceEntry{
+			0x15: testControllerEntryWithMethods(mutationSetExtRegisterMethod, mutationGetExtRegisterMethod),
+		},
+		order: []byte{0x15},
+	}
+	invoker := &mutationTestInvoker{}
+	admitted := false
+	builder := NewBuilder(nil, nil)
+	builder.SetAdmittedMutationSource(0x77)
+	builder.SetAdmittedMutationSourceProvider(func() (byte, bool) {
+		return 0x77, admitted
+	})
+	schema, err := NewSchema(builder, registry, invoker, nil)
+	if err != nil {
+		t.Fatalf("NewSchema() error = %v", err)
+	}
+
+	data := executeMutation(t, schema, `mutation {
+		setCircuitConfig(index: 1, field: "heatingCurve", value: "1.5") {
+			success
+			error
+		}
+	}`)
+	payload, _ := data["setCircuitConfig"].(map[string]any)
+	if success, _ := payload["success"].(bool); success {
+		t.Fatalf("withdrawn GraphQL mutation = %#v, want unavailable", payload)
+	}
+	if len(invoker.calls) != 0 {
+		t.Fatalf("withdrawn GraphQL invoker calls = %d, want 0", len(invoker.calls))
+	}
+}
+
 func TestApplyConfigMutation_FailsClosedBeforeSourceAdmission(t *testing.T) {
 	registry := mutationTestRegistry{
 		entries: map[byte]registry.DeviceEntry{

--- a/internal/adaptermux/connection_health_test.go
+++ b/internal/adaptermux/connection_health_test.go
@@ -8,6 +8,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
 )
 
 type managedFenceTransport struct {
@@ -515,6 +517,64 @@ func TestManagedExplicitWithdrawalFencesExistingAndNewProxyWork(t *testing.T) {
 	_ = laterClient.Close()
 	if err := mux.Close(); err != nil {
 		t.Fatalf("Close() error = %v", err)
+	}
+}
+
+func TestIssue851ManagedFatalListenerRetiresSessionsAndCachedFrames(t *testing.T) {
+	mux := New(Config{Protocol: "enh"})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mux.ctx, mux.cancel = ctx, cancel
+	mux.SetConnectionLostCallback(func() {})
+	mux.infoCacheMu.Lock()
+	mux.infoCache = map[transport.AdapterInfoID][]byte{transport.AdapterInfoVersion: {0x12, 0x34}}
+	mux.infoCacheMu.Unlock()
+
+	server, client := net.Pipe()
+	defer func() { _ = client.Close() }()
+	id := mux.AddSession(server)
+	if id == 0 {
+		t.Fatal("pre-failure AddSession returned 0")
+	}
+	mux.sessionsMu.Lock()
+	sess := mux.sessions[id]
+	mux.sessionsMu.Unlock()
+	if sess == nil {
+		t.Fatal("managed session not registered")
+	}
+
+	// Queue each forbidden post-failure class while net.Pipe's writer is
+	// deliberately blocked: passive traffic, cached INIT, and cached INFO.
+	sess.deliverReceived(0x99)
+	sess.handleInit(0x03)
+	sess.handleInfo(byte(transport.AdapterInfoVersion))
+
+	retired := make(chan struct{})
+	go func() {
+		mux.RetireManagedProxySessions()
+		close(retired)
+	}()
+	select {
+	case <-retired:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("managed session retirement was not bounded")
+	}
+
+	if _, err := mux.CachedInfo(transport.AdapterInfoVersion); err == nil {
+		t.Fatal("fatal listener retirement retained cached INFO")
+	}
+	// A net.Pipe endpoint may reject deadline changes once retirement has
+	// already closed it; either way the subsequent read must expose no bytes.
+	_ = client.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
+	buffer := make([]byte, 32)
+	if count, err := client.Read(buffer); count != 0 || err == nil {
+		t.Fatalf("retired client read = %d/%v bytes=%x, want closed with no passive/INIT/INFO", count, err, buffer[:count])
+	}
+	mux.sessionsMu.Lock()
+	remaining := len(mux.sessions)
+	mux.sessionsMu.Unlock()
+	if remaining != 0 {
+		t.Fatalf("managed sessions after fatal retirement = %d, want 0", remaining)
 	}
 }
 

--- a/internal/adaptermux/connection_health_test.go
+++ b/internal/adaptermux/connection_health_test.go
@@ -463,6 +463,115 @@ func TestManagedConnectionLossLinearizesProxyAdmissionAndProviderUse(t *testing.
 	})
 }
 
+func TestManagedExplicitWithdrawalFencesExistingAndNewProxyWork(t *testing.T) {
+	upstream := newManagedFenceTransport()
+	mux := New(Config{Protocol: "enh"})
+	ctx, cancel := context.WithCancel(context.Background())
+	mux.ctx, mux.cancel = ctx, cancel
+	mux.connMu.Lock()
+	mux.upstream = upstream
+	mux.connMu.Unlock()
+	mux.SetConnectionLostCallback(func() {})
+
+	server, client := net.Pipe()
+	defer func() { _ = client.Close() }()
+	id := mux.AddSession(server)
+	if id == 0 {
+		t.Fatal("pre-withdrawal AddSession returned 0")
+	}
+	if !mux.ManagedConnectionReady() {
+		t.Fatal("healthy managed mux reported not ready")
+	}
+	mux.arb.mu.Lock()
+	mux.arb.hasOwner = true
+	mux.arb.currentOwner = id
+	mux.arb.mu.Unlock()
+
+	// This is the non-blocking hook DriverManager invokes immediately before
+	// publishing STOPPING. Existing sessions remain allocated until bounded
+	// close, but none of their later bus operations may reach the old upstream.
+	mux.FenceManagedConnection()
+	if mux.ManagedConnectionReady() {
+		t.Fatal("withdrawn managed mux still reported ready")
+	}
+	if err := mux.doSend(id, 0x55); !errors.Is(err, errNotConnected) {
+		t.Fatalf("existing-session SEND error = %v, want errNotConnected", err)
+	}
+	if got := upstream.writes.Load(); got != 0 {
+		t.Fatalf("existing-session SEND reached withdrawn upstream: writes=%d", got)
+	}
+	result := <-mux.requestStartForSession(id, 0x31)
+	if !errors.Is(result.err, errNotConnected) {
+		t.Fatalf("existing-session START error = %v, want errNotConnected", result.err)
+	}
+	if got := upstream.startCalls.Load(); got != 0 {
+		t.Fatalf("existing-session START reached withdrawn upstream: starts=%d", got)
+	}
+
+	laterServer, laterClient := net.Pipe()
+	if got := mux.AddSession(laterServer); got != 0 {
+		t.Fatalf("post-withdrawal AddSession id = %d, want 0", got)
+	}
+	_ = laterClient.Close()
+	if err := mux.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+}
+
+func TestManagedConnectionReadinessDropsBeforeLossOwnerCallback(t *testing.T) {
+	upstream := newManagedFenceTransport()
+	mux := New(Config{Protocol: "enh"})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mux.ctx, mux.cancel = ctx, cancel
+	mux.connMu.Lock()
+	mux.upstream = upstream
+	mux.connMu.Unlock()
+	callbackEntered := make(chan struct{})
+	callbackRelease := make(chan struct{})
+	mux.SetConnectionLostCallback(func() {
+		close(callbackEntered)
+		<-callbackRelease
+	})
+	if !mux.ManagedConnectionReady() {
+		t.Fatal("healthy managed mux reported not ready")
+	}
+
+	reconnectDone := make(chan error, 1)
+	go func() {
+		delegated, err := mux.reconnect()
+		if !delegated && err == nil {
+			err = errors.New("reconnect did not delegate")
+		}
+		reconnectDone <- err
+	}()
+	select {
+	case <-callbackEntered:
+	case <-time.After(time.Second):
+		t.Fatal("loss owner callback was not reached")
+	}
+	// reconnect set the generation retirement flag before invoking its owner.
+	// A Portal read in this interval must not block behind publication and must
+	// not project the static listener-bound fact as READY.
+	readinessDone := make(chan bool, 1)
+	go func() { readinessDone <- mux.ManagedConnectionReady() }()
+	select {
+	case ready := <-readinessDone:
+		if ready {
+			t.Fatal("managed mux reported ready after loss fence but before owner callback returned")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("readiness blocked behind loss-owner callback")
+	}
+	close(callbackRelease)
+	if err := <-reconnectDone; err != nil {
+		t.Fatalf("reconnect() error = %v", err)
+	}
+	if err := mux.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+}
+
 func TestManagedConnectionLossDoesNotDeadlockCancelledStartQueueAdvance(t *testing.T) {
 	mock := &failingStartTransport{
 		p3MockTransport: newP3MockTransport(),

--- a/internal/adaptermux/connection_health_test.go
+++ b/internal/adaptermux/connection_health_test.go
@@ -4,10 +4,69 @@ import (
 	"context"
 	"errors"
 	"net"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 )
+
+type managedFenceTransport struct {
+	closeOnce  sync.Once
+	closed     chan struct{}
+	writeOnce  sync.Once
+	writeStart chan struct{}
+	startOnce  sync.Once
+	startStart chan struct{}
+	writes     atomic.Int32
+	startCalls atomic.Int32
+}
+
+func newManagedFenceTransport() *managedFenceTransport {
+	return &managedFenceTransport{
+		closed:     make(chan struct{}),
+		writeStart: make(chan struct{}),
+		startStart: make(chan struct{}),
+	}
+}
+
+func (transport *managedFenceTransport) ReadByte() (byte, error) {
+	<-transport.closed
+	return 0, net.ErrClosed
+}
+
+func (transport *managedFenceTransport) Write(payload []byte) (int, error) {
+	transport.writes.Add(1)
+	transport.writeOnce.Do(func() { close(transport.writeStart) })
+	<-transport.closed
+	return 0, net.ErrClosed
+}
+
+func (transport *managedFenceTransport) RequestStart(byte) error {
+	transport.startCalls.Add(1)
+	transport.startOnce.Do(func() { close(transport.startStart) })
+	<-transport.closed
+	return net.ErrClosed
+}
+
+func (transport *managedFenceTransport) Close() error {
+	transport.closeOnce.Do(func() { close(transport.closed) })
+	return nil
+}
+
+type blockingRemoteAddrConn struct {
+	net.Conn
+	once    sync.Once
+	reached chan struct{}
+	release chan struct{}
+}
+
+func (conn *blockingRemoteAddrConn) RemoteAddr() net.Addr {
+	conn.once.Do(func() {
+		close(conn.reached)
+		<-conn.release
+	})
+	return conn.Conn.RemoteAddr()
+}
 
 func TestManagedConnectionLossDelegatesRecoveryAndFencesOldMux(t *testing.T) {
 	reconnectTarget, err := net.Listen("tcp", "127.0.0.1:0")
@@ -143,5 +202,224 @@ func TestManagedConnectionLossDelegatesRecoveryAndFencesOldMux(t *testing.T) {
 		}
 	case <-time.After(250 * time.Millisecond):
 		t.Fatal("Close() did not remain bounded after managed connection loss")
+	}
+}
+
+func TestManagedConnectionLossLinearizesProxyAdmissionAndProviderUse(t *testing.T) {
+	newMux := func(t *testing.T, upstream *managedFenceTransport, callback func()) (*Mux, context.CancelFunc) {
+		t.Helper()
+		mux := New(Config{Protocol: "enh", ReconnectInitialDelay: time.Hour})
+		ctx, cancel := context.WithCancel(context.Background())
+		mux.ctx, mux.cancel = ctx, cancel
+		mux.connMu.Lock()
+		mux.upstream = upstream
+		mux.connMu.Unlock()
+		mux.SetConnectionLostCallback(callback)
+		return mux, cancel
+	}
+
+	t.Run("blocked write drains before BACKOFF publication", func(t *testing.T) {
+		upstream := newManagedFenceTransport()
+		writeDone := make(chan struct{})
+		callback := make(chan struct{})
+		mux, cancel := newMux(t, upstream, func() {
+			select {
+			case <-writeDone:
+			default:
+				t.Error("connection-loss callback crossed an admitted Write")
+			}
+			close(callback)
+		})
+		defer cancel()
+		mux.arb.mu.Lock()
+		mux.arb.hasOwner = true
+		mux.arb.currentOwner = 41
+		mux.arb.mu.Unlock()
+
+		go func() {
+			_ = mux.doSend(41, 0x55)
+			close(writeDone)
+		}()
+		select {
+		case <-upstream.writeStart:
+		case <-time.After(time.Second):
+			t.Fatal("Write did not reach the managed provider")
+		}
+
+		reconnectDone := make(chan error, 1)
+		go func() {
+			delegated, err := mux.reconnect()
+			if !delegated && err == nil {
+				err = errors.New("reconnect did not delegate")
+			}
+			reconnectDone <- err
+		}()
+		select {
+		case <-callback:
+		case <-time.After(time.Second):
+			t.Fatal("managed loss did not publish after closing the blocked Write")
+		}
+		if err := <-reconnectDone; err != nil {
+			t.Fatalf("reconnect() error = %v", err)
+		}
+		if err := mux.doSend(41, 0x56); !errors.Is(err, errNotConnected) {
+			t.Fatalf("post-BACKOFF Write error = %v, want errNotConnected", err)
+		}
+		if got := upstream.writes.Load(); got != 1 {
+			t.Fatalf("upstream Write calls = %d, want exactly pre-fence call", got)
+		}
+	})
+
+	t.Run("blocked request start drains before BACKOFF publication", func(t *testing.T) {
+		upstream := newManagedFenceTransport()
+		startDone := make(chan struct{})
+		callback := make(chan struct{})
+		mux, cancel := newMux(t, upstream, func() {
+			select {
+			case <-startDone:
+			default:
+				t.Error("connection-loss callback crossed an admitted RequestStart")
+			}
+			close(callback)
+		})
+		defer cancel()
+
+		go func() {
+			result := <-mux.requestStartForSession(41, 0x31)
+			if result.err == nil {
+				t.Error("RequestStart unexpectedly succeeded across loss")
+			}
+			close(startDone)
+		}()
+		select {
+		case <-upstream.startStart:
+		case <-time.After(time.Second):
+			t.Fatal("RequestStart did not reach the managed provider")
+		}
+
+		reconnectDone := make(chan error, 1)
+		go func() {
+			delegated, err := mux.reconnect()
+			if !delegated && err == nil {
+				err = errors.New("reconnect did not delegate")
+			}
+			reconnectDone <- err
+		}()
+		select {
+		case <-callback:
+		case <-time.After(time.Second):
+			t.Fatal("managed loss did not publish after closing RequestStart")
+		}
+		if err := <-reconnectDone; err != nil {
+			t.Fatalf("reconnect() error = %v", err)
+		}
+		result := <-mux.requestStartForSession(42, 0x32)
+		if !errors.Is(result.err, errNotConnected) {
+			t.Fatalf("post-BACKOFF START error = %v, want errNotConnected", result.err)
+		}
+		if got := upstream.startCalls.Load(); got != 1 {
+			t.Fatalf("upstream RequestStart calls = %d, want exactly pre-fence call", got)
+		}
+	})
+
+	t.Run("in-flight AddSession completes before BACKOFF and later admission rejects", func(t *testing.T) {
+		upstream := newManagedFenceTransport()
+		addID := make(chan uint64, 1)
+		addDone := make(chan struct{})
+		callback := make(chan struct{})
+		var mux *Mux
+		var cancel context.CancelFunc
+		mux, cancel = newMux(t, upstream, func() {
+			mux.sessionsMu.Lock()
+			sessionCount := len(mux.sessions)
+			mux.sessionsMu.Unlock()
+			if sessionCount != 1 {
+				t.Errorf("connection-loss callback observed %d sessions, want completed pre-fence admission", sessionCount)
+			}
+			close(callback)
+		})
+		defer cancel()
+		server, client := net.Pipe()
+		wrapped := &blockingRemoteAddrConn{Conn: server, reached: make(chan struct{}), release: make(chan struct{})}
+		go func() {
+			addID <- mux.AddSession(wrapped)
+			close(addDone)
+		}()
+		select {
+		case <-wrapped.reached:
+		case <-time.After(time.Second):
+			t.Fatal("AddSession did not enter its admitted critical section")
+		}
+
+		reconnectDone := make(chan error, 1)
+		go func() {
+			delegated, err := mux.reconnect()
+			if !delegated && err == nil {
+				err = errors.New("reconnect did not delegate")
+			}
+			reconnectDone <- err
+		}()
+		select {
+		case <-callback:
+			t.Fatal("BACKOFF published before pre-fence AddSession completed")
+		case <-time.After(20 * time.Millisecond):
+		}
+		close(wrapped.release)
+		select {
+		case <-callback:
+		case <-time.After(time.Second):
+			t.Fatal("BACKOFF did not publish after AddSession drained")
+		}
+		if err := <-reconnectDone; err != nil {
+			t.Fatalf("reconnect() error = %v", err)
+		}
+		if id := <-addID; id == 0 {
+			t.Fatal("pre-fence AddSession did not linearize before BACKOFF")
+		}
+
+		laterServer, laterClient := net.Pipe()
+		if id := mux.AddSession(laterServer); id != 0 {
+			t.Fatalf("post-BACKOFF AddSession id = %d, want 0", id)
+		}
+		_ = laterClient.Close()
+		_ = client.Close()
+		if err := mux.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+}
+
+func TestUnmanagedConnectionLossKeepsLegacyReconnectLoop(t *testing.T) {
+	mux := New(Config{Protocol: "enh", ReconnectInitialDelay: time.Hour})
+	ctx, cancel := context.WithCancel(context.Background())
+	mux.ctx, mux.cancel = ctx, cancel
+	mock := newP3MockTransport()
+	mux.connMu.Lock()
+	mux.upstream = mock
+	mux.connMu.Unlock()
+
+	done := make(chan struct {
+		delegated bool
+		err       error
+	}, 1)
+	go func() {
+		delegated, err := mux.reconnect()
+		done <- struct {
+			delegated bool
+			err       error
+		}{delegated: delegated, err: err}
+	}()
+	select {
+	case result := <-done:
+		t.Fatalf("unmanaged reconnect returned early: delegated=%v err=%v", result.delegated, result.err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	cancel()
+	result := <-done
+	if result.delegated || !errors.Is(result.err, context.Canceled) {
+		t.Fatalf("unmanaged reconnect = delegated:%v err:%v, want false/context.Canceled", result.delegated, result.err)
+	}
+	if err := mock.Close(); err != nil {
+		t.Fatalf("mock Close() error = %v", err)
 	}
 }

--- a/internal/adaptermux/connection_health_test.go
+++ b/internal/adaptermux/connection_health_test.go
@@ -2,24 +2,37 @@ package adaptermux
 
 import (
 	"context"
+	"errors"
+	"net"
 	"sync/atomic"
 	"testing"
 	"time"
 )
 
-func TestConnectionLostCallbackIgnoresIdleTimeoutAndReportsReconnectBoundary(t *testing.T) {
+func TestManagedConnectionLossDelegatesRecoveryAndFencesOldMux(t *testing.T) {
+	reconnectTarget, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen() error = %v", err)
+	}
+	defer reconnectTarget.Close()
+
 	mock := newP3MockTransport()
 	mock.readTimeout = 2 * time.Millisecond
 	mux := New(Config{
 		Protocol:              "enh",
 		Network:               "tcp",
-		Address:               "127.0.0.1:0",
+		Address:               reconnectTarget.Addr().String(),
+		DialTimeout:           20 * time.Millisecond,
 		ReadTimeout:           2 * time.Millisecond,
 		BlackholeThreshold:    time.Hour,
-		ReconnectInitialDelay: time.Hour,
+		ReconnectInitialDelay: 5 * time.Millisecond,
+		ReconnectMaxDelay:     5 * time.Millisecond,
 	})
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	defer func() {
+		cancel()
+		mux.wg.Wait()
+	}()
 	mux.ctx, mux.cancel = ctx, cancel
 	mux.connMu.Lock()
 	mux.upstream = mock
@@ -35,7 +48,11 @@ func TestConnectionLostCallbackIgnoresIdleTimeoutAndReportsReconnectBoundary(t *
 		}
 	})
 	mux.wg.Add(1)
-	go mux.readLoop()
+	readDone := make(chan struct{})
+	go func() {
+		mux.readLoop()
+		close(readDone)
+	}()
 
 	select {
 	case <-lost:
@@ -54,6 +71,73 @@ func TestConnectionLostCallbackIgnoresIdleTimeoutAndReportsReconnectBoundary(t *
 	if got := reports.Load(); got != 1 {
 		t.Fatalf("connection loss reports = %d, want 1", got)
 	}
-	cancel()
-	mux.wg.Wait()
+
+	select {
+	case <-readDone:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("managed read loop did not retire after delegating recovery")
+	}
+
+	// A managed generation must not run the mux's legacy reconnect loop. A
+	// listening endpoint makes any old-generation dial directly observable.
+	tcpTarget, ok := reconnectTarget.(*net.TCPListener)
+	if !ok {
+		t.Fatalf("listener type = %T, want *net.TCPListener", reconnectTarget)
+	}
+	if err := tcpTarget.SetDeadline(time.Now().Add(50 * time.Millisecond)); err != nil {
+		t.Fatalf("SetDeadline() error = %v", err)
+	}
+	conn, acceptErr := reconnectTarget.Accept()
+	if acceptErr == nil {
+		_ = conn.Close()
+		t.Fatal("retired managed mux dialed the adapter during manager-owned recovery")
+	}
+	var netErr net.Error
+	if !errors.As(acceptErr, &netErr) || !netErr.Timeout() {
+		t.Fatalf("Accept() error = %v, want timeout proving no reconnect dial", acceptErr)
+	}
+
+	// The generation-local proxy surface remains fenced while the manager is
+	// in BACKOFF: new sessions are rejected and START cannot reach upstream.
+	server, client := net.Pipe()
+	if id := mux.AddSession(server); id != 0 {
+		t.Fatalf("AddSession() id = %d after delegated loss, want 0", id)
+	}
+	_ = client.Close()
+	result := <-mux.requestStartForSession(41, 0x31)
+	if !errors.Is(result.err, errNotConnected) {
+		t.Fatalf("old-generation START error = %v, want errNotConnected", result.err)
+	}
+	if starts := mock.getStartRequests(); len(starts) != 0 {
+		t.Fatalf("old-generation START reached upstream after loss: %v", starts)
+	}
+
+	// Existing proxy sessions are fenced too. Simulate a previously granted
+	// external owner and prove its SEND cannot reach the retired transport.
+	mux.arb.mu.Lock()
+	mux.arb.hasOwner = true
+	mux.arb.currentOwner = 41
+	mux.arb.mu.Unlock()
+	if err := mux.doSend(41, 0x55); !errors.Is(err, errNotConnected) {
+		t.Fatalf("old-generation SEND error = %v, want errNotConnected", err)
+	}
+	mock.mu.Lock()
+	written := append([]byte(nil), mock.writtenBytes...)
+	mock.mu.Unlock()
+	if len(written) != 0 {
+		t.Fatalf("old-generation SEND reached upstream after loss: % X", written)
+	}
+
+	// Retirement remains normally closable; manager replacement will call the
+	// same Close path after its bounded backoff.
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- mux.Close() }()
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("Close() did not remain bounded after managed connection loss")
+	}
 }

--- a/internal/adaptermux/connection_health_test.go
+++ b/internal/adaptermux/connection_health_test.go
@@ -334,10 +334,7 @@ func TestManagedConnectionLossLinearizesProxyAdmissionAndProviderUse(t *testing.
 		requestReturned := make(chan (<-chan startResult), 1)
 		go func() { requestReturned <- mux.requestStartForSession(51, 0x33) }()
 		deadline := time.Now().Add(time.Second)
-		for {
-			if !mux.connectionUseMu.TryLock() {
-				break // the START admission owns R
-			}
+		for mux.connectionUseMu.TryLock() {
 			mux.connectionUseMu.Unlock()
 			if time.Now().After(deadline) {
 				mux.stateMu.Unlock()

--- a/internal/adaptermux/connection_health_test.go
+++ b/internal/adaptermux/connection_health_test.go
@@ -322,6 +322,83 @@ func TestManagedConnectionLossLinearizesProxyAdmissionAndProviderUse(t *testing.
 		}
 	})
 
+	t.Run("queued start is drained before BACKOFF and kick does not deadlock", func(t *testing.T) {
+		upstream := newManagedFenceTransport()
+		callback := make(chan struct{})
+		mux, cancel := newMux(t, upstream, func() { close(callback) })
+		defer cancel()
+
+		// Hold stateMu so requestStartForSession acquires the managed R fence
+		// and pauses immediately before the queue insertion.
+		mux.stateMu.Lock()
+		requestReturned := make(chan (<-chan startResult), 1)
+		go func() { requestReturned <- mux.requestStartForSession(51, 0x33) }()
+		deadline := time.Now().Add(time.Second)
+		for {
+			if !mux.connectionUseMu.TryLock() {
+				break // the START admission owns R
+			}
+			mux.connectionUseMu.Unlock()
+			if time.Now().After(deadline) {
+				mux.stateMu.Unlock()
+				t.Fatal("START admission did not acquire managed read fence")
+			}
+			time.Sleep(time.Millisecond)
+		}
+
+		reconnectDone := make(chan error, 1)
+		go func() {
+			delegated, err := mux.reconnect()
+			if !delegated && err == nil {
+				err = errors.New("reconnect did not delegate")
+			}
+			reconnectDone <- err
+		}()
+		select {
+		case <-upstream.closed:
+		case <-time.After(time.Second):
+			mux.stateMu.Unlock()
+			t.Fatal("managed loss did not detach/close upstream")
+		}
+
+		// The request now inserts while still holding R. The queued loss writer
+		// must acquire W next, fail that request, and publish BACKOFF before the
+		// post-enqueue idle kick can acquire a fresh R admission.
+		mux.stateMu.Unlock()
+		select {
+		case <-callback:
+		case <-time.After(time.Second):
+			t.Fatal("BACKOFF did not publish after draining queued START")
+		}
+		if err := <-reconnectDone; err != nil {
+			t.Fatalf("reconnect() error = %v", err)
+		}
+		var resultCh <-chan startResult
+		select {
+		case resultCh = <-requestReturned:
+		case <-time.After(time.Second):
+			t.Fatal("requestStartForSession deadlocked in nested managed admission")
+		}
+		select {
+		case result := <-resultCh:
+			if result.err == nil {
+				t.Fatal("pre-fence START survived managed BACKOFF")
+			}
+		case <-time.After(time.Second):
+			t.Fatal("pre-fence START remained unresolved after failAllPending")
+		}
+		mux.stateMu.Lock()
+		pendingStart := mux.pendingStart
+		mux.stateMu.Unlock()
+		mux.arb.mu.Lock()
+		pendingGateway := mux.arb.pendingGateway
+		pendingExternal := len(mux.arb.pendingExternal)
+		mux.arb.mu.Unlock()
+		if pendingStart != nil || pendingGateway != nil || pendingExternal != 0 {
+			t.Fatalf("pending START residue after BACKOFF: active=%v gateway=%v external=%d", pendingStart != nil, pendingGateway != nil, pendingExternal)
+		}
+	})
+
 	t.Run("in-flight AddSession completes before BACKOFF and later admission rejects", func(t *testing.T) {
 		upstream := newManagedFenceTransport()
 		addID := make(chan uint64, 1)

--- a/internal/adaptermux/connection_health_test.go
+++ b/internal/adaptermux/connection_health_test.go
@@ -14,7 +14,11 @@ func TestManagedConnectionLossDelegatesRecoveryAndFencesOldMux(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Listen() error = %v", err)
 	}
-	defer reconnectTarget.Close()
+	defer func() {
+		if closeErr := reconnectTarget.Close(); closeErr != nil && !errors.Is(closeErr, net.ErrClosed) {
+			t.Errorf("listener Close() error = %v", closeErr)
+		}
+	}()
 
 	mock := newP3MockTransport()
 	mock.readTimeout = 2 * time.Millisecond

--- a/internal/adaptermux/connection_health_test.go
+++ b/internal/adaptermux/connection_health_test.go
@@ -1,0 +1,59 @@
+package adaptermux
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestConnectionLostCallbackIgnoresIdleTimeoutAndReportsReconnectBoundary(t *testing.T) {
+	mock := newP3MockTransport()
+	mock.readTimeout = 2 * time.Millisecond
+	mux := New(Config{
+		Protocol:              "enh",
+		Network:               "tcp",
+		Address:               "127.0.0.1:0",
+		ReadTimeout:           2 * time.Millisecond,
+		BlackholeThreshold:    time.Hour,
+		ReconnectInitialDelay: time.Hour,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mux.ctx, mux.cancel = ctx, cancel
+	mux.connMu.Lock()
+	mux.upstream = mock
+	mux.connMu.Unlock()
+
+	lost := make(chan struct{}, 1)
+	var reports atomic.Int32
+	mux.SetConnectionLostCallback(func() {
+		reports.Add(1)
+		select {
+		case lost <- struct{}{}:
+		default:
+		}
+	})
+	mux.wg.Add(1)
+	go mux.readLoop()
+
+	select {
+	case <-lost:
+		t.Fatal("ordinary idle read timeout emitted connection loss")
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	if err := mock.Close(); err != nil {
+		t.Fatalf("mock Close() error = %v", err)
+	}
+	select {
+	case <-lost:
+	case <-time.After(time.Second):
+		t.Fatal("terminal read failure did not emit connection loss")
+	}
+	if got := reports.Load(); got != 1 {
+		t.Fatalf("connection loss reports = %d, want 1", got)
+	}
+	cancel()
+	mux.wg.Wait()
+}

--- a/internal/adaptermux/connection_health_test.go
+++ b/internal/adaptermux/connection_health_test.go
@@ -463,6 +463,136 @@ func TestManagedConnectionLossLinearizesProxyAdmissionAndProviderUse(t *testing.
 	})
 }
 
+func TestManagedConnectionLossDoesNotDeadlockCancelledStartQueueAdvance(t *testing.T) {
+	mock := &failingStartTransport{
+		p3MockTransport: newP3MockTransport(),
+		startGate:       make(chan struct{}),
+		startErr:        errors.New("adapter disconnected"),
+	}
+	mux := New(Config{
+		Protocol:        "enh",
+		PendingStartTTL: time.Hour,
+		SYNInterval:     time.Hour,
+		StartDeadline:   time.Hour,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mux.ctx, mux.cancel = ctx, cancel
+	mux.connMu.Lock()
+	mux.upstream = mock
+	mux.connMu.Unlock()
+
+	callback := make(chan struct{})
+	var callbackOnce sync.Once
+	mux.SetConnectionLostCallback(func() {
+		callbackOnce.Do(func() { close(callback) })
+	})
+	var releaseOnce sync.Once
+	releaseStart := func() { releaseOnce.Do(func() { close(mock.startGate) }) }
+	defer releaseStart()
+
+	firstResult := mux.arb.requestStart(41, 0x31)
+	grantDone := make(chan struct{})
+	go func() {
+		mux.tryGrantAndStart()
+		close(grantDone)
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		mux.stateMu.Lock()
+		pending := mux.pendingStart != nil && mux.pendingStart.sessionID == 41
+		mux.stateMu.Unlock()
+		if pending {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("first START did not enter managed provider use")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	// Cancel A while its RequestStart still holds the managed R admission,
+	// then queue B. When A later fails it will take the recursive queue-
+	// advance branch that previously tried to nest another RLock.
+	mux.cancelPendingStart(41)
+	secondResult := mux.arb.requestStart(42, 0x32)
+
+	reconnectDone := make(chan error, 1)
+	go func() {
+		delegated, err := mux.reconnect()
+		if !delegated && err == nil {
+			err = errors.New("reconnect did not delegate")
+		}
+		reconnectDone <- err
+	}()
+
+	// An existing reader does not block TryRLock. Failure here therefore
+	// proves the managed-loss writer is queued behind the first START before
+	// RequestStart is released, making the writer-preference deadlock exact.
+	deadline = time.Now().Add(time.Second)
+	for {
+		if mux.connectionUseMu.TryRLock() {
+			mux.connectionUseMu.RUnlock()
+		} else {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("managed loss writer did not queue behind RequestStart")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	releaseStart()
+
+	select {
+	case <-callback:
+	case <-time.After(time.Second):
+		t.Fatal("managed loss did not publish BACKOFF after cancelled START")
+	}
+	select {
+	case err := <-reconnectDone:
+		if err != nil {
+			t.Fatalf("reconnect() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("managed reconnect deadlocked behind nested queue advance")
+	}
+	select {
+	case <-grantDone:
+	case <-time.After(time.Second):
+		t.Fatal("tryGrantAndStart deadlocked after managed loss")
+	}
+	select {
+	case result := <-firstResult:
+		if !result.cancelled {
+			t.Fatalf("first START result = %#v, want cancelled", result)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cancelled first START remained unresolved")
+	}
+	select {
+	case result := <-secondResult:
+		if result.err == nil {
+			t.Fatal("queued second START survived managed connection loss")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("queued second START remained unresolved after BACKOFF")
+	}
+	mux.stateMu.Lock()
+	pendingStart := mux.pendingStart
+	mux.stateMu.Unlock()
+	mux.arb.mu.Lock()
+	pendingGateway := mux.arb.pendingGateway
+	pendingExternal := len(mux.arb.pendingExternal)
+	mux.arb.mu.Unlock()
+	if pendingStart != nil || pendingGateway != nil || pendingExternal != 0 {
+		t.Fatalf("pending START residue after managed loss: active=%v gateway=%v external=%d", pendingStart != nil, pendingGateway != nil, pendingExternal)
+	}
+	if err := mux.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+}
+
 func TestUnmanagedConnectionLossKeepsLegacyReconnectLoop(t *testing.T) {
 	mux := New(Config{Protocol: "enh", ReconnectInitialDelay: time.Hour})
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/adaptermux/listener.go
+++ b/internal/adaptermux/listener.go
@@ -21,11 +21,23 @@ type ProxyListener struct {
 	cancel   context.CancelFunc
 	wg       sync.WaitGroup
 	closed   atomic.Bool // AM54: prevent double-close panics
+	ready    atomic.Bool
+	failOnce sync.Once
+	onFatal  func(error)
 }
 
 // NewProxyListener creates and starts a proxy listener on listenAddr.
 // The listener runs until Close() is called or ctx is cancelled.
 func NewProxyListener(ctx context.Context, mux *Mux, listenAddr string, logger *log.Logger) (*ProxyListener, error) {
+	return NewProxyListenerWithFatalCallback(ctx, mux, listenAddr, logger, nil)
+}
+
+// NewProxyListenerWithFatalCallback creates a proxy listener and reports an
+// unexpected permanent Accept failure exactly once. Normal Close and context
+// cancellation are lifecycle teardown, not failures. The callback must not
+// call back into ProxyListener; managed callers use it to fence the mux and
+// notify their generation owner.
+func NewProxyListenerWithFatalCallback(ctx context.Context, mux *Mux, listenAddr string, logger *log.Logger, onFatal func(error)) (*ProxyListener, error) {
 	if mux == nil {
 		return nil, errors.New("adaptermux: proxy listener requires non-nil mux")
 	}
@@ -46,7 +58,10 @@ func NewProxyListener(ctx context.Context, mux *Mux, listenAddr string, logger *
 		logger:   logger,
 		ctx:      plCtx,
 		cancel:   plCancel,
+		onFatal:  onFatal,
 	}
+	pl.ready.Store(true)
+	mux.proxyListener.Store(pl)
 
 	pl.wg.Add(1)
 	// goroutine: closes the TCP listener when the context is cancelled,
@@ -67,6 +82,7 @@ func (pl *ProxyListener) Close() error {
 	if pl.closed.Swap(true) {
 		return nil // AM54: already closed, no-op
 	}
+	pl.ready.Store(false)
 	pl.cancel()
 	err := pl.listener.Close()
 	pl.wg.Wait()
@@ -74,6 +90,13 @@ func (pl *ProxyListener) Close() error {
 		return nil
 	}
 	return err
+}
+
+// Ready reports live accept-loop availability. A successful construction is
+// insufficient: permanent Accept failure clears readiness before notifying
+// the generation owner.
+func (pl *ProxyListener) Ready() bool {
+	return pl != nil && pl.ready.Load() && !pl.closed.Load() && pl.ctx.Err() == nil
 }
 
 // Addr returns the listener's network address (useful when bound to ":0").
@@ -85,6 +108,7 @@ func (pl *ProxyListener) Addr() net.Addr {
 func (pl *ProxyListener) watchCtx() {
 	defer pl.wg.Done()
 	<-pl.ctx.Done()
+	pl.ready.Store(false)
 	// Closing the listener unblocks Accept in the accept loop.
 	_ = pl.listener.Close()
 }
@@ -98,6 +122,7 @@ func (pl *ProxyListener) acceptLoop() {
 		if err != nil {
 			// Check if shutdown is in progress.
 			if pl.ctx.Err() != nil {
+				pl.ready.Store(false)
 				return
 			}
 			// Transient errors (fd exhaustion, etc.): log and retry.
@@ -109,6 +134,12 @@ func (pl *ProxyListener) acceptLoop() {
 				continue
 			}
 			// Non-transient error (listener closed, etc.): exit.
+			pl.ready.Store(false)
+			pl.failOnce.Do(func() {
+				if pl.onFatal != nil {
+					pl.onFatal(err)
+				}
+			})
 			pl.logger.Printf("adaptermux: proxy accept error (fatal): %v", err)
 			return
 		}

--- a/internal/adaptermux/listener_test.go
+++ b/internal/adaptermux/listener_test.go
@@ -2,6 +2,7 @@ package adaptermux
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -189,6 +190,81 @@ func TestProxyListenerContextCancel(t *testing.T) {
 	if err == nil {
 		closeOrLog(t, conn, "unexpected-open conn")
 		t.Fatal("expected dial to fail after context cancel, but it succeeded")
+	}
+}
+
+func TestProxyListenerFatalAcceptDropsReadinessAndReportsOnce(t *testing.T) {
+	mux, _, cleanup := newTestMux(t)
+	defer cleanup()
+	// Managed readiness is enabled only when a lifecycle owner exists.
+	mux.SetConnectionLostCallback(func() {})
+	fatal := make(chan error, 1)
+	var reports atomic.Int32
+	pl, err := NewProxyListenerWithFatalCallback(context.Background(), mux, "127.0.0.1:0", log.Default(), func(err error) {
+		mux.FenceManagedConnection()
+		reports.Add(1)
+		fatal <- err
+	})
+	if err != nil {
+		t.Fatalf("NewProxyListenerWithFatalCallback: %v", err)
+	}
+	if !pl.Ready() || !mux.ManagedConnectionReady() {
+		t.Fatal("successfully bound listener was not live")
+	}
+
+	// Close the underlying listener without canceling the owner context. This
+	// is the real accept-loop permanent-error path, not normal lifecycle Close.
+	if err := pl.listener.Close(); err != nil {
+		t.Fatalf("fatal listener close: %v", err)
+	}
+	select {
+	case acceptErr := <-fatal:
+		if !errors.Is(acceptErr, net.ErrClosed) {
+			t.Fatalf("fatal callback error = %v, want net.ErrClosed", acceptErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("permanent Accept failure was not reported")
+	}
+	if pl.Ready() || mux.ManagedConnectionReady() {
+		t.Fatal("fatal Accept failure retained proxy readiness")
+	}
+	if err := pl.Close(); err != nil {
+		t.Fatalf("Close() after fatal Accept error = %v", err)
+	}
+	if got := reports.Load(); got != 1 {
+		t.Fatalf("fatal reports = %d, want exactly 1", got)
+	}
+}
+
+func TestProxyListenerNormalRetirementDoesNotReportFatal(t *testing.T) {
+	for _, action := range []string{"close", "cancel"} {
+		t.Run(action, func(t *testing.T) {
+			mux := New(Config{})
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			var reports atomic.Int32
+			pl, err := NewProxyListenerWithFatalCallback(ctx, mux, "127.0.0.1:0", log.Default(), func(error) {
+				reports.Add(1)
+			})
+			if err != nil {
+				t.Fatalf("NewProxyListenerWithFatalCallback: %v", err)
+			}
+			switch action {
+			case "close":
+				if err := pl.Close(); err != nil {
+					t.Fatalf("Close() error = %v", err)
+				}
+				cancel()
+			case "cancel":
+				cancel()
+				if err := pl.Close(); err != nil {
+					t.Fatalf("Close() after cancel error = %v", err)
+				}
+			}
+			if pl.Ready() || reports.Load() != 0 {
+				t.Fatalf("normal %s readiness=%v fatal_reports=%d", action, pl.Ready(), reports.Load())
+			}
+		})
 	}
 }
 

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -1083,7 +1083,7 @@ func (m *Mux) beginManagedConnectionUse() (bool, bool) {
 		return false, true
 	}
 	m.connectionUseMu.RLock()
-	if m.connectionLossDelegated.Load() {
+	if m.connectionLossDelegated.Load() || m.ctx == nil || m.ctx.Err() != nil {
 		m.connectionUseMu.RUnlock()
 		return false, false
 	}
@@ -1094,6 +1094,37 @@ func (m *Mux) endManagedConnectionUse(gateHeld bool) {
 	if gateHeld {
 		m.connectionUseMu.RUnlock()
 	}
+}
+
+// FenceManagedConnection is the non-blocking generation-withdrawal half of
+// managed mux retirement. It is safe to call while DriverManager holds its
+// state lock: it performs one atomic store, never calls the lifecycle owner,
+// and never acquires a mux mutex. Existing pre-fence uses retain their R lease
+// until DriverRuntime closes the upstream; all later proxy START/SEND/session
+// admission is rejected by beginManagedConnectionUse. Callback-free muxes keep
+// their legacy reconnect behavior unchanged.
+func (m *Mux) FenceManagedConnection() {
+	if m != nil && m.connectionLossManaged.Load() {
+		m.connectionLossDelegated.Store(true)
+	}
+}
+
+// ManagedConnectionReady reports whether the current managed mux generation
+// can admit proxy work. Readiness is deliberately lock-free with respect to
+// connectionUseMu: reconnect holds its write side while publishing loss, and a
+// status request must report the already-set retirement flag rather than wait
+// behind that callback. The atomic flag is the readiness linearization point.
+func (m *Mux) ManagedConnectionReady() bool {
+	if m == nil || !m.connectionLossManaged.Load() || m.closing.Load() {
+		return false
+	}
+	if m.connectionLossDelegated.Load() || m.ctx == nil || m.ctx.Err() != nil {
+		return false
+	}
+	m.connMu.Lock()
+	ready := m.upstream != nil
+	m.connMu.Unlock()
+	return ready
 }
 
 // connect dials the adapter and performs the INIT handshake.

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -3487,7 +3487,15 @@ func (m *Mux) deliverToActive(symbol byte, countAsDelivered bool) {
 // rather than calling m.arb.requestStart directly, so both branches
 // of the C4 cancel + the C1 enqueue-kick are guaranteed to run.
 func (m *Mux) requestStartForSession(sessionID uint64, initiator byte) <-chan startResult {
-	if m.connectionLossDelegated.Load() {
+	managedGateHeld, admitted := m.beginManagedConnectionUse()
+	releaseManagedGate := func() {
+		if managedGateHeld {
+			m.endManagedConnectionUse(true)
+			managedGateHeld = false
+		}
+	}
+	defer releaseManagedGate()
+	if !admitted || m.closing.Load() {
 		ch := make(chan startResult, 1)
 		ch <- startResult{granted: false, initiator: initiator, err: errNotConnected}
 		return ch
@@ -3579,6 +3587,10 @@ func (m *Mux) requestStartForSession(sessionID uint64, initiator byte) <-chan st
 	idle := m.lastWireActivity.IsZero() ||
 		time.Since(m.lastWireActivity) >= m.cfg.SYNInterval
 	m.stateMu.Unlock()
+	// Release before the idle kick: tryGrantAndStart takes its own managed
+	// read admission. Keeping this R lock while a loss writer is queued would
+	// make the nested RLock self-deadlock under RWMutex writer preference.
+	releaseManagedGate()
 	if idle {
 		m.tryGrantAndStart()
 	}

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -686,8 +686,15 @@ type Mux struct {
 	// a terminal read failure or the duration-based blackhole threshold. Once
 	// installed, lifecycle ownership is delegated to that manager: this mux
 	// retires instead of running its legacy in-place reconnect loop.
-	connectionLostMu        sync.Mutex
-	connectionLostCallback  func()
+	connectionLostMu       sync.Mutex
+	connectionLostCallback func()
+	connectionLossManaged  atomic.Bool
+	// connectionUseMu is the managed-generation linearization fence. It is
+	// inactive for callback-free muxes. Managed proxy admission and physical
+	// START/SEND use hold R; terminal loss fences new work, closes the upstream
+	// to unblock existing use, drains R with W, tears state down, and publishes
+	// BACKOFF while W remains held.
+	connectionUseMu         sync.RWMutex
 	connectionLossDelegated atomic.Bool
 
 	// Lifecycle.
@@ -1057,21 +1064,36 @@ func (m *Mux) SetConnectionLostCallback(fn func()) {
 	m.connectionLostMu.Lock()
 	m.connectionLostCallback = fn
 	m.connectionLostMu.Unlock()
+	m.connectionLossManaged.Store(fn != nil)
 }
 
-func (m *Mux) emitConnectionLost() bool {
+func (m *Mux) connectionLostOwner() func() {
 	m.connectionLostMu.Lock()
 	fn := m.connectionLostCallback
 	m.connectionLostMu.Unlock()
-	if fn == nil {
-		return false
+	return fn
+
+}
+
+// beginManagedConnectionUse admits one generation-local proxy/provider use.
+// The bool pair is (gateHeld, admitted). Callback-free muxes avoid the RWMutex
+// hot path entirely and preserve legacy behavior.
+func (m *Mux) beginManagedConnectionUse() (bool, bool) {
+	if !m.connectionLossManaged.Load() {
+		return false, true
 	}
-	// Fence proxy and active-path work before publishing BACKOFF through the
-	// callback. This mux never clears the fence: a managed loss retires the
-	// whole generation and the manager constructs a fresh mux.
-	m.connectionLossDelegated.Store(true)
-	fn()
-	return true
+	m.connectionUseMu.RLock()
+	if m.connectionLossDelegated.Load() {
+		m.connectionUseMu.RUnlock()
+		return false, false
+	}
+	return true, true
+}
+
+func (m *Mux) endManagedConnectionUse(gateHeld bool) {
+	if gateHeld {
+		m.connectionUseMu.RUnlock()
+	}
 }
 
 // connect dials the adapter and performs the INIT handshake.
@@ -1440,10 +1462,40 @@ func (m *Mux) CachedInfo(id transport.AdapterInfoID) ([]byte, error) {
 // re-establish it in place; managed muxes delegate replacement to their
 // connection-loss owner and return delegated=true so readLoop retires.
 func (m *Mux) reconnect() (delegated bool, err error) {
-	// Publish loss before entering the legacy reconnect loop. A managed owner
-	// can withdraw admission immediately and retire this mux on its bounded
-	// replacement schedule. Close and ordinary idle timeouts do not emit it.
-	delegated = m.emitConnectionLost()
+	// A managed owner is the sole reconnect authority. Fence new work first,
+	// then detach/close the transport so already-admitted START/SEND calls
+	// unblock before we drain the managed-use gate. BACKOFF is published only
+	// after the common state teardown below, while the write gate remains held.
+	owner := m.connectionLostOwner()
+	delegated = owner != nil
+	managedGateHeld := false
+	if delegated {
+		m.connectionLossDelegated.Store(true)
+
+		m.connMu.Lock()
+		upstream := m.upstream
+		conn := m.conn
+		m.upstream = nil
+		m.conn = nil
+		m.connMu.Unlock()
+		if upstream != nil {
+			if closeErr := upstream.Close(); closeErr != nil {
+				m.logger.Printf("adaptermux: managed upstream close: %v", closeErr)
+			}
+		} else if conn != nil {
+			if closeErr := conn.Close(); closeErr != nil {
+				m.logger.Printf("adaptermux: managed conn close: %v", closeErr)
+			}
+		}
+
+		m.connectionUseMu.Lock()
+		managedGateHeld = true
+		defer func() {
+			if managedGateHeld {
+				m.connectionUseMu.Unlock()
+			}
+		}()
+	}
 
 	// Invalidate INFO cache immediately so CachedInfo returns errors
 	// during the disconnect window rather than serving stale data.
@@ -1551,16 +1603,22 @@ func (m *Mux) reconnect() (delegated bool, err error) {
 		m.logger.Printf("adaptermux: active channel full, dropping disconnect notification")
 	}
 
-	// Close old connection.
-	m.connMu.Lock()
-	if m.conn != nil {
-		if err := m.conn.Close(); err != nil {
-			m.logger.Printf("adaptermux: old conn close: %v", err)
+	// Close the old connection for callback-free muxes. Managed teardown
+	// detached and closed the transport before draining provider use above.
+	if !delegated {
+		m.connMu.Lock()
+		if m.conn != nil {
+			if err := m.conn.Close(); err != nil {
+				m.logger.Printf("adaptermux: old conn close: %v", err)
+			}
 		}
+		m.connMu.Unlock()
 	}
-	m.connMu.Unlock()
 	if delegated {
+		owner()
 		m.logger.Printf("adaptermux: connection recovery delegated to lifecycle owner")
+		m.connectionUseMu.Unlock()
+		managedGateHeld = false
 		return true, nil
 	}
 
@@ -3532,9 +3590,11 @@ func (m *Mux) requestStartForSession(sessionID uint64, initiator byte) <-chan st
 // this method is a no-op — the next tryGrantAndStart will fire after
 // the current one resolves.
 func (m *Mux) tryGrantAndStart() {
-	if m.connectionLossDelegated.Load() {
+	managedGateHeld, admitted := m.beginManagedConnectionUse()
+	if !admitted {
 		return
 	}
+	defer m.endManagedConnectionUse(managedGateHeld)
 	// Snapshot transport BEFORE acquiring stateMu to avoid stateMu → connMu
 	// lock nesting. doSend uses connMu → (release) → stateMu, so while not
 	// strictly ABBA, keeping consistent ordering is defensive best practice.
@@ -3558,10 +3618,6 @@ func (m *Mux) tryGrantAndStart() {
 	// internally).  No path holds arb.mu then acquires stateMu,
 	// so this is ABBA-safe.
 	m.stateMu.Lock()
-	if m.connectionLossDelegated.Load() {
-		m.stateMu.Unlock()
-		return
-	}
 	if m.pendingStart != nil {
 		m.logger.Printf("adaptermux: tryGrantAndStart skipped — pendingStart already set for session %d", m.pendingStart.sessionID)
 		m.stateMu.Unlock()
@@ -3873,7 +3929,16 @@ func (m *Mux) tryGrantAndStart() {
 		m.closeMu.Unlock()
 		go func() {
 			defer m.wg.Done()
-			if err := starter.StartArbitration(initiator); err != nil {
+			blockingGateHeld, blockingAdmitted := m.beginManagedConnectionUse()
+			var startErr error
+			if !blockingAdmitted {
+				startErr = errNotConnected
+			} else {
+				startErr = starter.StartArbitration(initiator)
+				m.endManagedConnectionUse(blockingGateHeld)
+			}
+			if startErr != nil {
+				err := startErr
 				m.logger.Printf("adaptermux: START arbitration failed for session %d: %v", sessionID, err)
 				// P1 fix (#3063005909): only send failure if we still own
 				// the pending slot.  cancelPendingStart may have cleared
@@ -4867,9 +4932,11 @@ func (m *Mux) doSend(sessionID uint64, data byte) error {
 			pacer.CancelEchoWatchdog()
 		}
 	}()
-	if m.connectionLossDelegated.Load() {
+	managedGateHeld, admitted := m.beginManagedConnectionUse()
+	if !admitted {
 		return errNotConnected
 	}
+	defer m.endManagedConnectionUse(managedGateHeld)
 
 	if !m.arb.isOwner(sessionID) {
 		return errNotBusOwner

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -1113,6 +1113,48 @@ func (m *Mux) FenceManagedConnection() {
 	}
 }
 
+// RetireManagedProxySessions synchronously removes and closes every external
+// session owned by a managed generation. Fatal proxy-listener loss calls this
+// before notifying DriverManager, so no queued passive/INIT/INFO frame can be
+// published after BACKOFF becomes visible. It deliberately does not acquire
+// connectionUseMu's write side: pre-fence upstream work may be blocked until
+// DriverRuntime closes the transport. AddSession rechecks the fence under
+// sessionsMu, which makes detachment linearizable without that lock-order risk.
+// Callback-free muxes retain their legacy session/reconnect behavior.
+func (m *Mux) RetireManagedProxySessions() {
+	if m == nil || !m.connectionLossManaged.Load() {
+		return
+	}
+	m.FenceManagedConnection()
+	m.clearInfoCache()
+
+	m.sessionsMu.Lock()
+	toClose := make([]*session, 0, len(m.sessions))
+	for id, sess := range m.sessions {
+		toClose = append(toClose, sess)
+		delete(m.sessions, id)
+	}
+	m.sessionsMu.Unlock()
+
+	var closeWG sync.WaitGroup
+	for _, sess := range toClose {
+		m.sessionRemoteAddrs.Delete(sess.id)
+		if value, ok := m.sessionPacers.Load(sess.id); ok {
+			if pacer, _ := value.(*v8classifier.Pacer); pacer != nil {
+				pacer.CancelEchoWatchdog()
+			}
+		}
+		m.sessionPacers.Delete(sess.id)
+		m.arb.removeSession(sess.id)
+		closeWG.Add(1)
+		go func(current *session) {
+			defer closeWG.Done()
+			current.close()
+		}(sess)
+	}
+	closeWG.Wait()
+}
+
 // ManagedConnectionReady reports whether the current managed mux generation
 // can admit proxy work. Readiness is deliberately lock-free with respect to
 // connectionUseMu: reconnect holds its write side while publishing loss, and a

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -3606,7 +3606,13 @@ func (m *Mux) tryGrantAndStart() {
 	if !admitted {
 		return
 	}
-	defer m.endManagedConnectionUse(managedGateHeld)
+	releaseManagedGate := func() {
+		if managedGateHeld {
+			m.endManagedConnectionUse(true)
+			managedGateHeld = false
+		}
+	}
+	defer releaseManagedGate()
 	// Snapshot transport BEFORE acquiring stateMu to avoid stateMu → connMu
 	// lock nesting. doSend uses connMu → (release) → stateMu, so while not
 	// strictly ABBA, keeping consistent ordering is defensive best practice.
@@ -3870,6 +3876,11 @@ func (m *Mux) tryGrantAndStart() {
 				}
 				m.stateMu.Unlock()
 				if shouldAdvance {
+					// A managed loss writer may already be waiting. Release the
+					// outer R admission before recursively advancing the queue;
+					// otherwise RWMutex writer preference blocks the nested RLock
+					// while this frame can never release its original read lock.
+					releaseManagedGate()
 					m.tryGrantAndStart()
 				}
 			}

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -681,6 +681,12 @@ type Mux struct {
 	passiveMu       sync.Mutex
 	passiveCallback func(PassiveEvent)
 
+	// connectionLostCallback is a generation-lifecycle signal for the
+	// in-process DriverManager. It fires when readLoop enters reconnect after
+	// a terminal read failure or the duration-based blackhole threshold.
+	connectionLostMu       sync.Mutex
+	connectionLostCallback func()
+
 	// Lifecycle.
 	ctx       context.Context
 	cancel    context.CancelFunc
@@ -1035,6 +1041,25 @@ func (m *Mux) SetPassiveCallback(fn func(PassiveEvent)) {
 	m.passiveMu.Lock()
 	defer m.passiveMu.Unlock()
 	m.passiveCallback = fn
+}
+
+// SetConnectionLostCallback installs a non-blocking generation-lifecycle
+// observer. The callback must not call back into Mux methods and should be set
+// before Start. Idle read timeouts and in-band RESETTED boundaries are not
+// connection-loss notifications.
+func (m *Mux) SetConnectionLostCallback(fn func()) {
+	m.connectionLostMu.Lock()
+	m.connectionLostCallback = fn
+	m.connectionLostMu.Unlock()
+}
+
+func (m *Mux) emitConnectionLost() {
+	m.connectionLostMu.Lock()
+	fn := m.connectionLostCallback
+	m.connectionLostMu.Unlock()
+	if fn != nil {
+		fn()
+	}
 }
 
 // connect dials the adapter and performs the INIT handshake.
@@ -1402,6 +1427,11 @@ func (m *Mux) CachedInfo(id transport.AdapterInfoID) ([]byte, error) {
 // reconnect tears down the current connection and re-establishes it.
 // Called from the read loop on adapter disconnect.
 func (m *Mux) reconnect() error {
+	// Publish loss before entering the legacy reconnect loop. A managed owner
+	// can withdraw admission immediately and retire this mux on its bounded
+	// replacement schedule. Close and ordinary idle timeouts do not emit it.
+	m.emitConnectionLost()
+
 	// Invalidate INFO cache immediately so CachedInfo returns errors
 	// during the disconnect window rather than serving stale data.
 	m.clearInfoCache()

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -696,6 +696,10 @@ type Mux struct {
 	// BACKOFF while W remains held.
 	connectionUseMu         sync.RWMutex
 	connectionLossDelegated atomic.Bool
+	// proxyListener is populated by NewProxyListener after a successful bind.
+	// ManagedConnectionReady consults its live accept-loop state so a fatal
+	// listener exit cannot be masked by an otherwise healthy upstream mux.
+	proxyListener atomic.Pointer[ProxyListener]
 
 	// Lifecycle.
 	ctx       context.Context
@@ -1119,6 +1123,9 @@ func (m *Mux) ManagedConnectionReady() bool {
 		return false
 	}
 	if m.connectionLossDelegated.Load() || m.ctx == nil || m.ctx.Err() != nil {
+		return false
+	}
+	if listener := m.proxyListener.Load(); listener != nil && !listener.Ready() {
 		return false
 	}
 	m.connMu.Lock()

--- a/internal/adaptermux/mux.go
+++ b/internal/adaptermux/mux.go
@@ -683,9 +683,12 @@ type Mux struct {
 
 	// connectionLostCallback is a generation-lifecycle signal for the
 	// in-process DriverManager. It fires when readLoop enters reconnect after
-	// a terminal read failure or the duration-based blackhole threshold.
-	connectionLostMu       sync.Mutex
-	connectionLostCallback func()
+	// a terminal read failure or the duration-based blackhole threshold. Once
+	// installed, lifecycle ownership is delegated to that manager: this mux
+	// retires instead of running its legacy in-place reconnect loop.
+	connectionLostMu        sync.Mutex
+	connectionLostCallback  func()
+	connectionLossDelegated atomic.Bool
 
 	// Lifecycle.
 	ctx       context.Context
@@ -1044,22 +1047,31 @@ func (m *Mux) SetPassiveCallback(fn func(PassiveEvent)) {
 }
 
 // SetConnectionLostCallback installs a non-blocking generation-lifecycle
-// observer. The callback must not call back into Mux methods and should be set
-// before Start. Idle read timeouts and in-band RESETTED boundaries are not
-// connection-loss notifications.
+// owner. The callback must not call back into Mux methods and should be set
+// before Start. On a terminal connection-loss boundary, the mux reports the
+// loss, rejects further generation-local work, and exits its read loop; the
+// owner is responsible for replacement. With no callback, the legacy in-place
+// reconnect behavior is preserved. Idle read timeouts and in-band RESETTED
+// boundaries are not connection-loss notifications.
 func (m *Mux) SetConnectionLostCallback(fn func()) {
 	m.connectionLostMu.Lock()
 	m.connectionLostCallback = fn
 	m.connectionLostMu.Unlock()
 }
 
-func (m *Mux) emitConnectionLost() {
+func (m *Mux) emitConnectionLost() bool {
 	m.connectionLostMu.Lock()
 	fn := m.connectionLostCallback
 	m.connectionLostMu.Unlock()
-	if fn != nil {
-		fn()
+	if fn == nil {
+		return false
 	}
+	// Fence proxy and active-path work before publishing BACKOFF through the
+	// callback. This mux never clears the fence: a managed loss retires the
+	// whole generation and the manager constructs a fresh mux.
+	m.connectionLossDelegated.Store(true)
+	fn()
+	return true
 }
 
 // connect dials the adapter and performs the INIT handshake.
@@ -1424,13 +1436,14 @@ func (m *Mux) CachedInfo(id transport.AdapterInfoID) ([]byte, error) {
 	return result, nil
 }
 
-// reconnect tears down the current connection and re-establishes it.
-// Called from the read loop on adapter disconnect.
-func (m *Mux) reconnect() error {
+// reconnect tears down the current connection. Unmanaged muxes then
+// re-establish it in place; managed muxes delegate replacement to their
+// connection-loss owner and return delegated=true so readLoop retires.
+func (m *Mux) reconnect() (delegated bool, err error) {
 	// Publish loss before entering the legacy reconnect loop. A managed owner
 	// can withdraw admission immediately and retire this mux on its bounded
 	// replacement schedule. Close and ordinary idle timeouts do not emit it.
-	m.emitConnectionLost()
+	delegated = m.emitConnectionLost()
 
 	// Invalidate INFO cache immediately so CachedInfo returns errors
 	// during the disconnect window rather than serving stale data.
@@ -1546,6 +1559,10 @@ func (m *Mux) reconnect() error {
 		}
 	}
 	m.connMu.Unlock()
+	if delegated {
+		m.logger.Printf("adaptermux: connection recovery delegated to lifecycle owner")
+		return true, nil
+	}
 
 	// Reconnection loop with exponential backoff.
 	delay := m.cfg.ReconnectInitialDelay
@@ -1554,7 +1571,7 @@ func (m *Mux) reconnect() error {
 		select {
 		case <-m.ctx.Done():
 			timer.Stop()
-			return m.ctx.Err()
+			return false, m.ctx.Err()
 		case <-timer.C:
 		}
 
@@ -1576,7 +1593,7 @@ func (m *Mux) reconnect() error {
 		// Broadcast RESETTED to external sessions.
 		m.broadcastResetToSessions()
 
-		return nil
+		return false, nil
 	}
 }
 
@@ -1633,8 +1650,12 @@ func (m *Mux) readLoop() {
 					m.logger.Printf("adaptermux: consecutive timeouts for %v (threshold %v), triggering reconnect (AM27)", time.Since(firstTimeoutTime).Round(time.Millisecond), m.cfg.BlackholeThreshold)
 					firstTimeoutTime = time.Time{}
 					lastDataTime = time.Time{} // reset after reconnect so quiet bus doesn't re-trigger
-					if reconnErr := m.reconnect(); reconnErr != nil {
+					delegated, reconnErr := m.reconnect()
+					if reconnErr != nil {
 						m.logger.Printf("adaptermux: reconnect gave up: %v", reconnErr)
+						return
+					}
+					if delegated {
 						return
 					}
 					continue
@@ -1691,8 +1712,12 @@ func (m *Mux) readLoop() {
 			m.logger.Printf("adaptermux: read error: %v", err)
 			firstTimeoutTime = time.Time{}
 			lastDataTime = time.Time{} // reset after reconnect so quiet bus doesn't trigger blackhole
-			if reconnErr := m.reconnect(); reconnErr != nil {
+			delegated, reconnErr := m.reconnect()
+			if reconnErr != nil {
 				m.logger.Printf("adaptermux: reconnect gave up: %v", reconnErr)
+				return
+			}
+			if delegated {
 				return
 			}
 			continue
@@ -3404,6 +3429,11 @@ func (m *Mux) deliverToActive(symbol byte, countAsDelivered bool) {
 // rather than calling m.arb.requestStart directly, so both branches
 // of the C4 cancel + the C1 enqueue-kick are guaranteed to run.
 func (m *Mux) requestStartForSession(sessionID uint64, initiator byte) <-chan startResult {
+	if m.connectionLossDelegated.Load() {
+		ch := make(chan startResult, 1)
+		ch <- startResult{granted: false, initiator: initiator, err: errNotConnected}
+		return ch
+	}
 	// Steps 1+2 MUST be atomic under stateMu so a concurrent
 	// tryGrantAndStart cannot pop the OLD request out of
 	// pendingExternal between the in-flight check and the
@@ -3502,6 +3532,9 @@ func (m *Mux) requestStartForSession(sessionID uint64, initiator byte) <-chan st
 // this method is a no-op — the next tryGrantAndStart will fire after
 // the current one resolves.
 func (m *Mux) tryGrantAndStart() {
+	if m.connectionLossDelegated.Load() {
+		return
+	}
 	// Snapshot transport BEFORE acquiring stateMu to avoid stateMu → connMu
 	// lock nesting. doSend uses connMu → (release) → stateMu, so while not
 	// strictly ABBA, keeping consistent ordering is defensive best practice.
@@ -3525,6 +3558,10 @@ func (m *Mux) tryGrantAndStart() {
 	// internally).  No path holds arb.mu then acquires stateMu,
 	// so this is ABBA-safe.
 	m.stateMu.Lock()
+	if m.connectionLossDelegated.Load() {
+		m.stateMu.Unlock()
+		return
+	}
 	if m.pendingStart != nil {
 		m.logger.Printf("adaptermux: tryGrantAndStart skipped — pendingStart already set for session %d", m.pendingStart.sessionID)
 		m.stateMu.Unlock()
@@ -4830,6 +4867,9 @@ func (m *Mux) doSend(sessionID uint64, data byte) error {
 			pacer.CancelEchoWatchdog()
 		}
 	}()
+	if m.connectionLossDelegated.Load() {
+		return errNotConnected
+	}
 
 	if !m.arb.isOwner(sessionID) {
 		return errNotBusOwner

--- a/internal/adaptermux/session.go
+++ b/internal/adaptermux/session.go
@@ -250,6 +250,17 @@ func (m *Mux) AddSession(conn net.Conn) uint64 {
 
 	// AM25/AM50: check + insert under a single lock to prevent TOCTOU.
 	m.sessionsMu.Lock()
+	// Fatal listener retirement does not take connectionUseMu's write side:
+	// an already-admitted START/SEND may be blocked in the upstream transport.
+	// Recheck the atomic fence under the session-map lock instead, so an
+	// AddSession that acquired its managed read lease before withdrawal cannot
+	// insert after RetireManagedProxySessions detached the generation's map.
+	if m.connectionLossManaged.Load() && m.connectionLossDelegated.Load() {
+		m.sessionsMu.Unlock()
+		m.logger.Printf("adaptermux: rejecting session — managed generation retired (AM13)")
+		_ = conn.Close()
+		return 0
+	}
 	if len(m.sessions) >= maxSessions {
 		m.sessionsMu.Unlock()
 		m.logger.Printf("adaptermux: rejecting session — max sessions (%d) reached (AM50)", maxSessions)

--- a/internal/adaptermux/session.go
+++ b/internal/adaptermux/session.go
@@ -222,12 +222,13 @@ const (
 
 // AddSession registers an external TCP connection as an ENH session.
 // Returns the session ID (>0). The session starts reader and writer
-// goroutines. Returns 0 if the mux is shutting down (context cancelled);
+// goroutines. Returns 0 if the mux is shutting down (context cancelled) or a
+// managed connection loss has delegated replacement to the lifecycle owner;
 // the connection is closed and no goroutines are leaked.
 func (m *Mux) AddSession(conn net.Conn) uint64 {
-	if m.ctx == nil || m.ctx.Err() != nil {
+	if m.ctx == nil || m.ctx.Err() != nil || m.connectionLossDelegated.Load() {
 		_ = conn.Close()
-		m.logger.Printf("adaptermux: rejecting session — mux not started or shutting down (AM13)")
+		m.logger.Printf("adaptermux: rejecting session — mux not available (AM13)")
 		return 0
 	}
 

--- a/internal/adaptermux/session.go
+++ b/internal/adaptermux/session.go
@@ -226,7 +226,14 @@ const (
 // managed connection loss has delegated replacement to the lifecycle owner;
 // the connection is closed and no goroutines are leaked.
 func (m *Mux) AddSession(conn net.Conn) uint64 {
-	if m.ctx == nil || m.ctx.Err() != nil || m.connectionLossDelegated.Load() {
+	managedGateHeld, admitted := m.beginManagedConnectionUse()
+	if !admitted {
+		_ = conn.Close()
+		m.logger.Printf("adaptermux: rejecting session — managed generation retired (AM13)")
+		return 0
+	}
+	defer m.endManagedConnectionUse(managedGateHeld)
+	if m.ctx == nil || m.ctx.Err() != nil {
 		_ = conn.Close()
 		m.logger.Printf("adaptermux: rejecting session — mux not available (AM13)")
 		return 0

--- a/internal/drivermanager/manager.go
+++ b/internal/drivermanager/manager.go
@@ -21,6 +21,8 @@ var (
 	ErrManagerClosed     = errors.New("driver manager is shutting down")
 )
 
+const defaultLateRetireTimeout = 2 * time.Second
+
 type DesiredState string
 
 const (
@@ -123,6 +125,8 @@ type RetryPolicy struct {
 }
 
 // Runtime is the protocol-neutral lifecycle boundary implemented by adapters.
+// Stop must honor ctx cancellation; Manager supplies an independent deadline
+// when retiring a provider admitted after its original operation was canceled.
 type Runtime interface {
 	Start(context.Context) (uint64, error)
 	Replace(context.Context) (uint64, error)
@@ -130,6 +134,15 @@ type Runtime interface {
 	Generation() uint64
 	Revision() uint64
 	SafetyQuarantined() bool
+}
+
+// withdrawalFencer is an optional internal hook for runtimes that expose
+// generation-local work outside Manager.Invoke (for example, an adapter proxy
+// listener). The hook runs while the manager state lock is held immediately
+// before STOPPING is published, so it MUST be non-blocking and MUST NOT call
+// back into Manager. Resource drain and close proof remain Runtime.Stop's job.
+type withdrawalFencer interface {
+	FenceWithdrawal()
 }
 
 // Admission keeps a provider handle private until its guarded callback runs.
@@ -162,9 +175,10 @@ type DriverConfig struct {
 }
 
 type Config struct {
-	Drivers     []DriverConfig
-	Now         func() time.Time
-	RetryJitter func(time.Duration) time.Duration
+	Drivers           []DriverConfig
+	Now               func() time.Time
+	RetryJitter       func(time.Duration) time.Duration
+	LateRetireTimeout time.Duration
 }
 
 type Manager struct {
@@ -172,6 +186,9 @@ type Manager struct {
 	cancel context.CancelFunc
 	now    func() time.Time
 	jitter func(time.Duration) time.Duration
+	// lateRetireTimeout bounds cleanup of a provider that completed admission
+	// after its manager operation had already been superseded.
+	lateRetireTimeout time.Duration
 
 	drivers map[string]*managedDriver
 	wg      sync.WaitGroup
@@ -220,7 +237,18 @@ func New(cfg Config) (*Manager, error) {
 		jitter = defaultRetryJitter
 	}
 	ctx, cancel := context.WithCancel(context.Background())
-	manager := &Manager{ctx: ctx, cancel: cancel, now: now, jitter: jitter, drivers: make(map[string]*managedDriver, len(cfg.Drivers))}
+	lateRetireTimeout := cfg.LateRetireTimeout
+	if lateRetireTimeout <= 0 {
+		lateRetireTimeout = defaultLateRetireTimeout
+	}
+	manager := &Manager{
+		ctx:               ctx,
+		cancel:            cancel,
+		now:               now,
+		jitter:            jitter,
+		lateRetireTimeout: lateRetireTimeout,
+		drivers:           make(map[string]*managedDriver, len(cfg.Drivers)),
+	}
 	for _, driverCfg := range cfg.Drivers {
 		id := strings.TrimSpace(driverCfg.ID)
 		if id == "" || id != driverCfg.ID {
@@ -405,6 +433,7 @@ func (manager *Manager) Replace(ctx context.Context, id string) error {
 	driver.desired = DesiredRunning
 	driver.retryRemaining = driver.cfg.Retry.Budget
 	operation := driver.nextOperationLocked()
+	manager.fenceWithdrawalLocked(driver)
 	manager.transitionLocked(driver, ObservedStopping, Reason{Code: ReasonStopRequested}, nil, nil)
 	driver.attempt++
 	driver.mu.Unlock()
@@ -445,6 +474,7 @@ func (manager *Manager) stopLocked(ctx context.Context, driver *managedDriver) e
 		return nil
 	}
 	driver.nextOperationLocked()
+	manager.fenceWithdrawalLocked(driver)
 	manager.transitionLocked(driver, ObservedStopping, Reason{Code: ReasonStopRequested}, nil, nil)
 	driver.mu.Unlock()
 	// activeAttempt is captured under the same lock that publishes STOPPED
@@ -523,10 +553,38 @@ func (manager *Manager) startAttempt(ctx context.Context, driver *managedDriver,
 		// A runtime that ignored cancellation may have admitted after STOPPED
 		// intent was published. Retire that stale completion immediately; it is
 		// never published as an effective manager generation.
-		_ = driver.cfg.Runtime.Stop(context.Background())
+		manager.retireSupersededAdmission(driver)
 		return
 	}
 	manager.finishAttempt(driver, control, operation, generation, err, replace)
+}
+
+func (manager *Manager) fenceWithdrawalLocked(driver *managedDriver) {
+	if driver == nil || driver.cfg.Runtime == nil {
+		return
+	}
+	if fencer, ok := driver.cfg.Runtime.(withdrawalFencer); ok {
+		fencer.FenceWithdrawal()
+	}
+}
+
+// retireSupersededAdmission handles the only path where a runtime can finish
+// admission after its manager operation was canceled. The cleanup deadline is
+// independent of the canceled caller and every unproven close is promoted to
+// process-epoch quarantine; a stale provider is never silently abandoned.
+func (manager *Manager) retireSupersededAdmission(driver *managedDriver) {
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), manager.lateRetireTimeout)
+	err := driver.cfg.Runtime.Stop(cleanupCtx)
+	cancel()
+	if err == nil && !driver.runtimeQuarantined() {
+		return
+	}
+
+	driver.mu.Lock()
+	driver.quarantined = true
+	driver.activeOperation = 0
+	manager.transitionLocked(driver, ObservedFailed, Reason{Code: ReasonCloseUnconfirmed}, nil, nil)
+	driver.mu.Unlock()
 }
 
 func (manager *Manager) finishAttempt(driver *managedDriver, control *attemptControl, operation, generation uint64, err error, replace bool) {

--- a/internal/drivermanager/manager.go
+++ b/internal/drivermanager/manager.go
@@ -186,6 +186,11 @@ type managedDriver struct {
 	retryCancel       context.CancelFunc
 	retryNeedsReplace bool
 	needsReplace      bool
+	activeAttempt     *attemptControl
+}
+
+type attemptControl struct {
+	cancel context.CancelFunc
 }
 
 func New(cfg Config) (*Manager, error) {
@@ -264,6 +269,11 @@ func (manager *Manager) Start(ctx context.Context, id string) error {
 	if driver == nil {
 		return ErrDriverNotFound
 	}
+	// Cancel an automatic or caller-owned construction before waiting for the
+	// lifecycle serializer. This lets Stop/Start intent interrupt a blocked
+	// factory through its context instead of waiting for the dial timeout.
+	manager.cancelRetry(driver)
+	manager.cancelAttempt(driver)
 	driver.opMu.Lock()
 	defer driver.opMu.Unlock()
 	manager.cancelRetry(driver)
@@ -293,6 +303,8 @@ func (manager *Manager) Replace(ctx context.Context, id string) error {
 	if driver == nil {
 		return ErrDriverNotFound
 	}
+	manager.cancelRetry(driver)
+	manager.cancelAttempt(driver)
 	driver.opMu.Lock()
 	defer driver.opMu.Unlock()
 	manager.cancelRetry(driver)
@@ -317,6 +329,8 @@ func (manager *Manager) Stop(ctx context.Context, id string) error {
 	if driver == nil {
 		return ErrDriverNotFound
 	}
+	manager.cancelRetry(driver)
+	manager.cancelAttempt(driver)
 	driver.opMu.Lock()
 	defer driver.opMu.Unlock()
 	return manager.stopLocked(ctx, driver)
@@ -366,6 +380,28 @@ func (manager *Manager) stopLocked(ctx context.Context, driver *managedDriver) e
 }
 
 func (manager *Manager) startAttempt(ctx context.Context, driver *managedDriver, operation uint64, replace bool) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	attemptCtx, cancel := context.WithCancel(ctx)
+	control := &attemptControl{cancel: cancel}
+	driver.mu.Lock()
+	if driver.activeOperation != operation || driver.desired != DesiredRunning || driver.quarantined {
+		driver.mu.Unlock()
+		cancel()
+		return
+	}
+	driver.activeAttempt = control
+	driver.mu.Unlock()
+	defer func() {
+		cancel()
+		driver.mu.Lock()
+		if driver.activeAttempt == control {
+			driver.activeAttempt = nil
+		}
+		driver.mu.Unlock()
+	}()
+
 	if driver.cfg.Runtime == nil {
 		manager.finishAttempt(driver, operation, 0, errors.New("provider unavailable"), replace)
 		return
@@ -373,9 +409,9 @@ func (manager *Manager) startAttempt(ctx context.Context, driver *managedDriver,
 	var generation uint64
 	var err error
 	if replace {
-		generation, err = driver.cfg.Runtime.Replace(ctx)
+		generation, err = driver.cfg.Runtime.Replace(attemptCtx)
 	} else {
-		generation, err = driver.cfg.Runtime.Start(ctx)
+		generation, err = driver.cfg.Runtime.Start(attemptCtx)
 	}
 	manager.finishAttempt(driver, operation, generation, err, replace)
 }
@@ -464,10 +500,18 @@ func (manager *Manager) cancelRetry(driver *managedDriver) {
 	driver.retryToken++
 	cancel := driver.retryCancel
 	driver.retryCancel = nil
-	driver.retry = nil
 	driver.mu.Unlock()
 	if cancel != nil {
 		cancel()
+	}
+}
+
+func (manager *Manager) cancelAttempt(driver *managedDriver) {
+	driver.mu.Lock()
+	attempt := driver.activeAttempt
+	driver.mu.Unlock()
+	if attempt != nil {
+		attempt.cancel()
 	}
 }
 
@@ -586,6 +630,8 @@ func (manager *Manager) Shutdown(ctx context.Context) error {
 	sort.Strings(ids)
 	for _, id := range ids {
 		driver := manager.drivers[id]
+		manager.cancelRetry(driver)
+		manager.cancelAttempt(driver)
 		driver.opMu.Lock()
 		_ = manager.stopLocked(ctx, driver)
 		driver.opMu.Unlock()

--- a/internal/drivermanager/manager.go
+++ b/internal/drivermanager/manager.go
@@ -1,0 +1,696 @@
+// Package drivermanager owns protocol-neutral in-process driver lifecycle state.
+package drivermanager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+var (
+	ErrDriverNotFound    = errors.New("driver not found")
+	ErrUnavailable       = errors.New("driver unavailable")
+	ErrStopTimeout       = errors.New("driver stop timed out")
+	ErrSafetyQuarantined = errors.New("driver safety quarantined")
+)
+
+type DesiredState string
+
+const (
+	DesiredRunning DesiredState = "RUNNING"
+	DesiredStopped DesiredState = "STOPPED"
+)
+
+type ObservedState string
+
+const (
+	ObservedDisabled ObservedState = "DISABLED"
+	ObservedStopped  ObservedState = "STOPPED"
+	ObservedStarting ObservedState = "STARTING"
+	ObservedRunning  ObservedState = "RUNNING"
+	ObservedDegraded ObservedState = "DEGRADED"
+	ObservedBackoff  ObservedState = "BACKOFF"
+	ObservedStopping ObservedState = "STOPPING"
+	ObservedFailed   ObservedState = "FAILED"
+)
+
+type ReasonCode string
+
+const (
+	ReasonNone                  ReasonCode = "NONE"
+	ReasonConfigDisabled        ReasonCode = "CONFIG_DISABLED"
+	ReasonOperatorStopped       ReasonCode = "OPERATOR_STOPPED"
+	ReasonStartRequested        ReasonCode = "START_REQUESTED"
+	ReasonStopRequested         ReasonCode = "STOP_REQUESTED"
+	ReasonConfigInvalid         ReasonCode = "CONFIG_INVALID"
+	ReasonProviderUnavailable   ReasonCode = "PROVIDER_UNAVAILABLE"
+	ReasonDependencyUnavailable ReasonCode = "DEPENDENCY_UNAVAILABLE"
+	ReasonRuntimeNotReady       ReasonCode = "RUNTIME_NOT_READY"
+	ReasonCapabilityDegraded    ReasonCode = "CAPABILITY_DEGRADED"
+	ReasonRetryScheduled        ReasonCode = "RETRY_SCHEDULED"
+	ReasonRetryExhausted        ReasonCode = "RETRY_EXHAUSTED"
+	ReasonStopTimeout           ReasonCode = "STOP_TIMEOUT"
+	ReasonCloseUnconfirmed      ReasonCode = "CLOSE_UNCONFIRMED"
+	ReasonInternalError         ReasonCode = "INTERNAL_ERROR"
+)
+
+type Capability string
+
+const (
+	CapabilityDiscovery          Capability = "DISCOVERY"
+	CapabilityRead               Capability = "READ"
+	CapabilityWrite              Capability = "WRITE"
+	CapabilityPairing            Capability = "PAIRING"
+	CapabilityTopology           Capability = "TOPOLOGY"
+	CapabilityRawEvidence        Capability = "RAW_EVIDENCE"
+	CapabilitySemanticProjection Capability = "SEMANTIC_PROJECTION"
+)
+
+type Reason struct {
+	Code      ReasonCode
+	Retryable bool
+}
+
+func (reason Reason) String() string { return string(reason.Code) }
+
+type RetrySnapshot struct {
+	Eligible        bool
+	BudgetRemaining int
+	NotBeforeUTC    time.Time
+}
+
+// Correlation fences callbacks from both stale generations and superseded
+// lifecycle operations. Operation is zero only during stable RUNNING/DEGRADED.
+type Correlation struct {
+	Generation uint64
+	Operation  uint64
+}
+
+type Snapshot struct {
+	DriverID              string
+	DesiredState          DesiredState
+	ObservedState         ObservedState
+	Reason                Reason
+	Retry                 *RetrySnapshot
+	Generation            uint64
+	Revision              uint64
+	Attempt               uint64
+	Capabilities          []Capability
+	EffectiveCapabilities []Capability
+	SafetyQuarantined     bool
+	ActiveOperation       uint64
+	ChangedAtUTC          time.Time
+}
+
+type Failure struct {
+	Reason Reason
+}
+
+type RetryPolicy struct {
+	Budget       int
+	InitialDelay time.Duration
+	MaxDelay     time.Duration
+}
+
+// Runtime is the protocol-neutral lifecycle boundary implemented by adapters.
+type Runtime interface {
+	Start(context.Context) (uint64, error)
+	Replace(context.Context) (uint64, error)
+	Stop(context.Context) error
+	Generation() uint64
+	Revision() uint64
+	SafetyQuarantined() bool
+}
+
+// Admission keeps a provider handle private until its guarded callback runs.
+type Admission struct {
+	Correlation Correlation
+	Invoke      func(func(any) error) error
+	Release     func() error
+}
+
+// AdmittingRuntime is optional for runtimes that expose provider invocations.
+type AdmittingRuntime interface {
+	Runtime
+	Admit(context.Context) (*Admission, error)
+}
+
+type DriverConfig struct {
+	ID            string
+	Enabled       bool
+	Runtime       Runtime
+	Capabilities  []Capability
+	ClassifyError func(error) Failure
+	Retry         RetryPolicy
+}
+
+type Config struct {
+	Drivers []DriverConfig
+	Now     func() time.Time
+}
+
+type Manager struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	now    func() time.Time
+
+	drivers map[string]*managedDriver
+	wg      sync.WaitGroup
+	once    sync.Once
+}
+
+type managedDriver struct {
+	cfg DriverConfig
+
+	opMu sync.Mutex
+	mu   sync.RWMutex
+
+	desired           DesiredState
+	observed          ObservedState
+	reason            Reason
+	retry             *RetrySnapshot
+	generation        uint64
+	revision          uint64
+	attempt           uint64
+	effective         []Capability
+	quarantined       bool
+	changedAt         time.Time
+	operationSeq      uint64
+	activeOperation   uint64
+	retryRemaining    int
+	retryToken        uint64
+	retryCancel       context.CancelFunc
+	retryNeedsReplace bool
+	needsReplace      bool
+}
+
+func New(cfg Config) (*Manager, error) {
+	now := cfg.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	manager := &Manager{ctx: ctx, cancel: cancel, now: now, drivers: make(map[string]*managedDriver, len(cfg.Drivers))}
+	for _, driverCfg := range cfg.Drivers {
+		id := strings.TrimSpace(driverCfg.ID)
+		if id == "" || id != driverCfg.ID {
+			cancel()
+			return nil, errors.New("driver id is empty or non-canonical")
+		}
+		if _, exists := manager.drivers[id]; exists {
+			cancel()
+			return nil, fmt.Errorf("duplicate driver id %q", id)
+		}
+		driverCfg.Capabilities = normalizeCapabilities(driverCfg.Capabilities)
+		driverCfg.Retry = normalizeRetryPolicy(driverCfg.Retry)
+		driver := &managedDriver{
+			cfg:            driverCfg,
+			revision:       1,
+			changedAt:      now(),
+			retryRemaining: driverCfg.Retry.Budget,
+		}
+		if driverCfg.Enabled {
+			driver.desired = DesiredRunning
+			driver.observed = ObservedStopped
+			driver.reason = Reason{Code: ReasonNone}
+		} else {
+			driver.desired = DesiredStopped
+			driver.observed = ObservedDisabled
+			driver.reason = Reason{Code: ReasonConfigDisabled}
+		}
+		manager.drivers[id] = driver
+	}
+	return manager, nil
+}
+
+func (manager *Manager) Snapshot(id string) (Snapshot, bool) {
+	driver := manager.drivers[id]
+	if driver == nil {
+		return Snapshot{}, false
+	}
+	driver.mu.RLock()
+	defer driver.mu.RUnlock()
+	return driver.snapshotLocked(), true
+}
+
+func (driver *managedDriver) snapshotLocked() Snapshot {
+	snapshot := Snapshot{
+		DriverID:              driver.cfg.ID,
+		DesiredState:          driver.desired,
+		ObservedState:         driver.observed,
+		Reason:                driver.reason,
+		Generation:            driver.generation,
+		Revision:              driver.revision,
+		Attempt:               driver.attempt,
+		Capabilities:          append([]Capability(nil), driver.cfg.Capabilities...),
+		EffectiveCapabilities: append([]Capability(nil), driver.effective...),
+		SafetyQuarantined:     driver.quarantined,
+		ActiveOperation:       driver.activeOperation,
+		ChangedAtUTC:          driver.changedAt,
+	}
+	if driver.retry != nil {
+		retry := *driver.retry
+		snapshot.Retry = &retry
+	}
+	return snapshot
+}
+
+func (manager *Manager) Start(ctx context.Context, id string) error {
+	driver := manager.drivers[id]
+	if driver == nil {
+		return ErrDriverNotFound
+	}
+	driver.opMu.Lock()
+	defer driver.opMu.Unlock()
+	manager.cancelRetry(driver)
+
+	driver.mu.Lock()
+	if driver.quarantined {
+		driver.mu.Unlock()
+		return ErrSafetyQuarantined
+	}
+	if driver.observed == ObservedRunning {
+		driver.mu.Unlock()
+		return nil
+	}
+	driver.desired = DesiredRunning
+	driver.retryRemaining = driver.cfg.Retry.Budget
+	operation := driver.nextOperationLocked()
+	replace := driver.needsReplace
+	manager.transitionLocked(driver, ObservedStarting, Reason{Code: ReasonStartRequested}, nil, nil)
+	driver.attempt++
+	driver.mu.Unlock()
+	manager.startAttempt(ctx, driver, operation, replace)
+	return nil
+}
+
+func (manager *Manager) Replace(ctx context.Context, id string) error {
+	driver := manager.drivers[id]
+	if driver == nil {
+		return ErrDriverNotFound
+	}
+	driver.opMu.Lock()
+	defer driver.opMu.Unlock()
+	manager.cancelRetry(driver)
+
+	driver.mu.Lock()
+	if driver.quarantined {
+		driver.mu.Unlock()
+		return ErrSafetyQuarantined
+	}
+	driver.desired = DesiredRunning
+	driver.retryRemaining = driver.cfg.Retry.Budget
+	operation := driver.nextOperationLocked()
+	manager.transitionLocked(driver, ObservedStopping, Reason{Code: ReasonStopRequested}, nil, nil)
+	driver.attempt++
+	driver.mu.Unlock()
+	manager.startAttempt(ctx, driver, operation, true)
+	return nil
+}
+
+func (manager *Manager) Stop(ctx context.Context, id string) error {
+	driver := manager.drivers[id]
+	if driver == nil {
+		return ErrDriverNotFound
+	}
+	driver.opMu.Lock()
+	defer driver.opMu.Unlock()
+	return manager.stopLocked(ctx, driver)
+}
+
+func (manager *Manager) stopLocked(ctx context.Context, driver *managedDriver) error {
+	manager.cancelRetry(driver)
+	driver.mu.Lock()
+	if driver.quarantined {
+		if driver.desired != DesiredStopped {
+			driver.desired = DesiredStopped
+			manager.transitionLocked(driver, ObservedFailed, Reason{Code: ReasonCloseUnconfirmed}, nil, nil)
+		}
+		driver.mu.Unlock()
+		return nil
+	}
+	driver.desired = DesiredStopped
+	if driver.observed == ObservedStopped || driver.observed == ObservedDisabled {
+		driver.mu.Unlock()
+		return nil
+	}
+	driver.nextOperationLocked()
+	manager.transitionLocked(driver, ObservedStopping, Reason{Code: ReasonStopRequested}, nil, nil)
+	driver.mu.Unlock()
+
+	var err error
+	if driver.cfg.Runtime != nil {
+		err = driver.cfg.Runtime.Stop(ctx)
+	}
+	driver.mu.Lock()
+	defer driver.mu.Unlock()
+	driver.activeOperation = 0
+	switch {
+	case err == nil:
+		driver.needsReplace = false
+		manager.transitionLocked(driver, ObservedStopped, Reason{Code: ReasonOperatorStopped}, nil, nil)
+	case errors.Is(err, ErrStopTimeout):
+		driver.needsReplace = false
+		manager.transitionLocked(driver, ObservedStopped, Reason{Code: ReasonStopTimeout}, nil, nil)
+	case errors.Is(err, ErrSafetyQuarantined) || driver.runtimeQuarantined():
+		driver.quarantined = true
+		manager.transitionLocked(driver, ObservedFailed, Reason{Code: ReasonCloseUnconfirmed}, nil, nil)
+	default:
+		manager.transitionLocked(driver, ObservedFailed, Reason{Code: ReasonInternalError}, nil, nil)
+	}
+	return nil
+}
+
+func (manager *Manager) startAttempt(ctx context.Context, driver *managedDriver, operation uint64, replace bool) {
+	if driver.cfg.Runtime == nil {
+		manager.finishAttempt(driver, operation, 0, errors.New("provider unavailable"), replace)
+		return
+	}
+	var generation uint64
+	var err error
+	if replace {
+		generation, err = driver.cfg.Runtime.Replace(ctx)
+	} else {
+		generation, err = driver.cfg.Runtime.Start(ctx)
+	}
+	manager.finishAttempt(driver, operation, generation, err, replace)
+}
+
+func (manager *Manager) finishAttempt(driver *managedDriver, operation, generation uint64, err error, replace bool) {
+	driver.mu.Lock()
+	defer driver.mu.Unlock()
+	if driver.activeOperation != operation || driver.desired != DesiredRunning {
+		return
+	}
+	if err == nil {
+		driver.generation = generation
+		driver.attempt = 1
+		driver.quarantined = false
+		driver.needsReplace = false
+		driver.retryRemaining = driver.cfg.Retry.Budget
+		driver.activeOperation = 0
+		manager.transitionLocked(driver, ObservedRunning, Reason{Code: ReasonNone}, nil, driver.cfg.Capabilities)
+		return
+	}
+	if errors.Is(err, ErrSafetyQuarantined) || driver.runtimeQuarantined() {
+		driver.quarantined = true
+		driver.activeOperation = 0
+		manager.transitionLocked(driver, ObservedFailed, Reason{Code: ReasonCloseUnconfirmed}, nil, nil)
+		return
+	}
+	failure := manager.classify(driver, err)
+	if errors.Is(err, ErrUnavailable) {
+		failure = Failure{Reason: Reason{Code: ReasonProviderUnavailable}}
+	}
+	if replace {
+		driver.needsReplace = true
+	}
+	if failure.Reason.Retryable && driver.retryRemaining > 0 {
+		manager.scheduleRetryLocked(driver, operation, replace)
+		return
+	}
+	if failure.Reason.Retryable {
+		failure.Reason = Reason{Code: ReasonRetryExhausted}
+	}
+	driver.activeOperation = 0
+	manager.transitionLocked(driver, ObservedFailed, failure.Reason, nil, nil)
+}
+
+func (manager *Manager) scheduleRetryLocked(driver *managedDriver, operation uint64, replace bool) {
+	delay := retryDelay(driver.cfg.Retry, driver.cfg.Retry.Budget-driver.retryRemaining)
+	retry := &RetrySnapshot{Eligible: true, BudgetRemaining: driver.retryRemaining, NotBeforeUTC: manager.now().Add(delay)}
+	manager.transitionLocked(driver, ObservedBackoff, Reason{Code: ReasonRetryScheduled, Retryable: true}, retry, nil)
+	driver.retryRemaining--
+	driver.retryToken++
+	token := driver.retryToken
+	driver.retryNeedsReplace = replace
+	retryCtx, cancel := context.WithCancel(manager.ctx)
+	driver.retryCancel = cancel
+	manager.wg.Add(1)
+	go manager.runRetry(retryCtx, driver, operation, token, delay)
+}
+
+func (manager *Manager) runRetry(ctx context.Context, driver *managedDriver, operation, token uint64, delay time.Duration) {
+	defer manager.wg.Done()
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return
+	case <-timer.C:
+	}
+
+	driver.opMu.Lock()
+	defer driver.opMu.Unlock()
+	driver.mu.Lock()
+	if driver.retryToken != token || driver.activeOperation != operation || driver.desired != DesiredRunning || driver.observed != ObservedBackoff || driver.quarantined {
+		driver.mu.Unlock()
+		return
+	}
+	driver.retryCancel = nil
+	replace := driver.retryNeedsReplace
+	manager.transitionLocked(driver, ObservedStarting, Reason{Code: ReasonStartRequested}, nil, nil)
+	driver.attempt++
+	driver.mu.Unlock()
+	manager.startAttempt(ctx, driver, operation, replace)
+}
+
+func (manager *Manager) cancelRetry(driver *managedDriver) {
+	driver.mu.Lock()
+	driver.retryToken++
+	cancel := driver.retryCancel
+	driver.retryCancel = nil
+	driver.retry = nil
+	driver.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (driver *managedDriver) nextOperationLocked() uint64 {
+	driver.operationSeq++
+	driver.activeOperation = driver.operationSeq
+	return driver.activeOperation
+}
+
+func (manager *Manager) transitionLocked(driver *managedDriver, observed ObservedState, reason Reason, retry *RetrySnapshot, effective []Capability) {
+	driver.observed = observed
+	driver.reason = normalizeReason(reason)
+	driver.retry = retry
+	driver.effective = normalizeCapabilities(effective)
+	driver.revision++
+	driver.changedAt = manager.now()
+}
+
+func (manager *Manager) classify(driver *managedDriver, err error) Failure {
+	failure := Failure{Reason: Reason{Code: ReasonInternalError}}
+	if driver.cfg.ClassifyError != nil {
+		failure = driver.cfg.ClassifyError(err)
+	}
+	failure.Reason = normalizeReason(failure.Reason)
+	return failure
+}
+
+func (driver *managedDriver) runtimeQuarantined() bool {
+	return driver.cfg.Runtime != nil && driver.cfg.Runtime.SafetyQuarantined()
+}
+
+// ReportDegraded is the stable-runtime convenience path. Lifecycle callbacks
+// with a non-zero operation use ReportDegradedCorrelated instead.
+func (manager *Manager) ReportDegraded(id string, generation uint64, effective []Capability, reason Reason) bool {
+	return manager.ReportDegradedCorrelated(id, Correlation{Generation: generation}, effective, reason)
+}
+
+func (manager *Manager) ReportDegradedCorrelated(id string, correlation Correlation, effective []Capability, reason Reason) bool {
+	driver := manager.drivers[id]
+	if driver == nil || reason.Code != ReasonCapabilityDegraded {
+		return false
+	}
+	effective = normalizeCapabilities(effective)
+	driver.mu.Lock()
+	defer driver.mu.Unlock()
+	if !driver.acceptsCallbackLocked(correlation) || (driver.observed != ObservedRunning && driver.observed != ObservedDegraded) || len(effective) == 0 || len(effective) >= len(driver.cfg.Capabilities) || !capabilitySubset(effective, driver.cfg.Capabilities) {
+		return false
+	}
+	manager.transitionLocked(driver, ObservedDegraded, reason, nil, effective)
+	return true
+}
+
+// ReportFailure atomically withdraws effective capability, then schedules a
+// replacement after the current callback releases its DriverRuntime admission.
+func (manager *Manager) ReportFailure(id string, correlation Correlation, failure Failure) bool {
+	driver := manager.drivers[id]
+	if driver == nil || !validReasonCode(failure.Reason.Code) {
+		return false
+	}
+	failure.Reason = normalizeReason(failure.Reason)
+	driver.mu.Lock()
+	defer driver.mu.Unlock()
+	if !driver.acceptsCallbackLocked(correlation) || (driver.observed != ObservedRunning && driver.observed != ObservedDegraded) {
+		return false
+	}
+	operation := driver.nextOperationLocked()
+	driver.needsReplace = true
+	driver.retryRemaining = driver.cfg.Retry.Budget
+	if failure.Reason.Retryable && driver.retryRemaining > 0 {
+		manager.scheduleRetryLocked(driver, operation, true)
+		return true
+	}
+	driver.activeOperation = 0
+	manager.transitionLocked(driver, ObservedFailed, failure.Reason, nil, nil)
+	return true
+}
+
+func (driver *managedDriver) acceptsCallbackLocked(correlation Correlation) bool {
+	return !driver.quarantined && driver.desired == DesiredRunning && driver.generation == correlation.Generation && driver.activeOperation == correlation.Operation
+}
+
+// Invoke checks effective capability and admits provider work while holding the
+// same state lock used to withdraw capabilities during Stop/Replace/failure.
+func (manager *Manager) Invoke(ctx context.Context, id string, capability Capability, fn func(any) error) (Correlation, error) {
+	driver := manager.drivers[id]
+	if driver == nil {
+		return Correlation{}, ErrUnavailable
+	}
+	driver.mu.Lock()
+	if !containsCapability(driver.effective, capability) || driver.quarantined {
+		correlation := Correlation{Generation: driver.generation, Operation: driver.activeOperation}
+		driver.mu.Unlock()
+		return correlation, ErrUnavailable
+	}
+	runtime, ok := driver.cfg.Runtime.(AdmittingRuntime)
+	if !ok {
+		correlation := Correlation{Generation: driver.generation, Operation: driver.activeOperation}
+		driver.mu.Unlock()
+		return correlation, ErrUnavailable
+	}
+	admission, err := runtime.Admit(ctx)
+	driver.mu.Unlock()
+	if err != nil {
+		return Correlation{}, err
+	}
+	defer func() { _ = admission.Release() }()
+	return admission.Correlation, admission.Invoke(fn)
+}
+
+func (manager *Manager) Shutdown(ctx context.Context) error {
+	manager.once.Do(manager.cancel)
+	ids := make([]string, 0, len(manager.drivers))
+	for id := range manager.drivers {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		driver := manager.drivers[id]
+		driver.opMu.Lock()
+		_ = manager.stopLocked(ctx, driver)
+		driver.opMu.Unlock()
+	}
+	done := make(chan struct{})
+	go func() {
+		manager.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func normalizeRetryPolicy(policy RetryPolicy) RetryPolicy {
+	if policy.Budget < 0 {
+		policy.Budget = 0
+	}
+	if policy.InitialDelay <= 0 {
+		policy.InitialDelay = time.Second
+	}
+	if policy.MaxDelay < policy.InitialDelay {
+		policy.MaxDelay = policy.InitialDelay
+	}
+	return policy
+}
+
+func retryDelay(policy RetryPolicy, index int) time.Duration {
+	delay := policy.InitialDelay
+	for n := 0; n < index && delay < policy.MaxDelay; n++ {
+		if delay > policy.MaxDelay/2 {
+			return policy.MaxDelay
+		}
+		delay *= 2
+	}
+	if delay > policy.MaxDelay {
+		return policy.MaxDelay
+	}
+	return delay
+}
+
+func normalizeCapabilities(capabilities []Capability) []Capability {
+	seen := make(map[Capability]struct{}, len(capabilities))
+	for _, capability := range capabilities {
+		if validCapability(capability) {
+			seen[capability] = struct{}{}
+		}
+	}
+	result := make([]Capability, 0, len(seen))
+	for capability := range seen {
+		result = append(result, capability)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i] < result[j] })
+	return result
+}
+
+func validCapability(capability Capability) bool {
+	switch capability {
+	case CapabilityDiscovery, CapabilityRead, CapabilityWrite, CapabilityPairing, CapabilityTopology, CapabilityRawEvidence, CapabilitySemanticProjection:
+		return true
+	default:
+		return false
+	}
+}
+
+func validReasonCode(code ReasonCode) bool {
+	switch code {
+	case ReasonNone, ReasonConfigDisabled, ReasonOperatorStopped, ReasonStartRequested, ReasonStopRequested, ReasonConfigInvalid, ReasonProviderUnavailable, ReasonDependencyUnavailable, ReasonRuntimeNotReady, ReasonCapabilityDegraded, ReasonRetryScheduled, ReasonRetryExhausted, ReasonStopTimeout, ReasonCloseUnconfirmed, ReasonInternalError:
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeReason(reason Reason) Reason {
+	if !validReasonCode(reason.Code) {
+		return Reason{Code: ReasonInternalError}
+	}
+	switch reason.Code {
+	case ReasonDependencyUnavailable, ReasonRuntimeNotReady, ReasonRetryScheduled:
+		return reason
+	default:
+		reason.Retryable = false
+		return reason
+	}
+}
+
+func containsCapability(capabilities []Capability, want Capability) bool {
+	index := sort.Search(len(capabilities), func(index int) bool { return capabilities[index] >= want })
+	return index < len(capabilities) && capabilities[index] == want
+}
+
+func capabilitySubset(candidate, allowed []Capability) bool {
+	for _, capability := range candidate {
+		if !containsCapability(allowed, capability) {
+			return false
+		}
+	}
+	return true
+}
+
+func containsSensitiveDriverText(value string) bool {
+	lower := strings.ToLower(value)
+	return strings.Contains(lower, "://") || strings.Contains(lower, "secret") || strings.Contains(lower, "password") || strings.Contains(lower, "@")
+}

--- a/internal/drivermanager/manager.go
+++ b/internal/drivermanager/manager.go
@@ -784,9 +784,12 @@ func (manager *Manager) ReportFailure(id string, correlation Correlation, failur
 	operation := driver.nextOperationLocked()
 	driver.needsReplace = true
 	driver.retryRemaining = driver.cfg.Retry.Budget
-	if failure.Reason.Retryable && driver.retryRemaining > 0 {
-		manager.scheduleRetryLocked(driver, operation, true)
-		return true
+	if failure.Reason.Retryable {
+		if driver.retryRemaining > 0 {
+			manager.scheduleRetryLocked(driver, operation, true)
+			return true
+		}
+		failure.Reason = Reason{Code: ReasonRetryExhausted}
 	}
 	driver.activeOperation = 0
 	manager.transitionLocked(driver, ObservedFailed, failure.Reason, nil, nil)

--- a/internal/drivermanager/manager.go
+++ b/internal/drivermanager/manager.go
@@ -505,7 +505,7 @@ func (manager *Manager) startAttempt(ctx context.Context, driver *managedDriver,
 	}()
 
 	if driver.cfg.Runtime == nil {
-		manager.finishAttempt(driver, operation, 0, errors.New("provider unavailable"), replace)
+		manager.finishAttempt(driver, control, operation, 0, errors.New("provider unavailable"), replace)
 		return
 	}
 	var generation uint64
@@ -526,10 +526,10 @@ func (manager *Manager) startAttempt(ctx context.Context, driver *managedDriver,
 		_ = driver.cfg.Runtime.Stop(context.Background())
 		return
 	}
-	manager.finishAttempt(driver, operation, generation, err, replace)
+	manager.finishAttempt(driver, control, operation, generation, err, replace)
 }
 
-func (manager *Manager) finishAttempt(driver *managedDriver, operation, generation uint64, err error, replace bool) {
+func (manager *Manager) finishAttempt(driver *managedDriver, control *attemptControl, operation, generation uint64, err error, replace bool) {
 	driver.mu.Lock()
 	var bindCorrelation Correlation
 	defer func() {
@@ -541,6 +541,14 @@ func (manager *Manager) finishAttempt(driver *managedDriver, operation, generati
 			binder.BindCorrelation(bindCorrelation)
 		}
 	}()
+	// Retire the completed construction before publishing any terminal or
+	// retry state. A repeated Start that observes BACKOFF must therefore see no
+	// stale in-flight attempt: it may atomically replace the scheduled retry,
+	// rather than canceling the only recovery path and then returning because
+	// this already-completed attempt still appeared active.
+	if driver.activeAttempt == control {
+		driver.activeAttempt = nil
+	}
 	if manager.closed.Load() || driver.activeOperation != operation || driver.desired != DesiredRunning {
 		return
 	}

--- a/internal/drivermanager/manager.go
+++ b/internal/drivermanager/manager.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -16,6 +17,7 @@ var (
 	ErrUnavailable       = errors.New("driver unavailable")
 	ErrStopTimeout       = errors.New("driver stop timed out")
 	ErrSafetyQuarantined = errors.New("driver safety quarantined")
+	ErrManagerClosed     = errors.New("driver manager is shutting down")
 )
 
 type DesiredState string
@@ -161,6 +163,8 @@ type Manager struct {
 	drivers map[string]*managedDriver
 	wg      sync.WaitGroup
 	once    sync.Once
+	taskMu  sync.Mutex
+	closed  atomic.Bool
 }
 
 type managedDriver struct {
@@ -265,27 +269,52 @@ func (driver *managedDriver) snapshotLocked() Snapshot {
 }
 
 func (manager *Manager) Start(ctx context.Context, id string) error {
+	return manager.start(ctx, id, false)
+}
+
+// StartAsync reserves STARTING synchronously, then runs construction as a
+// manager-owned task. Shutdown fences new tasks, cancels the attempt, and
+// accounts for it in the manager wait group.
+func (manager *Manager) StartAsync(ctx context.Context, id string) error {
+	return manager.start(ctx, id, true)
+}
+
+func (manager *Manager) start(ctx context.Context, id string, async bool) error {
 	driver := manager.drivers[id]
 	if driver == nil {
 		return ErrDriverNotFound
 	}
-	// Cancel an automatic or caller-owned construction before waiting for the
-	// lifecycle serializer. This lets Stop/Start intent interrupt a blocked
-	// factory through its context instead of waiting for the dial timeout.
+	// Cancel a pending backoff before reserving explicit start intent. An
+	// already STARTING driver remains idempotent and keeps its one construction.
 	manager.cancelRetry(driver)
-	manager.cancelAttempt(driver)
 	driver.opMu.Lock()
-	defer driver.opMu.Unlock()
 	manager.cancelRetry(driver)
 
 	driver.mu.Lock()
+	if manager.closed.Load() {
+		driver.mu.Unlock()
+		driver.opMu.Unlock()
+		return ErrManagerClosed
+	}
 	if driver.quarantined {
 		driver.mu.Unlock()
+		driver.opMu.Unlock()
 		return ErrSafetyQuarantined
 	}
 	if driver.observed == ObservedRunning {
 		driver.mu.Unlock()
+		driver.opMu.Unlock()
 		return nil
+	}
+	if driver.desired == DesiredRunning && driver.observed == ObservedStarting {
+		driver.mu.Unlock()
+		driver.opMu.Unlock()
+		return nil
+	}
+	if driver.observed == ObservedStopping {
+		driver.mu.Unlock()
+		driver.opMu.Unlock()
+		return ErrUnavailable
 	}
 	driver.desired = DesiredRunning
 	driver.retryRemaining = driver.cfg.Retry.Budget
@@ -294,6 +323,18 @@ func (manager *Manager) Start(ctx context.Context, id string) error {
 	manager.transitionLocked(driver, ObservedStarting, Reason{Code: ReasonStartRequested}, nil, nil)
 	driver.attempt++
 	driver.mu.Unlock()
+	driver.opMu.Unlock()
+
+	if async {
+		if !manager.beginTask() {
+			return ErrManagerClosed
+		}
+		go func() {
+			defer manager.wg.Done()
+			manager.startAttempt(manager.ctx, driver, operation, replace)
+		}()
+		return nil
+	}
 	manager.startAttempt(ctx, driver, operation, replace)
 	return nil
 }
@@ -304,15 +345,24 @@ func (manager *Manager) Replace(ctx context.Context, id string) error {
 		return ErrDriverNotFound
 	}
 	manager.cancelRetry(driver)
-	manager.cancelAttempt(driver)
 	driver.opMu.Lock()
-	defer driver.opMu.Unlock()
 	manager.cancelRetry(driver)
 
 	driver.mu.Lock()
+	if manager.closed.Load() {
+		driver.mu.Unlock()
+		driver.opMu.Unlock()
+		return ErrManagerClosed
+	}
 	if driver.quarantined {
 		driver.mu.Unlock()
+		driver.opMu.Unlock()
 		return ErrSafetyQuarantined
+	}
+	if driver.observed == ObservedStarting || driver.observed == ObservedStopping {
+		driver.mu.Unlock()
+		driver.opMu.Unlock()
+		return ErrUnavailable
 	}
 	driver.desired = DesiredRunning
 	driver.retryRemaining = driver.cfg.Retry.Budget
@@ -320,6 +370,7 @@ func (manager *Manager) Replace(ctx context.Context, id string) error {
 	manager.transitionLocked(driver, ObservedStopping, Reason{Code: ReasonStopRequested}, nil, nil)
 	driver.attempt++
 	driver.mu.Unlock()
+	driver.opMu.Unlock()
 	manager.startAttempt(ctx, driver, operation, true)
 	return nil
 }
@@ -419,7 +470,7 @@ func (manager *Manager) startAttempt(ctx context.Context, driver *managedDriver,
 func (manager *Manager) finishAttempt(driver *managedDriver, operation, generation uint64, err error, replace bool) {
 	driver.mu.Lock()
 	defer driver.mu.Unlock()
-	if driver.activeOperation != operation || driver.desired != DesiredRunning {
+	if manager.closed.Load() || driver.activeOperation != operation || driver.desired != DesiredRunning {
 		return
 	}
 	if err == nil {
@@ -466,7 +517,11 @@ func (manager *Manager) scheduleRetryLocked(driver *managedDriver, operation uin
 	driver.retryNeedsReplace = replace
 	retryCtx, cancel := context.WithCancel(manager.ctx)
 	driver.retryCancel = cancel
-	manager.wg.Add(1)
+	if !manager.beginTask() {
+		cancel()
+		driver.retryCancel = nil
+		return
+	}
 	go manager.runRetry(retryCtx, driver, operation, token, delay)
 }
 
@@ -481,10 +536,10 @@ func (manager *Manager) runRetry(ctx context.Context, driver *managedDriver, ope
 	}
 
 	driver.opMu.Lock()
-	defer driver.opMu.Unlock()
 	driver.mu.Lock()
-	if driver.retryToken != token || driver.activeOperation != operation || driver.desired != DesiredRunning || driver.observed != ObservedBackoff || driver.quarantined {
+	if manager.closed.Load() || driver.retryToken != token || driver.activeOperation != operation || driver.desired != DesiredRunning || driver.observed != ObservedBackoff || driver.quarantined {
 		driver.mu.Unlock()
+		driver.opMu.Unlock()
 		return
 	}
 	driver.retryCancel = nil
@@ -492,7 +547,18 @@ func (manager *Manager) runRetry(ctx context.Context, driver *managedDriver, ope
 	manager.transitionLocked(driver, ObservedStarting, Reason{Code: ReasonStartRequested}, nil, nil)
 	driver.attempt++
 	driver.mu.Unlock()
+	driver.opMu.Unlock()
 	manager.startAttempt(ctx, driver, operation, replace)
+}
+
+func (manager *Manager) beginTask() bool {
+	manager.taskMu.Lock()
+	defer manager.taskMu.Unlock()
+	if manager.closed.Load() {
+		return false
+	}
+	manager.wg.Add(1)
+	return true
 }
 
 func (manager *Manager) cancelRetry(driver *managedDriver) {
@@ -551,13 +617,13 @@ func (manager *Manager) ReportDegraded(id string, generation uint64, effective [
 
 func (manager *Manager) ReportDegradedCorrelated(id string, correlation Correlation, effective []Capability, reason Reason) bool {
 	driver := manager.drivers[id]
-	if driver == nil || reason.Code != ReasonCapabilityDegraded {
+	if driver == nil || manager.closed.Load() || reason.Code != ReasonCapabilityDegraded {
 		return false
 	}
 	effective = normalizeCapabilities(effective)
 	driver.mu.Lock()
 	defer driver.mu.Unlock()
-	if !driver.acceptsCallbackLocked(correlation) || (driver.observed != ObservedRunning && driver.observed != ObservedDegraded) || len(effective) == 0 || len(effective) >= len(driver.cfg.Capabilities) || !capabilitySubset(effective, driver.cfg.Capabilities) {
+	if manager.closed.Load() || !driver.acceptsCallbackLocked(correlation) || (driver.observed != ObservedRunning && driver.observed != ObservedDegraded) || len(effective) == 0 || len(effective) >= len(driver.cfg.Capabilities) || !capabilitySubset(effective, driver.cfg.Capabilities) {
 		return false
 	}
 	manager.transitionLocked(driver, ObservedDegraded, reason, nil, effective)
@@ -568,13 +634,13 @@ func (manager *Manager) ReportDegradedCorrelated(id string, correlation Correlat
 // replacement after the current callback releases its DriverRuntime admission.
 func (manager *Manager) ReportFailure(id string, correlation Correlation, failure Failure) bool {
 	driver := manager.drivers[id]
-	if driver == nil || !validReasonCode(failure.Reason.Code) {
+	if driver == nil || manager.closed.Load() || !validReasonCode(failure.Reason.Code) {
 		return false
 	}
 	failure.Reason = normalizeReason(failure.Reason)
 	driver.mu.Lock()
 	defer driver.mu.Unlock()
-	if !driver.acceptsCallbackLocked(correlation) || (driver.observed != ObservedRunning && driver.observed != ObservedDegraded) {
+	if manager.closed.Load() || !driver.acceptsCallbackLocked(correlation) || (driver.observed != ObservedRunning && driver.observed != ObservedDegraded) {
 		return false
 	}
 	operation := driver.nextOperationLocked()
@@ -597,11 +663,11 @@ func (driver *managedDriver) acceptsCallbackLocked(correlation Correlation) bool
 // same state lock used to withdraw capabilities during Stop/Replace/failure.
 func (manager *Manager) Invoke(ctx context.Context, id string, capability Capability, fn func(any) error) (Correlation, error) {
 	driver := manager.drivers[id]
-	if driver == nil {
+	if driver == nil || manager.closed.Load() {
 		return Correlation{}, ErrUnavailable
 	}
 	driver.mu.Lock()
-	if !containsCapability(driver.effective, capability) || driver.quarantined {
+	if manager.closed.Load() || !containsCapability(driver.effective, capability) || driver.quarantined {
 		correlation := Correlation{Generation: driver.generation, Operation: driver.activeOperation}
 		driver.mu.Unlock()
 		return correlation, ErrUnavailable
@@ -622,7 +688,10 @@ func (manager *Manager) Invoke(ctx context.Context, id string, capability Capabi
 }
 
 func (manager *Manager) Shutdown(ctx context.Context) error {
+	manager.taskMu.Lock()
+	manager.closed.Store(true)
 	manager.once.Do(manager.cancel)
+	manager.taskMu.Unlock()
 	ids := make([]string, 0, len(manager.drivers))
 	for id := range manager.drivers {
 		ids = append(ids, id)

--- a/internal/drivermanager/manager.go
+++ b/internal/drivermanager/manager.go
@@ -323,6 +323,14 @@ func (manager *Manager) start(ctx context.Context, id string, async bool) error 
 		driver.opMu.Unlock()
 		return nil
 	}
+	// Repeating desired RUNNING intent is also idempotent while the current
+	// generation is DEGRADED. Degradation deliberately withdraws a capability
+	// subset; only an explicit recovery/replacement operation may restore it.
+	if driver.desired == DesiredRunning && driver.observed == ObservedDegraded {
+		driver.mu.Unlock()
+		driver.opMu.Unlock()
+		return nil
+	}
 	if driver.desired == DesiredRunning && driver.observed == ObservedStarting {
 		driver.mu.Unlock()
 		driver.opMu.Unlock()

--- a/internal/drivermanager/manager.go
+++ b/internal/drivermanager/manager.go
@@ -165,6 +165,15 @@ type correlationBinder interface {
 	BindCorrelation(Correlation)
 }
 
+// correlationActivator is an optional pre-admission lifecycle hook. Manager
+// invokes it under the driver state lock after a provider generation has been
+// constructed but immediately before RUNNING publishes effective capability.
+// Implementations MUST be bounded and MUST NOT call back into Manager. Health
+// reporters that may re-enter Manager belong in correlationBinder instead.
+type correlationActivator interface {
+	ActivateCorrelation(Correlation)
+}
+
 type DriverConfig struct {
 	ID            string
 	Enabled       bool
@@ -617,8 +626,11 @@ func (manager *Manager) finishAttempt(driver *managedDriver, control *attemptCon
 		driver.needsReplace = false
 		driver.retryRemaining = driver.cfg.Retry.Budget
 		driver.activeOperation = 0
-		manager.transitionLocked(driver, ObservedRunning, Reason{Code: ReasonNone}, nil, driver.cfg.Capabilities)
 		bindCorrelation = Correlation{Generation: generation}
+		if activator, ok := driver.cfg.Runtime.(correlationActivator); ok {
+			activator.ActivateCorrelation(bindCorrelation)
+		}
+		manager.transitionLocked(driver, ObservedRunning, Reason{Code: ReasonNone}, nil, driver.cfg.Capabilities)
 		return
 	}
 	if errors.Is(err, ErrSafetyQuarantined) || driver.runtimeQuarantined() {

--- a/internal/drivermanager/manager.go
+++ b/internal/drivermanager/manager.go
@@ -782,6 +782,11 @@ func (manager *Manager) ReportFailure(id string, correlation Correlation, failur
 		return false
 	}
 	operation := driver.nextOperationLocked()
+	// Failure withdrawal has the same generation-local admission boundary as
+	// explicit Stop/Replace. The hook is non-blocking by contract and runs
+	// before BACKOFF/FAILED becomes observable; resource drain remains the
+	// later Runtime.Replace/Stop owner's responsibility.
+	manager.fenceWithdrawalLocked(driver)
 	driver.needsReplace = true
 	driver.retryRemaining = driver.cfg.Retry.Budget
 	if failure.Reason.Retryable {

--- a/internal/drivermanager/manager.go
+++ b/internal/drivermanager/manager.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
 	"sort"
 	"strings"
 	"sync"
@@ -116,6 +117,9 @@ type RetryPolicy struct {
 	Budget       int
 	InitialDelay time.Duration
 	MaxDelay     time.Duration
+	// JitterRatio is the symmetric jitter bound around each exponential
+	// delay. Zero selects the default 20%; a negative value disables jitter.
+	JitterRatio float64
 }
 
 // Runtime is the protocol-neutral lifecycle boundary implemented by adapters.
@@ -158,14 +162,16 @@ type DriverConfig struct {
 }
 
 type Config struct {
-	Drivers []DriverConfig
-	Now     func() time.Time
+	Drivers     []DriverConfig
+	Now         func() time.Time
+	RetryJitter func(time.Duration) time.Duration
 }
 
 type Manager struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 	now    func() time.Time
+	jitter func(time.Duration) time.Duration
 
 	drivers map[string]*managedDriver
 	wg      sync.WaitGroup
@@ -209,8 +215,12 @@ func New(cfg Config) (*Manager, error) {
 	if now == nil {
 		now = func() time.Time { return time.Now().UTC() }
 	}
+	jitter := cfg.RetryJitter
+	if jitter == nil {
+		jitter = defaultRetryJitter
+	}
 	ctx, cancel := context.WithCancel(context.Background())
-	manager := &Manager{ctx: ctx, cancel: cancel, now: now, drivers: make(map[string]*managedDriver, len(cfg.Drivers))}
+	manager := &Manager{ctx: ctx, cancel: cancel, now: now, jitter: jitter, drivers: make(map[string]*managedDriver, len(cfg.Drivers))}
 	for _, driverCfg := range cfg.Drivers {
 		id := strings.TrimSpace(driverCfg.ID)
 		if id == "" || id != driverCfg.ID {
@@ -562,7 +572,7 @@ func (manager *Manager) finishAttempt(driver *managedDriver, operation, generati
 }
 
 func (manager *Manager) scheduleRetryLocked(driver *managedDriver, operation uint64, replace bool) {
-	delay := retryDelay(driver.cfg.Retry, driver.cfg.Retry.Budget-driver.retryRemaining)
+	delay := retryDelay(driver.cfg.Retry, driver.cfg.Retry.Budget-driver.retryRemaining, manager.jitter)
 	retry := &RetrySnapshot{Eligible: true, BudgetRemaining: driver.retryRemaining, NotBeforeUTC: manager.now().Add(delay)}
 	manager.transitionLocked(driver, ObservedBackoff, Reason{Code: ReasonRetryScheduled, Retryable: true}, retry, nil)
 	driver.retryRemaining--
@@ -782,21 +792,53 @@ func normalizeRetryPolicy(policy RetryPolicy) RetryPolicy {
 	if policy.MaxDelay < policy.InitialDelay {
 		policy.MaxDelay = policy.InitialDelay
 	}
+	if policy.JitterRatio == 0 {
+		policy.JitterRatio = 0.2
+	} else if policy.JitterRatio < 0 {
+		policy.JitterRatio = 0
+	} else if policy.JitterRatio > 0.5 {
+		policy.JitterRatio = 0.5
+	}
 	return policy
 }
 
-func retryDelay(policy RetryPolicy, index int) time.Duration {
+func retryDelay(policy RetryPolicy, index int, jitter func(time.Duration) time.Duration) time.Duration {
 	delay := policy.InitialDelay
 	for n := 0; n < index && delay < policy.MaxDelay; n++ {
 		if delay > policy.MaxDelay/2 {
-			return policy.MaxDelay
+			delay = policy.MaxDelay
+			break
 		}
 		delay *= 2
+	}
+	if delay > policy.MaxDelay {
+		delay = policy.MaxDelay
+	}
+	limit := time.Duration(float64(delay) * policy.JitterRatio)
+	if limit <= 0 || jitter == nil {
+		return delay
+	}
+	adjustment := jitter(limit)
+	if adjustment > limit {
+		adjustment = limit
+	} else if adjustment < -limit {
+		adjustment = -limit
+	}
+	delay += adjustment
+	if delay < policy.InitialDelay {
+		return policy.InitialDelay
 	}
 	if delay > policy.MaxDelay {
 		return policy.MaxDelay
 	}
 	return delay
+}
+
+func defaultRetryJitter(limit time.Duration) time.Duration {
+	if limit <= 0 {
+		return 0
+	}
+	return time.Duration((rand.Float64()*2 - 1) * float64(limit))
 }
 
 func normalizeCapabilities(capabilities []Capability) []Capability {

--- a/internal/drivermanager/manager.go
+++ b/internal/drivermanager/manager.go
@@ -141,6 +141,13 @@ type AdmittingRuntime interface {
 	Admit(context.Context) (*Admission, error)
 }
 
+// correlationBinder is an optional internal lifecycle hook. It lets an
+// adapter bind generation-owned asynchronous health signals only after the
+// manager has published the corresponding stable RUNNING correlation.
+type correlationBinder interface {
+	BindCorrelation(Correlation)
+}
+
 type DriverConfig struct {
 	ID            string
 	Enabled       bool
@@ -311,6 +318,14 @@ func (manager *Manager) start(ctx context.Context, id string, async bool) error 
 		driver.opMu.Unlock()
 		return nil
 	}
+	// A canceled construction that ignored its context still owns the runtime
+	// retirement fence until startAttempt observes and retires its completion.
+	// Do not let a new Start race the stale cleanup's coarse Runtime.Stop.
+	if driver.activeAttempt != nil {
+		driver.mu.Unlock()
+		driver.opMu.Unlock()
+		return ErrUnavailable
+	}
 	if driver.observed == ObservedStopping {
 		driver.mu.Unlock()
 		driver.opMu.Unlock()
@@ -364,6 +379,11 @@ func (manager *Manager) Replace(ctx context.Context, id string) error {
 		driver.opMu.Unlock()
 		return ErrUnavailable
 	}
+	if driver.activeAttempt != nil {
+		driver.mu.Unlock()
+		driver.opMu.Unlock()
+		return ErrUnavailable
+	}
 	driver.desired = DesiredRunning
 	driver.retryRemaining = driver.cfg.Retry.Budget
 	operation := driver.nextOperationLocked()
@@ -390,22 +410,29 @@ func (manager *Manager) Stop(ctx context.Context, id string) error {
 func (manager *Manager) stopLocked(ctx context.Context, driver *managedDriver) error {
 	manager.cancelRetry(driver)
 	driver.mu.Lock()
+	attempt := driver.activeAttempt
 	if driver.quarantined {
 		if driver.desired != DesiredStopped {
 			driver.desired = DesiredStopped
 			manager.transitionLocked(driver, ObservedFailed, Reason{Code: ReasonCloseUnconfirmed}, nil, nil)
 		}
 		driver.mu.Unlock()
+		cancelAttemptControl(attempt)
 		return nil
 	}
 	driver.desired = DesiredStopped
 	if driver.observed == ObservedStopped || driver.observed == ObservedDisabled {
 		driver.mu.Unlock()
+		cancelAttemptControl(attempt)
 		return nil
 	}
 	driver.nextOperationLocked()
 	manager.transitionLocked(driver, ObservedStopping, Reason{Code: ReasonStopRequested}, nil, nil)
 	driver.mu.Unlock()
+	// activeAttempt is captured under the same lock that publishes STOPPED
+	// intent. Either construction installed its cancel handle first and is
+	// canceled here, or it observes desired STOPPED and never calls Runtime.
+	cancelAttemptControl(attempt)
 
 	var err error
 	if driver.cfg.Runtime != nil {
@@ -428,6 +455,12 @@ func (manager *Manager) stopLocked(ctx context.Context, driver *managedDriver) e
 		manager.transitionLocked(driver, ObservedFailed, Reason{Code: ReasonInternalError}, nil, nil)
 	}
 	return nil
+}
+
+func cancelAttemptControl(attempt *attemptControl) {
+	if attempt != nil {
+		attempt.cancel()
+	}
 }
 
 func (manager *Manager) startAttempt(ctx context.Context, driver *managedDriver, operation uint64, replace bool) {
@@ -464,12 +497,32 @@ func (manager *Manager) startAttempt(ctx context.Context, driver *managedDriver,
 	} else {
 		generation, err = driver.cfg.Runtime.Start(attemptCtx)
 	}
+	driver.mu.RLock()
+	superseded := manager.closed.Load() || driver.activeOperation != operation || driver.desired != DesiredRunning
+	currentGeneration := driver.generation
+	driver.mu.RUnlock()
+	if superseded && (err == nil || generation > currentGeneration) {
+		// A runtime that ignored cancellation may have admitted after STOPPED
+		// intent was published. Retire that stale completion immediately; it is
+		// never published as an effective manager generation.
+		_ = driver.cfg.Runtime.Stop(context.Background())
+		return
+	}
 	manager.finishAttempt(driver, operation, generation, err, replace)
 }
 
 func (manager *Manager) finishAttempt(driver *managedDriver, operation, generation uint64, err error, replace bool) {
 	driver.mu.Lock()
-	defer driver.mu.Unlock()
+	var bindCorrelation Correlation
+	defer func() {
+		driver.mu.Unlock()
+		if bindCorrelation.Generation == 0 {
+			return
+		}
+		if binder, ok := driver.cfg.Runtime.(correlationBinder); ok {
+			binder.BindCorrelation(bindCorrelation)
+		}
+	}()
 	if manager.closed.Load() || driver.activeOperation != operation || driver.desired != DesiredRunning {
 		return
 	}
@@ -481,6 +534,7 @@ func (manager *Manager) finishAttempt(driver *managedDriver, operation, generati
 		driver.retryRemaining = driver.cfg.Retry.Budget
 		driver.activeOperation = 0
 		manager.transitionLocked(driver, ObservedRunning, Reason{Code: ReasonNone}, nil, driver.cfg.Capabilities)
+		bindCorrelation = Correlation{Generation: generation}
 		return
 	}
 	if errors.Is(err, ErrSafetyQuarantined) || driver.runtimeQuarantined() {

--- a/internal/drivermanager/manager_test.go
+++ b/internal/drivermanager/manager_test.go
@@ -12,6 +12,7 @@ import (
 type scriptedRuntime struct {
 	mu           sync.Mutex
 	startResults []error
+	stopResults  []error
 	startCalls   int
 	stopCalls    int
 	generation   uint64
@@ -48,7 +49,15 @@ func (runtime *scriptedRuntime) Stop(context.Context) error {
 	defer runtime.mu.Unlock()
 	runtime.stopCalls++
 	runtime.revision++
-	return nil
+	var err error
+	if len(runtime.stopResults) != 0 {
+		err = runtime.stopResults[0]
+		runtime.stopResults = runtime.stopResults[1:]
+	}
+	if errors.Is(err, ErrSafetyQuarantined) {
+		runtime.quarantined = true
+	}
+	return err
 }
 
 func (runtime *scriptedRuntime) Generation() uint64 {
@@ -190,6 +199,81 @@ func TestManagerRejectsStaleGenerationHealthCallbackAfterReplace(t *testing.T) {
 	afterStale, _ := manager.Snapshot("ebus.primary")
 	if afterStale.ObservedState != ObservedRunning || afterStale.Generation != second.Generation || !reflect.DeepEqual(afterStale.EffectiveCapabilities, second.Capabilities) {
 		t.Fatalf("snapshot after stale callback = %#v", afterStale)
+	}
+}
+
+func TestManagerSafetyQuarantineMirrorsRuntimeAndBlocksRecovery(t *testing.T) {
+	runtime := &scriptedRuntime{stopResults: []error{ErrSafetyQuarantined}}
+	manager, err := New(Config{Drivers: []DriverConfig{{
+		ID:           "ebus.primary",
+		Enabled:      true,
+		Runtime:      runtime,
+		Capabilities: []Capability{CapabilityRead, CapabilityWrite},
+		Retry:        RetryPolicy{Budget: 2, InitialDelay: time.Millisecond, MaxDelay: time.Millisecond},
+	}}})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if err := manager.Start(context.Background(), "ebus.primary"); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	running := requireObservedState(t, manager, "ebus.primary", ObservedRunning, time.Second)
+	if err := manager.Stop(context.Background(), "ebus.primary"); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+	failed := requireObservedState(t, manager, "ebus.primary", ObservedFailed, time.Second)
+	if !failed.SafetyQuarantined || failed.Reason.Code != ReasonCloseUnconfirmed || len(failed.EffectiveCapabilities) != 0 {
+		t.Fatalf("quarantined snapshot = %#v", failed)
+	}
+	if failed.Generation != running.Generation {
+		t.Fatalf("quarantine generation = %d, want %d", failed.Generation, running.Generation)
+	}
+	if err := manager.Start(context.Background(), "ebus.primary"); !errors.Is(err, ErrSafetyQuarantined) {
+		t.Fatalf("Start() after quarantine error = %v, want ErrSafetyQuarantined", err)
+	}
+	if err := manager.Replace(context.Background(), "ebus.primary"); !errors.Is(err, ErrSafetyQuarantined) {
+		t.Fatalf("Replace() after quarantine error = %v, want ErrSafetyQuarantined", err)
+	}
+	if accepted := manager.ReportDegradedCorrelated("ebus.primary", Correlation{Generation: running.Generation}, []Capability{CapabilityRead}, Reason{Code: ReasonCapabilityDegraded}); accepted {
+		t.Fatal("late callback cleared process-epoch quarantine")
+	}
+	starts, stops := runtime.calls()
+	if starts != 1 || stops != 1 {
+		t.Fatalf("runtime calls after recovery attempts = start:%d stop:%d, want 1/1", starts, stops)
+	}
+}
+
+func TestManagerRejectsCallbackFromSupersededOperation(t *testing.T) {
+	runtime := &scriptedRuntime{}
+	manager, err := New(Config{Drivers: []DriverConfig{{
+		ID:           "ebus.primary",
+		Enabled:      true,
+		Runtime:      runtime,
+		Capabilities: []Capability{CapabilityRead, CapabilityWrite},
+		Retry:        RetryPolicy{Budget: 1, InitialDelay: 100 * time.Millisecond, MaxDelay: 100 * time.Millisecond},
+	}}})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer func() { _ = manager.Shutdown(context.Background()) }()
+	if err := manager.Start(context.Background(), "ebus.primary"); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	running := requireObservedState(t, manager, "ebus.primary", ObservedRunning, time.Second)
+	oldCorrelation := Correlation{Generation: running.Generation}
+	if accepted := manager.ReportFailure("ebus.primary", oldCorrelation, Failure{Reason: Reason{Code: ReasonDependencyUnavailable, Retryable: true}}); !accepted {
+		t.Fatal("first current-operation failure was rejected")
+	}
+	backoff := requireObservedState(t, manager, "ebus.primary", ObservedBackoff, time.Second)
+	if backoff.ActiveOperation == 0 {
+		t.Fatalf("BACKOFF snapshot has no active operation: %#v", backoff)
+	}
+	if accepted := manager.ReportFailure("ebus.primary", oldCorrelation, Failure{Reason: Reason{Code: ReasonDependencyUnavailable, Retryable: true}}); accepted {
+		t.Fatal("callback from superseded operation mutated BACKOFF state")
+	}
+	after, _ := manager.Snapshot("ebus.primary")
+	if after.Revision != backoff.Revision || after.ActiveOperation != backoff.ActiveOperation {
+		t.Fatalf("superseded callback changed snapshot: before=%#v after=%#v", backoff, after)
 	}
 }
 

--- a/internal/drivermanager/manager_test.go
+++ b/internal/drivermanager/manager_test.go
@@ -60,6 +60,131 @@ type lateAdmissionRuntime struct {
 	startRelease chan struct{}
 }
 
+type lateCleanupRuntime struct {
+	mu            sync.Mutex
+	generation    uint64
+	revision      uint64
+	stopCalls     int
+	running       bool
+	startEntered  chan struct{}
+	startRelease  chan struct{}
+	lateStopError error
+	quarantined   bool
+}
+
+type withdrawalFenceRuntime struct {
+	mu              sync.Mutex
+	generation      uint64
+	revision        uint64
+	fenced          bool
+	stopSawFence    bool
+	replaceSawFence bool
+}
+
+func (runtime *withdrawalFenceRuntime) FenceWithdrawal() {
+	runtime.mu.Lock()
+	runtime.fenced = true
+	runtime.mu.Unlock()
+}
+
+func (runtime *withdrawalFenceRuntime) Start(context.Context) (uint64, error) {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	runtime.generation++
+	runtime.revision++
+	runtime.fenced = false
+	return runtime.generation, nil
+}
+
+func (runtime *withdrawalFenceRuntime) Replace(context.Context) (uint64, error) {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	runtime.replaceSawFence = runtime.fenced
+	runtime.generation++
+	runtime.revision++
+	runtime.fenced = false
+	return runtime.generation, nil
+}
+
+func (runtime *withdrawalFenceRuntime) Stop(context.Context) error {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	runtime.stopSawFence = runtime.fenced
+	runtime.revision++
+	return nil
+}
+
+func (runtime *withdrawalFenceRuntime) Generation() uint64 {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	return runtime.generation
+}
+
+func (runtime *withdrawalFenceRuntime) Revision() uint64 {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	return runtime.revision
+}
+
+func (*withdrawalFenceRuntime) SafetyQuarantined() bool { return false }
+
+func (runtime *lateCleanupRuntime) Start(context.Context) (uint64, error) {
+	close(runtime.startEntered)
+	<-runtime.startRelease
+	runtime.mu.Lock()
+	runtime.generation++
+	runtime.revision++
+	runtime.running = true
+	generation := runtime.generation
+	runtime.mu.Unlock()
+	return generation, nil
+}
+
+func (runtime *lateCleanupRuntime) Replace(ctx context.Context) (uint64, error) {
+	return runtime.Start(ctx)
+}
+
+func (runtime *lateCleanupRuntime) Stop(ctx context.Context) error {
+	runtime.mu.Lock()
+	runtime.stopCalls++
+	call := runtime.stopCalls
+	runtime.revision++
+	runtime.running = false
+	err := runtime.lateStopError
+	runtime.mu.Unlock()
+	if call == 1 {
+		return nil
+	}
+	if err != nil {
+		if errors.Is(err, ErrSafetyQuarantined) {
+			runtime.mu.Lock()
+			runtime.quarantined = true
+			runtime.mu.Unlock()
+		}
+		return err
+	}
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (runtime *lateCleanupRuntime) Generation() uint64 {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	return runtime.generation
+}
+
+func (runtime *lateCleanupRuntime) Revision() uint64 {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	return runtime.revision
+}
+
+func (runtime *lateCleanupRuntime) SafetyQuarantined() bool {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	return runtime.quarantined
+}
+
 func (runtime *lateAdmissionRuntime) Start(context.Context) (uint64, error) {
 	close(runtime.startEntered)
 	<-runtime.startRelease // deliberately ignores cancellation and Stop
@@ -794,6 +919,97 @@ func TestManagerRetiresLateAdmissionAfterStopIntent(t *testing.T) {
 		t.Fatalf("late admission changed manager snapshot: %#v", after)
 	}
 	_ = manager.Shutdown(context.Background())
+}
+
+func TestManagerWithdrawalFencePrecedesStopAndReplace(t *testing.T) {
+	for _, action := range []string{"stop", "replace"} {
+		t.Run(action, func(t *testing.T) {
+			runtime := &withdrawalFenceRuntime{}
+			manager, err := New(Config{Drivers: []DriverConfig{{
+				ID: "ebus.primary", Enabled: true, Runtime: runtime, Capabilities: []Capability{CapabilityRead},
+			}}})
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+			if err := manager.Start(context.Background(), "ebus.primary"); err != nil {
+				t.Fatalf("Start() error = %v", err)
+			}
+			switch action {
+			case "stop":
+				if err := manager.Stop(context.Background(), "ebus.primary"); err != nil {
+					t.Fatalf("Stop() error = %v", err)
+				}
+			case "replace":
+				if err := manager.Replace(context.Background(), "ebus.primary"); err != nil {
+					t.Fatalf("Replace() error = %v", err)
+				}
+			}
+			runtime.mu.Lock()
+			stopSawFence := runtime.stopSawFence
+			replaceSawFence := runtime.replaceSawFence
+			runtime.mu.Unlock()
+			if action == "stop" && !stopSawFence {
+				t.Fatal("Runtime.Stop observed an unfenced external surface")
+			}
+			if action == "replace" && !replaceSawFence {
+				t.Fatal("Runtime.Replace observed an unfenced external surface")
+			}
+			_ = manager.Shutdown(context.Background())
+		})
+	}
+}
+
+func TestManagerLateAdmissionCleanupFailureQuarantinesProcessEpoch(t *testing.T) {
+	for _, test := range []struct {
+		name            string
+		lateStopError   error
+		cleanupDeadline time.Duration
+	}{
+		{name: "deadline-dependent cleanup", cleanupDeadline: 10 * time.Millisecond},
+		{name: "runtime safety quarantine", lateStopError: ErrSafetyQuarantined, cleanupDeadline: time.Second},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			runtime := &lateCleanupRuntime{
+				startEntered:  make(chan struct{}),
+				startRelease:  make(chan struct{}),
+				lateStopError: test.lateStopError,
+			}
+			manager, err := New(Config{
+				LateRetireTimeout: test.cleanupDeadline,
+				Drivers: []DriverConfig{{
+					ID: "ebus.primary", Enabled: true, Runtime: runtime, Capabilities: []Capability{CapabilityRead},
+				}},
+			})
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+			if err := manager.StartAsync(context.Background(), "ebus.primary"); err != nil {
+				t.Fatalf("StartAsync() error = %v", err)
+			}
+			select {
+			case <-runtime.startEntered:
+			case <-time.After(time.Second):
+				t.Fatal("late runtime did not enter Start")
+			}
+			if err := manager.Stop(context.Background(), "ebus.primary"); err != nil {
+				t.Fatalf("Stop() error = %v", err)
+			}
+			close(runtime.startRelease)
+			failed := requireObservedState(t, manager, "ebus.primary", ObservedFailed, time.Second)
+			if failed.DesiredState != DesiredStopped || failed.Reason.Code != ReasonCloseUnconfirmed || !failed.SafetyQuarantined || len(failed.EffectiveCapabilities) != 0 {
+				t.Fatalf("late cleanup failure snapshot = %#v", failed)
+			}
+			if err := manager.Start(context.Background(), "ebus.primary"); !errors.Is(err, ErrSafetyQuarantined) {
+				t.Fatalf("Start() after late cleanup failure error = %v, want ErrSafetyQuarantined", err)
+			}
+			runtime.mu.Lock()
+			stopCalls := runtime.stopCalls
+			runtime.mu.Unlock()
+			if stopCalls != 2 {
+				t.Fatalf("Runtime.Stop calls = %d, want initial stop plus bounded late retirement", stopCalls)
+			}
+		})
+	}
 }
 
 func requireObservedState(t *testing.T, manager *Manager, id string, want ObservedState, timeout time.Duration) Snapshot {

--- a/internal/drivermanager/manager_test.go
+++ b/internal/drivermanager/manager_test.go
@@ -20,6 +20,66 @@ type scriptedRuntime struct {
 	quarantined  bool
 }
 
+type cancelableConstructionRuntime struct {
+	mu              sync.Mutex
+	generation      uint64
+	revision        uint64
+	replaceCalls    int
+	stopCalls       int
+	replaceStarted  chan struct{}
+	replaceCanceled chan struct{}
+	startOnce       sync.Once
+	cancelOnce      sync.Once
+}
+
+func newCancelableConstructionRuntime() *cancelableConstructionRuntime {
+	return &cancelableConstructionRuntime{
+		replaceStarted:  make(chan struct{}),
+		replaceCanceled: make(chan struct{}),
+	}
+}
+
+func (runtime *cancelableConstructionRuntime) Start(context.Context) (uint64, error) {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	runtime.generation++
+	runtime.revision++
+	return runtime.generation, nil
+}
+
+func (runtime *cancelableConstructionRuntime) Replace(ctx context.Context) (uint64, error) {
+	runtime.mu.Lock()
+	runtime.replaceCalls++
+	generation := runtime.generation
+	runtime.mu.Unlock()
+	runtime.startOnce.Do(func() { close(runtime.replaceStarted) })
+	<-ctx.Done()
+	runtime.cancelOnce.Do(func() { close(runtime.replaceCanceled) })
+	return generation, ctx.Err()
+}
+
+func (runtime *cancelableConstructionRuntime) Stop(context.Context) error {
+	runtime.mu.Lock()
+	runtime.stopCalls++
+	runtime.revision++
+	runtime.mu.Unlock()
+	return nil
+}
+
+func (runtime *cancelableConstructionRuntime) Generation() uint64 {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	return runtime.generation
+}
+
+func (runtime *cancelableConstructionRuntime) Revision() uint64 {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	return runtime.revision
+}
+
+func (*cancelableConstructionRuntime) SafetyQuarantined() bool { return false }
+
 func (runtime *scriptedRuntime) Start(context.Context) (uint64, error) {
 	runtime.mu.Lock()
 	defer runtime.mu.Unlock()
@@ -274,6 +334,52 @@ func TestManagerRejectsCallbackFromSupersededOperation(t *testing.T) {
 	after, _ := manager.Snapshot("ebus.primary")
 	if after.Revision != backoff.Revision || after.ActiveOperation != backoff.ActiveOperation {
 		t.Fatalf("superseded callback changed snapshot: before=%#v after=%#v", backoff, after)
+	}
+}
+
+func TestManagerStopCancelsInFlightRetryConstruction(t *testing.T) {
+	runtime := newCancelableConstructionRuntime()
+	manager, err := New(Config{Drivers: []DriverConfig{{
+		ID:           "ebus.primary",
+		Enabled:      true,
+		Runtime:      runtime,
+		Capabilities: []Capability{CapabilityRead, CapabilityWrite},
+		Retry:        RetryPolicy{Budget: 1, InitialDelay: time.Millisecond, MaxDelay: time.Millisecond},
+	}}})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if err := manager.Start(context.Background(), "ebus.primary"); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	running := requireObservedState(t, manager, "ebus.primary", ObservedRunning, time.Second)
+	if accepted := manager.ReportFailure("ebus.primary", Correlation{Generation: running.Generation}, Failure{Reason: Reason{Code: ReasonDependencyUnavailable, Retryable: true}}); !accepted {
+		t.Fatal("ReportFailure() rejected current generation")
+	}
+	select {
+	case <-runtime.replaceStarted:
+	case <-time.After(time.Second):
+		t.Fatal("automatic retry construction did not start")
+	}
+
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- manager.Stop(context.Background(), "ebus.primary") }()
+	select {
+	case <-runtime.replaceCanceled:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("Stop did not cancel the in-flight retry construction")
+	}
+	select {
+	case err := <-stopDone:
+		if err != nil {
+			t.Fatalf("Stop() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not complete after construction cancellation")
+	}
+	stopped := requireObservedState(t, manager, "ebus.primary", ObservedStopped, time.Second)
+	if stopped.DesiredState != DesiredStopped || len(stopped.EffectiveCapabilities) != 0 {
+		t.Fatalf("STOPPED snapshot = %#v", stopped)
 	}
 }
 

--- a/internal/drivermanager/manager_test.go
+++ b/internal/drivermanager/manager_test.go
@@ -721,6 +721,39 @@ func TestManagerReportFailureWithZeroRetryBudgetPublishesRetryExhausted(t *testi
 	}
 }
 
+func TestIssue851ManagerReportFailureFencesRuntimeBeforeBackoff(t *testing.T) {
+	runtime := &withdrawalFenceRuntime{}
+	manager, err := New(Config{Drivers: []DriverConfig{{
+		ID:           "ebus.primary",
+		Enabled:      true,
+		Runtime:      runtime,
+		Capabilities: []Capability{CapabilityRead, CapabilityWrite},
+		Retry:        RetryPolicy{Budget: 1, InitialDelay: time.Hour, MaxDelay: time.Hour},
+	}}})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer func() { _ = manager.Shutdown(context.Background()) }()
+	if err := manager.Start(context.Background(), "ebus.primary"); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	running := requireObservedState(t, manager, "ebus.primary", ObservedRunning, time.Second)
+	if accepted := manager.ReportFailure(
+		"ebus.primary",
+		Correlation{Generation: running.Generation},
+		Failure{Reason: Reason{Code: ReasonDependencyUnavailable, Retryable: true}},
+	); !accepted {
+		t.Fatal("ReportFailure() rejected current generation")
+	}
+	backoff := requireObservedState(t, manager, "ebus.primary", ObservedBackoff, time.Second)
+	runtime.mu.Lock()
+	fenced := runtime.fenced
+	runtime.mu.Unlock()
+	if !fenced {
+		t.Fatalf("BACKOFF published before runtime withdrawal fence: %#v", backoff)
+	}
+}
+
 func TestManagerStopCancelsInFlightRetryConstruction(t *testing.T) {
 	runtime := newCancelableConstructionRuntime()
 	manager, err := New(Config{Drivers: []DriverConfig{{

--- a/internal/drivermanager/manager_test.go
+++ b/internal/drivermanager/manager_test.go
@@ -50,6 +50,55 @@ type repeatedStartRuntime struct {
 	startOnce    sync.Once
 }
 
+type lateAdmissionRuntime struct {
+	mu           sync.Mutex
+	generation   uint64
+	revision     uint64
+	stopCalls    int
+	running      bool
+	startEntered chan struct{}
+	startRelease chan struct{}
+}
+
+func (runtime *lateAdmissionRuntime) Start(context.Context) (uint64, error) {
+	close(runtime.startEntered)
+	<-runtime.startRelease // deliberately ignores cancellation and Stop
+	runtime.mu.Lock()
+	runtime.generation++
+	runtime.revision++
+	runtime.running = true
+	generation := runtime.generation
+	runtime.mu.Unlock()
+	return generation, nil
+}
+
+func (runtime *lateAdmissionRuntime) Replace(ctx context.Context) (uint64, error) {
+	return runtime.Start(ctx)
+}
+
+func (runtime *lateAdmissionRuntime) Stop(context.Context) error {
+	runtime.mu.Lock()
+	runtime.stopCalls++
+	runtime.revision++
+	runtime.running = false
+	runtime.mu.Unlock()
+	return nil
+}
+
+func (runtime *lateAdmissionRuntime) Generation() uint64 {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	return runtime.generation
+}
+
+func (runtime *lateAdmissionRuntime) Revision() uint64 {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	return runtime.revision
+}
+
+func (*lateAdmissionRuntime) SafetyQuarantined() bool { return false }
+
 func (runtime *repeatedStartRuntime) Start(context.Context) (uint64, error) {
 	runtime.mu.Lock()
 	runtime.startCalls++
@@ -537,6 +586,53 @@ func TestManagerRepeatedStartJoinsStartingIntent(t *testing.T) {
 		t.Fatalf("first Start() error = %v", err)
 	}
 	requireObservedState(t, manager, "ebus.primary", ObservedRunning, time.Second)
+	_ = manager.Shutdown(context.Background())
+}
+
+func TestManagerRetiresLateAdmissionAfterStopIntent(t *testing.T) {
+	runtime := &lateAdmissionRuntime{startEntered: make(chan struct{}), startRelease: make(chan struct{})}
+	manager, err := New(Config{Drivers: []DriverConfig{{
+		ID: "ebus.primary", Enabled: true, Runtime: runtime, Capabilities: []Capability{CapabilityRead},
+	}}})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if err := manager.StartAsync(context.Background(), "ebus.primary"); err != nil {
+		t.Fatalf("StartAsync() error = %v", err)
+	}
+	select {
+	case <-runtime.startEntered:
+	case <-time.After(time.Second):
+		t.Fatal("StartAsync did not enter runtime")
+	}
+	if err := manager.Stop(context.Background(), "ebus.primary"); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+	stopped := requireObservedState(t, manager, "ebus.primary", ObservedStopped, time.Second)
+	if stopped.Generation != 0 {
+		t.Fatalf("STOPPED generation = %d, want 0", stopped.Generation)
+	}
+	if err := manager.Start(context.Background(), "ebus.primary"); !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("Start() while stale admission retires error = %v, want ErrUnavailable", err)
+	}
+	close(runtime.startRelease)
+	deadline := time.Now().Add(time.Second)
+	for {
+		runtime.mu.Lock()
+		stopCalls, running := runtime.stopCalls, runtime.running
+		runtime.mu.Unlock()
+		if stopCalls >= 2 && !running {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("late admission was not retired: stopCalls=%d running=%v", stopCalls, running)
+		}
+		time.Sleep(time.Millisecond)
+	}
+	after, _ := manager.Snapshot("ebus.primary")
+	if after.ObservedState != ObservedStopped || after.Generation != 0 || len(after.EffectiveCapabilities) != 0 {
+		t.Fatalf("late admission changed manager snapshot: %#v", after)
+	}
 	_ = manager.Shutdown(context.Background())
 }
 

--- a/internal/drivermanager/manager_test.go
+++ b/internal/drivermanager/manager_test.go
@@ -682,6 +682,45 @@ func TestManagerRejectsCallbackFromSupersededOperation(t *testing.T) {
 	}
 }
 
+func TestManagerReportFailureWithZeroRetryBudgetPublishesRetryExhausted(t *testing.T) {
+	runtime := &scriptedRuntime{}
+	manager, err := New(Config{Drivers: []DriverConfig{{
+		ID:           "ebus.primary",
+		Enabled:      true,
+		Runtime:      runtime,
+		Capabilities: []Capability{CapabilityRead, CapabilityWrite},
+		Retry:        RetryPolicy{Budget: 0},
+	}}})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer func() { _ = manager.Shutdown(context.Background()) }()
+
+	if err := manager.Start(context.Background(), "ebus.primary"); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	running := requireObservedState(t, manager, "ebus.primary", ObservedRunning, time.Second)
+	if accepted := manager.ReportFailure(
+		"ebus.primary",
+		Correlation{Generation: running.Generation},
+		Failure{Reason: Reason{Code: ReasonDependencyUnavailable, Retryable: true}},
+	); !accepted {
+		t.Fatal("ReportFailure() rejected current generation")
+	}
+
+	failed := requireObservedState(t, manager, "ebus.primary", ObservedFailed, time.Second)
+	if failed.DesiredState != DesiredRunning || failed.Reason != (Reason{Code: ReasonRetryExhausted}) {
+		t.Fatalf("zero-budget failure snapshot = %#v", failed)
+	}
+	if failed.Retry != nil || len(failed.EffectiveCapabilities) != 0 || failed.ActiveOperation != 0 {
+		t.Fatalf("zero-budget failure retained retry/admission = %#v", failed)
+	}
+	starts, stops := runtime.calls()
+	if starts != 1 || stops != 0 {
+		t.Fatalf("zero-budget failure runtime calls = start:%d stop:%d, want 1/0", starts, stops)
+	}
+}
+
 func TestManagerStopCancelsInFlightRetryConstruction(t *testing.T) {
 	runtime := newCancelableConstructionRuntime()
 	manager, err := New(Config{Drivers: []DriverConfig{{

--- a/internal/drivermanager/manager_test.go
+++ b/internal/drivermanager/manager_test.go
@@ -261,6 +261,65 @@ func (runtime *scriptedRuntime) calls() (start, stop int) {
 	return runtime.startCalls, runtime.stopCalls
 }
 
+func TestRetryDelayUsesBoundedInjectableJitter(t *testing.T) {
+	policy := normalizeRetryPolicy(RetryPolicy{
+		InitialDelay: 10 * time.Millisecond,
+		MaxDelay:     80 * time.Millisecond,
+		JitterRatio:  0.25,
+	})
+	var observedLimit time.Duration
+	positive := retryDelay(policy, 1, func(limit time.Duration) time.Duration {
+		observedLimit = limit
+		return 10 * limit // manager must clamp an out-of-range source
+	})
+	if observedLimit != 5*time.Millisecond || positive != 25*time.Millisecond {
+		t.Fatalf("positive jitter limit/delay = %v/%v, want 5ms/25ms", observedLimit, positive)
+	}
+	negative := retryDelay(policy, 1, func(limit time.Duration) time.Duration { return -10 * limit })
+	if negative != 15*time.Millisecond {
+		t.Fatalf("negative jitter delay = %v, want 15ms", negative)
+	}
+	minimum := retryDelay(policy, 0, func(limit time.Duration) time.Duration { return -limit })
+	if minimum != policy.InitialDelay {
+		t.Fatalf("minimum jitter delay = %v, want floor %v", minimum, policy.InitialDelay)
+	}
+	maximum := retryDelay(policy, 3, func(limit time.Duration) time.Duration { return limit })
+	if maximum != policy.MaxDelay {
+		t.Fatalf("maximum jitter delay = %v, want ceiling %v", maximum, policy.MaxDelay)
+	}
+}
+
+func TestManagerRetrySnapshotUsesInjectedJitter(t *testing.T) {
+	now := time.Date(2026, time.August, 21, 12, 0, 0, 0, time.UTC)
+	runtime := &scriptedRuntime{startResults: []error{errors.New("offline")}}
+	manager, err := New(Config{
+		Now: func() time.Time { return now },
+		RetryJitter: func(limit time.Duration) time.Duration {
+			return limit
+		},
+		Drivers: []DriverConfig{{
+			ID:      "ebus.primary",
+			Enabled: true,
+			Runtime: runtime,
+			ClassifyError: func(error) Failure {
+				return Failure{Reason: Reason{Code: ReasonDependencyUnavailable, Retryable: true}}
+			},
+			Retry: RetryPolicy{Budget: 1, InitialDelay: 100 * time.Millisecond, MaxDelay: time.Second, JitterRatio: 0.25},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if err := manager.Start(context.Background(), "ebus.primary"); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	backoff := requireObservedState(t, manager, "ebus.primary", ObservedBackoff, time.Second)
+	if backoff.Retry == nil || !backoff.Retry.NotBeforeUTC.Equal(now.Add(125*time.Millisecond)) {
+		t.Fatalf("retry snapshot = %#v, want not-before %s", backoff.Retry, now.Add(125*time.Millisecond))
+	}
+	_ = manager.Stop(context.Background(), "ebus.primary")
+}
+
 func TestManagerInitialFailureBacksOffAndRecoversCategorically(t *testing.T) {
 	rawFailure := errors.New("dial tcp://user:secret@example.invalid:9999: refused")
 	runtime := &scriptedRuntime{startResults: []error{rawFailure, nil}}

--- a/internal/drivermanager/manager_test.go
+++ b/internal/drivermanager/manager_test.go
@@ -692,6 +692,63 @@ func TestManagerRepeatedStartJoinsStartingIntent(t *testing.T) {
 	_ = manager.Shutdown(context.Background())
 }
 
+func TestManagerRepeatedStartDuringRetryPublicationKeepsRecoveryLive(t *testing.T) {
+	runtime := &scriptedRuntime{startResults: []error{errors.New("offline"), nil}}
+	classification := make(chan bool, 1)
+	releaseClassification := make(chan struct{})
+	var manager *Manager
+	var err error
+	manager, err = New(Config{Drivers: []DriverConfig{{
+		ID:      "ebus.primary",
+		Enabled: true,
+		Runtime: runtime,
+		ClassifyError: func(error) Failure {
+			// finishAttempt holds driver.mu while classifying. The completed
+			// attempt must already be retired before BACKOFF and its sole retry
+			// can be published under that same lock.
+			classification <- manager.drivers["ebus.primary"].activeAttempt == nil
+			<-releaseClassification
+			return Failure{Reason: Reason{Code: ReasonDependencyUnavailable, Retryable: true}}
+		},
+		Retry: RetryPolicy{Budget: 1, InitialDelay: time.Second, MaxDelay: time.Second},
+	}}})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer func() { _ = manager.Shutdown(context.Background()) }()
+
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- manager.Start(context.Background(), "ebus.primary") }()
+	attemptRetired := <-classification
+
+	repeatedStarted := make(chan struct{})
+	repeatedDone := make(chan error, 1)
+	go func() {
+		close(repeatedStarted)
+		repeatedDone <- manager.Start(context.Background(), "ebus.primary")
+	}()
+	<-repeatedStarted
+	close(releaseClassification)
+
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first Start() error = %v", err)
+	}
+	if err := <-repeatedDone; err != nil {
+		t.Fatalf("repeated Start() error = %v", err)
+	}
+	if !attemptRetired {
+		t.Fatal("retry publication retained its completed active attempt")
+	}
+	running := requireObservedState(t, manager, "ebus.primary", ObservedRunning, time.Second)
+	if running.Generation != 1 || running.Reason.Code != ReasonNone || running.Retry != nil {
+		t.Fatalf("repeated Start stranded recovery: %#v", running)
+	}
+	starts, _ := runtime.calls()
+	if starts != 2 {
+		t.Fatalf("runtime Start calls = %d, want initial failure plus one recovery", starts)
+	}
+}
+
 func TestManagerRetiresLateAdmissionAfterStopIntent(t *testing.T) {
 	runtime := &lateAdmissionRuntime{startEntered: make(chan struct{}), startRelease: make(chan struct{})}
 	manager, err := New(Config{Drivers: []DriverConfig{{

--- a/internal/drivermanager/manager_test.go
+++ b/internal/drivermanager/manager_test.go
@@ -1,0 +1,208 @@
+package drivermanager
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+)
+
+type scriptedRuntime struct {
+	mu           sync.Mutex
+	startResults []error
+	startCalls   int
+	stopCalls    int
+	generation   uint64
+	revision     uint64
+	quarantined  bool
+}
+
+func (runtime *scriptedRuntime) Start(context.Context) (uint64, error) {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	runtime.startCalls++
+	runtime.revision++
+	var err error
+	if len(runtime.startResults) != 0 {
+		err = runtime.startResults[0]
+		runtime.startResults = runtime.startResults[1:]
+	}
+	if err != nil {
+		return runtime.generation, err
+	}
+	runtime.generation++
+	return runtime.generation, nil
+}
+
+func (runtime *scriptedRuntime) Replace(ctx context.Context) (uint64, error) {
+	if err := runtime.Stop(ctx); err != nil {
+		return runtime.Generation(), err
+	}
+	return runtime.Start(ctx)
+}
+
+func (runtime *scriptedRuntime) Stop(context.Context) error {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	runtime.stopCalls++
+	runtime.revision++
+	return nil
+}
+
+func (runtime *scriptedRuntime) Generation() uint64 {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	return runtime.generation
+}
+
+func (runtime *scriptedRuntime) Revision() uint64 {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	return runtime.revision
+}
+
+func (runtime *scriptedRuntime) SafetyQuarantined() bool {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	return runtime.quarantined
+}
+
+func (runtime *scriptedRuntime) calls() (start, stop int) {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	return runtime.startCalls, runtime.stopCalls
+}
+
+func TestManagerInitialFailureBacksOffAndRecoversCategorically(t *testing.T) {
+	rawFailure := errors.New("dial tcp://user:secret@example.invalid:9999: refused")
+	runtime := &scriptedRuntime{startResults: []error{rawFailure, nil}}
+	manager, err := New(Config{
+		Drivers: []DriverConfig{{
+			ID:           "ebus.primary",
+			Enabled:      true,
+			Runtime:      runtime,
+			Capabilities: []Capability{CapabilityWrite, CapabilityRead, CapabilityDiscovery, CapabilityRead},
+			ClassifyError: func(error) Failure {
+				return Failure{Reason: Reason{Code: ReasonDependencyUnavailable, Retryable: true}}
+			},
+			Retry: RetryPolicy{Budget: 2, InitialDelay: 5 * time.Millisecond, MaxDelay: 5 * time.Millisecond},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer func() { _ = manager.Shutdown(context.Background()) }()
+
+	if err := manager.Start(context.Background(), "ebus.primary"); err != nil {
+		t.Fatalf("Start() promoted a managed driver failure to caller error: %v", err)
+	}
+	backoff := requireObservedState(t, manager, "ebus.primary", ObservedBackoff, time.Second)
+	if backoff.DesiredState != DesiredRunning || backoff.Generation != 0 || backoff.Revision <= 1 {
+		t.Fatalf("BACKOFF snapshot = %#v", backoff)
+	}
+	if backoff.Reason.Code != ReasonRetryScheduled || !backoff.Reason.Retryable || backoff.Retry == nil {
+		t.Fatalf("BACKOFF reason/retry = %#v / %#v", backoff.Reason, backoff.Retry)
+	}
+	if rendered := backoff.Reason.String(); rendered == rawFailure.Error() || containsSensitiveDriverText(rendered) {
+		t.Fatalf("snapshot reason leaked raw construction detail: %q", rendered)
+	}
+
+	running := requireObservedState(t, manager, "ebus.primary", ObservedRunning, time.Second)
+	if running.Generation != 1 || running.Revision <= backoff.Revision || running.Reason.Code != ReasonNone {
+		t.Fatalf("RUNNING snapshot = %#v", running)
+	}
+	wantCapabilities := []Capability{CapabilityDiscovery, CapabilityRead, CapabilityWrite}
+	if !reflect.DeepEqual(running.Capabilities, wantCapabilities) || !reflect.DeepEqual(running.EffectiveCapabilities, wantCapabilities) {
+		t.Fatalf("capabilities static=%v effective=%v, want %v", running.Capabilities, running.EffectiveCapabilities, wantCapabilities)
+	}
+}
+
+func TestManagerStopCancelsBackoffWithoutResurrection(t *testing.T) {
+	runtime := &scriptedRuntime{startResults: []error{errors.New("offline"), nil}}
+	manager, err := New(Config{Drivers: []DriverConfig{{
+		ID:      "ebus.primary",
+		Enabled: true,
+		Runtime: runtime,
+		ClassifyError: func(error) Failure {
+			return Failure{Reason: Reason{Code: ReasonDependencyUnavailable, Retryable: true}}
+		},
+		Retry: RetryPolicy{Budget: 1, InitialDelay: 150 * time.Millisecond, MaxDelay: 150 * time.Millisecond},
+	}}})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	if err := manager.Start(context.Background(), "ebus.primary"); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	requireObservedState(t, manager, "ebus.primary", ObservedBackoff, time.Second)
+	if err := manager.Stop(context.Background(), "ebus.primary"); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+	stopped := requireObservedState(t, manager, "ebus.primary", ObservedStopped, time.Second)
+	if stopped.DesiredState != DesiredStopped || len(stopped.EffectiveCapabilities) != 0 || stopped.Reason.Code != ReasonOperatorStopped {
+		t.Fatalf("STOPPED snapshot = %#v", stopped)
+	}
+	time.Sleep(220 * time.Millisecond)
+	starts, _ := runtime.calls()
+	if starts != 1 {
+		t.Fatalf("runtime Start calls after stopped backoff = %d, want 1", starts)
+	}
+}
+
+func TestManagerRejectsStaleGenerationHealthCallbackAfterReplace(t *testing.T) {
+	runtime := &scriptedRuntime{}
+	manager, err := New(Config{Drivers: []DriverConfig{{
+		ID:           "ebus.primary",
+		Enabled:      true,
+		Runtime:      runtime,
+		Capabilities: []Capability{CapabilityDiscovery, CapabilityRead, CapabilityWrite},
+	}}})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer func() { _ = manager.Shutdown(context.Background()) }()
+
+	if err := manager.Start(context.Background(), "ebus.primary"); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	first := requireObservedState(t, manager, "ebus.primary", ObservedRunning, time.Second)
+	if accepted := manager.ReportDegraded("ebus.primary", first.Generation, []Capability{CapabilityRead}, Reason{Code: ReasonCapabilityDegraded}); !accepted {
+		t.Fatal("current generation degraded callback was rejected")
+	}
+	degraded := requireObservedState(t, manager, "ebus.primary", ObservedDegraded, time.Second)
+	if !reflect.DeepEqual(degraded.EffectiveCapabilities, []Capability{CapabilityRead}) {
+		t.Fatalf("degraded effective capabilities = %v", degraded.EffectiveCapabilities)
+	}
+
+	if err := manager.Replace(context.Background(), "ebus.primary"); err != nil {
+		t.Fatalf("Replace() error = %v", err)
+	}
+	second := requireObservedState(t, manager, "ebus.primary", ObservedRunning, time.Second)
+	if second.Generation != first.Generation+1 {
+		t.Fatalf("replacement generation = %d, want %d", second.Generation, first.Generation+1)
+	}
+	if accepted := manager.ReportDegraded("ebus.primary", first.Generation, []Capability{CapabilityRead}, Reason{Code: ReasonCapabilityDegraded}); accepted {
+		t.Fatal("stale generation callback mutated current state")
+	}
+	afterStale, _ := manager.Snapshot("ebus.primary")
+	if afterStale.ObservedState != ObservedRunning || afterStale.Generation != second.Generation || !reflect.DeepEqual(afterStale.EffectiveCapabilities, second.Capabilities) {
+		t.Fatalf("snapshot after stale callback = %#v", afterStale)
+	}
+}
+
+func requireObservedState(t *testing.T, manager *Manager, id string, want ObservedState, timeout time.Duration) Snapshot {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if snapshot, ok := manager.Snapshot(id); ok && snapshot.ObservedState == want {
+			return snapshot
+		}
+		time.Sleep(time.Millisecond)
+	}
+	snapshot, _ := manager.Snapshot(id)
+	t.Fatalf("driver %s state = %s, want %s; snapshot=%#v", id, snapshot.ObservedState, want, snapshot)
+	return Snapshot{}
+}

--- a/internal/drivermanager/manager_test.go
+++ b/internal/drivermanager/manager_test.go
@@ -32,6 +32,74 @@ type cancelableConstructionRuntime struct {
 	cancelOnce      sync.Once
 }
 
+type shutdownBlockingRuntime struct {
+	*scriptedRuntime
+	stopEntered chan struct{}
+	stopRelease chan struct{}
+	stopOnce    sync.Once
+}
+
+type repeatedStartRuntime struct {
+	mu           sync.Mutex
+	startCalls   int
+	stopCalls    int
+	generation   uint64
+	revision     uint64
+	startEntered chan struct{}
+	startRelease chan struct{}
+	startOnce    sync.Once
+}
+
+func (runtime *repeatedStartRuntime) Start(context.Context) (uint64, error) {
+	runtime.mu.Lock()
+	runtime.startCalls++
+	runtime.revision++
+	runtime.mu.Unlock()
+	runtime.startOnce.Do(func() { close(runtime.startEntered) })
+	<-runtime.startRelease
+	runtime.mu.Lock()
+	runtime.generation++
+	generation := runtime.generation
+	runtime.mu.Unlock()
+	return generation, nil
+}
+
+func (runtime *repeatedStartRuntime) Replace(ctx context.Context) (uint64, error) {
+	return runtime.Start(ctx)
+}
+
+func (runtime *repeatedStartRuntime) Stop(context.Context) error {
+	runtime.mu.Lock()
+	runtime.stopCalls++
+	runtime.revision++
+	runtime.mu.Unlock()
+	return nil
+}
+
+func (runtime *repeatedStartRuntime) Generation() uint64 {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	return runtime.generation
+}
+
+func (runtime *repeatedStartRuntime) Revision() uint64 {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	return runtime.revision
+}
+
+func (*repeatedStartRuntime) SafetyQuarantined() bool { return false }
+
+func (runtime *shutdownBlockingRuntime) Stop(ctx context.Context) error {
+	runtime.stopOnce.Do(func() { close(runtime.stopEntered) })
+	select {
+	case <-runtime.stopRelease:
+		return runtime.scriptedRuntime.Stop(ctx)
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 func newCancelableConstructionRuntime() *cancelableConstructionRuntime {
 	return &cancelableConstructionRuntime{
 		replaceStarted:  make(chan struct{}),
@@ -381,6 +449,95 @@ func TestManagerStopCancelsInFlightRetryConstruction(t *testing.T) {
 	if stopped.DesiredState != DesiredStopped || len(stopped.EffectiveCapabilities) != 0 {
 		t.Fatalf("STOPPED snapshot = %#v", stopped)
 	}
+}
+
+func TestManagerShutdownFencePreventsEarlierDriverResurrection(t *testing.T) {
+	firstRuntime := &scriptedRuntime{}
+	secondRuntime := &shutdownBlockingRuntime{
+		scriptedRuntime: &scriptedRuntime{},
+		stopEntered:     make(chan struct{}),
+		stopRelease:     make(chan struct{}),
+	}
+	manager, err := New(Config{Drivers: []DriverConfig{
+		{ID: "driver.a", Enabled: true, Runtime: firstRuntime, Capabilities: []Capability{CapabilityRead}},
+		{ID: "driver.b", Enabled: true, Runtime: secondRuntime, Capabilities: []Capability{CapabilityRead}},
+	}})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if err := manager.Start(context.Background(), "driver.a"); err != nil {
+		t.Fatalf("Start(driver.a) error = %v", err)
+	}
+	if err := manager.Start(context.Background(), "driver.b"); err != nil {
+		t.Fatalf("Start(driver.b) error = %v", err)
+	}
+
+	shutdownDone := make(chan error, 1)
+	go func() { shutdownDone <- manager.Shutdown(context.Background()) }()
+	select {
+	case <-secondRuntime.stopEntered:
+	case <-time.After(time.Second):
+		t.Fatal("Shutdown did not reach the second driver")
+	}
+	if err := manager.Start(context.Background(), "driver.a"); !errors.Is(err, ErrManagerClosed) {
+		t.Fatalf("Start(driver.a) during Shutdown error = %v, want ErrManagerClosed", err)
+	}
+	if err := manager.Replace(context.Background(), "driver.a"); !errors.Is(err, ErrManagerClosed) {
+		t.Fatalf("Replace(driver.a) during Shutdown error = %v, want ErrManagerClosed", err)
+	}
+	close(secondRuntime.stopRelease)
+	select {
+	case err := <-shutdownDone:
+		if err != nil {
+			t.Fatalf("Shutdown() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Shutdown did not finish")
+	}
+	first, _ := manager.Snapshot("driver.a")
+	if first.ObservedState != ObservedStopped || first.DesiredState != DesiredStopped {
+		t.Fatalf("driver.a resurrected after Shutdown: %#v", first)
+	}
+	starts, stops := firstRuntime.calls()
+	if starts != 1 || stops != 1 {
+		t.Fatalf("driver.a runtime calls = start:%d stop:%d, want 1/1", starts, stops)
+	}
+}
+
+func TestManagerRepeatedStartJoinsStartingIntent(t *testing.T) {
+	runtime := &repeatedStartRuntime{startEntered: make(chan struct{}), startRelease: make(chan struct{})}
+	manager, err := New(Config{Drivers: []DriverConfig{{
+		ID: "ebus.primary", Enabled: true, Runtime: runtime, Capabilities: []Capability{CapabilityRead},
+	}}})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- manager.Start(context.Background(), "ebus.primary") }()
+	select {
+	case <-runtime.startEntered:
+	case <-time.After(time.Second):
+		t.Fatal("first Start did not reach runtime")
+	}
+	if err := manager.Start(context.Background(), "ebus.primary"); err != nil {
+		t.Fatalf("repeated Start() error = %v", err)
+	}
+	snapshot, _ := manager.Snapshot("ebus.primary")
+	if snapshot.ObservedState != ObservedStarting || snapshot.Reason.Code != ReasonStartRequested {
+		t.Fatalf("repeated Start changed in-progress state: %#v", snapshot)
+	}
+	runtime.mu.Lock()
+	calls := runtime.startCalls
+	runtime.mu.Unlock()
+	if calls != 1 {
+		t.Fatalf("runtime Start calls = %d, want 1", calls)
+	}
+	close(runtime.startRelease)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first Start() error = %v", err)
+	}
+	requireObservedState(t, manager, "ebus.primary", ObservedRunning, time.Second)
+	_ = manager.Shutdown(context.Background())
 }
 
 func requireObservedState(t *testing.T, manager *Manager, id string, want ObservedState, timeout time.Duration) Snapshot {

--- a/internal/drivermanager/manager_test.go
+++ b/internal/drivermanager/manager_test.go
@@ -438,6 +438,50 @@ func TestManagerRejectsStaleGenerationHealthCallbackAfterReplace(t *testing.T) {
 	}
 }
 
+func TestManagerSameDesiredStartPreservesDegradedGenerationByteForByte(t *testing.T) {
+	runtime := &scriptedRuntime{}
+	manager, err := New(Config{Drivers: []DriverConfig{{
+		ID:           "ebus.primary",
+		Enabled:      true,
+		Runtime:      runtime,
+		Capabilities: []Capability{CapabilityDiscovery, CapabilityRead, CapabilityWrite},
+	}}})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer func() { _ = manager.Shutdown(context.Background()) }()
+
+	if err := manager.Start(context.Background(), "ebus.primary"); err != nil {
+		t.Fatalf("initial Start() error = %v", err)
+	}
+	running := requireObservedState(t, manager, "ebus.primary", ObservedRunning, time.Second)
+	if accepted := manager.ReportDegraded(
+		"ebus.primary",
+		running.Generation,
+		[]Capability{CapabilityRead},
+		Reason{Code: ReasonCapabilityDegraded},
+	); !accepted {
+		t.Fatal("ReportDegraded() rejected current generation")
+	}
+	before := requireObservedState(t, manager, "ebus.primary", ObservedDegraded, time.Second)
+	startsBefore, stopsBefore := runtime.calls()
+
+	if err := manager.Start(context.Background(), "ebus.primary"); err != nil {
+		t.Fatalf("same-desired Start() error = %v", err)
+	}
+	after, ok := manager.Snapshot("ebus.primary")
+	if !ok {
+		t.Fatal("Snapshot() missing driver")
+	}
+	startsAfter, stopsAfter := runtime.calls()
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("same-desired Start changed degraded snapshot\nbefore: %#v\nafter:  %#v", before, after)
+	}
+	if startsAfter != startsBefore || stopsAfter != stopsBefore {
+		t.Fatalf("same-desired Start runtime calls = start %d->%d stop %d->%d", startsBefore, startsAfter, stopsBefore, stopsAfter)
+	}
+}
+
 func TestManagerSafetyQuarantineMirrorsRuntimeAndBlocksRecovery(t *testing.T) {
 	runtime := &scriptedRuntime{stopResults: []error{ErrSafetyQuarantined}}
 	manager, err := New(Config{Drivers: []DriverConfig{{

--- a/joinbus.go
+++ b/joinbus.go
@@ -151,7 +151,7 @@ func ClassifyTransportAdmission(kind TransportProtocol) (TransportAdmissionPath,
 // adapter-direct, contradicting main.go's special-case. Centralising the
 // logic here keeps all call sites in agreement.
 func ResolveAdmissionPath(kind TransportProtocol) (path TransportAdmissionPath, adapterDirectSpecialCase bool) {
-	if kind == TransportAdapterDirect {
+	if isAdapterDirectTransportProtocol(kind) {
 		return TransportAdmissionSourceSelectionCapable, true
 	}
 	resolved, err := ClassifyTransportAdmission(kind)

--- a/passive_bus_tap.go
+++ b/passive_bus_tap.go
@@ -215,7 +215,7 @@ func (tap *PassiveBusTap) readLoop(tr transport.RawTransport) error {
 			return err
 		}
 
-		event, err := readPassiveTransportEvent(tr)
+		event, err := readPassiveTransportEvent(tap.ctx, tr)
 		if err != nil {
 			if errors.Is(err, ebuserrors.ErrTimeout) {
 				tap.emit(PassiveTapEvent{
@@ -459,9 +459,23 @@ func reconnectDelay(attempt int, initial, max time.Duration) time.Duration {
 	return delay
 }
 
-func readPassiveTransportEvent(tr transport.RawTransport) (transport.StreamEvent, error) {
+func readPassiveTransportEvent(ctx context.Context, tr transport.RawTransport) (transport.StreamEvent, error) {
+	if reader, ok := tr.(interface {
+		ReadEventContext(context.Context) (transport.StreamEvent, error)
+	}); ok {
+		return reader.ReadEventContext(ctx)
+	}
 	if reader, ok := tr.(transport.StreamEventReader); ok {
 		return reader.ReadEvent()
+	}
+	if reader, ok := tr.(interface {
+		ReadByteContext(context.Context) (byte, error)
+	}); ok {
+		value, err := reader.ReadByteContext(ctx)
+		if err != nil {
+			return transport.StreamEvent{}, err
+		}
+		return transport.StreamEvent{Kind: transport.StreamEventByte, Byte: value}, nil
 	}
 
 	value, err := tr.ReadByte()

--- a/portal/explorer.go
+++ b/portal/explorer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -20,6 +21,11 @@ import (
 type ExplorerBus interface {
 	Send(ctx context.Context, frame protocol.Frame) (*protocol.Frame, error)
 }
+
+// ErrExplorerSourceUnavailable means no current-session eBUS source is
+// admitted for Explorer traffic. Callers must surface this as unavailable and
+// must not fall back to a configured or historical source address.
+var ErrExplorerSourceUnavailable = errors.New("explorer source unavailable")
 
 // Scan phases.
 const (
@@ -115,11 +121,11 @@ type explorerSubscriber struct {
 }
 
 type explorerStore struct {
-	mu      sync.Mutex
-	current *ExplorerScanState
-	bus     ExplorerBus
-	source  byte
-	cancel  context.CancelFunc
+	mu             sync.Mutex
+	current        *ExplorerScanState
+	bus            ExplorerBus
+	sourceProvider func() (byte, bool)
+	cancel         context.CancelFunc
 
 	// SSE subscribers
 	subMu    sync.Mutex
@@ -128,15 +134,53 @@ type explorerStore struct {
 	scanNext uint64
 }
 
-func newExplorerStore(bus ExplorerBus, source byte) *explorerStore {
-	if source == 0 {
-		source = 0xF0
+func newExplorerStore(bus ExplorerBus, source byte, sourceProviders ...func() (byte, bool)) *explorerStore {
+	sourceProvider := func() (byte, bool) {
+		if source == 0 {
+			return 0xF0, true
+		}
+		return source, true
+	}
+	if len(sourceProviders) > 0 && sourceProviders[0] != nil {
+		sourceProvider = sourceProviders[0]
 	}
 	return &explorerStore{
-		bus:    bus,
-		source: source,
-		subs:   make(map[uint64]*explorerSubscriber),
+		bus:            bus,
+		sourceProvider: sourceProvider,
+		subs:           make(map[uint64]*explorerSubscriber),
 	}
+}
+
+func (es *explorerStore) resolveSource(requested byte) (byte, error) {
+	if es == nil || es.sourceProvider == nil {
+		return 0, ErrExplorerSourceUnavailable
+	}
+	admitted, ok := es.sourceProvider()
+	if !ok || admitted == 0 {
+		return 0, ErrExplorerSourceUnavailable
+	}
+	if requested != 0 && requested != admitted {
+		return 0, fmt.Errorf("%w: requested source 0x%02X is not admitted", ErrExplorerSourceUnavailable, requested)
+	}
+	return admitted, nil
+}
+
+type admittedExplorerBus struct{ store *explorerStore }
+
+func (bus admittedExplorerBus) Send(ctx context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+	if bus.store == nil || bus.store.bus == nil {
+		return nil, ErrExplorerSourceUnavailable
+	}
+	source, err := bus.store.resolveSource(frame.Source)
+	if err != nil {
+		return nil, err
+	}
+	frame.Source = source
+	return bus.store.bus.Send(ctx, frame)
+}
+
+func (es *explorerStore) sendWithRetry(ctx context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+	return explorerSendWithRetry(ctx, admittedExplorerBus{store: es}, frame)
 }
 
 func cloneExplorerScanState(state *ExplorerScanState) *ExplorerScanState {
@@ -281,9 +325,9 @@ func (es *explorerStore) startB524Scan(req ExplorerScanRequest) error {
 		}
 	}
 
-	source := req.Source
-	if source == 0 {
-		source = es.source
+	source, err := es.resolveSource(req.Source)
+	if err != nil {
+		return err
 	}
 	opcode := req.Opcode
 	if opcode == 0 {
@@ -322,9 +366,9 @@ func (es *explorerStore) startB509Scan(req ExplorerScanRequest) error {
 		}
 	}
 
-	source := req.Source
-	if source == 0 {
-		source = es.source
+	source, err := es.resolveSource(req.Source)
+	if err != nil {
+		return err
 	}
 	opcode := req.Opcode
 	if opcode == 0 {
@@ -392,6 +436,12 @@ func (es *explorerStore) runB524Scan(ctx context.Context, req ExplorerScanReques
 
 		group := byte(g)
 		val, err := es.readB524GroupDescriptor(ctx, req.Target, source, opcode, group)
+		if errors.Is(err, ErrExplorerSourceUnavailable) {
+			es.mu.Lock()
+			state.Error = ErrExplorerSourceUnavailable.Error()
+			es.mu.Unlock()
+			return
+		}
 
 		gr := ExplorerGroupResult{
 			Group:    group,
@@ -471,7 +521,13 @@ func (es *explorerStore) runB524Scan(ctx context.Context, req ExplorerScanReques
 					return
 				}
 				inst := byte(i)
-				present := es.probeInstance(ctx, req.Target, source, opcode, gr.Group, inst)
+				present, err := es.probeInstance(ctx, req.Target, source, opcode, gr.Group, inst)
+				if errors.Is(err, ErrExplorerSourceUnavailable) {
+					es.mu.Lock()
+					state.Error = ErrExplorerSourceUnavailable.Error()
+					es.mu.Unlock()
+					return
+				}
 				es.mu.Lock()
 				state.CompletedReads++
 				state.Progress = ExplorerProgress{
@@ -510,7 +566,13 @@ func (es *explorerStore) runB524Scan(ctx context.Context, req ExplorerScanReques
 			}
 
 			addr := uint16(r)
-			result := es.readB524Register(ctx, req.Target, source, opcode, tgt.group, tgt.instance, addr)
+			result, err := es.readB524Register(ctx, req.Target, source, opcode, tgt.group, tgt.instance, addr)
+			if errors.Is(err, ErrExplorerSourceUnavailable) {
+				es.mu.Lock()
+				state.Error = ErrExplorerSourceUnavailable.Error()
+				es.mu.Unlock()
+				return
+			}
 
 			es.mu.Lock()
 			state.Results = append(state.Results, result)
@@ -564,7 +626,13 @@ func (es *explorerStore) runB509Scan(ctx context.Context, req ExplorerScanReques
 		}
 
 		addr := uint16(a)
-		result := es.readB509Register(ctx, req.Target, source, addr, opcode)
+		result, err := es.readB509Register(ctx, req.Target, source, addr, opcode)
+		if errors.Is(err, ErrExplorerSourceUnavailable) {
+			es.mu.Lock()
+			state.Error = ErrExplorerSourceUnavailable.Error()
+			es.mu.Unlock()
+			return
+		}
 
 		es.mu.Lock()
 		state.Results = append(state.Results, result)
@@ -593,7 +661,7 @@ func (es *explorerStore) readB524GroupDescriptor(ctx context.Context, target, so
 		Data:      []byte{opcode, 0x00, group, 0x00, 0x00, 0x00},
 	}
 
-	resp, err := explorerSendWithRetry(ctx, es.bus, frame)
+	resp, err := es.sendWithRetry(ctx, frame)
 	if err != nil {
 		return 0, err
 	}
@@ -615,7 +683,7 @@ func (es *explorerStore) readB524GroupDescriptor(ctx context.Context, target, so
 }
 
 // probeInstance checks if instance exists by reading register 0x0000.
-func (es *explorerStore) probeInstance(ctx context.Context, target, source, opcode, group, instance byte) bool {
+func (es *explorerStore) probeInstance(ctx context.Context, target, source, opcode, group, instance byte) (bool, error) {
 	frame := protocol.Frame{
 		FrameType: protocol.FrameTypeForTarget(target),
 		Source:    source,
@@ -625,23 +693,23 @@ func (es *explorerStore) probeInstance(ctx context.Context, target, source, opco
 		Data:      []byte{opcode, 0x00, group, instance, 0x00, 0x00},
 	}
 
-	resp, err := explorerSendWithRetry(ctx, es.bus, frame)
+	resp, err := es.sendWithRetry(ctx, frame)
 	if err != nil {
-		return false
+		return false, err
 	}
 	if len(resp.Data) == 0 {
-		return false
+		return false, nil
 	}
 	// A non-error response with data indicates the instance exists.
 	// Single byte 0x00 is an error/empty marker.
 	if len(resp.Data) == 1 && resp.Data[0] == 0x00 {
-		return false
+		return false, nil
 	}
-	return true
+	return true, nil
 }
 
 // readB524Register reads a single B524 register.
-func (es *explorerStore) readB524Register(ctx context.Context, target, source, opcode, group, instance byte, addr uint16) ExplorerRegisterResult {
+func (es *explorerStore) readB524Register(ctx context.Context, target, source, opcode, group, instance byte, addr uint16) (ExplorerRegisterResult, error) {
 	result := ExplorerRegisterResult{
 		Group:    group,
 		Instance: instance,
@@ -658,16 +726,16 @@ func (es *explorerStore) readB524Register(ctx context.Context, target, source, o
 		Data:      []byte{opcode, 0x00, group, instance, byte(addr), byte(addr >> 8)},
 	}
 
-	resp, err := explorerSendWithRetry(ctx, es.bus, frame)
+	resp, err := es.sendWithRetry(ctx, frame)
 	if err != nil {
 		result.Error = err.Error()
-		return result
+		return result, err
 	}
 
 	payload := extractB524Payload(resp.Data, group, addr)
 	if len(payload) == 0 {
 		result.Error = "no data in response"
-		return result
+		return result, nil
 	}
 
 	result.RawHex = hex.EncodeToString(payload)
@@ -682,11 +750,11 @@ func (es *explorerStore) readB524Register(ctx context.Context, target, source, o
 		}
 	}
 
-	return result
+	return result, nil
 }
 
 // readB509Register reads a single B509 register.
-func (es *explorerStore) readB509Register(ctx context.Context, target, source byte, addr uint16, opcode byte) ExplorerRegisterResult {
+func (es *explorerStore) readB509Register(ctx context.Context, target, source byte, addr uint16, opcode byte) (ExplorerRegisterResult, error) {
 	result := ExplorerRegisterResult{
 		Addr:    addr,
 		AddrHex: fmt.Sprintf("%04x", addr),
@@ -704,15 +772,15 @@ func (es *explorerStore) readB509Register(ctx context.Context, target, source by
 		Data:      []byte{opcode, byte(addr >> 8), byte(addr)},
 	}
 
-	resp, err := explorerSendWithRetry(ctx, es.bus, frame)
+	resp, err := es.sendWithRetry(ctx, frame)
 	if err != nil {
 		result.Error = err.Error()
-		return result
+		return result, err
 	}
 
 	if len(resp.Data) == 0 {
 		result.Error = "no data in response"
-		return result
+		return result, nil
 	}
 
 	result.RawHex = hex.EncodeToString(resp.Data)
@@ -726,7 +794,7 @@ func (es *explorerStore) readB509Register(ctx context.Context, target, source by
 		}
 	}
 
-	return result
+	return result, nil
 }
 
 // extractB524Payload extracts register data from a B524 response.
@@ -772,25 +840,27 @@ func extractB524Payload(data []byte, group byte, addr uint16) []byte {
 }
 
 // singleB524Read performs a single synchronous B524 read.
-func (es *explorerStore) singleB524Read(ctx context.Context, target, source, opcode, group, instance byte, addr uint16) ExplorerRegisterResult {
-	if source == 0 {
-		source = es.source
+func (es *explorerStore) singleB524Read(ctx context.Context, target, source, opcode, group, instance byte, addr uint16) (ExplorerRegisterResult, error) {
+	resolved, err := es.resolveSource(source)
+	if err != nil {
+		return ExplorerRegisterResult{}, err
 	}
 	if opcode == 0 {
 		opcode = 0x02
 	}
-	return es.readB524Register(ctx, target, source, opcode, group, instance, addr)
+	return es.readB524Register(ctx, target, resolved, opcode, group, instance, addr)
 }
 
 // singleB509Read performs a single synchronous B509 read.
-func (es *explorerStore) singleB509Read(ctx context.Context, target, source byte, addr uint16, opcode byte) ExplorerRegisterResult {
-	if source == 0 {
-		source = es.source
+func (es *explorerStore) singleB509Read(ctx context.Context, target, source byte, addr uint16, opcode byte) (ExplorerRegisterResult, error) {
+	resolved, err := es.resolveSource(source)
+	if err != nil {
+		return ExplorerRegisterResult{}, err
 	}
 	if opcode == 0 {
 		opcode = 0x0D
 	}
-	return es.readB509Register(ctx, target, source, addr, opcode)
+	return es.readB509Register(ctx, target, resolved, addr, opcode)
 }
 
 // readScanID reads the device serial via B5.09 ScanID frames (QQ=0x24..0x27).
@@ -801,10 +871,12 @@ func (es *explorerStore) singleB509Read(ctx context.Context, target, source byte
 // return 9 bytes of raw serial data with no status prefix.  We try the status-byte
 // interpretation first; if it doesn't yield a formatted serial we fall back to
 // the full-9-byte interpretation.
-func (es *explorerStore) readScanID(ctx context.Context, target, source byte) ExplorerScanIDResult {
-	if source == 0 {
-		source = es.source
+func (es *explorerStore) readScanID(ctx context.Context, target, source byte) (ExplorerScanIDResult, error) {
+	resolved, err := es.resolveSource(source)
+	if err != nil {
+		return ExplorerScanIDResult{}, err
 	}
+	source = resolved
 	result := ExplorerScanIDResult{
 		Target: target,
 		Source: source,
@@ -827,8 +899,11 @@ func (es *explorerStore) readScanID(ctx context.Context, target, source byte) Ex
 			Secondary: 0x09,
 			Data:      []byte{qq},
 		}
-		resp, err := explorerSendWithRetry(ctx, es.bus, frame)
+		resp, err := es.sendWithRetry(ctx, frame)
 		if err != nil {
+			if errors.Is(err, ErrExplorerSourceUnavailable) {
+				return ExplorerScanIDResult{}, err
+			}
 			msg := fmt.Sprintf("chunk 0x%02x: %v", qq, err)
 			errs = append(errs, msg)
 			chunks = append(chunks, chunkResp{err: msg})
@@ -860,7 +935,7 @@ func (es *explorerStore) readScanID(ctx context.Context, target, source byte) Ex
 		serial := formatScanIDSerial(string(trimScanIDPadding(statusRaw)))
 		if serial != "" {
 			result.Serial = serial
-			return result
+			return result, nil
 		}
 	}
 
@@ -881,7 +956,7 @@ func (es *explorerStore) readScanID(ctx context.Context, target, source byte) Ex
 	if len(errs) > 0 {
 		result.Error = strings.Join(errs, "; ")
 	}
-	return result
+	return result, nil
 }
 
 // trimScanIDPadding strips leading and trailing NUL/space/0xFF bytes.
@@ -970,6 +1045,10 @@ func (h *handler) handleExplorerStartScan(w http.ResponseWriter, r *http.Request
 		return
 	}
 	if err != nil {
+		if errors.Is(err, ErrExplorerSourceUnavailable) {
+			http.Error(w, ErrExplorerSourceUnavailable.Error(), http.StatusServiceUnavailable)
+			return
+		}
 		http.Error(w, err.Error(), http.StatusConflict)
 		return
 	}
@@ -1098,7 +1177,11 @@ func (h *handler) handleExplorerSingleB524(w http.ResponseWriter, r *http.Reques
 		http.Error(w, "invalid addr", http.StatusBadRequest)
 		return
 	}
-	result := h.explorer.singleB524Read(r.Context(), target, source, opcode, group, instance, addr)
+	result, readErr := h.explorer.singleB524Read(r.Context(), target, source, opcode, group, instance, addr)
+	if errors.Is(readErr, ErrExplorerSourceUnavailable) {
+		http.Error(w, ErrExplorerSourceUnavailable.Error(), http.StatusServiceUnavailable)
+		return
+	}
 	writeJSON(w, http.StatusOK, result)
 }
 
@@ -1120,7 +1203,11 @@ func (h *handler) handleExplorerSingleB509(w http.ResponseWriter, r *http.Reques
 		http.Error(w, "invalid addr", http.StatusBadRequest)
 		return
 	}
-	result := h.explorer.singleB509Read(r.Context(), target, source, addr, opcode)
+	result, readErr := h.explorer.singleB509Read(r.Context(), target, source, addr, opcode)
+	if errors.Is(readErr, ErrExplorerSourceUnavailable) {
+		http.Error(w, ErrExplorerSourceUnavailable.Error(), http.StatusServiceUnavailable)
+		return
+	}
 	writeJSON(w, http.StatusOK, result)
 }
 
@@ -1136,7 +1223,11 @@ func (h *handler) handleExplorerScanID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	source, _ := parseHexByte(q.Get("source"))
-	result := h.explorer.readScanID(r.Context(), target, source)
+	result, readErr := h.explorer.readScanID(r.Context(), target, source)
+	if errors.Is(readErr, ErrExplorerSourceUnavailable) {
+		http.Error(w, ErrExplorerSourceUnavailable.Error(), http.StatusServiceUnavailable)
+		return
+	}
 	writeJSON(w, http.StatusOK, result)
 }
 
@@ -1206,6 +1297,9 @@ func explorerSendWithRetry(ctx context.Context, bus ExplorerBus, frame protocol.
 		cancel()
 
 		if err != nil {
+			if errors.Is(err, ErrExplorerSourceUnavailable) {
+				return nil, err
+			}
 			lastErr = err
 		} else if resp == nil {
 			lastErr = fmt.Errorf("empty response")

--- a/portal/explorer_test.go
+++ b/portal/explorer_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -426,6 +427,106 @@ func TestExplorerSingleB509Read(t *testing.T) {
 	}
 	if int(payload["raw_len"].(float64)) != 4 {
 		t.Fatalf("raw_len = %v; want 4", payload["raw_len"])
+	}
+}
+
+func TestExplorerReadsUseLiveAdmittedSourceAndFailClosedBeforeAdmission(t *testing.T) {
+	bus := &mockExplorerBus{
+		handler: func(_ context.Context, frame protocol.Frame) (*protocol.Frame, error) {
+			return &protocol.Frame{
+				Source:    frame.Target,
+				Target:    frame.Source,
+				Primary:   frame.Primary,
+				Secondary: frame.Secondary,
+				Data:      []byte{0x01, 0x02, 0x03, 0x04},
+			}, nil
+		},
+	}
+	var sourceMu sync.RWMutex
+	var source byte
+	var admitted bool
+	h := NewHandler(Options{
+		GatewayVersion: "test",
+		BuildID:        "test",
+		ExplorerBus:    bus,
+		ExplorerSourceProvider: func() (byte, bool) {
+			sourceMu.RLock()
+			defer sourceMu.RUnlock()
+			return source, admitted
+		},
+	})
+
+	read := func(path string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		return rec
+	}
+	preAdmission := read("/api/v1/explorer/read/b509?target=15&addr=0028")
+	if preAdmission.Code != http.StatusServiceUnavailable {
+		t.Fatalf("pre-admission status = %d, want %d", preAdmission.Code, http.StatusServiceUnavailable)
+	}
+	bus.mu.Lock()
+	preAdmissionSends := len(bus.requests)
+	bus.mu.Unlock()
+	if preAdmissionSends != 0 {
+		t.Fatalf("pre-admission Bus.Send calls = %d, want 0", preAdmissionSends)
+	}
+
+	sourceMu.Lock()
+	source = 0x77
+	admitted = true
+	sourceMu.Unlock()
+	postAdmission := read("/api/v1/explorer/read/b509?target=15&addr=0028")
+	if postAdmission.Code != http.StatusOK {
+		t.Fatalf("post-admission status = %d, want %d body=%s", postAdmission.Code, http.StatusOK, postAdmission.Body.String())
+	}
+	bus.mu.Lock()
+	requests := append([]protocol.Frame(nil), bus.requests...)
+	bus.mu.Unlock()
+	if len(requests) != 1 || requests[0].Source != 0x77 {
+		t.Fatalf("post-admission requests = %#v, want one frame from 0x77", requests)
+	}
+
+	// An explicit query source is not a second authority. It may match the
+	// admitted source, but cannot bypass it with another address.
+	notAdmitted := read("/api/v1/explorer/read/b509?target=15&source=f0&addr=0028")
+	if notAdmitted.Code != http.StatusServiceUnavailable {
+		t.Fatalf("non-admitted explicit source status = %d, want %d", notAdmitted.Code, http.StatusServiceUnavailable)
+	}
+	bus.mu.Lock()
+	finalSends := len(bus.requests)
+	bus.mu.Unlock()
+	if finalSends != 1 {
+		t.Fatalf("non-admitted explicit source added Bus.Send calls: got %d, want 1 total", finalSends)
+	}
+}
+
+func TestExplorerRetryRechecksAdmissionBeforeEveryBusSend(t *testing.T) {
+	var sourceMu sync.RWMutex
+	admitted := true
+	bus := &mockExplorerBus{
+		handler: func(context.Context, protocol.Frame) (*protocol.Frame, error) {
+			sourceMu.Lock()
+			admitted = false
+			sourceMu.Unlock()
+			return nil, fmt.Errorf("retryable bus error")
+		},
+	}
+	store := newExplorerStore(bus, 0, func() (byte, bool) {
+		sourceMu.RLock()
+		defer sourceMu.RUnlock()
+		return 0x77, admitted
+	})
+	_, err := store.sendWithRetry(context.Background(), protocol.Frame{Source: 0x77, Target: 0x15})
+	if !errors.Is(err, ErrExplorerSourceUnavailable) {
+		t.Fatalf("sendWithRetry() error = %v, want ErrExplorerSourceUnavailable", err)
+	}
+	bus.mu.Lock()
+	sends := len(bus.requests)
+	bus.mu.Unlock()
+	if sends != 1 {
+		t.Fatalf("underlying Bus.Send calls after admission withdrawal = %d, want 1", sends)
 	}
 }
 

--- a/portal/handler.go
+++ b/portal/handler.go
@@ -58,20 +58,21 @@ var (
 )
 
 type Options struct {
-	GraphQLPath         string
-	SnapshotPath        string
-	SubscriptionPath    string
-	MCPPath             string
-	EEBusAdminPath      string
-	GatewayVersion      string
-	BuildID             string
-	ListRegistry        func() []RegistryDevice
-	ListSemantic        func() SemanticSnapshot
-	GetBusObservability func() any
-	ListProjections     func() []ProjectionDevice
-	GetProjection       func(address byte, plane string) (ProjectionGraph, bool)
-	ExplorerBus         ExplorerBus // nil disables explorer
-	ExplorerSource      byte        // default eBUS source address (0xF0 if zero)
+	GraphQLPath            string
+	SnapshotPath           string
+	SubscriptionPath       string
+	MCPPath                string
+	EEBusAdminPath         string
+	GatewayVersion         string
+	BuildID                string
+	ListRegistry           func() []RegistryDevice
+	ListSemantic           func() SemanticSnapshot
+	GetBusObservability    func() any
+	ListProjections        func() []ProjectionDevice
+	GetProjection          func(address byte, plane string) (ProjectionGraph, bool)
+	ExplorerBus            ExplorerBus // nil disables explorer
+	ExplorerSource         byte        // static fallback for standalone/test handlers
+	ExplorerSourceProvider func() (byte, bool)
 	// EbusStandardServer is the in-process L7 catalog sub-server consumed
 	// by the M5_PORTAL read-only consumer UI. Nil disables the
 	// /api/v1/ebus-standard/* routes (they return 404) and hides the
@@ -607,7 +608,7 @@ func NewHandler(opts Options) http.Handler {
 		sessions:  newSessionStore(100),
 	}
 	if opts.ExplorerBus != nil {
-		h.explorer = newExplorerStore(opts.ExplorerBus, opts.ExplorerSource)
+		h.explorer = newExplorerStore(opts.ExplorerBus, opts.ExplorerSource, opts.ExplorerSourceProvider)
 	}
 	return h
 }


### PR DESCRIPTION
## What

Adds the protocol-neutral in-process DriverManager core and converts only the primary eBUS lifecycle to the merged `transport.DriverRuntime` seam. The gateway and HTTP/API shell remain alive behind a stable typed-unavailable eBUS slot when construction or dialing fails.

Closes #851

## Scope

- eBUS driver only; Modbus and eeBUS remain unconverted
- no public `drivers.v1` MCP/GraphQL/Portal controls
- no HA/add-on/deploy/release/live mutation
- exact dependency: `helianthus-ebusgo` `v0.5.1-0.20260821185245-872b442444f2` / `872b442444f286cd075831db68304bd46f09fd87`
- docs gate: `helianthus-docs-ebus` `e1de1c1dc5e1a2f0285c6176cf0ac30a32a2db44`

## Implementation

- closed desired/observed states and secret-free categorical reasons; sorted/deduped static and effective capabilities; generation/revision/attempt evidence
- bounded exponential retry with deterministic-testable 20% jitter, retry cancellation, and a process-epoch shutdown fence
- async manager-owned construction keeps HTTP/API available through slow, failed, or context-ignoring factories
- generation plus active-operation correlation; Stop/Replace withdraw admission before teardown, fence stale callbacks/read bytes, and retire late stale admissions
- bounded late cleanup publishes `FAILED/CLOSE_UNCONFIRMED` and quarantines the process epoch when close cannot be proven
- stable per-family transport slots preserve ENH/ENS and adapter-direct optional interfaces without changing plain TCP/UDP/ebusd shape
- adapter-owned demand-driven read pumps and close-proof handshakes retire long-lived blocking reads without stealing arbitration traffic or closing beneath arbitrary admitted callbacks
- active and passive loss trigger correlated replacement; injected active/passive transports are one-shot after retirement
- managed adaptermux loss fences AddSession/START/SEND and old proxy/provider work before BACKOFF; legacy unmanaged reconnect behavior is unchanged
- URI descriptors canonicalize once for slot shape and downstream admission/source/evidence policy; malformed descriptors fail immediately as `CONFIG_INVALID`
- proxy readiness is tied to the exact admitted generation, bound listener, and live mux/listener state; fatal Accept is one-shot, correlated, withdraws readiness, and cannot duplicate recovery
- early MCP/GraphQL/Portal handlers remain stable and fail closed before source admission, then resolve the live admitted source for each operation
- V8 operations remain under current-generation admission and the cumulative counter stays monotonic across replacement

`cmd/gateway/modbus_runtime_adapter_test.go` is a harness-only adaptation. The previous test expected adapter-direct startup failure to escape `run`; #851 intentionally keeps the process alive, so the harness now injects HTTP startup and context cancellation and verifies the same failure remains driver-local. No Modbus production path or lifecycle behavior changed.

The address-table/startup harnesses still prove active-probe admission and passive reconstruction. They synchronize on the existing discovery/passive-attach signals because HTTP now starts earlier and provide in-memory active plus passive transports because DriverManager owns both generation resources. No address-table or source-admission invariant was weakened.

## Strict RED-first evidence

Mode: `strict_red_first`.

Tests-only RED commit, preserved unchanged: `b01f7e7c0dfbc0043a1322ed8316b17425470cb5`.

GitHub observed exact RED HEAD failure in run `32516910702` before any implementation commit was pushed.

Command:

```text
GOWORK=off go test ./internal/drivermanager ./cmd/gateway -run 'TestManager|TestIssue851' -count=1
```

Observed RED excerpt:

```text
internal/drivermanager/manager_test.go:81:18: undefined: New
internal/drivermanager/manager_test.go:81:22: undefined: Config
cmd/gateway/driver_manager_process_red_test.go:49:79: undefined: transport.ErrDriverUnavailable
cmd/gateway/ebus_driver_runtime_test.go:58:51: undefined: transport.ManagedRawTransport
cmd/gateway/ebus_driver_runtime_test.go:63:10: undefined: newManagedEBusGeneration
cmd/gateway/ebus_driver_runtime_test.go:65:23: undefined: transport.NewDriverRuntime
FAIL github.com/Project-Helianthus/helianthus-ebusgateway/internal/drivermanager [build failed]
FAIL github.com/Project-Helianthus/helianthus-ebusgateway/cmd/gateway [build failed]
```

## Exact-HEAD GREEN evidence

Exact implementation HEAD: `08afd701f0372f5387f1d5f7f384265a7debbc07`.

- fatal proxy Accept recovery, race detector, 20 repetitions — PASS: adaptermux `52.215s`, gateway `23.376s`
- normal proxy retirement/non-fatal distinction, race detector, 100 repetitions — PASS: adaptermux `1.575s`
- full focused DriverManager/adaptermux/gateway lifecycle, race detector, 20 repetitions — PASS: manager `6.244s`, adaptermux `4.202s`, gateway `62.899s`
- standalone `GOWORK=off go test -race ./...` — PASS: gateway `82.549s`, adaptermux `115.192s`
- `GOWORK=off go vet ./...` — PASS
- `GOWORK=off go build ./...` — PASS
- `GOWORK=off golangci-lint run ./...` — PASS, 0 issues
- exact-head `GOWORK=off ./scripts/ci_local.sh` on `08afd70...` — terminology/gofmt/93 Portal/assets/vet/build/Linux32/full-race/source-selection/Python (`168+6+9+7+6+2`)/lint all PASS, lint 0, then stopped at the required transport report gate; no override reused and no T01..T88/P01..P06 PASS claim
- GitHub Actions run `32545698007` on exact HEAD — terminology, build, test, and lint all SUCCESS

Fresh exact-HEAD independent review: `NO_BLOCKING_FINDINGS`; no P3/P4 items.

Fresh exact-HEAD adversarial tester: `PASS`; no P0-P2 or P3/P4 items. Independent evidence included focused manager/adaptermux/gateway race tests, focused lifecycle/recovery stress, root/Portal race stress, vet, build, and diff check. Worktree remained clean.

## Gates

- [x] GitHub CI observed RED on exact tests-only HEAD
- [x] exact-head focused lifecycle race/stress green
- [x] exact-head full `go test -race ./...` green
- [x] exact-head vet, build, lint green
- [x] exact-head local CI pre-transport stages green
- [x] exact-head GitHub CI green
- [x] fresh exact-head independent review: `NO_BLOCKING_FINDINGS`
- [x] fresh exact-head adversarial tester: `PASS`
- [ ] T01..T88 transport matrix or new separately documented owner override for exact HEAD `08afd701f0372f5387f1d5f7f384265a7debbc07`; prior `fae0116...` approval invalidated by HEAD change
- [ ] passive smoke report or new separately documented owner override for exact HEAD `08afd701f0372f5387f1d5f7f384265a7debbc07`; prior `fae0116...` approval invalidated by HEAD change

### Transport gate owner override

The connected eBUS rig is physically unavailable, so this work did not run or claim T01..T88. Exact-head local CI stopped with:

```text
transport gate: cmd/gateway/main.go contains non-rename runtime diff
transport gate: TRANSPORT_MATRIX_REPORT is required for transport/protocol changes.
```

No prior override (including #170 or the dependency PR override) was reused. The owner separately approved a transport-gate override for PR #852 at exact HEAD `fae01162992914751e04c9117d3b62210244ea86`; label `transport-gate-override` and comment `<!-- transport-gate-override: ... -->` record the reason. T01..T88 remains not run and is not claimed PASS.

Exact-head local CI with the transport override passed the transport gate and every normal test/build/lint stage, then exposed the separate passive-smoke gate.

### Passive smoke gate owner override

The same runtime diff also requires `PASSIVE_SMOKE_REPORT`. That six-case report depends on the unavailable connected rig and was not run. The owner separately approved a passive-smoke override for PR #852 at exact HEAD `fae01162992914751e04c9117d3b62210244ea86`; label `passive-smoke-gate-override` and comment `<!-- passive-smoke-gate-override: ... -->` record the reason. P01..P06 remain not executed and are not claimed PASS.

Exact-head `GOWORK=off ./scripts/ci_local.sh` with both owner overrides completed with exit `0`; all ordinary tests/race/build/lint passed, and each gate reported its own owner-approved override. No code or HEAD change was made.


### HEAD-change override invalidation

The zero-budget failure-classification P2 was fixed in `8c832f001893e10c48857335b544376894c0c9a3`. Because both owner approvals were explicitly scoped to `fae01162992914751e04c9117d3b62210244ea86`, they do not apply to this new HEAD. Their labels were removed and the PR remains draft. The historical comments remain as audit evidence only.


### Fresh-review remediation at `b0b89aa...`

- adapter-direct broadcast generations close the generation-owned passive bridge before mux/pump closure proof;
- GraphQL daemon status resolves the live admitted mutation source per request and remains unavailable while pending/failed/withdrawn;
- TCP-family URI normalization validates host and numeric port before dial and returns typed invalid payload for static configuration errors.

Each finding was observed RED before its production fix. Focused race repetitions (source/URI x100, broadcast Stop/loss x20, adjacent lifecycle x10), full relevant race, vet, and build passed. Fresh exact-head review and tester remain required.


### Fresh-review remediation at `23a097b...`

- stable passive reads use the tap context, so a late read after Close snapshot is canceled without permanently fencing the reusable stable slot;
- managed reconnect/recovery reopens the passive tap and remains race-tested;
- GraphQL status and Portal Explorer expose the selected source only while DriverManager admits current write capability.

Shutdown-race, recovery, and source authority were observed RED before fix. Focused race x100, adjacent root/gateway/Portal race x20, full relevant race, vet, build, and diff-check passed. Fresh exact-head review and tester remain required.


### Adversarial-tester remediation at `e58091b...`

- one live driver-intersected source authority now gates GraphQL mutations, GraphQL/MCP writers, leaf capture, MCP raw RPC/status, B503, and Portal Explorer;
- fatal managed listener failure performs nonblocking DriverManager withdrawal fencing and retires all existing managed proxy sessions/cache before publishing BACKOFF;
- AddSession rechecks the fence under the session lock, closing the concurrent admission TOCTOU; unmanaged behavior is unchanged.

Each issue was observed RED before fix. Focused race x100, adjacent race x20, full relevant race, vet, build, and diff-check passed. Fresh exact-head review and tester remain required.


### B503 lifecycle remediation at `7010637...`

- B503 session ownership observes exact DriverManager activation and withdrawal lifecycle;
- withdrawal releases generation-N ownership once without spuriously advancing the epoch;
- activation advances to N+1; stale source-unavailable callbacks cannot disconnect the recovered issuer;
- both request-during-outage and no-request outage/recovery paths are regression-tested.

RED was observed before the fix. Focused race x100, full relevant race, vet, and build passed. Fresh exact-head review and tester remain required.


### B503 stale send-error remediation at `08afd70...`

Transport-down classification carries the request's `transportAtIssue` into lifecycle-serialized `disconnectIfCurrent`; a stale generation-N completion cannot disconnect an issuer admitted after recovery to N+1. The exact TOCTOU was observed RED before fix. Focused race x100, full relevant race, vet, and build passed. Fresh exact-head review and tester remain required.
