### PR TITLE
Tesla: add read-only HSC Modbus MCP prototype

### DIFF
--- a/cmd/gateway/modbus_mcp_provider.go
+++ b/cmd/gateway/modbus_mcp_provider.go
@@ -142,6 +142,23 @@ func (provider *gatewayModbusMCPProvider) CanonicalPV(_ context.Context, profile
 	return mcp.ModbusCanonicalPVResult{Snapshot: snapshot, ProducedAt: producedAt.Format(time.RFC3339Nano)}, nil
 }
 
+// TeslaHSCV1 exposes only the disabled-by-default profile state. It does not
+// open a serial endpoint, schedule acquisition, or transmit vendor frames.
+func (provider *gatewayModbusMCPProvider) TeslaHSCV1(_ context.Context) (mcp.TeslaHSCV1Result, error) {
+	profile, err := modbusreg.NewTeslaHSCProfile(modbusreg.TeslaHSCProfileConfig{
+		Node:                 0x10,
+		CompatibilityVersion: "unknown",
+	})
+	if err != nil {
+		return mcp.TeslaHSCV1Result{}, err
+	}
+	return mcp.TeslaHSCV1Result{
+		Disposition:     string(profile.Disposition()),
+		Compatibility:   "unknown",
+		OutboundAllowed: profile.OutboundAllowed(),
+	}, nil
+}
+
 func profileObservationResult(record modbusadapter.ProfileObservationRecord) (mcp.ModbusProfileObservationResult, error) {
 	spec := record.Observation.Spec()
 	encoded, err := json.Marshal(record.Observation)

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/Project-Helianthus/helianthus-ebusgo v0.5.1-0.20260521144203-f9919f4b1007
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260817174811-f8b7082b3fa4
 	github.com/Project-Helianthus/helianthus-eebusreg v0.1.35
-	github.com/Project-Helianthus/helianthus-modbus v0.0.0-20260810083147-eab30aed9eb6
-	github.com/Project-Helianthus/helianthus-modbusreg v0.2.1
+	github.com/Project-Helianthus/helianthus-modbus v0.1.0
+	github.com/Project-Helianthus/helianthus-modbusreg v0.3.0
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260817174811-f8b7082b3fa4
 	github.com/Project-Helianthus/helianthus-eebusreg v0.1.35
 	github.com/Project-Helianthus/helianthus-modbus v0.1.0
-	github.com/Project-Helianthus/helianthus-modbusreg v0.3.0
+	github.com/Project-Helianthus/helianthus-modbusreg v0.4.0
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,12 @@ github.com/Project-Helianthus/helianthus-eebusreg v0.1.35 h1:FDo4sFDstzVvX8WjhBj
 github.com/Project-Helianthus/helianthus-eebusreg v0.1.35/go.mod h1:+GjGePfl5rHaWVre2+S6Rs50TZsAFA3ix0oy4tVy9xw=
 github.com/Project-Helianthus/helianthus-modbus v0.0.0-20260810083147-eab30aed9eb6 h1:+l+s7VBz51iKqZYhm081RydM439iPM/Uf6bubzvA3/4=
 github.com/Project-Helianthus/helianthus-modbus v0.0.0-20260810083147-eab30aed9eb6/go.mod h1:Nr8SW7fE3SIjnp+rj8PCOtwk8JZ9wqafu1ZCgq3Zz+Q=
+github.com/Project-Helianthus/helianthus-modbus v0.1.0 h1:doB3rq5aCC2uZ5MmLBCTBzYbB7o3XixUAWxfYc+Sr8Q=
+github.com/Project-Helianthus/helianthus-modbus v0.1.0/go.mod h1:Nr8SW7fE3SIjnp+rj8PCOtwk8JZ9wqafu1ZCgq3Zz+Q=
 github.com/Project-Helianthus/helianthus-modbusreg v0.2.1 h1:IuWNO1FpYwTC/3b/Gf6G8DTlUwVb20kjjWlGQ7eFTDc=
 github.com/Project-Helianthus/helianthus-modbusreg v0.2.1/go.mod h1:b1DlK4MkW72E+j+ejZqXHbMBiMUexU/+QWIT10zZVjU=
+github.com/Project-Helianthus/helianthus-modbusreg v0.3.0 h1:siBwCR/Jg7tb1ahlhACsa+T0gMFopd/kjjeFS+L3ngE=
+github.com/Project-Helianthus/helianthus-modbusreg v0.3.0/go.mod h1:fSffulNXZ7QlJ4Iadp3xDBMcBIz378GolmMDAxrTCkM=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.15 h1:FhdTAcv/kckjVhao5ovAQmLRvTG0EEPZT8lmdwHuymY=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.15/go.mod h1:qPqQTDqmPjyOJCr0JMNjhSC1XW1k3h5P/EZqRGy80Vs=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.17 h1:/cB/sBi/p3ofzGd41ASb6Nl6TY6KlbIs+e5lYXsiT7I=

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/Project-Helianthus/helianthus-modbusreg v0.2.1 h1:IuWNO1FpYwTC/3b/Gf6
 github.com/Project-Helianthus/helianthus-modbusreg v0.2.1/go.mod h1:b1DlK4MkW72E+j+ejZqXHbMBiMUexU/+QWIT10zZVjU=
 github.com/Project-Helianthus/helianthus-modbusreg v0.3.0 h1:siBwCR/Jg7tb1ahlhACsa+T0gMFopd/kjjeFS+L3ngE=
 github.com/Project-Helianthus/helianthus-modbusreg v0.3.0/go.mod h1:fSffulNXZ7QlJ4Iadp3xDBMcBIz378GolmMDAxrTCkM=
+github.com/Project-Helianthus/helianthus-modbusreg v0.4.0 h1:syxHxJQFdHFvMSTyNJ/pZ3n222T4U3+X00J/kB2IR0s=
+github.com/Project-Helianthus/helianthus-modbusreg v0.4.0/go.mod h1:fSffulNXZ7QlJ4Iadp3xDBMcBIz378GolmMDAxrTCkM=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.15 h1:FhdTAcv/kckjVhao5ovAQmLRvTG0EEPZT8lmdwHuymY=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.15/go.mod h1:qPqQTDqmPjyOJCr0JMNjhSC1XW1k3h5P/EZqRGy80Vs=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.17 h1:/cB/sBi/p3ofzGd41ASb6Nl6TY6KlbIs+e5lYXsiT7I=

--- a/mcp/modbus_v1.go
+++ b/mcp/modbus_v1.go
@@ -138,9 +138,13 @@ func RegisterModbusV1Tools(server *Server, provider ModbusV1Provider) {
 			},
 		},
 	)
+	registerTeslaHSCV1Tool(server, provider)
 }
 
 func (server *Server) handleModbusV1Call(ctx context.Context, name string, args map[string]any) (map[string]any, bool) {
+	if result, handled := server.handleTeslaHSCV1Call(ctx, name, args); handled {
+		return result, true
+	}
 	modbusV1Providers.RLock()
 	provider := modbusV1Providers.byServer[server]
 	modbusV1Providers.RUnlock()

--- a/mcp/tesla_hsc_v1.go
+++ b/mcp/tesla_hsc_v1.go
@@ -1,0 +1,56 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+const TeslaHSCV1StatusGetTool = "modbus.v1.tesla.hsc.status.get"
+
+// TeslaHSCV1Result is the redacted, read-only Tesla profile snapshot.
+type TeslaHSCV1Result struct {
+	Disposition     string `json:"disposition"`
+	Compatibility   string `json:"compatibility"`
+	OutboundAllowed bool   `json:"outbound_allowed"`
+	RetainedLength  int    `json:"retained_length"`
+	RetainedDigest  string `json:"retained_digest"`
+}
+
+// TeslaHSCV1Provider supplies a redacted profile snapshot without transport I/O.
+type TeslaHSCV1Provider interface {
+	TeslaHSCV1(context.Context) (TeslaHSCV1Result, error)
+}
+
+var teslaHSCV1Providers = struct {
+	sync.RWMutex
+	byServer map[*Server]TeslaHSCV1Provider
+}{byServer: make(map[*Server]TeslaHSCV1Provider)}
+
+func registerTeslaHSCV1Tool(server *Server, provider ModbusV1Provider) {
+	tesla, ok := provider.(TeslaHSCV1Provider)
+	if !ok || tesla == nil {
+		return
+	}
+	teslaHSCV1Providers.Lock()
+	teslaHSCV1Providers.byServer[server] = tesla
+	teslaHSCV1Providers.Unlock()
+	server.tools = append(server.tools, Tool{Name: TeslaHSCV1StatusGetTool, Description: "Get the read-only Tesla HSC profile disposition and redacted opaque retention metadata.", InputSchema: map[string]any{"type": "object", "properties": map[string]any{}, "additionalProperties": false}})
+}
+
+func (server *Server) handleTeslaHSCV1Call(ctx context.Context, name string, args map[string]any) (map[string]any, bool) {
+	if name != TeslaHSCV1StatusGetTool {
+		return nil, false
+	}
+	if len(args) != 0 {
+		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("invalid Tesla HSC status arguments"), false, "RETAINED_PROFILE", "")), true), true
+	}
+	teslaHSCV1Providers.RLock()
+	provider := teslaHSCV1Providers.byServer[server]
+	teslaHSCV1Providers.RUnlock()
+	if provider == nil {
+		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("Tesla HSC provider unavailable"), false, "RETAINED_PROFILE", "")), true), true
+	}
+	result, err := provider.TeslaHSCV1(ctx)
+	return callToolResultText(mustJSON(newModbusV1Envelope(result, err, true, "RETAINED_PROFILE", "")), err != nil), true
+}

--- a/mcp/tesla_hsc_v1_test.go
+++ b/mcp/tesla_hsc_v1_test.go
@@ -1,0 +1,30 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+)
+
+type teslaHSCV1FixtureProvider struct{ *modbusV1FixtureProvider }
+
+func (*teslaHSCV1FixtureProvider) TeslaHSCV1(context.Context) (TeslaHSCV1Result, error) {
+	return TeslaHSCV1Result{Disposition: "disabled", Compatibility: "unknown", OutboundAllowed: false}, nil
+}
+
+func TestTeslaHSCV1StatusToolIsReadOnlyAndRedacted(t *testing.T) {
+	server, err := NewServer(&testRegistry{entries: make(map[byte]registry.DeviceEntry)}, &testInvoker{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	RegisterModbusV1Tools(server, &teslaHSCV1FixtureProvider{&modbusV1FixtureProvider{}})
+	result := msp06Call(t, server.Handler(), TeslaHSCV1StatusGetTool, map[string]any{})
+	if result.isError {
+		t.Fatalf("result = %#v", result)
+	}
+	data := msp06Map(t, result.envelope["data"], "data")
+	if data["disposition"] != "disabled" || data["outbound_allowed"] != false {
+		t.Fatalf("data = %#v", data)
+	}
+}


### PR DESCRIPTION
Closes #853

## Scope

Read-only `modbus.v1.tesla.hsc.status.get` MCP prototype through the existing Modbus registration seam. The tool returns profile disposition, compatibility and redacted retention metadata only.

## Strict RED-first

Tests-only RED commit: `58be4d3a99ff1b3c12041ca96ee3c6b965214564`; GitHub Actions run `32644972919` failed before implementation.

## Safety

- no serial open, acquisition scheduling, configuration bootstrap, or FC100–FC102 send path;
- no lifecycle, DriverManager, adaptermux, GraphQL, Portal, HA, Matter or eeBUS change;
- provider reports disabled-by-default profile state; all outbound admission stays false;
- wire semantics and opaque state remain owned by `helianthus-modbusreg`.

## Dependencies

- `helianthus-modbus` v0.1.0 / `f9fbdcca341fa4a8b056a8e9a74bab1bc917e7d8`;
- `helianthus-modbusreg` v0.4.0 / `45877b65b0364bcfb6d4930044c3b45de2b06ef0`, including the bounded TEDAPI semantic registry.

T01–T88 is eBUS-only and not applicable. Awaiting exact-HEAD CI and review.