### PR TITLE
Tesla MCP: fail-close HSC status provider result

### DIFF
--- a/mcp/tesla_hsc_v1.go
+++ b/mcp/tesla_hsc_v1.go
@@ -13,8 +13,8 @@ type TeslaHSCV1Result struct {
 	Disposition     string `json:"disposition"`
 	Compatibility   string `json:"compatibility"`
 	OutboundAllowed bool   `json:"outbound_allowed"`
-	RetainedLength  int    `json:"retained_length"`
-	RetainedDigest  string `json:"retained_digest"`
+	RetainedLength  int    `json:"retained_length,omitempty"`
+	RetainedDigest  string `json:"retained_digest,omitempty"`
 }
 
 // TeslaHSCV1Provider supplies a redacted profile snapshot without transport I/O.

--- a/mcp/tesla_hsc_v1.go
+++ b/mcp/tesla_hsc_v1.go
@@ -52,5 +52,16 @@ func (server *Server) handleTeslaHSCV1Call(ctx context.Context, name string, arg
 		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("Tesla HSC provider unavailable"), false, "RETAINED_PROFILE", "")), true), true
 	}
 	result, err := provider.TeslaHSCV1(ctx)
+	result = failClosedTeslaHSCV1Result(result)
 	return callToolResultText(mustJSON(newModbusV1Envelope(result, err, true, "RETAINED_PROFILE", "")), err != nil), true
+}
+
+// failClosedTeslaHSCV1Result preserves status-only profile information while
+// preventing a provider from granting operation admission or exposing opaque
+// retention metadata through the MCP boundary.
+func failClosedTeslaHSCV1Result(result TeslaHSCV1Result) TeslaHSCV1Result {
+	result.OutboundAllowed = false
+	result.RetainedLength = 0
+	result.RetainedDigest = ""
+	return result
 }

--- a/mcp/tesla_hsc_v1_test.go
+++ b/mcp/tesla_hsc_v1_test.go
@@ -2,7 +2,6 @@ package mcp
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
@@ -56,7 +55,10 @@ func TestTeslaHSCV1StatusToolFailsClosedForProviderOutput(t *testing.T) {
 	if data["outbound_allowed"] != false {
 		t.Fatalf("outbound_allowed = %#v", data["outbound_allowed"])
 	}
-	if fmt.Sprint(data["retained_length"]) != "0" || data["retained_digest"] != "" {
+	if _, exists := data["retained_length"]; exists {
+		t.Fatalf("retained_length was exposed: %#v", data)
+	}
+	if _, exists := data["retained_digest"]; exists {
 		t.Fatalf("retention metadata = %#v", data)
 	}
 }

--- a/mcp/tesla_hsc_v1_test.go
+++ b/mcp/tesla_hsc_v1_test.go
@@ -28,3 +28,34 @@ func TestTeslaHSCV1StatusToolIsReadOnlyAndRedacted(t *testing.T) {
 		t.Fatalf("data = %#v", data)
 	}
 }
+
+type teslaHSCV1UnsafeFixtureProvider struct{ *modbusV1FixtureProvider }
+
+func (*teslaHSCV1UnsafeFixtureProvider) TeslaHSCV1(context.Context) (TeslaHSCV1Result, error) {
+	return TeslaHSCV1Result{
+		Disposition:     "qualified_read_only",
+		Compatibility:   "fixture",
+		OutboundAllowed: true,
+		RetainedLength:  42,
+		RetainedDigest:  "sensitive-fixture-payload",
+	}, nil
+}
+
+func TestTeslaHSCV1StatusToolFailsClosedForProviderOutput(t *testing.T) {
+	server, err := NewServer(&testRegistry{entries: make(map[byte]registry.DeviceEntry)}, &testInvoker{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	RegisterModbusV1Tools(server, &teslaHSCV1UnsafeFixtureProvider{&modbusV1FixtureProvider{}})
+	result := msp06Call(t, server.Handler(), TeslaHSCV1StatusGetTool, map[string]any{})
+	if result.isError {
+		t.Fatalf("result = %#v", result)
+	}
+	data := msp06Map(t, result.envelope["data"], "data")
+	if data["outbound_allowed"] != false {
+		t.Fatalf("outbound_allowed = %#v", data["outbound_allowed"])
+	}
+	if data["retained_length"] != float64(0) || data["retained_digest"] != "" {
+		t.Fatalf("retention metadata = %#v", data)
+	}
+}

--- a/mcp/tesla_hsc_v1_test.go
+++ b/mcp/tesla_hsc_v1_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
@@ -55,7 +56,7 @@ func TestTeslaHSCV1StatusToolFailsClosedForProviderOutput(t *testing.T) {
 	if data["outbound_allowed"] != false {
 		t.Fatalf("outbound_allowed = %#v", data["outbound_allowed"])
 	}
-	if data["retained_length"] != float64(0) || data["retained_digest"] != "" {
+	if fmt.Sprint(data["retained_length"]) != "0" || data["retained_digest"] != "" {
 		t.Fatalf("retention metadata = %#v", data)
 	}
 }


### PR DESCRIPTION
Closes #855.

Disjoint from #852: owns only `mcp/tesla_hsc_v1.go` and `mcp/tesla_hsc_v1_test.go`.

RED-first hardening of the existing read-only status tool: provider output cannot claim outbound permission or return opaque retention metadata. No serial/transport/config/deployment or TEDAPI operation path is added.