### PR TITLE
Add injected read-only Tesla HSC MCP runtime

### DIFF
--- a/mcp/tesla_hsc_runtime_v1.go
+++ b/mcp/tesla_hsc_runtime_v1.go
@@ -39,6 +39,9 @@ func (runtime *TeslaHSCV1Runtime) TeslaHSCV1(ctx context.Context) (TeslaHSCV1Res
 	if err != nil {
 		return TeslaHSCV1Result{}, err
 	}
+	if len(responses) == 0 {
+		return TeslaHSCV1Result{}, errors.New("Tesla HSC correlated response batch is empty")
+	}
 	for _, response := range responses {
 		if !validTeslaHSCV1CorrelatedResponse(response) {
 			return TeslaHSCV1Result{}, errors.New("Tesla HSC correlated response is invalid")

--- a/mcp/tesla_hsc_runtime_v1.go
+++ b/mcp/tesla_hsc_runtime_v1.go
@@ -1,0 +1,62 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+)
+
+// TeslaHSCV1CorrelatedResponse is one inbound RTU exchange already correlated
+// by the transport. It has no request-construction or transmit capability.
+type TeslaHSCV1CorrelatedResponse struct {
+	Function byte
+	Payloads [][]byte
+}
+
+// TeslaHSCV1ResponseProvider supplies only completed correlated responses.
+type TeslaHSCV1ResponseProvider interface {
+	TeslaHSCV1Responses(context.Context) ([]TeslaHSCV1CorrelatedResponse, error)
+}
+
+// TeslaHSCV1Runtime projects injected Tesla response metadata into the
+// existing read-only MCP profile status surface.
+type TeslaHSCV1Runtime struct{ provider TeslaHSCV1ResponseProvider }
+
+func NewTeslaHSCV1Runtime(provider TeslaHSCV1ResponseProvider) (*TeslaHSCV1Runtime, error) {
+	if provider == nil {
+		return nil, errors.New("Tesla HSC response provider is required")
+	}
+	return &TeslaHSCV1Runtime{provider: provider}, nil
+}
+
+// TeslaHSCV1 validates only inbound response multiplicity and always projects
+// a fail-closed read-only result. It performs no I/O beyond calling its
+// injected response provider.
+func (runtime *TeslaHSCV1Runtime) TeslaHSCV1(ctx context.Context) (TeslaHSCV1Result, error) {
+	if runtime == nil || runtime.provider == nil || ctx == nil {
+		return TeslaHSCV1Result{}, errors.New("Tesla HSC runtime is unavailable")
+	}
+	responses, err := runtime.provider.TeslaHSCV1Responses(ctx)
+	if err != nil {
+		return TeslaHSCV1Result{}, err
+	}
+	for _, response := range responses {
+		if !validTeslaHSCV1CorrelatedResponse(response) {
+			return TeslaHSCV1Result{}, errors.New("Tesla HSC correlated response is invalid")
+		}
+	}
+	return TeslaHSCV1Result{Disposition: "framing_only", Compatibility: "correlated_response", OutboundAllowed: false}, nil
+}
+
+func validTeslaHSCV1CorrelatedResponse(response TeslaHSCV1CorrelatedResponse) bool {
+	if len(response.Payloads) == 0 || len(response.Payloads) > 8 {
+		return false
+	}
+	switch response.Function {
+	case 100:
+		return true
+	case 101, 102:
+		return len(response.Payloads) == 1
+	default:
+		return false
+	}
+}

--- a/mcp/tesla_hsc_runtime_v1.go
+++ b/mcp/tesla_hsc_runtime_v1.go
@@ -8,8 +8,8 @@ import (
 // TeslaHSCV1CorrelatedResponse is one inbound RTU exchange already correlated
 // by the transport. It has no request-construction or transmit capability.
 type TeslaHSCV1CorrelatedResponse struct {
-	Function byte
-	Payloads [][]byte
+	Function     byte
+	PayloadCount uint8
 }
 
 // TeslaHSCV1ResponseProvider supplies only completed correlated responses.
@@ -51,14 +51,14 @@ func (runtime *TeslaHSCV1Runtime) TeslaHSCV1(ctx context.Context) (TeslaHSCV1Res
 }
 
 func validTeslaHSCV1CorrelatedResponse(response TeslaHSCV1CorrelatedResponse) bool {
-	if len(response.Payloads) == 0 || len(response.Payloads) > 8 {
+	if response.PayloadCount == 0 || response.PayloadCount > 8 {
 		return false
 	}
 	switch response.Function {
 	case 100:
 		return true
 	case 101, 102:
-		return len(response.Payloads) == 1
+		return response.PayloadCount == 1
 	default:
 		return false
 	}

--- a/mcp/tesla_hsc_runtime_v1_test.go
+++ b/mcp/tesla_hsc_runtime_v1_test.go
@@ -2,13 +2,20 @@ package mcp
 
 import (
 	"context"
+	"reflect"
 	"testing"
 )
 
 func TestTeslaHSCV1RuntimeInjectsOnlyRedactedCorrelatedResponses(t *testing.T) {
+	responseType := reflect.TypeOf(TeslaHSCV1CorrelatedResponse{})
+	for field := 0; field < responseType.NumField(); field++ {
+		if typeContainsBytes(responseType.Field(field).Type) {
+			t.Fatalf("correlated response accepts raw bytes through %s", responseType.Field(field).Name)
+		}
+	}
 	runtime, err := NewTeslaHSCV1Runtime(&teslaHSCV1RuntimeFixture{responses: []TeslaHSCV1CorrelatedResponse{
-		{Function: 100, Payloads: [][]byte{{0}, {1, 0xaa}}},
-		{Function: 101, Payloads: [][]byte{{1, 0}}},
+		{Function: 100, PayloadCount: 2},
+		{Function: 101, PayloadCount: 1},
 	}})
 	if err != nil {
 		t.Fatal(err)
@@ -25,9 +32,16 @@ func TestTeslaHSCV1RuntimeInjectsOnlyRedactedCorrelatedResponses(t *testing.T) {
 	}
 }
 
+func typeContainsBytes(typ reflect.Type) bool {
+	if typ.Kind() == reflect.Array || typ.Kind() == reflect.Slice {
+		return typ.Elem().Kind() == reflect.Uint8 || typeContainsBytes(typ.Elem())
+	}
+	return false
+}
+
 func TestTeslaHSCV1RuntimeRejectsUncorrelatedOrOpaqueOutboundPaths(t *testing.T) {
 	for _, response := range []TeslaHSCV1CorrelatedResponse{
-		{Function: 101, Payloads: [][]byte{{1}, {2}}},
+		{Function: 101, PayloadCount: 2},
 		{Function: 102},
 	} {
 		runtime, err := NewTeslaHSCV1Runtime(&teslaHSCV1RuntimeFixture{responses: []TeslaHSCV1CorrelatedResponse{response}})

--- a/mcp/tesla_hsc_runtime_v1_test.go
+++ b/mcp/tesla_hsc_runtime_v1_test.go
@@ -1,0 +1,49 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+)
+
+func TestTeslaHSCV1RuntimeInjectsOnlyRedactedCorrelatedResponses(t *testing.T) {
+	runtime, err := NewTeslaHSCV1Runtime(&teslaHSCV1RuntimeFixture{responses: []TeslaHSCV1CorrelatedResponse{
+		{Function: 100, Payloads: [][]byte{{0}, {1, 0xaa}}},
+		{Function: 101, Payloads: [][]byte{{1, 0}}},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := runtime.TeslaHSCV1(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.OutboundAllowed || result.RetainedLength != 0 || result.RetainedDigest != "" {
+		t.Fatalf("unsafe result: %#v", result)
+	}
+	if result.Disposition != "framing_only" || result.Compatibility != "correlated_response" {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestTeslaHSCV1RuntimeRejectsUncorrelatedOrOpaqueOutboundPaths(t *testing.T) {
+	for _, response := range []TeslaHSCV1CorrelatedResponse{
+		{Function: 101, Payloads: [][]byte{{1}, {2}}},
+		{Function: 102},
+	} {
+		runtime, err := NewTeslaHSCV1Runtime(&teslaHSCV1RuntimeFixture{responses: []TeslaHSCV1CorrelatedResponse{response}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := runtime.TeslaHSCV1(context.Background()); err == nil {
+			t.Fatalf("invalid correlated response accepted: %#v", response)
+		}
+	}
+}
+
+type teslaHSCV1RuntimeFixture struct {
+	responses []TeslaHSCV1CorrelatedResponse
+}
+
+func (fixture *teslaHSCV1RuntimeFixture) TeslaHSCV1Responses(context.Context) ([]TeslaHSCV1CorrelatedResponse, error) {
+	return fixture.responses, nil
+}

--- a/mcp/tesla_hsc_v1_test.go
+++ b/mcp/tesla_hsc_v1_test.go
@@ -78,4 +78,7 @@ func TestTeslaHSCV1RuntimeRejectsEmptyCorrelatedResponseBatch(t *testing.T) {
 	if err == nil {
 		t.Fatalf("empty correlated response batch accepted as %#v", result)
 	}
+	if result != (TeslaHSCV1Result{}) {
+		t.Fatalf("empty correlated response batch retained result %#v", result)
+	}
 }

--- a/mcp/tesla_hsc_v1_test.go
+++ b/mcp/tesla_hsc_v1_test.go
@@ -62,3 +62,20 @@ func TestTeslaHSCV1StatusToolFailsClosedForProviderOutput(t *testing.T) {
 		t.Fatalf("retention metadata = %#v", data)
 	}
 }
+
+type teslaHSCV1EmptyResponseProvider struct{}
+
+func (teslaHSCV1EmptyResponseProvider) TeslaHSCV1Responses(context.Context) ([]TeslaHSCV1CorrelatedResponse, error) {
+	return nil, nil
+}
+
+func TestTeslaHSCV1RuntimeRejectsEmptyCorrelatedResponseBatch(t *testing.T) {
+	runtime, err := NewTeslaHSCV1Runtime(teslaHSCV1EmptyResponseProvider{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := runtime.TeslaHSCV1(context.Background())
+	if err == nil {
+		t.Fatalf("empty correlated response batch accepted as %#v", result)
+	}
+}


### PR DESCRIPTION
Closes #857

MCP-only injected runtime for already-correlated Tesla HSC RTU responses. Validates FC100 bounded multi-frame and FC101/102 single opaque normal response multiplicity, then projects fail-closed status only. No request construction, transmission, serial configuration, lifecycle wiring, or hardware I/O.

TDD RED test commit precedes implementation.