### PR TITLE
MCP: add injected read-only Growatt BMS V1.04 snapshot boundary

### DIFF
--- a/mcp/growatt_bms_v104_v1.go
+++ b/mcp/growatt_bms_v104_v1.go
@@ -1,0 +1,107 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+)
+
+const GrowattBMSV104Profile = "growatt.bms.low_voltage.can.v1_04"
+
+var (
+	ErrGrowattBMSV104ProviderUnavailable = errors.New("growatt BMS V1.04 provider is unavailable")
+	ErrGrowattBMSV104NotAdmitted         = errors.New("growatt BMS V1.04 snapshot is not admitted")
+)
+
+// GrowattBMSV104RawEvidence is retained by the injected provider only.
+// It is deliberately absent from the MCP-facing result.
+type GrowattBMSV104RawEvidence struct {
+	Identifier uint32
+	Data       [8]byte
+}
+
+type GrowattBMSV104Limits struct {
+	ChargeVoltageDecivolts   uint16 `json:"charge_voltage_decivolts"`
+	ChargeCurrentDeciamps    uint16 `json:"charge_current_deciamps"`
+	DischargeCurrentDeciamps uint16 `json:"discharge_current_deciamps"`
+	RawStatus                uint16 `json:"raw_status"`
+}
+
+type GrowattBMSV104Status struct {
+	Protection     [2]byte `json:"protection"`
+	Warning        [2]byte `json:"warning"`
+	PackCount      uint8   `json:"pack_count"`
+	Manufacturer   [2]byte `json:"manufacturer"`
+	TotalCellCount uint8   `json:"total_cell_count"`
+}
+
+type GrowattBMSV104Measurements struct {
+	VoltageCentivolts           int16 `json:"voltage_centivolts"`
+	CurrentDeciamps             int16 `json:"current_deciamps"`
+	MaximumCellTemperatureDeciC int16 `json:"maximum_cell_temperature_decic"`
+	SOCPercent                  uint8 `json:"soc_percent"`
+	SOHValue                    uint8 `json:"soh_value"`
+	SOHValid                    bool  `json:"soh_valid"`
+}
+
+// GrowattBMSV104ProviderSnapshot is the internal injected input boundary.
+type GrowattBMSV104ProviderSnapshot struct {
+	Profile         string                      `json:"profile"`
+	Admitted        bool                        `json:"admitted"`
+	OutboundAllowed bool                        `json:"outbound_allowed"`
+	Limits          GrowattBMSV104Limits        `json:"limits"`
+	Status          GrowattBMSV104Status        `json:"status"`
+	Measurements    GrowattBMSV104Measurements  `json:"measurements"`
+	RawEvidence     []GrowattBMSV104RawEvidence `json:"-"`
+}
+
+// GrowattBMSV104SnapshotProvider supplies an already-admitted snapshot without transport I/O.
+type GrowattBMSV104SnapshotProvider interface {
+	GrowattBMSV104Snapshot(context.Context) (GrowattBMSV104ProviderSnapshot, error)
+}
+
+// GrowattBMSV104Result is the safe, read-only MCP-facing projection.
+type GrowattBMSV104Result struct {
+	Profile             string                     `json:"profile"`
+	Admitted            bool                       `json:"admitted"`
+	OutboundAllowed     bool                       `json:"outbound_allowed"`
+	RawEvidenceRedacted bool                       `json:"raw_evidence_redacted"`
+	Limits              GrowattBMSV104Limits       `json:"limits"`
+	Status              GrowattBMSV104Status       `json:"status"`
+	Measurements        GrowattBMSV104Measurements `json:"measurements"`
+}
+
+// GrowattBMSV104Runtime owns the injected read-only snapshot boundary.
+type GrowattBMSV104Runtime struct {
+	provider GrowattBMSV104SnapshotProvider
+}
+
+func NewGrowattBMSV104Runtime(provider GrowattBMSV104SnapshotProvider) (*GrowattBMSV104Runtime, error) {
+	if provider == nil {
+		return nil, ErrGrowattBMSV104ProviderUnavailable
+	}
+	return &GrowattBMSV104Runtime{provider: provider}, nil
+}
+
+func (runtime *GrowattBMSV104Runtime) SnapshotGet(ctx context.Context) (GrowattBMSV104Result, error) {
+	if runtime == nil || runtime.provider == nil {
+		return GrowattBMSV104Result{}, ErrGrowattBMSV104ProviderUnavailable
+	}
+
+	snapshot, err := runtime.provider.GrowattBMSV104Snapshot(ctx)
+	if err != nil {
+		return GrowattBMSV104Result{}, err
+	}
+	if !snapshot.Admitted || snapshot.Profile != GrowattBMSV104Profile {
+		return GrowattBMSV104Result{}, ErrGrowattBMSV104NotAdmitted
+	}
+
+	return GrowattBMSV104Result{
+		Profile:             GrowattBMSV104Profile,
+		Admitted:            true,
+		OutboundAllowed:     false,
+		RawEvidenceRedacted: true,
+		Limits:              snapshot.Limits,
+		Status:              snapshot.Status,
+		Measurements:        snapshot.Measurements,
+	}, nil
+}

--- a/mcp/growatt_bms_v104_v1_test.go
+++ b/mcp/growatt_bms_v104_v1_test.go
@@ -52,7 +52,7 @@ func TestGrowattBMSV104SnapshotGetRedactsUnsafeProviderEvidence(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.OutboundAllowed || strings.Contains(string(encoded), "raw_evidence") || strings.Contains(string(encoded), "deadbeef") {
+	if result.OutboundAllowed || strings.Contains(string(encoded), "\"raw_evidence\":") || strings.Contains(string(encoded), "deadbeef") {
 		t.Fatalf("unsafe result = %s", encoded)
 	}
 }

--- a/mcp/growatt_bms_v104_v1_test.go
+++ b/mcp/growatt_bms_v104_v1_test.go
@@ -1,0 +1,104 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type growattBMSV104FixtureProvider struct {
+	snapshot GrowattBMSV104ProviderSnapshot
+	err      error
+}
+
+func (provider growattBMSV104FixtureProvider) GrowattBMSV104Snapshot(context.Context) (GrowattBMSV104ProviderSnapshot, error) {
+	return provider.snapshot, provider.err
+}
+
+func TestGrowattBMSV104SnapshotGetProjectsOnlyAdmittedReadOnlyData(t *testing.T) {
+	runtime, err := NewGrowattBMSV104Runtime(growattBMSV104FixtureProvider{snapshot: growattBMSV104FixtureSnapshot()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := runtime.SnapshotGet(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Profile != GrowattBMSV104Profile || !result.Admitted || result.OutboundAllowed || !result.RawEvidenceRedacted {
+		t.Fatalf("result = %#v", result)
+	}
+	if result.Limits.ChargeVoltageDecivolts != 568 || result.Measurements.SOCPercent != 80 || result.Status.PackCount != 2 {
+		t.Fatalf("projection = %#v", result)
+	}
+}
+
+func TestGrowattBMSV104SnapshotGetRedactsUnsafeProviderEvidence(t *testing.T) {
+	snapshot := growattBMSV104FixtureSnapshot()
+	snapshot.OutboundAllowed = true
+	snapshot.RawEvidence = []GrowattBMSV104RawEvidence{{Identifier: 0x311, Data: [8]byte{0xde, 0xad, 0xbe, 0xef}}}
+	runtime, err := NewGrowattBMSV104Runtime(growattBMSV104FixtureProvider{snapshot: snapshot})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := runtime.SnapshotGet(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.OutboundAllowed || strings.Contains(string(encoded), "raw_evidence") || strings.Contains(string(encoded), "deadbeef") {
+		t.Fatalf("unsafe result = %s", encoded)
+	}
+}
+
+func TestGrowattBMSV104SnapshotGetFailsClosed(t *testing.T) {
+	providerFailure := errors.New("provider failure")
+	for _, testCase := range []struct {
+		name     string
+		provider GrowattBMSV104SnapshotProvider
+		want     error
+	}{
+		{name: "nil provider", want: ErrGrowattBMSV104ProviderUnavailable},
+		{name: "provider failure", provider: growattBMSV104FixtureProvider{err: providerFailure}, want: providerFailure},
+		{name: "wrong profile", provider: growattBMSV104FixtureProvider{snapshot: GrowattBMSV104ProviderSnapshot{Admitted: true, Profile: "other"}}, want: ErrGrowattBMSV104NotAdmitted},
+		{name: "not admitted", provider: growattBMSV104FixtureProvider{snapshot: GrowattBMSV104ProviderSnapshot{Profile: GrowattBMSV104Profile}}, want: ErrGrowattBMSV104NotAdmitted},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			runtime, err := NewGrowattBMSV104Runtime(testCase.provider)
+			if testCase.provider == nil {
+				if !errors.Is(err, testCase.want) {
+					t.Fatalf("NewGrowattBMSV104Runtime() error = %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := runtime.SnapshotGet(context.Background()); !errors.Is(err, testCase.want) {
+				t.Fatalf("SnapshotGet() error = %v, want %v", err, testCase.want)
+			}
+		})
+	}
+}
+
+func growattBMSV104FixtureSnapshot() GrowattBMSV104ProviderSnapshot {
+	return GrowattBMSV104ProviderSnapshot{
+		Profile:         GrowattBMSV104Profile,
+		Admitted:        true,
+		OutboundAllowed: false,
+		Limits: GrowattBMSV104Limits{
+			ChargeVoltageDecivolts: 568,
+		},
+		Status: GrowattBMSV104Status{PackCount: 2, TotalCellCount: 16},
+		Measurements: GrowattBMSV104Measurements{
+			SOCPercent: 80,
+		},
+		RawEvidence: []GrowattBMSV104RawEvidence{{Identifier: 0x311, Data: [8]byte{0x02, 0x38}}},
+	}
+}


### PR DESCRIPTION
## Scope
- adds an injectable, read-only boundary for an already-admitted Growatt low-voltage BMS CAN V1.04 snapshot
- projects only bounded values; provider-only raw evidence is structurally absent from the result
- forces `outbound_allowed=false`; no SocketCAN, TX, registration, config, lifecycle, or server wiring

## Evidence
- RED commit: `9d203be03dda1f5bcaf1c0e76620d5f1750e9126` (remote CI failed on the intentionally missing contract)
- Green: targeted and full `mcp` tests pass locally
- Full local CI passes all stages before lint; the sole remaining lint issue is pre-existing in `origin/main` (`mcp/tesla_hsc_v1.go:52`, ST1005)

Closes #860