### PR TITLE
Make gateway AGENTS standalone and protocol-neutral

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,19 @@ private network, Home Assistant instance, or physical bus.
 - Existing eBUS MCP namespaces are compatibility surfaces, not a universal
   delivery rule for other protocol families.
 
+### eBUS MCP invoke safety
+
+`ebus.v1.rpc.invoke` is an eBUS compatibility and safety surface:
+
+- Every call requires explicit `intent` (`READ_ONLY` or `MUTATE`) and an
+  `allow_dangerous` boolean.
+- `READ_ONLY` is allowed only for a known method classified as read-only;
+  mutating or unknown methods fail closed.
+- `MUTATE` requires `allow_dangerous=true` and a non-empty
+  `idempotency_key`.
+- Missing or unknown intent and missing safety fields fail closed. Preserve
+  replay/idempotency behavior when changing invoke request normalization.
+
 Public eBUS and B524 contracts are documented at:
 
 - https://github.com/Project-Helianthus/helianthus-docs-ebus/blob/main/protocols/vaillant/ebus-vaillant-B524.md
@@ -59,6 +72,10 @@ Public eBUS and B524 contracts are documented at:
 - Transport or protocol-code changes require the applicable T01..T88 result with
   no unexpected fail or xpass unless the operator records a scope-specific
   override.
+- A transport-gate override requires both
+  `TRANSPORT_GATE_OWNER_OVERRIDE=OVERRIDE_TRANSPORT_GATE_BY_OWNER` and a
+  non-empty `TRANSPORT_GATE_OWNER_REASON`. The reason must identify the exact
+  scope and residual risk; an override never implies permission for live writes.
 - Prefer deterministic fixtures, replay, mocks, and local integration tests.
 - A real Home Assistant or live-device smoke is supplemental unless the issue
   explicitly requires it; it is not a prerequisite for ordinary contribution.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,23 @@ Existing `ebus.v1.*` tools are stable consumer contracts:
 - Missing or unknown intent and missing safety fields fail closed. Preserve
   replay/idempotency behavior when changing invoke request normalization.
 
+### eBUS MCP to GraphQL graduation and parity
+
+For eBUS capabilities, MCP remains the discovery and stabilization surface. A
+capability may graduate to GraphQL only when:
+
+1. it exists as a core stable `ebus.v1.*` MCP capability rather than only under
+   an experimental namespace;
+2. its determinism, contract, classification, and golden-snapshot tests are
+   green; and
+3. executable MCP-to-GraphQL parity coverage for that capability is green.
+
+Parity drift between an existing eBUS MCP contract and its GraphQL exposure is a
+CI failure. Home Assistant, Portal, and other consumers adopt the capability only
+after GraphQL parity and stability are established. These are eBUS compatibility
+rules for the current gateway; they do not impose MCP-first delivery on other
+protocol families.
+
 Public eBUS and B524 contracts are documented at:
 
 - https://github.com/Project-Helianthus/helianthus-docs-ebus/blob/main/protocols/vaillant/ebus-vaillant-B524.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,79 +1,69 @@
 # AGENTS
 
-This repository is part of the **Helianthus Multi-Protocol HVAC Gateway Platform**.
+## Repository scope
 
-## Dual-AI Operating Model
+`helianthus-ebusgateway` is the current Helianthus gateway runtime. It owns
+runtime composition, driver lifecycle, protocol-native integration, MCP and
+GraphQL surfaces, Portal behavior, and the HTTP/operator edge.
 
-All development follows the dual-AI orchestrator protocol defined in the workspace-root [`AGENTS.md`](../AGENTS.md):
+The repository keeps this name until a separately approved gateway rewrite.
+Do not rename it as part of unrelated work.
 
-- **Role binding:** `ORCHESTRATOR` and `CO_PILOT` are portable roles. The current workspace default is Claude as orchestrator and Codex as co-pilot, but this repo must remain swap-ready.
-- **Co-Pilot use:** Use the co-pilot only for adversarial/cooperative reasoning roles such as planner, bounded developer, reviewer, and second-opinion consultant. Do not spend Claude MCP or any equivalent co-pilot runtime on file reads, globs, grep, polling, or routine repo inspection.
-- **Fallback:** If the preferred co-pilot is unavailable, throttled, or not integrated, the active orchestrator spawns fresh-context agents on the available runtime and keeps the same supervision contract.
-- Phases: Adversarial Planning → Smart Routing → Dual Code Review
-- Hard rules: one issue/PR per repo, squash+merge only, doc-gate, transport-gate, MCP-first
+This repository is not the universal semantic owner. Cross-protocol canonical
+semantics belong to planned `helianthus-semreg` when that repository and scope
+become active. Until then, keep protocol-specific types and behavior inside their
+driver, adapter, or native projection boundaries.
 
-See the root AGENTS.md for the full protocol, routing tables, portable role prompts, and invariants. When running under Codex local orchestration, use the workspace-root skills `helianthus-orchestrator-supervision` and `helianthus-review-watch` as the portable supervision contract.
+## Workflow
 
----
+1. Create one scoped English GitHub issue.
+2. Create `issue/<number>-<slug>` from the repository's current `main`.
+3. Keep the change within the issue acceptance criteria and add focused tests.
+4. Run `./scripts/ci_local.sh` before push.
+5. Open one linked PR containing commands, results, applicable gates, and
+   residual risk.
+6. Resolve every valid P0-P2 finding and rerun validation after fixes.
+7. Obtain a fresh exact-HEAD `NO_BLOCKING_FINDINGS` review with all applicable
+   checks green.
+8. Squash merge, verify remote `main`, and stop at the requested boundary.
 
-## Repo-Specific Rules
+Use public GitHub URLs in tracked documentation. These instructions must work in
+a standalone clone and must not require a parent workspace, sibling checkout,
+private network, Home Assistant instance, or physical bus.
 
-These instructions apply to the entire repository.
+## Architecture boundaries
 
-### Workflow
+- Drivers own protocol-native connection, discovery, qualification, decoding,
+  and raw evidence.
+- Shared runtime code must not import vendor-specific or protocol-specific
+  implementation details merely for convenience.
+- Preserve native evidence such as frames, registers, SPINE data, Modbus
+  observations, or CAN messages alongside promoted views.
+- Keep candidate, qualified, promoted, unsupported, and unknown states distinct.
+- Partial failures must not wholesale replace valid last-known fields.
+- Consumers use stable public contracts; Portal and Home Assistant do not define
+  upstream protocol or semantic meaning.
+- Existing eBUS MCP namespaces are compatibility surfaces, not a universal
+  delivery rule for other protocol families.
 
-1. Work one issue at a time and keep changes scoped to that issue.
-2. Keep at most one open PR for this repository at any time.
-3. Run `./scripts/ci_local.sh` before pushing.
-4. React (emoji) to every review comment and reply with status when actioned.
-5. If a change modifies externally visible behavior (transport options, GraphQL/MCP surface, smoke behavior), open/update the corresponding docs in `helianthus-docs-ebus` and merge docs alongside code (doc-gate).
-6. Transport/protocol changes require a full 88-case runtime matrix pass (`TRANSPORT_MATRIX_REPORT=<index.json>`), unless explicitly overridden by owner approval (`TRANSPORT_GATE_OWNER_OVERRIDE=OVERRIDE_TRANSPORT_GATE_BY_OWNER` with a reason).
+Public eBUS and B524 contracts are documented at:
 
-### MCP-first Policy
+- https://github.com/Project-Helianthus/helianthus-docs-ebus/blob/main/protocols/vaillant/ebus-vaillant-B524.md
+- https://github.com/Project-Helianthus/helianthus-docs-ebus/blob/main/protocols/vaillant/ebus-vaillant-B524-register-map.md
+- https://github.com/Project-Helianthus/helianthus-docs-ebus/blob/main/architecture/b524-namespace-invariants.md
 
-#### Scope and ordering
-- MCP is the primary prototyping/exploration interface.
-- GraphQL is second and may reach parity only after MCP tools are deterministic and contract-solid.
-- Home Assistant and other consumers are enabled only after GraphQL parity and stability gates are met.
+## Gates and validation
 
-#### Tool taxonomy and naming
-- Core stable tools use versioned names: `ebus.v<MAJOR>.<domain>.<subdomain>.<verb>`.
-- Experimental tools live under `ebus.experimental.*` and are never used by external consumers.
-- Prefer composable tools over monolithic endpoints.
-
-#### Contract envelope (required for ebus.v1.*)
-Each `ebus.v1.*` tool returns:
-- `meta` with `contract`, `consistency`, `data_timestamp`, `data_hash`
-- `data`
-- `error` (null or structured error)
-
-#### Determinism requirements
-- List ordering must be stable.
-- Snapshot mode must produce stable `data_hash` for identical snapshot + request.
-- Tool schemas and outputs must have golden snapshots.
-
-#### Invoke safety
-`ebus.v1.rpc.invoke` requires:
-- explicit `intent` (`READ_ONLY` or `MUTATE`)
-- `allow_dangerous=true` for mutating or unknown methods
-- `idempotency_key` for mutating intent
-
-#### Graduation gates (MCP -> GraphQL)
-A capability may graduate to GraphQL only if:
-1. it exists as core stable MCP (`ebus.v1.*`)
-2. it passes determinism + contract + golden tests
-3. parity tests MCP <-> GraphQL are green
-
-#### End-of-cycle cleanup
-At cycle end, each `ebus.experimental.*` tool must be promoted, deleted, or moved to internal-only with written justification.
-No temporary/junk tool may remain in the showroom surface.
-
-#### CI gates
-- Breaking changes in `ebus.v1.*` require a new major namespace.
-- Parity drift MCP vs GraphQL fails CI.
-- MCP tool inventory must pass classification enforcement (`go test ./mcp -run TestToolClassificationPolicy`), and any unclassified tool fails the gate.
-
-#### Heat-source modeling boundary
-- Treat `scan` as cross-device discovery, not as a class-specific heat-source plane.
-- Keep `HEAT_SOURCE` and `REGULATOR` semantic domains isolated; cross-domain register access must be denied explicitly.
-- Architecture updates for heat-source design must be mirrored in `helianthus-docs-ebus` and be reusable for equivalent VWZ-class implementation.
+- Architecture, public API, protocol, semantic behavior, state-machine, or
+  reverse-engineering changes require the corresponding public docs gate.
+- Transport or protocol-code changes require the applicable T01..T88 result with
+  no unexpected fail or xpass unless the operator records a scope-specific
+  override.
+- Prefer deterministic fixtures, replay, mocks, and local integration tests.
+- A real Home Assistant or live-device smoke is supplemental unless the issue
+  explicitly requires it; it is not a prerequisite for ordinary contribution.
+- Obtain explicit operator confirmation immediately before credentials,
+  installation writes, live-device mutation, destructive actions, or
+  safety-relevant control.
+- Never commit private addresses, serial numbers, credentials, device
+  fingerprints, account data, or private captures.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,12 +50,12 @@ private network, Home Assistant instance, or physical bus.
 
 Existing `ebus.v1.*` tools are stable consumer contracts:
 
-- Preserve the top-level `meta`, `data`, and `error` envelope. `meta` retains
-  `contract`, `consistency`, `data_timestamp`, and deterministic `data_hash`
-  fields where the tool contract defines them.
+- Every tool returns the top-level `meta`, `data`, and `error` envelope. `meta`
+  contains `contract`, `consistency`, `data_timestamp`, and deterministic
+  `data_hash`; `error` is null or a structured error.
 - Keep list ordering and snapshot hashes deterministic for identical inputs and
-  state. Update and review golden snapshots whenever an intentional compatible
-  output change occurs.
+  state. Every tool schema and output has a golden snapshot. Update and review
+  those goldens whenever an intentional compatible output change occurs.
 - A breaking schema or behavior change requires a new major namespace; changing
   existing goldens does not by itself make a breaking `ebus.v1.*` change
   compatible.
@@ -90,6 +90,15 @@ after GraphQL parity and stability are established. These are eBUS compatibility
 rules for the current gateway; they do not impose MCP-first delivery on other
 protocol families.
 
+### eBUS heat-source modeling boundary
+
+- Treat `scan` as cross-device discovery, not as a class-specific heat-source
+  plane.
+- Keep `HEAT_SOURCE` and `REGULATOR` semantic domains isolated. Cross-domain
+  register access must be denied explicitly.
+- Mirror heat-source architecture changes in `helianthus-docs-ebus` and keep the
+  design reusable for equivalent VWZ-class implementations.
+
 Public eBUS and B524 contracts are documented at:
 
 - https://github.com/Project-Helianthus/helianthus-docs-ebus/blob/main/protocols/vaillant/ebus-vaillant-B524.md
@@ -106,7 +115,9 @@ Public eBUS and B524 contracts are documented at:
 - A transport-gate override requires both
   `TRANSPORT_GATE_OWNER_OVERRIDE=OVERRIDE_TRANSPORT_GATE_BY_OWNER` and a
   non-empty `TRANSPORT_GATE_OWNER_REASON`. The reason must identify the exact
-  scope and residual risk; an override never implies permission for live writes.
+  scope and residual risk. An override never implies permission for live writes
+  and never creates standing or permanent merge authorization; every use remains
+  bound to its recorded scope and current merge gates.
 - Prefer deterministic fixtures, replay, mocks, and local integration tests.
 - A real Home Assistant or live-device smoke is supplemental unless the issue
   explicitly requires it; it is not a prerequisite for ordinary contribution.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,21 @@ private network, Home Assistant instance, or physical bus.
 - Existing eBUS MCP namespaces are compatibility surfaces, not a universal
   delivery rule for other protocol families.
 
-### eBUS MCP invoke safety
+### eBUS MCP v1 compatibility and invoke safety
+
+Existing `ebus.v1.*` tools are stable consumer contracts:
+
+- Preserve the top-level `meta`, `data`, and `error` envelope. `meta` retains
+  `contract`, `consistency`, `data_timestamp`, and deterministic `data_hash`
+  fields where the tool contract defines them.
+- Keep list ordering and snapshot hashes deterministic for identical inputs and
+  state. Update and review golden snapshots whenever an intentional compatible
+  output change occurs.
+- A breaking schema or behavior change requires a new major namespace; changing
+  existing goldens does not by itself make a breaking `ebus.v1.*` change
+  compatible.
+- Keep experimental surfaces outside stable consumer dependencies until their
+  contract, determinism, and golden coverage are ready for promotion.
 
 `ebus.v1.rpc.invoke` is an eBUS compatibility and safety surface:
 

--- a/cmd/gateway/semantic_vaillant.go
+++ b/cmd/gateway/semantic_vaillant.go
@@ -154,7 +154,8 @@ const (
 
 // b524GroupDef binds a B524 group number to its owning opcode.
 // This eliminates the possibility of accidentally mixing OP/GG pairs.
-// See AGENTS.md §1.3.1 B524 Register Namespace Contract.
+// Public contract:
+// https://github.com/Project-Helianthus/helianthus-docs-ebus/blob/main/architecture/b524-namespace-invariants.md
 type b524GroupDef struct {
 	group  byte
 	opcode byte

--- a/matrix/M6a-transport-matrix.md
+++ b/matrix/M6a-transport-matrix.md
@@ -128,7 +128,7 @@ Each subsection states (a) the concrete signals that would trigger rollback, (b)
 - **Mechanism:**
   - For M4c2 regression: revert `547fd4e feat(M4c2): gateway responder runtime for FF 03-06 + meta.capabilities.responder emission` — the envelope composer reverts to minor=0 (no capability key); consumers fail-closed per rule 1.
   - For M5_PORTAL regression: revert `205c2a8 feat(M5_PORTAL): ebus_standard L7 consumer UI + XSS-hardened decode sandbox`; consumer surface rolls back independently of envelope contract.
-  - Feature-flag disable: set `TRANSPORT_GATE_OWNER_OVERRIDE=OVERRIDE_TRANSPORT_GATE_BY_OWNER` with documented reason per AGENTS.md §Workflow item 6, and disable responder emission at the bootstrap site by calling `SetResponderCapabilityProvider(nil)` unconditionally in `cmd/gateway/main.go` while a code-level revert is prepared.
+  - Feature-flag disable: set `TRANSPORT_GATE_OWNER_OVERRIDE=OVERRIDE_TRANSPORT_GATE_BY_OWNER` together with a non-empty `TRANSPORT_GATE_OWNER_REASON` per AGENTS.md §Gates and validation, and disable responder emission at the bootstrap site by calling `SetResponderCapabilityProvider(nil)` unconditionally in `cmd/gateway/main.go` while a code-level revert is prepared.
 
 ### §6.5 helianthus-ha-integration
 


### PR DESCRIPTION
Closes #859

## Summary

- replace workspace-dependent instructions with a self-contained gateway contract
- preserve the current `helianthus-ebusgateway` name until a separately approved rewrite
- identify planned `helianthus-semreg` as the future universal semantic owner without treating it as active
- replace the removed root B524 section reference with the public architecture URL

## Validation

- `GOWORK=off ./scripts/ci_local.sh` completed terminology, portal assets, Go vet/build, all Go race suites, and 198 Python tests; the final local `golangci-lint` step reports pre-existing `ST1005` at `mcp/tesla_hsc_v1.go:52`, unchanged from `main` and tracked separately
- `git diff --check` — PASS

## Gates

- docs gate: this PR redirects the existing B524 source pointer to the public docs; it introduces no new protocol claim
- transport gate: not applicable (instructions/comment only)
- review: fresh exact-HEAD review required before squash merge