### PR TITLE
Fix Tesla HSC provider error-string lint

### DIFF
--- a/mcp/tesla_hsc_v1.go
+++ b/mcp/tesla_hsc_v1.go
@@ -49,7 +49,7 @@ func (server *Server) handleTeslaHSCV1Call(ctx context.Context, name string, arg
 	provider := teslaHSCV1Providers.byServer[server]
 	teslaHSCV1Providers.RUnlock()
 	if provider == nil {
-		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("Tesla HSC provider unavailable"), false, "RETAINED_PROFILE", "")), true), true
+		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("tesla HSC provider unavailable"), false, "RETAINED_PROFILE", "")), true), true
 	}
 	result, err := provider.TeslaHSCV1(ctx)
 	result = failClosedTeslaHSCV1Result(result)


### PR DESCRIPTION
Closes #863

## Summary

- lowercase the provider-unavailable error string to satisfy staticcheck ST1005
- preserve the error envelope, retained-profile behavior, and all control flow
- keep this code-quality unblock separate from the AGENTS refactor

## Validation

- `GOWORK=off go test ./mcp -run TestTeslaHSCV1 -count=1` — PASS
- `GOWORK=off ./scripts/ci_local.sh` — PASS, including 93 Portal tests, Go vet/build/linux-386, all race suites, 198 Python tests, 0 lint issues
- transport/passive smoke gates: not triggered
- `git diff --check` — PASS

## Review

Fresh exact-HEAD review required before squash merge.