### PR TITLE
Expose injected Growatt Protocol II identity status

### DIFF
--- a/mcp/growatt_protocol_ii_runtime_v1.go
+++ b/mcp/growatt_protocol_ii_runtime_v1.go
@@ -6,8 +6,8 @@ import (
 )
 
 var (
-	ErrGrowattProtocolIIV1ProviderUnavailable = errors.New("Growatt Protocol II provider is unavailable")
-	ErrGrowattProtocolIIV1NotAdmitted         = errors.New("Growatt Protocol II identity is not admitted")
+	ErrGrowattProtocolIIV1ProviderUnavailable = errors.New("growatt Protocol II provider is unavailable")
+	ErrGrowattProtocolIIV1NotAdmitted         = errors.New("growatt Protocol II identity is not admitted")
 )
 
 // GrowattProtocolIIV1ProviderSnapshot is provider-private. RawIdentity is

--- a/mcp/growatt_protocol_ii_runtime_v1.go
+++ b/mcp/growatt_protocol_ii_runtime_v1.go
@@ -1,0 +1,59 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+)
+
+var (
+	ErrGrowattProtocolIIV1ProviderUnavailable = errors.New("Growatt Protocol II provider is unavailable")
+	ErrGrowattProtocolIIV1NotAdmitted         = errors.New("Growatt Protocol II identity is not admitted")
+)
+
+// GrowattProtocolIIV1ProviderSnapshot is provider-private. RawIdentity is
+// deliberately excluded from the MCP result.
+type GrowattProtocolIIV1ProviderSnapshot struct {
+	Profile                 string
+	Family                  string
+	OfflineIdentityAdmitted bool
+	OutboundAllowed         bool
+	RawIdentity             []uint16
+}
+
+type GrowattProtocolIIV1SnapshotProvider interface {
+	GrowattProtocolIIV1Snapshot(context.Context) (GrowattProtocolIIV1ProviderSnapshot, error)
+}
+
+type GrowattProtocolIIV1Runtime struct {
+	provider GrowattProtocolIIV1SnapshotProvider
+}
+
+func NewGrowattProtocolIIV1Runtime(provider GrowattProtocolIIV1SnapshotProvider) (*GrowattProtocolIIV1Runtime, error) {
+	if provider == nil {
+		return nil, ErrGrowattProtocolIIV1ProviderUnavailable
+	}
+	return &GrowattProtocolIIV1Runtime{provider: provider}, nil
+}
+
+func (runtime *GrowattProtocolIIV1Runtime) GrowattProtocolIIV1(ctx context.Context) (GrowattProtocolIIV1Result, error) {
+	if runtime == nil || runtime.provider == nil {
+		return GrowattProtocolIIV1Result{}, ErrGrowattProtocolIIV1ProviderUnavailable
+	}
+	snapshot, err := runtime.provider.GrowattProtocolIIV1Snapshot(ctx)
+	if err != nil {
+		return GrowattProtocolIIV1Result{}, err
+	}
+	if snapshot.Profile != GrowattProtocolIIV1Profile || !validGrowattProtocolIIV1Family(snapshot.Family) || !snapshot.OfflineIdentityAdmitted {
+		return GrowattProtocolIIV1Result{}, ErrGrowattProtocolIIV1NotAdmitted
+	}
+	return GrowattProtocolIIV1Result{Profile: GrowattProtocolIIV1Profile, Disposition: "OFFLINE_IDENTITY_ADMITTED", Family: snapshot.Family, IdentityQualified: true, IdentityRedacted: true, OutboundAllowed: false}, nil
+}
+
+func validGrowattProtocolIIV1Family(family string) bool {
+	switch family {
+	case "MAX", "MID", "MAC":
+		return true
+	default:
+		return false
+	}
+}

--- a/mcp/growatt_protocol_ii_runtime_v1_test.go
+++ b/mcp/growatt_protocol_ii_runtime_v1_test.go
@@ -1,0 +1,55 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type growattProtocolIIV1RuntimeFixture struct {
+	snapshot GrowattProtocolIIV1ProviderSnapshot
+	err      error
+}
+
+func (fixture growattProtocolIIV1RuntimeFixture) GrowattProtocolIIV1Snapshot(context.Context) (GrowattProtocolIIV1ProviderSnapshot, error) {
+	return fixture.snapshot, fixture.err
+}
+
+func TestGrowattProtocolIIV1RuntimeProjectsOnlySanitizedIdentityStatus(t *testing.T) {
+	runtime, err := NewGrowattProtocolIIV1Runtime(growattProtocolIIV1RuntimeFixture{snapshot: GrowattProtocolIIV1ProviderSnapshot{
+		Profile:                 GrowattProtocolIIV1Profile,
+		Family:                  "MAC",
+		OfflineIdentityAdmitted: true,
+		OutboundAllowed:         true,
+		RawIdentity:             []uint16{0x4657, 0x2d31, 0x1234},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := runtime.GrowattProtocolIIV1(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Profile != GrowattProtocolIIV1Profile || result.Family != "MAC" || !result.IdentityQualified ||
+		!result.IdentityRedacted || result.OutboundAllowed {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestGrowattProtocolIIV1RuntimeRejectsUnqualifiedOrUnexpectedSnapshots(t *testing.T) {
+	for name, snapshot := range map[string]GrowattProtocolIIV1ProviderSnapshot{
+		"wrong profile":  {Profile: "other", Family: "MAX", OfflineIdentityAdmitted: true},
+		"unknown family": {Profile: GrowattProtocolIIV1Profile, Family: "MIX", OfflineIdentityAdmitted: true},
+		"not admitted":   {Profile: GrowattProtocolIIV1Profile, Family: "MAX", OfflineIdentityAdmitted: false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			runtime, err := NewGrowattProtocolIIV1Runtime(growattProtocolIIV1RuntimeFixture{snapshot: snapshot})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := runtime.GrowattProtocolIIV1(context.Background()); !errors.Is(err, ErrGrowattProtocolIIV1NotAdmitted) {
+				t.Fatalf("error = %v", err)
+			}
+		})
+	}
+}

--- a/mcp/growatt_protocol_ii_v1.go
+++ b/mcp/growatt_protocol_ii_v1.go
@@ -1,0 +1,67 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+const (
+	GrowattProtocolIIV1IdentityGetTool = "modbus.v1.growatt.protocol_ii.identity.get"
+	GrowattProtocolIIV1Profile         = "growatt.protocol_ii.tl3_x.identity.readonly.v1"
+)
+
+// GrowattProtocolIIV1Result is the only identity status projected to MCP.
+// Raw identity words and individual tuple values remain provider-private.
+type GrowattProtocolIIV1Result struct {
+	Profile           string `json:"profile"`
+	Disposition       string `json:"disposition"`
+	Family            string `json:"family"`
+	IdentityQualified bool   `json:"identity_qualified"`
+	IdentityRedacted  bool   `json:"identity_redacted"`
+	OutboundAllowed   bool   `json:"outbound_allowed"`
+}
+
+type GrowattProtocolIIV1Provider interface {
+	GrowattProtocolIIV1(context.Context) (GrowattProtocolIIV1Result, error)
+}
+
+var growattProtocolIIV1Providers = struct {
+	sync.RWMutex
+	byServer map[*Server]GrowattProtocolIIV1Provider
+}{byServer: make(map[*Server]GrowattProtocolIIV1Provider)}
+
+func registerGrowattProtocolIIV1Tool(server *Server, provider ModbusV1Provider) {
+	growatt, ok := provider.(GrowattProtocolIIV1Provider)
+	if !ok || growatt == nil {
+		return
+	}
+	growattProtocolIIV1Providers.Lock()
+	growattProtocolIIV1Providers.byServer[server] = growatt
+	growattProtocolIIV1Providers.Unlock()
+	server.tools = append(server.tools, Tool{Name: GrowattProtocolIIV1IdentityGetTool, Description: "Get the redacted read-only Growatt Protocol II identity qualification.", InputSchema: map[string]any{"type": "object", "properties": map[string]any{}, "additionalProperties": false}})
+}
+
+func (server *Server) handleGrowattProtocolIIV1Call(ctx context.Context, name string, args map[string]any) (map[string]any, bool) {
+	if name != GrowattProtocolIIV1IdentityGetTool {
+		return nil, false
+	}
+	if len(args) != 0 {
+		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("invalid Growatt Protocol II identity arguments"), false, "RETAINED_PROFILE", "")), true), true
+	}
+	growattProtocolIIV1Providers.RLock()
+	provider := growattProtocolIIV1Providers.byServer[server]
+	growattProtocolIIV1Providers.RUnlock()
+	if provider == nil {
+		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("Growatt Protocol II provider unavailable"), false, "RETAINED_PROFILE", "")), true), true
+	}
+	result, err := provider.GrowattProtocolIIV1(ctx)
+	result = failClosedGrowattProtocolIIV1Result(result)
+	return callToolResultText(mustJSON(newModbusV1Envelope(result, err, true, "RETAINED_PROFILE", "")), err != nil), true
+}
+
+func failClosedGrowattProtocolIIV1Result(result GrowattProtocolIIV1Result) GrowattProtocolIIV1Result {
+	result.IdentityRedacted = true
+	result.OutboundAllowed = false
+	return result
+}

--- a/mcp/growatt_protocol_ii_v1.go
+++ b/mcp/growatt_protocol_ii_v1.go
@@ -53,7 +53,7 @@ func (server *Server) handleGrowattProtocolIIV1Call(ctx context.Context, name st
 	provider := growattProtocolIIV1Providers.byServer[server]
 	growattProtocolIIV1Providers.RUnlock()
 	if provider == nil {
-		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("Growatt Protocol II provider unavailable"), false, "RETAINED_PROFILE", "")), true), true
+		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("growatt Protocol II provider unavailable"), false, "RETAINED_PROFILE", "")), true), true
 	}
 	result, err := provider.GrowattProtocolIIV1(ctx)
 	result = failClosedGrowattProtocolIIV1Result(result)

--- a/mcp/growatt_protocol_ii_v1_test.go
+++ b/mcp/growatt_protocol_ii_v1_test.go
@@ -1,0 +1,72 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+)
+
+type growattProtocolIIV1FixtureProvider struct{ *modbusV1FixtureProvider }
+
+func (*growattProtocolIIV1FixtureProvider) GrowattProtocolIIV1(context.Context) (GrowattProtocolIIV1Result, error) {
+	return GrowattProtocolIIV1Result{
+		Profile:           GrowattProtocolIIV1Profile,
+		Disposition:       "OFFLINE_IDENTITY_ADMITTED",
+		Family:            "MAX",
+		IdentityQualified: true,
+		OutboundAllowed:   false,
+	}, nil
+}
+
+func TestGrowattProtocolIIV1IdentityToolIsReadOnlyAndRedacted(t *testing.T) {
+	server, err := NewServer(&testRegistry{entries: make(map[byte]registry.DeviceEntry)}, &testInvoker{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	RegisterModbusV1Tools(server, &growattProtocolIIV1FixtureProvider{&modbusV1FixtureProvider{}})
+	result := msp06Call(t, server.Handler(), GrowattProtocolIIV1IdentityGetTool, map[string]any{})
+	if result.isError {
+		t.Fatalf("result = %#v", result)
+	}
+	data := msp06Map(t, result.envelope["data"], "data")
+	if data["profile"] != GrowattProtocolIIV1Profile || data["disposition"] != "OFFLINE_IDENTITY_ADMITTED" ||
+		data["family"] != "MAX" || data["identity_qualified"] != true || data["identity_redacted"] != true ||
+		data["outbound_allowed"] != false {
+		t.Fatalf("data = %#v", data)
+	}
+	for _, forbidden := range []string{"words", "device_type", "model_build", "protocol_version", "firmware"} {
+		if _, found := data[forbidden]; found {
+			t.Fatalf("raw identity field %q leaked: %#v", forbidden, data)
+		}
+	}
+}
+
+type growattProtocolIIV1UnsafeProvider struct{ *modbusV1FixtureProvider }
+
+func (*growattProtocolIIV1UnsafeProvider) GrowattProtocolIIV1(context.Context) (GrowattProtocolIIV1Result, error) {
+	return GrowattProtocolIIV1Result{
+		Profile:           GrowattProtocolIIV1Profile,
+		Disposition:       "OFFLINE_IDENTITY_ADMITTED",
+		Family:            "MID",
+		IdentityQualified: true,
+		IdentityRedacted:  false,
+		OutboundAllowed:   true,
+	}, nil
+}
+
+func TestGrowattProtocolIIV1IdentityToolFailsClosedForProviderOutput(t *testing.T) {
+	server, err := NewServer(&testRegistry{entries: make(map[byte]registry.DeviceEntry)}, &testInvoker{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	RegisterModbusV1Tools(server, &growattProtocolIIV1UnsafeProvider{&modbusV1FixtureProvider{}})
+	result := msp06Call(t, server.Handler(), GrowattProtocolIIV1IdentityGetTool, map[string]any{})
+	if result.isError {
+		t.Fatalf("result = %#v", result)
+	}
+	data := msp06Map(t, result.envelope["data"], "data")
+	if data["outbound_allowed"] != false || data["identity_redacted"] != true {
+		t.Fatalf("unsafe provider output crossed MCP boundary: %#v", data)
+	}
+}

--- a/mcp/modbus_v1.go
+++ b/mcp/modbus_v1.go
@@ -139,10 +139,14 @@ func RegisterModbusV1Tools(server *Server, provider ModbusV1Provider) {
 		},
 	)
 	registerTeslaHSCV1Tool(server, provider)
+	registerGrowattProtocolIIV1Tool(server, provider)
 }
 
 func (server *Server) handleModbusV1Call(ctx context.Context, name string, args map[string]any) (map[string]any, bool) {
 	if result, handled := server.handleTeslaHSCV1Call(ctx, name, args); handled {
+		return result, true
+	}
+	if result, handled := server.handleGrowattProtocolIIV1Call(ctx, name, args); handled {
 		return result, true
 	}
 	modbusV1Providers.RLock()


### PR DESCRIPTION
## Scope

Adds an injected, read-only MCP status seam for the caller-supplied Growatt Protocol II identity disposition.

## Boundary

Only sanitized profile, family, qualification, disposition, redaction marker, and `outbound_allowed=false` may cross the MCP boundary. No raw words, identity values, endpoint data, auto-discovery, transport I/O, controls, or driver wiring.

## TDD

First commit is RED: the MCP tool and runtime contracts are intentionally absent.