### PR TITLE
Expose injected OutBack AXS read-only status

### DIFF
--- a/mcp/modbus_v1.go
+++ b/mcp/modbus_v1.go
@@ -140,6 +140,7 @@ func RegisterModbusV1Tools(server *Server, provider ModbusV1Provider) {
 	)
 	registerTeslaHSCV1Tool(server, provider)
 	registerGrowattProtocolIIV1Tool(server, provider)
+	registerOutBackAXSV1Tool(server, provider)
 }
 
 func (server *Server) handleModbusV1Call(ctx context.Context, name string, args map[string]any) (map[string]any, bool) {
@@ -147,6 +148,9 @@ func (server *Server) handleModbusV1Call(ctx context.Context, name string, args 
 		return result, true
 	}
 	if result, handled := server.handleGrowattProtocolIIV1Call(ctx, name, args); handled {
+		return result, true
+	}
+	if result, handled := server.handleOutBackAXSV1Call(ctx, name, args); handled {
 		return result, true
 	}
 	modbusV1Providers.RLock()

--- a/mcp/outback_axs_runtime_v1.go
+++ b/mcp/outback_axs_runtime_v1.go
@@ -1,0 +1,44 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+)
+
+var (
+	ErrOutBackAXSV1ProviderUnavailable = errors.New("outback AXS provider is unavailable")
+	ErrOutBackAXSV1NotQualified        = errors.New("outback AXS snapshot is not qualified")
+)
+
+type OutBackAXSV1ProviderSnapshot struct {
+	Profile                                                  string
+	Qualified                                                bool
+	FirmwareMajor, FirmwareMid, FirmwareMinor                uint16
+	BatteryTemperature, AmbientTemperature, TemperatureScale int16
+	Error, Status                                            uint16
+	RawWords                                                 []uint16
+}
+type OutBackAXSV1SnapshotProvider interface {
+	OutBackAXSV1Snapshot(context.Context) (OutBackAXSV1ProviderSnapshot, error)
+}
+type OutBackAXSV1Runtime struct{ provider OutBackAXSV1SnapshotProvider }
+
+func NewOutBackAXSV1Runtime(p OutBackAXSV1SnapshotProvider) (*OutBackAXSV1Runtime, error) {
+	if p == nil {
+		return nil, ErrOutBackAXSV1ProviderUnavailable
+	}
+	return &OutBackAXSV1Runtime{provider: p}, nil
+}
+func (r *OutBackAXSV1Runtime) OutBackAXSV1(ctx context.Context) (OutBackAXSV1Result, error) {
+	if r == nil || r.provider == nil {
+		return OutBackAXSV1Result{}, ErrOutBackAXSV1ProviderUnavailable
+	}
+	s, err := r.provider.OutBackAXSV1Snapshot(ctx)
+	if err != nil {
+		return OutBackAXSV1Result{}, err
+	}
+	if s.Profile != OutBackAXSV1Profile || !s.Qualified {
+		return OutBackAXSV1Result{}, ErrOutBackAXSV1NotQualified
+	}
+	return OutBackAXSV1Result{Profile: s.Profile, Qualified: true, FirmwareMajor: s.FirmwareMajor, FirmwareMid: s.FirmwareMid, FirmwareMinor: s.FirmwareMinor, BatteryTemperature: s.BatteryTemperature, AmbientTemperature: s.AmbientTemperature, TemperatureScale: s.TemperatureScale, Error: s.Error, Status: s.Status, RawRedacted: true, OutboundAllowed: false}, nil
+}

--- a/mcp/outback_axs_runtime_v1_test.go
+++ b/mcp/outback_axs_runtime_v1_test.go
@@ -1,0 +1,37 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type outBackAXSV1RuntimeFixture struct{ snapshot OutBackAXSV1ProviderSnapshot }
+
+func (f outBackAXSV1RuntimeFixture) OutBackAXSV1Snapshot(context.Context) (OutBackAXSV1ProviderSnapshot, error) {
+	return f.snapshot, nil
+}
+
+func TestOutBackAXSV1RuntimeRedactsRawAndDisablesOutbound(t *testing.T) {
+	runtime, err := NewOutBackAXSV1Runtime(outBackAXSV1RuntimeFixture{snapshot: OutBackAXSV1ProviderSnapshot{Profile: OutBackAXSV1Profile, Qualified: true, RawWords: []uint16{64110, 282}, FirmwareMajor: 1, FirmwareMid: 2, FirmwareMinor: 3}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := runtime.OutBackAXSV1(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Qualified || !result.RawRedacted || result.OutboundAllowed || result.FirmwareMajor != 1 {
+		t.Fatalf("result=%#v", result)
+	}
+}
+
+func TestOutBackAXSV1RuntimeRejectsUnqualifiedSnapshot(t *testing.T) {
+	runtime, err := NewOutBackAXSV1Runtime(outBackAXSV1RuntimeFixture{snapshot: OutBackAXSV1ProviderSnapshot{Profile: OutBackAXSV1Profile}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runtime.OutBackAXSV1(context.Background()); !errors.Is(err, ErrOutBackAXSV1NotQualified) {
+		t.Fatalf("err=%v", err)
+	}
+}

--- a/mcp/outback_axs_v1.go
+++ b/mcp/outback_axs_v1.go
@@ -1,0 +1,64 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+const (
+	OutBackAXSV1StatusGetTool = "modbus.v1.outback.axs.status.get"
+	OutBackAXSV1Profile       = "outback.axs.readonly.v1"
+)
+
+type OutBackAXSV1Result struct {
+	Profile            string `json:"profile"`
+	Qualified          bool   `json:"qualified"`
+	FirmwareMajor      uint16 `json:"firmware_major"`
+	FirmwareMid        uint16 `json:"firmware_mid"`
+	FirmwareMinor      uint16 `json:"firmware_minor"`
+	BatteryTemperature int16  `json:"battery_temperature"`
+	AmbientTemperature int16  `json:"ambient_temperature"`
+	TemperatureScale   int16  `json:"temperature_scale"`
+	Error              uint16 `json:"error"`
+	Status             uint16 `json:"status"`
+	RawRedacted        bool   `json:"raw_redacted"`
+	OutboundAllowed    bool   `json:"outbound_allowed"`
+}
+type OutBackAXSV1Provider interface {
+	OutBackAXSV1(context.Context) (OutBackAXSV1Result, error)
+}
+
+var outBackAXSV1Providers = struct {
+	sync.RWMutex
+	byServer map[*Server]OutBackAXSV1Provider
+}{byServer: make(map[*Server]OutBackAXSV1Provider)}
+
+func registerOutBackAXSV1Tool(server *Server, provider ModbusV1Provider) {
+	p, ok := provider.(OutBackAXSV1Provider)
+	if !ok || p == nil {
+		return
+	}
+	outBackAXSV1Providers.Lock()
+	outBackAXSV1Providers.byServer[server] = p
+	outBackAXSV1Providers.Unlock()
+	server.tools = append(server.tools, Tool{Name: OutBackAXSV1StatusGetTool, Description: "Get the redacted read-only OutBack AXS status.", InputSchema: map[string]any{"type": "object", "properties": map[string]any{}, "additionalProperties": false}})
+}
+func (server *Server) handleOutBackAXSV1Call(ctx context.Context, name string, args map[string]any) (map[string]any, bool) {
+	if name != OutBackAXSV1StatusGetTool {
+		return nil, false
+	}
+	if len(args) != 0 {
+		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("invalid OutBack AXS status arguments"), false, "RETAINED_PROFILE", "")), true), true
+	}
+	outBackAXSV1Providers.RLock()
+	p := outBackAXSV1Providers.byServer[server]
+	outBackAXSV1Providers.RUnlock()
+	if p == nil {
+		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("outback AXS provider unavailable"), false, "RETAINED_PROFILE", "")), true), true
+	}
+	r, err := p.OutBackAXSV1(ctx)
+	r.RawRedacted = true
+	r.OutboundAllowed = false
+	return callToolResultText(mustJSON(newModbusV1Envelope(r, err, true, "RETAINED_PROFILE", "")), err != nil), true
+}

--- a/mcp/outback_axs_v1_test.go
+++ b/mcp/outback_axs_v1_test.go
@@ -1,0 +1,35 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+)
+
+type outBackAXSV1FixtureProvider struct{ *modbusV1FixtureProvider }
+
+func (*outBackAXSV1FixtureProvider) OutBackAXSV1(context.Context) (OutBackAXSV1Result, error) {
+	return OutBackAXSV1Result{Profile: OutBackAXSV1Profile, Qualified: true, FirmwareMajor: 1, FirmwareMid: 2, FirmwareMinor: 3}, nil
+}
+
+func TestOutBackAXSV1ToolProjectsOnlyReadOnlyFacts(t *testing.T) {
+	server, err := NewServer(&testRegistry{entries: make(map[byte]registry.DeviceEntry)}, &testInvoker{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	RegisterModbusV1Tools(server, &outBackAXSV1FixtureProvider{&modbusV1FixtureProvider{}})
+	result := msp06Call(t, server.Handler(), OutBackAXSV1StatusGetTool, map[string]any{})
+	if result.isError {
+		t.Fatalf("result=%#v", result)
+	}
+	data := msp06Map(t, result.envelope["data"], "data")
+	if data["profile"] != OutBackAXSV1Profile || data["qualified"] != true || data["outbound_allowed"] != false || data["raw_redacted"] != true {
+		t.Fatalf("data=%#v", data)
+	}
+	for _, forbidden := range []string{"words", "config", "network", "mac", "credential", "control"} {
+		if _, ok := data[forbidden]; ok {
+			t.Fatalf("leaked %q: %#v", forbidden, data)
+		}
+	}
+}


### PR DESCRIPTION
Read-only injected OutBack AXS MCP seam. RED first; no raw/config/network/MAC/credential/control or outbound.