### PR TITLE
Fail transport gate on unexpected xpass

### DIFF
--- a/scripts/transport_gate.sh
+++ b/scripts/transport_gate.sh
@@ -277,7 +277,7 @@ def normalized_outcome(case):
 
 unexpected = []
 xfailed = 0
-xpassed = 0
+xpassed = []
 passed = 0
 blocked = 0
 blocked_invalid = []
@@ -289,7 +289,7 @@ for case in cases:
     elif value == "xfail":
         xfailed += 1
     elif value == "xpass":
-        xpassed += 1
+        xpassed.append(case_id)
     elif value == "blocked-infra":
         reason = str(case.get("infra_reason", "")).strip()
         if reason != "adapter_no_signal":
@@ -309,8 +309,11 @@ if unexpected:
     print(f"transport gate: matrix has unexpected failures/planned ({len(unexpected)}). sample={preview}")
     raise SystemExit(1)
 
-msg = f"transport gate: PASS (pass={passed}, xfail={xfailed}, xpass={xpassed}, blocked={blocked}, total={len(cases)})."
 if xpassed:
-    msg += " review expected-failure list (xpass present)."
+    preview = ",".join(xpassed[:10])
+    print(f"transport gate: matrix has unexpected xpass ({len(xpassed)}). sample={preview}")
+    raise SystemExit(1)
+
+msg = f"transport gate: PASS (pass={passed}, xfail={xfailed}, xpass={len(xpassed)}, blocked={blocked}, total={len(cases)})."
 print(msg)
 PY

--- a/scripts/transport_gate_test.py
+++ b/scripts/transport_gate_test.py
@@ -108,6 +108,32 @@ class TransportGateTests(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("TRANSPORT_MATRIX_REPORT is required", result.stdout)
 
+    def test_transport_gate_fails_when_matrix_contains_xpass(self) -> None:
+        repo_path, report_path = self._create_temp_repo(
+            "cmd/gateway/main.go",
+            base_text="package main\n\nfunc main() {\n\ttransportProtocol := \"ens\"\n\t_ = transportProtocol\n}\n",
+            modified_text="package main\n\nfunc main() {\n\ttransportProtocol := \"udp-plain\"\n\t_ = transportProtocol\n}\n",
+        )
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+        report["cases"][0]["outcome"] = "xpass"
+        report_path.write_text(json.dumps(report), encoding="utf-8")
+
+        result = subprocess.run(
+            ["bash", "scripts/transport_gate.sh"],
+            cwd=repo_path,
+            env=self._script_env(
+                TRANSPORT_GATE_BASE_REF="HEAD",
+                TRANSPORT_MATRIX_REPORT=str(report_path),
+            ),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("xpass", result.stdout)
+        self.assertIn("T01", result.stdout)
+
     def test_transport_gate_fails_for_runtime_control_flow_main_diff(self) -> None:
         repo_path, _ = self._create_temp_repo(
             "cmd/gateway/main.go",


### PR DESCRIPTION
Closes #869

## Summary

- fail the T01..T88 transport gate when any report row has `outcome: xpass`
- name the affected case IDs in the failure output
- preserve explicit owner override, expected xfail, pass, and supported blocked-infra behavior

## TDD evidence

- RED commit `890f999`: focused regression failed because the gate returned 0 for T01 xpass
- GREEN: `python3 scripts/transport_gate_test.py` — 10/10 PASS

## Validation

- `git diff --check` — PASS
- full `GOWORK=off ./scripts/ci_local.sh` running on this exact branch

## Gates

- docs gate: companion AGENTS clarification remains in gateway PR #862 and cannot merge first
- transport gate: implementation is the gate itself; focused mutation/regression coverage added
- fresh exact-HEAD review required before squash merge