### PR TITLE
Expose injected Huawei EMMA offline identity status

### DIFF
--- a/mcp/huawei_emma_v1.go
+++ b/mcp/huawei_emma_v1.go
@@ -1,0 +1,58 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+const (
+	HuaweiEMMAV1IdentityGetTool = "modbus.v1.huawei.emma.identity.get"
+	HuaweiEMMAV1Profile         = "huawei.emma.readonly.v1"
+)
+
+type HuaweiEMMAV1Result struct {
+	Profile         string `json:"profile"`
+	CanonicalClass  string `json:"canonical_class"`
+	ModelVariant    string `json:"model_variant"`
+	Qualified       bool   `json:"qualified"`
+	RawRedacted     bool   `json:"raw_redacted"`
+	OutboundAllowed bool   `json:"outbound_allowed"`
+}
+type HuaweiEMMAV1Provider interface {
+	HuaweiEMMAV1(context.Context) (HuaweiEMMAV1Result, error)
+}
+
+var huaweiEMMAV1Providers = struct {
+	sync.RWMutex
+	byServer map[*Server]HuaweiEMMAV1Provider
+}{byServer: map[*Server]HuaweiEMMAV1Provider{}}
+
+func registerHuaweiEMMAV1Tool(s *Server, p ModbusV1Provider) {
+	v, ok := p.(HuaweiEMMAV1Provider)
+	if !ok || v == nil {
+		return
+	}
+	huaweiEMMAV1Providers.Lock()
+	huaweiEMMAV1Providers.byServer[s] = v
+	huaweiEMMAV1Providers.Unlock()
+	s.tools = append(s.tools, Tool{Name: HuaweiEMMAV1IdentityGetTool, Description: "Get the redacted read-only Huawei EMMA identity qualification.", InputSchema: map[string]any{"type": "object", "properties": map[string]any{}, "additionalProperties": false}})
+}
+func (s *Server) handleHuaweiEMMAV1Call(ctx context.Context, n string, a map[string]any) (map[string]any, bool) {
+	if n != HuaweiEMMAV1IdentityGetTool {
+		return nil, false
+	}
+	if len(a) != 0 {
+		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("invalid Huawei EMMA identity arguments"), false, "RETAINED_PROFILE", "")), true), true
+	}
+	huaweiEMMAV1Providers.RLock()
+	p := huaweiEMMAV1Providers.byServer[s]
+	huaweiEMMAV1Providers.RUnlock()
+	if p == nil {
+		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("huawei EMMA provider unavailable"), false, "RETAINED_PROFILE", "")), true), true
+	}
+	r, e := p.HuaweiEMMAV1(ctx)
+	r.RawRedacted = true
+	r.OutboundAllowed = false
+	return callToolResultText(mustJSON(newModbusV1Envelope(r, e, true, "RETAINED_PROFILE", "")), e != nil), true
+}

--- a/mcp/huawei_emma_v1_test.go
+++ b/mcp/huawei_emma_v1_test.go
@@ -1,0 +1,33 @@
+package mcp
+
+import (
+	"context"
+	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+	"testing"
+)
+
+type emmaFixture struct{ *modbusV1FixtureProvider }
+
+func (*emmaFixture) HuaweiEMMAV1(context.Context) (HuaweiEMMAV1Result, error) {
+	return HuaweiEMMAV1Result{Profile: HuaweiEMMAV1Profile, CanonicalClass: "EMMA", ModelVariant: "EMMA-A02", Qualified: true}, nil
+}
+func TestHuaweiEMMAV1ToolRedactsOfflineIdentity(t *testing.T) {
+	s, e := NewServer(&testRegistry{entries: map[byte]registry.DeviceEntry{}}, &testInvoker{})
+	if e != nil {
+		t.Fatal(e)
+	}
+	RegisterModbusV1Tools(s, &emmaFixture{&modbusV1FixtureProvider{}})
+	r := msp06Call(t, s.Handler(), HuaweiEMMAV1IdentityGetTool, map[string]any{})
+	if r.isError {
+		t.Fatal(r)
+	}
+	d := msp06Map(t, r.envelope["data"], "data")
+	if d["qualified"] != true || d["raw_redacted"] != true || d["outbound_allowed"] != false {
+		t.Fatalf("%#v", d)
+	}
+	for _, k := range []string{"mei", "inventory", "endpoint", "offering", "firmware"} {
+		if _, ok := d[k]; ok {
+			t.Fatal(k)
+		}
+	}
+}

--- a/mcp/modbus_v1.go
+++ b/mcp/modbus_v1.go
@@ -141,6 +141,7 @@ func RegisterModbusV1Tools(server *Server, provider ModbusV1Provider) {
 	registerTeslaHSCV1Tool(server, provider)
 	registerGrowattProtocolIIV1Tool(server, provider)
 	registerOutBackAXSV1Tool(server, provider)
+	registerHuaweiEMMAV1Tool(server, provider)
 }
 
 func (server *Server) handleModbusV1Call(ctx context.Context, name string, args map[string]any) (map[string]any, bool) {
@@ -151,6 +152,9 @@ func (server *Server) handleModbusV1Call(ctx context.Context, name string, args 
 		return result, true
 	}
 	if result, handled := server.handleOutBackAXSV1Call(ctx, name, args); handled {
+		return result, true
+	}
+	if result, handled := server.handleHuaweiEMMAV1Call(ctx, name, args); handled {
 		return result, true
 	}
 	modbusV1Providers.RLock()


### PR DESCRIPTION
Read-only injected EMMA identity status; raw MEI/inventory and outbound are excluded.