### PR TITLE
Harden Explorer pagination and terminal SSE contracts

### DIFF
--- a/portal/explorer.go
+++ b/portal/explorer.go
@@ -187,12 +187,13 @@ func (es *explorerStore) getResults(offset, limit int) []ExplorerRegisterResult 
 	if offset >= len(results) {
 		return nil
 	}
-	end := offset + limit
-	if end > len(results) {
-		end = len(results)
+	remaining := len(results) - offset
+	pageLen := limit
+	if pageLen <= 0 || pageLen > remaining {
+		pageLen = remaining
 	}
-	out := make([]ExplorerRegisterResult, end-offset)
-	copy(out, results[offset:end])
+	out := make([]ExplorerRegisterResult, pageLen)
+	copy(out, results[offset:offset+pageLen])
 	return out
 }
 

--- a/portal/explorer.go
+++ b/portal/explorer.go
@@ -149,11 +149,34 @@ func cloneExplorerScanState(state *ExplorerScanState) *ExplorerScanState {
 	return &snap
 }
 
+func (es *explorerStore) hasSubscriberForScan(scanID uint64) bool {
+	es.subMu.Lock()
+	defer es.subMu.Unlock()
+	for _, sub := range es.subs {
+		if scanID == 0 || sub.scanID == 0 || scanID == sub.scanID {
+			return true
+		}
+	}
+	return false
+}
+
 func (es *explorerStore) notifySubscribers(states ...*ExplorerScanState) {
 	var state *ExplorerScanState
 	if len(states) > 0 {
+		if states[0] == nil || !es.hasSubscriberForScan(states[0].scanID) {
+			return
+		}
 		state = cloneExplorerScanState(states[0])
 	} else {
+		es.mu.Lock()
+		scanID := uint64(0)
+		if es.current != nil {
+			scanID = es.current.scanID
+		}
+		es.mu.Unlock()
+		if !es.hasSubscriberForScan(scanID) {
+			return
+		}
 		state = es.getState()
 	}
 

--- a/portal/explorer.go
+++ b/portal/explorer.go
@@ -75,6 +75,7 @@ type ExplorerRegisterResult struct {
 
 // ExplorerScanState is the current scan state returned to the frontend.
 type ExplorerScanState struct {
+	scanID         uint64
 	Phase          string                   `json:"phase"`
 	Kind           string                   `json:"kind"`
 	Target         byte                     `json:"target"`
@@ -108,6 +109,11 @@ type ExplorerScanIDResult struct {
 	Error  string   `json:"error,omitempty"`
 }
 
+type explorerSubscriber struct {
+	scanID uint64
+	ch     chan *ExplorerScanState
+}
+
 type explorerStore struct {
 	mu      sync.Mutex
 	current *ExplorerScanState
@@ -116,9 +122,10 @@ type explorerStore struct {
 	cancel  context.CancelFunc
 
 	// SSE subscribers
-	subMu   sync.Mutex
-	subs    map[uint64]chan struct{}
-	subNext uint64
+	subMu    sync.Mutex
+	subs     map[uint64]*explorerSubscriber
+	subNext  uint64
+	scanNext uint64
 }
 
 func newExplorerStore(bus ExplorerBus, source byte) *explorerStore {
@@ -128,29 +135,61 @@ func newExplorerStore(bus ExplorerBus, source byte) *explorerStore {
 	return &explorerStore{
 		bus:    bus,
 		source: source,
-		subs:   make(map[uint64]chan struct{}),
+		subs:   make(map[uint64]*explorerSubscriber),
 	}
 }
 
-func (es *explorerStore) notifySubscribers() {
+func cloneExplorerScanState(state *ExplorerScanState) *ExplorerScanState {
+	if state == nil {
+		return &ExplorerScanState{Phase: ExplorerPhaseIdle}
+	}
+	snap := *state
+	snap.Groups = append([]ExplorerGroupResult(nil), state.Groups...)
+	snap.Results = append([]ExplorerRegisterResult(nil), state.Results...)
+	return &snap
+}
+
+func (es *explorerStore) notifySubscribers(states ...*ExplorerScanState) {
+	var state *ExplorerScanState
+	if len(states) > 0 {
+		state = cloneExplorerScanState(states[0])
+	} else {
+		state = es.getState()
+	}
+
 	es.subMu.Lock()
 	defer es.subMu.Unlock()
-	for _, ch := range es.subs {
+	for _, sub := range es.subs {
+		if state.scanID != 0 && sub.scanID != 0 && state.scanID != sub.scanID {
+			continue
+		}
 		select {
-		case ch <- struct{}{}:
+		case sub.ch <- state:
 		default:
+			select {
+			case <-sub.ch:
+			default:
+			}
+			select {
+			case sub.ch <- state:
+			default:
+			}
 		}
 	}
 }
 
-func (es *explorerStore) subscribe() (uint64, chan struct{}) {
+func (es *explorerStore) subscribeWithState() (uint64, chan *ExplorerScanState, *ExplorerScanState) {
+	es.mu.Lock()
+	defer es.mu.Unlock()
+	state := cloneExplorerScanState(es.current)
+
 	es.subMu.Lock()
 	defer es.subMu.Unlock()
 	id := es.subNext
 	es.subNext++
-	ch := make(chan struct{}, 1)
-	es.subs[id] = ch
-	return id, ch
+	ch := make(chan *ExplorerScanState, 1)
+	es.subs[id] = &explorerSubscriber{scanID: state.scanID, ch: ch}
+	return id, ch, state
 }
 
 func (es *explorerStore) unsubscribe(id uint64) {
@@ -166,11 +205,7 @@ func (es *explorerStore) getState() *ExplorerScanState {
 	if es.current == nil {
 		return &ExplorerScanState{Phase: ExplorerPhaseIdle}
 	}
-	// Shallow copy to avoid data races on slices.
-	snap := *es.current
-	snap.Groups = append([]ExplorerGroupResult(nil), es.current.Groups...)
-	snap.Results = append([]ExplorerRegisterResult(nil), es.current.Results...)
-	return &snap
+	return cloneExplorerScanState(es.current)
 }
 
 // getResults returns a page of results.
@@ -235,7 +270,9 @@ func (es *explorerStore) startB524Scan(req ExplorerScanRequest) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	es.cancel = cancel
 
+	es.scanNext++
 	state := &ExplorerScanState{
+		scanID:     es.scanNext,
 		Phase:      ExplorerPhaseGroupDiscovery,
 		Kind:       ExplorerKindB524,
 		Target:     req.Target,
@@ -274,7 +311,9 @@ func (es *explorerStore) startB509Scan(req ExplorerScanRequest) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	es.cancel = cancel
 
+	es.scanNext++
 	state := &ExplorerScanState{
+		scanID:     es.scanNext,
 		Phase:      ExplorerPhaseRegisterScan,
 		Kind:       ExplorerKindB509,
 		Target:     req.Target,
@@ -300,8 +339,9 @@ func (es *explorerStore) runB524Scan(ctx context.Context, req ExplorerScanReques
 			}
 		}
 		state.FinishedUTC = time.Now().UTC().Format(time.RFC3339)
+		terminal := cloneExplorerScanState(state)
 		es.mu.Unlock()
-		es.notifySubscribers()
+		es.notifySubscribers(terminal)
 	}()
 
 	groupMin := int(req.GroupMin)
@@ -476,8 +516,9 @@ func (es *explorerStore) runB509Scan(ctx context.Context, req ExplorerScanReques
 			}
 		}
 		state.FinishedUTC = time.Now().UTC().Format(time.RFC3339)
+		terminal := cloneExplorerScanState(state)
 		es.mu.Unlock()
-		es.notifySubscribers()
+		es.notifySubscribers(terminal)
 	}()
 
 	addrMin := int(req.B509AddrMin)
@@ -973,13 +1014,12 @@ func (h *handler) handleExplorerStream(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("X-Accel-Buffering", "no")
 
-	subID, ch := h.explorer.subscribe()
+	subID, ch, state := h.explorer.subscribeWithState()
 	defer h.explorer.unsubscribe(subID)
 
 	ctx := r.Context()
 
 	// Send initial state and exit early if already terminal.
-	state := h.explorer.getState()
 	data, _ := json.Marshal(state)
 	if _, err := fmt.Fprintf(w, "data: %s\n\n", data); err != nil {
 		return
@@ -995,8 +1035,7 @@ func (h *handler) handleExplorerStream(w http.ResponseWriter, r *http.Request) {
 		select {
 		case <-ctx.Done():
 			return
-		case <-ch:
-			state := h.explorer.getState()
+		case state := <-ch:
 			data, _ := json.Marshal(state)
 			if _, err := fmt.Fprintf(w, "data: %s\n\n", data); err != nil {
 				return

--- a/portal/explorer_test.go
+++ b/portal/explorer_test.go
@@ -56,6 +56,22 @@ func explorerJSON(t *testing.T, rec *httptest.ResponseRecorder) map[string]any {
 	return payload
 }
 
+func explorerSSEStates(t *testing.T, body string) []ExplorerScanState {
+	t.Helper()
+	var states []ExplorerScanState
+	for _, line := range strings.Split(body, "\n") {
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		var state ExplorerScanState
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &state); err != nil {
+			t.Fatalf("unmarshal SSE state: %v; line=%s", err, line)
+		}
+		states = append(states, state)
+	}
+	return states
+}
+
 type explorerFlushRecorder struct {
 	*httptest.ResponseRecorder
 	flushed chan struct{}
@@ -67,6 +83,21 @@ func (rec *explorerFlushRecorder) Flush() {
 	case rec.flushed <- struct{}{}:
 	default:
 	}
+}
+
+type explorerBlockingFlushRecorder struct {
+	*httptest.ResponseRecorder
+	firstFlushed chan struct{}
+	releaseFirst chan struct{}
+	once         sync.Once
+}
+
+func (rec *explorerBlockingFlushRecorder) Flush() {
+	rec.ResponseRecorder.Flush()
+	rec.once.Do(func() {
+		close(rec.firstFlushed)
+		<-rec.releaseFirst
+	})
 }
 
 // --- Tests ---
@@ -280,6 +311,14 @@ func TestExplorerResults_MaxPositiveLimitDoesNotOverflow(t *testing.T) {
 	payload := explorerJSON(t, rec)
 	if got := int(payload["count"].(float64)); got != 1 {
 		t.Fatalf("count = %d; want 1", got)
+	}
+	results := payload["results"].([]any)
+	result := results[0].(map[string]any)
+	if got := int(result["addr"].(float64)); got != 2 {
+		t.Fatalf("returned addr = %d; want suffix addr 2", got)
+	}
+	if got := result["raw_hex"].(string); got != "02" {
+		t.Fatalf("returned raw_hex = %q; want 02", got)
 	}
 }
 
@@ -633,15 +672,38 @@ func TestExplorerSSEStream_InitialTerminalStatesEmitAndClose(t *testing.T) {
 	} {
 		t.Run(phase, func(t *testing.T) {
 			h := explorerHandler(&mockExplorerBus{}).(*handler)
-			if phase != ExplorerPhaseIdle {
-				h.explorer.current = &ExplorerScanState{Phase: phase}
+			h.explorer.current = &ExplorerScanState{
+				Phase:          phase,
+				Kind:           ExplorerKindB524,
+				Target:         0x15,
+				Source:         0xF0,
+				Opcode:         0x02,
+				StartedUTC:     "2026-08-25T00:00:00Z",
+				FinishedUTC:    "2026-08-25T00:00:01Z",
+				Error:          "fixture-error",
+				Results:        []ExplorerRegisterResult{{Addr: 0x1234, RawHex: "aabb"}},
+				Progress:       ExplorerProgress{Percent: 100, Description: "fixture-complete"},
+				TotalReads:     1,
+				CompletedReads: 1,
 			}
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-			defer cancel()
+			ctx, cancel := context.WithCancel(context.Background())
 			req := httptest.NewRequest(http.MethodGet, "/api/v1/explorer/scans/current/stream", nil)
 			req = req.WithContext(ctx)
 			rec := httptest.NewRecorder()
-			h.ServeHTTP(rec, req)
+			done := make(chan struct{})
+			go func() {
+				h.ServeHTTP(rec, req)
+				close(done)
+			}()
+
+			select {
+			case <-done:
+				cancel()
+			case <-time.After(500 * time.Millisecond):
+				cancel()
+				<-done
+				t.Fatal("initial terminal SSE handler did not close before request cancellation")
+			}
 
 			if rec.Code != http.StatusOK {
 				t.Fatalf("status = %d; want %d", rec.Code, http.StatusOK)
@@ -649,12 +711,16 @@ func TestExplorerSSEStream_InitialTerminalStatesEmitAndClose(t *testing.T) {
 			if got := rec.Header().Get("Content-Type"); got != "text/event-stream" {
 				t.Fatalf("Content-Type = %q; want text/event-stream", got)
 			}
-			body := rec.Body.String()
-			if !strings.Contains(body, fmt.Sprintf(`"phase":%q`, phase)) {
-				t.Fatalf("SSE body missing %s state: %s", phase, body)
+			states := explorerSSEStates(t, rec.Body.String())
+			if len(states) != 1 {
+				t.Fatalf("SSE event count = %d; want 1; body=%s", len(states), rec.Body.String())
 			}
-			if got := strings.Count(body, "data: "); got != 1 {
-				t.Fatalf("SSE event count = %d; want 1; body=%s", got, body)
+			state := states[0]
+			if state.Phase != phase || state.Kind != ExplorerKindB524 || state.Target != 0x15 {
+				t.Fatalf("initial state = %#v; want phase=%s kind=%s target=0x15", state, phase, ExplorerKindB524)
+			}
+			if len(state.Results) != 1 || state.Results[0].Addr != 0x1234 || state.Progress.Description != "fixture-complete" {
+				t.Fatalf("initial event did not preserve full state: %#v", state)
 			}
 		})
 	}
@@ -708,6 +774,79 @@ func TestExplorerSSEStream_ActiveToTerminalEmitsAndCloses(t *testing.T) {
 				t.Fatalf("SSE event count = %d; want 2; body=%s", got, body)
 			}
 		})
+	}
+}
+
+func TestExplorerSSEStream_QueuedTerminalSurvivesSuccessorScan(t *testing.T) {
+	h := explorerHandler(&mockExplorerBus{}).(*handler)
+	h.explorer.scanNext = 1
+	h.explorer.current = &ExplorerScanState{
+		scanID: 1,
+		Phase:  ExplorerPhaseRegisterScan,
+		Kind:   ExplorerKindB524,
+		Target: 0x15,
+	}
+	rec := &explorerBlockingFlushRecorder{
+		ResponseRecorder: httptest.NewRecorder(),
+		firstFlushed:     make(chan struct{}),
+		releaseFirst:     make(chan struct{}),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/explorer/scans/current/stream", nil).WithContext(ctx)
+	done := make(chan struct{})
+	go func() {
+		h.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	select {
+	case <-rec.firstFlushed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for initial SSE state")
+	}
+
+	terminalA := &ExplorerScanState{
+		scanID:      1,
+		Phase:       ExplorerPhaseDone,
+		Kind:        ExplorerKindB524,
+		Target:      0x15,
+		FinishedUTC: "2026-08-25T00:00:01Z",
+		Results:     []ExplorerRegisterResult{{Addr: 0x1234, RawHex: "aabb"}},
+	}
+	h.explorer.mu.Lock()
+	h.explorer.current = terminalA
+	h.explorer.mu.Unlock()
+	h.explorer.notifySubscribers(terminalA)
+
+	h.explorer.mu.Lock()
+	h.explorer.scanNext = 2
+	h.explorer.current = &ExplorerScanState{
+		scanID: 2,
+		Phase:  ExplorerPhaseRegisterScan,
+		Kind:   ExplorerKindB509,
+		Target: 0x08,
+	}
+	h.explorer.mu.Unlock()
+	h.explorer.notifySubscribers()
+	close(rec.releaseFirst)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stream did not emit the queued predecessor terminal and close")
+	}
+
+	states := explorerSSEStates(t, rec.Body.String())
+	if len(states) != 2 {
+		t.Fatalf("SSE event count = %d; want initial A plus terminal A; body=%s", len(states), rec.Body.String())
+	}
+	terminal := states[1]
+	if terminal.Phase != ExplorerPhaseDone || terminal.Kind != ExplorerKindB524 || terminal.Target != 0x15 {
+		t.Fatalf("terminal event = %#v; want predecessor A done state", terminal)
+	}
+	if len(terminal.Results) != 1 || terminal.Results[0].Addr != 0x1234 {
+		t.Fatalf("terminal event lost predecessor A results: %#v", terminal)
 	}
 }
 

--- a/portal/explorer_test.go
+++ b/portal/explorer_test.go
@@ -56,6 +56,19 @@ func explorerJSON(t *testing.T, rec *httptest.ResponseRecorder) map[string]any {
 	return payload
 }
 
+type explorerFlushRecorder struct {
+	*httptest.ResponseRecorder
+	flushed chan struct{}
+}
+
+func (rec *explorerFlushRecorder) Flush() {
+	rec.ResponseRecorder.Flush()
+	select {
+	case rec.flushed <- struct{}{}:
+	default:
+	}
+}
+
 // --- Tests ---
 
 func TestExplorerBootstrapCapability(t *testing.T) {
@@ -240,6 +253,33 @@ func TestExplorerResults_NegativeOffset(t *testing.T) {
 	payload := explorerJSON(t, rec)
 	if int(payload["count"].(float64)) != 0 {
 		t.Fatalf("count = %v; want 0 (no results in idle scan)", payload["count"])
+	}
+}
+
+func TestExplorerResults_MaxPositiveLimitDoesNotOverflow(t *testing.T) {
+	h := explorerHandler(&mockExplorerBus{}).(*handler)
+	h.explorer.current = &ExplorerScanState{
+		Phase: ExplorerPhaseDone,
+		Results: []ExplorerRegisterResult{
+			{Addr: 1, RawHex: "01"},
+			{Addr: 2, RawHex: "02"},
+		},
+	}
+	maxInt := int(^uint(0) >> 1)
+	req := httptest.NewRequest(
+		http.MethodGet,
+		fmt.Sprintf("/api/v1/explorer/scans/current/results?offset=1&limit=%d", maxInt),
+		nil,
+	)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; want %d", rec.Code, http.StatusOK)
+	}
+	payload := explorerJSON(t, rec)
+	if got := int(payload["count"].(float64)); got != 1 {
+		t.Fatalf("count = %d; want 1", got)
 	}
 }
 
@@ -584,27 +624,90 @@ func TestExplorerScanAlreadyRunning(t *testing.T) {
 	h.ServeHTTP(rec, req)
 }
 
-func TestExplorerSSEStream_TerminalState(t *testing.T) {
-	h := explorerHandler(&mockExplorerBus{})
+func TestExplorerSSEStream_InitialTerminalStatesEmitAndClose(t *testing.T) {
+	for _, phase := range []string{
+		ExplorerPhaseIdle,
+		ExplorerPhaseDone,
+		ExplorerPhaseCancelled,
+		ExplorerPhaseError,
+	} {
+		t.Run(phase, func(t *testing.T) {
+			h := explorerHandler(&mockExplorerBus{}).(*handler)
+			if phase != ExplorerPhaseIdle {
+				h.explorer.current = &ExplorerScanState{Phase: phase}
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/explorer/scans/current/stream", nil)
+			req = req.WithContext(ctx)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
 
-	// SSE stream when idle should return immediately with idle state.
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/explorer/scans/current/stream", nil)
-	req = req.WithContext(ctx)
-	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d; want %d", rec.Code, http.StatusOK)
+			}
+			if got := rec.Header().Get("Content-Type"); got != "text/event-stream" {
+				t.Fatalf("Content-Type = %q; want text/event-stream", got)
+			}
+			body := rec.Body.String()
+			if !strings.Contains(body, fmt.Sprintf(`"phase":%q`, phase)) {
+				t.Fatalf("SSE body missing %s state: %s", phase, body)
+			}
+			if got := strings.Count(body, "data: "); got != 1 {
+				t.Fatalf("SSE event count = %d; want 1; body=%s", got, body)
+			}
+		})
+	}
+}
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d; want %d", rec.Code, http.StatusOK)
-	}
-	ct := rec.Header().Get("Content-Type")
-	if ct != "text/event-stream" {
-		t.Fatalf("Content-Type = %q; want text/event-stream", ct)
-	}
-	body := rec.Body.String()
-	if !strings.Contains(body, `"phase":"idle"`) {
-		t.Fatalf("SSE body missing idle state: %s", body)
+func TestExplorerSSEStream_ActiveToTerminalEmitsAndCloses(t *testing.T) {
+	for _, terminal := range []string{
+		ExplorerPhaseDone,
+		ExplorerPhaseCancelled,
+		ExplorerPhaseError,
+	} {
+		t.Run(terminal, func(t *testing.T) {
+			h := explorerHandler(&mockExplorerBus{}).(*handler)
+			h.explorer.current = &ExplorerScanState{Phase: ExplorerPhaseRegisterScan}
+			rec := &explorerFlushRecorder{
+				ResponseRecorder: httptest.NewRecorder(),
+				flushed:          make(chan struct{}, 2),
+			}
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/explorer/scans/current/stream", nil)
+			done := make(chan struct{})
+			go func() {
+				h.ServeHTTP(rec, req)
+				close(done)
+			}()
+
+			select {
+			case <-rec.flushed:
+			case <-time.After(2 * time.Second):
+				t.Fatal("timed out waiting for initial SSE state")
+			}
+
+			h.explorer.mu.Lock()
+			h.explorer.current = &ExplorerScanState{Phase: terminal}
+			h.explorer.mu.Unlock()
+			h.explorer.notifySubscribers()
+
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				t.Fatal("timed out waiting for terminal SSE closure")
+			}
+
+			body := rec.Body.String()
+			if !strings.Contains(body, `"phase":"register_scan"`) {
+				t.Fatalf("SSE body missing active state: %s", body)
+			}
+			if !strings.Contains(body, fmt.Sprintf(`"phase":%q`, terminal)) {
+				t.Fatalf("SSE body missing terminal %s state: %s", terminal, body)
+			}
+			if got := strings.Count(body, "data: "); got != 2 {
+				t.Fatalf("SSE event count = %d; want 2; body=%s", got, body)
+			}
+		})
 	}
 }
 

--- a/portal/explorer_test.go
+++ b/portal/explorer_test.go
@@ -72,6 +72,23 @@ func explorerSSEStates(t *testing.T, body string) []ExplorerScanState {
 	return states
 }
 
+func waitExplorerPhase(t *testing.T, store *explorerStore, want string) *ExplorerScanState {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		state := store.getState()
+		if state.Phase == want {
+			return state
+		}
+		if state.Phase == ExplorerPhaseDone || state.Phase == ExplorerPhaseError {
+			t.Fatalf("scan reached %s while waiting for %s: %#v", state.Phase, want, state)
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for explorer phase %s; last=%#v", want, store.getState())
+	return nil
+}
+
 type explorerFlushRecorder struct {
 	*httptest.ResponseRecorder
 	flushed chan struct{}
@@ -848,6 +865,121 @@ func TestExplorerSSEStream_QueuedTerminalSurvivesSuccessorScan(t *testing.T) {
 	if len(terminal.Results) != 1 || terminal.Results[0].Addr != 0x1234 {
 		t.Fatalf("terminal event lost predecessor A results: %#v", terminal)
 	}
+}
+
+func TestExplorerNotifyWithoutSubscribersDoesNotCopyAccumulatedResults(t *testing.T) {
+	store := newExplorerStore(&mockExplorerBus{}, 0xF0)
+	store.current = &ExplorerScanState{
+		scanID:  1,
+		Phase:   ExplorerPhaseRegisterScan,
+		Results: make([]ExplorerRegisterResult, 1<<16),
+	}
+	if allocs := testing.AllocsPerRun(20, func() { store.notifySubscribers() }); allocs > 1 {
+		t.Fatalf("notify without subscribers allocated %.1f times; want at most lock overhead", allocs)
+	}
+}
+
+func TestExplorerSSEStream_RealCancellationBeforeAndDuringStream(t *testing.T) {
+	newCancellableHandler := func(t *testing.T) (*handler, <-chan struct{}) {
+		t.Helper()
+		started := make(chan struct{})
+		var once sync.Once
+		bus := &mockExplorerBus{
+			handler: func(ctx context.Context, _ protocol.Frame) (*protocol.Frame, error) {
+				once.Do(func() { close(started) })
+				<-ctx.Done()
+				return nil, ctx.Err()
+			},
+		}
+		return explorerHandler(bus).(*handler), started
+	}
+	startScan := func(t *testing.T, h *handler, started <-chan struct{}) {
+		t.Helper()
+		body := `{"kind":"b509","target":21,"b509_addr_min":0,"b509_addr_max":1}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/explorer/scans", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusAccepted {
+			t.Fatalf("start status = %d; want %d; body=%s", rec.Code, http.StatusAccepted, rec.Body.String())
+		}
+		select {
+		case <-started:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for cancellable scan worker")
+		}
+	}
+	cancelScan := func(t *testing.T, h *handler) {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodDelete, "/api/v1/explorer/scans/current", nil)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), `"status":"cancelled"`) {
+			t.Fatalf("cancel response = status %d body %s", rec.Code, rec.Body.String())
+		}
+	}
+
+	t.Run("connect_after_cancelled_terminal", func(t *testing.T) {
+		h, started := newCancellableHandler(t)
+		startScan(t, h, started)
+		cancelScan(t, h)
+		terminal := waitExplorerPhase(t, h.explorer, ExplorerPhaseCancelled)
+		if terminal.Kind != ExplorerKindB509 || terminal.Target != 0x15 {
+			t.Fatalf("cancelled terminal lost full scan state: %#v", terminal)
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/explorer/scans/current/stream", nil)
+		rec := httptest.NewRecorder()
+		done := make(chan struct{})
+		go func() {
+			h.ServeHTTP(rec, req)
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("pre-connected cancelled stream did not emit and close")
+		}
+		states := explorerSSEStates(t, rec.Body.String())
+		if len(states) != 1 || states[0].Phase != ExplorerPhaseCancelled || states[0].Kind != ExplorerKindB509 {
+			t.Fatalf("cancelled initial SSE states = %#v; want one full cancelled B509 state", states)
+		}
+	})
+
+	t.Run("cancel_already_active_stream", func(t *testing.T) {
+		h, started := newCancellableHandler(t)
+		startScan(t, h, started)
+		rec := &explorerFlushRecorder{
+			ResponseRecorder: httptest.NewRecorder(),
+			flushed:          make(chan struct{}, 2),
+		}
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/explorer/scans/current/stream", nil)
+		done := make(chan struct{})
+		go func() {
+			h.ServeHTTP(rec, req)
+			close(done)
+		}()
+		select {
+		case <-rec.flushed:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for active SSE state")
+		}
+
+		cancelScan(t, h)
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("active stream did not emit real cancelled terminal and close")
+		}
+		states := explorerSSEStates(t, rec.Body.String())
+		if len(states) < 2 || states[0].Phase != ExplorerPhaseRegisterScan || states[len(states)-1].Phase != ExplorerPhaseCancelled {
+			t.Fatalf("active cancellation SSE states = %#v; want active state(s) ending in cancelled", states)
+		}
+		terminal := states[len(states)-1]
+		if terminal.Kind != ExplorerKindB509 || terminal.Target != 0x15 || terminal.FinishedUTC == "" {
+			t.Fatalf("cancelled terminal lost full scan state: %#v", terminal)
+		}
+	})
 }
 
 func TestExtractB524Payload_5ByteHeader(t *testing.T) {


### PR DESCRIPTION
Closes #873

## Summary

- calculate Explorer result page length from the remaining slice to avoid `offset + limit` overflow
- prove maximum positive `limit` returns only available results without panic
- cover initial idle/done/cancelled/error SSE emission and closure
- cover active-to-done/cancelled/error full-state emission and closure

## TDD evidence

- RED commit `2d9a5b8`: focused test panicked with `makeslice: len out of range` at `portal/explorer.go:194`
- GREEN focused tests: normal and race variants pass

## Validation

- `GOWORK=off go test ./portal -run "TestExplorerResults_MaxPositiveLimitDoesNotOverflow|TestExplorerSSEStream_" -count=1` — PASS
- `GOWORK=off go test -race ./portal -run "TestExplorerResults_MaxPositiveLimitDoesNotOverflow|TestExplorerSSEStream_" -count=1` — PASS
- full `GOWORK=off ./scripts/ci_local.sh` running on this exact branch

## Gates

- docs gate: Project-Helianthus/helianthus-docs-ebus#490; docs must not merge first
- transport gate: not triggered; no bus framing/transport path changed
- fresh exact-HEAD review required before squash merge