### PR TITLE
Project redacted Tesla HSC provenance through MCP

### DIFF
--- a/mcp/tesla_hsc_provenance_v1.go
+++ b/mcp/tesla_hsc_provenance_v1.go
@@ -1,0 +1,70 @@
+package mcp
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+)
+
+const maxTeslaHSCV1ProvenancePayload = 252
+
+// TeslaHSCProvenanceV1Record is redacted, already-correlated terminal-response
+// provenance. It deliberately carries no raw response bytes or send authority.
+type TeslaHSCProvenanceV1Record struct {
+	Function        byte   `json:"function"`
+	PayloadLength   int    `json:"payload_length"`
+	PayloadDigest   string `json:"payload_digest"`
+	OutboundAllowed bool   `json:"outbound_allowed"`
+}
+
+// TeslaHSCProvenanceV1Provider supplies only selected FC101/FC102 terminal
+// provenance. It has no request-construction or transport-I/O capability.
+type TeslaHSCProvenanceV1Provider interface {
+	TeslaHSCProvenanceV1(context.Context) ([]TeslaHSCProvenanceV1Record, error)
+}
+
+// TeslaHSCProvenanceV1Runtime projects injected redacted terminal provenance
+// for an MCP caller without constructing a request or transmitting anything.
+type TeslaHSCProvenanceV1Runtime struct {
+	provider TeslaHSCProvenanceV1Provider
+}
+
+// NewTeslaHSCProvenanceV1Runtime constructs an injected read-only provenance
+// runtime. A nil provider is never an implicit transport fallback.
+func NewTeslaHSCProvenanceV1Runtime(provider TeslaHSCProvenanceV1Provider) (*TeslaHSCProvenanceV1Runtime, error) {
+	if provider == nil {
+		return nil, errors.New("tesla HSC provenance provider is required")
+	}
+	return &TeslaHSCProvenanceV1Runtime{provider: provider}, nil
+}
+
+// TeslaHSCProvenanceV1 validates and projects selected terminal provenance.
+// Every returned record is independently copied and permanently outbound-denied.
+func (runtime *TeslaHSCProvenanceV1Runtime) TeslaHSCProvenanceV1(ctx context.Context) ([]TeslaHSCProvenanceV1Record, error) {
+	if runtime == nil || runtime.provider == nil || ctx == nil {
+		return nil, errors.New("tesla HSC provenance runtime is unavailable")
+	}
+	records, err := runtime.provider.TeslaHSCProvenanceV1(ctx)
+	if err != nil {
+		return nil, err
+	}
+	projected := make([]TeslaHSCProvenanceV1Record, 0, len(records))
+	for _, record := range records {
+		if !validTeslaHSCProvenanceV1Record(record) {
+			return nil, errors.New("tesla HSC provenance record is invalid")
+		}
+		record.OutboundAllowed = false
+		projected = append(projected, record)
+	}
+	return projected, nil
+}
+
+func validTeslaHSCProvenanceV1Record(record TeslaHSCProvenanceV1Record) bool {
+	if (record.Function != 101 && record.Function != 102) ||
+		record.PayloadLength < 0 || record.PayloadLength > maxTeslaHSCV1ProvenancePayload {
+		return false
+	}
+	digest, err := hex.DecodeString(record.PayloadDigest)
+	return err == nil && len(digest) == sha256.Size
+}

--- a/mcp/tesla_hsc_provenance_v1_test.go
+++ b/mcp/tesla_hsc_provenance_v1_test.go
@@ -18,7 +18,7 @@ func (provider *teslaHSCProvenanceV1FixtureProvider) TeslaHSCProvenanceV1(contex
 
 func TestTeslaHSCProvenanceV1RuntimeProjectsOnlyRedactedSelectedTerminalMetadata(t *testing.T) {
 	provider := &teslaHSCProvenanceV1FixtureProvider{records: []TeslaHSCProvenanceV1Record{
-		{Function: 101, PayloadLength: 0, PayloadDigest: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+		{Function: 101, PayloadLength: 0, PayloadDigest: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", OutboundAllowed: true},
 		{Function: 102, PayloadLength: 2, PayloadDigest: "9ee50aea7e52b0fd0c9dcae1a059ac08b94c21ad3e2fa7e6cbf9b6b5279d93d8"},
 	}}
 	runtime, err := NewTeslaHSCProvenanceV1Runtime(provider)

--- a/mcp/tesla_hsc_provenance_v1_test.go
+++ b/mcp/tesla_hsc_provenance_v1_test.go
@@ -1,0 +1,60 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+)
+
+type teslaHSCProvenanceV1FixtureProvider struct {
+	calls   int
+	records []TeslaHSCProvenanceV1Record
+	err     error
+}
+
+func (provider *teslaHSCProvenanceV1FixtureProvider) TeslaHSCProvenanceV1(context.Context) ([]TeslaHSCProvenanceV1Record, error) {
+	provider.calls++
+	return provider.records, provider.err
+}
+
+func TestTeslaHSCProvenanceV1RuntimeProjectsOnlyRedactedSelectedTerminalMetadata(t *testing.T) {
+	provider := &teslaHSCProvenanceV1FixtureProvider{records: []TeslaHSCProvenanceV1Record{
+		{Function: 101, PayloadLength: 0, PayloadDigest: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+		{Function: 102, PayloadLength: 2, PayloadDigest: "9ee50aea7e52b0fd0c9dcae1a059ac08b94c21ad3e2fa7e6cbf9b6b5279d93d8"},
+	}}
+	runtime, err := NewTeslaHSCProvenanceV1Runtime(provider)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := runtime.TeslaHSCProvenanceV1(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if provider.calls != 1 || len(got) != 2 {
+		t.Fatalf("provider calls=%d, records=%#v", provider.calls, got)
+	}
+	for index, record := range got {
+		if record.Function != provider.records[index].Function ||
+			record.PayloadLength != provider.records[index].PayloadLength ||
+			record.PayloadDigest != provider.records[index].PayloadDigest ||
+			record.OutboundAllowed {
+			t.Fatalf("redacted provenance[%d] = %#v", index, record)
+		}
+	}
+}
+
+func TestTeslaHSCProvenanceV1RuntimeRejectsUnselectedOrMalformedMetadata(t *testing.T) {
+	for _, record := range []TeslaHSCProvenanceV1Record{
+		{Function: 100, PayloadLength: 0, PayloadDigest: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+		{Function: 101, PayloadLength: 253, PayloadDigest: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+		{Function: 102, PayloadLength: 1, PayloadDigest: "not-a-digest"},
+	} {
+		provider := &teslaHSCProvenanceV1FixtureProvider{records: []TeslaHSCProvenanceV1Record{record}}
+		runtime, err := NewTeslaHSCProvenanceV1Runtime(provider)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := runtime.TeslaHSCProvenanceV1(context.Background()); err == nil {
+			t.Fatalf("invalid provenance accepted: %#v", record)
+		}
+	}
+}


### PR DESCRIPTION
Closes #874

## RED

Committed test-only head fails because the new provenance runtime contract is absent.

## Scope

A self-contained, injected FC101/FC102 provenance seam: selected function, length, SHA-256 digest, and forced outbound denial only.

## Exclusions

No raw bytes, request, serial I/O, admission, typed semantics, main/config/lifecycle, dependency files, or #852/#858 files.
