### PR TITLE
Expose injected Huawei SmartLogger read-only status

### DIFF
--- a/mcp/huawei_smartlogger_v1.go
+++ b/mcp/huawei_smartlogger_v1.go
@@ -1,0 +1,61 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+const (
+	HuaweiSmartLoggerV1StatusGetTool = "modbus.v1.huawei.smartlogger.status.get"
+	HuaweiSmartLoggerV1Profile       = "huawei.smartlogger.readonly.v1"
+)
+
+// HuaweiSmartLoggerV1Result is intentionally limited to redacted, read-only
+// qualification status. Inventory and transport evidence remain private.
+type HuaweiSmartLoggerV1Result struct {
+	Profile         string `json:"profile"`
+	Family          string `json:"family"`
+	Qualified       bool   `json:"qualified"`
+	RawRedacted     bool   `json:"raw_redacted"`
+	OutboundAllowed bool   `json:"outbound_allowed"`
+}
+
+type HuaweiSmartLoggerV1Provider interface {
+	HuaweiSmartLoggerV1(context.Context) (HuaweiSmartLoggerV1Result, error)
+}
+
+var huaweiSmartLoggerV1Providers = struct {
+	sync.RWMutex
+	byServer map[*Server]HuaweiSmartLoggerV1Provider
+}{byServer: make(map[*Server]HuaweiSmartLoggerV1Provider)}
+
+func registerHuaweiSmartLoggerV1Tool(server *Server, provider ModbusV1Provider) {
+	value, ok := provider.(HuaweiSmartLoggerV1Provider)
+	if !ok || value == nil {
+		return
+	}
+	huaweiSmartLoggerV1Providers.Lock()
+	huaweiSmartLoggerV1Providers.byServer[server] = value
+	huaweiSmartLoggerV1Providers.Unlock()
+	server.tools = append(server.tools, Tool{Name: HuaweiSmartLoggerV1StatusGetTool, Description: "Get the redacted read-only Huawei SmartLogger status.", InputSchema: map[string]any{"type": "object", "properties": map[string]any{}, "additionalProperties": false}})
+}
+
+func (server *Server) handleHuaweiSmartLoggerV1Call(ctx context.Context, name string, args map[string]any) (map[string]any, bool) {
+	if name != HuaweiSmartLoggerV1StatusGetTool {
+		return nil, false
+	}
+	if len(args) != 0 {
+		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("invalid Huawei SmartLogger status arguments"), false, "RETAINED_PROFILE", "")), true), true
+	}
+	huaweiSmartLoggerV1Providers.RLock()
+	provider := huaweiSmartLoggerV1Providers.byServer[server]
+	huaweiSmartLoggerV1Providers.RUnlock()
+	if provider == nil {
+		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("huawei SmartLogger provider unavailable"), false, "RETAINED_PROFILE", "")), true), true
+	}
+	result, err := provider.HuaweiSmartLoggerV1(ctx)
+	result.RawRedacted = true
+	result.OutboundAllowed = false
+	return callToolResultText(mustJSON(newModbusV1Envelope(result, err, true, "RETAINED_PROFILE", "")), err != nil), true
+}

--- a/mcp/huawei_smartlogger_v1_test.go
+++ b/mcp/huawei_smartlogger_v1_test.go
@@ -1,0 +1,35 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+)
+
+type smartLoggerFixture struct{ *modbusV1FixtureProvider }
+
+func (*smartLoggerFixture) HuaweiSmartLoggerV1(context.Context) (HuaweiSmartLoggerV1Result, error) {
+	return HuaweiSmartLoggerV1Result{Profile: HuaweiSmartLoggerV1Profile, Family: "SmartLogger", Qualified: false}, nil
+}
+
+func TestHuaweiSmartLoggerV1ToolRedactsInventoryAndDisablesOutbound(t *testing.T) {
+	s, err := NewServer(&testRegistry{entries: map[byte]registry.DeviceEntry{}}, &testInvoker{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	RegisterModbusV1Tools(s, &smartLoggerFixture{&modbusV1FixtureProvider{}})
+	r := msp06Call(t, s.Handler(), HuaweiSmartLoggerV1StatusGetTool, map[string]any{})
+	if r.isError {
+		t.Fatal(r)
+	}
+	d := msp06Map(t, r.envelope["data"], "data")
+	if d["profile"] != HuaweiSmartLoggerV1Profile || d["family"] != "SmartLogger" || d["raw_redacted"] != true || d["outbound_allowed"] != false {
+		t.Fatalf("%#v", d)
+	}
+	for _, key := range []string{"mei", "inventory", "endpoint", "firmware", "child"} {
+		if _, ok := d[key]; ok {
+			t.Fatal(key)
+		}
+	}
+}

--- a/mcp/modbus_v1.go
+++ b/mcp/modbus_v1.go
@@ -142,6 +142,7 @@ func RegisterModbusV1Tools(server *Server, provider ModbusV1Provider) {
 	registerGrowattProtocolIIV1Tool(server, provider)
 	registerOutBackAXSV1Tool(server, provider)
 	registerHuaweiEMMAV1Tool(server, provider)
+	registerHuaweiSmartLoggerV1Tool(server, provider)
 }
 
 func (server *Server) handleModbusV1Call(ctx context.Context, name string, args map[string]any) (map[string]any, bool) {
@@ -155,6 +156,9 @@ func (server *Server) handleModbusV1Call(ctx context.Context, name string, args 
 		return result, true
 	}
 	if result, handled := server.handleHuaweiEMMAV1Call(ctx, name, args); handled {
+		return result, true
+	}
+	if result, handled := server.handleHuaweiSmartLoggerV1Call(ctx, name, args); handled {
 		return result, true
 	}
 	modbusV1Providers.RLock()


### PR DESCRIPTION
Read-only injected SmartLogger status: redacted inventory, no endpoint/firmware/control/lifecycle, outbound false.