### PR TITLE
Expose read-only Tesla FC100 wire summary through MCP

### DIFF
--- a/mcp/modbus_v1.go
+++ b/mcp/modbus_v1.go
@@ -138,6 +138,7 @@ func RegisterModbusV1Tools(server *Server, provider ModbusV1Provider) {
 			},
 		},
 	)
+	registerTeslaFC100SummaryV1Tool(server, provider)
 	registerTeslaHSCV1Tool(server, provider)
 	registerGrowattProtocolIIV1Tool(server, provider)
 	registerOutBackAXSV1Tool(server, provider)
@@ -145,6 +146,9 @@ func RegisterModbusV1Tools(server *Server, provider ModbusV1Provider) {
 }
 
 func (server *Server) handleModbusV1Call(ctx context.Context, name string, args map[string]any) (map[string]any, bool) {
+	if result, handled := server.handleTeslaFC100SummaryV1Call(ctx, name, args); handled {
+		return result, true
+	}
 	if result, handled := server.handleTeslaHSCV1Call(ctx, name, args); handled {
 		return result, true
 	}

--- a/mcp/tesla_fc100_summary_v1.go
+++ b/mcp/tesla_fc100_summary_v1.go
@@ -1,0 +1,120 @@
+package mcp
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"sync"
+)
+
+const (
+	TeslaFC100SummaryV1GetTool                        = "modbus.v1.tesla.fc100.summary.get"
+	TeslaFC100SummaryV1QualificationFramingOnly       = "framing_only"
+	TeslaFC100SummaryV1QualificationQualifiedReadOnly = "qualified_read_only"
+	maxTeslaFC100SummaryV1Entries                     = 64
+	maxTeslaFC100SummaryV1Message                     = 251
+)
+
+// TeslaFC100SummaryV1WireEntry is one redacted numeric protobuf wire key.
+// It contains no encoded value, field name, or operation identity.
+type TeslaFC100SummaryV1WireEntry struct {
+	FieldNumber uint64 `json:"field_number"`
+	WireType    uint8  `json:"wire_type"`
+}
+
+// TeslaFC100SummaryV1Result is an already-validated FC100 structural replay
+// summary. It contains no raw bytes, values, request, or send authority.
+type TeslaFC100SummaryV1Result struct {
+	Qualification   string                         `json:"qualification"`
+	EnvelopeLength  int                            `json:"envelope_length"`
+	MessageLength   int                            `json:"message_length"`
+	EntryCount      int                            `json:"entry_count"`
+	Entries         []TeslaFC100SummaryV1WireEntry `json:"entries"`
+	PayloadDigest   string                         `json:"payload_digest"`
+	OutboundAllowed bool                           `json:"outbound_allowed"`
+}
+
+// TeslaFC100SummaryV1Provider supplies only an already-validated FC100
+// structural summary. It has no request-construction or transport-I/O method.
+type TeslaFC100SummaryV1Provider interface {
+	TeslaFC100SummaryV1(context.Context) (TeslaFC100SummaryV1Result, error)
+}
+
+var teslaFC100SummaryV1Providers = struct {
+	sync.RWMutex
+	byServer map[*Server]TeslaFC100SummaryV1Provider
+}{byServer: make(map[*Server]TeslaFC100SummaryV1Provider)}
+
+func registerTeslaFC100SummaryV1Tool(server *Server, provider ModbusV1Provider) {
+	tesla, ok := provider.(TeslaFC100SummaryV1Provider)
+	if !ok || tesla == nil {
+		return
+	}
+	teslaFC100SummaryV1Providers.Lock()
+	teslaFC100SummaryV1Providers.byServer[server] = tesla
+	teslaFC100SummaryV1Providers.Unlock()
+	server.tools = append(server.tools, Tool{
+		Name:        TeslaFC100SummaryV1GetTool,
+		Description: "Get one read-only redacted Tesla FC100 structural wire summary.",
+		InputSchema: map[string]any{"type": "object", "properties": map[string]any{}, "additionalProperties": false},
+	})
+}
+
+func (server *Server) handleTeslaFC100SummaryV1Call(ctx context.Context, name string, args map[string]any) (map[string]any, bool) {
+	if name != TeslaFC100SummaryV1GetTool {
+		return nil, false
+	}
+	if len(args) != 0 {
+		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("invalid Tesla FC100 summary arguments"), false, "RETAINED_STRUCTURAL_PROVENANCE", "")), true), true
+	}
+	teslaFC100SummaryV1Providers.RLock()
+	provider := teslaFC100SummaryV1Providers.byServer[server]
+	teslaFC100SummaryV1Providers.RUnlock()
+	if provider == nil {
+		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("tesla FC100 summary provider unavailable"), false, "RETAINED_STRUCTURAL_PROVENANCE", "")), true), true
+	}
+	result, err := provider.TeslaFC100SummaryV1(ctx)
+	if err != nil || !validTeslaFC100SummaryV1Result(result) {
+		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("tesla FC100 summary unavailable"), true, "RETAINED_STRUCTURAL_PROVENANCE", "")), true), true
+	}
+	result = failClosedTeslaFC100SummaryV1Result(result)
+	return callToolResultText(mustJSON(newModbusV1Envelope(result, nil, true, "RETAINED_STRUCTURAL_PROVENANCE", "")), false), true
+}
+
+func validTeslaFC100SummaryV1Result(result TeslaFC100SummaryV1Result) bool {
+	if (result.Qualification != TeslaFC100SummaryV1QualificationFramingOnly &&
+		result.Qualification != TeslaFC100SummaryV1QualificationQualifiedReadOnly) ||
+		result.MessageLength < 1 || result.MessageLength > maxTeslaFC100SummaryV1Message ||
+		result.EnvelopeLength != result.MessageLength+1 ||
+		result.EntryCount < 1 || result.EntryCount > maxTeslaFC100SummaryV1Entries ||
+		len(result.Entries) != result.EntryCount {
+		return false
+	}
+	digest, err := hex.DecodeString(result.PayloadDigest)
+	if err != nil || len(digest) != sha256.Size {
+		return false
+	}
+	groups := make([]uint64, 0, result.EntryCount)
+	for _, entry := range result.Entries {
+		if entry.FieldNumber == 0 || entry.FieldNumber > (1<<29)-1 || entry.WireType > 5 {
+			return false
+		}
+		switch entry.WireType {
+		case 3:
+			groups = append(groups, entry.FieldNumber)
+		case 4:
+			if len(groups) == 0 || groups[len(groups)-1] != entry.FieldNumber {
+				return false
+			}
+			groups = groups[:len(groups)-1]
+		}
+	}
+	return len(groups) == 0
+}
+
+func failClosedTeslaFC100SummaryV1Result(result TeslaFC100SummaryV1Result) TeslaFC100SummaryV1Result {
+	result.Entries = append([]TeslaFC100SummaryV1WireEntry(nil), result.Entries...)
+	result.OutboundAllowed = false
+	return result
+}

--- a/mcp/tesla_fc100_summary_v1.go
+++ b/mcp/tesla_fc100_summary_v1.go
@@ -85,9 +85,9 @@ func (server *Server) handleTeslaFC100SummaryV1Call(ctx context.Context, name st
 func validTeslaFC100SummaryV1Result(result TeslaFC100SummaryV1Result) bool {
 	if (result.Qualification != TeslaFC100SummaryV1QualificationFramingOnly &&
 		result.Qualification != TeslaFC100SummaryV1QualificationQualifiedReadOnly) ||
-		result.MessageLength < 1 || result.MessageLength > maxTeslaFC100SummaryV1Message ||
+		result.MessageLength < 0 || result.MessageLength > maxTeslaFC100SummaryV1Message ||
 		result.EnvelopeLength != result.MessageLength+1 ||
-		result.EntryCount < 1 || result.EntryCount > maxTeslaFC100SummaryV1Entries ||
+		result.EntryCount < 0 || result.EntryCount > maxTeslaFC100SummaryV1Entries ||
 		len(result.Entries) != result.EntryCount {
 		return false
 	}

--- a/mcp/tesla_fc100_summary_v1_test.go
+++ b/mcp/tesla_fc100_summary_v1_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
@@ -47,8 +48,8 @@ func TestTeslaFC100SummaryV1MCPProjectsOnlyBoundedStructuralProvenance(t *testin
 	}
 	data := msp06Map(t, result.envelope["data"], "data")
 	if data["qualification"] != TeslaFC100SummaryV1QualificationFramingOnly ||
-		data["envelope_length"] != "8" || data["message_length"] != "7" ||
-		data["entry_count"] != "2" || data["outbound_allowed"] != false {
+		fmt.Sprint(data["envelope_length"]) != "8" || fmt.Sprint(data["message_length"]) != "7" ||
+		fmt.Sprint(data["entry_count"]) != "2" || data["outbound_allowed"] != false {
 		t.Fatalf("summary data = %#v", data)
 	}
 	for _, forbidden := range []string{"raw", "value", "operation", "capability", "request"} {

--- a/mcp/tesla_fc100_summary_v1_test.go
+++ b/mcp/tesla_fc100_summary_v1_test.go
@@ -59,6 +59,35 @@ func TestTeslaFC100SummaryV1MCPProjectsOnlyBoundedStructuralProvenance(t *testin
 	}
 }
 
+func TestTeslaFC100SummaryV1MCPProjectsEmptyFC100Message(t *testing.T) {
+	server, err := NewServer(&testRegistry{entries: make(map[byte]registry.DeviceEntry)}, &testInvoker{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider := &teslaFC100SummaryV1FixtureProvider{
+		modbusV1FixtureProvider: &modbusV1FixtureProvider{},
+		result: TeslaFC100SummaryV1Result{
+			Qualification:   TeslaFC100SummaryV1QualificationFramingOnly,
+			EnvelopeLength:  1,
+			MessageLength:   0,
+			EntryCount:      0,
+			PayloadDigest:   "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			OutboundAllowed: true,
+		},
+	}
+	RegisterModbusV1Tools(server, provider)
+	result := msp06Call(t, server.Handler(), TeslaFC100SummaryV1GetTool, map[string]any{})
+	if result.isError {
+		t.Fatalf("empty FC100 message = %#v", result)
+	}
+	data := msp06Map(t, result.envelope["data"], "data")
+	if fmt.Sprint(data["envelope_length"]) != "1" ||
+		fmt.Sprint(data["message_length"]) != "0" ||
+		fmt.Sprint(data["entry_count"]) != "0" || data["outbound_allowed"] != false {
+		t.Fatalf("empty FC100 summary data = %#v", data)
+	}
+}
+
 func TestTeslaFC100SummaryV1MCPFailsClosedForInvalidProviderSummary(t *testing.T) {
 	server, err := NewServer(&testRegistry{entries: make(map[byte]registry.DeviceEntry)}, &testInvoker{})
 	if err != nil {

--- a/mcp/tesla_fc100_summary_v1_test.go
+++ b/mcp/tesla_fc100_summary_v1_test.go
@@ -1,0 +1,80 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+)
+
+type teslaFC100SummaryV1FixtureProvider struct {
+	*modbusV1FixtureProvider
+	result TeslaFC100SummaryV1Result
+	err    error
+}
+
+func (provider *teslaFC100SummaryV1FixtureProvider) TeslaFC100SummaryV1(context.Context) (TeslaFC100SummaryV1Result, error) {
+	return provider.result, provider.err
+}
+
+func TestTeslaFC100SummaryV1MCPProjectsOnlyBoundedStructuralProvenance(t *testing.T) {
+	server, err := NewServer(&testRegistry{entries: make(map[byte]registry.DeviceEntry)}, &testInvoker{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider := &teslaFC100SummaryV1FixtureProvider{
+		modbusV1FixtureProvider: &modbusV1FixtureProvider{},
+		result: TeslaFC100SummaryV1Result{
+			Qualification:  TeslaFC100SummaryV1QualificationFramingOnly,
+			EnvelopeLength: 8,
+			MessageLength:  7,
+			EntryCount:     2,
+			Entries: []TeslaFC100SummaryV1WireEntry{
+				{FieldNumber: 1, WireType: 0},
+				{FieldNumber: 2, WireType: 2},
+			},
+			PayloadDigest:   "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			OutboundAllowed: true,
+		},
+	}
+	RegisterModbusV1Tools(server, provider)
+	if !server.hasToolNamed(TeslaFC100SummaryV1GetTool) {
+		t.Fatal("Tesla FC100 summary tool was not registered")
+	}
+	result := msp06Call(t, server.Handler(), TeslaFC100SummaryV1GetTool, map[string]any{})
+	if result.isError {
+		t.Fatalf("result = %#v", result)
+	}
+	data := msp06Map(t, result.envelope["data"], "data")
+	if data["qualification"] != TeslaFC100SummaryV1QualificationFramingOnly ||
+		data["envelope_length"] != float64(8) || data["message_length"] != float64(7) ||
+		data["entry_count"] != float64(2) || data["outbound_allowed"] != false {
+		t.Fatalf("summary data = %#v", data)
+	}
+	for _, forbidden := range []string{"raw", "value", "operation", "capability", "request"} {
+		if _, exists := data[forbidden]; exists {
+			t.Fatalf("summary exposed %q: %#v", forbidden, data)
+		}
+	}
+}
+
+func TestTeslaFC100SummaryV1MCPFailsClosedForInvalidProviderSummary(t *testing.T) {
+	server, err := NewServer(&testRegistry{entries: make(map[byte]registry.DeviceEntry)}, &testInvoker{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider := &teslaFC100SummaryV1FixtureProvider{
+		modbusV1FixtureProvider: &modbusV1FixtureProvider{},
+		result: TeslaFC100SummaryV1Result{
+			Qualification: TeslaFC100SummaryV1QualificationFramingOnly,
+			EnvelopeLength: 8, MessageLength: 7, EntryCount: 2,
+			Entries: []TeslaFC100SummaryV1WireEntry{{FieldNumber: 1, WireType: 0}},
+			PayloadDigest: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		},
+	}
+	RegisterModbusV1Tools(server, provider)
+	result := msp06Call(t, server.Handler(), TeslaFC100SummaryV1GetTool, map[string]any{})
+	if !result.isError || result.envelope["data"] != nil {
+		t.Fatalf("invalid summary did not fail closed: %#v", result)
+	}
+}

--- a/mcp/tesla_fc100_summary_v1_test.go
+++ b/mcp/tesla_fc100_summary_v1_test.go
@@ -47,8 +47,8 @@ func TestTeslaFC100SummaryV1MCPProjectsOnlyBoundedStructuralProvenance(t *testin
 	}
 	data := msp06Map(t, result.envelope["data"], "data")
 	if data["qualification"] != TeslaFC100SummaryV1QualificationFramingOnly ||
-		data["envelope_length"] != float64(8) || data["message_length"] != float64(7) ||
-		data["entry_count"] != float64(2) || data["outbound_allowed"] != false {
+		data["envelope_length"] != "8" || data["message_length"] != "7" ||
+		data["entry_count"] != "2" || data["outbound_allowed"] != false {
 		t.Fatalf("summary data = %#v", data)
 	}
 	for _, forbidden := range []string{"raw", "value", "operation", "capability", "request"} {
@@ -66,9 +66,9 @@ func TestTeslaFC100SummaryV1MCPFailsClosedForInvalidProviderSummary(t *testing.T
 	provider := &teslaFC100SummaryV1FixtureProvider{
 		modbusV1FixtureProvider: &modbusV1FixtureProvider{},
 		result: TeslaFC100SummaryV1Result{
-			Qualification: TeslaFC100SummaryV1QualificationFramingOnly,
+			Qualification:  TeslaFC100SummaryV1QualificationFramingOnly,
 			EnvelopeLength: 8, MessageLength: 7, EntryCount: 2,
-			Entries: []TeslaFC100SummaryV1WireEntry{{FieldNumber: 1, WireType: 0}},
+			Entries:       []TeslaFC100SummaryV1WireEntry{{FieldNumber: 1, WireType: 0}},
 			PayloadDigest: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 		},
 	}


### PR DESCRIPTION
Closes #882

## RED

Committed test-only head fails because the FC100 summary MCP seam is absent.

## Scope

Injected, already-validated FC100 structural summary only: qualification, numeric field/wire entries, lengths/count/digest, permanently outbound-denied.

## Exclusions

No raw bytes/values/names, request construction, typed Tesla semantics/capabilities/control, serial I/O, lifecycle/main/config/dependencies, #852 or #858 files. Docs #81 companion is required before merge.