### PR TITLE
Expose injected Fronius SunSpec read-only MCP status

### DIFF
--- a/mcp/fronius_sunspec_v1.go
+++ b/mcp/fronius_sunspec_v1.go
@@ -1,0 +1,100 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"math"
+	"sync"
+
+	modbusreg "github.com/Project-Helianthus/helianthus-modbusreg"
+)
+
+const (
+	FroniusSunSpecV1StatusGetTool = "modbus.v1.fronius.sunspec.status.get"
+	FroniusSunSpecV1Profile       = "sunspec.fronius.readonly.v1"
+)
+
+// FroniusSunSpecV1Telemetry is the bounded standard Model 113 projection
+// exposed by the read-only Fronius status tool.
+type FroniusSunSpecV1Telemetry struct {
+	ACActivePowerWatts      float64 `json:"ac_active_power_watts"`
+	ACFrequencyHertz        float64 `json:"ac_frequency_hertz"`
+	LifetimeEnergyWattHours float64 `json:"lifetime_energy_watt_hours"`
+	OperatingState          string  `json:"operating_state"`
+}
+
+type FroniusSunSpecV1Result struct {
+	Profile         string                     `json:"profile"`
+	Capability      string                     `json:"capability"`
+	Qualification   string                     `json:"qualification"`
+	Qualified       bool                       `json:"qualified"`
+	Telemetry       *FroniusSunSpecV1Telemetry `json:"telemetry,omitempty"`
+	RawRedacted     bool                       `json:"raw_redacted"`
+	OutboundAllowed bool                       `json:"outbound_allowed"`
+}
+
+type FroniusSunSpecV1Provider interface {
+	FroniusSunSpecV1(context.Context) (FroniusSunSpecV1Result, error)
+}
+
+var froniusSunSpecV1Providers = struct {
+	sync.RWMutex
+	byServer map[*Server]FroniusSunSpecV1Provider
+}{byServer: make(map[*Server]FroniusSunSpecV1Provider)}
+
+func registerFroniusSunSpecV1Tool(server *Server, provider ModbusV1Provider) {
+	p, ok := provider.(FroniusSunSpecV1Provider)
+	if !ok || p == nil {
+		return
+	}
+	froniusSunSpecV1Providers.Lock()
+	froniusSunSpecV1Providers.byServer[server] = p
+	froniusSunSpecV1Providers.Unlock()
+	server.tools = append(server.tools, Tool{Name: FroniusSunSpecV1StatusGetTool, Description: "Get the redacted, read-only Fronius SunSpec qualification and standard telemetry.", InputSchema: map[string]any{"type": "object", "properties": map[string]any{}, "additionalProperties": false}})
+}
+
+func (server *Server) handleFroniusSunSpecV1Call(ctx context.Context, name string, args map[string]any) (map[string]any, bool) {
+	if name != FroniusSunSpecV1StatusGetTool {
+		return nil, false
+	}
+	if len(args) != 0 {
+		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("invalid Fronius SunSpec status arguments"), false, "RETAINED_PROFILE", "")), true), true
+	}
+	froniusSunSpecV1Providers.RLock()
+	p := froniusSunSpecV1Providers.byServer[server]
+	froniusSunSpecV1Providers.RUnlock()
+	if p == nil {
+		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("fronius SunSpec provider unavailable"), false, "RETAINED_PROFILE", "")), true), true
+	}
+	result, err := p.FroniusSunSpecV1(ctx)
+	return callToolResultText(mustJSON(newModbusV1Envelope(normalizeFroniusSunSpecV1Result(result, err), err, true, "RETAINED_PROFILE", "")), err != nil), true
+}
+
+func normalizeFroniusSunSpecV1Result(result FroniusSunSpecV1Result, err error) FroniusSunSpecV1Result {
+	result.Profile = FroniusSunSpecV1Profile
+	result.Capability = modbusreg.SunSpecThreePhaseMonitoringCapabilityID
+	result.RawRedacted = true
+	result.OutboundAllowed = false
+	if err != nil || !result.Qualified || !validFroniusSunSpecV1Telemetry(result.Telemetry) {
+		result.Qualified = false
+		result.Qualification = "NOT_QUALIFIED"
+		result.Telemetry = nil
+		return result
+	}
+	result.Qualification = "QUALIFIED"
+	telemetry := *result.Telemetry
+	result.Telemetry = &telemetry
+	return result
+}
+
+func validFroniusSunSpecV1Telemetry(telemetry *FroniusSunSpecV1Telemetry) bool {
+	if telemetry == nil || math.IsNaN(telemetry.ACActivePowerWatts) || math.IsInf(telemetry.ACActivePowerWatts, 0) || math.IsNaN(telemetry.ACFrequencyHertz) || math.IsInf(telemetry.ACFrequencyHertz, 0) || math.IsNaN(telemetry.LifetimeEnergyWattHours) || math.IsInf(telemetry.LifetimeEnergyWattHours, 0) {
+		return false
+	}
+	switch telemetry.OperatingState {
+	case "OFF", "SLEEPING", "STARTING", "MPPT", "THROTTLED", "SHUTTING_DOWN", "FAULT", "STANDBY":
+		return true
+	default:
+		return false
+	}
+}

--- a/mcp/fronius_sunspec_v1_test.go
+++ b/mcp/fronius_sunspec_v1_test.go
@@ -1,0 +1,82 @@
+package mcp
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+	modbusreg "github.com/Project-Helianthus/helianthus-modbusreg"
+)
+
+type froniusSunSpecFixture struct{ *modbusV1FixtureProvider }
+
+func (*froniusSunSpecFixture) FroniusSunSpecV1(context.Context) (FroniusSunSpecV1Result, error) {
+	return FroniusSunSpecV1Result{
+		Qualified: true,
+		Telemetry: &FroniusSunSpecV1Telemetry{
+			ACActivePowerWatts:       8421.5,
+			ACFrequencyHertz:         50,
+			LifetimeEnergyWattHours:  123456.75,
+			OperatingState:           "MPPT",
+		},
+	}, nil
+}
+
+func TestFroniusSunSpecV1ToolProjectsOnlyQualifiedStandardTelemetry(t *testing.T) {
+	s, err := NewServer(&testRegistry{entries: map[byte]registry.DeviceEntry{}}, &testInvoker{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	RegisterModbusV1Tools(s, &froniusSunSpecFixture{&modbusV1FixtureProvider{}})
+	r := msp06Call(t, s.Handler(), FroniusSunSpecV1StatusGetTool, map[string]any{})
+	if r.isError {
+		t.Fatal(r)
+	}
+	d := msp06Map(t, r.envelope["data"], "data")
+	if d["profile"] != FroniusSunSpecV1Profile || d["capability"] != modbusreg.SunSpecThreePhaseMonitoringCapabilityID || d["qualification"] != "QUALIFIED" || d["qualified"] != true || d["raw_redacted"] != true || d["outbound_allowed"] != false {
+		t.Fatalf("%#v", d)
+	}
+	telemetry := msp06Map(t, d["telemetry"], "telemetry")
+	if telemetry["ac_active_power_watts"] != 8421.5 || telemetry["ac_frequency_hertz"] != 50.0 || telemetry["lifetime_energy_watt_hours"] != 123456.75 || telemetry["operating_state"] != "MPPT" {
+		t.Fatalf("%#v", telemetry)
+	}
+	for _, key := range []string{"endpoint", "raw", "replay", "firmware", "configuration", "control"} {
+		if _, ok := d[key]; ok {
+			t.Fatal(key)
+		}
+	}
+}
+
+func TestFroniusSunSpecV1ToolFailsClosedForUnqualifiedOrInvalidTelemetry(t *testing.T) {
+	for _, result := range []FroniusSunSpecV1Result{
+		{Qualified: false, Telemetry: &FroniusSunSpecV1Telemetry{ACActivePowerWatts: 1}},
+		{Qualified: true, Telemetry: &FroniusSunSpecV1Telemetry{ACActivePowerWatts: math.NaN()}},
+	} {
+		s, err := NewServer(&testRegistry{entries: map[byte]registry.DeviceEntry{}}, &testInvoker{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		RegisterModbusV1Tools(s, froniusSunSpecResultFixture{modbusV1FixtureProvider: &modbusV1FixtureProvider{}, result: result})
+		r := msp06Call(t, s.Handler(), FroniusSunSpecV1StatusGetTool, map[string]any{})
+		if r.isError {
+			t.Fatal(r)
+		}
+		d := msp06Map(t, r.envelope["data"], "data")
+		if d["qualification"] != "NOT_QUALIFIED" || d["qualified"] != false {
+			t.Fatalf("%#v", d)
+		}
+		if _, ok := d["telemetry"]; ok {
+			t.Fatalf("telemetry must be absent: %#v", d)
+		}
+	}
+}
+
+type froniusSunSpecResultFixture struct {
+	*modbusV1FixtureProvider
+	result FroniusSunSpecV1Result
+}
+
+func (f froniusSunSpecResultFixture) FroniusSunSpecV1(context.Context) (FroniusSunSpecV1Result, error) {
+	return f.result, nil
+}

--- a/mcp/fronius_sunspec_v1_test.go
+++ b/mcp/fronius_sunspec_v1_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"math"
 	"testing"
 
@@ -15,10 +16,10 @@ func (*froniusSunSpecFixture) FroniusSunSpecV1(context.Context) (FroniusSunSpecV
 	return FroniusSunSpecV1Result{
 		Qualified: true,
 		Telemetry: &FroniusSunSpecV1Telemetry{
-			ACActivePowerWatts:       8421.5,
-			ACFrequencyHertz:         50,
-			LifetimeEnergyWattHours:  123456.75,
-			OperatingState:           "MPPT",
+			ACActivePowerWatts:      8421.5,
+			ACFrequencyHertz:        50,
+			LifetimeEnergyWattHours: 123456.75,
+			OperatingState:          "MPPT",
 		},
 	}, nil
 }
@@ -38,7 +39,7 @@ func TestFroniusSunSpecV1ToolProjectsOnlyQualifiedStandardTelemetry(t *testing.T
 		t.Fatalf("%#v", d)
 	}
 	telemetry := msp06Map(t, d["telemetry"], "telemetry")
-	if telemetry["ac_active_power_watts"] != 8421.5 || telemetry["ac_frequency_hertz"] != 50.0 || telemetry["lifetime_energy_watt_hours"] != 123456.75 || telemetry["operating_state"] != "MPPT" {
+	if telemetry["ac_active_power_watts"] != json.Number("8421.5") || telemetry["ac_frequency_hertz"] != json.Number("50") || telemetry["lifetime_energy_watt_hours"] != json.Number("123456.75") || telemetry["operating_state"] != "MPPT" {
 		t.Fatalf("%#v", telemetry)
 	}
 	for _, key := range []string{"endpoint", "raw", "replay", "firmware", "configuration", "control"} {

--- a/mcp/modbus_v1.go
+++ b/mcp/modbus_v1.go
@@ -145,6 +145,7 @@ func RegisterModbusV1Tools(server *Server, provider ModbusV1Provider) {
 	registerHuaweiEMMAV1Tool(server, provider)
 	registerHuaweiSmartLoggerV1Tool(server, provider)
 	registerHuaweiSDongleV1Tool(server, provider)
+	registerFroniusSunSpecV1Tool(server, provider)
 }
 
 func (server *Server) handleModbusV1Call(ctx context.Context, name string, args map[string]any) (map[string]any, bool) {
@@ -167,6 +168,9 @@ func (server *Server) handleModbusV1Call(ctx context.Context, name string, args 
 		return result, true
 	}
 	if result, handled := server.handleHuaweiSDongleV1Call(ctx, name, args); handled {
+		return result, true
+	}
+	if result, handled := server.handleFroniusSunSpecV1Call(ctx, name, args); handled {
 		return result, true
 	}
 	modbusV1Providers.RLock()


### PR DESCRIPTION
## RED

Commit establishes the absent tool and fail-closed contract.

## Scope

Injected Fronius SunSpec profile/capability/qualification plus allowlisted standard telemetry only. No raw transport data, control, config, endpoint, lifecycle, discovery, or acquisition.

## Validation

Focused RED: `go test ./mcp -run TestFroniusSunSpecV1 -count=1` fails because the API is intentionally absent.