### PR TITLE
MCP-TESLA: expose qualified WC vitals replay

### DIFF
--- a/mcp/modbus_v1.go
+++ b/mcp/modbus_v1.go
@@ -140,6 +140,7 @@ func RegisterModbusV1Tools(server *Server, provider ModbusV1Provider) {
 	)
 	registerTeslaFC100SummaryV1Tool(server, provider)
 	registerTeslaHSCV1Tool(server, provider)
+	registerTeslaWCVitalsV1Tool(server, provider)
 	registerGrowattProtocolIIV1Tool(server, provider)
 	registerOutBackAXSV1Tool(server, provider)
 	registerHuaweiEMMAV1Tool(server, provider)
@@ -153,6 +154,9 @@ func (server *Server) handleModbusV1Call(ctx context.Context, name string, args 
 		return result, true
 	}
 	if result, handled := server.handleTeslaHSCV1Call(ctx, name, args); handled {
+		return result, true
+	}
+	if result, handled := server.handleTeslaWCVitalsV1Call(ctx, name, args); handled {
 		return result, true
 	}
 	if result, handled := server.handleGrowattProtocolIIV1Call(ctx, name, args); handled {

--- a/mcp/tesla_wcapi_get_vitals_v1.go
+++ b/mcp/tesla_wcapi_get_vitals_v1.go
@@ -1,0 +1,99 @@
+package mcp
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"sync"
+)
+
+const (
+	TeslaWCVitalsV1GetTool                = "modbus.v1.tesla.wcapi.get_vitals.replay.get"
+	TeslaWCVitalsV1Operation              = "tesla.hsc.fc100.wc_vitals.v1"
+	TeslaWCVitalsV1ProfileVersion         = "tesla_hsc_modbus_v1"
+	TeslaWCVitalsV1OperationVersion       = "wc3_24_44_3"
+	TeslaWCVitalsV1QualificationQualified = "qualified_read_only"
+	TeslaWCVitalsV1ReplayIntermediate     = "intermediate"
+	TeslaWCVitalsV1ReplayTerminal         = "terminal"
+	maxTeslaWCVitalsV1SnapshotBytes       = 251
+)
+
+// TeslaWCVitalsV1Result is an already-selected, bounded replay result. It
+// deliberately carries no raw PDU or decoded vitals values.
+type TeslaWCVitalsV1Result struct {
+	Operation        string `json:"operation"`
+	ProfileVersion   string `json:"profile_version"`
+	OperationVersion string `json:"operation_version"`
+	Qualification    string `json:"qualification"`
+	ReplayKind       string `json:"replay_kind"`
+	SnapshotLength   int    `json:"snapshot_length"`
+	SnapshotDigest   string `json:"snapshot_digest,omitempty"`
+	OutboundAllowed  bool   `json:"outbound_allowed"`
+}
+
+// TeslaWCVitalsV1Provider supplies an already-qualified replay. It has no
+// transport, request-construction, or serial-configuration method.
+type TeslaWCVitalsV1Provider interface {
+	TeslaWCVitalsV1(context.Context) (TeslaWCVitalsV1Result, error)
+}
+
+var teslaWCVitalsV1Providers = struct {
+	sync.RWMutex
+	byServer map[*Server]TeslaWCVitalsV1Provider
+}{byServer: make(map[*Server]TeslaWCVitalsV1Provider)}
+
+func registerTeslaWCVitalsV1Tool(server *Server, provider ModbusV1Provider) {
+	tesla, ok := provider.(TeslaWCVitalsV1Provider)
+	if !ok || tesla == nil {
+		return
+	}
+	teslaWCVitalsV1Providers.Lock()
+	teslaWCVitalsV1Providers.byServer[server] = tesla
+	teslaWCVitalsV1Providers.Unlock()
+	server.tools = append(server.tools, Tool{
+		Name:        TeslaWCVitalsV1GetTool,
+		Description: "Get the read-only redacted replay for the qualified Tesla WC vitals operation.",
+		InputSchema: map[string]any{"type": "object", "properties": map[string]any{}, "additionalProperties": false},
+	})
+}
+
+func (server *Server) handleTeslaWCVitalsV1Call(ctx context.Context, name string, args map[string]any) (map[string]any, bool) {
+	if name != TeslaWCVitalsV1GetTool {
+		return nil, false
+	}
+	if len(args) != 0 {
+		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("invalid tesla WC vitals arguments"), false, "RETAINED_QUALIFIED_OPERATION_REPLAY", "")), true), true
+	}
+	teslaWCVitalsV1Providers.RLock()
+	provider := teslaWCVitalsV1Providers.byServer[server]
+	teslaWCVitalsV1Providers.RUnlock()
+	if provider == nil {
+		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("tesla WC vitals provider unavailable"), false, "RETAINED_QUALIFIED_OPERATION_REPLAY", "")), true), true
+	}
+	result, err := provider.TeslaWCVitalsV1(ctx)
+	if err != nil || !validTeslaWCVitalsV1Result(result) {
+		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("tesla WC vitals replay unavailable"), true, "RETAINED_QUALIFIED_OPERATION_REPLAY", "")), true), true
+	}
+	result.OutboundAllowed = false
+	return callToolResultText(mustJSON(newModbusV1Envelope(result, nil, true, "RETAINED_QUALIFIED_OPERATION_REPLAY", "")), false), true
+}
+
+func validTeslaWCVitalsV1Result(result TeslaWCVitalsV1Result) bool {
+	if result.Operation != TeslaWCVitalsV1Operation ||
+		result.ProfileVersion != TeslaWCVitalsV1ProfileVersion ||
+		result.OperationVersion != TeslaWCVitalsV1OperationVersion ||
+		result.Qualification != TeslaWCVitalsV1QualificationQualified ||
+		result.SnapshotLength < 0 || result.SnapshotLength > maxTeslaWCVitalsV1SnapshotBytes {
+		return false
+	}
+	switch result.ReplayKind {
+	case TeslaWCVitalsV1ReplayIntermediate:
+		return result.SnapshotLength == 0 && result.SnapshotDigest == ""
+	case TeslaWCVitalsV1ReplayTerminal:
+		digest, err := hex.DecodeString(result.SnapshotDigest)
+		return err == nil && len(digest) == sha256.Size
+	default:
+		return false
+	}
+}

--- a/mcp/tesla_wcapi_get_vitals_v1_test.go
+++ b/mcp/tesla_wcapi_get_vitals_v1_test.go
@@ -1,0 +1,89 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+)
+
+type teslaWCVitalsV1FixtureProvider struct {
+	*modbusV1FixtureProvider
+	result TeslaWCVitalsV1Result
+	err    error
+	calls  int
+}
+
+func (provider *teslaWCVitalsV1FixtureProvider) TeslaWCVitalsV1(context.Context) (TeslaWCVitalsV1Result, error) {
+	provider.calls++
+	return provider.result, provider.err
+}
+
+func TestTeslaWCVitalsV1MCPProjectsOnlyQualifiedRedactedReplay(t *testing.T) {
+	server, err := NewServer(&testRegistry{entries: make(map[byte]registry.DeviceEntry)}, &testInvoker{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider := &teslaWCVitalsV1FixtureProvider{
+		modbusV1FixtureProvider: &modbusV1FixtureProvider{},
+		result: TeslaWCVitalsV1Result{
+			Operation:        TeslaWCVitalsV1Operation,
+			ProfileVersion:   TeslaWCVitalsV1ProfileVersion,
+			OperationVersion: TeslaWCVitalsV1OperationVersion,
+			Qualification:    TeslaWCVitalsV1QualificationQualified,
+			ReplayKind:       TeslaWCVitalsV1ReplayTerminal,
+			SnapshotLength:   2,
+			SnapshotDigest:   "fb8da7eb5b1b399e7321179dac9e9f65773d7331e1e30554e3911e4325e1ef19",
+			OutboundAllowed:  true,
+		},
+	}
+	RegisterModbusV1Tools(server, provider)
+	if !server.hasToolNamed(TeslaWCVitalsV1GetTool) {
+		t.Fatal("Tesla WC vitals tool was not registered")
+	}
+	result := msp06Call(t, server.Handler(), TeslaWCVitalsV1GetTool, map[string]any{})
+	if result.isError || provider.calls != 1 {
+		t.Fatalf("result = %#v, provider calls = %d", result, provider.calls)
+	}
+	data := msp06Map(t, result.envelope["data"], "data")
+	if data["operation"] != TeslaWCVitalsV1Operation || data["profile_version"] != TeslaWCVitalsV1ProfileVersion ||
+		data["operation_version"] != TeslaWCVitalsV1OperationVersion || data["qualification"] != TeslaWCVitalsV1QualificationQualified ||
+		data["replay_kind"] != TeslaWCVitalsV1ReplayTerminal || fmt.Sprint(data["snapshot_length"]) != "2" ||
+		data["outbound_allowed"] != false {
+		t.Fatalf("data = %#v", data)
+	}
+	for _, forbidden := range []string{"raw", "bytes", "value", "vitals", "function", "request", "fc101", "fc102"} {
+		if _, exists := data[forbidden]; exists {
+			t.Fatalf("MCP data exposed %q: %#v", forbidden, data)
+		}
+	}
+}
+
+func TestTeslaWCVitalsV1MCPFailsClosedForWrongOperationOrVersion(t *testing.T) {
+	for _, mutate := range []func(*TeslaWCVitalsV1Result){
+		func(result *TeslaWCVitalsV1Result) { result.Operation = "unknown" },
+		func(result *TeslaWCVitalsV1Result) { result.OperationVersion = "unknown" },
+		func(result *TeslaWCVitalsV1Result) { result.Qualification = "framing_only" },
+		func(result *TeslaWCVitalsV1Result) { result.ReplayKind = "fc101" },
+	} {
+		server, err := NewServer(&testRegistry{entries: make(map[byte]registry.DeviceEntry)}, &testInvoker{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		provider := &teslaWCVitalsV1FixtureProvider{
+			modbusV1FixtureProvider: &modbusV1FixtureProvider{},
+			result: TeslaWCVitalsV1Result{
+				Operation: TeslaWCVitalsV1Operation, ProfileVersion: TeslaWCVitalsV1ProfileVersion,
+				OperationVersion: TeslaWCVitalsV1OperationVersion, Qualification: TeslaWCVitalsV1QualificationQualified,
+				ReplayKind: TeslaWCVitalsV1ReplayIntermediate, OutboundAllowed: false,
+			},
+		}
+		mutate(&provider.result)
+		RegisterModbusV1Tools(server, provider)
+		result := msp06Call(t, server.Handler(), TeslaWCVitalsV1GetTool, map[string]any{})
+		if !result.isError || result.envelope["data"] != nil || provider.calls != 1 {
+			t.Fatalf("invalid provider result = %#v, calls = %d", result, provider.calls)
+		}
+	}
+}


### PR DESCRIPTION
Closes #888

Public RED: the injected-only qualified WC vitals MCP status/replay contract is intentionally absent.

No lifecycle, main/config, go.mod/go.sum, request dispatch, raw bytes/values, FC101/102 fallback, hardware I/O, or lab activation.