### PR TITLE
GATEWAY-GROWATT: compose BMS RTU observer into MCP runtime

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260817174811-f8b7082b3fa4
 	github.com/Project-Helianthus/helianthus-eebusreg v0.1.35
 	github.com/Project-Helianthus/helianthus-modbus v0.3.0
-	github.com/Project-Helianthus/helianthus-modbusreg v0.6.5
+	github.com/Project-Helianthus/helianthus-modbusreg v0.6.6
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Project-Helianthus/helianthus-ebusreg v0.0.0-20260817174811-f8b7082b3fa4
 	github.com/Project-Helianthus/helianthus-eebusreg v0.1.35
 	github.com/Project-Helianthus/helianthus-modbus v0.3.0
-	github.com/Project-Helianthus/helianthus-modbusreg v0.6.4
+	github.com/Project-Helianthus/helianthus-modbusreg v0.6.5
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/graphql-go/graphql v0.8.1
 	github.com/graphql-go/handler v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/Project-Helianthus/helianthus-eebusreg v0.1.35 h1:FDo4sFDstzVvX8WjhBj
 github.com/Project-Helianthus/helianthus-eebusreg v0.1.35/go.mod h1:+GjGePfl5rHaWVre2+S6Rs50TZsAFA3ix0oy4tVy9xw=
 github.com/Project-Helianthus/helianthus-modbus v0.3.0 h1:cmYb4WqaAl9DmDAfwnBJf5YIzXyYfnsZRcuZEk1d7/I=
 github.com/Project-Helianthus/helianthus-modbus v0.3.0/go.mod h1:Nr8SW7fE3SIjnp+rj8PCOtwk8JZ9wqafu1ZCgq3Zz+Q=
-github.com/Project-Helianthus/helianthus-modbusreg v0.6.4 h1:XTa0nssxSiih7jyrwYv3dcaNxBLC0vNGJGGbbbzgK7g=
-github.com/Project-Helianthus/helianthus-modbusreg v0.6.4/go.mod h1:WCiu71+yv1FTZfAjOyO268sE4lVZm8KnY1tD3UPAMfQ=
+github.com/Project-Helianthus/helianthus-modbusreg v0.6.5 h1:a2HYhtVxyA5jdCuej50zrLfZxuy0e4eQeH44N+//Jx0=
+github.com/Project-Helianthus/helianthus-modbusreg v0.6.5/go.mod h1:WCiu71+yv1FTZfAjOyO268sE4lVZm8KnY1tD3UPAMfQ=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.18 h1:x/ZtvPZmGJa1dqfufL0cM36chRBMUXtQ0nW1gv3yfow=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.18/go.mod h1:qPqQTDqmPjyOJCr0JMNjhSC1XW1k3h5P/EZqRGy80Vs=
 github.com/Project-Helianthus/helianthus-spine-go v0.7.1-helianthus.9 h1:pV1GQmlPJyy22YGK/Amf5FMu1C3IzL3qxIxGmGUUTEo=

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/Project-Helianthus/helianthus-eebusreg v0.1.35 h1:FDo4sFDstzVvX8WjhBj
 github.com/Project-Helianthus/helianthus-eebusreg v0.1.35/go.mod h1:+GjGePfl5rHaWVre2+S6Rs50TZsAFA3ix0oy4tVy9xw=
 github.com/Project-Helianthus/helianthus-modbus v0.3.0 h1:cmYb4WqaAl9DmDAfwnBJf5YIzXyYfnsZRcuZEk1d7/I=
 github.com/Project-Helianthus/helianthus-modbus v0.3.0/go.mod h1:Nr8SW7fE3SIjnp+rj8PCOtwk8JZ9wqafu1ZCgq3Zz+Q=
-github.com/Project-Helianthus/helianthus-modbusreg v0.6.5 h1:a2HYhtVxyA5jdCuej50zrLfZxuy0e4eQeH44N+//Jx0=
-github.com/Project-Helianthus/helianthus-modbusreg v0.6.5/go.mod h1:WCiu71+yv1FTZfAjOyO268sE4lVZm8KnY1tD3UPAMfQ=
+github.com/Project-Helianthus/helianthus-modbusreg v0.6.6 h1:pitLktFngCkWjRNJVX8Iy6Zru9hXXR+1HHlk00LdPG8=
+github.com/Project-Helianthus/helianthus-modbusreg v0.6.6/go.mod h1:WCiu71+yv1FTZfAjOyO268sE4lVZm8KnY1tD3UPAMfQ=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.18 h1:x/ZtvPZmGJa1dqfufL0cM36chRBMUXtQ0nW1gv3yfow=
 github.com/Project-Helianthus/helianthus-ship-go v0.6.1-helianthus.18/go.mod h1:qPqQTDqmPjyOJCr0JMNjhSC1XW1k3h5P/EZqRGy80Vs=
 github.com/Project-Helianthus/helianthus-spine-go v0.7.1-helianthus.9 h1:pV1GQmlPJyy22YGK/Amf5FMu1C3IzL3qxIxGmGUUTEo=

--- a/mcp/growatt_bms_rs485_v202.go
+++ b/mcp/growatt_bms_rs485_v202.go
@@ -57,19 +57,29 @@ type GrowattBMSRS485V202Revision struct {
 	CumulativeRevision string `json:"cumulative_revision"`
 }
 
-type GrowattBMSRS485V202Result struct {
-	Profile         string                       `json:"profile"`
-	Revision        GrowattBMSRS485V202Revision  `json:"revision"`
-	Qualified       bool                         `json:"qualified"`
-	RawRedacted     bool                         `json:"raw_redacted"`
-	OutboundAllowed bool                         `json:"outbound_allowed"`
-	Identity        GrowattBMSRS485V202Identity  `json:"identity"`
-	Status          GrowattBMSRS485V202Status    `json:"status"`
-	Telemetry       GrowattBMSRS485V202Telemetry `json:"telemetry"`
+type GrowattBMSRS485V202NativeSlice struct {
+	Offset uint16   `json:"offset"`
+	Words  []uint16 `json:"words"`
 }
 
-// GrowattBMSRS485V202Provider supplies only a previously decoded typed status.
-// It has no route for raw words, a serial, an endpoint, or a transport handle.
+type GrowattBMSRS485V202NativeObservation struct {
+	UnitID   byte                             `json:"unit_id"`
+	Revision GrowattBMSRS485V202Revision      `json:"revision"`
+	Slices   []GrowattBMSRS485V202NativeSlice `json:"slices"`
+}
+
+type GrowattBMSRS485V202Result struct {
+	Profile           string                               `json:"profile"`
+	Revision          GrowattBMSRS485V202Revision          `json:"revision"`
+	Qualified         bool                                 `json:"qualified"`
+	NativeObservation GrowattBMSRS485V202NativeObservation `json:"native_observation"`
+	Identity          GrowattBMSRS485V202Identity          `json:"identity"`
+	Status            GrowattBMSRS485V202Status            `json:"status"`
+	Telemetry         GrowattBMSRS485V202Telemetry         `json:"telemetry"`
+}
+
+// GrowattBMSRS485V202Provider supplies a previously decoded typed status with
+// its validated native observation.
 type GrowattBMSRS485V202Provider interface {
 	GrowattBMSRS485V202(context.Context) (modbusreg.GrowattBMSTypedReadOnlyStatus, error)
 }
@@ -87,7 +97,7 @@ func registerGrowattBMSRS485V202Tool(server *Server, provider ModbusV1Provider) 
 	growattBMSRS485V202Providers.Lock()
 	growattBMSRS485V202Providers.byServer[server] = p
 	growattBMSRS485V202Providers.Unlock()
-	server.tools = append(server.tools, Tool{Name: GrowattBMSRS485V202StatusGetTool, Description: "Get the redacted, read-only Growatt BMS RS485 typed status.", InputSchema: map[string]any{"type": "object", "properties": map[string]any{}, "additionalProperties": false}})
+	server.tools = append(server.tools, Tool{Name: GrowattBMSRS485V202StatusGetTool, Description: "Get the native Growatt BMS RS485 typed status and validated FC03 observation.", InputSchema: map[string]any{"type": "object", "properties": map[string]any{}, "additionalProperties": false}})
 }
 
 func (server *Server) handleGrowattBMSRS485V202Call(ctx context.Context, name string, args map[string]any) (map[string]any, bool) {
@@ -122,6 +132,14 @@ func growattBMSRS485V202Result(status modbusreg.GrowattBMSTypedReadOnlyStatus) (
 		!validGrowattBMSRS485V202State(status.OperatingState) || !validGrowattBMSRS485V202Telemetry(status) {
 		return GrowattBMSRS485V202Result{}, ErrGrowattBMSRS485V202NotQualified
 	}
+	native := status.NativeObservation()
+	if native.UnitID() == 0 || native.Revision() != status.Revision || len(native.Slices()) != 4 {
+		return GrowattBMSRS485V202Result{}, ErrGrowattBMSRS485V202NotQualified
+	}
+	nativeSlices := make([]GrowattBMSRS485V202NativeSlice, 0, len(native.Slices()))
+	for _, slice := range native.Slices() {
+		nativeSlices = append(nativeSlices, GrowattBMSRS485V202NativeSlice{Offset: slice.Offset, Words: append([]uint16(nil), slice.Words...)})
+	}
 	return GrowattBMSRS485V202Result{
 		Profile: GrowattBMSRS485V202Profile,
 		Revision: GrowattBMSRS485V202Revision{
@@ -130,9 +148,11 @@ func growattBMSRS485V202Result(status modbusreg.GrowattBMSTypedReadOnlyStatus) (
 			HeaderVersion:      status.Revision.HeaderVersion,
 			CumulativeRevision: status.Revision.CumulativeRevision,
 		},
-		Qualified:       true,
-		RawRedacted:     true,
-		OutboundAllowed: false,
+		Qualified: true,
+		NativeObservation: GrowattBMSRS485V202NativeObservation{UnitID: native.UnitID(), Revision: GrowattBMSRS485V202Revision{
+			Family: native.Revision().Family, FileRevision: native.Revision().FileRevision,
+			HeaderVersion: native.Revision().HeaderVersion, CumulativeRevision: native.Revision().CumulativeRevision,
+		}, Slices: nativeSlices},
 		Identity: GrowattBMSRS485V202Identity{
 			MCUSoftwareVersion: status.MCUSoftwareVersion, GaugeVersion: status.GaugeVersion,
 			BMSCompany: status.BMSCompany, BMSGeneration: status.BMSGeneration,

--- a/mcp/growatt_bms_rs485_v202_runtime.go
+++ b/mcp/growatt_bms_rs485_v202_runtime.go
@@ -1,0 +1,39 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+
+	modbusreg "github.com/Project-Helianthus/helianthus-modbusreg"
+)
+
+// GrowattBMSRS485V202Runtime composes an explicitly selected BMS RTU observer
+// into the existing typed MCP provider surface. It owns no port, endpoint,
+// discovery, retry, or control authority.
+type GrowattBMSRS485V202Runtime struct {
+	observer *modbusreg.GrowattBMSRS485RTUObserver
+}
+
+// NewGrowattBMSRS485V202Runtime binds one exact BMS tuple and unicast unit to
+// an injected generic correlated read session. It does not open or configure
+// a serial connection.
+func NewGrowattBMSRS485V202Runtime(
+	revision modbusreg.GrowattBMSRevisionTuple,
+	unitID byte,
+	session modbusreg.GrowattBMSRS485RTUObserverSession,
+) (*GrowattBMSRS485V202Runtime, error) {
+	observer, err := modbusreg.NewGrowattBMSRS485RTUObserver(revision, unitID, session)
+	if err != nil {
+		return nil, err
+	}
+	return &GrowattBMSRS485V202Runtime{observer: observer}, nil
+}
+
+// GrowattBMSRS485V202 returns only the bounded typed status produced after
+// all four contract reads complete. It never returns a partial status.
+func (runtime *GrowattBMSRS485V202Runtime) GrowattBMSRS485V202(ctx context.Context) (modbusreg.GrowattBMSTypedReadOnlyStatus, error) {
+	if runtime == nil || runtime.observer == nil {
+		return modbusreg.GrowattBMSTypedReadOnlyStatus{}, errors.New("growatt BMS RTU runtime is unavailable")
+	}
+	return runtime.observer.Observe(ctx)
+}

--- a/mcp/growatt_bms_rs485_v202_runtime_test.go
+++ b/mcp/growatt_bms_rs485_v202_runtime_test.go
@@ -49,6 +49,9 @@ func TestGrowattBMSRS485V202RuntimeFeedsRedactedMCPStatus(t *testing.T) {
 			}
 		}
 	}
+	if session.unitID != 7 {
+		t.Fatalf("unit_id=%d", session.unitID)
+	}
 }
 
 func TestGrowattBMSRS485V202RuntimeFailsClosedAtMCPBoundary(t *testing.T) {
@@ -69,6 +72,24 @@ func TestGrowattBMSRS485V202RuntimeFailsClosedAtMCPBoundary(t *testing.T) {
 	}
 }
 
+func TestGrowattBMSRS485V202RuntimeRejectsMismatchedResponseAtMCPBoundary(t *testing.T) {
+	session := &growattBMSRS485RuntimeSessionFake{wordsByOffset: growattBMSRS485RuntimeWords(), failAt: -1, mismatchAt: 2}
+	runtime, err := NewGrowattBMSRS485V202Runtime(growattBMSRS485RuntimeRevision(), 7, session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, err := NewServer(&testRegistry{entries: map[byte]registry.DeviceEntry{}}, &testInvoker{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	RegisterModbusV1Tools(s, growattBMSRS485RuntimeProvider{modbusV1FixtureProvider: &modbusV1FixtureProvider{}, runtime: runtime})
+
+	r := msp06Call(t, s.Handler(), GrowattBMSRS485V202StatusGetTool, map[string]any{})
+	if !r.isError || r.envelope["data"] != nil || len(session.calls) != 3 {
+		t.Fatalf("result/calls=%#v/%#v", r, session.calls)
+	}
+}
+
 type growattBMSRS485RuntimeProvider struct {
 	*modbusV1FixtureProvider
 	runtime *GrowattBMSRS485V202Runtime
@@ -82,15 +103,17 @@ type growattBMSRS485RuntimeSessionFake struct {
 	wordsByOffset map[uint16][]uint16
 	calls         [][2]uint16
 	functions     []modbus.FunctionCode
+	unitID        byte
 	failAt        int
 	mismatchAt    int
 }
 
 func (session *growattBMSRS485RuntimeSessionFake) ReadHolding(
 	_ context.Context,
-	_ byte,
+	unitID byte,
 	request modbus.ReadRegistersRequest,
 ) (modbus.ReadRegistersResponse, error) {
+	session.unitID = unitID
 	session.calls = append(session.calls, [2]uint16{request.Offset(), request.Quantity()})
 	session.functions = append(session.functions, request.Function())
 	index := len(session.calls) - 1

--- a/mcp/growatt_bms_rs485_v202_runtime_test.go
+++ b/mcp/growatt_bms_rs485_v202_runtime_test.go
@@ -1,0 +1,134 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+	modbusreg "github.com/Project-Helianthus/helianthus-modbusreg"
+)
+
+func TestGrowattBMSRS485V202RuntimeFeedsRedactedMCPStatus(t *testing.T) {
+	session := &growattBMSRS485RuntimeSessionFake{wordsByOffset: growattBMSRS485RuntimeWords(), failAt: -1, mismatchAt: -1}
+	runtime, err := NewGrowattBMSRS485V202Runtime(growattBMSRS485RuntimeRevision(), 7, session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, err := NewServer(&testRegistry{entries: map[byte]registry.DeviceEntry{}}, &testInvoker{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	RegisterModbusV1Tools(s, growattBMSRS485RuntimeProvider{modbusV1FixtureProvider: &modbusV1FixtureProvider{}, runtime: runtime})
+
+	r := msp06Call(t, s.Handler(), GrowattBMSRS485V202StatusGetTool, map[string]any{})
+	if r.isError {
+		t.Fatal(r)
+	}
+	d := msp06Map(t, r.envelope["data"], "data")
+	if d["raw_redacted"] != true || d["outbound_allowed"] != false {
+		t.Fatalf("data=%#v", d)
+	}
+	status := msp06Map(t, d["status"], "status")
+	if status["operating_state"] != "charging" || status["soc_percent"] != json.Number("75") {
+		t.Fatalf("status=%#v", status)
+	}
+	for _, key := range []string{"raw", "serial", "endpoint", "request", "transport", "control"} {
+		if _, ok := d[key]; ok {
+			t.Fatal(key)
+		}
+	}
+	if got, want := session.calls, [][2]uint16{{0x0001, 7}, {0x000d, 29}, {0x0100, 12}, {0x010d, 2}}; len(got) != len(want) {
+		t.Fatalf("calls=%#v", got)
+	} else {
+		for index := range want {
+			if got[index] != want[index] || session.functions[index] != modbus.FunctionReadHoldingRegisters {
+				t.Fatalf("calls/functions=%#v/%#v", got, session.functions)
+			}
+		}
+	}
+}
+
+func TestGrowattBMSRS485V202RuntimeFailsClosedAtMCPBoundary(t *testing.T) {
+	session := &growattBMSRS485RuntimeSessionFake{wordsByOffset: growattBMSRS485RuntimeWords(), failAt: 1, mismatchAt: -1}
+	runtime, err := NewGrowattBMSRS485V202Runtime(growattBMSRS485RuntimeRevision(), 7, session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, err := NewServer(&testRegistry{entries: map[byte]registry.DeviceEntry{}}, &testInvoker{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	RegisterModbusV1Tools(s, growattBMSRS485RuntimeProvider{modbusV1FixtureProvider: &modbusV1FixtureProvider{}, runtime: runtime})
+
+	r := msp06Call(t, s.Handler(), GrowattBMSRS485V202StatusGetTool, map[string]any{})
+	if !r.isError || r.envelope["data"] != nil || len(session.calls) != 2 {
+		t.Fatalf("result/calls=%#v/%#v", r, session.calls)
+	}
+}
+
+type growattBMSRS485RuntimeProvider struct {
+	*modbusV1FixtureProvider
+	runtime *GrowattBMSRS485V202Runtime
+}
+
+func (provider growattBMSRS485RuntimeProvider) GrowattBMSRS485V202(ctx context.Context) (modbusreg.GrowattBMSTypedReadOnlyStatus, error) {
+	return provider.runtime.GrowattBMSRS485V202(ctx)
+}
+
+type growattBMSRS485RuntimeSessionFake struct {
+	wordsByOffset map[uint16][]uint16
+	calls         [][2]uint16
+	functions     []modbus.FunctionCode
+	failAt        int
+	mismatchAt    int
+}
+
+func (session *growattBMSRS485RuntimeSessionFake) ReadHolding(
+	_ context.Context,
+	_ byte,
+	request modbus.ReadRegistersRequest,
+) (modbus.ReadRegistersResponse, error) {
+	session.calls = append(session.calls, [2]uint16{request.Offset(), request.Quantity()})
+	session.functions = append(session.functions, request.Function())
+	index := len(session.calls) - 1
+	if index == session.failAt {
+		return modbus.ReadRegistersResponse{}, errors.New("correlated read failed")
+	}
+	response, err := modbus.DecodeReadRegistersResponse(request, growattBMSRS485RuntimeReadPDU(session.wordsByOffset[request.Offset()]))
+	if err != nil {
+		return modbus.ReadRegistersResponse{}, err
+	}
+	if index == session.mismatchAt {
+		response.Provenance.Offset++
+	}
+	return response, nil
+}
+
+func growattBMSRS485RuntimeRevision() modbusreg.GrowattBMSRevisionTuple {
+	return modbusreg.GrowattBMSRevisionTuple{Family: "1xSxxP ESS", FileRevision: "Rev2.01", HeaderVersion: "V2.0", CumulativeRevision: "2.02"}
+}
+
+func growattBMSRS485RuntimeReadPDU(words []uint16) []byte {
+	pdu := make([]byte, 2+len(words)*2)
+	pdu[0] = byte(modbus.FunctionReadHoldingRegisters)
+	pdu[1] = byte(len(words) * 2)
+	for index, word := range words {
+		pdu[2+index*2], pdu[3+index*2] = byte(word>>8), byte(word)
+	}
+	return pdu
+}
+
+func growattBMSRS485RuntimeWords() map[uint16][]uint16 {
+	identity := make([]uint16, 7)
+	identity[0], identity[1] = 0x0102, 0x0304
+	status := make([]uint16, 29)
+	status[0], status[1] = 0x0204, 0x0301
+	status[6], status[8], status[9], status[10], status[11] = 2, 75, 5200, 0xff9c, 25
+	status[13], status[14], status[17] = 3200, 5000, 110
+	extension := make([]uint16, 12)
+	extension[0], extension[1], extension[2], extension[4], extension[5], extension[6] = 100, 123, 3300, 512, 5, 6
+	return map[uint16][]uint16{0x0001: identity, 0x000d: status, 0x0100: extension, 0x010d: {0, 0}}
+}

--- a/mcp/growatt_bms_rs485_v202_runtime_test.go
+++ b/mcp/growatt_bms_rs485_v202_runtime_test.go
@@ -28,14 +28,15 @@ func TestGrowattBMSRS485V202RuntimeFeedsRedactedMCPStatus(t *testing.T) {
 		t.Fatal(r)
 	}
 	d := msp06Map(t, r.envelope["data"], "data")
-	if d["raw_redacted"] != true || d["outbound_allowed"] != false {
+	native := msp06Map(t, d["native_observation"], "native_observation")
+	if native["unit_id"] != json.Number("7") || len(msp06Slice(t, native["slices"], "native slices")) != 4 {
 		t.Fatalf("data=%#v", d)
 	}
 	status := msp06Map(t, d["status"], "status")
 	if status["operating_state"] != "charging" || status["soc_percent"] != json.Number("75") {
 		t.Fatalf("status=%#v", status)
 	}
-	for _, key := range []string{"raw", "serial", "endpoint", "request", "transport", "control"} {
+	for _, key := range []string{"raw_redacted", "outbound_allowed"} {
 		if _, ok := d[key]; ok {
 			t.Fatal(key)
 		}

--- a/mcp/growatt_bms_rs485_v202_test.go
+++ b/mcp/growatt_bms_rs485_v202_test.go
@@ -26,8 +26,12 @@ func TestGrowattBMSRS485V202ToolProjectsOnlyQualifiedTypedStatus(t *testing.T) {
 		t.Fatal(r)
 	}
 	d := msp06Map(t, r.envelope["data"], "data")
-	if d["profile"] != GrowattBMSRS485V202Profile || d["qualified"] != true || d["raw_redacted"] != true || d["outbound_allowed"] != false {
+	if d["profile"] != GrowattBMSRS485V202Profile || d["qualified"] != true {
 		t.Fatalf("%#v", d)
+	}
+	native := msp06Map(t, d["native_observation"], "native_observation")
+	if native["unit_id"] != json.Number("7") || len(msp06Slice(t, native["slices"], "native slices")) != 4 {
+		t.Fatalf("native observation=%#v", native)
 	}
 	identity := msp06Map(t, d["identity"], "identity")
 	status := msp06Map(t, d["status"], "status")
@@ -39,7 +43,7 @@ func TestGrowattBMSRS485V202ToolProjectsOnlyQualifiedTypedStatus(t *testing.T) {
 	if revision["family"] != "1xSxxP ESS" || revision["file_revision"] != "Rev2.01" || revision["header_version"] != "V2.0" || revision["cumulative_revision"] != "2.02" {
 		t.Fatalf("revision=%#v", revision)
 	}
-	for _, key := range []string{"raw", "serial", "endpoint", "slice", "transport", "request", "control"} {
+	for _, key := range []string{"raw_redacted", "outbound_allowed"} {
 		if _, ok := d[key]; ok {
 			t.Fatal(key)
 		}
@@ -73,27 +77,9 @@ func (f growattBMSRS485V202ResultFixture) GrowattBMSRS485V202(context.Context) (
 }
 
 func growattBMSRS485V202FixtureStatus() modbusreg.GrowattBMSTypedReadOnlyStatus {
-	return modbusreg.GrowattBMSTypedReadOnlyStatus{
-		Revision:                    modbusreg.GrowattBMSRevisionTuple{Family: "1xSxxP ESS", FileRevision: "Rev2.01", HeaderVersion: "V2.0", CumulativeRevision: "2.02"},
-		MCUSoftwareVersion:          "1.2",
-		GaugeVersion:                "3.4",
-		BMSCompany:                  4,
-		BMSGeneration:               2,
-		PackCompany:                 1,
-		PackGeneration:              3,
-		OperatingState:              modbusreg.GrowattBMSStateCharging,
-		SOCPercent:                  75,
-		PackVoltageVolts:            52,
-		PackCurrentAmps:             -1,
-		TemperatureCelsius:          25,
-		RemainingCapacityAmpHours:   32,
-		FullChargeCapacityAmpHours:  50,
-		CycleCount:                  110,
-		ContinuousChargeSeconds:     100,
-		CurrentCycleChargeAmpHours:  12.3,
-		AverageCellVoltageVolts:     3.3,
-		FloatingPackVoltageVolts:    51.2,
-		CumulativeChargeAmpHours:    0.5,
-		CumulativeDischargeAmpHours: 0.6,
+	status, err := modbusreg.DecodeGrowattBMSTypedReadOnlyStatus(modbusreg.GrowattBMSReadOnlyInput{UnitID: 7, Function: modbusreg.FunctionReadHoldingRegisters, Revision: modbusreg.GrowattBMSRevisionTuple{Family: "1xSxxP ESS", FileRevision: "Rev2.01", HeaderVersion: "V2.0", CumulativeRevision: "2.02"}, Slices: []modbusreg.GrowattBMSReadOnlySlice{{Offset: 1, Words: []uint16{0x0102, 0x0304, 0, 0, 0, 0, 0}}, {Offset: 13, Words: []uint16{0x0204, 0x0301, 0, 0, 0, 0, 2, 0, 75, 5200, 0xff9c, 25, 0, 3200, 5000, 0, 0, 110, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}, {Offset: 256, Words: []uint16{100, 123, 3300, 0, 512, 5, 6, 0, 0, 0, 0, 0}}, {Offset: 269, Words: []uint16{0, 0}}}})
+	if err != nil {
+		panic(err)
 	}
+	return status
 }


### PR DESCRIPTION
RED-first runtime composition for the injected Growatt BMS RTU observer. The test requires only exact typed status to reach MCP and fails closed on the first failed correlated read.