### PR TITLE
fix: preserve Growatt V1.04 native evidence

### DIFF
--- a/mcp/growatt_bms_v104_v1.go
+++ b/mcp/growatt_bms_v104_v1.go
@@ -12,11 +12,17 @@ var (
 	ErrGrowattBMSV104NotAdmitted         = errors.New("growatt BMS V1.04 snapshot is not admitted")
 )
 
-// GrowattBMSV104RawEvidence is retained by the injected provider only.
-// It is deliberately absent from the MCP-facing result.
+// GrowattBMSV104RawEvidence preserves the available native observation context.
 type GrowattBMSV104RawEvidence struct {
-	Identifier uint32
-	Data       [8]byte
+	Interface      string  `json:"interface"`
+	Sequence       uint64  `json:"sequence"`
+	MonotonicNanos int64   `json:"monotonic_nanos"`
+	Identifier     uint32  `json:"identifier"`
+	Extended       bool    `json:"extended"`
+	RTR            bool    `json:"rtr"`
+	DLC            uint8   `json:"dlc"`
+	RawDLC         uint8   `json:"raw_dlc"`
+	Data           [8]byte `json:"data"`
 }
 
 type GrowattBMSV104Limits struct {
@@ -59,15 +65,15 @@ type GrowattBMSV104SnapshotProvider interface {
 	GrowattBMSV104Snapshot(context.Context) (GrowattBMSV104ProviderSnapshot, error)
 }
 
-// GrowattBMSV104Result is the safe, read-only MCP-facing projection.
+// GrowattBMSV104Result is the MCP-facing native and decoded projection.
 type GrowattBMSV104Result struct {
-	Profile             string                     `json:"profile"`
-	Admitted            bool                       `json:"admitted"`
-	OutboundAllowed     bool                       `json:"outbound_allowed"`
-	RawEvidenceRedacted bool                       `json:"raw_evidence_redacted"`
-	Limits              GrowattBMSV104Limits       `json:"limits"`
-	Status              GrowattBMSV104Status       `json:"status"`
-	Measurements        GrowattBMSV104Measurements `json:"measurements"`
+	Profile         string                      `json:"profile"`
+	Admitted        bool                        `json:"admitted"`
+	OutboundAllowed bool                        `json:"outbound_allowed"`
+	Limits          GrowattBMSV104Limits        `json:"limits"`
+	Status          GrowattBMSV104Status        `json:"status"`
+	Measurements    GrowattBMSV104Measurements  `json:"measurements"`
+	RawEvidence     []GrowattBMSV104RawEvidence `json:"raw_evidence"`
 }
 
 // GrowattBMSV104Runtime owns the injected read-only snapshot boundary.
@@ -95,13 +101,24 @@ func (runtime *GrowattBMSV104Runtime) SnapshotGet(ctx context.Context) (GrowattB
 		return GrowattBMSV104Result{}, ErrGrowattBMSV104NotAdmitted
 	}
 
+	rawEvidence := make([]GrowattBMSV104RawEvidence, 0, len(snapshot.RawEvidence))
+	for _, evidence := range snapshot.RawEvidence {
+		if growattBMSV104RawEvidenceValid(evidence) {
+			rawEvidence = append(rawEvidence, evidence)
+		}
+	}
+
 	return GrowattBMSV104Result{
-		Profile:             GrowattBMSV104Profile,
-		Admitted:            true,
-		OutboundAllowed:     false,
-		RawEvidenceRedacted: true,
-		Limits:              snapshot.Limits,
-		Status:              snapshot.Status,
-		Measurements:        snapshot.Measurements,
+		Profile:         GrowattBMSV104Profile,
+		Admitted:        true,
+		OutboundAllowed: snapshot.OutboundAllowed,
+		Limits:          snapshot.Limits,
+		Status:          snapshot.Status,
+		Measurements:    snapshot.Measurements,
+		RawEvidence:     rawEvidence,
 	}, nil
+}
+
+func growattBMSV104RawEvidenceValid(evidence GrowattBMSV104RawEvidence) bool {
+	return evidence.Identifier <= 0x7ff && !evidence.Extended && !evidence.RTR && evidence.DLC == 8 && evidence.RawDLC >= 8 && evidence.RawDLC <= 15
 }

--- a/mcp/growatt_bms_v104_v1_test.go
+++ b/mcp/growatt_bms_v104_v1_test.go
@@ -17,7 +17,7 @@ func (provider growattBMSV104FixtureProvider) GrowattBMSV104Snapshot(context.Con
 	return provider.snapshot, provider.err
 }
 
-func TestGrowattBMSV104SnapshotGetProjectsOnlyAdmittedReadOnlyData(t *testing.T) {
+func TestGrowattBMSV104SnapshotGetProjectsAdmittedNativeData(t *testing.T) {
 	runtime, err := NewGrowattBMSV104Runtime(growattBMSV104FixtureProvider{snapshot: growattBMSV104FixtureSnapshot()})
 	if err != nil {
 		t.Fatal(err)
@@ -27,18 +27,21 @@ func TestGrowattBMSV104SnapshotGetProjectsOnlyAdmittedReadOnlyData(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.Profile != GrowattBMSV104Profile || !result.Admitted || result.OutboundAllowed || !result.RawEvidenceRedacted {
+	if result.Profile != GrowattBMSV104Profile || !result.Admitted || result.OutboundAllowed || len(result.RawEvidence) != 1 {
 		t.Fatalf("result = %#v", result)
+	}
+	if result.RawEvidence[0].Identifier != 0x311 || result.RawEvidence[0].DLC != 8 || result.RawEvidence[0].RawDLC != 8 || result.RawEvidence[0].Data[0] != 0x02 {
+		t.Fatalf("raw evidence = %#v", result.RawEvidence)
 	}
 	if result.Limits.ChargeVoltageDecivolts != 568 || result.Measurements.SOCPercent != 80 || result.Status.PackCount != 2 {
 		t.Fatalf("projection = %#v", result)
 	}
 }
 
-func TestGrowattBMSV104SnapshotGetRedactsUnsafeProviderEvidence(t *testing.T) {
+func TestGrowattBMSV104SnapshotGetPreservesNativeEvidenceAndCapability(t *testing.T) {
 	snapshot := growattBMSV104FixtureSnapshot()
 	snapshot.OutboundAllowed = true
-	snapshot.RawEvidence = []GrowattBMSV104RawEvidence{{Identifier: 0x311, Data: [8]byte{0xde, 0xad, 0xbe, 0xef}}}
+	snapshot.RawEvidence = []GrowattBMSV104RawEvidence{{Interface: "can0", Sequence: 7, MonotonicNanos: 99, Identifier: 0x311, DLC: 8, RawDLC: 8, Data: [8]byte{0xde, 0xad, 0xbe, 0xef}}}
 	runtime, err := NewGrowattBMSV104Runtime(growattBMSV104FixtureProvider{snapshot: snapshot})
 	if err != nil {
 		t.Fatal(err)
@@ -52,8 +55,28 @@ func TestGrowattBMSV104SnapshotGetRedactsUnsafeProviderEvidence(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.OutboundAllowed || strings.Contains(string(encoded), "\"raw_evidence\":") || strings.Contains(string(encoded), "deadbeef") {
-		t.Fatalf("unsafe result = %s", encoded)
+	if !result.OutboundAllowed || !strings.Contains(string(encoded), "\"raw_evidence\":") || !strings.Contains(string(encoded), "\"interface\":\"can0\"") || !strings.Contains(string(encoded), "\"data\":[222,173,190,239,0,0,0,0]") {
+		t.Fatalf("result = %s", encoded)
+	}
+	if len(result.RawEvidence) != 1 || result.RawEvidence[0].Sequence != 7 || result.RawEvidence[0].MonotonicNanos != 99 || result.RawEvidence[0].Identifier != 0x311 || result.RawEvidence[0].Data[3] != 0xef {
+		t.Fatalf("raw evidence = %#v", result.RawEvidence)
+	}
+}
+
+func TestGrowattBMSV104SnapshotGetDropsMalformedRawEvidenceWithoutSuppressingProjection(t *testing.T) {
+	snapshot := growattBMSV104FixtureSnapshot()
+	snapshot.RawEvidence = []GrowattBMSV104RawEvidence{{Identifier: 0x311, Extended: true, DLC: 8, RawDLC: 8, Data: [8]byte{0xde, 0xad, 0xbe, 0xef}}}
+	runtime, err := NewGrowattBMSV104Runtime(growattBMSV104FixtureProvider{snapshot: snapshot})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := runtime.SnapshotGet(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.RawEvidence) != 0 || result.Measurements.SOCPercent != 80 || result.Status.PackCount != 2 {
+		t.Fatalf("result = %#v", result)
 	}
 }
 
@@ -99,6 +122,6 @@ func growattBMSV104FixtureSnapshot() GrowattBMSV104ProviderSnapshot {
 		Measurements: GrowattBMSV104Measurements{
 			SOCPercent: 80,
 		},
-		RawEvidence: []GrowattBMSV104RawEvidence{{Identifier: 0x311, Data: [8]byte{0x02, 0x38}}},
+		RawEvidence: []GrowattBMSV104RawEvidence{{Identifier: 0x311, DLC: 8, RawDLC: 8, Data: [8]byte{0x02, 0x38}}},
 	}
 }


### PR DESCRIPTION
Part of #899: Growatt low-voltage BMS CAN V1.04 MCP repair.

Preserves available native observation metadata and all eight valid V1.04 payload bytes, reflects the provider capability state, and excludes malformed raw records without suppressing the admitted decoded snapshot. Synthetic fixtures only.

Documentation gate: Project-Helianthus/helianthus-docs-canbus#28. This PR must not merge before that companion is merged.

Validation:
- `go test ./mcp -run GrowattBMSV104`
- `go vet ./mcp`

No transport I/O, transmit API, hardware access, or control behavior.