### PR TITLE
GATEWAY-GROWATT: expose native Protocol II identity observation

### DIFF
--- a/mcp/growatt_protocol_ii_runtime_v1.go
+++ b/mcp/growatt_protocol_ii_runtime_v1.go
@@ -10,8 +10,8 @@ var (
 	ErrGrowattProtocolIIV1NotAdmitted         = errors.New("growatt Protocol II identity is not admitted")
 )
 
-// GrowattProtocolIIV1ProviderSnapshot is provider-private. RawIdentity is
-// deliberately excluded from the MCP result.
+// GrowattProtocolIIV1ProviderSnapshot carries the caller-selected native
+// identity words validated by this runtime.
 type GrowattProtocolIIV1ProviderSnapshot struct {
 	Profile                 string
 	Family                  string
@@ -46,7 +46,10 @@ func (runtime *GrowattProtocolIIV1Runtime) GrowattProtocolIIV1(ctx context.Conte
 	if snapshot.Profile != GrowattProtocolIIV1Profile || !validGrowattProtocolIIV1Family(snapshot.Family) || !snapshot.OfflineIdentityAdmitted {
 		return GrowattProtocolIIV1Result{}, ErrGrowattProtocolIIV1NotAdmitted
 	}
-	return GrowattProtocolIIV1Result{Profile: GrowattProtocolIIV1Profile, Disposition: "OFFLINE_IDENTITY_ADMITTED", Family: snapshot.Family, IdentityQualified: true, IdentityRedacted: true, OutboundAllowed: false}, nil
+	if len(snapshot.RawIdentity) == 0 {
+		return GrowattProtocolIIV1Result{}, ErrGrowattProtocolIIV1NotAdmitted
+	}
+	return GrowattProtocolIIV1Result{Profile: GrowattProtocolIIV1Profile, Disposition: "OFFLINE_IDENTITY_ADMITTED", Family: snapshot.Family, IdentityQualified: true, NativeIdentity: GrowattProtocolIIV1NativeIdentity{Family: snapshot.Family, Words: append([]uint16(nil), snapshot.RawIdentity...)}}, nil
 }
 
 func validGrowattProtocolIIV1Family(family string) bool {

--- a/mcp/growatt_protocol_ii_runtime_v1.go
+++ b/mcp/growatt_protocol_ii_runtime_v1.go
@@ -17,7 +17,8 @@ type GrowattProtocolIIV1ProviderSnapshot struct {
 	Family                  string
 	OfflineIdentityAdmitted bool
 	OutboundAllowed         bool
-	RawIdentity             []uint16
+	UnitID                  byte
+	IdentitySlices          []GrowattProtocolIIV1NativeIdentitySlice
 }
 
 type GrowattProtocolIIV1SnapshotProvider interface {
@@ -46,10 +47,34 @@ func (runtime *GrowattProtocolIIV1Runtime) GrowattProtocolIIV1(ctx context.Conte
 	if snapshot.Profile != GrowattProtocolIIV1Profile || !validGrowattProtocolIIV1Family(snapshot.Family) || !snapshot.OfflineIdentityAdmitted {
 		return GrowattProtocolIIV1Result{}, ErrGrowattProtocolIIV1NotAdmitted
 	}
-	if len(snapshot.RawIdentity) == 0 {
+	if snapshot.UnitID == 0 || snapshot.UnitID > 247 || !validGrowattProtocolIISlices(snapshot.IdentitySlices) {
 		return GrowattProtocolIIV1Result{}, ErrGrowattProtocolIIV1NotAdmitted
 	}
-	return GrowattProtocolIIV1Result{Profile: GrowattProtocolIIV1Profile, Disposition: "OFFLINE_IDENTITY_ADMITTED", Family: snapshot.Family, IdentityQualified: true, NativeIdentity: GrowattProtocolIIV1NativeIdentity{Family: snapshot.Family, Words: append([]uint16(nil), snapshot.RawIdentity...)}}, nil
+	return GrowattProtocolIIV1Result{Profile: GrowattProtocolIIV1Profile, Disposition: "OFFLINE_IDENTITY_ADMITTED", Family: snapshot.Family, IdentityQualified: true, NativeIdentity: GrowattProtocolIIV1NativeIdentity{Family: snapshot.Family, UnitID: snapshot.UnitID, Slices: cloneGrowattProtocolIISlices(snapshot.IdentitySlices)}}, nil
+}
+
+func validGrowattProtocolIISlices(slices []GrowattProtocolIIV1NativeIdentitySlice) bool {
+	want := [...]struct {
+		offset uint16
+		words  int
+	}{{9, 6}, {23, 5}, {43, 1}, {82, 2}, {88, 1}}
+	if len(slices) != len(want) {
+		return false
+	}
+	for i, expected := range want {
+		if slices[i].Offset != expected.offset || len(slices[i].Words) != expected.words {
+			return false
+		}
+	}
+	return true
+}
+
+func cloneGrowattProtocolIISlices(slices []GrowattProtocolIIV1NativeIdentitySlice) []GrowattProtocolIIV1NativeIdentitySlice {
+	cloned := make([]GrowattProtocolIIV1NativeIdentitySlice, len(slices))
+	for i, slice := range slices {
+		cloned[i] = GrowattProtocolIIV1NativeIdentitySlice{Offset: slice.Offset, Words: append([]uint16(nil), slice.Words...)}
+	}
+	return cloned
 }
 
 func validGrowattProtocolIIV1Family(family string) bool {

--- a/mcp/growatt_protocol_ii_runtime_v1_test.go
+++ b/mcp/growatt_protocol_ii_runtime_v1_test.go
@@ -21,7 +21,8 @@ func TestGrowattProtocolIIV1RuntimeProjectsOnlySanitizedIdentityStatus(t *testin
 		Family:                  "MAC",
 		OfflineIdentityAdmitted: true,
 		OutboundAllowed:         true,
-		RawIdentity:             []uint16{0x4657, 0x2d31, 0x1234},
+		UnitID:                  1,
+		IdentitySlices:          growattProtocolIITestSlices(),
 	}})
 	if err != nil {
 		t.Fatal(err)
@@ -31,7 +32,7 @@ func TestGrowattProtocolIIV1RuntimeProjectsOnlySanitizedIdentityStatus(t *testin
 		t.Fatal(err)
 	}
 	if result.Profile != GrowattProtocolIIV1Profile || result.Family != "MAC" || !result.IdentityQualified ||
-		result.NativeIdentity.Family != "MAC" || len(result.NativeIdentity.Words) != 3 {
+		result.NativeIdentity.Family != "MAC" || result.NativeIdentity.UnitID != 1 || len(result.NativeIdentity.Slices) != 5 {
 		t.Fatalf("result = %#v", result)
 	}
 }

--- a/mcp/growatt_protocol_ii_runtime_v1_test.go
+++ b/mcp/growatt_protocol_ii_runtime_v1_test.go
@@ -31,7 +31,7 @@ func TestGrowattProtocolIIV1RuntimeProjectsOnlySanitizedIdentityStatus(t *testin
 		t.Fatal(err)
 	}
 	if result.Profile != GrowattProtocolIIV1Profile || result.Family != "MAC" || !result.IdentityQualified ||
-		!result.IdentityRedacted || result.OutboundAllowed {
+		result.NativeIdentity.Family != "MAC" || len(result.NativeIdentity.Words) != 3 {
 		t.Fatalf("result = %#v", result)
 	}
 }

--- a/mcp/growatt_protocol_ii_v1.go
+++ b/mcp/growatt_protocol_ii_v1.go
@@ -12,7 +12,13 @@ const (
 )
 
 type GrowattProtocolIIV1NativeIdentity struct {
-	Family string   `json:"family"`
+	Family string                                   `json:"family"`
+	UnitID byte                                     `json:"unit_id"`
+	Slices []GrowattProtocolIIV1NativeIdentitySlice `json:"slices"`
+}
+
+type GrowattProtocolIIV1NativeIdentitySlice struct {
+	Offset uint16   `json:"offset"`
 	Words  []uint16 `json:"words"`
 }
 

--- a/mcp/growatt_protocol_ii_v1.go
+++ b/mcp/growatt_protocol_ii_v1.go
@@ -11,15 +11,19 @@ const (
 	GrowattProtocolIIV1Profile         = "growatt.protocol_ii.tl3_x.identity.readonly.v1"
 )
 
-// GrowattProtocolIIV1Result is the only identity status projected to MCP.
-// Raw identity words and individual tuple values remain provider-private.
+type GrowattProtocolIIV1NativeIdentity struct {
+	Family string   `json:"family"`
+	Words  []uint16 `json:"words"`
+}
+
+// GrowattProtocolIIV1Result projects the validated native identity supplied
+// by the caller-selected Protocol II runtime.
 type GrowattProtocolIIV1Result struct {
-	Profile           string `json:"profile"`
-	Disposition       string `json:"disposition"`
-	Family            string `json:"family"`
-	IdentityQualified bool   `json:"identity_qualified"`
-	IdentityRedacted  bool   `json:"identity_redacted"`
-	OutboundAllowed   bool   `json:"outbound_allowed"`
+	Profile           string                            `json:"profile"`
+	Disposition       string                            `json:"disposition"`
+	Family            string                            `json:"family"`
+	IdentityQualified bool                              `json:"identity_qualified"`
+	NativeIdentity    GrowattProtocolIIV1NativeIdentity `json:"native_identity"`
 }
 
 type GrowattProtocolIIV1Provider interface {
@@ -39,7 +43,7 @@ func registerGrowattProtocolIIV1Tool(server *Server, provider ModbusV1Provider) 
 	growattProtocolIIV1Providers.Lock()
 	growattProtocolIIV1Providers.byServer[server] = growatt
 	growattProtocolIIV1Providers.Unlock()
-	server.tools = append(server.tools, Tool{Name: GrowattProtocolIIV1IdentityGetTool, Description: "Get the redacted read-only Growatt Protocol II identity qualification.", InputSchema: map[string]any{"type": "object", "properties": map[string]any{}, "additionalProperties": false}})
+	server.tools = append(server.tools, Tool{Name: GrowattProtocolIIV1IdentityGetTool, Description: "Get the native Growatt Protocol II identity qualification.", InputSchema: map[string]any{"type": "object", "properties": map[string]any{}, "additionalProperties": false}})
 }
 
 func (server *Server) handleGrowattProtocolIIV1Call(ctx context.Context, name string, args map[string]any) (map[string]any, bool) {
@@ -56,12 +60,5 @@ func (server *Server) handleGrowattProtocolIIV1Call(ctx context.Context, name st
 		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("growatt Protocol II provider unavailable"), false, "RETAINED_PROFILE", "")), true), true
 	}
 	result, err := provider.GrowattProtocolIIV1(ctx)
-	result = failClosedGrowattProtocolIIV1Result(result)
 	return callToolResultText(mustJSON(newModbusV1Envelope(result, err, true, "RETAINED_PROFILE", "")), err != nil), true
-}
-
-func failClosedGrowattProtocolIIV1Result(result GrowattProtocolIIV1Result) GrowattProtocolIIV1Result {
-	result.IdentityRedacted = true
-	result.OutboundAllowed = false
-	return result
 }

--- a/mcp/growatt_protocol_ii_v1_test.go
+++ b/mcp/growatt_protocol_ii_v1_test.go
@@ -15,7 +15,7 @@ func (*growattProtocolIIV1FixtureProvider) GrowattProtocolIIV1(context.Context) 
 		Disposition:       "OFFLINE_IDENTITY_ADMITTED",
 		Family:            "MAX",
 		IdentityQualified: true,
-		OutboundAllowed:   false,
+		NativeIdentity:    GrowattProtocolIIV1NativeIdentity{Family: "MAX", Words: []uint16{0x0102}},
 	}, nil
 }
 
@@ -54,8 +54,7 @@ func (*growattProtocolIIV1UnsafeProvider) GrowattProtocolIIV1(context.Context) (
 		Disposition:       "OFFLINE_IDENTITY_ADMITTED",
 		Family:            "MID",
 		IdentityQualified: true,
-		IdentityRedacted:  false,
-		OutboundAllowed:   true,
+		NativeIdentity:    GrowattProtocolIIV1NativeIdentity{Family: "MID", Words: []uint16{0x0102}},
 	}, nil
 }
 
@@ -70,7 +69,7 @@ func TestGrowattProtocolIIV1IdentityToolFailsClosedForProviderOutput(t *testing.
 		t.Fatalf("result = %#v", result)
 	}
 	data := msp06Map(t, result.envelope["data"], "data")
-	if data["outbound_allowed"] != false || data["identity_redacted"] != true {
-		t.Fatalf("unsafe provider output crossed MCP boundary: %#v", data)
+	if native := msp06Map(t, data["native_identity"], "native_identity"); native["family"] != "MID" {
+		t.Fatalf("native provider output was lost: %#v", data)
 	}
 }

--- a/mcp/growatt_protocol_ii_v1_test.go
+++ b/mcp/growatt_protocol_ii_v1_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
@@ -15,7 +16,7 @@ func (*growattProtocolIIV1FixtureProvider) GrowattProtocolIIV1(context.Context) 
 		Disposition:       "OFFLINE_IDENTITY_ADMITTED",
 		Family:            "MAX",
 		IdentityQualified: true,
-		NativeIdentity:    GrowattProtocolIIV1NativeIdentity{Family: "MAX", Words: []uint16{0x0102}},
+		NativeIdentity:    GrowattProtocolIIV1NativeIdentity{Family: "MAX", UnitID: 1, Slices: growattProtocolIITestSlices()},
 	}, nil
 }
 
@@ -41,7 +42,7 @@ func TestGrowattProtocolIIV1IdentityToolPreservesNativeIdentity(t *testing.T) {
 		t.Fatalf("observation invented operation authority: %#v", data)
 	}
 	native := msp06Map(t, data["native_identity"], "native_identity")
-	if native["family"] != "MAX" || len(msp06Slice(t, native["words"], "native words")) == 0 {
+	if native["family"] != "MAX" || native["unit_id"] != json.Number("1") || len(msp06Slice(t, native["slices"], "native slices")) != 5 {
 		t.Fatalf("native identity = %#v", native)
 	}
 }
@@ -54,8 +55,12 @@ func (*growattProtocolIIV1UnsafeProvider) GrowattProtocolIIV1(context.Context) (
 		Disposition:       "OFFLINE_IDENTITY_ADMITTED",
 		Family:            "MID",
 		IdentityQualified: true,
-		NativeIdentity:    GrowattProtocolIIV1NativeIdentity{Family: "MID", Words: []uint16{0x0102}},
+		NativeIdentity:    GrowattProtocolIIV1NativeIdentity{Family: "MID", UnitID: 2, Slices: growattProtocolIITestSlices()},
 	}, nil
+}
+
+func growattProtocolIITestSlices() []GrowattProtocolIIV1NativeIdentitySlice {
+	return []GrowattProtocolIIV1NativeIdentitySlice{{Offset: 9, Words: make([]uint16, 6)}, {Offset: 23, Words: make([]uint16, 5)}, {Offset: 43, Words: []uint16{1}}, {Offset: 82, Words: []uint16{2, 3}}, {Offset: 88, Words: []uint16{4}}}
 }
 
 func TestGrowattProtocolIIV1IdentityToolFailsClosedForProviderOutput(t *testing.T) {

--- a/mcp/growatt_protocol_ii_v1_test.go
+++ b/mcp/growatt_protocol_ii_v1_test.go
@@ -19,7 +19,7 @@ func (*growattProtocolIIV1FixtureProvider) GrowattProtocolIIV1(context.Context) 
 	}, nil
 }
 
-func TestGrowattProtocolIIV1IdentityToolIsReadOnlyAndRedacted(t *testing.T) {
+func TestGrowattProtocolIIV1IdentityToolPreservesNativeIdentity(t *testing.T) {
 	server, err := NewServer(&testRegistry{entries: make(map[byte]registry.DeviceEntry)}, &testInvoker{})
 	if err != nil {
 		t.Fatal(err)
@@ -31,14 +31,18 @@ func TestGrowattProtocolIIV1IdentityToolIsReadOnlyAndRedacted(t *testing.T) {
 	}
 	data := msp06Map(t, result.envelope["data"], "data")
 	if data["profile"] != GrowattProtocolIIV1Profile || data["disposition"] != "OFFLINE_IDENTITY_ADMITTED" ||
-		data["family"] != "MAX" || data["identity_qualified"] != true || data["identity_redacted"] != true ||
-		data["outbound_allowed"] != false {
+		data["family"] != "MAX" || data["identity_qualified"] != true {
 		t.Fatalf("data = %#v", data)
 	}
-	for _, forbidden := range []string{"words", "device_type", "model_build", "protocol_version", "firmware"} {
-		if _, found := data[forbidden]; found {
-			t.Fatalf("raw identity field %q leaked: %#v", forbidden, data)
-		}
+	if _, found := data["identity_redacted"]; found {
+		t.Fatalf("identity redaction survived: %#v", data)
+	}
+	if _, found := data["outbound_allowed"]; found {
+		t.Fatalf("observation invented operation authority: %#v", data)
+	}
+	native := msp06Map(t, data["native_identity"], "native_identity")
+	if native["family"] != "MAX" || len(msp06Slice(t, native["words"], "native words")) == 0 {
+		t.Fatalf("native identity = %#v", native)
 	}
 }
 


### PR DESCRIPTION
RED-only: MCP currently suppresses the runtime native identity tuple. This PR requires native identity projection with synthetic test data only, and removes redaction/operation-authority flags that do not reflect a concrete operation contract.