### PR TITLE
MCP-TESLA: expose native HSC named records

### DIFF
--- a/mcp/tesla_hsc_runtime_v1.go
+++ b/mcp/tesla_hsc_runtime_v1.go
@@ -71,8 +71,7 @@ func validTeslaHSCV1CorrelatedResponse(response TeslaHSCV1CorrelatedResponse) bo
 		return false
 	}
 	for _, record := range response.Records {
-		if record.Function != response.Function || len(record.Payload) > 252 ||
-			record.Compatibility == "" || record.Provenance == "" {
+		if record.Function != response.Function || !validTeslaHSCV1NativeRecord(record) {
 			return false
 		}
 	}

--- a/mcp/tesla_hsc_runtime_v1.go
+++ b/mcp/tesla_hsc_runtime_v1.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 )
 
-// TeslaHSCV1CorrelatedResponse is one inbound RTU exchange already correlated
-// by the transport. It has no request-construction or transmit capability.
+// TeslaHSCV1CorrelatedResponse is one RTU exchange already correlated by the
+// transport. Native records are copied into the MCP result without invoking
+// transport or constructing a request.
 type TeslaHSCV1CorrelatedResponse struct {
-	Function     byte
-	PayloadCount uint8
+	Function        byte
+	OutboundAllowed bool
+	Records         []TeslaHSCV1NativeRecord
 }
 
 // TeslaHSCV1ResponseProvider supplies only completed correlated responses.
@@ -17,8 +19,8 @@ type TeslaHSCV1ResponseProvider interface {
 	TeslaHSCV1Responses(context.Context) ([]TeslaHSCV1CorrelatedResponse, error)
 }
 
-// TeslaHSCV1Runtime projects injected Tesla response metadata into the
-// existing read-only MCP profile status surface.
+// TeslaHSCV1Runtime projects injected Tesla native records into the MCP
+// profile status surface.
 type TeslaHSCV1Runtime struct{ provider TeslaHSCV1ResponseProvider }
 
 func NewTeslaHSCV1Runtime(provider TeslaHSCV1ResponseProvider) (*TeslaHSCV1Runtime, error) {
@@ -28,9 +30,8 @@ func NewTeslaHSCV1Runtime(provider TeslaHSCV1ResponseProvider) (*TeslaHSCV1Runti
 	return &TeslaHSCV1Runtime{provider: provider}, nil
 }
 
-// TeslaHSCV1 validates only inbound response multiplicity and always projects
-// a fail-closed read-only result. It performs no I/O beyond calling its
-// injected response provider.
+// TeslaHSCV1 validates only already-correlated native record multiplicity. It
+// performs no I/O beyond calling its injected response provider.
 func (runtime *TeslaHSCV1Runtime) TeslaHSCV1(ctx context.Context) (TeslaHSCV1Result, error) {
 	if runtime == nil || runtime.provider == nil || ctx == nil {
 		return TeslaHSCV1Result{}, errors.New("tesla HSC runtime is unavailable")
@@ -42,24 +43,44 @@ func (runtime *TeslaHSCV1Runtime) TeslaHSCV1(ctx context.Context) (TeslaHSCV1Res
 	if len(responses) == 0 {
 		return TeslaHSCV1Result{}, errors.New("tesla HSC correlated response batch is empty")
 	}
+	result := TeslaHSCV1Result{Disposition: "native_records", Compatibility: "correlated_response"}
 	for _, response := range responses {
 		if !validTeslaHSCV1CorrelatedResponse(response) {
 			return TeslaHSCV1Result{}, errors.New("tesla HSC correlated response is invalid")
 		}
+		result.OutboundAllowed = result.OutboundAllowed || response.OutboundAllowed
+		for _, record := range response.Records {
+			result.NativeRecords = append(result.NativeRecords, copyTeslaHSCV1NativeRecord(record))
+		}
 	}
-	return TeslaHSCV1Result{Disposition: "framing_only", Compatibility: "correlated_response", OutboundAllowed: false}, nil
+	return result, nil
 }
 
 func validTeslaHSCV1CorrelatedResponse(response TeslaHSCV1CorrelatedResponse) bool {
-	if response.PayloadCount == 0 || response.PayloadCount > 8 {
+	if len(response.Records) == 0 || len(response.Records) > 8 {
 		return false
 	}
 	switch response.Function {
 	case 100:
-		return true
+		// FC100 may retain a bounded echo/result sequence.
 	case 101, 102:
-		return response.PayloadCount == 1
+		if len(response.Records) != 1 {
+			return false
+		}
 	default:
 		return false
 	}
+	for _, record := range response.Records {
+		if record.Function != response.Function || len(record.Payload) > 252 ||
+			record.Compatibility == "" || record.Provenance == "" {
+			return false
+		}
+	}
+	return true
+}
+
+func copyTeslaHSCV1NativeRecord(record TeslaHSCV1NativeRecord) TeslaHSCV1NativeRecord {
+	record.Payload = append([]byte(nil), record.Payload...)
+	record.FieldNames = append([]string(nil), record.FieldNames...)
+	return record
 }

--- a/mcp/tesla_hsc_runtime_v1.go
+++ b/mcp/tesla_hsc_runtime_v1.go
@@ -48,6 +48,9 @@ func (runtime *TeslaHSCV1Runtime) TeslaHSCV1(ctx context.Context) (TeslaHSCV1Res
 		if !validTeslaHSCV1CorrelatedResponse(response) {
 			return TeslaHSCV1Result{}, errors.New("tesla HSC correlated response is invalid")
 		}
+		if len(result.NativeRecords)+len(response.Records) > maxTeslaHSCV1NativeRecords {
+			return TeslaHSCV1Result{}, errors.New("tesla HSC correlated response aggregate exceeds bound")
+		}
 		result.OutboundAllowed = result.OutboundAllowed || response.OutboundAllowed
 		for _, record := range response.Records {
 			result.NativeRecords = append(result.NativeRecords, copyTeslaHSCV1NativeRecord(record))

--- a/mcp/tesla_hsc_runtime_v1_test.go
+++ b/mcp/tesla_hsc_runtime_v1_test.go
@@ -1,21 +1,22 @@
 package mcp
 
 import (
+	"bytes"
 	"context"
-	"reflect"
 	"testing"
 )
 
-func TestTeslaHSCV1RuntimeInjectsOnlyRedactedCorrelatedResponses(t *testing.T) {
-	responseType := reflect.TypeOf(TeslaHSCV1CorrelatedResponse{})
-	for field := 0; field < responseType.NumField(); field++ {
-		if typeContainsBytes(responseType.Field(field).Type) {
-			t.Fatalf("correlated response accepts raw bytes through %s", responseType.Field(field).Name)
-		}
-	}
+func TestTeslaHSCV1RuntimeRetainsInjectedNativeRecords(t *testing.T) {
+	payload := []byte{0x32, 0x02, 0x2a, 0x00}
 	runtime, err := NewTeslaHSCV1Runtime(&teslaHSCV1RuntimeFixture{responses: []TeslaHSCV1CorrelatedResponse{
-		{Function: 100, PayloadCount: 2},
-		{Function: 101, PayloadCount: 1},
+		{Function: 100, Records: []TeslaHSCV1NativeRecord{{
+			Function: 100, Payload: payload, Compatibility: "wc3_24_44_3", Provenance: "synthetic-replay",
+			Family: 6, RequestTag: 5, ResponseTag: 6, RequestName: "GetConfig", ResponseName: "WCConfig",
+			FieldNames: []string{"settings", "wifi_config"},
+		}}},
+		{Function: 101, OutboundAllowed: true, Records: []TeslaHSCV1NativeRecord{{
+			Function: 101, Payload: []byte{}, Compatibility: "wc3_24_44_3", Provenance: "synthetic-replay",
+		}}},
 	}})
 	if err != nil {
 		t.Fatal(err)
@@ -24,25 +25,26 @@ func TestTeslaHSCV1RuntimeInjectsOnlyRedactedCorrelatedResponses(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.OutboundAllowed || result.RetainedLength != 0 || result.RetainedDigest != "" {
-		t.Fatalf("unsafe result: %#v", result)
-	}
-	if result.Disposition != "framing_only" || result.Compatibility != "correlated_response" {
+	if result.Disposition != "native_records" || result.Compatibility != "correlated_response" || !result.OutboundAllowed || len(result.NativeRecords) != 2 {
 		t.Fatalf("result = %#v", result)
 	}
-}
-
-func typeContainsBytes(typ reflect.Type) bool {
-	if typ.Kind() == reflect.Array || typ.Kind() == reflect.Slice {
-		return typ.Elem().Kind() == reflect.Uint8 || typeContainsBytes(typ.Elem())
+	if record := result.NativeRecords[0]; !bytes.Equal(record.Payload, payload) || record.RequestName != "GetConfig" || record.ResponseName != "WCConfig" || len(record.FieldNames) != 2 {
+		t.Fatalf("record = %#v", record)
 	}
-	return false
+	payload[0] = 0
+	if result.NativeRecords[0].Payload[0] != 0x32 {
+		t.Fatalf("native payload was not copied: %#v", result.NativeRecords[0])
+	}
 }
 
-func TestTeslaHSCV1RuntimeRejectsUncorrelatedOrOpaqueOutboundPaths(t *testing.T) {
+func TestTeslaHSCV1RuntimeRejectsInvalidCorrelatedRecords(t *testing.T) {
+	valid := TeslaHSCV1NativeRecord{Function: 101, Payload: []byte{}, Compatibility: "wc3_24_44_3", Provenance: "synthetic-replay"}
 	for _, response := range []TeslaHSCV1CorrelatedResponse{
-		{Function: 101, PayloadCount: 2},
+		{Function: 101, Records: []TeslaHSCV1NativeRecord{valid, valid}},
 		{Function: 102},
+		{Function: 101, Records: []TeslaHSCV1NativeRecord{{Function: 102, Compatibility: "wc3_24_44_3", Provenance: "synthetic-replay"}}},
+		{Function: 100, Records: []TeslaHSCV1NativeRecord{{Function: 100, Payload: bytes.Repeat([]byte{1}, 253), Compatibility: "wc3_24_44_3", Provenance: "synthetic-replay"}}},
+		{Function: 100, Records: []TeslaHSCV1NativeRecord{{Function: 100, Compatibility: "", Provenance: "synthetic-replay"}}},
 	} {
 		runtime, err := NewTeslaHSCV1Runtime(&teslaHSCV1RuntimeFixture{responses: []TeslaHSCV1CorrelatedResponse{response}})
 		if err != nil {

--- a/mcp/tesla_hsc_runtime_v1_test.go
+++ b/mcp/tesla_hsc_runtime_v1_test.go
@@ -43,6 +43,7 @@ func TestTeslaHSCV1RuntimeRejectsInvalidCorrelatedRecords(t *testing.T) {
 		{Function: 101, Records: []TeslaHSCV1NativeRecord{valid, valid}},
 		{Function: 102},
 		{Function: 101, Records: []TeslaHSCV1NativeRecord{{Function: 102, Compatibility: "wc3_24_44_3", Provenance: "synthetic-replay"}}},
+		{Function: 102, Records: []TeslaHSCV1NativeRecord{{Function: 102, Compatibility: "wc3_24_44_3", Provenance: "synthetic-replay", ResponseName: "unqualified"}}},
 		{Function: 100, Records: []TeslaHSCV1NativeRecord{{Function: 100, Payload: bytes.Repeat([]byte{1}, 253), Compatibility: "wc3_24_44_3", Provenance: "synthetic-replay"}}},
 		{Function: 100, Records: []TeslaHSCV1NativeRecord{{Function: 100, Compatibility: "", Provenance: "synthetic-replay"}}},
 	} {

--- a/mcp/tesla_hsc_runtime_v1_test.go
+++ b/mcp/tesla_hsc_runtime_v1_test.go
@@ -57,6 +57,22 @@ func TestTeslaHSCV1RuntimeRejectsInvalidCorrelatedRecords(t *testing.T) {
 	}
 }
 
+func TestTeslaHSCV1RuntimeRejectsOversizedAggregate(t *testing.T) {
+	responses := make([]TeslaHSCV1CorrelatedResponse, 0, 9)
+	for range 9 {
+		responses = append(responses, TeslaHSCV1CorrelatedResponse{Function: 101, Records: []TeslaHSCV1NativeRecord{{
+			Function: 101, Compatibility: "wc3_24_44_3", Provenance: "synthetic-replay",
+		}}})
+	}
+	runtime, err := NewTeslaHSCV1Runtime(&teslaHSCV1RuntimeFixture{responses: responses})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runtime.TeslaHSCV1(context.Background()); err == nil {
+		t.Fatal("oversized aggregate accepted")
+	}
+}
+
 type teslaHSCV1RuntimeFixture struct {
 	responses []TeslaHSCV1CorrelatedResponse
 }

--- a/mcp/tesla_hsc_v1.go
+++ b/mcp/tesla_hsc_v1.go
@@ -8,16 +8,31 @@ import (
 
 const TeslaHSCV1StatusGetTool = "modbus.v1.tesla.hsc.status.get"
 
-// TeslaHSCV1Result is the redacted, read-only Tesla profile snapshot.
-type TeslaHSCV1Result struct {
-	Disposition     string `json:"disposition"`
-	Compatibility   string `json:"compatibility"`
-	OutboundAllowed bool   `json:"outbound_allowed"`
-	RetainedLength  int    `json:"retained_length,omitempty"`
-	RetainedDigest  string `json:"retained_digest,omitempty"`
+// TeslaHSCV1NativeRecord retains one native Tesla HSC message with the
+// firmware-scoped names and provenance supplied by the selected codec.
+type TeslaHSCV1NativeRecord struct {
+	Function      byte     `json:"function"`
+	Payload       []byte   `json:"payload"`
+	Compatibility string   `json:"compatibility"`
+	Provenance    string   `json:"provenance"`
+	Family        uint64   `json:"family,omitempty"`
+	RequestTag    uint64   `json:"request_tag,omitempty"`
+	ResponseTag   uint64   `json:"response_tag,omitempty"`
+	RequestName   string   `json:"request_name,omitempty"`
+	ResponseName  string   `json:"response_name,omitempty"`
+	FieldNames    []string `json:"field_names,omitempty"`
 }
 
-// TeslaHSCV1Provider supplies a redacted profile snapshot without transport I/O.
+// TeslaHSCV1Result is the native Tesla HSC profile snapshot. It carries the
+// complete records emitted by an already-correlated injected provider.
+type TeslaHSCV1Result struct {
+	Disposition     string                   `json:"disposition"`
+	Compatibility   string                   `json:"compatibility"`
+	OutboundAllowed bool                     `json:"outbound_allowed"`
+	NativeRecords   []TeslaHSCV1NativeRecord `json:"native_records,omitempty"`
+}
+
+// TeslaHSCV1Provider supplies a native profile snapshot without transport I/O.
 type TeslaHSCV1Provider interface {
 	TeslaHSCV1(context.Context) (TeslaHSCV1Result, error)
 }
@@ -35,7 +50,7 @@ func registerTeslaHSCV1Tool(server *Server, provider ModbusV1Provider) {
 	teslaHSCV1Providers.Lock()
 	teslaHSCV1Providers.byServer[server] = tesla
 	teslaHSCV1Providers.Unlock()
-	server.tools = append(server.tools, Tool{Name: TeslaHSCV1StatusGetTool, Description: "Get the read-only Tesla HSC profile disposition and redacted opaque retention metadata.", InputSchema: map[string]any{"type": "object", "properties": map[string]any{}, "additionalProperties": false}})
+	server.tools = append(server.tools, Tool{Name: TeslaHSCV1StatusGetTool, Description: "Get native Tesla HSC records and firmware-scoped provenance from an injected correlated provider.", InputSchema: map[string]any{"type": "object", "properties": map[string]any{}, "additionalProperties": false}})
 }
 
 func (server *Server) handleTeslaHSCV1Call(ctx context.Context, name string, args map[string]any) (map[string]any, bool) {
@@ -52,16 +67,5 @@ func (server *Server) handleTeslaHSCV1Call(ctx context.Context, name string, arg
 		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("tesla HSC provider unavailable"), false, "RETAINED_PROFILE", "")), true), true
 	}
 	result, err := provider.TeslaHSCV1(ctx)
-	result = failClosedTeslaHSCV1Result(result)
 	return callToolResultText(mustJSON(newModbusV1Envelope(result, err, true, "RETAINED_PROFILE", "")), err != nil), true
-}
-
-// failClosedTeslaHSCV1Result preserves status-only profile information while
-// preventing a provider from granting operation admission or exposing opaque
-// retention metadata through the MCP boundary.
-func failClosedTeslaHSCV1Result(result TeslaHSCV1Result) TeslaHSCV1Result {
-	result.OutboundAllowed = false
-	result.RetainedLength = 0
-	result.RetainedDigest = ""
-	return result
 }

--- a/mcp/tesla_hsc_v1.go
+++ b/mcp/tesla_hsc_v1.go
@@ -8,6 +8,8 @@ import (
 
 const TeslaHSCV1StatusGetTool = "modbus.v1.tesla.hsc.status.get"
 
+const maxTeslaHSCV1NativeRecords = 8
+
 // TeslaHSCV1NativeRecord retains one native Tesla HSC message with the
 // firmware-scoped names and provenance supplied by the selected codec.
 type TeslaHSCV1NativeRecord struct {
@@ -67,5 +69,33 @@ func (server *Server) handleTeslaHSCV1Call(ctx context.Context, name string, arg
 		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("tesla HSC provider unavailable"), false, "RETAINED_PROFILE", "")), true), true
 	}
 	result, err := provider.TeslaHSCV1(ctx)
+	if err == nil && !validTeslaHSCV1Result(result) {
+		result = TeslaHSCV1Result{}
+		err = errors.New("tesla HSC native provider result is invalid")
+	}
 	return callToolResultText(mustJSON(newModbusV1Envelope(result, err, true, "RETAINED_PROFILE", "")), err != nil), true
+}
+
+func validTeslaHSCV1Result(result TeslaHSCV1Result) bool {
+	if len(result.NativeRecords) > maxTeslaHSCV1NativeRecords {
+		return false
+	}
+	for _, record := range result.NativeRecords {
+		if !validTeslaHSCV1NativeRecord(record) {
+			return false
+		}
+	}
+	return true
+}
+
+func validTeslaHSCV1NativeRecord(record TeslaHSCV1NativeRecord) bool {
+	if len(record.Payload) > 252 || record.Compatibility == "" || record.Provenance == "" {
+		return false
+	}
+	switch record.Function {
+	case 100, 101, 102:
+		return true
+	default:
+		return false
+	}
 }

--- a/mcp/tesla_hsc_v1.go
+++ b/mcp/tesla_hsc_v1.go
@@ -69,9 +69,14 @@ func (server *Server) handleTeslaHSCV1Call(ctx context.Context, name string, arg
 		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("tesla HSC provider unavailable"), false, "RETAINED_PROFILE", "")), true), true
 	}
 	result, err := provider.TeslaHSCV1(ctx)
-	if err == nil && !validTeslaHSCV1Result(result) {
+	if err != nil {
+		result = TeslaHSCV1Result{}
+	} else if !validTeslaHSCV1Result(result) {
 		result = TeslaHSCV1Result{}
 		err = errors.New("tesla HSC native provider result is invalid")
+	}
+	if err != nil {
+		return callToolResultText(mustJSON(newModbusV1Envelope(nil, err, true, "RETAINED_PROFILE", "")), true), true
 	}
 	return callToolResultText(mustJSON(newModbusV1Envelope(result, err, true, "RETAINED_PROFILE", "")), err != nil), true
 }

--- a/mcp/tesla_hsc_v1.go
+++ b/mcp/tesla_hsc_v1.go
@@ -8,7 +8,11 @@ import (
 
 const TeslaHSCV1StatusGetTool = "modbus.v1.tesla.hsc.status.get"
 
-const maxTeslaHSCV1NativeRecords = 8
+const (
+	maxTeslaHSCV1NativeRecords       = 8
+	maxTeslaHSCV1NativeMetadataBytes = 128
+	maxTeslaHSCV1NativeFieldNames    = 64
+)
 
 // TeslaHSCV1NativeRecord retains one native Tesla HSC message with the
 // firmware-scoped names and provenance supplied by the selected codec.
@@ -82,7 +86,9 @@ func (server *Server) handleTeslaHSCV1Call(ctx context.Context, name string, arg
 }
 
 func validTeslaHSCV1Result(result TeslaHSCV1Result) bool {
-	if len(result.NativeRecords) > maxTeslaHSCV1NativeRecords {
+	if len(result.Disposition) > maxTeslaHSCV1NativeMetadataBytes ||
+		len(result.Compatibility) > maxTeslaHSCV1NativeMetadataBytes ||
+		len(result.NativeRecords) > maxTeslaHSCV1NativeRecords {
 		return false
 	}
 	for _, record := range result.NativeRecords {
@@ -94,8 +100,18 @@ func validTeslaHSCV1Result(result TeslaHSCV1Result) bool {
 }
 
 func validTeslaHSCV1NativeRecord(record TeslaHSCV1NativeRecord) bool {
-	if len(record.Payload) > 252 || record.Compatibility == "" || record.Provenance == "" {
+	if len(record.Payload) > 252 || record.Compatibility == "" || record.Provenance == "" ||
+		len(record.Compatibility) > maxTeslaHSCV1NativeMetadataBytes ||
+		len(record.Provenance) > maxTeslaHSCV1NativeMetadataBytes ||
+		len(record.RequestName) > maxTeslaHSCV1NativeMetadataBytes ||
+		len(record.ResponseName) > maxTeslaHSCV1NativeMetadataBytes ||
+		len(record.FieldNames) > maxTeslaHSCV1NativeFieldNames {
 		return false
+	}
+	for _, fieldName := range record.FieldNames {
+		if len(fieldName) > maxTeslaHSCV1NativeMetadataBytes {
+			return false
+		}
 	}
 	switch record.Function {
 	case 100:

--- a/mcp/tesla_hsc_v1.go
+++ b/mcp/tesla_hsc_v1.go
@@ -93,8 +93,11 @@ func validTeslaHSCV1NativeRecord(record TeslaHSCV1NativeRecord) bool {
 		return false
 	}
 	switch record.Function {
-	case 100, 101, 102:
+	case 100:
 		return true
+	case 101, 102:
+		return record.Family == 0 && record.RequestTag == 0 && record.ResponseTag == 0 &&
+			record.RequestName == "" && record.ResponseName == "" && len(record.FieldNames) == 0
 	default:
 		return false
 	}

--- a/mcp/tesla_hsc_v1_test.go
+++ b/mcp/tesla_hsc_v1_test.go
@@ -78,6 +78,26 @@ func TestTeslaHSCV1StatusToolPreservesNativePayloadAndContext(t *testing.T) {
 	}
 }
 
+type teslaHSCV1InvalidNativeFixtureProvider struct{ *modbusV1FixtureProvider }
+
+func (*teslaHSCV1InvalidNativeFixtureProvider) TeslaHSCV1(context.Context) (TeslaHSCV1Result, error) {
+	return TeslaHSCV1Result{Compatibility: "fixture", NativeRecords: []TeslaHSCV1NativeRecord{{
+		Function: 101, Payload: make([]byte, 253), Compatibility: "wc3_24_44_3", Provenance: "synthetic-replay",
+	}}}, nil
+}
+
+func TestTeslaHSCV1StatusToolRejectsUnboundedNativeProviderRecord(t *testing.T) {
+	server, err := NewServer(&testRegistry{entries: make(map[byte]registry.DeviceEntry)}, &testInvoker{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	RegisterModbusV1Tools(server, &teslaHSCV1InvalidNativeFixtureProvider{&modbusV1FixtureProvider{}})
+	result := msp06Call(t, server.Handler(), TeslaHSCV1StatusGetTool, map[string]any{})
+	if !result.isError {
+		t.Fatalf("unbounded native record accepted: %#v", result)
+	}
+}
+
 type teslaHSCV1EmptyResponseProvider struct{}
 
 func (teslaHSCV1EmptyResponseProvider) TeslaHSCV1Responses(context.Context) ([]TeslaHSCV1CorrelatedResponse, error) {

--- a/mcp/tesla_hsc_v1_test.go
+++ b/mcp/tesla_hsc_v1_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -95,6 +96,26 @@ func TestTeslaHSCV1StatusToolRejectsInvalidNativeProviderRecord(t *testing.T) {
 	result := msp06Call(t, server.Handler(), TeslaHSCV1StatusGetTool, map[string]any{})
 	if !result.isError {
 		t.Fatalf("invalid native record accepted: %#v", result)
+	}
+}
+
+type teslaHSCV1ErrorFixtureProvider struct{ *modbusV1FixtureProvider }
+
+func (*teslaHSCV1ErrorFixtureProvider) TeslaHSCV1(context.Context) (TeslaHSCV1Result, error) {
+	return TeslaHSCV1Result{NativeRecords: []TeslaHSCV1NativeRecord{{
+		Function: 101, Payload: []byte{1}, Compatibility: "wc3_24_44_3", Provenance: "synthetic-replay",
+	}}}, errors.New("synthetic provider error")
+}
+
+func TestTeslaHSCV1StatusToolClearsNativeRecordsOnProviderError(t *testing.T) {
+	server, err := NewServer(&testRegistry{entries: make(map[byte]registry.DeviceEntry)}, &testInvoker{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	RegisterModbusV1Tools(server, &teslaHSCV1ErrorFixtureProvider{&modbusV1FixtureProvider{}})
+	result := msp06Call(t, server.Handler(), TeslaHSCV1StatusGetTool, map[string]any{})
+	if !result.isError || result.envelope["data"] != nil {
+		t.Fatalf("provider-error result = %#v", result)
 	}
 }
 

--- a/mcp/tesla_hsc_v1_test.go
+++ b/mcp/tesla_hsc_v1_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
@@ -37,16 +38,16 @@ func (*teslaHSCV1UnsafeFixtureProvider) TeslaHSCV1(context.Context) (TeslaHSCV1R
 		Compatibility:   "fixture",
 		OutboundAllowed: true,
 		NativeRecords: []TeslaHSCV1NativeRecord{{
-			Function:     100,
-			Payload:      []byte{0x32, 0x02, 0x2a, 0x00},
+			Function:      100,
+			Payload:       []byte{0x32, 0x02, 0x2a, 0x00},
 			Compatibility: "wc3_24_44_3",
-			Provenance:   "synthetic-replay",
-			Family:       6,
-			RequestTag:   5,
-			ResponseTag:  6,
-			RequestName:  "GetConfig",
-			ResponseName: "WCConfig",
-			FieldNames:   []string{"settings", "wifi_config"},
+			Provenance:    "synthetic-replay",
+			Family:        6,
+			RequestTag:    5,
+			ResponseTag:   6,
+			RequestName:   "GetConfig",
+			ResponseName:  "WCConfig",
+			FieldNames:    []string{"settings", "wifi_config"},
 		}},
 	}, nil
 }
@@ -70,7 +71,7 @@ func TestTeslaHSCV1StatusToolPreservesNativePayloadAndContext(t *testing.T) {
 		t.Fatalf("native_records = %#v", data["native_records"])
 	}
 	record, ok := records[0].(map[string]any)
-	if !ok || record["function"] != float64(100) || record["payload"] == nil ||
+	if !ok || fmt.Sprint(record["function"]) != "100" || record["payload"] != "MgIqAA==" ||
 		record["compatibility"] != "wc3_24_44_3" || record["provenance"] != "synthetic-replay" ||
 		record["request_name"] != "GetConfig" || record["response_name"] != "WCConfig" {
 		t.Fatalf("native record = %#v", records[0])
@@ -92,7 +93,7 @@ func TestTeslaHSCV1RuntimeRejectsEmptyCorrelatedResponseBatch(t *testing.T) {
 	if err == nil {
 		t.Fatalf("empty correlated response batch accepted as %#v", result)
 	}
-	if result != (TeslaHSCV1Result{}) {
+	if result.Disposition != "" || result.Compatibility != "" || result.OutboundAllowed || len(result.NativeRecords) != 0 {
 		t.Fatalf("empty correlated response batch retained result %#v", result)
 	}
 }

--- a/mcp/tesla_hsc_v1_test.go
+++ b/mcp/tesla_hsc_v1_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
@@ -116,6 +117,26 @@ func TestTeslaHSCV1StatusToolClearsNativeRecordsOnProviderError(t *testing.T) {
 	result := msp06Call(t, server.Handler(), TeslaHSCV1StatusGetTool, map[string]any{})
 	if !result.isError || result.envelope["data"] != nil {
 		t.Fatalf("provider-error result = %#v", result)
+	}
+}
+
+type teslaHSCV1OversizedMetadataFixtureProvider struct{ *modbusV1FixtureProvider }
+
+func (*teslaHSCV1OversizedMetadataFixtureProvider) TeslaHSCV1(context.Context) (TeslaHSCV1Result, error) {
+	return TeslaHSCV1Result{NativeRecords: []TeslaHSCV1NativeRecord{{
+		Function: 100, Payload: []byte{}, Compatibility: strings.Repeat("x", 129), Provenance: "synthetic-replay",
+	}}}, nil
+}
+
+func TestTeslaHSCV1StatusToolRejectsOversizedNativeMetadata(t *testing.T) {
+	server, err := NewServer(&testRegistry{entries: make(map[byte]registry.DeviceEntry)}, &testInvoker{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	RegisterModbusV1Tools(server, &teslaHSCV1OversizedMetadataFixtureProvider{&modbusV1FixtureProvider{}})
+	result := msp06Call(t, server.Handler(), TeslaHSCV1StatusGetTool, map[string]any{})
+	if !result.isError || result.envelope["data"] != nil {
+		t.Fatalf("oversized metadata accepted: %#v", result)
 	}
 }
 

--- a/mcp/tesla_hsc_v1_test.go
+++ b/mcp/tesla_hsc_v1_test.go
@@ -82,11 +82,11 @@ type teslaHSCV1InvalidNativeFixtureProvider struct{ *modbusV1FixtureProvider }
 
 func (*teslaHSCV1InvalidNativeFixtureProvider) TeslaHSCV1(context.Context) (TeslaHSCV1Result, error) {
 	return TeslaHSCV1Result{Compatibility: "fixture", NativeRecords: []TeslaHSCV1NativeRecord{{
-		Function: 101, Payload: make([]byte, 253), Compatibility: "wc3_24_44_3", Provenance: "synthetic-replay",
+		Function: 101, Compatibility: "wc3_24_44_3", Provenance: "synthetic-replay", ResponseName: "unqualified",
 	}}}, nil
 }
 
-func TestTeslaHSCV1StatusToolRejectsUnboundedNativeProviderRecord(t *testing.T) {
+func TestTeslaHSCV1StatusToolRejectsInvalidNativeProviderRecord(t *testing.T) {
 	server, err := NewServer(&testRegistry{entries: make(map[byte]registry.DeviceEntry)}, &testInvoker{})
 	if err != nil {
 		t.Fatal(err)
@@ -94,7 +94,7 @@ func TestTeslaHSCV1StatusToolRejectsUnboundedNativeProviderRecord(t *testing.T) 
 	RegisterModbusV1Tools(server, &teslaHSCV1InvalidNativeFixtureProvider{&modbusV1FixtureProvider{}})
 	result := msp06Call(t, server.Handler(), TeslaHSCV1StatusGetTool, map[string]any{})
 	if !result.isError {
-		t.Fatalf("unbounded native record accepted: %#v", result)
+		t.Fatalf("invalid native record accepted: %#v", result)
 	}
 }
 

--- a/mcp/tesla_hsc_v1_test.go
+++ b/mcp/tesla_hsc_v1_test.go
@@ -13,7 +13,7 @@ func (*teslaHSCV1FixtureProvider) TeslaHSCV1(context.Context) (TeslaHSCV1Result,
 	return TeslaHSCV1Result{Disposition: "disabled", Compatibility: "unknown", OutboundAllowed: false}, nil
 }
 
-func TestTeslaHSCV1StatusToolIsReadOnlyAndRedacted(t *testing.T) {
+func TestTeslaHSCV1StatusToolRetainsNativeNamedRecords(t *testing.T) {
 	server, err := NewServer(&testRegistry{entries: make(map[byte]registry.DeviceEntry)}, &testInvoker{})
 	if err != nil {
 		t.Fatal(err)
@@ -36,12 +36,22 @@ func (*teslaHSCV1UnsafeFixtureProvider) TeslaHSCV1(context.Context) (TeslaHSCV1R
 		Disposition:     "qualified_read_only",
 		Compatibility:   "fixture",
 		OutboundAllowed: true,
-		RetainedLength:  42,
-		RetainedDigest:  "sensitive-fixture-payload",
+		NativeRecords: []TeslaHSCV1NativeRecord{{
+			Function:     100,
+			Payload:      []byte{0x32, 0x02, 0x2a, 0x00},
+			Compatibility: "wc3_24_44_3",
+			Provenance:   "synthetic-replay",
+			Family:       6,
+			RequestTag:   5,
+			ResponseTag:  6,
+			RequestName:  "GetConfig",
+			ResponseName: "WCConfig",
+			FieldNames:   []string{"settings", "wifi_config"},
+		}},
 	}, nil
 }
 
-func TestTeslaHSCV1StatusToolFailsClosedForProviderOutput(t *testing.T) {
+func TestTeslaHSCV1StatusToolPreservesNativePayloadAndContext(t *testing.T) {
 	server, err := NewServer(&testRegistry{entries: make(map[byte]registry.DeviceEntry)}, &testInvoker{})
 	if err != nil {
 		t.Fatal(err)
@@ -52,14 +62,18 @@ func TestTeslaHSCV1StatusToolFailsClosedForProviderOutput(t *testing.T) {
 		t.Fatalf("result = %#v", result)
 	}
 	data := msp06Map(t, result.envelope["data"], "data")
-	if data["outbound_allowed"] != false {
+	if data["outbound_allowed"] != true {
 		t.Fatalf("outbound_allowed = %#v", data["outbound_allowed"])
 	}
-	if _, exists := data["retained_length"]; exists {
-		t.Fatalf("retained_length was exposed: %#v", data)
+	records, ok := data["native_records"].([]any)
+	if !ok || len(records) != 1 {
+		t.Fatalf("native_records = %#v", data["native_records"])
 	}
-	if _, exists := data["retained_digest"]; exists {
-		t.Fatalf("retention metadata = %#v", data)
+	record, ok := records[0].(map[string]any)
+	if !ok || record["function"] != float64(100) || record["payload"] == nil ||
+		record["compatibility"] != "wc3_24_44_3" || record["provenance"] != "synthetic-replay" ||
+		record["request_name"] != "GetConfig" || record["response_name"] != "WCConfig" {
+		t.Fatalf("native record = %#v", records[0])
 	}
 }
 


### PR DESCRIPTION
Closes #903.\n\nRED: this commit introduces the native named-record MCP contract; the existing result is digest-only/redacted and lacks the record type.\n\nScope: injected data only; no serial configuration, credentials, deployment, or real hardware I/O.