### PR TITLE
MCP-FRONIUS: preserve native SunSpec observation state

### DIFF
--- a/mcp/fronius_sunspec_v1.go
+++ b/mcp/fronius_sunspec_v1.go
@@ -50,7 +50,7 @@ func registerFroniusSunSpecV1Tool(server *Server, provider ModbusV1Provider) {
 	froniusSunSpecV1Providers.Lock()
 	froniusSunSpecV1Providers.byServer[server] = p
 	froniusSunSpecV1Providers.Unlock()
-	server.tools = append(server.tools, Tool{Name: FroniusSunSpecV1StatusGetTool, Description: "Get the redacted, read-only Fronius SunSpec qualification and standard telemetry.", InputSchema: map[string]any{"type": "object", "properties": map[string]any{}, "additionalProperties": false}})
+	server.tools = append(server.tools, Tool{Name: FroniusSunSpecV1StatusGetTool, Description: "Get the native Fronius SunSpec qualification and standard telemetry observation.", InputSchema: map[string]any{"type": "object", "properties": map[string]any{}, "additionalProperties": false}})
 }
 
 func (server *Server) handleFroniusSunSpecV1Call(ctx context.Context, name string, args map[string]any) (map[string]any, bool) {
@@ -73,8 +73,6 @@ func (server *Server) handleFroniusSunSpecV1Call(ctx context.Context, name strin
 func normalizeFroniusSunSpecV1Result(result FroniusSunSpecV1Result, err error) FroniusSunSpecV1Result {
 	result.Profile = FroniusSunSpecV1Profile
 	result.Capability = modbusreg.SunSpecThreePhaseMonitoringCapabilityID
-	result.RawRedacted = true
-	result.OutboundAllowed = false
 	if err != nil || !result.Qualified || !validFroniusSunSpecV1Telemetry(result.Telemetry) {
 		result.Qualified = false
 		result.Qualification = "NOT_QUALIFIED"

--- a/mcp/fronius_sunspec_v1_test.go
+++ b/mcp/fronius_sunspec_v1_test.go
@@ -14,7 +14,9 @@ type froniusSunSpecFixture struct{ *modbusV1FixtureProvider }
 
 func (*froniusSunSpecFixture) FroniusSunSpecV1(context.Context) (FroniusSunSpecV1Result, error) {
 	return FroniusSunSpecV1Result{
-		Qualified: true,
+		Qualified:       true,
+		RawRedacted:     false,
+		OutboundAllowed: true,
 		Telemetry: &FroniusSunSpecV1Telemetry{
 			ACActivePowerWatts:      8421.5,
 			ACFrequencyHertz:        50,
@@ -35,7 +37,7 @@ func TestFroniusSunSpecV1ToolProjectsOnlyQualifiedStandardTelemetry(t *testing.T
 		t.Fatal(r)
 	}
 	d := msp06Map(t, r.envelope["data"], "data")
-	if d["profile"] != FroniusSunSpecV1Profile || d["capability"] != modbusreg.SunSpecThreePhaseMonitoringCapabilityID || d["qualification"] != "QUALIFIED" || d["qualified"] != true || d["raw_redacted"] != true || d["outbound_allowed"] != false {
+	if d["profile"] != FroniusSunSpecV1Profile || d["capability"] != modbusreg.SunSpecThreePhaseMonitoringCapabilityID || d["qualification"] != "QUALIFIED" || d["qualified"] != true || d["raw_redacted"] != false || d["outbound_allowed"] != true {
 		t.Fatalf("%#v", d)
 	}
 	telemetry := msp06Map(t, d["telemetry"], "telemetry")


### PR DESCRIPTION
Closes #905

## RED
- `go test ./mcp -run "^TestFroniusSunSpecV1Tool" -count=1` fails because `normalizeFroniusSunSpecV1Result` overwrites caller-supplied `raw_redacted=false` and `outbound_allowed=true`.

## Scope
- Preserves supplied native observation state for the existing Fronius status MCP tool.
- Retains qualification and finite telemetry validation.

## Boundaries
No transport, discovery, lifecycle, configuration, control execution, deployment, or live I/O. Fixtures are synthetic.