### PR TITLE
MCP-OUTBACK: preserve AXS native observation data

### DIFF
--- a/mcp/outback_axs_runtime_v1.go
+++ b/mcp/outback_axs_runtime_v1.go
@@ -17,6 +17,7 @@ type OutBackAXSV1ProviderSnapshot struct {
 	BatteryTemperature, AmbientTemperature, TemperatureScale int16
 	Error, Status                                            uint16
 	RawWords                                                 []uint16
+	OutboundAllowed                                          bool
 }
 type OutBackAXSV1SnapshotProvider interface {
 	OutBackAXSV1Snapshot(context.Context) (OutBackAXSV1ProviderSnapshot, error)
@@ -40,5 +41,5 @@ func (r *OutBackAXSV1Runtime) OutBackAXSV1(ctx context.Context) (OutBackAXSV1Res
 	if s.Profile != OutBackAXSV1Profile || !s.Qualified {
 		return OutBackAXSV1Result{}, ErrOutBackAXSV1NotQualified
 	}
-	return OutBackAXSV1Result{Profile: s.Profile, Qualified: true, FirmwareMajor: s.FirmwareMajor, FirmwareMid: s.FirmwareMid, FirmwareMinor: s.FirmwareMinor, BatteryTemperature: s.BatteryTemperature, AmbientTemperature: s.AmbientTemperature, TemperatureScale: s.TemperatureScale, Error: s.Error, Status: s.Status, RawRedacted: true, OutboundAllowed: false}, nil
+	return OutBackAXSV1Result{Profile: s.Profile, Qualified: true, FirmwareMajor: s.FirmwareMajor, FirmwareMid: s.FirmwareMid, FirmwareMinor: s.FirmwareMinor, BatteryTemperature: s.BatteryTemperature, AmbientTemperature: s.AmbientTemperature, TemperatureScale: s.TemperatureScale, Error: s.Error, Status: s.Status, RawWords: append([]uint16(nil), s.RawWords...), OutboundAllowed: s.OutboundAllowed}, nil
 }

--- a/mcp/outback_axs_runtime_v1_test.go
+++ b/mcp/outback_axs_runtime_v1_test.go
@@ -12,8 +12,9 @@ func (f outBackAXSV1RuntimeFixture) OutBackAXSV1Snapshot(context.Context) (OutBa
 	return f.snapshot, nil
 }
 
-func TestOutBackAXSV1RuntimeRedactsRawAndDisablesOutbound(t *testing.T) {
-	runtime, err := NewOutBackAXSV1Runtime(outBackAXSV1RuntimeFixture{snapshot: OutBackAXSV1ProviderSnapshot{Profile: OutBackAXSV1Profile, Qualified: true, RawWords: []uint16{64110, 282}, FirmwareMajor: 1, FirmwareMid: 2, FirmwareMinor: 3}})
+func TestOutBackAXSV1RuntimePreservesNativeObservation(t *testing.T) {
+	snapshot := OutBackAXSV1ProviderSnapshot{Profile: OutBackAXSV1Profile, Qualified: true, RawWords: []uint16{64110, 282}, OutboundAllowed: true, FirmwareMajor: 1, FirmwareMid: 2, FirmwareMinor: 3}
+	runtime, err := NewOutBackAXSV1Runtime(outBackAXSV1RuntimeFixture{snapshot: snapshot})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -21,8 +22,12 @@ func TestOutBackAXSV1RuntimeRedactsRawAndDisablesOutbound(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !result.Qualified || !result.RawRedacted || result.OutboundAllowed || result.FirmwareMajor != 1 {
+	if !result.Qualified || !result.OutboundAllowed || result.FirmwareMajor != 1 || len(result.RawWords) != 2 || result.RawWords[0] != 64110 {
 		t.Fatalf("result=%#v", result)
+	}
+	snapshot.RawWords[0] = 0
+	if result.RawWords[0] != 64110 {
+		t.Fatalf("raw words aliased provider snapshot: %#v", result.RawWords)
 	}
 }
 

--- a/mcp/outback_axs_v1.go
+++ b/mcp/outback_axs_v1.go
@@ -12,18 +12,18 @@ const (
 )
 
 type OutBackAXSV1Result struct {
-	Profile            string `json:"profile"`
-	Qualified          bool   `json:"qualified"`
-	FirmwareMajor      uint16 `json:"firmware_major"`
-	FirmwareMid        uint16 `json:"firmware_mid"`
-	FirmwareMinor      uint16 `json:"firmware_minor"`
-	BatteryTemperature int16  `json:"battery_temperature"`
-	AmbientTemperature int16  `json:"ambient_temperature"`
-	TemperatureScale   int16  `json:"temperature_scale"`
-	Error              uint16 `json:"error"`
-	Status             uint16 `json:"status"`
-	RawRedacted        bool   `json:"raw_redacted"`
-	OutboundAllowed    bool   `json:"outbound_allowed"`
+	Profile            string   `json:"profile"`
+	Qualified          bool     `json:"qualified"`
+	FirmwareMajor      uint16   `json:"firmware_major"`
+	FirmwareMid        uint16   `json:"firmware_mid"`
+	FirmwareMinor      uint16   `json:"firmware_minor"`
+	BatteryTemperature int16    `json:"battery_temperature"`
+	AmbientTemperature int16    `json:"ambient_temperature"`
+	TemperatureScale   int16    `json:"temperature_scale"`
+	Error              uint16   `json:"error"`
+	Status             uint16   `json:"status"`
+	RawWords           []uint16 `json:"raw_words"`
+	OutboundAllowed    bool     `json:"outbound_allowed"`
 }
 type OutBackAXSV1Provider interface {
 	OutBackAXSV1(context.Context) (OutBackAXSV1Result, error)
@@ -42,7 +42,7 @@ func registerOutBackAXSV1Tool(server *Server, provider ModbusV1Provider) {
 	outBackAXSV1Providers.Lock()
 	outBackAXSV1Providers.byServer[server] = p
 	outBackAXSV1Providers.Unlock()
-	server.tools = append(server.tools, Tool{Name: OutBackAXSV1StatusGetTool, Description: "Get the redacted read-only OutBack AXS status.", InputSchema: map[string]any{"type": "object", "properties": map[string]any{}, "additionalProperties": false}})
+	server.tools = append(server.tools, Tool{Name: OutBackAXSV1StatusGetTool, Description: "Get the native OutBack AXS observation status.", InputSchema: map[string]any{"type": "object", "properties": map[string]any{}, "additionalProperties": false}})
 }
 func (server *Server) handleOutBackAXSV1Call(ctx context.Context, name string, args map[string]any) (map[string]any, bool) {
 	if name != OutBackAXSV1StatusGetTool {
@@ -58,7 +58,6 @@ func (server *Server) handleOutBackAXSV1Call(ctx context.Context, name string, a
 		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("outback AXS provider unavailable"), false, "RETAINED_PROFILE", "")), true), true
 	}
 	r, err := p.OutBackAXSV1(ctx)
-	r.RawRedacted = true
-	r.OutboundAllowed = false
+	r.RawWords = append([]uint16(nil), r.RawWords...)
 	return callToolResultText(mustJSON(newModbusV1Envelope(r, err, true, "RETAINED_PROFILE", "")), err != nil), true
 }

--- a/mcp/outback_axs_v1_test.go
+++ b/mcp/outback_axs_v1_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
@@ -10,7 +11,15 @@ import (
 type outBackAXSV1FixtureProvider struct{ *modbusV1FixtureProvider }
 
 func (*outBackAXSV1FixtureProvider) OutBackAXSV1(context.Context) (OutBackAXSV1Result, error) {
-	return OutBackAXSV1Result{Profile: OutBackAXSV1Profile, Qualified: true, FirmwareMajor: 1, FirmwareMid: 2, FirmwareMinor: 3}, nil
+	return OutBackAXSV1Result{
+		Profile:         OutBackAXSV1Profile,
+		Qualified:       true,
+		FirmwareMajor:   1,
+		FirmwareMid:     2,
+		FirmwareMinor:   3,
+		RawWords:        []uint16{64110, 282},
+		OutboundAllowed: true,
+	}, nil
 }
 
 func TestOutBackAXSV1ToolProjectsOnlyReadOnlyFacts(t *testing.T) {
@@ -24,12 +33,11 @@ func TestOutBackAXSV1ToolProjectsOnlyReadOnlyFacts(t *testing.T) {
 		t.Fatalf("result=%#v", result)
 	}
 	data := msp06Map(t, result.envelope["data"], "data")
-	if data["profile"] != OutBackAXSV1Profile || data["qualified"] != true || data["outbound_allowed"] != false || data["raw_redacted"] != true {
+	if data["profile"] != OutBackAXSV1Profile || data["qualified"] != true || data["outbound_allowed"] != true {
 		t.Fatalf("data=%#v", data)
 	}
-	for _, forbidden := range []string{"words", "config", "network", "mac", "credential", "control"} {
-		if _, ok := data[forbidden]; ok {
-			t.Fatalf("leaked %q: %#v", forbidden, data)
-		}
+	rawWords := msp06Slice(t, data["raw_words"], "raw_words")
+	if len(rawWords) != 2 || rawWords[0] != json.Number("64110") || rawWords[1] != json.Number("282") {
+		t.Fatalf("raw_words=%#v", rawWords)
 	}
 }


### PR DESCRIPTION
Closes #907

## RED
`go test ./mcp -run "^TestOutBackAXSV1" -count=1` fails to compile because AXS native `RawWords` and provider `OutboundAllowed` are not projected through the runtime/MCP result.

## Scope
- Expose provider-supplied AXS raw observation words with defensive copies.
- Preserve caller-supplied outbound context.
- Remove the forced `raw_redacted` marker.

## Boundaries
No transport/discovery/lifecycle/configuration/control execution/deployment/live I-O. Synthetic fixtures only. Documentation companion #113 is the public contract gate.