### PR TITLE
MCP-HUAWEI: preserve EMMA native identity state

### DIFF
--- a/mcp/huawei_emma_v1.go
+++ b/mcp/huawei_emma_v1.go
@@ -36,7 +36,7 @@ func registerHuaweiEMMAV1Tool(s *Server, p ModbusV1Provider) {
 	huaweiEMMAV1Providers.Lock()
 	huaweiEMMAV1Providers.byServer[s] = v
 	huaweiEMMAV1Providers.Unlock()
-	s.tools = append(s.tools, Tool{Name: HuaweiEMMAV1IdentityGetTool, Description: "Get the redacted read-only Huawei EMMA identity qualification.", InputSchema: map[string]any{"type": "object", "properties": map[string]any{}, "additionalProperties": false}})
+	s.tools = append(s.tools, Tool{Name: HuaweiEMMAV1IdentityGetTool, Description: "Get the native Huawei EMMA identity qualification.", InputSchema: map[string]any{"type": "object", "properties": map[string]any{}, "additionalProperties": false}})
 }
 func (s *Server) handleHuaweiEMMAV1Call(ctx context.Context, n string, a map[string]any) (map[string]any, bool) {
 	if n != HuaweiEMMAV1IdentityGetTool {
@@ -52,7 +52,5 @@ func (s *Server) handleHuaweiEMMAV1Call(ctx context.Context, n string, a map[str
 		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("huawei EMMA provider unavailable"), false, "RETAINED_PROFILE", "")), true), true
 	}
 	r, e := p.HuaweiEMMAV1(ctx)
-	r.RawRedacted = true
-	r.OutboundAllowed = false
 	return callToolResultText(mustJSON(newModbusV1Envelope(r, e, true, "RETAINED_PROFILE", "")), e != nil), true
 }

--- a/mcp/huawei_emma_v1_test.go
+++ b/mcp/huawei_emma_v1_test.go
@@ -9,9 +9,9 @@ import (
 type emmaFixture struct{ *modbusV1FixtureProvider }
 
 func (*emmaFixture) HuaweiEMMAV1(context.Context) (HuaweiEMMAV1Result, error) {
-	return HuaweiEMMAV1Result{Profile: HuaweiEMMAV1Profile, CanonicalClass: "EMMA", ModelVariant: "EMMA-A02", Qualified: true}, nil
+	return HuaweiEMMAV1Result{Profile: HuaweiEMMAV1Profile, CanonicalClass: "EMMA", ModelVariant: "EMMA-A02", Qualified: true, RawRedacted: false, OutboundAllowed: true}, nil
 }
-func TestHuaweiEMMAV1ToolRedactsOfflineIdentity(t *testing.T) {
+func TestHuaweiEMMAV1ToolPreservesNativeIdentityState(t *testing.T) {
 	s, e := NewServer(&testRegistry{entries: map[byte]registry.DeviceEntry{}}, &testInvoker{})
 	if e != nil {
 		t.Fatal(e)
@@ -22,7 +22,7 @@ func TestHuaweiEMMAV1ToolRedactsOfflineIdentity(t *testing.T) {
 		t.Fatal(r)
 	}
 	d := msp06Map(t, r.envelope["data"], "data")
-	if d["qualified"] != true || d["raw_redacted"] != true || d["outbound_allowed"] != false {
+	if d["qualified"] != true || d["raw_redacted"] != false || d["outbound_allowed"] != true {
 		t.Fatalf("%#v", d)
 	}
 	for _, k := range []string{"mei", "inventory", "endpoint", "offering", "firmware"} {


### PR DESCRIPTION
Closes #909

## RED
`go test ./mcp -run "^TestHuaweiEMMAV1" -count=1` fails because the handler overwrites caller-supplied `raw_redacted=false` and `outbound_allowed=true`.

## Scope
Preserve injected native state only. No transport, discovery, lifecycle, control, deployment, or live I-O; fixture is synthetic.