### PR TITLE
MCP-HUAWEI: preserve S-Dongle native disposition

### DIFF
--- a/mcp/huawei_sdongle_v1.go
+++ b/mcp/huawei_sdongle_v1.go
@@ -36,7 +36,7 @@ func registerHuaweiSDongleV1Tool(s *Server, p ModbusV1Provider) {
 	huaweiSDongleV1Providers.Lock()
 	huaweiSDongleV1Providers.byServer[s] = v
 	huaweiSDongleV1Providers.Unlock()
-	s.tools = append(s.tools, Tool{Name: HuaweiSDongleV1StatusGetTool, Description: "Get the redacted pre-live Huawei S-Dongle status.", InputSchema: map[string]any{"type": "object", "properties": map[string]any{}, "additionalProperties": false}})
+	s.tools = append(s.tools, Tool{Name: HuaweiSDongleV1StatusGetTool, Description: "Get the native Huawei S-Dongle status.", InputSchema: map[string]any{"type": "object", "properties": map[string]any{}, "additionalProperties": false}})
 }
 func (s *Server) handleHuaweiSDongleV1Call(ctx context.Context, n string, a map[string]any) (map[string]any, bool) {
 	if n != HuaweiSDongleV1StatusGetTool {
@@ -52,11 +52,5 @@ func (s *Server) handleHuaweiSDongleV1Call(ctx context.Context, n string, a map[
 		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("huawei S-Dongle provider unavailable"), false, "RETAINED_PROFILE", "")), true), true
 	}
 	r, e := p.HuaweiSDongleV1(ctx)
-	r.Profile = HuaweiSDongleV1Profile
-	r.Family = "S-Dongle"
-	r.Disposition = "PRE_LIVE_INSUFFICIENT_EVIDENCE"
-	r.Qualified = false
-	r.RawRedacted = true
-	r.OutboundAllowed = false
 	return callToolResultText(mustJSON(newModbusV1Envelope(r, e, true, "RETAINED_PROFILE", "")), e != nil), true
 }

--- a/mcp/huawei_sdongle_v1_test.go
+++ b/mcp/huawei_sdongle_v1_test.go
@@ -10,10 +10,10 @@ import (
 type sdongleFixture struct{ *modbusV1FixtureProvider }
 
 func (*sdongleFixture) HuaweiSDongleV1(context.Context) (HuaweiSDongleV1Result, error) {
-	return HuaweiSDongleV1Result{Profile: HuaweiSDongleV1Profile, Family: "S-Dongle", Disposition: "PRE_LIVE_INSUFFICIENT_EVIDENCE"}, nil
+	return HuaweiSDongleV1Result{Profile: HuaweiSDongleV1Profile, Family: "S-DongleA-05", Disposition: "OBSERVED_UNQUALIFIED", Qualified: false, RawRedacted: false, OutboundAllowed: true}, nil
 }
 
-func TestHuaweiSDongleV1ToolStaysPreLiveAndRedacted(t *testing.T) {
+func TestHuaweiSDongleV1ToolPreservesNativeDisposition(t *testing.T) {
 	s, err := NewServer(&testRegistry{entries: map[byte]registry.DeviceEntry{}}, &testInvoker{})
 	if err != nil {
 		t.Fatal(err)
@@ -24,7 +24,7 @@ func TestHuaweiSDongleV1ToolStaysPreLiveAndRedacted(t *testing.T) {
 		t.Fatal(r)
 	}
 	d := msp06Map(t, r.envelope["data"], "data")
-	if d["profile"] != HuaweiSDongleV1Profile || d["disposition"] != "PRE_LIVE_INSUFFICIENT_EVIDENCE" || d["qualified"] != false || d["raw_redacted"] != true || d["outbound_allowed"] != false {
+	if d["profile"] != HuaweiSDongleV1Profile || d["family"] != "S-DongleA-05" || d["disposition"] != "OBSERVED_UNQUALIFIED" || d["qualified"] != false || d["raw_redacted"] != false || d["outbound_allowed"] != true {
 		t.Fatalf("%#v", d)
 	}
 	for _, key := range []string{"timeout", "endpoint", "mei", "firmware", "child"} {


### PR DESCRIPTION
Closes #911

## RED
`go test ./mcp -run "^TestHuaweiSDongleV1" -count=1` fails because the handler overwrites every caller-supplied S-Dongle state field with a fixed pre-live/redacted result.

## Scope
Preserve injected native disposition/status only. No live qualification, transport, discovery, lifecycle, control, deployment, or hardware I-O. Fixtures are synthetic.