### PR TITLE
MCP-HUAWEI: preserve SmartLogger native state

### DIFF
--- a/mcp/huawei_smartlogger_v1.go
+++ b/mcp/huawei_smartlogger_v1.go
@@ -11,8 +11,8 @@ const (
 	HuaweiSmartLoggerV1Profile       = "huawei.smartlogger.readonly.v1"
 )
 
-// HuaweiSmartLoggerV1Result is intentionally limited to redacted, read-only
-// qualification status. Inventory and transport evidence remain private.
+// HuaweiSmartLoggerV1Result is the provider-supplied native qualification
+// status. Inventory acquisition remains outside this MCP seam.
 type HuaweiSmartLoggerV1Result struct {
 	Profile         string `json:"profile"`
 	Family          string `json:"family"`
@@ -38,7 +38,7 @@ func registerHuaweiSmartLoggerV1Tool(server *Server, provider ModbusV1Provider) 
 	huaweiSmartLoggerV1Providers.Lock()
 	huaweiSmartLoggerV1Providers.byServer[server] = value
 	huaweiSmartLoggerV1Providers.Unlock()
-	server.tools = append(server.tools, Tool{Name: HuaweiSmartLoggerV1StatusGetTool, Description: "Get the redacted read-only Huawei SmartLogger status.", InputSchema: map[string]any{"type": "object", "properties": map[string]any{}, "additionalProperties": false}})
+	server.tools = append(server.tools, Tool{Name: HuaweiSmartLoggerV1StatusGetTool, Description: "Get the native Huawei SmartLogger status.", InputSchema: map[string]any{"type": "object", "properties": map[string]any{}, "additionalProperties": false}})
 }
 
 func (server *Server) handleHuaweiSmartLoggerV1Call(ctx context.Context, name string, args map[string]any) (map[string]any, bool) {
@@ -55,7 +55,5 @@ func (server *Server) handleHuaweiSmartLoggerV1Call(ctx context.Context, name st
 		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("huawei SmartLogger provider unavailable"), false, "RETAINED_PROFILE", "")), true), true
 	}
 	result, err := provider.HuaweiSmartLoggerV1(ctx)
-	result.RawRedacted = true
-	result.OutboundAllowed = false
 	return callToolResultText(mustJSON(newModbusV1Envelope(result, err, true, "RETAINED_PROFILE", "")), err != nil), true
 }

--- a/mcp/huawei_smartlogger_v1_test.go
+++ b/mcp/huawei_smartlogger_v1_test.go
@@ -10,10 +10,10 @@ import (
 type smartLoggerFixture struct{ *modbusV1FixtureProvider }
 
 func (*smartLoggerFixture) HuaweiSmartLoggerV1(context.Context) (HuaweiSmartLoggerV1Result, error) {
-	return HuaweiSmartLoggerV1Result{Profile: HuaweiSmartLoggerV1Profile, Family: "SmartLogger", Qualified: false}, nil
+	return HuaweiSmartLoggerV1Result{Profile: HuaweiSmartLoggerV1Profile, Family: "SmartLogger", Qualified: false, RawRedacted: false, OutboundAllowed: true}, nil
 }
 
-func TestHuaweiSmartLoggerV1ToolRedactsInventoryAndDisablesOutbound(t *testing.T) {
+func TestHuaweiSmartLoggerV1ToolPreservesNativeState(t *testing.T) {
 	s, err := NewServer(&testRegistry{entries: map[byte]registry.DeviceEntry{}}, &testInvoker{})
 	if err != nil {
 		t.Fatal(err)
@@ -24,7 +24,7 @@ func TestHuaweiSmartLoggerV1ToolRedactsInventoryAndDisablesOutbound(t *testing.T
 		t.Fatal(r)
 	}
 	d := msp06Map(t, r.envelope["data"], "data")
-	if d["profile"] != HuaweiSmartLoggerV1Profile || d["family"] != "SmartLogger" || d["raw_redacted"] != true || d["outbound_allowed"] != false {
+	if d["profile"] != HuaweiSmartLoggerV1Profile || d["family"] != "SmartLogger" || d["raw_redacted"] != false || d["outbound_allowed"] != true {
 		t.Fatalf("%#v", d)
 	}
 	for _, key := range []string{"mei", "inventory", "endpoint", "firmware", "child"} {


### PR DESCRIPTION
Closes #913

## RED
`go test ./mcp -run "^TestHuaweiSmartLoggerV1" -count=1` fails because the handler overwrites caller-supplied `raw_redacted=false` and `outbound_allowed=true`.

## Scope
Preserve injected native state only. No inventory acquisition, transport, lifecycle, control, deployment, or hardware I-O. Fixtures are synthetic.