### PR TITLE
fix: retain Tesla native HSC records

### DIFF
--- a/mcp/tesla_hsc_provenance_v1.go
+++ b/mcp/tesla_hsc_provenance_v1.go
@@ -2,19 +2,18 @@ package mcp
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 )
 
 const maxTeslaHSCV1ProvenancePayload = 252
 
-// TeslaHSCProvenanceV1Record is redacted, already-correlated terminal-response
-// provenance. It deliberately carries no raw response bytes or send authority.
+// TeslaHSCProvenanceV1Record is one already-correlated native FC101 or FC102
+// terminal response with its firmware-scoped compatibility and provenance.
 type TeslaHSCProvenanceV1Record struct {
 	Function        byte   `json:"function"`
-	PayloadLength   int    `json:"payload_length"`
-	PayloadDigest   string `json:"payload_digest"`
+	Payload         []byte `json:"payload"`
+	Compatibility   string `json:"compatibility"`
+	Provenance      string `json:"provenance"`
 	OutboundAllowed bool   `json:"outbound_allowed"`
 }
 
@@ -24,8 +23,8 @@ type TeslaHSCProvenanceV1Provider interface {
 	TeslaHSCProvenanceV1(context.Context) ([]TeslaHSCProvenanceV1Record, error)
 }
 
-// TeslaHSCProvenanceV1Runtime projects injected redacted terminal provenance
-// for an MCP caller without constructing a request or transmitting anything.
+// TeslaHSCProvenanceV1Runtime projects injected native terminal records without
+// constructing a request or transmitting anything.
 type TeslaHSCProvenanceV1Runtime struct {
 	provider TeslaHSCProvenanceV1Provider
 }
@@ -39,8 +38,8 @@ func NewTeslaHSCProvenanceV1Runtime(provider TeslaHSCProvenanceV1Provider) (*Tes
 	return &TeslaHSCProvenanceV1Runtime{provider: provider}, nil
 }
 
-// TeslaHSCProvenanceV1 validates and projects selected terminal provenance.
-// Every returned record is independently copied and permanently outbound-denied.
+// TeslaHSCProvenanceV1 validates and projects selected native terminal records.
+// Every returned record is independently copied while retaining its context.
 func (runtime *TeslaHSCProvenanceV1Runtime) TeslaHSCProvenanceV1(ctx context.Context) ([]TeslaHSCProvenanceV1Record, error) {
 	if runtime == nil || runtime.provider == nil || ctx == nil {
 		return nil, errors.New("tesla HSC provenance runtime is unavailable")
@@ -54,17 +53,27 @@ func (runtime *TeslaHSCProvenanceV1Runtime) TeslaHSCProvenanceV1(ctx context.Con
 		if !validTeslaHSCProvenanceV1Record(record) {
 			return nil, errors.New("tesla HSC provenance record is invalid")
 		}
-		record.OutboundAllowed = false
-		projected = append(projected, record)
+		projected = append(projected, copyTeslaHSCProvenanceV1Record(record))
 	}
 	return projected, nil
 }
 
 func validTeslaHSCProvenanceV1Record(record TeslaHSCProvenanceV1Record) bool {
 	if (record.Function != 101 && record.Function != 102) ||
-		record.PayloadLength < 0 || record.PayloadLength > maxTeslaHSCV1ProvenancePayload {
+		len(record.Payload) > maxTeslaHSCV1ProvenancePayload ||
+		record.Compatibility == "" || record.Provenance == "" ||
+		len(record.Compatibility) > maxTeslaHSCV1NativeMetadataBytes ||
+		len(record.Provenance) > maxTeslaHSCV1NativeMetadataBytes {
 		return false
 	}
-	digest, err := hex.DecodeString(record.PayloadDigest)
-	return err == nil && len(digest) == sha256.Size
+	return true
+}
+
+func copyTeslaHSCProvenanceV1Record(record TeslaHSCProvenanceV1Record) TeslaHSCProvenanceV1Record {
+	if record.Payload != nil {
+		payload := make([]byte, len(record.Payload))
+		copy(payload, record.Payload)
+		record.Payload = payload
+	}
+	return record
 }

--- a/mcp/tesla_hsc_provenance_v1_test.go
+++ b/mcp/tesla_hsc_provenance_v1_test.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"bytes"
 	"context"
 	"testing"
 )
@@ -16,10 +17,10 @@ func (provider *teslaHSCProvenanceV1FixtureProvider) TeslaHSCProvenanceV1(contex
 	return provider.records, provider.err
 }
 
-func TestTeslaHSCProvenanceV1RuntimeProjectsOnlyRedactedSelectedTerminalMetadata(t *testing.T) {
+func TestTeslaHSCProvenanceV1RuntimePreservesNativeTerminalRecords(t *testing.T) {
 	provider := &teslaHSCProvenanceV1FixtureProvider{records: []TeslaHSCProvenanceV1Record{
-		{Function: 101, PayloadLength: 0, PayloadDigest: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", OutboundAllowed: true},
-		{Function: 102, PayloadLength: 2, PayloadDigest: "9ee50aea7e52b0fd0c9dcae1a059ac08b94c21ad3e2fa7e6cbf9b6b5279d93d8"},
+		{Function: 101, Payload: []byte{}, Compatibility: "wc3_24_44_3", Provenance: "synthetic-replay", OutboundAllowed: true},
+		{Function: 102, Payload: []byte{0x42, 0x99}, Compatibility: "wc3_24_44_3", Provenance: "synthetic-replay"},
 	}}
 	runtime, err := NewTeslaHSCProvenanceV1Runtime(provider)
 	if err != nil {
@@ -34,19 +35,28 @@ func TestTeslaHSCProvenanceV1RuntimeProjectsOnlyRedactedSelectedTerminalMetadata
 	}
 	for index, record := range got {
 		if record.Function != provider.records[index].Function ||
-			record.PayloadLength != provider.records[index].PayloadLength ||
-			record.PayloadDigest != provider.records[index].PayloadDigest ||
-			record.OutboundAllowed {
-			t.Fatalf("redacted provenance[%d] = %#v", index, record)
+			!bytes.Equal(record.Payload, provider.records[index].Payload) ||
+			record.Compatibility != provider.records[index].Compatibility ||
+			record.Provenance != provider.records[index].Provenance ||
+			record.OutboundAllowed != provider.records[index].OutboundAllowed {
+			t.Fatalf("native provenance[%d] = %#v", index, record)
 		}
+	}
+	if got[0].Payload == nil {
+		t.Fatalf("non-nil empty payload became nil: %#v", got[0])
+	}
+	provider.records[1].Payload[0] = 0
+	if got[1].Payload[0] != 0x42 {
+		t.Fatalf("native payload was not copied: %#v", got[1])
 	}
 }
 
-func TestTeslaHSCProvenanceV1RuntimeRejectsUnselectedOrMalformedMetadata(t *testing.T) {
+func TestTeslaHSCProvenanceV1RuntimeRejectsInvalidNativeRecords(t *testing.T) {
 	for _, record := range []TeslaHSCProvenanceV1Record{
-		{Function: 100, PayloadLength: 0, PayloadDigest: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
-		{Function: 101, PayloadLength: 253, PayloadDigest: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
-		{Function: 102, PayloadLength: 1, PayloadDigest: "not-a-digest"},
+		{Function: 100, Payload: []byte{}, Compatibility: "wc3_24_44_3", Provenance: "synthetic-replay"},
+		{Function: 101, Payload: bytes.Repeat([]byte{1}, 253), Compatibility: "wc3_24_44_3", Provenance: "synthetic-replay"},
+		{Function: 102, Payload: []byte{}, Provenance: "synthetic-replay"},
+		{Function: 102, Payload: []byte{}, Compatibility: "wc3_24_44_3"},
 	} {
 		provider := &teslaHSCProvenanceV1FixtureProvider{records: []TeslaHSCProvenanceV1Record{record}}
 		runtime, err := NewTeslaHSCProvenanceV1Runtime(provider)

--- a/mcp/tesla_hsc_runtime_v1.go
+++ b/mcp/tesla_hsc_runtime_v1.go
@@ -82,7 +82,11 @@ func validTeslaHSCV1CorrelatedResponse(response TeslaHSCV1CorrelatedResponse) bo
 }
 
 func copyTeslaHSCV1NativeRecord(record TeslaHSCV1NativeRecord) TeslaHSCV1NativeRecord {
-	record.Payload = append([]byte(nil), record.Payload...)
+	if record.Payload != nil {
+		payload := make([]byte, len(record.Payload))
+		copy(payload, record.Payload)
+		record.Payload = payload
+	}
 	record.FieldNames = append([]string(nil), record.FieldNames...)
 	return record
 }

--- a/mcp/tesla_hsc_runtime_v1_test.go
+++ b/mcp/tesla_hsc_runtime_v1_test.go
@@ -31,6 +31,9 @@ func TestTeslaHSCV1RuntimeRetainsInjectedNativeRecords(t *testing.T) {
 	if record := result.NativeRecords[0]; !bytes.Equal(record.Payload, payload) || record.RequestName != "GetConfig" || record.ResponseName != "WCConfig" || len(record.FieldNames) != 2 {
 		t.Fatalf("record = %#v", record)
 	}
+	if payload := result.NativeRecords[1].Payload; payload == nil || len(payload) != 0 {
+		t.Fatalf("non-nil empty payload = %#v", payload)
+	}
 	payload[0] = 0
 	if result.NativeRecords[0].Payload[0] != 0x32 {
 		t.Fatalf("native payload was not copied: %#v", result.NativeRecords[0])

--- a/mcp/tesla_hsc_v1.go
+++ b/mcp/tesla_hsc_v1.go
@@ -72,12 +72,7 @@ func (server *Server) handleTeslaHSCV1Call(ctx context.Context, name string, arg
 	if provider == nil {
 		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("tesla HSC provider unavailable"), false, "RETAINED_PROFILE", "")), true), true
 	}
-	result, err := provider.TeslaHSCV1(ctx)
-	valid := validTeslaHSCV1Result(result)
-	if !valid {
-		result = TeslaHSCV1Result{}
-		err = errors.New("tesla HSC native provider result is invalid")
-	}
+	result, err, valid := normalizeTeslaHSCV1ProviderResult(provider.TeslaHSCV1(ctx))
 	if err != nil {
 		var data any
 		if valid {
@@ -86,6 +81,17 @@ func (server *Server) handleTeslaHSCV1Call(ctx context.Context, name string, arg
 		return callToolResultText(mustJSON(newModbusV1Envelope(data, err, true, "RETAINED_PROFILE", "")), true), true
 	}
 	return callToolResultText(mustJSON(newModbusV1Envelope(result, err, true, "RETAINED_PROFILE", "")), err != nil), true
+}
+
+func normalizeTeslaHSCV1ProviderResult(result TeslaHSCV1Result, providerErr error) (TeslaHSCV1Result, error, bool) {
+	if validTeslaHSCV1Result(result) {
+		return result, providerErr, true
+	}
+	validationErr := errors.New("tesla HSC native provider result is invalid")
+	if providerErr != nil {
+		validationErr = errors.Join(providerErr, validationErr)
+	}
+	return TeslaHSCV1Result{}, validationErr, false
 }
 
 func validTeslaHSCV1Result(result TeslaHSCV1Result) bool {

--- a/mcp/tesla_hsc_v1.go
+++ b/mcp/tesla_hsc_v1.go
@@ -73,14 +73,17 @@ func (server *Server) handleTeslaHSCV1Call(ctx context.Context, name string, arg
 		return callToolResultText(mustJSON(newModbusV1Envelope(nil, errors.New("tesla HSC provider unavailable"), false, "RETAINED_PROFILE", "")), true), true
 	}
 	result, err := provider.TeslaHSCV1(ctx)
-	if err != nil {
-		result = TeslaHSCV1Result{}
-	} else if !validTeslaHSCV1Result(result) {
+	valid := validTeslaHSCV1Result(result)
+	if !valid {
 		result = TeslaHSCV1Result{}
 		err = errors.New("tesla HSC native provider result is invalid")
 	}
 	if err != nil {
-		return callToolResultText(mustJSON(newModbusV1Envelope(nil, err, true, "RETAINED_PROFILE", "")), true), true
+		var data any
+		if valid {
+			data = result
+		}
+		return callToolResultText(mustJSON(newModbusV1Envelope(data, err, true, "RETAINED_PROFILE", "")), true), true
 	}
 	return callToolResultText(mustJSON(newModbusV1Envelope(result, err, true, "RETAINED_PROFILE", "")), err != nil), true
 }

--- a/mcp/tesla_hsc_v1.go
+++ b/mcp/tesla_hsc_v1.go
@@ -84,7 +84,7 @@ func (server *Server) handleTeslaHSCV1Call(ctx context.Context, name string, arg
 }
 
 func normalizeTeslaHSCV1ProviderResult(result TeslaHSCV1Result, providerErr error) (TeslaHSCV1Result, error, bool) {
-	if validTeslaHSCV1Result(result) {
+	if validTeslaHSCV1Result(result) && (providerErr == nil || meaningfulTeslaHSCV1Result(result)) {
 		return result, providerErr, true
 	}
 	validationErr := errors.New("tesla HSC native provider result is invalid")
@@ -92,6 +92,10 @@ func normalizeTeslaHSCV1ProviderResult(result TeslaHSCV1Result, providerErr erro
 		validationErr = errors.Join(providerErr, validationErr)
 	}
 	return TeslaHSCV1Result{}, validationErr, false
+}
+
+func meaningfulTeslaHSCV1Result(result TeslaHSCV1Result) bool {
+	return result.Disposition != "" || result.Compatibility != "" || result.OutboundAllowed || len(result.NativeRecords) != 0
 }
 
 func validTeslaHSCV1Result(result TeslaHSCV1Result) bool {

--- a/mcp/tesla_hsc_v1_test.go
+++ b/mcp/tesla_hsc_v1_test.go
@@ -108,15 +108,54 @@ func (*teslaHSCV1ErrorFixtureProvider) TeslaHSCV1(context.Context) (TeslaHSCV1Re
 	}}}, errors.New("synthetic provider error")
 }
 
-func TestTeslaHSCV1StatusToolClearsNativeRecordsOnProviderError(t *testing.T) {
+func TestTeslaHSCV1StatusToolRetainsValidNativeRecordsOnProviderError(t *testing.T) {
 	server, err := NewServer(&testRegistry{entries: make(map[byte]registry.DeviceEntry)}, &testInvoker{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	RegisterModbusV1Tools(server, &teslaHSCV1ErrorFixtureProvider{&modbusV1FixtureProvider{}})
 	result := msp06Call(t, server.Handler(), TeslaHSCV1StatusGetTool, map[string]any{})
-	if !result.isError || result.envelope["data"] != nil {
+	if !result.isError {
 		t.Fatalf("provider-error result = %#v", result)
+	}
+	data := msp06Map(t, result.envelope["data"], "data")
+	records, ok := data["native_records"].([]any)
+	if !ok || len(records) != 1 {
+		t.Fatalf("native_records = %#v", data["native_records"])
+	}
+	record, ok := records[0].(map[string]any)
+	if !ok || fmt.Sprint(record["function"]) != "101" || record["payload"] != "AQ==" ||
+		record["compatibility"] != "wc3_24_44_3" || record["provenance"] != "synthetic-replay" {
+		t.Fatalf("native record = %#v", records[0])
+	}
+}
+
+type teslaHSCV1EmptyPayloadFixtureProvider struct{ *modbusV1FixtureProvider }
+
+func (*teslaHSCV1EmptyPayloadFixtureProvider) TeslaHSCV1(context.Context) (TeslaHSCV1Result, error) {
+	return TeslaHSCV1Result{NativeRecords: []TeslaHSCV1NativeRecord{{
+		Function: 101, Payload: []byte{}, Compatibility: "wc3_24_44_3", Provenance: "synthetic-replay",
+	}}}, nil
+}
+
+func TestTeslaHSCV1StatusToolPreservesNonNilEmptyPayload(t *testing.T) {
+	server, err := NewServer(&testRegistry{entries: make(map[byte]registry.DeviceEntry)}, &testInvoker{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	RegisterModbusV1Tools(server, &teslaHSCV1EmptyPayloadFixtureProvider{&modbusV1FixtureProvider{}})
+	result := msp06Call(t, server.Handler(), TeslaHSCV1StatusGetTool, map[string]any{})
+	if result.isError {
+		t.Fatalf("result = %#v", result)
+	}
+	data := msp06Map(t, result.envelope["data"], "data")
+	records, ok := data["native_records"].([]any)
+	if !ok || len(records) != 1 {
+		t.Fatalf("native_records = %#v", data["native_records"])
+	}
+	record, ok := records[0].(map[string]any)
+	if !ok || record["payload"] != "" {
+		t.Fatalf("empty native payload = %#v", records[0])
 	}
 }
 

--- a/mcp/tesla_hsc_v1_test.go
+++ b/mcp/tesla_hsc_v1_test.go
@@ -110,6 +110,14 @@ func TestTeslaHSCV1ProviderResultRetainsProviderErrorWhenNativeDataIsInvalid(t *
 	}
 }
 
+func TestTeslaHSCV1ProviderResultTreatsZeroValueErrorResultAsAbsent(t *testing.T) {
+	providerErr := errors.New("synthetic provider error")
+	result, err, valid := normalizeTeslaHSCV1ProviderResult(TeslaHSCV1Result{}, providerErr)
+	if valid || len(result.NativeRecords) != 0 || !errors.Is(err, providerErr) || !strings.Contains(err.Error(), "invalid") {
+		t.Fatalf("result=%#v err=%v valid=%t", result, err, valid)
+	}
+}
+
 type teslaHSCV1ErrorFixtureProvider struct{ *modbusV1FixtureProvider }
 
 func (*teslaHSCV1ErrorFixtureProvider) TeslaHSCV1(context.Context) (TeslaHSCV1Result, error) {

--- a/mcp/tesla_hsc_v1_test.go
+++ b/mcp/tesla_hsc_v1_test.go
@@ -100,6 +100,16 @@ func TestTeslaHSCV1StatusToolRejectsInvalidNativeProviderRecord(t *testing.T) {
 	}
 }
 
+func TestTeslaHSCV1ProviderResultRetainsProviderErrorWhenNativeDataIsInvalid(t *testing.T) {
+	providerErr := errors.New("synthetic decoder error")
+	result, err, valid := normalizeTeslaHSCV1ProviderResult(TeslaHSCV1Result{NativeRecords: []TeslaHSCV1NativeRecord{{
+		Function: 101, Compatibility: "wc3_24_44_3", Provenance: "synthetic-replay", ResponseName: "unqualified",
+	}}}, providerErr)
+	if valid || len(result.NativeRecords) != 0 || !errors.Is(err, providerErr) || !strings.Contains(err.Error(), "invalid") {
+		t.Fatalf("result=%#v err=%v valid=%t", result, err, valid)
+	}
+}
+
 type teslaHSCV1ErrorFixtureProvider struct{ *modbusV1FixtureProvider }
 
 func (*teslaHSCV1ErrorFixtureProvider) TeslaHSCV1(context.Context) (TeslaHSCV1Result, error) {


### PR DESCRIPTION
Closes #898

## Scope
- preserves valid native HSC records even when the injected provider also reports an error
- preserves the distinction between an empty native payload and no payload
- replaces the exported Tesla provenance digest-only projection with bounded native payload, compatibility, and provenance context

## Safety and boundaries
- synthetic fixtures only; no credentials, endpoints, private captures, hardware I/O, or deployment
- no transport/lifecycle/main/DriverManager/semreg work
- T01–T88 does not apply: this PR changes MCP projection and tests only; #852 remains separately merged under its historical written T01–T88/P01–P06 waiver, with those matrices unrun and not declared PASS

## TDD evidence
- strict RED commit `fd862d9640d2d528364c95a972a77fef4e3a43d9`
- local RED: `go test ./mcp -run 'TeslaHSC(V1|Provenance)' -count=1` fails because the existing provenance API lacks native fields\n- Green and full local CI will follow after the PR CI has observed RED.