### PR TITLE
Refactor gateway HTTP control-plane phases

### DIFF
--- a/cmd/gateway/eebus_admin_wiring_test.go
+++ b/cmd/gateway/eebus_admin_wiring_test.go
@@ -97,11 +97,15 @@ func TestIssue817GatewayMountsOneCredentialFreeTypedOperatorBoundary(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
+	controlPlaneContent, err := os.ReadFile("gateway_http_control_plane.go")
+	if err != nil {
+		t.Fatal(err)
+	}
 	configContent, err := os.ReadFile("eebus_admin_config.go")
 	if err != nil {
 		t.Fatal(err)
 	}
-	source := string(content) + "\n" + string(httpContent) + "\n" + string(configContent)
+	source := string(content) + "\n" + string(httpContent) + "\n" + string(controlPlaneContent) + "\n" + string(configContent)
 	for _, required := range []string{
 		`mux.Handle("/admin/eebus/v1/", eebusAdminHandler)`,
 		`eebusAdminHandler := eebusadmin.NewUnavailableHandler()`,

--- a/cmd/gateway/eebus_mcp_wiring_test.go
+++ b/cmd/gateway/eebus_mcp_wiring_test.go
@@ -142,11 +142,8 @@ func TestMSP06GatewayRegistersProviderConditionallyBeforeMCPMount(t *testing.T) 
 					commandRegisterPosition = value.Pos()
 				}
 			}
-			if selector, ok := value.Fun.(*ast.SelectorExpr); ok && selector.Sel.Name == "Handle" && len(value.Args) > 0 {
-				pathSelector, ok := value.Args[0].(*ast.SelectorExpr)
-				if ok && pathSelector.Sel.Name == "MCPPath" {
-					mountPosition = value.Pos()
-				}
+			if function, ok := value.Fun.(*ast.Ident); ok && function.Name == "registerHTTPControlPlaneCoreRoutes" {
+				mountPosition = value.Pos()
 			}
 		case *ast.IfStmt:
 			containsRegistration := false
@@ -359,7 +356,7 @@ func TestMSP06ProviderRegistrationDoesNotEscapeMCPBootstrap(t *testing.T) {
 		}
 		clean := filepath.Clean(relative)
 		allowedMCP := strings.HasPrefix(clean, filepath.Clean("../../mcp")+string(filepath.Separator))
-		allowedGateway := clean == filepath.Clean("../../cmd/gateway/main.go") || clean == filepath.Clean("../../cmd/gateway/gateway_http_server.go") || clean == filepath.Clean("../../cmd/gateway/eebus_runtime_adapter.go")
+		allowedGateway := clean == filepath.Clean("../../cmd/gateway/main.go") || clean == filepath.Clean("../../cmd/gateway/gateway_http_server.go") || clean == filepath.Clean("../../cmd/gateway/gateway_http_control_plane.go") || clean == filepath.Clean("../../cmd/gateway/eebus_runtime_adapter.go")
 		if !allowedMCP && !allowedGateway {
 			t.Errorf("MSP-06 provider registration escaped MCP/bootstrap boundary into %s", relative)
 		}

--- a/cmd/gateway/gateway_http_control_plane.go
+++ b/cmd/gateway/gateway_http_control_plane.go
@@ -37,41 +37,76 @@ func newHTTPControlPlaneGraphQLHandlers(
 	return queryHandler, snapshotHandler, subscriptionHandler, nil
 }
 
-func httpControlPlaneRouteManifest(cfg ebusgateway.Config, hasBusObservability bool) []string {
-	routes := make([]string, 0, 13)
+type httpControlPlaneRoutePlan struct {
+	metricsPath      string
+	graphqlPath      string
+	snapshotPath     string
+	subscriptionPath string
+	mcpPath          string
+	dumpUploadPath   string
+	uiPath           string
+	portalPath       string
+}
+
+func newHTTPControlPlaneRoutePlan(cfg ebusgateway.Config, hasBusObservability bool) httpControlPlaneRoutePlan {
+	plan := httpControlPlaneRoutePlan{
+		graphqlPath:      cfg.GraphQLPath,
+		snapshotPath:     cfg.SnapshotPath,
+		subscriptionPath: cfg.SubscriptionPath,
+		mcpPath:          cfg.MCPPath,
+	}
 	if hasBusObservability {
-		routes = append(routes, normalizeMountPath(cfg.MetricsPath, ebusgateway.DefaultMetricsPath))
+		plan.metricsPath = normalizeMountPath(cfg.MetricsPath, ebusgateway.DefaultMetricsPath)
+	}
+	if cfg.DumpUploadPath != "" {
+		plan.dumpUploadPath = cfg.DumpUploadPath
+		if !strings.HasPrefix(plan.dumpUploadPath, "/") {
+			plan.dumpUploadPath = "/" + plan.dumpUploadPath
+		}
+	}
+	if cfg.UIPath != "" {
+		plan.uiPath = normalizeMountPath(cfg.UIPath, "/ui")
+	}
+	if cfg.PortalPath != "" {
+		plan.portalPath = normalizeMountPath(cfg.PortalPath, "/portal")
+	}
+	return plan
+}
+
+func (plan httpControlPlaneRoutePlan) manifest() []string {
+	routes := make([]string, 0, 13)
+	if plan.metricsPath != "" {
+		routes = append(routes, plan.metricsPath)
 	}
 	routes = append(routes,
 		"/debug/vars",
 		"/debug/v8/admin-events",
-		cfg.GraphQLPath,
-		cfg.SnapshotPath,
-		cfg.SubscriptionPath,
-		cfg.MCPPath,
+		plan.graphqlPath,
+		plan.snapshotPath,
+		plan.subscriptionPath,
+		plan.mcpPath,
 		"/admin/eebus/v1/",
 	)
-	if cfg.DumpUploadPath != "" {
-		uploadPath := cfg.DumpUploadPath
-		if !strings.HasPrefix(uploadPath, "/") {
-			uploadPath = "/" + uploadPath
-		}
-		routes = append(routes, uploadPath)
+	if plan.dumpUploadPath != "" {
+		routes = append(routes, plan.dumpUploadPath)
 	}
-	if cfg.UIPath != "" {
-		uiPath := normalizeMountPath(cfg.UIPath, "/ui")
-		routes = append(routes, uiPath+"/", uiPath)
+	if plan.uiPath != "" {
+		routes = append(routes, plan.uiPath+"/", plan.uiPath)
 	}
-	if cfg.PortalPath != "" {
-		portalPath := normalizeMountPath(cfg.PortalPath, "/portal")
-		routes = append(routes, portalPath+"/", portalPath)
+	if plan.portalPath != "" {
+		routes = append(routes, plan.portalPath+"/", plan.portalPath)
 	}
 	return routes
 }
 
+func httpControlPlaneRouteManifest(cfg ebusgateway.Config, hasBusObservability bool) []string {
+	return newHTTPControlPlaneRoutePlan(cfg, hasBusObservability).manifest()
+}
+
 func registerHTTPControlPlaneCoreRoutes(
 	mux *http.ServeMux,
-	cfg ebusgateway.Config,
+	plan httpControlPlaneRoutePlan,
+	dumpOutputDir string,
 	busObservability *ebusgateway.BusObservabilityStore,
 	queryHandler http.Handler,
 	snapshotHandler http.Handler,
@@ -79,31 +114,26 @@ func registerHTTPControlPlaneCoreRoutes(
 	mcpServer *mcp.Server,
 	eebusAdminHandler http.Handler,
 ) {
-	if busObservability != nil {
-		mux.Handle(normalizeMountPath(cfg.MetricsPath, ebusgateway.DefaultMetricsPath), busObservability.MetricsHandler())
+	if plan.metricsPath != "" {
+		mux.Handle(plan.metricsPath, busObservability.MetricsHandler())
 	}
 	// The gateway owns its mux, so expvar's default-mux registration must be
 	// mounted explicitly.
 	mux.Handle("/debug/vars", expvar.Handler())
 	mux.HandleFunc("/debug/v8/admin-events", handleV8AdminEvents)
-	mux.Handle(cfg.GraphQLPath, queryHandler)
-	mux.Handle(cfg.SnapshotPath, snapshotHandler)
-	mux.Handle(cfg.SubscriptionPath, subscriptionHandler)
-	mux.Handle(cfg.MCPPath, mcpServer.Handler())
+	mux.Handle(plan.graphqlPath, queryHandler)
+	mux.Handle(plan.snapshotPath, snapshotHandler)
+	mux.Handle(plan.subscriptionPath, subscriptionHandler)
+	mux.Handle(plan.mcpPath, mcpServer.Handler())
 	mux.Handle("/admin/eebus/v1/", eebusAdminHandler)
-	if cfg.DumpUploadPath != "" {
-		uploadPath := cfg.DumpUploadPath
-		if !strings.HasPrefix(uploadPath, "/") {
-			uploadPath = "/" + uploadPath
-		}
-		mux.Handle(uploadPath, ebusgateway.NewRegisterDumpUploadHandler(cfg.DumpOutputDir))
+	if plan.dumpUploadPath != "" {
+		mux.Handle(plan.dumpUploadPath, ebusgateway.NewRegisterDumpUploadHandler(dumpOutputDir))
 	}
-	if cfg.UIPath != "" {
-		uiPath := normalizeMountPath(cfg.UIPath, "/ui")
-		uiHandler := ui.NewHandler(cfg.GraphQLPath)
-		mux.Handle(uiPath+"/", http.StripPrefix(uiPath, uiHandler))
-		mux.HandleFunc(uiPath, func(w http.ResponseWriter, r *http.Request) {
-			http.Redirect(w, r, uiPath+"/", http.StatusMovedPermanently)
+	if plan.uiPath != "" {
+		uiHandler := ui.NewHandler(plan.graphqlPath)
+		mux.Handle(plan.uiPath+"/", http.StripPrefix(plan.uiPath, uiHandler))
+		mux.HandleFunc(plan.uiPath, func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, plan.uiPath+"/", http.StatusMovedPermanently)
 		})
 	}
 }

--- a/cmd/gateway/gateway_http_control_plane.go
+++ b/cmd/gateway/gateway_http_control_plane.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"context"
+	"expvar"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"strings"
+
+	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/graphql"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/mdns"
+	"github.com/Project-Helianthus/helianthus-ebusgateway/ui"
+)
+
+func newHTTPControlPlaneGraphQLHandlers(
+	gateway *ebusgateway.Gateway,
+	builder *graphql.Builder,
+	hub *graphql.BroadcastHub,
+) (http.Handler, http.Handler, http.Handler, error) {
+	queryHandler, err := graphql.NewInvokeHandler(builder, gateway.Registry, gateway.Router)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	snapshotHandler, err := graphql.NewProjectionSnapshotHandler(builder)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	subscriptionHandler, err := graphql.NewSubscriptionHandler(builder, gateway.Registry, gateway.Router, hub)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return queryHandler, snapshotHandler, subscriptionHandler, nil
+}
+
+func httpControlPlaneRouteManifest(cfg ebusgateway.Config, hasBusObservability bool) []string {
+	routes := make([]string, 0, 13)
+	if hasBusObservability {
+		routes = append(routes, normalizeMountPath(cfg.MetricsPath, ebusgateway.DefaultMetricsPath))
+	}
+	routes = append(routes,
+		"/debug/vars",
+		"/debug/v8/admin-events",
+		cfg.GraphQLPath,
+		cfg.SnapshotPath,
+		cfg.SubscriptionPath,
+		cfg.MCPPath,
+		"/admin/eebus/v1/",
+	)
+	if cfg.DumpUploadPath != "" {
+		uploadPath := cfg.DumpUploadPath
+		if !strings.HasPrefix(uploadPath, "/") {
+			uploadPath = "/" + uploadPath
+		}
+		routes = append(routes, uploadPath)
+	}
+	if cfg.UIPath != "" {
+		uiPath := normalizeMountPath(cfg.UIPath, "/ui")
+		routes = append(routes, uiPath+"/", uiPath)
+	}
+	if cfg.PortalPath != "" {
+		portalPath := normalizeMountPath(cfg.PortalPath, "/portal")
+		routes = append(routes, portalPath+"/", portalPath)
+	}
+	return routes
+}
+
+func registerHTTPControlPlaneCoreRoutes(
+	mux *http.ServeMux,
+	cfg ebusgateway.Config,
+	busObservability *ebusgateway.BusObservabilityStore,
+	queryHandler http.Handler,
+	snapshotHandler http.Handler,
+	subscriptionHandler http.Handler,
+	mcpServer *mcp.Server,
+	eebusAdminHandler http.Handler,
+) {
+	if busObservability != nil {
+		mux.Handle(normalizeMountPath(cfg.MetricsPath, ebusgateway.DefaultMetricsPath), busObservability.MetricsHandler())
+	}
+	// The gateway owns its mux, so expvar's default-mux registration must be
+	// mounted explicitly.
+	mux.Handle("/debug/vars", expvar.Handler())
+	mux.HandleFunc("/debug/v8/admin-events", handleV8AdminEvents)
+	mux.Handle(cfg.GraphQLPath, queryHandler)
+	mux.Handle(cfg.SnapshotPath, snapshotHandler)
+	mux.Handle(cfg.SubscriptionPath, subscriptionHandler)
+	mux.Handle(cfg.MCPPath, mcpServer.Handler())
+	mux.Handle("/admin/eebus/v1/", eebusAdminHandler)
+	if cfg.DumpUploadPath != "" {
+		uploadPath := cfg.DumpUploadPath
+		if !strings.HasPrefix(uploadPath, "/") {
+			uploadPath = "/" + uploadPath
+		}
+		mux.Handle(uploadPath, ebusgateway.NewRegisterDumpUploadHandler(cfg.DumpOutputDir))
+	}
+	if cfg.UIPath != "" {
+		uiPath := normalizeMountPath(cfg.UIPath, "/ui")
+		uiHandler := ui.NewHandler(cfg.GraphQLPath)
+		mux.Handle(uiPath+"/", http.StripPrefix(uiPath, uiHandler))
+		mux.HandleFunc(uiPath, func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, uiPath+"/", http.StatusMovedPermanently)
+		})
+	}
+}
+
+func startHTTPControlPlaneListener(
+	ctx context.Context,
+	cfg ebusgateway.Config,
+	mux *http.ServeMux,
+	gateway *ebusgateway.Gateway,
+	mcpServer *mcp.Server,
+	eebusProvider mcp.EEBusV1Provider,
+) (*http.Server, mdns.Advertiser, error) {
+	var operatorEndpoint io.Closer
+	var err error
+	if eebusProvider != nil {
+		operatorEndpoint, err = mcpServer.StartEEBusV1OperatorEndpoint(ctx)
+		if err != nil {
+			return nil, nil, fmt.Errorf("start eeBUS operator MCP endpoint: %w", err)
+		}
+	}
+
+	listener, err := net.Listen("tcp", cfg.HTTPAddr)
+	if err != nil {
+		if operatorEndpoint != nil {
+			_ = operatorEndpoint.Close()
+		}
+		return nil, nil, err
+	}
+
+	server := &http.Server{Handler: mux}
+	if operatorEndpoint != nil {
+		server.RegisterOnShutdown(func() {
+			_ = operatorEndpoint.Close()
+		})
+	}
+	go func() {
+		defer func() {
+			if operatorEndpoint != nil {
+				_ = operatorEndpoint.Close()
+			}
+		}()
+		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+			log.Printf("http server error: %v", err)
+		}
+	}()
+
+	var advertiser mdns.Advertiser
+	if cfg.MDNSAdvertise {
+		port := listener.Addr().(*net.TCPAddr).Port
+		advertiser, err = mdns.Advertise(ctx, mdns.Service{
+			Instance: cfg.MDNSInstance,
+			Service:  mdns.ServiceTypeGateway,
+			Port:     port,
+			Text:     gatewayMDNSText(cfg),
+		})
+		if err != nil {
+			_ = server.Close()
+			if operatorEndpoint != nil {
+				_ = operatorEndpoint.Close()
+			}
+			return nil, nil, err
+		}
+	}
+
+	go func() {
+		<-ctx.Done()
+		_ = server.Shutdown(context.Background())
+		if operatorEndpoint != nil {
+			_ = operatorEndpoint.Close()
+		}
+	}()
+	return server, advertiser, nil
+}

--- a/cmd/gateway/gateway_http_server.go
+++ b/cmd/gateway/gateway_http_server.go
@@ -180,11 +180,12 @@ func startHTTPServer(
 	}
 
 	mux := http.NewServeMux()
+	routePlan := newHTTPControlPlaneRoutePlan(cfg, busObservability != nil)
 	registerHTTPControlPlaneCoreRoutes(
-		mux, cfg, busObservability, queryHandler, snapshotHandler, subscriptionHandler, mcpServer, eebusAdminHandler,
+		mux, routePlan, cfg.DumpOutputDir, busObservability, queryHandler, snapshotHandler, subscriptionHandler, mcpServer, eebusAdminHandler,
 	)
-	if cfg.PortalPath != "" {
-		portalPath := normalizeMountPath(cfg.PortalPath, "/portal")
+	if routePlan.portalPath != "" {
+		portalPath := routePlan.portalPath
 		var getPortalBusObservability func() any
 		if busObservability != nil {
 			getPortalBusObservability = func() any {

--- a/cmd/gateway/gateway_http_server.go
+++ b/cmd/gateway/gateway_http_server.go
@@ -2,11 +2,8 @@ package main
 
 import (
 	"context"
-	"expvar"
 	"fmt"
-	"io"
 	"log"
-	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -17,7 +14,6 @@ import (
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mcp/ebus_standard"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/mdns"
 	"github.com/Project-Helianthus/helianthus-ebusgateway/portal"
-	"github.com/Project-Helianthus/helianthus-ebusgateway/ui"
 	"github.com/Project-Helianthus/helianthus-ebusreg/registry"
 )
 
@@ -65,15 +61,7 @@ func startHTTPServer(
 		return nil, nil, fmt.Errorf("portal PV configuration: %w", err)
 	}
 
-	queryHandler, err := graphql.NewInvokeHandler(builder, gateway.Registry, gateway.Router)
-	if err != nil {
-		return nil, nil, err
-	}
-	snapshotHandler, err := graphql.NewProjectionSnapshotHandler(builder)
-	if err != nil {
-		return nil, nil, err
-	}
-	subscriptionHandler, err := graphql.NewSubscriptionHandler(builder, gateway.Registry, gateway.Router, hub)
+	queryHandler, snapshotHandler, subscriptionHandler, err := newHTTPControlPlaneGraphQLHandlers(gateway, builder, hub)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -192,67 +180,9 @@ func startHTTPServer(
 	}
 
 	mux := http.NewServeMux()
-	if busObservability != nil {
-		mux.Handle(normalizeMountPath(cfg.MetricsPath, ebusgateway.DefaultMetricsPath), busObservability.MetricsHandler())
-	}
-	// Expose expvar surfaces (including the 11 startup_source_selection_* counters
-	// from M5) via /debug/vars. The expvar package's init registers the
-	// handler on http.DefaultServeMux, but the gateway uses its own mux so
-	// the handler must be wired explicitly. Resolves cruise-run #20
-	// validation finding: M5 expvars were defined + Publish()'d but not
-	// reachable over HTTP.
-	mux.Handle("/debug/vars", expvar.Handler())
-	// F-NEW-26 (2026-05-21): expose the v8 classifier's admin
-	// event ring buffer over HTTP so operators can introspect the
-	// byte-level detail behind the helianthus_v8_shadow_would_have_dropped_total
-	// counter. Without this endpoint the aggregate counter is a
-	// black box: an operator running v8 in shadow mode sees the
-	// count rising but cannot distinguish true-positive (real wire
-	// AA-injection that SHOULD be filtered when promoted to enforce)
-	// from false-positive (legitimate traffic v8 over-eagerly flags).
-	// The per-event detail (byte value + FSM state + escape
-	// provenance + timestamp) is the operator's evidence base for
-	// the shadow→enforce promotion gate documented in
-	// helianthus-docs-ebus/deployment/prometheus-alerts.md.
-	//
-	// Endpoint contract:
-	//   GET /debug/v8/admin-events
-	//   Response: application/json
-	//   Body: {"events": [<ClassifierAdminEvent>...], "dropped": <uint64>}
-	//
-	// DRAIN semantics: each successful GET returns the events
-	// accumulated since the last drain and EMPTIES the ring
-	// buffer. Operators MUST poll at a steady cadence (every
-	// few seconds in production); a stuck consumer drops the
-	// OLDEST events FIFO and the "dropped" field surfaces the
-	// saturation.
-	//
-	// Nil-safe: when the classifier is unset (non-adapter-direct
-	// transport, or run() not yet completed), the handler returns
-	// `{"events": [], "dropped": 0}` — the surface stays
-	// available so tooling that probes it unconditionally does
-	// not 404.
-	mux.HandleFunc("/debug/v8/admin-events", handleV8AdminEvents)
-	mux.Handle(cfg.GraphQLPath, queryHandler)
-	mux.Handle(cfg.SnapshotPath, snapshotHandler)
-	mux.Handle(cfg.SubscriptionPath, subscriptionHandler)
-	mux.Handle(cfg.MCPPath, mcpServer.Handler())
-	mux.Handle("/admin/eebus/v1/", eebusAdminHandler)
-	if cfg.DumpUploadPath != "" {
-		uploadPath := cfg.DumpUploadPath
-		if !strings.HasPrefix(uploadPath, "/") {
-			uploadPath = "/" + uploadPath
-		}
-		mux.Handle(uploadPath, ebusgateway.NewRegisterDumpUploadHandler(cfg.DumpOutputDir))
-	}
-	if cfg.UIPath != "" {
-		uiPath := normalizeMountPath(cfg.UIPath, "/ui")
-		uiHandler := ui.NewHandler(cfg.GraphQLPath)
-		mux.Handle(uiPath+"/", http.StripPrefix(uiPath, uiHandler))
-		mux.HandleFunc(uiPath, func(w http.ResponseWriter, r *http.Request) {
-			http.Redirect(w, r, uiPath+"/", http.StatusMovedPermanently)
-		})
-	}
+	registerHTTPControlPlaneCoreRoutes(
+		mux, cfg, busObservability, queryHandler, snapshotHandler, subscriptionHandler, mcpServer, eebusAdminHandler,
+	)
 	if cfg.PortalPath != "" {
 		portalPath := normalizeMountPath(cfg.PortalPath, "/portal")
 		var getPortalBusObservability func() any
@@ -437,67 +367,5 @@ func startHTTPServer(
 		})
 	}
 
-	var operatorEndpoint io.Closer
-	if eebusProvider != nil {
-		operatorEndpoint, err = mcpServer.StartEEBusV1OperatorEndpoint(ctx)
-		if err != nil {
-			return nil, nil, fmt.Errorf("start eeBUS operator MCP endpoint: %w", err)
-		}
-	}
-
-	listener, err := net.Listen("tcp", cfg.HTTPAddr)
-	if err != nil {
-		if operatorEndpoint != nil {
-			_ = operatorEndpoint.Close()
-		}
-		return nil, nil, err
-	}
-
-	server := &http.Server{
-		Handler: mux,
-	}
-	if operatorEndpoint != nil {
-		server.RegisterOnShutdown(func() {
-			_ = operatorEndpoint.Close()
-		})
-	}
-
-	go func() {
-		defer func() {
-			if operatorEndpoint != nil {
-				_ = operatorEndpoint.Close()
-			}
-		}()
-		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
-			log.Printf("http server error: %v", err)
-		}
-	}()
-
-	var advertiser mdns.Advertiser
-	if cfg.MDNSAdvertise {
-		port := listener.Addr().(*net.TCPAddr).Port
-		advertiser, err = mdns.Advertise(ctx, mdns.Service{
-			Instance: cfg.MDNSInstance,
-			Service:  mdns.ServiceTypeGateway,
-			Port:     port,
-			Text:     gatewayMDNSText(cfg),
-		})
-		if err != nil {
-			_ = server.Close()
-			if operatorEndpoint != nil {
-				_ = operatorEndpoint.Close()
-			}
-			return nil, nil, err
-		}
-	}
-
-	go func() {
-		<-ctx.Done()
-		_ = server.Shutdown(context.Background())
-		if operatorEndpoint != nil {
-			_ = operatorEndpoint.Close()
-		}
-	}()
-
-	return server, advertiser, nil
+	return startHTTPControlPlaneListener(ctx, cfg, mux, gateway, mcpServer, eebusProvider)
 }

--- a/cmd/gateway/gateway_http_server_control_plane_test.go
+++ b/cmd/gateway/gateway_http_server_control_plane_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	ebusgateway "github.com/Project-Helianthus/helianthus-ebusgateway"
+)
+
+func TestHTTPControlPlaneRouteManifestIsDeterministic(t *testing.T) {
+	cfg := ebusgateway.DefaultConfig()
+	cfg.GraphQLPath = "/graphql"
+	cfg.SnapshotPath = "/snapshot"
+	cfg.SubscriptionPath = "/subscription"
+	cfg.MCPPath = "/mcp"
+	cfg.MetricsPath = "/metrics"
+	cfg.DumpUploadPath = "dump"
+	cfg.UIPath = "/ui"
+	cfg.PortalPath = "/portal"
+
+	want := []string{
+		"/metrics",
+		"/debug/vars",
+		"/debug/v8/admin-events",
+		"/graphql",
+		"/snapshot",
+		"/subscription",
+		"/mcp",
+		"/admin/eebus/v1/",
+		"/dump",
+		"/ui/",
+		"/ui",
+		"/portal/",
+		"/portal",
+	}
+	if got := httpControlPlaneRouteManifest(cfg, true); !reflect.DeepEqual(got, want) {
+		t.Fatalf("route manifest = %#v; want %#v", got, want)
+	}
+}
+
+func TestHTTPControlPlaneRouteManifestOmitsDisabledOptionalRoutes(t *testing.T) {
+	cfg := ebusgateway.DefaultConfig()
+	cfg.GraphQLPath = "/graphql"
+	cfg.SnapshotPath = "/snapshot"
+	cfg.SubscriptionPath = "/subscription"
+	cfg.MCPPath = "/mcp"
+	cfg.DumpUploadPath = ""
+	cfg.UIPath = ""
+	cfg.PortalPath = ""
+
+	want := []string{
+		"/debug/vars",
+		"/debug/v8/admin-events",
+		"/graphql",
+		"/snapshot",
+		"/subscription",
+		"/mcp",
+		"/admin/eebus/v1/",
+	}
+	if got := httpControlPlaneRouteManifest(cfg, false); !reflect.DeepEqual(got, want) {
+		t.Fatalf("route manifest = %#v; want %#v", got, want)
+	}
+}
+
+func TestMainStartsControlPlaneBeforeWarmupAndRetiresItInLIFOOrder(t *testing.T) {
+	source, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	text := string(source)
+
+	start := strings.Index(text, "server, advertiser, err := startHTTPServerFn(")
+	warmup := strings.Index(text, "ebusDriver.WaitRunning(ctx)")
+	if start < 0 || warmup < 0 || start > warmup {
+		t.Fatalf("control-plane start must precede WaitRunning warmup: start=%d warmup=%d", start, warmup)
+	}
+
+	last := -1
+	for _, closeCall := range []string{
+		"listener.Close()",
+		"deduplicator.Close()",
+		"reconstructor.Close()",
+		"busObservability.Close()",
+		"advertiser.Close()",
+		"server.Close()",
+	} {
+		next := strings.Index(text, closeCall)
+		if next < 0 || next < last {
+			t.Fatalf("teardown call %q is absent or out of order", closeCall)
+		}
+		last = next
+	}
+}

--- a/cmd/gateway/synchronized_evidence_runtime_test.go
+++ b/cmd/gateway/synchronized_evidence_runtime_test.go
@@ -252,18 +252,14 @@ func TestIssue764GatewayRegistersPrivateCaptureExactlyOnceBeforeMCPMount(t *test
 		if !ok {
 			return true
 		}
-		selector, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok {
-			return true
-		}
-		if selector.Sel.Name == "RegisterSynchronizedEvidenceCapture" {
-			count++
-			registration = call.Pos()
-		}
-		if selector.Sel.Name == "Handle" && len(call.Args) > 0 {
-			if path, ok := call.Args[0].(*ast.SelectorExpr); ok && path.Sel.Name == "MCPPath" {
-				mount = call.Pos()
+		if selector, ok := call.Fun.(*ast.SelectorExpr); ok {
+			if selector.Sel.Name == "RegisterSynchronizedEvidenceCapture" {
+				count++
+				registration = call.Pos()
 			}
+		}
+		if function, ok := call.Fun.(*ast.Ident); ok && function.Name == "registerHTTPControlPlaneCoreRoutes" {
+			mount = call.Pos()
 		}
 		return true
 	})


### PR DESCRIPTION
## Scope
- characterize the deterministic HTTP route manifest and control-plane ordering
- mechanically split GraphQL handler construction, core-route registration, and listener/mDNS lifecycle into same-package helpers
- preserve routes and process lifecycle behavior

## TDD
- RED `3d69284b175660b7644aedb54bc48deb770db4fd`: absent route-manifest helper
- GREEN `51f186bcdad80770b9168d5fed66c14e8d18ab57`

## Gates
- docs gate: not required; mechanical same-package refactor with unchanged public surfaces
- transport/live I/O: not applicable
- focused gateway tests passed; full package CI running